### PR TITLE
optimize intersection1OnTrue() for intEq

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -4959,7 +4959,7 @@ algorithm
         end for;
 
         lstall := List.map(row, Util.tuple31);
-        (_, lst, _) := List.intersection1OnTrue(lstall, lst, intEq);
+        (_, lst, _) := List.intIntersection1OnTrue(lstall, lst);
         _ := List.fold1(lst, markNegativ, rowmark, mark);
         row := listAppend(row1,row);
       then

--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -2200,7 +2200,7 @@ algorithm
       // the partition consists of 2 equations
       varIdcs1 = arrayGet(m, eqIdx1);
       varIdcs2 = arrayGet(m, eqIdx2);
-      (sharedVarIdcs, varIdcs1, varIdcs2) = List.intersection1OnTrue(varIdcs1, varIdcs2, intEq);
+      (sharedVarIdcs, varIdcs1, varIdcs2) = List.intIntersection1OnTrue(varIdcs1, varIdcs2);
         //print("sharedVarIdcs "+stringDelimitList(List.map(sharedVarIdcs, intString), ", ")+"\n");
       {varIdx1} = varIdcs1;
       {varIdx2} = varIdcs2;
@@ -2265,7 +2265,7 @@ algorithm
           {eqIdx1, eqIdx2} := loop1;
           varIdcs1 := arrayGet(m, eqIdx1);
           varIdcs2 := arrayGet(m, eqIdx2);
-          (sharedVarIdcs, varIdcs1, varIdcs2) := List.intersection1OnTrue(varIdcs1, varIdcs2, intEq);
+          (sharedVarIdcs, varIdcs1, varIdcs2) := List.intIntersection1OnTrue(varIdcs1, varIdcs2);
             //print("sharedVarIdcs "+stringDelimitList(List.map(sharedVarIdcs, intString), ", ")+"\n");
             //print("varIdcs1 "+stringDelimitList(List.map(varIdcs1, intString), ", ")+"\n");
             //print("varIdcs2 "+stringDelimitList(List.map(varIdcs2, intString), ", ")+"\n");

--- a/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
+++ b/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
@@ -3293,14 +3293,14 @@ algorithm
   // Condition -2
   condition2 := "Condition-2 \"All variables of interest must be involved in SET_C or SET_S\"";
   print(condition2 +  "\n" + UNDERLINE + "\n");
-  (tmplist1, tmplist2, tmplist3) := List.intersection1OnTrue(matchedknownssetc, knowns, intEq);
+  (tmplist1, tmplist2, tmplist3) := List.intIntersection1OnTrue(matchedknownssetc, knowns);
 
   if listEmpty(tmplist3) then
     print("-Passed\n");
     BackendDump.dumpVarList(List.map1r(tmplist1, BackendVariable.getVarAt, allVars), "-SET_C has all known variables:" + dumplistInteger(tmplist1));
    // check in sets
   elseif not listEmpty(tmplist3) then
-    (tmplist1sets, tmplist2, _) := List.intersection1OnTrue(tmplist3, matchedknownssets, intEq);
+    (tmplist1sets, tmplist2, _) := List.intIntersection1OnTrue(tmplist3, matchedknownssets);
     if not listEmpty(tmplist2) then
       str := dumplistInteger(tmplist2);
       print("-Failed\n");
@@ -3342,7 +3342,7 @@ algorithm
   //Condition-4
   condition4 := "Condition-4 \"SET_S should contain all intermediate variables involved in SET_C\"";
   print(condition4 + "\n" + UNDERLINE + "\n");
-  (tmplistvar1, tmplistvar2, tmplistvar3) := List.intersection1OnTrue(matchedunknownssetc, matchedunknownssets, intEq);
+  (tmplistvar1, tmplistvar2, tmplistvar3) := List.intIntersection1OnTrue(matchedunknownssetc, matchedunknownssets);
 
   if listEmpty(matchedunknownssetc) then
     print("-Passed"+"\n"+"-SET_C contains No Intermediate Variables\n\n");

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -1715,7 +1715,7 @@ algorithm
           //print("unassNodes: \n"+stringDelimitList(List.map(unassNodes,intString)," ; ")+"\n");
         necessaryPredecessors = List.flatten(List.map4(List.map(necessaryPredecessors,List.create),BLS_getDependentGroups,iGraph,iGraphT,unassNodes,{}));  // get all unassigned dependents for the necessary predecessors
         necessaryPredecessors = List.unique(necessaryPredecessors);
-        (necessaryPredecessors,_,unassNodes) = List.intersection1OnTrue(necessaryPredecessors,unassNodes,intEq);
+        (necessaryPredecessors,_,unassNodes) = List.intIntersection1OnTrue(necessaryPredecessors,unassNodes);
 
         // build the section
         section = critPathNode::necessaryPredecessors;
@@ -1791,7 +1791,7 @@ algorithm
       dependentNodes = BLS_getDependentGroups({node},iGraph,iGraphT,nodesIn,{});
       section = node::dependentNodes;
       section = List.unique(section);
-      (_,rest,_) = List.intersection1OnTrue(rest,dependentNodes,intEq);
+      (_,rest,_) = List.intIntersection1OnTrue(rest,dependentNodes);
       section = listReverse(section);
       //print("section: \n"+stringDelimitList(List.map(section,intString)," ; ")+"\n");
       sections = BLS_mergeDependentLevelTask(rest,iGraph,iGraphT,section::sectionsIn);
@@ -1821,8 +1821,8 @@ algorithm
       predecessors = arrayGet(iGraphT,node);
       //print("successors: \n"+stringDelimitList(List.map(successors,intString)," ; ")+"\n");
       //print("predecessors: \n"+stringDelimitList(List.map(predecessors,intString)," ; ")+"\n");
-      (successors,_,referenceNodes) = List.intersection1OnTrue(successors,referenceNodesIn,intEq);
-      (predecessors,_,referenceNodes) = List.intersection1OnTrue(predecessors,referenceNodes,intEq);
+      (successors,_,referenceNodes) = List.intIntersection1OnTrue(successors,referenceNodesIn);
+      (predecessors,_,referenceNodes) = List.intIntersection1OnTrue(predecessors,referenceNodes);
       //print("successors: \n"+stringDelimitList(List.map(successors,intString)," ; ")+"\n");
       //print("predecessors: \n"+stringDelimitList(List.map(predecessors,intString)," ; ")+"\n");
       dependentNodes = listAppend(predecessors,successors);
@@ -1909,7 +1909,7 @@ protected function deleteIntListMembers "author: Waurich TUD 2014-07
   input list<Integer> lst2;
   output list<Integer> lstOut;
 algorithm
-  (_,lstOut,_):= List.intersection1OnTrue(lst1,lst2,intEq);
+  (_,lstOut,_):= List.intIntersection1OnTrue(lst1,lst2);
 end deleteIntListMembers;
 
 
@@ -3785,7 +3785,7 @@ algorithm
         clTasks = listHead(allCluster);// the current cluster
         //print("clTasks :"+intListString(clTasks)+"\n");
         origPredTasks = arrayGet(taskGraphTOrig,node);
-        (clPredTasks,origPredTasks,_) = List.intersection1OnTrue(origPredTasks,clTasks,intEq);
+        (clPredTasks,origPredTasks,_) = List.intIntersection1OnTrue(origPredTasks,clTasks);
         //print("origPredTasks :"+intListString(origPredTasks)+"\n");
         pos = List.map1(clPredTasks,List.position,clTasks);
         clTasks = arrayGet(procAssIn,threadIdx);
@@ -3793,7 +3793,7 @@ algorithm
         //print("clTasks :"+intListString(clTasks)+"\n");
         clPredTasks = List.map1(pos,List.getIndexFirst,clTasks);
         //print("clPredTasks :"+intListString(clPredTasks)+"\n");
-        (duplPredTasks,_,_) = List.intersection1OnTrue(clPredTasks,clTasks,intEq);
+        (duplPredTasks,_,_) = List.intIntersection1OnTrue(clPredTasks,clTasks);
         //print("duplPredTasks :"+intListString(duplPredTasks)+"\n");
         taskGraph = List.fold1(duplPredTasks,Array.appendToElement,{node},taskGraphIn); // add edges from duplicated predecessors to task
         taskGraphOut = List.fold1(origPredTasks,Array.appendToElement,{node},taskGraph); // add edges from non duplicated predecessors to task
@@ -3939,7 +3939,7 @@ algorithm
   clTasks := listHead(allCluster);// the current cluster
   //print("clTasks :"+intListString(clTasks)+"\n");
   origPredTasks := arrayGet(taskGraphTOrig,node);
-  (clPredTasks,origPredTasks,_) := List.intersection1OnTrue(origPredTasks,clTasks,intEq);
+  (clPredTasks,origPredTasks,_) := List.intIntersection1OnTrue(origPredTasks,clTasks);
   //print("origPredTasks :"+intListString(origPredTasks)+"\n");
   pos := List.map1(clPredTasks,List.position,clTasks);
   clTasks := arrayGet(procAssOut,threadIdx);
@@ -3947,7 +3947,7 @@ algorithm
   //print("clTasks :"+intListString(clTasks)+"\n");
   clPredTasks := List.map1(pos,List.getIndexFirst,clTasks);
   //print("clPredTasks :"+intListString(clPredTasks)+"\n");
-  (duplPredTasks,_,_) := List.intersection1OnTrue(clPredTasks,clTasks,intEq);
+  (duplPredTasks,_,_) := List.intIntersection1OnTrue(clPredTasks,clTasks);
   //print("duplPredTasks :"+intListString(duplPredTasks)+"\n");
   taskGraph := List.fold1(duplPredTasks,Array.appendToElement,{taskIdx},taskGraphIn); // add edges from duplicated predecessors to task
   taskGraphOut := List.fold1(origPredTasks,Array.appendToElement,{taskIdx},taskGraph); // add edges from non duplicated predecessors to task
@@ -4939,8 +4939,8 @@ algorithm
         //print("Node: " + intString(node) + "\n");
         //print("Children: {" + stringDelimitList(List.map(childNodes, intString), ",") + "}\n");
         //print("Parents: {" + stringDelimitList(List.map(parentNodes, intString), ",") + "}\n");
-        (_,otherParents,_) = List.intersection1OnTrue(parentNodes,sameProcTasks,intEq);
-        (_,otherChildren,_) = List.intersection1OnTrue(childNodes,sameProcTasks,intEq);
+        (_,otherParents,_) = List.intIntersection1OnTrue(parentNodes,sameProcTasks);
+        (_,otherChildren,_) = List.intIntersection1OnTrue(childNodes,sameProcTasks);
         //print("Other children: {" + stringDelimitList(List.map(otherChildren, intString), ",") + "}\n");
         //print("Other parents: {" + stringDelimitList(List.map(otherParents, intString), ",") + "}\n");
         // keep the locks that are superfluous, remove them later

--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -1550,7 +1550,7 @@ algorithm
   graphTmp := arrayCopy(graphIn);
   (graphOdeOut,cutNodes) := cutTaskGraph(graphTmp,stateNodes,whenNodes);
   cutNodeChildren := List.flatten(List.map1(listAppend(cutNodes,whenNodes),Array.getIndexFirst,graphIn)); // for computing new root-nodes when cutting out when-equations
-  (_,cutNodeChildren,_) := List.intersection1OnTrue(cutNodeChildren,cutNodes,intEq);
+  (_,cutNodeChildren,_) := List.intIntersection1OnTrue(cutNodeChildren,cutNodes);
   graphDataOdeOut := cutSystemData(graphDataIn,listAppend(cutNodes,{}),cutNodeChildren);
 end getOdeSystem;
 
@@ -1654,7 +1654,7 @@ algorithm
         sizeDAE = arrayLength(graphIn);
         graphT = AdjacencyMatrix.transposeAdjacencyMatrix(graphIn,sizeDAE);
         odeNodes = listAppend(exceptNodes,getAllSuccessors(exceptNodes,graphT));//the ODE-System
-        (_,odeNodes,_) = List.intersection1OnTrue(odeNodes,whenNodes,intEq);
+        (_,odeNodes,_) = List.intIntersection1OnTrue(odeNodes,whenNodes);
         (odeNodes,_,_) = List.intersection1OnTrue(List.intRange(sizeDAE),odeNodes,intEq);
 
         odeNodes = List.sort(odeNodes,intGt);
@@ -2405,7 +2405,7 @@ algorithm
   graphTmp := iTaskGraph; //arrayCopy(graphIn);
   (graphTmp,cutNodes) := cutTaskGraph(graphTmp,discreteNodes,{});
   cutNodeChildren := List.flatten(List.map1(cutNodes,Array.getIndexFirst,iTaskGraph)); // for computing new root-nodes when cutting out nodes
-  (_,cutNodeChildren,_) := List.intersection1OnTrue(cutNodeChildren,cutNodes,intEq);
+  (_,cutNodeChildren,_) := List.intIntersection1OnTrue(cutNodeChildren,cutNodes);
   oTaskGraphMeta := cutSystemData(iTaskGraphMeta,cutNodes,cutNodeChildren);
   oTaskGraph := graphTmp;
 end getEventSystem;
@@ -3354,8 +3354,8 @@ algorithm
         //get the single nodes, sort them according to their exeCosts in decreasing order
         (_,singleNodes) = List.filterOnTrueSync(arrayList(iTaskGraph),listEmpty,List.intRange(arrayLength(iTaskGraph)));  //nodes without successor
         (_,singleNodes1) = List.filterOnTrueSync(arrayList(taskGraphT),listEmpty,List.intRange(arrayLength(taskGraphT))); //nodes without predecessor
-        (singleNodes,_,_) = List.intersection1OnTrue(singleNodes,singleNodes1,intEq);
-        (_,singleNodes,_) = List.intersection1OnTrue(singleNodes,doNotMergeIn,intEq);
+        (singleNodes,_,_) = List.intIntersection1OnTrue(singleNodes,singleNodes1);
+        (_,singleNodes,_) = List.intIntersection1OnTrue(singleNodes,doNotMergeIn);
         exeCosts = List.map1(singleNodes,getExeCostReqCycles,iTaskGraphMeta);
         (exeCosts,pos) = HpcOmScheduler.quicksortWithOrder(exeCosts);
         singleNodes = List.map1(pos,List.getIndexFirst,singleNodes);

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -5892,7 +5892,7 @@ algorithm
       //update m
       for e in eqIdxs loop
         row := m[e];
-        (_,row,_) := List.intersection1OnTrue(row,varIdxs,intEq);
+        (_,row,_) := List.intIntersection1OnTrue(row,varIdxs);
         arrayUpdate(m,e,row);
         //update mt
         for varIdx in varIdxs loop
@@ -5937,7 +5937,7 @@ algorithm
         //print("remove edges between eq: "+intString(idx)+" and vars "+stringDelimitList(List.map(varIdxs,intString),", ")+"\n");
       //update m
       row := m[idx];
-      (_,row,_) := List.intersection1OnTrue(row,varIdxs,intEq);
+      (_,row,_) := List.intIntersection1OnTrue(row,varIdxs);
       arrayUpdate(m,idx,row);
       //update mt
       for varIdx in varIdxs loop

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -872,7 +872,7 @@ algorithm
       (resolvedEq, m_row) = resolveClosedLoop(loop1,mIn,mTIn,eqMap,varMap,daeEqsIn,daeVarsIn);
 
       // get the equation that will be replaced and the rest
-      (crossEqs,eqs,_) = List.intersection1OnTrue(loop1,eqCrossLstIn,intEq);  // replace a crossEq in the loop
+      (crossEqs,eqs,_) = List.intIntersection1OnTrue(loop1,eqCrossLstIn);  // replace a crossEq in the loop
       replEqs = List.intersectionOnTrue(replEqsIn,loop1,intEq);  // just consider the already replaced equations in this loop
 
       // first try to replace a non cross node, otherwise an already replaced eq, or if none of them is available take a crossnode (THIS IS NOT YET CLEAR)
@@ -893,7 +893,7 @@ algorithm
       eqVars = List.map1(loop1,Array.getIndexFirst,mIn);
       vars = List.flatten(eqVars);
       loopVars = doubleEntriesInLst(vars);  // the vars in the loop
-      (_,adjVars,_) = List.intersection1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
+      (_,adjVars,_) = List.intIntersection1OnTrue(vars,loopVars); // the vars adjacent to the loop
 
       // update adjacencyMatrix
       List.map2_0(loopVars,Array.updateIndexFirst,{},mTIn);  //delete the vars in the loop
@@ -925,7 +925,7 @@ algorithm
       (resolvedEq, m_row) = resolveClosedLoop(loop1,mIn,mTIn,eqMap,varMap,daeEqsIn,daeVarsIn);
 
       // get the equation that will be replaced and the rest
-      (replEqs,_,eqs) = List.intersection1OnTrue(replEqsIn,loop1,intEq);  // just consider the already replaced equations in this loop
+      (replEqs,_,eqs) = List.intIntersection1OnTrue(replEqsIn,loop1);  // just consider the already replaced equations in this loop
 
       //priorize the not yet replaced equations
       eqs = priorizeEqsWithVarCrosses(eqs,mIn,varCrossLstIn);
@@ -942,10 +942,10 @@ algorithm
       eqVars = List.map1(loop1,Array.getIndexFirst,mIn);
       vars = List.flatten(eqVars);
       loopVars = doubleEntriesInLst(vars);  // the vars in the loop
-      (crossVars,loopVars,_) = List.intersection1OnTrue(loopVars,varCrossLstIn,intEq);  // some crossVars have to remain
+      (crossVars,loopVars,_) = List.intIntersection1OnTrue(loopVars,varCrossLstIn);  // some crossVars have to remain
       //print("loopVars: "+stringDelimitList(List.map(loopVars,intString),",")+"\n");
 
-      (_,adjVars,_) = List.intersection1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
+      (_,adjVars,_) = List.intIntersection1OnTrue(vars,loopVars); // the vars adjacent to the loop
       adjVars = listAppend(crossVars,adjVars);
       adjVars = List.unique(adjVars);
 
@@ -979,7 +979,7 @@ algorithm
       (resolvedEq, m_row) = resolveClosedLoop(loop1,mIn,mTIn,eqMap,varMap,daeEqsIn,daeVarsIn);
 
       // update AdjacencyMatrix
-      (_,crossEqs,_) = List.intersection1OnTrue(loop1,replEqsIn,intEq);  // do not replace an already replaced Eq
+      (_,crossEqs,_) = List.intIntersection1OnTrue(loop1,replEqsIn);  // do not replace an already replaced Eq
       (pos::_) = crossEqs;  // the equation that will be replaced = pos
       eqVars = List.map1(loop1,Array.getIndexFirst,mIn);
       vars = List.flatten(eqVars);
@@ -1097,7 +1097,7 @@ protected
   list<Integer> entry;
 algorithm
   entry := arrayGet(arrIn,idx);
-  (_,entry,_) := List.intersection1OnTrue(entry,delEntries,intEq);
+  (_,entry,_) := List.intIntersection1OnTrue(entry,delEntries);
   _ := arrayUpdate(arrIn,idx,entry);
 end arrayGetDeleteInLst;
 
@@ -1262,7 +1262,7 @@ algorithm
       // get the vars that are shared of the 2 equations
       adjVars1 := m_row;
       adjVars2 := arrayGet(m,eqIdx2);
-      (adjVars, adjVars1, adjVars2) := List.intersection1OnTrue(adjVars1, adjVars2, intEq);
+      (adjVars, adjVars1, adjVars2) := List.intIntersection1OnTrue(adjVars1, adjVars2);
 
       // split shared vars by sign
       (posVars, negVars) := List.splitOnTrue(adjVars, function varSign(varMap = varMap, daeVarsIn = daeVarsIn, eq1 = eq, eq2 = eq2));
@@ -1503,7 +1503,7 @@ algorithm
         adjEqs = list(List.deleteMemberOnTrue(crossEq, eq, intEq) for eq in adjEqs); // REMARK: this works only if there are no varCrossNodes
         adjEqs = List.filterOnFalse(adjEqs,listEmpty);
         nextEqs = List.flatten(adjEqs);
-        (endEqs,unfinEqs,_) = List.intersection1OnTrue(nextEqs,allEqCrossNodes,intEq);
+        (endEqs,unfinEqs,_) = List.intIntersection1OnTrue(nextEqs,allEqCrossNodes);
         paths = List.map1(endEqs,cons1,{crossEq}); //TODO: replace this stupid cons1
         paths = listAppend(paths,eqPathsIn) annotation(__OpenModelica_DisableListAppendWarning=true);
         unfinPaths = List.map1(unfinEqs,cons1,{crossEq});
@@ -1521,7 +1521,7 @@ algorithm
         adjEqs = List.filterOnFalse(adjEqs,listEmpty);
         nextEqs = List.map(adjEqs,listHead);
         (nextEqs,_) = List.deleteMemberOnTrue(prevEq,nextEqs,intEq); //do not take the path back to the previous node
-        (endEqs,unfinEqs,_) = List.intersection1OnTrue(nextEqs,allEqCrossNodes,intEq);
+        (endEqs,unfinEqs,_) = List.intIntersection1OnTrue(nextEqs,allEqCrossNodes);
         paths = List.map1(endEqs,cons1,pathStart); //TODO: replace this stupid cons1
         paths = listAppend(paths,eqPathsIn) annotation(__OpenModelica_DisableListAppendWarning=true);
         unfinPaths = List.map1(unfinEqs,cons1,pathStart);

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -947,7 +947,7 @@ algorithm
         end if;
         // mark tearing var
         markTVarsOrResiduals(tSel_always, ass1);
-        (_,unsolv,_) = List.intersection1OnTrue(unsolvables,tSel_always,intEq);
+        (_,unsolv,_) = List.intIntersection1OnTrue(unsolvables,tSel_always);
         // equations not yet assigned containing the tvars
         vareqns = findVareqns(ass2,isAssignedSaveEnhanced,mt,tSel_always);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -1037,7 +1037,7 @@ algorithm
           print("omcTearingSelectTearingVar Candidates(unassigned vars):\n");
           BackendDump.debuglst(freeVars,intString,", ","\n");
         end if;
-        (_,freeVars,_) = List.intersection1OnTrue(freeVars,tSel_never,intEq);
+        (_,freeVars,_) = List.intIntersection1OnTrue(freeVars,tSel_never);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Candidates without variables with annotation attribute 'never':\n");
           BackendDump.debuglst(freeVars,intString,", ","\n");
@@ -2527,7 +2527,7 @@ algorithm
       // ascertain if there are new unsolvables now
       unsolvables = getUnsolvableVarsConsiderMatching(arrayLength(meTIn),meTIn,ass1In,ass2In);
       if debug then execStat("Tearing.CellierTearing2 - 1.3"); end if;
-      (_,unsolvables,_) = List.intersection1OnTrue(unsolvables,tvars,intEq);
+      (_,unsolvables,_) = List.intIntersection1OnTrue(unsolvables,tvars);
 
       if debug then execStat("Tearing.CellierTearing2 - 1 done"); end if;
 
@@ -2587,7 +2587,7 @@ algorithm
 
       // ascertain if there are new unsolvables now
       unsolvables = getUnsolvableVarsConsiderMatching(arrayLength(meTIn),meTIn,ass1In,ass2In);
-      (_,unsolvables,_) = List.intersection1OnTrue(unsolvables,tvars,intEq);
+      (_,unsolvables,_) = List.intIntersection1OnTrue(unsolvables,tvars);
       if debug then execStat("Tearing.CellierTearing2 - 2"); end if;
 
       // repeat until system is causal
@@ -2694,7 +2694,7 @@ algorithm
     print("1st: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n");
   end if;
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(selectedcols1,discreteVars);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2730,7 +2730,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(varlst,discreteVars);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2771,7 +2771,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(selectedcols1,discreteVars);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2813,7 +2813,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(varlst,discreteVars);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2860,7 +2860,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(selectedcols1,discreteVars);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2902,7 +2902,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(varlst,discreteVars);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2949,7 +2949,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(selectedcols1,discreteVars);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2998,7 +2998,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  (_,selectedcols1,_) := List.intIntersection1OnTrue(varlst,discreteVars);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -3048,7 +3048,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols0,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  (_,selectedcols0,_) := List.intIntersection1OnTrue(varlst,discreteVars);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols0);
@@ -3154,14 +3154,14 @@ algorithm
   // 3. Remove variables we don't want as tearing variables
   // ******************************************************
   // Remove variables with attribute '__OpenModelica_tearingSelect = TearingSelect.never'
-  (_,potentialTVars,_) := List.intersection1OnTrue(potentialTVars,tSel_never,intEq);
+  (_,potentialTVars,_) := List.intIntersection1OnTrue(potentialTVars,tSel_never);
   if listEmpty(potentialTVars) then
     Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = TearingSelect.never'.");
     return;
   end if;
 
   // Remove discrete variables
-  (_,potentialTVars2,_) := List.intersection1OnTrue(potentialTVars,discreteVars,intEq);
+  (_,potentialTVars2,_) := List.intIntersection1OnTrue(potentialTVars,discreteVars);
 
   // Only discrete potentials, then allow discrete tearing variables
   if listEmpty(potentialTVars2) then

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -428,7 +428,7 @@ algorithm
         extractedvars=getVariablesAfterExtraction(tempsetC,tempsetS,mExt);
         extractedsetsvars=getVariablesAfterExtraction(tempsetS,{},mExt);
         finalvarlist=getRemovedEquationSolvedVariables(listAppend(tempsetC,tempsetS),var);
-        (finalvarlist,inputvarlist,_)=List.intersection1OnTrue(extractedvars,finalvarlist,intEq);
+        (finalvarlist,inputvarlist,_)=List.intIntersection1OnTrue(extractedvars,finalvarlist);
 
         inputvarlist=List.setDifferenceOnTrue(inputvarlist,knowns,intEq);
 
@@ -608,7 +608,7 @@ algorithm
        var:=List.map1r({varnumber},BackendVariable.getVarAt,allVars);
        depeqs:=List.map1r(List.map1r(eqs, listGet, arrayList(mapIncRowEqn)), BackendEquation.get, allEqs);
        (kn1,kn2,kn3):=List.intersection1OnTrue(varlist,listAppend(knowns,constantvars),intEq);
-       //(c1,c2,c3):=List.intersection1OnTrue(varlist,constantvars,intEq);
+       //(c1,c2,c3):=List.intIntersection1OnTrue(varlist,constantvars);
 
        if(listEmpty(kn1)) then
           print("\n-The intermediate variable: " + intString(varnumber) + " does not have any knowns or constants as Leaf");
@@ -742,14 +742,14 @@ algorithm
 
    // Condition -2
    print("Condition-2 " + "\"All variables of interest must be involved in SET_C or SET_S\"" + "\n" +UNDERLINE  +"\n");
-   (tmplist1,tmplist2,tmplist3):=List.intersection1OnTrue(matchedknownssetc,knowns,intEq);
+   (tmplist1,tmplist2,tmplist3):=List.intIntersection1OnTrue(matchedknownssetc,knowns);
 
    if(listEmpty(tmplist3)) then
          print("-Passed \n");
          BackendDump.dumpVarList(List.map1r(tmplist1,BackendVariable.getVarAt,allVars),"-SET_C has all known variables:" +dumplistInteger(tmplist1));
     // check in sets
    elseif(not listEmpty(tmplist3)) then
-         (tmplist1sets,tmplist2,_):=List.intersection1OnTrue(tmplist3,matchedknownssets,intEq);
+         (tmplist1sets,tmplist2,_):=List.intIntersection1OnTrue(tmplist3,matchedknownssets);
          if(not listEmpty(tmplist2)) then
               str:=dumplistInteger(tmplist2);
               print("-Failed\n");
@@ -774,7 +774,7 @@ algorithm
 
    //Condition-4
     print("Condition-4 " +"\"SET_S should contain all intermediate variables involved in SET_C\"" + "\n" + UNDERLINE +"\n");
-   (tmplistvar1,tmplistvar2,tmplistvar3):=List.intersection1OnTrue(matchedunknownssetc,matchedunknownssets,intEq);
+   (tmplistvar1,tmplistvar2,tmplistvar3):=List.intIntersection1OnTrue(matchedunknownssetc,matchedunknownssets);
 
    if(listEmpty(matchedunknownssetc))then
        print("-Passed"+"\n"+"-SET_C contains No Intermediate Variables \n\n");
@@ -813,7 +813,7 @@ algorithm
    /*
    if(not listEmpty(matchedunknownssetc)) then
        (sets_eqs,sets_vars):=getSolvedDependentEquationAndVars(matchedunknownssetc,solvedvar);
-       (tmplist1,tmplist2,tmplist3):=List.intersection1OnTrue(sets_eqs,sets,intEq);
+       (tmplist1,tmplist2,tmplist3):=List.intIntersection1OnTrue(sets_eqs,sets);
        if(listEmpty(tmplist2)) then
           BackendDump.dumpVarList(List.map1r(matchedunknownssetc,BackendVariable.getVarAt,allVars),"-SET_C has intermediate variables:" +dumplistInteger(matchedunknownssetc));
           BackendDump.dumpEquationList(List.map1r(List.map1r(sets_eqs, listGet, arrayList(mapIncRowEqn)), BackendEquation.get, allEqs),"-SET_S has equations which can compute above intermediate variable");
@@ -849,8 +849,8 @@ algorithm
        Boolean found=false;
    case(tmpvars,tmpknowns,tmpExt,tmpsolveeqvar,tempsolvedvars,tempsolvedeqs,tmpconstantvars)
      equation
-     (t1,t2,t3)=List.intersection1OnTrue(tmpvars,tmpknowns,intEq);
-     (c1,c2,c3)=List.intersection1OnTrue(tmpvars,tmpconstantvars,intEq);
+     (t1,t2,t3)=List.intIntersection1OnTrue(tmpvars,tmpknowns);
+     (c1,c2,c3)=List.intIntersection1OnTrue(tmpvars,tmpconstantvars);
      //print("\n tempvars:=>"+anyString(tmpvars)+"t1:=>"+anyString(t1) +"t2:=>"+ anyString(t2) +"c1:=>" + anyString(c1) + "c2:=>" + anyString (c2));
      if(not listEmpty(c1)) then
          //print("\n constant leaf found:=>" + anyString(c1));
@@ -873,7 +873,7 @@ algorithm
          //print("\n false loop-1" + anyString(tempsolvedeqs) +" "+ anyString(tempeqs));
          (tempvars1,tempvars2)=getVariableOccurence(tempeqs,mExt,knowns);
          allvars=List.unique(listAppend(tempvars1,tempvars2));
-         (tmp1,tmp2,tmp3)=List.intersection1OnTrue(allvars,solvedvars,intEq);
+         (tmp1,tmp2,tmp3)=List.intIntersection1OnTrue(allvars,solvedvars);
          if(not listEmpty(tmp2)) then
             (tempsolvedvars,tempsolvedeqs)=BuildSquareSubSetHelper(tmp2,tmpknowns,tmpExt,tmpsolveeqvar,tempsolvedvars,tempsolvedeqs,tmpconstantvars);
          end if;
@@ -924,7 +924,7 @@ algorithm
        (tempvars1,tempvars2):=getVariableOccurence({i},mExt,knowns);
        varnumber:=listGet(invars,count);
        allvars:=List.unique(listAppend(tempvars1,tempvars2));
-      //(t1,t2,t3):=List.intersection1OnTrue(allvars,invars,intEq);
+      //(t1,t2,t3):=List.intIntersection1OnTrue(allvars,invars);
        (t1,t2,t3):=List.intersection1OnTrue(allvars,{varnumber},intEq);
        (tmpvars,tmpeqs):=BuildSquareSubSetHelper(allvars,knowns,mExt,solvedeqvar,{varnumber},{i},constantvars);
        solvedvars:=listAppend(solvedvars,tmpvars) annotation(__OpenModelica_DisableListAppendWarning=true);
@@ -1561,7 +1561,7 @@ algorithm
             */
             (setc1,sets1):=extractMixedBlock(blockitem,blockvarlist);
             // put the approximated equations front if present
-            (tmplist1,tmplist2,tmplist3):=List.intersection1OnTrue(setc1,approximatedEquation,intEq);
+            (tmplist1,tmplist2,tmplist3):=List.intIntersection1OnTrue(setc1,approximatedEquation);
             setc1:=listAppend(tmplist1,tmplist2);
             setc:=listAppend(List.restOrEmpty(setc1),setc);
             sets:=listAppend(sets,sets1) annotation(__OpenModelica_DisableListAppendWarning=true);

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13293,7 +13293,7 @@ protected
   list<Integer> preEqs,reqEqs;
 algorithm
   preEqs := arrayGet(tree,eq);
-  (_,preEqs,_) := List.intersection1OnTrue(preEqs,eqsIn,intEq);
+  (_,preEqs,_) := List.intIntersection1OnTrue(preEqs,eqsIn);
   reqEqs := listAppend(preEqs,eqsIn);
   eqsOut := List.fold1(preEqs,collectReqSimEqs,tree,reqEqs);
 end collectReqSimEqs;

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -1564,7 +1564,6 @@ public function intersection1OnTrue<T>
     output Boolean outIsEqual;
   end CompFunc;
 protected
-  Option<T> oe;
   list<T> lst1 = inList1, lst2 = inList2;
 algorithm
   if listEmpty(inList1) then
@@ -1597,6 +1596,91 @@ algorithm
   outList1Rest := if isPresent(outList1Rest) then listReverseInPlace(outList1Rest) else {};
   outList2Rest := if isPresent(outList2Rest) then setDifferenceOnTrue(inList2, outIntersection, inCompFunc) else {};
 end intersection1OnTrue;
+
+public function intIntersection1OnTrue
+  "Takes two lists of Integers. It returns the intersection of the two lists.
+   This function also returns a list of the elements from list 1 which is not
+   in list 2 and a list of the elements from list 2 which is not in list 1."
+  input list<Integer> inList1;
+  input list<Integer> inList2;
+  output list<Integer> outIntersection = {};
+  output list<Integer> outList1Rest = {};
+  output list<Integer> outList2Rest = inList2;
+protected
+  list<Integer> lst1 = inList1, lst2 = inList2;
+  Integer e1, e2;
+algorithm
+  if listEmpty(inList1) then
+    return;
+  end if;
+  if listEmpty(inList2) then
+    outList1Rest := inList1;
+    return;
+  end if;
+  lst1 := sort(inList1, intGt);
+  lst2 := sort(inList2, intGt);
+  if isPresent(outList1Rest) then
+    if isPresent(outList2Rest) then
+        (outIntersection, outList1Rest, outList2Rest) := intSortedIntersection1OnTrue(inList1, inList2);
+    else
+        (outIntersection, outList1Rest, _) := intSortedIntersection1OnTrue(inList1, inList2);
+    end if;
+  else
+    if isPresent(outList2Rest) then
+        (outIntersection, _, outList2Rest) := intSortedIntersection1OnTrue(inList1, inList2);
+    else
+        (outIntersection, _, _) := intSortedIntersection1OnTrue(inList1, inList2);
+    end if;
+  end if;
+end intIntersection1OnTrue;
+
+public function intSortedIntersection1OnTrue
+  "Takes two lists of Integers. It returns the intersection of the two lists.
+   This function also returns a list of the elements from list 1 which is not
+   in list 2 and a list of the elements from list 2 which is not in list 1."
+  input list<Integer> inList1;
+  input list<Integer> inList2;
+  output list<Integer> outIntersection = {};
+  output list<Integer> outList1Rest = {};
+  output list<Integer> outList2Rest = inList2;
+protected
+  list<Integer> lst1 = inList1, lst2 = inList2;
+  Integer e1, e2;
+algorithm
+  if listEmpty(inList1) then
+    return;
+  end if;
+  if listEmpty(inList2) then
+    outList1Rest := inList1;
+    return;
+  end if;
+
+  while not (listEmpty(lst1) or listEmpty(lst2)) loop
+    e1 := listHead(lst1);
+    e2 := listHead(lst2);
+    if e1 == e2 then
+      outIntersection := e1 :: outIntersection;
+      lst1 := listRest(lst1);
+      lst2 := listRest(lst2);
+    elseif e1 < e2 then
+      outList1Rest := e1 :: outList1Rest;
+      lst1 := listRest(lst1);
+    else
+      outList2Rest := e2 :: outList2Rest;
+      lst2 := listRest(lst2);
+    end if;
+  end while;
+  for e in lst1 loop
+    outList1Rest := e1 :: outList1Rest;
+  end for;
+  for e in lst2 loop
+    outList2Rest := e2 :: outList2Rest;
+  end for;
+
+  outIntersection := listReverseInPlace(outIntersection);
+  outList1Rest := if isPresent(outList1Rest) then listReverseInPlace(outList1Rest) else {};
+  outList2Rest := if isPresent(outList2Rest) then listReverseInPlace(outList2Rest) else {};
+end intSortedIntersection1OnTrue;
 
 public function setDifferenceIntN
   "Provides same functionality as setDifference, but for integer values
@@ -4913,7 +4997,9 @@ algorithm
 
     if inCompareFunc(inValue, e) then
       outList := listAppend(listReverseInPlace(acc), rest);
-      outDeletedElement := SOME(e);
+      if isPresent(outDeletedElement) then
+        outDeletedElement := SOME(e);
+      end if;
       return;
     end if;
 


### PR DESCRIPTION
### Related Issues

#12677 

### Purpose

Reduce running time

### Approach

Integer lists can be easily sorted (O(n log(n))), then intersection is O(n) operation
This could be optimized further for each call, if sorting can be omitted. In this case just call `inSortedtIntersection1OnTrue()` instead of `intIntersection1OnTrue()`