### PR TITLE
Removed PythonInterface folder used for OMPython

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -263,47 +263,6 @@ testlogwindows:
 	cat testsuite/testsuite-trace.txt | grep "==== Log" | wc -l
 	cat testsuite/testsuite-trace.txt | grep "==== Log" ; echo DONE!
 
-builddir_lib=$(OMBUILDDIR)/lib
-builddir_share=$(OMBUILDDIR)/share
-IDLPYTHON = $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/bin/x86_win32/omniidl -bpython -Wbglobal=_OMCIDL -Wbpackage=OMPythonIDL
-IDLPYTHONTARGET = $(builddir_share)/omc/scripts/PythonInterface/OMPythonIDL/omc_communication_idl.py
-IDLFILE=OMCompiler/Compiler/runtime/omc_communication.idl
-
-install-python: script-files-python # $(IDLPYTHONTARGET)
-
-.PHONY: script-files-python
-
-script-files-python: mkbuilddirs-python
-	# copy library files neeeded by OMPython
-	(cp -puf $(OMDEV)/lib/omniORB-4.2.0-mingw64/bin/x86_win32/omni*_rt.dll $(builddir_lib)/python)
-	(cp -puf $(OMDEV)/lib/omniORB-4.2.0-mingw64/bin/x86_win32/COS*_rt.dll $(builddir_lib)/python)
-	(cp -puf $(OMDEV)/lib/omniORB-4.2.0-mingw64/bin/x86_win32/lib*.dll $(builddir_lib)/python)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/x86_win32/_omnipy.pyd $(builddir_lib)/python)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/__init__.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/boxes_idl.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/CORBA.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/corbaidl_idl.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/minorCodes.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/PortableServer.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/tcInternal.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/omniPolicy.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/pollable_idl.py $(builddir_lib)/python/omniORB/)
-	#(cp -puf $(OMDEV)/lib/omniORBpy-4.2.0-mingw64/lib/python/omniORB/messaging_idl.py $(builddir_lib)/python/omniORB/)
-	# copy OMPython files
-	cp -rfp OMPython/setup.py $(builddir_share)/omc/scripts/PythonInterface
-	cp -rfp OMPython/OMPython/* $(builddir_share)/omc/scripts/PythonInterface/OMPython
-
-$(IDLPYTHONTARGET) : $(IDLFILE)
-	$(IDLPYTHON) -C$(builddir_share)/omc/scripts/PythonInterface $(IDLFILE)
-
-mkbuilddirs-python:
-	# create directories
-	mkdir -p $(builddir_lib)/python/omniORB
-	mkdir -p $(builddir_share)/omc/scripts/PythonInterface/OMPython/OMParser
-
-clean-python:
-	rm -rf $(builddir_share)/omc/scripts/PythonInterface $(builddir_lib)/python
-
 clean:
 	$(MAKE) -f $(defaultMakefileTarget) -C OMCompiler clean OMBUILDDIR=$(OMBUILDDIR)
 	test ! -d $(OMBUILDDIR) || rm -rf $(OMBUILDDIR)

--- a/OMCompiler/Compiler/runtime/Makefile.in
+++ b/OMCompiler/Compiler/runtime/Makefile.in
@@ -22,18 +22,15 @@ OMC=@OMC@
 ifdef USE_CORBA
   CORBAINCL = @CORBACFLAGS@
   OMCCORBASRC = omc_communication.o omc_communication_impl.o Corba_omc.o
-  IDLPYTHONTARGET = $(builddir_share)/omc/scripts/PythonInterface/stubs/omc_communication_idl.py
 else
   CORBAINCL =
   OMCCORBASRC = corbaimpl_stub_omc.o
-  IDLPYTHONTARGET =
 endif
 
 SHELL	= /bin/sh
 CC	= @CC@
 CXX	= @CXX@
 IDL	= @IDLCMD@
-IDLPYTHON = @IDLPYTHONCMD@
 CXXFLAGS = @CXXFLAGS@
 CPPFLAGS = @CPPFLAGS@ -I$(OMC_CONFIG_INC) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc -I. $(CORBAINCL) $(GCINCLUDE) -I$(FMIINCLUDE) -I$(GRAPHINCLUDE) -I$(CJSONINCLUDE) -I$(ZMQINCLUDE)  -I"$(TOP_DIR)/3rdParty/zlib" -I"$(TOP_DIR)/3rdParty/libffi/install/include/"
 TRIPLE=@host_short@

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -113,9 +113,6 @@ LD_LAPACK=-lopenblas
 GRAPHLIB=libmetis.a
 GRAPHINCLUDE=3rdParty/metis-5.1.0/include/ -DUSE_METIS -DUSE_GRAPH
 BOOTSTRAP_FMIL_DEP=fmil
-IDLPYTHON = $(OMDEV)/lib/omniORB-4.2.0-mingw64/bin/x86_win32/omniidl -T -bcxx -Wbh=.h -Wbs=.cc -p../../lib/python -Wbdebug
-IDLPYTHONTARGET = $(builddir_share)/omc/scripts/PythonInterface/OMPythonIDL/omc_communication_idl.py
-IDLFILE=$(top_builddir)/Compiler/runtime/omc_communication.idl
 LIB_OMC=lib/omc
 LIBMODELICAEXTERNALC=$(OMBUILDDIR)/lib/omc/libModelicaExternalC$(STAEXT)
 LIBMODELICASTANDARDTABLES=$(OMBUILDDIR)/lib/omc/libModelicaStandardTables$(STAEXT)


### PR DESCRIPTION
### Purpose

Remove OMPython installation in the PythonInterface folder as it will not work and is wrong.

### Approach

Install OMPython via pip.
