### PR TITLE
optimize intersection1OnTrue for only second output used

### DIFF
--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -1402,7 +1402,7 @@ algorithm
 
         const = intEq(listLength(scalars),listLength(constVars));
         constScalarCrefs = List.filter1OnTrue(constCrefs,ComponentReference.crefInLst,constVars);
-        (_,varCrefs,_) = List.intersection1OnTrue(scalars,constScalarCrefs,ComponentReference.crefEqual);
+        varCrefs = List.remove1OnTrue(scalars,constScalarCrefs,ComponentReference.crefEqual);
         //constCompl = if_(const,cref::constComplexLstIn,constComplexLstIn);
         constCompl = if false then cref::constComplexLstIn else constComplexLstIn;
         //varCompl = if_(not const,cref::varComplexLstIn,varComplexLstIn);

--- a/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
@@ -584,8 +584,8 @@ algorithm
     else numIterNew := numIter;
     end if;
   //take the non-assigned vars only
-  (_,varIdcs,_) := List.intersection1OnTrue(List.intRange(size),varIdcs,intEq);
-  (_,eqIdcs,_) := List.intersection1OnTrue(List.intRange(size),eqIdcs,intEq);
+  varIdcs := List.remove1OnTrue(List.intRange(size),varIdcs,intEq);
+  eqIdcs := List.remove1OnTrue(List.intRange(size),eqIdcs,intEq);
   eqsOut := BackendEquation.getList(eqIdcs,eqArr);
   varsOut := List.map1(varIdcs,BackendVariable.getVarAtIndexFirst,varArr);
   if numIterNew<>0 then (eqsOut,varsOut,resEqsOut) := simplifyNewEquations(eqsOut,varsOut,resEqsOut,numAux,numIterNew-1,shared);

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -1753,7 +1753,7 @@ algorithm
         unassNodes = critPathNode::unassNodes;
         unassNodes = List.unique(unassNodes);
         levelNodeCluster = BLS_mergeDependentLevelTask(unassNodes,iGraph,iGraphT,{});
-        (_,unassNodes,_) = List.intersection1OnTrue(unassNodes,List.flatten(levelNodeCluster),intEq);
+        unassNodes = List.remove1OnTrue(unassNodes,List.flatten(levelNodeCluster),intEq);
         sectionLst = levelNodeCluster::sectionsIn;
           //print("section: \n"+stringDelimitList(List.map(levelNodeCluster,intListString),"  |  ")+"\n");
 
@@ -1791,7 +1791,7 @@ algorithm
       dependentNodes = BLS_getDependentGroups({node},iGraph,iGraphT,nodesIn,{});
       section = node::dependentNodes;
       section = List.unique(section);
-      (_,rest,_) = List.intersection1OnTrue(rest,dependentNodes,intEq);
+      rest = List.remove1OnTrue(rest,dependentNodes,intEq);
       section = listReverse(section);
       //print("section: \n"+stringDelimitList(List.map(section,intString)," ; ")+"\n");
       sections = BLS_mergeDependentLevelTask(rest,iGraph,iGraphT,section::sectionsIn);
@@ -4939,8 +4939,8 @@ algorithm
         //print("Node: " + intString(node) + "\n");
         //print("Children: {" + stringDelimitList(List.map(childNodes, intString), ",") + "}\n");
         //print("Parents: {" + stringDelimitList(List.map(parentNodes, intString), ",") + "}\n");
-        (_,otherParents,_) = List.intersection1OnTrue(parentNodes,sameProcTasks,intEq);
-        (_,otherChildren,_) = List.intersection1OnTrue(childNodes,sameProcTasks,intEq);
+        otherParents = List.remove1OnTrue(parentNodes,sameProcTasks,intEq);
+        otherChildren = List.remove1OnTrue(childNodes,sameProcTasks,intEq);
         //print("Other children: {" + stringDelimitList(List.map(otherChildren, intString), ",") + "}\n");
         //print("Other parents: {" + stringDelimitList(List.map(otherParents, intString), ",") + "}\n");
         // keep the locks that are superfluous, remove them later
@@ -5056,7 +5056,7 @@ protected function removeLocksFromLockList "author:Waurich TUD 2013-12
   input list<HpcOmSimCode.Task> lockTasks;
   output list<HpcOmSimCode.Task> lockIdsOut;
 algorithm
-  (_,lockIdsOut,_) := List.intersection1OnTrue(lockIdsIn,lockTasks,tasksEqual);
+  lockIdsOut := List.remove1OnTrue(lockIdsIn,lockTasks,tasksEqual);
 end removeLocksFromLockList;
 
 protected function removeLocksFromThread "author:Waurich TUD 2013-12
@@ -5065,7 +5065,7 @@ protected function removeLocksFromThread "author:Waurich TUD 2013-12
   input list<HpcOmSimCode.Task> lockLst;
   output list<HpcOmSimCode.Task> threadOut;
 algorithm
-  (_,threadOut,_) := List.intersection1OnTrue(threadIn,lockLst,tasksEqual);
+  threadOut := List.remove1OnTrue(threadIn,lockLst,tasksEqual);
 end removeLocksFromThread;
 
 protected function getSuperfluousLocks "author:Waurich TUD 2013-12

--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -1550,7 +1550,7 @@ algorithm
   graphTmp := arrayCopy(graphIn);
   (graphOdeOut,cutNodes) := cutTaskGraph(graphTmp,stateNodes,whenNodes);
   cutNodeChildren := List.flatten(List.map1(listAppend(cutNodes,whenNodes),Array.getIndexFirst,graphIn)); // for computing new root-nodes when cutting out when-equations
-  (_,cutNodeChildren,_) := List.intersection1OnTrue(cutNodeChildren,cutNodes,intEq);
+  cutNodeChildren := List.remove1OnTrue(cutNodeChildren,cutNodes,intEq);
   graphDataOdeOut := cutSystemData(graphDataIn,listAppend(cutNodes,{}),cutNodeChildren);
 end getOdeSystem;
 
@@ -1654,7 +1654,7 @@ algorithm
         sizeDAE = arrayLength(graphIn);
         graphT = AdjacencyMatrix.transposeAdjacencyMatrix(graphIn,sizeDAE);
         odeNodes = listAppend(exceptNodes,getAllSuccessors(exceptNodes,graphT));//the ODE-System
-        (_,odeNodes,_) = List.intersection1OnTrue(odeNodes,whenNodes,intEq);
+        odeNodes = List.remove1OnTrue(odeNodes,whenNodes,intEq);
         (odeNodes,_,_) = List.intersection1OnTrue(List.intRange(sizeDAE),odeNodes,intEq);
 
         odeNodes = List.sort(odeNodes,intGt);
@@ -2405,7 +2405,7 @@ algorithm
   graphTmp := iTaskGraph; //arrayCopy(graphIn);
   (graphTmp,cutNodes) := cutTaskGraph(graphTmp,discreteNodes,{});
   cutNodeChildren := List.flatten(List.map1(cutNodes,Array.getIndexFirst,iTaskGraph)); // for computing new root-nodes when cutting out nodes
-  (_,cutNodeChildren,_) := List.intersection1OnTrue(cutNodeChildren,cutNodes,intEq);
+  cutNodeChildren := List.remove1OnTrue(cutNodeChildren,cutNodes,intEq);
   oTaskGraphMeta := cutSystemData(iTaskGraphMeta,cutNodes,cutNodeChildren);
   oTaskGraph := graphTmp;
 end getEventSystem;
@@ -3355,7 +3355,7 @@ algorithm
         (_,singleNodes) = List.filterOnTrueSync(arrayList(iTaskGraph),listEmpty,List.intRange(arrayLength(iTaskGraph)));  //nodes without successor
         (_,singleNodes1) = List.filterOnTrueSync(arrayList(taskGraphT),listEmpty,List.intRange(arrayLength(taskGraphT))); //nodes without predecessor
         (singleNodes,_,_) = List.intersection1OnTrue(singleNodes,singleNodes1,intEq);
-        (_,singleNodes,_) = List.intersection1OnTrue(singleNodes,doNotMergeIn,intEq);
+        singleNodes = List.remove1OnTrue(singleNodes,doNotMergeIn,intEq);
         exeCosts = List.map1(singleNodes,getExeCostReqCycles,iTaskGraphMeta);
         (exeCosts,pos) = HpcOmScheduler.quicksortWithOrder(exeCosts);
         singleNodes = List.map1(pos,List.getIndexFirst,singleNodes);
@@ -4216,7 +4216,7 @@ algorithm
   //mergedPaths := List.map1(mergedPaths,List.sort,intGt);
   startNodes := List.map(mergedPaths,List.last);
   //startNodes := List.map(mergedPaths,listHead);
-  (_,deleteNodes,_) := List.intersection1OnTrue(List.flatten(mergedPaths),startNodes,intEq);
+  deleteNodes := List.remove1OnTrue(List.flatten(mergedPaths),startNodes,intEq);
   //deleteNodes := List.map(mergedPaths,List.rest);
   inCompsLst := arrayList(inCompsIn);
   inCompsLst := List.fold2(List.intRange(arrayLength(inCompsIn)),updateInComps1,(startNodes,deleteNodes,mergedPaths),inCompsIn,inCompsLst);

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -5892,7 +5892,7 @@ algorithm
       //update m
       for e in eqIdxs loop
         row := m[e];
-        (_,row,_) := List.intersection1OnTrue(row,varIdxs,intEq);
+        row := List.remove1OnTrue(row,varIdxs,intEq);
         arrayUpdate(m,e,row);
         //update mt
         for varIdx in varIdxs loop
@@ -5937,7 +5937,7 @@ algorithm
         //print("remove edges between eq: "+intString(idx)+" and vars "+stringDelimitList(List.map(varIdxs,intString),", ")+"\n");
       //update m
       row := m[idx];
-      (_,row,_) := List.intersection1OnTrue(row,varIdxs,intEq);
+      row := List.remove1OnTrue(row,varIdxs,intEq);
       arrayUpdate(m,idx,row);
       //update mt
       for varIdx in varIdxs loop

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -443,7 +443,7 @@ algorithm
 
         simpleLoops := getDoubles(paths1,{});  // get 2 adjacent equations which form a simple loop i.e. they share 2 variables
         //print("all simpleLoop-paths: \n"+stringDelimitList(List.map(simpleLoops,HpcOmTaskGraph.intLstString)," / ")+"\n");
-        (_,paths,_) := List.intersection1OnTrue(paths1,simpleLoops,intLstIsEqual);
+        paths := List.remove1OnTrue(paths1,simpleLoops,intLstIsEqual);
 
         // special case to find more complex structures (arrays and triple loops)
         if listEmpty(simpleLoops) then
@@ -893,7 +893,7 @@ algorithm
       eqVars = List.map1(loop1,Array.getIndexFirst,mIn);
       vars = List.flatten(eqVars);
       loopVars = doubleEntriesInLst(vars);  // the vars in the loop
-      (_,adjVars,_) = List.intersection1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
+      adjVars = List.remove1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
 
       // update adjacencyMatrix
       List.map2_0(loopVars,Array.updateIndexFirst,{},mTIn);  //delete the vars in the loop
@@ -945,7 +945,7 @@ algorithm
       (crossVars,loopVars,_) = List.intersection1OnTrue(loopVars,varCrossLstIn,intEq);  // some crossVars have to remain
       //print("loopVars: "+stringDelimitList(List.map(loopVars,intString),",")+"\n");
 
-      (_,adjVars,_) = List.intersection1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
+      adjVars = List.remove1OnTrue(vars,loopVars,intEq); // the vars adjacent to the loop
       adjVars = listAppend(crossVars,adjVars);
       adjVars = List.unique(adjVars);
 
@@ -979,7 +979,7 @@ algorithm
       (resolvedEq, m_row) = resolveClosedLoop(loop1,mIn,mTIn,eqMap,varMap,daeEqsIn,daeVarsIn);
 
       // update AdjacencyMatrix
-      (_,crossEqs,_) = List.intersection1OnTrue(loop1,replEqsIn,intEq);  // do not replace an already replaced Eq
+      crossEqs = List.remove1OnTrue(loop1,replEqsIn,intEq);  // do not replace an already replaced Eq
       (pos::_) = crossEqs;  // the equation that will be replaced = pos
       eqVars = List.map1(loop1,Array.getIndexFirst,mIn);
       vars = List.flatten(eqVars);
@@ -1097,7 +1097,7 @@ protected
   list<Integer> entry;
 algorithm
   entry := arrayGet(arrIn,idx);
-  (_,entry,_) := List.intersection1OnTrue(entry,delEntries,intEq);
+  entry := List.remove1OnTrue(entry,delEntries,intEq);
   _ := arrayUpdate(arrIn,idx,entry);
 end arrayGetDeleteInLst;
 

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -947,7 +947,7 @@ algorithm
         end if;
         // mark tearing var
         markTVarsOrResiduals(tSel_always, ass1);
-        (_,unsolv,_) = List.intersection1OnTrue(unsolvables,tSel_always,intEq);
+        unsolv = List.remove1OnTrue(unsolvables,tSel_always,intEq);
         // equations not yet assigned containing the tvars
         vareqns = findVareqns(ass2,isAssignedSaveEnhanced,mt,tSel_always);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -1037,7 +1037,7 @@ algorithm
           print("omcTearingSelectTearingVar Candidates(unassigned vars):\n");
           BackendDump.debuglst(freeVars,intString,", ","\n");
         end if;
-        (_,freeVars,_) = List.intersection1OnTrue(freeVars,tSel_never,intEq);
+        freeVars = List.remove1OnTrue(freeVars,tSel_never,intEq);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Candidates without variables with annotation attribute 'never':\n");
           BackendDump.debuglst(freeVars,intString,", ","\n");
@@ -2527,7 +2527,7 @@ algorithm
       // ascertain if there are new unsolvables now
       unsolvables = getUnsolvableVarsConsiderMatching(arrayLength(meTIn),meTIn,ass1In,ass2In);
       if debug then execStat("Tearing.CellierTearing2 - 1.3"); end if;
-      (_,unsolvables,_) = List.intersection1OnTrue(unsolvables,tvars,intEq);
+      unsolvables = List.remove1OnTrue(unsolvables,tvars,intEq);
 
       if debug then execStat("Tearing.CellierTearing2 - 1 done"); end if;
 
@@ -2587,7 +2587,7 @@ algorithm
 
       // ascertain if there are new unsolvables now
       unsolvables = getUnsolvableVarsConsiderMatching(arrayLength(meTIn),meTIn,ass1In,ass2In);
-      (_,unsolvables,_) = List.intersection1OnTrue(unsolvables,tvars,intEq);
+      unsolvables = List.remove1OnTrue(unsolvables,tvars,intEq);
       if debug then execStat("Tearing.CellierTearing2 - 2"); end if;
 
       // repeat until system is causal
@@ -2694,7 +2694,7 @@ algorithm
     print("1st: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n");
   end if;
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(selectedcols1,discreteVars,intEq);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2730,7 +2730,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(varlst,discreteVars,intEq);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2771,7 +2771,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(selectedcols1,discreteVars,intEq);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2813,7 +2813,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(varlst,discreteVars,intEq);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2860,7 +2860,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(selectedcols1,discreteVars,intEq);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2902,7 +2902,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(varlst,discreteVars,intEq);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -2949,7 +2949,7 @@ algorithm
   end if;
 
   // Without discrete:
-  (_,selectedcols1,_) := List.intersection1OnTrue(selectedcols1,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(selectedcols1,discreteVars,intEq);
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("Without Discrete: " + stringDelimitList(List.map(selectedcols1,intString),",") + "\n(Variables in the equation(s) with most Variables)\n\n");
   end if;
@@ -2998,7 +2998,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols1,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  selectedcols1 := List.remove1OnTrue(varlst,discreteVars,intEq);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols1);
@@ -3048,7 +3048,7 @@ algorithm
 
   // 0. Consider only non-discrete Vars
   varlst := getUnassigned(ass1In);
-  (_,selectedcols0,_) := List.intersection1OnTrue(varlst,discreteVars,intEq);
+  selectedcols0 := List.remove1OnTrue(varlst,discreteVars,intEq);
 
   // 1. choose rows (vars) with most nonzero entries and write the indexes in a list
   (edges,selectedcols1) := getVarsOccurringInMostEquations(mtIn, selectedcols0);
@@ -3154,14 +3154,14 @@ algorithm
   // 3. Remove variables we don't want as tearing variables
   // ******************************************************
   // Remove variables with attribute '__OpenModelica_tearingSelect = TearingSelect.never'
-  (_,potentialTVars,_) := List.intersection1OnTrue(potentialTVars,tSel_never,intEq);
+  potentialTVars := List.remove1OnTrue(potentialTVars,tSel_never,intEq);
   if listEmpty(potentialTVars) then
     Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = TearingSelect.never'.");
     return;
   end if;
 
   // Remove discrete variables
-  (_,potentialTVars2,_) := List.intersection1OnTrue(potentialTVars,discreteVars,intEq);
+  potentialTVars2 := List.remove1OnTrue(potentialTVars,discreteVars,intEq);
 
   // Only discrete potentials, then allow discrete tearing variables
   if listEmpty(potentialTVars2) then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13293,7 +13293,7 @@ protected
   list<Integer> preEqs,reqEqs;
 algorithm
   preEqs := arrayGet(tree,eq);
-  (_,preEqs,_) := List.intersection1OnTrue(preEqs,eqsIn,intEq);
+  preEqs := List.remove1OnTrue(preEqs,eqsIn,intEq);
   reqEqs := listAppend(preEqs,eqsIn);
   eqsOut := List.fold1(preEqs,collectReqSimEqs,tree,reqEqs);
 end collectReqSimEqs;

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -1564,7 +1564,6 @@ public function intersection1OnTrue<T>
     output Boolean outIsEqual;
   end CompFunc;
 protected
-  Option<T> oe;
   list<T> lst1 = inList1, lst2 = inList2;
 algorithm
   if listEmpty(inList1) then
@@ -1597,6 +1596,48 @@ algorithm
   outList1Rest := if isPresent(outList1Rest) then listReverseInPlace(outList1Rest) else {};
   outList2Rest := if isPresent(outList2Rest) then setDifferenceOnTrue(inList2, outIntersection, inCompFunc) else {};
 end intersection1OnTrue;
+
+public function remove1OnTrue<T>
+  "Takes two lists and a comparison function over two elements of the lists. It
+   returns a list of the elements from list 1 which is not in list 2."
+  input list<T> inList1;
+  input list<T> inList2;
+  input CompFunc inCompFunc;
+  output list<T> outList1Rest = {};
+
+  partial function CompFunc
+    input T inElement1;
+    input T inElement2;
+    output Boolean outIsEqual;
+  end CompFunc;
+protected
+  list<T> lst1 = inList1, lst2 = inList2;
+algorithm
+  if listEmpty(inList1) then
+    return;
+  end if;
+  if listEmpty(inList2) then
+    outList1Rest := inList1;
+    return;
+  end if;
+
+  while not (listEmpty(lst1) or listEmpty(lst2)) loop
+    if not inCompFunc(listHead(lst1), listHead(lst2)) then
+      break;
+    end if;
+
+    lst1 := listRest(lst1);
+    lst2 := listRest(lst2);
+  end while;
+
+  for e in lst1 loop
+    if not isMemberOnTrue(e, inList2, inCompFunc) then
+      outList1Rest := e :: outList1Rest;
+    end if;
+  end for;
+
+  outList1Rest := listReverseInPlace(outList1Rest);
+end remove1OnTrue;
 
 public function setDifferenceIntN
   "Provides same functionality as setDifference, but for integer values
@@ -2129,7 +2170,7 @@ algorithm
   end for;
 
   outList1 := listReverseInPlace(outList1);
-  outList2 := listReverseInPlace(outList2);
+  outList2 := if isPresent(outList2) then listReverseInPlace(outList2) else {};
 end map1_2;
 
 public function map2<TI, TO, ArgT1, ArgT2>
@@ -2258,7 +2299,7 @@ algorithm
   end for;
 
   outList1 := listReverseInPlace(outList1);
-  outList2 := listReverseInPlace(outList2);
+  outList2 := if isPresent(outList2) then listReverseInPlace(outList2) else {};
 end map2_2;
 
 public function map3<TI, TO, ArgT1, ArgT2, ArgT3>


### PR DESCRIPTION
### Related Issues

#12677

### Approach

`(_, foo, _) := intersection1OnTrue()` -> `foo := remove1OnTrue()`
