### PR TITLE
[NB] update inlining of array constructors

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1855,6 +1855,7 @@ public
       ComponentRef. Fails if the component ref cannot be found."
       input VariablePointers variables;
       input ComponentRef cref;
+      input Boolean report = true;
       output Pointer<Variable> var_ptr;
     protected
       Integer index;
@@ -1862,7 +1863,9 @@ public
       var_ptr := match UnorderedMap.get(cref, variables.map)
         case SOME(index) guard(index > 0) then ExpandableArray.get(index, variables.varArr);
         else algorithm
-          Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for " + ComponentRef.toString(cref)});
+          if report then
+            Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for " + ComponentRef.toString(cref)});
+          end if;
         then fail();
       end match;
     end getVarSafe;

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -225,7 +225,8 @@ public
       // if it has a statement index, it already has been created as a statement inside an algorithm (0 implies no index)
       if cond.stmt_index == 0 then
         // lower the subscripts (containing iterators)
-        lhs_cref := ComponentRef.mapSubscripts(BVariable.getVarName(aux_var), function Subscript.mapExp(func = function BackendDAE.lowerComponentReferenceExp(variables = variables)));
+        lhs_cref := ComponentRef.mapSubscripts(BVariable.getVarName(aux_var), function Subscript.mapExp(
+          func = function BackendDAE.lowerComponentReferenceExp(variables = variables, complete = true)));
         aux_eqn := Equation.makeAssignment(Expression.fromCref(lhs_cref), cond.exp, idx, "EVT", cond.iter, EquationAttributes.default(EquationKind.DISCRETE, false));
         auxiliary_eqns := aux_eqn :: auxiliary_eqns;
       end if;
@@ -248,7 +249,8 @@ public
         // add all new statements to the algorithm body
         for tpl in Util.getOption(bucket.aux_stmts) loop
           (cond, aux) := tpl;
-          aux               := ComponentRef.mapSubscripts(aux, function Subscript.mapExp(func = function BackendDAE.lowerComponentReferenceExp(variables = variables)));
+          aux               := ComponentRef.mapSubscripts(aux, function Subscript.mapExp(func =
+            function BackendDAE.lowerComponentReferenceExp(variables = variables, complete = true)));
           new_stmt          := Statement.makeAssignment(Expression.fromCref(aux), cond.exp, ComponentRef.getSubscriptedType(aux), DAE.emptyElementSource);
           new_stmts         := new_stmt :: new_stmts;
         end for;


### PR DESCRIPTION
  - if an array constructor was previously inside a function body, the iterator has not been lowered
  - allow in-time lowering of these iterators and lower the component references
  - implement an "incomplete" version of lowering to allow that only the new iterators are updated (this only surpresses errors/warnings)