### PR TITLE
stash also the testsuite/special/FMPy/ as is needed later on

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
                 writeFile file: 'testsuite/special/FmuExportCrossCompile/VERSION', text: common.getVersion()
                 sh 'make -C testsuite/special/FmuExportCrossCompile/ dockerpull'
                 sh 'make -C testsuite/special/FmuExportCrossCompile/ test'
-                stash name: 'cross-fmu', includes: 'testsuite/special/FmuExportCrossCompile/*.fmu'
+                stash name: 'cross-fmu', includes: 'testsuite/special/FmuExportCrossCompile/*.fmu, testsuite/special/FMPy/Makefile'
                 stash name: 'cross-fmu-extras', includes: 'testsuite/special/FmuExportCrossCompile/*.mos, testsuite/special/FmuExportCrossCompile/*.csv, testsuite/special/FmuExportCrossCompile/*.sh, testsuite/special/FmuExportCrossCompile/*.opt, testsuite/special/FmuExportCrossCompile/*.txt, testsuite/special/FmuExportCrossCompile/VERSION'
                 archiveArtifacts "testsuite/special/FmuExportCrossCompile/*.fmu"
               }


### PR DESCRIPTION
PR jobs fail randomly in the linux-FMPy stage with:
```
+ cd testsuite/special/FMPy/
/var/lib/jenkins1/ws/OpenModelica_PR-13745_tmp/durable-d6d6a394/script.sh.copy: 3: cd: can't cd to testsuite/special/FMPy/
``` 
It seems we do stash and then `rm -f testsuite/` somewhere in the process and when we unstash we don't have that directory anymore. Just add it to the stash.
