### PR TITLE
[NB] use state order when differentiation for index reduction

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -2317,6 +2317,18 @@ public
       end match;
     end setVariables;
 
+    function getStateOrder
+      input VarData varData;
+      output UnorderedMap<ComponentRef, ComponentRef> state_order;
+    algorithm
+      state_order := match varData
+        case VAR_DATA_SIM() then varData.state_order;
+        else algorithm
+          Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed because of incorrect record type."});
+        then fail();
+      end match;
+    end getStateOrder;
+
     // used to add specific types. Fill up with Jacobian/Hessian types
     type VarType = enumeration(STATE, STATE_DER, ALGEBRAIC, DISCRETE, DISC_STATE, PREVIOUS, START, PARAMETER, ITERATOR, RECORD, CLOCK);
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
@@ -172,7 +172,8 @@ public
       end if;
 
       // Build differentiation argument structure
-      diffArguments     := Differentiate.DifferentiationArguments.default(NBDifferentiate.DifferentiationType.TIME, funcTree);
+      diffArguments           := Differentiate.DifferentiationArguments.default(NBDifferentiate.DifferentiationType.TIME, funcTree);
+      diffArguments.diff_map  := SOME(VarData.getStateOrder(varData));
       diffArguments_ptr := Pointer.create(diffArguments);
 
       if Flags.isSet(Flags.DUMMY_SELECT) then


### PR DESCRIPTION
 - rename jacobianHT to diff_map because it can be used for any differentiation rules