### PR TITLE
Don't strip parentheses in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -2533,17 +2533,22 @@ algorithm
 end getString;
 
 public function stripCommentExpressions
+  "Strips comment expressions from the given expression. If onlyComments is
+   false it also strips parentheses (represented by tuples)."
   input output Absyn.Exp exp;
+  input Boolean onlyComments = false;
 algorithm
-  (exp,_) := traverseExp(exp, stripCommentExpressionsHelper, true);
+  (exp,_) := traverseExp(exp, stripCommentExpressionsHelper, onlyComments);
 end stripCommentExpressions;
 
-protected function stripCommentExpressionsHelper<T>
+protected function stripCommentExpressionsHelper
   input output Absyn.Exp exp;
-  input output T extra;
+  input output Boolean onlyComments;
+protected
+  Absyn.Exp e;
 algorithm
   exp := match exp
-    case Absyn.TUPLE({exp}) then exp;
+    case Absyn.TUPLE({e}) guard not onlyComments then e;
     case Absyn.EXPRESSIONCOMMENT() then exp.exp;
     else exp;
   end match;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1844,7 +1844,7 @@ algorithm
       then
         json;
 
-    else JSON.makeString(Dump.printExpStr(AbsynUtil.stripCommentExpressions(exp)));
+    else JSON.makeString(Dump.printExpStr(AbsynUtil.stripCommentExpressions(exp, true)));
   end match;
 end dumpJSONAbsynExpression;
 
@@ -2133,7 +2133,7 @@ algorithm
         end if;
 
         if isSome(mod.binding) then
-          binding_json := JSON.makeString(Dump.printExpStr(AbsynUtil.stripCommentExpressions(Util.getOption(mod.binding))));
+          binding_json := JSON.makeString(Dump.printExpStr(AbsynUtil.stripCommentExpressions(Util.getOption(mod.binding), true)));
 
           if JSON.isNull(json) then
             json := binding_json;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding11.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding11.mos
@@ -1,0 +1,52 @@
+// name: GetModelInstanceBinding11
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    Real x = (1 - 2) / (3);
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"modifiers\": \"(1 - 2)/(3)\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"binary_op\",
+//           \"lhs\": {
+//             \"$kind\": \"binary_op\",
+//             \"lhs\": 1,
+//             \"op\": \"-\",
+//             \"rhs\": 2
+//           },
+//           \"op\": \"/\",
+//           \"rhs\": 3
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 4,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -28,6 +28,7 @@ GetModelInstanceBinding7.mos \
 GetModelInstanceBinding8.mos \
 GetModelInstanceBinding9.mos \
 GetModelInstanceBinding10.mos \
+GetModelInstanceBinding11.mos \
 GetModelInstanceBreak1.mos \
 GetModelInstanceChoices1.mos \
 GetModelInstanceChoices2.mos \


### PR DESCRIPTION
- Make stripping parentheses (tuples) in `AbsynUtil.stripCommentExpressions` optional, and disable it for `getModelInstance`.

Fixes #13755