### PR TITLE
Fix size() of untyped variable

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
@@ -79,6 +79,7 @@ public
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
   constant Type VALID_TYPENAME_SCOPE = intBitOr(ITERATION_RANGE, DIMENSION);
   constant Type DISCRETE_SCOPE = intBitOr(WHEN, intBitOr(INITIAL, FUNCTION));
+  constant Type NON_EXP_FLAGS = intBitOr(GLOBAL_FLAGS, intBitOr(CLASS, FUNCTION));
 
   function set
     input Type context;
@@ -122,6 +123,13 @@ public
   algorithm
     outContext := intBitAnd(context, GLOBAL_FLAGS);
   end clearScopeFlags;
+
+  function clearExpFlags
+    input Type context;
+    output Type outContext;
+  algorithm
+    outContext := intBitAnd(context, NON_EXP_FLAGS);
+  end clearExpFlags;
 
   function inRelaxed
     input Type context;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1102,6 +1102,7 @@ Size3.mo \
 Size4.mo \
 Size5.mo \
 Size6.mo \
+Size7.mo \
 SizeInvalidArgs1.mo \
 SizeInvalidArgs2.mo \
 SizeInvalidIndex1.mo \

--- a/testsuite/flattening/modelica/scodeinst/Size7.mo
+++ b/testsuite/flattening/modelica/scodeinst/Size7.mo
@@ -1,0 +1,29 @@
+// name: Size7
+// keywords: size
+// status: correct
+//
+// Tests the builtin size operator.
+//
+
+model Size7
+  type listE = enumeration(one, two);
+  parameter listE values[:] = {listE(i) for i in 1:size(Nlist, 1)};
+  parameter Boolean Nlist[listE] = fill(true, size(Nlist, 1));
+end Size7;
+
+// Result:
+// function Size7.listE "Automatically generated conversion operator for listE"
+//   input Integer index;
+//   output enumeration(one, two) value;
+// algorithm
+//   assert(index >= 1 and index <= 2, "Enumeration index '" + String(index, 0, true) + "' out of bounds in call to listE()");
+//   value := {listE.one, listE.two}[index];
+// end Size7.listE;
+//
+// class Size7
+//   parameter enumeration(one, two) values[1] = listE.one;
+//   parameter enumeration(one, two) values[2] = listE.two;
+//   parameter Boolean Nlist[listE.one] = true;
+//   parameter Boolean Nlist[listE.two] = true;
+// end Size7;
+// endResult


### PR DESCRIPTION
- Strip expression flags in Typing.typeExpDim to avoid them influencing the typing when typing e.g. a `size()` expression.

Fixes #13752