### PR TITLE
Add execStatReset to CevalScriptBackend.mo

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -6136,6 +6136,7 @@ algorithm
     // handle normal models
     case (env,_,_)
       equation
+        ExecStat.execStatReset();
         (cache,env,odae) = runFrontEnd(cache,env,className,false);
         SOME(dae) = odae;
         (varSize,eqnSize,simpleEqnSize) = CheckModel.checkModel(dae);


### PR DESCRIPTION
I and @sjoelund saw that the reset function for checkModel does not reset and therefore reports higher values than it should

### Purpose
Fix checkModel so that the profiling reports the correct timings

### Approach
Added a call to ExecStat.execStatReset in the applicable function 
