### PR TITLE
Remove support for deprecated tearing select syntax

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1186,7 +1186,7 @@ algorithm
   tearingSelect := lookupTearingSelectMember(name);
 
   if isNone(tearingSelect) then
-    Error.addSourceMessage(Error.UNKNOWN_ANNOTATION_VALUE, {Dump.printExpStr(val)}, info);
+    Error.addSourceMessage(Error.UNKNOWN_ANNOTATION_VALUE, {Dump.printExpStr(val), "__OpenModelica_tearingSelect"}, info);
   end if;
 end setTearingSelectAttribute;
 
@@ -1202,12 +1202,12 @@ algorithm
              Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {})))
       then name;
 
-    // Single name without the TearingSelect prefix is deprecated but still accepted.
+    // Single name without the TearingSelect prefix is deprecated and no longer accepted.
     case Absyn.Exp.CREF(componentRef = Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {}))
       algorithm
         Error.addSourceMessage(Error.DEPRECATED_EXPRESSION, {name, "TearingSelect." + name}, info);
       then
-        name;
+        "";
 
     else "";
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -1425,7 +1425,7 @@ public
       tearingSelect := lookupTearingSelectMember(name);
 
       if isNone(tearingSelect) then
-        Error.addSourceMessage(Error.UNKNOWN_ANNOTATION_VALUE, {Dump.printExpStr(val)}, info);
+        Error.addSourceMessage(Error.UNKNOWN_ANNOTATION_VALUE, {Dump.printExpStr(val), "__OpenModelica_tearingSelect"}, info);
       end if;
     end createTearingSelect;
 
@@ -1441,12 +1441,12 @@ public
                  Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {})))
           then name;
 
-        // Single name without the TearingSelect prefix is deprecated but still accepted.
+        // Single name without the TearingSelect prefix is deprecated and no longer accepted.
         case Absyn.Exp.CREF(componentRef = Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {}))
           algorithm
             Error.addSourceMessage(Error.DEPRECATED_EXPRESSION, {name, "TearingSelect." + name}, info);
           then
-            name;
+            "";
 
         else "";
       end match;

--- a/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
@@ -33,9 +33,7 @@ val(i3,0.0); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
-// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
-// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-minimal.mos
@@ -33,9 +33,7 @@ val(i3,0.0); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
-// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
-// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect-omc.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-omc.mos
@@ -33,9 +33,7 @@ val(i3,0.0); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
-// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
-// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect.mo
+++ b/testsuite/simulation/modelica/tearing/tearingSelect.mo
@@ -1,10 +1,10 @@
 model tearingSelect
    Real u0;
-   Real i1 annotation(__OpenModelica_tearingSelect=prefer);
+   Real i1 annotation(__OpenModelica_tearingSelect=TearingSelect.prefer);
    Real i2 (start=1);
    Real i3;
    Real u1;
-   Real u2 (start=1) annotation(__OpenModelica_tearingSelect=avoid);
+   Real u2 (start=1) annotation(__OpenModelica_tearingSelect=TearingSelect.avoid);
    Real u3;
    parameter Real r1=10;
    parameter Real r2=10;


### PR DESCRIPTION
- Remove support for the deprecated non-enumeration syntax for the `__OpenModelica_tearingSelect` annotation.