### PR TITLE
Optimize Print.printBuf

### DIFF
--- a/OMCompiler/Compiler/Util/Print.mo
+++ b/OMCompiler/Compiler/Util/Print.mo
@@ -70,7 +70,7 @@ end getErrorString;
 public function printBuf
   input String inString;
 
-  external "C" Print_printBuf(OpenModelica.threadData(),inString) annotation(Library = "omcruntime");
+  external "C" Print_printBufLen(OpenModelica.threadData(),inString,stringLength(inString)) annotation(Library = "omcruntime");
 end printBuf;
 
 public function clearBuf

--- a/OMCompiler/Compiler/runtime/Print_omc.c
+++ b/OMCompiler/Compiler/runtime/Print_omc.c
@@ -63,7 +63,14 @@ extern void Print_printErrorBuf(threadData_t *threadData,const char* str)
 extern void Print_printBuf(threadData_t *threadData,const char* str)
 {
   // fprintf(stderr, "Print_printBuf: %s\n", str);
-  if (PrintImpl__printBuf(threadData,str))
+  if (PrintImpl__printBuf(threadData,str,strlen(str)))
+    MMC_THROW();
+}
+
+extern void Print_printBufLen(threadData_t *threadData,const char* str, long len)
+{
+  // fprintf(stderr, "Print_printBuf: %s\n", str);
+  if (PrintImpl__printBuf(threadData,str,len))
     MMC_THROW();
 }
 

--- a/OMCompiler/Compiler/runtime/printimpl.c
+++ b/OMCompiler/Compiler/runtime/printimpl.c
@@ -277,10 +277,9 @@ static const char* PrintImpl__getErrorString(threadData_t *threadData)
 }
 
 /* returns 0 on success */
-static int PrintImpl__printBuf(threadData_t *threadData,const char* str)
+static int PrintImpl__printBuf(threadData_t *threadData,const char* str,long len)
 {
   print_members* members = getMembers(threadData);
-  long len = strlen(str);
   /* printf("cursize: %d, nfilled %d, strlen: %d\n",cursize,nfilled,strlen(str)); */
 
   while (nfilled + len + 1 > cursize) {

--- a/OMCompiler/Compiler/runtime/printimpl.h
+++ b/OMCompiler/Compiler/runtime/printimpl.h
@@ -34,6 +34,7 @@ extern int Print_saveAndClearBuf(threadData_t *threadData);
 extern void Print_restoreBuf(threadData_t *threadData, int handle);
 extern void Print_printErrorBuf(threadData_t *threadData, const char* str);
 extern void Print_printBuf(threadData_t *threadData, const char* str);
+extern void Print_printBufLen(threadData_t *threadData, const char* str, long len);
 extern int Print_hasBufNewLineAtEnd(threadData_t *threadData);
 extern int Print_getBufLength(threadData_t *threadData);
 extern const char* Print_getString(threadData_t *threadData);


### PR DESCRIPTION
- Pass the length of the string to the external implementation of `Print.printBuf` to avoid expensive `strlen` calls.