### PR TITLE
CMake: Fix omcbackendruntime build

### DIFF
--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -153,6 +153,7 @@ target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::zlib)
+target_link_libraries(omcbackendruntime PUBLIC omc::3rd::FMIL::expat)
 
 target_include_directories(omcbackendruntime PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcbackendruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
It seems expat must be linked in omcbackendruntime to avoid this error:
```
[1303/4423] Building CXX object OMCompiler/Compiler/runtime/CMakeFiles/omcbackendruntime.dir/HpcOmBenchmarkExt_omc.cpp.o
FAILED: OMCompiler/Compiler/runtime/CMakeFiles/omcbackendruntime.dir/HpcOmBenchmarkExt_omc.cpp.o 
$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DGC_THREADS -DOM_HAVE_PTHREADS -DWIN32_LEAN_AND_MEAN -I$SRC_DIR/OMCompiler/Compiler/runtime -I$SRC_DIR/OMCompiler -I$SRC_DIR/OMCompiler/SimulationRuntime/c -I$SRC_DIR/OMCompiler/3rdParty/gc/include -I$SRC_DIR/OMCompiler/3rdParty/ryu -I$SRC_DIR/OMCompiler/3rdParty/ryu/ryu -I$SRC_DIR/OMCompiler/3rdParty/metis-5.1.0/include -I$SRC_DIR/OMCompiler/3rdParty/FMIL/include -I$SRC_DIR/OMCompiler/3rdParty/zlib -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/omcompiler-1.25.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3  -std=c++17 -fPIC -MD -MT OMCompiler/Compiler/runtime/CMakeFiles/omcbackendruntime.dir/HpcOmBenchmarkExt_omc.cpp.o -MF OMCompiler/Compiler/runtime/CMakeFiles/omcbackendruntime.dir/HpcOmBenchmarkExt_omc.cpp.o.d -o OMCompiler/Compiler/runtime/CMakeFiles/omcbackendruntime.dir/HpcOmBenchmarkExt_omc.cpp.o -c $SRC_DIR/OMCompiler/Compiler/runtime/HpcOmBenchmarkExt_omc.cpp
In file included from $SRC_DIR/OMCompiler/Compiler/runtime/HpcOmBenchmarkExt_omc.cpp:13:
$SRC_DIR/OMCompiler/Compiler/runtime/HpcOmBenchmarkExt.cpp:24:10: fatal error: expat.h: No such file or directory
```
/cc @perost 
