### PR TITLE
Fix array dimension type matching

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2270,7 +2270,7 @@ function matchDimensions
   output Dimension compatibleDim;
   output Boolean compatible;
 algorithm
-  if Dimension.isEqual(dim1, dim2) then
+  if Dimension.isEqualKnown(dim1, dim2) then
     compatibleDim := dim1;
     compatible := true;
   else

--- a/testsuite/simulation/modelica/equations/ArrayEquation1.mo
+++ b/testsuite/simulation/modelica/equations/ArrayEquation1.mo
@@ -1,0 +1,16 @@
+record R
+  parameter String components[:];
+  parameter Integer n = size(components, 1);
+end R;
+
+function f
+  input R r;
+  output Real x[r.n] = ones(r.n);
+end f;
+
+model ArrayEquation1
+  parameter R r(components = {"a", "b"});
+  Real x[r.n];
+equation
+  x = f(r);
+end ArrayEquation1;

--- a/testsuite/simulation/modelica/equations/ArrayEquation1.mos
+++ b/testsuite/simulation/modelica/equations/ArrayEquation1.mos
@@ -1,0 +1,22 @@
+// name:     ArrayEquation1
+// keywords:
+// status: correct
+// teardown_command: rm -rf ArrayEquation2_* ArrayEquation2 ArrayEquation2.exe ArrayEquation2.cpp ArrayEquation2.makefile ArrayEquation2.libs ArrayEquation2.log output.log
+
+loadFile("ArrayEquation1.mo");
+getErrorString();
+simulate(ArrayEquation1);
+getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ArrayEquation1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ArrayEquation1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/equations/Makefile
+++ b/testsuite/simulation/modelica/equations/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 VariableSubscriptAlias.mos \
 ActivateWhenEquation.mos \
 AliasEquations.mos \
+ArrayEquation1.mos \
 BouncingBall.mos BouncingBall2.mos BouncingBallExamples.mos \
 constantLinSys.mos \
 Cross.mos \


### PR DESCRIPTION
- Return the other dimension if either dimension is unknown in `NFTypeCheck.matchDimensions` instead of just returning the first one.

Fixes #13790