### PR TITLE
Show the error message when translateModel fails

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1763,6 +1763,14 @@ void SimulationDialog::performSimulation(const SimulationOptions &simulationOpti
       MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::notificationLevel));
       return;
     }
+  } else {
+    /* issue #13790
+     * Always add this error message.
+     * It could be that translateModel fails without any error so in this case atleast this simple message is shown.
+     * If translateModel fails with error then its errors and this message is shown.
+     */
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Translation of <b>%1</b> failed.").arg(mClassName),
+                                                          Helper::scriptingKind, Helper::errorLevel));
   }
 }
 


### PR DESCRIPTION
### Related Issues

#13790

### Purpose

Let the user know if the model translation fails without error message.

### Approach

Always show the error message from OMEdit even if compiler fails without any error message.
