### PR TITLE
Fix externalInputData when initializing models

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -478,13 +478,13 @@ int initializeModel(DATA* data, threadData_t *threadData, const char* init_initM
 
   copyStartValuestoInitValues(data);
 
+  data->localData[0]->timeValue = simInfo->startTime;
+
   /* read input vars */
   data->callback->input_function_init(data, threadData);
   externalInputUpdate(data);
   data->callback->input_function_updateStartValues(data, threadData);
   data->callback->input_function(data, threadData);
-
-  data->localData[0]->timeValue = simInfo->startTime;
 
   threadData->currentErrorStage = ERROR_SIMULATION;
   /* try */


### PR DESCRIPTION
- Initialize `data->localData[0]->timeValue` before calling `externalInputData`, since `externalInputData` depends on it.