### PR TITLE
Improve handling of Modelica.Utilities.Files.loadResource

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -438,6 +438,11 @@ constant Function SUM = Function.FUNCTION(Path.IDENT("sum"),
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
+constant Function FMU_LOAD_RESOURCE = Function.FUNCTION(Path.IDENT("OpenModelica_fmuLoadResource"),
+  InstNode.EMPTY_NODE(), {STRING_PARAM}, {STRING_PARAM}, {}, {},
+    Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
 constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path.IDENT("sample")),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, {}, listArray({}),

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -793,11 +793,20 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
   function getDerivedComments
     input Class cls;
     input output list<SCode.Comment> cmts;
+  protected
+    ClassTree cls_tree;
   algorithm
     cmts := match cls
       case EXPANDED_DERIVED() then InstNode.getComments(cls.baseClass, cmts);
       case TYPED_DERIVED() then InstNode.getComments(cls.baseClass, cmts);
-      else cmts;
+      else
+        algorithm
+          for ext in ClassTree.getExtends(classTree(cls)) loop
+            cmts := InstNode.getComments(ext, cmts);
+          end for;
+        then
+          cmts;
+
     end match;
   end getDerivedComments;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -275,6 +275,7 @@ algorithm
     case "getInstanceName"  then Ceval.evalGetInstanceName(listHead(args));
     case "$OMC$PositiveMax" then simplifyPositiveMax(args, call);
     case "$OMC$inStreamDiv" then simplifyInStreamDiv(args, call);
+    case "OpenModelica_uriToFilename" then simplifyURIToFilename(listHead(args), call);
 
     else Expression.CALL(call);
   end match;
@@ -1818,6 +1819,18 @@ algorithm
     else exp;
   end match;
 end removeTrivialScalarProduct;
+
+function simplifyURIToFilename
+  input Expression arg;
+  input Call call;
+  output Expression outExp;
+algorithm
+  if Flags.getConfigBool(Flags.BUILDING_FMU) then
+    outExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.FMU_LOAD_RESOURCE, {arg}, Call.variability(call), NFPrefixes.Purity.IMPURE));
+  else
+    outExp := Expression.CALL(call);
+  end if;
+end simplifyURIToFilename;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFSimplifyExp;

--- a/testsuite/flattening/modelica/mosfiles/LoadResource1.mos
+++ b/testsuite/flattening/modelica/mosfiles/LoadResource1.mos
@@ -1,0 +1,28 @@
+// name: LoadResource1
+// status: correct
+//
+// Checks that loadResource calls are inlined.
+//
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+loadString("
+  model M
+    String filename = \"modelica://test\";
+    String s1 = Modelica.Utilities.Files.loadResource(filename);
+  end M;
+");
+getErrorString();
+instantiateModel(M); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "class M
+//   String filename = \"modelica://test\";
+//   String s1 = OpenModelica_uriToFilename(filename);
+// end M;
+// "
+// ""
+// endResult

--- a/testsuite/flattening/modelica/mosfiles/Makefile
+++ b/testsuite/flattening/modelica/mosfiles/Makefile
@@ -20,6 +20,7 @@ GroupImport.mos \
 IntMulOverflow.mos IntPowOverflow.mos IntDivOverflow.mos IntAddSubOverflow.mos \
 ISO-8859-1.mos \
 LeastSquares.mos \
+LoadResource1.mos \
 LookupBuiltin.mos \
 LookupPackageFail.mos \
 Model1.mos \


### PR DESCRIPTION
- Also use comments from extended classes when checking whether to inline a function.
- Convert `OpenModelica_uriToFilename` to `OpenModelica_fmuLoadResource` when building FMUs.