### PR TITLE
Exit show element mode when dependencies are reloaded

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -311,13 +311,10 @@ public:
   void emitDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) {emit dataChanged(topLeft, bottomRight);}
   void createLibraryTreeItems(LibraryTreeItem *pLibraryTreeItem);
   void unloadFileChildren(LibraryTreeItem *pLibraryTreeItem);
-  void emitModelStateChanged(const QString &name) {emit modelStateChanged(name);}
-  bool isCreatingAutoLoadedLibrary() const {return mCreatingAutoLoadedLibrary;}
-  void setCreatingAutoLoadedLibrary(bool creatingAutoLoadedLibrary) {mCreatingAutoLoadedLibrary = creatingAutoLoadedLibrary;}
+  void emitModelStateChanged(const QString &name, bool unload) {emit modelStateChanged(name, unload);}
 private:
   LibraryWidget *mpLibraryWidget;
   LibraryTreeItem *mpRootLibraryTreeItem;
-  bool mCreatingAutoLoadedLibrary = false;
 
   QModelIndex libraryTreeItemIndexHelper(const LibraryTreeItem *pLibraryTreeItem, const LibraryTreeItem *pParentLibraryTreeItem, const QModelIndex &parentIndex) const;
   LibraryTreeItem* getLibraryTreeItemFromFileHelper(LibraryTreeItem *pLibraryTreeItem, QString fileName, int lineNumber);
@@ -343,7 +340,7 @@ private:
 protected:
   Qt::DropActions supportedDropActions() const override;
 signals:
-  void modelStateChanged(const QString &name);
+  void modelStateChanged(const QString &name, bool unload);
 };
 
 class LibraryTreeView : public QTreeView
@@ -480,11 +477,16 @@ public:
   void openLibraryTreeItem(QString nameStructure);
   void loadAutoLoadedLibrary(const QString &modelName);
   bool isLoadingLibraries() const {return mLoadingLibraries;}
-  void setLoadingLibraries(bool loadingLibraries) {mLoadingLibraries = loadingLibraries;}
+  void setLoadingLibraries(bool loadingLibraries);
+  bool isCreatingAutoLoadedLibrary() const {return mCreatingAutoLoadedLibrary;}
+  void setCreatingAutoLoadedLibrary(bool creatingAutoLoadedLibrary);
+  void addModelToUpdate(const QString &model) {mModelsToUpdate.append(model);}
 private:
-  bool mLoadingLibraries;
+  bool mLoadingLibraries = false;
+  bool mCreatingAutoLoadedLibrary = false;
   QTimer mAutoLoadedLibrariesTimer;
   QStringList mAutoLoadedLibrariesList;
+  QStringList mModelsToUpdate;
   TreeSearchFilters *mpTreeSearchFilters;
   LibraryTreeModel *mpLibraryTreeModel;
   LibraryTreeProxyModel *mpLibraryTreeProxyModel;
@@ -503,6 +505,7 @@ private:
   void saveTotalLibraryTreeItemHelper(LibraryTreeItem *pLibraryTreeItem);
   bool resolveConflictWithLoadedLibraries(const QString &library, const QStringList classes);
   static void cancelLoadingLibraries(const QStringList classes);
+  void reDrawModelsToUpdate();
 private slots:
   void handleAutoLoadedLibrary();
 public slots:

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -652,8 +652,9 @@ private:
   void drawOMSElement(LibraryTreeItem *pLibraryTreeItem, const QString &annotation);
   void drawOMSModelConnections();
   void associateBusWithConnectors(Element *pBusComponent, GraphicsView *pGraphicsView);
-  bool dependsOnModel(const QString &modelName);
+  bool dependsOnModel(const QString &modelName, bool unload);
   void updateElementModeButtons();
+  void reDrawModelWidgetHelper();
 private slots:
   void showIconView(bool checked);
   void showDiagramView(bool checked);
@@ -667,7 +668,7 @@ public slots:
   void showDocumentationView();
   void handleCanUndoChanged(bool canUndo);
   void handleCanRedoChanged(bool canRedo);
-  void updateModelIfDependsOn(const QString &modelName);
+  void updateModelIfDependsOn(const QString &modelName, bool unload);
 protected:
   virtual void closeEvent(QCloseEvent *event) override;
 };

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -237,7 +237,6 @@ public:
   OMCInterface::convertUnits_res convertUnits(QString from, QString to);
   QList<QString> getDerivedUnits(QString baseUnit);
   QString getNamedAnnotation(const QString &className, const QString &annotation, StringHandler::ResultType type = StringHandler::String);
-  QString getCommandLineOptionsAnnotation(QString className);
   QList<QString> getAnnotationNamedModifiers(QString className, QString annotation);
   QString getAnnotationModifierValue(QString className, QString annotation, QString modifier);
   QString getSimulationFlagsAnnotation(QString className);


### PR DESCRIPTION
### Related Issues

#13822

### Purpose

Avoid crashing OMEdit when in show element mode.

### Approach

Use flag `--loadMissingLibraries=false` when unloading libraries so that libraries are not automatically due to usage. Removed undefined `getCommandLineOptionsAnnotation` from `OMCProxy`.