### PR TITLE
copy external modelicaStandardTable sources to fmu

### DIFF
--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaStandardTablesDummyUsertab.c
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaStandardTablesDummyUsertab.c
@@ -1,0 +1,55 @@
+/* ModelicaStandardTablesDummyUsertab.c - A dummy usertab function
+
+   Copyright (C) 2013-2020, Modelica Association and contributors
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* The usertab function needs to be in a separate object or clang/gcc
+   optimize the code in such a way that the user-defined usertab gets
+   sent the wrong input.
+
+   NOTE: If a dummy usertab is included in your code, you may be unable
+   to also provide a user-defined usertab. If you use dynamic linking
+   this is sometimes possible: when the simulation executable provides
+   a usertab object, it will be part of the table of loaded objects and
+   when later loading the shared object version of ModelicaStandardTables,
+   the dummy usertab will not be loaded by the dynamic linker; this is
+   what can confuse C-compilers and why this function is in a separate
+   file).
+
+   The interface of usertab is defined in ModelicaStandardTables.c
+ */
+
+/*
+ when compiling from the sources we need to have the usertab() function defined
+ otherwise we get unresolved symbols and linking errors from ModelicaStandardTables.c
+ The below function does not check anything and this function can be overridden.
+*/
+int usertab(char* tableName, int nipo, int dim[], int* colWise, double** table) {
+  return 0;
+}

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -356,11 +356,14 @@ clean:
 	(! test -f $(EXTERNALCBUILDDIR)/Makefile) || make -C $(EXTERNALCBUILDDIR) clean
 	(! test -f $(EXTERNALCBUILDDIR)/Makefile) || make -C $(EXTERNALCBUILDDIR) distclean
 
-sourcedist: sourcedist1 sourcedist2
+sourcedist: sourcedist1 sourcedist2 sourcedist3
 sourcedist1:
 	$(MAKE) -f $(LIBMAKEFILE) OMC_MINIMAL_RUNTIME=1 OMC_FMI_RUNTIME=1 sourcedist_internal
 sourcedist2:
 	$(MAKE) -C ../fmi/export/buildproject -f $(defaultMakefileTarget)
+sourcedist3:
+	mkdir -p $(builddir_inc)/c/ModelicaExternalC
+	cp -p ../ModelicaExternalC/C-Sources/*.h ../ModelicaExternalC/C-Sources/*.c $(builddir_inc)/c/ModelicaExternalC
 
 # Copied files need to preserve the time-stamp or the external solvers builds
 # over and over again

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
@@ -30,6 +30,17 @@ encapsulated package RuntimeSources
 
   constant list<String> simrt_c_sundials_sources={@SOURCE_FMU_CVODE_RUNTIME_FILES@};
 
+  constant list<String> modelica_external_c_sources={"ModelicaExternalC/ModelicaStandardTables.c",
+                                                     "ModelicaExternalC/ModelicaMatIO.c",
+                                                     "ModelicaExternalC/ModelicaIO.c",
+                                                     "ModelicaExternalC/ModelicaStandardTablesDummyUsertab.c"};
+
+  constant list<String> modelica_external_c_headers={"ModelicaExternalC/ModelicaStandardTables.h",
+                                                     "ModelicaExternalC/ModelicaMatIO.h",
+                                                     "ModelicaExternalC/ModelicaIO.h",
+                                                     "ModelicaExternalC/safe-math.h",
+                                                     "ModelicaExternalC/read_data_impl.h"};
+
   constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
 
   constant list<String> dgesv_sources={@SOURCE_FMU_DGESV_FILES@};

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
@@ -26,6 +26,17 @@ encapsulated package RuntimeSources
   constant list<String> simrt_c_sundials_sources={"simulation/solver/cvode_solver.c",
                                                   "simulation/solver/sundials_error.c"};
 
+  constant list<String> modelica_external_c_sources={"ModelicaExternalC/ModelicaStandardTables.c",
+                                                     "ModelicaExternalC/ModelicaMatIO.c",
+                                                     "ModelicaExternalC/ModelicaIO.c",
+                                                     "ModelicaExternalC/ModelicaStandardTablesDummyUsertab.c"};
+
+  constant list<String> modelica_external_c_headers={"ModelicaExternalC/ModelicaStandardTables.h",
+                                                     "ModelicaExternalC/ModelicaMatIO.h",
+                                                     "ModelicaExternalC/ModelicaIO.h",
+                                                     "ModelicaExternalC/safe-math.h",
+                                                     "ModelicaExternalC/read_data_impl.h"};
+
   constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
   constant list<String> dgesv_sources={DGESV_FILES};
 


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/13260

### Purpose

Copy the modelicaStandardTables source files to fmus for source code cross compilation
