### PR TITLE
Fix Qt compilation warnings

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -202,7 +202,11 @@ void BitmapAnnotation::drawAnnotation(QPainter *painter)
   QPointF centerPoint = rect.center() - image.rect().center();
   QRectF target(centerPoint.x(), centerPoint.y(), image.width(), image.height());
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+  painter->drawImage(target, mImage.flipped())
+#else
   painter->drawImage(target, mImage.mirrored());
+#endif
 }
 
 /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -124,17 +124,24 @@ namespace IAEX
       exit(1);
     }
 
-    QString translationDirectory = installationDirectoryPath + QString("/share/omnotebook/nls");
-    // install Qt's default translations
-  #ifdef Q_OS_WIN
-    qtTranslator.load("qt_" + QLocale::system().name(), translationDirectory);
+    QString locale = QLocale::system().name();
+
+  #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QString qtTranslationDirectory = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
   #else
-    qtTranslator.load("qt_" + QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    QString qtTranslationDirectory = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
   #endif
-    app_->installTranslator(&qtTranslator);
+
+    // install Qt's default translations
+    if (qtTranslator.load("qt_" + locale, qtTranslationDirectory)) {
+      app_->installTranslator(&qtTranslator);
+    }
+
+    QString translationDirectory = installationDirectoryPath + QString("/share/omnotebook/nls");
     // install application translations
-    translator.load("OMNotebook_" + QLocale::system().name(), translationDirectory);
-    app_->installTranslator(&translator);
+    if (translator.load("OMNotebook_" + QLocale::system().name(), translationDirectory)) {
+      app_->installTranslator(&translator);
+    }
 
     mainWindow = new QMainWindow();
     QDir dir;


### PR DESCRIPTION
- Use `QImage::flipped` instead of `QImage::mirrored` on Qt >= 6.9.0.
- Update loading of translations in OMNotebook.