### PR TITLE
Update deprecated Autoconf macros

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/configure.ac
+++ b/OMCompiler/SimulationRuntime/OMSICpp/configure.ac
@@ -176,4 +176,5 @@ fi
 AC_ARG_WITH(build-type,  [  --with-build-type=[Release|Debug|RelWithDebInfo]       (set the cmake build type)],[CMAKE_BUILDTYPE="$withval"],[])
 AC_MSG_RESULT([Build type is set to $CMAKE_BUILDTYPE])
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/OMCompiler/SimulationRuntime/cpp/configure.ac
+++ b/OMCompiler/SimulationRuntime/cpp/configure.ac
@@ -176,4 +176,5 @@ fi
 AC_ARG_WITH(build-type,  [  --with-build-type=[Release|Debug|RelWithDebInfo]       (set the cmake build type)],[CMAKE_BUILDTYPE="$withval"],[])
 AC_MSG_RESULT([Build type is set to $CMAKE_BUILDTYPE])
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -177,7 +177,7 @@ AC_ARG_WITH(msys, [  --with-msys[=no]              Point to an msys installation
 CFLAGS_BEFORE="$CFLAGS"
 CFLAGS="$CFLAGS -Werror"
 AC_MSG_CHECKING([if -Werror works])
-AC_TRY_LINK([void abc() {}], [abc();], [AC_MSG_RESULT([ok])], [AC_MSG_ERROR([failed (check your CFLAGS)])])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[void abc() {}]], [[abc();]])],[AC_MSG_RESULT([ok])],[AC_MSG_ERROR([failed (check your CFLAGS)])])
 CFLAGS="$CFLAGS_BEFORE"
 
 dnl Disables the default CFLAGS="-g -O2"
@@ -188,7 +188,7 @@ else
 CFLAGS_BEFORE="$CFLAGS"
 CFLAGS="-O3 -march=native"
 AC_MSG_CHECKING([looking for -march=native])
-AC_TRY_LINK([void abc() {}], [abc();], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no]);CFLAGS="-O3"])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[void abc() {}]], [[abc();]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]);CFLAGS="-O3"])
 fi
 fi
 
@@ -196,7 +196,7 @@ LDFLAGS_BEFORE="$LDFLAGS"
 LIBS_BEFORE="$LIBS"
 LDFLAGS="$LDFLAGS -Wl,--no-undefined"
 AC_MSG_CHECKING([looking for --no-undefined])
-AC_TRY_LINK([void abc() {}], [abc();], [AC_MSG_RESULT([yes]);LD_NOUNDEFINED=" -Wl,--no-undefined"], [AC_MSG_RESULT([no])])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[void abc() {}]], [[abc();]])],[AC_MSG_RESULT([yes]);LD_NOUNDEFINED=" -Wl,--no-undefined"],[AC_MSG_RESULT([no])])
 LDFLAGS="$LDFLAGS_BEFORE"
 LIBS="$LIBS_BEFORE"
 
@@ -222,7 +222,7 @@ AC_MSG_CHECKING([for flags to append to CFLAGS ($TRY_FLAGS)])
 for flag in $TRY_FLAGS; do
   OLD_CFLAGS="$CFLAGS"
   CFLAGS="$RUNTIMECFLAGS $flag -Werror"
-  AC_TRY_LINK([], [return 0;], [CFLAGS="$OLD_CFLAGS $flag"],[CFLAGS="$OLD_CFLAGS"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[CFLAGS="$OLD_CFLAGS $flag"],[CFLAGS="$OLD_CFLAGS"])
 done
 AC_MSG_RESULT([$CFLAGS])
 
@@ -230,21 +230,21 @@ AC_MSG_CHECKING([for flags to append to LDFLAGS ($TRY_FLAGS_LD)])
 for flag in $TRY_FLAGS_LD; do
   OLD_LDFLAGS="$LDFLAGS"
   LDFLAGS="$flag -Werror"
-  AC_TRY_LINK([], [return 0;], [LDFLAGS="$OLD_LDFLAGS $flag"],[LDFLAGS="$OLD_LDFLAGS"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[LDFLAGS="$OLD_LDFLAGS $flag"],[LDFLAGS="$OLD_LDFLAGS"])
 done
 AC_MSG_RESULT([$LDFLAGS])
 
 OLD_CFLAGS="$CFLAGS"
 for flag in -Wno-parentheses-equality -Wno-unused-variable; do
   CFLAGS="$RUNTIMECFLAGS $flag -Werror"
-  AC_TRY_LINK([], [return 0;], [
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[
     CHECK_C_ERRORS="$CHECK_C_ERRORS $flag"
     EXTRA_CFLAGS_GENERATED_CODE="$EXTRA_CFLAGS_GENERATED_CODE $flag"
   ],[])
 done
 for flag in -Werror=implicit-function-declaration -Werror=incompatible-pointer-types; do
   CFLAGS="$RUNTIMECFLAGS $flag -Werror"
-  AC_TRY_LINK([], [return 0;], [
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[
     CHECK_C_ERRORS="$CHECK_C_ERRORS $flag"
     EXTRA_CFLAGS_GENERATED_CODE="$EXTRA_CFLAGS_GENERATED_CODE $flag"
   ],[])
@@ -257,7 +257,7 @@ EXTRA_FCFLAGS=""
 AC_MSG_CHECKING([for flags to append to FCFLAGS])
 for flag in -fallow-argument-mismatch; do
   FCFLAGS="$flag -Werror"
-  AC_TRY_LINK([], [], [
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[]])],[
     EXTRA_FCFLAGS="$EXTRA_FCFLAGS $flag"
   ],[])
 done
@@ -276,7 +276,7 @@ if echo $CFLAGS | grep -q -- -fPIC; then
 else
   CFLAGS_BEFORE="$CFLAGS"
   CFLAGS="$CFLAGS -fPIC -Werror"
-  AC_TRY_LINK([void abc() {}], [abc();], [AC_MSG_RESULT([adding -fPIC]); CFLAGS="$CFLAGS_BEFORE -fPIC"; FPIC="-fPIC"], [AC_MSG_RESULT([does not need -fPIC]); CFLAGS="$CFLAGS_BEFORE"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[void abc() {}]], [[abc();]])],[AC_MSG_RESULT([adding -fPIC]); CFLAGS="$CFLAGS_BEFORE -fPIC"; FPIC="-fPIC"],[AC_MSG_RESULT([does not need -fPIC]); CFLAGS="$CFLAGS_BEFORE"])
 fi
 
 else
@@ -288,7 +288,7 @@ if echo $CFLAGS | grep -q -- -fPIC; then
 else
   CFLAGS_BEFORE="$CFLAGS"
   CFLAGS="$CFLAGS -fPIC -Werror"
-  AC_TRY_LINK([void abc() {}], [abc();], [AC_MSG_RESULT([adding -fPIC]); CFLAGS="$CFLAGS_BEFORE -fPIC"; FPIC="-fPIC"], [AC_MSG_RESULT([does not need -fPIC]); CFLAGS="$CFLAGS_BEFORE"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[void abc() {}]], [[abc();]])],[AC_MSG_RESULT([adding -fPIC]); CFLAGS="$CFLAGS_BEFORE -fPIC"; FPIC="-fPIC"],[AC_MSG_RESULT([does not need -fPIC]); CFLAGS="$CFLAGS_BEFORE"])
 fi
 
 fi
@@ -299,11 +299,7 @@ AC_LANG_PUSH([C++])
 OLD_CXXFLAGS=$CXXFLAGS
 for flag in -stdlib=libstdc++; do
   CXXFLAGS="$OLD_CXXFLAGS $flag"
-  AC_TRY_LINK(
-    [#include <regex>],
-    [int main() {return 0;}],
-    [LDFLAGS_LIBSTDCXX="$flag"],
-    [CXXFLAGS="$OLD_CXXFLAGS"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <regex>]], [[int main() {return 0;}]])],[LDFLAGS_LIBSTDCXX="$flag"],[CXXFLAGS="$OLD_CXXFLAGS"])
 done
 AC_LANG_POP([C++])
 
@@ -318,7 +314,7 @@ dnl Simulations spin forever unless -msse2 -mfpmath=sse is set
 CFLAGS_BEFORE=$CFLAGS
 CFLAGS="-mfpmath=sse -Werror"
 AC_MSG_CHECKING([for floating point bugs])
-AC_TRY_LINK([int abc() {}], [abc();], [AC_MSG_RESULT([force SSE2]); FPMATHFORTRAN="-msse -mfpmath=sse"], [AC_MSG_RESULT([no]); FPMATHFORTRAN=-ffloat-store])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[int abc() {}]], [[abc();]])],[AC_MSG_RESULT([force SSE2]); FPMATHFORTRAN="-msse -mfpmath=sse"],[AC_MSG_RESULT([no]); FPMATHFORTRAN=-ffloat-store])
 CFLAGS=$CFLAGS_BEFORE
 
 fi # End x86-specific CFLAGS
@@ -370,10 +366,6 @@ else
   BOOST_INCLUDE=""
 fi
 
-
-dnl Checks for header files.
-AC_HEADER_STDC
-
 AC_CHECK_HEADERS(sys/time.h, [], [AC_MSG_ERROR(Missing header file sys/time.h)])
 # AC_CHECK_HEADERS(sqlite3.h, [], [AC_MSG_ERROR(Missing header file sqlite3.h)])
 
@@ -405,9 +397,9 @@ AC_CHECK_FUNCS(getcwd select strdup strerror)
 dnl Check if scandir is available
 AC_MSG_CHECKING([for scandir])
 
-AC_TRY_LINK([
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <dirent.h>
-], [
+]], [[
 int file_select_directories(const struct dirent *entry) {
  return 0;
 }
@@ -419,8 +411,7 @@ struct dirent **files;
 scandir(dir, &files, file_select_directories, 0);
 return 0;
 }
-], [AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_SCANDIR])],
-      [AC_MSG_RESULT([no])])
+]])],[AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_SCANDIR])],[AC_MSG_RESULT([no])])
 
 dnl Check if OpenMP is available
 AC_MSG_CHECKING([for OpenMP])
@@ -431,20 +422,20 @@ for OMPCCTEST in "-fopenmp=libomp" "-fopenmp=libiomp5" "-fopenmp"; do
     CFLAGS_OLD="$CFLAGS"
     CFLAGS="$OMPCCTEST"
 
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
     #if !defined(_OPENMP)
       #error "Not an OpenMP compiler"
     #endif
     #include <omp.h>
     #include <stdio.h>
-    ], [
+    ]], [[
       int i;
     #pragma omp parallel for private(i) schedule(dynamic)
       for (i=0; i<16; i++)
         printf("Thread %d doing work %d\n", omp_get_thread_num(), i);
       return 0;
-    ], [OMPCFLAGS="$CFLAGS"; CONFIG_WITH_OPENMP=1]
-    )
+    ]])],[OMPCFLAGS="$CFLAGS"; CONFIG_WITH_OPENMP=1
+    ],[])
     CFLAGS="$CFLAGS_OLD"
   fi
 done
@@ -468,17 +459,17 @@ fi
 AC_MSG_CHECKING([runtime compiler])
 if test -z "$RUNTIMECFLAGS"; then
   CFLAGS="$FPIC -Werror"
-  AC_TRY_LINK([], [return 0;], [AC_MSG_RESULT($CC ok);],[AC_MSG_ERROR($CC failed)])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[AC_MSG_RESULT($CC ok);],[AC_MSG_ERROR($CC failed)])
   CFLAGS="$FPIC"
   AC_MSG_CHECKING([runtime compiler CFLAGS])
   RUNTIMECFLAGS="$FPIC"
   for flag in -falign-functions -mfpmath=sse -fno-dollars-in-identifiers -Wno-parentheses-equality; do
     CFLAGS="$FPIC $flag -Werror"
-    AC_TRY_LINK([], [return 0;], [RUNTIMECFLAGS="$RUNTIMECFLAGS $flag"],[])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[RUNTIMECFLAGS="$RUNTIMECFLAGS $flag"],[])
   done
 else
   CFLAGS="$RUNTIMECFLAGS $FPIC -Werror"
-  AC_TRY_LINK([], [return 0;], [RUNTIMECFLAGS="$RUNTIMECFLAGS $FPIC"],[AC_MSG_ERROR([$CC $CFLAGS -Werror failed])])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[RUNTIMECFLAGS="$RUNTIMECFLAGS $FPIC"],[AC_MSG_ERROR([$CC $CFLAGS -Werror failed])])
 fi
 AC_MSG_RESULT([$RUNTIMECFLAGS])
 
@@ -540,7 +531,7 @@ AC_CHECK_LIB(sqlite3,sqlite3_libversion,[],[AC_MSG_ERROR([sqlite3 not found])])
 if test "$WANT_STATIC_SQLITE" = "no"; then
   OMC_LIBS=$LIBS
 elif test ! -f "$WANT_STATIC_SQLITE" ; then
-  AC_ERROR([File not found: $WANT_STATIC_SQLITE])
+  AC_MSG_ERROR(File not found: $WANT_STATIC_SQLITE)
 else
   OMC_LIBS=$WANT_STATIC_SQLITE
 fi
@@ -571,18 +562,18 @@ AC_CHECK_HEADERS(locale.h libintl.h,[],[HAVE_GETTEXT="#define NO_GETTEXT 1"])
 if test -z "$HAVE_GETTEXT"; then
   AC_MSG_CHECKING([gettext linking])
 
-  AC_TRY_LINK([
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
     #include <libintl.h>
-  ], [
+  ]], [[
   gettext("");
-  ], [AC_MSG_RESULT([in C-library])],
+  ]])], [AC_MSG_RESULT([in C-library])],
   [
     LIBS="-lintl";
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <libintl.h>
-    ], [
+    ]], [[
       gettext("");
-    ], [AC_MSG_RESULT([in intl]); GETTEXT_LIBS="-lintl"], [HAVE_GETTEXT="#define NO_GETTEXT 1"])
+    ]])], [AC_MSG_RESULT([in intl]); GETTEXT_LIBS="-lintl"], [HAVE_GETTEXT="#define NO_GETTEXT 1"])
   ])
 
   LIBS=""
@@ -591,22 +582,21 @@ if test -z "$HAVE_GETTEXT"; then
 
   AC_MSG_CHECKING([setlocale linking])
 
-  AC_TRY_LINK([
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
     /* Also include libintl.h as MacOS then uses a different setlocale... */
     #include <libintl.h>
     #include <locale.h>
-  ], [
+  ]], [[
     setlocale(LC_ALL, "");
-  ], [AC_MSG_RESULT([in C-library])],
-  [
+  ]])],[AC_MSG_RESULT([in C-library])],[
     LIBS="-lintl";
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       /* Also include libintl.h as MacOS then uses a different setlocale... */
       #include <libintl.h>
       #include <locale.h>
-    ], [
+    ]], [[
       setlocale(LC_ALL, "");
-    ], [AC_MSG_RESULT([in intl]); GETTEXT_LIBS="-lintl"], [AC_MSG_RESULT([no]); HAVE_GETTEXT="#define NO_GETTEXT 1"])
+    ]])], [AC_MSG_RESULT([in intl]); GETTEXT_LIBS="-lintl"], [AC_MSG_RESULT([no]); HAVE_GETTEXT="#define NO_GETTEXT 1"])
   ])
 
   fi
@@ -667,7 +657,7 @@ AS_IF([test "x$with_SUITESPARSE" = xyes],
 
 OLD_LDFLAGS="$LDFLAGS"
 LDFLAGS="$LDFLAGS -Wl,-Bstatic  -Wl,-Bdynamic"
-AC_TRY_LINK([], [return 0;], [BSTATIC="true"],[BSTATIC="false"; AC_MSG_RESULT(["Don't know the flags to force static linking"])])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[BSTATIC="true"],[BSTATIC="false"; AC_MSG_RESULT(["Don't know the flags to force static linking"])])
 LDFLAGS="$OLD_LDFLAGS"
 
 # check for ipopt
@@ -906,7 +896,7 @@ AC_MSG_NOTICE(["Given CMAKE: $OMC_CMAKE_EXE])
 OLD_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$CFLAGS $CXXFLAGS -Werror"
 AC_LANG_PUSH([C++])
-AC_TRY_LINK([], [], [CXXFLAGS="$CFLAGS $OLD_CXXFLAGS"], [CXXFLAGS="$OLD_CXXFLAGS"])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[CXXFLAGS="$CFLAGS $OLD_CXXFLAGS"],[CXXFLAGS="$OLD_CXXFLAGS"])
 AC_LANG_POP([C++])
 
 date=`date "+%Y-%m-%d %H:%M:%S"`
@@ -963,6 +953,7 @@ done
 
 AC_CONFIG_COMMANDS([omc_config.unix.h.fix],[./configure-post.sh $ac_cs_config])
 
-AC_OUTPUT(${GENERATED_AUTOCONF_FILES})
+AC_CONFIG_FILES([${GENERATED_AUTOCONF_FILES}])
+AC_OUTPUT
 
 echo -e "$FINAL_MESSAGES"

--- a/OMCompiler/m4/lapack.m4
+++ b/OMCompiler/m4/lapack.m4
@@ -18,7 +18,7 @@ AC_DEFUN([OMC_AC_LAPACK], [
     LAPACK_LINKER_FLAGS=""
     for flag in -Wl,--no-undefined; do
       LIBS="$LAPACK_LINKER_FLAGS $flag"
-      AC_TRY_LINK([], [return 0;], [LAPACK_LINKER_FLAGS="$LIBS"],[])
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])], [LAPACK_LINKER_FLAGS="$LIBS"],[])
     done
     LIBS=""
 

--- a/OMEdit/configure.ac
+++ b/OMEdit/configure.ac
@@ -158,7 +158,7 @@ exit(1);
 for flag in -Wno-clobbered; do
   OLD_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS $flag -Werror"
-  AC_TRY_LINK([], [return 0;], [CXXFLAGS="$OLD_CXXFLAGS $flag"],[CXXFLAGS="$OLD_CXXFLAGS"])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[CXXFLAGS="$OLD_CXXFLAGS $flag"],[CXXFLAGS="$OLD_CXXFLAGS"])
 done
 
 AC_MSG_CHECKING([for LSB description])
@@ -173,4 +173,5 @@ fi
 m4_include([common/m4/semver.m4])
 SOURCE_REVISION="$SOURCE_REVISION$NON_FREE_VERSION"
 
-AC_OUTPUT(Makefile.unix omedit_config.h OMEditLIB/OMEditLIB.unix.config.pri OMEditLIB/Debugger/Parser/Makefile.unix OMEditLIB/Debugger/Parser/Makefile.lib.unix OMEditGUI/OMEditGUI.unix.config.pri Testsuite/Makefile.unix)
+AC_CONFIG_FILES([Makefile.unix omedit_config.h OMEditLIB/OMEditLIB.unix.config.pri OMEditLIB/Debugger/Parser/Makefile.unix OMEditLIB/Debugger/Parser/Makefile.lib.unix OMEditGUI/OMEditGUI.unix.config.pri Testsuite/Makefile.unix])
+AC_OUTPUT

--- a/OMNotebook/configure.ac
+++ b/OMNotebook/configure.ac
@@ -38,4 +38,5 @@ DRMODELICADIR=`pwd`/DrModelica
 AC_SUBST([DRCONTROLDIR])
 AC_SUBST([DRMODELICADIR])
 
-AC_OUTPUT(Makefile OMNotebook/OMNotebookGUI/Makefile.unix OMNotebook/OMNotebookGUI/OMNotebook.config OMNotebook/OMNotebookGUI/omc_config.h)
+AC_CONFIG_FILES([Makefile OMNotebook/OMNotebookGUI/Makefile.unix OMNotebook/OMNotebookGUI/OMNotebook.config OMNotebook/OMNotebookGUI/omc_config.h])
+AC_OUTPUT

--- a/OMPlot/configure.ac
+++ b/OMPlot/configure.ac
@@ -35,4 +35,5 @@ m4_include([common/m4/qmake.m4])
 m4_include([common/m4/omhome.m4])
 FIND_OPENMODELICAHOME()
 
-AC_OUTPUT(Makefile qwt/Makefile.unix OMPlot/OMPlotGUI/Makefile.unix OMPlot/OMPlotGUI/OMPlotGUI.config qwt/qwt.config)
+AC_CONFIG_FILES([Makefile qwt/Makefile.unix OMPlot/OMPlotGUI/Makefile.unix OMPlot/OMPlotGUI/OMPlotGUI.config qwt/qwt.config])
+AC_OUTPUT

--- a/OMShell/configure.ac
+++ b/OMShell/configure.ac
@@ -68,5 +68,6 @@ else
   fi
 fi
 
-AC_OUTPUT(Makefile OMShell/OMShellGUI/Makefile.unix OMShell/OMShellGUI/OMShell.config mosh/src/Makefile OMShell/OMShellGUI/omc_config.h mosh/src/omc_config.h)
+AC_CONFIG_FILES([Makefile OMShell/OMShellGUI/Makefile.unix OMShell/OMShellGUI/OMShell.config mosh/src/Makefile OMShell/OMShellGUI/omc_config.h mosh/src/omc_config.h])
+AC_OUTPUT
 # AC_CONFIG_COMMANDS([Clean qmake stuff],[make clean])

--- a/common/m4/omhome.m4
+++ b/common/m4/omhome.m4
@@ -80,7 +80,7 @@ if test -z "$USINGPRESETBUILDDIR"; then
   # exact same command running outside of autoconf
   LDFLAGS_SAVE="$LDFLAGS"
   LDFLAGS="$LDFLAGS -L$OPENMODELICAHOME/lib/$host_short/omc -lOpenModelicaCompiler"
-  AC_TRY_LINK([], [], [AC_MSG_RESULT([ok])], [AC_MSG_ERROR([failed])])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])], [AC_MSG_RESULT([ok])], [AC_MSG_ERROR([failed])])
   LDFLAGS="$LDFLAGS_SAVE"
   AC_LANG_POP([C])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -62,4 +62,5 @@ if test ! -z "$USE_CORBA"; then
   AC_CONFIG_SUBDIRS([OMOptim])
 fi
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
- Use `AC_CONFIG_FILES` instead of giving arguments to `AC_OUTPUT`.
- Replace `AC_TRY_LINK` with `AC_LINK_IFELSE`.