### PR TITLE
Normalize paths to silence CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,11 +122,20 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 omc_add_to_report(CMAKE_INSTALL_PREFIX)
 
-# We prefer to install libs to "<library architecture>/omc" dir inside lib directory (e.g lib/x86_64-linux-gnu/omc/).
-set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/omc/")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  cmake_path(APPEND CMAKE_INSTALL_LIBDIR "${CMAKE_LIBRARY_ARCHITECTURE}" "omc")
+else()
+  set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/omc/")
+endif()
+message(STATUS "CMAKE_INSTALL_LIBDIR: ${CMAKE_INSTALL_LIBDIR}")
 
 # We prefer to install headers to "include/omc" dir inside.
-set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/omc/")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  cmake_path(APPEND CMAKE_INSTALL_INCLUDEDIR "omc")
+else()
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/omc/")
+endif()
+message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 
 # On macOS we want BUNDLEs (.app) to go to an 'Applications/' directory instead of a 'bin/' directory
 if(APPLE)

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -61,8 +61,15 @@ set(SOURCE_FMU_COMMON_FILES_LIST ./gc/memory_pool.c
 foreach(source_file ${SOURCE_FMU_COMMON_FILES_LIST})
   list(APPEND SOURCE_FMU_COMMON_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+    cmake_path(APPEND SOURCE_FMU_SOURCES_DEST_DIR "${SOURCE_FMU_SOURCES_DIR}" "${DEST_DIR}")
+    cmake_path(NORMAL_PATH SOURCE_FMU_SOURCES_DEST_DIR)
+  else()
+    set(SOURCE_FMU_SOURCES_DEST_DIR "${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}")
+  endif()
+
   install(FILES ${source_file}
-          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          DESTINATION ${SOURCE_FMU_SOURCES_DEST_DIR}
           COMPONENT fmu)
 endforeach()
 string(REPLACE ";" ",\n                                         " SOURCE_FMU_COMMON_FILES "${SOURCE_FMU_COMMON_FILES_LIST_QUOTED}")


### PR DESCRIPTION
- Use `cmake_path` if it's available to normalize some of the paths that CMake otherwise complains about.