### PR TITLE
CMake: Add an option to fetch bootstrap sources

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -2,35 +2,41 @@ cmake_minimum_required(VERSION 3.14)
 project(bomc)
 
 # fetch the sources from the OM server, maybe we should put them in git someplace
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz")
-# do nothing!
-else()
-#download and unpack the sources
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
-file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz
-     ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz
-     SHOW_PROGRESS
-     STATUS status
-     LOG log)
-# fetch the elements of the status!
-list(GET status 0 status_code)
-list(GET status 1 status_string)
-# check the download status!
-if(NOT status_code EQUAL 0)
-message(FATAL_ERROR "error: downloading 'https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz' failed
-        status_code: ${status_code}
-        status_string: ${status_string}
-        log: ${log}")
-endif()
-message(STATUS "downloading bootstrapping sources ... done")
-execute_process(COMMAND tar xzf sources.tar.gz --strip-components=1
-                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
-endif()
+option(OM_FETCH_BOOTSTRAP_SOURCES "Update bootstrap sources" ON)
+if (OM_FETCH_BOOTSTRAP_SOURCES)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz")
+  # do nothing!
+  else()
+    #download and unpack the sources
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
+    file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz
+        ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz
+        SHOW_PROGRESS
+        STATUS status
+        LOG log)
+    # fetch the elements of the status!
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
+    # check the download status!
+    if(NOT status_code EQUAL 0)
+      message(FATAL_ERROR "error: downloading 'https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz' failed
+              status_code: ${status_code}
+              status_string: ${status_string}
+              log: ${log}")
+    endif()
+    message(STATUS "downloading bootstrapping sources ... done")
+    execute_process(COMMAND tar xzf sources.tar.gz --strip-components=1
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
+  endif()
 
-# OpenModelicaBootstrappingHeader.h should probably be added to source control and
-# updated just like the bootstrap-source c files.
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bomc/tarball-include/OpenModelicaBootstrappingHeader.h
-                ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h)
+  # OpenModelicaBootstrappingHeader.h should probably be added to source control and
+  # updated just like the bootstrap-source c files.
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bomc/tarball-include/OpenModelicaBootstrappingHeader.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h)
+else ()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tarball-include/OpenModelicaBootstrappingHeader.h
+                  ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h)
+endif ()
 
 file(GLOB BOOTSTRAP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bomc/bootstrap-sources/build/*.c)
 

--- a/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
+++ b/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
@@ -1821,7 +1821,7 @@ extern struct record_description Absyn_Within_WITHIN__desc;
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_Class_CLASS__desc_added
 #define Absyn_Class_CLASS__desc_added
-ADD_METARECORD_DEFINITIONS const char* Absyn_Class_CLASS__desc__fields[7] = {"name","partialPrefix","finalPrefix","encapsulatedPrefix","restriction","body","info"};
+ADD_METARECORD_DEFINITIONS const char* Absyn_Class_CLASS__desc__fields[9] = {"name","partialPrefix","finalPrefix","encapsulatedPrefix","restriction","body","commentsBeforeEnd","commentsAfterEnd","info"};
 ADD_METARECORD_DEFINITIONS struct record_description Absyn_Class_CLASS__desc = {
   "Absyn_Class_CLASS",
   "Absyn.Class.CLASS",
@@ -1831,8 +1831,8 @@ ADD_METARECORD_DEFINITIONS struct record_description Absyn_Class_CLASS__desc = {
 #else /* Only use the file as a header */
 extern struct record_description Absyn_Class_CLASS__desc;
 #endif
-#define Absyn__CLASS_3dBOX7 3
-#define Absyn__CLASS(name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,info) (mmc_mk_box8(3,&Absyn_Class_CLASS__desc,name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,info))
+#define Absyn__CLASS_3dBOX9 3
+#define Absyn__CLASS(name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,commentsBeforeEnd,commentsAfterEnd,info) (mmc_mk_box(10, 3,&Absyn_Class_CLASS__desc,name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,commentsBeforeEnd,commentsAfterEnd,info))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_ClassDef_PDER__desc_added
 #define Absyn_ClassDef_PDER__desc_added


### PR DESCRIPTION
### Purpose

Allows for reproducible builds, as sometimes we dont want build depending on the state of some git repo
