### PR TITLE
Update OMCompiler/3rdParty on maintenance/v1.25

### DIFF
--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -373,7 +373,7 @@ sourcedist_internal:
 	 $(LIBF2C_OBJS:%=$(LAPACKDIR)/libf2c/%.c) \
 	 "./external_solvers/"
 	cp -p \
-	 "$(CMINPACKDIR)/minpack.h" "$(CMINPACKDIR)/cminpack.h" \
+	 "$(CMINPACKDIR)/minpack.h" "$(CMINPACKDIR)/minpackP.h" "$(CMINPACKDIR)/cminpack.h" \
 	 "$(LAPACKDIR)/include/blaswrap.h" \
 	 "$(LAPACKDIR)/include/clapack.h" \
 	 "$(LAPACKDIR)/include/f2c.h" \

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
@@ -34,7 +34,7 @@ encapsulated package RuntimeSources
 
   constant list<String> dgesv_sources={@SOURCE_FMU_DGESV_FILES@};
 
-  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h"};
+  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h", "./external_solvers/minpackP.h"};
 
   constant list<String> cminpack_sources = {@SOURCE_FMU_CMINPACK_FILES@};
 

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
@@ -29,7 +29,7 @@ encapsulated package RuntimeSources
   constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
   constant list<String> dgesv_sources={DGESV_FILES};
 
-  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h"};
+  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h", "./external_solvers/minpackP.h"};
   constant list<String> cminpack_sources = {CMINPACK_FILES};
 
   constant list<String> simrt_linear_solver_sources={LS_FILES};


### PR DESCRIPTION
get rid of gcc 15 issues with function pointers in f2c translated C files