### PR TITLE
Relax error checking when checking partial model

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -254,7 +254,7 @@ algorithm
     execStat("replaceArrayConstructors");
   end if;
 
-  VerifyModel.verify(flatModel);
+  VerifyModel.verify(flatModel, InstNode.isPartial(inst_cls));
 
   (flatModel, functions) := InstUtil.expandSlicedCrefs(flatModel, functions);
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -637,7 +637,7 @@ algorithm
     flat_model.variables := List.filterOnFalse(flat_model.variables, Variable.isEmptyArray);
   end if;
 
-  VerifyModel.verify(flat_model);
+  VerifyModel.verify(flat_model, InstNode.isPartial(inst_cls));
 
   // Convert the flat model to a DAE.
   (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs);

--- a/testsuite/flattening/modelica/arrays/Makefile
+++ b/testsuite/flattening/modelica/arrays/Makefile
@@ -133,6 +133,7 @@ MatrixRowIndexing.mo \
 MatrixSubtraction.mo \
 modelica_1_1_Array9.mo \
 NestedSubscriptFor.mo \
+OutOfBoundsPartial1.mos \
 PolynomialEvaluator1.mo \
 PolynomialEvaluator2.mo \
 PolynomialEvaluator3.mo \

--- a/testsuite/flattening/modelica/arrays/OutOfBoundsPartial1.mos
+++ b/testsuite/flattening/modelica/arrays/OutOfBoundsPartial1.mos
@@ -1,0 +1,26 @@
+// name:     OutOfBoundsCheck1
+// keywords: array subscript
+// status:   correct
+//
+// A partial model with out of bounds subscripts should not make checkModel fail.
+//
+
+loadString("
+  partial model M
+    Real x[1];
+  equation
+    x[2] = 1;
+  end M;
+");
+
+checkModel(M);
+getErrorString();
+
+// Result:
+// true
+// "Check of M completed successfully.
+// Class M has 1 equation(s) and 1 variable(s).
+// 1 of these are trivial equation(s)."
+// "[<interactive>:5:5-5:13:writable] Error: Subscript '2' for dimension 1 (size = 1) of x is out of bounds.
+// "
+// endResult

--- a/testsuite/flattening/modelica/equations/Makefile
+++ b/testsuite/flattening/modelica/equations/Makefile
@@ -54,6 +54,7 @@ WhenEquation.mo \
 WhenNestedEquation.mo \
 WhenNotInitial.mo \
 WhenNotValid.mo \
+WhenPartial1.mos \
 WhenValidResult.mo \
 WhenSemantics1.mo \
 WhenVectorPredicateEquation.mo \

--- a/testsuite/flattening/modelica/equations/WhenPartial1.mos
+++ b/testsuite/flattening/modelica/equations/WhenPartial1.mos
@@ -1,0 +1,26 @@
+// name:     WhenPartial1
+// keywords: when
+// status:   correct
+//
+// Discrete variables in a partial model does not need to be assigned in a when-equation.
+//
+
+loadString("
+  partial model M
+    Real x;
+    discrete Real xd;
+  equation
+    x = xd;
+  end M;
+");
+
+checkModel(M);
+getErrorString();
+
+// Result:
+// true
+// "Check of M completed successfully.
+// Class M has 1 equation(s) and 2 variable(s).
+// 1 of these are trivial equation(s)."
+// ""
+// endResult


### PR DESCRIPTION
- Skip checking when-requirements when checking a partial model.
- Don't fail when checking partial models with out of bounds subscripts.