### PR TITLE
Improve getAllSubtypeOf API

### DIFF
--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -3537,6 +3537,7 @@ end removeExtendsModifiersInElement;
 public function mkFullyQual
   input GraphicEnvCache env;
   input Absyn.Path ipath;
+  input Boolean failOnError = false;
   output FCore.Cache ocache;
   output Absyn.Path opath;
 protected
@@ -3546,7 +3547,7 @@ algorithm
   if Flags.isSet(Flags.NF_API) then
     ocache := cacheFromGraphicEnvCache(env);
     (program, cpath) := cacheProgramAndPath(env);
-    opath := NFApi.mkFullyQual(program, cpath, ipath);
+    opath := NFApi.mkFullyQual(program, cpath, ipath, failOnError);
   else
     (ocache, opath) := Inst.makeFullyQualified(cacheFromGraphicEnvCache(env), envFromGraphicEnvCache(env), ipath);
   end if;

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -2364,6 +2364,7 @@ end getElementAttributeValues;
 public function qualifyPath
   input GraphicEnvCache inEnv;
   input Absyn.Path inPath;
+  input Boolean failOnError = false;
   output Absyn.Path outPath;
 protected
   String n;
@@ -2378,12 +2379,16 @@ algorithm
       algorithm
         try
           if Flags.isSet(Flags.NF_API) then
-            (_, outPath) := Interactive.mkFullyQual(inEnv, inPath);
+            (_, outPath) := Interactive.mkFullyQual(inEnv, inPath, failOnError);
           else
             outPath := qualifyType(Interactive.envFromGraphicEnvCache(inEnv), inPath);
           end if;
         else
-          outPath := inPath;
+          if failOnError then
+            fail();
+          else
+            outPath := inPath;
+          end if;
         end try;
       then
         outPath;
@@ -3864,9 +3869,10 @@ algorithm
 
   try
     genv := createEnvironment(inProgram, NONE(), inParentClass);
-    fqpath := qualifyPath(genv, inClass);
+    fqpath := qualifyPath(genv, inClass, failOnError = true);
   else
-    fqpath := inClass;
+    paths := {};
+    return;
   end try;
 
   paths := {};

--- a/OMCompiler/Compiler/Stubs/NFApi.mo
+++ b/OMCompiler/Compiler/Stubs/NFApi.mo
@@ -57,6 +57,7 @@ function mkFullyQual
   input Absyn.Program absynProgram;
   input Absyn.Path classPath;
   input Absyn.Path pathToQualify;
+  input Boolean failOnError = false;
   output Absyn.Path qualPath = pathToQualify;
 end mkFullyQual;
 

--- a/testsuite/openmodelica/interactive-API/GetAllSubtypeOf4.mos
+++ b/testsuite/openmodelica/interactive-API/GetAllSubtypeOf4.mos
@@ -1,0 +1,24 @@
+// name: GetAllSubtypeOf4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the getAllSubtypeOf API function.
+//
+
+loadString("
+  model M1 = Base;
+
+  model M
+    M1 m1;
+  end M;
+");
+
+getAllSubtypeOf(Base, M, false, false, false);
+getErrorString();
+
+// Result:
+// true
+// {}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -48,6 +48,7 @@ ForStatement8.mos \
 GetAllSubtypeOf1.mos \
 GetAllSubtypeOf2.mos \
 GetAllSubtypeOf3.mos \
+GetAllSubtypeOf4.mos \
 getClassComment.mos \
 getClassNames.mos \
 getCommandLineOptions.mos \


### PR DESCRIPTION
- Return an empty list if the class being searched for does not exist.
- Use the top scope as scope in NFApi.frontEndLookup when searching all loaded classes instead of failing.