### PR TITLE
Create a connection and add it to the model instance

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -255,6 +255,16 @@ QString DynamicAnnotation::toQString() const
   return mExp.toQString();
 }
 
+/*!
+ * \brief DynamicAnnotation::serialize
+ * Unparses the Annotation into a JSON value.
+ * \return
+ */
+QJsonValue DynamicAnnotation::serialize() const
+{
+  return mExp.serialize();
+}
+
 void DynamicAnnotation::setExp()
 {
   if (mState == State::None) {

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -83,6 +83,7 @@ class DynamicAnnotation
     virtual FlatModelica::Expression toExp() const = 0;
     bool isDynamicSelectExpression() const;
     QString toQString() const;
+    QJsonValue serialize() const;
 
   protected:
     virtual void fromExp(const FlatModelica::Expression &exp) = 0;

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -91,6 +91,7 @@ public:
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
+  QJsonObject getShapeAnnotationJSON();
   void addPoint(QPointF point) override;
   void addGeometry();
   void removePoint(int index);
@@ -146,7 +147,7 @@ public:
   void updateOMSConnection();
   void updateToolTip();
   void showOMSConnection();
-  void updateTransistion(const QString& condition, const bool immediate, const bool rest, const bool synchronize, const int priority);
+  void updateTransistion();
   void setProperties(const QString& condition, const bool immediate, const bool rest, const bool synchronize, const int priority);
 
   static QColor findLineColorForConnection(Element *pComponent);

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -520,6 +520,24 @@ QString TextAnnotation::getShapeAnnotation()
   return QString("Text(").append(annotationString.join(",")).append(")");
 }
 
+/*!
+ * \brief TextAnnotation::getShapeAnnotationJSON
+ * Returns Text annotation in JSON format.
+ * \return
+ */
+QJsonObject TextAnnotation::getShapeAnnotationJSON()
+{
+  QJsonObject jsonObject;
+  jsonObject.insert("extent", mExtent.serialize());
+  jsonObject.insert("textString", mTextString.serialize());
+  jsonObject.insert("fontSize", mFontSize.serialize());
+  jsonObject.insert("textColor", mLineColor.serialize());
+  jsonObject.insert("fontName", mFontName.serialize());
+  jsonObject.insert("textStyle", mTextStyles.serialize());
+  jsonObject.insert("horizontalAlignment", mHorizontalAlignment.serialize());
+  return jsonObject;
+}
+
 void TextAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
 {
   // set the default values

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
@@ -66,6 +66,7 @@ public:
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
+  QJsonObject getShapeAnnotationJSON();
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
   ModelInstance::Extend *getExtend() const override;
   void setText(ModelInstance::Text *pText) {mpText = pText;}

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -373,43 +373,6 @@ void DeleteComponentCommand::undo()
   mpGraphicsView->addElementToClass(mpComponent);
 }
 
-AddConnectionCommand::AddConnectionCommand(LineAnnotation *pConnectionLineAnnotation, bool addConnection, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpConnectionLineAnnotation = pConnectionLineAnnotation;
-  mAddConnection = addConnection;
-  setText(QString("Add Connection connect(%1, %2)").arg(mpConnectionLineAnnotation->getStartElementName(), mpConnectionLineAnnotation->getEndElementName()));
-
-  mpConnectionLineAnnotation->drawCornerItems();
-  mpConnectionLineAnnotation->setCornerItemsActiveOrPassive();
-}
-
-/*!
- * \brief AddConnectionCommand::redoInternal
- * redoInternal the AddConnectionCommand.
- */
-void AddConnectionCommand::redoInternal()
-{
-  mpConnectionLineAnnotation->getGraphicsView()->addConnectionToView(mpConnectionLineAnnotation, false);
-  if (mAddConnection) {
-    if (!mpConnectionLineAnnotation->getGraphicsView()->addConnectionToClass(mpConnectionLineAnnotation)) {
-      setFailed(true);
-      return;
-    }
-  }
-  mpConnectionLineAnnotation->getGraphicsView()->getModelWidget()->setHandleCollidingConnectionsNeeded(true);
-}
-
-/*!
- * \brief AddConnectionCommand::undo
- * Undo the AddConnectionCommand.
- */
-void AddConnectionCommand::undo()
-{
-  mpConnectionLineAnnotation->getGraphicsView()->deleteConnectionFromClass(mpConnectionLineAnnotation);
-  mpConnectionLineAnnotation->getGraphicsView()->getModelWidget()->setHandleCollidingConnectionsNeeded(true);
-}
-
 UpdateConnectionCommand::UpdateConnectionCommand(LineAnnotation *pConnectionLineAnnotation, QString oldAnnotaton, QString newAnnotation, UndoCommand *pParent)
   : UndoCommand(pParent)
 {
@@ -441,66 +404,6 @@ void UpdateConnectionCommand::redrawConnectionWithAnnotation(QString const& anno
 {
   auto updateFunction = std::bind(&LineAnnotation::updateConnectionAnnotation, mpConnectionLineAnnotation);
   mpConnectionLineAnnotation->redraw(annotation, updateFunction);
-}
-
-DeleteConnectionCommand::DeleteConnectionCommand(LineAnnotation *pConnectionLineAnnotation, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpConnectionLineAnnotation = pConnectionLineAnnotation;
-  setText(QString("Delete Connection connect(%1, %2)").arg(mpConnectionLineAnnotation->getStartElementName(), mpConnectionLineAnnotation->getEndElementName()));
-}
-
-/*!
- * \brief DeleteConnectionCommand::redoInternal
- * redoInternal the DeleteConnectionCommand.
- */
-void DeleteConnectionCommand::redoInternal()
-{
-  mpConnectionLineAnnotation->getGraphicsView()->deleteConnectionFromClass(mpConnectionLineAnnotation);
-}
-
-/*!
- * \brief DeleteConnectionCommand::undo
- * Undo the DeleteConnectionCommand.
- */
-void DeleteConnectionCommand::undo()
-{
-  mpConnectionLineAnnotation->getGraphicsView()->addConnectionToView(mpConnectionLineAnnotation, false);
-  mpConnectionLineAnnotation->getGraphicsView()->addConnectionToClass(mpConnectionLineAnnotation, true);
-}
-
-AddTransitionCommand::AddTransitionCommand(LineAnnotation *pTransitionLineAnnotation, bool addTransition, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpTransitionLineAnnotation = pTransitionLineAnnotation;
-  mAddTransition = addTransition;
-  setText(QString("Add Transition transition(%1, %2)").arg(mpTransitionLineAnnotation->getStartElementName(), mpTransitionLineAnnotation->getEndElementName()));
-
-  mpTransitionLineAnnotation->updateToolTip();
-  mpTransitionLineAnnotation->drawCornerItems();
-  mpTransitionLineAnnotation->setCornerItemsActiveOrPassive();
-}
-
-/*!
- * \brief AddTransitionCommand::redoInternal
- * redoInternal the AddTransitionCommand.
- */
-void AddTransitionCommand::redoInternal()
-{
-  mpTransitionLineAnnotation->getGraphicsView()->addTransitionToView(mpTransitionLineAnnotation, false);
-  if (mAddTransition) {
-    mpTransitionLineAnnotation->getGraphicsView()->addTransitionToClass(mpTransitionLineAnnotation);
-  }
-}
-
-/*!
- * \brief AddTransitionCommand::undo
- * Undo the AddTransitionCommand.
- */
-void AddTransitionCommand::undo()
-{
-  mpTransitionLineAnnotation->getGraphicsView()->removeTransitionFromView(mpTransitionLineAnnotation);
-  mpTransitionLineAnnotation->getGraphicsView()->deleteTransitionFromClass(mpTransitionLineAnnotation);
 }
 
 UpdateTransitionCommand::UpdateTransitionCommand(LineAnnotation *pTransitionLineAnnotation, QString oldCondition, bool oldImmediate,
@@ -552,73 +455,15 @@ void UpdateTransitionCommand::redrawTransitionWithUpdateFunction(const QString& 
 void UpdateTransitionCommand::updateTransistionWithNewConditions()
 {
   mpTransitionLineAnnotation->setProperties(mNewCondition, mNewImmediate, mNewReset, mNewSynchronize, mNewPriority);
-  mpTransitionLineAnnotation->updateTransistion(mOldCondition, mOldImmediate, mOldReset, mOldSynchronize, mOldPriority);
+  mpTransitionLineAnnotation->updateTransistion();
+  mpTransitionLineAnnotation->updateTransitionAnnotation(mOldCondition, mOldImmediate, mOldReset, mOldSynchronize, mOldPriority);
 }
 
 void UpdateTransitionCommand::updateTransistionWithOldConditions()
 {
   mpTransitionLineAnnotation->setProperties(mOldCondition, mOldImmediate, mOldReset, mOldSynchronize, mOldPriority);
-  mpTransitionLineAnnotation->updateTransistion(mNewCondition, mNewImmediate, mNewReset, mNewSynchronize, mNewPriority);
-}
-
-DeleteTransitionCommand::DeleteTransitionCommand(LineAnnotation *pTransitionLineAnnotation, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpTransitionLineAnnotation = pTransitionLineAnnotation;
-}
-
-/*!
- * \brief DeleteTransitionCommand::redoInternal
- * redoInternal the DeleteTransitionCommand.
- */
-void DeleteTransitionCommand::redoInternal()
-{
-  mpTransitionLineAnnotation->getGraphicsView()->removeTransitionFromView(mpTransitionLineAnnotation);
-  mpTransitionLineAnnotation->getGraphicsView()->deleteTransitionFromClass(mpTransitionLineAnnotation);
-}
-
-/*!
- * \brief DeleteTransitionCommand::undo
- * Undo the DeleteTransitionCommand.
- */
-void DeleteTransitionCommand::undo()
-{
-  mpTransitionLineAnnotation->getGraphicsView()->addTransitionToView(mpTransitionLineAnnotation, false);
-  mpTransitionLineAnnotation->getGraphicsView()->addTransitionToClass(mpTransitionLineAnnotation);
-}
-
-AddInitialStateCommand::AddInitialStateCommand(LineAnnotation *pInitialStateLineAnnotation, bool addInitialState, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpInitialStateLineAnnotation = pInitialStateLineAnnotation;
-  mAddInitialState = addInitialState;
-  setText(QString("Add InitialState initialState(%1)").arg(mpInitialStateLineAnnotation->getStartElementName()));
-
-  mpInitialStateLineAnnotation->setToolTip(QString("<b>initialState</b>(%1)").arg(mpInitialStateLineAnnotation->getStartElementName()));
-  mpInitialStateLineAnnotation->drawCornerItems();
-  mpInitialStateLineAnnotation->setCornerItemsActiveOrPassive();
-}
-
-/*!
- * \brief AddInitialStateCommand::redoInternal
- * redoInternal the AddInitialStateCommand.
- */
-void AddInitialStateCommand::redoInternal()
-{
-  mpInitialStateLineAnnotation->getGraphicsView()->addInitialStateToView(mpInitialStateLineAnnotation, false);
-  if (mAddInitialState) {
-    mpInitialStateLineAnnotation->getGraphicsView()->addInitialStateToClass(mpInitialStateLineAnnotation);
-  }
-}
-
-/*!
- * \brief AddInitialStateCommand::undo
- * Undo the AddInitialStateCommand.
- */
-void AddInitialStateCommand::undo()
-{
-  mpInitialStateLineAnnotation->getGraphicsView()->removeInitialStateFromView(mpInitialStateLineAnnotation);
-  mpInitialStateLineAnnotation->getGraphicsView()->deleteInitialStateFromClass(mpInitialStateLineAnnotation);
+  mpTransitionLineAnnotation->updateTransistion();
+  mpTransitionLineAnnotation->updateTransitionAnnotation(mNewCondition, mNewImmediate, mNewReset, mNewSynchronize, mNewPriority);
 }
 
 UpdateInitialStateCommand::UpdateInitialStateCommand(LineAnnotation *pInitialStateLineAnnotation, QString oldAnnotaton, QString newAnnotation, UndoCommand *pParent)
@@ -652,32 +497,6 @@ void UpdateInitialStateCommand::redrawInitialStateWithAnnotation(const QString& 
 {
   auto updateFunction = std::bind(&LineAnnotation::updateInitialStateAnnotation ,mpInitialStateLineAnnotation);
   mpInitialStateLineAnnotation->redraw(annotation, updateFunction);
-}
-
-DeleteInitialStateCommand::DeleteInitialStateCommand(LineAnnotation *pInitialStateLineAnnotation, UndoCommand *pParent)
-  : UndoCommand(pParent)
-{
-  mpInitialStateLineAnnotation = pInitialStateLineAnnotation;
-}
-
-/*!
- * \brief DeleteInitialStateCommand::redoInternal
- * redoInternal the DeleteInitialStateCommand.
- */
-void DeleteInitialStateCommand::redoInternal()
-{
-  mpInitialStateLineAnnotation->getGraphicsView()->removeInitialStateFromView(mpInitialStateLineAnnotation);
-  mpInitialStateLineAnnotation->getGraphicsView()->deleteInitialStateFromClass(mpInitialStateLineAnnotation);
-}
-
-/*!
- * \brief DeleteInitialStateCommand::undo
- * Undo the DeleteInitialStateCommand.
- */
-void DeleteInitialStateCommand::undo()
-{
-  mpInitialStateLineAnnotation->getGraphicsView()->addInitialStateToView(mpInitialStateLineAnnotation, false);
-  mpInitialStateLineAnnotation->getGraphicsView()->addInitialStateToClass(mpInitialStateLineAnnotation);
 }
 
 UpdateCoordinateSystemCommand::UpdateCoordinateSystemCommand(GraphicsView *pGraphicsView, const ModelInstance::CoordinateSystem oldCoordinateSystem,

--- a/OMEdit/OMEditLIB/Modeling/Commands.h
+++ b/OMEdit/OMEditLIB/Modeling/Commands.h
@@ -130,17 +130,6 @@ private:
   GraphicsView *mpGraphicsView;
 };
 
-class AddConnectionCommand : public UndoCommand
-{
-public:
-  AddConnectionCommand(LineAnnotation *pConnectionLineAnnotation, bool addConnection, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpConnectionLineAnnotation;
-  bool mAddConnection;
-};
-
 class UpdateConnectionCommand : public UndoCommand
 {
 public:
@@ -152,27 +141,6 @@ private:
   LineAnnotation *mpConnectionLineAnnotation;
   QString mOldAnnotation;
   QString mNewAnnotation;
-};
-
-class DeleteConnectionCommand : public UndoCommand
-{
-public:
-  DeleteConnectionCommand(LineAnnotation *pConnectionLineAnnotation, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpConnectionLineAnnotation;
-};
-
-class AddTransitionCommand : public UndoCommand
-{
-public:
-  AddTransitionCommand(LineAnnotation *pTransitionLineAnnotation, bool addTransition, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpTransitionLineAnnotation;
-  bool mAddTransition;
 };
 
 class UpdateTransitionCommand : public UndoCommand
@@ -202,27 +170,6 @@ private:
   QString mNewAnnotation;
 };
 
-class DeleteTransitionCommand : public UndoCommand
-{
-public:
-  DeleteTransitionCommand(LineAnnotation *pTransitionLineAnnotation, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpTransitionLineAnnotation;
-};
-
-class AddInitialStateCommand : public UndoCommand
-{
-public:
-  AddInitialStateCommand(LineAnnotation *pInitialStateLineAnnotation, bool addInitialState, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpInitialStateLineAnnotation;
-  bool mAddInitialState;
-};
-
 class UpdateInitialStateCommand : public UndoCommand
 {
 public:
@@ -234,16 +181,6 @@ private:
   LineAnnotation *mpInitialStateLineAnnotation;
   QString mOldAnnotation;
   QString mNewAnnotation;
-};
-
-class DeleteInitialStateCommand : public UndoCommand
-{
-public:
-  DeleteInitialStateCommand(LineAnnotation *pInitialStateLineAnnotation, UndoCommand *pParent = 0);
-  void redoInternal();
-  void undo();
-private:
-  LineAnnotation *mpInitialStateLineAnnotation;
 };
 
 class UpdateCoordinateSystemCommand : public UndoCommand

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -629,8 +629,14 @@ private:
     QList<Element *> getComponents() const;
     size_t componentCount() const;
     const QList<Import> &getImports() const {return mImports;}
+    void addConnection(Connection *pConnection) {mConnections.append(pConnection);}
+    void removeConnection(const QString &startConnectorName, const QString &endConnectorName);
     const QList<Connection *> &getConnections() const {return mConnections;}
+    void addTransition(Transition *pTransition) {mTransitions.append(pTransition);}
+    void removeTransition(const QString &startConnectorName, const QString &endConnectorName);
     const QList<Transition *> &getTransitions() const {return mTransitions;}
+    void addInitialState(InitialState *pInitialState) {mInitialStates.append(pInitialState);}
+    void removeInitialState(const QString &startConnectorName);
     const QList<InitialState *> &getInitialStates() const {return mInitialStates;}
     const Source &getSource() const {return mSource;}
 
@@ -845,6 +851,7 @@ private:
   {
   public:
     Connector();
+    Connector(const QString &kind, const QString &name);
     void deserialize(const QJsonObject &jsonObject);
 
     QString getName() const;
@@ -870,6 +877,7 @@ private:
   {
   public:
     Connection(Model *pParentModel);
+    Connection(Model *pParentModel, const QString &startConnector, const QString &endConnector, const QJsonObject &annotationJsonObject);
     void deserialize(const QJsonObject &jsonObject);
 
     Model *getParentModel() const {return mpParentModel;}
@@ -888,16 +896,23 @@ private:
   {
   public:
     Transition(Model *pParentModel);
+    Transition(Model *pParentModel, const QString &startConnector, const QString &endConnector, bool condition, bool immediate, bool reset,
+               bool synchronize, int priority, const QJsonObject &annotationJsonObject);
     void deserialize(const QJsonObject &jsonObject);
 
     Model *getParentModel() const {return mpParentModel;}
     Connector *getStartConnector() const {return mpStartConnector.get();}
     Connector *getEndConnector() const {return mpEndConnector.get();}
     bool getCondition() const {return mCondition;}
+    void setCondition(bool condition) {mCondition = condition;}
     bool getImmediate() const {return mImmediate;}
+    void setImmediate(bool immediate) {mImmediate = immediate;}
     bool getReset() const {return mReset;}
+    void setReset(bool reset) {mReset = reset;}
     bool getSynchronize() const {return mSynchronize;}
+    void setSynchronize(bool synchronize) {mSynchronize = synchronize;}
     int getPriority() const {return mPriority;}
+    void setPriority(int priority) {mPriority = priority;}
     Annotation *getAnnotation() const;
     QString toString() const;
   private:
@@ -916,6 +931,7 @@ private:
   {
   public:
     InitialState(Model *pParentModel);
+    InitialState(Model *pParentModel, const QString &startConnector, const QJsonObject &annotationJsonObject);
     void deserialize(const QJsonObject &jsonObject);
 
     Model *getParentModel() const {return mpParentModel;}

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -450,8 +450,6 @@ void GraphicsView::drawConnections(ModelInstance::Model *pModelInstance, bool in
         modelInfoIndex++;
         if (modelInfo.mConnectionsList.isEmpty() || inherited) {
           LineAnnotation *pConnectionLineAnnotation = new LineAnnotation(pConnection, pStartConnectorElement, pEndConnectorElement, inherited, this);
-          pConnectionLineAnnotation->drawCornerItems();
-          pConnectionLineAnnotation->setCornerItemsActiveOrPassive();
           addConnectionToView(pConnectionLineAnnotation, inherited);
         } else { // update case
           if (modelInfoIndex < modelInfo.mConnectionsList.size()) {
@@ -522,8 +520,6 @@ void GraphicsView::drawTransitions(ModelInstance::Model *pModelInstance, bool in
         modelInfoIndex++;
         if (modelInfo.mTransitionsList.isEmpty() || inherited) {
           LineAnnotation *pTransitionLineAnnotation = new LineAnnotation(pTransition, pStartElement, pEndElement, inherited, this);
-          pTransitionLineAnnotation->drawCornerItems();
-          pTransitionLineAnnotation->setCornerItemsActiveOrPassive();
           addTransitionToView(pTransitionLineAnnotation, inherited);
         } else { // update case
           if (modelInfoIndex < modelInfo.mTransitionsList.size()) {
@@ -578,8 +574,6 @@ void GraphicsView::drawInitialStates(ModelInstance::Model *pModelInstance, bool 
         modelInfoIndex++;
         if (modelInfo.mInitialStatesList.isEmpty() || inherited) {
           LineAnnotation *pInitialStateLineAnnotation = new LineAnnotation(pInitialState, pStartElement, inherited, this);
-          pInitialStateLineAnnotation->drawCornerItems();
-          pInitialStateLineAnnotation->setCornerItemsActiveOrPassive();
           addInitialStateToView(pInitialStateLineAnnotation, inherited);
         } else { // update case
           if (modelInfoIndex < modelInfo.mInitialStatesList.size()) {
@@ -836,7 +830,7 @@ ModelInstance::Component *GraphicsView::createModelInstanceComponent(ModelInstan
   MainWindow::instance()->getOMCProxy()->deleteClass(dummyClass);
   const QJsonArray elementsArray = modelJSON.value("elements").toArray();
   if (!elementsArray.isEmpty()) {
-    pModelInstance->deserializeElements(modelJSON.value("elements").toArray());
+    pModelInstance->deserializeElements(elementsArray);
     QList<ModelInstance::Element*> elements = pModelInstance->getElements();
     if (!elements.isEmpty()) {
       return dynamic_cast<ModelInstance::Component*>(elements.last());
@@ -1303,6 +1297,53 @@ bool GraphicsView::checkElementName(const QString &nameStructure, QString elemen
 }
 
 /*!
+ * \brief GraphicsView::createModelInstanceConnection
+ * Creates a Connection and returns it.
+ * \param pModelInstance
+ * \param pConnectionLineAnnotation
+ * \return
+ */
+ModelInstance::Connection *GraphicsView::createModelInstanceConnection(ModelInstance::Model *pModelInstance, LineAnnotation *pConnectionLineAnnotation)
+{
+  ModelInstance::Connection *pConnection = new ModelInstance::Connection(pModelInstance, pConnectionLineAnnotation->getStartElementName(),
+                                                                         pConnectionLineAnnotation->getEndElementName(), pConnectionLineAnnotation->getShapeAnnotationJSON());
+  pModelInstance->addConnection(pConnection);
+  return pConnection;
+}
+
+/*!
+ * \brief GraphicsView::addConnectionHelper
+ * Helper function to add connection.
+ * \param pConnectionLineAnnotation
+ * \return
+ */
+bool GraphicsView::addConnectionHelper(LineAnnotation *pConnectionLineAnnotation)
+{
+  const QString startElementName = pConnectionLineAnnotation->getStartElementName();
+  const QString endElementName = pConnectionLineAnnotation->getEndElementName();
+  if (mpModelWidget->getModelInstance()->isValidConnection(startElementName, endElementName)) {
+    ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
+    ModelInstance::Connection *pConnection = GraphicsView::createModelInstanceConnection(mpModelWidget->getModelInstance(), pConnectionLineAnnotation);
+    if (pConnection) {
+      addConnectionToView(pConnectionLineAnnotation, false);
+      addConnectionToClass(pConnectionLineAnnotation);
+      ModelInfo newModelInfo = mpModelWidget->createModelInfo();
+      mpModelWidget->getUndoStack()->push(new OMCUndoCommand(mpModelWidget->getLibraryTreeItem(), oldModelInfo, newModelInfo, "Add Connection", true));
+      mpModelWidget->updateModelText();
+      return true;
+    } else {
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Failed to add connection <b>connect(%1, %2)</b>.").arg(startElementName, endElementName),
+                                                            Helper::scriptingKind, Helper::errorLevel));
+      return false;
+    }
+  } else {
+    QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                          GUIMessages::getMessage(GUIMessages::MISMATCHED_CONNECTORS_IN_CONNECT).arg(startElementName, endElementName), QMessageBox::Ok);
+    return false;
+  }
+}
+
+/*!
  * \brief GraphicsView::connectionExists
  * Checks if the connection already exists.
  * \param startElementName
@@ -1406,6 +1447,10 @@ void GraphicsView::addConnectionDetails(LineAnnotation *pConnectionLineAnnotatio
  */
 void GraphicsView::addConnectionToView(LineAnnotation *pConnectionLineAnnotation, bool inherited)
 {
+  // first remove any corner items if they exist just to avoid double drawing
+  pConnectionLineAnnotation->removeCornerItems();
+  pConnectionLineAnnotation->drawCornerItems();
+  pConnectionLineAnnotation->setCornerItemsActiveOrPassive();
   addConnectionDetails(pConnectionLineAnnotation);
   if (inherited) {
     addInheritedConnectionToList(pConnectionLineAnnotation);
@@ -1587,10 +1632,14 @@ void GraphicsView::deleteConnectionFromClass(LineAnnotation *pConnectionLineAnno
       }
     }
   }
-  // Call removeConnectionDetails() now to remove the conneciton and set the start and end connector element to nullptr.
+  // Call removeConnectionDetails() now to remove the connection and set the start and end connector element to nullptr.
   removeConnectionDetails(pConnectionLineAnnotation);
   addConnectionToOutOfSceneList(pConnectionLineAnnotation);
   removeItem(pConnectionLineAnnotation);
+  // Since we don't call getModelInstance on deleting a connection so we need to update instance JSON manually by removing the connection from it.
+  if (mpModelWidget->getModelInstance()) {
+    mpModelWidget->getModelInstance()->removeConnection(pConnectionLineAnnotation->getStartElementName(), pConnectionLineAnnotation->getEndElementName());
+  }
 }
 
 /*!
@@ -1636,18 +1685,6 @@ void GraphicsView::removeConnectionDetails(LineAnnotation *pConnectionLineAnnota
     }
   }
   pConnectionLineAnnotation->setEndElement(0);
-}
-
-/*!
- * \brief GraphicsView::removeConnectionsFromView
- * Removes the connections from the view.
- */
-void GraphicsView::removeConnectionsFromView()
-{
-  foreach (LineAnnotation *pConnectionLineAnnotation, mConnectionsList) {
-    deleteConnectionFromList(pConnectionLineAnnotation);
-    removeItem(pConnectionLineAnnotation);
-  }
 }
 
 /*!
@@ -1707,6 +1744,84 @@ QString GraphicsView::getConnectorName(Element *pConnector)
 }
 
 /*!
+ * \brief GraphicsView::createModelInstanceTransition
+ * Creates a transition object and adds it to the model instance.
+ * \param pModelInstance
+ * \param pTransitionLineAnnotation
+ * \return
+ */
+ModelInstance::Transition *GraphicsView::createModelInstanceTransition(ModelInstance::Model *pModelInstance, LineAnnotation *pTransitionLineAnnotation)
+{
+  //! @todo We should change condition to expression instead of boolean value.
+  ModelInstance::Transition *pTransition = new ModelInstance::Transition(pModelInstance, pTransitionLineAnnotation->getStartElementName(),
+                                                                         pTransitionLineAnnotation->getEndElementName(), /*pTransitionLineAnnotation->getCondition()*/true,
+                                                                         pTransitionLineAnnotation->getImmediate(), pTransitionLineAnnotation->getReset(),
+                                                                         pTransitionLineAnnotation->getSynchronize(), pTransitionLineAnnotation->getPriority(),
+                                                                         pTransitionLineAnnotation->getShapeAnnotationJSON());
+  pModelInstance->addTransition(pTransition);
+  return pTransition;
+}
+
+/*!
+ * \brief GraphicsView::addTransitionHelper
+ * Helper function to add the transition.
+ * \param pTransitionLineAnnotation
+ * \return
+ */
+bool GraphicsView::addTransitionHelper(LineAnnotation *pTransitionLineAnnotation)
+{
+  const QString startElementName = pTransitionLineAnnotation->getStartElementName();
+  const QString endElementName = pTransitionLineAnnotation->getEndElementName();
+  ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
+  ModelInstance::Transition *pTransition = GraphicsView::createModelInstanceTransition(mpModelWidget->getModelInstance(), pTransitionLineAnnotation);
+  if (pTransition) {
+    addTransitionToView(pTransitionLineAnnotation, false);
+    addTransitionToClass(pTransitionLineAnnotation);
+    ModelInfo newModelInfo = mpModelWidget->createModelInfo();
+    mpModelWidget->getUndoStack()->push(new OMCUndoCommand(mpModelWidget->getLibraryTreeItem(), oldModelInfo, newModelInfo, "Add Transition", true));
+    mpModelWidget->updateModelText();
+    return true;
+  } else {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Failed to add transition <b>transition(%1, %2)</b>.").arg(startElementName, endElementName),
+                                                          Helper::scriptingKind, Helper::errorLevel));
+    return false;
+  }
+}
+
+/*!
+ * \brief GraphicsView::updateTransition
+ * Updates the transition.
+ * \param pTransitionLineAnnotation
+ * \return
+ */
+bool GraphicsView::updateTransition(LineAnnotation *pTransitionLineAnnotation)
+{
+  const QString startElementName = pTransitionLineAnnotation->getStartElementName();
+  const QString endElementName = pTransitionLineAnnotation->getEndElementName();
+  ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
+  QList<ModelInstance::Transition*> transitions = mpModelWidget->getModelInstance()->getTransitions();
+  for (int i = 0; i < transitions.size(); ++i) {
+    auto pTransition = transitions.at(i);
+    if (pTransition->getStartConnector()->getName().compare(startElementName) == 0 && pTransition->getEndConnector()->getName().compare(endElementName) == 0) {
+      //! @todo We should change condition to expression instead of boolean value.
+      pTransition->setCondition(/*pTransitionLineAnnotation->getCondition()*/true);
+      pTransition->setImmediate(pTransitionLineAnnotation->getImmediate());
+      pTransition->setReset(pTransitionLineAnnotation->getReset());
+      pTransition->setSynchronize(pTransitionLineAnnotation->getSynchronize());
+      pTransition->setPriority(pTransitionLineAnnotation->getPriority());
+      ModelInfo newModelInfo = mpModelWidget->createModelInfo();
+      mpModelWidget->getUndoStack()->push(new OMCUndoCommand(mpModelWidget->getLibraryTreeItem(), oldModelInfo, newModelInfo, "Add Transition", true));
+      mpModelWidget->updateModelText();
+      return true;
+    }
+  }
+
+  MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Failed to update transition <b>transition(%1, %2)</b>.").arg(startElementName, endElementName),
+                                                        Helper::scriptingKind, Helper::errorLevel));
+  return false;
+}
+
+/*!
  * \brief GraphicsView::addTransitionToView
  * Adds the transition to the view.
  * \param pTransitionLineAnnotation
@@ -1714,6 +1829,10 @@ QString GraphicsView::getConnectorName(Element *pConnector)
  */
 void GraphicsView::addTransitionToView(LineAnnotation *pTransitionLineAnnotation, bool inherited)
 {
+  // first remove any corner items if they exist just to avoid double drawing
+  pTransitionLineAnnotation->removeCornerItems();
+  pTransitionLineAnnotation->drawCornerItems();
+  pTransitionLineAnnotation->setCornerItemsActiveOrPassive();
   addConnectionDetails(pTransitionLineAnnotation);
   if (inherited) {
     addInheritedTransitionToList(pTransitionLineAnnotation);
@@ -1777,6 +1896,11 @@ void GraphicsView::deleteTransitionFromClass(LineAnnotation *pTransitionLineAnno
                               pTransitionLineAnnotation->getEndElementName(), pTransitionLineAnnotation->getCondition(),
                               pTransitionLineAnnotation->getImmediate(), pTransitionLineAnnotation->getReset(),
                               pTransitionLineAnnotation->getSynchronize(), pTransitionLineAnnotation->getPriority());
+
+  // Since we don't call getModelInstance on deleting a transition so we need to update instance JSON manually by removing the transition from it.
+  if (mpModelWidget->getModelInstance()) {
+    mpModelWidget->getModelInstance()->removeTransition(pTransitionLineAnnotation->getStartElementName(), pTransitionLineAnnotation->getEndElementName());
+  }
 }
 
 /*!
@@ -1792,6 +1916,21 @@ void GraphicsView::removeTransitionsFromView()
 }
 
 /*!
+ * \brief GraphicsView::createModelInstanceInitialState
+ * Creates the InitialState object and adds it to the model instance.
+ * \param pModelInstance
+ * \param pInitialStateLineAnnotation
+ * \return
+ */
+ModelInstance::InitialState *GraphicsView::createModelInstanceInitialState(ModelInstance::Model *pModelInstance, LineAnnotation *pInitialStateLineAnnotation)
+{
+  ModelInstance::InitialState *pInitialState = new ModelInstance::InitialState(pModelInstance, pInitialStateLineAnnotation->getStartElementName(),
+                                                                               pInitialStateLineAnnotation->getShapeAnnotationJSON());
+  pModelInstance->addInitialState(pInitialState);
+  return pInitialState;
+}
+
+/*!
  * \brief GraphicsView::addInitialStateToView
  * Adds the initial state to the view.
  * \param pInitialStateLineAnnotation
@@ -1799,6 +1938,10 @@ void GraphicsView::removeTransitionsFromView()
  */
 void GraphicsView::addInitialStateToView(LineAnnotation *pInitialStateLineAnnotation, bool inherited)
 {
+  // first remove any corner items if they exist just to avoid double drawing
+  pInitialStateLineAnnotation->removeCornerItems();
+  pInitialStateLineAnnotation->drawCornerItems();
+  pInitialStateLineAnnotation->setCornerItemsActiveOrPassive();
   addConnectionDetails(pInitialStateLineAnnotation);
   if (inherited) {
     addInheritedInitialStateToList(pInitialStateLineAnnotation);
@@ -1845,6 +1988,10 @@ void GraphicsView::deleteInitialStateFromClass(LineAnnotation *pInitialStateLine
 {
   OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
   pOMCProxy->deleteInitialState(mpModelWidget->getLibraryTreeItem()->getNameStructure(), pInitialStateLineAnnotation->getStartElementName());
+  // Since we don't call getModelInstance on deleting a initial state so we need to update instance JSON manually by removing the initial state from it.
+  if (mpModelWidget->getModelInstance()) {
+    mpModelWidget->getModelInstance()->removeInitialState(pInitialStateLineAnnotation->getStartElementName());
+  }
 }
 
 /*!
@@ -3208,8 +3355,6 @@ void GraphicsView::addConnection(Element *pElement, bool createConnector)
         mpConnectionLineAnnotation->setStartElementName(startElementName);
         mpConnectionLineAnnotation->setEndElementName(endElementName);
         if (mpModelWidget->getLibraryTreeItem()->isSSP()) {
-          mpConnectionLineAnnotation->drawCornerItems();
-          mpConnectionLineAnnotation->setCornerItemsActiveOrPassive();
           addConnectionToView(mpConnectionLineAnnotation, false);
           if (addConnectionToClass(mpConnectionLineAnnotation)) {
             mpModelWidget->createOMSimulatorUndoCommand(QString("Add OMS Connection connect(%1, %2)").arg(mpConnectionLineAnnotation->getStartElementName(),
@@ -3225,16 +3370,9 @@ void GraphicsView::addConnection(Element *pElement, bool createConnector)
              * We know for sure that both connectors are compatible in this case so its okay not to check for validity.
              */
             if (createConnector) {
-              mpConnectionLineAnnotation->drawCornerItems();
-              mpConnectionLineAnnotation->setCornerItemsActiveOrPassive();
               addConnectionToView(mpConnectionLineAnnotation, false);
               addConnectionToClass(mpConnectionLineAnnotation);
-            } else if (mpModelWidget->getModelInstance()->isValidConnection(startElementName, endElementName)) {
-              mpModelWidget->getUndoStack()->push(new AddConnectionCommand(mpConnectionLineAnnotation, true));
-              mpModelWidget->updateModelText();
-            } else {
-              QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                                    GUIMessages::getMessage(GUIMessages::MISMATCHED_CONNECTORS_IN_CONNECT).arg(startElementName, endElementName), QMessageBox::Ok);
+            } else if (!addConnectionHelper(mpConnectionLineAnnotation)) {
               removeCurrentConnection();
             }
           } else {
@@ -3939,8 +4077,6 @@ void GraphicsView::pasteItems(QPointF positionOffset)
           // the start and end element of connection is added in ModelWidget::drawConnections() when the connection is updated
           pConnectionLineAnnotation->setStartElementName(connectionObject.value("from").toString());
           pConnectionLineAnnotation->setEndElementName(connectionObject.value("to").toString());
-          pConnectionLineAnnotation->drawCornerItems();
-          pConnectionLineAnnotation->setCornerItemsActiveOrPassive();
           // always add the connections to diagram layer.
           GraphicsView *pDiagramGraphicsView = mpModelWidget->getDiagramGraphicsView();
           pDiagramGraphicsView->addConnectionToView(pConnectionLineAnnotation, false);
@@ -4280,8 +4416,16 @@ void GraphicsView::setInitialState()
     mpTransitionLineAnnotation->setStartElementName(startComponentName);
     mpTransitionLineAnnotation->setEndElementName("");
     mpTransitionLineAnnotation->setLineType(LineAnnotation::InitialStateType);
-    mpModelWidget->getUndoStack()->push(new AddInitialStateCommand(mpTransitionLineAnnotation, true));
-    mpModelWidget->updateModelText();
+
+    ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
+    ModelInstance::InitialState *pInitialState = GraphicsView::createModelInstanceInitialState(mpModelWidget->getModelInstance(), mpTransitionLineAnnotation);
+    if (pInitialState) {
+      addInitialStateToView(mpTransitionLineAnnotation, false);
+      addInitialStateToClass(mpTransitionLineAnnotation);
+      ModelInfo newModelInfo = mpModelWidget->createModelInfo();
+      mpModelWidget->getUndoStack()->push(new OMCUndoCommand(mpModelWidget->getLibraryTreeItem(), oldModelInfo, newModelInfo, "Add Initial State", true));
+      mpModelWidget->updateModelText();
+    }
     setIsCreatingTransition(false);
   }
 }
@@ -7190,8 +7334,6 @@ void ModelWidget::drawOMSModelConnections()
         pConnectionLineAnnotation->setStartElementName(pStartConnectorComponent->getLibraryTreeItem() ? pStartConnectorComponent->getLibraryTreeItem()->getNameStructure() : "");
         pConnectionLineAnnotation->setEndElementName(pEndConnectorComponent->getLibraryTreeItem() ? pEndConnectorComponent->getLibraryTreeItem()->getNameStructure() : "");
         pConnectionLineAnnotation->setOMSConnectionType(pConnections[i]->type);
-        pConnectionLineAnnotation->drawCornerItems();
-        pConnectionLineAnnotation->setCornerItemsActiveOrPassive();
         mpDiagramGraphicsView->addConnectionToView(pConnectionLineAnnotation, false);
         // Check if the connectors of the connection belongs to a bus
         if (pStartConnectorComponent->isInBus() && pEndConnectorComponent->isInBus()) {

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -270,6 +270,8 @@ public:
   QList<Element*> getElementsList() {return mElementsList;}
   QList<Element*> getInheritedElementsList() {return mInheritedElementsList;}
   QList<LineAnnotation*> getConnectionsList() {return mConnectionsList;}
+  static ModelInstance::Connection* createModelInstanceConnection(ModelInstance::Model *pModelInstance, LineAnnotation *pConnectionLineAnnotation);
+  bool addConnectionHelper(LineAnnotation *pConnectionLineAnnotation);
   bool connectionExists(const QString &startElementName, const QString &endElementName, bool inherited);
   void addConnectionDetails(LineAnnotation *pConnectionLineAnnotation);
   void addConnectionToView(LineAnnotation *pConnectionLineAnnotation, bool inherited);
@@ -281,11 +283,13 @@ public:
   void deleteConnectionFromList(LineAnnotation *pConnectionLineAnnotation) {mConnectionsList.removeOne(pConnectionLineAnnotation);}
   void deleteConnectionFromOutOfSceneList(LineAnnotation *pConnectionLineAnnotation) {mOutOfSceneConnectionsList.removeOne(pConnectionLineAnnotation);}
   void removeConnectionDetails(LineAnnotation *pConnectionLineAnnotation);
-  void removeConnectionsFromView();
   void deleteInheritedConnectionFromList(LineAnnotation *pConnectionLineAnnotation) {mInheritedConnectionsList.removeOne(pConnectionLineAnnotation);}
   int numberOfElementConnections(Element *pElement, LineAnnotation *pExcludeConnectionLineAnnotation = 0);
   QString getConnectorName(Element *pConnector);
   QList<LineAnnotation*> getTransitionsList() {return mTransitionsList;}
+  static ModelInstance::Transition* createModelInstanceTransition(ModelInstance::Model *pModelInstance, LineAnnotation *pTransitionLineAnnotation);
+  bool addTransitionHelper(LineAnnotation *pTransitionLineAnnotation);
+  bool updateTransition(LineAnnotation *pTransitionLineAnnotation);
   void addTransitionToView(LineAnnotation *pTransitionLineAnnotation, bool inherited);
   void addTransitionToClass(LineAnnotation *pTransitionLineAnnotation);
   void removeTransitionFromView(LineAnnotation *pTransitionLineAnnotation);
@@ -298,6 +302,7 @@ public:
   void removeTransitionsFromView();
   void deleteInheritedTransitionFromList(LineAnnotation *pTransitionLineAnnotation) {mInheritedTransitionsList.removeOne(pTransitionLineAnnotation);}
   QList<LineAnnotation*> getInitialStatesList() {return mInitialStatesList;}
+  static ModelInstance::InitialState* createModelInstanceInitialState(ModelInstance::Model *pModelInstance, LineAnnotation *pInitialStateLineAnnotation);
   void addInitialStateToView(LineAnnotation *pInitialStateLineAnnotation, bool inherited);
   void addInitialStateToClass(LineAnnotation *pInitialStateLineAnnotation);
   void removeInitialStateFromView(LineAnnotation *pInitialStateLineAnnotation);

--- a/OMEdit/OMEditLIB/OMS/BusDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/BusDialog.cpp
@@ -1835,8 +1835,6 @@ void TLMConnectionDialog::addTLMConnection()
     mpConnectionLineAnnotation->setZfr(mpAngularImpedanceTextBox->text());
     mpConnectionLineAnnotation->setOMSConnectionType(oms_connection_tlm);
 
-    mpConnectionLineAnnotation->drawCornerItems();
-    mpConnectionLineAnnotation->setCornerItemsActiveOrPassive();
     mpGraphicsView->addConnectionToView(mpConnectionLineAnnotation, false);
     if (mpGraphicsView->addConnectionToClass(mpConnectionLineAnnotation)) {
       mpGraphicsView->getModelWidget()->createOMSimulatorUndoCommand(QString("Add TLM Connection connect(%1, %2)").arg(mpConnectionLineAnnotation->getStartElementName(),


### PR DESCRIPTION
#13888
When we create a connection we don't call `getModelInstance()`. So in order to keep the model instance synchronized with the model. We need to add the connection to the model instance and similarly remove it when connection is deleted.

Do the same for transition and initial state.