### PR TITLE
Only clear the shapes when in element mode

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -6381,14 +6381,18 @@ void ModelWidget::reDrawModelWidget(const ModelInfo &modelInfo)
     mpDiagramGraphicsView->resetCoordinateSystem();
   }
   // reset if we are inside element mode
-  clearGraphicsViewsExceptOutOfSceneItems();
-  mModelInstanceList.clear();
-  mModelInstancesPos = -1;
-  mpElementModeLabel->setText("");
-  mPreservedIconShapesList.clear();
-  mPreservedDiagramShapesList.clear();
-  setComponentModified(false);
-  updateElementModeButtons();
+  if (isElementMode()) {
+    clearGraphicsViewsExceptOutOfSceneItems();
+    mModelInstanceList.clear();
+    mModelInstancesPos = -1;
+    mpElementModeLabel->setText("");
+    mpIconGraphicsView->setShapesList(mPreservedIconShapesList);
+    mPreservedIconShapesList.clear();
+    mpDiagramGraphicsView->setShapesList(mPreservedDiagramShapesList);
+    mPreservedDiagramShapesList.clear();
+    setComponentModified(false);
+    updateElementModeButtons();
+  }
   loadModelInstance(false, modelInfo);
   // update the coordinate system according to new values
   mpIconGraphicsView->resetZoom();


### PR DESCRIPTION
### Related Issues

#13908

### Purpose

Do not crash when doing copy paste of shapes.

### Approach

Clear the shapes only when inside the element mode.
