### PR TITLE
Improve overconstrained connection handling (#13920)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -71,6 +71,7 @@ import FlatModel = NFFlatModel;
 import ComponentRef = NFComponentRef;
 import Equation = NFEquation;
 import NFConnections;
+import Variable = NFVariable;
 
 type FlatEdge = NFConnections.BrokenEdge
 "a tuple with two crefs and equation(s) for calling the equalityConstraint function call";
@@ -81,6 +82,7 @@ type FlatEdges = NFConnections.BrokenEdges
 protected
 import Absyn;
 import NFBuiltin;
+import Binding = NFBinding;
 import Call = NFCall;
 import Ceval = NFCeval;
 import Class = NFClass;
@@ -184,26 +186,21 @@ function handleOverconstrainedConnections
   input output FlatModel flatModel;
   input Connections conns;
   input IsDeletedFn isDeleted;
-  output FlatEdges outBroken;
+  output FlatEdges broken;
 protected
   NFOCConnectionGraph graph = EMPTY;
-  list<Equation> eql = {}, ieql;
-  FlatEdges broken, connected;
+  FlatEdges connected;
+  list<Equation> eql;
   Boolean print_trace = Flags.isSet(Flags.CGRAPH);
 algorithm
   // Add roots and branches from the model to the graph.
   graph := addBreakableBranches(conns.connections, isDeleted, print_trace, graph);
   (eql, graph) := addRootsAndBranches(flatModel.equations, print_trace, graph);
+  flatModel.equations := eql;
 
   // now we have the graph, remove the broken connects and evaluate the equation operators
-  ieql := flatModel.initialEquations;
-  (eql, ieql, connected, broken) := handleOverconstrainedConnections_dispatch(graph, FlatModel.fullName(flatModel), eql, ieql);
-
-  eql := removeBrokenConnects(eql, connected, broken, isDeleted);
-
-  flatModel.equations := eql;
-  flatModel.initialEquations := ieql;
-  outBroken := broken;
+  (flatModel, connected, broken) := handleOverconstrainedConnections_dispatch(graph, flatModel);
+  flatModel.equations := removeBrokenConnects(flatModel.equations, connected, broken, isDeleted);
 end handleOverconstrainedConnections;
 
 protected
@@ -382,55 +379,42 @@ function handleOverconstrainedConnections_dispatch
  - evaluates Connections.isRoot in the input DAE
  - evaluates Connections.uniqueRootIndices in the input DAE
  - evaluates the rooted operator in the input DAE"
-  input NFOCConnectionGraph inGraph;
-  input String modelNameQualified;
-  input list<Equation> inEquations;
-  input list<Equation> inInitialEquations;
-  output list<Equation> outEquations;
-  output list<Equation> outInitialEquations;
-  output FlatEdges outConnected;
-  output FlatEdges outBroken;
+  input NFOCConnectionGraph graph;
+  input output FlatModel flatModel;
+        output FlatEdges connected;
+        output FlatEdges broken;
+protected
+  list<Equation> eqs, ieqs;
+  list<ComponentRef> roots;
+  CrefIndexTable rooted;
 algorithm
-  (outEquations, outInitialEquations, outConnected, outBroken) := matchcontinue(inGraph, modelNameQualified, inEquations, inInitialEquations)
-    local
-      NFOCConnectionGraph graph;
-      list<Equation> eqs, ieqs;
-      list<ComponentRef> roots;
-      FlatEdges broken, connected;
+  try
+    if Flags.isSet(Flags.CGRAPH) then
+      print("Summary: \n\t" +
+       "Nr Roots:           " + intString(listLength(getDefiniteRoots(graph))) + "\n\t" +
+       "Nr Potential Roots: " + intString(listLength(getPotentialRoots(graph))) + "\n\t" +
+       "Nr Unique Roots:    " + intString(listLength(getUniqueRoots(graph))) + "\n\t" +
+       "Nr Branches:        " + intString(listLength(getBranches(graph))) + "\n\t" +
+       "Nr Connections:     " + intString(listLength(getConnections(graph))) + "\n");
+    end if;
 
-    // handle the connection breaking
-    case (graph, _, eqs, ieqs)
-      algorithm
-        if Flags.isSet(Flags.CGRAPH) then
-          print("Summary: \n\t" +
-           "Nr Roots:           " + intString(listLength(getDefiniteRoots(graph))) + "\n\t" +
-           "Nr Potential Roots: " + intString(listLength(getPotentialRoots(graph))) + "\n\t" +
-           "Nr Unique Roots:    " + intString(listLength(getUniqueRoots(graph))) + "\n\t" +
-           "Nr Branches:        " + intString(listLength(getBranches(graph))) + "\n\t" +
-           "Nr Connections:     " + intString(listLength(getConnections(graph))) + "\n");
-        end if;
+    (roots, connected, broken) := findResultGraph(graph, FlatModel.fullName(flatModel));
 
-        (roots, connected, broken) := findResultGraph(graph, modelNameQualified);
+    if Flags.isSet(Flags.CGRAPH) then
+      print("Roots: " + stringDelimitList(List.map(roots, ComponentRef.toString), ", ") + "\n");
+      print("Broken connections: " + stringDelimitList(List.map1(broken, printConnectionStr, "broken"), ", ") + "\n");
+      print("Allowed connections: " + stringDelimitList(List.map1(connected, printConnectionStr, "allowed"), ", ") + "\n");
+    end if;
 
-        if Flags.isSet(Flags.CGRAPH) then
-          print("Roots: " + stringDelimitList(List.map(roots, ComponentRef.toString), ", ") + "\n");
-          print("Broken connections: " + stringDelimitList(List.map1(broken, printConnectionStr, "broken"), ", ") + "\n");
-          print("Allowed connections: " + stringDelimitList(List.map1(connected, printConnectionStr, "allowed"), ", ") + "\n");
-        end if;
-
-        eqs := evalConnectionsOperators(roots, graph, eqs);
-        ieqs := evalConnectionsOperators(roots, graph, ieqs);
-      then
-        (eqs, ieqs, connected, broken);
-
-    // handle the connection breaking
-    else
-      algorithm
-        true := Flags.isSet(Flags.CGRAPH);
-        print("- NFOCConnectionGraph.handleOverconstrainedConnections failed for model: " + modelNameQualified + "\n");
-      then
-        fail();
-  end matchcontinue;
+    rooted := buildRootedTable(roots, graph);
+    flatModel.variables := list(evalConnectionsOperatorsVar(roots, rooted, graph, v) for v in flatModel.variables);
+    flatModel.equations := evalConnectionsOperatorsEqs(roots, rooted, graph, flatModel.equations);
+    flatModel.initialEquations := evalConnectionsOperatorsEqs(roots, rooted, graph, flatModel.initialEquations);
+  else
+    true := Flags.isSet(Flags.CGRAPH);
+    print("- NFOCConnectionGraph.handleOverconstrainedConnections failed for model: " + FlatModel.fullName(flatModel) + "\n");
+    fail();
+  end try;
 end handleOverconstrainedConnections_dispatch;
 
 function addDefiniteRoot
@@ -915,6 +899,24 @@ algorithm
   end match;
 end printPotentialRootTuple;
 
+protected function buildRootedTable
+  input list<ComponentRef> roots;
+  input NFOCConnectionGraph graph;
+  output CrefIndexTable rooted;
+protected
+  CrefRootsTable table;
+algorithm
+  table := UnorderedMap.new<DefiniteRoots>(ComponentRef.hash, ComponentRef.isEqual);
+
+  // Add branches and connections to table.
+  List.map1_0(getBranches(graph), addBranches, table);
+  List.map1_0(getConnections(graph), addConnectionsRooted, table);
+
+  // Get distance to root.
+  rooted := UnorderedMap.new<Integer>(ComponentRef.hash, ComponentRef.isEqual);
+  setRootDistance(roots, table, 0, {}, rooted);
+end buildRootedTable;
+
 protected function setRootDistance
   input list<ComponentRef> finalRoots;
   input CrefRootsTable table;
@@ -996,53 +998,37 @@ algorithm
   UnorderedMap.addUpdate(cref1, function updateRooted(newRoot = cref2), table);
 end addConnectionRooted;
 
-protected function evalConnectionsOperators
-"evaluation of Connections.rooted, Connections.isRoot, Connections.uniqueRootIndices
- - replaces all [Connections.]rooted calls by true or false depending on wheter branche frame_a or frame_b is closer to root
- - return true or false for Connections.isRoot operator if is a root or not
- - return an array of indices for Connections.uniqueRootIndices, see Modelica_StateGraph2
-   See Modelica_StateGraph2:
-    https://github.com/modelica/Modelica_StateGraph2 and
-    https://trac.modelica.org/Modelica/ticket/984 and
-    http://www.ep.liu.se/ecp/043/041/ecp09430108.pdf
-   for a specification of this operator"
+protected function evalConnectionsOperatorsEqs
   input list<ComponentRef> inRoots;
+  input CrefIndexTable rooted;
   input NFOCConnectionGraph graph;
-  input list<Equation> inEquations;
-  output list<Equation> outEquations;
+  input output list<Equation> equations;
 algorithm
-  outEquations := matchcontinue(inRoots,graph,inEquations)
-    local
-      CrefIndexTable rooted;
-      CrefRootsTable table;
-      Edges branches;
-      FlatEdges connections;
+  equations := list(Equation.mapExpShallow(eq,
+      function evaluateOperators(rooted = rooted, roots = inRoots, graph = graph, info = Equation.info(eq)))
+    for eq in equations);
+end evalConnectionsOperatorsEqs;
 
-    case (_,_, {}) then {};
-
-    else
-      equation
-        // built table
-        table = newCrefRootsTable();
-        // add branches to table
-        branches = getBranches(graph);
-        List.map1_0(branches, addBranches, table);
-        // add connections to table
-        connections = getConnections(graph);
-        List.map1_0(connections, addConnectionsRooted, table);
-        // get distance to root
-        //  print("Roots: " + stringDelimitList(List.map(inRoots,ComponentRef.toString),"\n") + "\n");
-        rooted = newCrefIndexTable();
-        setRootDistance(inRoots, table, 0, {}, rooted);
-        outEquations = list(Equation.mapExp(eq,
-            function evaluateOperators(rooted = rooted, roots = inRoots, graph = graph, info = Equation.info(eq)))
-          for eq in inEquations);
-      then outEquations;
-
-  end matchcontinue;
-end evalConnectionsOperators;
+protected function evalConnectionsOperatorsVar
+  input list<ComponentRef> roots;
+  input CrefIndexTable rooted;
+  input NFOCConnectionGraph graph;
+  input output Variable var;
+algorithm
+  var.binding := Binding.mapExpShallow(var.binding,
+    function evaluateOperators(rooted = rooted, roots = roots, graph = graph, info = var.info));
+end evalConnectionsOperatorsVar;
 
 function evaluateOperators
+  "evaluation of Connections.rooted, Connections.isRoot, Connections.uniqueRootIndices
+   - replaces all [Connections.]rooted calls by true or false depending on wheter branche frame_a or frame_b is closer to root
+   - return true or false for Connections.isRoot operator if is a root or not
+   - return an array of indices for Connections.uniqueRootIndices, see Modelica_StateGraph2
+     See Modelica_StateGraph2:
+      https://github.com/modelica/Modelica_StateGraph2 and
+      https://trac.modelica.org/Modelica/ticket/984 and
+      http://www.ep.liu.se/ecp/043/041/ecp09430108.pdf
+     for a specification of this operator"
   input output Expression exp;
   input CrefIndexTable rooted;
   input list<ComponentRef> roots;
@@ -1751,18 +1737,6 @@ function newCrefCrefTable
 algorithm
   table := UnorderedMap.new<ComponentRef>(ComponentRef.hash, ComponentRef.isEqual);
 end newCrefCrefTable;
-
-function newCrefIndexTable
-  output CrefIndexTable table;
-algorithm
-  table := UnorderedMap.new<Integer>(ComponentRef.hash, ComponentRef.isEqual);
-end newCrefIndexTable;
-
-function newCrefRootsTable
-  output CrefRootsTable table;
-algorithm
-  table := UnorderedMap.new<DefiniteRoots>(ComponentRef.hash, ComponentRef.isEqual);
-end newCrefRootsTable;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFOCConnectionGraph;

--- a/testsuite/flattening/modelica/scodeinst/EqualityConstraint3.mo
+++ b/testsuite/flattening/modelica/scodeinst/EqualityConstraint3.mo
@@ -24,10 +24,11 @@ end C;
 
 model Source
   C c;
+  parameter Boolean coRoot = Connections.isRoot(c.o);
 equation
   c.e = 1;
   Connections.potentialRoot(c.o);
-  if Connections.isRoot(c.o) then
+  if coRoot then
     c.o = {1, 0};
   end if;
 end Source;
@@ -56,6 +57,7 @@ end EqualityConstraint3;
 //   Real source.c.o[1];
 //   Real source.c.o[2];
 //   Real source.c.g;
+//   parameter Boolean source.coRoot = true;
 //   Real sink1.c.e;
 //   Real sink1.c.f;
 //   Real sink1.c.o[1];
@@ -76,8 +78,10 @@ end EqualityConstraint3;
 //   sink2.c.f + sink1.c.f + source.c.f = 0.0;
 //   sink2.c.g + sink1.c.g + source.c.g = 0.0;
 //   source.c.e = 1.0;
-//   source.c.o[1] = 1.0;
-//   source.c.o[2] = 0.0;
+//   if source.coRoot then
+//     source.c.o[1] = 1.0;
+//     source.c.o[2] = 0.0;
+//   end if;
 //   sink1.c.f = 1.0;
 //   sink1.c.g = 1.0;
 //   sink2.c.f = 1.0;


### PR DESCRIPTION
- Evaluate `Connections.isRoot` and `Connections.rooted` in binding equations too.
- Clean up the building of the rooted table to avoid doing it multiple times.
- Use `Equation.mapExpShallow` instead of `Equation.mapExp` when calling `evaluateOperators` to avoid double recursion.