### PR TITLE
Make Qt WebEngine usable

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -1177,6 +1177,8 @@ void DocumentationWidget::updateActions()
     mpSubscriptAction->setChecked(false);
     mpSuperscriptAction->setEnabled(false);
     mpSuperscriptAction->setChecked(false);
+    mpTextColorToolButton->setEnabled(false);
+    mpBackgroundColorToolButton->setEnabled(false);
     mpAlignLeftToolButton->setEnabled(false);
     mpAlignLeftToolButton->setChecked(false);
     mpAlignCenterToolButton->setEnabled(false);
@@ -1185,6 +1187,8 @@ void DocumentationWidget::updateActions()
     mpAlignRightToolButton->setChecked(false);
     mpJustifyToolButton->setEnabled(false);
     mpJustifyToolButton->setChecked(false);
+    mpDecreaseIndentAction->setEnabled(false);
+    mpIncreaseIndentAction->setEnabled(false);
     mpBulletListAction->setEnabled(false);
     mpBulletListAction->setChecked(false);
     mpNumberedListAction->setEnabled(false);
@@ -1203,10 +1207,14 @@ void DocumentationWidget::updateActions()
     mpStrikethroughAction->setEnabled(true);
     mpSubscriptAction->setEnabled(true);
     mpSuperscriptAction->setEnabled(true);
+    mpTextColorToolButton->setEnabled(true);
+    mpBackgroundColorToolButton->setEnabled(true);
     mpAlignLeftToolButton->setEnabled(true);
     mpAlignCenterToolButton->setEnabled(true);
     mpAlignRightToolButton->setEnabled(true);
     mpJustifyToolButton->setEnabled(true);
+    mpDecreaseIndentAction->setEnabled(true);
+    mpIncreaseIndentAction->setEnabled(true);
     mpBulletListAction->setEnabled(true);
     mpNumberedListAction->setEnabled(true);
     mpLinkAction->setEnabled(true);

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -1027,6 +1027,10 @@ void DocumentationWidget::saveDocumentation(LibraryTreeItem *pNextLibraryTreeIte
         oldDocAnnotationList.append(QString("__OpenModelica_infoHeader=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(2))));
       }
       QString oldDocAnnotationString = QString("annotate=Documentation(%1)").arg(oldDocAnnotationList.join(","));
+      // if we are on html editor tab then update the source before saving the documentation
+      if (mpTabBar->currentIndex() == 0) {
+        updateHTMLSourceEditor();
+      }
       // new documentation annotation
       QList<QString> newDocAnnotationList;
       if (mEditType == EditType::Info) { // if editing the info section
@@ -1104,6 +1108,7 @@ void DocumentationWidget::toggleEditor(int tabIndex)
 {
   switch (tabIndex) {
     case 1:
+      updateHTMLSourceEditor();
       mpHTMLEditorWidget->hide();
       mpHTMLSourceEditor->show();
       mpHTMLSourceEditor->getPlainTextEdit()->setFocus(Qt::ActiveWindowFocusReason);

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -840,8 +840,13 @@ void DocumentationWidget::updateActionsHelper()
   mpStyleComboBox->blockSignals(state);
   state = mpFontComboBox->blockSignals(true);
   QString fontName = queryCommandValue("fontName");
-  // font name has extra single quote around it so remove it.
+#ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
+  // Remove quotes around the font name.
+  fontName = StringHandler::removeFirstLastQuotes(fontName);
+#else // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
+  // Remove single quote around the font name.
   fontName = StringHandler::removeFirstLastSingleQuotes(fontName);
+#endif // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
   /* Issue #13038
    * We get the current font name by calling `document.queryCommandValue("fontName")` via JavaScript on current cursor position.
    * The webkit returns `-webkit-standard` for default font name instead of the actual font name.
@@ -869,14 +874,14 @@ void DocumentationWidget::updateActionsHelper()
   mpStrikethroughAction->setChecked(queryCommandState("strikeThrough"));
   mpSubscriptAction->setChecked(queryCommandState("subscript"));
   mpSuperscriptAction->setChecked(queryCommandState("superscript"));
-#else
+#else // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
   mpBoldAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleBold)->isChecked());
   mpItalicAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleItalic)->isChecked());
   mpUnderlineAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleUnderline)->isChecked());
   mpStrikethroughAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleStrikethrough)->isChecked());
   mpSubscriptAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleSubscript)->isChecked());
   mpSuperscriptAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleSuperscript)->isChecked());
-#endif
+#endif // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
   mpAlignLeftToolButton->setChecked(queryCommandState("justifyLeft"));
   mpAlignCenterToolButton->setChecked(queryCommandState("justifyCenter"));
   mpAlignRightToolButton->setChecked(queryCommandState("justifyRight"));

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -233,7 +233,7 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   mpSubscriptAction->setStatusTip(tr("Type very small letters just below the line of text"));
   mpSubscriptAction->setCheckable(true);
 #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
-  // TODO: ToggleSubscript
+  connect(mpSubscriptAction, SIGNAL(triggered()), SLOT(subscript()));
 #else
   connect(mpSubscriptAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleSubscript), SLOT(trigger()));
 #endif
@@ -242,7 +242,7 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   mpSuperscriptAction->setStatusTip(tr("Type very small letters just above the line of text"));
   mpSuperscriptAction->setCheckable(true);
 #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
-  // TODO: ToggleSuperscript
+  connect(mpSuperscriptAction, SIGNAL(triggered()), SLOT(superscript()));
 #else
   connect(mpSuperscriptAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleSuperscript), SLOT(trigger()));
 #endif
@@ -868,7 +868,7 @@ void DocumentationWidget::updateActionsHelper()
   mpUnderlineAction->setChecked(queryCommandState("underline"));
   mpStrikethroughAction->setChecked(queryCommandState("strikeThrough"));
   mpSubscriptAction->setChecked(queryCommandState("subscript"));
-  mpSubscriptAction->setChecked(queryCommandState("superscript"));
+  mpSuperscriptAction->setChecked(queryCommandState("superscript"));
 #else
   mpBoldAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleBold)->isChecked());
   mpItalicAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleItalic)->isChecked());
@@ -1259,6 +1259,24 @@ void DocumentationWidget::fontSize(int size)
 //  execCommand("styleWithCSS", "true");
   execCommand("fontSize", QString::number(size));
 //  execCommand("styleWithCSS", "false");
+}
+
+/*!
+ * \brief DocumentationWidget::subscript
+ * Subscript the text by executing command subscript.
+ */
+void DocumentationWidget::subscript()
+{
+  execCommand("subscript");
+}
+
+/*!
+ * \brief DocumentationWidget::superscript
+ * Superscript the text by executing command superscript.
+ */
+void DocumentationWidget::superscript()
+{
+  execCommand("superscript");
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -1401,8 +1401,7 @@ void DocumentationWidget::createLink()
                                "getLinkHref()");
   QString href;
 #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
-  QWebEnginePage *pWebPage = mpHTMLEditor->page();
-  pWebPage->runJavaScript(javaScript, [&](const QVariant & arg){ href = arg.toString(); });
+  href = runJavaScript(javaScript).toString();
 #else // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
   QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
   href = pWebFrame->evaluateJavaScript(javaScript).toString();

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -162,6 +162,7 @@ private:
   void writeDocumentationFile(QString documentation);
   bool isLinkSelected();
   bool removeDocumentationHistory(LibraryTreeItem *pLibraryTreeItem);
+  void updateActionsHelper();
 public slots:
   void previousDocumentation();
   void nextDocumentation();

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -162,7 +162,7 @@ private:
   void writeDocumentationFile(QString documentation);
   bool isLinkSelected();
   bool removeDocumentationHistory(LibraryTreeItem *pLibraryTreeItem);
-  void updateActionsHelper();
+  void updateHTMLSourceEditor();
 public slots:
   void previousDocumentation();
   void nextDocumentation();
@@ -173,6 +173,7 @@ public slots:
   void cancelDocumentation();
   void toggleEditor(int tabIndex);
   void updateActions();
+  void updateActionsHelper();
   void formatBlock(int index);
   void fontName(QFont font);
   void fontSize(int size);
@@ -188,7 +189,6 @@ public slots:
   void numberedList();
   void createLink();
   void removeLink();
-  void updateHTMLSourceEditor();
 #endif // #ifndef OM_DISABLE_DOCUMENTATION
 };
 

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -178,6 +178,8 @@ public slots:
   void formatBlock(int index);
   void fontName(QFont font);
   void fontSize(int size);
+  void subscript();
+  void superscript();
   void applyTextColor();
   void applyTextColor(QColor color);
   void applyBackgroundColor();

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -42,6 +42,7 @@
 #ifndef OM_DISABLE_DOCUMENTATION
 #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
 #include <QWebEngineView>
+#include <QWebEnginePage>
 #else // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
 #include <QWebView>
 #endif // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
@@ -194,6 +195,21 @@ public slots:
 
 #ifndef OM_DISABLE_DOCUMENTATION
 #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
+class DocumentationPage : public QWebEnginePage
+{
+  Q_OBJECT
+private:
+  QUrl mUrl;
+public:
+  DocumentationPage(QObject *parent = nullptr);
+protected:
+  virtual bool acceptNavigationRequest(const QUrl &url, NavigationType type, bool isMainFrame) override;
+signals:
+  void linkClicked(const QUrl &url);
+private slots:
+  void emitLinkClicked();
+};
+
 class DocumentationViewer : public QWebEngineView
 #else // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
 class DocumentationViewer : public QWebView
@@ -205,6 +221,9 @@ class DocumentationViewer : public QWidget
   Q_OBJECT
 private:
   DocumentationWidget *mpDocumentationWidget;
+#ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
+  DocumentationPage *mpDocumentationPage;
+#endif // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
 public:
   DocumentationViewer(DocumentationWidget *pDocumentationWidget, bool isContentEditable = false);
 #ifndef OM_DISABLE_DOCUMENTATION

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -92,6 +92,9 @@ public:
 #ifndef OM_DISABLE_DOCUMENTATION
   void execCommand(const QString &commandName);
   void execCommand(const QString &commandName, const QString &valueArgument);
+#ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
+  QVariant runJavaScript(const QString &javaScript);
+#endif // #ifdef OM_OMEDIT_ENABLE_QTWEBENGINE
   bool queryCommandState(const QString &commandName);
   QString queryCommandValue(const QString &commandName);
   void saveScrollPosition();


### PR DESCRIPTION
 - [x] Javascript runs asynchronously so wait for the result.
 - [x] `QWebEnginePage` signal `selectionChanged` doesn't emit when cursor position changes unlike `QWebPage`. It only emits when a text is selected or unselected. So we need to update the page editing tool buttons based on selection.
 - [x] There is not `contentsChanged` signal in Qt WebEngine. So the code to update the source is adapted for both Qt Webkit and Qt WebEngine.
 - [x] There is no `setLinkDelegationPolicy` so subclass `QWebEnginePage` and override `acceptNavigationRequest` to handle link clicks.
 - [x] Handle `subscript` and `superscript` actions.