### PR TITLE
Show the default values as arrays, either as {0, 0, 0} or fill(0, 3)

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -256,6 +256,7 @@ public:
   GraphicsView *getGraphicsView() const {return mpGraphicsView;}
   bool hasElement() const {return mpElement ? true : false;}
   bool isElementArray() const {return mpElement->getDimensions().isArray();}
+  QString getElementDimensions() const {return mpElement->getDimensions().getTypedDimensionsString();}
   bool isInherited() const {return mInherited;}
   QString getModification() const {return mModification;}
   void applyFinalStartFixedAndDisplayUnitModifiers(Parameter *pParameter, ModelInstance::Modifier *pModifier, bool defaultValue, bool isElementModification);


### PR DESCRIPTION
### Related Issues

Fixes #11847

### Purpose

The name of array element in shown without dimension.
Show the default values of array elements as array instead of scalars.

### Approach

Added array notation to the name.
Show the default values as arrays, either as `{0, 0, 0}` or `fill(0, 3)`.
