### PR TITLE
Change InstNode::emptyMMNode to a method

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/ClassNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassNode.cpp
@@ -80,7 +80,7 @@ MetaModelica::Value ClassNode::toMetaModelica() const
       _visibility.toSCode(),
       cls_ptr,
       MetaModelica::Array{3, noCache},
-      InstNode::emptyMMNode,
+      InstNode::emptyMMNode(),
       MetaModelica::Value(static_cast<int64_t>(0))
     });
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
@@ -55,7 +55,7 @@ MetaModelica::Value ComponentNode::toMetaModelica() const
       _definition->toSCode(),
       _visibility.toSCode(),
       comp_ptr,
-      InstNode::emptyMMNode,
+      InstNode::emptyMMNode(),
       MetaModelica::Value(static_cast<int64_t>(0))
     }};
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
@@ -4,5 +4,8 @@ using namespace OpenModelica;
 
 extern record_description NFInstNode_InstNode_EMPTY__NODE__desc;
 
-const MetaModelica::Value OpenModelica::InstNode::emptyMMNode =
-  MetaModelica::Record(InstNode::EMPTY_NODE, NFInstNode_InstNode_EMPTY__NODE__desc, {});
+MetaModelica::Value InstNode::emptyMMNode()
+{
+  static auto val = MetaModelica::Record{InstNode::EMPTY_NODE, NFInstNode_InstNode_EMPTY__NODE__desc, {}};
+  return val;
+}

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.h
@@ -24,7 +24,7 @@ namespace OpenModelica
       static constexpr int VAR_NODE = 7;
       static constexpr int EMPTY_NODE = 8;
 
-      static const MetaModelica::Value emptyMMNode;
+      static MetaModelica::Value emptyMMNode();
 
     public:
       virtual ~InstNode() = default;

--- a/OMCompiler/Compiler/FrontEndCpp/InstNodeType.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNodeType.cpp
@@ -61,7 +61,7 @@ bool BaseClassType::isBuiltin() const
 MetaModelica::Value BaseClassType::toMetaModelica() const
 {
   return MetaModelica::Record(BASE_CLASS, NFInstNode_InstNodeType_BASE__CLASS__desc, {
-    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode,
+    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode(),
     _definition->toSCode(),
     // TODO: Use actual node type.
     NormalClassType().toMetaModelica()
@@ -97,7 +97,7 @@ MetaModelica::Value TopScopeType::toMetaModelica() const
 MetaModelica::Value RootClassType::toMetaModelica() const
 {
   return MetaModelica::Record(ROOT_CLASS, NFInstNode_InstNodeType_ROOT__CLASS__desc, {
-    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode
+    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode()
   });
 }
 
@@ -109,14 +109,14 @@ MetaModelica::Value NormalComponentType::toMetaModelica() const
 MetaModelica::Value RedeclaredComponentType::toMetaModelica() const
 {
   return MetaModelica::Record(REDECLARED_COMP, NFInstNode_InstNodeType_REDECLARED__COMP__desc, {
-    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode
+    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode()
   });
 }
 
 MetaModelica::Value RedeclaredClassType::toMetaModelica() const
 {
   return MetaModelica::Record(REDECLARED_CLASS, NFInstNode_InstNodeType_REDECLARED__CLASS__desc, {
-    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode
+    _parent ? _parent->toMetaModelica() : InstNode::emptyMMNode()
   });
 }
 


### PR DESCRIPTION
- Change InstNode::emptyMMNode to a method to avoid potentially initializing it before the GC is initialized.