### PR TITLE
Improve flexible array handling

### DIFF
--- a/.CI/compliance.failures
+++ b/.CI/compliance.failures
@@ -1,9 +1,6 @@
 ModelicaCompliance.Algorithms.For.RealRange
 ModelicaCompliance.Algorithms.For.ShadowedIterator
 ModelicaCompliance.Algorithms.For.StringRange
-ModelicaCompliance.Arrays.Flexible.ArrayFlexibleWithColon1
-ModelicaCompliance.Arrays.Flexible.ArrayFlexibleWithColon2
-ModelicaCompliance.Arrays.Flexible.ArrayFlexibleWithColon3
 ModelicaCompliance.Arrays.Functions.Conversion.DimConversionMatrix
 ModelicaCompliance.Classes.Balancing.CorrectBalance5
 ModelicaCompliance.Classes.Declarations.Long.QuotedIdentifiers.?abfnrtv

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -344,8 +344,13 @@ algorithm
   ty := Type.mapDims(ty, function applyReplacementsDim(map = map));
 
   result := match ty
-    case Type.ARRAY() guard buildArrayBinding and Type.hasKnownSize(ty)
-      then Expression.fillType(ty, Expression.EMPTY(Type.arrayElementType(ty)));
+    case Type.ARRAY() guard buildArrayBinding
+      then
+        if Type.hasKnownSize(ty) then
+          Expression.fillType(ty, Expression.EMPTY(Type.arrayElementType(ty)))
+        else
+          Expression.makeEmptyArray(ty);
+
     case Type.COMPLEX() then buildRecordBinding(node, map, mutableParams);
     else Expression.EMPTY(ty);
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -281,7 +281,7 @@ public
     Type ty;
   algorithm
     Expression.RANGE(ty = ty) := exp;
-    expanded := Type.hasKnownSize(ty);
+    expanded := Expression.isLiteral(exp);
 
     if expanded then
       outExp := Ceval.evalExp(exp);


### PR DESCRIPTION
- Initialize flexible arrays to an empty array when evaluating functions.
- Change expansion of ranges to only expand ranges with literal expressions, to avoid trying to evaluate ranges such as `i:i` which has a known size but can't be evaluated.