### PR TITLE
[C] unify Jacobian evaluation

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.c
@@ -113,8 +113,7 @@ void freeJacobian(JACOBIAN *jac)
  *  \param [ref] [threadData]
  *  \param [ref] [jacobian]        Pointer to Jacobian
  *  \param [ref] [parentJacobian]  Pointer to parent Jacobian
- *  \param [out] [jac]             Output buffer, size nnz (sparse) or #rows * #cols (dense),
- *                                 sparse: can be non zero initialized (values will be overwritten), dense: all zeros must be zero when calling
+ *  \param [out] [jac]             Output buffer, size nnz (sparse) or #rows * #cols (dense), non zero-initialized
  *  \param [ref] [isDense]         Flag to set dense / sparse output
  */
 void evalJacobian(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jac, modelica_boolean isDense)
@@ -125,6 +124,12 @@ void evalJacobian(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACO
   /* evaluate constant equations of Jacobian */
   if (jacobian->constantEqns != NULL) {
     jacobian->constantEqns(data, threadData, jacobian, parentJacobian);
+  }
+
+  if (isDense) {
+    /* memset to zero for dense, since solvers might destroy "hard zeros"
+     * does not apply for sparse, since the values are overwritten */
+    memset(jac, 0.0, jacobian->sizeRows * jacobian->sizeCols * sizeof(modelica_real));
   }
 
   /* evaluate Jacobian */

--- a/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.h
@@ -44,8 +44,7 @@ void initJacobian(JACOBIAN* jacobian, unsigned int sizeCols, unsigned int sizeRo
 JACOBIAN* copyJacobian(JACOBIAN* source);
 void freeJacobian(JACOBIAN* jac);
 
-void evalJacobianSparse(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jacCSC);
-void evalJacobianDense(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jacDense);
+void evalJacobian(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jac, modelica_boolean isDense);
 
 SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int numberOfNonZeros, unsigned int maxColors);
 void freeSparsePattern(SPARSE_PATTERN *spp);

--- a/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.h
@@ -44,7 +44,8 @@ void initJacobian(JACOBIAN* jacobian, unsigned int sizeCols, unsigned int sizeRo
 JACOBIAN* copyJacobian(JACOBIAN* source);
 void freeJacobian(JACOBIAN* jac);
 
-void evalJacobian(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jac);
+void evalJacobianSparse(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jacCSC);
+void evalJacobianDense(DATA* data, threadData_t *threadData, JACOBIAN* jacobian, JACOBIAN* parentJacobian, modelica_real* jacDense);
 
 SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int numberOfNonZeros, unsigned int maxColors);
 void freeSparsePattern(SPARSE_PATTERN *spp);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -600,7 +600,7 @@ int nlsSparseSymJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
   const SPARSE_PATTERN* sp = jacobian->sparsePattern;
   assertStreamPrint(threadData, NULL != sp, "sp is NULL");
   double *xScaling = NV_DATA_S(kinsolData->xScale);
-  long int color, column, row, nz;
+  long int column, nz;
 
   if (SUNMatGetID(Jac) != SUNMATRIX_SPARSE || SM_SPARSETYPE_S(Jac) == CSR_MAT) {
     errorStreamPrint(OMC_LOG_STDOUT, 0,
@@ -612,8 +612,8 @@ int nlsSparseSymJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
   rt_ext_tp_tick(&nlsData->jacobianTimeClock);
 
   /* call generic sparse Jacobian with CSC buffer "SM_DATA_S(Jac)" */
-  evalJacobianSparse(data, threadData, jacobian, NULL, SM_DATA_S(Jac));
-  setSundialSparsePattern(jacobian, Jac);
+  evalJacobian(data, threadData, jacobian, NULL, SM_DATA_S(Jac), FALSE);
+  setSundialsSparsePattern(jacobian, Jac);
 
   /* scaling */
   if (kinsolData->nominalJac) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -114,7 +114,7 @@ void getAnalyticalJacobianLapack(DATA* data, threadData_t *threadData, LINEAR_SY
   JACOBIAN* parentJacobian = systemData->parDynamicData[omc_get_thread_num()].parentJacobian;
 
   /* call generic dense Jacobian */
-  evalJacobianDense(data, threadData, jacobian, parentJacobian, jac);
+  evalJacobian(data, threadData, jacobian, parentJacobian, jac, TRUE);
 
   for (k = 0; k < (jacobian->sizeRows) * (jacobian->sizeCols); k++)
     jac[k] = -jac[k];

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -113,7 +113,8 @@ void getAnalyticalJacobianLapack(DATA* data, threadData_t *threadData, LINEAR_SY
   JACOBIAN* jacobian = systemData->parDynamicData[omc_get_thread_num()].jacobian;
   JACOBIAN* parentJacobian = systemData->parDynamicData[omc_get_thread_num()].parentJacobian;
 
-  evalJacobian(data, threadData, jacobian, parentJacobian, jac);
+  /* call generic dense Jacobian */
+  evalJacobianDense(data, threadData, jacobian, parentJacobian, jac);
 
   for (k = 0; k < (jacobian->sizeRows) * (jacobian->sizeCols); k++)
     jac[k] = -jac[k];

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -342,7 +342,7 @@ void getAnalyticalJacobianTotalPivot(DATA* data, threadData_t *threadData, LINEA
   JACOBIAN* parentJacobian = systemData->parDynamicData[omc_get_thread_num()].parentJacobian;
 
   /* call generic dense Jacobian */
-  evalJacobianDense(data, threadData, jacobian, parentJacobian, jac);
+  evalJacobian(data, threadData, jacobian, parentJacobian, jac, TRUE);
 }
 
 /*! \fn wrapper_fvec_hybrd for the residual Function

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -341,7 +341,8 @@ void getAnalyticalJacobianTotalPivot(DATA* data, threadData_t *threadData, LINEA
   JACOBIAN* jacobian = systemData->parDynamicData[omc_get_thread_num()].jacobian;
   JACOBIAN* parentJacobian = systemData->parDynamicData[omc_get_thread_num()].parentJacobian;
 
-  evalJacobian(data, threadData, jacobian, parentJacobian, jac);
+  /* call generic dense Jacobian */
+  evalJacobianDense(data, threadData, jacobian, parentJacobian, jac);
 }
 
 /*! \fn wrapper_fvec_hybrd for the residual Function

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
@@ -135,7 +135,8 @@ double** getJacobian( DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DAT
     jac = (modelica_real*) calloc(jacobian->sizeRows * jacobian->sizeCols, sizeof(modelica_real*));
     assertStreamPrint(threadData, NULL != jac, "out of memory");
 
-    evalJacobian(data, threadData, jacobian, NULL, jac);
+    /* call generic dense Jacobian */
+    evalJacobianDense(data, threadData, jacobian, NULL, jac);
 
     /* copy jacobian from column-major to row-major */
     for (i = 0; i < jacobian->sizeRows; ++i)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
@@ -136,7 +136,7 @@ double** getJacobian( DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DAT
     assertStreamPrint(threadData, NULL != jac, "out of memory");
 
     /* call generic dense Jacobian */
-    evalJacobianDense(data, threadData, jacobian, NULL, jac);
+    evalJacobian(data, threadData, jacobian, NULL, jac, TRUE);
 
     /* copy jacobian from column-major to row-major */
     for (i = 0; i < jacobian->sizeRows; ++i)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -832,7 +832,8 @@ int getAnalyticalJacobianHomotopy(DATA_HOMOTOPY* solverData, double* jac)
   JACOBIAN* jacobian = solverData->userData->analyticJacobian;
   const SPARSE_PATTERN* sp = jacobian->sparsePattern;
 
-  evalJacobian(data, threadData, jacobian, NULL, jac);
+  /* call generic dense Jacobian */
+  evalJacobianDense(data, threadData, jacobian, NULL, jac);
 
   /* apply scaling to each column */
   for (j = 0; j < jacobian->sizeCols; j++) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -833,7 +833,7 @@ int getAnalyticalJacobianHomotopy(DATA_HOMOTOPY* solverData, double* jac)
   const SPARSE_PATTERN* sp = jacobian->sparsePattern;
 
   /* call generic dense Jacobian */
-  evalJacobianDense(data, threadData, jacobian, NULL, jac);
+  evalJacobian(data, threadData, jacobian, NULL, jac, TRUE);
 
   /* apply scaling to each column */
   for (j = 0; j < jacobian->sizeCols; j++) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -266,7 +266,7 @@ static int getAnalyticalJacobian(NLS_USERDATA* hybrdUserData, double* jac)
   JACOBIAN* jacobian = hybrdUserData->analyticJacobian;
 
   /* call generic dense Jacobian */
-  evalJacobianDense(data, threadData, jacobian, NULL, jac);
+  evalJacobian(data, threadData, jacobian, NULL, jac, TRUE);
 
   memcpy(solverData->fjacobian, jac, (jacobian->sizeRows) * (jacobian->sizeCols) * sizeof(modelica_real));
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -265,7 +265,8 @@ static int getAnalyticalJacobian(NLS_USERDATA* hybrdUserData, double* jac)
   DATA_HYBRD* solverData = (DATA_HYBRD*)(systemData->solverData);
   JACOBIAN* jacobian = hybrdUserData->analyticJacobian;
 
-  evalJacobian(data, threadData, jacobian, NULL, jac);
+  /* call generic dense Jacobian */
+  evalJacobianDense(data, threadData, jacobian, NULL, jac);
 
   memcpy(solverData->fjacobian, jac, (jacobian->sizeRows) * (jacobian->sizeCols) * sizeof(modelica_real));
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -96,7 +96,8 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
     rt_ext_tp_tick(&nlsData->jacobianTimeClock);
 
     if(nlsData->jacobianIndex != -1 && jacobian != NULL ) {
-      evalJacobian(data, threadData, jacobian, NULL, solverData->fjac);
+      /* call generic dense Jacobian */
+      evalJacobianDense(data, threadData, jacobian, NULL, solverData->fjac);
     } else {
       double delta_h = sqrt(solverData->epsfcn);
       double delta_hh;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -97,7 +97,7 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
 
     if(nlsData->jacobianIndex != -1 && jacobian != NULL ) {
       /* call generic dense Jacobian */
-      evalJacobianDense(data, threadData, jacobian, NULL, solverData->fjac);
+      evalJacobian(data, threadData, jacobian, NULL, solverData->fjac, TRUE);
     } else {
       double delta_h = sqrt(solverData->epsfcn);
       double delta_hh;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
@@ -188,7 +188,8 @@ static void getAnalyticalJacobianSet(DATA* data, threadData_t *threadData, unsig
 
   modelica_real* jac = data->simulationInfo->stateSetData[index].J;
 
-  evalJacobian(data, threadData, jacobian, NULL, jac);
+  /* call generic dense Jacobian */
+  evalJacobianDense(data, threadData, jacobian, NULL, jac);
 
   if(OMC_ACTIVE_STREAM(OMC_LOG_DSS_JAC))
   {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
@@ -189,7 +189,7 @@ static void getAnalyticalJacobianSet(DATA* data, threadData_t *threadData, unsig
   modelica_real* jac = data->simulationInfo->stateSetData[index].J;
 
   /* call generic dense Jacobian */
-  evalJacobianDense(data, threadData, jacobian, NULL, jac);
+  evalJacobian(data, threadData, jacobian, NULL, jac, TRUE);
 
   if(OMC_ACTIVE_STREAM(OMC_LOG_DSS_JAC))
   {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -79,6 +79,28 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
 }
 
 /**
+ * @brief Set Sundials sparse pattern from SimRuntime SPARSE_PATTERN
+ *
+ * @param jacobian  Jacobian
+ * @param Jac       Sundials Matrix
+ */
+void setSundialSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac) {
+  const SPARSE_PATTERN* sp = jacobian->sparsePattern;
+  long int column, row, nz;
+
+  for (column = 0; column < jacobian->sizeCols; column++) {
+    for (nz = sp->leadindex[column]; nz < sp->leadindex[column + 1]; nz++) {
+      /* set row, col */
+      row = sp->index[nz];
+      if (column > 0 && SM_INDEXPTRS_S(Jac)[column] == 0) {
+        SM_INDEXPTRS_S(Jac)[column] = nz;
+      }
+      SM_INDEXVALS_S(Jac)[nz] = row;
+    }
+  }
+}
+
+/**
  * @brief             Scaling of a sparse matrix column-wise by a vector
  *
  * @param A           Sparse matrix in CSC. Will be scaled on return.

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -84,7 +84,7 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
  * @param jacobian  Jacobian
  * @param Jac       Sundials Matrix
  */
-void setSundialSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac) {
+void setSundialsSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac) {
   const SPARSE_PATTERN* sp = jacobian->sparsePattern;
   long int column, row, nz;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
@@ -49,8 +49,10 @@ extern "C" {
 
 #ifdef WITH_SUNDIALS
 #include <sundials/sundials_matrix.h>
+#include "../jacobian_util.h"
 
 void setJacElementSundialsSparse(int row, int column, int nth, double value, void* Jac, int nRows);
+void setSundialSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac);
 int _omc_SUNMatScaleIAdd_Sparse(realtype c, SUNMatrix A);
 int _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
@@ -52,7 +52,7 @@ extern "C" {
 #include "../jacobian_util.h"
 
 void setJacElementSundialsSparse(int row, int column, int nth, double value, void* Jac, int nRows);
-void setSundialSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac);
+void setSundialsSparsePattern(JACOBIAN* jacobian, SUNMatrix Jac);
 int _omc_SUNMatScaleIAdd_Sparse(realtype c, SUNMatrix A);
 int _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale);
 


### PR DESCRIPTION
- unify Jacobian evaluations in evalJacobian()
- use sparse evaluation for KINSOL

### Related Issues
This is work towards https://github.com/OpenModelica/OpenModelica/issues/13551

### WIP
Follow up on ([#13709](https://github.com/OpenModelica/OpenModelica/pull/13709))

-  generic dense and sparse Jacobian evaluations with automatic numeric / symbolic and (non) colored Jacobian
-  unify remaining functions
-  incorporate scaling
-  handle solvers with set(row, col, val) functions (e.g. Sundials)
-  invert coloring

### Goal
use evalJacobian() for most Jacobian evaluations, removes duplicate Code, less error prone

