### PR TITLE
do not delete temporary files to support multiple execution (#13976)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.cpp
+++ b/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.cpp
@@ -317,7 +317,7 @@ void createHtmlReportFordataReconciliation(DATA *data, csvData &csvinputs, matri
       }
     }
     nonreconcilevarsip.close();
-    omc_unlink(nonReconciledVarsFilename.c_str());
+    //omc_unlink(nonReconciledVarsFilename.c_str());
   }
 
   /* Add Overview Data */
@@ -2793,7 +2793,7 @@ int reconcileBoundaryConditions(DATA * data, threadData_t * threadData, inputDat
       }
     }
     boundaryConditionVarsip.close();
-    omc_unlink(boundaryConditionsVarsFilename.c_str());
+    //omc_unlink(boundaryConditionsVarsFilename.c_str());
   }
   else
   {


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/13742

### Purpose

do not delete temporary files to support multiple execution when running data Reconciliation algorithm in runtime
