### PR TITLE
force qt6 compilation if we are on Ubuntu Plucky

### DIFF
--- a/common/m4/qmake.m4
+++ b/common/m4/qmake.m4
@@ -5,6 +5,16 @@ AC_SUBST(LRELEASE)
 AC_SUBST(WITH_QT6)
 AC_ARG_WITH(qt6,  [  --with-qt6       (build with qt6)],[WITH_QT6="$withval"],[WITH_QT6="no"])
 
+# check if we have ubuntu plucky and activate --with-qt6
+# if so as we don't have webkit in that one.
+# maybe we should check if qt5webkit exists and if not activate qt6
+# but I have no idea how to do that
+
+if "lsb_release -cs" | grep plucky; then
+  WITH_QT6="yes"
+  AC_MSG_RESULT([Forcing qt6 as we don't have webkit in plucky distro])
+fi
+
 AC_MSG_CHECKING([if qt6 is requested])
 if test "$WITH_QT6" = "yes"; then
   QMAKE=qmake6


### PR DESCRIPTION
### Related Issues

OM cannot be compiled on Ubuntu Plucky with qt5 as it doesn't have webkit, activate qt6.