### PR TITLE
use the correct type as some compiler generate errors if not

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -609,8 +609,8 @@ static int nlsKinsolDenseDerivativeTest(DATA *data, NONLINEAR_SYSTEM_DATA *nlsDa
   sunindextype columns = SUNSparseMatrix_Columns(Jsym);
   sunindextype rows = SUNSparseMatrix_Rows(Jsym);
 
-  long int *colPointers = SM_INDEXPTRS_S(Jsym);
-  long int *rowIndices = SM_INDEXVALS_S(Jsym);
+  sunindextype *colPointers = SM_INDEXPTRS_S(Jsym);
+  sunindextype *rowIndices = SM_INDEXVALS_S(Jsym);
   realtype *symValues = SM_DATA_S(Jsym);
 
   // allocate temporary memory for dense finite-diff matrix


### PR DESCRIPTION
```
./simulation/solver/kinsolSolver.c:612:13: error: incompatible pointer types initializing 'long *' with an expression of type 'sunindextype *' (aka 'long long *') [-Werror,-Wincompatible-pointer-types]
  long int *colPointers = SM_INDEXPTRS_S(Jsym);
            ^             ~~~~~~~~~~~~~~~~~~~~
./simulation/solver/kinsolSolver.c:613:13: error: incompatible pointer types initializing 'long *' with an expression of type 'sunindextype *' (aka 'long long *') [-Werror,-Wincompatible-pointer-types]
  long int *rowIndices = SM_INDEXVALS_S(Jsym);
            ^            ~~~~~~~~~~~~~~~~~~~~
```