### PR TITLE
Improve CSE performance

### DIFF
--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -66,6 +66,7 @@ import List;
 import ResolveLoops;
 import StringUtil;
 import Types;
+import UnorderedSet;
 
 uniontype CSE_Equation
   record CSE_EQUATION
@@ -407,7 +408,7 @@ algorithm
       id2 := BaseHashTable.get(call, ht);
       CSE_EQUATION(cse=cse2, call=call2, dependencies=dependencies2) := ExpandableArray.get(id2, exarray);
       cse2 := mergeCSETuples(cse, cse2);
-      ExpandableArray.update(id2, CSE_EQUATION(cse2, call, List.unique(listAppend(dependencies,dependencies2))), exarray);
+      ExpandableArray.update(id2, CSE_EQUATION(cse2, call, UnorderedSet.unique_list(listAppend(dependencies,dependencies2), Util.id, intEq)), exarray);
       ExpandableArray.update(id, CSE_EQUATION(cse, cse2, {}), exarray);
 
 
@@ -2050,7 +2051,7 @@ algorithm
     (_, eqIdcs) := List.filter1OnTrueSync(lengthLst, intEq, 2, range);
     (eqLst, eqIdcs) := List.filterOnTrueSync(BackendEquation.getList(eqIdcs, eqsIn),BackendEquation.isNotAlgorithm,eqIdcs); // no algorithms
     eqs := BackendEquation.listEquation(eqLst);
-    varIdcs := List.unique(List.flatten(List.map1(eqIdcs, Array.getIndexFirst, mIn)));
+    varIdcs := UnorderedSet.unique_list(List.flatten(List.map1(eqIdcs, Array.getIndexFirst, mIn)), Util.id, intEq);
     varLst := List.map1(varIdcs, BackendVariable.getVarAtIndexFirst, varsIn);
     //(varLst,varIdcs) := List.filterOnTrueSync(varLst,BackendVariable.isVarNonDiscrete,varIdcs);// no discrete vars
     vars := BackendVariable.listVar1(varLst);

--- a/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
@@ -169,7 +169,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Equations (5, 5)
 // ========================================
-// 1/1 (1): system.thetaRef / time = system.omega_internal   [dynamic |0|0|0|0|]
+// 1/1 (1): system.theta / time = system.omega_internal   [dynamic |0|0|0|0|]
 // 2/2 (1): system.omega = 314.1592653589793   [dynamic |0|0|0|0|]
 // 3/3 (1): system.thetaRef = system.omega * time   [dynamic |0|0|0|0|]
 // 4/4 (1): 0.0 = -system.thetaRel   [unknown |0|0|0|0|]
@@ -427,7 +427,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Equations (5, 5)
 // ========================================
-// 1/1 (1): system.omega_internal = system.thetaRef / time   [dynamic |0|0|0|0|]
+// 1/1 (1): system.omega_internal = system.theta / time   [dynamic |0|0|0|0|]
 // 2/2 (1): system.omega = 314.1592653589793   [dynamic |0|0|0|0|]
 // 3/3 (1): system.thetaRef = system.omega * time   [dynamic |0|0|0|0|]
 // 4/4 (1): system.thetaRel = 0.0   [unknown |0|0|0|0|]


### PR DESCRIPTION
- Use `UnorderedSet.unique_list` instead of `List.unique` for better scaling in the `CommonSubExpressions` module.