### PR TITLE
Fix evaluation of record fields

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -636,7 +636,7 @@ algorithm
       algorithm
         exp := makeRecordFieldBindingFromParent(cref, target);
       then
-        Binding.CEVAL_BINDING(exp);
+        if Expression.isEmpty(exp) then NFBinding.EMPTY_BINDING else Binding.CEVAL_BINDING(exp);
 
     // A record component without an explicit binding, create one from its children.
     case Component.COMPONENT(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node)))

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1009,6 +1009,7 @@ RecordBinding13.mo \
 RecordBinding14.mo \
 RecordBinding15.mo \
 RecordBinding16.mo \
+RecordBinding17.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
 RecordConstructor3.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding17.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding17.mo
@@ -1,0 +1,30 @@
+// name: RecordBinding17
+// keywords:
+// status: correct
+//
+
+record R
+  Real x(start = 0);
+  Integer y(start = 0);
+end R;
+
+function f
+  output R r;
+algorithm
+  r.x := 0;
+end f;
+
+model RecordBinding17
+  final parameter R m = f() annotation(Evaluate = true);
+  final parameter Integer m_type = if m.y > 0.5 then -1 else 1;
+end RecordBinding17;
+
+// Result:
+// class RecordBinding17
+//   final parameter Real m.x(start = 0.0) = 0.0;
+//   final parameter Integer m.y(start = 0);
+//   final parameter Integer m_type = 1;
+// end RecordBinding17;
+// [flattening/modelica/scodeinst/RecordBinding17.mo:8:3-8:23:writable] Warning: Parameter m.y has no value, and is fixed during initialization (fixed=true), using available start value (start=0) as default value.
+//
+// endResult


### PR DESCRIPTION
- When fetching a binding for a record field from its parent's binding, return an empty binding if the expression is empty.