### PR TITLE
Optimize RemoveSimpleEquations

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -7502,7 +7502,7 @@ algorithm
   end match;
 end traverseExpBidirSubs;
 
-protected function traverseExpTopDownSubs
+public function traverseExpTopDownSubs
   input list<DAE.Subscript> inSubscript;
   input FuncType rel;
   input Argument iarg;


### PR DESCRIPTION
- Change `replaceCrefWithBindExp` to use `UnorderedSet` to reduce the amount of allocations.
- Avoid unnecessary allocations in `traverseCrefUnreplaceable`.