### PR TITLE
fix hermite interpolation and reduce number of RHS calls

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -1760,6 +1760,7 @@ int gbode_singlerate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverIn
         gbData->stats.nErrorTestFailures++;
         infoStreamPrint(OMC_LOG_SOLVER, 0, "Reject step from %10g to %10g, error %10g, new stepsize %10g",
                         gbData->time, gbData->time + gbData->lastStepSize, gbData->errValues[0], gbData->stepSize);
+        continue;
       }
 
       // store right hand values for latter interpolation


### PR DESCRIPTION
In case of step rejection, some calculations can be skipped (RHS calls, updating the ring buffer, etc.)
