### PR TITLE
Fix use of arrow operator instead of dot on factory<T>::operator=()

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/Utils/extension/impl/factory.hpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Utils/extension/impl/factory.hpp
@@ -39,7 +39,7 @@ public:
   factory(factory<T> const& first) : func(first.func) {}
 
   factory& operator=(factory<T> const& first) {
-    this->func = first->func;
+    this->func = first.func;
     return *this;
   }
 


### PR DESCRIPTION
Compilation fails on MacOS with clang 17.0.0

Error message is:
factory.hpp:42:23: error: member reference type 'const factory<T>' is not a pointer; did you mean to use '.'?
   42 |     this->func = first->func;

The problem is on method factory<T>::operator=(factory<T> const& first) on OMCompiler/SimulationRuntime/cpp/Core/Utils/extension/impl/factory.hpp line 41:
  factory& operator=(factory<T> const& first) {
    this->func = first->func;
    return *this;
  }

parameter first is a reference, not a pointer (and factory<T> does not override a -> operator). As such, the use of the arrow operator seem to be a mistake.

The method rewritten with the dot operator reads:
  factory& operator=(factory<T> const& first) {
    this->func = first.func;
    return *this;
  }

This version compiles without warning on Clang 17.0.0 for MacOS and gcc 14.2 for linux.

<!--- How does this address the problem? -->
