### PR TITLE
[NB] update dae mode variable lowering

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1980,7 +1980,7 @@ public
       ComponentRef. Fails if the component ref cannot be found."
       input VariablePointers variables;
       input ComponentRef cref;
-      input Boolean report = true;
+      input Option<SourceInfo> info = NONE();
       output Pointer<Variable> var_ptr;
     protected
       Integer index;
@@ -1988,8 +1988,8 @@ public
       var_ptr := match UnorderedMap.get(cref, variables.map)
         case SOME(index) guard(index > 0) then ExpandableArray.get(index, variables.varArr);
         else algorithm
-          if report then
-            Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for " + ComponentRef.toString(cref)});
+          if Util.isSome(info) then
+            Error.addInternalError(getInstanceName() + " failed for " + ComponentRef.toString(cref), Util.getOption(info));
           end if;
         then fail();
       end match;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -844,7 +844,7 @@ protected
         BackendInfo binfo;
         VariableKind varKind;
       case Variable.VARIABLE(backendinfo = binfo as BackendInfo.BACKEND_INFO(varKind = varKind as VariableKind.RECORD())) algorithm
-        varKind.children := list(VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(child.name)) for child in var.children);
+        varKind.children := list(VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(child.name), SOME(sourceInfo())) for child in var.children);
         // set parent for all children
         varKind.children := list(BVariable.setParent(child, var_ptr) for child in varKind.children);
         binfo.varKind := varKind;
@@ -1412,7 +1412,7 @@ protected
   algorithm
     try
       if not ComponentRef.isWild(cref) then
-        var := VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(cref), complete);
+        var  := VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(cref), if complete then SOME(sourceInfo()) else NONE());
         cref := lowerComponentReferenceInstNode(cref, var);
         cref := ComponentRef.mapSubscripts(cref, function Subscript.mapExp(func = function lowerComponentReferenceExp(variables = variables, complete = true)));
       end if;
@@ -1494,7 +1494,7 @@ protected
     ComponentRef cref = ComponentRef.fromNode(node, Type.INTEGER(), {}, NFComponentRef.Origin.ITERATOR);
     Pointer<Variable> var;
   algorithm
-    var := VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(cref));
+    var := VariablePointers.getVarSafe(variables, ComponentRef.stripSubscriptsAll(cref), SOME(sourceInfo()));
     node := InstNode.VAR_NODE(InstNode.name(node), var);
   end lowerInstNode;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBDAEMode.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBDAEMode.mo
@@ -50,7 +50,7 @@ protected
   import Partition = NBPartition;
   import Tearing = NBTearing;
   import BVariable = NBVariable;
-  import NBVariable.VariablePointer;
+  import NBVariable.{VariablePointer, VariablePointers, VarData};
 
 public
   function main extends Module.wrapper;
@@ -64,10 +64,11 @@ public
         local
           list<Partition.Partition> ode;
           EqData eqData;
+          VariablePointers variables;
 
-        case BackendDAE.MAIN(ode = ode, eqData = eqData as EqData.EQ_DATA_SIM())
+        case BackendDAE.MAIN(ode = ode, eqData = eqData as EqData.EQ_DATA_SIM(), varData = VarData.VAR_DATA_SIM(variables = variables))
           algorithm
-            bdae.dae := SOME(func(ode, eqData.uniqueIndex));
+            bdae.dae := SOME(func(ode, variables, eqData.uniqueIndex));
         then bdae;
 
         else algorithm
@@ -117,8 +118,9 @@ protected
           part.equations := EquationPointers.clone(part.equations, false);
           // inline record and tuple equations and then create residuals
           new_eqns := Pointer.create({});
+
           EquationPointers.map(part.equations, function Inline.inlineRecordTupleArrayEquation(
-              iter = Iterator.EMPTY(), variables = part.unknowns, new_eqns = new_eqns, set = dummy_set, index = uniqueIndex, inlineSimple = true));
+              iter = Iterator.EMPTY(), variables = variables, new_eqns = new_eqns, set = dummy_set, index = uniqueIndex, inlineSimple = true));
           part.equations := EquationPointers.addList(Pointer.access(new_eqns), EquationPointers.compress(part.equations));
           EquationPointers.mapPtr(part.equations, function Equation.createResidual(new = false));
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
@@ -153,6 +153,7 @@ public
     "DAEMode
      This function is only allowed to create a list of new partitions for dae Mode."
     input output list<Partition.Partition> partitions;
+    input VariablePointers variables;
     input Pointer<Integer> uniqueIndex;
   end daeModeInterface;
 


### PR DESCRIPTION
 - add correct array for all variables when lowering variables for record children (record children can be of non partition specific unknown variables like parameters)
 - upgrade VariablePointers.getVarSafe to get source info for better error reporting
 - addresses regressions mentioned in #14147