### PR TITLE
Don't update bindings of redeclared parameters

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2360,6 +2360,11 @@ protected
   Absyn.Exp aexp;
   list<Absyn.Exp> args;
 algorithm
+  if InstContext.inRedeclared(context) then
+    // Don't update the binding if the parameter is being redeclared.
+    return;
+  end if;
+
   comp := InstNode.component(node);
 
   if not Component.isFixed(comp) or InstNode.hasBinding(node) then

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1184,6 +1184,7 @@ UnboundParameter3.mo \
 UnboundParameter4.mo \
 UnboundParameter5.mo \
 UnboundParameter6.mo \
+UnboundParameter7.mo \
 usertype1.mo \
 usertype2.mo \
 usertype3.mo \

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter7.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter7.mo
@@ -1,0 +1,18 @@
+// name: UnboundParameter7
+// keywords:
+// status: correct
+//
+
+model A
+  replaceable parameter Real x(start = 1.0);
+end A;
+
+model UnboundParameter7
+  extends A(redeclare Real x = 1.0);
+end UnboundParameter7;
+
+// Result:
+// class UnboundParameter7
+//   parameter Real x(start = 1.0) = 1.0;
+// end UnboundParameter7;
+// endResult


### PR DESCRIPTION
- Don't create a binding from the start value of an unbound parameter if the parameter is being redeclared.

Fixes #14099