### PR TITLE
Avoid dangerous Element->getModel()->isConnector()

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1411,7 +1411,7 @@ void LineAnnotation::handleCollidingConnections()
   QList<QGraphicsItem*> items = collidingItems(Qt::IntersectsItemShape);
   for (int i = 0; i < items.size(); ++i) {
     if (Element *pElement = dynamic_cast<Element*>(items.at(i))) {
-      if ((pElement->getModel() && pElement->getModel()->isConnector())
+      if (pElement->isConnector()
           || (pElement->getLibraryTreeItem() && (pElement->getLibraryTreeItem()->getOMSConnector() || pElement->getLibraryTreeItem()->getOMSBusConnector()
                                                  || pElement->getLibraryTreeItem()->getOMSTLMBusConnector()))) {
         mCollidingConnectorElements.append(pElement);

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -401,7 +401,7 @@ QRectF Element::boundingRect() const
   } else if (isPort()) {
     ExtentAnnotation extent;
     if (mpModelComponent) {
-      if (mpModelComponent->getModel()->isConnector() && (mpGraphicsView->isDiagramView()) && canUseDiagramAnnotation()) {
+      if (mpModelComponent->isConnector() && (mpGraphicsView->isDiagramView()) && canUseDiagramAnnotation()) {
         mpModelComponent->getAnnotation()->getPlacementAnnotation().getTransformation().getExtent();
       } else {
         mpModelComponent->getAnnotation()->getPlacementAnnotation().getIconTransformation().getExtent();
@@ -557,7 +557,7 @@ ModelInstance::CoordinateSystem Element::getCoordinateSystem() const
 {
   ModelInstance::CoordinateSystem coordinateSystem;
   if (mpModelComponent && mpModel) {
-    if (mpModelComponent->getModel()->isConnector() && (mpGraphicsView->isDiagramView()) && canUseDiagramAnnotation()) {
+    if (mpModelComponent->isConnector() && (mpGraphicsView->isDiagramView()) && canUseDiagramAnnotation()) {
       coordinateSystem = mpModel->getAnnotation()->getDiagramAnnotation()->mMergedCoordinateSystem;
     } else {
       coordinateSystem = mpModel->getAnnotation()->getIconAnnotation()->mMergedCoordinateSystem;
@@ -626,7 +626,7 @@ QString Element::getPlacementAnnotation(bool ModelicaSyntax)
       placementAnnotationString.append(QString("visible=%1,").arg(mTransformation.getVisible().toQString()));
     }
   }
-  if ((mpLibraryTreeItem && mpLibraryTreeItem->isConnector()) || (mpModelComponent && mpModelComponent->getModel()->isConnector())) {
+  if ((mpLibraryTreeItem && mpLibraryTreeItem->isConnector()) || (mpModelComponent && mpModelComponent->isConnector())) {
     if (mpGraphicsView->isIconView()) {
       // first get the component from diagram view and get the transformations
       Element *pElement = mpGraphicsView->getModelWidget()->getDiagramGraphicsView()->getElementObject(getName());
@@ -692,7 +692,7 @@ QString Element::getOMCPlacementAnnotation(QPointF position)
   if (mTransformation.isValid()) {
     placementAnnotationString.append(mTransformation.getVisible() ? "true" : "false");
   }
-  if ((mpLibraryTreeItem && mpLibraryTreeItem->isConnector()) || (mpModelComponent && mpModelComponent->getModel()->isConnector())) {
+  if ((mpLibraryTreeItem && mpLibraryTreeItem->isConnector()) || (mpModelComponent && mpModelComponent->isConnector())) {
     if (mpGraphicsView->isIconView()) {
       // first get the component from diagram view and get the transformations
       Element *pElement;
@@ -744,6 +744,16 @@ QString Element::getTransformationExtent()
   transformationExtent.append(QString::number(extent2.x())).append(",");
   transformationExtent.append(QString::number(extent2.y())).append("}");
   return transformationExtent;
+}
+
+/*!
+ * \brief Element::isConnector
+ * Returns true if the Element class is connector.
+ * \return
+ */
+bool Element::isConnector() const
+{
+  return mpModel && mpModel->isConnector();
 }
 
 /*!
@@ -891,7 +901,7 @@ void Element::createClassElements()
     foreach (auto pElement, elements) {
       if (pElement->isComponent()) {
         auto pComponent = dynamic_cast<ModelInstance::Component*>(pElement);
-        if (pComponent->isPublic() && pComponent->getModel() && pComponent->getModel()->isConnector()) {
+        if (pComponent->isPublic() && pComponent->isConnector()) {
           mElementsList.append(new Element(pComponent, this, getRootParentElement()));
         }
       }
@@ -1530,11 +1540,11 @@ void Element::createClassShapes()
     // Always use the IconMap here. Only IconMap makes sense for drawing icons of Element.
     if (!(pExtendModel && !pExtendModel->getIconDiagramMapPrimitivesVisible(true))) {
       /* issue #12074
-       * Use mpModelComponent->getModel()->isConnector() here instead of mpModel->isConnector()
+       * Use mpModelComponent->isConnector() here instead of mpModel->isConnector()
        * So when called for extends we use the top level element restriction.
        * We use the same mpModelComponent for top level and extends elements. See Element constructor above for extends element type.
        */
-      if (mpModelComponent && mpModelComponent->getModel()->isConnector() && mpGraphicsView->isDiagramView() && canUseDiagramAnnotation()) {
+      if (mpModelComponent && mpModelComponent->isConnector() && mpGraphicsView->isDiagramView() && canUseDiagramAnnotation()) {
         shapes = mpModel->getAnnotation()->getDiagramAnnotation()->getGraphics();
       } else {
         shapes = mpModel->getAnnotation()->getIconAnnotation()->getGraphics();

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -159,6 +159,7 @@ public:
   QString getOMCPlacementAnnotation(QPointF position);
   QString getTransformationOrigin();
   QString getTransformationExtent();
+  bool isConnector() const;
   bool isExpandableConnector() const;
   bool isArray() const;
   QStringList getAbsynArrayIndexes() const;

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -234,7 +234,7 @@ void UpdateComponentTransformationsCommand::redoInternal()
 {
   ModelWidget *pModelWidget = mpComponent->getGraphicsView()->getModelWidget();
   if (mMoveConnectorsTogether && pModelWidget->getLibraryTreeItem()->isModelica()
-      && (mpComponent->getModel() && mpComponent->getModel()->isConnector())) {
+      && mpComponent->isConnector()) {
     GraphicsView *pGraphicsView;
     if (mpComponent->getGraphicsView()->isIconView()) {
       pGraphicsView = pModelWidget->getDiagramGraphicsView();
@@ -274,8 +274,7 @@ void UpdateComponentTransformationsCommand::redoInternal()
 void UpdateComponentTransformationsCommand::undo()
 {
   ModelWidget *pModelWidget = mpComponent->getGraphicsView()->getModelWidget();
-  if (mMoveConnectorsTogether && pModelWidget->getLibraryTreeItem()->isModelica()
-      && (mpComponent->getModel() && mpComponent->getModel()->isConnector())) {
+  if (mMoveConnectorsTogether && pModelWidget->getLibraryTreeItem()->isModelica() && mpComponent->isConnector()) {
     GraphicsView *pGraphicsView;
     if (mpComponent->getGraphicsView()->isIconView()) {
       pGraphicsView = pModelWidget->getDiagramGraphicsView();

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1514,7 +1514,7 @@ namespace ModelInstance
     if (connector.size() == 1) return true;
 
     auto elem = model.lookupElement(connector.first().getName(false));
-    return elem && elem->getModel() && elem->getModel()->isConnector();
+    return elem && elem->isConnector();
   }
 
   bool isCompatibleConnectorDirection(const Element &lhs, bool lhsOutside, const Element &rhs, bool rhsOutside)
@@ -2091,6 +2091,16 @@ namespace ModelInstance
   bool Element::isRedeclare() const
   {
     return mpPrefixes ? mpPrefixes.get()->isRedeclare() : false;
+  }
+
+  bool Element::isConnector() const
+  {
+    return mpModel && mpModel->isConnector();
+  }
+
+  bool Element::isExpandableConnector() const
+  {
+    return mpModel && mpModel->isExpandableConnector();
   }
 
   QString Element::getConnector() const

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -699,6 +699,8 @@ private:
     bool isInput() const;
     Replaceable *getReplaceable() const;
     bool isRedeclare() const;
+    bool isConnector() const;
+    bool isExpandableConnector() const;
     QString getConnector() const;
     QString getVariability() const;
     QString getDirectionPrefix() const;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -370,7 +370,7 @@ void GraphicsView::drawElements(ModelInstance::Model *pModelInstance, bool inher
       if (pModelInstanceElement->isComponent() && pModelInstanceElement->getModel()) {
         auto pModelInstanceComponent = dynamic_cast<ModelInstance::Component*>(pModelInstanceElement);
         elementIndex++;
-        if (pModelInstanceComponent->getModel()->isConnector()) {
+        if (pModelInstanceComponent->isConnector()) {
           connectorIndex++;
         }
         if (modelInfo.mDiagramElementsList.isEmpty() || inherited) {
@@ -386,7 +386,7 @@ void GraphicsView::drawElements(ModelInstance::Model *pModelInstance, bool inher
               pDiagramGraphicsView->addElementItem(pDiagramElement);
               pDiagramGraphicsView->addElementToList(pDiagramElement);
               pDiagramGraphicsView->deleteElementFromOutOfSceneList(pDiagramElement);
-              if (pModelInstanceComponent->getModel()->isConnector() && connectorIndex < modelInfo.mIconElementsList.size()) {
+              if (pModelInstanceComponent->isConnector() && connectorIndex < modelInfo.mIconElementsList.size()) {
                 Element *pIconElement = modelInfo.mIconElementsList.at(connectorIndex);
                 if (pIconElement) {
                   pIconElement->setModelComponent(pModelInstanceComponent);
@@ -938,14 +938,14 @@ void GraphicsView::addElementToView(ModelInstance::Component *pComponent, bool i
   GraphicsView *pDiagramGraphicsView = mpModelWidget->getDiagramGraphicsView();
 
   // if element is of connector type.
-  if (pComponent && pComponent->getModel()->isConnector()) {
+  if (pComponent && pComponent->isConnector()) {
     // Connector type elements exists on icon view as well
     pIconElement = new Element(pComponent, inherited, pIconGraphicsView, createTransformation, position, placementAnnotation);
   }
   pDiagramElement = new Element(pComponent, inherited, pDiagramGraphicsView, createTransformation, position, placementAnnotation);
 
   // if element is of connector type && containing class is Modelica type.
-  if (pIconElement && pComponent->getModel()->isConnector()) {
+  if (pIconElement && pComponent->isConnector()) {
     // Connector type elements exists on icon view as well
     if (pIconElement->mTransformation.isValid() && pIconElement->mTransformation.getVisible()) {
       pIconGraphicsView->addElementItem(pIconElement);
@@ -1120,7 +1120,7 @@ void GraphicsView::deleteElement(Element *pElement)
   if (mpModelWidget->getLibraryTreeItem()->isSSP()) {
     OMSProxy::instance()->omsDelete(pElement->getLibraryTreeItem()->getNameStructure());
   } else {
-    if (pElement->getModel() && pElement->getModel()->isConnector()) {
+    if (pElement->isConnector()) {
       GraphicsView *pGraphicsView;
       if (isIconView()) {
         pGraphicsView = mpModelWidget->getDiagramGraphicsView();
@@ -3113,12 +3113,12 @@ Element* GraphicsView::connectorElementAtPosition(QPoint position)
         return 0;
       } else if (pRootElement && !pRootElement->isSelected()) {
         // Issue #11310. If both root and element are connectors then use the root.
-        if (pRootElement->getModel() && pRootElement->getModel()->isConnector() && pElement && pElement->getModel() && pElement->getModel()->isConnector()) {
+        if (pRootElement->isConnector() && pElement && pElement->isConnector()) {
           pElement = pRootElement;
         }
         if (MainWindow::instance()->getConnectModeAction()->isChecked() && isDiagramView() &&
             !(mpModelWidget->getLibraryTreeItem()->isSystemLibrary() || mpModelWidget->isElementMode() || isVisualizationView()) &&
-            ((pElement->getModel() && pElement->getModel()->isConnector()) ||
+            (pElement->isConnector() ||
              (mpModelWidget->getLibraryTreeItem()->isSSP() &&
               (pElement->getLibraryTreeItem()->getOMSConnector() || pElement->getLibraryTreeItem()->getOMSBusConnector()
                || pElement->getLibraryTreeItem()->getOMSTLMBusConnector() || pElement->isPort())))) {
@@ -3640,7 +3640,7 @@ void GraphicsView::copyItems(bool cut)
           QJsonObject componentJsonObject;
           componentJsonObject.insert(QLatin1String("classname"), pElement->getClassName());
           componentJsonObject.insert(QLatin1String("name"), pElement->getName());
-          componentJsonObject.insert(QLatin1String("connector"), pElement->getModel() ? pElement->getModel()->isConnector() : false);
+          componentJsonObject.insert(QLatin1String("connector"), pElement->isConnector());
           componentJsonObject.insert(QLatin1String("placement"), pElement->getOMCPlacementAnnotation(QPointF(0, 0)));
           componentsJsonArray.append(componentJsonObject);
         } else if (ShapeAnnotation *pShapeAnnotation = dynamic_cast<ShapeAnnotation*>(itemsList.at(i))) {
@@ -7018,7 +7018,7 @@ void ModelWidget::selectDeselectElement(const QString &name, bool selected)
       pDiagramElement->setIgnoreSelection(true);
       pDiagramElement->setSelected(selected);
       pDiagramElement->setIgnoreSelection(false);
-      if (mpIconGraphicsView && pDiagramElement->getModel() && pDiagramElement->getModel()->isConnector()) {
+      if (mpIconGraphicsView && pDiagramElement->isConnector()) {
         Element *pIconElement = mpIconGraphicsView->getElementObjectFromQualifiedName(name);
         pIconElement->setIgnoreSelection(true);
         pIconElement->setSelected(selected);


### PR DESCRIPTION
- Fix missing checks for if an elements model exists before trying to use it by adding `Element::isConnector` and using that instead of `Element->getModel()->isConnector()`.