### PR TITLE
Fix indexing when vectorizing equations/statements

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1196,6 +1196,7 @@ VectorizeBindings2.mo \
 VectorizeBindings3.mo \
 VectorizeBindings4.mo \
 VectorizeBindings5.mo \
+VectorizeBindings6.mo \
 VectorTest.mo \
 Visibility1.mo \
 Visibility2.mo \

--- a/testsuite/flattening/modelica/scodeinst/VectorizeBindings6.mo
+++ b/testsuite/flattening/modelica/scodeinst/VectorizeBindings6.mo
@@ -1,0 +1,41 @@
+// name: VectorizeBindings6
+// keywords:
+// status: correct
+//
+
+model VectorizeBindings6
+  model A
+    Real x;
+    Real y;
+  equation
+    x = 1;
+  algorithm
+    y := 1;
+  end A;
+
+  model B
+    A[2] a;
+  end B;
+
+  B[2] b;
+  annotation(__OpenModelica_commandLineOptions="--newBackend");
+end VectorizeBindings6;
+
+// Result:
+// class VectorizeBindings6
+//   Real[2, 2] b.a.x;
+//   Real[2, 2] b.a.y;
+// equation
+//   for $i2 in 1:2 loop
+//     for $i1 in 1:2 loop
+//       b[$i1].a[$i2].x = 1.0;
+//     end for;
+//   end for;
+// algorithm
+//   for $i2 in 1:2 loop
+//     for $i1 in 1:2 loop
+//       b[$i1].a[$i2].y := 1.0;
+//     end for;
+//   end for;
+// end VectorizeBindings6;
+// endResult


### PR DESCRIPTION
- Check what the currently used index is when vectorizing equations/statements to avoid nested iterators with the same name.

Fixes #14138