### PR TITLE
[C, BE, TPL] set NLS start value for initialization to cref value

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -7524,8 +7524,9 @@ algorithm
   end if;
 
   // Create SimCode Equation for special globalKnownVars
-  if (BackendVariable.isParam(globalKnownVar) and BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
-    or ( /* parameter has non-trivial start equation - this is not the correct condition though */ BackendVariable.isParam(globalKnownVar) and BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar) and BackendVariable.varHasStartValue(globalKnownVar))
+  if (BackendVariable.isParam(globalKnownVar) and
+         (BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+      or (BackendVariable.varHasStartValue(globalKnownVar) and not BackendVariable.varHasConstantStartExp(globalKnownVar)))
     or (BackendVariable.isVarAlg(globalKnownVar) and not BackendVariable.isInput(globalKnownVar)) and BackendVariable.varFixed(globalKnownVar)
     or (BackendVariable.isExtObj(globalKnownVar) and BackendVariable.varHasBindExp(globalKnownVar) and BackendVariable.varFixed(globalKnownVar))
    then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -7313,7 +7313,7 @@ algorithm
   startValueEquations := matchcontinue (syst, shared, acc)
     local
       BackendDAE.Variables vars, av;
-      list<BackendDAE.Equation>  startValueEquationsTmp2;
+      list<BackendDAE.Equation> startValueEquationsTmp2;
       list<SimCode.SimEqSystem> simeqns, simeqns1;
       Integer uniqueEqIndex;
       BackendDAE.Variables globalKnownVars;
@@ -7524,7 +7524,7 @@ algorithm
   end if;
 
   // Create SimCode Equation for special globalKnownVars
-  if (BackendVariable.isParam(globalKnownVar) and BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+  if (BackendVariable.isParam(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
     or (BackendVariable.isVarAlg(globalKnownVar) and not BackendVariable.isInput(globalKnownVar)) and BackendVariable.varFixed(globalKnownVar)
     or (BackendVariable.isExtObj(globalKnownVar) and BackendVariable.varHasBindExp(globalKnownVar) and BackendVariable.varFixed(globalKnownVar))
    then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -7524,7 +7524,8 @@ algorithm
   end if;
 
   // Create SimCode Equation for special globalKnownVars
-  if (BackendVariable.isParam(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+  if (BackendVariable.isParam(globalKnownVar) and BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+    or ( /* parameter has non-trivial start equation - this is not the correct condition though */ BackendVariable.isParam(globalKnownVar) and BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar) and BackendVariable.varHasStartValue(globalKnownVar))
     or (BackendVariable.isVarAlg(globalKnownVar) and not BackendVariable.isInput(globalKnownVar)) and BackendVariable.varFixed(globalKnownVar)
     or (BackendVariable.isExtObj(globalKnownVar) and BackendVariable.varHasBindExp(globalKnownVar) and BackendVariable.varFixed(globalKnownVar))
    then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -7525,8 +7525,8 @@ algorithm
 
   // Create SimCode Equation for special globalKnownVars
   if (BackendVariable.isParam(globalKnownVar) and
-         (BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
-      or (BackendVariable.varHasStartValue(globalKnownVar) and not BackendVariable.varHasConstantStartExp(globalKnownVar)))
+         ((BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+      or (BackendVariable.varHasStartValue(globalKnownVar) and not BackendVariable.varHasConstantStartExp(globalKnownVar))))
     or (BackendVariable.isVarAlg(globalKnownVar) and not BackendVariable.isInput(globalKnownVar)) and BackendVariable.varFixed(globalKnownVar)
     or (BackendVariable.isExtObj(globalKnownVar) and BackendVariable.varHasBindExp(globalKnownVar) and BackendVariable.varFixed(globalKnownVar))
    then

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -6557,7 +6557,7 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
         let &preExp = buffer ""
         let &varDecls = buffer ""
         let &auxFunction = buffer ""
-        let START = if init then crefOrStartCref(name, context, &preExp, &varDecls, &auxFunction) else cref(name, &sub)
+        let START = cref(name, &sub)
         let PREV = if stringEq(&preExp, "") then "" else &preExp + "\n"
         let DECL = if stringEq(&varDecls, "") then "" else &varDecls + "\n"
         let AUX = if stringEq(&auxFunction, "") then "" else &auxFunction + "\n"
@@ -6612,7 +6612,7 @@ template equationNonlinearAlternativeTearing(SimEqSystem eq, Context context, St
           let &preExp = buffer ""
           let &varDecls = buffer ""
           let &auxFunction = buffer ""
-          let START = if init then crefOrStartCref(name, context, &preExp, &varDecls, &auxFunction) else cref(name, &sub)
+          let START = cref(name, &sub)
           let PREV = if stringEq(&preExp, "") then "" else &preExp + "\n"
           let DECL = if stringEq(&varDecls, "") then "" else &varDecls + "\n"
           let AUX = if stringEq(&auxFunction, "") then "" else &auxFunction + "\n"

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4791,7 +4791,6 @@ template initializeDAEmodeData(Integer nResVars, list<SimVar> algVars, Integer n
   let colPtr = genSPCRSPtr(listLength(sparsepattern), sparsepattern, "colPtrIndex")
   let rowIndex = genSPCRSRows(lengthListElements(unzipSecond(sparsepattern)), sparsepattern, "rowIndex")
   let colorString = genSPColors(colorList, "daeModeData->sparsePattern->colorCols")
-  let maxColorStr = '<%maxColor%>'
   let algIndexes = genVarIndexes(algVars, "algIndexes")
   <<
   /* initialize the daeMode variables */
@@ -6513,7 +6512,6 @@ match eq
 case eqn as SES_MIXED(__) then
   let &sub = buffer ""
   let &tmp += equation_impl(-1, -1, cont, context, modelNamePrefixStr, init)
-  let numDiscVarsStr = listLength(discVars)
   <<
   /* Continuous equation part */
   <% if profileSome() then 'SIM_PROF_TICK_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%index%>).profileBlockIndex);' %>
@@ -6530,14 +6528,6 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
 ::=
   match eq
     case eq as SES_NONLINEAR(nlSystem=nls as NONLINEARSYSTEM(__), alternativeTearing = at) then
-      let size = listLength(nls.crefs)
-      let &tmp = buffer ""
-      let innerBody = (nls.eqs |> eq2 =>
-         functionExtraResidualsPreBody(eq2, &tmp, modelNamePrefix)
-       ;separator="\n")
-      let nonlinindx = nls.indexNonLinearSystem
-      let returnval = match at case at as SOME(__) then 'return 1;' case at as NONE() then ''
-      let returnval2 = match at case at as SOME(__) then 'return 0;' case at as NONE() then ''
       <<
       int retValue;
       if(OMC_ACTIVE_STREAM(OMC_LOG_DT))
@@ -6554,28 +6544,22 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       /* get old value */
       <%nls.crefs |> name hasindex i0 =>
         let &sub = buffer ""
-        let &preExp = buffer ""
-        let &varDecls = buffer ""
-        let &auxFunction = buffer ""
         let START = cref(name, &sub)
-        let PREV = if stringEq(&preExp, "") then "" else &preExp + "\n"
-        let DECL = if stringEq(&varDecls, "") then "" else &varDecls + "\n"
-        let AUX = if stringEq(&auxFunction, "") then "" else &auxFunction + "\n"
-        '<%DECL%><%PREV%><%AUX%>data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsxOld[<%i0%>] = <%START%>;'
+        'data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsxOld[<%i0%>] = <%START%>;'
       ;separator="\n"%>
       retValue = solve_nonlinear_system(data, threadData, <%nls.indexNonLinearSystem%>);
       /* check if solution process was successful */
       if (retValue > 0){
         const int indexes[2] = {1,<%nls.index%>};
         throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
-        <%returnval2%>
+        <%match at case SOME(__) then 'return 0;'%>
       }
       /* write solution */
       <%nls.crefs |> name hasindex i0 =>
         let &sub = buffer ""
         '<%cref(name, &sub)%> = data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsx[<%i0%>];' ;separator="\n"%>
       <% if profileSome() then 'SIM_PROF_ACC_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%nls.index%>).profileBlockIndex);' %>
-      <%returnval%>
+      <%match at case SOME(__) then 'return 1;'%>
       >>
 end equationNonlinear;
 
@@ -6584,12 +6568,6 @@ template equationNonlinearAlternativeTearing(SimEqSystem eq, Context context, St
 ::=
   match eq
     case eq as SES_NONLINEAR(nlSystem = nls as NONLINEARSYSTEM(__), alternativeTearing = SOME(at as NONLINEARSYSTEM(__))) then
-      let size = listLength(at.crefs)
-      let &tmp = buffer ""
-      let innerBody = (at.eqs |> eq2 =>
-         functionExtraResidualsPreBody(eq2, &tmp, modelNamePrefix)
-       ;separator="\n")
-      let nonlinindx = at.indexNonLinearSystem
       <<
       int retValue;
       if(OMC_ACTIVE_STREAM(OMC_LOG_DT))
@@ -6609,14 +6587,8 @@ template equationNonlinearAlternativeTearing(SimEqSystem eq, Context context, St
         /* get old value */
         <%at.crefs |> name hasindex i0 =>
           let &sub = buffer ""
-          let &preExp = buffer ""
-          let &varDecls = buffer ""
-          let &auxFunction = buffer ""
           let START = cref(name, &sub)
-          let PREV = if stringEq(&preExp, "") then "" else &preExp + "\n"
-          let DECL = if stringEq(&varDecls, "") then "" else &varDecls + "\n"
-          let AUX = if stringEq(&auxFunction, "") then "" else &auxFunction + "\n"
-          '<%DECL%><%PREV%><%AUX%>data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsxOld[<%i0%>] = <%START%>;'
+          'data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsxOld[<%i0%>] = <%START%>;'
         ;separator="\n"%>
         retValue = solve_nonlinear_system(data, threadData, <%at.indexNonLinearSystem%>);
         /* The casual tearing set found a solution */

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4801,19 +4801,6 @@ end contextIteratorName;
   else crefToCStr(cr, 0, false, false, &sub)
 end cref;
 
-/* public */ template crefOrStartCref(ComponentRef cr, Context context, Text &preExp, Text &varDecls, Text &auxFunction)
- "Only during intialization and if the start expression cannot be
-  evaluated to a constant use the full expression. Otherwise return the
-  cref itself. Used to resolve Ticket: #5807"
-::=
-let &sub = buffer ""
-  match cref2simvar(cr, getSimCode())
-  case SIMVAR(initialValue = SOME(startExp)) then
-    if boolNot(Expression.isConst(startExp)) then daeExp(startExp, context, &preExp, &varDecls, &auxFunction)
-    else cref(cr, &sub)
-  else cref(cr, &sub)
-end crefOrStartCref;
-
 /* public */ template crefOld(ComponentRef cr, Integer ix)
  "Generates C equivalent name for component reference.
   used in Compiler/Template/CodegenFMU.tpl"

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -193,7 +193,6 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   *
   *  This function calculates bound parameters that depend on other parameters,
   *  e.g. parameter Real n=1/m;
-  *  obsolete: bound_parameters
   *
   *  \param [ref] [data]
   */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -727,17 +727,19 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
   int initMethod = IIM_SYMBOLIC; /* default method */
   int retVal = -1;
   int i;
+  modelica_boolean read_init_from_file = (pInitFile && strcmp(pInitFile, ""));
+  modelica_boolean fmi_init_method = !strcmp(pInitMethod, "fmi");
 
   data->simulationInfo->homotopySteps = 0;
 
   infoStreamPrint(OMC_LOG_INIT, 0, "### START INITIALIZATION ###");
 
-  if (strcmp(pInitMethod, "fmi"))
+  if (!fmi_init_method)
     setAllParamsToStart(data);
 
 #if !defined(OMC_MINIMAL_RUNTIME)
   /* import start values from extern mat-file */
-  if(pInitFile && strcmp(pInitFile, ""))
+  if(read_init_from_file)
   {
     data->callback->updateBoundParameters(data, threadData);
     data->callback->updateBoundVariableAttributes(data, threadData);
@@ -749,10 +751,10 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
   }
 #endif
   /* set up all variables with their start-values */
-  if (strcmp(pInitMethod, "fmi"))
+  if (!fmi_init_method)
     setAllVarsToStart(data);
 
-  if(!(pInitFile && strcmp(pInitFile, ""))) {
+  if(!read_init_from_file) {
     data->callback->updateBoundParameters(data, threadData);
     data->callback->updateBoundVariableAttributes(data, threadData);
   }
@@ -764,7 +766,7 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
   updateStaticDataOfNonlinearSystems(data, threadData);
 
   /* if there are user-specified options, use them! */
-  if (pInitMethod && (strcmp(pInitMethod, "") && strcmp(pInitMethod, "fmi"))) {
+  if (pInitMethod && (strcmp(pInitMethod, "") && !fmi_init_method)) {
     initMethod = IIM_UNKNOWN;
 
     for (i=1; i<IIM_MAX; ++i) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -746,51 +746,6 @@ void setAllVarsToStart(DATA *data)
   TRACE_POP
 }
 
-/*! \fn setAllStartToVars
- *
- *  This function sets the start-attribute of all variables to their current values.
- *
- *  \param [ref] [data]
- *
- *  \author lochel
- */
-void setAllStartToVars(DATA *data)
-{
-  TRACE_PUSH
-  SIMULATION_DATA *sData = data->localData[0];
-  MODEL_DATA      *mData = data->modelData;
-  long i;
-
-  debugStreamPrint(OMC_LOG_DEBUG, 1, "the start-attribute of all variables to their current values:");
-  for(i=0; i<mData->nVariablesReal; ++i)
-  {
-    mData->realVarsData[i].attribute.start = sData->realVars[i];
-    debugStreamPrint(OMC_LOG_DEBUG, 0, "Real var %s(start=%g)", mData->realVarsData[i].info.name, sData->realVars[i]);
-  }
-  for(i=0; i<mData->nVariablesInteger; ++i)
-  {
-    mData->integerVarsData[i].attribute.start = sData->integerVars[i];
-    debugStreamPrint(OMC_LOG_DEBUG, 0, "Integer var %s(start=%ld)", mData->integerVarsData[i].info.name, sData->integerVars[i]);
-  }
-  for(i=0; i<mData->nVariablesBoolean; ++i)
-  {
-    mData->booleanVarsData[i].attribute.start = sData->booleanVars[i];
-    debugStreamPrint(OMC_LOG_DEBUG, 0, "Boolean var %s(start=%s)", mData->booleanVarsData[i].info.name, sData->booleanVars[i] ? "true" : "false");
-  }
-#if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING>0
-  for(i=0; i<mData->nVariablesString; ++i)
-  {
-    mData->stringVarsData[i].attribute.start = MMC_STRINGDATA(sData->stringVars[i]);
-    debugStreamPrint(OMC_LOG_DEBUG, 0, "String var %s(start=%s)", mData->stringVarsData[i].info.name, MMC_STRINGDATA(sData->stringVars[i]));
-  }
-#endif
-  if (OMC_DEBUG_STREAM(OMC_LOG_DEBUG)) {
-    messageClose(OMC_LOG_DEBUG);
-  }
-
-  TRACE_POP
-}
-
 /*! \fn setAllParamsToStart
  *
  *  This function sets all parameters and their initial values to their start-attribute.

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -99,7 +99,6 @@ void printRingBufferSimulationData(RINGBUFFER* rb, DATA* data);
 void restoreExtrapolationDataOld(DATA *data);
 
 void setAllVarsToStart(DATA* data);
-void setAllStartToVars(DATA* data);
 void setAllParamsToStart(DATA *data);
 
 void restoreOldValues(DATA *data);

--- a/testsuite/simulation/modelica/start_value_selection/Makefile
+++ b/testsuite/simulation/modelica/start_value_selection/Makefile
@@ -11,7 +11,7 @@ TESTFILES = \
 	overrideParamStartFromFile_param.mos \
 
 
-# test that currently fail. Move up when fixed. 
+# test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=  \
 
@@ -22,7 +22,7 @@ FAILINGTESTFILES=  \
 DEPENDENCIES = \
 *.mo \
 *.mos \
-Makefile 
+Makefile
 
 
 
@@ -36,8 +36,8 @@ test:
 	@echo
 	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
 	@$(TEST) $(TESTFILES)
-	
-# Cleans all files that are not listed as dependencies 
+
+# Cleans all files that are not listed as dependencies
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -f $(CLEAN)
@@ -46,11 +46,11 @@ clean :
 # do it after cleaning and updating the folder
 # then you can get a list of file names (which must be dependencies
 # since you got them from repository + your own new files)
-# then add them to the DEPENDENCIES. You can find the 
-# list in deps.txt 
-getdeps: 
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
-	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt	
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
 	@echo Dependency list saved in deps.txt.
 	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
 

--- a/testsuite/simulation/modelica/start_value_selection/Makefile
+++ b/testsuite/simulation/modelica/start_value_selection/Makefile
@@ -6,6 +6,9 @@ TESTFILES = \
 	MinimalModel.mos \
 	asmaFlow.mos \
 	ticket5807.mos \
+	overrideLiteralStartFromFile_alg.mos \
+	overrideParamStartFromFile_alg.mos \
+	overrideParamStartFromFile_param.mos \
 
 
 # test that currently fail. Move up when fixed. 

--- a/testsuite/simulation/modelica/start_value_selection/UnevaluateableFixedAttribute.mos
+++ b/testsuite/simulation/modelica/start_value_selection/UnevaluateableFixedAttribute.mos
@@ -1,6 +1,7 @@
 // name:     fixed value notevaluateable
 // keywords: fixed
 // status:   correct
+// teardown_command: rm -rf UnevaluateableFixedAttribute_* UnevaluateableFixedAttribute UnevaluateableFixedAttribute.exe
 // cflags: -d=-newInst
 
 

--- a/testsuite/simulation/modelica/start_value_selection/overrideLiteralStartFromFile_alg.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideLiteralStartFromFile_alg.mos
@@ -1,0 +1,124 @@
+// name:     overrideLiteralStartFromFile_alg.mos [BUG: #14163]
+// keywords: start value selection
+// status:   correct
+// teardown_command: rm -rf *overrideLiteralStartFromFile_alg_model*
+// cflags:
+
+// set start value in second run from file (T=909.9999) not from literal start value (1173
+
+loadString("
+model overrideLiteralStartFromFile_alg_model
+  Real T(start = 1173);
+equation
+  T + 1e-6*log(T) = 910;
+  annotation(experiment(StopTime = 0));
+end overrideLiteralStartFromFile_alg_model;
+");getErrorString();
+
+simulate(overrideLiteralStartFromFile_alg_model, simflags="-r=init_overrideLiteralStartFromFile_alg_model.mat");getErrorString();
+simulate(overrideLiteralStartFromFile_alg_model, simflags="-iif=init_overrideLiteralStartFromFile_alg_model.mat -lv=LOG_INIT_V,LOG_NLS_V");getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "init_overrideLiteralStartFromFile_alg_model.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideLiteralStartFromFile_alg_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=init_overrideLiteralStartFromFile_alg_model.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "overrideLiteralStartFromFile_alg_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideLiteralStartFromFile_alg_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif=init_overrideLiteralStartFromFile_alg_model.mat -lv=LOG_INIT_V,LOG_NLS_V'",
+//     messages = "LOG_NLS           | info    | initialize non-linear system solvers
+// |                 | |       | | 2 non-linear systems
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | import start values
+// |                 | |       | file: init_overrideLiteralStartFromFile_alg_model.mat
+// |                 | |       | time: 0
+// LOG_INIT          | info    | import real variables
+// LOG_INIT_V        | info    | | T(start=910)
+// LOG_INIT          | info    | import integer variables
+// LOG_INIT          | info    | import boolean variables
+// LOG_INIT          | info    | import real parameters
+// LOG_INIT          | info    | import integer parameters
+// LOG_INIT          | info    | import boolean parameters
+// LOG_NLS           | info    | update static data of non-linear system solvers
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 2 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 1
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_INIT_V        | info    | parameter values
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real $cse1(start=-2.63e+08, nominal=1) = -2.63e+08 (pre: -2.63e+08)
+// |                 | |       | | | [2] Real T(start=910, nominal=1) = 910 (pre: 910)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 7 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 1
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 7 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 2
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// LOG_NLS           | info    | free non-linear system solvers
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_alg.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_alg.mos
@@ -1,0 +1,129 @@
+// name:     overrideParamStartFromFile_alg.mos [BUG: #14163]
+// keywords: start value selection
+// status:   correct
+// teardown_command: rm -rf *overrideParamStartFromFile_alg_model*
+// cflags:
+
+//  set start value in second run from file (T=909.9999) not from binding (start = Tstart)
+
+loadString("
+model overrideParamStartFromFile_alg_model
+  Real T(start = Tstart);
+  parameter Real Tstart = 1173;
+equation
+  T + 1e-6*log(T) = 910;
+  annotation(experiment(StopTime = 0));
+end overrideParamStartFromFile_alg_model;
+");getErrorString();
+
+simulate(overrideParamStartFromFile_alg_model, simflags="-r=init_overrideParamStartFromFile_alg_model.mat");getErrorString();
+simulate(overrideParamStartFromFile_alg_model, simflags="-iif=init_overrideParamStartFromFile_alg_model.mat -lv=LOG_INIT_V,LOG_NLS_V");getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "init_overrideParamStartFromFile_alg_model.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamStartFromFile_alg_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=init_overrideParamStartFromFile_alg_model.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "overrideParamStartFromFile_alg_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamStartFromFile_alg_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif=init_overrideParamStartFromFile_alg_model.mat -lv=LOG_INIT_V,LOG_NLS_V'",
+//     messages = "LOG_NLS           | info    | initialize non-linear system solvers
+// |                 | |       | | 2 non-linear systems
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT_V        | info    | updated start value: T(start=1173)
+// LOG_INIT          | info    | import start values
+// |                 | |       | file: init_overrideParamStartFromFile_alg_model.mat
+// |                 | |       | time: 0
+// LOG_INIT          | info    | import real variables
+// LOG_INIT_V        | info    | | T(start=910)
+// LOG_INIT          | info    | import integer variables
+// LOG_INIT          | info    | import boolean variables
+// LOG_INIT          | info    | import real parameters
+// LOG_INIT_V        | info    | | Tstart(start=1173)
+// LOG_INIT          | info    | import integer parameters
+// LOG_INIT          | info    | import boolean parameters
+// LOG_NLS           | info    | update static data of non-linear system solvers
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 2 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 1
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real Tstart(start=1173, fixed=true) = 1173
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real $cse1(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real T(start=910, nominal=1) = 910 (pre: 910)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 7 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 1
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 7 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 2
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// LOG_NLS           | info    | free non-linear system solvers
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_param.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_param.mos
@@ -1,0 +1,90 @@
+// name:     overrideParamStartFromFile_param.mos [BUG: #14163]
+// keywords: start value selection
+// status:   correct
+// teardown_command: rm -rf *overrideParamStartFromFile_param_model*
+// cflags:
+
+// set parameter start value in second run from file (T=909.9999) not from binding (start = Tstart)
+
+loadString("
+model overrideParamStartFromFile_param_model
+  parameter Real T(start = Tstart, fixed=false);
+  parameter Real Tstart(start= 1173);
+initial equation
+  T + 1e-6*log(T) = 910;
+  annotation(experiment(StopTime = 0));
+end overrideParamStartFromFile_param_model;
+");getErrorString();
+
+simulate(overrideParamStartFromFile_param_model, simflags="-r=init_overrideParamStartFromFile_param_model.mat");getErrorString();
+simulate(overrideParamStartFromFile_param_model, simflags="-iif=init_overrideParamStartFromFile_param_model.mat -lv=LOG_INIT_V,LOG_NLS_V");getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "init_overrideParamStartFromFile_param_model.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamStartFromFile_param_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=init_overrideParamStartFromFile_param_model.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "[<interactive>:4:3-4:37:writable] Warning: Parameter Tstart has no value, and is fixed during initialization (fixed=true), using available start value (start=1173) as default value.
+// "
+// record SimulationResult
+//     resultFile = "overrideParamStartFromFile_param_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamStartFromFile_param_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif=init_overrideParamStartFromFile_param_model.mat -lv=LOG_INIT_V,LOG_NLS_V'",
+//     messages = "LOG_NLS           | info    | initialize non-linear system solvers
+// |                 | |       | | 1 non-linear systems
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | import start values
+// |                 | |       | file: init_overrideParamStartFromFile_param_model.mat
+// |                 | |       | time: 0
+// LOG_INIT          | info    | import real variables
+// LOG_INIT          | info    | import integer variables
+// LOG_INIT          | info    | import boolean variables
+// LOG_INIT          | info    | import real parameters
+// LOG_INIT_V        | info    | | T(start=910)
+// LOG_INIT_V        | info    | | Tstart(start=1173)
+// LOG_INIT          | info    | import integer parameters
+// LOG_INIT          | info    | import boolean parameters
+// LOG_NLS           | info    | update static data of non-linear system solvers
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
+// |                 | |       | | initial variable values:
+// |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1
+// LOG_NLS_V         | info    | Start solving Non-Linear System 2 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |        909.99999                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |        909.99999
+// |                 | |       | | regular initial point!!!
+// LOG_NLS           | info    | | Solution status: SOLVED
+// |                 | |       | | |  number of iterations           : 0
+// |                 | |       | | |  number of function evaluations : 1
+// |                 | |       | | |  number of jacobian evaluations : 0
+// |                 | |       | | | solution values:
+// |                 | |       | | | [ 1]                              T  =        909.99999
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real T(start=910, fixed=false) = 910
+// |                 | |       | | | [2] parameter Real Tstart(start=1173, fixed=true) = 1173
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// LOG_NLS           | info    | free non-linear system solvers
+// "
+// end SimulationResult;
+// "[<interactive>:4:3-4:37:writable] Warning: Parameter Tstart has no value, and is fixed during initialization (fixed=true), using available start value (start=1173) as default value.
+// "
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/14163
https://trac.openmodelica.org/OpenModelica/ticket/5807

### Purpose

- Fixes https://github.com/OpenModelica/OpenModelica/issues/14163 by setting the NLS start value in initialization to the current realVars value. 

- ~~will cause https://trac.openmodelica.org/OpenModelica/ticket/5807 to fail again~~ fixed by generating the function updateBoundParameters for all parameters with non-const binding or start value