### PR TITLE
Add second y-axis for plotting

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1690,7 +1690,7 @@ void MainWindow::PlotCallbackFunction(void *p, int externalWindow, const char* f
           }
         }
         pVariablesTreeModel->setData(index, Qt::Checked, Qt::CheckStateRole);
-        pMainWindow->getVariablesWidget()->plotVariables(index, pPlotWindow->getCurveWidth(), pPlotWindow->getCurveStyle(), false, pPlotCurve);
+        pMainWindow->getVariablesWidget()->plotVariables(index, pPlotWindow->getCurveWidth(), pPlotWindow->getCurveStyle(), Qt::NoModifier, pPlotCurve);
       }
     }
     // variables list is empty for plotAll

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -322,6 +322,7 @@ void PlotWindowContainer::addPlotWindow()
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
     pPlotWindow->getPlot()->setFontSizes(pPlottingPage->getTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
+                                         pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
@@ -357,6 +358,7 @@ void PlotWindowContainer::addParametricPlotWindow()
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
     pPlotWindow->getPlot()->setFontSizes(pPlottingPage->getTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
+                                         pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
@@ -400,6 +402,7 @@ void PlotWindowContainer::addArrayPlotWindow()
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
     pPlotWindow->getPlot()->setFontSizes(pPlottingPage->getTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
+                                         pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
@@ -438,6 +441,7 @@ PlotWindow* PlotWindowContainer::addInteractivePlotWindow(QString owner, int por
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
     pPlotWindow->getPlot()->setFontSizes(pPlottingPage->getTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
+                                         pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     pPlotWindow->setSubWindow(pSubWindow);
@@ -483,6 +487,7 @@ void PlotWindowContainer::addArrayParametricPlotWindow()
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
     pPlotWindow->getPlot()->setFontSizes(pPlottingPage->getTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
+                                         pPlottingPage->getVerticalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getVerticalAxisNumbersFontSizeSpinBox()->value(),
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1944,7 +1944,7 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
  * \param index
  * \param curveThickness
  * \param curveStyle
- * \param shiftKey
+ * \param keyDown
  * \param pPlotCurve
  * \param pPlotWindow
  */
@@ -1998,6 +1998,7 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
       return;
     }
     connect(pPlotWindow, SIGNAL(prefixUnitsChanged()), this, SLOT(updatePlottedVariablesDisplayUnitAndValue()), Qt::UniqueConnection);
+    bool ctrl = Qt::KeyboardModifiers(keyDown).testFlag(Qt::ControlModifier);
     // if plottype is PLOT or PLOTARRAY then
     if (pPlotWindow->isPlot() || pPlotWindow->isPlotArray()) {
       // check the item checkstate
@@ -2054,6 +2055,10 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
               pPlotCurve->updateXAxisValue(i, Utilities::convertUnit(pPlotCurve->mXAxisVector.at(i), convertUnit.offset, convertUnit.scaleFactor));
             }
           }
+        }
+        if (ctrl && pPlotCurve) {
+          pPlotCurve->setYAxisRight(true);
+          requiresUpdate = true;
         }
         if (requiresUpdate) {
           pPlotCurve->plotData();
@@ -2168,6 +2173,10 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
               } else {
                 pPlotCurve->setYDisplayUnit(plotParametricVariable.displayUnit);
               }
+            }
+            if (ctrl && pPlotCurve) {
+                pPlotCurve->setYAxisRight(true);
+                requiresUpdate = true;
             }
             if (requiresUpdate) {
               pPlotCurve->plotData();

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -447,7 +447,8 @@ bool VariablesTreeModel::setData(const QModelIndex &index, const QVariant &value
   if (index.column() == 0 && role == Qt::CheckStateRole) {
     if (!signalsBlocked()) {
       PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
-      emit itemChecked(index, pPlottingPage->getCurveThickness(), pPlottingPage->getCurvePattern(), QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier));
+      int keyDown = static_cast<int>(QApplication::keyboardModifiers());
+      emit itemChecked(index, pPlottingPage->getCurveThickness(), pPlottingPage->getCurvePattern(), keyDown);
     }
   } else if (index.column() == 1) { // value
     if (!signalsBlocked()) {
@@ -1036,7 +1037,7 @@ void VariablesTreeModel::plotAllVariables(VariablesTreeItem *pVariablesTreeItem,
       }
     }
     setData(index, Qt::Checked, Qt::CheckStateRole);
-    mpVariablesTreeView->getVariablesWidget()->plotVariables(index, pPlotWindow->getCurveWidth(), pPlotWindow->getCurveStyle(), false, pPlotCurve);
+    mpVariablesTreeView->getVariablesWidget()->plotVariables(index, pPlotWindow->getCurveWidth(), pPlotWindow->getCurveStyle(), Qt::NoModifier, pPlotCurve);
   } else {
     for (int i = 0 ; i < variablesTreeItems.size() ; i++) {
       plotAllVariables(variablesTreeItems[i], pPlotWindow);
@@ -1511,7 +1512,7 @@ VariablesWidget::VariablesWidget(QWidget *pParent)
   connect(mpTreeSearchFilters->getCollapseAllButton(), SIGNAL(clicked()), mpVariablesTreeView, SLOT(collapseAll()));
   connect(mpVariablesTreeModel, SIGNAL(rowsInserted(QModelIndex,int,int)), mpVariableTreeProxyModel, SLOT(invalidate()));
   connect(mpVariablesTreeModel, SIGNAL(rowsRemoved(QModelIndex,int,int)), mpVariableTreeProxyModel, SLOT(invalidate()));
-  connect(mpVariablesTreeModel, SIGNAL(itemChecked(QModelIndex,qreal,int,bool)), SLOT(plotVariables(QModelIndex,qreal,int,bool)));
+  connect(mpVariablesTreeModel, SIGNAL(itemChecked(QModelIndex,qreal,int,int)), SLOT(plotVariables(QModelIndex,qreal,int,int)));
   connect(mpVariablesTreeModel, SIGNAL(unitChanged(QModelIndex)), SLOT(unitChanged(QModelIndex)));
   connect(mpVariablesTreeModel, SIGNAL(valueEntered(QModelIndex)), SLOT(valueEntered(QModelIndex)));
   connect(mpVariablesTreeView, SIGNAL(customContextMenuRequested(QPoint)), SLOT(showContextMenu(QPoint)));
@@ -1589,7 +1590,7 @@ void VariablesWidget::variablesUpdated()
             pPlotCurve->resetPrefixUnit(false);
             QModelIndex index = mpVariablesTreeModel->variablesTreeItemIndex(pVariablesTreeItem);
             mpVariablesTreeModel->setData(index, Qt::Checked, Qt::CheckStateRole);
-            plotVariables(index, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), false, pPlotCurve, pPlotWindow);
+            plotVariables(index, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), Qt::NoModifier, pPlotCurve, pPlotWindow);
             mpVariablesTreeModel->blockSignals(state);
           } else {
             pPlotWindow->getPlot()->removeCurve(pPlotCurve);
@@ -1609,14 +1610,14 @@ void VariablesWidget::variablesUpdated()
             pPlotCurve->resetPrefixUnit(false);
             QModelIndex xIndex = mpVariablesTreeModel->variablesTreeItemIndex(pXVariablesTreeItem);
             mpVariablesTreeModel->setData(xIndex, Qt::Checked, Qt::CheckStateRole);
-            plotVariables(xIndex, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), true, pPlotCurve, pPlotWindow);
+            plotVariables(xIndex, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), Qt::ShiftModifier, pPlotCurve, pPlotWindow);
             updateDisplayUnitAndValue(pPlotCurve->getYUnitPrefix(), pPlotCurve->getYDisplayUnit(), pYVariablesTreeItem);
             pPlotCurve->setYUnit(pYVariablesTreeItem->getUnit());
             pPlotCurve->setYDisplayUnit(pYVariablesTreeItem->getDisplayUnit());
             // No need to call pPlotCurve->resetPrefixUnit(false); again, is already done above
             QModelIndex yIndex = mpVariablesTreeModel->variablesTreeItemIndex(pYVariablesTreeItem);
             mpVariablesTreeModel->setData(yIndex, Qt::Checked, Qt::CheckStateRole);
-            plotVariables(yIndex, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), false, pPlotCurve, pPlotWindow);
+            plotVariables(yIndex, pPlotCurve->getCurveWidth(), pPlotCurve->getCurveStyle(), Qt::NoModifier, pPlotCurve, pPlotWindow);
             mpVariablesTreeModel->blockSignals(state);
           } else {
             pPlotWindow->getPlot()->removeCurve(pPlotCurve);
@@ -1947,7 +1948,7 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
  * \param pPlotCurve
  * \param pPlotWindow
  */
-void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickness, int curveStyle, bool shiftKey, PlotCurve *pPlotCurve, PlotWindow *pPlotWindow)
+void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickness, int curveStyle, int keyDown, PlotCurve *pPlotCurve, PlotWindow *pPlotWindow)
 {
   if (index.column() > 0) {
     return;
@@ -2083,7 +2084,7 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
           return;
         }
 
-        if (shiftKey) {
+        if (Qt::KeyboardModifiers(keyDown).testFlag(Qt::ShiftModifier)) {
           if (!mPlotParametricCurves.isEmpty()) {
             PlotParametricCurve plotParametricCurve = mPlotParametricCurves.last();
             if (plotParametricCurve.yVariables.isEmpty()) {

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -174,7 +174,7 @@ private:
   void getVariableInformation(ModelicaMatReader *pMatReader, QString variableToFind, QString *type, QString *value, bool *changeAble, QString *variability,
                               QString *unit, QString *displayUnit, QString *description);
 signals:
-  void itemChecked(const QModelIndex &index, qreal curveThickness, int curveStyle, bool shiftKey);
+  void itemChecked(const QModelIndex &index, qreal curveThickness, int curveStyle, int keyDown);
   void unitChanged(const QModelIndex &index);
   void valueEntered(const QModelIndex &index);
   void variableTreeItemRemoved(QString variable);
@@ -268,7 +268,7 @@ private:
   void unCheckCurveVariable(const QString &variable);
   void updateDisplayUnitAndValue(const QString &unitPrefix, const QString &displayUnit, VariablesTreeItem *pVariablesTreeItem);
 public slots:
-  void plotVariables(const QModelIndex &index, qreal curveThickness, int curveStyle, bool shiftKey, OMPlot::PlotCurve *pPlotCurve = 0, OMPlot::PlotWindow *pPlotWindow = 0);
+  void plotVariables(const QModelIndex &index, qreal curveThickness, int curveStyle, int keyDown, OMPlot::PlotCurve *pPlotCurve = 0, OMPlot::PlotWindow *pPlotWindow = 0);
   void unitChanged(const QModelIndex &index);
   void updatePlottedVariablesDisplayUnitAndValue();
   void simulationTimeChanged(int value);

--- a/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
@@ -55,6 +55,10 @@ Legend::Legend(Plot *pParent)
   mpToggleSignAction->setCheckable(true);
   connect(mpToggleSignAction, SIGNAL(triggered(bool)), SLOT(toggleSign(bool)));
 
+  mpToggleAxisAction = new QAction(tr("Right Y-Axis"), this);
+  mpToggleAxisAction->setCheckable(true);
+  connect(mpToggleAxisAction, SIGNAL(triggered(bool)), SLOT(switchAxis(bool)));
+    
   mpSetupAction = new QAction(tr("Setup"), this);
   connect(mpSetupAction, SIGNAL(triggered()), SLOT(showSetupDialog()));
 
@@ -111,6 +115,16 @@ void Legend::toggleSign(bool checked)
   }
 }
 
+void Legend::switchAxis(bool checked)
+{
+    if (mpPlotCurve) {
+        mpPlotCurve->setYAxisRight(checked);
+        mpPlotCurve = 0;
+        mpPlot->getParentPlotWindow()->updatePlot();
+    }
+    return;
+}
+
 void Legend::showSetupDialog()
 {
   if (mpPlotCurve) {
@@ -133,7 +147,11 @@ void Legend::legendMenu(const QPoint& pos)
     bool state = mpToggleSignAction->blockSignals(true);
     mpToggleSignAction->setChecked(mpPlotCurve->getToggleSign());
     mpToggleSignAction->blockSignals(state);
+    state = mpToggleAxisAction->blockSignals(true);
+    mpToggleAxisAction->setChecked(mpPlotCurve->isYAxisRight());
+    mpToggleAxisAction->blockSignals(state);
     menu.addAction(mpToggleSignAction);
+    menu.addAction(mpToggleAxisAction);
     menu.addSeparator();
     menu.addAction(mpSetupAction);
     menu.exec(mapToGlobal(pos));

--- a/OMPlot/OMPlot/OMPlotGUI/Legend.h
+++ b/OMPlot/OMPlot/OMPlotGUI/Legend.h
@@ -50,12 +50,14 @@ public:
   bool eventFilter(QObject *object, QEvent *event);
 public slots:
   void toggleSign(bool checked);
+  void switchAxis(bool checked);
   void showSetupDialog();
   void legendMenu(const QPoint&);
 private:
   Plot *mpPlot;
   PlotCurve *mpPlotCurve;
   QAction *mpToggleSignAction;
+  QAction* mpToggleAxisAction;
   QAction *mpSetupAction;
 protected:
   virtual QWidget *createWidget(const QwtLegendData &data) const;

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -57,6 +57,7 @@ private:
   PlotGrid *mpPlotGrid;
   ScaleDraw *mpXScaleDraw;
   ScaleDraw *mpYScaleDraw;
+  ScaleDraw* mpYRightScaleDraw;
   PlotZoomer *mpPlotZoomer;
   PlotPanner *mpPlotPanner;
   PlotPicker *mpPlotPicker;
@@ -74,6 +75,7 @@ public:
   PlotGrid* getPlotGrid();
   ScaleDraw *getXScaleDraw() const {return mpXScaleDraw;}
   ScaleDraw *getYScaleDraw() const {return mpYScaleDraw;}
+  ScaleDraw* getYRightScaleDraw() const {return mpYRightScaleDraw;}
   PlotZoomer* getPlotZoomer();
   PlotPanner* getPlotPanner();
   QList<PlotCurve*> getPlotCurvesList();
@@ -81,8 +83,9 @@ public:
   void addPlotCurve(PlotCurve *pCurve);
   void removeCurve(PlotCurve *pCurve);
   QColor getUniqueColor(int index, int total);
-  void setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, double verticalAxisNumbersFontSize, double horizontalAxisTitleFontSize,
-                    double horizontalAxisNumbersFontSize, double footerFontSize, double legendFontSize);
+  void setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, double verticalAxisNumbersFontSize,
+      double rightVerticalAxisTitleFontSize, double rightVerticalAxisNumbersFontSize, double horizontalAxisTitleFontSize,
+      double horizontalAxisNumbersFontSize, double footerFontSize, double legendFontSize);
   static bool prefixableUnit(const QString &unit);
   static QString convertUnitToSymbol(const QString &displayUnit);
   static QString convertSymbolToUnit(const QString &symbol);

--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -468,8 +468,7 @@ void Plot::replot()
 
   if (mpParentPlotWindow->getYRightCustomLabel().isEmpty()) {
     setAxisTitle(QwtPlot::yRight, "");
-  }
-  else {
+  } else {
     setAxisTitle(QwtPlot::yRight, mpParentPlotWindow->getYRightCustomLabel());
   }
 

--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -57,6 +57,7 @@ Plot::Plot(PlotWindow *pParent)
 {
   setAutoReplot(false);
   mpParentPlotWindow = pParent;
+  enableAxis(QwtPlot::yRight);
   // create an instance of legend
   mpLegend = new Legend(this);
   insertLegend(mpLegend, QwtPlot::TopLegend);
@@ -69,11 +70,14 @@ Plot::Plot(PlotWindow *pParent)
   LinearScaleEngine *pYLinearScaleEngine = new LinearScaleEngine;
   setAxisScaleEngine(QwtPlot::yLeft, pYLinearScaleEngine);
   setAxisAutoScale(QwtPlot::yLeft);
+  setAxisVisible(QwtPlot::yRight, false);   // y axis initially hidden
   // create the scale draw
   mpXScaleDraw = new ScaleDraw(true, this);
   setAxisScaleDraw(QwtPlot::xBottom, mpXScaleDraw);
   mpYScaleDraw = new ScaleDraw(false, this);
   setAxisScaleDraw(QwtPlot::yLeft, mpYScaleDraw);
+  mpYRightScaleDraw = new ScaleDraw(false, this);
+  setAxisScaleDraw(QwtPlot::yRight, mpYRightScaleDraw);
   // create an instance of zoomer
   mpPlotZoomer = new PlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft, canvas());
   // create an instance of panner
@@ -104,10 +108,13 @@ Plot::Plot(PlotWindow *pParent)
   QwtText bottomTitle = axisTitle(QwtPlot::xBottom);
   bottomTitle.setFont(QFont(monospaceFont.family(), 11));
   setAxisTitle(QwtPlot::xBottom, bottomTitle);
-  // set the left axis title font size small.
+  // set the left and right axis title font size small.
   QwtText leftTitle = axisTitle(QwtPlot::yLeft);
   leftTitle.setFont(QFont(monospaceFont.family(), 11));
   setAxisTitle(QwtPlot::yLeft, leftTitle);
+  QwtText rightTitle = axisTitle(QwtPlot::yRight);
+  rightTitle.setFont(QFont(monospaceFont.family(), 11));
+  setAxisTitle(QwtPlot::yRight, rightTitle);
   // fill colors list
   fillColorsList();
   setAutoReplot(true);
@@ -203,7 +210,8 @@ QColor Plot::getUniqueColor(int index, int total)
     return mColorsList.at(index);
 }
 
-void Plot::setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, double verticalAxisNumbersFontSize, double horizontalAxisTitleFontSize,
+void Plot::setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, double verticalAxisNumbersFontSize, 
+                        double rightVerticalAxisTitleFontSize, double rightVerticalAxisNumbersFontSize, double horizontalAxisTitleFontSize,
                         double horizontalAxisNumbersFontSize, double footerFontSize, double legendFontSize)
 {
   // title
@@ -220,6 +228,16 @@ void Plot::setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, 
   font = axisWidget(QwtPlot::yLeft)->font();
   font.setPointSizeF(verticalAxisNumbersFontSize);
   axisWidget(QwtPlot::yLeft)->setFont(font);
+  // right vertical axis title
+  QwtText verticalRightTitle = axisWidget(QwtPlot::yRight)->title();
+  font = verticalRightTitle.font();
+  font.setPointSizeF(rightVerticalAxisTitleFontSize);
+  verticalRightTitle.setFont(font);
+  axisWidget(QwtPlot::yRight)->setTitle(verticalRightTitle);
+  // right vertical axis numbers
+  font = axisWidget(QwtPlot::yRight)->font();
+  font.setPointSizeF(rightVerticalAxisNumbersFontSize);
+  axisWidget(QwtPlot::yRight)->setFont(font);
   // horizontal axis title
   QwtText horizontalTitle = axisWidget(QwtPlot::xBottom)->title();
   font = horizontalTitle.font();
@@ -406,9 +424,12 @@ void Plot::replot()
 {
   mpXScaleDraw->invalidateCache();
   mpYScaleDraw->invalidateCache();
+  mpYRightScaleDraw->invalidateCache();
   QwtPlot::replot();
 
   // Now we need to again loop through curves to set the color and title.
+  // Also display y-axis (left or right) only if axis is assigned to at least one curve
+  bool leftAxisVisible = false, rightAxisVisible = false;
   for (int i = 0 ; i < mPlotCurvesList.length() ; i++) {
     // if user has set the custom color for the curve then dont get automatic color for it
     if (!mPlotCurvesList[i]->hasCustomColor()) {
@@ -417,7 +438,11 @@ void Plot::replot()
       mPlotCurvesList[i]->setPen(pen);
     }
     mPlotCurvesList[i]->setTitleLocal();
+    rightAxisVisible = rightAxisVisible || mPlotCurvesList[i]->isYAxisRight();
+    leftAxisVisible = leftAxisVisible || (!mPlotCurvesList[i]->isYAxisRight());
   }
+  setAxisVisible(QwtPlot::yLeft, leftAxisVisible);
+  setAxisVisible(QwtPlot::yRight, rightAxisVisible);
 
   if (mpParentPlotWindow->getXCustomLabel().isEmpty()) {
     // ScaleDraw::getUnitPrefix is only set when time is on x-axis
@@ -440,6 +465,14 @@ void Plot::replot()
   } else {
     setAxisTitle(QwtPlot::yLeft, mpParentPlotWindow->getYCustomLabel());
   }
+
+  if (mpParentPlotWindow->getYRightCustomLabel().isEmpty()) {
+    setAxisTitle(QwtPlot::yRight, "");
+  }
+  else {
+    setAxisTitle(QwtPlot::yRight, mpParentPlotWindow->getYRightCustomLabel());
+  }
+
 }
 
 } // namespace OMPlot

--- a/OMPlot/OMPlot/OMPlotGUI/PlotCurve.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotCurve.cpp
@@ -59,6 +59,7 @@ PlotCurve::PlotCurve(const QString &fileName, const QString &absoluteFilePath, c
   setYDisplayUnit(yDisplayUnit);
   mCustomTitle = "";
   setToggleSign(false);
+  setYAxisRight(false);  // default to left y-axis
   setTitleLocal();
   /* set curve width and style */
   setCurveWidth(mpParentPlot->getParentPlotWindow()->getCurveWidth());
@@ -94,6 +95,10 @@ void PlotCurve::setTitleLocal()
     // Add - sign if curve is toggled
     if (getToggleSign()) {
       titleStr.prepend(QString("-"));
+    }
+     // Append right arrow if curve is plotted on right axis
+    if (isYAxisRight()) {
+      titleStr.append(QChar(0x2794)); 
     }
     setTitle(titleStr);
     // visibility
@@ -250,6 +255,16 @@ bool PlotCurve::hasCustomColor()
 void PlotCurve::toggleVisibility(bool visibility)
 {
   setVisible(visibility);
+}
+
+/*!
+ * \brief PlotCurve::setYAxisRight
+ * Assigns the curve to the right or left y-axis
+*/
+void PlotCurve::setYAxisRight(bool right)
+{
+    auto axis = right ? QwtPlot::yRight : QwtPlot::yLeft;
+    QwtPlotCurve::setYAxis(axis);
 }
 
 /*!

--- a/OMPlot/OMPlot/OMPlotGUI/PlotCurve.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotCurve.h
@@ -99,6 +99,8 @@ public:
   void addYAxisValue(double value);
   void updateYAxisValue(int index, double value);
   void clearYAxisVector() {mYAxisVector.clear();}
+  void setYAxisRight(bool right);
+  bool isYAxisRight() const {return QwtPlotCurve::yAxis() == QwtAxis::Position::YRight;}
   int getXAxisSize() const;
   int getYAxisSize() const;
   void setFileName(QString fileName);

--- a/OMPlot/OMPlot/OMPlotGUI/PlotGrid.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotGrid.cpp
@@ -53,12 +53,24 @@ PlotGrid::~PlotGrid()
 
 void PlotGrid::setGrid()
 {
+  enableX(true);
   enableXMin(false);
+  enableY(true);
   enableYMin(false);
 }
 
 void PlotGrid::setDetailedGrid()
 {
+  enableX(true);
   enableXMin(true);
+  enableY(true);
   enableYMin(true);
+}
+
+void PlotGrid::setXGrid()
+{
+  enableX(true);
+  enableXMin(true);
+  enableY(false);
+  enableYMin(false);
 }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
@@ -48,6 +48,7 @@ public:
   QPen getMinorPen() {return QPen(Qt::lightGray, 0.0, Qt::DotLine);}
   void setGrid();
   void setDetailedGrid();
+  void setXGrid();
 };
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -200,9 +200,13 @@ void PlotWindow::initializePlot(QStringList arguments)
 
 // assign y-axes appropriately to each curve, if specified
   if (plotRightYAxis.size() > 0) {
+    // if only one axis was specified, apply to all newly plotted curves
+    bool scalarSetToRight = (plotRightYAxis.size()==1) && plotRightYAxis.cbegin().value();
     foreach(PlotCurve* curve, getPlot()->getPlotCurvesList()) {
-        bool right = plotRightYAxis.value(curve->getYVariable(), false);
-        curve->setYAxisRight(right);
+        if (variablesToRead.contains(curve->getYVariable())) {
+            bool setToRight = scalarSetToRight || plotRightYAxis.value(curve->getYVariable(), false);
+            curve->setYAxisRight(setToRight);
+        }
     }
     updatePlot();
   }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -155,10 +155,27 @@ void PlotWindow::initializePlot(QStringList arguments)
   setPrefixUnits(true);
   /* read variables */
   QStringList variablesToRead;
-  for(int i = 18; i < arguments.length(); i++)
+  for(int i = 19; i < arguments.length(); i++)
     variablesToRead.append(QString(arguments[i]));
 
   setVariablesList(variablesToRead);
+
+  /* assign y-axis to each variable, in order*/
+  int i=0;
+  QHash<QString, bool> plotRightYAxis;
+  foreach(QString yAxis, QString(arguments[18]).split(QChar(','), Qt::SkipEmptyParts)) {
+      if (i >= variablesToRead.size()) {  // ignore extra yAxis specifications
+          break;
+      } else if (yAxis == "2") {
+          plotRightYAxis.insert(variablesToRead[i], true);
+      } else if (yAxis == "1") {
+          plotRightYAxis.insert(variablesToRead[i], false);
+      } else {
+          throw PlotException("Invalid input" + arguments[18]);
+      }
+      i++;
+  }
+
   //Plot
   if(plotType.toLower().compare("plot") == 0)
   {
@@ -180,6 +197,16 @@ void PlotWindow::initializePlot(QStringList arguments)
     setPlotType(PlotWindow::PLOTINTERACTIVE);
     plotInteractive();
   }
+
+// assign y-axes appropriately to each curve, if specified
+  if (plotRightYAxis.size() > 0) {
+    foreach(PlotCurve* curve, getPlot()->getPlotCurvesList()) {
+        bool right = plotRightYAxis.value(curve->getYVariable(), false);
+        curve->setYAxisRight(right);
+    }
+    updatePlot();
+  }
+  
 }
 
 void PlotWindow::setVariablesList(QStringList variables)

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -95,15 +95,20 @@ private:
   QString mYLabel;
   QString mXCustomLabel;
   QString mYCustomLabel;
+  QString mYRightCustomLabel;
   QString mXUnit;
   QString mXDisplayUnit;
   QString mYUnit;
   QString mYDisplayUnit;
+  QString mYRightUnit;
+  QString mYRightDisplayUnit;
   QString mTimeUnit;
   QString mXRangeMin;
   QString mXRangeMax;
   QString mYRangeMin;
   QString mYRangeMax;
+  QString mYRightRangeMin;
+  QString mYRightRangeMax;
   double mCurveWidth;
   int mCurveStyle;
   QFont mLegendFont;
@@ -164,6 +169,8 @@ public:
   QString getXCustomLabel() const {return mXCustomLabel;}
   void setYCustomLabel(const QString &label) {mYCustomLabel = label;}
   QString getYCustomLabel() const {return mYCustomLabel;}
+  void setYRightCustomLabel(const QString& label) {mYRightCustomLabel = label;}
+  QString getYRightCustomLabel() const {return mYRightCustomLabel;}
   void setXUnit(QString xUnit) {mXUnit = xUnit;}
   QString getXUnit() {return mXUnit;}
   void setXDisplayUnit(QString xDisplayUnit) {mXDisplayUnit = xDisplayUnit;}
@@ -172,6 +179,10 @@ public:
   QString getYUnit() {return mYUnit;}
   void setYDisplayUnit(QString yDisplayUnit) {mYDisplayUnit = yDisplayUnit;}
   QString getYDisplayUnit() {return mYDisplayUnit;}
+  void setYRightUnit(QString yUnit) { mYRightUnit = yUnit; }
+  QString getYRightUnit() { return mYRightUnit; }
+  void setYRightDisplayUnit(QString yDisplayUnit) { mYRightDisplayUnit = yDisplayUnit; }
+  QString getYRightDisplayUnit() { return mYRightDisplayUnit; }
   void setTimeUnit(QString timeUnit) {mTimeUnit = timeUnit;}
   QString getTimeUnit() {return mTimeUnit;}
   void setXRange(double min, double max);
@@ -180,6 +191,9 @@ public:
   void setYRange(double min, double max);
   QString getYRangeMin();
   QString getYRangeMax();
+  void setYRightRange(double min, double max);
+  QString getYRightRangeMin();
+  QString getYRightRangeMax();
   void setCurveWidth(double width);
   double getCurveWidth();
   void setCurveStyle(int style);
@@ -220,6 +234,7 @@ public slots:
   void setLogY(bool on);
   void setAutoScale(bool on);
   bool toggleSign(PlotCurve *pPlotCurve, bool checked);
+  void setYAxisRight(PlotCurve* pPlotCurve, bool right);
   void showSetupDialog();
   void showSetupDialog(QString variable);
   void interactiveSimulationStarted();
@@ -269,6 +284,7 @@ private:
   QDoubleSpinBox *mpThicknessSpinBox;
   QCheckBox *mpHideCheckBox;
   QCheckBox *mpToggleSignCheckBox;
+  QCheckBox *mpRightYAxisCheckBox;
 public:
   VariablePageWidget(PlotCurve *pPlotCurve, SetupDialog *pSetupDialog);
   void setCurvePickColorButtonIcon();
@@ -281,6 +297,7 @@ public:
   QDoubleSpinBox* getThicknessSpinBox() {return mpThicknessSpinBox;}
   QCheckBox* getHideCheckBox() {return mpHideCheckBox;}
   QCheckBox* getToggleSignCheckBox() const {return mpToggleSignCheckBox;}
+  QCheckBox* getYRightAxisCheckBox() const {return mpRightYAxisCheckBox;}
 public slots:
   void resetLabel();
   void pickColor();
@@ -309,6 +326,12 @@ private:
   QDoubleSpinBox *mpVerticalAxisTitleFontSizeSpinBox;
   QLabel *mpVerticalAxisNumbersFontSizeLabel;
   QDoubleSpinBox *mpVerticalAxisNumbersFontSizeSpinBox;
+  QLabel* mpRightVerticalAxisLabel;
+  QLineEdit* mpRightVerticalAxisTextBox;
+  QLabel* mpRightVerticalAxisTitleFontSizeLabel;
+  QDoubleSpinBox* mpRightVerticalAxisTitleFontSizeSpinBox;
+  QLabel* mpRightVerticalAxisNumbersFontSizeLabel;
+  QDoubleSpinBox* mpRightVerticalAxisNumbersFontSizeSpinBox;
   QLabel *mpHorizontalAxisLabel;
   QLineEdit *mpHorizontalAxisTextBox;
   QLabel *mpHorizontalAxisTitleFontSizeLabel;
@@ -338,6 +361,11 @@ private:
   QLineEdit *mpYMinimumTextBox;
   QLabel *mpYMaximumLabel;
   QLineEdit *mpYMaximumTextBox;
+  QGroupBox* mpYRightAxisGroupBox;
+  QLabel* mpYRightMinimumLabel;
+  QLineEdit* mpYRightMinimumTextBox;
+  QLabel* mpYRightMaximumLabel;
+  QLineEdit* mpYRightMaximumTextBox;
   QCheckBox *mpPrefixUnitsCheckbox;
   /* buttons */
   QPushButton *mpOkButton;

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -72,99 +72,102 @@ class PlotCurve;
 
 class PlotWindow : public QMainWindow
 {
-  Q_OBJECT
+	Q_OBJECT
 public:
-  enum PlotType {PLOT, PLOTALL, PLOTPARAMETRIC, PLOTINTERACTIVE, PLOTARRAY, PLOTARRAYPARAMETRIC};
+	enum PlotType { PLOT, PLOTALL, PLOTPARAMETRIC, PLOTINTERACTIVE, PLOTARRAY, PLOTARRAYPARAMETRIC };
 private:
-  Plot *mpPlot;
-  QCheckBox *mpLogXCheckBox;
-  QCheckBox *mpLogYCheckBox;
-  QComboBox *mpGridComboBox;
-  QToolButton *mpAutoScaleButton;
-  QToolButton *mpSetupButton;
-  QToolButton *mpStartSimulationToolButton;
-  QToolButton *mpPauseSimulationToolButton;
-  QLabel *mpSimulationSpeedLabel;
-  QComboBox *mpSimulationSpeedComboBox;
-  QTextStream *mpTextStream;
-  QFile mFile;
-  QStringList mVariablesList;
-  PlotType mPlotType;
-  QString mGridType;
-  QString mXLabel;
-  QString mYLabel;
-  QString mXCustomLabel;
-  QString mYCustomLabel;
-  QString mYRightCustomLabel;
-  QString mXUnit;
-  QString mXDisplayUnit;
-  QString mYUnit;
-  QString mYDisplayUnit;
-  QString mYRightUnit;
-  QString mYRightDisplayUnit;
-  QString mTimeUnit;
-  QString mXRangeMin;
-  QString mXRangeMax;
-  QString mYRangeMin;
-  QString mYRangeMax;
-  QString mYRightRangeMin;
-  QString mYRightRangeMax;
-  double mCurveWidth;
-  int mCurveStyle;
-  QFont mLegendFont;
-  double mTime;
-  bool mIsInteractiveSimulation;
-  QString mInteractiveTreeItemOwner;
-  int mInteractivePort;
-  QwtSeriesData<QPointF>* mpInteractiveData;
-  QString mInteractiveModelName;
-  bool mPrefixUnits;
-  QMdiSubWindow *mpSubWindow;
+	Plot* mpPlot;
+	QCheckBox* mpLogXCheckBox;
+	QCheckBox* mpLogYCheckBox;
+	QComboBox* mpGridComboBox;
+	QToolButton* mpAutoScaleButton;
+	QToolButton* mpSetupButton;
+	QToolButton* mpStartSimulationToolButton;
+	QToolButton* mpPauseSimulationToolButton;
+	QLabel* mpSimulationSpeedLabel;
+	QComboBox* mpSimulationSpeedComboBox;
+	QTextStream* mpTextStream;
+	QFile mFile;
+	QStringList mVariablesList;
+	PlotType mPlotType;
+	QString mGridType;
+	QString mXLabel;
+	QString mYLabel;
+	QString mYRightLabel;
+	QString mXCustomLabel;
+	QString mYCustomLabel;
+	QString mYRightCustomLabel;
+	QString mXUnit;
+	QString mXDisplayUnit;
+	QString mYUnit;
+	QString mYDisplayUnit;
+	QString mYRightUnit;
+	QString mYRightDisplayUnit;
+	QString mTimeUnit;
+	QString mXRangeMin;
+	QString mXRangeMax;
+	QString mYRangeMin;
+	QString mYRangeMax;
+	QString mYRightRangeMin;
+	QString mYRightRangeMax;
+	double mCurveWidth;
+	int mCurveStyle;
+	QFont mLegendFont;
+	double mTime;
+	bool mIsInteractiveSimulation;
+	QString mInteractiveTreeItemOwner;
+	int mInteractivePort;
+	QwtSeriesData<QPointF>* mpInteractiveData;
+	QString mInteractiveModelName;
+	bool mPrefixUnits;
+	QMdiSubWindow* mpSubWindow;
 public:
-  PlotWindow(QStringList arguments = QStringList(), QWidget *parent = 0, bool isInteractiveSimulation = false, int toolbarIconSize = 0);
+	PlotWindow(QStringList arguments = QStringList(), QWidget* parent = 0, bool isInteractiveSimulation = false, int toolbarIconSize = 0);
 
-  ~PlotWindow();
+	~PlotWindow();
 
-  void setUpWidget(int toolbarIconSize);
-  void initializePlot(QStringList arguments);
-  void setVariablesList(QStringList variables);
-  void setPlotType(PlotType type);
-  bool isPlot() const {return mPlotType == PlotWindow::PLOT;}
-  bool isPlotAll() const {return mPlotType == PlotWindow::PLOTALL;}
-  bool isPlotParametric() const {return mPlotType == PlotWindow::PLOTPARAMETRIC;}
-  bool isPlotInteractive() const {return mPlotType == PlotWindow::PLOTINTERACTIVE;}
-  bool isPlotArray() const {return mPlotType == PlotWindow::PLOTARRAY;}
-  bool isPlotArrayParametric() const {return mPlotType == PlotWindow::PLOTARRAYPARAMETRIC;}
-  PlotType getPlotType() const {return mPlotType;}
-  void initializeFile(QString file);
-  void getStartStopTime(double &start, double &stop);
-  void setupToolbar(int toolbarIconSize);
-  void plot(PlotCurve *pPlotCurve = 0);
-  void plotParametric(PlotCurve *pPlotCurve = 0);
-  void plotArray(double time, PlotCurve *pPlotCurve = 0);
-  void plotArrayParametric(double time, PlotCurve *pPlotCurve = 0);
-  QPair<QVector<double>*, QVector<double>*> plotInteractive(PlotCurve *pPlotCurve = 0);
-  void setInteractiveOwner(const QString &interactiveTreeItemOwner);
-  void setInteractivePort(const int port);
-  void setInteractivePlotData(QwtSeriesData<QPointF>* pInteractiveData);
-  void setSubWindow(QMdiSubWindow *pSubWindow) {mpSubWindow = pSubWindow;}
-  QMdiSubWindow* getSubWindow() {return mpSubWindow;}
-  void setInteractiveModelName(const QString &modelName);
-  QString getInteractiveOwner() {return mInteractiveTreeItemOwner;}
-  int getInteractivePort() {return mInteractivePort;}
-  void setTitle(QString title);
-  void setGrid(QString grid);
-  QString getGrid();
-  QCheckBox* getLogXCheckBox();
-  QCheckBox* getLogYCheckBox();
-  QToolButton* getAutoScaleButton() {return mpAutoScaleButton;}
-  QToolButton* getStartSimulationButton() {return mpStartSimulationToolButton;}
-  QToolButton* getPauseSimulationButton() {return mpPauseSimulationToolButton;}
-  QComboBox* getSimulationSpeedBox() {return mpSimulationSpeedComboBox;}
-  void setXLabel(const QString &label) {mXLabel = label;}
-  QString getXLabel() const {return mXLabel;}
-  void setYLabel(const QString &label) {mYLabel = label;}
-  QString getYLabel() const {return mYLabel;}
+	void setUpWidget(int toolbarIconSize);
+	void initializePlot(QStringList arguments);
+	void setVariablesList(QStringList variables);
+	void setPlotType(PlotType type);
+	bool isPlot() const { return mPlotType == PlotWindow::PLOT; }
+	bool isPlotAll() const { return mPlotType == PlotWindow::PLOTALL; }
+	bool isPlotParametric() const { return mPlotType == PlotWindow::PLOTPARAMETRIC; }
+	bool isPlotInteractive() const { return mPlotType == PlotWindow::PLOTINTERACTIVE; }
+	bool isPlotArray() const { return mPlotType == PlotWindow::PLOTARRAY; }
+	bool isPlotArrayParametric() const { return mPlotType == PlotWindow::PLOTARRAYPARAMETRIC; }
+	PlotType getPlotType() const { return mPlotType; }
+	void initializeFile(QString file);
+	void getStartStopTime(double& start, double& stop);
+	void setupToolbar(int toolbarIconSize);
+	void plot(PlotCurve* pPlotCurve = 0);
+	void plotParametric(PlotCurve* pPlotCurve = 0);
+	void plotArray(double time, PlotCurve* pPlotCurve = 0);
+	void plotArrayParametric(double time, PlotCurve* pPlotCurve = 0);
+	QPair<QVector<double>*, QVector<double>*> plotInteractive(PlotCurve* pPlotCurve = 0);
+	void setInteractiveOwner(const QString& interactiveTreeItemOwner);
+	void setInteractivePort(const int port);
+	void setInteractivePlotData(QwtSeriesData<QPointF>* pInteractiveData);
+	void setSubWindow(QMdiSubWindow* pSubWindow) { mpSubWindow = pSubWindow; }
+	QMdiSubWindow* getSubWindow() { return mpSubWindow; }
+	void setInteractiveModelName(const QString& modelName);
+	QString getInteractiveOwner() { return mInteractiveTreeItemOwner; }
+	int getInteractivePort() { return mInteractivePort; }
+	void setTitle(QString title);
+	void setGrid(QString grid);
+	QString getGrid();
+	QCheckBox* getLogXCheckBox();
+	QCheckBox* getLogYCheckBox();
+	QToolButton* getAutoScaleButton() { return mpAutoScaleButton; }
+	QToolButton* getStartSimulationButton() { return mpStartSimulationToolButton; }
+	QToolButton* getPauseSimulationButton() { return mpPauseSimulationToolButton; }
+	QComboBox* getSimulationSpeedBox() { return mpSimulationSpeedComboBox; }
+	void setXLabel(const QString& label) { mXLabel = label; }
+	QString getXLabel() const { return mXLabel; }
+	void setYLabel(const QString& label) { mYLabel = label; }
+	QString getYLabel() const { return mYLabel; }
+	void setYRightLabel(const QString& label) {mYRightLabel = label;}
+	QString getYRightLabel() const { return mYRightLabel; }
   void setXCustomLabel(const QString &label) {mXCustomLabel = label;}
   QString getXCustomLabel() const {return mXCustomLabel;}
   void setYCustomLabel(const QString &label) {mYCustomLabel = label;}

--- a/OMPlot/OMPlot/OMPlotGUI/main.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/main.cpp
@@ -83,9 +83,11 @@ void printUsage(bool shortDescription)
     printf("    --title=TITLE              Sets the TITLE of the plot window\n");
     printf("    --xlabel=LABEL             Use LABEL as the label of the x-axis\n");
     printf("    --xrange=LEFT:RIGHT        Sets the initial range of the x-axis to LEFT:RIGHT\n");
-    printf("    --yaxis=AXES               Sets the y-axis (1=left, 2=right) for each variable. Each axis in AXES should be separated by a comma i.e. 1,2,1,1\n");
-    printf("    --ylabel=LABEL             Use LABEL as the label of the y-axis\n");
-    printf("    --yrange=LEFT:RIGHT        Sets the initial range of the y-axis to LEFT:RIGHT\n");
+    printf("    --yaxis=AXES               Sets the y-axis (L=left, R=right) for each variable. Each axis in AXES should be separated by a comma i.e. L,R,L,L\n");
+    printf("    --ylabel=LABEL             Use LABEL as the label of the left y-axis\n");
+    printf("    --yrange=LEFT:RIGHT        Sets the initial range of the left y-axis to LEFT:RIGHT\n");
+    printf("    --ylabel-right=LABEL       Use LABEL as the label of the right y-axis\n");
+    printf("    --yrange-right=LEFT:RIGHT  Sets the initial range of the right y-axis to LEFT:RIGHT\n");
   }
 }
 
@@ -101,10 +103,13 @@ int main(int argc, char *argv[])
   bool logy = false;
   QString xlabel("time");
   QString ylabel("");
+  QString ylabelRight("");
   double xrange1 = 0.0;
   double xrange2 = 0.0;
   double yrange1 = 0.0;
   double yrange2 = 0.0;
+  double yrange1right = 0.0;
+  double yrange2right = 0.0;
   double curveWidth = 1.0;
   int curveStyle = 1;
   QString legendPosition = "top";
@@ -137,8 +142,10 @@ int main(int argc, char *argv[])
     } else if (strncmp(argv[i], "--xlabel=",9) == 0) {
       xlabel = argv[i]+9;
     } else if (strncmp(argv[i], "--ylabel=",9) == 0) {
-      ylabel = argv[i]+9;
-    } else if (strncmp(argv[i], "--xrange=",9) == 0) {
+        ylabel = argv[i]+9;
+    } else if (strncmp(argv[i], "--ylabel-right=",15) == 0) {
+        ylabelRight = argv[i]+15;
+    } else if (strncmp(argv[i], "--xrange=", 9) == 0) {
       if (2 != sscanf(argv[i]+9, "%lf:%lf", &xrange1, &xrange2)) {
         fprintf(stderr, "Error: Expected format double:double, but got %s\n", argv[i]);
         return 1;
@@ -147,6 +154,11 @@ int main(int argc, char *argv[])
       if (2 != sscanf(argv[i]+9, "%lf:%lf", &yrange1, &yrange2)) {
         fprintf(stderr, "Error: Expected format double:double, but got %s\n", argv[i]);
         return 1;
+      }
+    } else if (strncmp(argv[i], "--yrange-right=",15) == 0) {
+      if (2 != sscanf(argv[i]+15, "%lf:%lf", &yrange1right, &yrange2right)) {
+         fprintf(stderr, "Error: Expected format double:double, but got %s\n", argv[i]);
+         return 1;
       }
     } else if (strncmp(argv[i], "--new-window=",13) == 0) {
       CONSUME_BOOL_ARG(i,13,newApplication);
@@ -170,8 +182,8 @@ int main(int argc, char *argv[])
       yaxisID = argv[i] + 8;
       bool digit = true;
       for (int j = 0; j < yaxisID.length(); j++, digit = !digit) {
-          if ((digit && !(yaxisID[j]=='1' || yaxisID[j]=='2')) || (!digit && yaxisID[j]!=',')) {
-              fprintf(stderr, "Error: each 'yaxis' should be '1' or '2', separated by commas (','), but got %s\n", argv[i]);
+          if ((digit && !(yaxisID[j]=='L' || yaxisID[j]=='R')) || (!digit && yaxisID[j]!=',')) {
+              fprintf(stderr, "Error: each 'yaxis' should be 'L' or 'R', separated by commas (','), but got %s\n", argv[i]);
               return 1;
           }
       }
@@ -249,6 +261,9 @@ int main(int argc, char *argv[])
   arguments.append(footer);
   arguments.append(autoScale ? "true" : "false");
   arguments.append(yaxisID);
+  arguments.append(ylabelRight);
+  arguments.append(QString::number(yrange1right));
+  arguments.append(QString::number(yrange2right));
   arguments.append(vars);
   // create the plot application object that is used to check that only one instance of application is running
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))

--- a/OMPlot/OMPlot/OMPlotGUI/main.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/main.cpp
@@ -83,6 +83,7 @@ void printUsage(bool shortDescription)
     printf("    --title=TITLE              Sets the TITLE of the plot window\n");
     printf("    --xlabel=LABEL             Use LABEL as the label of the x-axis\n");
     printf("    --xrange=LEFT:RIGHT        Sets the initial range of the x-axis to LEFT:RIGHT\n");
+    printf("    --yaxis=AXES               Sets the y-axis (1=left, 2=right) for each variable. Each axis in AXES should be separated by a comma i.e. 1,2,1,1\n");
     printf("    --ylabel=LABEL             Use LABEL as the label of the y-axis\n");
     printf("    --yrange=LEFT:RIGHT        Sets the initial range of the y-axis to LEFT:RIGHT\n");
   }
@@ -109,6 +110,7 @@ int main(int argc, char *argv[])
   QString legendPosition = "top";
   QString footer("");
   bool autoScale = true;
+  QString yaxisID("");
   QStringList vars;
   QString filename;
   for(int i = 1; i < argc; i++)
@@ -164,6 +166,15 @@ int main(int argc, char *argv[])
       footer = argv[i]+9;
     } else if (strncmp(argv[i], "--auto-scale=",13) == 0) {
       CONSUME_BOOL_ARG(i,13,autoScale);
+    } else if (strncmp(argv[i], "--yaxis=", 8) == 0) {
+      yaxisID = argv[i] + 8;
+      bool digit = true;
+      for (int j = 0; j < yaxisID.length(); j++, digit = !digit) {
+          if ((digit && !(yaxisID[j]=='1' || yaxisID[j]=='2')) || (!digit && yaxisID[j]!=',')) {
+              fprintf(stderr, "Error: each 'yaxis' should be '1' or '2', separated by commas (','), but got %s\n", argv[i]);
+              return 1;
+          }
+      }
     } else if (strncmp(argv[i], "--", 2) == 0) {
       fprintf(stderr, "Error: Unknown option: %s\n", argv[i]);
       return 1;
@@ -237,6 +248,7 @@ int main(int argc, char *argv[])
   arguments.append(legendPosition);
   arguments.append(footer);
   arguments.append(autoScale ? "true" : "false");
+  arguments.append(yaxisID);
   arguments.append(vars);
   // create the plot application object that is used to check that only one instance of application is running
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1085,6 +1085,8 @@ Plot Window Menu
 
       -  *Toggle Sign* - Toggles the sign of curve.
 
+      -  *Plot on Right Y-Axis* - Display curve on right-side y-axis.
+
   -  *Titles* - Plot, axes and footer titles settings.
 
   -  *Legend* - Sets legend position and font.


### PR DESCRIPTION
### Related Issues

#11217 

### Purpose

In OMPlot, allow user to plot a variable on a second (right) y-axis

### Approach

Allows user to assign a plotted curve to the right y-axis. User can also adjust the range, and add custom axis titles to this second axis.
