### PR TITLE
Improve handling of __OpenModelica_commandLineOptions

### DIFF
--- a/testsuite/flattening/modelica/others/Homotopy.mo
+++ b/testsuite/flattening/modelica/others/Homotopy.mo
@@ -9,6 +9,5 @@
 model HomotopyTest
   parameter Real a = 20;
   parameter Real p = homotopy(a + 1, a);
-  annotation(__OpenModelica_commandLineOptions="-d=-newInst");
 end HomotopyTest;
 


### PR DESCRIPTION
- Refactor the handling of `__OpenModelica_commandLineOptions` to its own function instead of having the same code in multiple places.
- Apply `__OpenModelica_commandLineOptions` to `instantiateModel` and `checkModel`.

Fixes #14149