### PR TITLE
Fix copyClass

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1539,19 +1539,28 @@ public function pathStripSamePrefix
   "strips the same prefix paths and returns the stripped path. e.g pathStripSamePrefix(P.M.A, P.M.B) => A"
   input Absyn.Path inPath1;
   input Absyn.Path inPath2;
-  output Absyn.Path outPath = inPath1;
+  output Option<Absyn.Path> outPath;
 protected
-  Absyn.Path path2 = inPath2;
+  Absyn.Path path1 = inPath1, path2 = inPath2;
 algorithm
-  while pathFirstIdent(outPath) == pathFirstIdent(path2) loop
-    outPath := pathRest(outPath);
+  while pathFirstIdent(path1) == pathFirstIdent(path2) loop
+    if pathIsIdent(path1) then
+      // The whole first path is a prefix of the second.
+      outPath := NONE();
+      return;
+    end if;
+
+    path1 := pathRest(path1);
 
     if pathIsIdent(path2) then
-      return;
+      // The whole second path is a prefix of the first.
+      break;
     end if;
 
     path2 := pathRest(path2);
   end while;
+
+  outPath := SOME(path1);
 end pathStripSamePrefix;
 
 public function pathPrefix

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -5452,7 +5452,7 @@ algorithm
     modification := InteractiveUtil.makeModifierFromArgs(bindingExp, modifier, info);
     (io, redecl, attr) := getDefaultPrefixes(program, typeName);
 
-    ty_path := AbsynUtil.pathStripSamePrefix(typeName, classPath);
+    SOME(ty_path) := AbsynUtil.pathStripSamePrefix(typeName, classPath);
 
     if AbsynUtil.pathContains(classPath, AbsynUtil.pathFirstIdent(ty_path)) then
       // Keep the full type name if the first identifier of the stripped name

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -2746,6 +2746,7 @@ function updateMovedPath
   input MoveEnv env;
 protected
   Absyn.Path qualified_path;
+  Option<Absyn.Path> opt_path;
 algorithm
   // Try to look up the qualified path needed to be able to find the name in
   // this scope even if the root class that contains the scope is moved elsewhere.
@@ -2764,10 +2765,16 @@ algorithm
     if AbsynUtil.pathIsQual(qualified_path) then
       // If the path is qualified it needs to be joined with the original path,
       // but we remove any part of the path that's the same as the destination.
-      qualified_path := AbsynUtil.pathStripSamePrefix(qualified_path, env.destinationPath);
+      opt_path := AbsynUtil.pathStripSamePrefix(qualified_path, env.destinationPath);
 
-      if AbsynUtil.pathIsQual(qualified_path) then
-        path := AbsynUtil.joinPaths(AbsynUtil.pathPrefix(qualified_path), path);
+      if isSome(opt_path) then
+        SOME(qualified_path) := opt_path;
+
+        if AbsynUtil.pathIsQual(qualified_path) then
+          path := AbsynUtil.joinPaths(AbsynUtil.pathPrefix(qualified_path), path);
+        end if;
+      else
+        fail();
       end if;
     elseif AbsynUtil.pathFirstIdent(qualified_path) == AbsynUtil.pathFirstIdent(env.destinationPath) then
       // Special case, the path refers to the destination package, e.g. moving path A.B.C into A.
@@ -2856,6 +2863,7 @@ function updateMovedCref
   input MoveEnv env;
 protected
   Absyn.Path qualified_path;
+  Option<Absyn.Path> opt_path;
 algorithm
   if AbsynUtil.crefIsFullyQualified(cref) or AbsynUtil.crefIsWild(cref) then
     return;
@@ -2878,10 +2886,14 @@ algorithm
     if AbsynUtil.pathIsQual(qualified_path) then
       // If the path is qualified it needs to be joined with the original cref,
       // but we remove any part of the path that's the same as the destination.
-      qualified_path := AbsynUtil.pathStripSamePrefix(qualified_path, env.destinationPath);
+      opt_path := AbsynUtil.pathStripSamePrefix(qualified_path, env.destinationPath);
 
-      if AbsynUtil.pathIsQual(qualified_path) then
-        cref := AbsynUtil.joinCrefs(AbsynUtil.pathToCref(AbsynUtil.pathPrefix(qualified_path)), cref);
+      if isSome(opt_path) then
+        SOME(qualified_path) := opt_path;
+
+        if AbsynUtil.pathIsQual(qualified_path) then
+          cref := AbsynUtil.joinCrefs(AbsynUtil.pathToCref(AbsynUtil.pathPrefix(qualified_path)), cref);
+        end if;
       end if;
     elseif AbsynUtil.pathFirstIdent(qualified_path) == AbsynUtil.pathFirstIdent(env.destinationPath) then
       // Special case, the cref refers to the destination package, e.g. moving path A.B.C into A.


### PR DESCRIPTION
- Rewrite `AbsynUtil.pathStripSamePrefix` to return an option, to be able to handle the case where the whole path is a prefix.
- Fix NFApi.updateMovedPath/Cref to skip prefixing the path when the whole qualified path is a prefix.