### PR TITLE
Reduce List.zip usage in NBSlice

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -210,7 +210,6 @@ public
           Subscript sub;
           list<list<Subscript>> subs_lst;
           list<Integer> slice = {}, dim_sizes, values;
-          list<tuple<Integer, Integer>> ranges;
 
         // no subscripts -> create full index list
         case {} then subscriptedIndices(start, length, {});
@@ -230,8 +229,7 @@ public
           dim_sizes := list(Dimension.size(dim) for dim in dims);
           for sub_lst in listReverse(subs_lst) loop
             values  := list(Subscript.toInteger(s) for s in sub_lst);
-            ranges  := List.zip(dim_sizes, values);
-            slice   := Slice.locationToIndex(ranges, start) :: slice;
+            slice   := Slice.locationToIndex(dim_sizes, values, start) :: slice;
           end for;
         then slice;
 


### PR DESCRIPTION
- Change `NBSlice.locationToIndex` to take two lists instead of a zipped list, to reduce the amount of memory allocations.
- Adapt `NBSlice.resolveDimensionsSubscripts` to the change above by only returning the computed values instead of zipping them with the sizes.