### PR TITLE
Optimize NBAdjacency.Mode hash functions

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -302,7 +302,7 @@ public
 
     function hash
       input Mode mode;
-      output Integer hash = stringHashDjb2(toString(mode));
+      output Integer hash = ComponentRef.hash(mode.eqn_name);
     end hash;
 
     function isEqual
@@ -346,7 +346,12 @@ public
 
     function keyHash
       input Key key;
-      output Integer hash = stringHashDjb2(keyString(key));
+      output Integer hash;
+    protected
+      Integer e,v;
+    algorithm
+      (e,v) := key;
+      hash := e * 31 + v;
     end keyHash;
 
     function keyEqual


### PR DESCRIPTION
- Change `NBAdjacency.Mode.hash` to only use the equation name for the hash instead of using `toString`.
- Change `NBAdjacency.Mode.keyHash` to create the hash directly from the integers instead of using `keyString`.