### PR TITLE
Improve typing of functions with record outputs

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/FunctionRecordArg6.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionRecordArg6.mo
@@ -1,0 +1,55 @@
+// name: FunctionRecordArg6
+// keywords:
+// status: correct
+//
+
+function f
+  input R inR;
+  output R outR = inR;
+algorithm
+  outR.v[end] := 0.0;
+end f;
+
+record R
+  Real v[:];
+end R;
+
+model FunctionRecordArg6
+  record R2
+    extends R(v = {1,1,1});
+  end R2;
+
+  R2 r1;
+  R2 r2 = f(r1);
+end FunctionRecordArg6;
+
+// Result:
+// function FunctionRecordArg6.R2 "Automatically generated record constructor for FunctionRecordArg6.R2"
+//   input Real[:] v = {1.0, 1.0, 1.0};
+//   output R2 res;
+// end FunctionRecordArg6.R2;
+//
+// function R "Automatically generated record constructor for R"
+//   input Real[:] v;
+//   output R res;
+// end R;
+//
+// function f
+//   input R inR;
+//   output R outR = inR;
+// algorithm
+//   outR.v[size(outR.v, 1)] := 0.0;
+// end f;
+//
+// class FunctionRecordArg6
+//   Real r1.v[1];
+//   Real r1.v[2];
+//   Real r1.v[3];
+//   Real r2.v[1];
+//   Real r2.v[2];
+//   Real r2.v[3];
+// equation
+//   r1.v = {1.0, 1.0, 1.0};
+//   r2 = f(r1);
+// end FunctionRecordArg6;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -707,6 +707,7 @@ FunctionRecordArg2.mo \
 FunctionRecordArg3.mo \
 FunctionRecordArg4.mo \
 FunctionRecordArg5.mo \
+FunctionRecordArg6.mo \
 FunctionRecursive1.mo \
 FunctionRecursive2.mo \
 FunctionSections1.mo \


### PR DESCRIPTION
- Improve `NFCall.evaluateCallType` to also handle record return types.

Fixes #14204