### PR TITLE
Remove absolute tolerance settings from OMEdit 

### DIFF
--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -802,17 +802,16 @@ bool OMSProxy::getSystemType(QString cref, oms_system_enu_t *pType)
  * \brief OMSProxy::getTolerance
  * Gets the tolerance.
  * \param cref
- * \param absoluteTolerance
  * \param relativeTolerance
  * \return
  */
-bool OMSProxy::getTolerance(QString cref, double *absoluteTolerance, double *relativeTolerance)
+bool OMSProxy::getTolerance(QString cref, double *relativeTolerance)
 {
   QString command = "oms_getTolerance";
   QStringList args;
   args << "\"" + cref + "\"";
   LOG_COMMAND(command, args);
-  oms_status_enu_t status = oms_getTolerance(cref.toUtf8().constData(), absoluteTolerance, relativeTolerance);
+  oms_status_enu_t status = oms_getTolerance(cref.toUtf8().constData(), relativeTolerance);
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }
@@ -1334,16 +1333,16 @@ void OMSProxy::setTempDirectory(QString path)
  * \brief OMSProxy::setTolerance
  * Sets the tolerance.
  * \param cref
- * \param tolerance
+ * \param relativeTolerance
  * \return
  */
-bool OMSProxy::setTolerance(QString cref, double absoluteTolerance, double relativeTolerance)
+bool OMSProxy::setTolerance(QString cref, double relativeTolerance)
 {
   QString command = "oms_setTolerance";
   QStringList args;
-  args << "\"" + cref + "\"" << QString::number(absoluteTolerance) << QString::number(relativeTolerance);
+  args << "\"" + cref + "\"" << QString::number(relativeTolerance);
   LOG_COMMAND(command, args);
-  oms_status_enu_t status = oms_setTolerance(cref.toUtf8().constData(), absoluteTolerance, relativeTolerance);
+  oms_status_enu_t status = oms_setTolerance(cref.toUtf8().constData(), relativeTolerance);
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -99,7 +99,7 @@ public:
   bool getStopTime(QString cref, double* stopTime);
   bool getSubModelPath(QString cref, QString* pPath);
   bool getSystemType(QString cref, oms_system_enu_t *pType);
-  bool getTolerance(QString cref, double* absoluteTolerance, double* relativeTolerance);
+  bool getTolerance(QString cref, double* relativeTolerance);
   bool getVariableStepSize(QString cref, double* initialStepSize, double* minimumStepSize, double* maximumStepSize);
   bool instantiate(QString cref);
   bool initialize(QString cref);
@@ -129,7 +129,7 @@ public:
   bool setStartTime(QString cref, double startTime);
   bool setStopTime(QString cref, double stopTime);
   void setTempDirectory(QString path);
-  bool setTolerance(QString cref, double absoluteTolerance, double relativeTolerance);
+  bool setTolerance(QString cref, double relativeTolerance);
   bool setVariableStepSize(QString cref, double initialStepSize, double minimumStepSize, double maximumStepSize);
   void setWorkingDirectory(QString path);
   bool terminate(QString cref);

--- a/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.cpp
@@ -78,18 +78,13 @@ SystemSimulationInformationWidget::SystemSimulationInformationWidget(ModelWidget
       mpMinimumStepSizeTextBox->setText(QString::number(minimumStepSize));
       mpMaximumStepSizeTextBox->setText(QString::number(maximumStepSize));
     }
-    // absolute tolerance
-    mpAbsoluteToleranceLabel = new Label("Absolute Tolerance:");
-    mpAbsoluteToleranceTextBox = new QLineEdit;
-    mpAbsoluteToleranceTextBox->setValidator(pDoubleValidator);
     // relative tolerance
     mpRelativeToleranceLabel = new Label("Relative Tolerance:");
     mpRelativeToleranceTextBox = new QLineEdit;
     mpRelativeToleranceTextBox->setValidator(pDoubleValidator);
 
-    double absoluteTolerance, relativeTolerance;
-    if (OMSProxy::instance()->getTolerance(mpModelWidget->getLibraryTreeItem()->getNameStructure(), &absoluteTolerance, &relativeTolerance)) {
-      mpAbsoluteToleranceTextBox->setText(QString::number(absoluteTolerance));
+    double relativeTolerance;
+    if (OMSProxy::instance()->getTolerance(mpModelWidget->getLibraryTreeItem()->getNameStructure(), &relativeTolerance)) {
       mpRelativeToleranceTextBox->setText(QString::number(relativeTolerance));
     }
   }
@@ -131,8 +126,6 @@ SystemSimulationInformationWidget::SystemSimulationInformationWidget(ModelWidget
     pMainLayout->addWidget(mpMinimumStepSizeTextBox, row++, 1);
     pMainLayout->addWidget(mpMaximumStepSizeLabel, row, 0);
     pMainLayout->addWidget(mpMaximumStepSizeTextBox, row++, 1);
-    pMainLayout->addWidget(mpAbsoluteToleranceLabel, row, 0);
-    pMainLayout->addWidget(mpAbsoluteToleranceTextBox, row++, 1);
     pMainLayout->addWidget(mpRelativeToleranceLabel, row, 0);
     pMainLayout->addWidget(mpRelativeToleranceTextBox, row++, 1);
   }
@@ -210,12 +203,6 @@ bool SystemSimulationInformationWidget::setSystemSimulationInformation(bool push
         break;
     }
 
-    if (mpAbsoluteToleranceTextBox->text().isEmpty()) {
-      QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                            GUIMessages::getMessage(GUIMessages::ENTER_VALUE).arg("Absolute Tolerance"), QMessageBox::Ok);
-      return false;
-    }
-
     if (mpRelativeToleranceTextBox->text().isEmpty()) {
       QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
                             GUIMessages::getMessage(GUIMessages::ENTER_VALUE).arg("Relative Tolerance"), QMessageBox::Ok);
@@ -250,7 +237,7 @@ bool SystemSimulationInformationWidget::setSystemSimulationInformation(bool push
         break;
     }
     // set tolerance
-    if (!OMSProxy::instance()->setTolerance(cref, mpAbsoluteToleranceTextBox->text().toDouble(), mpRelativeToleranceTextBox->text().toDouble())) {
+    if (!OMSProxy::instance()->setTolerance(cref, mpRelativeToleranceTextBox->text().toDouble())) {
       return false;
     }
   }

--- a/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
+++ b/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
@@ -70,8 +70,6 @@ private:
   QLineEdit *mpMinimumStepSizeTextBox;
   Label *mpMaximumStepSizeLabel;
   QLineEdit *mpMaximumStepSizeTextBox;
-  Label *mpAbsoluteToleranceLabel;
-  QLineEdit *mpAbsoluteToleranceTextBox;
   Label *mpRelativeToleranceLabel;
   QLineEdit *mpRelativeToleranceTextBox;
 private slots:


### PR DESCRIPTION
  - Current version of OMSimulator no longer have an absolute tolerance parameter (removed by commit [61ef2f4d8eeb5e186c57a5dc84e6bb3a23e91d1d](https://github.com/OpenModelica/OMSimulator/commit/61ef2f4d8eeb5e186c57a5dc84e6bb3a23e91d1d))



This fully fixes issue #14228 and allows building OMEdit with current master branch of OMSimulator.


### Approach

absoluteTolerance settings were removed from SystemSimulationInformation Dialog and OMSProxy.
