### PR TITLE
Adjust references to tolerance settings om OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -298,6 +298,25 @@ else()
   qt5_add_translation(OMEDITLIB_TRANSLATIONS ${TS_FILES})
 endif()
 
+# Attempts to detect version of OMSimulator by parsing its Version.cpp file.
+#  This is being done to accomodate an API change in version 3.0 that
+#  removed absolute tolerance setting.
+set(OMS_SHORT_VERSION_STRING "unknown")
+if(EXISTS "${CMAKE_BINARY_DIR}/OMSimulator/src/OMSimulatorLib/Version.cpp")
+   file(READ "${CMAKE_BINARY_DIR}/OMSimulator/src/OMSimulatorLib/Version.cpp" OMS_VERSIONCPP_CONTENT)
+   string(REGEX MATCH "OMSimulator v([0-9]+(\.[0-9]+)*)" OMS_VERSIONCPP_CONTENT_MATCH "${OMS_VERSIONCPP_CONTENT}")
+   if(NOT "${CMAKE_MATCH_1}" STREQUAL "")
+      set(OMS_SHORT_VERSION_STRING "${CMAKE_MATCH_1}")
+   endif()
+endif()
+message(STATUS "OMSimulator version detected: ${OMS_SHORT_VERSION_STRING}")
+
+# Asume that for major versions equal 2, OMSimulator api has absolute tolerance settings.
+#   Otherwise, assume no absolute tolerance
+if("${OMS_SHORT_VERSION_STRING}" MATCHES "^2")
+   add_compile_definitions(OMS_HAS_ABSOLUTETOLERANCE)
+endif()
+
 # Add the OpenModelica generated files to sources
 set(OMEDITLIB_HEADERS ${OMEDITLIB_HEADERS} ${OMCompiler_SOURCE_DIR}/Compiler/Script/OpenModelicaScriptingAPIQt.h)
 set(OMEDITLIB_SOURCES ${OMEDITLIB_SOURCES} ${OMCompiler_SOURCE_DIR}/Compiler/Script/OpenModelicaScriptingAPIQt.cpp)

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -798,6 +798,7 @@ bool OMSProxy::getSystemType(QString cref, oms_system_enu_t *pType)
   return statusToBool(status);
 }
 
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
 /*!
  * \brief OMSProxy::getTolerance
  * Gets the tolerance.
@@ -816,6 +817,25 @@ bool OMSProxy::getTolerance(QString cref, double *absoluteTolerance, double *rel
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }
+#else // OMS_HAS_ABSOLUTETOLERANCE
+/*!
+ * \brief OMSProxy::getTolerance
+ * Gets the tolerance.
+ * \param cref
+ * \param relativeTolerance
+ * \return
+ */
+bool OMSProxy::getTolerance(QString cref, double *relativeTolerance)
+{
+  QString command = "oms_getTolerance";
+  QStringList args;
+  args << "\"" + cref + "\"";
+  LOG_COMMAND(command, args);
+  oms_status_enu_t status = oms_getTolerance(cref.toUtf8().constData(), relativeTolerance);
+  logResponse(command, status, &commandTime);
+  return statusToBool(status);
+}
+#endif // OMS_HAS_ABSOLUTETOLERANCE
 
 /*!
  * \brief OMSProxy::getVariableStepSize
@@ -1330,11 +1350,13 @@ void OMSProxy::setTempDirectory(QString path)
   logResponse(command, status, &commandTime);
 }
 
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
 /*!
  * \brief OMSProxy::setTolerance
  * Sets the tolerance.
  * \param cref
- * \param tolerance
+ * \param absoluteTolerance
+ * \param relativeTolerance
  * \return
  */
 bool OMSProxy::setTolerance(QString cref, double absoluteTolerance, double relativeTolerance)
@@ -1347,6 +1369,26 @@ bool OMSProxy::setTolerance(QString cref, double absoluteTolerance, double relat
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }
+#else // OMS_HAS_ABSOLUTETOLERANCE
+/*!
+ * \brief OMSProxy::setTolerance
+ * Sets the tolerance.
+ * \param cref
+ * \param absoluteTolerance
+ * \param relativeTolerance
+ * \return
+ */
+bool OMSProxy::setTolerance(QString cref, double relativeTolerance)
+{
+  QString command = "oms_setTolerance";
+  QStringList args;
+  args << "\"" + cref + "\"" << QString::number(relativeTolerance);
+  LOG_COMMAND(command, args);
+  oms_status_enu_t status = oms_setTolerance(cref.toUtf8().constData(), relativeTolerance);
+  logResponse(command, status, &commandTime);
+  return statusToBool(status);
+}
+#endif // OMS_HAS_ABSOLUTETOLERANCE
 
 /*!
  * \brief OMSProxy::setVariableStepSize

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -99,7 +99,11 @@ public:
   bool getStopTime(QString cref, double* stopTime);
   bool getSubModelPath(QString cref, QString* pPath);
   bool getSystemType(QString cref, oms_system_enu_t *pType);
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
   bool getTolerance(QString cref, double* absoluteTolerance, double* relativeTolerance);
+#else
+  bool getTolerance(QString cref, double* relativeTolerance);
+#endif
   bool getVariableStepSize(QString cref, double* initialStepSize, double* minimumStepSize, double* maximumStepSize);
   bool instantiate(QString cref);
   bool initialize(QString cref);
@@ -129,7 +133,11 @@ public:
   bool setStartTime(QString cref, double startTime);
   bool setStopTime(QString cref, double stopTime);
   void setTempDirectory(QString path);
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
   bool setTolerance(QString cref, double absoluteTolerance, double relativeTolerance);
+#else
+  bool setTolerance(QString cref, double relativeTolerance);
+#endif
   bool setVariableStepSize(QString cref, double initialStepSize, double minimumStepSize, double maximumStepSize);
   void setWorkingDirectory(QString path);
   bool terminate(QString cref);

--- a/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.cpp
@@ -78,20 +78,29 @@ SystemSimulationInformationWidget::SystemSimulationInformationWidget(ModelWidget
       mpMinimumStepSizeTextBox->setText(QString::number(minimumStepSize));
       mpMaximumStepSizeTextBox->setText(QString::number(maximumStepSize));
     }
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
     // absolute tolerance
     mpAbsoluteToleranceLabel = new Label("Absolute Tolerance:");
     mpAbsoluteToleranceTextBox = new QLineEdit;
     mpAbsoluteToleranceTextBox->setValidator(pDoubleValidator);
+#endif
     // relative tolerance
     mpRelativeToleranceLabel = new Label("Relative Tolerance:");
     mpRelativeToleranceTextBox = new QLineEdit;
     mpRelativeToleranceTextBox->setValidator(pDoubleValidator);
 
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
     double absoluteTolerance, relativeTolerance;
     if (OMSProxy::instance()->getTolerance(mpModelWidget->getLibraryTreeItem()->getNameStructure(), &absoluteTolerance, &relativeTolerance)) {
       mpAbsoluteToleranceTextBox->setText(QString::number(absoluteTolerance));
       mpRelativeToleranceTextBox->setText(QString::number(relativeTolerance));
     }
+#else
+    double relativeTolerance;
+    if (OMSProxy::instance()->getTolerance(mpModelWidget->getLibraryTreeItem()->getNameStructure(),&relativeTolerance)) {
+      mpRelativeToleranceTextBox->setText(QString::number(relativeTolerance));
+    }
+#endif
   }
 
   if (mpModelWidget->getLibraryTreeItem()->isWCSystem()) { // oms_system_wc
@@ -131,8 +140,10 @@ SystemSimulationInformationWidget::SystemSimulationInformationWidget(ModelWidget
     pMainLayout->addWidget(mpMinimumStepSizeTextBox, row++, 1);
     pMainLayout->addWidget(mpMaximumStepSizeLabel, row, 0);
     pMainLayout->addWidget(mpMaximumStepSizeTextBox, row++, 1);
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
     pMainLayout->addWidget(mpAbsoluteToleranceLabel, row, 0);
     pMainLayout->addWidget(mpAbsoluteToleranceTextBox, row++, 1);
+#endif
     pMainLayout->addWidget(mpRelativeToleranceLabel, row, 0);
     pMainLayout->addWidget(mpRelativeToleranceTextBox, row++, 1);
   }
@@ -209,12 +220,13 @@ bool SystemSimulationInformationWidget::setSystemSimulationInformation(bool push
         }
         break;
     }
-
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
     if (mpAbsoluteToleranceTextBox->text().isEmpty()) {
       QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
                             GUIMessages::getMessage(GUIMessages::ENTER_VALUE).arg("Absolute Tolerance"), QMessageBox::Ok);
       return false;
     }
+#endif
 
     if (mpRelativeToleranceTextBox->text().isEmpty()) {
       QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
@@ -250,9 +262,14 @@ bool SystemSimulationInformationWidget::setSystemSimulationInformation(bool push
         break;
     }
     // set tolerance
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
     if (!OMSProxy::instance()->setTolerance(cref, mpAbsoluteToleranceTextBox->text().toDouble(), mpRelativeToleranceTextBox->text().toDouble())) {
+#else
+    if (!OMSProxy::instance()->setTolerance(cref, mpRelativeToleranceTextBox->text().toDouble())) {
+#endif
       return false;
     }
+
   }
   // push on stack
   if (pushOnStack) {

--- a/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
+++ b/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
@@ -70,8 +70,10 @@ private:
   QLineEdit *mpMinimumStepSizeTextBox;
   Label *mpMaximumStepSizeLabel;
   QLineEdit *mpMaximumStepSizeTextBox;
+#ifdef OMS_HAS_ABSOLUTETOLERANCE
   Label *mpAbsoluteToleranceLabel;
   QLineEdit *mpAbsoluteToleranceTextBox;
+#endif
   Label *mpRelativeToleranceLabel;
   QLineEdit *mpRelativeToleranceTextBox;
 private slots:


### PR DESCRIPTION
### Related Issues

 - Newer versions of OMSimulator have removed absoluteTolerance settings from its api (see OpenModelica/OMSimulator#1400). This setting remains on older branches, including those used by the integration tests (see #14241). As such, OMEdit potentially need to be compiled with two different OMSimulator APIs.
 - Fixes #14228

### Purpose

Currently, OMEdit cannot be build with the master branch of OMSimulator due to the change in API. Yet, a simple removal of absoluteTolerance references will make it fail to build on older branches. The goal of this patch is to make it accommodate both versions of OMSimulator's API.

### Approach

A modified CMakeLists.txt file attempt to identify OMSimulator version (by parsing its `Version.cpp` file).
If a major version 2 is detected, it sets macro `OMS_HAS_ABSOLUTETOLERANCE`. Files `OMSProxy.h`, `OMSProxy.cpp`, `SystemSimulationInformationDialog.h` and `SystemSimulationInformationDialog.cpp` conditionally include the appropriate API.

Admittedly, those `#ifdef` aren't pretty. I still like #14241 better, but it fails current integration tests that use the older OMSimulator API. Unfortunately, I can't see a cleaner way to handle both APIs.

