### PR TITLE
Handle `\r\n` in Tpl.writeStr

### DIFF
--- a/OMCompiler/Compiler/Template/Tpl.mo
+++ b/OMCompiler/Compiler/Template/Tpl.mo
@@ -164,7 +164,7 @@ algorithm
 
     // a new-line is inside
     else
-      writeChars(inText, System.strtokIncludingDelimiters(inStr, "\n"));
+      writeChars(inText, System.splitOnNewline(inStr, includeDelimiter = true));
   end match;
 end writeStr;
 
@@ -280,6 +280,12 @@ algorithm
       then
         writeChars(txt, chars);
 
+    case (txt, "\r\n" :: chars )
+      equation
+        txt = newLine(txt);
+      then
+        writeChars(txt, chars);
+
     //non-new-line at the start of the string, so a string or line only follows
     case (txt, c :: chars )
       equation
@@ -361,6 +367,10 @@ algorithm
         ({}, {}, false);
 
     case ("\n" :: chars)
+      then
+        ({"\n"}, chars, true);
+
+    case ("\r\n" :: chars)
       then
         ({"\n"}, chars, true);
 

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -194,6 +194,18 @@ public function strtokIncludingDelimiters
   external "C" strings=System_strtokIncludingDelimiters(string,token) annotation(Library = "omcruntime");
 end strtokIncludingDelimiters;
 
+public function splitOnNewline
+  "Splits a string on new lines (\n and \r\n). If includeDelimiter is true then
+   the new line delimiters are included in the list as separate tokens.
+     splitOnNewline(a\nb\r\nc) = {a, b, c}
+     splitOnNewline(a\nb\r\nc, true) = {a, \n, b, \r\n, c}"
+  input String str;
+  input Boolean includeDelimiter = false;
+  output list<String> strings;
+
+  external "C" strings=System_splitOnNewline(str, includeDelimiter) annotation(Library = "omcruntime");
+end splitOnNewline;
+
 public function setCCompiler
   input String inString;
 

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -1099,6 +1099,51 @@ int System_isRML()
   return 0;
 }
 
+extern void* System_splitOnNewline(const char *str, int includeDelimiter)
+{
+  const char *start = str;
+  const char *current = start;
+  size_t sz;
+  void *lst = mmc_mk_nil();
+
+  while (*current != '\0') {
+    // Split on \n and \r\n.
+    if (*current == '\n' || (*current == '\r' && *(current + 1) == '\n')) {
+      sz = current - start;
+
+      // Save the string up to the newline.
+      if (sz > 0) {
+        lst = mmc_mk_cons(mmc_mk_scon_n(start, sz), lst);
+      }
+
+      // Is the newline one character (\n) or two (\r\n)?
+      if (*current == '\r' && *(current + 1) == '\n') {
+        sz = 2;
+      } else {
+        sz = 1;
+      }
+
+      // Save the newline if includeDelimiter = true.
+      if (includeDelimiter) {
+        lst = mmc_mk_cons(mmc_mk_scon_n(current, sz), lst);
+      }
+
+      // Move to the next character after the newline.
+      current += sz;
+      start = current;
+    } else {
+      ++current;
+    }
+  }
+
+  // Save the rest of the string if there's anything left.
+  if (current != start) {
+    lst = mmc_mk_cons(mmc_mk_scon_n(start, current - start), lst);
+  }
+
+  return listReverse(lst);
+}
+
 extern void* System_strtokIncludingDelimiters(const char *str0, const char *delimit)
 {
   char* str = (char*)str0;

--- a/OMCompiler/SimulationRuntime/c/util/modelica_string.h
+++ b/OMCompiler/SimulationRuntime/c/util/modelica_string.h
@@ -100,6 +100,29 @@ static inline void* mmc_mk_scon_len(mmc_uint_t nbytes)
     return res;
 }
 
+static inline void* mmc_mk_scon_n(const char *s, int length)
+{
+    size_t header = MMC_STRINGHDR(length);
+    size_t nwords = MMC_HDRSLOTS(header) + 1;
+    struct mmc_string *p;
+    void *res;
+    if (length == 0) return mmc_emptystring;
+    if (length == 1) {
+      unsigned char c = *s;
+      return mmc_strings_len1[(unsigned int)c];
+    }
+    p = (struct mmc_string *) mmc_check_out_of_memory(omc_alloc_interface.malloc_atomic(nwords*sizeof(void*)));
+    p->header = header;
+    memcpy(p->data, s, length);
+    p->data[length] = '\0';
+    res = MMC_TAGPTR(p);
+    MMC_CHECK_STRING(res);
+#ifdef MMC_MK_DEBUG
+    fprintf(stderr, "STRING slots: %u size: %d str: %s\n", MMC_HDRSLOTS(header), length, s); fflush(NULL);
+#endif
+    return res;
+}
+
 static inline void* mmc_mk_scon(const char *s)
 {
     size_t nbytes = strlen(s);


### PR DESCRIPTION
- Add `System.splitOnNewline` that can handle both `\n` and `\r\n` and use it in `Tpl.writeStr` to avoid splitting up `\r\n` tokens.