### PR TITLE
Select appropriate background highlight color on OMEdit on dark modes

### DIFF
--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -840,11 +840,35 @@ QTextCharFormat Utilities::getParenthesesMisMatchFormat()
   return parenthesesMisMatchFormat;
 }
 
+// Tries to find an appropriate highlight color from the background
+static QColor utilitiesCalcHighlightColor(void) {
+  // Get default background color's HSV values
+  int h, s, v;
+  // Default QTextEdit background color
+  QTextEdit().palette().color(QPalette::Normal, QPalette::Base).getHsv(&h, &s, &v);
+  // For a pure white background, this is the equivalent of r=232, g=242, b=254
+  // Darken light backgrounds, brighten dark ones
+  if(v>127)
+    v -= 1;
+  else
+    v += 20;
+  // Unsaturated background, set it to light blue
+  if(s<5) {
+    h = 212;
+    s = 22;
+  } else {   // set it to +45 degrees
+    h += (0x20)&0xff;
+  }
+  QColor ret = QColor::fromHsv(h, s, v);
+  return ret;
+}
+
 void Utilities::highlightCurrentLine(QPlainTextEdit *pPlainTextEdit)
 {
   QList<QTextEdit::ExtraSelection> selections = pPlainTextEdit->extraSelections();
   QTextEdit::ExtraSelection selection;
-  QColor lineColor = QColor(232, 242, 254);
+  // This is static, so it can't react to system palette change.
+  static const QColor lineColor = utilitiesCalcHighlightColor();
   selection.format.setBackground(lineColor);
   selection.format.setProperty(QTextFormat::FullWidthSelection, true);
   selection.cursor = pPlainTextEdit->textCursor();


### PR DESCRIPTION
### Related Issues

OMEdit currently uses a fixed highlight background color (232, 242, 254).
This is an acceptable color for a bright theme with dark text and white background.
Unfortunately, under dark themes, text color must be bright to contrast with dark background. This makes the currently highlighted line unreadable.

### Purpose

This patch attempts to select a suitable highlight color both for bright and dark themes.

### Approach

The function `Utilities::highlightCurrentLine` was modified so the `lineColor` variable is created from an heuristic that adapts the default color obtained from `QTextEdit().palette().color(QPalette::Normal, QPalette::Base)`.
The color modification heuristic matches current (232, 242, 254) under a pure white background. It attempts to slightly brighten the background on dark modes. 
Hue should be slightly blue for grayscale backgrounds, and shifted +45 degrees for colored backgrounds.

To avoid calculation overhead each time `Utilities::highlightCurrentLine`  is invoked, the  `lineColor` variable was declared `static const`. The downside of this approach is that the highlight color won't follow system palette changes after the application has started. 

Perhaps a better approach would be to react to system palette change events and recalculate the color, but the current solution should be an improvement over current state.