### PR TITLE
[C, Tpl] only run homotopy initialization when operator is present

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1313,7 +1313,7 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
       <%symbolName(modelNamePrefixStr,"function_initSpatialDistribution")%>,
       <%symbolName(modelNamePrefixStr,"updateBoundVariableAttributes")%>,
       <%symbolName(modelNamePrefixStr,"functionInitialEquations")%>,
-      <%if Config.adaptiveHomotopy() then (if Config.globalHomotopy() then '2' else '3') else (if Config.globalHomotopy() then '1' else '0')%>, /* useHomotopy - 0: local homotopy (equidistant lambda), 1: global homotopy (equidistant lambda), 2: new global homotopy approach (adaptive lambda), 3: new local homotopy approach (adaptive lambda)*/
+      <%if Config.replacedHomotopy() then 'NO_HOMOTOPY' else if Config.adaptiveHomotopy() then (if Config.globalHomotopy() then 'GLOBAL_ADAPTIVE_HOMOTOPY' else 'LOCAL_ADAPTIVE_HOMOTOPY') else (if Config.globalHomotopy() then 'GLOBAL_EQUIDISTANT_HOMOTOPY' else 'LOCAL_EQUIDISTANT_HOMOTOPY')%>,
       <%if intEq(listLength(initialEquations_lambda0), 0) then "NULL" else '<%symbolName(modelNamePrefixStr,"functionInitialEquations_lambda0")%>'%>,
       <%symbolName(modelNamePrefixStr,"functionRemovedInitialEquations")%>,
       <%symbolName(modelNamePrefixStr,"updateBoundParameters")%>,

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4034,6 +4034,10 @@ package Config
     output Boolean outBoolean;
   end globalHomotopy;
 
+  function replacedHomotopy
+    output Boolean outBoolean;
+  end replacedHomotopy;
+
   function adaptiveHomotopy
     output Boolean outBoolean;
   end adaptiveHomotopy;

--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -631,6 +631,15 @@ algorithm
   end match;
 end adaptiveHomotopy;
 
+public function replacedHomotopy
+  output Boolean outBoolean;
+protected
+  String replaceHomotopy;
+algorithm
+  replaceHomotopy := Flags.getConfigString(Flags.REPLACE_HOMOTOPY);
+  outBoolean := replaceHomotopy == "actual" or replaceHomotopy == "simplified";
+end replacedHomotopy;
+
 public function synchronousFeaturesAllowed
 "@autor: adrpo
  checks returns true if language standard is above or equal to Modelica 3.3"

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -168,8 +168,9 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   * 1: global homotopy approach (equidistant lambda steps)
   * 2: new global homotopy approach (adaptive lambda steps)
   * 3: new local homotopy approach (adaptive lambda steps)
+  * 4: no homotopy
   */
-  int useHomotopy;
+  HOMOTOPY_METHOD homotopyMethod;
 
   /*! \fn functionInitialEquations_lambda0
   *

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -1697,11 +1697,11 @@ static int homotopyAlgorithm(DATA_HOMOTOPY* solverData, double *x)
     if(solverData->initHomotopy && OMC_ACTIVE_STREAM(OMC_LOG_INIT_HOMOTOPY))
     {
       if (omc_flag[FLAG_OUTPUT_PATH]) { /* Add output path to file name */
-        sprintf(buffer, "%s/%s_nonlinsys%d_adaptive_%s_homotopy_%s.csv", omc_flagValue[FLAG_OUTPUT_PATH], data->modelData->modelFilePrefix, sysNumber, data->callback->useHomotopy == 2 ? "global" : "local", solverData->startDirection > 0 ? "pos" : "neg");
+        sprintf(buffer, "%s/%s_nonlinsys%d_adaptive_%s_homotopy_%s.csv", omc_flagValue[FLAG_OUTPUT_PATH], data->modelData->modelFilePrefix, sysNumber, data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY ? "global" : "local", solverData->startDirection > 0 ? "pos" : "neg");
       }
       else
       {
-        sprintf(buffer, "%s_nonlinsys%d_adaptive_%s_homotopy_%s.csv", data->modelData->modelFilePrefix, sysNumber, data->callback->useHomotopy == 2 ? "global" : "local", solverData->startDirection > 0 ? "pos" : "neg");
+        sprintf(buffer, "%s_nonlinsys%d_adaptive_%s_homotopy_%s.csv", data->modelData->modelFilePrefix, sysNumber, data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY ? "global" : "local", solverData->startDirection > 0 ? "pos" : "neg");
       }
       infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 0, "The homotopy path will be exported to %s.", buffer);
       pFile = omc_fopen(buffer, "wt");

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -533,7 +533,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
 #if !defined(OMC_MINIMAL_RUNTIME)
   case NLS_HYBRID:
     solverData = (struct dataSolver*) malloc(sizeof(struct dataSolver));
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       solverData->ordinaryData = allocateHybrdData(size-1, nlsUserData);
       nlsUserData = initNlsUserData(data, threadData, sysNum, nonlinsys, jacobian); /* Seperate userData for homotopy solver */
       solverData->initHomotopyData = (void*) allocateHomotopyData(size-1, nlsUserData);
@@ -544,7 +544,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     break;
   case NLS_KINSOL:
     solverData = (struct dataSolver*) malloc(sizeof(struct dataSolver));
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       solverData->initHomotopyData = (void*) allocateHomotopyData(size-1, nlsUserData);
     } else {
       nonlinsys->solverData = (void*) nlsKinsolAllocate(size, nlsUserData, TRUE, nonlinsys->isPatternAvailable);
@@ -554,7 +554,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     break;
   case NLS_KINSOL_B:
     solverData = (struct dataSolver*) malloc(sizeof(struct dataSolver));
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       solverData->initHomotopyData = (void*) allocateHomotopyData(size-1, nlsUserData);
     } else {
       nonlinsys->solverData = (void*) B_nlsKinsolAllocate(size, nlsUserData, TRUE, nonlinsys->isPatternAvailable);
@@ -564,7 +564,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     break;
   case NLS_NEWTON:
     solverData = (struct dataSolver*) malloc(sizeof(struct dataSolver));
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       solverData->ordinaryData = (void*) allocateNewtonData(size-1, nlsUserData);
       nlsUserData = initNlsUserData(data, threadData, sysNum, nonlinsys, jacobian); /* Seperate userData for homotopy solver */
       solverData->initHomotopyData = (void*) allocateHomotopyData(size-1, nlsUserData);
@@ -575,7 +575,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     break;
   case NLS_MIXED:
     mixedSolverData = (struct dataMixedSolver*) malloc(sizeof(struct dataMixedSolver));
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       mixedSolverData->newtonHomotopyData = (void*) allocateHomotopyData(size-1, nlsUserData);
       nlsUserData = initNlsUserData(data, threadData, sysNum, nonlinsys, jacobian); /* Seperate userData for hybrid solver */
       mixedSolverData->hybridData = (void*) allocateHybrdData(size-1, nlsUserData);
@@ -588,7 +588,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     break;
 #endif
   case NLS_HOMOTOPY:
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       nonlinsys->solverData = (void*) allocateHomotopyData(size-1, nlsUserData);
     } else {
       nonlinsys->solverData = (void*) allocateHomotopyData(size, nlsUserData);
@@ -739,13 +739,13 @@ void freeNonlinearSyst(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DA
 #if !defined(OMC_MINIMAL_RUNTIME)
   case NLS_HYBRID:
     freeHybrdData(((struct dataSolver*) nonlinsys->solverData)->ordinaryData);
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       freeHomotopyData(((struct dataSolver*) nonlinsys->solverData)->initHomotopyData);
     }
     free(nonlinsys->solverData);
     break;
   case NLS_KINSOL:
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       freeHomotopyData(((struct dataSolver*) nonlinsys->solverData)->initHomotopyData);
     } else {
       nlsKinsolFree(((struct dataSolver*) nonlinsys->solverData)->ordinaryData);
@@ -753,7 +753,7 @@ void freeNonlinearSyst(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DA
     free(nonlinsys->solverData);
     break;
   case NLS_KINSOL_B:
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       freeHomotopyData(((struct dataSolver*) nonlinsys->solverData)->initHomotopyData);
     } else {
       B_nlsKinsolFree(((struct dataSolver*) nonlinsys->solverData)->ordinaryData);
@@ -762,7 +762,7 @@ void freeNonlinearSyst(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DA
     break;
   case NLS_NEWTON:
     freeNewtonData(((struct dataSolver*) nonlinsys->solverData)->ordinaryData);
-    if (nonlinsys->homotopySupport && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3)) {
+    if (nonlinsys->homotopySupport && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY )) {
       freeHomotopyData(((struct dataSolver*) nonlinsys->solverData)->initHomotopyData);
     }
     free(nonlinsys->solverData);
@@ -1299,23 +1299,26 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
   MMC_TRY_INTERNAL(simulationJumpBuffer)
 #endif
 
+  // TODO: refactor this logic
+
   /* handle asserts */
   saveJumpState = threadData->currentErrorStage;
   threadData->currentErrorStage = ERROR_NONLINEARSOLVER;
 
   equidistantHomotopy = data->simulationInfo->initial
                         && nonlinsys->homotopySupport
-                        && (data->callback->useHomotopy == 0 && init_lambda_steps >= 1);
+                        && (data->callback->homotopyMethod == LOCAL_EQUIDISTANT_HOMOTOPY && init_lambda_steps >= 1);
 
   solveWithHomotopySolver = data->simulationInfo->initial
                             && nonlinsys->homotopySupport
-                            && (data->callback->useHomotopy == 2 || data->callback->useHomotopy == 3);
+                            && (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY );
 
-  homotopyDeactivated = !data->simulationInfo->initial           // Not an initialization system
-                        || !nonlinsys->homotopySupport           // There is no homotopy in this component
-                        || (data->callback->useHomotopy == 1)    // Equidistant homotopy is performed globally in symbolic_initialization()
-                        || (data->callback->useHomotopy == 0     // Equidistant local homotopy is selected but homotopy is deactivated ...
-                            && init_lambda_steps <= 0);          // ... by the number of steps
+  homotopyDeactivated = (!data->simulationInfo->initial                                    // Not an initialization system
+                        || !nonlinsys->homotopySupport                                     // There is no homotopy in this component
+                        || (data->callback->homotopyMethod == GLOBAL_EQUIDISTANT_HOMOTOPY) // Equidistant homotopy is performed globally in symbolic_initialization()
+                        || (data->callback->homotopyMethod == LOCAL_EQUIDISTANT_HOMOTOPY   // Equidistant local homotopy is selected but homotopy is deactivated ...
+                        && init_lambda_steps <= 0))
+                        || data->callback->homotopyMethod == NO_HOMOTOPY ;                 // No Homotopy present
 
   nonlinsys->solved = NLS_FAILED;
   nonlinsys->initHomotopy = 0;
@@ -1343,7 +1346,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
     if (!omc_flag[FLAG_HOMOTOPY_ON_FIRST_TRY] && !kinsol)
       warningStreamPrint(OMC_LOG_ASSERT, 0, "Failed to solve the initial system %d without homotopy method.", sysNumber);
     data->simulationInfo->lambda = 0.0;
-    if (data->callback->useHomotopy == 3) {
+    if (data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY ) {
       // First solve the lambda0-system separately
       infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 0, "Local homotopy with adaptive step size started for nonlinear system %d.", sysNumber);
       infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 1, "homotopy process\n---------------------------");
@@ -1362,7 +1365,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
       messageClose(OMC_LOG_INIT_HOMOTOPY);
     }
     /* SOLVE! */
-    if (data->callback->useHomotopy == 2 || nonlinsys->solved == NLS_SOLVED) {
+    if (data->callback->homotopyMethod == GLOBAL_ADAPTIVE_HOMOTOPY || nonlinsys->solved == NLS_SOLVED) {
       infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 0, "run along the homotopy path and solve the actual system");
       nonlinsys->initHomotopy = 1;
       nonlinsys->solved = solveWithInitHomotopy(data, threadData, nonlinsys);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -496,7 +496,7 @@ int initializeModel(DATA* data, threadData_t *threadData, const char* init_initM
         infoStreamPrint(OMC_LOG_SUCCESS, 0, "The initialization finished successfully without homotopy method.");
       }
       else {
-        usedLocal = data->callback->useHomotopy == 0 || data->callback->useHomotopy == 3;
+        usedLocal = data->callback->homotopyMethod == LOCAL_EQUIDISTANT_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY ;
         infoStreamPrint(OMC_LOG_SUCCESS, 0, "The initialization finished successfully with %d %shomotopy steps.", data->simulationInfo->homotopySteps, usedLocal? "local ":"");
       }
     }

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -219,6 +219,19 @@ typedef struct EXTERNAL_INPUT
   modelica_integer i;
 } EXTERNAL_INPUT;
 
+/**
+ * @brief Specifies homotopy method
+ *
+ */
+typedef enum HOMOTOPY_METHOD
+{
+  LOCAL_EQUIDISTANT_HOMOTOPY = 0,   // 0: local homotopy (equidistant lambda)
+  GLOBAL_EQUIDISTANT_HOMOTOPY = 1,  // 1: global homotopy (equidistant lambda)
+  GLOBAL_ADAPTIVE_HOMOTOPY = 2,     // 2: new global homotopy approach (adaptive lambda)
+  LOCAL_ADAPTIVE_HOMOTOPY = 3,      // 3: new local homotopy approach (adaptive lambda)
+  NO_HOMOTOPY = 4                   // 4: no homotopy / else
+} HOMOTOPY_METHOD;
+
 /* Alias data with various types */
 typedef struct DATA_ALIAS
 {

--- a/testsuite/simulation/modelica/initialization/bug_2207.mos
+++ b/testsuite/simulation/modelica/initialization/bug_2207.mos
@@ -39,7 +39,6 @@ simulate(initializationTests.bug_2207, simflags="-lv=LOG_INIT_V"); getErrorStrin
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT_V        | info    | updated start value: x(start=200)
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real a(start=100, fixed=true) = 100

--- a/testsuite/simulation/modelica/initialization/bug_2990.mos
+++ b/testsuite/simulation/modelica/initialization/bug_2990.mos
@@ -37,7 +37,6 @@ simulate(initializationTests.bug_2990, simflags="-lv=LOG_INIT_V -iim=none"); get
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real L(start=2.5, fixed=true) = 2.5

--- a/testsuite/simulation/modelica/initialization/bug_2994.mos
+++ b/testsuite/simulation/modelica/initialization/bug_2994.mos
@@ -32,7 +32,6 @@ simulate(initializationTests.bug_2994, simflags="-lv=LOG_INIT_V -override=a=2");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real a(start=1, fixed=true) = 1
@@ -56,7 +55,6 @@ simulate(initializationTests.bug_2994, simflags="-lv=LOG_INIT_V -override=a=2");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real a(start=2, fixed=true) = 2

--- a/testsuite/simulation/modelica/initialization/bug_3052.mos
+++ b/testsuite/simulation/modelica/initialization/bug_3052.mos
@@ -34,7 +34,6 @@ val(b, 0.0); getErrorString();
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real a(start=0, fixed=false) = 2

--- a/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
@@ -167,7 +167,21 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with equidistant step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path of system 0 will be exported to initializationTests.homotopy4_solver_nonlinsys0_equidistant_local_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -177,22 +191,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.956376 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -17.3731 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.04362 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.95638 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
 // |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -254,7 +268,21 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with equidistant step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path of system 0 will be exported to initializationTests.homotopy4_solver_nonlinsys0_equidistant_local_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -264,22 +292,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -341,7 +369,21 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with equidistant step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path of system 0 will be exported to initializationTests.homotopy4_solver_nonlinsys0_equidistant_local_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -351,7 +393,7 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956373 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956366 (pre: 0)
 // |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
@@ -366,7 +408,7 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -428,7 +470,21 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with equidistant step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path of system 0 will be exported to initializationTests.homotopy4_solver_nonlinsys0_equidistant_local_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -438,22 +494,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -515,7 +571,21 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with equidistant step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path of system 0 will be exported to initializationTests.homotopy4_solver_nonlinsys0_equidistant_local_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | [system 0] homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -525,22 +595,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -1141,111 +1211,7 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -17.3731 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.04362 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.95638 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
-// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Automatically set -homotopyOnFirstTry, because trying without homotopy first is not supported for the local global approach in combination with KINSOL.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
 // LOG_INIT_HOMOTOPY | info    | homotopy process
 // |                 | |       | ---------------------------
@@ -1376,7 +1342,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -1387,22 +1380,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956373 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
 // |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95637 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
 // |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04363 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
 // |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -1480,7 +1473,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -1491,22 +1511,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -1584,7 +1604,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve nonlinear initial system 0 without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -1595,22 +1642,153 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -1694,115 +1872,7 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve the initialization problem without homotopy first.
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -17.3731 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.04362 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.95638 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
-// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Automatically set -homotopyOnFirstTry, because trying without homotopy first is not supported for the adaptive global approach in combination with KINSOL.
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
 // LOG_INIT_HOMOTOPY | info    | homotopy process
 // |                 | |       | ---------------------------
@@ -1933,7 +2003,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve the initialization problem without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -1959,7 +2056,7 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -2037,7 +2134,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve the initialization problem without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -2048,22 +2172,22 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
@@ -2141,7 +2265,34 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Try to solve the initialization problem without homotopy first.
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
@@ -2152,22 +2303,153 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
 // |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
 // |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
 // |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true

--- a/testsuite/simulation/modelica/initialization/parameters.mos
+++ b/testsuite/simulation/modelica/initialization/parameters.mos
@@ -45,7 +45,6 @@ simulate(initializationTests.parameters, simflags="-lv=LOG_INIT_V"); getErrorStr
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // |                 | |       | | real parameters
 // |                 | |       | | | [1] parameter Real r1(start=0, fixed=true) = 0

--- a/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
@@ -42,7 +42,6 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // LOG_INIT_V        | info    | updated start value: x(start=50000)
 // LOG_NLS           | info    | update static data of non-linear system solvers
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              y  =            5e-06		 nom =            1e-05

--- a/testsuite/simulation/modelica/others/Bug2788.mos
+++ b/testsuite/simulation/modelica/others/Bug2788.mos
@@ -22,14 +22,13 @@ val(y1, 1.0); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "foo_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'foo', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'foo', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V'",
 //     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
 // LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_INIT_V        | info    | parameter values
 // LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
 // |                 | |       | | other real variables

--- a/testsuite/simulation/modelica/start_value_selection/overrideLiteralStartFromFile_alg.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideLiteralStartFromFile_alg.mos
@@ -51,7 +51,6 @@ simulate(overrideLiteralStartFromFile_alg_model, simflags="-iif=init_overrideLit
 // LOG_INIT          | info    | import boolean parameters
 // LOG_NLS           | info    | update static data of non-linear system solvers
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1

--- a/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_alg.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_alg.mos
@@ -54,7 +54,6 @@ simulate(overrideParamStartFromFile_alg_model, simflags="-iif=init_overrideParam
 // LOG_INIT          | info    | import boolean parameters
 // LOG_NLS           | info    | update static data of non-linear system solvers
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1

--- a/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_param.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideParamStartFromFile_param.mos
@@ -54,7 +54,6 @@ simulate(overrideParamStartFromFile_param_model, simflags="-iif=init_overridePar
 // LOG_INIT          | info    | import boolean parameters
 // LOG_NLS           | info    | update static data of non-linear system solvers
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
 // LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              T  =        909.99999		 nom =                1


### PR DESCRIPTION
### Related Issues / Problem

- warning in ticket https://github.com/OpenModelica/OpenModelica/issues/14162 is based on a wrong condition
- incorrect homotopy initializations happen even if no homotopy operator is present (if `--replaceHomotopy != "none"`)

### Purpose

- fixes homotopy initialization for `--replaceHomotopy != "none"`
-> now: only dump the warning of [#14162](https://github.com/OpenModelica/OpenModelica/issues/14162), if there exists an NLS, which contains a homotopy operator
-> before: false homotopy initializations could occur even if no homotopy operator was present in the model
- adds enumeration `HOMOTOPY_METHOD` to improve code readability
- TODO: clean up the homotopy logic to further improve code readability