### PR TITLE
[NB] make jacobian generic calls unique

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimCode.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCode.mo
@@ -120,7 +120,6 @@ public
       Integer jacobianIndex;
       Integer residualIndex;
       Integer implicitIndex; // this can be removed i think -> moved to solve
-      //Integer genericCallIndex;  this is replaced by UnorderedMap.size(generic_call_map)
       Integer extObjIndex;
 
       UnorderedMap<AliasInfo, Integer> alias_map;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -6300,29 +6300,29 @@ template equationGenericAssign(SimEqSystem eq, Context context,
                                  Text &varDecls, Text &auxFunction, String modelNamePrefix)
  "Generate a call for a generic for-loop structure with an index-list."
 ::=
+  let jac = match context case JACOBIAN_CONTEXT() then ", jacobian" else ""
+  let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
 <<
 <%modelicaLine(eqInfo(eq))%>
 <%match eq
 case eqn as SES_RESIZABLE_ASSIGN() then
   let &preExp = buffer ""
   let &sub = buffer ""
-  let jac = match context case JACOBIAN_CONTEXT() then ", jacobian" else ""
   let forIter = (iters |> it => forIterator(it, context, &preExp, &varDecls, &auxFunction, &sub);separator="\n";empty)
   let forNames = (iters |> it => forIteratorName(it, context, &preExp, &varDecls, &auxFunction, &sub);separator=", ";empty)
   let forTail = (iters |> it => "}";separator="\n";empty)
   <<
     <%forIter%>
     <%preExp%>
-    genericCall_<%call_index%>(data, threadData<%jac%>, equationIndexes, <%forNames%>); /*<%symbolName(modelNamePrefix,"genericCall")%>*/
+    genericCall_<%sub_name%><%call_index%>(data, threadData<%jac%>, equationIndexes, <%forNames%>); /*<%symbolName(modelNamePrefix,"genericCall")%>*/
     <%forTail%>
   >>
 case eqn as SES_GENERIC_ASSIGN() then
   let idx_len = listLength(scal_indices)
-  let jac = match context case JACOBIAN_CONTEXT() then ", jacobian" else ""
   <<
   const int idx_lst[<%idx_len%>] = {<%(scal_indices |> idx => '<%idx%>';separator=", ")%>};
   for(int i=0; i<<%idx_len%>; i++)
-    genericCall_<%call_index%>(data, threadData<%jac%>, equationIndexes, idx_lst[i]); /*<%symbolName(modelNamePrefix,"genericCall")%>*/
+    genericCall_<%sub_name%><%call_index%>(data, threadData<%jac%>, equationIndexes, idx_lst[i]); /*<%symbolName(modelNamePrefix,"genericCall")%>*/
   >>
 %>
 <%endModelicaLine()%>
@@ -6382,9 +6382,10 @@ template entwinedSingleCall(SimEqSystem eq, Integer i0, Context context,
 <%match eq
 case eqn as SES_GENERIC_ASSIGN() then
   let jac = match context case JACOBIAN_CONTEXT() then ", jacobian" else ""
+  let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
   <<
     case <%call_index%>:
-      genericCall_<%call_index%>(data, threadData<%jac%>, equationIndexes, idx_lst_<%call_index%>[call_indices[<%i0%>]]);
+      genericCall_<%sub_name%><%call_index%>(data, threadData<%jac%>, equationIndexes, idx_lst_<%call_index%>[call_indices[<%i0%>]]);
       call_indices[<%i0%>]++;
       break;
   >>
@@ -7398,6 +7399,7 @@ template genericCallBodies(list<SimGenericCall> genericCalls, Context context)
  "Generates the body for a set of generic calls."
 ::=
   let jac = match context case JACOBIAN_CONTEXT() then ", JACOBIAN *jacobian" else ""
+  let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
   (genericCalls |> call =>
     let comment = escapeCComments(simGenericCallString(call))
     let &sub = buffer ""
@@ -7416,7 +7418,7 @@ template genericCallBodies(list<SimGenericCall> genericCalls, Context context)
       <%comment%>
       */
       <%auxFunction%>
-      void genericCall_<%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
+      void genericCall_<%sub_name%><%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
       {
         <%idx_copy%>
         <%varDecls%>
@@ -7436,7 +7438,7 @@ template genericCallBodies(list<SimGenericCall> genericCalls, Context context)
       <%comment%>
       */
       <%auxFunction%>
-      void genericCall_<%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
+      void genericCall_<%sub_name%><%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
       {
         <%idx_copy%>
         <%varDecls%>
@@ -7456,7 +7458,7 @@ template genericCallBodies(list<SimGenericCall> genericCalls, Context context)
       <%comment%>
       */
       <%auxFunction%>
-      void genericCall_<%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
+      void genericCall_<%sub_name%><%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>)
       {
         <%idx_copy%>
         <%varDecls%>
@@ -7611,6 +7613,7 @@ template genericCallHeaders(list<SimGenericCall> genericCalls, Context context)
  "Generates the header for a set of generic calls."
 ::=
   let jac = match context case JACOBIAN_CONTEXT() then ", JACOBIAN *jacobian" else ""
+  let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
   (genericCalls |> call => match call
     case SINGLE_GENERIC_CALL()
     case IF_GENERIC_CALL() then
@@ -7619,7 +7622,7 @@ template genericCallHeaders(list<SimGenericCall> genericCalls, Context context)
       let &varDecls = buffer ""
       let &auxFunction = buffer ""
       let idx_ = if resizable then (iters |> it => 'modelica_integer <%forIteratorName(it, context, &preExp, &varDecls, &auxFunction, &sub)%>';separator=", ";empty) else "int idx"
-      <<void genericCall_<%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>);>>;
+      <<void genericCall_<%sub_name%><%index%>(DATA *data, threadData_t *threadData<%jac%>, const int equationIndexes[2], <%idx_%>);>>;
   separator="\n\n")
 end genericCallHeaders;
 

--- a/testsuite/simulation/modelica/NBackend/differentation/Makefile
+++ b/testsuite/simulation/modelica/NBackend/differentation/Makefile
@@ -2,6 +2,7 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 allTheBuildins.mos \
+diff_subs.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/differentation/diff_subs.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/diff_subs.mos
@@ -1,0 +1,110 @@
+// name: diff_subs
+// keywords: NewBackend
+// status: correct
+
+loadString("
+record A
+  Real[2,3] x;
+end A;
+
+model diff_subs
+  A[2] a;
+  Real y(start = 0, fixed = true);
+equation
+  a[1].x[2,3] = sin(time);
+  a[2].x[2,3] = cos(time);
+  a[1].x[1,3] = sin(time);
+  a[2].x[1,3] = cos(time);
+  for i in 1:2 loop
+    for j in 1:2 loop
+      a[1].x[i,j] = i*sin(j*time);
+      a[2].x[i,j] = i*cos(j*time);
+    end for;
+  end for;
+  der(y) = sum(a.x);
+end diff_subs;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend --generateDynamicJacobian=symbolic -d=debugDifferentiation"); getErrorString();
+
+buildModel(diff_subs); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [FOR-] (2) ($RES_AUX_10)
+// [----] for $i2 in 1:2 loop
+// [----]   [SCAL] (1) $FUN_4[$i2] = cos($i2 * time) ($RES_AUX_11)
+// [----] end for;
+// [AFTER ] [FOR-] (2) ($RES_AUX_10)
+// [----] for $i2 in 1:2 loop
+// [----]   [SCAL] (1) $pDER_ODE_JAC.$FUN_4[$i2] = -0.0 ($RES_AUX_11)
+// [----] end for;
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [FOR-] (4) ($RES_SIM_1)
+// [----] for {$i1 in 1:2, $i2 in 1:2} loop
+// [----]   [SCAL] (1) a[2].x[$i1, $i2] = $i1 * $FUN_4[$i2] ($RES_SIM_2)
+// [----] end for;
+// [AFTER ] [FOR-] (4) ($RES_SIM_1)
+// [----] for {$i1 in 1:2, $i2 in 1:2} loop
+// [----]   [SCAL] (1) $pDER_ODE_JAC.a[2].x[$i1, $i2] = $i1 * $pDER_ODE_JAC.$FUN_4[$i2] ($RES_SIM_2)
+// [----] end for;
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [FOR-] (2) ($RES_AUX_12)
+// [----] for $i2 in 1:2 loop
+// [----]   [SCAL] (1) $FUN_3[$i2] = sin($i2 * time) ($RES_AUX_13)
+// [----] end for;
+// [AFTER ] [FOR-] (2) ($RES_AUX_12)
+// [----] for $i2 in 1:2 loop
+// [----]   [SCAL] (1) $pDER_ODE_JAC.$FUN_3[$i2] = 0.0 ($RES_AUX_13)
+// [----] end for;
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [FOR-] (4) ($RES_SIM_3)
+// [----] for {$i1 in 1:2, $i2 in 1:2} loop
+// [----]   [SCAL] (1) a[1].x[$i1, $i2] = $i1 * $FUN_3[$i2] ($RES_SIM_4)
+// [----] end for;
+// [AFTER ] [FOR-] (4) ($RES_SIM_3)
+// [----] for {$i1 in 1:2, $i2 in 1:2} loop
+// [----]   [SCAL] (1) $pDER_ODE_JAC.a[1].x[$i1, $i2] = $i1 * $pDER_ODE_JAC.$FUN_3[$i2] ($RES_SIM_4)
+// [----] end for;
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $FUN_2 = cos(time) ($RES_AUX_14)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_2 = -0.0 ($RES_AUX_14)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) a[2].x[2, 3] = $FUN_2 ($RES_SIM_7)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.a[2].x[2, 3] = $pDER_ODE_JAC.$FUN_2 ($RES_SIM_7)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) a[2].x[1, 3] = $FUN_2 ($RES_SIM_5)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.a[2].x[1, 3] = $pDER_ODE_JAC.$FUN_2 ($RES_SIM_5)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $FUN_1 = sin(time) ($RES_AUX_15)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_1 = 0.0 ($RES_AUX_15)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) a[1].x[2, 3] = $FUN_1 ($RES_SIM_8)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.a[1].x[2, 3] = $pDER_ODE_JAC.$FUN_1 ($RES_SIM_8)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) a[1].x[1, 3] = $FUN_1 ($RES_SIM_6)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.a[1].x[1, 3] = $pDER_ODE_JAC.$FUN_1 ($RES_SIM_6)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $FUN_5 = sum(a.x) ($RES_AUX_9)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_5 = sum($pDER_ODE_JAC.a.x) ($RES_AUX_9)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $DER.y = $FUN_5 ($RES_SIM_0)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.y = $pDER_ODE_JAC.$FUN_5 ($RES_SIM_0)
+//
+// {"diff_subs", "diff_subs_init.xml"}
+// ""
+// endResult


### PR DESCRIPTION
 - follow up to subscript fix that was meant to fix subscript differentiation by #14270
 - let jacobian generic calls have a unique name in code generation
 - [testsuite] add test case for subscript differentiation