### PR TITLE
[MOO] fix linking on macOS, require Fortran compiler for MOO

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -21,6 +21,9 @@ if(OM_OMC_ENABLE_IPOPT AND NOT OM_OMC_ENABLE_FORTRAN)
 endif()
 
 omc_option(OM_OMC_ENABLE_MOO "Should we enable dynamic optimization support with MOO." ON)
+if(OM_OMC_ENABLE_MOO AND NOT OM_OMC_ENABLE_FORTRAN)
+  message(FATAL_ERROR "Building MOO library requires Fortran support to be enabled. You can disable MOO by adding -OM_OMC_ENABLE_MOO=OFF to the CMake configure command.")
+endif()
 
 omc_option(OM_OMC_ENABLE_CPP_RUNTIME "Enable, build, and install the C++ simulation runtime libraries." ON)
 


### PR DESCRIPTION
### Related Issues

- fixes issue described in https://github.com/OpenModelica/OpenModelica/pull/14279

### Purpose

- fixes linking of MOO library on macOS
- building MOO now requires a Fortran compiler (just as for the current dynamic optimization runtime)
-> cmake configure results in `FATAL_ERROR` if `OM_OMC_ENABLE_MOO=ON` and `OM_OMC_ENABLE_FORTRAN=OFF`