### PR TITLE
Re-adding tests for irksco with GBODE

### DIFF
--- a/testsuite/simulation/modelica/solver/Makefile
+++ b/testsuite/simulation/modelica/solver/Makefile
@@ -7,6 +7,7 @@ problem1-dasslsteps.mos \
 problem1-impeuler.mos \
 problem1-trapezoid.mos \
 problem1-imprk.mos \
+problem1-irksco.mos \
 problem1-ida.mos \
 problem1-cvode.mos \
 problem1-symSolverImp.mos \
@@ -18,6 +19,7 @@ problem2-dasslsteps.mos \
 problem2-impeuler.mos \
 problem2-trapezoid.mos \
 problem2-imprk.mos \
+problem2-irksco.mos \
 problem2-ida.mos \
 problem2-idaLinearSolver.mos \
 problem2-idaJacobian.mos \
@@ -36,6 +38,7 @@ problem4-symSolverExp.mos \
 problem5-symSolverImp.mos \
 problem5-symSolverExp.mos \
 problem6-cvode.mos \
+problem6-irksco.mos \
 problem6-symSolverImp.mos \
 problem6-symSolverExp.mos \
 

--- a/testsuite/simulation/modelica/solver/problem1-irksco.mos
+++ b/testsuite/simulation/modelica/solver/problem1-irksco.mos
@@ -1,0 +1,62 @@
+// name: problem1-irksco
+// status: correct
+// teardown_command: rm -f testSolver.problem1* output.log
+// cflags: -d=-newInst
+
+loadFile("testSolverPackage.mo"); getErrorString();
+simulate(testSolver.problem1, stopTime=2e-6, method="gbode", simflags="-gbm=trapezoid"); getErrorString();
+
+res := OpenModelica.Scripting.compareSimulationResults("testSolver.problem1_res.mat",
+  getEnvironmentVar("REFERENCEFILES")+"/solver/testSolver.problem1.mat",
+  "testSolver.problem1_diff.csv",0.01,0.0001,
+{
+"u[1]",
+"u[5]",
+"u[15]",
+"u[20]",
+"u[25]",
+"u[30]",
+"u[35]",
+"u[40]",
+"u[45]",
+"u[50]",
+"u[55]",
+"u[60]",
+"u[65]",
+"u[70]",
+"u[75]",
+"u[80]",
+"u[85]",
+"u[90]",
+"u[95]",
+"u[100]",
+"u[105]",
+"u[115]",
+"u[120]",
+"u[125]",
+"u[130]",
+"u[135]",
+"u[140]",
+"u[145]",
+"u[150]"
+});
+getErrorString();
+
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "testSolver.problem1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2e-06, numberOfIntervals = 500, tolerance = 1e-06, method = 'gbode', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-gbm=trapezoid'",
+//     messages = "LOG_STDOUT        | warning | Numerical Jacobians without coloring are currently not supported by GBODE. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// {"Files Equal!"}
+// "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.
+// "
+// endResult

--- a/testsuite/simulation/modelica/solver/problem2-irksco.mos
+++ b/testsuite/simulation/modelica/solver/problem2-irksco.mos
@@ -1,0 +1,67 @@
+// name: problem2-irksco
+// status: correct
+// teardown_command: rm -f testSolver.problem2* output.log
+// cflags: -d=-newInst
+
+stopTime := 321.8122;
+loadFile("testSolverPackage.mo"); getErrorString();
+simulate(testSolver.problem2, stopTime=stopTime, numberOfIntervals=12000, method="gbode", simflags="-gbm=trapezoid"); getErrorString();
+
+res := OpenModelica.Scripting.compareSimulationResults("testSolver.problem2_res.mat",
+  getEnvironmentVar("REFERENCEFILES")+"/solver/testSolver.problem2.mat",
+  "testSolver.problem2_diff.csv",0.1,0.1,
+{
+"y[1]",
+"y[2]",
+"y[3]",
+"y[4]",
+"y[5]",
+"y[6]",
+"y[7]",
+"y[8]",
+"der(y[1])",
+"der(y[2])",
+"der(y[3])",
+"der(y[4])",
+"der(y[5])",
+"der(y[6])",
+"der(y[7])",
+"der(y[8])"
+});
+getErrorString();
+
+val(y[1], stopTime);
+val(y[2], stopTime);
+val(y[3], stopTime);
+val(y[4], stopTime);
+val(y[5], stopTime);
+val(y[6], stopTime);
+val(y[7], stopTime);
+val(y[8], stopTime);
+
+// Result:
+// 321.8122
+// true
+// ""
+// record SimulationResult
+//     resultFile = "testSolver.problem2_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 321.8122, numberOfIntervals = 12000, tolerance = 1e-06, method = 'gbode', fileNamePrefix = 'testSolver.problem2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-gbm=trapezoid'",
+//     messages = "LOG_STDOUT        | warning | Numerical Jacobians without coloring are currently not supported by GBODE. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// {"Files Equal!"}
+// "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.
+// "
+// 0.0007366178626765966
+// 0.0001441704812983621
+// 5.881808635647067e-05
+// 0.001174685232618241
+// 0.002372321728263835
+// 0.006195567228064969
+// 0.002839857562499992
+// 0.002860142433740553
+// endResult

--- a/testsuite/simulation/modelica/solver/problem6-irksco.mos
+++ b/testsuite/simulation/modelica/solver/problem6-irksco.mos
@@ -1,0 +1,44 @@
+// name: problem6-irksco
+// status: correct
+// teardown_command: rm -f testSolver.problem6* output.log
+// cflags: -d=-newInst
+
+loadFile("./testSolverPackage.mo");
+getErrorString();
+
+resfile := "testSolver.problem6_res.mat";
+simulate(testSolver.problem6, stopTime=3.0, method="gbode", simflags="-gbm=trapezoid"); getErrorString();
+
+echo(false);
+s:=readSimulationResultSize(resfile);
+res:=readSimulationResult(resfile,{flying},s);
+res2:=readSimulationResult(resfile,{n_bounce},s);
+res3:=readSimulationResult(resfile,{h},s);
+echo(true);
+res[1,1];
+res[1,s];
+res2[1,s];
+if res3[1,s] > -1e-2 then 1 else 0;
+
+
+
+// Result:
+// true
+// ""
+// "testSolver.problem6_res.mat"
+// record SimulationResult
+//     resultFile = "testSolver.problem6_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'gbode', fileNamePrefix = 'testSolver.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-gbm=trapezoid'",
+//     messages = "LOG_STDOUT        | warning | Numerical Jacobians without coloring are currently not supported by GBODE. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// true
+// 1.0
+// 0.0
+// 33.0
+// 1
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/pull/14286

### Purpose

Maybe tests were a good idea after all.

### Approach

- Added tests that I removed in #14286, but changed method to GBODE
  - Problem6 (BouncingBall) had a too low number of bounces in the reference result. Updated it to `33`. With the controlled step-sized the number of bounces matches the one from DASSL.
