### PR TITLE
Compile on Windows using CMake + MinGW Makefiles

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -295,16 +295,25 @@ endif()
 # install just the files in this component by specifying its name.
 if(WIN32)
   # Escape the environment variable path
+  if(NOT DEFINED ENV{OMDEV})
+    message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
+  endif()
   if(NOT DEFINED ENV{MSYSTEM_PREFIX})
     message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
   endif()
-  string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+
+  if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles" AND "$ENV{VisualStudioVersion}" STREQUAL "")
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
+  else()
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+  endif()
 
   set(OMCOMPILER_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/Compiler/bin)
   set(SIMULATION_RUNTIME_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/SimulationRuntime/c)
   set(GC_RUNTIME_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/3rdParty/gc)
   set(RUNTIME_LIB_DIRS ${OMPLOT_LIB_DIR} ${OMSIMULATOR_LIB_DIR} ${OMCOMPILER_LIB_DIR} ${SIMULATION_RUNTIME_LIB_DIR} ${GC_RUNTIME_LIB_DIR})
 
+  message(STATUS "Looking for runtime dependencies of OpenModelicaCompiler in ${MSYSTEM_PREFIX_ESCAPED}/bin ${RUNTIME_LIB_DIRS}")
   install(TARGETS OpenModelicaCompiler
           RUNTIME_DEPENDENCIES
             DIRECTORIES ${MSYSTEM_PREFIX_ESCAPED}/bin ${RUNTIME_LIB_DIRS}

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -40,11 +40,11 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
   # Install the Qt5/Qt6 plugins directories
   message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} plugins from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/")
   install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt5/plugins)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/)
   # Install the Qt5/Qt6 translation directories
   message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} translation from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/")
   install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt5/translations)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt${OM_QT_MAJOR_VERSION}/translations)
 
   # TODO: This is stupid, but I can't get install with RUNTIME_DEPENDENCIES to run.
   # It needs to link to libs that are installed to ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR},

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -24,26 +24,27 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
   if(NOT DEFINED ENV{OMDEV})
     message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
   endif()
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    string(REPLACE "\\" "/" OMDEV_MSYS_ESCAPED "$ENV{OMDEV}\\tools\\msys")
-    set(UCRT_DIR "${OMDEV_MSYS_ESCAPED}/ucrt64")
-    message(STATUS "MSYS environment UCRT64: ${OMDEV}\\tools\\msys")
-  else()
+  if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(FATAL_ERROR "No 32-bit version of UCRT available!")
   endif()
   if(NOT DEFINED ENV{MSYSTEM_PREFIX})
     message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
   endif()
-  string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+
+  if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles" AND "$ENV{VisualStudioVersion}" STREQUAL "")
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
+  else()
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+  endif()
 
   # Install the Qt5/Qt6 plugins directories
   message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} plugins from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/")
   install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/    # Note the slash at the end!
-          TYPE BIN)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt5/plugins)
   # Install the Qt5/Qt6 translation directories
   message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} translation from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/")
   install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/    # Note the slash at the end!
-          TYPE BIN)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt5/translations)
 
   # TODO: This is stupid, but I can't get install with RUNTIME_DEPENDENCIES to run.
   # It needs to link to libs that are installed to ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR},
@@ -60,6 +61,8 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
   install(FILES
           ${MSYSTEM_PREFIX_ESCAPED}/bin/Qt5OpenGL.dll
           TYPE BIN)
+
+  message(STATUS "Looking for runtime dependencies of OMEdit in ${MSYSTEM_PREFIX_ESCAPED}/bin ${RUNTIME_LIB_DIRS}")
 
   install(TARGETS OMEdit
           RUNTIME_DEPENDENCIES


### PR DESCRIPTION
### Related Issues

The path conversion with cygpath doesn't seem to work when using a Windows terminal (CMD, PowerShell) when compiling OpenModelica with CMake and the generator 'MingGW Makefiles'

### Purpose

With these changes it is possible to use VS Code and extension [cmake-tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) to compile OpenModelica with a single press of a button.

How to:

1. Open command pallet and select `CMake: Select a kit` -> `Scan recursively for kits in specific directories` to find cland and gcc from OMDev <img width="1103" height="446" alt="grafik" src="https://github.com/user-attachments/assets/60958a0b-ab5f-4920-b8b2-620129a94360" /> The resulting *AppData/Local/CMakeTools/cmake-tools-kits.json* should look something like:
   
   ```json
   [
    {
      "name": "Clang 18.1.8 x86_64-w64-windows-gnu (ucrt64)",
      "compilers": {
        "C": "c:\\OMDev\\tools\\msys\\ucrt64\\bin\\clang.exe",
        "CXX": "c:\\OMDev\\tools\\msys\\ucrt64\\bin\\clang++.exe"
      },
      "isTrusted": true,
      "environmentVariables": {
        "CMT_MINGW_PATH": "c:\\OMDev\\tools\\msys\\ucrt64\\bin",
        "MSYSTEM": "UCRT64",
        "MSYSTEM_PREFIX": "/ucrt64",
        "PATH": "c:\\OMDev\\tools\\msys\\ucrt64\\bin;c:\\OMDev\\tools\\msys\\usr\\bin;${env:PATH}"
      },
      "preferredGenerator": {
        "name": "MinGW Makefiles"
      }
    },
    {
      "name": "GCC 14.2.0 x86_64-w64-mingw32 (ucrt64)",
      "compilers": {
        "C": "c:\\OMDev\\tools\\msys\\ucrt64\\bin\\gcc.exe",
        "CXX": "c:\\OMDev\\tools\\msys\\ucrt64\\bin\\g++.exe"
      },
      "isTrusted": true,
      "environmentVariables": {
        "CMT_MINGW_PATH": "c:\\OMDev\\tools\\msys\\ucrt64\\bin",
        "MSYSTEM": "UCRT64",
        "MSYSTEM_PREFIX": "/ucrt64",
        "PATH": "c:\\OMDev\\tools\\msys\\ucrt64\\bin;c:\\OMDev\\tools\\msys\\usr\\bin;${env:PATH}"
      },
      "preferredGenerator": {
        "name": "MinGW Makefiles"
      }
    }
    ]
   ```

2. Add CMake Settings to your `.vscode/settings.json` inside the OpenModelica root directory. You'll need to disable MOO for now.

```json
{
  "cmake.buildDirectory": "${workspaceFolder}/build_cmake",
  "cmake.installPrefix": "${workspaceFolder}/build_cmake/install_cmake",
  "cmake.cmakePath": "C:/OMDev/tools/msys/ucrt64/bin/cmake.exe",
  "cmake.generator": "MinGW Makefiles",
  "cmake.configureSettings": {
    "OM_OMC_ENABLE_MOO": "OFF"
  }
}
```

3. Select the `install` target and hit the build button: 
<img width="122" height="57" alt="grafik" src="https://github.com/user-attachments/assets/619c16b3-05f3-44fe-b1fe-51c8b9957c2b" />


### Approach

  - Add absolute path based on OMDEV for 'MingGW Makefiles' to the runtime_dependencies stuff.
  - Copy Qt directories
