### PR TITLE
Don't mark parameter subscripts as structural

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -53,6 +53,7 @@ protected
   import Variable = NFVariable;
   import Binding = NFBinding;
   import NFBackendExtension.{BackendInfo, Annotations};
+  import Structural = NFStructural;
 
   import ComponentRef = NFComponentRef;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -821,6 +821,7 @@ protected
   Integer set;
   ComponentRef cr;
 algorithm
+  Structural.markCrefSubscripts(cref);
   cr := ComponentRef.evaluateSubscripts(cref);
   c := Connector.CONNECTOR(cr, Type.UNKNOWN(), Face.INSIDE,
     ConnectorType.STREAM, DAE.emptyElementSource);
@@ -987,6 +988,7 @@ protected
   Expression flow_exp, stream_exp, instream_exp;
   Operator op;
 algorithm
+  Structural.markCrefSubscripts(streamCref);
   stream_cref := ComponentRef.evaluateSubscripts(streamCref);
   flowCref := associatedFlowCref(stream_cref);
   flow_dir := evaluateFlowDirection(flowCref, variables);

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -38,14 +38,15 @@ encapsulated uniontype NFConnections
   import NFPrefixes.ConnectorType;
 
 protected
+  import Component = NFComponent;
   import Connections = NFConnections;
   import ElementSource;
   import ExpandExp = NFExpandExp;
   import Expression = NFExpression;
   import Flags;
   import MetaModelica.Dangerous.listReverseInPlace;
-  import Component = NFComponent;
   import NFInstNode.InstNode;
+  import Structural = NFStructural;
   import Type = NFType;
 
 public
@@ -119,7 +120,9 @@ public
         case Equation.CONNECT(lhs = Expression.CREF(ty = ty1, cref = lhs),
                               rhs = Expression.CREF(ty = ty2, cref = rhs), source = source)
           algorithm
+            Structural.markCrefSubscripts(lhs);
             lhs := ComponentRef.evaluateSubscripts(lhs);
+            Structural.markCrefSubscripts(rhs);
             rhs := ComponentRef.evaluateSubscripts(rhs);
             conns.connections := makeConnections(lhs, ty1, rhs, ty2, source, isDeleted, conns.connections);
           then

--- a/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
@@ -356,7 +356,7 @@ public
     () := match exp
       case Expression.CREF()
         algorithm
-          ComponentRef.applySubscripts(exp.cref, markSubscript);
+          markCrefSubscripts(exp.cref);
         then
           ();
 
@@ -364,13 +364,19 @@ public
     end match;
   end markSubscripts;
 
+  function markCrefSubscripts
+    input ComponentRef cref;
+  algorithm
+    ComponentRef.applySubscripts(cref, markSubscript);
+  end markCrefSubscripts;
+
   function markSubscript
     input Subscript sub;
   algorithm
     () := match sub
-        case Subscript.UNTYPED() algorithm markExp(sub.exp); then ();
-        case Subscript.INDEX() algorithm markExp(sub.index); then ();
-        case Subscript.SLICE() algorithm markExp(sub.slice); then ();
+      case Subscript.UNTYPED() algorithm markExp(sub.exp); then ();
+      case Subscript.INDEX() algorithm markExp(sub.index); then ();
+      case Subscript.SLICE() algorithm markExp(sub.slice); then ();
       else ();
     end match;
   end markSubscript;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2082,13 +2082,6 @@ algorithm
     typedSubs := sub :: typedSubs;
     variability := Prefixes.variabilityMax(variability, var);
     i := i + 1;
-
-    // Mark parameter subscripts as structural so that they're evaluated.
-    // TODO: Ideally this shouldn't be needed, but the old frontend does it and
-    //       the backend relies on it.
-    if var == Variability.PARAMETER then
-      Structural.markSubscript(sub);
-    end if;
   end for;
 
   typedSubs := listReverseInPlace(typedSubs);


### PR DESCRIPTION
- Marking parameter subscripts as structural indiscriminately causes e.g. non-fixed parameters to be marked as structural, and it might not be needed since there were no library improvements when it was added.
- Connection related subscripts which are evaluated should still be marked as structural though.