### PR TITLE
Improve choicesAllMatching handling in OMEdit

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6913,5 +6913,20 @@ algorithm
     Absyn.ElementSpec.CLASSDEF(class_ = cls))) := item;
 end elementItemClass;
 
+function classDefStringComment
+  input Absyn.ClassDef def;
+  output String comment;
+algorithm
+  comment := match def
+    case Absyn.ClassDef.PARTS(comment = SOME(comment)) then comment;
+    case Absyn.ClassDef.DERIVED(comment = SOME(Absyn.Comment.COMMENT(comment = SOME(comment)))) then comment;
+    case Absyn.ClassDef.ENUMERATION(comment = SOME(Absyn.Comment.COMMENT(comment = SOME(comment)))) then comment;
+    case Absyn.ClassDef.OVERLOAD(comment = SOME(Absyn.Comment.COMMENT(comment = SOME(comment)))) then comment;
+    case Absyn.ClassDef.CLASS_EXTENDS(comment = SOME(comment)) then comment;
+    case Absyn.ClassDef.PDER(comment = SOME(Absyn.Comment.COMMENT(comment = SOME(comment)))) then comment;
+    else "";
+  end match;
+end classDefStringComment;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3122,6 +3122,17 @@ external "builtin";
 annotation(preferredView="text");
 end getAllSubtypeOf;
 
+function getReplaceableChoices
+  "Returns all replaceable choices for a class with choicesAllMatching."
+  input TypeName baseClass;
+  input TypeName parentClass;
+  input Boolean includePartial = false;
+  input Boolean sort = false;
+  output String choices[:, :];
+external "builtin";
+annotation(preferredView="text");
+end getReplaceableChoices;
+
 function plot
   "Displays a plot with selected variables using OMPlot."
   input VariableNames vars "The variables you want to plot";

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3367,6 +3367,17 @@ external "builtin";
 annotation(preferredView="text");
 end getAllSubtypeOf;
 
+function getReplaceableChoices
+  "Returns all replaceable choices for a class with choicesAllMatching."
+  input TypeName baseClass;
+  input TypeName parentClass;
+  input Boolean includePartial = false;
+  input Boolean sort = false;
+  output String choices[:, :];
+external "builtin";
+annotation(preferredView="text");
+end getReplaceableChoices;
+
 function plot
   "Displays a plot with selected variables using OMPlot."
   input VariableNames vars "The variables you want to plot";

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1529,14 +1529,20 @@ algorithm
     case ("getAllSubtypeOf",{
           Values.CODE(Absyn.C_TYPENAME(path)),
           Values.CODE(Absyn.C_TYPENAME(parentClass)),
-          Values.BOOL(qualified),
+          _, // qualified not used
           Values.BOOL(includePartial),
           Values.BOOL(sort)})
       algorithm
-        paths := InteractiveUtil.getAllSubtypeOf(path, parentClass, SymbolTable.getAbsyn(), qualified, includePartial, sort);
-        paths := if sort then List.sort(paths, AbsynUtil.pathGe) else paths;
+        paths := InteractiveUtil.getAllSubtypeOf(path, parentClass, SymbolTable.getAbsyn(), includePartial, sort);
       then
         ValuesUtil.makeCodeTypeNameArray(paths);
+
+    case ("getReplaceableChoices", {
+          Values.CODE(Absyn.C_TYPENAME(path)),
+          Values.CODE(Absyn.C_TYPENAME(parentClass)),
+          Values.BOOL(includePartial),
+          Values.BOOL(sort)})
+      then InteractiveUtil.getReplaceableChoices(path, parentClass, SymbolTable.getAbsyn(), includePartial, sort);
 
     // check for OMSimulator API calls
     case (_,_)

--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -609,8 +609,9 @@ void Parameter::createValueWidget()
   OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
   QString className = mpModelInstanceElement->getType();
   QString constrainedByClassName = QStringLiteral("$Any");
-  QString replaceable = "", replaceableText = "", replaceableChoice = "", parentClassName = "", restriction = "", elementName = "";
-  QStringList enumerationLiterals, enumerationLiteralsDisplay, replaceableChoices, choices, choicesComment;
+  QString replaceable = "", replaceableText = "", parentClassName = "", restriction = "", elementName = "";
+  QStringList enumerationLiterals, enumerationLiteralsDisplay, choices, choicesComment, replaceableChoice;
+  QList<QList<QString>> replaceableChoices;
 
   switch (mValueType) {
     case Parameter::Boolean:
@@ -688,28 +689,28 @@ void Parameter::createValueWidget()
 
       // choicesAllMatching
       if (mpModelInstanceElement->getAnnotation()->isChoicesAllMatching()) {
-        replaceableChoices = pOMCProxy->getAllSubtypeOf(constrainedByClassName, parentClassName);
+        replaceableChoices = pOMCProxy->getReplaceableChoices(constrainedByClassName, parentClassName);
       }
       for (i = 0; i < replaceableChoices.size(); i++) {
         replaceableChoice = replaceableChoices[i];
         if (isReplaceableComponent() || isReplaceableClass()) {
-          QString str = (pOMCProxy->getClassInformation(replaceableChoice)).comment;
-          if (!str.isEmpty()) {
-            str = " \"" + str + "\"";
+          replaceableText = "redeclare " + replaceableChoice[0];
+          // add comment if available
+          if (!replaceableChoice[1].isEmpty()) {
+            replaceableText += " \"" + replaceableChoice[1] + "\"";
           }
-          replaceableText = "redeclare " + replaceableChoice + str;
           // if replaceableChoices points to a class in this scope, remove scope
-          if (replaceableChoice.startsWith(parentClassName + ".")) {
-            replaceableChoice.remove(0, parentClassName.size() + 1);
+          if (replaceableChoice[0].startsWith(parentClassName + ".")) {
+            replaceableChoice[0].remove(0, parentClassName.size() + 1);
           }
           if (isReplaceableClass()) {
-            replaceable = QString("redeclare %1 %2 = %3").arg(restriction, elementName, replaceableChoice);
+            replaceable = QString("redeclare %1 %2 = %3").arg(restriction, elementName, replaceableChoice[0]);
           } else {
-            replaceable = QString("redeclare %1 %2").arg(replaceableChoice, elementName);
+            replaceable = QString("redeclare %1 %2").arg(replaceableChoice[0], elementName);
           }
           mpValueComboBox->addItem(replaceableText, replaceable);
         } else {
-          mpValueComboBox->addItem(replaceableChoice, replaceableChoice);
+          mpValueComboBox->addItem(replaceableChoice[0], replaceableChoice[0]);
         }
       }
 

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -2926,19 +2926,32 @@ int OMCProxy::numProcessors()
 
 /*!
  * \brief OMCProxy::getAllSubtypeOf
- * Returns the list of all classes that extend from className given a parentClass where the lookup for className should start.
- * \param parentClassName = $TypeName(AllLoadedClasses) - is the name of the class whose sub classes are retrieved.
- * \param className - the name of the class that is subtype of
- * \param qualified = false
+ * Returns the list of all classes that extend from baseClass given a parentClass that the subtypes should be reachable from.
+ * \param baseClass - the name of the base class to look for subtypes of
+ * \param parentClass - the class that the subtypes should be reachable from
  * \param includePartial = false
  * \param sort = false
  * \return
  */
-QStringList OMCProxy::getAllSubtypeOf(QString className, QString parentClassName, bool qualified, bool includePartial, bool sort)
+QStringList OMCProxy::getAllSubtypeOf(QString baseClass, QString parentClass, bool includePartial, bool sort)
 {
-  return mpOMCInterface->getAllSubtypeOf(className, parentClassName, qualified, includePartial, sort);
+  return mpOMCInterface->getAllSubtypeOf(baseClass, parentClass, false /*deprecated*/, includePartial, sort);
 }
 
+
+/*!
+ * \brief OMCProxy::getReplaceableChoices
+ * Returns class names and comments for choicesAllMatching candidates
+ * \param baseClass - the name of the base class to look for subtypes of
+ * \param parentClass - the class that the subtypes should be reachable from
+ * \param includePartial = false
+ * \param sort = false
+ * \return
+ */
+QList<QList<QString>> OMCProxy::getReplaceableChoices(QString baseClass, QString parentClass, bool includePartial, bool sort)
+{
+  return mpOMCInterface->getReplaceableChoices(baseClass, parentClass, includePartial, sort);
+}
 
 /*!
  * \brief OMCProxy::help

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -241,7 +241,8 @@ public:
   QString getAnnotationModifierValue(QString className, QString annotation, QString modifier);
   QString getSimulationFlagsAnnotation(QString className);
   int numProcessors();
-  QStringList getAllSubtypeOf(QString className, QString parentClassName = QString("AllLoadedClasses"), bool qualified = false, bool includePartial = false, bool sort = false);
+  QStringList getAllSubtypeOf(QString className, QString parentClassName = QString("AllLoadedClasses"), bool includePartial = false, bool sort = false);
+  QList<QList<QString>> getReplaceableChoices(QString baseClass, QString parentClass, bool includePartial = false, bool sort = false);
   QString help(QString topic);
   OMCInterface::getConfigFlagValidOptions_res getConfigFlagValidOptions(QString topic);
   QString getCompiler();

--- a/testsuite/openmodelica/interactive-API/GetReplaceableChoices1.mos
+++ b/testsuite/openmodelica/interactive-API/GetReplaceableChoices1.mos
@@ -1,0 +1,32 @@
+// name: GetReplaceableChoices1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the getReplaceableChoices API function.
+//
+
+loadString("
+  model Base \"Comment for Base\"
+  end Base;
+
+  model M1 = Base \"Comment for M1\";
+
+  model M2 \"Comment for M2\"
+    extends Base;
+  end M2;
+
+  model M3 = Base;
+
+  model M
+  end M;
+");
+
+getReplaceableChoices(Base, M);
+getErrorString();
+
+// Result:
+// true
+// {{"Base", "Comment for Base"}, {"M1", "Comment for M1"}, {"M2", "Comment for M2"}, {"M3", ""}}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -70,6 +70,7 @@ getNthComponentAnnotation.mos \
 getNthConnector.mos \
 getNthConnectorIconAnnotation.mos \
 getNthImport.mos \
+GetReplaceableChoices1.mos \
 getSimulationOptions1.mos \
 getSimulationOptions2.mos \
 getSimulationOptions3.mos \


### PR DESCRIPTION
- Add `getReplaceableChoices` API to the compiler that returns both the name and comment for replaceable choices.
- Use `getReplaceableChoices` in OMEdit to construct the replaceable choices instead of using `getAllSubtypeOf` and looking up the comment for each class separately.
- Fix the sorting in the implementation of `getAllSubtypeOf` and remove it from the scripting interface to avoid sorting twice.