### PR TITLE
Cmake fmu export fix

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -754,7 +754,7 @@ algorithm
       Boolean b, exportDocumentation;
       Boolean needSundials = false;
       String fileprefix, fileNamePrefixHash;
-      String install_include_omc_dir, install_include_omc_c_dir, install_share_buildproject_dir, install_fmu_sources_dir, fmu_tmp_sources_dir;
+      String install_include_omc_dir, install_include_omc_c_dir, install_include_omc_modelicaexternalc_dir, install_share_buildproject_dir, install_fmu_sources_dir, fmu_tmp_sources_dir;
       String cmakelistsStr, needCvode, cvodeDirectory;
       list<String> sourceFiles, model_desc_src_files, fmi2HeaderFiles, modelica_standard_table_sources;
       list<String> dgesv_sources, cminpack_sources, simrt_c_sundials_sources, simrt_linear_solver_sources, simrt_non_linear_solver_sources;
@@ -849,6 +849,7 @@ algorithm
 
         install_include_omc_dir := Settings.getInstallationDirectoryPath() + "/include/omc/";
         install_include_omc_c_dir := install_include_omc_dir + "c/";
+        install_include_omc_modelicaexternalc_dir := install_include_omc_dir + "ModelicaExternalC/";
         install_share_buildproject_dir :=  Settings.getInstallationDirectoryPath() + "/share/omc/runtime/c/fmi/buildproject/";
         install_fmu_sources_dir := Settings.getInstallationDirectoryPath() + RuntimeSources.fmu_sources_dir;
         fmu_tmp_sources_dir := fmutmp + "/sources/";
@@ -910,8 +911,8 @@ algorithm
         * Check if modelicaStandardTables source files are needed
         * this is not clear as of now, may be we should copy all the external C sources by default
         */
-        copyFiles(RuntimeSources.modelica_external_c_sources, source=install_include_omc_c_dir, destination=fmu_tmp_sources_dir);
-        copyFiles(RuntimeSources.modelica_external_c_headers, source=install_include_omc_c_dir, destination=fmu_tmp_sources_dir);
+        copyFiles(RuntimeSources.modelica_external_c_sources, source=install_include_omc_modelicaexternalc_dir, destination=fmu_tmp_sources_dir);
+        copyFiles(RuntimeSources.modelica_external_c_headers, source=install_include_omc_modelicaexternalc_dir, destination=fmu_tmp_sources_dir);
         modelica_standard_table_sources := RuntimeSources.modelica_external_c_sources;
 
         System.writeFile(fmutmp+"/sources/isfmi" + (if FMUVersion=="1.0" then "1" else "2"), "");

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
@@ -141,6 +141,25 @@ elseif(MSVC)
   set_target_properties(ModelicaStandardTables_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
+# Common source files for all source-code-FMUs
+set(SOURCE_FMU_MODELICA_EXTERNAL_C_FILES_LIST
+  C-Sources/ModelicaStandardTables.c
+  C-Sources/ModelicaStandardTablesDummyUsertab.c
+  C-Sources/ModelicaMatIO.c
+  C-Sources/ModelicaIO.c
+  C-Sources/snprintf.c)
+
+set(SOURCE_FMU_MODELICA_EXTERNAL_HEADER_FILES_LIST
+  C-Sources/ModelicaStandardTables.h
+  C-Sources/ModelicaMatIO.h
+  C-Sources/ModelicaIO.h
+  C-Sources/safe-math.h
+  C-Sources/read_data_impl.h
+)
+
+install(FILES ${SOURCE_FMU_MODELICA_EXTERNAL_C_FILES_LIST}
+              ${SOURCE_FMU_MODELICA_EXTERNAL_HEADER_FILES_LIST}
+              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ModelicaExternalC)
 
 ## Install
 # Install the static libs to the normal lib dir.

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -357,14 +357,11 @@ clean:
 	(! test -f $(EXTERNALCBUILDDIR)/Makefile) || make -C $(EXTERNALCBUILDDIR) clean
 	(! test -f $(EXTERNALCBUILDDIR)/Makefile) || make -C $(EXTERNALCBUILDDIR) distclean
 
-sourcedist: sourcedist1 sourcedist2 sourcedist3
+sourcedist: sourcedist1 sourcedist2
 sourcedist1:
 	$(MAKE) -f $(LIBMAKEFILE) OMC_MINIMAL_RUNTIME=1 OMC_FMI_RUNTIME=1 sourcedist_internal
 sourcedist2:
 	$(MAKE) -C ../fmi/export/buildproject -f $(defaultMakefileTarget)
-sourcedist3:
-	mkdir -p $(builddir_inc)/c/ModelicaExternalC
-	cp -p ../ModelicaExternalC/C-Sources/*.h ../ModelicaExternalC/C-Sources/*.c $(builddir_inc)/c/ModelicaExternalC
 
 # Copied files need to preserve the time-stamp or the external solvers builds
 # over and over again

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
@@ -30,17 +30,17 @@ encapsulated package RuntimeSources
 
   constant list<String> simrt_c_sundials_sources={@SOURCE_FMU_CVODE_RUNTIME_FILES@};
 
-  constant list<String> modelica_external_c_sources={"ModelicaExternalC/ModelicaStandardTables.c",
-                                                     "ModelicaExternalC/ModelicaMatIO.c",
-                                                     "ModelicaExternalC/ModelicaIO.c",
-                                                     "ModelicaExternalC/ModelicaStandardTablesDummyUsertab.c",
-                                                     "ModelicaExternalC/snprintf.c"};
+  constant list<String> modelica_external_c_sources={"ModelicaStandardTables.c",
+                                                     "ModelicaMatIO.c",
+                                                     "ModelicaIO.c",
+                                                     "ModelicaStandardTablesDummyUsertab.c",
+                                                     "snprintf.c"};
 
-  constant list<String> modelica_external_c_headers={"ModelicaExternalC/ModelicaStandardTables.h",
-                                                     "ModelicaExternalC/ModelicaMatIO.h",
-                                                     "ModelicaExternalC/ModelicaIO.h",
-                                                     "ModelicaExternalC/safe-math.h",
-                                                     "ModelicaExternalC/read_data_impl.h"};
+  constant list<String> modelica_external_c_headers={"ModelicaStandardTables.h",
+                                                     "ModelicaMatIO.h",
+                                                     "ModelicaIO.h",
+                                                     "safe-math.h",
+                                                     "read_data_impl.h"};
 
   constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
 
@@ -58,4 +58,3 @@ encapsulated package RuntimeSources
 
 annotation(__OpenModelica_Interface="backend");
 end RuntimeSources;
-

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
@@ -26,17 +26,17 @@ encapsulated package RuntimeSources
   constant list<String> simrt_c_sundials_sources={"simulation/solver/cvode_solver.c",
                                                   "simulation/solver/sundials_error.c"};
 
-  constant list<String> modelica_external_c_sources={"ModelicaExternalC/ModelicaStandardTables.c",
-                                                     "ModelicaExternalC/ModelicaMatIO.c",
-                                                     "ModelicaExternalC/ModelicaIO.c",
-                                                     "ModelicaExternalC/ModelicaStandardTablesDummyUsertab.c",
-                                                     "ModelicaExternalC/snprintf.c"};
+  constant list<String> modelica_external_c_sources={"ModelicaStandardTables.c",
+                                                     "ModelicaMatIO.c",
+                                                     "ModelicaIO.c",
+                                                     "ModelicaStandardTablesDummyUsertab.c",
+                                                     "snprintf.c"};
 
-  constant list<String> modelica_external_c_headers={"ModelicaExternalC/ModelicaStandardTables.h",
-                                                     "ModelicaExternalC/ModelicaMatIO.h",
-                                                     "ModelicaExternalC/ModelicaIO.h",
-                                                     "ModelicaExternalC/safe-math.h",
-                                                     "ModelicaExternalC/read_data_impl.h"};
+  constant list<String> modelica_external_c_headers={"ModelicaStandardTables.h",
+                                                     "ModelicaMatIO.h",
+                                                     "ModelicaIO.h",
+                                                     "safe-math.h",
+                                                     "read_data_impl.h"};
 
   constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
   constant list<String> dgesv_sources={DGESV_FILES};
@@ -49,4 +49,3 @@ encapsulated package RuntimeSources
   constant list<String> simrt_mixed_solver_sources={MIXED_FILES};
 annotation(__OpenModelica_Interface="backend");
 end RuntimeSources;
-

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -224,7 +224,8 @@ set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c)
 
 set(3RD_CMINPACK_HEADERS  ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h)
+                          ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h
+                          ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpackP.h)
 
 install(FILES ${3RD_CMINPACK_HEADERS}
               ${3RD_CMINPACK_FMU_FILES}


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14350.

### Purpose

FMU build failed to copy some Modelica external C files.

### Approach

  - Also install `CMinpack/minpackP.h` with CMake
  - Modelica external C source files are now installed with `ModelicaExternalC/CMakeListst.txt` file instead of C runtime makefile `c/Makefile.common`.
  - Changed install location to `install/include/omc/ModelicaExternalC/`
  - Updated copy call in `SimCodeMain.mo` to use new location
