### PR TITLE
Request debugging symbols in FMU via `gendebugsymbols`

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -964,6 +964,12 @@ algorithm
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_NAME_IN@", simCode.fileNamePrefix);     // Name with underscored instead of dots
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_TARGET_NAME@", simCode.fmuTargetName);  // Name with dots
 
+        // Include debugging symbols?
+        if Flags.isSet(Flags.GEN_DEBUG_SYMBOLS) then
+          cmakelistsStr := System.stringReplace(cmakelistsStr, "@CMAKE_BUILD_TYPE@", "Debug");
+        else
+          cmakelistsStr := System.stringReplace(cmakelistsStr, "@CMAKE_BUILD_TYPE@", "Release");
+        end if;
         // Set CMake runtime dependencies level
         _ := match (Flags.getConfigString(Flags.FMU_RUNTIME_DEPENDS))
           local

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -7,7 +7,7 @@ set(FMU_NAME_HASH @FMU_NAME_HASH_IN@)
 # build the project with fmu hash string to make shorter paths (e.g) ToroidalCoreQuadraticCrossSection.dir => 759.dir
 project(${FMU_NAME_HASH} C)
 
-set(CMAKE_RELEASE_TYPE @CMAKE_RELEASE_TYPE@)
+set(CMAKE_BUILD_TYPE @CMAKE_BUILD_TYPE@)
 
 # FMU compilation options
 set(BUILD_SHARED_LIBS

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -7,6 +7,8 @@ set(FMU_NAME_HASH @FMU_NAME_HASH_IN@)
 # build the project with fmu hash string to make shorter paths (e.g) ToroidalCoreQuadraticCrossSection.dir => 759.dir
 project(${FMU_NAME_HASH} C)
 
+set(CMAKE_RELEASE_TYPE @CMAKE_RELEASE_TYPE@)
+
 # FMU compilation options
 set(BUILD_SHARED_LIBS
     ON


### PR DESCRIPTION
### Purpose
I need debugging symbols in FMU to debug some crashes and had to manually rebuild the FMU enough times to figure out I might address the root-cause and add a switch to the build-process.

### Approach

`omc -d=gendebugsymbols` will now set the `Debug` CMake build type in the CMakefile for the FMU. Correspondingly, you'll get debugging symbols in the resulting `.so`:

New behaviour – note the `with debug_info`:
```
$ omc -d=gendebugsymbols ...
$ file binaries/linux64/roomM370.so 
binaries/linux64/roomM370.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=8c02e32da730bd86d119ffefa27c5dc412eb75df, with debug_info, not stripped
```

Original behaviour:
```
$ file binaries/linux64/roomM370.so 
binaries/linux64/roomM370.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=a1872dc468fdb28ce69fa5be66db7c699f5432e0, not stripped
```

Please squash if/when merging.