### PR TITLE
[FMI] Archive FMPy/*.fmu in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -486,6 +486,7 @@ pipeline {
                 stash name: 'fmpy-fmu', includes: 'testsuite/special/FMPy/*.fmu'
                 stash name: 'cross-fmu-extras', includes: 'testsuite/special/FmuExportCrossCompile/*.mos, testsuite/special/FmuExportCrossCompile/*.csv, testsuite/special/FmuExportCrossCompile/*.sh, testsuite/special/FmuExportCrossCompile/*.opt, testsuite/special/FmuExportCrossCompile/*.txt, testsuite/special/FmuExportCrossCompile/VERSION'
                 archiveArtifacts "testsuite/special/FmuExportCrossCompile/*.fmu"
+                archiveArtifacts "testsuite/special/FMPy/*.fmu"
               }
             }
           }


### PR DESCRIPTION
### Related Issues

I can't figgure out why https://github.com/OpenModelica/OpenModelica/pull/14377 doesn't work. So let's compare the FMUs generated on master and maintenance branch.

### Approach

Save `TableTest.fmu` in Jenins run.
