### PR TITLE
Snap to grid when pasting items

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -4010,7 +4010,7 @@ void GraphicsView::pasteItems(QPointF positionOffset)
       QPointF cursorPositionAtCopy = MainWindow::instance()->getModelWidgetContainer()->mCursorPositionAtCopy;
       QRect copiedItemsBoundingRect = MainWindow::instance()->getModelWidgetContainer()->mCopiedItemsBoundingRect;
       if (!cursorPositionAtCopy.isNull() && cursorPositionAtCopy != cursorPosition) {
-        cursorPosition = cursorPosition - QPointF(copiedItemsBoundingRect.left(), copiedItemsBoundingRect.bottom());
+        cursorPosition = snapPointToGrid(cursorPosition - QPointF(copiedItemsBoundingRect.left(), copiedItemsBoundingRect.bottom()));
       } else {
         cursorPosition = QPointF(0, 0);
       }


### PR DESCRIPTION
### Related Issues

Fixes #14361

### Purpose

Avoid adding the pasted components at odd coordinates.

### Approach

Snap the point to grid when pasting components.
