### PR TITLE
Add flag `causalizeDaeMode`

### DIFF
--- a/OMCompiler/Compiler/BackEnd/DAEMode.mo
+++ b/OMCompiler/Compiler/BackEnd/DAEMode.mo
@@ -277,7 +277,7 @@ protected
   Boolean isStateVarInvoled;
 algorithm
   varCrefLst := list(v.varName for v in inVars);
-  isStateVarInvoled := Util.boolOrList(list(BackendVariable.isStateVar(v) for v in inVars));
+  isStateVarInvoled := not Flags.getConfigBool(Flags.CAUSALIZE_DAE_MODE) or Util.boolOrList(list(BackendVariable.isStateVar(v) for v in inVars));
   (traverserArgs) :=
   matchcontinue(inEqns, traverserArgs.recursiveStrongComponentRun, isStateVarInvoled)
     local

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1377,6 +1377,9 @@ constant ConfigFlag EVALUATE_STRUCTURAL_PARAMETERS = CONFIG_FLAG(158, "evaluateS
 constant ConfigFlag LOAD_MISSING_LIBRARIES = CONFIG_FLAG(159, "loadMissingLibraries",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Automatically try to load a matching library if a name can't be found during name lookup."));
+constant ConfigFlag CAUSALIZE_DAE_MODE = CONFIG_FLAG(160, "causalizeDaeMode",
+  NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
+  Gettext.gettext("The system is partially causalized and simple assignments are generated for equations that can be solved explicitly. Only works with --daeMode."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -418,7 +418,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.MAX_SIZE_LINEARIZATION,
   Flags.RESIZABLE_ARRAYS,
   Flags.EVALUATE_STRUCTURAL_PARAMETERS,
-  Flags.LOAD_MISSING_LIBRARIES
+  Flags.LOAD_MISSING_LIBRARIES,
+  Flags.CAUSALIZE_DAE_MODE
 };
 
 public function new


### PR DESCRIPTION
### Related Issues

dynawo/dynawo/issues/3614

### Purpose

If set to false, this flag optionally disables partial causalization of the system in DAE mode.