### PR TITLE
Fix Susan array traversal with unused mapped items

### DIFF
--- a/OMCompiler/Compiler/Template/TplAbsyn.mo
+++ b/OMCompiler/Compiler/Template/TplAbsyn.mo
@@ -2759,10 +2759,15 @@ algorithm
         (mapstmts, maplocals)
           = addGetIndex(isUsed, freshIdxName, mapstmts, imlicitTxt, maplocals);
 
-        //assume the array element is the first identifier in case locals
+        //define identifiers for array traversal
         idxName = "i";
         arrName = "items";
-        (eltName, _) :: _ = caseLocals;
+        eltName = match mexp
+          case BIND_MATCH(eltName)
+            then eltName;
+          case REST_MATCH()
+            then "";
+        end match;
 
         mapctx = MAP_CONTEXT(ofbind, mapexp, iopts, hasIndexIdentOpt, useiter);
 

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 #download and unpack the sources
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
 # the OMBOOTSTRAPPING_GIT_HASH needs updating when the boostrapping sources change
-SET(OMBOOTSTRAPPING_GIT_HASH f707623a9b9eed5d67e940e4859e9d92c7eb22f9)
+SET(OMBOOTSTRAPPING_GIT_HASH TODO)
 file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/${OMBOOTSTRAPPING_GIT_HASH}.tar.gz
      ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz
      SHOW_PROGRESS

--- a/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
+++ b/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
@@ -135,7 +135,9 @@ try
 >>
 %>
   for <%idxName%> in 1:arrayLength(<%arrName%>) loop
+    <%if eltName then <<
     <%eltName%> := arrayGet(<%arrName%>, <%idxName%>);
+    >>%>
     <%statements |> it => '<%mmExp(it, ":=")%>;' ;separator="\n"%>
   end for;<% if debugSusan() then
 <<


### PR DESCRIPTION
### Related Issues

Fix an issue unforeseen in https://github.com/OpenModelica/OpenModelica/pull/12648 and reported in https://github.com/OpenModelica/OpenModelica/pull/14394#issuecomment-3346181151: Considering the array map operator `array |> element => statement`, if the array element is not used in the statement (this typically occurs with `hasindex`), then its related identifier in not present in the local variables of the generated function, thus it is not possible to retrieve it from the `caseLocals` list.

### Purpose

Prevent translation error in this case, and avoid calling `arrayGet()` unnecessarily.

### Approach

The obvious fix would be to check for an empty list and provide an empty name in this case:
```modelica
        eltName = match caseLocals
          case {}
            then "";
          case (eltName, _) :: _
            then eltName;
        end match;
```

However, instead of relying on the assumption that the element identifier is first in the list, it is possible to verify if it is actually part of the statement and to retrieve it directly from `mexp`, otherwise it is automatically stripped out from `mexp` by `TplAbsyn.rewriteMatchExpByLocalNames()` (see second `//eliminate the non-used binding`):
```modelica
        eltName = match mexp
          case BIND_MATCH(eltName)
            then eltName;
          case REST_MATCH()
            then "";
        end match;
```
(I was not able to figure out how to achieve this while working on https://github.com/OpenModelica/OpenModelica/pull/12648 because the code is quite obscure.)

### Example

For instance, with this change:
```diff
diff --git a/OMCompiler/Compiler/Template/CodegenC.tpl b/OMCompiler/Compiler/Template/CodegenC.tpl
index 63ef069efe..1a5a08521f 100644
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3907,7 +3907,7 @@ template functionXXX_system_HPCOM(list<SimEqSystem> derivativEquations, String n
           }
           >>
         case ("pthreads") then
-          let threadDecl = arrayList(hpcOmSchedule.threadTasks) |> tt hasindex i0 fromindex 0 => functionXXX_system0_HPCOM_PThread_decl(i0); separator="\n"
+          let threadDecl = hpcOmSchedule.threadTasks |> tt hasindex i0 fromindex 0 => functionXXX_system0_HPCOM_PThread_decl(i0); separator="\n"
           let threadFuncs = arrayList(hpcOmSchedule.threadTasks) |> tt hasindex i0 fromindex 0 => functionXXX_system0_HPCOM_PThread_func(derivativEquations, name, n, hpcOmSchedule.threadTasks, type, i0, modelNamePrefixStr); separator="\n"
           let threadFuncCalls = arrayList(hpcOmSchedule.threadTasks) |> tt hasindex i0 fromindex 0 => functionXXX_system0_HPCOM_PThread_call(name, n, i0); separator="\n"
           let threadStart = arrayList(hpcOmSchedule.threadTasks) |> tt hasindex i0 fromindex 0 => functionXXX_system0_HPCOM_PThread_start(i0); separator="\n"
```
The generated function is this one:
```modelica
protected function am_455
  input output Tpl.Text txt;

  input array<list<HpcOmSimCode.Task>> items;
protected
  Integer x_i0;
algorithm
  for i in 1:arrayLength(items) loop
    x_i0 := Tpl.getIteri_i0(txt);
    txt := functionXXX_system0_HPCOM_PThread_decl(txt, x_i0);
    txt := Tpl.nextIter(txt);
  end for;
end am_455;
```
You can see that `i_tt := arrayGet(items, i);` is not present.