### PR TITLE
Improve NFFlatten.evaluateBindingConnOp

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2512,17 +2512,17 @@ function evaluateBindingConnOp
   input UnorderedMap<ComponentRef, Variable> variables;
   input CardinalityTable.Table ctable;
 protected
-  Binding binding;
   Expression exp, eval_exp;
 algorithm
   () := match var
-    case Variable.VARIABLE(binding = binding as Binding.TYPED_BINDING(bindingExp = exp))
+    case Variable.VARIABLE()
+      guard Binding.hasExp(var.binding)
       algorithm
+        exp := Binding.getExp(var.binding);
         eval_exp := ConnectEquations.evaluateOperators(exp, sets, setsArray, variables, ctable);
 
         if not referenceEq(exp, eval_exp) then
-          binding.bindingExp := eval_exp;
-          var.binding := binding;
+          var.binding := Binding.setExp(eval_exp, var.binding);
         end if;
       then
         ();

--- a/testsuite/flattening/modelica/scodeinst/InStreamArray2.mo
+++ b/testsuite/flattening/modelica/scodeinst/InStreamArray2.mo
@@ -1,0 +1,70 @@
+// name: InStreamArray2
+// keywords: stream instream connector
+// status: correct
+//
+
+connector C
+  Real p;
+  flow Real f;
+  stream Real s;
+end C;
+
+partial model A
+  C c;
+end A;
+
+model M
+  A1 a1;
+  A2 a2;
+  input Real s;
+equation
+  connect(a1.c, a2.c);
+end M;
+
+model A1
+  extends A;
+equation
+  c.p = sin(time);
+  c.s = cos(time);
+end A1;
+
+model A2
+  extends A;
+equation
+  c.f = sin(time);
+  c.s = cos(time);
+end A2;
+
+model InStreamArray2
+  M[2] m(s={inStream(m[i].a1.c.s) + inStream(m[i].a2.c.s) for i in 1:2});
+  annotation(__OpenModelica_commandLineOptions="--newBackend");
+end InStreamArray2;
+
+// Result:
+// class InStreamArray2
+//   Real[2] m.a1.c.p;
+//   Real[2] m.a1.c.f;
+//   Real[2] m.a1.c.s;
+//   Real[2] m.a2.c.p;
+//   Real[2] m.a2.c.f;
+//   Real[2] m.a2.c.s;
+//   Real[2] m.s = {m[1].a1.c.s + m[1].a2.c.s, m[2].a1.c.s + m[2].a2.c.s};
+// equation
+//   m[2].a1.c.p = m[2].a2.c.p;
+//   m[1].a1.c.p = m[1].a2.c.p;
+//   m[1].a2.c.f + m[1].a1.c.f = 0.0;
+//   m[2].a2.c.f + m[2].a1.c.f = 0.0;
+//   for $i4 in 1:2 loop
+//     m[$i4].a1.c.p = sin(time);
+//   end for;
+//   for $i3 in 1:2 loop
+//     m[$i3].a1.c.s = cos(time);
+//   end for;
+//   for $i2 in 1:2 loop
+//     m[$i2].a2.c.f = sin(time);
+//   end for;
+//   for $i1 in 1:2 loop
+//     m[$i1].a2.c.s = cos(time);
+//   end for;
+// end InStreamArray2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -837,6 +837,7 @@ InnerOuterReplaceable3.mo \
 InstanceRestriction1.mo \
 InstanceRestriction2.mo \
 InStreamArray.mo \
+InStreamArray2.mo \
 InStreamFlowThreshold.mo \
 InStreamInsideOutside.mo \
 InStreamNominalThreshold.mo \


### PR DESCRIPTION
- Make `NFFlatten.evaluateBindingConnOp` more general instead of only handling TYPED_BINDING:s.