### PR TITLE
Disable Qt's 'signals' macro during inclusion of OMSimulator.h

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -36,7 +36,21 @@
 #define LINEANNOTATION_H
 
 #include "ShapeAnnotation.h"
+
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define LINEANNOTATION_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef LINEANNOTATION_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef LINEANNOTATION_H_DISABLED_QT_SIGNALS
+#endif
 
 #include <QTreeView>
 #include <QSortFilterProxyModel>

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -48,7 +48,21 @@
 #include "Editors/TextEditor.h"
 #include "Editors/MetaModelicaEditor.h"
 #include "LibraryTreeWidget.h"
+
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define MODELWIDGETCONTAINER_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef MODELWIDGETCONTAINER_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef MODELWIDGETCONTAINER_H_DISABLED_QT_SIGNALS
+#endif
 
 #include <QOpenGLContext>
 #include <QGraphicsView>

--- a/OMEdit/OMEditLIB/OMS/BusDialog.h
+++ b/OMEdit/OMEditLIB/OMS/BusDialog.h
@@ -34,7 +34,20 @@
 #ifndef ADDBUSDIALOG_H
 #define ADDBUSDIALOG_H
 
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#endif
 
 #include <QDialog>
 #include <QFrame>

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -34,7 +34,21 @@
 #ifndef OMSPROXY_H
 #define OMSPROXY_H
 
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define OMSPROXY_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef OMSPROXY_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef OMSPROXY_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "Modeling/MessagesWidget.h"
 
 #include <QObject>

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.h
@@ -36,7 +36,21 @@
 
 #include "Util/Utilities.h"
 #include "Util/StringHandler.h"
+
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef ADDBUSDIALOG_H_DISABLED_QT_SIGNALS
+#endif
 
 #include <QWidget>
 #include <QProgressBar>

--- a/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
+++ b/OMEdit/OMEditLIB/OMS/SystemSimulationInformationDialog.h
@@ -34,7 +34,20 @@
 #ifndef SYSTEMSIMULATIONINFORMATIONDIALOG_H
 #define SYSTEMSIMULATIONINFORMATIONDIALOG_H
 
+// Temporarily disable Qt's "signals" macro, as OMSimulator.h uses it as a parameter name
+#ifdef signals
+#  pragma push_macro("signals")
+#  undef signals
+#  define SYSTEMSIMULATIONINFORMATIONDIALOG_H_DISABLED_QT_SIGNALS
+#endif
+
 #include "OMSimulator/OMSimulator.h"
+
+// Restore Qt's "signals" macro
+#ifdef SYSTEMSIMULATIONINFORMATIONDIALOG_H_DISABLED_QT_SIGNALS
+#  pragma pop_macro("signals")
+#  undef SYSTEMSIMULATIONINFORMATIONDIALOG_H_DISABLED_QT_SIGNALS
+#endif
 
 #include <QDialog>
 #include <QLineEdit>


### PR DESCRIPTION
### Purpose

OMSimulator has introduced a new function that uses ```signals``` as a parameter.
That conflicts with Qt6 applications such as OMEdit.
Any inclusion of OMSimulator.h with ```signals``` defined in a Qt context will cause the build to fail.

- Towards fixing #14228

See[ this comment](https://github.com/OpenModelica/OpenModelica/issues/14228#issuecomment-3379002518) for more details.

### Approach

Currently OMSimulator.h is being included in LineAnotation.h, ModelWidgetContainer.h, BusDialog.h, OMSProxy.h, OMSSimulationOutputWidget.h and SystemSimulationInformationDialog.h.

The inclusion of OMSimulator.h on those files was guarded by a temporary supression of the ```signals``` macro definition.