### PR TITLE
Parameter array index mapping

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1278,8 +1278,6 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
 
     <%functionODE(odeEquations,(match simulationSettingsOpt case SOME(settings as SIMULATION_SETTINGS(__)) then settings.method else ""), hpcomData.schedules, modelNamePrefixStr)%>
 
-    <%computeVarIndices(modelInfo.vars, modelNamePrefixStr)%>
-
     /* forward the main in the simulation runtime */
     extern int _main_SimulationRuntime(int argc, char **argv, DATA *data, threadData_t *threadData);
     extern int _main_OptimizationRuntime(int argc, char **argv, DATA *data, threadData_t *threadData);
@@ -1301,7 +1299,6 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
       NULL,
       #endif    /* initializeStateSets */
       <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>,
-      <%symbolName(modelNamePrefixStr,"computeVarIndices")%>,
       <%symbolName(modelNamePrefixStr,"functionODE")%>,
       <%symbolName(modelNamePrefixStr,"functionAlgebraics")%>,
       <%symbolName(modelNamePrefixStr,"functionDAE")%>,
@@ -1549,21 +1546,25 @@ template populateModelInfo(ModelInfo modelInfo, String fileNamePrefix, String gu
     %>
     data->modelData->runTestsuite = <%if Testsuite.isRunning() then "1" else "0"%>;
     data->modelData->nStates = <%varInfo.numStateVars%>;
-    data->modelData->nVariablesRealArray = <%nVariablesReal(varInfo)%>;
     data->modelData->nDiscreteReal = <%varInfo.numDiscreteReal%>;
+    data->modelData->nVariablesRealArray = <%nVariablesReal(varInfo)%>;
     data->modelData->nVariablesIntegerArray = <%varInfo.numIntAlgVars%>;
     data->modelData->nVariablesBooleanArray = <%varInfo.numBoolAlgVars%>;
     data->modelData->nVariablesStringArray = <%varInfo.numStringAlgVars%>;
+    data->modelData->nParametersRealArray = <%varInfo.numParams%>;
+    data->modelData->nParametersIntegerArray = <%varInfo.numIntParams%>;
+    data->modelData->nParametersBooleanArray = <%varInfo.numBoolParams%>;
+    data->modelData->nParametersStringArray = <%varInfo.numStringParamVars%>;
     data->modelData->nParametersReal = <%varInfo.numParams%>;
     data->modelData->nParametersInteger = <%varInfo.numIntParams%>;
     data->modelData->nParametersBoolean = <%varInfo.numBoolParams%>;
     data->modelData->nParametersString = <%varInfo.numStringParamVars%>;
-    data->modelData->nInputVars = <%varInfo.numInVars%>;
-    data->modelData->nOutputVars = <%varInfo.numOutVars%>;
     data->modelData->nAliasReal = <%varInfo.numAlgAliasVars%>;
     data->modelData->nAliasInteger = <%varInfo.numIntAliasVars%>;
     data->modelData->nAliasBoolean = <%varInfo.numBoolAliasVars%>;
     data->modelData->nAliasString = <%varInfo.numStringAliasVars%>;
+    data->modelData->nInputVars = <%varInfo.numInVars%>;
+    data->modelData->nOutputVars = <%varInfo.numOutVars%>;
     data->modelData->nZeroCrossings = <%varInfo.numZeroCrossings%>;
     data->modelData->nSamples = <%varInfo.numTimeEvents%>;
     data->modelData->nRelations = <%varInfo.numRelations%>;
@@ -4669,89 +4670,6 @@ template genVarIndexes(list<SimVar> vars, String arrayName)
   const int <%arrayName%>[<%size%>] = {<%varIndexes%>};
   >>
 end genVarIndexes;
-
-template computeVarIndices(SimVars vars, String modelNamePrefix)
-""
-::=
-  match vars
-  case SIMVARS(__) then
-    <<
-    void <%symbolName(modelNamePrefix,"computeVarIndices")%>(DATA* data, size_t* realIndex, size_t* integerIndex, size_t* booleanIndex, size_t* stringIndex)
-    {
-      TRACE_PUSH
-
-      size_t i_real = 0;
-      size_t i_integer = 0;
-      size_t i_boolean = 0;
-      size_t i_string = 0;
-
-      realIndex[0] = 0;
-      integerIndex[0] = 0;
-      booleanIndex[0] = 0;
-      stringIndex[0] = 0;
-
-      /* temporary fix for https://github.com/OpenModelica/OpenModelica/issues/13999 */
-      for (i_real = 0; i_real < data->modelData->nVariablesRealArray + 1; i_real++)
-        realIndex[i_real] = i_real;
-      for (i_integer = 0; i_integer < data->modelData->nVariablesIntegerArray + 1; i_integer++)
-        integerIndex[i_integer] = i_integer;
-      for (i_boolean = 0; i_boolean < data->modelData->nVariablesBooleanArray + 1; i_boolean++)
-        booleanIndex[i_boolean] = i_boolean;
-      for (i_string = 0; i_string < data->modelData->nVariablesStringArray + 1; i_string++)
-        stringIndex[i_string] = i_string;
-
-      /* stateVars */
-      <%computeVarIndicesList(stateVars)%>
-
-      /* derivativeVars */
-      <%computeVarIndicesList(derivativeVars)%>
-
-      /* algVars */
-      <%computeVarIndicesList(algVars)%>
-
-      /* discreteAlgVars */
-      <%computeVarIndicesList(discreteAlgVars)%>
-
-      /* realOptimizeConstraintsVars */
-      <%computeVarIndicesList(realOptimizeConstraintsVars)%>
-
-      /* realOptimizeFinalConstraintsVars */
-      <%computeVarIndicesList(realOptimizeFinalConstraintsVars)%>
-
-
-      /* intAlgVars */
-      <%computeVarIndicesList(intAlgVars)%>
-
-      /* boolAlgVars */
-      <%computeVarIndicesList(boolAlgVars)%>
-
-      /* stringAlgVars */
-      <%computeVarIndicesList(stringAlgVars)%>
-
-      TRACE_POP
-    }
-    >>
-end computeVarIndices;
-
-template computeVarIndicesList(list<SimVar> vars)
-::=
-  '/* skip for #13999 */'
-  /*
-  (vars |> var as SIMVAR(__) =>
-      let &preExp = buffer ""
-      let &varDecls = buffer ""
-      let &auxFunction = buffer ""
-      let ty = crefShortType(name)
-      let i = 'i_<%ty%>'
-      let size = daeExp(DAEUtil.typeExp(type_), contextOther, &preExp, &varDecls, &auxFunction)
-      <<
-      <%preExp%>
-      <%varDecls%>
-      <%auxFunction%>
-      <%ty%>Index[<%i%>+1] = <%ty%>Index[<%i%>] + <%size%>; <%i%>++; <%crefCCommentWithVariability(var)%>>>; separator="")
-  */
-end computeVarIndicesList;
-
 
 template initializeDAEmodeData(Integer nResVars, list<SimVar> algVars, Integer nAuxVars, SparsityPattern sparsepattern, list<list<Integer>> colorList, Integer maxColor, String modelNamePrefix)
   "Generates initialization function for daeMode."

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7858,7 +7858,9 @@ template varArrayNameValues(SimVar var, Integer ix, Boolean isPre, Boolean isSta
           '<%daeExpSimpleLiteral(value)%><%c_comment%>'
         case SIMVAR(varKind=PARAM())
         case SIMVAR(varKind=OPT_TGRID()) then
-          '(<%arr%>data->simulationInfo-><%crefShortType(name)%>Parameter[<%index%>]<%crefCCommentWithVariability(var)%>)<%&sub%>'
+          let c_comment = CodegenUtil.crefCCommentWithVariability(var)
+          let ty = crefShortType(name)
+          '(<%arr%>data->simulationInfo-><%crefShortType(name)%>Parameter[data->simulationInfo-><%ty%>ParamsIndex[<%index%>]]<%c_comment%>)<%&sub%>'
         case SIMVAR(varKind=EXTOBJ()) then
           '(<%arr%>data->simulationInfo->extObjs[<%index%>])<%&sub%>'
         case SIMVAR(__) then

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -101,9 +101,6 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   */
   int (*initializeDAEmodeData)(DATA *data, DAEMODE_DATA* daeModeData);
 
-  /* computes index map with the sizes of all (resizable) variables */
-  void (*computeVarIndices)(DATA* data, size_t* realIndex, size_t* integerIndex, size_t* booleanIndex, size_t* stringIndex);
-
   /* functionODE contains those equations that are needed
   * to calculate the dynamic part of the system */
   int (*functionODE)(DATA *data, threadData_t*);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -976,23 +976,42 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
   }
 
   /* allocate index map */
-  data->simulationInfo->realVarsIndex     = (size_t*) calloc(data->modelData->nVariablesRealArray + 1, sizeof(size_t));
+  data->simulationInfo->realVarsIndex = (size_t*) calloc(data->modelData->nVariablesRealArray + 1, sizeof(size_t));
   assertStreamPrint(threadData, NULL != data->simulationInfo->realVarsIndex, "out of memory");
-  data->simulationInfo->integerVarsIndex  = (size_t*) calloc(data->modelData->nVariablesIntegerArray + 1, sizeof(size_t));
+  data->simulationInfo->integerVarsIndex = (size_t*) calloc(data->modelData->nVariablesIntegerArray + 1, sizeof(size_t));
   assertStreamPrint(threadData, NULL != data->simulationInfo->integerVarsIndex, "out of memory");
-  data->simulationInfo->booleanVarsIndex  = (size_t*) calloc(data->modelData->nVariablesBooleanArray + 1, sizeof(size_t));
+  data->simulationInfo->booleanVarsIndex = (size_t*) calloc(data->modelData->nVariablesBooleanArray + 1, sizeof(size_t));
   assertStreamPrint(threadData, NULL != data->simulationInfo->booleanVarsIndex, "out of memory");
-  data->simulationInfo->stringVarsIndex   = (size_t*) calloc(data->modelData->nVariablesStringArray + 1, sizeof(size_t));
+  data->simulationInfo->stringVarsIndex = (size_t*) calloc(data->modelData->nVariablesStringArray + 1, sizeof(size_t));
   assertStreamPrint(threadData, NULL != data->simulationInfo->stringVarsIndex, "out of memory");
+  data->simulationInfo->realParamsIndex = (size_t*) calloc(data->modelData->nParametersRealArray + 1, sizeof(size_t));
+  assertStreamPrint(threadData, NULL != data->simulationInfo->realParamsIndex, "out of memory");
+  data->simulationInfo->integerParamsIndex = (size_t*) calloc(data->modelData->nParametersIntegerArray + 1, sizeof(size_t));
+  assertStreamPrint(threadData, NULL != data->simulationInfo->integerParamsIndex, "out of memory");
+  data->simulationInfo->booleanParamsIndex = (size_t*) calloc(data->modelData->nParametersBooleanArray + 1, sizeof(size_t));
+  assertStreamPrint(threadData, NULL != data->simulationInfo->booleanParamsIndex, "out of memory");
+  data->simulationInfo->stringParamsIndex = (size_t*) calloc(data->modelData->nParametersStringArray + 1, sizeof(size_t));
+  assertStreamPrint(threadData, NULL != data->simulationInfo->stringParamsIndex, "out of memory");
 
   /* compute index map */
-  data->callback->computeVarIndices(data, data->simulationInfo->realVarsIndex, data->simulationInfo->integerVarsIndex, data->simulationInfo->booleanVarsIndex, data->simulationInfo->stringVarsIndex);
+  for (i = 0; i < data->modelData->nVariablesRealArray + 1; i++)     data->simulationInfo->realVarsIndex[i]      = i;
+  for (i = 0; i < data->modelData->nVariablesIntegerArray + 1; i++)  data->simulationInfo->integerVarsIndex[i]   = i;
+  for (i = 0; i < data->modelData->nVariablesBooleanArray + 1; i++)  data->simulationInfo->booleanVarsIndex[i]   = i;
+  for (i = 0; i < data->modelData->nVariablesStringArray + 1; i++)   data->simulationInfo->stringVarsIndex[i]    = i;
+  for (i = 0; i < data->modelData->nParametersRealArray + 1; i++)    data->simulationInfo->realParamsIndex[i]    = i;
+  for (i = 0; i < data->modelData->nParametersIntegerArray + 1; i++) data->simulationInfo->integerParamsIndex[i] = i;
+  for (i = 0; i < data->modelData->nParametersBooleanArray + 1; i++) data->simulationInfo->booleanParamsIndex[i] = i;
+  for (i = 0; i < data->modelData->nParametersStringArray + 1; i++)  data->simulationInfo->stringParamsIndex[i]  = i;
 
   /* compute scalar number of variables */
   data->modelData->nVariablesReal     = data->simulationInfo->realVarsIndex[data->modelData->nVariablesRealArray];
   data->modelData->nVariablesInteger  = data->simulationInfo->integerVarsIndex[data->modelData->nVariablesIntegerArray];
   data->modelData->nVariablesBoolean  = data->simulationInfo->booleanVarsIndex[data->modelData->nVariablesBooleanArray];
   data->modelData->nVariablesString   = data->simulationInfo->stringVarsIndex[data->modelData->nVariablesStringArray];
+  data->modelData->nParametersReal    = data->simulationInfo->realParamsIndex[data->modelData->nParametersRealArray];
+  data->modelData->nParametersInteger = data->simulationInfo->integerParamsIndex[data->modelData->nParametersIntegerArray];
+  data->modelData->nParametersBoolean = data->simulationInfo->booleanParamsIndex[data->modelData->nParametersBooleanArray];
+  data->modelData->nParametersString  = data->simulationInfo->stringParamsIndex[data->modelData->nParametersStringArray];
 
   /* prepare RingBuffer */
   for (i = 0; i < SIZERINGBUFFER; i++) {
@@ -1310,6 +1329,10 @@ void deInitializeDataStruc(DATA *data)
   free(data->simulationInfo->integerVarsIndex);
   free(data->simulationInfo->booleanVarsIndex);
   free(data->simulationInfo->stringVarsIndex);
+  free(data->simulationInfo->realParamsIndex);
+  free(data->simulationInfo->integerParamsIndex);
+  free(data->simulationInfo->booleanParamsIndex);
+  free(data->simulationInfo->stringParamsIndex);
 
   /* free buffer for old state variables */
   free(data->simulationInfo->realVarsOld);

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -631,25 +631,35 @@ typedef struct MODEL_DATA
 
   long nBaseClocks;                    /* total number of base-clocks*/
 
-  fortran_integer nStates;
+  /* Number of un-scalrarized variables (arrays count as one variable) */
+  long nStatesArray;            /* Number of array + scalar state variables */
+  long nVariablesRealArray;     /* Number of array + scalar real variables: states + state derivatives + real algebraic variables */
+  long nVariablesIntegerArray;  /* Number of array + scalar integer variables */
+  long nVariablesBooleanArray;  /* Number of array + scalar boolean variables */
+  long nVariablesStringArray;   /* Number of array + scalar string variables */
+  long nParametersRealArray;    /* Number of array + scalar real parameters */
+  long nParametersIntegerArray; /* Number of array + scalar integer parameters */
+  long nParametersBooleanArray; /* Number of array + scalar boolean parameters */
+  long nParametersStringArray;  /* Number of array + scalar string parameters */
 
-  /* numbers of unscalarized variables (arrays counted as one variable, used for index map) */
-  size_t nVariablesRealArray;
-  size_t nVariablesIntegerArray;
-  size_t nVariablesBooleanArray;
-  size_t nVariablesStringArray;
+  /* Number of scalarized variables (arrays are flatten to scalar elements.) */
+  long nStates;                 /* Number of state variables*/
+  long nVariablesReal;          /* Number of real variables: states + state derivatives + real algebraic variables + real discrete variables */
+  long nDiscreteReal;           /* Number of all discrete real variables */
+  long nVariablesInteger;       /* Number of integer variables */
+  long nVariablesBoolean;       /* Number of boolean variables */
+  long nVariablesString;        /* Number of string variables */
+  long nParametersReal;         /* Number of real parameters */
+  long nParametersInteger;      /* Number of integer parameters */
+  long nParametersBoolean;      /* Number of boolean parameters */
+  long nParametersString;       /* Number of string parameters */
+  long nInputVars;              /* Number of input variables */
+  long nOutputVars;             /* Number of output variables */
 
-  long nVariablesReal;                 /* all Real Variables of the model (states, statesderivatives, algebraics, real discretes) */
-  long nDiscreteReal;                  /* only all _discrete_ reals */
-  long nVariablesInteger;
-  long nVariablesBoolean;
-  long nVariablesString;
-  long nParametersReal;
-  long nParametersInteger;
-  long nParametersBoolean;
-  long nParametersString;
-  long nInputVars;
-  long nOutputVars;
+  long nAliasReal;              /* Number of real alias variables */
+  long nAliasInteger;           /* Number of integer alias variables */
+  long nAliasBoolean;           /* Number of boolean alias variables */
+  long nAliasString;            /* Number of string alias variables */
 
   long nZeroCrossings;
   long nRelations;
@@ -664,11 +674,6 @@ typedef struct MODEL_DATA
   long nInlineVars;                    /* number of additional variables for the inline solver */
   long nOptimizeConstraints;           /* number of additional variables for constraint in dynamic optimization */
   long nOptimizeFinalConstraints;      /* number of additional variables for final constraint in dynamic optimization */
-
-  long nAliasReal;
-  long nAliasInteger;
-  long nAliasBoolean;
-  long nAliasString;
 
   long nJacobians;
 
@@ -829,6 +834,10 @@ typedef struct SIMULATION_INFO
   size_t* integerVarsIndex;
   size_t* booleanVarsIndex;
   size_t* stringVarsIndex;
+  size_t* realParamsIndex;
+  size_t* integerParamsIndex;
+  size_t* booleanParamsIndex;
+  size_t* stringParamsIndex;
 
   /* old vars for event handling */
   modelica_real timeValueOld;


### PR DESCRIPTION
### Related Issues

Closes https://github.com/OpenModelica/OpenModelica/issues/14453

### Purpose

Adding index mapping for array variables of type parameter.

### Approach

- Added new index maps for real, integer, boolean and string parameters.
- Added identity index mapping.
- Removed `computeVarIndices` callback and code generation. Will be handled by the C runtime by utilizing information from the  init XML.
