### PR TITLE
Use hashContinue in hash functions

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
@@ -1282,7 +1282,12 @@ protected
 
   function keyHash
     input Key key;
-    output Integer hash = stringHashDjb2(keyString(key));
+    output Integer hash;
+  algorithm
+    hash := stringHashDjb2(intString(listHead(key)));
+    for k in listRest(key) loop
+      hash := stringHashDjb2Continue(intString(k), hash);
+    end for;
   end keyHash;
 
   function keyEqual

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -454,7 +454,12 @@ public
 
   function hashList
     input list<Dimension> dims;
-    output Integer i = stringHashDjb2(toStringList(dims));
+    output Integer hash;
+  algorithm
+    hash := stringHashDjb2(toString(listHead(dims)));
+    for dim in listRest(dims) loop
+      hash := stringHashDjb2Continue(toString(dim), hash);
+    end for;
   end hashList;
 
   function toStringList

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -416,6 +416,7 @@ public
   function hash
     input Expression exp;
     output Integer hash = stringHashDjb2(toString(exp));
+    // TODO use stringHashDjb2Continue
   end hash;
 
   function isEqual

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
@@ -203,12 +203,7 @@ end isMaster;
 
 public function hashUnit
   input Unit inKey;
-  output Integer outHash;
-protected
-  String str;
-algorithm
-  str := unit2string(inKey);
-  outHash := stringHashDjb2(str);
+  output Integer outHash = stringHashDjb2(unit2string(inKey));
 end hashUnit;
 
 public function unitEqual

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4364,7 +4364,7 @@ algorithm
 
   isWindows := Autoconf.os == "Windows_NT";
 
-  fmutmp := substring(intString(stringHashDjb2(filenameprefix)), 1, 3) + ".fmutmp";
+  fmutmp := Util.hashFileNamePrefix(filenameprefix) + ".fmutmp";
   logfile := filenameprefix + ".log";
   dir := fmutmp+"/sources/";
 

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -762,7 +762,7 @@ algorithm
       SimCode.VarInfo varInfo;
     case (SimCode.SIMCODE(),"C")
       algorithm
-        fileNamePrefixHash := substring(intString(stringHashDjb2(simCode.fileNamePrefix)), 1, 3);
+        fileNamePrefixHash := Util.hashFileNamePrefix(simCode.fileNamePrefix);
         fmutmp := fileNamePrefixHash + ".fmutmp";
         if System.directoryExists(fmutmp) then
           if not System.removeDirectory(fmutmp) then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -738,7 +738,7 @@ algorithm
     end if;
 
     // fix issue https://github.com/OpenModelica/OpenModelica/issues/12916
-    fileNamePrefixHash := substring(intString(stringHashDjb2(filenamePrefix)), 1, 3);
+    fileNamePrefixHash := Util.hashFileNamePrefix(filenamePrefix);
 
     // Set fullPathPrefix for FMUs
     if isFMU then

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -64,7 +64,7 @@ match simCode
 case sc as SIMCODE(modelInfo=modelInfo as MODELINFO(__)) then
   let guid = getUUIDStr()
   let target  = simulationCodeTarget()
-  let fileNamePrefixHash = '<%substring(intString(stringHashDjb2(fileNamePrefix)), 1, 3)%>'
+  let fileNamePrefixHash = Util.hashFileNamePrefix(fileNamePrefix)
   let fileNamePrefixTmpDir = '<%fileNamePrefixHash%>.fmutmp/sources/<%fileNamePrefix%>'
   let()= textFile(simulationLiteralsFile(fileNamePrefix, literals), '<%fileNamePrefixTmpDir%>_literals.h')
   let()= textFile(simulationFunctionsHeaderFile(fileNamePrefix, modelInfo.functions, recordDecls, sc.generic_loop_calls), '<%fileNamePrefixTmpDir%>_functions.h')
@@ -1252,7 +1252,7 @@ end mapInitialUnknownsIndependentCrefs;
 template getPlatformString2(String modelNamePrefix, String platform, String fileNamePrefix, String fmuTargetName, String dirExtra, String libsPos1, String libsPos2, String omhome, String FMUVersion)
  "returns compilation commands for the platform. "
 ::=
-let fmudirname = '<%substring(intString(stringHashDjb2(fileNamePrefix)), 1, 3)%>.fmutmp'
+let fmudirname = '<%Util.hashFileNamePrefix(fileNamePrefix)%>.fmutmp'
 match platform
   case "win32"
   case "win64" then
@@ -1349,7 +1349,7 @@ template fmuMakefile(String target, SimCode simCode, String FMUVersion, list<Str
       let libsStr = (makefileParams.libs |> lib => lib ;separator=" ")
       let libsPos1 = if not dirExtra then libsStr //else ""
       let libsPos2 = if dirExtra then libsStr // else ""
-      let fmudirname = '<%substring(intString(stringHashDjb2(fileNamePrefix)), 1, 3)%>.fmutmp'
+      let fmudirname = '<%Util.hashFileNamePrefix(fileNamePrefix)%>.fmutmp'
       let compilecmds = getPlatformString2(modelNamePrefix(simCode), makefileParams.platform, fileNamePrefix, fmuTargetName, dirExtra, libsPos1, libsPos2, makefileParams.omhome, FMUVersion)
       let mkdir = match makefileParams.platform case "win32" case "win64" then '"mkdir.exe"' else 'mkdir'
       <<

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3555,6 +3555,11 @@ package Util
   output Boolean outBoolean;
   end stringBool;
 
+  function hashFileNamePrefix
+    input String inFileNamePrefix;
+    output String hashStr;
+  end hashFileNamePrefix;
+
 end Util;
 
 package List

--- a/OMCompiler/Compiler/Util/HashTable5.mo
+++ b/OMCompiler/Compiler/Util/HashTable5.mo
@@ -81,12 +81,7 @@ end FuncExpStr;
 protected function hashFunc
 "Calculates a hash value for Key"
   input Key cr;
-  output Integer res;
-protected
-  String crstr;
-algorithm
-  crstr := Dump.printComponentRefStr(cr);
-  res := stringHashDjb2(crstr);
+  output Integer res = stringHashDjb2(Dump.printComponentRefStr(cr));
 end hashFunc;
 
 public function emptyHashTable

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1443,6 +1443,11 @@ algorithm
  end if;
 end absoluteOrRelative;
 
+public function hashFileNamePrefix
+  input String inFileNamePrefix;
+  output String hashStr = substring(intString(stringHashDjb2(inFileNamePrefix)), 1, 3);
+end hashFileNamePrefix;
+
 public function intLstString
   input list<Integer> lst;
   output String s;


### PR DESCRIPTION
Rather than converting lists to string and hashing the string, we can directly iterate over the list and use `stringHashDjb2Continue`.

CC @kabdelhak