### PR TITLE
Type crefs involving name nodes better

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2042,6 +2042,16 @@ algorithm
       then
         (cref, Variability.CONSTANT);
 
+    case ComponentRef.CREF(node = InstNode.NAME_NODE())
+      algorithm
+        (subs, subs_var) := typeSubscripts(cref.subscripts, cref.ty,
+          Expression.CREF(cref.ty, cref), context, info, checkSubscripts = false);
+        (rest_cr, rest_var) := typeCref2(cref.restCref, context, info, false);
+        cref.restCref := rest_cr;
+        subsVariability := Prefixes.variabilityMax(subs_var, rest_var);
+      then
+        (cref, rest_var);
+
     else (cref, Variability.CONSTANT);
   end match;
 end typeCref2;
@@ -2052,6 +2062,7 @@ function typeSubscripts
   input Expression subscriptedExp;
   input InstContext.Type context;
   input SourceInfo info;
+  input Boolean checkSubscripts = true;
   output list<Subscript> typedSubs;
   output Variability variability = Variability.CONSTANT;
 protected
@@ -2071,15 +2082,20 @@ algorithm
   next_context := InstContext.set(context, NFInstContext.SUBSCRIPT);
   i := 1;
 
-  if listLength(subscripts) > listLength(dims) then
+  if listLength(subscripts) > listLength(dims) and checkSubscripts then
     Error.addSourceMessage(Error.WRONG_NUMBER_OF_SUBSCRIPTS,
       {Expression.toString(subscriptedExp), String(listLength(subscripts)), String(listLength(dims))}, info);
     fail();
   end if;
 
   for s in subscripts loop
-    dim :: dims := dims;
-    (sub, var) := typeSubscript(s, dim, subscriptedExp, i, next_context, info);
+    if checkSubscripts then
+      dim :: dims := dims;
+    else
+      dim := Dimension.UNKNOWN();
+    end if;
+
+    (sub, var) := typeSubscript(s, dim, subscriptedExp, i, next_context, info, checkSubscripts);
     typedSubs := sub :: typedSubs;
     variability := Prefixes.variabilityMax(variability, var);
     i := i + 1;
@@ -2102,6 +2118,7 @@ function typeSubscript
   input Integer index;
   input InstContext.Type context;
   input SourceInfo info;
+  input Boolean checkSubscript;
   output Subscript outSubscript = subscript;
   output Variability variability = Variability.CONSTANT;
 protected
@@ -2115,7 +2132,12 @@ algorithm
       algorithm
         e := evaluateEnd(subscript.exp, dimension, subscriptedExp, index, context, info);
         (e, ty, variability) := typeExp(e, context, info);
-        (e, matched_ty) := checkSubscriptType(e, Type.arrayElementType(ty), dimension, info);
+
+        if checkSubscript then
+          (e, matched_ty) := checkSubscriptType(e, Type.arrayElementType(ty), dimension, info);
+        else
+          matched_ty := ty;
+        end if;
 
         if Type.isArray(ty) then
           outSubscript := Subscript.SLICE(e);
@@ -2132,14 +2154,24 @@ algorithm
     // Other subscripts have already been typed, but still need to be type checked.
     case Subscript.INDEX(index = e)
       algorithm
-        (e, ty) := checkSubscriptType(e, Expression.typeOf(e), dimension, info);
+        if checkSubscript then
+          (e, ty) := checkSubscriptType(e, Expression.typeOf(e), dimension, info);
+        else
+          ty := Expression.typeOf(e);
+        end if;
+
         outSubscript := Subscript.INDEX(e);
       then
         (ty, Expression.variability(e));
 
     case Subscript.SLICE(slice = e)
       algorithm
-        (e, ty) := checkSubscriptType(e, Type.unliftArray(Expression.typeOf(e)), dimension, info);
+        if checkSubscript then
+          (e, ty) := checkSubscriptType(e, Type.unliftArray(Expression.typeOf(e)), dimension, info);
+        else
+          ty := Type.unliftArray(Expression.typeOf(e));
+        end if;
+
         outSubscript := Subscript.SLICE(e);
       then
         (ty, Expression.variability(e));


### PR DESCRIPTION
- Type the subscripts and the rest of the cref when encountering a name node (used for undeclared connectors).