### PR TITLE
Adding OMSI to CMake build

### DIFF
--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -1,10 +1,9 @@
 
 omc_add_subdirectory(c)
-omc_add_subdirectory(fmi)
-
 if(OM_OMC_ENABLE_CPP_RUNTIME)
   omc_add_subdirectory(cpp)
 endif()
+omc_add_subdirectory(fmi)
 
 # ModelicaExternalC
 # Disable ModelicaExternalC for MSVC since right now we are building static
@@ -15,6 +14,10 @@ if(NOT MSVC)
   omc_add_subdirectory(ModelicaExternalC)
 endif()
 
+omc_add_subdirectory(OMSI)
+#omc_add_subdirectory(OMSIC)
+#omc_add_subdirectory(OMSICpp)
+
 # omc_add_subdirectory(opc)
 
 # ParModelica
@@ -22,7 +25,3 @@ endif()
 if(NOT MSVC)
   omc_add_subdirectory(ParModelica)
 endif()
-
-#ADD_SUBDIRECTORY(cpp)
-#ADD_SUBDIRECTORY(interactive)
-

--- a/OMCompiler/SimulationRuntime/OMSI/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSI/CMakeLists.txt
@@ -1,6 +1,5 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
-MESSAGE(STATUS "CMake version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
 
 PROJECT(OMSIBaseSimulationRuntime)
 
@@ -14,8 +13,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 message(STATUS "Compiling with C flags: ${CMAKE_C_FLAGS}")
 
-
-
 if(NOT PLATFORM OR PLATFORM STREQUAL "dynamic")
   set(BUILD_SHARED_LIBS ON)
 elseif(PLATFORM STREQUAL "static")
@@ -23,15 +20,11 @@ elseif(PLATFORM STREQUAL "static")
 else()
 endif()
 
-
-
 IF(BUILD_SHARED_LIBS)
   SET(LIBSUFFIX "")
 ELSE(BUILD_SHARED_LIBS)
   SET(LIBSUFFIX "_static")
 ENDIF(BUILD_SHARED_LIBS)
-
-
 
 IF(MSVC)
   MESSAGE(STATUS "MSVC")
@@ -49,28 +42,38 @@ ELSE(MSVC)
 ENDIF(MSVC)
 message(STATUS "Libs will be installed in ${CMAKE_INSTALL_PREFIX}/${LIBINSTALLEXT}")
 
+
+# OMSIBaseSimulationRuntime interface library
+add_library(OMSIBaseSimulationRuntime INTERFACE)
+target_include_directories(OMSIBaseSimulationRuntime INTERFACE include)
+target_include_directories(OMSIBaseSimulationRuntime INTERFACE include/fmi2)
+target_include_directories(OMSIBaseSimulationRuntime INTERFACE solver/include)
+
+install(DIRECTORY include DESTINATION include/omc/omsi)
+install(DIRECTORY include/fmi2 DESTINATION include/omc/omsi/fmi2)
+
 SET(OSUBaseName ${LIBPREFIX}OMSIBase${LIBSUFFIX})
 SET(OMSISolverName ${LIBPREFIX}OMSISolver${LIBSUFFIX})
 
-include_directories ("${CMAKE_SOURCE_DIR}/include")
+include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/include")
+
 # omsi base simulation runtime
 ADD_SUBDIRECTORY(solver)
 ADD_SUBDIRECTORY(base)
 
-
 install(FILES
-  ${CMAKE_SOURCE_DIR}/include/omsi.h
-  ${CMAKE_SOURCE_DIR}/include/omsi_callbacks.h
-  ${CMAKE_SOURCE_DIR}/include/omsi_api_functions.h
+  include/omsi.h
+  include/omsi_callbacks.h
+  include/omsi_api_functions.h
   DESTINATION include/omc/omsi)
 
 install(FILES
-  ${CMAKE_SOURCE_DIR}/include/fmi2/omsi_fmi2_cs.h
-  ${CMAKE_SOURCE_DIR}/include/fmi2/omsi_fmi2_me.h
-  ${CMAKE_SOURCE_DIR}/include/fmi2/omsi_fmi2_wrapper.h
-  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2Functions.h
-  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2FunctionTypes.h
-  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2TypesPlatform.h
+  include/fmi2/omsi_fmi2_cs.h
+  include/fmi2/omsi_fmi2_me.h
+  include/fmi2/omsi_fmi2_wrapper.h
+  include/fmi2/fmi2Functions.h
+  include/fmi2/fmi2FunctionTypes.h
+  include/fmi2/fmi2TypesPlatform.h
   DESTINATION include/omc/omsi/fmi2/)
 
 # uninstall target

--- a/OMCompiler/SimulationRuntime/OMSI/base/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSI/base/CMakeLists.txt
@@ -1,23 +1,25 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
-#OMSI base simulation runtime
-PROJECT(OMSIBASE)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
 
-# Set exapat lib for visual studio compiler
-# TODO: This relies on the static expat libexpat.a on MSVC but it's only build for mingw target!
-IF(MSVC)
-  INCLUDE_DIRECTORIES($ENV{OMDEV}/lib/expat-win32-msvc)
-  FIND_LIBRARY(LIB_EXPAT NAMES expat libexpat PATHS ${OMBUILDDIR}/lib/omc ${OMBUILDDIR}/lib/omc/msvc ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/ $ENV{OMDEV}/lib/expat-win32-msvc $ENV{OMDEV}/lib/lapack-win32-msvc)
-ELSE(MSVC)
-  FIND_LIBRARY(LIB_EXPAT NAMES expat libexpat PATHS ${OMBUILDDIR}/lib/omc ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/)
-ENDIF(MSVC)
-IF(NOT LIB_EXPAT)
-  MESSAGE(FATAL_ERROR "Could not find static expat library!\nSearched in:\n${OMBUILDDIR}/lib/omc ${OMBUILDDIR}/lib/omc/msvc ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/ $ENV{OMDEV}/lib/expat-win32-msvc $ENV{OMDEV}/lib/lapack-win32-msvc")
-ENDIF(NOT LIB_EXPAT)
-MESSAGE(STATUS "Using expat library ${LIB_EXPAT}")
+#OMSI base simulation runtime
+PROJECT(OMSIBASE)
 
-include_directories ("${CMAKE_SOURCE_DIR}/base/include" "${CMAKE_SOURCE_DIR}/solver/include")
-add_library( ${OSUBaseName} 
+IF(NOT TARGET omc::3rd::FMIL::expat)
+  # Set exapat lib for visual studio compiler
+  # TODO: This relies on the static expat libexpat.a on MSVC but it's only build for mingw target!
+  IF(MSVC)
+    INCLUDE_DIRECTORIES($ENV{OMDEV}/lib/expat-win32-msvc)
+    FIND_LIBRARY(LIB_EXPAT NAMES expat libexpat PATHS ${OMBUILDDIR}/lib/omc ${OMBUILDDIR}/lib/omc/msvc ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/ $ENV{OMDEV}/lib/expat-win32-msvc $ENV{OMDEV}/lib/lapack-win32-msvc)
+  ELSE(MSVC)
+    FIND_LIBRARY(LIB_EXPAT NAMES expat libexpat PATHS ${OMBUILDDIR}/lib/omc ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/)
+  ENDIF(MSVC)
+  IF(NOT LIB_EXPAT)
+    MESSAGE(FATAL_ERROR "Could not find static expat library!\nSearched in:\n${OMBUILDDIR}/lib/omc ${OMBUILDDIR}/lib/omc/msvc ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/ $ENV{OMDEV}/lib/expat-win32-msvc $ENV{OMDEV}/lib/lapack-win32-msvc")
+  ENDIF(NOT LIB_EXPAT)
+  MESSAGE(STATUS "Using expat library ${LIB_EXPAT}")
+ENDIF(NOT TARGET omc::3rd::FMIL::expat)
+
+add_library(${OSUBaseName}
   src/omsi_event_helper.c
   src/omsi_getters_and_setters.c
   src/omsi_initialization.c
@@ -30,7 +32,7 @@ add_library( ${OSUBaseName}
   src/omsi_solve_alg_system.c
   src/omsi_utils.c)
 
-include_directories ("${OMSI_SOURCE_DIR}/solver/include")
+target_include_directories(${OSUBaseName} PUBLIC include)
 
 # Set RPATH for mac to use lib from build tree and install location
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -42,29 +44,38 @@ IF("${isSystemDir}" STREQUAL "-1")
    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
-IF(WIN32)
-  target_link_libraries(${OSUBaseName} ${OMSISolverName} ${CMAKE_DL_LIBS} wsock32 ws2_32 ${LIB_EXPAT})
-ELSE(WIN32)
-  target_link_libraries(${OSUBaseName} ${OMSISolverName} ${CMAKE_DL_LIBS} ${LIB_EXPAT})
-ENDIF(WIN32)
+target_link_libraries(${OSUBaseName} PUBLIC OMSIBaseSimulationRuntime)
+target_link_libraries(${OSUBaseName} PUBLIC ${OMSISolverName})
+target_link_libraries(${OSUBaseName} PUBLIC ${CMAKE_DL_LIBS})
+IF(TARGET omc::3rd::FMIL::expat)
+  target_link_libraries(${OSUBaseName} PUBLIC omc::3rd::FMIL::expat)
+ELSE(TARGET omc::3rd::FMIL::expat)
+  target_link_libraries(${OSUBaseName} PUBLIC ${LIB_EXPAT})
+ENDIF(TARGET omc::3rd::FMIL::expat)
 
+IF(WIN32)
+  target_link_libraries(${OSUBaseName} PRIVATE wsock32)
+  target_link_libraries(${OSUBaseName} PRIVATE ws2_32)
+ENDIF(WIN32)
 
 install(TARGETS ${OSUBaseName} DESTINATION ${LIBINSTALLEXT})
 
-install(FILES ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ThirdParty/Expat/expat-2.1.0/libexpat.a DESTINATION ${LIBINSTALLEXT})
+IF(NOT TARGET omc::3rd::FMIL::expat)
+  install(FILES ../../../3rdParty/FMIL/build/ThirdParty/Expat/expat-2.1.0/libexpat.a DESTINATION ${LIBINSTALLEXT})
+ENDIF(NOT TARGET omc::3rd::FMIL::expat)
 
 install(FILES
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_event_helper.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_getters_and_setters.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_global.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_initialization.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_input_json.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_input_model_variables.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_input_sim_data.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_input_xml.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_mmap.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_posix_func.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_solve_alg_system.h
-  ${CMAKE_SOURCE_DIR}/base/include/omsi_utils.h
-  ${CMAKE_SOURCE_DIR}/base/include/uthash.h
+  include/omsi_event_helper.h
+  include/omsi_getters_and_setters.h
+  include/omsi_global.h
+  include/omsi_initialization.h
+  include/omsi_input_json.h
+  include/omsi_input_model_variables.h
+  include/omsi_input_sim_data.h
+  include/omsi_input_xml.h
+  include/omsi_mmap.h
+  include/omsi_posix_func.h
+  include/omsi_solve_alg_system.h
+  include/omsi_utils.h
+  include/uthash.h
   DESTINATION include/omc/omsi/base)

--- a/OMCompiler/SimulationRuntime/OMSI/solver/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSI/solver/CMakeLists.txt
@@ -1,8 +1,9 @@
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
+SET(CMAKE_VERBOSE_MAKEFILE ON)
+
 #OpenModelica Simulation Interface solver
 PROJECT(OMSISolver)
-SET(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Global Variables
 IF(NOT OMCTRUNCHOME)
@@ -38,74 +39,77 @@ ENDIF(MSVC)
 ############################
 # Find SUNDIALS  libraries #
 ############################
-IF(MSVC)
-  SET(SUNDIALS_PATH ${OMCTRUNCHOME}/OMCompiler/3rdParty/sundials-5.4.0/build_msvc)
-ELSE(MSVC)
-  # Shouldn't this point to the build directory with the installed libraries?
-  SET(SUNDIALS_PATH ${OMCTRUNCHOME}/OMCompiler/3rdParty/sundials-5.4.0/build)
-ENDIF(MSVC)
-GET_FILENAME_COMPONENT(SUNDIALS_PATH "${SUNDIALS_PATH}" ABSOLUTE)
-MESSAGE(STATUS "Sundials PATH:")
-MESSAGE(STATUS "${SUNDIALS_PATH}")
 
-file(GLOB
-  SUNDIALS_POTENTIAL_LIBS
-  LIST_DIRECTORIES true
-  ${SUNDIALS_PATH}/lib*/* ${SUNDIALS_PATH}/lib*
-)
+# Fallback for "standalone" makefile build
+# TODO: Remove when switching to CMake build
+if(NOT TARGET omc::3rd::sundials::kinsol)
+  IF(MSVC)
+    SET(SUNDIALS_PATH ${OMCTRUNCHOME}/OMCompiler/3rdParty/sundials-5.4.0/build_msvc)
+  ELSE(MSVC)
+    # Shouldn't this point to the build directory with the installed libraries?
+    SET(SUNDIALS_PATH ${OMCTRUNCHOME}/OMCompiler/3rdParty/sundials-5.4.0/build)
+  ENDIF(MSVC)
+  GET_FILENAME_COMPONENT(SUNDIALS_PATH "${SUNDIALS_PATH}" ABSOLUTE)
+  MESSAGE(STATUS "Sundials PATH:")
+  MESSAGE(STATUS "${SUNDIALS_PATH}")
 
-FIND_PATH(SUNDIALS_LIB_DIR NAMES sundials_nvecserial libsundials_nvecserial sundials_nvecserial.dll libsundials_nvecserial.so sundials_nvecserial.a libsundials_nvecserial.a sundials_nvecserial.lib PATHS ${SUNDIALS_POTENTIAL_LIBS} )
+  file(GLOB
+    SUNDIALS_POTENTIAL_LIBS
+    LIST_DIRECTORIES true
+    ${SUNDIALS_PATH}/lib*/* ${SUNDIALS_PATH}/lib*
+  )
 
-MESSAGE(STATUS "Sundials libs:")
-MESSAGE(STATUS "${SUNDIALS_LIB_DIR}")
+  FIND_PATH(SUNDIALS_LIB_DIR NAMES sundials_nvecserial libsundials_nvecserial sundials_nvecserial.dll libsundials_nvecserial.so sundials_nvecserial.a libsundials_nvecserial.a sundials_nvecserial.lib PATHS ${SUNDIALS_POTENTIAL_LIBS} )
 
-# SUNDIALS Header
-FIND_PATH(SUNDIALS_INCLUDE_DIR "sundials/sundials_config.h" ${SUNDIALS_PATH}/include/sundials NO_DEFAULT_PATH)
+  MESSAGE(STATUS "Sundials libs:")
+  MESSAGE(STATUS "${SUNDIALS_LIB_DIR}")
 
-MESSAGE(STATUS "Sundials include:")
-MESSAGE(STATUS "${SUNDIALS_INCLUDE_DIR}")
-INCLUDE_DIRECTORIES(${SUNDIALS_INCLUDE_DIR})
+  # SUNDIALS Header
+  FIND_PATH(SUNDIALS_INCLUDE_DIR "sundials/sundials_config.h" ${SUNDIALS_PATH}/include/sundials NO_DEFAULT_PATH)
 
-# SUNDIALS Libraires
-FIND_LIBRARY(SUNDIALS_LIBRARY_NVEC    NAMES sundials_nvecserial    PATHS ${SUNDIALS_LIB_DIR})
-FIND_LIBRARY(SUNDIALS_KINSOL          NAMES sundials_kinsol        PATHS ${SUNDIALS_LIB_DIR})
+  MESSAGE(STATUS "Sundials include:")
+  MESSAGE(STATUS "${SUNDIALS_INCLUDE_DIR}")
+  INCLUDE_DIRECTORIES(${SUNDIALS_INCLUDE_DIR})
 
-# Check if all libraries found
-IF(NOT SUNDIALS_LIBRARY_NVEC)
-  MESSAGE(FATAL_ERROR "Could not find libsundials_nvecserial!")
-ENDIF()
-IF(NOT SUNDIALS_KINSOL)
-  MESSAGE(FATAL_ERROR "Could not find libsundials_kinsol!")
-ENDIF()
+  # SUNDIALS Libraires
+  FIND_LIBRARY(SUNDIALS_LIBRARY_NVEC    NAMES sundials_nvecserial    PATHS ${SUNDIALS_LIB_DIR})
+  FIND_LIBRARY(SUNDIALS_KINSOL          NAMES sundials_kinsol        PATHS ${SUNDIALS_LIB_DIR})
 
-SET(SUNDIALS_LIBRARIES ${SUNDIALS_LIBRARY_NVEC} ${SUNDIALS_KINSOL})
-MESSAGE(STATUS "Used Sundials libraries: ${SUNDIALS_LIBRARIES}")
+  # Check if all libraries found
+  IF(NOT SUNDIALS_LIBRARY_NVEC)
+    MESSAGE(FATAL_ERROR "Could not find libsundials_nvecserial!")
+  ENDIF()
+  IF(NOT SUNDIALS_KINSOL)
+    MESSAGE(FATAL_ERROR "Could not find libsundials_kinsol!")
+  ENDIF()
 
-# Extract the version number from sundials_config.h
-SET(SUNDIALS_CONFIG_FILE "${SUNDIALS_INCLUDE_DIR}/sundials/sundials_config.h")
-IF(NOT EXISTS "${SUNDIALS_CONFIG_FILE}")
-  MESSAGE(FATAL_ERROR "Could not find sundials_config.h")
-ENDIF()
-FILE(READ "${SUNDIALS_CONFIG_FILE}" SUNDIALS_CONFIG_FILE_CONTENT)
-STRING(REGEX MATCH "#define SUNDIALS_VERSION .([0-9]+)\\.([0-9]+)\\.([0-9]+)." _ ${SUNDIALS_CONFIG_FILE_CONTENT})
+  SET(SUNDIALS_LIBRARIES ${SUNDIALS_LIBRARY_NVEC} ${SUNDIALS_KINSOL})
+  MESSAGE(STATUS "Used Sundials libraries: ${SUNDIALS_LIBRARIES}")
 
-IF(DEFINED CMAKE_MATCH_1 AND DEFINED CMAKE_MATCH_2 AND DEFINED CMAKE_MATCH_3)
-  SET(SUNDIALS_MAJOR_VERSION "${CMAKE_MATCH_1}")
-  SET(SUNDIALS_MINOR_VERSION "${CMAKE_MATCH_2}")
-  SET(SUNDIALS_PATCH_VERSION "${CMAKE_MATCH_3}")
+  # Extract the version number from sundials_config.h
+  SET(SUNDIALS_CONFIG_FILE "${SUNDIALS_INCLUDE_DIR}/sundials/sundials_config.h")
+  IF(NOT EXISTS "${SUNDIALS_CONFIG_FILE}")
+    MESSAGE(FATAL_ERROR "Could not find sundials_config.h")
+  ENDIF()
+  FILE(READ "${SUNDIALS_CONFIG_FILE}" SUNDIALS_CONFIG_FILE_CONTENT)
+  STRING(REGEX MATCH "#define SUNDIALS_VERSION .([0-9]+)\\.([0-9]+)\\.([0-9]+)." _ ${SUNDIALS_CONFIG_FILE_CONTENT})
 
-  ADD_DEFINITIONS("-DSUNDIALS_MAJOR_VERSION=${SUNDIALS_MAJOR_VERSION}")
-  ADD_DEFINITIONS("-DSUNDIALS_MINOR_VERSION=${SUNDIALS_MINOR_VERSION}")
-ELSE()
-  MESSAGE(FATAL_ERROR "Could not determine sundials version")
-ENDIF()
-MESSAGE(STATUS "Using sundials ${SUNDIALS_MAJOR_VERSION}.${SUNDIALS_MINOR_VERSION}.${SUNDIALS_PATCH_VERSION}")
+  IF(DEFINED CMAKE_MATCH_1 AND DEFINED CMAKE_MATCH_2 AND DEFINED CMAKE_MATCH_3)
+    SET(SUNDIALS_MAJOR_VERSION "${CMAKE_MATCH_1}")
+    SET(SUNDIALS_MINOR_VERSION "${CMAKE_MATCH_2}")
+    SET(SUNDIALS_PATCH_VERSION "${CMAKE_MATCH_3}")
 
+    ADD_DEFINITIONS("-DSUNDIALS_MAJOR_VERSION=${SUNDIALS_MAJOR_VERSION}")
+    ADD_DEFINITIONS("-DSUNDIALS_MINOR_VERSION=${SUNDIALS_MINOR_VERSION}")
+  ELSE()
+    MESSAGE(FATAL_ERROR "Could not determine sundials version")
+  ENDIF()
+  MESSAGE(STATUS "Using sundials ${SUNDIALS_MAJOR_VERSION}.${SUNDIALS_MINOR_VERSION}.${SUNDIALS_PATCH_VERSION}")
+endif(NOT TARGET omc::3rd::sundials::kinsol)
 
 ####################################
 # OMSISolver includes
 ####################################
-include_directories ("${CMAKE_SOURCE_DIR}/solver/include" ${SUNDIALS_INCLUDE_DIR})
 
 add_library(${OMSISolverName}
   src/solver_api.c
@@ -114,14 +118,28 @@ add_library(${OMSISolverName}
   src/solver_lapack.c
 )
 
+target_include_directories(${OMSISolverName} PUBLIC include)
+if(NOT TARGET omc::3rd::sundials::kinsol)
+  target_include_directories(${OMSISolverName} PUBLIC ${SUNDIALS_INCLUDE_DIR})
+endif()
+
 set(CMAKE_MACOSX_RPATH 1)   # Handle rpath on mac in makefiles
-target_link_libraries(${OMSISolverName} ${CMAKE_DL_LIBS} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${SUNDIALS_LIBRARIES})
+
+target_link_libraries(${OMSISolverName} INTERFACE ${CMAKE_DL_LIBS})
+target_link_libraries(${OMSISolverName} PUBLIC ${LAPACK_LIBRARIES})
+if(TARGET omc::3rd::sundials::kinsol)
+  target_link_libraries(${OMSISolverName} PUBLIC omc::3rd::sundials::kinsol)
+  target_link_libraries(${OMSISolverName} PUBLIC omc::3rd::sundials::sunlinsolklu)
+  target_link_libraries(${OMSISolverName} PUBLIC omc::3rd::sundials::sunlinsollapackdense)
+else()
+  target_link_libraries(${OMSISolverName} PUBLIC ${SUNDIALS_LIBRARIES})
+endif()
+
 
 install(TARGETS ${OMSISolverName} DESTINATION ${LIBINSTALLEXT})
 
 install(FILES
-  ${CMAKE_SOURCE_DIR}/solver/include/omsi_solver.h
-  ${CMAKE_SOURCE_DIR}/solver/include/solver_api.h
-  ${CMAKE_SOURCE_DIR}/solver/include/solver_helper.h
+  include/omsi_solver.h
+  include/solver_api.h
+  include/solver_helper.h
 DESTINATION include/omc/omsi/solver)
-


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/14387

### Purpose

- First step in switching OMSI to pure CMake build.

### Approach

- Adding fallback for Autoconf+Makefile build for finding sundials and expat.
- Updating CMake minimum version to 3.14.
