### PR TITLE
Adding armhf CI build option to Jenkins

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -529,6 +529,14 @@ def shouldWeBuildUCRT() {
   return params.BUILD_MSYS2_UCRT64
 }
 
+def shouldWeBuildARMHF() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/Build DEBIAN-ARMHF")) {
+      return true
+    }
+  }
+}
+
 def shouldWeDisableAllCMakeBuilds() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Disable/All")) {

--- a/.CI/toolchain/toolchain.armhf.cmake
+++ b/.CI/toolchain/toolchain.armhf.cmake
@@ -11,6 +11,10 @@ set(CMAKE_FIND_ROOT_PATH
   /usr/lib/arm-linux-gnueabihf
   /usr/include/arm-linux-gnueabihf)
 
+# Set path to FindBoost.cmake
+set(Boost_DIR
+  /usr/lib/arm-linux-gnueabihf/cmake/Boost-1.74.0/)
+
 # Only search in target paths for libraries and includes
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/.CI/toolchain/toolchain.armhf.cmake
+++ b/.CI/toolchain/toolchain.armhf.cmake
@@ -1,0 +1,22 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Specify the cross compiler
+set(CMAKE_C_COMPILER   arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+set(CMAKE_Fortran_COMPILER arm-linux-gnueabihf-gfortran)
+
+# Set the search paths for libraries and includes
+set(CMAKE_FIND_ROOT_PATH
+  /usr/lib/arm-linux-gnueabihf
+  /usr/include/arm-linux-gnueabihf)
+
+# Only search in target paths for libraries and includes
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# FFI tests binaries break when cross-compiling
+set(HAVE_MMAP_DEV_ZERO 0)
+set(HAVE_ALLOCA 0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,6 @@ pipeline {
                 -DOM_OMC_ENABLE_CPP_RUNTIME=OFF \
                 -DOM_OMC_ENABLE_MOO=OFF \
                 -DOM_OMC_ENABLE_OPTIMIZATION=OFF \
-                -DOM_OMC_ENABLE_PARMODELICA=OFF \
                 -DOM_OMC_ENABLE_FORTRAN=OFF \
                 -DNEED_FORTRAN_NAME_MANGLING=OFF \
                 -DOM_ENABLE_GUI_CLIENTS=OFF \

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -36,9 +36,6 @@ omc_option(OM_OMC_USE_CORBA "Should use corba." OFF)
 
 omc_option(OM_OMC_USE_LAPACK "Should we use lapack." ON)
 
-omc_option(OM_OMC_ENABLE_PARMODELICA "Enable ParModelica runtime." ON)
-
-
 # Remove -DNDEBUG from release build command lines. The reason is that -DNDEBUG completely
 # removes assert(...) statements. We have some assert statements with side effects. Of course,
 # these should be removed and the flag enabled so that we can benefit from removing asserts from

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -36,6 +36,8 @@ omc_option(OM_OMC_USE_CORBA "Should use corba." OFF)
 
 omc_option(OM_OMC_USE_LAPACK "Should we use lapack." ON)
 
+omc_option(OM_OMC_ENABLE_PARMODELICA "Enable ParModelica runtime." ON)
+
 
 # Remove -DNDEBUG from release build command lines. The reason is that -DNDEBUG completely
 # removes assert(...) statements. We have some assert statements with side effects. Of course,

--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -19,10 +19,9 @@ endif()
 
 # ParModelica
 # Disable for MSVC. There are some issues with Boost which need to be fixed.
-if(NOT MSVC)
+if(OM_OMC_ENABLE_PARMODELICA AND NOT MSVC)
   omc_add_subdirectory(ParModelica)
 endif()
 
 #ADD_SUBDIRECTORY(cpp)
 #ADD_SUBDIRECTORY(interactive)
-

--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 # ParModelica
 # Disable for MSVC. There are some issues with Boost which need to be fixed.
-if(OM_OMC_ENABLE_PARMODELICA AND NOT MSVC)
+if(NOT MSVC)
   omc_add_subdirectory(ParModelica)
 endif()
 


### PR DESCRIPTION
### Related Issues

I introduced some build error for 32-bit ARM build in https://github.com/OpenModelica/OpenModelica/pull/14464#issuecomment-3400852265. To make it simpler to check if a commit breaks/fixes 32-bit ARM builds add a CI option to build omc on Debian Bookworm armhf by adding label `CI/Build DEBIAN-ARMHF` to the PR.

### Purpose

Add option to build omc on armfh.

### Approach

- Adding new build stage `bookworm-armhf-cmake-clang` to CI, activated by setting label `CI/Build DEBIAN-ARMHF`.
  - Added new toolchain file `toolchain-arm-linux-gnueabihf.cmake`  for CMake build of this.
  - Cross compiler for `arm-linux-gnueabihf`
