### PR TITLE
[FMI] Fix memory allocation alias variables

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1559,10 +1559,6 @@ template populateModelInfo(ModelInfo modelInfo, String fileNamePrefix, String gu
     data->modelData->nParametersInteger = <%varInfo.numIntParams%>;
     data->modelData->nParametersBoolean = <%varInfo.numBoolParams%>;
     data->modelData->nParametersString = <%varInfo.numStringParamVars%>;
-    data->modelData->nAliasRealArray = <%varInfo.numAlgAliasVars%>;
-    data->modelData->nAliasIntegerArray = <%varInfo.numIntAliasVars%>;
-    data->modelData->nAliasBooleanArray = <%varInfo.numBoolAliasVars%>;
-    data->modelData->nAliasStringArray = <%varInfo.numStringAliasVars%>;
     data->modelData->nInputVars = <%varInfo.numInVars%>;
     data->modelData->nOutputVars = <%varInfo.numOutVars%>;
     data->modelData->nZeroCrossings = <%varInfo.numZeroCrossings%>;

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -964,7 +964,7 @@ void read_input_xml(MODEL_DATA* modelData,
   simulationInfo->OPENMODELICAHOME = GC_strdup(findHashStringString(mi->md,"OPENMODELICAHOME")); // Can be set by generated code
   infoStreamPrint(OMC_LOG_SIMULATION, 0, "OPENMODELICAHOME: %s", simulationInfo->OPENMODELICAHOME);
 
-  allocModelDataVars(modelData, threadData);
+  allocModelDataVars(modelData, TRUE, threadData);
 
   read_variables(simulationInfo, T_REAL,    modelData->realVarsData,         mi->rSta, "real states",            0,                    modelData->nStatesArray,                               &mapAlias,      &mapAliasParam, &sensitivityParIndex);
   read_variables(simulationInfo, T_REAL,    modelData->realVarsData,         mi->rDer, "real state derivatives", modelData->nStatesArray,   modelData->nStatesArray,                               &mapAlias,      &mapAliasParam, &sensitivityParIndex);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -66,7 +66,7 @@ extern double homTauMin;
 extern double homTauStart;
 extern int homBacktraceStrategy;
 
-void allocModelDataVars(MODEL_DATA* modelData, threadData_t* threadData);
+void allocModelDataVars(MODEL_DATA* modelData, modelica_boolean allocAlias, threadData_t* threadData);
 
 void freeModelDataVars(MODEL_DATA* modelData);
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -638,7 +638,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
    * to handle model that have startTime > 0 (e.g) startTime = 0.2
    */
   comp->fmuData->callback->read_simulation_info(comp->fmuData->simulationInfo);
-  allocModelDataVars(comp->fmuData->modelData, comp->threadData);
+  allocModelDataVars(comp->fmuData->modelData, FALSE, comp->threadData);
   calculateAllScalarLength(comp->fmuData->modelData);
 
   /* setup model data with default start data */

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -28,6 +28,7 @@ fmi_attributes_24.mos \
 fmi_attributes_25.mos \
 fmiFilterTest.mos \
 FMUResourceTest.mos \
+ModelWithAlias.mos \
 QuotedIdentifierExport.mos \
 RealFFT1.mos \
 testBug2764.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ModelWithAlias.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ModelWithAlias.mos
@@ -1,0 +1,75 @@
+// name:     ModelWithAlias
+// keywords: fmu export simulation alias
+// status: correct
+// teardown_command: rm -rf index.html model_res.mat ModelWithAlias.log ModelWithAlias_* ModelWithAlias_tmp.xml ModelWithAlias.fmu ModelWithAlias_me_systemCall.log ModelWithAlias-tmp/
+// cflags: -d=-newInst
+//
+// Export of 2.0 ME FMU with alias variables.
+// For issue https://github.com/OpenModelica/OpenModelica/issues/14513
+// Alias variables aren't used by the C FMI runtime.
+
+loadString("
+model ModelWithAlias
+  Real x (start=1, fixed=true);
+  Real y;
+equation
+  x = y;
+  der(x) = -x;
+end ModelWithAlias;
+"); getErrorString();
+
+buildModelFMU(ModelWithAlias, version="2.0", fmuType="me", platforms={"dynamic"}); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq ModelWithAlias.fmu modelDescription.xml > ModelWithAlias_tmp.xml"); getErrorString();
+
+system("sed -i -n '/<ModelVariables/,/<\\/ModelVariables>/p' ModelWithAlias_tmp.xml"); getErrorString();
+readFile("ModelWithAlias_tmp.xml"); getErrorString();
+
+// Simulate with OMSimulator
+system(getInstallationDirectoryPath() + "/bin/OMSimulator ModelWithAlias.fmu --mode=me --stopTime=0.0 --suppressPath=true --tempDir=\"ModelWithAlias-tmp\"", "ModelWithAlias_me_systemCall.log"); getErrorString();
+readFile("ModelWithAlias_me_systemCall.log");
+
+// Result:
+// true
+// ""
+// "ModelWithAlias.fmu"
+// ""
+// 0
+// ""
+// 0
+// ""
+// "  <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"x\"
+//     valueReference=\"0\"
+//     initial=\"exact\">
+//     <Real start=\"1.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"der(x)\"
+//     valueReference=\"1\"
+//     >
+//     <Real derivative=\"1\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"y\"
+//     valueReference=\"0\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   </ModelVariables>
+// "
+// ""
+// 0
+// ""
+// "info:    maximum step size for 'model.root': 0.002000
+// info:    Result file: model_res.mat (bufferSize=10)
+// info:    Final Statistics for 'model.root':
+//          NumSteps = 0 NumRhsEvals  = 0 NumLinSolvSetups = 0
+//          NumNonlinSolvIters = 0 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/index.html
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/index.html
@@ -1,5 +1,0 @@
-
-<h1>fmi_attributes_15</h1>
-<p> <i></i> </p>
-<h4> <u> Information </u> </h4>
-<h4> <u> Revisions </u> </h4>


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14513.
Issue was caused by https://github.com/OpenModelica/OpenModelica/issues/14453.

### Purpose

- Fix memory allocation with uninitialized number of alias variables

### Approach

- Don't write number of alias variables to C files anymore.
  - The C runtime reads this information from init XML file.
  - The FMI runtime doesn't use alias variables at all, so the info isn't needed.
- Don't allocate memory for alias variable static data in FMI case.
- Check if alias data is NULL before trying to free its members.
