### PR TITLE
Fixing some warnings for wrong format

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
+++ b/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
@@ -678,7 +678,7 @@ void solver_print_data (solver_data*    solver,
 
     length = 0;
     if (header) {
-        length += snprintf(buffer, MAX_BUFFER_SIZE-length, header);
+        length += snprintf(buffer, MAX_BUFFER_SIZE-length, "%s", header);
         length += snprintf(buffer+length, MAX_BUFFER_SIZE-length, "\n");
     }
     length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
@@ -709,20 +709,20 @@ void solver_print_data (solver_data*    solver,
     }
 
     length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-            "\t solver_callbacks set: \t\t %s \t ( Address: %x )\n", solver->solver_callbacks?"yes":"no", solver->solver_callbacks);
+            "\t solver_callbacks set: \t\t %s \t ( Address: %p )\n", solver->solver_callbacks?"yes":"no", solver->solver_callbacks);
     switch (solver->linear) {
         case solver_true:
             lin_callbacks = solver->solver_callbacks;
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_A_element set: \t %s \t ( Address: %x )\n", lin_callbacks->get_A_element?"yes":"no", lin_callbacks->get_A_element);
+                    "\t\t get_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_A_element?"yes":"no", (void*) lin_callbacks->get_A_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_A_element set: \t %s \t ( Address: %x )\n", lin_callbacks->set_A_element?"yes":"no", lin_callbacks->set_A_element);
+                    "\t\t set_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_A_element?"yes":"no", (void*) lin_callbacks->set_A_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_b_element set: \t %s \t ( Address: %x )\n", lin_callbacks->get_b_element?"yes":"no", lin_callbacks->get_b_element);
+                    "\t\t get_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_b_element?"yes":"no", (void*) lin_callbacks->get_b_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_b_element set: \t %s \t ( Address: %x )\n", lin_callbacks->set_b_element?"yes":"no", lin_callbacks->set_b_element);
+                    "\t\t set_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_b_element?"yes":"no", (void*) lin_callbacks->set_b_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t solve_eq_system set: \t %s \t ( Address: %x )\n", lin_callbacks->solve_eq_system?"yes":"no", lin_callbacks->solve_eq_system);
+                    "\t\t solve_eq_system set: \t %s \t ( Address: %p )\n", lin_callbacks->solve_eq_system?"yes":"no", (void*) lin_callbacks->solve_eq_system);
             break;
         default:
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -219,6 +219,7 @@ static const double INTEGER_MAX = (double)MODELICA_INT_MAX;
 /* Private function prototypes */
 static modelica_real read_value_real(const char *s, modelica_real default_value);
 static modelica_integer read_value_long(const char *s, modelica_integer default_value);
+static int read_value_int(const char *s, int default_value);
 static modelica_boolean read_value_bool(const char *s);
 static modelica_string read_value_string(const char *s);
 
@@ -396,7 +397,7 @@ static void read_var_info(omc_ModelVariable *var, VAR_INFO *info)
 {
   info->name = strdup(findHashStringString(var,"name"));
   info->inputIndex = read_value_long(findHashStringStringNull(var,"inputIndex"), -1);
-  info->id = read_value_long(findHashStringString(var,"valueReference"), -1);
+  info->id = read_value_int(findHashStringString(var,"valueReference"), -1);
   assertStreamPrint(NULL, info->id != -1, "read_var_info: Missing valueReference!");
   info->comment = strdup(findHashStringStringEmpty(var,"description"));
   info->info.filename = strdup(findHashStringString(var,"fileName"));
@@ -435,11 +436,18 @@ static void read_var_dimension(omc_ModelVariable *v, DIMENSION_INFO *dimension_i
   char* key;
   int len;
   DIMENSION_ATTRIBUTE* dim;
+  modelica_integer numDimensions;
   modelica_integer i;
 
-  dimension_info->numberOfDimensions = read_value_long(findHashStringStringEmpty(v, "num_dimensions"), -1);
-  if (dimension_info->numberOfDimensions <= 0) {
+  numDimensions = read_value_long(findHashStringStringEmpty(v, "num_dimensions"), 0);
+  if (numDimensions < 0) {
+    throwStreamPrint(NULL, "Illegal value while parsing 'num_dimensions'. Expected positive number.");
+  }
+  dimension_info->numberOfDimensions = (size_t) numDimensions;
+  if (dimension_info->numberOfDimensions == 0) {
     // No <dimension> tags
+    dimension_info->dimensions = NULL;
+    dimension_info->scalar_length = 1;
     return;
   }
 
@@ -1045,6 +1053,28 @@ static inline modelica_integer read_value_long(const char *s, modelica_integer d
     return 0;
   } else {
     return atol(s);
+  }
+}
+
+/**
+ * @brief Read int value from string.
+ *
+ * @param s                   Null terminated string to read.
+ *                            Treat string value `"true"` as `1` and `"false"`
+ *                            as `0`.
+ * @param default_value       Default value if string is empty.
+ * @return modelica_integer   Integer.
+ */
+static inline int read_value_int(const char *s, int default_value)
+{
+  if (s == NULL || *s == '\0') {
+    return default_value;
+  } else if (0 == strcmp(s, "true")) {
+    return 1;
+  } else if (0 == strcmp(s, "false")) {
+    return 0;
+  } else {
+    return atoi(s);
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -73,8 +73,8 @@ typedef int (*initialAnalyticalJacobian_func_ptr)(DATA* data, threadData_t* thre
 /* Model info structures */
 typedef struct VAR_INFO
 {
-  long id;
-  int inputIndex; /* -1 means not an input */
+  int id;               /* -1 if no value reference set */
+  int inputIndex;       /* -1 means not an input */
   const char *name;
   const char *comment;
   FILE_INFO info;


### PR DESCRIPTION
### Related Issues

I introduced some format warnings in https://github.com/OpenModelica/OpenModelica/pull/14498.
Fixing them.

### Purpose

- Fix new warnings.
- Fix some OMSI warning while I'm on it.

### Approach

- Changed `VAR_INFO.id` back to `int`.  It matches the types of IDs of equations and functions.
- Re-added `read_value_int` for XML parsing.
