### PR TITLE
Fix Expression.sizeOf for empty records

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -272,7 +272,7 @@ algorithm
   end if;
 
   //(var_count, eq_count) := CheckModel.checkModel(flatModel);
-  //print(name + " has " + String(var_count) + " variable(s) and " + String(eq_count) + " equation(s).\n");
+  //print(AbsynUtil.pathString(classPath) + " has " + String(var_count) + " variable(s) and " + String(eq_count) + " equation(s).\n");
 
   clearCaches();
 end instClassInProgram;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1450,7 +1450,7 @@ public
       case CLOCK() then 1;
       case ENUMERATION() then 1;
       case ARRAY() then sizeOf(ty.elementType) * Dimension.sizesProduct(ty.dimensions, resize);
-      case TUPLE() then List.fold(list(sizeOf(t) for t in ty.types), intAdd, 0);
+      case TUPLE() then sum(sizeOf(t) for t in ty.types);
       case COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT()) then 1;
       case COMPLEX(complexTy = ComplexType.RECORD())
         then ClassTree.foldComponents(Class.classTree(InstNode.getClass(ty.cls)), fold_comp_size, 0);


### PR DESCRIPTION
- Change `Expression.sizeOf` to use `sum` instead of `List.reduce` when counting variables in a record, since `List.reduce` fails on an empty list.