### PR TITLE
Initialize number of alias vars

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1559,6 +1559,10 @@ template populateModelInfo(ModelInfo modelInfo, String fileNamePrefix, String gu
     data->modelData->nParametersInteger = <%varInfo.numIntParams%>;
     data->modelData->nParametersBoolean = <%varInfo.numBoolParams%>;
     data->modelData->nParametersString = <%varInfo.numStringParamVars%>;
+    data->modelData->nAliasRealArray = <%varInfo.numAlgAliasVars%>;
+    data->modelData->nAliasIntegerArray = <%varInfo.numIntAliasVars%>;
+    data->modelData->nAliasBooleanArray = <%varInfo.numBoolAliasVars%>;
+    data->modelData->nAliasStringArray = <%varInfo.numStringAliasVars%>;
     data->modelData->nInputVars = <%varInfo.numInVars%>;
     data->modelData->nOutputVars = <%varInfo.numOutVars%>;
     data->modelData->nZeroCrossings = <%varInfo.numZeroCrossings%>;


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14531.

### Purpose

- Fix usage of uninitialized number of alias variables on aarch64. Bug was introduced in https://github.com/OpenModelica/OpenModelica/pull/14464.
- Only used for FMI and there it should always be zero, since FMUs don't
  use alias variables internally.

### Approach

- Generate C code to initialize number of array variables.

