### PR TITLE
[FMI] Fix FMI RunimeSources.mo CMinpack headers

### DIFF
--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -214,16 +214,14 @@ string(REPLACE ";" "," SOURCE_FMU_NLS_FILES "${SOURCE_FMU_NLS_FILES_LIST_QUOTED}
 
 
 # CMinPack files for NLS
-set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/hybrj_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dpmpar_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qrfac_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qform_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dogleg_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1updt_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c)
+set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/hybrj_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dpmpar_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qrfac_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qform_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dogleg_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1updt_.c
+                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c)
 
 set(3RD_CMINPACK_HEADERS  ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
                           ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h

--- a/testsuite/special/FmuExportCrossCompile/fmuExportCrossCompile.mos
+++ b/testsuite/special/FmuExportCrossCompile/fmuExportCrossCompile.mos
@@ -62,26 +62,13 @@ end FmuExportCrossCompile;") then
 end if;
 getErrorString();
 
-platforms := if false then {
-  "x86_64-apple-darwin15 docker run -e CROSS_TRIPLE=x86_64-apple-darwin multiarch/crossbuild",
-  "arm-linux-gnueabihf docker run -e CROSS_TRIPLE=arm-linux-gnueabihf multiarch/crossbuild",
-  "x86_64-linux-gnu docker run multiarch/crossbuild",
-  "i686-linux-gnu docker run multiarch/crossbuild",
-  "x86_64-w64-mingw32 docker run -e CROSS_TRIPLE=x86_64-w64-mingw32 multiarch/crossbuild",
-  "i686-w64-mingw32 docker run -e CROSS_TRIPLE=i686-w64-mingw32 multiarch/crossbuild"
-} else if true then {
+platforms := {
   "x86_64-apple-darwin15 docker run docker.openmodelica.org/osxcross-omsimulator:v2.0",
   "arm-linux-gnueabihf docker run docker.openmodelica.org/armcross-omsimulator:v2.0",
   "x86_64-linux-gnu docker run docker.openmodelica.org/build-deps:v1.13",
   "i686-linux-gnu docker run docker.openmodelica.org/build-deps:v1.13-i386",
   "x86_64-w64-mingw32 docker run docker.openmodelica.org/msyscross-omsimulator:v2.0",
   "i686-w64-mingw32 docker run docker.openmodelica.org/msyscross-omsimulator:v2.0"
-} else {
-  "arm-linux-gnueabihf",
-  "x86_64-linux-gnu",
-  "i686-linux-gnu",
-  "x86_64-w64-mingw32",
-  "i686-w64-mingw32"
 };
 
 for c in {"FmuExportCrossCompile","RoomHeating_OM.RH","WaterTank.Control","WaterTank.TestSingleWaterTank","BouncingBall"} loop


### PR DESCRIPTION
### Related Issues

I'm trying to fix the last issue in https://github.com/OpenModelica/OpenModelica/pull/14538. But when trying to reproduce the issue on my machine I noticed that the CMake build behaves differently than then Autoconf+Makefile build on Jenkins.

### Purpose

- When OpenModelica is build with CMake the list of runtime cminpack source fiels contained CMinpack header files.
- This breaks the FMU compilation on some OS if CMinpack is needed.

### Approach

- Remove header files from `3RD_CMINPACK_FMU_FILES`
