### PR TITLE
Disable prefix units by default in OMPlot

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -314,6 +314,7 @@ void PlotWindowContainer::addPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setCanHavePrefixUnits(true);
     pPlotWindow->setPrefixUnits(OptionsDialog::instance()->getPlottingPage()->getPrefixUnitsCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
     pPlotWindow->setXLabel(QString("time"));
@@ -351,6 +352,7 @@ void PlotWindowContainer::addParametricPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setCanHavePrefixUnits(true);
     pPlotWindow->setPrefixUnits(OptionsDialog::instance()->getPlottingPage()->getPrefixUnitsCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
     pPlotWindow->installEventFilter(this);
@@ -387,6 +389,7 @@ void PlotWindowContainer::addArrayPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setCanHavePrefixUnits(true);
     pPlotWindow->setPrefixUnits(OptionsDialog::instance()->getPlottingPage()->getPrefixUnitsCheckbox()->isChecked());
     QComboBox* unitComboBox = MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox();
     if (unitComboBox->currentText() == ""){
@@ -433,6 +436,7 @@ PlotWindow* PlotWindowContainer::addInteractivePlotWindow(QString owner, int por
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setCanHavePrefixUnits(true);
     pPlotWindow->setPrefixUnits(OptionsDialog::instance()->getPlottingPage()->getPrefixUnitsCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
     pPlotWindow->setXLabel(QString("time"));
@@ -473,6 +477,7 @@ void PlotWindowContainer::addArrayParametricPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setCanHavePrefixUnits(true);
     pPlotWindow->setPrefixUnits(OptionsDialog::instance()->getPlottingPage()->getPrefixUnitsCheckbox()->isChecked());
     QComboBox* unitComboBox = MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox();
     if (unitComboBox->currentText() == ""){

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -174,7 +174,6 @@ void PlotWindow::initializePlot(QStringList arguments)
   setYRightCustomLabel(getYRightLabel());
   setYRightRange(QString(arguments[20]).toDouble(), QString(arguments[21]).toDouble());
   setTimeUnit("");
-  setPrefixUnits(true);
   /* read variables */
   QStringList variablesToRead;
   for(int i = 22; i < arguments.length(); i++)
@@ -2293,7 +2292,8 @@ SetupDialog::SetupDialog(PlotWindow *pPlotWindow)
   mpYRightMinimumTextBox->setValidator(pDoubleValidator);
   mpYRightMaximumTextBox->setValidator(pDoubleValidator);
   mpPrefixUnitsCheckbox = new QCheckBox(tr("Prefix Units"));
-  mpPrefixUnitsCheckbox->setChecked(mpPlotWindow->getPrefixUnits());
+  mpPrefixUnitsCheckbox->setChecked(mpPlotWindow->getPrefixUnits() && mpPlotWindow->canHavePrefixUnits());
+  mpPrefixUnitsCheckbox->setEnabled(mpPlotWindow->canHavePrefixUnits());
   // range tab layout
   QVBoxLayout *pRangeTabVerticalLayout = new QVBoxLayout;
   pRangeTabVerticalLayout->setAlignment(Qt::AlignTop);

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -119,7 +119,8 @@ private:
 	int mInteractivePort;
 	QwtSeriesData<QPointF>* mpInteractiveData;
 	QString mInteractiveModelName;
-	bool mPrefixUnits;
+    bool mCanHavePrefixUnits = false;
+    bool mPrefixUnits = false;
 	QMdiSubWindow* mpSubWindow;
 public:
 	PlotWindow(QStringList arguments = QStringList(), QWidget* parent = 0, bool isInteractiveSimulation = false, int toolbarIconSize = 0);
@@ -207,6 +208,8 @@ public:
   QString getLegendPosition();
   void setFooter(QString footer);
   QString getFooter();
+  bool canHavePrefixUnits() const { return mCanHavePrefixUnits; }
+  void setCanHavePrefixUnits(bool canHavePrefixUnits) { mCanHavePrefixUnits = canHavePrefixUnits; }
   bool getPrefixUnits() const;
   void setPrefixUnits(bool prefixUnits);
   void checkForErrors(QStringList variables, QStringList variablesPlotted);


### PR DESCRIPTION
### Related Issues

Fixes #14088