### PR TITLE
[NB] allow creation of start equations for pre() and post() variables

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
@@ -912,6 +912,7 @@ public
   end collectNonInitial;
 
   function collectAlgorithmOutputs
+    "collect all non-pre variable outputs"
     input output Equation eqn;
     input UnorderedSet<ComponentRef> outputs;
   algorithm
@@ -923,7 +924,10 @@ public
       case Equation.ALGORITHM(alg = alg) algorithm
         out_crefs := List.flatten(list(BVariable.getRecordChildrenCrefOrSelf(o) for o in alg.outputs));
         for cr in out_crefs loop
-          UnorderedSet.add(cr, outputs);
+          // do not apply for previous() or discretes that have a previous() variable
+          if not (BVariable.checkCref(cr, BVariable.isPrevious, sourceInfo()) or BVariable.checkCref(cr, BVariable.hasPre, sourceInfo())) then
+            UnorderedSet.add(cr, outputs);
+          end if;
         end for;
 
       then ();


### PR DESCRIPTION
 - if an algorithms output has a variable that is assigned a start variable via fixed, prevent creation of start equation if its not a pre() or post() variable