### PR TITLE
Free external function after successful use

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1192,6 +1192,7 @@ algorithm
     (mapped_args, specs) := mapExternalArgs(fn, args, extArgs);
     ret_ty := if ComponentRef.isCref(outputRef) then ComponentRef.nodeType(outputRef) else Type.NORETCALL();
     (res, output_vals) := FFI.callFunction(fn_handle, mapped_args, specs, ret_ty);
+    freeLibraryFunction(fn_handle, debug);
   else
     freeLibraryFunction(fn_handle, debug);
     fail();


### PR DESCRIPTION
I think this is a bug introduced in #14583. @perost is this correct?