### PR TITLE
[FMI] Fix regression introduced in #14538

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
@@ -1033,7 +1033,7 @@ int cvode_solver_fmi_step(ModelInstance *comp, double tNext, double* states)
   }
   flag = CVodeSetStopTime(cvodeData->cvode_mem, tNext);
   if (flag < 0) {
-    filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2DoStep: ##CVODE## CVodeSetStopTime failed with flag %i.", flag);
+    FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2DoStep: ##CVODE## CVodeSetStopTime failed with flag %i.", flag)
     return -1;
   }
   flag = CVode(cvodeData->cvode_mem,
@@ -1044,11 +1044,11 @@ int cvode_solver_fmi_step(ModelInstance *comp, double tNext, double* states)
   /* Error handling */
   if ((flag == CV_SUCCESS || flag == CV_TSTOP_RETURN) && solverInfo->currentTime >= tNext)
   {
-    filteredLog(comp, fmi2OK, LOG_ALL, "fmi2DoStep:##CVODE## step done to time = %.15g.", comp->solverInfo->currentTime);
+    FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2DoStep:##CVODE## step done to time = %.15g.", comp->solverInfo->currentTime)
   }
   else
   {
-    filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2DoStep: ##CVODE## %d error occurred at time = %.15g.", flag, solverInfo->currentTime);
+    FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2DoStep: ##CVODE## %d error occurred at time = %.15g.", flag, solverInfo->currentTime)
     return -1;
   }
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
@@ -117,7 +117,29 @@ typedef struct {
   modelica_string* stringParameter;
 } INTERNAL_FMU_STATE;
 
-void filteredLog(ModelInstance *instance, fmi2Status status, int categoryIndex, const char *fmt, ...);
+fmi2Boolean isCategoryLogged(ModelInstance *comp, int categoryIndex);
+
+static fmi2String logCategoriesNames[] = {"logEvents", "logSingularLinearSystems", "logNonlinearSystems", "logDynamicStateSelection",
+    "logStatusWarning", "logStatusDiscard", "logStatusError", "logStatusFatal", "logStatusPending", "logAll", "logFmi2Call"};
+
+#ifndef FILTERED_LOG
+/**
+ * @brief Macro to be used to log messages.
+ *
+ * The macro check if current log category is active and, if true, call the
+ * logger provided by simulator. Prevents evaluation of arguments if logging
+ * category is disabled.
+ *
+ * @param instance        FMU instance.
+ * @param status          FMI2 status.
+ * @param categoryIndex   Category name index of array `logCategoriesNames`.
+ * @param message         Pointer to null-terminated format string to log.
+ * @param ...             Arguments specifying data to log.
+ */
+#define FILTERED_LOG(instance, status, categoryIndex, message, ...) if (isCategoryLogged(instance, categoryIndex)) { \
+    instance->functions->logger(instance->functions->componentEnvironment, instance->instanceName, status, \
+        logCategoriesNames[categoryIndex], message, ##__VA_ARGS__); }
+#endif
 
 /* reset alignment policy to the one set before reading this file */
 #if defined _MSC_VER || defined __GNUC__

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c
@@ -179,11 +179,11 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
   strcat(flags_filename, "/");
   strcat(flags_filename, comp->fmuData->modelData->modelFilePrefix);
   strcat(flags_filename, "_flags.json");
-  filteredLog(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Trying to find simulation settings %s.", flags_filename);
+  FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Trying to find simulation settings %s.", flags_filename)
 
   if( omc_file_exists( flags_filename) )
   {
-    filteredLog(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Found simulation settings %s.", flags_filename);
+    FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Found simulation settings %s.", flags_filename)
     omc_mmap_read mmap_reader = {0};
     mmap_reader = omc_mmap_open_read(flags_filename);
     parseFlags(solverInfo, mmap_reader.data);
@@ -191,14 +191,14 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
   }
   else
   {
-    filteredLog(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Using default simulation settings.");
+    FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Using default simulation settings.")
     solverInfo->solverMethod = S_EULER;
   }
 
   /* If no states are present, we can use Euler's method since it is doing nothing. */
   if (data->modelData->nStates < 1)
   {
-    filteredLog(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: No states present, continuing without ODE solver.");
+    FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: No states present, continuing without ODE solver.")
     solverInfo->solverMethod = S_EULER;
   }
 
@@ -212,10 +212,10 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
 #ifdef WITH_SUNDIALS
       omc_useStream[OMC_LOG_SOLVER] = 1;
       CVODE_SOLVER* cvodeData = NULL;
-      filteredLog(comp, fmi2OK, LOG_ALL, "Initializing CVODE ODE Solver");
+      FILTERED_LOG(comp, fmi2OK, LOG_ALL, "Initializing CVODE ODE Solver")
       cvodeData = (CVODE_SOLVER*) functions->allocateMemory(1, sizeof(CVODE_SOLVER));
       if (!cvodeData) {
-        filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: Out of memory.");
+        FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: Out of memory.")
         retValue = -1;
       } else {
         retValue = cvode_solver_initial(data, threadData, solverInfo, cvodeData, 1 /* is FMI */);   /* TODO: cvode_solver_initial needs to use malloc and free from fmi2CallbackFunctions */
@@ -224,12 +224,12 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
       omc_useStream[OMC_LOG_SOLVER] = 0;
 #else
       solverInfo->solverData = NULL;
-      filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: FMU not compiled with SUNDIALS but solver CVODE selected.");
+      FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: FMU not compiled with SUNDIALS but solver CVODE selected.")
       retValue = -1;
 #endif /* WITH_SUNDIALS */
       break;
     default:
-      filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: Unknown solver method.");
+      FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: Unknown solver method.")
       retValue = -1;
   }
 
@@ -264,7 +264,7 @@ int FMI2CS_deInitializeSolverData(ModelInstance* comp)
   solverInfo = comp->solverInfo;
 
   /* Log function call */
-  filteredLog(comp, fmi2OK, LOG_ALL, "fmi2FreeInstance: Freeing solver data.");
+  FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2FreeInstance: Freeing solver data.")
 
   switch (solverInfo->solverMethod)
   {
@@ -277,12 +277,12 @@ int FMI2CS_deInitializeSolverData(ModelInstance* comp)
       retValue = cvode_solver_deinitial(solverInfo->solverData);
       break;
 #else
-      filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: FMU not compiled with SUNDIALS but solver CVODE selected.");
+      FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: FMU not compiled with SUNDIALS but solver CVODE selected.")
       retValue = -1;
       break;
 #endif /* WITH_SUNDIALS */
     default:
-      filteredLog(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2FreeInstance: Unknown solver method.");
+      FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2FreeInstance: Unknown solver method.")
       retValue = -1;
   }
 


### PR DESCRIPTION
### Related Issues

Fixes [regression](https://libraries.openmodelica.org/branches/history/master-fmi/2025-10-30%2011:55:14..2025-11-01%2010:45:45.html) introduced in https://github.com/OpenModelica/OpenModelica/pull/14538.

<img width="2450" height="516" alt="grafik" src="https://github.com/user-attachments/assets/ea7b012c-e37e-4041-a71a-01aee6dfc036" />


### Purpose

Fix filtered logging in FMUs.
Simulation times for FMUs increased by factor 10 (or roughly that magnitude).

### Approach

- filteredLog wasn't filtering, so print arguments are evaluated even if logging is disabled.
- Revert function `filteredLog` back to `FILTERED_LOG`.
- Move macro `FILTERED_LOG` to header file for other files to use.

