### PR TITLE
Fix error message for not found external functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1370,7 +1370,7 @@ algorithm
   ErrorExt.rollBack(getInstanceName());
 
   if not found then
-    paths := list("  " + Testsuite.friendly(uriToFilename(p)) for p in paths);
+    paths := list("  " + Testsuite.friendly(uriToFilename(p)) for p guard not stringEmpty(p) in paths);
     Error.addSourceMessage(Error.EXTERNAL_FUNCTION_NOT_FOUND,
       {fnName, stringDelimitList(paths, "\n")}, info);
     fail();


### PR DESCRIPTION
- Filter out empty strings from the paths when emitting the "not found" error message for external functions, to avoid triggering an assertion in `uriToFilename`. This can happen when an external function has no annotation and the function can't be found in the compiler itself.