### PR TITLE
Improve evaluation of call types

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -3054,20 +3054,25 @@ protected
     input Expression exp;
     input ParameterTree ptree;
     output Expression outExp;
+  protected
+    list<ComponentRef> cref_parts;
+    ComponentRef cref;
+    Option<Expression> oexp;
   algorithm
     outExp := match exp
-      local
-        InstNode node;
-        Option<Expression> oexp;
-        Expression e;
-
-      case Expression.CREF(cref = ComponentRef.CREF(node = node, restCref = ComponentRef.EMPTY()))
+      case Expression.CREF(cref = ComponentRef.CREF())
         algorithm
-          oexp := ParameterTree.getOpt(ptree, InstNode.name(node));
+          cref :: cref_parts := ComponentRef.toListReverse(exp.cref);
+          oexp := ParameterTree.getOpt(ptree, InstNode.name(ComponentRef.node(cref)));
 
           if isSome(oexp) then
             SOME(outExp) := oexp;
-            // TODO: Apply subscripts.
+            outExp := Expression.applySubscripts(ComponentRef.getSubscripts(cref), outExp);
+
+            for cr in cref_parts loop
+              outExp := Expression.recordElement(InstNode.name(ComponentRef.node(cr)), outExp);
+              outExp := Expression.applySubscripts(ComponentRef.getSubscripts(cr), outExp);
+            end for;
           else
             outExp := exp;
           end if;

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown18.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown18.mo
@@ -1,0 +1,42 @@
+// name: DimUnknown18
+// keywords:
+// status: correct
+//
+//
+
+record R
+  parameter String names[:] = {""};
+end R;
+
+function f
+  input R r;
+  output String names[size(r.names, 1)];
+algorithm
+  names := r.names;
+end f;
+
+model DimUnknown18
+  parameter R r = R(names = {"a", "b", "c"});
+  parameter String names[:] = f(r);
+end DimUnknown18;
+
+// Result:
+// function R "Automatically generated record constructor for R"
+//   input String[:] names = {""};
+//   output R res;
+// end R;
+//
+// function f
+//   input R r;
+//   output String[size(r.names, 1)] names;
+// algorithm
+//   names := r.names;
+// end f;
+//
+// class DimUnknown18
+//   parameter String r.names[1] = "a";
+//   parameter String r.names[2] = "b";
+//   parameter String r.names[3] = "c";
+//   parameter String[3] names = f(r);
+// end DimUnknown18;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -375,6 +375,7 @@ DimUnknown14.mo \
 DimUnknown15.mo \
 DimUnknown16.mo \
 DimUnknown17.mo \
+DimUnknown18.mo \
 dim1.mo \
 dim13.mo \
 dim16.mo \


### PR DESCRIPTION
- Handle qualified crefs and subscripts in `Call.evaluateCallTypeDimExp`.

Fixes #14606