### PR TITLE
Improve handling of connects in NB

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -367,6 +367,19 @@ public
     end match;
   end isCallNamed;
 
+  function isConnectionCall
+    input Expression exp;
+    output Boolean isConnection;
+  algorithm
+    isConnection := match exp
+      case CALL()
+        then Call.isConnectionsOperator(exp.call) or
+             Call.isStreamOperator(exp.call) or
+             Call.isCardinality(exp.call);
+      else false;
+    end match;
+  end isConnectionCall;
+
   function isTrue
     input Expression exp;
     output Boolean isTrue;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -391,6 +391,10 @@ algorithm
   InstUtil.dumpFlatModelDebug("flatten", flatModel);
 
   if getConnectionResolved then
+    if settings.newBackend then
+      flatModel.equations := evaluateIfWithConnects(flatModel.equations);
+    end if;
+
     if settings.arrayConnect then
       flatModel := resolveArrayConnections(flatModel);
     else
@@ -1313,21 +1317,14 @@ function vectorizeEquation
   input output list<Equation> equations;
 protected
   list<Equation> eql;
+  Type ty;
+  Expression lhs, rhs;
 algorithm
   // Flatten with an empty prefix to get rid of any split indices.
   eql := flattenEquation(eqn, EMPTY_PREFIX, {}, settings);
 
   for eq in eql loop
     equations := match eq
-      local
-        Type ty;
-        InstNode iter, scope;
-        list<InstNode> iters;
-        Expression lhs, rhs, range;
-        list<Expression> ranges;
-        list<Subscript> subs;
-        DAE.ElementSource src;
-
       // convert simple equality of crefs to array equality
       // kabdelhak: only do it if all subscripts are simple enough
       //            will lead to complicated code if not index or whole dim
@@ -1351,27 +1348,40 @@ algorithm
       // wrap general equation into for loop
       else
         algorithm
-          (iters, ranges, subs) := makeIterators(Prefix.prefix(prefix), dimensions);
-          subs := listReverseInPlace(subs);
-          eq := Equation.mapExp(eq, function addIterator(prefix = prefix, subscripts = subs));
-          scope := Equation.scope(eqn);
-          src := Equation.source(eqn);
-
-          iter :: iters := iters;
-          range :: ranges := ranges;
-          eq := Equation.FOR(iter, SOME(range), {eq}, scope, src);
-
-          while not listEmpty(iters) loop
-            iter :: iters := iters;
-            range :: ranges := ranges;
-            eq := Equation.FOR(iter, SOME(range), {eq}, scope, src);
-          end while;
+          eq := vectorizeEquationGeneric(eq, dimensions, prefix);
         then
           splitForLoop(eq, EMPTY_PREFIX, equations, settings);
 
     end match;
   end for;
 end vectorizeEquation;
+
+function vectorizeEquationGeneric
+  input Equation eqn;
+  input list<Dimension> dimensions;
+  input Prefix prefix;
+  output Equation vectorizedEqn;
+protected
+  InstNode iter;
+  list<InstNode> iters;
+  Expression range;
+  list<Expression> ranges;
+  list<Subscript> subs;
+  InstNode scope;
+  DAE.ElementSource src;
+algorithm
+  (iters, ranges, subs) := makeIterators(Prefix.prefix(prefix), dimensions);
+  subs := listReverseInPlace(subs);
+  vectorizedEqn := Equation.mapExp(eqn, function addIterator(prefix = prefix, subscripts = subs));
+  scope := Equation.scope(eqn);
+  src := Equation.source(eqn);
+
+  while not listEmpty(iters) loop
+    iter :: iters := iters;
+    range :: ranges := ranges;
+    vectorizedEqn := Equation.FOR(iter, SOME(range), {vectorizedEqn}, scope, src);
+  end while;
+end vectorizeEquationGeneric;
 
 function vectorizeAlgorithms
   input list<Algorithm> algs;
@@ -1974,8 +1984,10 @@ algorithm
           if var <= Variability.STRUCTURAL_PARAMETER then
             if Expression.isPure(cond) then
               if has_connect then
-                // If-equations containing connects must be evaluated.
-                should_eval := true;
+                // If-equations containing connects must be evaluated, but with
+                // the new backend it needs to be done after vectorization.
+                should_eval := not settings.newBackend;
+                structural := true;
               elseif settings.minimalEval then
                 // Don't evaluate if --evaluateStructuralParameters=strictlyNecessary
                 should_eval := false;
@@ -2008,7 +2020,7 @@ algorithm
             end if;
 
             // Conditions in an if-equation that contains connects must be possible to evaluate.
-            if not Expression.isBoolean(cond) and has_connect then
+            if not Expression.isBoolean(cond) and has_connect and not settings.newBackend then
               Error.addInternalError(
                 "Failed to evaluate branch condition in if equation containing connect equations: `" +
                 Expression.toString(cond) + "`", info);
@@ -2128,7 +2140,7 @@ protected
 algorithm
   Equation.FOR(iter, opt_range, body, scope, src) := forLoop;
   body := flattenEquations(body, EMPTY_PREFIX, settings);
-  (connects, non_connects) := splitForLoop2(body);
+  (connects, non_connects) := splitForLoop2(body, settings);
 
   if not listEmpty(connects) then
     if isSome(opt_range) then
@@ -2154,23 +2166,12 @@ end splitForLoop;
 
 function splitForLoop2
   input list<Equation> forBody;
+  input FlattenSettings settings;
   output list<Equation> connects = {};
   output list<Equation> nonConnects = {};
 protected
-  function is_conn_operator
-    input Expression exp;
-    output Boolean res;
-  algorithm
-    res := match exp
-      case Expression.CALL()
-        then Call.isConnectionsOperator(exp.call) or
-             Call.isStreamOperator(exp.call) or
-             Call.isCardinality(exp.call);
-      else false;
-    end match;
-  end is_conn_operator;
-protected
-  list<Equation> conns, nconns;
+  list<Equation> conns, nconns, eql;
+  Expression cond;
 algorithm
   for eq in forBody loop
     () := match eq
@@ -2182,7 +2183,7 @@ algorithm
 
       case Equation.FOR()
         algorithm
-          (conns, nconns) := splitForLoop2(eq.body);
+          (conns, nconns) := splitForLoop2(eq.body, settings);
 
           if not listEmpty(conns) then
             connects := Equation.FOR(eq.iterator, eq.range, conns, eq.scope, eq.source) :: connects;
@@ -2196,7 +2197,8 @@ algorithm
 
       else
         algorithm
-          if Equation.containsExp(eq, function Expression.contains(func = is_conn_operator)) then
+          if Equation.contains(eq, Equation.isConnect) or
+             Equation.containsExp(eq, function Expression.contains(func = Expression.isConnectionCall)) then
             connects := eq :: connects;
           else
             nonConnects := eq :: nonConnects;
@@ -3128,6 +3130,61 @@ algorithm
     end if;
   end if;
 end updateVariability;
+
+function evaluateIfWithConnects
+  input list<Equation> eql;
+  output list<Equation> outEql = {};
+algorithm
+  for eq in eql loop
+    outEql := evaluateIfWithConnects2(eq, outEql);
+  end for;
+
+  outEql := listReverseInPlace(outEql);
+end evaluateIfWithConnects;
+
+function evaluateIfWithConnects2
+  input Equation eq;
+  input output list<Equation> equations;
+protected
+  Expression cond;
+  Variability var;
+  list<Equation> eql;
+  Ceval.EvalTarget target;
+algorithm
+  equations := match eq
+    case Equation.IF()
+      guard Equation.contains(eq, Equation.isConnect) or
+            Equation.containsExp(eq, function Expression.contains(func = Expression.isConnectionCall))
+      algorithm
+        target := Ceval.EvalTarget.new(Equation.info(eq));
+
+        for branch in eq.branches loop
+          Equation.Branch.BRANCH(cond, var, eql) := branch;
+
+          if var <= Variability.STRUCTURAL_PARAMETER then
+            if Expression.isPure(cond) then
+              Structural.markExp(cond);
+              cond := Ceval.evalExp(cond, target);
+            end if;
+
+            if Expression.isTrue(cond) then
+              eql := evaluateIfWithConnects(eql);
+              equations := listAppend(eql, equations);
+              break;
+            elseif not Expression.isFalse(cond) then
+              Error.addInternalError(
+                "Failed to evaluate branch condition in if equation containing connect equations: `" +
+                Expression.toString(cond) + "`", Equation.info(eq));
+              fail();
+            end if;
+          end if;
+        end for;
+      then
+        equations;
+
+    else eq :: equations;
+  end match;
+end evaluateIfWithConnects2;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFFlatten;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -912,6 +912,7 @@ NoScalarize1.mo \
 NoScalarize2.mo \
 NoScalarizeConnect1.mo \
 NoScalarizeConnect2.mo \
+NoScalarizeConnect3.mo \
 OperationAdd1.mo \
 OperationAddEW1.mo \
 OperationDiv1.mo \

--- a/testsuite/flattening/modelica/scodeinst/NoScalarizeConnect3.mo
+++ b/testsuite/flattening/modelica/scodeinst/NoScalarizeConnect3.mo
@@ -1,0 +1,98 @@
+// name: NoScalarizeConnect3
+// keywords:
+// status: correct
+//
+
+connector Port
+  Real foo;
+  flow Real fooFlow;
+end Port;
+
+model Source
+  parameter Real val;
+  Port port;
+equation
+  port.foo = val;
+end Source;
+
+model M1
+  Port port1, port2;
+equation
+  port1.fooFlow + port2.fooFlow = 0;
+  port1.fooFlow = port1.foo-port2.foo;
+end M1;
+
+model M2
+  parameter Boolean useM1 = false;
+  Port port1, port2;
+  M1 m1 if useM1;
+
+equation
+  if useM1 then
+    connect(port1, m1.port1);
+    connect(m1.port2, port2);
+  else
+    connect(port1, port2);
+  end if;
+end M2;
+
+model NoScalarizeConnect3
+  Source SO1(val=1), SO2(val=0);
+  M2[3] m2A(useM1={true, true, true});
+equation
+  connect(SO1.port, m2A[1].port1);
+  connect(SO2.port, m2A[3].port2);
+  for i in 1:2 loop
+    connect(m2A[i].port2, m2A[i+1].port1);
+  end for;
+  annotation(__OpenModelica_commandLineOptions="--newBackend");
+end NoScalarizeConnect3;
+
+// Result:
+// class NoScalarizeConnect3
+//   parameter Real SO1.val = 1.0;
+//   Real SO1.port.foo;
+//   Real SO1.port.fooFlow;
+//   parameter Real SO2.val = 0.0;
+//   Real SO2.port.foo;
+//   Real SO2.port.fooFlow;
+//   final parameter Boolean[3] m2A.useM1 = {true, true, true};
+//   Real[3] m2A.port1.foo;
+//   Real[3] m2A.port1.fooFlow;
+//   Real[3] m2A.port2.foo;
+//   Real[3] m2A.port2.fooFlow;
+//   Real[3] m2A.m1.port1.foo;
+//   Real[3] m2A.m1.port1.fooFlow;
+//   Real[3] m2A.m1.port2.foo;
+//   Real[3] m2A.m1.port2.fooFlow;
+// equation
+//   m2A[3].m1.port2.foo = m2A[3].port2.foo;
+//   m2A[3].port1.foo = m2A[3].m1.port1.foo;
+//   m2A[3].m1.port1.fooFlow - m2A[3].port1.fooFlow = 0.0;
+//   m2A[2].m1.port2.foo = m2A[2].port2.foo;
+//   m2A[2].port1.foo = m2A[2].m1.port1.foo;
+//   m2A[2].m1.port1.fooFlow - m2A[2].port1.fooFlow = 0.0;
+//   m2A[1].m1.port2.foo = m2A[1].port2.foo;
+//   m2A[1].port1.foo = m2A[1].m1.port1.foo;
+//   m2A[1].m1.port1.fooFlow - m2A[1].port1.fooFlow = 0.0;
+//   SO1.port.foo = m2A[1].port1.foo;
+//   SO2.port.foo = m2A[3].port2.foo;
+//   m2A[1].port2.foo = m2A[2].port1.foo;
+//   m2A[2].port2.foo = m2A[3].port1.foo;
+//   m2A[1].port1.fooFlow + SO1.port.fooFlow = 0.0;
+//   m2A[3].port2.fooFlow + SO2.port.fooFlow = 0.0;
+//   m2A[1].port2.fooFlow + m2A[2].port1.fooFlow = 0.0;
+//   m2A[2].port2.fooFlow + m2A[3].port1.fooFlow = 0.0;
+//   m2A[1].m1.port2.fooFlow - m2A[1].port2.fooFlow = 0.0;
+//   m2A[2].m1.port2.fooFlow - m2A[2].port2.fooFlow = 0.0;
+//   m2A[3].m1.port2.fooFlow - m2A[3].port2.fooFlow = 0.0;
+//   SO1.port.foo = SO1.val;
+//   SO2.port.foo = SO2.val;
+//   for $i2 in 1:3 loop
+//     m2A[$i2].m1.port1.fooFlow + m2A[$i2].m1.port2.fooFlow = 0.0;
+//   end for;
+//   for $i1 in 1:3 loop
+//     m2A[$i1].m1.port1.fooFlow = m2A[$i1].m1.port1.foo - m2A[$i1].m1.port2.foo;
+//   end for;
+// end NoScalarizeConnect3;
+// endResult


### PR DESCRIPTION
- Don't evaluate if-conditions while flattening the if-equations, they need to be kept until they've been vectorized.
- Detect if-equations that contain connects when splitting for-loops, and apply branch selection on them.