### PR TITLE
Fix dumping of flat model with NB

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -80,7 +80,17 @@ protected
   DAE.Element class_elem;
 algorithm
   daeFunctions := convertFunctionTree(functions);
+  dae := convertModel(flatModel);
+  execStat(getInstanceName());
+end convert;
 
+function convertModel
+  input FlatModel flatModel;
+  output DAE.DAElist dae;
+protected
+  list<DAE.Element> elems;
+  DAE.Element class_elem;
+algorithm
   elems := convertVariables(flatModel.variables, {});
   elems := convertEquations(flatModel.equations, elems);
   elems := convertInitialEquations(flatModel.initialEquations, elems);
@@ -89,9 +99,7 @@ algorithm
 
   class_elem := DAE.COMP(FlatModel.fullName(flatModel), elems, flatModel.source, ElementSource.getOptComment(flatModel.source));
   dae := DAE.DAE({class_elem});
-
-  execStat(getInstanceName());
-end convert;
+end convertModel;
 
 function convertStatements
   input list<Statement> statements;

--- a/OMCompiler/Compiler/NSimCode/NSimCode.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCode.mo
@@ -270,6 +270,7 @@ public
       input String fileNamePrefix;
       input Option<OldSimCode.SimulationSettings> simSettingsOpt;
       output SimCode simCode;
+      output DAE.FunctionTree oldFunctionTree;
     protected
       partial function mapExp
         input output Expression exp;
@@ -400,7 +401,10 @@ public
             // Will probably be mostly the same in all other regards
             program := SymbolTable.getAbsyn();
             directory := CevalScriptBackend.getFileDir(AbsynUtil.pathToCref(name), program);
-            (libs, libPaths, _, includeDirs, recordDecls, functions, _) := OldSimCodeUtil.createFunctions(program, ConvertDAE.convertFunctionTree(funcTree));
+            // The OB function tree is needed both here and when dumping the flat model,
+            // but converting it is destructive so return it to avoid doing it again.
+            oldFunctionTree := ConvertDAE.convertFunctionTree(funcTree);
+            (libs, libPaths, _, includeDirs, recordDecls, functions, _) := OldSimCodeUtil.createFunctions(program, oldFunctionTree);
             makefileParams := OldSimCodeFunctionUtil.createMakefileParams(includeDirs, libs, libPaths, false, false);
 
             (linearLoops, nonlinearLoops, jacobians, simCodeIndices) := collectAlgebraicLoops(init, init_0, ode, algebraic, daeModeData, simCodeIndices, simcode_map);


### PR DESCRIPTION
- Return the OB function tree that's used in `NSimCode.SimCode.create` so it can be reused when dumping the flat model, since the conversion is destructive and can fail if done twice.