### PR TITLE
[WIP, NB] Fix symbolic jacobian for algebraic loops

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -310,14 +310,6 @@ public
 
             (sparsity, sparsityT, coloring) := createSparsity(jacobian, idx_map);
 
-            if listLength(columnEqns) > 0 then
-              // also add to the global simcode map when we have a non-empty jacobian
-              // so the vars can be found by cref2simvar
-              SimCodeUtil.addListSimCodeMap(seedVars, simcode_map);
-              SimCodeUtil.addListSimCodeMap(resVars, simcode_map);
-              SimCodeUtil.addListSimCodeMap(tmpVars, simcode_map);
-            end if;
-
             jac := SIM_JAC(
               name                = jacobian.name,
               jacobianIndex       = indices.jacobianIndex,

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -6465,8 +6465,8 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       %>
       /* get old value */
       <%nls.crefs |> name hasindex i0 =>
-        let &sub = buffer ""
-        let START = cref(name, &sub)
+        let &auxFunction = buffer ""
+        let START = contextCrefNoPrevExp(name, context, &auxFunction)
         'data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsxOld[<%i0%>] = <%START%>;'
       ;separator="\n"%>
       retValue = solve_nonlinear_system(data, threadData, <%nls.indexNonLinearSystem%>);
@@ -6478,8 +6478,8 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       }
       /* write solution */
       <%nls.crefs |> name hasindex i0 =>
-        let &sub = buffer ""
-        '<%cref(name, &sub)%> = data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsx[<%i0%>];' ;separator="\n"%>
+        let &auxFunction = buffer ""
+        '<%contextCrefNoPrevExp(name, context, &auxFunction)%> = data->simulationInfo->nonlinearSystemData[<%nls.indexNonLinearSystem%>].nlsx[<%i0%>];' ;separator="\n"%>
       <% if profileSome() then 'SIM_PROF_ACC_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%nls.index%>).profileBlockIndex);' %>
       <%match at case SOME(__) then 'return 1;'%>
       >>

--- a/testsuite/simulation/modelica/NBackend/differentation/Makefile
+++ b/testsuite/simulation/modelica/NBackend/differentation/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 allTheBuildins.mos \
 diff_subs.mos \
 arrayDiff.mos \
+algebraicLoop.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/differentation/algebraicLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/algebraicLoop.mos
@@ -14,6 +14,7 @@ loadString("
 setCommandLineOptions("--newBackend --generateDynamicJacobian=symbolic -d=dumpSimCode"); getErrorString();
 
 buildModel(algebraicLoop); getErrorString();
+
 // Result:
 // true
 // ""


### PR DESCRIPTION
### Purpose

The issue was that the iteration variables of algebraic loop jacobian could not be found during runtime. Adding the jacobian variables (`resVars`, `seedVars`, `tmpVars`) (only when the jacobian is actually generated) fixes that issue as is shown in the test case.

There are two issues remaining:
1. the equations inside the algebraic loop jacobian are not generated during code gen although they exist in SimCode.
2. the iteration variables inside the algebraic loop jacobian are taken from `parentJacobian` and not `jacobian` which might be incorrect.

(@phannebohm, @kabdelhak)