### PR TITLE
Update tearing section in the User's Guide

### DIFF
--- a/doc/UsersGuide/source/solving.rst
+++ b/doc/UsersGuide/source/solving.rst
@@ -512,19 +512,17 @@ Several compiler and simulation flags influence initialization with homotopy:
 :ref:`-ils <simflag-ils>`.
 
 
-.. _cruntime-algebraic-solvers :
-
 Tearing
 -------
 
 The size of linear and nonlinear equation systems can be substantially reduced by
 means of the Tearing method. Consider a system of :math:`N` equations. The Tearing method requires
-to pick :math:`M << N` variables :math:`x_t` as *tearing* or *iteration* variables, so that
+to pick :math:`M < N` variables :math:`x_t` as *tearing* or *iteration* variables, so that
 assuming their values are known, :math:`N - M` *torn* equations can be solved explicitly for the
 remaining :math:`N - M` *torn* variables, by sorting them appropriately. Then, the remaining
 M equations are put in *residual* form :math:`f(x_t) = 0`, where the residuals can ultimately be
-computed by explicit computations as a function of the tearing variables :math:`x_t` only. 
-The result is thus an equivalent implicit system of :math:`M << N` equations in the :math:`M`
+computed by explicit computations as a function of the tearing variables :math:`x_t` only.
+The result is thus an equivalent implicit system of :math:`M < N` equations in the :math:`M`
 tearing variables, with an explicit procedure to compute the residual function :math:`f(x_t)`.
 The Jacobian of that function, which is required by the Newton method, can then be obtained
 by either symbolic or numerical differentiation techniques.
@@ -537,9 +535,9 @@ The Tearing method has three main advantages:
   guess values are set to the start attributes of the tearing variables;
 - the method allows to solve mixed systems containing Real and discrete (Boolean or Integer)
   variables and equations by means of standard nonlinear equation solvers, as long as the
-  discrete variables are selected as torn variables and the resulting residual equations have 
+  discrete variables are selected as torn variables and the resulting residual equations have
   a continuous dependency on the Real tearing variables.
-  
+
 OpenModelica implements some heuristic algorithms to automatically choose the set of
 tearing variables. The tearing algorithm can be selected with the compiler flags:
 :ref:`--tearingMethod <omcflag-tearingMethod>`,
@@ -552,17 +550,21 @@ disabled for systems above a certain size, see
 As of Modelica 3.6, there is no standardized way to influence the choice of tearing variables. OpenModelica
 provides a custom `__OpenModelica_tearingSelect` annotation that can be added to variable declarations to
 influence the choice of tearing variables:
-	
+
 .. code-block:: modelica
-Real x annotation(__OpenModelica_tearingSelect = TearingSelect.always);
-Real y annotation(__OpenModelica_tearingSelect = TearingSelect.prefer);
-Real z annotation(__OpenModelica_tearingSelect = TearingSelect.default);
-Real v annotation(__OpenModelica_tearingSelect = TearingSelect.avoid);
-Real w annotation(__OpenModelica_tearingSelect = TearingSelect.never);
+
+  Real x annotation(__OpenModelica_tearingSelect = TearingSelect.always);
+  Real y annotation(__OpenModelica_tearingSelect = TearingSelect.prefer);
+  Real z annotation(__OpenModelica_tearingSelect = TearingSelect.default);
+  Real v annotation(__OpenModelica_tearingSelect = TearingSelect.avoid);
+  Real w annotation(__OpenModelica_tearingSelect = TearingSelect.never);
 
 This feature is currently experimental. There is discussion going on within the MAP-Lang group of the
 Modelica Association to standardize features for the selection of tearing variables and residual
 equations.
+
+
+.. _cruntime-algebraic-solvers :
 
 Algebraic Solvers
 -----------------


### PR DESCRIPTION
Trying to fix rendering the code-block. I can't test it on my machine but looking at the other examples the blank line seems to be important.

Also I feel a bit uncomfortable with the _much-less_ sign $<<$, typographically and semantically. $M$ may still be close to $N$ in some models. If that was on purpose though, I suggest $\ll$ (`\ll`) which looks a bit better. @casella any preference?