### PR TITLE
Update build-deps to Noble

### DIFF
--- a/.CI/Jenkinsfile.debug.symbols
+++ b/.CI/Jenkinsfile.debug.symbols
@@ -23,7 +23,7 @@ pipeline {
     stage('Ubuntu-Noble') {
       agent {
         docker {
-          image 'docker.openmodelica.org/build-deps:noble.nightly.amd64'
+          image 'ghcr.io/openmodelica/build-deps:v1.26.0'
           label 'linux'
           alwaysPull true
           args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +

--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.22.2
+FROM ghcr.io/openmodelica/build-deps:v1.26.0
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -22,10 +22,10 @@ pipeline {
     }
     stage('build') {
       parallel {
-        stage('autoconf-jammy-gcc') {
+        stage('autoconf-noble-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -37,7 +37,7 @@ pipeline {
             stash name: 'omc-gcc', includes: 'build/bin/OMCppOSUSimulation, build/include/omc/omsi/**, build/include/omc/omsic/**, build/lib/x86_64-linux-gnu/omc/omsi/**, build/lib/x86_64-linux-gnu/omc/omsicpp/**, **/config.status'
           }
         }
-        stage('cmake-jammy-gcc') {
+        stage('cmake-noble-gcc') {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -53,8 +53,8 @@ container.
 
 ## Caveats
 
-- The images need an additional Dockerfile to add an non-root user with your
-  user name and UID.
+- The images need an additional Dockerfile to add a non-root user with your
+  user name and UID or rename an existing user.
 - Because on Windows and Unix the environment variable containing the user name
   are different and only one should be set both are added to devcontainer.json:
   If your user name isn't correct update it:

--- a/.devcontainer/build-deps/Dockerfile
+++ b/.devcontainer/build-deps/Dockerfile
@@ -5,23 +5,13 @@ ENV SHELL=/bin/bash
 
 ARG USERNAME=openmodelica-user
 ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
 # Additional software (gdb, valgrind)
-RUN apt-get update \
-    && apt-get install -qy build-essential gdb valgrind \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-# Create the user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
-
-# [Optional] Add sudo support. Omit if you don't need to install software after connecting.
-RUN apt-get update \
-    && apt-get install -y sudo \
-    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update                                                             \
+    && apt-get install -qy build-essential gdb valgrind                        \
+    && apt-get clean                                                           \
+    && rm -rf /var/lib/apt/lists/*                                             \
+    && usermod -l $USERNAME ubuntu                                             \
+    && usermod -u $USER_UID $USERNAME
 
 ENV USER=$USERNAME

--- a/.devcontainer/build-deps/devcontainer.json
+++ b/.devcontainer/build-deps/devcontainer.json
@@ -1,13 +1,13 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-  "name": "build-deps:v1.22",
+  "name": "build-deps:v1.26",
 
   // Dockerfile
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "BASE_IMAGE": "docker.openmodelica.org/build-deps:v1.22.2",
+        "BASE_IMAGE": "ghcr.io/openmodelica/build-deps:v1.26.0",
         // On Windows USERNAME is set, on Linux USER is set
         // We hope only one is set
         "USERNAME": "${localEnv:USER}${localEnv:USERNAME}"
@@ -24,7 +24,8 @@
         "lextudio.restructuredtext",
         "trond-snekvik.simple-rst",
         "ms-python.python",
-        "ms-python.vscode-pylance"
+        "ms-python.vscode-pylance",
+        "eamodio.gitlens"
       ]
     }
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         stage('gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args '''
@@ -75,7 +75,7 @@ pipeline {
         stage('clang') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args '''
@@ -148,10 +148,10 @@ pipeline {
             }
           }
         }
-        stage('cmake-jammy-gcc') {
+        stage('cmake-noble-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args '''
@@ -233,7 +233,7 @@ pipeline {
         stage('checks') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args '''
@@ -560,7 +560,7 @@ pipeline {
         stage('10 build-gui-clang-qt5') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -577,7 +577,7 @@ pipeline {
         stage('11 build-gui-clang-qt6') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.6-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -594,8 +594,8 @@ pipeline {
         stage('12 testsuite-clang-parmod') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
-              label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
+              label 'linux'
               alwaysPull true
               // No runtest.db cache necessary; the tests run in serial and do not load libraries!
             }
@@ -616,7 +616,7 @@ pipeline {
         stage('13 testsuite-clang-metamodelica') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
             }
           }
@@ -634,7 +634,7 @@ pipeline {
         stage('14 testsuite-matlab-translator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
             }
@@ -656,7 +656,7 @@ pipeline {
         stage('15 test-clang-icon-generator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               args '''
                 --mount type=volume,source=runtest-clang-icon-generator,target=/cache/runtest \
@@ -686,7 +686,7 @@ pipeline {
         stage('16 testsuite-unit-test-C') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args '''
@@ -826,7 +826,7 @@ pipeline {
         stage('clang-qt5-omedit-testsuite') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -845,7 +845,7 @@ pipeline {
         stage('clang-qt6-omedit-testsuite') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.6-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -868,7 +868,7 @@ pipeline {
         stage('fmuchecker-results') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
             }
@@ -896,7 +896,7 @@ pipeline {
         stage('upload-compliance') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
             }
@@ -914,7 +914,7 @@ pipeline {
         stage('upload-doc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.26.0'
               label 'linux'
               alwaysPull true
             }

--- a/OMCompiler/Compiler/NSimCode/NSimCode.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCode.mo
@@ -404,7 +404,7 @@ public
             // The OB function tree is needed both here and when dumping the flat model,
             // but converting it is destructive so return it to avoid doing it again.
             oldFunctionTree := ConvertDAE.convertFunctionTree(FunctionTree.fromList(UnorderedMap.toList(funcMap)));
-            (libs, libPaths, _, includeDirs, recordDecls, functions, _) := OldSimCodeUtil.createFunctions(program, oldFunctionTree);
+            (libs, libPaths, externalFunctionIncludes, includeDirs, recordDecls, functions, _) := OldSimCodeUtil.createFunctions(program, oldFunctionTree);
             makefileParams := OldSimCodeFunctionUtil.createMakefileParams(includeDirs, libs, libPaths, false, false);
 
             (linearLoops, nonlinearLoops, jacobians, simCodeIndices) := collectAlgebraicLoops(init, init_0, ode, algebraic, daeModeData, simCodeIndices, simcode_map);

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -7617,7 +7617,8 @@ template genericCallHeaders(list<SimGenericCall> genericCalls, Context context)
   let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
   (genericCalls |> call => match call
     case SINGLE_GENERIC_CALL()
-    case IF_GENERIC_CALL() then
+    case IF_GENERIC_CALL()
+    case WHEN_GENERIC_CALL() then
       let &sub = buffer ""
       let &preExp = buffer ""
       let &varDecls = buffer ""

--- a/OMEdit/OMEdit.config.pre.pri
+++ b/OMEdit/OMEdit.config.pre.pri
@@ -32,7 +32,9 @@ QT += network core gui xml svg opengl printsupport widgets concurrent
 equals(QT_MAJOR_VERSION, 6) {
   QT += core5compat openglwidgets
   greaterThan(QT_MINOR_VERSION, 3) {
-    QT += httpserver
+    qtHaveModule(httpserver) {
+      QT += httpserver
+    }
   }
   win32 {
     # disable documentation since we don't have webkit on qt6 and webengine is not yet supported.

--- a/common/m4/qmake.m4
+++ b/common/m4/qmake.m4
@@ -5,12 +5,12 @@ AC_SUBST(LRELEASE)
 AC_SUBST(WITH_QT6)
 AC_ARG_WITH(qt6,  [  --with-qt6       (build with qt6)],[WITH_QT6="$withval"],[WITH_QT6="no"])
 
-# check if we have ubuntu plucky or debian trixie and activate --with-qt6
-# if so as we don't have webkit in that one.
+# check if we have ubuntu noble/plucky or debian trixie and activate --with-qt6
+# if so as we don't have webkit in those distros.
 # maybe we should check if qt5webkit exists and if not activate qt6
 # but I have no idea how to do that
 
-if "lsb_release" -cs | grep "plucky\|trixie\|questing"; then
+if "lsb_release" -cs | grep "noble\|plucky\|trixie\|questing"; then
   WITH_QT6="yes"
   AC_MSG_RESULT([Forcing qt6 as we don't have webkit in newer distros])
 fi

--- a/doc/UsersGuide/README.md
+++ b/doc/UsersGuide/README.md
@@ -5,7 +5,7 @@ OpenModelica User's Guide using Sphinx (Python Documentation Generator).
 ## Dependencies
 
 Getting all dependencies right is a nightmare. Just use the dev container
-`build-deps:v1.22.0` from
+`build-deps:v1.26.0` from
 [.devcontainer/README.md](./../../.devcontainer/README.md) and set
 `GITHUB_AUTH`.
 


### PR DESCRIPTION
### Related Issues

Fixes #14653 

### Purpose

- Test if we can compile everything with `ghcr.io/openmodelica/build-deps:v1.26.0`

### Approach

New image https://github.com/OpenModelica/build-deps/pkgs/container/build-deps/579668289?tag=v1.26.0-dev.
The image will be re-tagged to `v1.26.0` and re-released if this PR is looking good. I will update the tag to the final version before merging this PR.
