### PR TITLE
Fix missing function declaration for desctructors

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2458,7 +2458,7 @@ protected function addDestructor2
   output HashTableStringToPath.HashTable ht = inHt;
 algorithm
   if not BaseHashTable.hasKey(pathstr, ht) then
-    BaseHashTable.add((pathstr, path), ht);
+    ht := BaseHashTable.add((pathstr, path), ht);
   end if;
 end addDestructor2;
 


### PR DESCRIPTION
### Related Issues

Fixes #14663.

### Purpose

Fix missing function declaration for desctructors in MetaModelica

### Approach

  - Fixing update of has table in `SimCodeFunctionUtil.addDestructor2`.
