### PR TITLE
Don't initialize with NAN

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -708,7 +708,7 @@ void initSample(DATA* data, threadData_t *threadData, double startTime, double s
   long i;
 
   data->callback->function_initSample(data, threadData);              /* set-up sample */
-  data->simulationInfo->nextSampleEvent = NAN;  /* should never be reached */
+  data->simulationInfo->nextSampleEvent = DBL_MAX;                    /* should never be reached */
   for(i=0; i<data->modelData->nSamples; ++i) {
     if(startTime < data->modelData->samplesInfo[i].start) {
       data->simulationInfo->nextSampleTimes[i] = data->modelData->samplesInfo[i].start;


### PR DESCRIPTION
### Related Issues

Fixes #10975.

### Purpose

- Don't initialize with NAN

### Approach

  - Replace with DBL_MAX to prevent SIGFPE throw
