### PR TITLE
Fix OMSI incompatible function poiter type

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenOMSI_common.tpl
+++ b/OMCompiler/Compiler/Template/CodegenOMSI_common.tpl
@@ -102,7 +102,7 @@ template generateOmsiFunctionCode(OMSIFunction omsiFunction, String FileNamePref
   let _ = generateOmsiFunctionCode_inner(omsiFunction, FileNamePrefix, modelFunctionnamePrefixStr,omsiName, &includes, &evaluationCode, &functionCall, "", &functionPrototypes, omsiName)
 
   // generate header file
-  let &functionPrototypes +='omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(omsi_function_t* simulation, omsi_values* model_vars_and_params, void* data);<%\n%>'
+  let &functionPrototypes +='omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(struct omsi_function_t* simulation, const omsi_values* model_vars_and_params, void* data);<%\n%>'
 
 
   let headerFileName =     '<%fileNamePrefix%>_<%omsiName%>'
@@ -131,7 +131,7 @@ template generateOmsiFunctionCode(OMSIFunction omsiFunction, String FileNamePref
 
 
     /* Equations evaluation */
-    omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(omsi_function_t* <%omsiName%>, omsi_values* model_vars_and_params, void* data){
+    omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(struct omsi_function_t* <%omsiName%>, const omsi_values* model_vars_and_params, void* data){
 
 
       /* Variables */


### PR DESCRIPTION
### Related Issues

Fixing compiler error on clang version 18.1.3 (1ubuntu1)

```bash
clang -fPIC -Wall -Wextra -ansi -pedantic -g -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsi  -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsi/base -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsi/solver -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsi/fmi2 -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsic -I'/var/lib/jenkins/ws/OpenModelica_PR-14654/build/bin/..'/include/omc/omsic/fmi2 -c helloWorldOMSU_init_eqns.c
helloWorldOMSU_init_eqns.c:66:27: error: incompatible function pointer types assigning to 'omsi_status (*)(struct omsi_function_t *, const omsi_values *, void *)' (aka 'omsi_status (*)(struct omsi_function_t *, const struct omsi_values *, void *)') from 'omsi_status (omsi_function_t *, omsi_values *, void *)' (aka 'omsi_status (struct omsi_function_t *, struct omsi_values *, void *)') [-Wincompatible-function-pointer-types]
   66 |   omsi_function->evaluate = helloWorldOMSU_init_eqns_allEqns;
      |                           ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Purpose

This issue blocks https://github.com/OpenModelica/OpenModelica/pull/14654.

### Approach

- Fix incompatible function declaration.
