### PR TITLE
Ignore empty lines in package.order

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -4802,32 +4802,34 @@ bool LibraryWidget::saveModelicaLibraryTreeItemFolder(LibraryTreeItem *pLibraryT
     QTextStream textStream(&file);
     while (!textStream.atEnd()) {
       QString currentLine = textStream.readLine();
-      bool classExists = false;
-      for (int i = 0; i < pLibraryTreeItem->childrenSize(); i++) {
-        // Issue #12567. Compare case insensitive on Windows as `a` and `A` means the same thing.
-#ifdef Q_OS_WIN
-        if (pLibraryTreeItem->child(i)->getName().compare(currentLine, Qt::CaseInsensitive) == 0) {
-#else // #ifdef Q_OS_WIN
-        if (pLibraryTreeItem->child(i)->getName().compare(currentLine) == 0) {
-#endif // #ifdef Q_OS_WIN
-          classExists = true;
-          break;
-        }
-      }
-      if (!classExists) {
-        if (QDir().exists(QString("%1/%2").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine))) {
-          if (OptionsDialog::instance()->getGeneralSettingsPage()->getCreateBackupFileCheckbox()->isChecked()) {
-            QFile::rename(QString("%1/%2/package.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine),
-                          QString("%1/%2/package.bak-mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
-          } else {
-            Utilities::removeDirectoryRecursively(QString("%1/%2").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+      if (!currentLine.isEmpty()) { // ignore empty lines in package.order
+        bool classExists = false;
+        for (int i = 0; i < pLibraryTreeItem->childrenSize(); i++) {
+          // Issue #12567. Compare case insensitive on Windows as `a` and `A` means the same thing.
+  #ifdef Q_OS_WIN
+          if (pLibraryTreeItem->child(i)->getName().compare(currentLine, Qt::CaseInsensitive) == 0) {
+  #else // #ifdef Q_OS_WIN
+          if (pLibraryTreeItem->child(i)->getName().compare(currentLine) == 0) {
+  #endif // #ifdef Q_OS_WIN
+            classExists = true;
+            break;
           }
-        } else {
-          if (OptionsDialog::instance()->getGeneralSettingsPage()->getCreateBackupFileCheckbox()->isChecked()) {
-            QFile::rename(QString("%1/%2.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine),
-                          QString("%1/%2.bak-mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+        }
+        if (!classExists) {
+          if (QDir().exists(QString("%1/%2").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine))) {
+            if (OptionsDialog::instance()->getGeneralSettingsPage()->getCreateBackupFileCheckbox()->isChecked()) {
+              QFile::rename(QString("%1/%2/package.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine),
+                            QString("%1/%2/package.bak-mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+            } else {
+              Utilities::removeDirectoryRecursively(QString("%1/%2").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+            }
           } else {
-            QFile::remove(QString("%1/%2.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+            if (OptionsDialog::instance()->getGeneralSettingsPage()->getCreateBackupFileCheckbox()->isChecked()) {
+              QFile::rename(QString("%1/%2.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine),
+                            QString("%1/%2.bak-mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+            } else {
+              QFile::remove(QString("%1/%2.mo").arg(fileInfo.absoluteDir().absolutePath()).arg(currentLine));
+            }
           }
         }
       }
@@ -4835,12 +4837,9 @@ bool LibraryWidget::saveModelicaLibraryTreeItemFolder(LibraryTreeItem *pLibraryT
     file.close();
   }
   // create a package.order file
-  QString contents = "";
   /* Ticket #4152. package.order should contain constants and classes.*/
   QStringList childClasses = MainWindow::instance()->getOMCProxy()->getClassNames(pLibraryTreeItem->getNameStructure(), false, false, false, false, true, true);
-  for (int i = 0; i < childClasses.size(); i++) {
-    contents.append(childClasses.at(i)).append("\n");
-  }
+  const QString contents = childClasses.isEmpty() ? "" : childClasses.join("\n") + "\n";
   // create a new package.order file
   saveFile(QString("%1/package.order").arg(fileInfo.absoluteDir().absolutePath()), contents);
   return true;


### PR DESCRIPTION
### Related Issues

#14703

### Purpose

Avoid corrupting package contents

### Approach

Ignore empty lines in package.order so we don't remove package contents
