### PR TITLE
Fix 'GC_THREADS' macro redefinition

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -39,7 +39,9 @@
 
 #include "OMEditApplication.h"
 #include "CrashReport/CrashReportDialog.h"
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 
 extern "C" {
 #include "meta/meta_modelica.h"


### PR DESCRIPTION
### Related Issues

```
[build] [100%] Building CXX object OMEdit/OMEditGUI/CMakeFiles/OMEdit.dir/main.cpp.o
[build] /home/andreas/workdir/OM/OpenModelicaMaster/OMEdit/OMEditGUI/main.cpp:42:9: warning: 'GC_THREADS' macro redefined [-Wmacro-redefined]
[build]    42 | #define GC_THREADS
[build]       |         ^
[build] <command line>:4:9: note: previous definition is here
[build]     4 | #define GC_THREADS 1
[build]       |         ^
[build] 1 warning generated.
```

### Purpose

Fix compiler warning.

### Approach

Guard definition with `#ifdef`.
