### PR TITLE
Fix compiler warnings

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.cpp
@@ -870,9 +870,10 @@ bool ShapePropertiesDialog::applyShapeProperties()
           fileName = "";
         }
         QFile imageFile(fileName);
-        imageFile.open(QIODevice::ReadOnly);
-        QByteArray imageByteArray = imageFile.readAll();
-        mpShapeAnnotation->setImageSource(imageByteArray.toBase64());
+        if (imageFile.open(QIODevice::ReadOnly)) {
+          QByteArray imageByteArray = imageFile.readAll();
+          mpShapeAnnotation->setImageSource(imageByteArray.toBase64());
+        }
       }
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
       mpShapeAnnotation->setImage(mpPreviewImageLabel->pixmap(Qt::ReturnByValue).toImage());

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1414,16 +1414,20 @@ void MainWindow::exportModelToOMNotebook(LibraryTreeItem *pLibraryTreeItem)
   mpProgressBar->setValue(value++);
   // create a file object and write the xml in it.
   QFile omnotebookFile(omnotebookFileName);
-  omnotebookFile.open(QIODevice::WriteOnly);
-  QTextStream textStream(&omnotebookFile);
+  if (omnotebookFile.open(QIODevice::WriteOnly)) {
+    QTextStream textStream(&omnotebookFile);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  textStream.setEncoding(QStringConverter::Utf8);
+    textStream.setEncoding(QStringConverter::Utf8);
 #else
-  textStream.setCodec(Helper::utf8.toUtf8().constData());
+    textStream.setCodec(Helper::utf8.toUtf8().constData());
 #endif
-  textStream.setGenerateByteOrderMark(false);
-  textStream << xmlDocument.toString();
-  omnotebookFile.close();
+    textStream.setGenerateByteOrderMark(false);
+    textStream << xmlDocument.toString();
+    omnotebookFile.close();
+  } else {
+    QString msg = tr("Unable to open %1").arg(omnotebookFileName);
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
+  }
   mpProgressBar->setValue(value++);
   // hide the progressbar and clear the message in status bar
   mpStatusBar->clearMessage();

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -728,15 +728,16 @@ void DocumentationWidget::updatePreviousNextButtons()
 void DocumentationWidget::writeDocumentationFile(QString documentation)
 {
   /* Create a local file with the html we want to view as otherwise JavaScript does not run properly. */
-  mDocumentationFile.open(QIODevice::WriteOnly);
-  QTextStream out(&mDocumentationFile);
+  if (mDocumentationFile.open(QIODevice::WriteOnly)) {
+    QTextStream out(&mDocumentationFile);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  out.setEncoding(QStringConverter::Utf8);
+    out.setEncoding(QStringConverter::Utf8);
 #else
-  out.setCodec(Helper::utf8.toUtf8().constData());
+    out.setCodec(Helper::utf8.toUtf8().constData());
 #endif
-  out << documentation;
-  mDocumentationFile.close();
+    out << documentation;
+    mDocumentationFile.close();
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -509,19 +509,25 @@ void OpenModelicaFile::convertModelicaFiles(QStringList filesAndDirectories, QSt
 void OpenModelicaFile::convertModelicaFile(QString fileName, QTextCodec *pCodec)
 {
   QFile file(fileName);
-  file.open(QIODevice::ReadOnly);
-  QString fileData(pCodec->toUnicode(file.readAll()));
-  file.close();
-  file.open(QIODevice::WriteOnly | QIODevice::Truncate);
-  QTextStream out(&file);
+
+  if (file.open(QIODevice::ReadOnly))
+  {
+    QString fileData(pCodec->toUnicode(file.readAll()));
+    file.close();
+
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+    {
+      QTextStream out(&file);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  out.setEncoding(QStringConverter::Utf8);
+      out.setEncoding(QStringConverter::Utf8);
 #else
-  out.setCodec(Helper::utf8.toUtf8().constData());
+      out.setCodec(Helper::utf8.toUtf8().constData());
 #endif
-  out.setGenerateByteOrderMark(false);
-  out << fileData;
-  file.close();
+      out.setGenerateByteOrderMark(false);
+      out << fileData;
+      file.close();
+    }
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1848,16 +1848,20 @@ void VariablesWidget::updateInitXmlFile(VariablesTreeItem *pVariablesTreeItem, S
                                                             .arg(initFile.fileName()), Helper::scriptingKind, Helper::errorLevel));
     }
     initFile.close();
-    initFile.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    QTextStream textStream(&initFile);
+    if (initFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+      QTextStream textStream(&initFile);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    textStream.setEncoding(QStringConverter::Utf8);
+      textStream.setEncoding(QStringConverter::Utf8);
 #else
-    textStream.setCodec(Helper::utf8.toUtf8().constData());
+      textStream.setCodec(Helper::utf8.toUtf8().constData());
 #endif
-    textStream.setGenerateByteOrderMark(false);
-    textStream << initXmlDocument.toString();
-    initFile.close();
+      textStream.setGenerateByteOrderMark(false);
+      textStream << initXmlDocument.toString();
+      initFile.close();
+    } else {
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, GUIMessages::getMessage(GUIMessages::ERROR_OPENING_FILE).arg(initFile.fileName())
+                                                            .arg(initFile.errorString()), Helper::scriptingKind, Helper::errorLevel));
+    }
   } else {
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, GUIMessages::getMessage(GUIMessages::ERROR_OPENING_FILE).arg(initFile.fileName())
                                                           .arg(initFile.errorString()), Helper::scriptingKind, Helper::errorLevel));

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -469,8 +469,7 @@ void SimulationOutputWidget::addGeneratedFileTab(QString fileName)
 {
   QFile file(fileName);
   QFileInfo fileInfo(fileName);
-  if (file.exists()) {
-    file.open(QIODevice::ReadOnly);
+  if (file.open(QIODevice::ReadOnly)) {
     BaseEditor *pEditor;
     if (Utilities::isCFile(fileInfo.suffix())) {
       pEditor = new CEditor(MainWindow::instance());

--- a/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
@@ -1238,10 +1238,9 @@ void TransformationsWidget::fetchEquationData(int equationIndex)
     }
   }
   QFile file(fileName);
-  if (file.exists()) {
+  if (file.open(QIODevice::ReadOnly)) {
     mpTSourceEditorFileLabel->setText(file.fileName());
     mpTSourceEditorFileLabel->show();
-    file.open(QIODevice::ReadOnly);
     mpTransformationsEditor->getPlainTextEdit()->setPlainText(QString(file.readAll()));
     mpTSourceEditorInfoBar->hide();
     file.close();
@@ -1385,10 +1384,9 @@ void TransformationsWidget::fetchVariableData(const QModelIndex &index)
     }
   }
   QFile file(fileName);
-  if (file.exists()) {
+  if (file.open(QIODevice::ReadOnly)) {
     mpTSourceEditorFileLabel->setText(file.fileName());
     mpTSourceEditorFileLabel->show();
-    file.open(QIODevice::ReadOnly);
     mpTransformationsEditor->getPlainTextEdit()->setPlainText(QString(file.readAll()));
     mpTSourceEditorInfoBar->hide();
     file.close();

--- a/OMEdit/Testsuite/AutoCompletion/AutoCompletionTest.cpp
+++ b/OMEdit/Testsuite/AutoCompletion/AutoCompletionTest.cpp
@@ -39,7 +39,9 @@
 #include "Editors/ModelicaEditor.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/BrowseMSL/BrowseMSL.cpp
+++ b/OMEdit/Testsuite/BrowseMSL/BrowseMSL.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/Diagram/Diagram.cpp
+++ b/OMEdit/Testsuite/Diagram/Diagram.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
+++ b/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "FlatModelica/Expression.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/Homotopy/HomotopyTest.cpp
+++ b/OMEdit/Testsuite/Homotopy/HomotopyTest.cpp
@@ -39,7 +39,9 @@
 #include "Modeling/LibraryTreeWidget.h"
 #include "Simulation/SimulationOutputWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
+++ b/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/StringHandler/StringHandlerTest.cpp
+++ b/OMEdit/Testsuite/StringHandler/StringHandlerTest.cpp
@@ -37,7 +37,9 @@
 #include "OMEditApplication.h"
 #include "MainWindow.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/Transformation/TransformationTest.cpp
+++ b/OMEdit/Testsuite/Transformation/TransformationTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Element/Transformation.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/Utilities/UtilitiesTest.cpp
+++ b/OMEdit/Testsuite/Utilities/UtilitiesTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Util/Utilities.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMEdit/Testsuite/VariableValue/VariableValueTest.cpp
+++ b/OMEdit/Testsuite/VariableValue/VariableValueTest.cpp
@@ -38,7 +38,9 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 
+#ifndef GC_THREADS
 #define GC_THREADS
+#endif
 extern "C" {
 #include "meta/meta_modelica.h"
 }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -262,7 +262,9 @@ void PlotWindow::getStartStopTime(double &start, double &stop){
   {
     QString currentLine;
     // open the file
-    mFile.open(QIODevice::ReadOnly);
+    if (!mFile.open(QIODevice::ReadOnly)) {
+      throw PlotException(tr("Failed to open simulation result file %1").arg(mFile.fileName()));
+    }
     mpTextStream = new QTextStream(&mFile);
     // read the interval size from the file
     int intervalSize = 0;
@@ -468,7 +470,9 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
   if (mFile.fileName().endsWith("plt"))
   {
     // open the file
-    mFile.open(QIODevice::ReadOnly);
+    if (!mFile.open(QIODevice::ReadOnly)) {
+      throw PlotException(tr("Failed to open simulation result file %1").arg(mFile.fileName()));
+    }
     mpTextStream = new QTextStream(&mFile);
     // read the interval size from the file
     int intervalSize = 0;
@@ -704,7 +708,9 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
     {
       QString currentLine;
       // open the file
-      mFile.open(QIODevice::ReadOnly);
+      if (!mFile.open(QIODevice::ReadOnly)) {
+        throw PlotException(tr("Failed to open simulation result file %1").arg(mFile.fileName()));
+      }
       mpTextStream = new QTextStream(&mFile);
       // read the interval size from the file
       int intervalSize = 0;


### PR DESCRIPTION
- Don't discard return value of `QFile::open`.
- Don't redefine GC_THREADS in OMEdit testsuite.