### PR TITLE
[C] Remove USE_DEBUG_OUTPUT

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/options.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/options.c
@@ -90,17 +90,6 @@ int checkCommandLineArguments(int argc, char **argv)
     omc_flagValue[i] = NULL;
   }
 
-#ifdef USE_DEBUG_OUTPUT
-  // FIXME there is no messageCloseDebug so we use infoStreamPrint here
-  infoStreamPrint(OMC_LOG_STDOUT, 1, "used command line options");
-  for(i=1; i<argc; ++i)
-    debugStreamPrint(OMC_LOG_STDOUT, 0, "%s", argv[i]);
-  messageClose(OMC_LOG_STDOUT);
-
-  // FIXME there is no messageCloseDebug so we use infoStreamPrint here
-  infoStreamPrint(OMC_LOG_STDOUT, 1, "interpreted command line options");
-#endif
-
   for(i=1; i<argc; ++i)
   {
     int found=0;
@@ -122,10 +111,6 @@ int checkCommandLineArguments(int argc, char **argv)
         // All good.
         found=1;
 
-#ifdef USE_DEBUG_OUTPUT
-        debugStreamPrint(OMC_LOG_STDOUT, 0, "-%s", FLAG_NAME[j]);
-#endif
-
         break;
       }
       else if((FLAG_TYPE[j] == FLAG_TYPE_OPTION) && flagSet(FLAG_NAME[j], 1, argv+i) && (i+1 < argc))
@@ -144,10 +129,6 @@ int checkCommandLineArguments(int argc, char **argv)
         // All good.
         found = 1;
         i++;
-
-#ifdef USE_DEBUG_OUTPUT
-        debugStreamPrint(OMC_LOG_STDOUT, 0, "-%s %s", FLAG_NAME[j], omc_flagValue[j]);
-#endif
 
         break;
       }
@@ -168,26 +149,16 @@ int checkCommandLineArguments(int argc, char **argv)
         // All good.
         found = 1;
 
-#ifdef USE_DEBUG_OUTPUT
-        debugStreamPrint(OMC_LOG_STDOUT, 0, "-%s=%s", FLAG_NAME[j], omc_flagValue[j]);
-#endif
         break;
       }
     }
 
     if(!found)
     {
-#ifdef USE_DEBUG_OUTPUT
-      messageClose(OMC_LOG_STDOUT);
-#endif
       warningStreamPrint(OMC_LOG_STDOUT, 0, "invalid command line option: %s", argv[i]);
       return 1;
     }
   }
-
-#ifdef USE_DEBUG_OUTPUT
-  messageClose(OMC_LOG_STDOUT);
-#endif
 
   return 0;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -409,18 +409,7 @@ static void read_var_info(omc_ModelVariable *var, VAR_INFO *info)
   info->info.colEnd = read_value_long(findHashStringString(var,"endColumn"), 0);
   info->info.readonly = read_value_long(findHashStringString(var,"fileWritable"), 0);
 
-  // FIXME there is no messageCloseDebug so we use infoStreamPrint here
-  infoStreamPrint(OMC_LOG_DEBUG, 1, "read var %s from setup file", info->name);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read input index %d from setup file", info->inputIndex);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s id %d from setup file", info->name, info->id);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s description \"%s\" from setup file", info->name, info->comment);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s filename %s from setup file", info->name, info->info.filename);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s lineStart %d from setup file", info->name, info->info.lineStart);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s colStart %d from setup file", info->name, info->info.colStart);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s lineEnd %d from setup file", info->name, info->info.lineEnd);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s colEnd %d from setup file", info->name, info->info.colEnd);
-  debugStreamPrint(OMC_LOG_DEBUG, 0, "read for %s readonly %d from setup file", info->name, info->info.readonly);
-  messageClose(OMC_LOG_DEBUG);
+  infoStreamPrint(OMC_LOG_DEBUG, 0, "read var %s from setup file", info->name);
 }
 
 
@@ -676,7 +665,7 @@ static void read_variables(SIMULATION_INFO* simulationInfo,
   mmc_sint_t i, j;
   omc_ModelVariable *v;
 
-  infoStreamPrint(OMC_LOG_DEBUG, 1, "read xml file for %s", debugName);
+  infoStreamPrint(OMC_LOG_DEBUG, 0, "read xml file for %s", debugName);
   for (i = 0; i < numVariables; i++) {
     j = start + i;
     v = *findHashLongVar(in, i);
@@ -747,7 +736,6 @@ static void read_variables(SIMULATION_INFO* simulationInfo,
 
     /* create a mapping for Alias variable to get the correct index */
     addHashStringLong(mapAlias, info->name, j);
-    debugStreamPrint(OMC_LOG_DEBUG, 0, "%s %s: mapAlias[%s] = %ld", type_name, debugName, info->name, (long)(j));
     if (omc_flag[FLAG_IDAS] && 0 == strcmp(debugName, "real sensitivities")) {
       if (0 == strcmp(findHashStringString(v, "isValueChangeable"), "true")) {
         long *it = findHashStringLongPtr(*mapAliasParam, info->name);
@@ -758,7 +746,6 @@ static void read_variables(SIMULATION_INFO* simulationInfo,
       }
     }
   }
-  messageClose(OMC_LOG_DEBUG);
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
@@ -575,7 +575,6 @@ int dassl_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
   /* If an event is triggered and processed restart dassl. */
   if(!dasslData->dasslAvoidEventRestart && (solverInfo->didEventStep || 0 == dasslData->idid))
   {
-    debugStreamPrint(OMC_LOG_EVENTS_V, 0, "Event-management forced reset of DDASKR");
     /* obtain reset */
     dasslData->info[0] = 0;
     dasslData->idid = 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
@@ -92,32 +92,16 @@ int checkForStateEvent(DATA* data, LIST *eventList)
   TRACE_PUSH
   long i=0;
 
-  debugStreamPrint(OMC_LOG_EVENTS, 1, "check state-event zerocrossing at time %g", data->localData[0]->timeValue);
-
   for(i=0; i<data->modelData->nZeroCrossings; i++)
   {
     int *eq_indexes;
-    if (OMC_DEBUG_STREAM(OMC_LOG_EVENTS))
-    {
-      const char *exp_str = data->callback->zeroCrossingDescription(i,&eq_indexes);
-      debugStreamPrintWithEquationIndexes(OMC_LOG_EVENTS, omc_dummyFileInfo, 1, eq_indexes, "%s", exp_str);
-    }
 
+    // Check if sign of zero crossing changed
     if(sign(data->simulationInfo->zeroCrossings[i]) != sign(data->simulationInfo->zeroCrossingsPre[i]))
     {
-      debugStreamPrint(OMC_LOG_EVENTS, 0, "changed:   %s", (data->simulationInfo->zeroCrossingsPre[i] > 0) ? "TRUE -> FALSE" : "FALSE -> TRUE");
       listPushFront(eventList, &(data->simulationInfo->zeroCrossingIndex[i]));
     }
-    else
-    {
-      debugStreamPrint(OMC_LOG_EVENTS, 0, "unchanged: %s", (data->simulationInfo->zeroCrossingsPre[i] > 0) ? "TRUE -- TRUE" : "FALSE -- FALSE");
-    }
-
-    if (OMC_DEBUG_STREAM(OMC_LOG_EVENTS))
-      messageClose(OMC_LOG_EVENTS);
   }
-  if (OMC_DEBUG_STREAM(OMC_LOG_EVENTS))
-    messageClose(OMC_LOG_EVENTS);
 
   if(listLen(eventList) > 0)
   {
@@ -265,13 +249,13 @@ void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *
       }
     }
 
-    for(i=0; i<data->modelData->nSamples; ++i)
-      if((i == 0) || (data->simulationInfo->nextSampleTimes[i] < data->simulationInfo->nextSampleEvent))
+    for(i=0; i<data->modelData->nSamples; ++i) {
+      if((i == 0) || (data->simulationInfo->nextSampleTimes[i] < data->simulationInfo->nextSampleEvent)) {
         data->simulationInfo->nextSampleEvent = data->simulationInfo->nextSampleTimes[i];
+      }
+    }
 
     data->simulationInfo->sampleActivated = 0;
-
-    debugStreamPrint(OMC_LOG_EVENTS, 0, "next sample-event at t = %g", data->simulationInfo->nextSampleEvent);
 
     solverInfo->sampleEvents++;
   }
@@ -340,15 +324,12 @@ double findRoot(DATA* data, threadData_t* threadData, LIST* eventList, double ti
 
   listClear(eventList);
 
-  debugStreamPrint(OMC_LOG_EVENTS, 0, (listLen(tmpEventList) == 1) ? "found event: " : "found events: ");
   while(listLen(tmpEventList) > 0)
   {
     long event_id = *((long*)listFirstData(tmpEventList));
     listPushFrontNodeNoCopy(eventList, listPopFrontNode(tmpEventList));
     infoStreamPrint(OMC_LOG_ZEROCROSSINGS, 0, "Event id: %ld", event_id);
   }
-
-  debugStreamPrint(OMC_LOG_EVENTS, 0, "time: %.10e", time_right);
 
   data->localData[0]->timeValue = time_left;
   memcpy(data->localData[0]->realVars, states_left, data->modelData->nStates * sizeof(double));

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
@@ -180,15 +180,12 @@ double findRoot_gb(DATA* data, threadData_t* threadData, SOLVER_INFO* solverInfo
 
   listClear(eventList);
 
-  debugStreamPrint(OMC_LOG_EVENTS, 0, (listLen(tmpEventList) == 1) ? "found event: " : "found events: ");
   while(listLen(tmpEventList) > 0)
   {
     long event_id = *((long*)listFirstData(tmpEventList));
     listPushFrontNodeNoCopy(eventList, listPopFrontNode(tmpEventList));
     infoStreamPrint(OMC_LOG_ZEROCROSSINGS, 0, "Event id: %ld", event_id);
   }
-
-  debugStreamPrint(OMC_LOG_EVENTS, 0, "time: %.10e", time_right);
 
   data->localData[0]->timeValue = time_left;
   memcpy(data->localData[0]->realVars, states_left, data->modelData->nStates * sizeof(double));

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -795,8 +795,6 @@ int ida_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInf
   /* reinit solver */
   if (!idaData->setInitialSolution)
   {
-    debugStreamPrint(OMC_LOG_SOLVER, 0, "Re-initialized IDA Solver");
-
     /* initialize states and der(states) */
     if (idaData->daeMode)
     {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -722,12 +722,6 @@ void initSample(DATA* data, threadData_t *threadData, double startTime, double s
     }
   }
 
-  if(stopTime < data->simulationInfo->nextSampleEvent) {
-    debugStreamPrint(OMC_LOG_EVENTS, 0, "there are no sample-events");
-  } else {
-    debugStreamPrint(OMC_LOG_EVENTS, 0, "first sample-event at t = %g", data->simulationInfo->nextSampleEvent);
-  }
-
   TRACE_POP
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/mixedSearchSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/mixedSearchSolver.c
@@ -207,19 +207,17 @@ int solveMixedSearch(DATA *data, int sysNumber)
     systemData->updateIterationExps(data);
 
     /* set new values of boolean variable */
-    for(i=0;i<systemData->size;++i)
+    for(i=0;i<systemData->size;++i) {
       solverData->iterationVars2[i] = *(systemData->iterationVarsPtr[i]);
-
+    }
 
     found_solution = systemData->continuous_solution;
-    debugStreamPrint(OMC_LOG_MIXED, 0, "####  continuous system solution status = %d", found_solution);
 
     /* restart if any relation has changed */
     if(checkRelations(data))
     {
       updateRelationsPre(data);
       systemData->updateIterationExps(data);
-      debugStreamPrint(OMC_LOG_MIXED, 0, "#### System relation changed restart iteration");
       if(mixedIterations++ > 200)
         found_solution = -4; /* mixedIterations++ > 200 */
     }
@@ -228,21 +226,18 @@ int solveMixedSearch(DATA *data, int sysNumber)
     {
       /* system of equations failed */
       found_solution = -2;
-      debugStreamPrint(OMC_LOG_MIXED, 0, "####  NO SOLUTION ");
     }
     else
     {
       found_solution = 1;
       for(i = 0; i < systemData->size; i++)
       {
-        debugStreamPrint(OMC_LOG_MIXED, 0, " check iterationVar[%d] = %d <-> %d", i, solverData->iterationVars[i], solverData->iterationVars2[i]);
         if(solverData->iterationVars[i] != solverData->iterationVars2[i])
         {
           found_solution  = 0;
           break;
         }
       }
-      debugStreamPrint(OMC_LOG_MIXED, 0, "#### SOLUTION = %c", found_solution  ? 'T' : 'F');
     }
 
     if(!found_solution )
@@ -250,7 +245,6 @@ int solveMixedSearch(DATA *data, int sysNumber)
       /* try next set of values*/
       if(nextVar(solverData->stateofSearch, systemData->size))
       {
-        debugStreamPrint(OMC_LOG_MIXED, 0, "#### set next STATE ");
         for(i = 0; i < systemData->size; i++)
           *(systemData->iterationVarsPtr[i]) = *(systemData->iterationPreVarsPtr[i]) != solverData->stateofSearch[i];
 
@@ -262,7 +256,6 @@ int solveMixedSearch(DATA *data, int sysNumber)
           {
             ix = (systemData->iterationVarsPtr[i]-data->localData[0]->booleanVars);
             __name = data->modelData->booleanVarsData[ix].info.name;
-            debugStreamPrint(OMC_LOG_MIXED, 0, "%s changed : %d -> %d", __name, solverData->iterationVars[i], *(systemData->iterationVarsPtr[i]));
           }
         }
       }
@@ -287,13 +280,10 @@ int solveMixedSearch(DATA *data, int sysNumber)
       if(OMC_ACTIVE_STREAM(OMC_LOG_MIXED))
       {
         const char * __name;
-        debugStreamPrint(OMC_LOG_MIXED, 0, "#### SOLUTION FOUND! (system %d)", eqSystemNumber);
         for(i = 0; i < systemData->size; i++)
         {
           ix = (systemData->iterationVarsPtr[i]-data->localData[0]->booleanVars);
           __name = data->modelData->booleanVarsData[ix].info.name;
-          debugStreamPrint(OMC_LOG_MIXED, 0, "%s = %d  pre(%s)= %d", __name, *systemData->iterationVarsPtr[i], __name,
-              *systemData->iterationPreVarsPtr[i]);
         }
       }
     }
@@ -304,6 +294,5 @@ int solveMixedSearch(DATA *data, int sysNumber)
   }while(!found_solution);
 
   messageClose(OMC_LOG_MIXED);
-  debugStreamPrint(OMC_LOG_MIXED, 0, "####  Finished mixed equation system in steps %d.\n", stepCount);
   return success;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -84,15 +84,6 @@ void saveZeroCrossings(DATA *data, threadData_t *threadData);
 
 void copyStartValuestoInitValues(DATA *data);
 
-/* functions that are only used in USE_DEBUG_OUTPUT mode */
-#ifdef USE_DEBUG_OUTPUT
-  void printAllVarsDebug(DATA *data, int ringSegment, int stream);
-  void printRelationsDebug(DATA *data, int stream);
-#else
-  #define printAllVarsDebug(data, ringSegment, stream) {}
-  #define printRelationsDebug(data, stream) {}
-#endif
-
 void printAllVars(DATA *data, int ringSegment, int stream);
 void printRelations(DATA *data, int stream);
 void printZeroCrossings(DATA *data, int stream);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -312,8 +312,6 @@ static void fmtEmitStep(DATA* data, threadData_t *threadData, MEASURE_TIME* mt, 
       data->real_time_sync.maxLate = res;
     }
   }
-
-  printAllVarsDebug(data, 0, OMC_LOG_DEBUG);  /* ??? */
 #endif
 }
 
@@ -404,7 +402,6 @@ int prefixedName_performSimulation(DATA* data, threadData_t *threadData, SOLVER_
   MEASURE_TIME fmt;
   fmtInit(data, &fmt);
 
-  printAllVarsDebug(data, 0, OMC_LOG_DEBUG); /* ??? */
   if (!compiledInDAEMode)
   {
     printSparseStructure(data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern,

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -561,32 +561,6 @@ void va_errorStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int inde
 }
 #endif
 
-#ifdef USE_DEBUG_OUTPUT
-void debugStreamPrint(int stream, int indentNext, const char *format, ...)
-{
-  if (omc_useStream[stream]) {
-    char logBuffer[SIZE_LOG_BUFFER];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-    va_end(args);
-    messageFunction(OMC_LOG_TYPE_DEBUG, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
-  }
-}
-
-void debugStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...)
-{
-  if (omc_useStream[stream]) {
-    char logBuffer[SIZE_LOG_BUFFER];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-    va_end(args);
-    messageFunction(OMC_LOG_TYPE_DEBUG, stream, info, indentNext, logBuffer, 0, indexes);
-  }
-}
-#endif
-
 static inline jmp_buf* getBestJumpBuffer(threadData_t *threadData)
 {
   switch (threadData->currentErrorStage) {

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -75,7 +75,6 @@ void omc_assert_warning_function(FILE_INFO info,  const char *msg, ...);
 void omc_terminate_function(FILE_INFO info, const char *msg, ...);
 void omc_throw_function(threadData_t*) __attribute__ ((noreturn));
 
-/* #define USE_DEBUG_OUTPUT */
 /* #define USE_DEBUG_TRACE */
 
 enum OMC_LOG_STREAM
@@ -168,12 +167,6 @@ extern int omc_showAllWarnings;
 #define OMC_ACTIVE_STREAM(stream)    (omc_useStream[stream])
 #define OMC_ACTIVE_WARNING_STREAM(stream)    (omc_showAllWarnings || omc_useStream[stream])
 
-#ifdef USE_DEBUG_OUTPUT
-  #define OMC_DEBUG_STREAM(stream)    (omc_useStream[stream])
-#else
-  #define OMC_DEBUG_STREAM(stream)    (0)
-#endif
-
 #ifdef USE_DEBUG_TRACE
   extern int DEBUG_TRACE_PUSH_HELPER(const char* pFnc, const char* pFile, const long ln);
   extern int DEBUG_TRACE_POP_HELPER(int traceID);
@@ -244,16 +237,6 @@ static void OMC_INLINE assertStreamPrint(threadData_t *threadData, int cond, con
     throwStreamPrint(NULL, "%s:%d: %s: Assertion `%s` failed.\n",  __FILE__, __LINE__, OMC_FUNCTION, #expr); \
     exit(1); \
   }
-
-#ifdef USE_DEBUG_OUTPUT
-void debugStreamPrint(int stream, FILE_INFO info, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
-void debugStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 5, 6)));
-#else
-static OMC_INLINE void debugStreamPrint(int stream __attribute__((unused)), int indentNext __attribute__((unused)), const char *format __attribute__((unused)), ...) __attribute__ ((format (printf, 3, 4)));
-static OMC_INLINE void debugStreamPrint(int stream __attribute__((unused)), int indentNext __attribute__((unused)), const char *format __attribute__((unused)), ...) {/* Do nothing */}
-static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream __attribute__((unused)), FILE_INFO info, int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...) __attribute__ ((format (printf, 5, 6)));
-static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream  __attribute__((unused)), FILE_INFO info __attribute__((unused)), int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...)  {/* Do nothing */}
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION

### Related Issues

- Functions `debugStreamPrint` and `debugStreamPrintWithEquationIndexes` are not compiled by default. In most cases use a C/C++ debugger instead of print-debugging.
- Function `debugStreamPrint` is confusing and incompatible with `messageClose`.

### Purpose

- Simplify code base.

### Approach

- Removed macros `USE_DEBUG_OUTPUT`, `OMC_DEBUG_STREAM`
- Removed functions `debugStreamPrint`, `debugStreamPrintWithEquationIndexes`
