### PR TITLE
OMEdit: Fix build with qt 6.10

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3931,7 +3931,7 @@ void GraphicsView::getCoordinateSystemAndGraphics(QStringList &coOrdinateSystemL
   }
   // add the initial scale
   if (mCoordinateSystem.hasInitialScale()) {
-    coOrdinateSystemList.append(QString("initialScale=%1").arg(mCoordinateSystem.getInitialScale()));
+    coOrdinateSystemList.append(QString("initialScale=%1").arg(mCoordinateSystem.getInitialScale().toQString()));
   }
   // add the grid
   if (mCoordinateSystem.hasGrid()) {


### PR DESCRIPTION
else I get:
```
openmodelica/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp:3946:63: error: no matching function for call to 'QString::arg(const RealAnnotation&)'
 3946 |     coOrdinateSystemList.append(QString("initialScale=%1").arg(mCoordinateSystem.getInitialScale()));
```

