### PR TITLE
Fix scope for outer components in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1383,7 +1383,7 @@ algorithm
         try
           ty_node := Lookup.lookupName(path, scope, InstContext.set(NFInstContext.RELAXED, NFInstContext.FAST_LOOKUP),
             checkAccessViolations = false);
-          json := JSON.addPair("type", dumpJSONSCodeClass(InstNode.definition(ty_node), ty_node, scope, isRedeclare = false), json);
+          json := JSON.addPair("type", dumpJSONSCodeClass(InstNode.definition(ty_node), ty_node, InstNode.resolveInner(component), isRedeclare = false), json);
         else
           json := JSON.addPair("type", dumpJSONPath(path), json);
         end try;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter7.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter7.mos
@@ -1,0 +1,252 @@
+// name: GetModelInstanceInnerOuter6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model A
+    parameter String s = \"str\";
+    annotation(Icon(graphics = {Text(textString = s)}));
+  end A;
+
+  model B
+    outer A a;
+  end B;
+
+  model M
+    B b;
+    inner A a;
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"b\",
+//       \"type\": {
+//         \"name\": \"B\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"a\",
+//             \"type\": {
+//               \"$kind\": \"class\",
+//               \"name\": \"A\",
+//               \"restriction\": \"model\",
+//               \"annotation\": {
+//                 \"Icon\": {
+//                   \"graphics\": [
+//                     {
+//                       \"$kind\": \"record\",
+//                       \"name\": \"Text\",
+//                       \"elements\": [
+//                         true,
+//                         [
+//                           0,
+//                           0
+//                         ],
+//                         0,
+//                         [
+//                           0,
+//                           0,
+//                           0
+//                         ],
+//                         [
+//                           0,
+//                           0,
+//                           0
+//                         ],
+//                         {
+//                           \"$kind\": \"enum\",
+//                           \"name\": \"LinePattern.Solid\",
+//                           \"index\": 2
+//                         },
+//                         {
+//                           \"$kind\": \"enum\",
+//                           \"name\": \"FillPattern.None\",
+//                           \"index\": 1
+//                         },
+//                         0.25,
+//                         [
+//                           [
+//                             -10,
+//                             -10
+//                           ],
+//                           [
+//                             10,
+//                             10
+//                           ]
+//                         ],
+//                         {
+//                           \"$kind\": \"cref\",
+//                           \"parts\": [
+//                             {
+//                               \"name\": \"a\"
+//                             },
+//                             {
+//                               \"name\": \"s\"
+//                             }
+//                           ]
+//                         },
+//                         0,
+//                         [
+//                           -1,
+//                           -1,
+//                           -1
+//                         ],
+//                         \"\",
+//                         [
+//
+//                         ],
+//                         {
+//                           \"$kind\": \"enum\",
+//                           \"name\": \"TextAlignment.Center\",
+//                           \"index\": 2
+//                         }
+//                       ]
+//                     }
+//                   ]
+//                 }
+//               }
+//             },
+//             \"prefixes\": {
+//               \"outer\": true
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 7,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 9,
+//           \"columnEnd\": 8
+//         }
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"annotation\": {
+//           \"Icon\": {
+//             \"graphics\": [
+//               {
+//                 \"$kind\": \"record\",
+//                 \"name\": \"Text\",
+//                 \"elements\": [
+//                   true,
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   0,
+//                   [
+//                     0,
+//                     0,
+//                     0
+//                   ],
+//                   [
+//                     0,
+//                     0,
+//                     0
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"LinePattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"FillPattern.None\",
+//                     \"index\": 1
+//                   },
+//                   0.25,
+//                   [
+//                     [
+//                       -10,
+//                       -10
+//                     ],
+//                     [
+//                       10,
+//                       10
+//                     ]
+//                   ],
+//                   {
+//                     \"$kind\": \"cref\",
+//                     \"parts\": [
+//                       {
+//                         \"name\": \"a\"
+//                       },
+//                       {
+//                         \"name\": \"s\"
+//                       }
+//                     ]
+//                   },
+//                   0,
+//                   [
+//                     -1,
+//                     -1,
+//                     -1
+//                   ],
+//                   \"\",
+//                   [
+//
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"TextAlignment.Center\",
+//                     \"index\": 2
+//                   }
+//                 ]
+//               }
+//             ]
+//           }
+//         },
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"s\",
+//             \"type\": \"String\",
+//             \"modifiers\": \"\\\"str\\\"\",
+//             \"value\": {
+//               \"binding\": \"str\"
+//             },
+//             \"prefixes\": {
+//               \"variability\": \"parameter\"
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 5,
+//           \"columnEnd\": 8
+//         }
+//       },
+//       \"prefixes\": {
+//         \"inner\": true
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 11,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 14,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -72,6 +72,7 @@ GetModelInstanceInnerOuter3.mos \
 GetModelInstanceInnerOuter4.mos \
 GetModelInstanceInnerOuter5.mos \
 GetModelInstanceInnerOuter6.mos \
+GetModelInstanceInnerOuter7.mos \
 GetModelInstanceMissingClass1.mos \
 GetModelInstanceMissingClass2.mos \
 GetModelInstanceMissingClass3.mos \


### PR DESCRIPTION
- Use the inner component for lookup when dumping outer components with getModelInstance.

Fixes #14795