### PR TITLE
Fix simplification of subscript expressions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -1355,7 +1355,7 @@ algorithm
   subscriptedExp := simplify(e);
   subs := Subscript.simplifyList(subs, Type.arrayDims(Expression.typeOf(e)));
 
-  if not split and not List.all(subs, Subscript.isLiteral) then
+  if not split and not List.all(subs, Subscript.isLiteral) and Type.isScalar(ty) then
     // Select the first element as long as the subscripted expression is an
     // array where all elements are equal, unless all the subscripts are literal
     // in which case it's cheaper to just apply them.

--- a/testsuite/flattening/modelica/scodeinst/CevalArrayConstructor3.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalArrayConstructor3.mo
@@ -1,0 +1,20 @@
+// name: CevalArrayConstructor3
+// keywords:
+// status: correct
+//
+//
+
+model CevalArrayConstructor3
+  parameter Real x[3] = {2, 2, 2};
+  parameter Real y[:] = {sum(x[1:i]) for i in 1:2} annotation(Evaluate=true);
+end CevalArrayConstructor3;
+
+// Result:
+// class CevalArrayConstructor3
+//   final parameter Real x[1] = 2.0;
+//   final parameter Real x[2] = 2.0;
+//   final parameter Real x[3] = 2.0;
+//   final parameter Real y[1] = 2.0;
+//   final parameter Real y[2] = 4.0;
+// end CevalArrayConstructor3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -119,6 +119,7 @@ CevalArrayConstant2.mo \
 CevalArrayConstant3.mo \
 CevalArrayConstructor1.mo \
 CevalArrayConstructor2.mo \
+CevalArrayConstructor3.mo \
 CevalAsin1.mo \
 CevalAtan1.mo \
 CevalAtan21.mo \


### PR DESCRIPTION
- Avoid simplification to single element if the subscript expression is sliced and should result in an array.

Fixes #14784 and #14785