### PR TITLE
[C] fix dense output extrapolation data for 'internal' GBODE

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
@@ -294,14 +294,14 @@ static void gbInternal_evalJacobian(DATA *data, threadData_t *threadData, DATA_G
         {
           // we follow the procedure of DASSL for the selection of perturbation h_i
 
-          // h * f'(x)_i
+          // h * f(x)_i
           double delta_hhh = delta_h * der_x_ref[state];
 
-          // scal_raw = ATOL * NOMINAL + RTOL * abs(Y_i), we use the real (un-transformed) integrator tolerances though
+          // scal_raw = ATOL * NOMINAL + RTOL * abs(x_i), we use the real (un-transformed) integrator tolerances though
           double raw_weight = nls->tol_integrator.atol * data->modelData->realVarsData[state].attribute.nominal + nls->tol_integrator.rtol * fabs(x[state]);
 
-          // choose h_i := h * max(of all these)
-          delta_hh[state] = delta_h * fmax(fmax(fabs(x[state]) /* x_i */, fabs(delta_hhh) /* h * f_i */), fabs(raw_weight)  /* 1 / wt_i */);
+          // choose h_i := h * max(abs(x_i), h * f(x)_i, 1 / (ATOL * NOMINAL + RTOL * abs(x_i)), 1e-3)
+          delta_hh[state] = delta_h * fmax(fmax(fmax(fabs(x[state]) /* x_i */, 1e-3), fabs(delta_hhh) /* h * f_i */), fabs(raw_weight)  /* 1 / wt_i */);
 
           // some floating point magic
           delta_hh[state] = x[state] + delta_hh[state] - x[state];

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -1606,6 +1606,17 @@ int gbode_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
         retries = 0;
       }
 
+      /* Step is accepted from here on, as err <= 1 */
+
+      /* remember last time values for dense output extrapolation with yLast, kLast */
+      gbData->extrapolationBaseTime = gbData->time;
+      gbData->extrapolationStepSize = gbData->stepSize;
+      gbData->eventHappened = FALSE;
+
+      /* remember kLast and yLast for dense output extrapolation */
+      memcpy(gbData->kLast, gbData->k, nStates * nStages * sizeof(double));
+      memcpy(gbData->yLast, gbData->yOld, nStates * sizeof(double));
+
       // Rotate the error and step size ring buffers to make room for the latest values.
       // The oldest entries are shifted one position towards the end,
       // and the newest error and step size values are stored at the front (index 0).
@@ -1696,15 +1707,6 @@ int gbode_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
         messageClose(OMC_LOG_GBODE_V);
       }
     } while (err > 1 && gbData->ctrl_method != GB_CTRL_CNST);
-
-    /* remember last time values for dense output extrapolation with yLast, kLast */
-    gbData->extrapolationBaseTime = gbData->time;
-    gbData->extrapolationStepSize = gbData->stepSize;
-    gbData->eventHappened = FALSE;
-
-    /* remember kLast and yLast for dense output extrapolation */
-    memcpy(gbData->kLast, gbData->k, nStates * nStages * sizeof(double));
-    memcpy(gbData->yLast, gbData->yOld, nStates * sizeof(double));
 
     // count processed steps
     gbData->stats.nStepsTaken++;


### PR DESCRIPTION
- fix location where dense output extrapolation data is saved to gbData
- update numerical Jacobian to have a global lower bound on the perturbation size h = 1e-8 * 1e-3