### PR TITLE
Fallback nominal attribute for index=-1 variables.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7908,7 +7908,7 @@ end crefVarInfo;
 template initializeStaticLSVars(list<SimVar> vars, Integer index)
 ::=
   let len = listLength(vars)
-  let indices = (vars |> var => varIndexWithComment(var) ;separator=",\n")
+  let indices = (vars |> var as SIMVAR(__) => '<%index%> /* <%crefCComment(var, crefStrNoUnderscore(name))%> */' ;separator=",\n")
   <<
   void initializeStaticLSData<%index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
   {
@@ -7916,20 +7916,19 @@ template initializeStaticLSVars(list<SimVar> vars, Integer index)
       <%indices%>
     };
     for (int i = 0; i < <%len%>; ++i) {
-      linearSystemData->nominal[i] = data->modelData->realVarsData[indices[i]].attribute.nominal;
-      linearSystemData->min[i]     = data->modelData->realVarsData[indices[i]].attribute.min;
-      linearSystemData->max[i]     = data->modelData->realVarsData[indices[i]].attribute.max;
+      if (indices[i] == -1) {
+        linearSystemData->nominal[i] = 1.0;
+        linearSystemData->min[i]     = -DBL_MAX;
+        linearSystemData->max[i]     = DBL_MAX;
+      } else {
+        linearSystemData->nominal[i] = data->modelData->realVarsData[indices[i]].attribute.nominal;
+        linearSystemData->min[i]     = data->modelData->realVarsData[indices[i]].attribute.min;
+        linearSystemData->max[i]     = data->modelData->realVarsData[indices[i]].attribute.max;
+      }
     }
   }
   >>
 end initializeStaticLSVars;
-
-template varIndexWithComment(SimVar var)
-::=
-  match var
-  case SIMVAR(index=-1) then varIndexWithComment(cref2simvar(crefRemovePrePrefix(name), getSimCode()))
-  case SIMVAR(__) then '<%index%> /* <%crefCComment(var, crefStrNoUnderscore(name))%> */'
-end varIndexWithComment;
 
 template crefIndexWithComment(ComponentRef cr)
 ::=

--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -246,31 +246,31 @@ end getVariablity;
 template variabilityString(VarKind varKind)
 ::=
   match varKind
-    case VARIABLE() then "variable"
-    case STATE(derName=NONE()) then 'STATE(<%index%>)'
+    case VARIABLE()               then "variable"
+    case STATE(derName=NONE())    then 'STATE(<%index%>)'
     case STATE(derName=SOME(dcr)) then 'STATE(<%index%>,<%crefStrNoUnderscore(dcr)%>)'
-    case STATE_DER()   then "STATE_DER"
-    case DUMMY_DER()   then "DUMMY_DER"
-    case DUMMY_STATE() then "DUMMY_STATE"
-    case CLOCKED_STATE()  then "CLOCKED_STATE"
-    case DISCRETE()    then "DISCRETE"
-    case PARAM()       then "PARAM"
-    case CONST()       then "CONST"
-    case EXTOBJ()  then 'EXTOBJ: <%dotPath(fullClassName)%>'
-    case JAC_VAR()     then "JACOBIAN_VAR"
-    case JAC_TMP_VAR()then "JACOBIAN_TMP_VAR"
-    case SEED_VAR()    then "SEED_VAR"
-    case OPT_CONSTR()  then "OPT_CONSTR"
-    case OPT_FCONSTR()  then "OPT_FCONSTR"
-    case OPT_INPUT_WITH_DER()  then "OPT_INPUT_WITH_DER"
-    case OPT_INPUT_DER()  then "OPT_INPUT_DER"
-    case OPT_TGRID()  then "OPT_TGRID"
-    case OPT_LOOP_INPUT()  then "OPT_LOOP_INPUT"
-    case ALG_STATE()  then "ALG_STATE"
-    case DAE_RESIDUAL_VAR() then "DAE_RESIDUAL_VAR"
-    case DAE_AUX_VAR() then "DAE_AUX_VAR"
-    case LOOP_ITERATION() then "LOOP_ITERATION"
-    case LOOP_SOLVED() then "LOOP_SOLVED"
+    case STATE_DER()              then "STATE_DER"
+    case DUMMY_DER()              then "DUMMY_DER"
+    case DUMMY_STATE()            then "DUMMY_STATE"
+    case CLOCKED_STATE()          then "CLOCKED_STATE"
+    case DISCRETE()               then "DISCRETE"
+    case PARAM()                  then "PARAM"
+    case CONST()                  then "CONST"
+    case EXTOBJ()                 then 'EXTOBJ: <%dotPath(fullClassName)%>'
+    case JAC_VAR()                then "JACOBIAN_VAR"
+    case JAC_TMP_VAR()            then "JACOBIAN_TMP_VAR"
+    case SEED_VAR()               then "SEED_VAR"
+    case OPT_CONSTR()             then "OPT_CONSTR"
+    case OPT_FCONSTR()            then "OPT_FCONSTR"
+    case OPT_INPUT_WITH_DER()     then "OPT_INPUT_WITH_DER"
+    case OPT_INPUT_DER()          then "OPT_INPUT_DER"
+    case OPT_TGRID()              then "OPT_TGRID"
+    case OPT_LOOP_INPUT()         then "OPT_LOOP_INPUT"
+    case ALG_STATE()              then "ALG_STATE"
+    case DAE_RESIDUAL_VAR()       then "DAE_RESIDUAL_VAR"
+    case DAE_AUX_VAR()            then "DAE_AUX_VAR"
+    case LOOP_ITERATION()         then "LOOP_ITERATION"
+    case LOOP_SOLVED()            then "LOOP_SOLVED"
     else "#UNKNOWN_VARKIND"
   end match
 end variabilityString;

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
@@ -3,7 +3,6 @@
 // status:   correct
 // depends: ./NewDataReconciliationSimpleTests/resources/DataReconciliationSimpleTests.TSP_FourFlows_Inputs.csv
 
-
 setCommandLineOptions("--preOptModules+=dataReconciliation");
 getErrorString();
 


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14875.

`initializeStaticLSData` was initially refactored in https://github.com/OpenModelica/OpenModelica/pull/11146.

### Purpose

Jacobian tmp variables don't have a nominal value and the index after removing the prefix is for `parentJacobian->tmpVars` and can't be used for `data->modelData->realVarsData`. Prevents illegal memory access.

### Approach

Don't remove prefix for variables with `index=-1` and fall back to default nominal, min and max values in that case.
