### PR TITLE
Fix evaluation of end in functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -468,7 +468,7 @@ protected
   InstNode parent, node;
 algorithm
   // Explode the cref into a list of parts in reverse order.
-  cref_parts := ComponentRef.toListReverse(cref, includeScope = false);
+  cref_parts := ComponentRef.toListReverse(cref, includeScope = true);
 
   // If the list is empty it's probably an iterator or _, which shouldn't be replaced.
   if listEmpty(cref_parts) then

--- a/testsuite/flattening/modelica/scodeinst/FunctionRecordArg7.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionRecordArg7.mo
@@ -1,0 +1,42 @@
+// name: FunctionRecordArg7
+// keywords:
+// status: correct
+//
+
+record flowParametersInternal
+  parameter Integer n annotation(Evaluate = true);
+  parameter Real V_flow[n];
+end flowParametersInternal;
+
+function power
+  input flowParametersInternal pressure;
+  output Real power[11];
+algorithm
+  power := {pressure.V_flow[end]*i for i in 0:10};
+end power;
+
+model FunctionRecordArg7
+  parameter flowParametersInternal pCur1(n = 3, V_flow = ones(3));
+  parameter Real powEu_internal[:] = power(pressure = pCur1);
+  annotation(__OpenModelica_commandLineOptions="-d=evaluateAllParameters");
+end FunctionRecordArg7;
+
+// Result:
+// class FunctionRecordArg7
+//   final parameter Integer pCur1.n = 3;
+//   final parameter Real pCur1.V_flow[1] = 1.0;
+//   final parameter Real pCur1.V_flow[2] = 1.0;
+//   final parameter Real pCur1.V_flow[3] = 1.0;
+//   final parameter Real powEu_internal[1] = 0.0;
+//   final parameter Real powEu_internal[2] = 1.0;
+//   final parameter Real powEu_internal[3] = 2.0;
+//   final parameter Real powEu_internal[4] = 3.0;
+//   final parameter Real powEu_internal[5] = 4.0;
+//   final parameter Real powEu_internal[6] = 5.0;
+//   final parameter Real powEu_internal[7] = 6.0;
+//   final parameter Real powEu_internal[8] = 7.0;
+//   final parameter Real powEu_internal[9] = 8.0;
+//   final parameter Real powEu_internal[10] = 9.0;
+//   final parameter Real powEu_internal[11] = 10.0;
+// end FunctionRecordArg7;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -713,6 +713,7 @@ FunctionRecordArg3.mo \
 FunctionRecordArg4.mo \
 FunctionRecordArg5.mo \
 FunctionRecordArg6.mo \
+FunctionRecordArg7.mo \
 FunctionRecursive1.mo \
 FunctionRecursive2.mo \
 FunctionSections1.mo \


### PR DESCRIPTION
- Include the scope when looking for replacements in EvalFunction, to fix the case where a record field might have a dimension that gets prefixed with its scope and then used to replace `end` inside a function.
