### PR TITLE
[GBODE] fabs nominal for error tolerance

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -915,7 +915,7 @@ int gbodef_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, d
       for (i = 0, err=0; i < nFastStates; i++) {
         ii = gbData->fastStatesIdx[i];
         // calculate corresponding values for the error estimator and step size control
-        gbfData->errtol[ii] = Atol * data->modelData->realVarsData[ii].attribute.nominal + fmax(fabs(gbfData->y[ii]), fabs(gbfData->yt[ii])) * Rtol;
+        gbfData->errtol[ii] = Atol * fabs(data->modelData->realVarsData[ii].attribute.nominal) + fmax(fabs(gbfData->y[ii]), fabs(gbfData->yt[ii])) * Rtol;
         gbfData->errest[ii] = fabs(gbfData->y[ii] - gbfData->yt[ii]);
         gbfData->err[ii] = gbData->tableau->fac * gbfData->errest[ii] / gbfData->errtol[ii];
         err += gbfData->err[ii] * gbfData->err[ii];
@@ -1391,12 +1391,12 @@ int gbode_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
 
       // Calculate error estimators and tolerance scaling for each state variable
       // Compute error tolerance for the i-th state based on relative and absolute tolerances:
-      // errtol = Rtol * max(|current state|, |previous state|) + Atol * nominal(state)
+      // errtol = Rtol * max(|current state|, |previous state|) + Atol * |nominal(state)|
       // TODO: make errtol and errest local variables
 
       for (i = 0, err=0; i < nStates; i++) {
         // calculate corresponding values for the error estimator and step size control
-        gbData->errtol[i] = Atol * data->modelData->realVarsData[i].attribute.nominal + fmax(fabs(gbData->y[i]), fabs(gbData->yt[i])) * Rtol;
+        gbData->errtol[i] = Atol * fabs(data->modelData->realVarsData[i].attribute.nominal) + fmax(fabs(gbData->y[i]), fabs(gbData->yt[i])) * Rtol;
         gbData->errest[i] = fabs(gbData->y[i] - gbData->yt[i]);
         gbData->err[i] = gbData->tableau->fac * gbData->errest[i] / gbData->errtol[i];
         err += gbData->err[i] * gbData->err[i];


### PR DESCRIPTION
### Related Issues

While working on https://github.com/OpenModelica/OpenModelica/pull/14771 I noticed a small inconsistency with the nominal values. It is allowed to use negative nominal vales, but very unusual.

### Purpose

* Use absolute value of nominal when computing tolerances.

### Approach

* Adding `fabs`.
