### PR TITLE
Don't require = to set a flag value

### DIFF
--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -643,9 +643,7 @@ algorithm
       // Stop parsing arguments if -- is encountered.
       break;
     else
-      if not readArg(arg, flags) then
-        outArgs := arg :: outArgs;
-      end if;
+      (rest_args, outArgs) := readArg(arg, flags, rest_args, outArgs);
     end if;
   end while;
 
@@ -663,7 +661,8 @@ protected function readArg
   consumed, otherwise false."
   input String inArg;
   input Flags.Flag inFlags;
-  output Boolean outConsumed;
+  input output list<String> restArgs;
+  input output list<String> nonFlags;
 protected
   String flagtype;
   Integer len;
@@ -675,40 +674,38 @@ algorithm
   if flagtype == "+" then
     if len == 1 then
       // + alone is not a valid flag.
-      parseFlag(inArg, Flags.NO_FLAGS());
+      parseFlag(inArg, Flags.NO_FLAGS(), restArgs);
     else
-      parseFlag(System.substring(inArg, 2, len), inFlags, flagtype);
+      restArgs := parseFlag(System.substring(inArg, 2, len), inFlags, restArgs, flagtype);
     end if;
-    outConsumed := true;
   // Flags beginning with - must have another - for long flags, i.e. -h or --help.
   elseif flagtype == "-" then
     if len == 1 then
       // - alone is not a valid flag.
-      parseFlag(inArg, Flags.NO_FLAGS());
+      parseFlag(inArg, Flags.NO_FLAGS(), restArgs);
     elseif len == 2 then
       // Short flag without argument, i.e. -h.
-      parseFlag(System.substring(inArg, 2, 2), inFlags, flagtype);
+      restArgs := parseFlag(System.substring(inArg, 2, 2), inFlags, restArgs, flagtype);
     elseif stringGetStringChar(inArg, 2) == "-" then
       if len < 4 or stringGetStringChar(inArg, 4) == "=" then
         // Short flags may not be used with --, i.e. --h or --h=debug.
-        parseFlag(inArg, Flags.NO_FLAGS());
+        parseFlag(inArg, Flags.NO_FLAGS(), restArgs);
       else
         // Long flag, i.e. --help or --help=debug.
-        parseFlag(System.substring(inArg, 3, len), inFlags, "--");
+        restArgs := parseFlag(System.substring(inArg, 3, len), inFlags, restArgs, "--");
       end if;
     else
       if stringGetStringChar(inArg, 3) == "=" then
         // Short flag with argument, i.e. -h=debug.
-        parseFlag(System.substring(inArg, 2, len), inFlags, flagtype);
+        restArgs := parseFlag(System.substring(inArg, 2, len), inFlags, restArgs, flagtype);
       else
         // Long flag used with -, i.e. -help, which is not allowed.
-        parseFlag(inArg, Flags.NO_FLAGS());
+        parseFlag(inArg, Flags.NO_FLAGS(), restArgs);
       end if;
     end if;
-    outConsumed := true;
   else
     // Arguments that don't begin with + or - are not flags, ignore them.
-    outConsumed := false;
+    nonFlags := inArg :: nonFlags;
   end if;
 end readArg;
 
@@ -716,14 +713,16 @@ protected function parseFlag
   "Parses a single flag."
   input String inFlag;
   input Flags.Flag inFlags;
+  input output list<String> restArgs;
   input String inFlagPrefix = "";
 protected
   String flag;
   list<String> values;
+  Boolean missing_value;
 algorithm
   flag :: values := System.strtok(inFlag, "=");
-  values := List.flatten(List.map1(values, System.strtok, ","));
-  parseConfigFlag(flag, values, inFlags, inFlagPrefix);
+  missing_value := listEmpty(values) and not StringUtil.endsWith(inFlag, "=");
+  restArgs := parseConfigFlag(flag, values, inFlags, restArgs, inFlagPrefix, missing_value);
 end parseFlag;
 
 protected function parseConfigFlag
@@ -731,12 +730,26 @@ protected function parseConfigFlag
   input String inFlag;
   input list<String> inValues;
   input Flags.Flag inFlags;
+  input output list<String> restArgs;
   input String inFlagPrefix;
+  input Boolean missingValue;
 protected
   Flags.ConfigFlag config_flag;
+  list<String> values;
 algorithm
   config_flag := lookupConfigFlag(inFlag, inFlagPrefix);
-  evaluateConfigFlag(config_flag, inValues, inFlags);
+
+  if missingValue and flagRequiresValue(config_flag) and not listEmpty(restArgs) then
+    // If no value was given using = and the flag requires a value,
+    // use the next argument as the value.
+    values := {listHead(restArgs)};
+    restArgs := listRest(restArgs);
+  else
+    values := inValues;
+  end if;
+
+  values := List.flatten(List.map1(values, System.strtok, ","));
+  evaluateConfigFlag(config_flag, values, inFlags);
 end parseConfigFlag;
 
 protected function lookupConfigFlag
@@ -765,6 +778,16 @@ algorithm
     then index1 == index2;
   end match;
 end configFlagEq;
+
+protected function flagRequiresValue
+  input Flags.ConfigFlag flag;
+  output Boolean requiresValue;
+algorithm
+  requiresValue := match flag
+    case Flags.CONFIG_FLAG(defaultValue = Flags.BOOL_FLAG()) then false;
+    else true;
+  end match;
+end flagRequiresValue;
 
 protected function setAdditionalOptModules
   input Flags.ConfigFlag inFlag;

--- a/testsuite/openmodelica/interactive-API/FlagParsing.mos
+++ b/testsuite/openmodelica/interactive-API/FlagParsing.mos
@@ -64,6 +64,13 @@ setCommandLineOptions("fish"); getErrorString();
 // only take flags.
 setCommandLineOptions("-- -d=failtrace"); getErrorString();
 
+// Should work, flags don't require =.
+setCommandLineOptions("-d failtrace"); getErrorString();
+setCommandLineOptions("-d failtrace --debug=ceval"); getErrorString();
+
+// Shouldn't work, some flags require a value.
+setCommandLineOptions("-i="); getErrorString();
+
 // Result:
 // true
 // ""
@@ -143,4 +150,11 @@ setCommandLineOptions("-- -d=failtrace"); getErrorString();
 // ""
 // false
 // ""
+// true
+// ""
+// true
+// ""
+// false
+// "Error: Invalid type of flag instClass, expected a string but got nothing.
+// "
 // endResult


### PR DESCRIPTION
- If a command line flag doesn't specify a value with = and requires a value, use the next argument as the value (to allow e.g. `-i test`).