### PR TITLE
Handle the edit case of choicesAllMatching

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -851,7 +851,7 @@ void Parameter::editClassButtonClicked()
   QString type;
   QString value;
   QString defaultValue;
-  if (isReplaceableComponent() || isReplaceableClass()) {
+  if (isReplaceableComponent() || isReplaceableClass() || isChoicesAllMatching()) {
     value = mpValueComboBox->lineEdit()->text();
     defaultValue = mpValueComboBox->lineEdit()->placeholderText();
   } else {

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -110,6 +110,7 @@ public:
   bool isEnumeration() const {return mValueType == Enumeration;}
   bool isReplaceableComponent() const {return mValueType == ReplaceableComponent;}
   bool isReplaceableClass() const {return mValueType == ReplaceableClass;}
+  bool isChoicesAllMatching() const {return mValueType == ChoicesAllMatching;}
   bool isRecord() const {return mValueType == Record;}
   bool isChoices() const {return mValueType == Choices;}
   QWidget* getValueWidget();


### PR DESCRIPTION
### Related Issues

Issue reported via the crash report, see #14916.

### Purpose

OMEdit should not crash when editing replaceable class with choicesAllMatching annotation.

### Approach

Check for choicesAllMatching when editing the class to avoid the crash.
