### PR TITLE
Improve Ceval error messages

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -948,7 +948,7 @@ algorithm
     comp_var := Component.variability(comp);
     if comp_var <= Variability.STRUCTURAL_PARAMETER or binding_var <= Variability.STRUCTURAL_PARAMETER then
       // Constant evaluate parameters that are structural/constant.
-      binding_exp := Ceval.evalExp(binding_exp);
+      binding_exp := Ceval.evalExp(binding_exp, Ceval.EvalTarget.new(info, NFInstContext.BINDING));
       binding_exp := flattenExp(binding_exp, prefix, Binding.getInfo(binding));
     elseif binding_var == Variability.PARAMETER and Component.isFinal(comp) then
       // Try to use inlining first.

--- a/testsuite/flattening/modelica/scodeinst/CevalRecord8.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalRecord8.mo
@@ -1,0 +1,37 @@
+// name: CevalRecord8
+// keywords:
+// status: incorrect
+//
+// Checks that the division by zero error is shown when in a record.
+//
+
+record R
+  parameter Real x[:];
+end R;
+
+record R2
+  parameter Real x;
+end R2;
+
+function f
+  input R r;
+  output R2 r2;
+algorithm
+  r2.x := if max(r.x) < 0 then 0 else 1;
+end f;
+
+model CevalRecord8
+  parameter R r(x = 1/0*{0, 1, 2});
+  parameter R2 r2 = f(r) annotation(Evaluate=true);
+end CevalRecord8;
+
+// Result:
+// Error processing file: CevalRecord8.mo
+// [flattening/modelica/scodeinst/CevalRecord8.mo:24:17-24:34:writable] Notification: From here:
+// [flattening/modelica/scodeinst/CevalRecord8.mo:20:3-20:40:writable] Error: Division by zero in 1.0 / 0.0
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -199,6 +199,7 @@ CevalRecord4.mo \
 CevalRecord5.mo \
 CevalRecord6.mo \
 CevalRecord7.mo \
+CevalRecord8.mo \
 CevalRecordArray1.mo \
 CevalRecordArray2.mo \
 CevalRecordArray3.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecursiveConstants1.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecursiveConstants1.mo
@@ -10,6 +10,8 @@ end RecursiveConstants1;
 
 // Result:
 // Error processing file: RecursiveConstants1.mo
+// [flattening/modelica/scodeinst/RecursiveConstants1.mo:8:3-8:22:writable] Notification: From here:
+// [flattening/modelica/scodeinst/RecursiveConstants1.mo:7:3-7:22:writable] Notification: From here:
 // [flattening/modelica/scodeinst/RecursiveConstants1.mo:8:3-8:22:writable] Error: Variable 'y' has a cyclic dependency and has variability constant.
 //
 // # Error encountered! Exiting...

--- a/testsuite/flattening/modelica/scodeinst/loop1.mo
+++ b/testsuite/flattening/modelica/scodeinst/loop1.mo
@@ -15,6 +15,7 @@ end A;
 
 // Result:
 // Error processing file: loop1.mo
+// [flattening/modelica/scodeinst/loop1.mo:11:3-11:25:writable] Notification: From here:
 // [flattening/modelica/scodeinst/loop1.mo:12:3-12:24:writable] Error: Dimension 1 of x, 'i', could not be evaluated due to a cyclic dependency.
 //
 // # Error encountered! Exiting...


### PR DESCRIPTION
- Include info when evaluating record bindings so that error messages are shown.
- Add a "from here" message when evaluating component bindings to make it clearer where the error is coming from.

Fixes #14902