### PR TITLE
Improve handling of comma separated flag values

### DIFF
--- a/testsuite/openmodelica/interactive-API/Cmd2.mos
+++ b/testsuite/openmodelica/interactive-API/Cmd2.mos
@@ -1,0 +1,10 @@
+// name: Cmd2
+// status: correct
+// cflags: --cmd="max(1, 2)"
+
+print("test");
+
+// Result:
+// 2
+// test
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -22,6 +22,7 @@ checkAllModelsRecursive1.mos \
 CheckModelExtObj1.mos \
 choicesAllMatching.mos \
 Cmd1.mos \
+Cmd2.mos \
 ConnectionList.mos \
 ConversionVersions.mos \
 ConvertUnits.mos \


### PR DESCRIPTION
- Only split comma separated flag values to lists of strings for flags that actually expect a list of values, to allow flag values with commas in them (for e.g. `--cmd`).