### PR TITLE
Translate command line arguments from C to Cpp

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -557,27 +557,15 @@ vector<const char *> OMCFactory::handleComplexCRuntimeArguments(int argc, const 
       else if ((oit = opts.find(arg)) != opts.end() && i < argc - 1)
           opts[oit->first] = argv[++i]; // regular override
       else if (strncmp(argv[i], "-override=", 10) == 0) {
-          // FIXME startTime, stopTime, ... are no longer used with override
-          map<string, string> supported = MAP_LIST_OF
-            "startTime", "-S" MAP_LIST_SEP "stopTime", "-E" MAP_LIST_SEP
-            "stepSize", "-H" MAP_LIST_SEP "numberOfIntervals", "-G" MAP_LIST_SEP
-            "solver", "-I" MAP_LIST_SEP "tolerance", "-T" MAP_LIST_SEP
-            "outputFormat", "-P" MAP_LIST_SEP "variableFilter", "-B" MAP_LIST_END;
           vector<string> strs;
           boost::split(strs, argv[i], boost::is_any_of(",="));
           for (int j = 1; j < strs.size(); j++) {
-              if ((oit = supported.find(strs[j])) != supported.end()
-                  && j < strs.size() - 1) {
-                  opts[oit->second] = strs[++j];
-              }
-              else {
-                  // leave unrecognized overrides
-                  if (overrideOMEdit.size() > 10)
-                      overrideOMEdit += ",";
-                  overrideOMEdit += strs[j];
-                  if (j < strs.size() - 1)
-                      overrideOMEdit += "=" + strs[++j];
-              }
+              // leave unrecognized overrides
+              if (overrideOMEdit.size() > 10)
+                  overrideOMEdit += ",";
+              overrideOMEdit += strs[j];
+              if (j < strs.size() - 1)
+                  overrideOMEdit += "=" + strs[++j];
           }
           if (overrideOMEdit.size() > 10)
               optv.push_back(strdup(overrideOMEdit.c_str()));
@@ -602,6 +590,12 @@ void OMCFactory::fillArgumentsToIgnore()
 void OMCFactory::fillArgumentsToReplace()
 {
   _argumentsToReplace = map<string, string>();
+  _argumentsToReplace.insert(pair<string,string>("-startTime", "start-time"));
+  _argumentsToReplace.insert(pair<string,string>("-stopTime", "stop-time"));
+  _argumentsToReplace.insert(pair<string,string>("-stepSize", "step-size"));
+  _argumentsToReplace.insert(pair<string,string>("-s", "solver"));
+  _argumentsToReplace.insert(pair<string,string>("-outputFormat", "output-format"));
+  _argumentsToReplace.insert(pair<string,string>("-variableFilter", "variable-filter"));
   _argumentsToReplace.insert(pair<string,string>("-r", "results-file"));
   _argumentsToReplace.insert(pair<string,string>("-ls", "lin-solver"));
   _argumentsToReplace.insert(pair<string,string>("-nls", "non-lin-solver"));

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.h
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.h
@@ -45,7 +45,7 @@ public:
 
 protected:
   /**
-   * This function handles complex c-runtime arguments like "-override=startTime=0,...". The
+   * This function handles complex c-runtime arguments like "-override=varName=0,...". The
    * arguments are separated correctly returned as vector. Furthermore the are added to the given
    * opts-map (old values are overwritten).
    * @param argc Number of arguments in the argv-array.


### PR DESCRIPTION
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough

Command-line argument processing in OMCFactory is refactored to remove runtime override mappings for specific parameters and introduce argument rename mappings converting legacy short-form options to new long-form names. Documentation is updated to reflect the generalized override syntax.

## Changes

| Cohort / File(s) | Summary |
|---|---|
| **Argument processing updates** <br> `OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp` | Removal of runtime override mappings for startTime, stopTime, stepSize, solver, outputFormat, and variableFilter in `handleComplexCRuntimeArguments`; all unrecognized overrides now appended to overrideOMEdit. Addition of argument rename mappings in `fillArgumentsToReplace` for legacy short-form options (`-startTime`, `-stopTime`, `-stepSize`, `-s`, `-outputFormat`, `-variableFilter`) to new long-form names (`start-time`, `stop-time`, `step-size`, `solver`, `output-format`, `variable-filter`). |
| **Documentation update** <br> `OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.h` | Comment updated for `handleComplexCRuntimeArguments` from describing specific override mappings to generalized syntax (`-override=varName=0,...`). |

## Estimated code review effort

🎯 3 (Moderate) | ⏱️ ~25 minutes

---

Auto-generated by @coderabbit.ai.