### PR TITLE
Fixing real array variables filter init, modelData free

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -367,12 +367,12 @@ void initializeOutputFilter(MODEL_DATA *modelData, const char *variableFilter, i
     return;
   }
 
-  for(mmc_sint_t i=0; i<modelData->nVariablesReal; i++) {
+  for(mmc_sint_t i=0; i<modelData->nVariablesRealArray; i++) {
     if(!modelData->realVarsData[i].filterOutput) {
       modelData->realVarsData[i].filterOutput = regexec(&myregex, modelData->realVarsData[i].info.name, 0, NULL, 0) != 0;
     }
   }
-  for(mmc_sint_t i=0; i<modelData->nAliasReal; i++) {
+  for(mmc_sint_t i=0; i<modelData->nAliasRealArray; i++) {
     if(!modelData->realAlias[i].filterOutput) {
       if(modelData->realAlias[i].aliasType == ALIAS_TYPE_VARIABLE) {
         modelData->realAlias[i].filterOutput = regexec(&myregex, modelData->realAlias[i].info.name, 0, NULL, 0) != 0;
@@ -388,12 +388,12 @@ void initializeOutputFilter(MODEL_DATA *modelData, const char *variableFilter, i
     }
   }
 
-  for (mmc_sint_t i=0; i<modelData->nVariablesInteger; i++) {
+  for (mmc_sint_t i=0; i<modelData->nVariablesIntegerArray; i++) {
     if(!modelData->integerVarsData[i].filterOutput) {
       modelData->integerVarsData[i].filterOutput = regexec(&myregex, modelData->integerVarsData[i].info.name, 0, NULL, 0) != 0;
     }
   }
-  for (mmc_sint_t i=0; i<modelData->nAliasInteger; i++) {
+  for (mmc_sint_t i=0; i<modelData->nAliasIntegerArray; i++) {
     if(!modelData->integerAlias[i].filterOutput) {
       if(modelData->integerAlias[i].aliasType == ALIAS_TYPE_VARIABLE) {
         modelData->integerAlias[i].filterOutput = regexec(&myregex, modelData->integerAlias[i].info.name, 0, NULL, 0) != 0;
@@ -409,12 +409,12 @@ void initializeOutputFilter(MODEL_DATA *modelData, const char *variableFilter, i
     }
   }
 
-  for (mmc_sint_t i=0; i<modelData->nVariablesBoolean; i++) {
+  for (mmc_sint_t i=0; i<modelData->nVariablesBooleanArray; i++) {
     if(!modelData->booleanVarsData[i].filterOutput) {
       modelData->booleanVarsData[i].filterOutput = regexec(&myregex, modelData->booleanVarsData[i].info.name, 0, NULL, 0) != 0;
     }
   }
-  for (mmc_sint_t i=0; i<modelData->nAliasBoolean; i++) {
+  for (mmc_sint_t i=0; i<modelData->nAliasBooleanArray; i++) {
     if(!modelData->booleanAlias[i].filterOutput) {
       if(modelData->booleanAlias[i].aliasType == ALIAS_TYPE_VARIABLE) {
         modelData->booleanAlias[i].filterOutput = regexec(&myregex, modelData->booleanAlias[i].info.name, 0, NULL, 0) != 0;
@@ -430,12 +430,12 @@ void initializeOutputFilter(MODEL_DATA *modelData, const char *variableFilter, i
     }
   }
 
-  for (mmc_sint_t i=0; i<modelData->nVariablesString; i++) {
+  for (mmc_sint_t i=0; i<modelData->nVariablesStringArray; i++) {
     if(!modelData->stringVarsData[i].filterOutput) {
       modelData->stringVarsData[i].filterOutput = regexec(&myregex, modelData->stringVarsData[i].info.name, 0, NULL, 0) != 0;
     }
   }
-  for (mmc_sint_t i=0; i<modelData->nAliasString; i++) {
+  for (mmc_sint_t i=0; i<modelData->nAliasStringArray; i++) {
     if(!modelData->stringAlias[i].filterOutput) {
       if(modelData->stringAlias[i].aliasType == ALIAS_TYPE_VARIABLE) {
         modelData->stringAlias[i].filterOutput = regexec(&myregex, modelData->stringAlias[i].info.name, 0, NULL, 0) != 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -881,45 +881,45 @@ void freeModelDataVars(MODEL_DATA* modelData)
   unsigned int i;
 
   // Variables
-  for(i=0; i < modelData->nVariablesReal; i++) {
+  for(i=0; i < modelData->nVariablesRealArray; i++) {
     freeVarInfo(&modelData->realVarsData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->realVarsData);
 
-  for(i=0; i < modelData->nVariablesInteger; i++) {
+  for(i=0; i < modelData->nVariablesIntegerArray; i++) {
     freeVarInfo(&modelData->integerVarsData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->integerVarsData);
 
-  for(i=0; i < modelData->nVariablesBoolean; i++) {
+  for(i=0; i < modelData->nVariablesBooleanArray; i++) {
     freeVarInfo(&modelData->booleanVarsData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->booleanVarsData);
 
 #if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING>0
-  for(i=0; i < modelData->nVariablesString; i++) {
+  for(i=0; i < modelData->nVariablesStringArray; i++) {
     freeVarInfo(&modelData->stringVarsData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->stringVarsData);
 #endif
 
   // Parameters
-  for(i=0; i < modelData->nParametersReal; i++) {
+  for(i=0; i < modelData->nParametersRealArray; i++) {
     freeVarInfo(&modelData->realParameterData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->realParameterData);
 
-  for(i=0; i < modelData->nParametersInteger; i++) {
+  for(i=0; i < modelData->nParametersIntegerArray; i++) {
     freeVarInfo(&modelData->integerParameterData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->integerParameterData);
 
-  for(i=0; i < modelData->nParametersBoolean; i++) {
+  for(i=0; i < modelData->nParametersBooleanArray; i++) {
     freeVarInfo(&modelData->booleanParameterData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->booleanParameterData);
 
-  for(i=0; i < modelData->nParametersString; i++) {
+  for(i=0; i < modelData->nParametersStringArray; i++) {
     freeVarInfo(&modelData->stringParameterData[i].info);
   }
   omc_alloc_interface.free_uncollectable(modelData->stringParameterData);
@@ -932,28 +932,28 @@ void freeModelDataVars(MODEL_DATA* modelData)
 
   // Alias Variables
   if (modelData->realAlias != NULL) {
-    for(i=0; i < modelData->nAliasReal; i++) {
+    for(i=0; i < modelData->nAliasRealArray; i++) {
       freeVarInfo(&modelData->realAlias[i].info);
     }
     omc_alloc_interface.free_uncollectable(modelData->realAlias);
   }
 
   if (modelData->integerAlias != NULL) {
-    for(i=0; i < modelData->nAliasInteger; i++) {
+    for(i=0; i < modelData->nAliasIntegerArray; i++) {
       freeVarInfo(&modelData->integerAlias[i].info);
     }
     omc_alloc_interface.free_uncollectable(modelData->integerAlias);
   }
 
   if (modelData->booleanAlias != NULL) {
-    for(i=0; i < modelData->nAliasBoolean; i++) {
+    for(i=0; i < modelData->nAliasBooleanArray; i++) {
       freeVarInfo(&modelData->booleanAlias[i].info);
     }
     omc_alloc_interface.free_uncollectable(modelData->booleanAlias);
   }
 
   if (modelData->stringAlias != NULL) {
-    for(i=0; i < modelData->nAliasString; i++) {
+    for(i=0; i < modelData->nAliasStringArray; i++) {
       freeVarInfo(&modelData->stringAlias[i].info);
     }
     omc_alloc_interface.free_uncollectable(modelData->stringAlias);

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -232,9 +232,9 @@ typedef enum HOMOTOPY_METHOD
 } HOMOTOPY_METHOD;
 
 enum ALIAS_TYPE {
-  ALIAS_TYPE_VARIABLE = 0,
-  ALIAS_TYPE_PARAMETER = 1,
-  ALIAS_TYPE_TIME = 2,
+  ALIAS_TYPE_VARIABLE = 0,  /* Alias of a variable */
+  ALIAS_TYPE_PARAMETER = 1, /* Alias of a parameter */
+  ALIAS_TYPE_TIME = 2,      /* Alias of time */
 };
 
 /* Alias data with various types */


### PR DESCRIPTION
### Related Issues

Fixes some segmentation faults when simulating models with compiler flags `--newBackend --simCodeScalarize=false`, e.g. for `testsuite/simulation/modelica/NBackend/basics/simpleForLoop.mos`.

Not directly related to MAT files, so I moved these changes from https://github.com/OpenModelica/OpenModelica/pull/14922 into this independent PR.

### Purpose

- Fix segmentation fault when initializing output filters.
- Fix segmentation fault when freeing modelData variables.

### Approach

- Use array variant of number of variables: `modelData->nVariablesTYPE` ==> `modelData->nVariablesTYPEArray`
