### PR TITLE
[Cpp] Zero crossing for real equality

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -12284,6 +12284,10 @@ template giveZeroFunc3(Integer index1, Exp relation, Text &varDecls /*BUFP*/,Tex
         <<
         f[<%index1%>] = std::abs(<%e2%> - <%e1%>);
         >>
+      case EQUAL(ty = T_REAL(__)) then
+        <<
+        f[<%index1%>] = std::abs(<%e2%> - _zeroTol - <%e1%>);
+        >>
       else
         <<
         error(sourceInfo(), 'Unsupported relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')

--- a/OMCompiler/Compiler/Template/CodegenCppOMSI.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOMSI.tpl
@@ -12122,6 +12122,10 @@ template giveZeroFunc3(Integer index1, Exp relation, Text &varDecls /*BUFP*/,Tex
         <<
         f[<%index1%>] = std::abs(<%e2%> - <%e1%>);
         >>
+      case EQUAL(ty = T_REAL(__)) then
+        <<
+        f[<%index1%>] = std::abs(<%e2%> - _zeroTol - <%e1%>);
+        >>
       else
         <<
         error(sourceInfo(), 'Unsupported relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')


### PR DESCRIPTION
### Related Issues

Fixes #14934.

### Purpose

Handle the (very much not recommended) edge case for real equality relations in C++ runtime.

### Approach

Add code generation for $|equation_2 - \epsilon - equation_1|$ with $\epsilon > 0$  for type `T_REAL`.

The small zero tolerance is needed to prevent
```
DASKR--  R IS ILL-DEFINED.  ZERO VALUES WERE FOUND AT TWO                       
         VERY CLOSE T VALUES, AT T = R1                                         
      In above message,  R1 =   1.0000000000000E-25
DASKR--  R IS ILL-DEFINED.  ZERO VALUES WERE FOUND AT TWO                       
         VERY CLOSE T VALUES, AT T = R1                                         
      In above message,  R1 =   1.0000000000000E-25
```