### PR TITLE
Handle real discrete array variables without scalarization

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1643,7 +1643,7 @@ template populateModelInfo(ModelInfo modelInfo, String fileNamePrefix, String gu
     %>
     data->modelData->runTestsuite = <%if Testsuite.isRunning() then "1" else "0"%>;
     data->modelData->nStatesArray = <%varInfo.numStateVars%>;
-    data->modelData->nDiscreteReal = <%varInfo.numDiscreteReal%>;
+    data->modelData->nDiscreteRealArray = <%varInfo.numDiscreteReal%>;
     data->modelData->nVariablesRealArray = <%nVariablesReal(varInfo)%>;
     data->modelData->nVariablesIntegerArray = <%varInfo.numIntAlgVars%>;
     data->modelData->nVariablesBooleanArray = <%varInfo.numBoolAlgVars%>;
@@ -6269,14 +6269,42 @@ case SES_SIMPLE_ASSIGN_CONSTRAINTS(__) then
                     <%name%>,
                     (<%crefType(popCref(cref))%>) <%cref(popCref(cref), &sub)%>);
     >>
+  let lhs = equationSimpleAssignLhs(cref, context, &preExp, &varDecls, &auxFunction, &sub)
   <<
   <%modelicaLine(eqInfo(eq))%>
   <%preExp%>
-  <%contextCref(cref, context, &preExp, &varDecls, auxFunction, &sub)%> = <%expPart%>;
+  <%lhs%> = <%expPart%>;
   <%postExp%>
   <%endModelicaLine()%>
   >>
 end equationSimpleAssign;
+
+template equationSimpleAssignLhs(ComponentRef cref, Context context,
+                                 Text &preExp, Text &varDecls, Text &auxFunction, Text &sub)
+ "Generates the left hand side cref of a simple assignment.
+  When sim code scalarization is disabled (new backend), array elements like
+  arr[2] are not standalone simvars. They have to be addressed relative to the
+  first element of the array using a flattened index, the same way the right
+  hand side and variable subscripts are handled in daeExpCref*SimContext."
+::=
+  match context
+  case FUNCTION_CONTEXT(__)
+  case JACOBIAN_CONTEXT(__)
+  case OMSI_CONTEXT(__) then
+    contextCref(cref, context, &preExp, &varDecls, &auxFunction, &sub)
+  else
+    // Note: $START crefs address the (array valued) start attribute and must
+    // not be flattened here, they keep the regular handling.
+    if boolAnd(boolAnd(Flags.getConfigBool(Flags.NEW_BACKEND), boolNot(Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE))), boolNot(isStartCref(cref))) then
+      match crefSubs(crefArrayGetFirstCref(cref))
+      case {} then
+        contextCref(cref, context, &preExp, &varDecls, &auxFunction, &sub)
+      else
+        let &idxSub = buffer '<%indexSubs(crefDims(cref), crefSubs(crefArrayGetFirstCref(cref)), context, &preExp, &varDecls, &auxFunction)%>'
+        contextCref(crefStripSubs(cref), context, &preExp, &varDecls, &auxFunction, &idxSub)
+    else
+      contextCref(cref, context, &preExp, &varDecls, &auxFunction, &sub)
+end equationSimpleAssignLhs;
 
 template equationForLoop(SimEqSystem eq, Context context, Text &varDecls, Text &auxFunction)
  "Generates an equation that is a for-loop."

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5506,15 +5506,28 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
     slicedArray
 
   case ecr as CREF(componentRef=cr, ty=ty) then
-    if crefIsScalarWithAllConstSubs(cr) then
-      // let cast = typeCastContextInt(context, ty)
-      let &sub = buffer ""
-      '<%contextCref(cr, context, &preExp, &varDecls, &auxFunction, &sub)%>'
-    else if crefIsScalarWithVariableSubs(cr) then
+    if crefIsScalarWithVariableSubs(cr) then
       let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
       let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
       // let cast = typeCastContextInt(context, ty)
       '<%nosubname%>'
+    else if boolAnd(boolAnd(Flags.getConfigBool(Flags.NEW_BACKEND), boolNot(Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE))), boolNot(isStartCref(cr))) then
+      // Without sim code scalarization array elements like arr[2] are not
+      // standalone simvars and have to be addressed relative to the first
+      // element of the array using a flattened index. $START crefs address the
+      // (array valued) start attribute and keep the regular handling.
+      match crefSubs(crefArrayGetFirstCref(cr))
+      case {} then
+        let &sub = buffer ""
+        '<%contextCref(cr, context, &preExp, &varDecls, &auxFunction, &sub)%>'
+      else
+        let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
+        let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
+        '<%nosubname%>'
+    else if crefIsScalarWithAllConstSubs(cr) then
+      // let cast = typeCastContextInt(context, ty)
+      let &sub = buffer ""
+      '<%contextCref(cr, context, &preExp, &varDecls, &auxFunction, &sub)%>'
     else
       error(sourceInfo(),'daeExpCrefRhsSimContext: UNHANDLED CREF: <%ExpressionDumpTpl.dumpExp(ecr,"\"")%>')
 end daeExpCrefRhsSimContext;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4173,6 +4173,7 @@ package Flags
   constant ConfigFlag MAX_SIZE_LINEARIZATION;
   constant ConfigFlag NEW_BACKEND;
   constant ConfigFlag FMI_EXTRA_ANNOTATIONS;
+  constant ConfigFlag SIM_CODE_SCALARIZE;
 
   function isSet
     input DebugFlag inFlag;

--- a/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.c
@@ -300,25 +300,13 @@ void printFlattenedNames(FILE *stream,
                          const char *name,
                          DIMENSION_INFO *dimension_info)
 {
-  if (dimension_info == NULL || dimension_info->numberOfDimensions <= 0 || dimension_info->dimensions == NULL)
-  {
-    throwStreamPrint(NULL, "Invalid dimension info.");
-  }
-  if (stream == NULL)
-  {
-    throwStreamPrint(NULL, "Invalid stream.");
-  }
-  if (separator == NULL)
-  {
-    throwStreamPrint(NULL, "Invalid separator.");
-  }
+  assertStreamPrint(NULL, dimension_info != NULL && dimension_info->numberOfDimensions > 0 && dimension_info->dimensions != NULL, "Invalid dimension info.");
+  assertStreamPrint(NULL, stream != NULL, "Invalid stream.");
+  assertStreamPrint(NULL, separator != NULL, "Invalid separator.");
 
   /* Temporary index array */
   size_t *idx = (size_t *)calloc(dimension_info->numberOfDimensions, sizeof(size_t));
-  if (!idx)
-  {
-    throwStreamPrint(NULL, "Out of memory.");
-  }
+  assertStreamPrint(NULL, idx != NULL, "Out of memory");
 
   for (size_t linear = 0; linear < dimension_info->scalar_length; linear++)
   {
@@ -385,29 +373,16 @@ size_t *linearToMultiDimArrayIndex(DIMENSION_INFO *dimension_info,
 {
   size_t k;
 
-  if (dimension_info == NULL || dimension_info->numberOfDimensions <= 0 || dimension_info->dimensions == NULL)
-  {
-    throwStreamPrint(NULL, "Invalid dimension info.");
-  }
-
-  if(linear_address >= dimension_info->scalar_length) {
-    throwStreamPrint(NULL, "Array out of range: %zu not in [0, %zu]", linear_address, dimension_info->scalar_length);
-  }
+  assertStreamPrint(NULL, dimension_info != NULL && dimension_info->numberOfDimensions > 0 && dimension_info->dimensions != NULL, "Invalid dimension info.");
+  assertStreamPrint(NULL, linear_address < dimension_info->scalar_length, "Array out of range: %zu not in [0, %zu]", linear_address, dimension_info->scalar_length);
 
   /* Allocate array for indices; caller is responsible for freeing */
   size_t *array_index = (size_t *)calloc(dimension_info->numberOfDimensions, sizeof(size_t));
-  if (!array_index)
-  {
-    throwStreamPrint(NULL, "Out of memory.");
-  }
+  assertStreamPrint(NULL, array_index != NULL, "Out of memory");
 
   /* Compute sizes of later dimensions for row-major ordering */
   size_t *stride = (size_t *)calloc(dimension_info->numberOfDimensions, sizeof(size_t));
-  if (!stride)
-  {
-    free(array_index);
-    throwStreamPrint(NULL, "Out of memory.");
-  }
+  assertStreamPrint(NULL, stride != NULL, "Out of memory");
 
   /* stride[k] = product of dimensions[k+1..dimension->numberOfDimensions-1];
    * last stride = 1 */
@@ -427,6 +402,46 @@ size_t *linearToMultiDimArrayIndex(DIMENSION_INFO *dimension_info,
 
   free(stride);
   return array_index;
+}
+
+/**
+ * @brief Format a flattened (row-major) index into multi-dimensional indices.
+ *
+ * Converts `linear_address` into a sequence of multi-dimensional indices
+ * according to `dimension_info` and writes the result into `buffer` as
+ * for example "[i][j][k]". If `dimension_info` is NULL or has zero
+ * dimensions an empty string is written.
+ *
+ * The caller must ensure `buffer` has sufficient space for the output. When
+ * `dimension_info` is non-NULL the `linear_address` must be within bounds
+ * (i.e. less than `dimension_info->scalar_length`).
+ *
+ * @param dimension_info Pointer to the dimension metadata (may be NULL).
+ * @param linear_address Flattened (row-major) index to convert.
+ * @param buffer         Destination buffer where formatted indices are written.
+ * @param buffer_size    Size of `buffer` in bytes.
+ */
+void printMultiDimArrayIndex(DIMENSION_INFO *dimension_info,
+                             size_t linear_address,
+                             char* buffer,
+                             size_t buffer_size)
+{
+  if (dimension_info == NULL || dimension_info->numberOfDimensions == 0)
+  {
+    snprintf(buffer, buffer_size - 1, "");
+    return;
+  }
+
+  size_t written = 0;
+  size_t *array_index = linearToMultiDimArrayIndex(dimension_info, linear_address);
+
+  for (size_t dim = 0; dim < dimension_info->numberOfDimensions; dim++)
+  {
+    written += snprintf(buffer + written, buffer_size - written - 1, "[%zu]", array_index[dim]);
+  }
+
+  free(array_index);
+  return;
 }
 
 /**
@@ -467,21 +482,13 @@ size_t multiDimArrayToLinearIndex(DIMENSION_INFO* dimension_info,
   size_t linear_address = 0;
   size_t dim_product;
 
-  if (dimension_info == NULL || dimension_info->numberOfDimensions <= 0 || dimension_info->dimensions == NULL)
-  {
-    throwStreamPrint(NULL, "Invalid dimension info.");
-  }
-
-  if (array_index == NULL)
-  {
-    throwStreamPrint(NULL, "Array index pointer is NULL.");
-  }
+  assertStreamPrint(NULL, dimension_info != NULL && dimension_info->numberOfDimensions > 0 && dimension_info->dimensions != NULL, "Invalid dimension info.");
+  assertStreamPrint(NULL, array_index != NULL, "Array index pointer is NULL.");
 
    for (size_t k = 0; k < dimension_info->numberOfDimensions; k++) {
-     if (array_index[k] >= dimension_info->dimensions[k].start) {
-       throwStreamPrint(NULL, "Index out of bounds: array_index[%zu] = %zu >= %zu",
-                        k, array_index[k], dimension_info->dimensions[k].start);
-     }
+    assertStreamPrint(NULL, array_index[k] <  dimension_info->dimensions[k].start,
+                      "Index out of bounds: array_index[%zu] = %zu >= %zu",
+                      k, array_index[k], dimension_info->dimensions[k].start);
 
      dim_product = 1;
      /* multiply sizes of later dimensions (k+1 .. n-1) for row-major */
@@ -759,26 +766,23 @@ modelica_real getStartFromScalarIdx(const SIMULATION_INFO *simulationInfo,
       switch(kind)
       {
         case VAR_KIND_STATE:
-          if (scalar_idx >= modelData->nStates) {
-            throwStreamPrint(NULL, "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nStates);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nStates,
+                            "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nStates);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.start, revIndex->dim_idx);
 
         case VAR_KIND_VARIABLE:
-          if (scalar_idx >= modelData->nVariablesReal) {
-            throwStreamPrint(NULL, "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nVariablesReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nVariablesReal,
+                            "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nVariablesReal);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.start, revIndex->dim_idx);
 
         case VAR_KIND_PARAMETER:
-          if (scalar_idx >= modelData->nParametersReal) {
-            throwStreamPrint(NULL, "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nParametersReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nParametersReal,
+                            "getStartFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nParametersReal);
           revIndex = &simulationInfo->realParamsReverseIndex[scalar_idx];
           return real_get(modelData->realParameterData[revIndex->array_idx].attribute.start, revIndex->dim_idx);
 
@@ -818,26 +822,23 @@ modelica_real getNominalFromScalarIdx(const SIMULATION_INFO *simulationInfo,
   switch(kind)
   {
     case VAR_KIND_STATE:
-      if (scalar_idx >= modelData->nStates) {
-        throwStreamPrint(NULL, "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                          scalar_idx, modelData->nStates);
-      }
+      assertStreamPrint(NULL, scalar_idx < modelData->nStates,
+                        "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                        scalar_idx, modelData->nStates);
       revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
       return real_get(modelData->realVarsData[revIndex->array_idx].attribute.nominal, revIndex->dim_idx);
 
     case VAR_KIND_VARIABLE:
-      if (scalar_idx >= modelData->nVariablesReal) {
-        throwStreamPrint(NULL, "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                          scalar_idx, modelData->nVariablesReal);
-      }
+      assertStreamPrint(NULL, scalar_idx < modelData->nVariablesReal,
+                        "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                        scalar_idx, modelData->nVariablesReal);
       revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
       return real_get(modelData->realVarsData[revIndex->array_idx].attribute.nominal, revIndex->dim_idx);
 
     case VAR_KIND_PARAMETER:
-      if (scalar_idx >= modelData->nParametersReal) {
-        throwStreamPrint(NULL, "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                          scalar_idx, modelData->nParametersReal);
-      }
+      assertStreamPrint(NULL, scalar_idx < modelData->nParametersReal,
+                        "getNominalFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                        scalar_idx, modelData->nParametersReal);
       revIndex = &simulationInfo->realParamsReverseIndex[scalar_idx];
       return real_get(modelData->realParameterData[revIndex->array_idx].attribute.nominal, revIndex->dim_idx);
 
@@ -878,26 +879,23 @@ modelica_real getMinFromScalarIdx(const SIMULATION_INFO *simulationInfo,
       switch(kind)
       {
         case VAR_KIND_STATE:
-          if (scalar_idx >= modelData->nStates) {
-            throwStreamPrint(NULL, "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nStates);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nStates,
+                            "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nStates);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.min, revIndex->dim_idx);
 
         case VAR_KIND_VARIABLE:
-          if (scalar_idx >= modelData->nVariablesReal) {
-            throwStreamPrint(NULL, "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nVariablesReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nVariablesReal,
+                            "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nVariablesReal);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.min, revIndex->dim_idx);
 
         case VAR_KIND_PARAMETER:
-          if (scalar_idx >= modelData->nParametersReal) {
-            throwStreamPrint(NULL, "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nParametersReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nParametersReal,
+                            "getMinFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nParametersReal);
           revIndex = &simulationInfo->realParamsReverseIndex[scalar_idx];
           return real_get(modelData->realParameterData[revIndex->array_idx].attribute.min, revIndex->dim_idx);
 
@@ -943,26 +941,23 @@ modelica_real getMaxFromScalarIdx(const SIMULATION_INFO *simulationInfo,
       switch(kind)
       {
         case VAR_KIND_STATE:
-          if (scalar_idx >= modelData->nStates) {
-            throwStreamPrint(NULL, "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nStates);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nStates,
+                            "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nStates);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.max, revIndex->dim_idx);
 
         case VAR_KIND_VARIABLE:
-          if (scalar_idx >= modelData->nVariablesReal) {
-            throwStreamPrint(NULL, "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nVariablesReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nVariablesReal,
+                            "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nVariablesReal);
           revIndex = &simulationInfo->realVarsReverseIndex[scalar_idx];
           return real_get(modelData->realVarsData[revIndex->array_idx].attribute.max, revIndex->dim_idx);
 
         case VAR_KIND_PARAMETER:
-          if (scalar_idx >= modelData->nParametersReal) {
-            throwStreamPrint(NULL, "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %lu)",
-                              scalar_idx, modelData->nParametersReal);
-          }
+          assertStreamPrint(NULL, scalar_idx < modelData->nParametersReal,
+                            "getMaxFromScalarIdx: scalar_idx %zu out of bounds [0, %zu)",
+                            scalar_idx, modelData->nParametersReal);
           revIndex = &simulationInfo->realParamsReverseIndex[scalar_idx];
           return real_get(modelData->realParameterData[revIndex->array_idx].attribute.max, revIndex->dim_idx);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.h
@@ -63,6 +63,11 @@ extern "C"
   size_t *linearToMultiDimArrayIndex(DIMENSION_INFO *dimension,
                                      size_t linear_address);
 
+  void printMultiDimArrayIndex(DIMENSION_INFO *dimension_info,
+                               size_t linear_address,
+                               char* buffer,
+                               size_t buffer_size);
+
   void calculateAllScalarLength(MODEL_DATA *modelData);
 
   void computeVarIndices(SIMULATION_INFO *simulationInfo,

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -956,7 +956,6 @@ void read_model_description_sizes(omc_ModelDescription *md, MODEL_DATA *modelDat
   numRealAlgVars = read_value_long(findHashStringString(md, "numberOfRealAlgebraicVariables"), 0);
   modelData->nVariablesRealArray = 2*modelData->nStatesArray + numRealAlgVars;
   modelData->nAliasRealArray = read_value_long(findHashStringString(md, "numberOfRealAlgebraicAliasVariables"), 0);
-  // TODO: How to get data->modelData->nDiscreteReal or its array version?
   modelData->nParametersRealArray = read_value_long(findHashStringString(md, "numberOfRealParameters"), 0);
 
   modelData->nParametersIntegerArray = read_value_long(findHashStringString(md, "numberOfIntegerParameters"), 0);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
@@ -26,6 +26,7 @@
  */
 
 #include "discrete_changes.h"
+#include "../arrayIndex.h"
 
 /**
  * @brief Check for changes in discrete variables since the previous step.
@@ -46,107 +47,131 @@
 modelica_boolean checkForDiscreteChanges(DATA *data, threadData_t *threadData)
 {
   MODEL_DATA *modelData = data->modelData;
+  SIMULATION_INFO *simulationInfo = data->simulationInfo;
 
   /* No discrete variables */
-  if (modelData->nDiscreteReal == 0 &&
-      modelData->nVariablesInteger == 0 &&
-      modelData->nVariablesBoolean == 0 &&
-      modelData->nVariablesString == 0)
+  if (modelData->nDiscreteRealArray == 0 &&
+      modelData->nVariablesIntegerArray == 0 &&
+      modelData->nVariablesBooleanArray == 0 &&
+      modelData->nVariablesStringArray == 0)
   {
     return FALSE;
   }
 
   modelica_boolean needToIterate = FALSE;
+  char* index_buffer;
+  size_t buffer_size = 2000;
   if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
   {
     infoStreamPrint(OMC_LOG_EVENTS_V, 1, "check for discrete changes at time=%.12g",
                     data->localData[0]->timeValue);
+    index_buffer = (char*) malloc(buffer_size*sizeof(char));
   }
 
   /* Real discrete variables */
-  for (long i = modelData->nVariablesReal - modelData->nDiscreteReal; i < modelData->nVariablesReal; i++)
+  for (long arrayIdx = modelData->nVariablesRealArray - modelData->nDiscreteRealArray; arrayIdx < modelData->nVariablesRealArray; arrayIdx++)
   {
-    if (strncmp(modelData->realVarsData[i].info.name, "$cse", 4))
+    if (strncmp(modelData->realVarsData[arrayIdx].info.name, "$cse", 4))
     {
-      modelica_real v1 = data->simulationInfo->realVarsPre[i];
-      modelica_real v2 = data->localData[0]->realVars[i];
-      if (v1 != v2)
+      for (size_t i = 0; i < modelData->realVarsData[arrayIdx].dimension.scalar_length; i++)
       {
-        needToIterate = TRUE;
-        if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+        size_t scalarIdx = simulationInfo->realVarsIndex[arrayIdx] + i;
+        modelica_real v1 = simulationInfo->realVarsPre[scalarIdx];
+        modelica_real v2 = data->localData[0]->realVars[scalarIdx];
+        if (v1 != v2)
         {
-          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %g to %g",
-                          modelData->realVarsData[i].info.name, v1, v2);
-        }
-        else
-        {
-          return needToIterate;
+          needToIterate = TRUE;
+          if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+          {
+            printMultiDimArrayIndex(&modelData->realVarsData[arrayIdx].dimension, scalarIdx, index_buffer, buffer_size);
+            infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s%s from %g to %g",
+                            modelData->realVarsData[arrayIdx].info.name, index_buffer, v1, v2);
+          }
+          else
+          {
+            return needToIterate;
+          }
         }
       }
     }
   }
 
-  for (long i = 0; i < modelData->nVariablesInteger; i++)
+  for (long arrayIdx = 0; arrayIdx < modelData->nVariablesIntegerArray; arrayIdx++)
   {
-    if (strncmp(modelData->integerVarsData[i].info.name, "$cse", 4))
+    if (strncmp(modelData->integerVarsData[arrayIdx].info.name, "$cse", 4))
     {
-      modelica_integer v1 = data->simulationInfo->integerVarsPre[i];
-      modelica_integer v2 = data->localData[0]->integerVars[i];
-      if (v1 != v2)
+      for (size_t i = 0; i < modelData->integerVarsData[arrayIdx].dimension.scalar_length; i++)
       {
-        needToIterate = TRUE;
-        if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+        size_t scalarIdx = simulationInfo->integerVarsIndex[arrayIdx] + i;
+        modelica_integer v1 = simulationInfo->integerVarsPre[scalarIdx];
+        modelica_integer v2 = data->localData[0]->integerVars[scalarIdx];
+        if (v1 != v2)
         {
-          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %ld to %ld",
-                          modelData->integerVarsData[i].info.name, (long)v1, (long)v2);
-        }
-        else
-        {
-          return needToIterate;
+          needToIterate = TRUE;
+          if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+          {
+            printMultiDimArrayIndex(&modelData->integerVarsData[arrayIdx].dimension, scalarIdx, index_buffer, buffer_size);
+            infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s%s from %ld to %ld",
+                            modelData->integerVarsData[arrayIdx].info.name, index_buffer, (long)v1, (long)v2);
+          }
+          else
+          {
+            return needToIterate;
+          }
         }
       }
     }
   }
 
-  for (long i = 0; i < modelData->nVariablesBoolean; i++)
+  for (long arrayIdx = 0; arrayIdx < modelData->nVariablesBooleanArray; arrayIdx++)
   {
-    if (strncmp(modelData->booleanVarsData[i].info.name, "$cse", 4))
+    if (strncmp(modelData->booleanVarsData[arrayIdx].info.name, "$cse", 4))
     {
-      modelica_boolean v1 = data->simulationInfo->booleanVarsPre[i];
-      modelica_boolean v2 = data->localData[0]->booleanVars[i];
-      if (v1 != v2)
+      for (size_t i = 0; i < modelData->booleanVarsData[arrayIdx].dimension.scalar_length; i++)
       {
-        needToIterate = TRUE;
-        if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+        size_t scalarIdx = simulationInfo->booleanVarsIndex[arrayIdx] + i;
+        modelica_boolean v1 = simulationInfo->booleanVarsPre[scalarIdx];
+        modelica_boolean v2 = data->localData[0]->booleanVars[scalarIdx];
+        if (v1 != v2)
         {
-          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s",
-                          modelData->booleanVarsData[i].info.name, v1 ? "true" : "false", v2 ? "true" : "false");
-        }
-        else
-        {
-          return needToIterate;
+          needToIterate = TRUE;
+          if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+          {
+            printMultiDimArrayIndex(&modelData->booleanVarsData[arrayIdx].dimension, scalarIdx, index_buffer, buffer_size);
+            infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s%s from %s to %s",
+                            modelData->booleanVarsData[arrayIdx].info.name, index_buffer, v1 ? "true" : "false", v2 ? "true" : "false");
+          }
+          else
+          {
+            return needToIterate;
+          }
         }
       }
     }
   }
 
-  for (long i = 0; i < modelData->nVariablesString; i++)
+  for (long arrayIdx = 0; arrayIdx < modelData->nVariablesStringArray; arrayIdx++)
   {
-    if (strncmp(modelData->stringVarsData[i].info.name, "$cse", 4))
+    if (strncmp(modelData->stringVarsData[arrayIdx].info.name, "$cse", 4))
     {
-      modelica_string v1 = data->simulationInfo->stringVarsPre[i];
-      modelica_string v2 = data->localData[0]->stringVars[i];
-      if (0 != strcmp(MMC_STRINGDATA(v1), MMC_STRINGDATA(v2)))
+      for (size_t i = 0; i < modelData->stringVarsData[arrayIdx].dimension.scalar_length; i++)
       {
-        needToIterate = TRUE;
-        if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+        size_t scalarIdx = simulationInfo->stringVarsIndex[arrayIdx] + i;
+        modelica_string v1 = simulationInfo->stringVarsPre[scalarIdx];
+        modelica_string v2 = data->localData[0]->stringVars[scalarIdx];
+        if (0 != strcmp(MMC_STRINGDATA(v1), MMC_STRINGDATA(v2)))
         {
-          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s",
-                          modelData->stringVarsData[i].info.name, MMC_STRINGDATA(v1), MMC_STRINGDATA(v2));
-        }
-        else
-        {
-          return needToIterate;
+          needToIterate = TRUE;
+          if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
+          {
+            printMultiDimArrayIndex(&modelData->stringVarsData[arrayIdx].dimension, scalarIdx, index_buffer, buffer_size);
+            infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s",
+                            modelData->stringVarsData[arrayIdx].info.name, MMC_STRINGDATA(v1), MMC_STRINGDATA(v2));
+          }
+          else
+          {
+            return needToIterate;
+          }
         }
       }
     }
@@ -155,6 +180,7 @@ modelica_boolean checkForDiscreteChanges(DATA *data, threadData_t *threadData)
   if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
   {
     messageClose(OMC_LOG_EVENTS_V);
+    free(index_buffer);
   }
 
   return needToIterate;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
@@ -1153,7 +1153,7 @@ void newtonDiagnostics(DATA* data, threadData_t *threadData, int sysNumber)
       (data->modelData->integerParameterData[i].info.name),
       (data->modelData->integerParameterData[i].attribute.start));
 
-  printf("   ****** Number of discrete real params  : %ld\n", data->modelData->nDiscreteReal);
+  printf("   ****** Number of discrete real params  : %ld\n", data->modelData->nDiscreteRealArray);
   printf("   ****** Number of real parameters       : %ld\n", data->modelData->nParametersReal);
   for( unsigned int i = 0; i < data->modelData->nParametersReal; ++i)
     printf("   ****** %2d: id=%d, name=%10s, value=%10f\n", i+1, (data->modelData->realParameterData[i].info.id),

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -647,6 +647,7 @@ typedef struct MODEL_DATA
   /* Number of un-scalrarized variables (arrays count as one variable) */
   long nStatesArray;            /* Number of array + scalar state variables */
   long nVariablesRealArray;     /* Number of array + scalar real variables: states + state derivatives + real algebraic variables */
+  long nDiscreteRealArray;      /* Number of array + scalar real discrete variables */
   long nVariablesIntegerArray;  /* Number of array + scalar integer variables */
   long nVariablesBooleanArray;  /* Number of array + scalar boolean variables */
   long nVariablesStringArray;   /* Number of array + scalar string variables */
@@ -665,7 +666,6 @@ typedef struct MODEL_DATA
   /* Number of scalarized variables (arrays are flatten to scalar elements.) */
   long nStates;                 /* Number of state variables*/
   long nVariablesReal;          /* Number of real variables: states + state derivatives + real algebraic variables + real discrete variables */
-  long nDiscreteReal;           /* Number of all discrete real variables */
   long nVariablesInteger;       /* Number of integer variables */
   long nVariablesBoolean;       /* Number of boolean variables */
   long nVariablesString;        /* Number of string variables */

--- a/testsuite/simulation/modelica/NBackend/basics/Makefile
+++ b/testsuite/simulation/modelica/NBackend/basics/Makefile
@@ -1,21 +1,24 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
+arrayCascade.mos \
+arrayReadElements.mos \
+detectStates.mos \
 emptyModel.mos \
-helloWorld.mos \
+enumeration.mos \
 evaluateFalse.mos \
+for_if_if.mos \
+helloWorld.mos \
+implicitEquation.mos \
+minArr.mos \
 parameterIndex.mos \
 parameterSystem.mos \
-simpleNonlinearLoop.mos \
-implicitEquation.mos \
-underdetermined_init.mos \
 partitioning.mos \
-variability.mos \
-enumeration.mos \
 simpleForLoop.mos \
+simpleNonlinearLoop.mos \
 solveSingleEquation.mos \
-detectStates.mos \
-for_if_if.mos \
+underdetermined_init.mos \
+variability.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/basics/arrayCascade.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/arrayCascade.mos
@@ -1,0 +1,46 @@
+// name: arrayCascade
+// keywords: NewBackend
+// status: correct
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+loadString("
+  model arrayCascade
+    Real[3] x;
+  equation
+    x[1] = time;
+    x[2] = 2*x[1];
+    x[3] = x[1] + x[2];
+  end arrayCascade;
+"); getErrorString();
+
+simulate(arrayCascade); getErrorString();
+
+val(x[1], 0.0);
+val(x[2], 0.0);
+val(x[3], 0.0);
+
+val(x[1], 1.0);
+val(x[2], 1.0);
+val(x[3], 1.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "arrayCascade_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'arrayCascade', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 0.0
+// 1.0
+// 2.0
+// 3.0
+// endResult

--- a/testsuite/simulation/modelica/NBackend/basics/arrayReadElements.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/arrayReadElements.mos
@@ -1,0 +1,41 @@
+// name: arrayReadElements
+// keywords: NewBackend
+// status: correct
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+loadString("
+  model arrayReadElements
+    Real[3] arr;
+    Real s;
+  equation
+    arr = {time, 2*time, 3*time};
+    s = arr[1] + arr[2] + arr[3];
+  end arrayReadElements;
+"); getErrorString();
+
+simulate(arrayReadElements); getErrorString();
+
+val(arr[1], 1.0);
+val(arr[2], 1.0);
+val(arr[3], 1.0);
+val(s, 1.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "arrayReadElements_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'arrayReadElements', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 2.0
+// 3.0
+// 6.0
+// endResult

--- a/testsuite/simulation/modelica/NBackend/basics/for_if_if.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/for_if_if.mos
@@ -2,6 +2,8 @@
 // keywords: NewBackend
 // status: correct
 
+setCommandLineOptions("--newBackend --simCodeScalarize=true"); getErrorString();
+
 loadString("
 model for_if_if
   Real[2] r, x;
@@ -20,15 +22,37 @@ equation
   end for;
 end for_if_if;"); getErrorString();
 
-setCommandLineOptions("--newBackend"); getErrorString();
+simulate(for_if_if); getErrorString();
 
-buildModel(for_if_if); getErrorString();
+val(x[1], 0.0);
+val(x[2], 0.0);
+val(r[1], 0.0);
+val(r[2], 0.0);
+
+val(x[1], 1.0);
+val(x[2], 1.0);
+val(r[1], 1.0);
+val(r[2], 1.0);
 
 // Result:
 // true
 // ""
 // true
 // ""
-// {"for_if_if", "for_if_if_init.xml"}
+// record SimulationResult
+//     resultFile = "for_if_if_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'for_if_if', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
 // ""
+// 0.0
+// 0.0
+// 0.0
+// 0.0
+// 1.0
+// 1.0
+// 1.0
+// 2.0
 // endResult

--- a/testsuite/simulation/modelica/NBackend/basics/minArr.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/minArr.mos
@@ -1,7 +1,8 @@
-// name: minimal_array
+// name: minArr
 // keywords: NewBackend
 // status: correct
 
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
 
 loadString("
   model minimal_array
@@ -15,6 +16,41 @@ loadString("
   end minimal_array;
 "); getErrorString();
 
-setCommandLineOptions("--newBackend -d=-nfScalarize,dumpSetBasedGraphs --matchingAlgorithm=SBGraph");
 simulate(minimal_array); getErrorString();
 
+val(arr[1], 0.0);
+val(arr[2], 0.0);
+val(for_arr[1], 0.0);
+val(for_arr[2], 0.0);
+val(for_arr[3], 0.0);
+
+val(arr[1], 1.0);
+val(arr[2], 1.0);
+val(for_arr[1], 1.0);
+val(for_arr[2], 1.0);
+val(for_arr[3], 1.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "minimal_array_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'minimal_array', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 1.0
+// 0.0
+// 0.0
+// 0.0
+// 0.8414709848078965
+// 0.5403023058681398
+// 1.0
+// 2.0
+// 3.0
+// endResult


### PR DESCRIPTION
### Related Issues

Related to https://github.com/OpenModelica/OpenModelica/issues/14908.

### Purpose

Handle real discrete variables that are of real array type.
Some preparations for `--simCodeScalarize=false`.

### Approach

- Prepare `checkForDiscreteChanges` for array case
- Count discrete real array variables
- Change `if (something) {throwStreamPrint();}` to `assertStreamPrint(!something)`
- Add util function `printMultiDimArrayIndex`
- Prepare test cases `for_if_if.mos` and `minArr.mos` to be tested without scalarization.