### PR TITLE
Instantiate replaceable classes for getModelInstance

### DIFF
--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -4,6 +4,10 @@
   "description": "The result of calling the getModelInstance API",
   "type": "object",
   "properties": {
+    "$kind": {
+      "description": "Optional specifier of what kind of class it is",
+      "type": "string"
+    },
     "name": {
       "description": "The name of the class",
       "type": "string"
@@ -13,7 +17,7 @@
       "$ref": "#/definitions/dimensions"
     },
     "restriction": {
-      "description": "The kind of class",
+      "description": "The class's restriction",
       "type": "string"
     },
     "prefixes": {
@@ -301,48 +305,7 @@
     "replaceableClass": {
       "description": "A replaceable class definition",
       "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "class"
-        },
-        "name": {
-          "description": "Name of the class",
-          "type": "string"
-        },
-        "restriction": {
-          "description": "The kind of class",
-          "type": "string"
-        },
-        "prefixes": {
-          "description": "The class' prefixes",
-          "$ref": "#/definitions/classPrefixes"
-        },
-        "baseClass": {
-          "description": "The name of the extended class of a short class definition",
-          "type": "string"
-        },
-        "dims": {
-          "description": "The class' dimensions for a short class definition",
-          "$ref": "#/definitions/dimensions"
-        },
-        "modifiers": {
-          "description": "Modifier from the SCode (on short class definitions or class extends)",
-          "$ref": "#/definitions/scodeModifier"
-        },
-        "comment": {
-          "description": "The class' comment",
-          "$ref": "#/definitions/comment"
-        },
-        "annotation": {
-          "description": "The annotation on the replaceble class definition",
-          "$ref": "#/definitions/annotation"
-        },
-        "source": {
-          "$ref": "#/definitions/source"
-        }
-      },
-      "required": ["$kind", "name"]
+      "$ref": "#"
     },
     "classPrefixes": {
       "description": "The class prefixes",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation13.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation13.mos
@@ -64,12 +64,121 @@ getErrorString();
 //     },
 //     {
 //       \"$kind\": \"class\",
-//       \"name\": \"C\",
+//       \"name\": \"M.C\",
 //       \"restriction\": \"model\",
 //       \"prefixes\": {
 //         \"replaceable\": true
 //       },
-//       \"baseClass\": \"P.C\",
+//       \"elements\": [
+//         {
+//           \"$kind\": \"extends\",
+//           \"baseClass\": {
+//             \"name\": \"P.C\",
+//             \"restriction\": \"model\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"b\",
+//                 \"type\": \"Boolean\",
+//                 \"modifiers\": \"false\",
+//                 \"value\": {
+//                   \"binding\": false
+//                 },
+//                 \"prefixes\": {
+//                   \"variability\": \"parameter\"
+//                 }
+//               },
+//               {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"e\",
+//                 \"type\": {
+//                   \"name\": \"P.E\",
+//                   \"restriction\": \"type\",
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"extends\",
+//                       \"baseClass\": \"enumeration\"
+//                     },
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"A\"
+//                     },
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"B\"
+//                     },
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"C\"
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 9,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 9,
+//                     \"columnEnd\": 34
+//                   }
+//                 },
+//                 \"modifiers\": \"E.B\",
+//                 \"value\": {
+//                   \"binding\": {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"P.E.B\",
+//                     \"index\": 2
+//                   }
+//                 },
+//                 \"prefixes\": {
+//                   \"variability\": \"parameter\"
+//                 }
+//               },
+//               {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"Real\",
+//                 \"modifiers\": \"0\",
+//                 \"value\": {
+//                   \"binding\": 0
+//                 },
+//                 \"prefixes\": {
+//                   \"variability\": \"parameter\"
+//                 },
+//                 \"annotation\": {
+//                   \"Dialog\": {
+//                     \"enable\": {
+//                       \"$kind\": \"binary_op\",
+//                       \"lhs\": {
+//                         \"$kind\": \"cref\",
+//                         \"parts\": [
+//                           {
+//                             \"name\": \"C\"
+//                           },
+//                           {
+//                             \"name\": \"e\"
+//                           }
+//                         ]
+//                       },
+//                       \"op\": \"==\",
+//                       \"rhs\": {
+//                         \"$kind\": \"enum\",
+//                         \"name\": \"P.E.A\",
+//                         \"index\": 1
+//                       }
+//                     }
+//                   }
+//                 }
+//               }
+//             ],
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 3,
+//               \"columnStart\": 5,
+//               \"lineEnd\": 7,
+//               \"columnEnd\": 10
+//             }
+//           }
+//         }
+//       ],
 //       \"source\": {
 //         \"filename\": \"<interactive>\",
 //         \"lineStart\": 15,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation8.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation8.mos
@@ -49,7 +49,7 @@ getErrorString();
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"C\",
+//             \"name\": \"M.C\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": {
@@ -68,7 +68,22 @@ getErrorString();
 //                 }
 //               }
 //             },
-//             \"baseClass\": \"A\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"A\",
+//                   \"restriction\": \"model\",
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 2,
+//                     \"columnStart\": 3,
+//                     \"lineEnd\": 3,
+//                     \"columnEnd\": 8
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 7,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived4.mos
@@ -68,15 +68,139 @@ getModelInstance(HierarchicalEditingGUI.Problem1, prettyPrint = true); getErrorS
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"NestModel\",
+//             \"name\": \"HierarchicalEditingGUI.Main.NestModel\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
-//             \"baseClass\": \"HierarchicalEditingGUI.Nested1\",
 //             \"annotation\": {
 //               \"choicesAllMatching\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"HierarchicalEditingGUI.Nested1\",
+//                   \"restriction\": \"model\",
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"p1A\",
+//                       \"type\": \"Real\",
+//                       \"prefixes\": {
+//                         \"variability\": \"parameter\"
+//                       }
+//                     },
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"p1B\",
+//                       \"type\": \"Real\",
+//                       \"prefixes\": {
+//                         \"variability\": \"parameter\"
+//                       }
+//                     },
+//                     {
+//                       \"$kind\": \"class\",
+//                       \"name\": \"HierarchicalEditingGUI.Main.NestModel.InnerNestedModel\",
+//                       \"restriction\": \"model\",
+//                       \"prefixes\": {
+//                         \"replaceable\": true
+//                       },
+//                       \"annotation\": {
+//                         \"choicesAllMatching\": true
+//                       },
+//                       \"elements\": [
+//                         {
+//                           \"$kind\": \"extends\",
+//                           \"baseClass\": {
+//                             \"name\": \"HierarchicalEditingGUI.Nested2\",
+//                             \"restriction\": \"model\",
+//                             \"elements\": [
+//                               {
+//                                 \"$kind\": \"component\",
+//                                 \"name\": \"p2A\",
+//                                 \"type\": \"Real\",
+//                                 \"prefixes\": {
+//                                   \"variability\": \"parameter\"
+//                                 }
+//                               }
+//                             ],
+//                             \"source\": {
+//                               \"filename\": \"<interactive>\",
+//                               \"lineStart\": 11,
+//                               \"columnStart\": 5,
+//                               \"lineEnd\": 14,
+//                               \"columnEnd\": 16
+//                             }
+//                           }
+//                         }
+//                       ],
+//                       \"source\": {
+//                         \"filename\": \"<interactive>\",
+//                         \"lineStart\": 6,
+//                         \"columnStart\": 19,
+//                         \"lineEnd\": 6,
+//                         \"columnEnd\": 89
+//                       }
+//                     },
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"nested2\",
+//                       \"type\": {
+//                         \"name\": \"HierarchicalEditingGUI.Main.NestModel.InnerNestedModel\",
+//                         \"restriction\": \"model\",
+//                         \"prefixes\": {
+//                           \"replaceable\": true
+//                         },
+//                         \"annotation\": {
+//                           \"choicesAllMatching\": true
+//                         },
+//                         \"elements\": [
+//                           {
+//                             \"$kind\": \"extends\",
+//                             \"baseClass\": {
+//                               \"name\": \"HierarchicalEditingGUI.Nested2\",
+//                               \"restriction\": \"model\",
+//                               \"elements\": [
+//                                 {
+//                                   \"$kind\": \"component\",
+//                                   \"name\": \"p2A\",
+//                                   \"type\": \"Real\",
+//                                   \"prefixes\": {
+//                                     \"variability\": \"parameter\"
+//                                   }
+//                                 }
+//                               ],
+//                               \"source\": {
+//                                 \"filename\": \"<interactive>\",
+//                                 \"lineStart\": 11,
+//                                 \"columnStart\": 5,
+//                                 \"lineEnd\": 14,
+//                                 \"columnEnd\": 16
+//                               }
+//                             }
+//                           }
+//                         ],
+//                         \"source\": {
+//                           \"filename\": \"<interactive>\",
+//                           \"lineStart\": 6,
+//                           \"columnStart\": 19,
+//                           \"lineEnd\": 6,
+//                           \"columnEnd\": 89
+//                         }
+//                       }
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 3,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 9,
+//                     \"columnEnd\": 16
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 18,
@@ -139,15 +263,40 @@ getModelInstance(HierarchicalEditingGUI.Problem1, prettyPrint = true); getErrorS
 //                       },
 //                       {
 //                         \"$kind\": \"class\",
-//                         \"name\": \"InnerNestedModel\",
+//                         \"name\": \"HierarchicalEditingGUI.Main.NestModel.InnerNestedModel\",
 //                         \"restriction\": \"model\",
 //                         \"prefixes\": {
 //                           \"replaceable\": true
 //                         },
-//                         \"baseClass\": \"HierarchicalEditingGUI.Nested2\",
 //                         \"annotation\": {
 //                           \"choicesAllMatching\": true
 //                         },
+//                         \"elements\": [
+//                           {
+//                             \"$kind\": \"extends\",
+//                             \"baseClass\": {
+//                               \"name\": \"HierarchicalEditingGUI.Nested2\",
+//                               \"restriction\": \"model\",
+//                               \"elements\": [
+//                                 {
+//                                   \"$kind\": \"component\",
+//                                   \"name\": \"p2A\",
+//                                   \"type\": \"Real\",
+//                                   \"prefixes\": {
+//                                     \"variability\": \"parameter\"
+//                                   }
+//                                 }
+//                               ],
+//                               \"source\": {
+//                                 \"filename\": \"<interactive>\",
+//                                 \"lineStart\": 11,
+//                                 \"columnStart\": 5,
+//                                 \"lineEnd\": 14,
+//                                 \"columnEnd\": 16
+//                               }
+//                             }
+//                           }
+//                         ],
 //                         \"source\": {
 //                           \"filename\": \"<interactive>\",
 //                           \"lineStart\": 6,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived5.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived5.mos
@@ -78,15 +78,40 @@ getModelInstance(HierarchicalEditingGUI.Main.NestModel, prettyPrint = true); get
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"InnerNestedModel\",
+//             \"name\": \"HierarchicalEditingGUI.Main.NestModel.InnerNestedModel\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
-//             \"baseClass\": \"HierarchicalEditingGUI.Nested2\",
 //             \"annotation\": {
 //               \"choicesAllMatching\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"HierarchicalEditingGUI.Nested2\",
+//                   \"restriction\": \"model\",
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"p2A\",
+//                       \"type\": \"Real\",
+//                       \"prefixes\": {
+//                         \"variability\": \"parameter\"
+//                       }
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 11,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 14,
+//                     \"columnEnd\": 16
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 6,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -39,11 +39,18 @@ getModelInstance(M, prettyPrint = true);
 //     },
 //     {
 //       \"$kind\": \"class\",
-//       \"name\": \"M\",
+//       \"name\": \"M.M\",
 //       \"restriction\": \"model\",
 //       \"prefixes\": {
 //         \"replaceable\": true
 //       },
+//       \"elements\": [
+//         {
+//           \"$kind\": \"component\",
+//           \"name\": \"x\",
+//           \"type\": \"Real\"
+//         }
+//       ],
 //       \"source\": {
 //         \"filename\": \"<interactive>\",
 //         \"lineStart\": 5,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -21,11 +21,15 @@ loadString("
   end A;
 
   model M
-    extends A(redeclare model B = MB, redeclare model C = C(y = 2.0));
+    extends A(redeclare model B = MB, redeclare model C = MC(y = 2.0));
 
     model MB
       Real x = 2.0;
     end MB;
+
+    model MC
+      Real y;
+    end MC;
   end M;
 ");
 
@@ -59,7 +63,7 @@ getModelInstance(M, prettyPrint = true);
 //             \"prefixes\": {
 //               \"redeclare\": true
 //             },
-//             \"baseClass\": \"C\",
+//             \"baseClass\": \"MC\",
 //             \"modifiers\": {
 //               \"y\": \"2.0\"
 //             }
@@ -117,37 +121,93 @@ getModelInstance(M, prettyPrint = true);
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"B\",
+//             \"name\": \"M.B\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
-//               \"replaceable\": true
+//               \"redeclare\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"M.MB\",
+//                   \"restriction\": \"model\",
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"x\",
+//                       \"type\": \"Real\",
+//                       \"modifiers\": \"2.0\",
+//                       \"value\": {
+//                         \"binding\": 2
+//                       }
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 19,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 21,
+//                     \"columnEnd\": 11
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
-//               \"lineStart\": 5,
-//               \"columnStart\": 17,
-//               \"lineEnd\": 7,
-//               \"columnEnd\": 10
+//               \"lineStart\": 17,
+//               \"columnStart\": 25,
+//               \"lineEnd\": 17,
+//               \"columnEnd\": 37
 //             }
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"C\",
+//             \"name\": \"M.C\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
-//               \"replaceable\": true
+//               \"redeclare\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"modifiers\": {
+//                   \"y\": \"2.0\"
+//                 },
+//                 \"baseClass\": {
+//                   \"name\": \"M.MC\",
+//                   \"restriction\": \"model\",
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"y\",
+//                       \"type\": \"Real\",
+//                       \"value\": {
+//                         \"binding\": 2
+//                       }
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 23,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 25,
+//                     \"columnEnd\": 11
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
-//               \"lineStart\": 9,
-//               \"columnStart\": 17,
-//               \"lineEnd\": 11,
-//               \"columnEnd\": 10
+//               \"lineStart\": 17,
+//               \"columnStart\": 49,
+//               \"lineEnd\": 17,
+//               \"columnEnd\": 70
 //             }
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"D\",
+//             \"name\": \"M.D\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": {
@@ -157,7 +217,54 @@ getModelInstance(M, prettyPrint = true);
 //                 }
 //               }
 //             },
-//             \"baseClass\": \"A.C\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"M.C\",
+//                   \"restriction\": \"model\",
+//                   \"prefixes\": {
+//                     \"redeclare\": true
+//                   },
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"extends\",
+//                       \"modifiers\": {
+//                         \"y\": \"2.0\"
+//                       },
+//                       \"baseClass\": {
+//                         \"name\": \"M.MC\",
+//                         \"restriction\": \"model\",
+//                         \"elements\": [
+//                           {
+//                             \"$kind\": \"component\",
+//                             \"name\": \"y\",
+//                             \"type\": \"Real\",
+//                             \"value\": {
+//                               \"binding\": 1
+//                             }
+//                           }
+//                         ],
+//                         \"source\": {
+//                           \"filename\": \"<interactive>\",
+//                           \"lineStart\": 23,
+//                           \"columnStart\": 5,
+//                           \"lineEnd\": 25,
+//                           \"columnEnd\": 11
+//                         }
+//                       }
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 17,
+//                     \"columnStart\": 49,
+//                     \"lineEnd\": 17,
+//                     \"columnEnd\": 70
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 13,
@@ -172,7 +279,7 @@ getModelInstance(M, prettyPrint = true);
 //           \"lineStart\": 17,
 //           \"columnStart\": 5,
 //           \"lineEnd\": 17,
-//           \"columnEnd\": 70
+//           \"columnEnd\": 71
 //         }
 //       }
 //     }
@@ -181,7 +288,7 @@ getModelInstance(M, prettyPrint = true);
 //     \"filename\": \"<interactive>\",
 //     \"lineStart\": 16,
 //     \"columnStart\": 3,
-//     \"lineEnd\": 22,
+//     \"lineEnd\": 26,
 //     \"columnEnd\": 8
 //   }
 // }"

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable4.mos
@@ -42,11 +42,18 @@ getModelInstance(P.M, prettyPrint = true);
 //         \"elements\": [
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"B\",
+//             \"name\": \"P.A.B\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"Real\"
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 4,
@@ -57,11 +64,18 @@ getModelInstance(P.M, prettyPrint = true);
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"C\",
+//             \"name\": \"P.A.C\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"y\",
+//                 \"type\": \"Real\"
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 8,
@@ -72,14 +86,39 @@ getModelInstance(P.M, prettyPrint = true);
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"D\",
+//             \"name\": \"P.A.D\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": {
 //                 \"constrainedby\": \"C\"
 //               }
 //             },
-//             \"baseClass\": \"P.A.C\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"P.A.C\",
+//                   \"restriction\": \"model\",
+//                   \"prefixes\": {
+//                     \"replaceable\": true
+//                   },
+//                   \"elements\": [
+//                     {
+//                       \"$kind\": \"component\",
+//                       \"name\": \"y\",
+//                       \"type\": \"Real\"
+//                     }
+//                   ],
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 8,
+//                     \"columnStart\": 19,
+//                     \"lineEnd\": 10,
+//                     \"columnEnd\": 12
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 12,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceableComment.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceableComment.mos
@@ -46,13 +46,28 @@ getModelInstance(ReplaceableRecordDescription.View, prettyPrint = true);
 //         \"elements\": [
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"replRecord\",
+//             \"name\": \"ReplaceableRecordDescription.ClassWithReplaceables.replRecord\",
 //             \"restriction\": \"record\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
-//             \"baseClass\": \"ReplaceableRecordDescription.RecordToBeReplaced\",
 //             \"comment\": \"Description string for replaceable record\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"ReplaceableRecordDescription.RecordToBeReplaced\",
+//                   \"restriction\": \"record\",
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 16,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 17,
+//                     \"columnEnd\": 27
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 5,
@@ -63,13 +78,28 @@ getModelInstance(ReplaceableRecordDescription.View, prettyPrint = true);
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"replModel\",
+//             \"name\": \"ReplaceableRecordDescription.ClassWithReplaceables.replModel\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": true
 //             },
-//             \"baseClass\": \"ReplaceableRecordDescription.ModelToBeReplaced\",
 //             \"comment\": \"Description string for replaceable model\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"ReplaceableRecordDescription.ModelToBeReplaced\",
+//                   \"restriction\": \"model\",
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 13,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 14,
+//                     \"columnEnd\": 26
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 7,
@@ -80,7 +110,7 @@ getModelInstance(ReplaceableRecordDescription.View, prettyPrint = true);
 //           },
 //           {
 //             \"$kind\": \"class\",
-//             \"name\": \"replModelConstraint\",
+//             \"name\": \"ReplaceableRecordDescription.ClassWithReplaceables.replModelConstraint\",
 //             \"restriction\": \"model\",
 //             \"prefixes\": {
 //               \"replaceable\": {
@@ -88,7 +118,22 @@ getModelInstance(ReplaceableRecordDescription.View, prettyPrint = true);
 //                 \"comment\": \"Description string for replaceable model with constraint\"
 //               }
 //             },
-//             \"baseClass\": \"ReplaceableRecordDescription.ModelToBeReplaced\",
+//             \"elements\": [
+//               {
+//                 \"$kind\": \"extends\",
+//                 \"baseClass\": {
+//                   \"name\": \"ReplaceableRecordDescription.ModelToBeReplaced\",
+//                   \"restriction\": \"model\",
+//                   \"source\": {
+//                     \"filename\": \"<interactive>\",
+//                     \"lineStart\": 13,
+//                     \"columnStart\": 5,
+//                     \"lineEnd\": 14,
+//                     \"columnEnd\": 26
+//                   }
+//                 }
+//               }
+//             ],
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 9,


### PR DESCRIPTION
- Instantiate and dump replaceable classes as instance trees instead of just dumping the SCode for them.