### PR TITLE
Clean up zero-based List functions

### DIFF
--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -1728,7 +1728,7 @@ protected
   array<ComponentInfo> compInformations;
 algorithm
   TASKGRAPHMETA(inComps=inComps, varCompMapping=varCompMapping, eqCompMapping=eqCompMapping, compParamMapping=compParamMapping, compNames=compNames, compDescs=compDescs, exeCosts=exeCosts, commCosts=commCosts, nodeMark=nodeMark, compInformations=compInformations) := graphDataIn;
-  inComps := listArray(List.deletePositions(arrayList(inComps),List.map1(cutNodes,intSub,1)));
+  inComps := listArray(List.deletePositions(arrayList(inComps),cutNodes));
   rangeLst := List.intRange(arrayLength(nodeMark));
   nodeMark := List.fold1(rangeLst, markRemovedNodes,cutNodes,nodeMark);
   graphDataOut :=TASKGRAPHMETA(inComps,varCompMapping,eqCompMapping,compParamMapping,compNames,compDescs,exeCosts,commCosts,nodeMark,compInformations);
@@ -1961,14 +1961,12 @@ protected function deleteRowInAdjLst "author: waurich TUD 2013-06
 protected
   array<list<Integer>> adjLst;
   list<Integer> copiedRows;
-  list<Integer> rowsDel1;
   Integer size;
 algorithm
   size := arrayLength(adjacencyLstIn)-listLength(rowsDel);
   adjLst := arrayCreate(size,{});
   copiedRows := List.intRange(arrayLength(adjacencyLstIn));
-  rowsDel1 := List.map1(rowsDel,intSub,1);
-  copiedRows := List.deletePositions(copiedRows,rowsDel1);
+  copiedRows := List.deletePositions(copiedRows,rowsDel);
   adjacencyLstOut := arrayCopyRows(adjacencyLstIn,adjLst,copiedRows,1);
   odeMapping := copiedRows;
 end deleteRowInAdjLst;

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -1423,7 +1423,7 @@ protected
   list<tuple<list<Integer>,list<tuple<list<Integer>,Integer>>,list<tuple<list<String>,Integer>>,list<Integer>,list<Integer>>> tmppredecessortargetinfo;
 algorithm
   // first loop
-  tmpcount:=0;
+  tmpcount:=1;
   usedblocks:={};
   print("\nLoop-1\n"+ "========\n");
   for blocks in predecessortargetinfo loop

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7014,7 +7014,7 @@ algorithm
   vars1 := listReverse(vars1);
   equations1 := List.deletePositions(equations, is);
   equations1 := list(DAEUtil.moveElementToInitialSection(eq) for eq in equations);
-  i := 0;
+  i := 1;
   for eq in equations1 loop
     _ := match eq
       case DAE.INITIALEQUATION(exp1=DAE.CREF(ty=DAE.T_COMPLEX()), exp2=DAE.CALL(path=path))
@@ -7052,7 +7052,7 @@ Helper function for propagateBinding"
   input DAE.ComponentRef inCref;
   input list<DAE.Element> inEquations;
   output DAE.Exp outExp;
-  input output Integer i=0;
+  input output Integer i=1;
 algorithm
   outExp :=match (inCref, inEquations)
     local

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -204,7 +204,7 @@ algorithm
     // filter sliced variables
     // ToDo: do this more efficiently and not create them in the first place
     if not (listEmpty(indices) or listLength(indices) == listLength(vars)) then
-      vars := List.keepPositions(vars, indices);
+      vars := List.keepPositions(vars, indices, zeroBased = true);
     end if;
   else
     Error.assertion(false, getInstanceName() + " failed for: " + Variable.toString(var), sourceInfo());

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -145,19 +145,16 @@ public
   function toIndexList
     input Subscript subscript;
     input Integer length;
-    input Boolean baseZero = true;
     output list<Integer> indices;
-  protected
-    Integer shift = if baseZero then 1 else 0;
   algorithm
     indices := match subscript
       local
         array<Expression> elems;
         Integer start, step, stop;
 
-      case INDEX() then {toInteger(subscript)-shift};
+      case INDEX() then {toInteger(subscript)};
 
-      case WHOLE() then List.intRange2(1-shift,length-shift);
+      case WHOLE() then List.intRange2(1,length);
 
       case SLICE(slice = Expression.ARRAY(elements = elems))
       then list(Expression.toInteger(e) for e in elems);
@@ -166,13 +163,13 @@ public
         start = Expression.INTEGER(start),
         step  = SOME(Expression.INTEGER(step)),
         stop  = Expression.INTEGER(stop)))
-      then List.intRange3(start-shift, step, stop-shift);
+      then List.intRange3(start, step, stop);
 
       case SLICE(slice = Expression.RANGE(
         start = Expression.INTEGER(start),
         step  = NONE(),
         stop  = Expression.INTEGER(stop)))
-      then List.intRange2(start-shift, stop-shift);
+      then List.intRange2(start, stop);
 
       else algorithm
         Error.assertion(false, getInstanceName() + " got an incorrect subscript type " + toString(subscript) + ".", sourceInfo());

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -4474,27 +4474,29 @@ end deleteMemberOnTrue;
 
 public function deletePositions<T>
   "Takes a list and a list of positions, and deletes the positions from the
-   list. Note that positions are indexed from 0.
-     Example: deletePositions({1, 2, 3, 4, 5}, {2, 0, 3}) => {2, 5}"
+   list.
+     Example: deletePositions({1, 2, 3, 4, 5}, {3, 1, 4}) => {2, 5}"
   input list<T> inList;
   input list<Integer> inPositions;
+  input Boolean zeroBased = false;
   output list<T> outList;
 protected
   list<Integer> sorted_pos;
 algorithm
   sorted_pos := sortedUnique(sort(inPositions, intGt), intEq);
-  outList := deletePositionsSorted(inList, sorted_pos);
+  outList := deletePositionsSorted(inList, sorted_pos, zeroBased);
 end deletePositions;
 
 public function deletePositionsSorted<T>
   "Takes a list and a sorted list of positions (smallest index first), and
-   deletes the positions from the list. Note that positions are indexed from 0.
-     Example: deletePositionsSorted({1, 2, 3, 4, 5}, {0, 2, 3}) => {2, 5}"
+   deletes the positions from the list.
+     Example: deletePositionsSorted({1, 2, 3, 4, 5}, {1, 3, 4}) => {2, 5}"
   input list<T> inList;
   input list<Integer> inPositions;
+  input Boolean zeroBased = false;
   output list<T> outList = {};
 protected
-  Integer i = 0;
+  Integer i = if zeroBased then 0 else 1;
   T e;
   list<T> rest = inList;
 algorithm
@@ -4514,27 +4516,29 @@ end deletePositionsSorted;
 
 public function keepPositions<T>
   "Takes a list and a list of positions, and deletes all other elements from the
-   list. Note that positions are indexed from 0.
-     Example: keepPositions({1, 2, 3, 4, 5}, {2, 0, 3}) => {1, 3, 4}"
+   list.
+     Example: keepPositions({1, 2, 3, 4, 5}, {3, 1, 4}) => {1, 3, 4}"
   input list<T> inList;
   input list<Integer> inPositions;
+  input Boolean zeroBased = false;
   output list<T> outList;
 protected
   list<Integer> sorted_pos;
 algorithm
   sorted_pos := sortedUnique(sort(inPositions, intGt), intEq);
-  outList := keepPositionsSorted(inList, sorted_pos);
+  outList := keepPositionsSorted(inList, sorted_pos, zeroBased);
 end keepPositions;
 
 public function keepPositionsSorted<T>
   "Takes a list and a sorted list of positions (smallest index first), and
-   deletes all other positions from the list. Note that positions are indexed from 0.
-     Example: deletePositionsSorted({1, 2, 3, 4, 5}, {0, 2, 3}) => {1, 3, 4}"
+   deletes all other positions from the list.
+     Example: deletePositionsSorted({1, 2, 3, 4, 5}, {1, 3, 4}) => {1, 3, 4}"
   input list<T> inList;
   input list<Integer> inPositions;
+  input Boolean zeroBased = false;
   output list<T> outList = {};
 protected
-  Integer i = 0;
+  Integer i = if zeroBased then 0 else 1;
   T e;
   list<T> rest = inList;
 algorithm


### PR DESCRIPTION
- Change `List.deletePositions` and `List.keepPositions` to use one-based indices by default, like MetaModelica, with a flag for enabling the old zero-based behaviour.
- Change some code that were using zero-based indices for no particular reason to use one-based indices.