### PR TITLE
[C] ensure scaling vectors are finite

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
@@ -478,8 +478,13 @@ void compute_scaling_vector(DATA_NEWTON* solverData, double* scalingVector) {
     jac_row_start = i*solverData->n;
     scalingVector[i] = _omc_gen_maximumVectorNorm(&(solverData->fjac[jac_row_start]), solverData->n);
     if(scalingVector[i] <= 0.0) {
-      warningStreamPrint(OMC_LOG_NLS_V, 1, "Jacobian matrix is singular.");
+      warningStreamPrint(OMC_LOG_NLS_V, 0, "Jacobian matrix is singular. Scaling of residual entry is set to 1e-16.");
       scalingVector[i] = 1e-16;
+    }
+    else if (!isfinite(scalingVector[i]))
+    {
+      warningStreamPrint(OMC_LOG_NLS_V, 0, "Jacobian entry is inf or nan. Scaling of residual entry will be set to 1.0.");
+      scalingVector[i] = 1.0;
     }
   }
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -590,6 +590,21 @@ double vecMaxNorm(int n, double *x)
   return norm;
 }
 
+/**
+ * @brief Sets all infs and nans of a vector to 1.
+ */
+void vecMakeFinite(int n, double *a)
+{
+  for (int i = 0; i < n; i++)
+  {
+    if (!isfinite(a[i]))
+    {
+      warningStreamPrint(OMC_LOG_NLS_V, 0, "Entry of scaling vector is inf or nan. Element will be set to 1.0.");
+      a[i] = 1;
+    }
+  }
+}
+
 void vecAdd(int n, double *a, double *b, double *c)
 {
   int i;
@@ -2247,6 +2262,7 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
           memcpy(relationsPreBackup, data->simulationInfo->relations, sizeof(modelica_boolean)*data->modelData->nRelations);
         /* calculate scaling factor of residuals */
         matVecMultAbsBB(homotopyData->n, homotopyData->fJac, homotopyData->ones, homotopyData->resScaling);
+        vecMakeFinite(homotopyData->n, homotopyData->resScaling);
         debugVectorDouble(OMC_LOG_NLS_JAC, "residuum scaling:", homotopyData->resScaling, homotopyData->n);
         scaleMatrixRows(homotopyData->n, homotopyData->m, homotopyData->fJac);
 


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14950

### Purpose

If the Jacobian contains a value of infinity, the scaling vectors in Newton and Homotopy NLS solvers are also infinite. Therefore, every residual will be scaled to zero and the current solution accepted. 

=> set inf or nan values in scaling vectors to 1, such that the residual will not be accepted unless the residual is actually tiny