### PR TITLE
Ignore more failures when evaluating parameters

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/CevalBinding10.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalBinding10.mo
@@ -1,0 +1,27 @@
+// name: CevalBinding10
+// status: correct
+//
+//
+
+pure function ext_fun
+  input Real u1;
+  output Real y;
+  external "C";
+end ext_fun;
+
+model CevalBinding10
+  parameter Real Q = ext_fun(0) annotation(Evaluate=true);
+end CevalBinding10;
+
+// Result:
+// function ext_fun
+//   input Real u1;
+//   output Real y;
+//
+//   external "C" y = ext_fun(u1);
+// end ext_fun;
+//
+// class CevalBinding10
+//   final parameter Real Q = ext_fun(0.0);
+// end CevalBinding10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -132,6 +132,7 @@ CevalBinding6.mo \
 CevalBinding7.mo \
 CevalBinding8.mo \
 CevalBinding9.mo \
+CevalBinding10.mo \
 CevalConstant1.mo \
 CevalCeil1.mo \
 CevalCos1.mo \


### PR DESCRIPTION
- Ignore evaluation failures of structural parameters in EvalConstants, to avoid failing on e.g. parameters with Evaluate=true that aren't critical to evaluate. Actually structural parameters should already have been evaluated at that point, so failures are not critical.