### PR TITLE
Adapt C++ options parser to changes in OMEdit (#14810)

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -540,47 +540,36 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      return settings;
 }
 
-vector<const char *> OMCFactory::handleComplexCRuntimeArguments(int argc, const char* argv[], map<string, string> &opts)
+vector<const char *> OMCFactory::handleOverrides(int argc, const char* argv[], map<string, string> &opts)
 {
-  map<string, string>::const_iterator oit;
+  map<string, string> mapOMEdit = MAP_LIST_OF
+    "-startTime", "-S" MAP_LIST_SEP "-stopTime", "-E" MAP_LIST_SEP
+    "-stepSize", "-H" MAP_LIST_SEP "-numberOfIntervals", "-G" MAP_LIST_SEP
+    "-s", "-I" MAP_LIST_SEP "-tolerance", "-T" MAP_LIST_SEP
+    "-outputFormat", "-P" MAP_LIST_SEP "-variableFilter", "-B" MAP_LIST_END;
+  map<string, string>::const_iterator oit, mit;
   vector<const char *> optv;
 
   optv.push_back(strdup(argv[0]));
-  std::string overrideOMEdit = "-override=";      // unrecognized OMEdit overrides
   for (int i = 1; i < argc; i++) {
-
       string arg = argv[i];
       int j;
+      // Cpp overrides with =
       if (arg[0] == '-' && arg[1] != '-' && (j = arg.find('=')) > 0
           && (oit = opts.find(arg.substr(0, j))) != opts.end())
           opts[oit->first] = arg.substr(j + 1); // split at = and override
+      // Cpp overrides with space
       else if ((oit = opts.find(arg)) != opts.end() && i < argc - 1)
           opts[oit->first] = argv[++i]; // regular override
-      else if (strncmp(argv[i], "-override=", 10) == 0) {
-          // FIXME startTime, stopTime, ... are no longer used with override
-          map<string, string> supported = MAP_LIST_OF
-            "startTime", "-S" MAP_LIST_SEP "stopTime", "-E" MAP_LIST_SEP
-            "stepSize", "-H" MAP_LIST_SEP "numberOfIntervals", "-G" MAP_LIST_SEP
-            "solver", "-I" MAP_LIST_SEP "tolerance", "-T" MAP_LIST_SEP
-            "outputFormat", "-P" MAP_LIST_SEP "variableFilter", "-B" MAP_LIST_END;
-          vector<string> strs;
-          boost::split(strs, argv[i], boost::is_any_of(",="));
-          for (int j = 1; j < strs.size(); j++) {
-              if ((oit = supported.find(strs[j])) != supported.end()
-                  && j < strs.size() - 1) {
-                  opts[oit->second] = strs[++j];
-              }
-              else {
-                  // leave unrecognized overrides
-                  if (overrideOMEdit.size() > 10)
-                      overrideOMEdit += ",";
-                  overrideOMEdit += strs[j];
-                  if (j < strs.size() - 1)
-                      overrideOMEdit += "=" + strs[++j];
-              }
+      // OMEdit options
+      else if (arg[0] == '-' && arg[1] != '-' && (j = arg.find('=')) > 0
+               && (mit = mapOMEdit.find(arg.substr(0, j))) != mapOMEdit.end()) {
+          if ((oit = opts.find(mit->second)) != opts.end())
+              opts[oit->first] = arg.substr(j + 1); // split at = and override value
+          else {
+              std::cout << "Passing through: " << argv[i] << std::endl;
+              optv.push_back(strdup(argv[i])); // pass through
           }
-          if (overrideOMEdit.size() > 10)
-              optv.push_back(strdup(overrideOMEdit.c_str()));
       }
       else
           optv.push_back(strdup(argv[i]));     // pass through
@@ -595,13 +584,11 @@ vector<const char *> OMCFactory::handleComplexCRuntimeArguments(int argc, const 
 
 void OMCFactory::fillArgumentsToIgnore()
 {
-  _argumentsToIgnore = unordered_set<string>();
   _argumentsToIgnore.insert("-abortSlowSimulation"); // used by nightly tests
 }
 
 void OMCFactory::fillArgumentsToReplace()
 {
-  _argumentsToReplace = map<string, string>();
   _argumentsToReplace.insert(pair<string,string>("-r", "results-file"));
   _argumentsToReplace.insert(pair<string,string>("-ls", "lin-solver"));
   _argumentsToReplace.insert(pair<string,string>("-nls", "non-lin-solver"));
@@ -620,7 +607,7 @@ pair<shared_ptr<ISimController>,SimSettings>
 OMCFactory::createSimulation(int argc, const char* argv[],
                              map<string, string> &opts)
 {
-  vector<const char *> optv = handleComplexCRuntimeArguments(argc, argv, opts);
+  vector<const char *> optv = handleOverrides(argc, argv, opts);
 
   SimSettings settings = readSimulationParameter(optv.size(), &optv[0]);
   type_map simcontroller_type_map;

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.h
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.h
@@ -45,15 +45,14 @@ public:
 
 protected:
   /**
-   * This function handles complex c-runtime arguments like "-override=startTime=0,...". The
-   * arguments are separated correctly returned as vector. Furthermore the are added to the given
-   * opts-map (old values are overwritten).
+   * This function handles overridden options, e.g. from OMEdit "-endTime=10".
+   * Furthermore they are added to the given opts-map (old values are overwritten).
    * @param argc Number of arguments in the argv-array.
    * @param argv The command line arguments as c-string array.
    * @param opts Already parsed command line arguments (as key-value-pairs)
    * @return All arguments as simple entries.
    */
-  std::vector<const char *> handleComplexCRuntimeArguments(int argc, const char* argv[], std::map<std::string, std::string> &opts);
+  std::vector<const char *> handleOverrides(int argc, const char* argv[], std::map<std::string, std::string> &opts);
 
   /**
    * Evaluate all given command line arguments and store their values into the SimSettings structure.

--- a/testsuite/openmodelica/cppruntime/omedit/BouncingBall_OMEdit_flags.mos
+++ b/testsuite/openmodelica/cppruntime/omedit/BouncingBall_OMEdit_flags.mos
@@ -15,7 +15,6 @@ res := OpenModelica.Scripting.compareSimulationResults("BouncingBall_res.mat",
   "BouncingBall_diff.csv",0.01,0.0001,
   {"h","v"});
 
-
 // Result:
 // true
 // true
@@ -24,15 +23,20 @@ res := OpenModelica.Scripting.compareSimulationResults("BouncingBall_res.mat",
 //     resultFile = "BouncingBall_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 100, tolerance = 1e-10, method = 'dassl', fileNamePrefix = 'BouncingBall', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-logFormat=xml -startTime=0 -stopTime=1 -tolerance=1e-10 -s=dassl -outputFormat=mat -variableFilter=.* -r=BouncingBall_res.mat -dasslJacobian=coloredNumerical -emit_protected -w -lv=LOG_STATS'",
 //     messages = "<message stream=\"other\" type=\"warning\" text=\"Warning: unrecognized command line options -dasslJacobian=coloredNumerical \" />
+// <message stream=\"solver\" type=\"info\" text=\"SimManager: Start initialization\" />
 // <message stream=\"solver\" type=\"info\" text=\"SimManager: Start simulation at t = 0.000000\" />
 // <message stream=\"solver\" type=\"info\" text=\"SimManager: Simulation stop time: 1.000000\" />
 // <message stream=\"solver\" type=\"info\" text=\"Simulation info from solver:\" >
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: number steps = 23\" />
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: function evaluations 'f' = 24\" />
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: linear solver setups 'nsetups' = 22\" />
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: nonlinear iterations 'nni' = 23\" />
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: convergence failures 'ncfn' = 0\" />
-// <message stream=\"solver\" type=\"info\" text=\"Cvode: number of evaluateODE calls 'eODE' = 88\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: steps taken nst = 223\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: residual evaluations nre = 293\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: jacobian evaluations nje = 131\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: root evaluations nrt = 253\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: error test failures netf = 20\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: nonlinear convergence failures ncfn = 0\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: nonlinear iterations nni = 293\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: last evaluation time t = 1.007607\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: last step size h = 0.010000\" />
+// <message stream=\"solver\" type=\"info\" text=\"DASSL: last used order k = 2\" />
 // </message>
 // "
 // end SimulationResult;

--- a/testsuite/openmodelica/cppruntime/omedit/Makefile
+++ b/testsuite/openmodelica/cppruntime/omedit/Makefile
@@ -1,10 +1,9 @@
 TEST = ../../../rtest -v
 
-TESTFILES = 
-
-
-FAILINGTESTFILES= \
+TESTFILES =  \
 BouncingBall_OMEdit_flags.mos
+
+FAILINGTESTFILES=
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.


### PR DESCRIPTION
No use of explicit -override anymore; the functionality remains though.

