### PR TITLE
Add context argument to getModelInstance

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1645,25 +1645,20 @@ public function pathToStringList
   input Absyn.Path path;
   output list<String> outPaths;
 algorithm
-  outPaths := listReverse(pathToStringListWork(path,{}));
+  outPaths := listReverse(pathToStringListReverse(path));
 end pathToStringList;
 
-protected function pathToStringListWork
+public function pathToStringListReverse
   input Absyn.Path path;
-  input list<String> acc;
+  input list<String> acc = {};
   output list<String> outPaths;
 algorithm
-  outPaths := match(path,acc)
-    local
-      String n;
-      Absyn.Path p;
-
-    case (Absyn.IDENT(name = n),_) then n::acc;
-    case (Absyn.FULLYQUALIFIED(path = p),_) then pathToStringListWork(p,acc);
-    case (Absyn.QUALIFIED(name = n,path = p),_)
-      then pathToStringListWork(p,n::acc);
+  outPaths := match path
+    case Absyn.IDENT() then path.name :: acc;
+    case Absyn.QUALIFIED() then pathToStringListReverse(path.path, path.name :: acc);
+    case Absyn.FULLYQUALIFIED() then pathToStringListReverse(path.path, acc);
   end match;
-end pathToStringListWork;
+end pathToStringListReverse;
 
 public function addSubscriptsLast
   "Function for appending subscripts at end of last ident"

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -5363,6 +5363,7 @@ end convertPackageToLibrary;
 function getModelInstance
   "Dumps a model instance as a JSON string."
   input TypeName className;
+  input TypeName context = $TypeName(__NoContext);
   input String modifier = "";
   input Boolean prettyPrint = false;
   output String result;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1543,11 +1543,27 @@ public
             obj := JSON.addPair("subscripts", Subscript.toJSONList(cref.subscripts), obj);
           end if;
         then
-          toJSON_impl(cref.restCref, obj :: accum);
+          if isEmpty(cref.restCref) then toJSON_context(cref.node, obj :: accum) else
+                                         toJSON_impl(cref.restCref, obj :: accum);
 
       else accum;
     end match;
   end toJSON_impl;
+
+  function toJSON_context
+    input InstNode node;
+    input output list<JSON> accum;
+  protected
+    Option<Absyn.Path> opt_context;
+  algorithm
+    opt_context := InstNode.rootClassContext(InstNode.parent(node));
+
+    if isSome(opt_context) then
+      for name in AbsynUtil.pathToStringListReverse(Util.getOption(opt_context)) loop
+        accum := JSON.addPair("name", JSON.makeString(name), JSON.emptyListObject()) :: accum;
+      end for;
+    end if;
+  end toJSON_context;
 
   function hash
     input ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -467,7 +467,7 @@ uniontype Function
         guard InstNode.isEnumerationType(fnNode)
         algorithm
           node := makeEnumConversionOp(fnNode);
-          node := InstNode.setNodeType(NFInstNode.InstNodeType.ROOT_CLASS(parent), node);
+          node := InstNode.makeRootClass(node, parent);
           (node, cmts) := instFunction3(node, context, info);
           fn := new(fnPath, node, cmts);
           fnNode := InstNode.cacheAddFunc(fnNode, fn, false);
@@ -480,7 +480,7 @@ uniontype Function
             OperatorOverloading.checkOperatorRestrictions(fnNode);
           end if;
 
-          fnNode := InstNode.setNodeType(NFInstNode.InstNodeType.ROOT_CLASS(parent), fnNode);
+          fnNode := InstNode.makeRootClass(fnNode, parent);
           (fnNode, cmts) := instFunction3(fnNode, context, info);
           fn := new(fnPath, fnNode, cmts);
           specialBuiltin := isSpecialBuiltin(fn);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -388,7 +388,7 @@ algorithm
 
   clsNode := InstUtil.mergeScalars(clsNode, path, isRootClass = true);
   checkInstanceRestriction(clsNode, path, context);
-  clsNode := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), clsNode);
+  clsNode := InstNode.makeRootClass(clsNode);
 end lookupRootClass;
 
 function instantiateRootClass

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -94,6 +94,7 @@ uniontype InstNodeType
     "The root of the instance tree, i.e. the class that the instantiation starts from."
     InstNode parent "The parent of the class, e.g. when instantiating a function
                      in a component where the component is the parent.";
+    Option<Absyn.Path> context "Used by getModelInstance to add context to instances.";
   end ROOT_CLASS;
 
   record NORMAL_COMP
@@ -409,6 +410,14 @@ uniontype InstNode
     end match;
   end isDerivedClass;
 
+  function makeRootClass
+    input output InstNode node;
+    input InstNode parent = EMPTY_NODE();
+    input Option<Absyn.Path> context = NONE();
+  algorithm
+    node := setNodeType(InstNodeType.ROOT_CLASS(parent, context), node);
+  end makeRootClass;
+
   function isRootClass
     input InstNode node;
     output Boolean res;
@@ -418,6 +427,16 @@ uniontype InstNode
       else false;
     end match;
   end isRootClass;
+
+  function rootClassContext
+    input InstNode node;
+    output Option<Absyn.Path> context;
+  algorithm
+    context := match node
+      case CLASS_NODE(nodeType = InstNodeType.ROOT_CLASS(context = context)) then context;
+      else NONE();
+    end match;
+  end rootClassContext;
 
   function isFunction
     input InstNode node;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -5608,6 +5608,7 @@ end convertPackageToLibrary;
 function getModelInstance
   "Dumps a model instance as a JSON string."
   input TypeName className;
+  input TypeName context = $TypeName(__NoContext);
   input String modifier = "";
   input Boolean prettyPrint = false;
   output String result;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -129,7 +129,7 @@ algorithm
 
   next_context := InstContext.set(context, NFInstContext.RELAXED);
   next_context := InstContext.set(next_context, NFInstContext.FUNCTION);
-  recordNode := InstNode.setNodeType(NFInstNode.InstNodeType.ROOT_CLASS(InstNode.parent(node)), recordNode);
+  recordNode := InstNode.makeRootClass(recordNode, InstNode.parent(node));
   recordNode := Inst.instantiate(recordNode, context = next_context);
   Inst.instExpressions(recordNode, context = next_context, settings = InstSettings.create());
 end instRecord;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3113,8 +3113,8 @@ algorithm
     case ("convertPackageToLibrary", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path)), Values.STRING(str)})
       then convertPackageToLibrary(classpath, path, str);
 
-    case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(str), Values.BOOL(b)})
-      then NFApi.getModelInstance(classpath, str, b);
+    case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path)), Values.STRING(str), Values.BOOL(b)})
+      then NFApi.getModelInstance(classpath, path, str, b);
 
     case ("getModelInstanceAnnotation", {Values.CODE(Absyn.C_TYPENAME(classpath)), v as Values.ARRAY(), Values.BOOL(b)})
       then NFApi.getModelInstanceAnnotation(classpath, ValuesUtil.arrayValueStrings(v), b);

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -574,7 +574,7 @@ algorithm
 
   // Look up the class to instantiate and mark it as the root class.
   cls := Lookup.lookupClassName(classPath, top, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
-  cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), cls);
+  cls := InstNode.makeRootClass(cls);
 
   // Instantiate the class.
   inst_cls := NFInst.instantiate(cls, context = NFInstContext.RELAXED);
@@ -788,6 +788,7 @@ constant InstanceTree ENUM_BASE = InstanceTree.BUILTIN_BASE_CLASS("enumeration")
 
 function getModelInstance
   input Absyn.Path classPath;
+  input Absyn.Path contextPath;
   input String modifier;
   input Boolean prettyPrint;
   output Values.Value res;
@@ -812,6 +813,10 @@ algorithm
     if SCodeUtil.isFunction(InstNode.definition(cls_node)) then
       context := InstContext.unset(context, NFInstContext.CLASS);
       context := InstContext.set(context, NFInstContext.FUNCTION);
+    end if;
+
+    if AbsynUtil.pathFirstIdent(contextPath) <> "__NoContext" then
+      cls_node := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE(), SOME(contextPath)), cls_node);
     end if;
 
     cls_node := Inst.instantiateRootClass(cls_node, context, mod);
@@ -1172,7 +1177,7 @@ algorithm
     ErrorExt.setCheckpoint(getInstanceName());
     try
       context := InstContext.set(NFInstContext.CLASS, NFInstContext.RELAXED);
-      scope := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), scope);
+      scope := InstNode.makeRootClass(scope);
       scope := Inst.instantiate(scope, context = context, instPartial = true);
       Inst.insertGeneratedInners(scope, InstNode.topScope(scope), context);
       Inst.instExpressions(scope, context = context, settings = NFInst.DEFAULT_SETTINGS);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -859,7 +859,7 @@ ModelInstance::Component *GraphicsView::createModelInstanceComponent(ModelInstan
   /* We use getModelInstance with icon flag for bettter performance
    * This model will be updated right after this so it doesn't matter if the Component has complete model or not.
    */
-  ModelInstance::Model *pModel = new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(className, "", false, true));
+  ModelInstance::Model *pModel = new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(className, "", "", false, true));
   pModel->setRestriction(isConnector ? "connector" : "model");
   pComponent->setModel(pModel);
   pModelInstance->addElement(pComponent);
@@ -5835,7 +5835,7 @@ void ModelWidget::loadModelInstance(bool icon, const ModelInfo &modelInfo)
   QElapsedTimer timer;
   timer.start();
   // call getModelInstance
-  const QJsonObject jsonObject = MainWindow::instance()->getOMCProxy()->getModelInstance(mpLibraryTreeItem->getNameStructure(), "", false, icon);
+  const QJsonObject jsonObject = MainWindow::instance()->getOMCProxy()->getModelInstance(mpLibraryTreeItem->getNameStructure(), "", "", false, icon);
   // set the new ModelInstance
   mpModelInstance = new ModelInstance::Model(jsonObject);
   if (MainWindow::instance()->isNewApiProfiling()) {

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3390,12 +3390,14 @@ QList<QString> OMCProxy::getAvailablePackageConversionsFrom(const QString &pkg, 
  * \param icon
  * \return
  */
-QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &modifier, bool prettyPrint, bool icon)
+QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &context, const QString &modifier, bool prettyPrint, bool icon)
 {
   QElapsedTimer timer;
   timer.start();
 
   QString modelInstanceJson = "";
+  QString cnt = context.isEmpty() ? QString("__NoContext") : context;
+
   if (icon) {
     QList<QString> filter;
     filter << "Icon" << "IconMap" << "Diagram" << "DiagramMap" << "experiment";
@@ -3410,10 +3412,10 @@ QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &
       } else {
         getErrorString();
       }
-      modelInstanceJson = mpOMCInterface->getModelInstance(className, modifier, prettyPrint);
+      modelInstanceJson = mpOMCInterface->getModelInstance(className, cnt, modifier, prettyPrint);
     }
   } else {
-    modelInstanceJson = mpOMCInterface->getModelInstance(className, modifier, prettyPrint);
+    modelInstanceJson = mpOMCInterface->getModelInstance(className, cnt, modifier, prettyPrint);
   }
 
   if (MainWindow::instance()->isNewApiProfiling()) {

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -275,7 +275,7 @@ public:
   QStringList getAvailablePackageVersions(QString pkg, QString version);
   bool convertPackageToLibrary(const QString &packageToConvert, const QString &library, const QString &libraryVersion);
   QList<QString> getAvailablePackageConversionsFrom(const QString &pkg, const QString &version);
-  QJsonObject getModelInstance(const QString &className, const QString &modifier = QString(""), bool prettyPrint = false, bool icon = false);
+  QJsonObject getModelInstance(const QString &className, const QString &context = QString(""), const QString &modifier = QString(""), bool prettyPrint = false, bool icon = false);
   QJsonObject modifierToJSON(const QString &modifier, bool prettyPrint = false);
   int storeAST();
   bool restoreAST(int id);

--- a/testsuite/openmodelica/instance-API/GetModelInstanceContext1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceContext1.mos
@@ -1,0 +1,106 @@
+// name: GetModelInstanceContext1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model A
+    Real x;
+  end A;
+
+  model M
+    A a;
+    Real y = a.x;
+    Real z = y;
+  end M;
+");
+
+getModelInstance(M, context = b.c, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"x\",
+//             \"type\": \"Real\"
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 4,
+//           \"columnEnd\": 8
+//         }
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"y\",
+//       \"type\": \"Real\",
+//       \"modifiers\": \"a.x\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"b\"
+//             },
+//             {
+//               \"name\": \"c\"
+//             },
+//             {
+//               \"name\": \"a\"
+//             },
+//             {
+//               \"name\": \"x\"
+//             }
+//           ]
+//         }
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"z\",
+//       \"type\": \"Real\",
+//       \"modifiers\": \"y\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"b\"
+//             },
+//             {
+//               \"name\": \"c\"
+//             },
+//             {
+//               \"name\": \"y\"
+//             }
+//           ]
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 6,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 10,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -41,6 +41,7 @@ GetModelInstanceConnection3.mos \
 GetModelInstanceConnection4.mos \
 GetModelInstanceConnection5.mos \
 GetModelInstanceConnection6.mos \
+GetModelInstanceContext1.mos \
 GetModelInstanceDerived1.mos \
 GetModelInstanceDerived2.mos \
 GetModelInstanceDerived3.mos \


### PR DESCRIPTION
- Adds a context argument to getModelInstance that can be used to prefix component references that refers to components in the root class.