### PR TITLE
Remove useless UserSimSettingsMAT to avoid calling TimeManager::setHVisual()

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -76,11 +76,6 @@
 
 class VisualizationAbstract; // Forward declaration for passing a pointer to various constructors before class declaration
 
-struct UserSimSettingsMAT
-{
-  double speedup;
-};
-
 class UpdateVisitor : public osg::NodeVisitor
 {
 public:

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
@@ -100,12 +100,6 @@ void VisualizationMAT::readMat(const std::string& modelFile, const std::string& 
      */
 }
 
-void VisualizationMAT::setSimulationSettings(const UserSimSettingsMAT& simSetMAT)
-{
-  auto newVal = simSetMAT.speedup * mpTimeManager->getHVisual();
-  mpTimeManager->setHVisual(newVal);
-}
-
 void VisualizationMAT::updateScene(const double time)
 {
   mpTimeManager->updateTick();  //for real-time measurement

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.h
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.h
@@ -49,7 +49,6 @@ public:
   void initData() override;
   void initializeVisAttributes(const double time) override;
   void readMat(const std::string& modelFile, const std::string& path);
-  void setSimulationSettings(const UserSimSettingsMAT& simSetMAT);
   void simulate(TimeManager& omvm) override {Q_UNUSED(omvm);}
   void updateScene(const double time) override;
   void updateVisualizerAttribute(VisualizerAttribute& attr, const double time) override;


### PR DESCRIPTION
### Related Issues

#14851

~~To be rebased on #14996.~~ [done]
