### PR TITLE
Set timer interval with requested visual time step

### DIFF
--- a/OMEdit/OMEditLIB/Animation/TimeManager.cpp
+++ b/OMEdit/OMEditLIB/Animation/TimeManager.cpp
@@ -50,7 +50,7 @@ TimeManager::TimeManager(const double simTime, const double realTime, const doub
 {
   mpUpdateSceneTimer = new QTimer();
   mpUpdateSceneTimer->setTimerType(Qt::PreciseTimer);
-  mpUpdateSceneTimer->setInterval(100);
+  mpUpdateSceneTimer->setInterval(int(_hVisual * 1000.0));
   rt_ext_tp_tick_realtime(&_visualTimer);
 }
 


### PR DESCRIPTION
### Related Issues

#14851

~~To be rebased on #14998.~~ [done]

### Purpose

To make the timer consistent with the increment used in the computation of the next animation/diagram/plot time: https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1270 https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp#L3074

With reasonable frame rates, this allows for smooth playback in real time.
