### PR TITLE
Smooth animation by increasing frame rate to 60 Hz

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1193,7 +1193,7 @@ VisualizationAbstract::VisualizationAbstract(const std::string& modelFile, const
   : _visType(visType),
     mpOMVisScene(new OMVisScene(this)),
     mpOMVisualBase(new OMVisualBase(this, modelFile, path)),
-    mpTimeManager(new TimeManager(0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 1.0))
+    mpTimeManager(new TimeManager(0.0, 0.0, 0.0, 0.0, 0.016, 0.0, 1.0))
 {
   mpOMVisScene->getScene().setPath(path);
 }

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1510,7 +1510,7 @@ VariablesWidget::VariablesWidget(QWidget *pParent)
   mpToolBar->addWidget(mpSpeedLabel);
   mpToolBar->addWidget(mpSpeedComboBox);
   // time manager
-  mpTimeManager = new TimeManager(0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 1.0);
+  mpTimeManager = new TimeManager(0.0, 0.0, 0.0, 0.0, 0.016, 0.0, 1.0);
   mpTimeManager->setStartTime(0.0);
   mpTimeManager->setEndTime(1.0);
   mpTimeManager->setVisTime(mpTimeManager->getStartTime());


### PR DESCRIPTION
### Related Issues

#14851

~~To be rebased on #14999.~~ [done]

### Purpose

To avoid jerky playback. 60 Hz is the lowest (standard) refresh rate on most modern monitors.
