### PR TITLE
Keep last time when switching plot/diagram windows

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2869,7 +2869,6 @@ void VariablesWidget::updateVariablesTree(QMdiSubWindow *pSubWindow)
   }
   /* if the same sub window is activated again then just return */
   if (mpLastActiveSubWindow == pSubWindow) {
-    mpLastActiveSubWindow = pSubWindow;
     return;
   }
   mpLastActiveSubWindow = pSubWindow;
@@ -2879,7 +2878,7 @@ void VariablesWidget::updateVariablesTree(QMdiSubWindow *pSubWindow)
    */
   pSubWindow = MainWindow::instance()->getPlotWindowContainer()->getPlotSubWindowFromMdi();
   updateVariablesTreeHelper(pSubWindow);
-  initializeVisualization();
+  updateVisualization();
 }
 
 void VariablesWidget::showContextMenu(QPoint point)


### PR DESCRIPTION
### Related Issues

~~To be rebased on #15000.~~ [done]

### Purpose

To avoid resetting the visualization time when the user changes the active subwindow in the plotting area.

This is especially important when there are multiple plots of interest for the same simulation result and the user wants to inspect each of them at a specific timestamp.

### Approach

Update diagram and plots instead of reinitializing them.

### Testing

This test model allows to open both an array plot of `params` and a diagram window showing `time`:
 ```modelica
model test
  final Real params[:] = {time * i for i in 1:3};
equation
  annotation(
    Diagram(graphics = {Text(
      extent = {{-100, 100}, {100, -100}},
      textString = DynamicSelect("time", String(time, significantDigits = 4))
    )}),
    experiment(StartTime = 1, StopTime = 2)
  );
end test;
```

### Further Issues

There are more problems regarding plot/diagram update.

---

When switching between modeling and plotting perspectives, the time is reset as well. I tried to avoid reinitializing visualization in case the model widget remains the same, however this doesn't work when the diagram window is open because in this case the diagram is removed from the window layout since the diagram is used both for modeling and for plotting: https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/MainWindow.cpp#L4497-L4511 https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Plotting/DiagramWindow.cpp#L97

Also there are a couple of places where visualization is (re)initialized only if the current active subwindow is the diagram window, which seems a bit inconsistent, meaning, this should probably happen independently of the active subwindow type:
https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp#L294-L300 https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp#L726-L731 That seems to work, though, but I didn't push my investigations too far. Only thing I saw a few times, is that the "Enable Time Controls" action wasn't in the correct state, probably because of this `mpActiveVariablesTreeItem` being set only within the non-diagram window condition, but I may be wrong and didn't test further: https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp#L2895-L2899

---

When multiple result files are available and there are array plots open for several of them, changing the time for the active plot also updates all other plots, even those from different simulations. This leads to errors when the time ranges of both simulations are not the same, i.e., when the time value goes out of the valid interval for the non-active plots.

Ideally, each result file should have its own associated time and speed controls. When the user enables controls for another simulation result, time and speed would be reset to the last values stored for this simulation, and updates would be disabled for plots related to other simulations. Maybe there should be some marker to indicate that these plots haven't been updated, either greyed out time text in the plot footer or an icon next to it, or anything else.

Perhaps I'm missing a critical point, like, if it's actually possible to select array variables from different simulation results in the same array plot. Which, anyway, might not always make sense if the time range is different.

---

Since I'm not familiar enough with this part of the code, I leave it up to you.

If my remarks are not clear enough, I'd be glad to provide more information.
