### PR TITLE
Increase precision of time text in plot footer

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2088,8 +2088,8 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
             pPlotWindow->toggleSign(pPlotCurve, true);
           }
         } else {/* i.e., pPlotWindow->isPlotArray() */
-          double timePercent = mpTimeTextBox->text().toDouble();
-          pPlotWindow->plotArray(timePercent, pPlotCurve);
+          double time = mpTimeManager->getVisTime();
+          pPlotWindow->plotArray(time, pPlotCurve);
         }
         if (!pPlotCurve) {
           pPlotCurve = pPlotWindow->getPlot()->getPlotCurvesList().last();
@@ -2203,8 +2203,8 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
                 pPlotWindow->toggleSign(pPlotCurve, true);
               }
             } else { /* i.e., pPlotWindow->isPlotArrayParametric() */
-              double timePercent = mpTimeTextBox->text().toDouble();
-              pPlotWindow->plotArrayParametric(timePercent, pPlotCurve);
+              double time = mpTimeManager->getVisTime();
+              pPlotWindow->plotArrayParametric(time, pPlotCurve);
             }
             if (!pPlotCurve) {
               pPlotCurve = pPlotWindow->getPlot()->getPlotCurvesList().last();

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -998,9 +998,11 @@ double getTimeUnitFactor(QString timeUnit)
 
 void PlotWindow::updateTimeText()
 {
-  QString unit = getTimeUnit();
-  double timeUnitFactor = getTimeUnitFactor(unit);
-  mpPlot->setFooter(QString("t = %1 " + unit).arg(getTime()*timeUnitFactor,0,'g',3));
+  double time = getTime();
+  QString timeUnit = getTimeUnit();
+  double timeUnitFactor = getTimeUnitFactor(timeUnit);
+  QString timeString = QString::number(time * timeUnitFactor);
+  mpPlot->setFooter(QString("t = %1 %2").arg(timeString).arg(timeUnit));
   mpPlot->replot();
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -216,7 +216,7 @@ public:
   Plot* getPlot();
   void receiveMessage(QStringList arguments);
   void closeEvent(QCloseEvent *event);
-  void setTime(double time){mTime = time;}
+  void setTime(double time) {mTime = time;}
   double getTime() {return mTime;}
   void updateTimeText();
   void updatePlot();


### PR DESCRIPTION
### Related Issues

~~To be rebased on #15001.~~ [done]

### Purpose

The point is that the time value shown in the plot footer should have at least the resolution of the time text box in the variable browser. In fact, since the user can enter any (`double`) value, the plot footer should display the same string as the text box.

One reason is when the user takes screenshots of plots at two subsequent timesteps, then in this case the time values shall _not_ be identical. (Currently they might be!)

### Approach

I don't know if we can retrieve the text box's `QString`/`double` value directly because OMPlot is supposed to be independent of OMEdit. That being said, I don't think OMPlot on its own can create array plots, can it? Hence maybe we could pass both the `double` and `QString` time values from OMEdit. (I didn't investigate further yet.)

[EDIT: That seems correct. One difficulty though is that the time value must be multiplied by the time unit factor in `PlotWindow::updateTimeText()`. Maybe there should be a special case where we bypass the multiplication if the factor is unity (seconds) so that we preserve the original `QString`. Otherwise this multiplication would not be a problem since it would yield a different value than in the time text box and we could convert the new `double` value to a `QString`. However, in this case we would still face the same issue that we might not know how many digits to show for the converted value. Perhaps that is why we should use `QLocale::FloatingPointShortest` (see below) when conversion is unavoidable. See [this comment](https://github.com/OpenModelica/OpenModelica/pull/15002#issuecomment-4000074348) for implementing this proposal.]

I tried to set the special format specifier [`QLocale::FloatingPointShortest`](https://doc.qt.io/qt-6/qlocale.html#FloatingPointPrecisionOption-enum) but it results sometimes in numbers with too many decimal digits (e.g. 0.7000000000000001 while the text box only shows 0.7).

I was thinking you may use the Ryu library for accurate floating-point to string conversions, however I suspect it would result in the same annoying "uncut digits" as `QLocale::FloatingPointShortest`, wouldn't it? (I didn't actually try.)

For the moment, as a simple improvement, I made such that the plot footer shows a time value with the same resolution as the time slider (i.e. 0.001 seconds) within the _default_ time interval `[0, 1]`. Meaning, if you set the [start, stop] interval to e.g. `[10, 20]` and move the slider then you will still lack one decimal digit in the plot.

[EDIT: Instead of just changing the precision of `QString::arg()` from 3 to 4 significant digits in `PlotWindow::updateTimeText()`, I found out that the time text box is simply set with the default `QString::number()` conversion of the `double` time manager's value, that is, 6 significant digits. Thus in OMPlot we can compute `QString timeString = QString::number(time * timeUnitFactor);` and this will yield the same string representation as in the text box (for the "s" time unit). See [this comment](https://github.com/OpenModelica/OpenModelica/pull/15002#issuecomment-4000316837) for a more detailed explanation.]
