### PR TITLE
Remove non-standard "ms" time unit

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -988,8 +988,7 @@ void readPLTArray(QTextStream *mpTextStream, QString variable, double alpha, int
 
 double getTimeUnitFactor(QString timeUnit)
 {
-  if (timeUnit == "ms") return 1000.0;
-  else if (timeUnit == "s") return 1.0;
+  if (timeUnit == "s") return 1.0;
   else if (timeUnit == "min") return 1.0/60.0;
   else if (timeUnit == "h") return 1.0/3600.0;
   else if (timeUnit == "d") return 1.0/86400.0;


### PR DESCRIPTION
### Related Issues

~~To be rebased on #15003.~~ [done]

### Approach

See https://github.com/OpenModelica/OpenModelica/blob/7fc040b83ae63ba545e90e845c4d9d4d643b7d80/OMCompiler/Compiler/runtime/unitparser.cpp#L910-L912