### PR TITLE
New Backend with Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -9840,6 +9840,20 @@ template equation_function_create_single_body(SimEqSystem eq, Context context, S
       equationForEquation(e, context, &varDeclsLocal, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace,
                           additionalFuncs, method, classnameext, stateDerVectorName, useFlatArrayNotation,
                           createMeasureTime, assignToStartValues, overwriteOldStartValue, varDeclsLocal)
+    case e as SES_ALIAS(__)
+      then
+      /* should call alias; duplicate equation code for now
+      <<
+      initEquation_<%aliasOf%>();
+      >>
+      */
+      // get equation from initialization system
+      match simCode
+      case SIMCODE(__) then
+        equation_function_create_single_body(getSimEqSysForIndex(e.aliasOf, initialEquations), context, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace,
+                                             &additionalFuncs, method, classnameext, stateDerVectorName /*=__zDot*/, useFlatArrayNotation,
+                                             createMeasureTime, assignToStartValues, overwriteOldStartValue, &varDeclsLocal)
+      end match
     else
       error(sourceInfo(), 'NOT IMPLEMENTED EQUATION: <%dumpEqs(fill(eq,1))%>')
   end match

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -10905,13 +10905,15 @@ case CREF(componentRef = c, ty = ty) then
   match cref2simvar(c, simCode)
   case SIMVAR(varKind=varKind) then
     match varKind
+/* don't use __zDot due to SIMVAR indexing of new backend
     case STATE()
     case STATE_DER() then
       //STATE vars are flat vectors
       <<
-      /*assign to <%cref(c,useFlatArrayNotation)%>*/
+      // assign to <%cref(c,useFlatArrayNotation)%>
       memcpy(&<%lhsStr%>, <%arr%>.getData(), <%arr%>.getNumElems()*sizeof(double));
       >>
+*/
     case JAC_VAR()
     case JAC_TMP_VAR()
     case SEED_VAR() then

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -233,10 +233,12 @@ template representationCref(ComponentRef inCref, SimCode simCode, Text& extraFun
   else
     let representation = cref2simvar(inCref, simCode) |> var as SIMVAR(varKind=varKind, index=i, matrixName=matrixName) =>
     match varKind
+/* don't use __zDot due to SIMVAR indexing of new backend
     case STATE() then
       '__z[<%i%>]'
     case STATE_DER() then
       '__zDot[<%i%>]'
+*/
     case DAE_RESIDUAL_VAR() then
       '__daeResidual[<%i%>]'
     case JAC_VAR() then
@@ -428,8 +430,10 @@ template daeExpCrefRhsArrayBox(ComponentRef cr, DAE.Type ty, Context context, Te
   else
     let box = cref2simvar(cr, simCode) |> var as SIMVAR(index=i, matrixName=matrixName) =>
       match varKind
+/* don't use __zDot due to SIMVAR indexing of new backend
         case STATE()
         case STATE_DER()
+*/
         case DAE_RESIDUAL_VAR() then
           let arrdata = representationCref(cr, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, context, varDecls, stateDerVectorName, useFlatArrayNotation)
           daeExpCrefRhsArrayBox2(arrdata, ty, false, context, preExp, varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace)

--- a/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
@@ -305,6 +305,18 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       type: FOR_EQUATION
       <%forstatement%>
       >>
+    case e as SES_ALIAS(__) then
+      <<
+      equation index: <%equationIndex(e)%>
+      type: ALIAS
+        alias of <%e.aliasOf%>
+      >>
+    case e as SES_ENTWINED_ASSIGN(__) then
+      <<
+      equation index: <%equationIndex(e)%>
+      type: ENTWINED_ASSIGN
+        <%dumpEqs(e.single_calls)%>
+      >>
     else
       <<
       unknown equation

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1352,6 +1352,12 @@ package SimCodeUtil
     output list<SimCode.SimEqSystem> deps;
   end computeDependencies;
 
+  function getSimEqSysForIndex
+    input Integer idx;
+    input list<SimCode.SimEqSystem> allSimEqs;
+    output SimCode.SimEqSystem outSimEq;
+  end getSimEqSysForIndex;
+
   function getSimEqSystemsByIndexLst
     input list<Integer> idcs;
     input list<SimCode.SimEqSystem> allSes;

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -566,10 +566,8 @@ vector<const char *> OMCFactory::handleOverrides(int argc, const char* argv[], m
                && (mit = mapOMEdit.find(arg.substr(0, j))) != mapOMEdit.end()) {
           if ((oit = opts.find(mit->second)) != opts.end())
               opts[oit->first] = arg.substr(j + 1); // split at = and override value
-          else {
-              std::cout << "Passing through: " << argv[i] << std::endl;
+          else
               optv.push_back(strdup(argv[i])); // pass through
-          }
       }
       else
           optv.push_back(strdup(argv[i]));     // pass through

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -22,6 +22,7 @@ mslElectricalMachinesTest.mos \
 mslElectricalMachinesTestDAE.mos \
 mslElectricalSensorsTest.mos \
 mslMathFFT1Test.mos \
+mslThermalMassesTestNB.mos \
 nameClashTest.mos \
 functionPointerTest.mos \
 recordTupleReturnTest.mos \

--- a/testsuite/openmodelica/cppruntime/mslThermalMassesTestNB.mos
+++ b/testsuite/openmodelica/cppruntime/mslThermalMassesTestNB.mos
@@ -1,0 +1,30 @@
+// name: mslThermalMassesTestNB
+// keywords: new backend
+// status: correct
+// teardown_command: rm -f *TwoMasses*
+// cflags: -d=newInst
+
+setCommandLineOptions("--simCodeTarget=Cpp");
+setCommandLineOptions("--newBackend");
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+
+simulate(Modelica.Thermal.HeatTransfer.Examples.TwoMasses);
+val(Tsensor1.T, 1.0);
+val(Tsensor2.T, 1.0);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Modelica.Thermal.HeatTransfer.Examples.TwoMasses_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Thermal.HeatTransfer.Examples.TwoMasses', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 63.1798571052807
+// 36.82014289471914
+// ""
+// endResult


### PR DESCRIPTION
### Purpose

The C++ runtime shall work with the new backend as well.

### Approach

1. add support for alias equations --
    at the moment by generating the respective equations twice -- should be improved
2. Stop using __z(Dot) for state(derivatives) and add test
    The new backend uses SIMVAR indices with offset for state derivatives. Accessing the model variables with their actual names solves this and simplifies code generation a bit.
3. Add a first test case
