### PR TITLE
Change handling of misplaced external annotations

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
@@ -49,6 +49,7 @@ public import AbsynUtil;
 public import SCode;
 
 protected
+import Config;
 import Debug;
 import Error;
 import Flags;
@@ -449,7 +450,7 @@ algorithm
         cos = translateClassdefConstraints(parts);
         scodeCmt = translateCommentList(ann, cmtString);
         decl = translateClassdefExternaldecls(parts);
-        decl = translateAlternativeExternalAnnotation(decl,scodeCmt);
+        decl = translateAlternativeExternalAnnotation(decl, scodeCmt, info);
       then
         (SCode.PARTS(els,eqs,initeqs,als,initals,cos,classAttrs,decl),scodeCmt);
 
@@ -487,7 +488,7 @@ algorithm
         mod = translateMod(SOME(Absyn.CLASSMOD(cmod,Absyn.NOMOD())), SCode.NOT_FINAL(), SCode.NOT_EACH(), NONE(), AbsynUtil.dummyInfo);
         scodeCmt = translateCommentList(ann, cmtString);
         decl = translateClassdefExternaldecls(parts);
-        decl = translateAlternativeExternalAnnotation(decl,scodeCmt);
+        decl = translateAlternativeExternalAnnotation(decl, scodeCmt, info);
       then
         (SCode.CLASS_EXTENDS(mod,SCode.PARTS(els,eqs,initeqs,als,initals,cos,{},decl)),scodeCmt);
 
@@ -507,54 +508,53 @@ algorithm
 end translateClassdef;
 
 protected function translateAlternativeExternalAnnotation
-"first class annotation instead, since it is very common that an element
-  annotation is used for this purpose.
-  For instance, instead of external \"C\" annotation(Library=\"foo.lib\";
-  it says external \"C\" ; annotation(Library=\"foo.lib\";"
-input Option<SCode.ExternalDecl> decl;
-input SCode.Comment comment;
-output Option<SCode.ExternalDecl> outDecl;
+  "Checks if the annotation for an external declaration is misplaced, i.e.
+     external \"C\"; annotation(Library=\"foo.lib\");
+   instead of
+     external \"C\" annotation(Library=\"foo.lib\");
+  "
+  input Option<SCode.ExternalDecl> decl;
+  input SCode.Comment comment;
+  input SourceInfo info;
+  output Option<SCode.ExternalDecl> outDecl;
+protected
+  SCode.ExternalDecl ext_decl;
+  SCode.Annotation ann;
+
+  function whitelist_mod
+    input SCode.SubMod submod;
+    output Boolean keep;
+  algorithm
+    keep := match submod.ident
+      case "Library" then true;
+      case "Include" then true;
+      case "LibraryDirectory" then true;
+      case "SourceDirectory" then true;
+      case "License" then true;
+      else false;
+    end match;
+  end whitelist_mod;
 algorithm
-  outDecl := match (decl,comment)
-    local
-      Option<SCode.Ident> name ;
-      Option<String> l ;
-      Option<Absyn.ComponentRef> out ;
-      list<Absyn.Exp> a;
-      Option<SCode.Annotation> ann1,ann2,ann;
-    // none
-    case (NONE(),_) then NONE();
-    // Else, merge
-    case (SOME(SCode.EXTERNALDECL(name,l,out,a,ann1)),SCode.COMMENT(annotation_=ann2))
-      equation
-        ann = SCodeUtil.mergeSCodeOptAnn(ann1, ann2);
-      then SOME(SCode.EXTERNALDECL(name,l,out,a,ann));
+  outDecl := match (decl, comment)
+    // The external declaration is missing an annotation but there is one on the function.
+    case (SOME(ext_decl as SCode.EXTERNALDECL(annotation_ = NONE())), SCode.COMMENT(annotation_ = SOME(ann)))
+      algorithm
+        // Filter out only the modifiers allowed on an external declaration.
+        ann.modification := SCodeUtil.filterSubMods(ann.modification, whitelist_mod);
+
+        // If any matching modifiers were found, issue a warning and copy them to the external declaration.
+        if not SCodeUtil.isEmptyMod(ann.modification) then
+          if Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+            Error.addSourceMessage(Error.MISPLACED_EXTERNAL_ANNOTATION, {}, info);
+          end if;
+          ext_decl.annotation_ := SOME(ann);
+        end if;
+      then
+        SOME(ext_decl);
+
+    else decl;
   end match;
 end translateAlternativeExternalAnnotation;
-
-protected function mergeSCodeAnnotationsFromParts
-  input Absyn.ClassPart part;
-  input Option<SCode.Annotation> inMod;
-  output Option<SCode.Annotation> outMod;
-algorithm
-  outMod := match (part,inMod)
-    local
-      Absyn.Annotation aann;
-      Option<SCode.Annotation> ann;
-      list<Absyn.ElementItem> rest;
-    case (Absyn.EXTERNAL(_,SOME(aann)),_)
-      equation
-        ann = translateAnnotation(aann);
-        ann = SCodeUtil.mergeSCodeOptAnn(ann, inMod);
-      then ann;
-    case (Absyn.PUBLIC(_::rest),_)
-      then mergeSCodeAnnotationsFromParts(Absyn.PUBLIC(rest),inMod);
-    case (Absyn.PROTECTED(_::rest),_)
-      then mergeSCodeAnnotationsFromParts(Absyn.PROTECTED(rest),inMod);
-
-    else inMod;
-  end match;
-end mergeSCodeAnnotationsFromParts;
 
 protected function translateEnumlist
 "Convert an EnumLiteral list to an Ident list.

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1870,8 +1870,8 @@ impure function alarm
   "Schedules an alarm signal for the process."
   input Integer seconds;
   output Integer previousSeconds;
-external "builtin";
-annotation(__OpenModelica_Impure=true,Library = {"omcruntime"},Documentation(info="<html>
+external "builtin" annotation(Library = {"omcruntime"});
+annotation(__OpenModelica_Impure=true,Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/alarm\">alarm(2)</a>.</p>
 <p>Note that OpenModelica also sends SIGALRM to the process group when the alarm is triggered (in order to kill running simulations).</p>
 </html>"));

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
@@ -230,10 +230,6 @@ protected
       local
         SCode.Annotation ann;
 
-      case SCode.Element.CLASS(classDef = SCode.ClassDef.PARTS(
-          externalDecl = SOME(SCode.ExternalDecl.EXTERNALDECL(annotation_ = SOME(ann)))))
-        then SCodeUtil.lookupAnnotations(ann, "derivative");
-
       case SCode.Element.CLASS(cmt = SCode.Comment.COMMENT(annotation_ = SOME(ann)))
         then SCodeUtil.lookupAnnotations(ann, "derivative");
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
@@ -114,10 +114,6 @@ protected
       local
         SCode.Annotation ann;
 
-      case SCode.Element.CLASS(classDef = SCode.ClassDef.PARTS(
-          externalDecl = SOME(SCode.ExternalDecl.EXTERNALDECL(annotation_ = SOME(ann)))))
-        then SCodeUtil.lookupAnnotations(ann, "inverse");
-
       case SCode.Element.CLASS(cmt = SCode.Comment.COMMENT(annotation_ = SOME(ann)))
         then SCodeUtil.lookupAnnotations(ann, "inverse");
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2116,8 +2116,8 @@ impure function alarm
   "Schedules an alarm signal for the process."
   input Integer seconds;
   output Integer previousSeconds;
-external "builtin";
-annotation(__OpenModelica_Impure=true,Library = {"omcruntime"},Documentation(info="<html>
+external "builtin" annotation(Library = {"omcruntime"});
+annotation(__OpenModelica_Impure=true,Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/alarm\">alarm(2)</a>.</p>
 <p>Note that OpenModelica also sends SIGALRM to the process group when the alarm is triggered (in order to kill running simulations).</p>
 </html>"));

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1147,6 +1147,8 @@ public constant ErrorTypes.Message REINIT_IN_ALGORITHM = ErrorTypes.MESSAGE(618,
   Gettext.gettext("Operator reinit may not be used in an algorithm section (use translation flag --allowNonStandardModelica=reinitInAlgorithms to ignore)."));
 public constant ErrorTypes.Message HIDE_RESULT_NOT_EVALUATED = ErrorTypes.MESSAGE(619, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("Ignoring the hideResult annotation on '%s' which could not be evaluated, probably due to missing annotation(Evaluate=true)."));
+public constant ErrorTypes.Message MISPLACED_EXTERNAL_ANNOTATION = ErrorTypes.MESSAGE(620, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  Gettext.gettext("External function annotation should occur on the external-clause, not on the function."));
 
 public constant ErrorTypes.Message MATCH_SHADOWING = ErrorTypes.MESSAGE(5001, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Local variable '%s' shadows another variable."));

--- a/testsuite/flattening/libraries/3rdParty/Buildings/System2.mo
+++ b/testsuite/flattening/libraries/3rdParty/Buildings/System2.mo
@@ -1896,7 +1896,8 @@ package Modelica
           discrete input Modelica.SIunits.Time pre_nextTimeEvent;
           input Real tableAvailable annotation(__OpenModelica_UnusedVariable = true);
           output Real y;
-          external "C" y = ModelicaStandardTables_CombiTimeTable_getValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent) annotation(Library = {"ModelicaStandardTables"}, derivative(noDerivative = nextTimeEvent, noDerivative = pre_nextTimeEvent, noDerivative = tableAvailable) = getDerTableValue);
+          external "C" y = ModelicaStandardTables_CombiTimeTable_getValue(tableID, icol, timeIn, nextTimeEvent, pre_nextTimeEvent) annotation(Library = {"ModelicaStandardTables"});
+          annotation(derivative(noDerivative = nextTimeEvent, noDerivative = pre_nextTimeEvent, noDerivative = tableAvailable) = getDerTableValue);
         end getTableValue;
 
         function getTableValueNoDer
@@ -8720,6 +8721,6 @@ end System2;
 //   booToReaRad.y = if booToReaRad.u then booToReaRad.realTrue else booToReaRad.realFalse;
 //   not1.y = not not1.u;
 // end System2;
-// [flattening/libraries/3rdParty/Buildings/System2.mo:4451:7-4466:18:writable] Warning: Pure function 'Modelica.Utilities.Strings.isEmpty' contains a call to impure function 'Modelica.Utilities.Strings.Advanced.skipWhiteSpace'.
+// [flattening/libraries/3rdParty/Buildings/System2.mo:4452:7-4467:18:writable] Warning: Pure function 'Modelica.Utilities.Strings.isEmpty' contains a call to impure function 'Modelica.Utilities.Strings.Advanced.skipWhiteSpace'.
 //
 // endResult

--- a/testsuite/flattening/libraries/biochem/ContainerTotal.mo
+++ b/testsuite/flattening/libraries/biochem/ContainerTotal.mo
@@ -71,7 +71,7 @@ http://www.Modelica.org/licenses/ModelicaLicense2</a>.
       input Real u;
       output SI.Angle y;
 
-      external "C" y=asin(u) ;
+      external "C" y=asin(u) annotation(Library="ModelicaExternalC");
       annotation(Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-90,0},{68,0}}, color={192,192,192}),Polygon(points={{90,0},{68,8},{68,-8},{90,0}}, lineColor={192,192,192}, fillColor={192,192,192}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-79.2,-72.8},{-77.6,-67.5},{-73.6,-59.4},{-66.3,-49.8},{-53.5,-37.3},{-30.2,-19.7},{37.4,24.8},{57.5,40.8},{68.7,52.7},{75.2,62.2},{77.6,67.5},{80,80}}, color={0,0,0}),Text(extent={{-88,78},{-16,30}}, lineColor={192,192,192}, textString="asin")}), Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Text(extent={{-40,-72},{-15,-88}}, textString="-pi/2", lineColor={0,0,255}),Text(extent={{-38,88},{-13,72}}, textString=" pi/2", lineColor={0,0,255}),Text(extent={{68,-9},{88,-29}}, textString="+1", lineColor={0,0,255}),Text(extent={{-90,21},{-70,1}}, textString="-1", lineColor={0,0,255}),Line(points={{-100,0},{84,0}}, color={95,95,95}),Polygon(points={{98,0},{82,6},{82,-6},{98,0}}, lineColor={95,95,95}, fillColor={95,95,95}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-79.2,-72.8},{-77.6,-67.5},{-73.6,-59.4},{-66.3,-49.8},{-53.5,-37.3},{-30.2,-19.7},{37.4,24.8},{57.5,40.8},{68.7,52.7},{75.2,62.2},{77.6,67.5},{80,80}}, color={0,0,255}, thickness=0.5),Text(extent={{82,24},{102,4}}, lineColor={95,95,95}, textString="u"),Line(points={{0,80},{86,80}}, color={175,175,175}, smooth=Smooth.None),Line(points={{80,86},{80,-10}}, color={175,175,175}, smooth=Smooth.None)}), Documentation(info="<html>
 <p>
 This function returns y = asin(u), with -1 &le; u &le; +1:
@@ -80,7 +80,7 @@ This function returns y = asin(u), with -1 &le; u &le; +1:
 <p>
 <img src=\"../Images/Math/asin.png\">
 </p>
-</html>"), Library="ModelicaExternalC");
+</html>"));
     end asin;
 
     function exp "Exponential, base e"
@@ -88,7 +88,7 @@ This function returns y = asin(u), with -1 &le; u &le; +1:
       input Real u;
       output Real y;
 
-      external "C" y=exp(u) ;
+      external "C" y=exp(u) annotation(Library="ModelicaExternalC");
       annotation(Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-90,-80.3976},{68,-80.3976}}, color={192,192,192}),Polygon(points={{90,-80.3976},{68,-72.3976},{68,-88.3976},{90,-80.3976}}, lineColor={192,192,192}, fillColor={192,192,192}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-31,-77.9},{-6.03,-74},{10.9,-68.4},{23.7,-61},{34.2,-51.6},{43,-40.3},{50.3,-27.8},{56.7,-13.5},{62.3,2.23},{67.1,18.6},{72,38.2},{76,57.6},{80,80}}, color={0,0,0}),Text(extent={{-86,50},{-14,2}}, lineColor={192,192,192}, textString="exp")}), Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-100,-80.3976},{84,-80.3976}}, color={95,95,95}),Polygon(points={{98,-80.3976},{82,-74.3976},{82,-86.3976},{98,-80.3976}}, lineColor={95,95,95}, fillColor={95,95,95}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-31,-77.9},{-6.03,-74},{10.9,-68.4},{23.7,-61},{34.2,-51.6},{43,-40.3},{50.3,-27.8},{56.7,-13.5},{62.3,2.23},{67.1,18.6},{72,38.2},{76,57.6},{80,80}}, color={0,0,255}, thickness=0.5),Text(extent={{-31,72},{-11,88}}, textString="20", lineColor={0,0,255}),Text(extent={{-92,-81},{-72,-101}}, textString="-3", lineColor={0,0,255}),Text(extent={{66,-81},{86,-101}}, textString="3", lineColor={0,0,255}),Text(extent={{2,-69},{22,-89}}, textString="1", lineColor={0,0,255}),Text(extent={{78,-54},{98,-74}}, lineColor={95,95,95}, textString="u"),Line(points={{0,80},{88,80}}, color={175,175,175}, smooth=Smooth.None),Line(points={{80,84},{80,-84}}, color={175,175,175}, smooth=Smooth.None)}), Documentation(info="<html>
 <p>
 This function returns y = exp(u), with -&infin; &lt; u &lt; &infin;:
@@ -97,7 +97,7 @@ This function returns y = exp(u), with -&infin; &lt; u &lt; &infin;:
 <p>
 <img src=\"../Images/Math/exp.png\">
 </p>
-</html>"), Library="ModelicaExternalC");
+</html>"));
     end exp;
 
     partial function baseIcon2 "Basic icon for mathematical function with y-axis in middle"

--- a/testsuite/flattening/libraries/biochem/CytosolTotal.mo
+++ b/testsuite/flattening/libraries/biochem/CytosolTotal.mo
@@ -71,7 +71,7 @@ http://www.Modelica.org/licenses/ModelicaLicense2</a>.
       input Real u;
       output SI.Angle y;
 
-      external "C" y=asin(u) ;
+      external "C" y=asin(u) annotation(Library="ModelicaExternalC");
       annotation(Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-90,0},{68,0}}, color={192,192,192}),Polygon(points={{90,0},{68,8},{68,-8},{90,0}}, lineColor={192,192,192}, fillColor={192,192,192}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-79.2,-72.8},{-77.6,-67.5},{-73.6,-59.4},{-66.3,-49.8},{-53.5,-37.3},{-30.2,-19.7},{37.4,24.8},{57.5,40.8},{68.7,52.7},{75.2,62.2},{77.6,67.5},{80,80}}, color={0,0,0}),Text(extent={{-88,78},{-16,30}}, lineColor={192,192,192}, textString="asin")}), Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Text(extent={{-40,-72},{-15,-88}}, textString="-pi/2", lineColor={0,0,255}),Text(extent={{-38,88},{-13,72}}, textString=" pi/2", lineColor={0,0,255}),Text(extent={{68,-9},{88,-29}}, textString="+1", lineColor={0,0,255}),Text(extent={{-90,21},{-70,1}}, textString="-1", lineColor={0,0,255}),Line(points={{-100,0},{84,0}}, color={95,95,95}),Polygon(points={{98,0},{82,6},{82,-6},{98,0}}, lineColor={95,95,95}, fillColor={95,95,95}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-79.2,-72.8},{-77.6,-67.5},{-73.6,-59.4},{-66.3,-49.8},{-53.5,-37.3},{-30.2,-19.7},{37.4,24.8},{57.5,40.8},{68.7,52.7},{75.2,62.2},{77.6,67.5},{80,80}}, color={0,0,255}, thickness=0.5),Text(extent={{82,24},{102,4}}, lineColor={95,95,95}, textString="u"),Line(points={{0,80},{86,80}}, color={175,175,175}, smooth=Smooth.None),Line(points={{80,86},{80,-10}}, color={175,175,175}, smooth=Smooth.None)}), Documentation(info="<html>
 <p>
 This function returns y = asin(u), with -1 &le; u &le; +1:
@@ -80,7 +80,7 @@ This function returns y = asin(u), with -1 &le; u &le; +1:
 <p>
 <img src=\"../Images/Math/asin.png\">
 </p>
-</html>"), Library="ModelicaExternalC");
+</html>"));
     end asin;
 
     function exp "Exponential, base e"
@@ -88,7 +88,7 @@ This function returns y = asin(u), with -1 &le; u &le; +1:
       input Real u;
       output Real y;
 
-      external "C" y=exp(u) ;
+      external "C" y=exp(u) annotation(Library="ModelicaExternalC");
       annotation(Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-90,-80.3976},{68,-80.3976}}, color={192,192,192}),Polygon(points={{90,-80.3976},{68,-72.3976},{68,-88.3976},{90,-80.3976}}, lineColor={192,192,192}, fillColor={192,192,192}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-31,-77.9},{-6.03,-74},{10.9,-68.4},{23.7,-61},{34.2,-51.6},{43,-40.3},{50.3,-27.8},{56.7,-13.5},{62.3,2.23},{67.1,18.6},{72,38.2},{76,57.6},{80,80}}, color={0,0,0}),Text(extent={{-86,50},{-14,2}}, lineColor={192,192,192}, textString="exp")}), Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}, grid={2,2}), graphics={Line(points={{-100,-80.3976},{84,-80.3976}}, color={95,95,95}),Polygon(points={{98,-80.3976},{82,-74.3976},{82,-86.3976},{98,-80.3976}}, lineColor={95,95,95}, fillColor={95,95,95}, fillPattern=FillPattern.Solid),Line(points={{-80,-80},{-31,-77.9},{-6.03,-74},{10.9,-68.4},{23.7,-61},{34.2,-51.6},{43,-40.3},{50.3,-27.8},{56.7,-13.5},{62.3,2.23},{67.1,18.6},{72,38.2},{76,57.6},{80,80}}, color={0,0,255}, thickness=0.5),Text(extent={{-31,72},{-11,88}}, textString="20", lineColor={0,0,255}),Text(extent={{-92,-81},{-72,-101}}, textString="-3", lineColor={0,0,255}),Text(extent={{66,-81},{86,-101}}, textString="3", lineColor={0,0,255}),Text(extent={{2,-69},{22,-89}}, textString="1", lineColor={0,0,255}),Text(extent={{78,-54},{98,-74}}, lineColor={95,95,95}, textString="u"),Line(points={{0,80},{88,80}}, color={175,175,175}, smooth=Smooth.None),Line(points={{80,84},{80,-84}}, color={175,175,175}, smooth=Smooth.None)}), Documentation(info="<html>
 <p>
 This function returns y = exp(u), with -&infin; &lt; u &lt; &infin;:
@@ -97,7 +97,7 @@ This function returns y = exp(u), with -&infin; &lt; u &lt; &infin;:
 <p>
 <img src=\"../Images/Math/exp.png\">
 </p>
-</html>"), Library="ModelicaExternalC");
+</html>"));
     end exp;
 
     partial function baseIcon2 "Basic icon for mathematical function with y-axis in middle"

--- a/testsuite/flattening/modelica/ffi/FFITest/package.mo
+++ b/testsuite/flattening/modelica/ffi/FFITest/package.mo
@@ -3,7 +3,7 @@ package FFITest
     function real1
       input Real x;
       output Real y;
-    external "C" y = real1_ext(x);
+    external "C" y = real1_ext(x)
       annotation(Library="FFITestLib");
     end real1;
 
@@ -16,7 +16,7 @@ package FFITest
       input Real y;
       input Real z;
       output Real r;
-    external "C" r = real2_ext(x, y, z);
+    external "C" r = real2_ext(x, y, z)
       annotation(Library="FFITestLib");
     end real2;
 
@@ -28,7 +28,7 @@ package FFITest
       input Real x;
       input Real y;
       output Real r;
-    external "C" real3_ext(x, y, r);
+    external "C" real3_ext(x, y, r)
       annotation(Library="FFITestLib");
     end real3;
 
@@ -39,7 +39,7 @@ package FFITest
     function integer1
       input Integer x;
       output Integer y;
-    external "C" y = integer1_ext(x);
+    external "C" y = integer1_ext(x)
       annotation(Library="FFITestLib");
     end integer1;
 
@@ -52,7 +52,7 @@ package FFITest
       input Integer y;
       input Integer z;
       output Integer r;
-    external "C" r = integer2_ext(x, y, z);
+    external "C" r = integer2_ext(x, y, z)
       annotation(Library="FFITestLib");
     end integer2;
 
@@ -63,7 +63,7 @@ package FFITest
     function boolean1
       input Boolean x;
       output Boolean y;
-    external "C" y = boolean1_ext(x);
+    external "C" y = boolean1_ext(x)
       annotation(Library="FFITestLib");
     end boolean1;
 
@@ -77,7 +77,7 @@ package FFITest
       input Boolean y;
       input Boolean z;
       output Boolean r;
-    external "C" r = boolean2_ext(x, y, z);
+    external "C" r = boolean2_ext(x, y, z)
       annotation(Library="FFITestLib");
     end boolean2;
 
@@ -91,7 +91,7 @@ package FFITest
     function enum1
       input E1 x;
       output E1 y;
-    external "C" y = enum1_ext(x);
+    external "C" y = enum1_ext(x)
       annotation(Library="FFITestLib");
     end enum1;
 
@@ -104,7 +104,7 @@ package FFITest
       input E1 x;
       input E1 y;
       output E1 r;
-    external "C" r = enum2_ext(x, y);
+    external "C" r = enum2_ext(x, y)
       annotation(Library="FFITestLib");
     end enum2;
 
@@ -119,7 +119,7 @@ package FFITest
     function string1
       input String x;
       output Integer y;
-    external "C" y = string1_ext(x);
+    external "C" y = string1_ext(x)
       annotation(Library="FFITestLib");
     end string1;
 
@@ -131,7 +131,7 @@ package FFITest
       output String s;
     protected
       Boolean eof;
-    external "C" s = ModelicaInternal_readLine("String2.mos", 1, eof);
+    external "C" s = ModelicaInternal_readLine("String2.mos", 1, eof)
       annotation(Library="ModelicaExternalC");
     end string2;
 
@@ -144,7 +144,7 @@ package FFITest
     function realArray1
       input Real x[:];
       output Real y[size(x, 1)];
-    external "C" realArray1_ext(x, size(x, 1), y);
+    external "C" realArray1_ext(x, size(x, 1), y)
       annotation(Library="FFITestLib");
     end realArray1;
 
@@ -155,7 +155,7 @@ package FFITest
     function stringArray1
       input String s[:];
       output Integer lens[size(s, 1)];
-    external "C" stringArray1_ext(s, size(s, 1), lens);
+    external "C" stringArray1_ext(s, size(s, 1), lens)
       annotation(Library="FFITestLib");
     end stringArray1;
 
@@ -172,7 +172,7 @@ package FFITest
     function record1
       input R1 r1;
       output Real x;
-    external "C" x = record1_ext(r1);
+    external "C" x = record1_ext(r1)
       annotation(Library="FFITestLib");
     end record1;
 
@@ -192,7 +192,7 @@ package FFITest
       input Real y;
       input Real z;
       output R2 r2;
-    external "C" record2_ext(r2, x, y, z);
+    external "C" record2_ext(r2, x, y, z)
       annotation(Library="FFITestLib");
     end record2;
 
@@ -211,7 +211,7 @@ package FFITest
       input Real r;
       input Integer i2;
       output R3 r3;
-    external "C" record3_ext(r3, i1, r, i2);
+    external "C" record3_ext(r3, i1, r, i2)
       annotation(Library="FFITestLib");
     end record3;
 
@@ -228,7 +228,7 @@ package FFITest
     function record4
       input Real arr[5];
       output R4 r4;
-    external "C" record4_ext(arr, r4);
+    external "C" record4_ext(arr, r4)
       annotation(Library="FFITestLib");
     end record4;
 
@@ -239,7 +239,7 @@ package FFITest
     function record5
       input Real x;
       output R1 r1;
-    external "C" r1 = record5_ext(x);
+    external "C" r1 = record5_ext(x)
       annotation(Library="FFITestLib");
     end record5;
 
@@ -251,7 +251,7 @@ package FFITest
   package ErrorChecking
     function missingFunction1
       output Real x;
-    external "C" x = missingFunction1_ext();
+    external "C" x = missingFunction1_ext()
       annotation(Library="FFITestLib");
     end missingFunction1;
 
@@ -261,7 +261,7 @@ package FFITest
 
     function arrayResult1
       output Real[3] x;
-    external "C" x = arrayResult1_ext();
+    external "C" x = arrayResult1_ext()
       annotation(Library="FFITestLib");
     end arrayResult1;
 
@@ -294,7 +294,7 @@ package FFITest
     function countLines
       input String filename;
       output Integer lines;
-    external "C" lines = ModelicaInternal_countLines(filename);
+    external "C" lines = ModelicaInternal_countLines(filename)
       annotation(Library="ModelicaExternalC");
     end countLines;
 
@@ -309,7 +309,7 @@ package FFITest
       output Real number;
     protected
       Integer nextIndex;
-    external "C" ModelicaStrings_scanReal(string, startIndex, unsigned, nextIndex, number);
+    external "C" ModelicaStrings_scanReal(string, startIndex, unsigned, nextIndex, number)
       annotation(Library="ModelicaExternalC");
     end scanReal;
 
@@ -324,7 +324,7 @@ package FFITest
       output Integer number;
     protected
       Integer nextIndex;
-    external "C" ModelicaStrings_scanInteger(string, startIndex, unsigned, nextIndex, number);
+    external "C" ModelicaStrings_scanInteger(string, startIndex, unsigned, nextIndex, number)
       annotation(Library="ModelicaExternalC");
     end scanInteger;
 
@@ -338,7 +338,7 @@ package FFITest
       output String outString;
     protected
       Integer nextIndex;
-    external "C" ModelicaStrings_scanString(string, startIndex, nextIndex, outString);
+    external "C" ModelicaStrings_scanString(string, startIndex, nextIndex, outString)
       annotation(Library="ModelicaExternalC");
     end scanString;
 

--- a/testsuite/flattening/modelica/streams/StreamConcept_NoMedium_Total.mo
+++ b/testsuite/flattening/modelica/streams/StreamConcept_NoMedium_Total.mo
@@ -555,7 +555,7 @@ and the accompanying <b>disclaimer</b>
     input SI.Angle u;
     output Real y;
 
-  external "C" y=  sin(u);
+  external "C" y=  sin(u) annotation(Library="ModelicaExternalC");
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -626,7 +626,7 @@ This function returns y = sin(u), with -&infin; &lt; u &lt; &infin;:
 <p>
 <img src=\"../Images/Math/sin.png\">
 </p>
-</html>"),   Library="ModelicaExternalC");
+</html>"));
   end sin;
 
   function asin "Inverse sine (-1 <= u <= 1)"
@@ -634,7 +634,7 @@ This function returns y = sin(u), with -&infin; &lt; u &lt; &infin;:
     input Real u;
     output SI.Angle y;
 
-  external "C" y=  asin(u);
+  external "C" y=  asin(u) annotation(Library="ModelicaExternalC");
     annotation (
       Icon(coordinateSystem(
           preserveAspectRatio=true,
@@ -705,7 +705,7 @@ This function returns y = asin(u), with -1 &le; u &le; +1:
 <p>
 <img src=\"../Images/Math/asin.png\">
 </p>
-</html>"),   Library="ModelicaExternalC");
+</html>"));
   end asin;
 
   partial function baseIcon1

--- a/testsuite/omsimulator/testSynchronousFMU_01.mos
+++ b/testsuite/omsimulator/testSynchronousFMU_01.mos
@@ -41,7 +41,9 @@ diffSimulationResults(
 // true
 // ""
 // true
-// ""
+// "[Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// "
 // true
 // record SimulationResult
 //     resultFile = "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample_res.csv",
@@ -50,9 +52,13 @@ diffSimulationResults(
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// ""
+// "[Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// "
 // "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample.fmu"
-// ""
+// "[Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// "
 // 0
 // ""
 // (true, {})

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -51,6 +51,8 @@ val(y[10], 1.0);
 // Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation from VectorizedBlocksTest.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // "
 //
 // ########################################
@@ -202,6 +204,8 @@ val(y[10], 1.0);
 // "Warning: Requested package Modelica_Synchronous of version 0.92.1, but this package was already loaded with version 0.93.0-dev. There are no conversion annotations and 0.92.1 is older than 0.93.0-dev, so the libraries are probably incompatible.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // Warning: The initial conditions are over specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // 10.0

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -129,6 +129,7 @@ ReverseLookup3.mos \
 RunScript.mos \
 saveShort.mos \
 saveTotalModel.mos \
+saveTotalModel2.mos \
 setComponentComment.mos \
 setComponentModifierValue.mos \
 setElementAnnotation.mos \

--- a/testsuite/openmodelica/interactive-API/saveTotalModel2.mos
+++ b/testsuite/openmodelica/interactive-API/saveTotalModel2.mos
@@ -1,0 +1,45 @@
+// name: saveTotalModel2
+// keywords:
+// status: correct
+//
+
+loadString("
+  function f1
+    external \"C\" f1_ext();
+    annotation(Include = \"f1.h\", derivative = f1_der);
+  end f1;
+
+  function f1_der
+  end f1_der;
+
+  model M
+  equation
+    f1();
+  end M;
+");
+
+saveTotalSCode("M.mo", M); getErrorString();
+readFile("M.mo");
+
+// Result:
+// true
+// true
+// "[<interactive>:2:3-5:9:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// "
+// "function f1
+//   external \"C\" f1_ext() annotation(Include = \"f1.h\");
+//   annotation(Include = \"f1.h\", derivative = f1_der);
+// end f1;
+//
+// function f1_der end f1_der;
+//
+// model M
+// equation
+//   f1();
+// end M;
+//
+// model M_total
+//   extends M;
+// end M_total;
+// "
+// endResult

--- a/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager.mos
+++ b/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager.mos
@@ -23,13 +23,19 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager', options = '', outputFormat = 'mat', variableFilter = 'time|unpackInt.y|getInteger.y.1.|unpackInt1.y', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
+// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager', options = '', outputFormat = 'mat', variableFilter = 'time|unpackInt.y|getInteger.y.1.|unpackInt1.y', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
 // Warning: Requested package Modelica_Synchronous of version 0.92.2, but this package was already loaded with version 0.93.0-dev. There are no conversion annotations and 0.92.2 is older than 0.93.0-dev, so the libraries are probably incompatible.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/EmbeddedTargets/STM32F4/Functions/HAL.mo:6:3-12:14:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/OperatingSystem/DynamicArray.mo:6:3-94:18:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1041:3-1062:27:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1064:3-1092:25:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // Warning: Alias equations of external objects are not Modelica compliant as in:
 //     addBoolean.pkgOut[1].pkg = resetPointer.pkgIn.pkg
 //     getBoolean.pkgIn.pkg = getInteger.pkgOut[1].pkg

--- a/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_ExternalTrigger.mos
+++ b/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_ExternalTrigger.mos
@@ -23,13 +23,19 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_ExternalTrigger', options = '', outputFormat = 'mat', variableFilter = 'time|getInteger.y.1.', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
+// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_ExternalTrigger', options = '', outputFormat = 'mat', variableFilter = 'time|getInteger.y.1.', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_ExternalTrigger_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
 // Warning: Requested package Modelica_Synchronous of version 0.92.2, but this package was already loaded with version 0.93.0-dev. There are no conversion annotations and 0.92.2 is older than 0.93.0-dev, so the libraries are probably incompatible.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/EmbeddedTargets/STM32F4/Functions/HAL.mo:6:3-12:14:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/OperatingSystem/DynamicArray.mo:6:3-94:18:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1041:3-1062:27:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1064:3-1092:25:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // Warning: Alias equations of external objects are not Modelica compliant as in:
 //     getInteger.pkgIn.pkg = unpackInt1.pkgOut[1].pkg
 //     unpackInt.pkgOut[1].pkg = unpackInt1.pkgIn.pkg

--- a/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_String.mos
+++ b/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_String.mos
@@ -30,13 +30,19 @@ runScript(modelTesting);getErrorString();
 // \"Modelica_DeviceDrivers\"
 // "
 // ""
-// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_String', options = '', outputFormat = 'mat', variableFilter = 'time|findString.y', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
+// Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_String', options = '', outputFormat = 'mat', variableFilter = 'time|findString.y', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_String_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
 // Warning: Requested package Modelica_Synchronous of version 0.92.2, but this package was already loaded with version 0.93.0-dev. There are no conversion annotations and 0.92.2 is older than 0.93.0-dev, so the libraries are probably incompatible.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/EmbeddedTargets/STM32F4/Functions/HAL.mo:6:3-12:14:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/OperatingSystem/DynamicArray.mo:6:3-94:18:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1041:3-1062:27:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_DeviceDrivers 1.8.2/Incubate/Utilities/Functions.mo:1064:3-1092:25:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // Warning: Alias equations of external objects are not Modelica compliant as in:
 //     addInteger.pkgOut[1].pkg = resetPointer.pkgIn.pkg
 //     getInteger.pkgIn.pkg = getString.pkgOut[1].pkg

--- a/testsuite/simulation/modelica/external_functions/ExtObj.mo
+++ b/testsuite/simulation/modelica/external_functions/ExtObj.mo
@@ -14,13 +14,13 @@ package ExtObj
       input Real[:] vals={1,2,3};
       output MyTable outTable;
 
-      external "C" outTable=initMyTable(fileName,tableName,vals,size(vals,1)) ;
+      external "C" outTable=initMyTable(fileName,tableName,vals,size(vals,1))
       annotation(Include="#include \"ExtObj.h\"",Library="ExtObj.lib");
     end constructor;
     function destructor
           input MyTable inTable;
 
-      external "C" closeMyTable(inTable) ;
+      external "C" closeMyTable(inTable)
       annotation(Include="#include \"ExtObj.h\"",Library="ExtObj.lib");
     end destructor;
   end MyTable;

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mo
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mo
@@ -12,7 +12,7 @@ encapsulated package ExternalCFuncInputOnly
 
   function WriteData
     input Data data;
-   external"C" WriteDataC(data);
+   external"C" WriteDataC(data)
    annotation(Library = "ExternalCFuncInputOnly.o", Include="#include \"ExternalCFuncInputOnly.h\"");
   end WriteData;
 

--- a/testsuite/simulation/modelica/external_functions/ImplicitArray.mos
+++ b/testsuite/simulation/modelica/external_functions/ImplicitArray.mos
@@ -9,7 +9,7 @@ model Ticket4009
     input Real x;
     input T t_in;
     output Real y;
-    external \"C\";
+    external \"C\"
   annotation(Include =
   \"
   #include <stddef.h>

--- a/testsuite/simulation/modelica/external_functions/extObj_ticket3446.mo
+++ b/testsuite/simulation/modelica/external_functions/extObj_ticket3446.mo
@@ -5,7 +5,7 @@ package TestMyExternalObj
       input Integer size=3;
       output MyExternalObj outMyExternalObj;
 
-      external "C" outMyExternalObj=initMyExternalObj(size);
+      external "C" outMyExternalObj=initMyExternalObj(size)
       annotation(Include="
         #include <stdio.h>
         #include <stdlib.h> /* for Linux malloc and exit */
@@ -32,7 +32,7 @@ package TestMyExternalObj
     function destructor
       input MyExternalObj inMyExternalObj;
 
-      external "C" closeMyExternalObj(inMyExternalObj) ;
+      external "C" closeMyExternalObj(inMyExternalObj)
       annotation(Include="
         #include <stdio.h>
         #include <stdlib.h> /* for Linux malloc and exit */
@@ -56,7 +56,7 @@ package TestMyExternalObj
     input Integer i;
     output Real y;
 
-    external "C" y=readFromMyExternalObj(extObj, i);
+    external "C" y=readFromMyExternalObj(extObj, i)
     annotation(Include="
       #include <stdio.h>
       #include <stdlib.h> /* for Linux malloc and exit */

--- a/testsuite/simulation/modelica/synchronous/TestClockParameterEvaluation.mos
+++ b/testsuite/simulation/modelica/synchronous/TestClockParameterEvaluation.mos
@@ -19,26 +19,32 @@ simulate(Modelica_Synchronous.Examples.SimpleControlledDrive.ClockedWithDiscreti
 // true
 // "Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // "
 // record SimulationResult
 //     resultFile = "Modelica_Synchronous.Examples.Systems.ControlledMixingUnit_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 300.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_Synchronous.Examples.Systems.ControlledMixingUnit', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 300.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica_Synchronous.Examples.Systems.ControlledMixingUnit', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // "
 // record SimulationResult
 //     resultFile = "Modelica_Synchronous.Examples.SimpleControlledDrive.ClockedWithDiscretizedContinuousController_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_Synchronous.Examples.SimpleControlledDrive.ClockedWithDiscretizedContinuousController', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica_Synchronous.Examples.SimpleControlledDrive.ClockedWithDiscretizedContinuousController', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:11:9-20:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
+// [Modelica_Synchronous 0.92.2/WorkInProgress.mo:130:9-144:24:writable] Warning: External function annotation should occur on the external-clause, not on the function.
 // Warning: It was not possible to determine if the initialization problem is consistent, because of not evaluable parameters/start values during compile time: PI.y = PI.y_start (0.0 = PI.y_start)
 // Warning: The initial conditions are over specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "


### PR DESCRIPTION
- Copy external function annotations that are misplaced on the function itself to the external declaration if the external declaration has no annotation, and issue a warning if that happens. Previously the annotation on the function and the external declaration were always merged, which could result in invalid annotations on the external declaration and could also cause the annotation to grow each time e.g. saveTotalModel was used on the function.