### PR TITLE
[GBODE] add contractive defect based errors to Radau IIA (3, 5, 7) and Gauss (3, 5)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.h
@@ -65,8 +65,8 @@ void gbInternalContraction(DATA *data,
                            threadData_t *threadData,
                            NONLINEAR_SYSTEM_DATA *nonlinsys,
                            DATA_GBODE *gbData,
-                           double *yt,
-                           double *y);
+                           const double *y,
+                           double *yt);
 
 void gbInternalLinearCombinationSVP(STAGE_VALUE_PREDICTORS *svp,
                                     int active_stage,


### PR DESCRIPTION
## Related
https://github.com/OpenModelica/OpenModelica/issues/14022

## Summary

This PR adds data and routines for contractive error estimates of superconvergent FIRK methods (Gauss and Radau) in `-gbnls=internal`.

## Background
As its quite theoretically challenging, I will give a brief overview.

Due to the superconvergent nature of FIRK methods, constructing accurate error estimates is challenging. Standard embedded methods can achieve at most order $s-1$ for $s$ stages, while the underlying collocation methods have much higher order:

- Gauss: order $2s$
- Radau: order $2s-1$
- Lobatto: order $2s-2$

Ideally, one would like an embedded method of order just one less or even one higher than the main method to get a reliable error estimate. Unfortunately, this is not feasible for superconvergent FIRK methods. An order 
$s−1$ estimate provides only very limited information about the true error and is generally insufficient for accurate step control. In addition, these standard embedded methods are not A-stable, so they lose an important property of the main solver. If the controller rejects large steps in stiff regimes, because of overestimates of the error, what is the point of using a stiff implicit method?

E.g. see the Radau IIA 3-step in the linear test problem of https://github.com/OpenModelica/OpenModelica/issues/14022#issuecomment-3641910960. It requires 125 steps taken and 547 calls of functionODE, which still is a lot and achieves a precision that is not even requested because the step size control forces such small steps. With this PR we require just 53 steps and 291 ODE functionODE calls and obtain a good maximum error of $3 \cdot 10^{-7}$ on the solver grid.


## Contractive Error Estimate

For collocation methods with at least one real eigenvalue $\gamma$ and $0$ as a non-collocated point (so Radau IIA or Gauss), we can compute an A-stable error estimate of order $s$ with one extra function evaluation and one LU solve:

```math
\begin{equation}
\text{ERR} = (I - h \gamma J)^{-1}  h \gamma  \left[f(x_0, y_0) - d(0)^T A k\right],
\end{equation}
```
where $d(0)^T$ is the row of the Differentation matrix with respect to node $0$. The term  $h  (f(x_0, y_0) - d(0)^T A k)$ describes the defect of the collocation polynomial at node 0. Since this is unbounded if $h \lambda \rightarrow \infty$, we have to perform a contraction which adds an overall factor of $\frac{1}{1 - \gamma h \lambda}$ to its stability function, thus making it A-stable (limit is $-1$ for $h \lambda \rightarrow \infty$).

Since the LU decomposition of $\frac{1}{h\gamma} I - J$ is already available from the Newton iteration, in the code we compute:

```math
\begin{equation}
\text{ERR} = (\frac{1}{h\gamma} I - J)^{-1} \left[f(x_0, y_0) - d(0)^T A k\right]
\end{equation}
```

The code is general and also allows evaluation at other non-collocated nodes $u$, which might be useful for Lobatto IIIA for example:
```math
\begin{equation}
\text{ERR} = (\frac{1}{h\gamma} I - J)^{-1}  \left[f(x_0 + u h, y(x_0 + u h)) - d(u)^T A k\right]
\end{equation}
```

Note that for $u \neq 0$, the stability region is limited, but still usually much better than the standard embedded method.
The PR only enables the estimates for Gauss and Radau IIA though.

## Double Contraction

Optionally, a second contraction step can be performed via

```math
\begin{equation}
\text{ERR}_2 = (\frac{1}{h\gamma} I - J)^{-1} \left[f(x_0 + u h, y_0 + h \cdot \text{ERR}) - d(u)^T A k\right],
\end{equation}
```

where $\text{ERR}$ is the previous error.

This $\text{ERR}_2$ is A-stable for $u \neq 0$ (e.g. Lobatto IIIA) and L-stable for $u = 0$ (e.g. Gauss, Radau)
It doubles the cost, so it is not yet implemented, but e.g. Hairer uses it after step rejections.
