### PR TITLE
[NF] fix getting subscript from cref with wholedim

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -921,7 +921,7 @@ public
         subs := {};
         for size in listReverse(sizes_) loop
           if size <> 1 then
-            subs := Subscript.SLICE(Expression.RANGE(Type.INTEGER(), Expression.INTEGER(1), NONE(), Expression.INTEGER(size))) :: subs;
+            subs := Subscript.SLICE(Expression.makeRange(Expression.INTEGER(1), NONE(), Expression.INTEGER(size))) :: subs;
           end if;
         end for;
       then subscriptsAllWithWhole(cref.restCref, subs :: accumSubs);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -932,6 +932,9 @@ public
       case SLICE() then listHead(Type.arrayDims(Expression.typeOf(subscript.slice)));
       case WHOLE() then Dimension.UNKNOWN();
       case SPLIT_INDEX() then Dimension.fromInteger(1);
+      else algorithm
+        Error.assertion(false, getInstanceName() + " got wrong subscript " + toString(subscript) + "\n", sourceInfo());
+      then fail();
     end match;
   end toDimension;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1188,6 +1188,9 @@ public
               case Subscript.SLICE() then Subscript.toDimension(sub) :: subbed_dims;
               case Subscript.WHOLE() then dim :: subbed_dims;
               case Subscript.SPLIT_INDEX() then subbed_dims;
+              else algorithm
+                Error.assertion(false, getInstanceName() + " got wrong subscript " + Subscript.toString(sub) + "\n", sourceInfo());
+              then fail();
             end match;
           end for;
 


### PR DESCRIPTION
 - use correct function to create range to have correct type
 - add errors for some functions when incorrect record is passed