### PR TITLE
Udpate error message OPENMODELICALIBRARY/MODELICAPATH

### DIFF
--- a/.openmodelica.aspell
+++ b/.openmodelica.aspell
@@ -7,6 +7,7 @@ SIunits
 MetaModelica
 MSL
 OpenModelica
+OPENMODELICALIBRARY
 lookup
 redeclared
 elsewhen

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1193,7 +1193,7 @@ annotation(Documentation(info="<html>
 <p>
   Note that if the file basename is package.mo and the parent directory is the top-level class, or if the file is a directory, the library structure is loaded as if loadModel(ClassName) was called.
   Uses-annotations are respected if uses=true.
-  The main difference from loadModel is that loadFile appends this directory to the MODELICAPATH (for this call only).
+  The main difference from loadModel is that loadFile appends this directory to OPENMODELICALIBRARY (MODELICAPATH in the language specification) (for this call only).
 </p>
 </html>"), preferredView="text");
 end loadFile;
@@ -1607,7 +1607,7 @@ function setModelicaPath
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Sets the OPENMODELICALIBRARY (MODELICAPATH in the language specification) environment variable in OpenModelica. See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.</p>
+<p>Sets the OPENMODELICALIBRARY (MODELICAPATH in the language specification) environment variable in OpenModelica. See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what OPENMODELICALIBRARY is used for.</p>
 <p>Set it to empty string to clear it: setModelicaPath(\"\");</p>
 </html>"),
   preferredView="text");

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1618,7 +1618,7 @@ function getModelicaPath
   output String modelicaPath;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>The MODELICAPATH is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
+<p>The OPENMODELICALIBRARY (MODELICAPATH in the language specification) is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
 <p>To override the default path (<a href=\"modelica://OpenModelica.Scripting.getInstallationDirectoryPath\">OPENMODELICAHOME</a>/lib/omlibrary/:~/.openmodelica/libraries/), set the environment variable OPENMODELICALIBRARY=...</p>
 <p>On Windows the HOME directory '~' is replaced by %APPDATA%</p>
 </html>"),

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1863,7 +1863,7 @@ function setModelicaPath
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Sets the OPENMODELICALIBRARY (MODELICAPATH in the language specification) environment variable in OpenModelica. See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.</p>
+<p>Sets the OPENMODELICALIBRARY (MODELICAPATH in the language specification) environment variable in OpenModelica. See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what OPENMODELICALIBRARY is used for.</p>
 <p>Set it to empty string to clear it: setModelicaPath(\"\");</p>
 </html>"),
   preferredView="text");

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1449,7 +1449,7 @@ annotation(Documentation(info="<html>
 <p>
   Note that if the file basename is package.mo and the parent directory is the top-level class, or if the file is a directory, the library structure is loaded as if loadModel(ClassName) was called.
   Uses-annotations are respected if uses=true.
-  The main difference from loadModel is that loadFile appends this directory to the MODELICAPATH (for this call only).
+  The main difference from loadModel is that loadFile appends this directory to OPENMODELICALIBRARY (MODELICAPATH in the language specification) (for this call only).
 </p>
 </html>"), preferredView="text");
 end loadFile;
@@ -1874,7 +1874,7 @@ function getModelicaPath
   output String modelicaPath;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>The MODELICAPATH is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
+<p>The OPENMODELICALIBRARY (MODELICAPATH in the language specification) is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
 <p>To override the default path (<a href=\"modelica://OpenModelica.Scripting.getInstallationDirectoryPath\">OPENMODELICAHOME</a>/lib/omlibrary/:~/.openmodelica/libraries/), set the environment variable OPENMODELICALIBRARY=...</p>
 <p>On Windows the HOME directory '~' is replaced by %APPDATA%</p>
 </html>"),

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -453,7 +453,7 @@ algorithm
 end checkUsesAndUpdateProgram;
 
 public function loadModel
-  input list<tuple<Absyn.Path,String,list<String>,Boolean /* Only use the first entry on the MODELICAPATH */>> imodelsToLoad;
+  input list<tuple<Absyn.Path,String,list<String>,Boolean /* Only use the first entry on the OPENMODELICALIBRARY (MODELICAPATH in the language specification) */>> imodelsToLoad;
   input String modelicaPath;
   input Absyn.Program ip;
   input Boolean forceLoad;

--- a/OMCompiler/Compiler/Script/ProgramUtil.mo
+++ b/OMCompiler/Compiler/Script/ProgramUtil.mo
@@ -1288,7 +1288,7 @@ algorithm
     case ("modelica://", name, mp, true)
       algorithm
         name::_ := System.strtok(name,".");
-        str := "Could not resolve modelica://" + name + " with MODELICAPATH: " + mp;
+        str := "Could not resolve modelica://" + name + " with OPENMODELICALIBRARY (MODELICAPATH in the language specification): " + mp;
         Error.addMessage(Error.COMPILER_ERROR,{str});
       then fail();
   end matchcontinue;

--- a/OMCompiler/Compiler/Translation/openmodelica.pot
+++ b/OMCompiler/Compiler/Translation/openmodelica.pot
@@ -1057,7 +1057,7 @@ msgstr ""
 
 #: ../Util/Error.mo:498
 #, c-format
-msgid "Failed to load package %s (%s) using MODELICAPATH %s."
+msgid "Failed to load package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s."
 msgstr ""
 
 #: ../Util/Error.mo:500
@@ -2138,7 +2138,7 @@ msgstr ""
 #: ../Util/Error.mo:841
 #, c-format
 msgid ""
-"Skipped loading package %s (%s) using MODELICAPATH %s (uses-annotation may "
+"Skipped loading package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s (uses-annotation may "
 "be wrong)."
 msgstr ""
 

--- a/OMCompiler/Compiler/Translation/openmodelica.pot
+++ b/OMCompiler/Compiler/Translation/openmodelica.pot
@@ -1057,7 +1057,9 @@ msgstr ""
 
 #: ../Util/Error.mo:498
 #, c-format
-msgid "Failed to load package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s."
+msgid ""
+"Failed to load package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in "
+"the language specification) %s."
 msgstr ""
 
 #: ../Util/Error.mo:500
@@ -2138,8 +2140,8 @@ msgstr ""
 #: ../Util/Error.mo:841
 #, c-format
 msgid ""
-"Skipped loading package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s (uses-annotation may "
-"be wrong)."
+"Skipped loading package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in "
+"the language specification) %s (uses-annotation may be wrong)."
 msgstr ""
 
 #: ../Util/Error.mo:843

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1127,7 +1127,7 @@ public constant ErrorTypes.Message ERROR_PKG_NOT_FOUND_VERSION = ErrorTypes.MESS
 public constant ErrorTypes.Message ERROR_PKG_NOT_EXACT_MATCH = ErrorTypes.MESSAGE(603, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The package index did not contain an entry for package %s of version %s. There are other versions that claim to be compatible: %s.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_ON_PATH = ErrorTypes.MESSAGE(604, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  "The OPENMODELICALIBRARY (MODELICAPATH in the language specification) (%s) does not contain %s, so the package index cannot be used.");
+  "OPENMODELICALIBRARY (MODELICAPATH in the language specification) (%s) does not contain %s, so the package index cannot be used.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_FOUND = ErrorTypes.MESSAGE(605, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The package index does not exist: %s.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_PARSED = ErrorTypes.MESSAGE(606, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -444,7 +444,7 @@ public constant ErrorTypes.Message EMPTY_ARRAY = ErrorTypes.MESSAGE(182, ErrorTy
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS = ErrorTypes.MESSAGE(183, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   "Requested package %s of version %s, but this package was already loaded with version %s. OpenModelica cannot reason about compatibility between the two packages since they are not semantic versions.");
 public constant ErrorTypes.Message LOAD_MODEL_FAILED = ErrorTypes.MESSAGE(184, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  "Failed to load package %s (%s) using MODELICAPATH %s.");
+  "Failed to load package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s.");
 public constant ErrorTypes.Message LOAD_FILE_FAILED = ErrorTypes.MESSAGE(185, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "Failed to load file %s: %s.");
 public constant ErrorTypes.Message INVALID_SIZE_INDEX = ErrorTypes.MESSAGE(186, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -1031,7 +1031,7 @@ public constant ErrorTypes.Message MISSING_INTERFACE_TYPE = ErrorTypes.MESSAGE(5
 public constant ErrorTypes.Message CLASS_NOT_FOUND = ErrorTypes.MESSAGE(555, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   "Class %s not found inside class %s.");
 public constant ErrorTypes.Message NOTIFY_LOAD_MODEL_FAILED = ErrorTypes.MESSAGE(556, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
-  "Skipped loading package %s (%s) using MODELICAPATH %s (uses-annotation may be wrong).");
+  "Skipped loading package %s (%s) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) %s (uses-annotation may be wrong).");
 public constant ErrorTypes.Message ROOT_USER_INTERACTIVE = ErrorTypes.MESSAGE(557, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "You are trying to run OpenModelica as a server using the root user.\nThis is a very bad idea:\n* The socket interface does not authenticate the user.\n* OpenModelica allows execution of arbitrary commands.");
 public constant ErrorTypes.Message USES_MISSING_VERSION = ErrorTypes.MESSAGE(558, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
@@ -1127,7 +1127,7 @@ public constant ErrorTypes.Message ERROR_PKG_NOT_FOUND_VERSION = ErrorTypes.MESS
 public constant ErrorTypes.Message ERROR_PKG_NOT_EXACT_MATCH = ErrorTypes.MESSAGE(603, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The package index did not contain an entry for package %s of version %s. There are other versions that claim to be compatible: %s.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_ON_PATH = ErrorTypes.MESSAGE(604, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  "The MODELICAPATH (%s) does not contain %s, so the package index cannot be used.");
+  "The OPENMODELICALIBRARY (MODELICAPATH in the language specification) (%s) does not contain %s, so the package index cannot be used.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_FOUND = ErrorTypes.MESSAGE(605, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The package index does not exist: %s.");
 public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_PARSED = ErrorTypes.MESSAGE(606, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1032,7 +1032,7 @@ public function realMaxLit "Returns the maximum real that can be represent using
 end realMaxLit;
 
 public function uriToClassAndPath "Handles modelica:// and file:// URI's. The result is an absolute path on the local system.
-  The result depends on the current MODELICAPATH. Sets the error buffer on failure."
+  The result depends on the current OPENMODELICALIBRARY (MODELICAPATH in the language specification). Sets the error buffer on failure."
   input String uri;
   output String scheme "file:// or modelica://, in lower-case";
   output String classname "empty if file:// is used";

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -3804,9 +3804,9 @@ LibrariesPage::LibrariesPage(OptionsDialog *pOptionsDialog)
   : QWidget(pOptionsDialog)
 {
   mpOptionsDialog = pOptionsDialog;
-  // MODELICAPATH
+  // OPENMODELICALIBRARY
   QGroupBox *pModelicaPathGroupBox = new QGroupBox(Helper::general);
-  mpModelicaPathLabel = new Label("MODELICAPATH");
+  mpModelicaPathLabel = new Label("OPENMODELICALIBRARY");
   mpModelicaPathTextBox = new QLineEdit;
   mpModelicaPathTextBox->setPlaceholderText(Helper::ModelicaPath);
   mpModelicaPathTextBox->setToolTip(Helper::modelicaPathTip);
@@ -3823,7 +3823,7 @@ LibrariesPage::LibrariesPage(OptionsDialog *pOptionsDialog)
   // system libraries groupbox
   mpSystemLibrariesGroupBox = new QGroupBox(tr("System libraries loaded automatically on startup *"));
   // system libraries note
-  mpSystemLibrariesNoteLabel = new Label(tr("The system libraries are read from the MODELICAPATH and are always read-only."));
+  mpSystemLibrariesNoteLabel = new Label(tr("The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only."));
   mpSystemLibrariesNoteLabel->setElideMode(Qt::ElideMiddle);
   // load latest Modeica checkbox
   mpLoadLatestModelicaCheckbox = new QCheckBox(tr("Load latest Modelica version on startup"));

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_de.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_de.ts
@@ -1983,7 +1983,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4528,8 +4528,8 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
-        <translation>Die Systembibliotheken werden aus dem MODELICAPATH geladen und sind schreibgeschützt.</translation>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
+        <translation>Die Systembibliotheken werden aus OPENMODELICALIBRARY (MODELICAPATH im Sprachstandard) geladen und sind schreibgeschützt.</translation>
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3734"/>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_es.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_es.ts
@@ -1993,7 +1993,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4527,7 +4527,7 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_fr.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_fr.ts
@@ -2051,7 +2051,7 @@ Vous pouvez choisir entre attendre plus longtemps ou annuler le débuggage.</num
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation>Une erreur s&apos;est produite lors du chargement du modèle&#xa0;:
 %1.</translation>
@@ -4559,8 +4559,8 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
-        <translation>Les bibliothèques systèmes sont lues à partir de MODELICAPATH et sont toujours en lecture seule.</translation>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
+        <translation>Les bibliothèques système sont lues à partir de OPENMODELICALIBRARY (MODELICAPATH dans la spécification du langage) et sont toujours en lecture seule.</translation>
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3734"/>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_it.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_it.ts
@@ -1988,7 +1988,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4527,7 +4527,7 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_ja.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_ja.ts
@@ -2007,7 +2007,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4533,8 +4533,8 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
-        <translation>システムライブラリはMODELICAPATHから読み込まれ常に読込専用です.</translation>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
+        <translation>システムライブラリは OPENMODELICALIBRARY（言語仕様では MODELICAPATH）から読み込まれ、常に読み取り専用です。</translation>
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3734"/>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_ro.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_ro.ts
@@ -2004,7 +2004,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4528,7 +4528,7 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_ru.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_ru.ts
@@ -2005,9 +2005,9 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
-        <translation>При загрузке модели произошла ошибка: 
+        <translation>При загрузке модели произошла ошибка:
 %1.</translation>
     </message>
     <message>
@@ -4543,8 +4543,8 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
-        <translation>Системные библиотеки читаются из MODELICAPATH и всегда доступны только для чтения.</translation>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
+        <translation>Системные библиотеки читаются из OPENMODELICALIBRARY (в спецификации языка — MODELICAPATH) и всегда доступны только для чтения.</translation>
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3734"/>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_sv.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_sv.ts
@@ -2030,7 +2030,7 @@ Du kan välja mellan att vänta ett tag till eller att avbryta debuggningen.</nu
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4530,7 +4530,7 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/OMEdit/OMEditLIB/Resources/nls/OMEdit_zh_CN.ts
+++ b/OMEdit/OMEditLIB/Resources/nls/OMEdit_zh_CN.ts
@@ -2021,7 +2021,7 @@ You can choose between waiting longer or abort debugging.</source>
     </message>
     <message>
         <location filename="../../Util/Helper.cpp" line="841"/>
-        <source>Error has occurred while loading the model : 
+        <source>Error has occurred while loading the model :
 %1.</source>
         <translation>加载模型 %1 时出现错误。</translation>
     </message>
@@ -4543,8 +4543,8 @@ Please check the Messages browser for error messages and possibly undo the lates
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3731"/>
-        <source>The system libraries are read from the MODELICAPATH and are always read-only.</source>
-        <translation>系统库从 MODELICAPATH 读取并且是只读的。</translation>
+        <source>The system libraries are read from OPENMODELICALIBRARY (MODELICAPATH in the language specification) and are always read-only.</source>
+        <translation>系统库从 OPENMODELICALIBRARY（在语言规范中为 MODELICAPATH）读取，并始终为只读。</translation>
     </message>
     <message>
         <location filename="../../Options/OptionsDialog.cpp" line="3734"/>

--- a/doc/UsersGuide/source/faq.rst
+++ b/doc/UsersGuide/source/faq.rst
@@ -4,6 +4,8 @@ Frequently Asked Questions (FAQ)
 Below are some frequently asked questions in three areas, with
 associated answers.
 
+.. _faq-openmodelica-general :
+
 OpenModelica General
 --------------------
 
@@ -11,11 +13,17 @@ OpenModelica General
        even though this is part of the Modelica Language Specification.
 
 -  A: Use the OPENMODELICALIBRARY environment variable instead. We have
-       temporarily switched to this variable, in order not to interfere
-       with other Modelica tools which might be installed on the same
-       system. In the future, we might switch to a solution with a
-       settings file, that also allows the user to turn on the
-       MODELICAPATH functionality if desired.
+       switched to this variable, in order not to interfere with other
+       Modelica tools which might be installed on the same system.
+       MODELICAPATH is not read at all: OPENMODELICALIBRARY does not
+       extend or override it. Like MODELICAPATH, it is a list of
+       directories, separated by colon (:) on all operating systems
+       except Windows, which uses semicolon (;). If it is not set,
+       OpenModelica defaults to OPENMODELICAHOME/lib/omlibrary/ and
+       ~/.openmodelica/libraries/ (on Windows '~' is %APPDATA%).
+       In the future, we might switch to a solution with a settings
+       file, that also allows the user to turn on the MODELICAPATH
+       functionality if desired.
 
 -  Q: How do I enter multi-line models into OMShell since it evaluates
        when typing the Enter/Return key?

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1471,7 +1471,7 @@ Libraries Options
 
 -  General
 
-  -  *MODELICAPATH* - Sets the MODELICAPATH. MODELICAPATH is used to load libraries.
+  -  *OPENMODELICALIBRARY* - Sets the OPENMODELICALIBRARY. OPENMODELICALIBRARY is used to load libraries.
 
 -  System libraries loaded automatically on startup - The list of system libraries that are loaded on startup.
 

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1471,7 +1471,9 @@ Libraries Options
 
 -  General
 
-  -  *OPENMODELICALIBRARY* - Sets the OPENMODELICALIBRARY. OPENMODELICALIBRARY is used to load libraries.
+  -  *OPENMODELICALIBRARY* - The list of paths searched while loading a library, i.e. the
+     OPENMODELICALIBRARY environment variable (MODELICAPATH in the language specification).
+     Paths are separated by ``;`` on Windows and ``:`` on Linux and macOS.
 
 -  System libraries loaded automatically on startup - The list of system libraries that are loaded on startup.
 

--- a/doc/UsersGuide/source/packagemanager.rst
+++ b/doc/UsersGuide/source/packagemanager.rst
@@ -27,7 +27,7 @@ can find them.
 
 The default place where OpenModelica looks for packages is set by environment variable ``OPENMODELICALIBRARY``.
 The variable `OPENMODELICALIBRARY <https://specification.modelica.org/maint/3.6/packages.html#the-modelica-library-path-modelicapath>`_
-from the language specification is ignored by OpenModelica, see `FAQ OpenModelica General <faq-openmodelica-general>`_.
+from the language specification is ignored by OpenModelica, see :ref:`FAQ OpenModelica General <faq-openmodelica-general>`.
 You can check where it is by typing ``getModelicaPath()`` in the Interactive Environment (Tools | OpenModelica Compiler CLI in OMEdit),
 or by browsing the General group under Tools|Options|Libraries. Installed read-only libraries are all placed by default
 in the ``OPENMODELICALIBRARY``.

--- a/doc/UsersGuide/source/packagemanager.rst
+++ b/doc/UsersGuide/source/packagemanager.rst
@@ -26,7 +26,7 @@ computer) loads your package, provided they are installed in places on the compu
 can find them.
 
 The default place where OpenModelica looks for packages is set by environment variable ``OPENMODELICALIBRARY``.
-The variable `OPENMODELICALIBRARY <https://specification.modelica.org/maint/3.6/packages.html#the-modelica-library-path-modelicapath>`_
+The variable `MODELICAPATH <https://specification.modelica.org/maint/3.6/packages.html#the-modelica-library-path-modelicapath>`_
 from the language specification is ignored by OpenModelica, see :ref:`FAQ OpenModelica General <faq-openmodelica-general>`.
 You can check where it is by typing ``getModelicaPath()`` in the Interactive Environment (Tools | OpenModelica Compiler CLI in OMEdit),
 or by browsing the General group under Tools|Options|Libraries. Installed read-only libraries are all placed by default

--- a/doc/UsersGuide/source/packagemanager.rst
+++ b/doc/UsersGuide/source/packagemanager.rst
@@ -25,18 +25,20 @@ that are required to compile the models in your own package next time you (or so
 computer) loads your package, provided they are installed in places on the computer's file system where OpenModelica
 can find them.
 
-The default place where OpenModelica looks for packages is the so-called
-`MODELICAPATH <https://specification.modelica.org/maint/3.6/packages.html#the-modelica-library-path-modelicapath>`_.
+The default place where OpenModelica looks for packages is set by environment variable ``OPENMODELICALIBRARY``.
+The variable `OPENMODELICALIBRARY <https://specification.modelica.org/maint/3.6/packages.html#the-modelica-library-path-modelicapath>`_
+from the language specification is ignored by OpenModelica, see `FAQ OpenModelica General <faq-openmodelica-general>`_.
 You can check where it is by typing ``getModelicaPath()`` in the Interactive Environment (Tools | OpenModelica Compiler CLI in OMEdit),
-or by browsing the General group under Tools|Options|Libraries. Installed read-only libraries are all placed by default in the MODELICAPATH.
+or by browsing the General group under Tools|Options|Libraries. Installed read-only libraries are all placed by default
+in the ``OPENMODELICALIBRARY``.
 
 However, when you open a package directly from the file system, OpenModelica will also look for
 packages it depends upon in the same directory that contains the package you just opened. For example, if you open
 ``/home/John/ModelicaPackages/MoonShot/package.mo``, and your MoonShot package contains ``annotation(uses(Rockets));``,
 OpenModelica will also check ``/home/John/ModelicaPackages/Rockets/package.mo`` and ``/home/John/ModelicaPackages/Rockets.mo``.
 So, if you are developing several packages with dependencies among them, you can place them in the same common root directory
-to make sure that all the dependencies are loaded automatically, without the need of putting them in the MODELICAPATH, or
-to change it to include that directory.
+to make sure that all the dependencies are loaded automatically, without the need of putting them in the
+``OPENMODELICALIBRARY``, or to change it to include that directory.
 
 Please note that if the ``uses`` annotation refers to a specific version of a package, that package will only be loaded
 if the name of the directory or of the single file that contains it also indicates the version number, as allowed by
@@ -44,9 +46,10 @@ the Modelica Specification, `Section 18.8.3
 <https://specification.modelica.org/maint/3.6/annotations.html#mapping-of-versions-to-file-system>`_. For example,
 if MoonShot contains ``annotation(uses(Rockets(version = "2.0.0"));``, OpenModelica will try to load
 ``/home/John/ModelicaPackages/Rockets 2.0.0/package.mo`` or ``/home/John/ModelicaPackages/Rockets 2.0.0.mo``;
-in this case, packages without the version number in their root directory, such as 
-``/home/John/ModelicaPackages/Rockets/package.mo``, will be ignored. All installed packages in the MODELICAPATH
-include version numbers in their directory name, which also allows to install multiple versions of the same library.
+in this case, packages without the version number in their root directory, such as
+``/home/John/ModelicaPackages/Rockets/package.mo``, will be ignored. All installed packages in the
+``OPENMODELICALIBRARY`` include version numbers in their directory name, which also allows to install multiple versions
+of the same library.
 
 When a new version of certain package comes out, `conversion annotations
 <https://specification.modelica.org/maint/3.5/annotations.html#version-handling>`_ in it declare whether your models using
@@ -54,7 +57,7 @@ a certain older version of it can be used as they are with the new one, which is
 they need to be upgraded by running a conversion script, provided with the new version of the package. The former case
 is declared explicitly by a ``conversion(noneFromVersion)`` annotation. For example, a ``conversion(noneFromVersion="3.0.0")``
 annotation in version ``3.1.0`` of a certain package means that all packages using version ``3.0.0`` can use ``3.1.0``
-without any change. Of course it is preferrable to use a newer, backwards-compatible version, as it contains bugfixes
+without any change. Of course it is preferable to use a newer, backwards-compatible version, as it contains bugfixes
 and possibly new features.
 
 Hence, if you install a new version of a library which is 100% backwards-compatible with the previous ones, all your models that
@@ -66,7 +69,7 @@ your library that uses it, by running the provided conversion scripts.
 OpenModelica has a package manager that can be used to install and update libraries on your computer, and is able to run
 conversion scripts. Keep in mind there are three stages in package usage: *available* packages are indexed on the
 OSMC servers and can be downloaded from public repositories;
-*installed* packages are stored in the MODELICAPATH of your computer; *loaded* packages are loaded in memory
+*installed* packages are stored in the ``OPENMODELICALIBRARY`` of your computer; *loaded* packages are loaded in memory
 in an active OMC session, either via the Interactive Environment, or via the OMEdit GUI, where they are shown in the
 Libraries Browser. When you load a package, OpenModelica tries to load the best possible installed versions of all
 the dependencies declared in the uses annotation.

--- a/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
+++ b/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
@@ -110,6 +110,6 @@ loadModel(Invalid);getErrorString();
 // "Invalid"
 // false
 // "[flattening/modelica/mosfiles/TestLibrary/Invalid/package.mo:1:1-2:12:writable] Error: The same class is defined in multiple files: flattening/modelica/mosfiles/TestLibrary/Invalid/Duplicate.mo, flattening/modelica/mosfiles/TestLibrary/Invalid/Duplicate/package.mo.
-// Error: Failed to load package Invalid (default) using MODELICAPATH TestLibrary/.
+// Error: Failed to load package Invalid (default) using OPENMODELICALIBRARY (MODELICAPATH in the language specification) TestLibrary/.
 // "
 // endResult


### PR DESCRIPTION
### Related Issues

Fixes #14877 

### Purpose

Clarify that OpenModelica will use environment variable `OPENMODELICALIBRARY` instead of `MODELICAPATH`.

### Approach

* Updated User's Guide
* Update error message
* Update error message translations
