### PR TITLE
[FMI] Remove unused fmiType

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -2368,7 +2368,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real realValuesReferences[:];
         input Real inFlowStatesInput;
         output Real realValues[size(realValuesReferences, 1)];
-        external "C" fmi2GetReal_OMC(fmi2me, size(realValuesReferences, 1), realValuesReferences, inFlowStatesInput, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2GetReal_OMC(fmi2me, size(realValuesReferences, 1), realValuesReferences, inFlowStatesInput, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2GetReal;
 
       function fmi2SetReal
@@ -2376,7 +2376,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real realValueReferences[:];
         input Real realValues[size(realValueReferences, 1)];
         output Real outValues[size(realValueReferences, 1)] = realValues;
-        external "C" fmi2SetReal_OMC(fmi2me, size(realValueReferences, 1), realValueReferences, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetReal_OMC(fmi2me, size(realValueReferences, 1), realValueReferences, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetReal;
 
       function fmi2SetRealParameter
@@ -2384,7 +2384,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real realValueReferences[:];
         input Real realValues[size(realValueReferences, 1)];
         output Real out_Value = 1;
-        external "C" fmi2SetReal_OMC(fmi2me, size(realValueReferences, 1), realValueReferences, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetReal_OMC(fmi2me, size(realValueReferences, 1), realValueReferences, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetRealParameter;
 
       function fmi2GetInteger
@@ -2392,7 +2392,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real integerValueReferences[:];
         input Real inFlowStatesInput;
         output Integer integerValues[size(integerValueReferences, 1)];
-        external "C" fmi2GetInteger_OMC(fmi2me, size(integerValueReferences, 1), integerValueReferences, inFlowStatesInput, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2GetInteger_OMC(fmi2me, size(integerValueReferences, 1), integerValueReferences, inFlowStatesInput, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2GetInteger;
 
       function fmi2SetInteger
@@ -2400,7 +2400,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real integerValuesReferences[:];
         input Integer integerValues[size(integerValuesReferences, 1)];
         output Integer outValues[size(integerValuesReferences, 1)] = integerValues;
-        external "C" fmi2SetInteger_OMC(fmi2me, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetInteger_OMC(fmi2me, size(integerValuesReferences, 1), integerValuesReferences, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetInteger;
 
       function fmi2SetIntegerParameter
@@ -2408,7 +2408,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real integerValuesReferences[:];
         input Integer integerValues[size(integerValuesReferences, 1)];
         output Real out_Value = 1;
-        external "C" fmi2SetInteger_OMC(fmi2me, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetInteger_OMC(fmi2me, size(integerValuesReferences, 1), integerValuesReferences, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetIntegerParameter;
 
       function fmi2GetBoolean
@@ -2416,7 +2416,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real booleanValuesReferences[:];
         input Real inFlowStatesInput;
         output Boolean booleanValues[size(booleanValuesReferences, 1)];
-        external "C" fmi2GetBoolean_OMC(fmi2me, size(booleanValuesReferences, 1), booleanValuesReferences, inFlowStatesInput, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2GetBoolean_OMC(fmi2me, size(booleanValuesReferences, 1), booleanValuesReferences, inFlowStatesInput, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2GetBoolean;
 
       function fmi2SetBoolean
@@ -2424,7 +2424,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real booleanValueReferences[:];
         input Boolean booleanValues[size(booleanValueReferences, 1)];
         output Boolean outValues[size(booleanValueReferences, 1)] = booleanValues;
-        external "C" fmi2SetBoolean_OMC(fmi2me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetBoolean_OMC(fmi2me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetBoolean;
 
       function fmi2SetBooleanParameter
@@ -2432,7 +2432,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real booleanValueReferences[:];
         input Boolean booleanValues[size(booleanValueReferences, 1)];
         output Real out_Value = 1;
-        external "C" fmi2SetBoolean_OMC(fmi2me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetBoolean_OMC(fmi2me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetBooleanParameter;
 
       function fmi2GetString
@@ -2440,7 +2440,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real stringValuesReferences[:];
         input Real inFlowStatesInput;
         output String stringValues[size(stringValuesReferences, 1)];
-        external "C" fmi2GetString_OMC(fmi2me, size(stringValuesReferences, 1), stringValuesReferences, inFlowStatesInput, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2GetString_OMC(fmi2me, size(stringValuesReferences, 1), stringValuesReferences, inFlowStatesInput, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2GetString;
 
       function fmi2SetString
@@ -2448,7 +2448,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real stringValueReferences[:];
         input String stringValues[size(stringValueReferences, 1)];
         output String outValues[size(stringValueReferences, 1)] = stringValues;
-        external "C" fmi2SetString_OMC(fmi2me, size(stringValueReferences, 1), stringValueReferences, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetString_OMC(fmi2me, size(stringValueReferences, 1), stringValueReferences, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetString;
 
       function fmi2SetStringParameter
@@ -2456,7 +2456,7 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input Real stringValueReferences[:];
         input String stringValues[size(stringValueReferences, 1)];
         output Real out_Value = 1;
-        external "C" fmi2SetString_OMC(fmi2me, size(stringValueReferences, 1), stringValueReferences, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        external "C" fmi2SetString_OMC(fmi2me, size(stringValueReferences, 1), stringValueReferences, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi2SetStringParameter;
 
       function fmi2StartEventUpdate


### PR DESCRIPTION
### Related Issues

Clean the FMI2Common code before doing changes in #15054.
Related to #14462.

### Purpose

- Clean the code base a bit.


### Approach

- fmiType probably specifies if an FMU is ME or CS, but was always hard coded to 1
- [AI] Added Doxygen comments to functions in FMI2Common.c
