### PR TITLE
[CodeGen] Replace dots in qualified crefs for extern function arguments

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2548,9 +2548,10 @@ template extFunCallVardecl(SimExtArg arg, Text &varDecls, Text &auxFunction, Boo
   case SIMEXTARG(isInput = true, isArray = true, type_ = ty, cref = c) then
     match expTypeShort(ty)
     case "integer" then
-      let var_name = '<%contextCrefNoPrevExp(c, contextFunction, &auxFunction)%>'
-      let &varDecls += 'integer_array <%var_name%>_packed;<%\n%>'
-      'pack_alloc_integer_array(&<%var_name%>, &<%var_name%>_packed);<%\n%>'
+      let argName = '<%contextCrefNoPrevExp(c, contextFunction, &auxFunction)%>'
+      let cVarName = System.stringReplace(argName, ".", "_") + "_packed"
+      let &varDecls += 'integer_array <%cVarName%>;<%\n%>'
+      'pack_alloc_integer_array(&<%argName%>, &<%cVarName%>);<%\n%>'
     else ""
 
   // Array argument (string)
@@ -2751,12 +2752,18 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &auxFunctio
   match extArg
   // Array argument
   case SIMEXTARG(cref=c, outputIndex=oi, isArray=true, type_=t, isInput=isInput) then
-    let name = contextCrefNoPrevExp(c,contextFunction,&auxFunction)
+    let argName = contextCrefNoPrevExp(c, contextFunction, &auxFunction)
+    let cVarName = System.stringReplace(argName, ".", "_")
+    let cType = extType(t, isInput, true, false)
     let shortTypeStr = expTypeShort(t)
-    let &varDecls += 'void *<%name%>_c89;<%\n%>'
-    let arg_name = if isInput then (match shortTypeStr case "integer" then '<%name%>_packed' else name) else name
-    let &preExp += '<%name%>_c89 = (void*) data_of_<%shortTypeStr%>_c89_array(<%arg_name%>);<%\n%>'
-    '(<%extType(t,isInput,true,false)%>) <%name%>_c89'
+    let &varDecls += '<%cType%> <%cVarName%>_c89;<%\n%>'
+    let packedArgName = if isInput then (
+        match shortTypeStr
+          case "integer" then '<%cVarName%>_packed'
+          else argName)
+      else argName
+    let &preExp += '<%cVarName%>_c89 = data_of_<%shortTypeStr%>_c89_array(<%packedArgName%>);<%\n%>'
+    '<%cVarName%>_c89'
 
   // Scalar argument, no output
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then

--- a/testsuite/simulation/modelica/external_functions/Makefile
+++ b/testsuite/simulation/modelica/external_functions/Makefile
@@ -1,19 +1,20 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
-MDD_test.mos \
-extObj_ticket3446.mos \
-ExtObj.mos \
-ExtObjStringParam.mos \
 ExternalCFuncInputOnly.mos \
 ExternalLibraries.mos \
 ExternalRHSFlag.mos \
+extObj_ticket3446.mos \
+ExtObj.mos \
+ExtObjStringParam.mos \
 ImplicitArray.mos \
 LapackInverse.mos \
-Matrix.mos  \
+Matrix.mos \
+MDD_test.mos \
 ModelicaUtilities.mos \
-TestRoots.mos \
 QualifiedCrefArg.mos \
+RecordMemberArguments.mos \
+TestRoots.mos \
 ts.mos
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mo
+++ b/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mo
@@ -1,0 +1,80 @@
+model ExtRecordMemberArguments
+  record R
+    Real myRealMatrix[2,3];
+    Real myRealVar;
+    Integer myIntegerArray[3];
+    Integer myIntegerVar;
+    // TODO: Boolean arrays are still broken
+    // Boolean myBooleanArray[:];
+    Boolean myBooleanVar;
+    String myStringArray[2];
+    String myStringVar;
+  end R;
+
+  function foo
+    input R r;
+
+    external "C" foo(r.myRealMatrix, size(r.myRealMatrix, 1), size(r.myRealMatrix, 2), r.myRealVar, r.myIntegerArray, size(r.myIntegerArray, 1), r.myIntegerVar, r.myBooleanVar, r.myStringArray, size(r.myStringArray, 1), r.myStringVar)
+    annotation (
+
+    Include="
+void foo(const double* myRealMatrix, size_t dim_myRealMatrix_1, size_t dim_myRealMatrix_2, const double myRealVar, const int* myIntegerArray, size_t dim_myIntegerArray_1, int myIntegerVar, int myBooleanVar, const char** myStringArray, size_t dim_myStringArray_1, const char* myStringVar) {
+  size_t i, j;
+  printf(\"myRealMatrix (%zu x %zu):\\n\", dim_myRealMatrix_1, dim_myRealMatrix_2);
+  for (i = 0; i < dim_myRealMatrix_1; ++i) {
+    printf(\"{\");
+    for (j = 0; j < dim_myRealMatrix_2; ++j) {
+      /* Modelica arrays are row-major: myRealMatrix[i*dim_myRealMatrix_2 + j] */
+      printf(\"%g\", myRealMatrix[i*dim_myRealMatrix_2 + j]);
+      if (j + 1 < dim_myRealMatrix_2) printf(\", \");
+    }
+    printf(\"}\\n\");
+  }
+
+  printf(\"myRealVar: %g\\n\", myRealVar);
+
+  printf(\"myIntegerArray: {\");
+  for (i = 0; i < dim_myIntegerArray_1; ++i) {
+    printf(\"%d\", myIntegerArray[i]);
+    if (i + 1 < dim_myIntegerArray_1) printf(\", \");
+  }
+  printf(\"}\\n\");
+
+  printf(\"myIntegerVar: %d\\n\", myIntegerVar);
+
+  /* TODO: Boolean arrays are still broken */
+  // printf(\"myBooleanArray: {\");
+  // for (i = 0; i < dim_myBooleanArray_1; ++i) {
+  //   printf(\"%s\", myBooleanArray[i] ? \"true\" : \"false\");
+  //   if (i + 1 < dim_myBooleanArray_1) printf(\", \");
+  // }
+  // printf(\"}\\n\");
+
+  printf(\"myBooleanVar: %s\\n\", myBooleanVar ? \"true\" : \"false\");
+
+  printf(\"myStringArray: {\");
+  for (i = 0; i < dim_myStringArray_1; ++i) {
+    printf(\"'%s'\", myStringArray[i] ? myStringArray[i] : \"(null)\");
+    if (i + 1 < dim_myStringArray_1) printf(\", \");
+  }
+  printf(\"}\\n\");
+
+  printf(\"myStringVar: '%s'\\n\", myStringVar ? myStringVar : \"(null)\");
+  }
+");
+  end foo;
+
+  R r(myRealMatrix = [1.0, 2.0, 3.0;
+                      4.0, 5.0, 6.0],
+      myRealVar = 7.0,
+      myIntegerArray = {-1, -2, -3},
+      myIntegerVar = -4,
+      // myBooleanArray = {true, false, false, true, true, true},
+      myBooleanVar = true,
+      myStringArray = {"one", "two"},
+      myStringVar = "scalar");
+equation
+  when sample(0.5, 1) then
+    foo(r);
+  end when;
+end ExtRecordMemberArguments;

--- a/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mos
+++ b/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mos
@@ -1,0 +1,32 @@
+// name: RecordMemberArguments
+// keywords: external, record, member, array
+// status: correct
+// teardown_command: rm -f ExtRecordMemberArguments*
+//
+// Issue https://github.com/OpenModelica/OpenModelica/issues/14462
+// TODO: This test is missing the boolean array part.
+
+loadFile("RecordMemberArguments.mo"); getErrorString();
+simulate(ExtRecordMemberArguments); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ExtRecordMemberArguments_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ExtRecordMemberArguments', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// myRealMatrix (2 x 3):
+// {1, 2, 3}
+// {4, 5, 6}
+// myRealVar: 7
+// myIntegerArray: {-1, -2, -3}
+// myIntegerVar: -4
+// myBooleanVar: true
+// myStringArray: {'one', 'two'}
+// myStringVar: 'scalar'
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/14462

### Purpose

* Fix C code generation for record arguments passed to external C function.

### Approach

* Replace `.` with `_` for temp C variable declarations.
* Adding test case with record of most simple Modelica types.
  * Boolean array is missing special handling (`unsigned char` in OpenModelica vs `int` in Modelica FFI)
