### PR TITLE
[build] CMake spellcheck instead of Make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.claude/
 /.externalToolBuilders/*.launch
 /.metadata/
 /.project

--- a/Makefile.in
+++ b/Makefile.in
@@ -118,8 +118,7 @@ fix-whitespace:
 	find . -type f \( ! -path '*/.svn/*' -or -path '*/.git/*' -prune \) -regextype posix-egrep -regex '.*\.(cpp|c|h|mo|tpl)$$' -exec sh -c 'sed -i -e "s/	/  /g" -e "s/ *\$$//" "{}"' ";"
 
 spellcheck:
-	grep -oE 'gettext[(]["]([^"]|([\\]["]))*["]' `ls OMCompiler/Compiler/*/*.mo | grep -v "Flags.*mo"` | sed "s/[\\%]./ /g" | aspell -p ./.openmodelica.aspell --mode=ccpp --lang=en_US list | sort -u | sed 's/^/aspell: /' | tee aspell.log
-	@test ! -s aspell.log
+	bash cmake/spellcheck.sh . aspell
 thumbsdb-error:
 	! find . -name "Thumbs.db" | grep Thumbs.db
 

--- a/cmake/omc_spellcheck.cmake
+++ b/cmake/omc_spellcheck.cmake
@@ -1,0 +1,27 @@
+# cmake/omc_spellcheck.cmake
+#
+# Adds a 'spellcheck' target that checks spelling of gettext strings in the
+# Modelica compiler sources using aspell and the personal word list
+# .openmodelica.aspell in the root of the repository.
+#
+# Run with:
+#   cmake --build <build_dir> --target spellcheck
+
+find_program(ASPELL aspell)
+
+if(ASPELL)
+  add_custom_target(spellcheck
+    COMMAND bash ${CMAKE_SOURCE_DIR}/cmake/spellcheck.sh ${CMAKE_SOURCE_DIR} ${ASPELL}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running aspell spellcheck on gettext strings in Modelica compiler sources"
+    USES_TERMINAL
+  )
+else()
+  add_custom_target(spellcheck
+    COMMAND ${CMAKE_COMMAND} -E echo
+      "WARNING: aspell not found. Install aspell to enable spellchecking."
+    COMMENT "aspell not found, spellcheck target is a no-op"
+  )
+  message(STATUS "aspell not found. The 'spellcheck' target will be a no-op. "
+    "Install aspell to enable spellchecking.")
+endif()

--- a/cmake/spellcheck.sh
+++ b/cmake/spellcheck.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# cmake/spellcheck.sh
+#
+# Spellcheck gettext strings in Modelica compiler sources using aspell.
+# Used by the 'spellcheck' CMake target (cmake/omc_spellcheck.cmake) and
+# the 'spellcheck' Makefile target (Makefile.in).
+#
+# Usage: spellcheck.sh <source_dir> <aspell_executable>
+# Exit code: 0 on success, 1 on spellcheck failure.
+
+SOURCE_DIR="$1"
+ASPELL="$2"
+
+if [[ -z "$SOURCE_DIR" || -z "$ASPELL" ]]; then
+  echo "Usage: $0 <source_dir> <aspell_executable>"
+  exit 1
+fi
+
+git p=$(ls "$SOURCE_DIR"/OMCompiler/Compiler/*/*.mo | grep -v "Flags.*mo")
+
+ASPELL_OUTPUT=$(grep -oE 'gettext[(]["]([^"]|([\\]["]))*["]' $MO_FILES \
+    | sed "s/[\\%]./ /g" \
+    | "$ASPELL" -p "$SOURCE_DIR/.openmodelica.aspell" --mode=ccpp --lang=en_US list \
+    | sort -u \
+    | sed 's/^/aspell: /')
+
+if [[ -n "$ASPELL_OUTPUT" ]]; then
+  echo "$ASPELL_OUTPUT"
+  printf '\nSpellcheck failed! To fix, add the flagged word(s) to the personal word list:\n'
+  printf '  %s/.openmodelica.aspell\n' "$SOURCE_DIR"
+  exit 1
+fi
+
+echo "Spellcheck passed."


### PR DESCRIPTION
### Related Issues

Part of https://github.com/OpenModelica/OpenModelica/issues/14371.

### Purpose

* Prepare transfer of spell check test to CMake

### Approach

* Only one script to run spell check.
* Call script from Makefile and CMake.
* Add hint on how to fix failing spellcheck.
