### PR TITLE
Reduce memory allocations in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -6383,7 +6383,7 @@ public
       case ENUM_LITERAL()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("enum"), json);
+          json := JSON.addPair("$kind", JSON.STRING("enum"), json);
           json := JSON.addPair("name", JSON.makeString(toString(exp)), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
         then
@@ -6397,7 +6397,7 @@ public
       case TYPENAME()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("typename"), json);
+          json := JSON.addPair("$kind", JSON.STRING("typename"), json);
           json := JSON.addPair("name", JSON.makeString(Type.toString(exp.ty)), json);
         then
           json;
@@ -6414,7 +6414,7 @@ public
       case RANGE()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("range"), json);
+          json := JSON.addPair("$kind", JSON.STRING("range"), json);
           json := JSON.addPair("start", toJSON(exp.start), json);
 
           if isSome(exp.step) then
@@ -6428,7 +6428,7 @@ public
       case TUPLE()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("tuple"), json);
+          json := JSON.addPair("$kind", JSON.STRING("tuple"), json);
           json := JSON.addPair("elements",
             JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
         then
@@ -6437,7 +6437,7 @@ public
       case RECORD()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("record"), json);
+          json := JSON.addPair("$kind", JSON.STRING("record"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(exp.path)), json);
           json := JSON.addPair("elements",
             JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
@@ -6450,8 +6450,8 @@ public
       case SIZE()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("call"), json);
-          json := JSON.addPair("name", JSON.makeString("size"), json);
+          json := JSON.addPair("$kind", JSON.STRING("call"), json);
+          json := JSON.addPair("name", JSON.STRING("size"), json);
 
           if isSome(exp.dimIndex) then
             json := JSON.addPair("arguments",
@@ -6465,9 +6465,9 @@ public
       case BINARY()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("$kind", JSON.STRING("binary_op"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
         then
           json;
@@ -6475,8 +6475,8 @@ public
       case UNARY()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("unary_op"), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("$kind", JSON.STRING("unary_op"), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
           json;
@@ -6484,9 +6484,9 @@ public
       case LBINARY()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("$kind", JSON.STRING("binary_op"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
         then
           json;
@@ -6494,8 +6494,8 @@ public
       case LUNARY()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("unary_op"), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("$kind", JSON.STRING("unary_op"), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
           json;
@@ -6503,9 +6503,9 @@ public
       case RELATION()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("$kind", JSON.STRING("binary_op"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
         then
           json;
@@ -6513,19 +6513,19 @@ public
       case MULTARY()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("multary_op"), json);
+          json := JSON.addPair("$kind", JSON.STRING("multary_op"), json);
           json := JSON.addPair("args",
             JSON.makeArray(list(toJSON(a) for a in exp.arguments)), json);
           json := JSON.addPair("inv_args",
             JSON.makeArray(list(toJSON(a) for a in exp.inv_arguments)), json);
-          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
+          json := JSON.addPair("op", Operator.toJSON(exp.operator), json);
         then
           json;
 
       case IF()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("if"), json);
+          json := JSON.addPair("$kind", JSON.STRING("if"), json);
           json := JSON.addPair("condition", toJSON(exp.condition), json);
           json := JSON.addPair("true", toJSON(exp.trueBranch), json);
           json := JSON.addPair("false", toJSON(exp.falseBranch), json);
@@ -6539,7 +6539,7 @@ public
       case SUBSCRIPTED_EXP()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("sub"), json);
+          json := JSON.addPair("$kind", JSON.STRING("sub"), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
           json := JSON.addPair("subscripts", Subscript.toJSONList(exp.subscripts), json);
         then
@@ -6548,7 +6548,7 @@ public
       case TUPLE_ELEMENT()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("tuple_element"), json);
+          json := JSON.addPair("$kind", JSON.STRING("tuple_element"), json);
           json := JSON.addPair("exp", toJSON(exp.tupleExp), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
         then
@@ -6557,7 +6557,7 @@ public
       case RECORD_ELEMENT()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("record_element"), json);
+          json := JSON.addPair("$kind", JSON.STRING("record_element"), json);
           json := JSON.addPair("exp", toJSON(exp.recordExp), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
           json := JSON.addPair("field", JSON.makeString(exp.fieldName), json);
@@ -6567,7 +6567,7 @@ public
       case PARTIAL_FUNCTION_APPLICATION()
         algorithm
           json := JSON.emptyListObject();
-          json := JSON.addPair("$kind", JSON.makeString("function"), json);
+          json := JSON.addPair("$kind", JSON.STRING("function"), json);
           json := JSON.addPair("name", JSON.makeString(ComponentRef.toString(exp.fn)), json);
           json := JSON.addPair("arguments", JSON.makeArray(
             list(dump_arg(name, arg) threaded for arg in exp.args, name in exp.argNames)), json);

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
@@ -39,6 +39,7 @@ public
   import Absyn;
   import AbsynUtil;
   import DAE;
+  import JSON;
 
   type Op = enumeration(
     // Basic arithmetic operators.
@@ -459,6 +460,53 @@ public
 
     symbol := spacing + symbol + spacing;
   end symbol;
+
+  function toJSON
+    input Operator operator;
+    output JSON json;
+  protected
+    constant array<JSON> symbols = MetaModelica.Dangerous.listArrayLiteral({
+      JSON.STRING("+"),
+      JSON.STRING("-"),
+      JSON.STRING("*"),
+      JSON.STRING("/"),
+      JSON.STRING("^"),
+      JSON.STRING(".+"),
+      JSON.STRING(".-"),
+      JSON.STRING(".*"),
+      JSON.STRING("./"),
+      JSON.STRING(".^"),
+      JSON.STRING(".+"),
+      JSON.STRING(".+"),
+      JSON.STRING(".-"),
+      JSON.STRING(".-"),
+      JSON.STRING("*"),
+      JSON.STRING(".*"),
+      JSON.STRING("*"),
+      JSON.STRING("*"),
+      JSON.STRING("*"),
+      JSON.STRING("*"),
+      JSON.STRING("./"),
+      JSON.STRING("/"),
+      JSON.STRING(".^"),
+      JSON.STRING(".^"),
+      JSON.STRING("^"),
+      JSON.STRING("-"),
+      JSON.STRING("and"),
+      JSON.STRING("or"),
+      JSON.STRING("not"),
+      JSON.STRING("<"),
+      JSON.STRING("<="),
+      JSON.STRING(">"),
+      JSON.STRING(">="),
+      JSON.STRING("=="),
+      JSON.STRING("<>")
+    });
+
+    Op op = operator.op;
+  algorithm
+    json := symbols[Integer(op)];
+  end toJSON;
 
   function priority
     input Operator op;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1189,7 +1189,7 @@ function dumpJSONInstanceAnnotationExtends
   input list<String> filter;
   output JSON json = JSON.makeNull();
 algorithm
-  json := JSON.addPair("$kind", JSON.makeString("extends"), json);
+  json := JSON.addPair("$kind", JSON.STRING("extends"), json);
   json := JSON.addPair("baseClass", dumpJSONInstanceAnnotation(ext, filter), json);
 end dumpJSONInstanceAnnotationExtends;
 
@@ -1255,7 +1255,7 @@ algorithm
   cls_def := InstNode.definition(node);
   SOME(ext_def) := InstNode.extendsDefinition(node);
 
-  json := JSON.addPair("$kind", JSON.makeString("extends"), json);
+  json := JSON.addPair("$kind", JSON.STRING("extends"), json);
   json := dumpJSONSCodeMod(getExtendsModifier(ext_def, node), node, json);
   json := dumpJSONCommentOpt(SCodeUtil.getElementComment(ext_def), node, json);
 
@@ -1271,7 +1271,7 @@ function dumpJSONBuiltinBaseClass
   input String name;
   output JSON json = JSON.makeNull();
 algorithm
-  json := JSON.addPair("$kind", JSON.makeString("extends"), json);
+  json := JSON.addPair("$kind", JSON.STRING("extends"), json);
   json := JSON.addPair("baseClass", JSON.makeString(name), json);
 end dumpJSONBuiltinBaseClass;
 
@@ -1325,7 +1325,7 @@ algorithm
   elem := InstNode.definition(node);
   scope := InstNode.parent(node);
 
-  json := JSON.addPair("$kind", JSON.makeString("component"), json);
+  json := JSON.addPair("$kind", JSON.STRING("component"), json);
   json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
 
   () := match (comp, elem)
@@ -1484,7 +1484,7 @@ function dumpJSONEnumTypeLiteral
   input InstNode scope;
   output JSON json = JSON.makeNull();
 algorithm
-  json := JSON.addPair("$kind", JSON.makeString("component"), json);
+  json := JSON.addPair("$kind", JSON.STRING("component"), json);
   json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
   json := dumpJSONComment(Component.comment(InstNode.component(node)), scope, json);
 end dumpJSONEnumTypeLiteral;
@@ -1605,9 +1605,9 @@ algorithm
   end if;
 
   if AbsynUtil.isInput(attrs.direction) then
-    json := JSON.addPair("direction", JSON.makeString("input"), json);
+    json := JSON.addPair("direction", JSON.STRING("input"), json);
   elseif AbsynUtil.isOutput(attrs.direction) then
-    json := JSON.addPair("direction", JSON.makeString("output"), json);
+    json := JSON.addPair("direction", JSON.STRING("output"), json);
   end if;
 end dumpJSONAttributes;
 
@@ -1925,7 +1925,7 @@ algorithm
     case Absyn.Exp.CALL()
       algorithm
         json := JSON.makeNull();
-        json := JSON.addPair("$kind", JSON.makeString("call"), json);
+        json := JSON.addPair("$kind", JSON.STRING("call"), json);
         json := JSON.addPair("name", dumpJSONAbsynCref(exp.function_), json);
         json := dumpJSONAbsynFunctionArgs(exp.functionArgs, json);
       then
@@ -2289,7 +2289,7 @@ algorithm
   json := match element
     case SCode.Element.COMPONENT()
       algorithm
-        json := JSON.addPair("$kind", JSON.makeString("component"), json);
+        json := JSON.addPair("$kind", JSON.STRING("component"), json);
         json := JSON.addPair("name", JSON.makeString(element.name), json);
         json := JSON.addPair("type", dumpJSONPath(AbsynUtil.typeSpecPath(element.typeSpec)), json);
         json := JSON.addPairNotNull("dims", dumpJSONDims(element.attributes.arrayDims, {}), json);
@@ -2339,7 +2339,7 @@ algorithm
   () := match element
     case SCode.CLASS()
       algorithm
-        json := JSON.addPair("$kind", JSON.makeString("class"), json);
+        json := JSON.addPair("$kind", JSON.STRING("class"), json);
 
         if InstNode.isEmpty(node) or isRedeclare then
           json := JSON.addPair("name", JSON.makeString(element.name), json);
@@ -2388,7 +2388,7 @@ algorithm
 
       for ext in exts loop
         json_ext := JSON.makeNull();
-        json_ext := JSON.addPair("$kind", JSON.makeString("extends"), json_ext);
+        json_ext := JSON.addPair("$kind", JSON.STRING("extends"), json_ext);
         json_ext := JSON.addPair("baseClass", dumpJSONSCodeClass(InstNode.definition(ext), ext, scope, false), json_ext);
         json_elements := JSON.addElement(json_ext, json_elements);
       end for;


### PR DESCRIPTION
- Manually inline `JSON.makeString` for literal strings to avoid unnecessary allocations, since letting the compiler do it doesn't work.
- Add an `Operator.toJSON` function to allow using constant JSON values.