### PR TITLE
Add JSON array list type

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1500,7 +1500,7 @@ public
         algorithm
           json := JSON.emptyListObject();
           json := JSON.addPair("$kind", JSON.makeString("cref"), json);
-          json := JSON.addPair("parts", JSON.makeArray(toJSON_impl(cref)), json);
+          json := JSON.addPair("parts", JSON.makeList(toJSON_impl(cref)), json);
         then
           json;
 
@@ -1510,7 +1510,7 @@ public
         algorithm
           json := JSON.emptyListObject();
           json := JSON.addPair("$kind", JSON.makeString("cref"), json);
-          json := JSON.addPair("parts", JSON.makeArray(
+          json := JSON.addPair("parts", JSON.makeList(
             {JSON.fromPair("name", JSON.makeString("_"))}), json);
         then
           json;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -6403,13 +6403,7 @@ public
           json;
 
       case ARRAY()
-        algorithm
-          json := JSON.emptyArray(arrayLength(exp.elements));
-          for e in exp.elements loop
-            json := JSON.addElement(toJSON(e), json);
-          end for;
-        then
-          json;
+        then JSON.makeList(list(toJSON(e) for e in exp.elements));
 
       case RANGE()
         algorithm
@@ -6430,7 +6424,7 @@ public
           json := JSON.emptyListObject();
           json := JSON.addPair("$kind", JSON.STRING("tuple"), json);
           json := JSON.addPair("elements",
-            JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
+            JSON.makeList(list(toJSON(e) for e in exp.elements)), json);
         then
           json;
 
@@ -6440,7 +6434,7 @@ public
           json := JSON.addPair("$kind", JSON.STRING("record"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(exp.path)), json);
           json := JSON.addPair("elements",
-            JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
+            JSON.makeList(list(toJSON(e) for e in exp.elements)), json);
         then
           json;
 
@@ -6455,7 +6449,7 @@ public
 
           if isSome(exp.dimIndex) then
             json := JSON.addPair("arguments",
-              JSON.makeArray({toJSON(exp.exp), toJSON(Util.getOption(exp.dimIndex))}), json);
+              JSON.makeList({toJSON(exp.exp), toJSON(Util.getOption(exp.dimIndex))}), json);
           else
             json := JSON.addPair("arguments", JSON.makeArray({toJSON(exp.exp)}), json);
           end if;
@@ -6569,7 +6563,7 @@ public
           json := JSON.emptyListObject();
           json := JSON.addPair("$kind", JSON.STRING("function"), json);
           json := JSON.addPair("name", JSON.makeString(ComponentRef.toString(exp.fn)), json);
-          json := JSON.addPair("arguments", JSON.makeArray(
+          json := JSON.addPair("arguments", JSON.makeList(
             list(dump_arg(name, arg) threaded for arg in exp.args, name in exp.argNames)), json);
         then
           json;


### PR DESCRIPTION
- Add a JSON array type implemented as a list, to avoid the overhead of creating a Vector for JSON arrays that are just created and dumped.
- Use the new JSON list when dumping expressions to JSON.