### PR TITLE
Check for Expression.isNull()

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -268,7 +268,7 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
       }
     });
 
-    if (!value && !expression.isLiteral()) {
+    if (!value && !expression.isLiteral() && !expression.isNull()) {
       // qDebug() << "Expression is not literal:" << expression.toQString();
       return evaluate_helper(&expression, pModel, readFromResultFileForDynamicSelect, time, value);
     } else {


### PR DESCRIPTION
### Related Issues

Fixes #15095

### Purpose

Stop OMEdit from crashing.

### Approach

Avoid going in the infinite loop for null expression.
