### PR TITLE
Added apparent power unit `V.A` to prefixable units

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -296,6 +296,7 @@ bool Plot::prefixableUnit(const QString &unit)
     "Ohm",
     "S",
     "W",
+    "V.A",
     "W/m",
     "W/m2",
     "Wh",


### PR DESCRIPTION
### Related Issues

Fixes #15107