### PR TITLE
Fix flag parsing

### DIFF
--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -743,9 +743,11 @@ protected
 algorithm
   config_flag := lookupConfigFlag(inFlag, inFlagPrefix);
 
-  if missingValue and flagRequiresValue(config_flag) and not listEmpty(restArgs) then
+  if missingValue and flagRequiresValue(config_flag) and not listEmpty(restArgs)
+     and not StringUtil.startsWith(listHead(restArgs), "-") then
     // If no value was given using = and the flag requires a value,
-    // use the next argument as the value.
+    // use the next argument as the value unless the next argument is another
+    // flag (starts with -).
     value := listHead(restArgs);
     restArgs := listRest(restArgs);
   else

--- a/testsuite/openmodelica/interactive-API/FlagParsing.mos
+++ b/testsuite/openmodelica/interactive-API/FlagParsing.mos
@@ -71,6 +71,9 @@ setCommandLineOptions("-d failtrace --debug=ceval"); getErrorString();
 // Shouldn't work, some flags require a value.
 setCommandLineOptions("-i="); getErrorString();
 
+// Shouldn't work, argument beginning with - are always treated as flags.
+setCommandLineOptions("--debug -failtrace");
+
 // Result:
 // true
 // ""
@@ -157,4 +160,5 @@ setCommandLineOptions("-i="); getErrorString();
 // false
 // "Error: Invalid type of flag instClass, expected a string but got nothing.
 // "
+// false
 // endResult


### PR DESCRIPTION
- Don't use arguments beginning with - as a flag value, to avoid e.g. string list flags from eating the next flag.