### PR TITLE
Add specific plot exception for time out of bounds

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -1045,7 +1045,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
     if (it < 0) {
       mFile.close();
-      throw PlotException("Time out of bounds.");
+      throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
     }
     QString currentVariable;  //without index part
     // Read variable values and plot them
@@ -1093,7 +1093,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
     if (it < 0) {
       omc_free_csv_reader(csvReader);
-      throw PlotException("Time out of bounds.");
+      throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
     }
     QStringList::Iterator itVarList;
     for (itVarList = mVariablesList.begin(); itVarList != mVariablesList.end(); itVarList++){
@@ -1155,7 +1155,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
-        throw PlotException("Time out of bounds.");
+        throw TimeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
       }
       QStringList::Iterator itVarList;
       for (itVarList = mVariablesList.begin(); itVarList != mVariablesList.end(); itVarList++){
@@ -1258,7 +1258,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
       if (it < 0) {
         mFile.close();
-        throw PlotException("Time out of bounds.");
+        throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
       }
       if (editCase) {
         pPlotCurve->clearXAxisVector();
@@ -1305,7 +1305,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
       if (it < 0) {
         omc_free_csv_reader(csvReader);
-        throw PlotException("Time out of bounds.");
+        throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
       }
       if (!editCase) {
         QFileInfo fileInfo(mFile);
@@ -1380,7 +1380,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
-        throw PlotException("Time out of bounds.");
+        throw TimeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
       }
       pPlotCurve->clearXAxisVector();
       pPlotCurve->clearYAxisVector();
@@ -1991,6 +1991,12 @@ void PlotWindow::interactiveSimulationStarted()
 void PlotWindow::interactiveSimulationPaused()
 {
   setInteractiveControls(true);
+}
+
+TimeOutOfBoundsException::TimeOutOfBoundsException(const QFileInfo &fileInfo, double startTime, double stopTime)
+  : PlotException(QString("%1: %2. (StartTime = %3, StopTime = %4)")
+      .arg(fileInfo.fileName()).arg(QObject::tr("Time out of bounds")).arg(startTime).arg(stopTime))
+{
 }
 
 /*!

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -44,6 +44,7 @@
 #include <QToolButton>
 #include <QLabel>
 #include <QFile>
+#include <QFileInfo>
 #include <QMdiSubWindow>
 #include <QGroupBox>
 #include <QPushButton>
@@ -265,6 +266,12 @@ class NoVariableException : public PlotException
 {
 public:
   NoVariableException(const char *varName) : PlotException(varName) {}
+};
+
+class TimeOutOfBoundsException : public PlotException
+{
+public:
+  TimeOutOfBoundsException(const QFileInfo &fileInfo, double startTime, double stopTime);
 };
 
 class SetupDialog;


### PR DESCRIPTION
### Related Issues

~~To be rebased on #15004.~~ [done]

### Purpose

With multiple simulation result files available and several array (parametric) plots shown, it is not obvious which plot triggers the exception when the time value is out of bounds.

### Approach

Add a specific `TimeOutOfBoundsException` extending `PlotException` with the result file name as well as the start and stop times.

### Further Work

It may be worth adding the plot name as a prefix to all the `PlotException`s in order to know exactly which plot triggers each error. The one thing is, the default plot name is not very elegant. The other thing is, the error message might become verbose. I leave it up to you.
