### PR TITLE
Fix plot initialization when switching result file

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1910,11 +1910,14 @@ void VariablesWidget::initializeVisualization()
       mpTimeManager->setPause(true);
       // reset the visualization controls
       mpTimeTextBox->setText(QString::number(mpTimeManager->getVisTime()));
+      bool state = mpSimulationTimeSlider->blockSignals(true);
       mpSimulationTimeSlider->setValue(mpTimeManager->getTimeFraction());
+      mpSimulationTimeSlider->blockSignals(state);
     }
     mpTimeControlsDescriptionLabel->setText(tr("Enabled for %1").arg(pVariablesTreeItem->getVariableName()));
     enableVisualizationControls(true);
     updateVisualization();
+    updatePlotWindows();
   } else {
     mpTimeControlsDescriptionLabel->setText("");
     // disable visualization controls so the call to rewindVisualization doesn't try to update visualization.


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/pull/15055#issuecomment-3981287071

### Purpose

A problem may arise when you have two result files in the variable tree, with different start times.

If you click on "Enable Time Controls" action to switch the active result file while you are on an array (parametric) plot and the time slider is at its initial position, then the plot won't be updated. But if you moved the slider away from the start value before you clicked the action, then the plot would update. That is because calling `setValue()` on the slider during the result file switch triggers a slider's signal but only if its value actually changed.

### Approach

This change makes it consistent with the rest of the code where we always block signals before calling `mpSimulationTimeSlider->setValue()` and always call `updatePlotWindows()` after `updateVisualization()`.
