### PR TITLE
Clean up pure/impure handling

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -1102,17 +1102,23 @@ partial function EvaluateSingletonTypeFunction
   output Type ty;
 end EvaluateSingletonTypeFunction;
 
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN = FUNCTION_ATTRIBUTES(NO_INLINE(),true,false,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_DEFAULT = FUNCTION_ATTRIBUTES(DEFAULT_INLINE(),true,false,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,true,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,true,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN = FUNCTION_ATTRIBUTES(NO_INLINE(),Purity.PURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_DEFAULT = FUNCTION_ATTRIBUTES(DEFAULT_INLINE(),Purity.PURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),Purity.IMPURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),Purity.IMPURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
+
+public type Purity = enumeration(
+  PURE,      // Function with pure prefix
+  IMPURE,    // Function with impure prefix
+  UNDEFINED, // Function with neither pure nor impure prefix
+  OM_IMPURE  // Function with __OpenModelica_Impure=true annotation (only used by the OF)
+);
 
 public
 uniontype FunctionAttributes
   record FUNCTION_ATTRIBUTES
     InlineType inline;
-    Boolean isOpenModelicaPure "if the function has __OpenModelica_Impure";
-    Boolean isImpure "if the function has prefix *impure* is true, else false";
+    Purity purity;
     Boolean isFunctionPointer "if the function is a local variable";
     FunctionBuiltin isBuiltin;
     FunctionParallelism functionParallelism;

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7172,31 +7172,34 @@ i.e. Inline and Purity"
   input list<DAE.Var> vl;
   input SCode.Comment inheritedComment;
   output DAE.FunctionAttributes attr;
+protected
+  SCode.Restriction restriction;
+  SCode.FunctionRestriction fres;
+  Boolean isOpenModelicaPure, isImpure, hasOutVars, unboxArgs;
+  DAE.FunctionBuiltin isBuiltin;
+  DAE.InlineType inlineType;
+  String name;
+  list<DAE.Var> inVars,outVars;
+  Absyn.FunctionPurity purity;
+  DAE.Purity daePurity;
 algorithm
-  attr := matchcontinue cl
-    local
-      SCode.Restriction restriction;
-      Boolean isOpenModelicaPure, isImpure, hasOutVars, unboxArgs;
-      DAE.FunctionBuiltin isBuiltin;
-      DAE.InlineType inlineType;
-      String name;
-      list<DAE.Var> inVars,outVars;
-      Absyn.FunctionPurity purity;
+  restriction := SCodeUtil.getClassRestriction(cl);
+  SCode.Restriction.R_FUNCTION(functionRestriction = fres) := restriction;
+  daePurity := getFunctionRestrictionPurity(SCodeUtil.getFunctionRestrictionPurity(fres), inheritedComment, newFrontend = false);
 
-    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(purity)))
+  attr := matchcontinue fres
+    case SCode.FR_EXTERNAL_FUNCTION(purity)
       equation
         isImpure = AbsynUtil.isImpure(purity);
         inVars = List.select(vl,Types.isInputVar);
         outVars = List.select(vl,Types.isOutputVar);
         name = SCodeUtil.isBuiltinFunction(cl,List.map(inVars,Types.getVarName),List.map(outVars,Types.getVarName));
         inlineType = commentIsInlineFunc(inheritedComment);
-        isOpenModelicaPure = not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
-        isImpure = if isImpure then true else SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__ModelicaAssociation_Impure");
         unboxArgs = SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment, "__OpenModelica_UnboxArguments");
-      then (DAE.FUNCTION_ATTRIBUTES(inlineType,isOpenModelicaPure,isImpure,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_NON_PARALLEL()));
+      then (DAE.FUNCTION_ATTRIBUTES(inlineType,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_NON_PARALLEL()));
 
     //parallel functions: There are some builtin functions.
-    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_PARALLEL_FUNCTION()))
+    case SCode.FR_PARALLEL_FUNCTION()
       equation
         inVars = List.select(vl,Types.isInputVar);
         outVars = List.select(vl,Types.isOutputVar);
@@ -7204,31 +7207,57 @@ algorithm
         inlineType = commentIsInlineFunc(inheritedComment);
         isOpenModelicaPure = not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
         unboxArgs = SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment, "__OpenModelica_UnboxArguments");
-      then (DAE.FUNCTION_ATTRIBUTES(inlineType,isOpenModelicaPure,false,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_PARALLEL_FUNCTION()));
+      then (DAE.FUNCTION_ATTRIBUTES(inlineType,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_PARALLEL_FUNCTION()));
 
     //parallel functions: non-builtin
-    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_PARALLEL_FUNCTION()))
+    case SCode.FR_PARALLEL_FUNCTION()
       equation
         inlineType = commentIsInlineFunc(inheritedComment);
         isBuiltin = if SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_BuiltinPtr") then DAE.FUNCTION_BUILTIN_PTR() else DAE.FUNCTION_NOT_BUILTIN();
         isOpenModelicaPure = not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
-      then DAE.FUNCTION_ATTRIBUTES(inlineType,isOpenModelicaPure,false,false,isBuiltin,DAE.FP_PARALLEL_FUNCTION());
+      then DAE.FUNCTION_ATTRIBUTES(inlineType,daePurity,false,isBuiltin,DAE.FP_PARALLEL_FUNCTION());
 
     //kernel functions: never builtin and never inlined.
-    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_KERNEL_FUNCTION()))
-      then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(), true, false, false, DAE.FUNCTION_NOT_BUILTIN(),DAE.FP_KERNEL_FUNCTION());
+    case SCode.FR_KERNEL_FUNCTION()
+      then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(), daePurity, false, DAE.FUNCTION_NOT_BUILTIN(),DAE.FP_KERNEL_FUNCTION());
 
-    case SCode.CLASS(restriction=restriction)
-      equation
-        inlineType = commentIsInlineFunc(inheritedComment);
-        hasOutVars = List.any(vl,Types.isOutputVar);
-        isBuiltin = if SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_BuiltinPtr") then DAE.FUNCTION_BUILTIN_PTR() else DAE.FUNCTION_NOT_BUILTIN();
-        isOpenModelicaPure = not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
-        // In Modelica 3.2 and before, external functions with side-effects are not marked
-        isImpure = SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__ModelicaAssociation_Impure") or SCodeUtil.isRestrictionImpure(restriction,hasOutVars or Config.languageStandardAtLeast(Config.LanguageStandard.'3.3'));
-      then DAE.FUNCTION_ATTRIBUTES(inlineType,isOpenModelicaPure,isImpure,false,isBuiltin,DAE.FP_NON_PARALLEL());
+    else
+      algorithm
+        inlineType := commentIsInlineFunc(inheritedComment);
+        hasOutVars := List.any(vl,Types.isOutputVar);
+        isBuiltin := if SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_BuiltinPtr") then DAE.FUNCTION_BUILTIN_PTR() else DAE.FUNCTION_NOT_BUILTIN();
+
+        // In Modelica 3.2 and before, external functions with side-effects are not marked.
+        if daePurity == DAE.Purity.UNDEFINED and SCodeUtil.isExternalFunctionRestriction(fres) and
+           not (hasOutVars or Config.languageStandardAtLeast(Config.LanguageStandard.'3.3')) then
+          daePurity := DAE.Purity.IMPURE;
+        end if;
+      then
+        DAE.FUNCTION_ATTRIBUTES(inlineType,daePurity,false,isBuiltin,DAE.FP_NON_PARALLEL());
   end matchcontinue;
 end getFunctionAttributes;
+
+public function getFunctionRestrictionPurity
+  input Absyn.FunctionPurity purity;
+  input SCode.Comment cmt;
+  input Boolean newFrontend;
+  output DAE.Purity outPurity;
+algorithm
+  outPurity := match purity
+    case Absyn.FunctionPurity.PURE() then DAE.Purity.PURE;
+    case Absyn.FunctionPurity.IMPURE() then DAE.Purity.IMPURE;
+    else DAE.Purity.UNDEFINED;
+  end match;
+
+  if outPurity == DAE.Purity.UNDEFINED then
+    if SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__ModelicaAssociation_Impure") then
+      outPurity := DAE.Purity.IMPURE;
+    elseif not newFrontend and SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__OpenModelica_Impure") then
+      // __OpenModelica_Impure is only used for MetaModelica, which the NF doesn't care about.
+      outPurity := DAE.Purity.OM_IMPURE;
+    end if;
+  end if;
+end getFunctionRestrictionPurity;
 
 public function checkFunctionElement
 "Verifies that an element of a function is correct, i.e.

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -4575,6 +4575,17 @@ algorithm
   end match;
 end isRestrictionImpure;
 
+public function getFunctionRestrictionPurity
+  input SCode.FunctionRestriction restr;
+  output Absyn.FunctionPurity purity;
+algorithm
+  purity := match restr
+    case SCode.FR_NORMAL_FUNCTION(purity = purity) then purity;
+    case SCode.FR_EXTERNAL_FUNCTION(purity = purity) then purity;
+    else Absyn.FunctionPurity.NO_PURITY();
+  end match;
+end getFunctionRestrictionPurity;
+
 public function elementInnerOuter
   input SCode.Element element;
   output Absyn.InnerOuter io;

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -7393,7 +7393,7 @@ protected
   DAE.Type restype,functype;
   DAE.FunctionBuiltin isBuiltin;
   DAE.FunctionParallelism funcParal;
-  Boolean isPure,tuple_,builtin,isImpure;
+  Boolean tuple_,builtin,isImpure;
   DAE.InlineType inlineType;
   Absyn.Path fn_1;
   DAE.Properties prop,prop_1;
@@ -7406,14 +7406,14 @@ protected
   FCore.Cache cache;
   Boolean didInline;
   Boolean b,onlyOneFunction,isFunctionPointer;
+  DAE.Purity purity;
 algorithm
   onlyOneFunction := listLength(typelist) == 1;
   (cache,
    args_1,
    constlist,
    restype,
-   functype as DAE.T_FUNCTION(functionAttributes=DAE.FUNCTION_ATTRIBUTES(isOpenModelicaPure=isPure,
-                                                                         isImpure=isImpure,
+   functype as DAE.T_FUNCTION(functionAttributes=DAE.FUNCTION_ATTRIBUTES(purity=purity,
                                                                          inline=inlineType,
                                                                          isFunctionPointer=isFunctionPointer,
                                                                          functionParallelism=funcParal)),
@@ -7421,6 +7421,7 @@ algorithm
    slots) := elabTypes(inCache, inEnv, args, nargs, typeVars, typelist, onlyOneFunction, true/* Check types*/, impl,pre,info)
    "The constness of a function depends on the inputs. If all inputs are constant the call itself is constant.";
 
+  isImpure := purity == DAE.Purity.IMPURE;
   (fn_1,functype) := deoverloadFuncname(fn, functype, inEnv);
   tuple_ := Types.isTuple(restype);
   (isBuiltin,builtin,fn_1) := isBuiltinFunc(fn_1,functype);
@@ -7429,7 +7430,7 @@ algorithm
   true := isValidWRTParallelScope(fn,builtin,funcParal,inEnv,info);
 
   const := List.fold(constlist, Types.constAnd, DAE.C_CONST());
-  const := if (Flags.isSet(Flags.RML) and not builtin) or (not isPure) then DAE.C_VAR() else const "in RML no function needs to be ceval'ed; this speeds up compilation significantly when bootstrapping";
+  const := if (Flags.isSet(Flags.RML) and not builtin) or purity == DAE.Purity.OM_IMPURE then DAE.C_VAR() else const "in RML no function needs to be ceval'ed; this speeds up compilation significantly when bootstrapping";
   (cache,const) := determineConstSpecialFunc(cache,inEnv,const,fn_1);
   tyconst := elabConsts(restype, const);
   prop := getProperties(restype, tyconst);
@@ -7439,7 +7440,7 @@ algorithm
   (args_2, slots2) := addDefaultArgs(slots, info);
   // DO NOT CHECK IF ALL SLOTS ARE FILLED!
   true := List.fold(slots2, slotAnd, true);
-  callExp := DAE.CALL(fn_1,args_2,DAE.CALL_ATTR(tp,tuple_,builtin,isImpure or (not isPure),isFunctionPointer,inlineType,DAE.NO_TAIL()));
+  callExp := DAE.CALL(fn_1,args_2,DAE.CALL_ATTR(tp,tuple_,builtin,isImpure or purity == DAE.Purity.OM_IMPURE,isFunctionPointer,inlineType,DAE.NO_TAIL()));
   // ExpressionDump.dumpExpWithTitle("function elabCallArgs3: ", callExp);
 
   // create a replacement for input variables -> their binding

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -8038,14 +8038,11 @@ public function makeCallAttr
   output DAE.CallAttributes callAttr;
 protected
   Boolean isImpure,isT,isB;
-  DAE.FunctionBuiltin isbuiltin;
-  DAE.InlineType isinline;
-  Option<String> name;
 algorithm
-  DAE.FUNCTION_ATTRIBUTES(isBuiltin=isbuiltin,isImpure=isImpure,inline=isinline) := attr;
   isT := isTuple(ty);
-  isB := isBuiltin(isbuiltin);
-  callAttr := DAE.CALL_ATTR(ty,isT,isB,isImpure,false,isinline,DAE.NO_TAIL());
+  isB := isBuiltin(attr.isBuiltin);
+  isImpure := attr.purity == DAE.Purity.IMPURE;
+  callAttr := DAE.CALL_ATTR(ty,isT,isB,isImpure,false,attr.inline,DAE.NO_TAIL());
 end makeCallAttr;
 
 public function builtinName

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -383,7 +383,7 @@ public
 
     args := {};
     var := Variability.CONSTANT;
-    pur := if Function.isImpure(func) or Function.isOMImpure(func) then Purity.IMPURE else Purity.PURE;
+    pur := if Function.isImpure(func) then Purity.IMPURE else Purity.PURE;
 
     for a in typed_args loop
       TypedArg.TYPED_ARG(value = arg_exp, var = arg_var, purity = arg_pur) := a;
@@ -589,7 +589,7 @@ public
   algorithm
     isImpure := match call
       case UNTYPED_CALL() then Function.isImpure(listHead(Function.getRefCache(call.ref)));
-      case TYPED_CALL(purity = Purity.IMPURE) then Function.isImpure(call.fn) or Function.isOMImpure(call.fn);
+      case TYPED_CALL(purity = Purity.IMPURE) then Function.isImpure(call.fn);
       else false;
     end match;
   end isImpure;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1655,7 +1655,7 @@ uniontype Function
       // The function does contain impure calls, mark the function as impure.
       if not pure then
         attr := fn.attributes;
-        attr.isImpure := true;
+        attr.purity := DAE.Purity.IMPURE;
         fn.attributes := attr;
       end if;
     end if;
@@ -1727,7 +1727,7 @@ uniontype Function
     fn :: _ := typeRefCache(fn_ref);
     slots_arr := listArray(fn.slots);
 
-    purity := if Function.isImpure(fn) or Function.isOMImpure(fn) then Purity.IMPURE else Purity.PURE;
+    purity := if Function.isImpure(fn) then Purity.IMPURE else Purity.PURE;
     variability := Variability.CONSTANT;
 
     // Type the arguments and add them to the slots.
@@ -1919,13 +1919,8 @@ uniontype Function
 
   function isImpure
     input Function fn;
-    output Boolean isImpure = fn.attributes.isImpure;
+    output Boolean isImpure = fn.attributes.purity == DAE.Purity.IMPURE;
   end isImpure;
-
-  function isOMImpure
-    input Function fn;
-    output Boolean isImpure = not fn.attributes.isOpenModelicaPure;
-  end isOMImpure;
 
   function isFunctionPointer
     input Function fn;
@@ -2039,7 +2034,7 @@ uniontype Function
   algorithm
     vis := SCode.PUBLIC(); // TODO: Use the actual visibility.
     par := false; // TODO: Use the actual partial prefix.
-    impr := fn.attributes.isImpure;
+    impr := fn.attributes.purity == DAE.Purity.IMPURE;
     ity := fn.attributes.inline;
     ty := makeDAEType(fn);
     unused_inputs := analyseUnusedParameters(fn);
@@ -2436,12 +2431,6 @@ protected
       not SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__OpenModelica_Impure");
   end hasOMPure;
 
-  function hasImpure
-    input SCode.Comment cmt;
-    output Boolean res =
-      SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__ModelicaAssociation_Impure");
-  end hasImpure;
-
   function getBuiltinPtr
     input SCode.Comment cmt;
     output DAE.FunctionBuiltin builtin =
@@ -2488,6 +2477,7 @@ protected
     SCode.FunctionRestriction fres;
     Boolean is_partial;
     SCode.Comment cmt;
+    DAE.Purity purity;
   algorithm
     def := InstNode.classDefinition(Class.lastBaseClass(node));
     res := SCodeUtil.getClassRestriction(def);
@@ -2498,27 +2488,26 @@ protected
     is_partial := InstNode.isPartial(node);
 
     cmt := mergeFunctionAnnotations(comments);
+    purity := InstUtil.getFunctionRestrictionPurity(SCodeUtil.getFunctionRestrictionPurity(fres), cmt, newFrontend = true);
 
     attr := matchcontinue fres
       local
-        Boolean is_impure, is_om_pure, has_out_params, has_unbox_args;
+        Boolean has_unbox_args;
         String name;
         list<String> in_params, out_params;
         DAE.InlineType inline_ty;
         DAE.FunctionBuiltin builtin;
-        Absyn.FunctionPurity purity;
 
       // External builtin function.
-      case SCode.FunctionRestriction.FR_EXTERNAL_FUNCTION(purity)
+      case SCode.FunctionRestriction.FR_EXTERNAL_FUNCTION()
         algorithm
           in_params := list(InstNode.name(i) for i in inputs);
           out_params := list(InstNode.name(o) for o in outputs);
           name := SCodeUtil.isBuiltinFunction(def, in_params, out_params);
           inline_ty := InstUtil.commentIsInlineFunc(cmt);
-          is_impure := AbsynUtil.isImpure(purity) or hasImpure(cmt);
           has_unbox_args := hasUnboxArgsAnnotation(cmt);
         then
-          DAE.FUNCTION_ATTRIBUTES(inline_ty, hasOMPure(cmt), is_impure, is_partial,
+          DAE.FUNCTION_ATTRIBUTES(inline_ty, purity, is_partial,
             DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_NON_PARALLEL());
 
       // Parallel function: there are some builtin functions.
@@ -2530,7 +2519,7 @@ protected
           inline_ty := InstUtil.commentIsInlineFunc(cmt);
           has_unbox_args := hasUnboxArgsAnnotation(cmt);
         then
-          DAE.FUNCTION_ATTRIBUTES(inline_ty, hasOMPure(cmt), false, is_partial,
+          DAE.FUNCTION_ATTRIBUTES(inline_ty, purity, is_partial,
             DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_PARALLEL_FUNCTION());
 
       // Parallel function: non-builtin.
@@ -2538,12 +2527,12 @@ protected
         algorithm
           inline_ty := InstUtil.commentIsInlineFunc(cmt);
         then
-          DAE.FUNCTION_ATTRIBUTES(inline_ty, hasOMPure(cmt), false, is_partial,
+          DAE.FUNCTION_ATTRIBUTES(inline_ty, purity, is_partial,
             getBuiltinPtr(cmt), DAE.FP_PARALLEL_FUNCTION());
 
       // Kernel functions: never builtin and never inlined.
       case SCode.FunctionRestriction.FR_KERNEL_FUNCTION()
-        then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(), true, false, is_partial,
+        then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(), purity, is_partial,
           DAE.FUNCTION_NOT_BUILTIN(), DAE.FP_KERNEL_FUNCTION());
 
       // Normal function.
@@ -2551,17 +2540,16 @@ protected
         algorithm
           inline_ty := InstUtil.commentIsInlineFunc(cmt);
 
-          // In Modelica 3.2 and before, external functions with side-effects are not marked.
-          is_impure := SCodeUtil.isRestrictionImpure(res,
-              Config.languageStandardAtMost(Config.LanguageStandard.'3.2')) or
-            SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__ModelicaAssociation_Impure");
+          // Since Modelica 3.3, normal functions are pure by default and external functions are impure.
+          if purity == DAE.Purity.UNDEFINED and Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+            purity := if SCodeUtil.isExternalFunctionRestriction(fres) then DAE.Purity.IMPURE else DAE.Purity.PURE;
+          end if;
 
           if SCodeUtil.hasNamedExternalCall("ModelicaError", SCodeUtil.getClassDef(def)) then
-            is_impure := false;
+            purity := DAE.Purity.PURE;
           end if;
         then
-          DAE.FUNCTION_ATTRIBUTES(inline_ty, hasOMPure(cmt), is_impure, is_partial,
-            getBuiltinPtr(cmt), DAE.FP_NON_PARALLEL());
+          DAE.FUNCTION_ATTRIBUTES(inline_ty, purity, is_partial, getBuiltinPtr(cmt), DAE.FP_NON_PARALLEL());
 
     end matchcontinue;
   end makeAttributes;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -64,7 +64,7 @@ end der;
 impure function initial "True if in initialization phase"
   discrete output Boolean isInitial;
 external "builtin";
-annotation(__OpenModelica_builtin=true, __OpenModelica_Impure=true, Documentation(info="<html>
+annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'initial()'\">initial()</a>
 </html>"));
 end initial;
@@ -72,7 +72,7 @@ end initial;
 impure function terminal "True after successful analysis"
   discrete output Boolean isTerminal;
 external "builtin";
-annotation(__OpenModelica_builtin=true, __OpenModelica_Impure=true, Documentation(info="<html>
+annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'terminal()'\">terminal()</a>
 </html>"));
 end terminal;
@@ -367,8 +367,8 @@ annotation(__OpenModelica_builtin=true, __OpenModelica_EarlyInline = true, prefe
 </html>"));
 end skew;
 
-function delay = $overload(OpenModelica.Internal.delay2,OpenModelica.Internal.delay3) "Delay expression"
-  annotation(__OpenModelica_builtin=true, __OpenModelica_Impure=true, Documentation(info="<html>
+impure function delay = $overload(OpenModelica.Internal.delay2,OpenModelica.Internal.delay3) "Delay expression"
+  annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'delay()'\">delay()</a>
 </html>"));
 
@@ -631,7 +631,7 @@ impure function DynamicSelect<__Any> "select static or dynamic expressions in th
   input __Any dynamic;
   output __Any selected;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_Impure=true, Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Annotations.DynamicSelect\">DynamicSelect</a>
 </html>"));
 end DynamicSelect;
@@ -804,7 +804,7 @@ end Subtask;
 impure function print "Prints to stdout, useful for debugging."
   input String str;
   external "builtin";
-  annotation(__OpenModelica_Impure=true, version="OpenModelica extension");
+  annotation(version="OpenModelica extension");
 end print;
 
 function classDirectory "Non-standard operator"
@@ -1553,7 +1553,7 @@ impure function system "Similar to system(3). Executes the given command in the 
   input String outputFile = "" "The output is redirected to this file (unless already done by callStr)";
   output Integer retval "Return value of the system call; usually 0 on success";
 external "builtin";
-annotation(__OpenModelica_Impure=true, preferredView="text");
+annotation(preferredView="text");
 end system;
 
 impure function system_parallel "Similar to system(3). Executes the given commands in the system shell, in parallel if omc was compiled using OpenMP."
@@ -1561,7 +1561,7 @@ impure function system_parallel "Similar to system(3). Executes the given comman
   input Integer numThreads = numProcessors();
   output Integer retval[:] "Return value of the system call; usually 0 on success";
 external "builtin";
-annotation(__OpenModelica_Impure=true, preferredView="text");
+annotation(preferredView="text");
 end system_parallel;
 
 function saveAll "Saves the entire loaded AST to file."
@@ -2059,7 +2059,7 @@ impure function stat
   output Real fileSize;
   output Real mtime;
 external "builtin";
-annotation(__OpenModelica_Impure=true, Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/stat\">stat(2)</a>, except the output is of type real because of limited precision of Integer.</p>
 </html>"),
   preferredView="text");
@@ -2070,7 +2070,7 @@ impure function readFile
   input String fileName;
   output String contents;
 external "builtin";
-annotation(__OpenModelica_Impure=true, Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Returns the contents of a file as a string or an empty string if the file couldn't be read. If the file couldn't be read an error message is emitted which can be viewed with <a href=\"modelica://OpenModelica.Scripting.getErrorString\">getErrorString()</a>.</p>
 </html>"),
   preferredView="text");
@@ -2083,7 +2083,7 @@ impure function writeFile
   input Boolean append = false;
   output Boolean success;
 external "builtin";
-annotation(__OpenModelica_Impure=true, Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Returns true on success. If <code>append = true</code> the data is appended to the file, otherwise the file is overwritten with the new content.</p>
 </html>"),
   preferredView="text");
@@ -2095,7 +2095,7 @@ impure function compareFilesAndMove
   input String oldFile;
   output Boolean success;
 external "builtin";
-annotation(__OpenModelica_Impure=true,Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Compares <i>newFile</i> and <i>oldFile</i>. If they differ, overwrite <i>oldFile</i> with <i>newFile</i></p>
 <p>Basically: test -f ../oldFile && cmp newFile oldFile || mv newFile oldFile</p>
 </html>"));
@@ -2107,7 +2107,7 @@ impure function compareFiles
   input String file2;
   output Boolean isEqual;
 external "builtin";
-annotation(__OpenModelica_Impure=true,Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Compares <i>file1</i> and <i>file2</i> and returns true if their content is equal, otherwise false.</p>
 </html>"));
 end compareFiles;
@@ -2117,7 +2117,7 @@ impure function alarm
   input Integer seconds;
   output Integer previousSeconds;
 external "builtin" annotation(Library = {"omcruntime"});
-annotation(__OpenModelica_Impure=true,Documentation(info="<html>
+annotation(Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/alarm\">alarm(2)</a>.</p>
 <p>Note that OpenModelica also sends SIGALRM to the process group when the alarm is triggered (in order to kill running simulations).</p>
 </html>"));


### PR DESCRIPTION
- Change purity in DAE.FunctionAttributes to an enum instead of a Boolean, to allow distinguishing between functions that are pure, impure, or have no declared purity.
- Remove separate handling of `__OpenModelica_Impure` and just treat it as if the function is declared impure.