### PR TITLE
check for CompilationProcess is not Null

### DIFF
--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
@@ -490,21 +490,29 @@ void FmuExportOutputWidget::postCompilationProcessFinished(int exitCode, QProces
 {
   mIsPostCompilationProcessRunning = false;
   QString exitCodeStr = tr("Post compilation process failed. Exited with code %1.").arg(Utilities::formatExitCode(exitCode));
-  // Handle the null pointer case
-  if (!mpCompilationProcess) {
-    return;
-  }
+
   if (exitStatus == QProcess::NormalExit && exitCode == 0) {
     writePostCompilationOutput(tr("Build finished successfully.\n"), Qt::blue);
     postCompilationProcessFinishedHelper(exitCode, exitStatus);
     zipFMU();
-  } else if (mpCompilationProcess->error() == QProcess::UnknownError) {
+    return;
+  }
+
+  // Null pointer safety
+  if (!mpCompilationProcess) {
     writePostCompilationOutput(exitCodeStr, Qt::red);
     postCompilationProcessFinishedHelper(exitCode, exitStatus);
+    return;
+  }
+
+  // Error handling
+  if (mpCompilationProcess->error() == QProcess::UnknownError) {
+    writePostCompilationOutput(exitCodeStr, Qt::red);
   } else {
     writePostCompilationOutput(mpCompilationProcess->errorString() + "\n" + exitCodeStr, Qt::red);
-    postCompilationProcessFinishedHelper(exitCode, exitStatus);
   }
+
+  postCompilationProcessFinishedHelper(exitCode, exitStatus);
 }
 
 /*!


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/14890

### Purpose

Check for Null pointers for cpp runtime of FMU Export

