### PR TITLE
Use correct context in getModelInstanceAnnotation

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1128,7 +1128,7 @@ protected
   Boolean annotation_is_literal = true;
   SCode.Element def;
 algorithm
-  Inst.expand(node, ANNOTATION_CONTEXT);
+  Inst.expand(node, NFInstContext.RELAXED);
   def := InstNode.definition(node);
   json := JSON.addPair("name", dumpJSONNodePath(node), json);
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon6.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon6.mos
@@ -1,0 +1,158 @@
+// name: GetModelInstanceIcon1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package IconMap
+    model ClassWithInstance
+      MainClass mainClass annotation(Placement(transformation(extent = {{-20, -20}, {20, 20}})));
+      equation
+    end ClassWithInstance;
+
+    model MainClass
+      extends IconMap.BaseClass annotation(IconMap(primitivesVisible=false));
+      annotation(
+        Icon(graphics = {Ellipse(origin = {0, 20}, lineColor = {238, 46, 47}, fillColor = {255, 0, 0}, fillPattern = FillPattern.Solid, extent = {{-60, 60}, {60, -60}})}));
+    end MainClass;
+
+    model BaseClass
+      annotation(
+        Icon(graphics = {Rectangle(origin = {0, -50}, lineColor = {0, 0, 255}, fillColor = {0, 0, 255}, fillPattern = FillPattern.Solid, extent = {{-80, 30}, {80, -30}})}));
+    end BaseClass;
+  end IconMap;
+");
+
+getModelInstanceAnnotation(IconMap.MainClass, prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"IconMap.MainClass\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"extends\",
+//       \"baseClass\": {
+//         \"name\": \"IconMap.BaseClass\",
+//         \"restriction\": \"model\",
+//         \"annotation\": {
+//           \"Icon\": {
+//             \"graphics\": [
+//               {
+//                 \"$kind\": \"record\",
+//                 \"name\": \"Rectangle\",
+//                 \"elements\": [
+//                   true,
+//                   [
+//                     0,
+//                     -50
+//                   ],
+//                   0,
+//                   [
+//                     0,
+//                     0,
+//                     255
+//                   ],
+//                   [
+//                     0,
+//                     0,
+//                     255
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"LinePattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"FillPattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   0.25,
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"BorderPattern.None\",
+//                     \"index\": 1
+//                   },
+//                   [
+//                     [
+//                       -80,
+//                       30
+//                     ],
+//                     [
+//                       80,
+//                       -30
+//                     ]
+//                   ],
+//                   0
+//                 ]
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     }
+//   ],
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"graphics\": [
+//         {
+//           \"$kind\": \"record\",
+//           \"name\": \"Ellipse\",
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               20
+//             ],
+//             0,
+//             [
+//               238,
+//               46,
+//               47
+//             ],
+//             [
+//               255,
+//               0,
+//               0
+//             ],
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"FillPattern.Solid\",
+//               \"index\": 2
+//             },
+//             0.25,
+//             [
+//               [
+//                 -60,
+//                 60
+//               ],
+//               [
+//                 60,
+//                 -60
+//               ]
+//             ],
+//             0,
+//             360,
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"EllipseClosure.Chord\",
+//               \"index\": 2
+//             }
+//           ]
+//         }
+//       ]
+//     }
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -66,6 +66,7 @@ GetModelInstanceIcon2.mos \
 GetModelInstanceIcon3.mos \
 GetModelInstanceIcon4.mos \
 GetModelInstanceIcon5.mos \
+GetModelInstanceIcon6.mos \
 GetModelInstanceImport1.mos \
 GetModelInstanceImport2.mos \
 GetModelInstanceInnerOuter1.mos \


### PR DESCRIPTION
- Don't use an annotation context when instantiating the class for getModelInstanceAnnotation, since that's only meant for actual annotations and can cause lookup issues otherwise.

Fixes #15161