### PR TITLE
Avoid recurring exceptions when time out of bounds

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2117,10 +2117,7 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
         if (!pPlotCurve && !pPlotWindow->getPlot()->getPlotCurvesList().isEmpty()) {
           pPlotCurve = pPlotWindow->getPlot()->getPlotCurvesList().last();
         }
-        if (pPlotCurve == pLastPlotCurve) {
-          unCheckVariableAndErrorMessage(index, tr("Plot curve not drawn. An error occurred while plotting (e.g., time out of bounds)."));
-          return;
-        }
+        assert(pPlotCurve != pLastPlotCurve);
         bool requiresUpdate = false;
         if (!pVariablesTreeItem->isString() && pVariablesTreeItem->getUnit().compare(pVariablesTreeItem->getDisplayUnit()) != 0) {
           OMCInterface::convertUnits_res convertUnit = MainWindow::instance()->getOMCProxy()->convertUnits(pVariablesTreeItem->getUnit(), pVariablesTreeItem->getDisplayUnit());
@@ -2237,10 +2234,7 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
             if (!pPlotCurve && !pPlotWindow->getPlot()->getPlotCurvesList().isEmpty()) {
               pPlotCurve = pPlotWindow->getPlot()->getPlotCurvesList().last();
             }
-            if (pPlotCurve == pLastPlotCurve) {
-              unCheckVariableAndErrorMessage(index, tr("Plot curve not drawn. An error occurred while plotting (e.g., time out of bounds)."));
-              return;
-            }
+            assert(pPlotCurve != pLastPlotCurve);
             bool requiresUpdate = false;
             // convert x value
             if (!plotParametricCurve.xVariable.isString && plotParametricCurve.xVariable.unit.compare(plotParametricCurve.xVariable.displayUnit) != 0) {
@@ -2588,6 +2582,8 @@ void VariablesWidget::updatePlotWindows()
           }
         }
       }
+    } catch (RecurringPlotException &e) {
+      // Silence repeated exceptions
     } catch (PlotException &e) {
       MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, e.what(), Helper::scriptingKind, Helper::errorLevel));
     }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -1045,11 +1045,12 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
     if (it < 0) {
       mFile.close();
+      TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
       if (mTimeOutOfBounds) {
-        return;
+        throw RecurringPlotException(timeOutOfBoundsException);
       }
       mTimeOutOfBounds = true;
-      throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
+      throw timeOutOfBoundsException;
     } else {
       mTimeOutOfBounds = false;
     }
@@ -1099,11 +1100,12 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
     if (it < 0) {
       omc_free_csv_reader(csvReader);
+      TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
       if (mTimeOutOfBounds) {
-        return;
+        throw RecurringPlotException(timeOutOfBoundsException);
       }
       mTimeOutOfBounds = true;
-      throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
+      throw timeOutOfBoundsException;
     } else {
       mTimeOutOfBounds = false;
     }
@@ -1167,11 +1169,12 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
+        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
         if (mTimeOutOfBounds) {
-          return;
+          throw RecurringPlotException(timeOutOfBoundsException);
         }
         mTimeOutOfBounds = true;
-        throw TimeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
+        throw timeOutOfBoundsException;
       } else {
         mTimeOutOfBounds = false;
       }
@@ -1276,11 +1279,12 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
       if (it < 0) {
         mFile.close();
+        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
         if (mTimeOutOfBounds) {
-          return;
+          throw RecurringPlotException(timeOutOfBoundsException);
         }
         mTimeOutOfBounds = true;
-        throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
+        throw timeOutOfBoundsException;
       } else {
         mTimeOutOfBounds = false;
       }
@@ -1329,11 +1333,12 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
       if (it < 0) {
         omc_free_csv_reader(csvReader);
+        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
         if (mTimeOutOfBounds) {
-          return;
+          throw RecurringPlotException(timeOutOfBoundsException);
         }
         mTimeOutOfBounds = true;
-        throw TimeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
+        throw timeOutOfBoundsException;
       } else {
         mTimeOutOfBounds = false;
       }
@@ -1410,11 +1415,12 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
+        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
         if (mTimeOutOfBounds) {
-          return;
+          throw RecurringPlotException(timeOutOfBoundsException);
         }
         mTimeOutOfBounds = true;
-        throw TimeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
+        throw timeOutOfBoundsException;
       } else {
         mTimeOutOfBounds = false;
       }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -275,6 +275,12 @@ public:
   TimeOutOfBoundsException(const QFileInfo &fileInfo, double startTime, double stopTime);
 };
 
+class RecurringPlotException : public PlotException
+{
+public:
+  RecurringPlotException(const PlotException &e) : PlotException(e) {}
+};
+
 class SetupDialog;
 class VariablePageWidget : public QWidget
 {


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/pull/15137#issuecomment-4005838654

~~To be rebased on #15137.~~ [done]

### Purpose

The `TimeOutOfBoundsException` appeared repeatedly, that is, every time the current time value is out of bounds for the current plot curve, thus filling the message browser continuously with the same error.

### Approach

Keep an internal time-out-of-bounds state. When an exception has already been thrown, this avoids throwing it again. The state is reset once the time gets back inside bounds, so that the next time it gets out again, the user is informed with a new exception. In other words, the exception is thrown at the moments the time passes from "in" to "out" of bounds.

EDIT: When the internal time-out-of-bounds state is already set, we have to throw a specifically-tagged recurring exception instead of simply returning. See https://github.com/OpenModelica/OpenModelica/pull/15174#issuecomment-4042784835 for a detailed explanation.
