### PR TITLE
Prefix plot exceptions with plot window title

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1625,14 +1625,14 @@ void MainWindow::PlotCallbackFunction(void *p, int externalWindow, const char* f
     } else if (QString(logX) == "false") {
       pPlotWindow->setLogX(false);
     } else {
-      throw OMPlot::InvalidInputException(QString(logX));
+      throw OMPlot::InvalidInputException(pPlotWindow->windowTitle(), QString(logX));
     }
     if (QString(logY) == "true") {
       pPlotWindow->setLogY(true);
     } else if (QString(logY) == "false") {
       pPlotWindow->setLogY(false);
     } else {
-      throw OMPlot::InvalidInputException(QString(logY));
+      throw OMPlot::InvalidInputException(pPlotWindow->windowTitle(), QString(logY));
     }
     pPlotWindow->setXLabel(QString(xLabel));
     pPlotWindow->setYLabel(QString(yLabel));
@@ -1647,7 +1647,7 @@ void MainWindow::PlotCallbackFunction(void *p, int externalWindow, const char* f
     } else if (QString(autoScale) == "false") {
       pPlotWindow->setAutoScale(false);
     } else {
-      throw OMPlot::InvalidInputException(QString(autoScale));
+      throw OMPlot::InvalidInputException(pPlotWindow->windowTitle(), QString(autoScale));
     }
     // plot variables
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -136,14 +136,14 @@ void PlotWindow::initializePlot(QStringList arguments)
   } else if (QString(arguments[5]) == "false") {
     setLogX(false);
   } else {
-    throw InvalidInputException(arguments[5]);
+    throw InvalidInputException(windowTitle(), arguments[5]);
   }
   if (QString(arguments[6]) == "true") {
     setLogY(true);
   } else if (QString(arguments[6]) == "false") {
     setLogY(false);
   } else {
-    throw InvalidInputException(arguments[6]);
+    throw InvalidInputException(windowTitle(), arguments[6]);
   }
   setXLabel(QString(arguments[7]));
   setYLabel(QString(arguments[8]));
@@ -166,7 +166,7 @@ void PlotWindow::initializePlot(QStringList arguments)
   } else if (QString(arguments[17]) == "false") {
     setAutoScale(false);
   } else {
-    throw InvalidInputException(arguments[17]);
+    throw InvalidInputException(windowTitle(), arguments[17]);
   }
   QList<bool> plotRightYAxis;
 
@@ -182,7 +182,7 @@ void PlotWindow::initializePlot(QStringList arguments)
     } else if (yAxis == "L") {
        plotRightYAxis.append(false);
     } else {
-       throw InvalidInputException(arguments[18]);
+       throw InvalidInputException(windowTitle(), arguments[18]);
     }
   }
   setYRightLabel(QString(arguments[19]));
@@ -267,18 +267,19 @@ void PlotWindow::initializeFile(QString file)
 {
   mFile.setFileName(file);
   if (!mFile.exists()) {
-    throw NoFileException(ERROR_FILE_NOT_FOUND, file);
+    throw NoFileException(windowTitle(), ERROR_FILE_NOT_FOUND, file);
   }
 }
 
-void PlotWindow::getStartStopTime(double &start, double &stop){
+void PlotWindow::getStartStopTime(double &start, double &stop)
+{
   //PLOT PLT
   if (mFile.fileName().endsWith("plt"))
   {
     QString currentLine;
     // open the file
     if (!mFile.open(QIODevice::ReadOnly)) {
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
     }
     mpTextStream = new QTextStream(&mFile);
     // read the interval size from the file
@@ -318,7 +319,7 @@ void PlotWindow::getStartStopTime(double &start, double &stop){
     }
     if (mpTextStream->atEnd()) {
       mFile.close();
-      throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+      throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
     }
     // close the file
     mFile.close();
@@ -330,13 +331,13 @@ void PlotWindow::getStartStopTime(double &start, double &stop){
     struct csv_data *csvReader;
     csvReader = read_csv(mFile.fileName().toStdString().c_str());
     if (csvReader == NULL) {
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
     }
     //Read in timevector
     double *timeVals = read_csv_dataset(csvReader, "time");
     if (timeVals == NULL) {
       omc_free_csv_reader(csvReader);
-      throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+      throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
     }
     start = timeVals[0];
     stop = timeVals[csvReader->numsteps-1];
@@ -351,7 +352,7 @@ void PlotWindow::getStartStopTime(double &start, double &stop){
     const char *msg = "";
     //Read in mat file
     if(0 != (msg = omc_new_matlab4_reader(mFile.fileName().toStdString().c_str(), &reader))) {
-      throw PlotException(msg);
+      throw PlotException(windowTitle(), msg);
     }
 
     //Read in timevector
@@ -361,7 +362,7 @@ void PlotWindow::getStartStopTime(double &start, double &stop){
     // close the file
     omc_free_matlab4_reader(&reader);
   } else {
-    throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+    throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
   }
 }
 
@@ -483,7 +484,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
 {
   QString currentLine;
   if (mVariablesList.isEmpty() && isPlot())
-    throw NoVariableException(ERROR_NO_VARIABLES_SPECIFIED);
+    throw NoVariableException(windowTitle(), ERROR_NO_VARIABLES_SPECIFIED);
 
   bool editCase = pPlotCurve ? true : false;
   //PLOT PLT
@@ -491,7 +492,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
   {
     // open the file
     if (!mFile.open(QIODevice::ReadOnly)) {
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
     }
     mpTextStream = new QTextStream(&mFile);
     // read the interval size from the file
@@ -559,7 +560,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
     struct csv_data *csvReader;
     csvReader = read_csv(mFile.fileName().toStdString().c_str());
     if (csvReader == NULL)
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
 
     //Read in timevector
     double *timeVals = read_csv_dataset(csvReader, "time");
@@ -569,7 +570,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
       if (timeVals == NULL)
       {
         omc_free_csv_reader(csvReader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time or lambda");
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time or lambda");
       }
       setXLabel("lambda");
     }
@@ -584,7 +585,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
         if (vals == NULL)
         {
           omc_free_csv_reader(csvReader);
-          throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
+          throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
         }
 
         if (!editCase) {
@@ -621,12 +622,12 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
 
     //Read in mat file
     if(0 != (msg = omc_new_matlab4_reader(mFile.fileName().toStdString().c_str(), &reader))) {
-      throw PlotException(msg);
+      throw PlotException(windowTitle(), msg);
     }
 
     if (reader.nvar < 1) {
       omc_free_matlab4_reader(&reader);
-      throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+      throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
     }
 
     double startTime = omc_matlab4_startTime(&reader);
@@ -635,7 +636,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
     double *timeVals = omc_matlab4_read_vals(&reader,1);
     if (!timeVals) {
       omc_free_matlab4_reader(&reader);
-      throw NoVariableException(ERROR_CORRUPTED_FILE, reader.nvar);
+      throw NoVariableException(windowTitle(), ERROR_CORRUPTED_FILE, reader.nvar);
     }
     // read in all values
     for (uint32_t i = 0; i < reader.nall; i++) {
@@ -651,7 +652,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
         var = omc_matlab4_find_var(&reader, reader.allInfo[i].name);
         if (!var) {
           omc_free_matlab4_reader(&reader);
-          throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, reader.allInfo[i].name);
+          throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, reader.allInfo[i].name);
         }
         // clear previous curve data
         pPlotCurve->clearXAxisVector();
@@ -661,7 +662,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
           double *vals = omc_matlab4_read_vals(&reader,var->index);
           if (!vals) {
             omc_free_matlab4_reader(&reader);
-            throw NoVariableException(ERROR_CORRUPTED_FILE, reader.nvar);
+            throw NoVariableException(windowTitle(), ERROR_CORRUPTED_FILE, reader.nvar);
           }
           // set plot curve data and attach it to plot
           for (uint32_t i = 0 ; i < reader.nrows ; i++) {
@@ -675,7 +676,7 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
           double val;
           if (omc_matlab4_val(&val,&reader,var,0.0)) {
             omc_free_matlab4_reader(&reader);
-            throw NoVariableException(ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, reader.allInfo[i].name);
+            throw NoVariableException(windowTitle(), ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, reader.allInfo[i].name);
           }
 
           pPlotCurve->addXAxisValue(startTime);
@@ -702,9 +703,9 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
   int pair = 0;
 
   if (mVariablesList.isEmpty())
-    throw NoVariableException(ERROR_NO_VARIABLES_SPECIFIED);
+    throw NoVariableException(windowTitle(), ERROR_NO_VARIABLES_SPECIFIED);
   else if (mVariablesList.size()%2 != 0)
-    throw NoVariableException(ERROR_SPECIFY_VARIABLE_PAIRS);
+    throw NoVariableException(windowTitle(), ERROR_SPECIFY_VARIABLE_PAIRS);
 
   bool editCase = pPlotCurve ? true : false;
 
@@ -729,7 +730,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
       QString currentLine;
       // open the file
       if (!mFile.open(QIODevice::ReadOnly)) {
-        throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+        throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
       }
       mpTextStream = new QTextStream(&mFile);
       // read the interval size from the file
@@ -805,7 +806,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
       struct csv_data *csvReader;
       csvReader = read_csv(mFile.fileName().toStdString().c_str());
       if (csvReader == NULL)
-        throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+        throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
 
       double *xVals = NULL, *yVals = NULL;
       // read in all values
@@ -817,7 +818,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
           xVals = read_csv_dataset(csvReader, csvReader->variables[i]);
           if (xVals == NULL) {
             omc_free_csv_reader(csvReader);
-            throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
+            throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
           }
         }
         if ((yVariable.compare(csvReader->variables[i]) == 0))
@@ -826,7 +827,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
           yVals = read_csv_dataset(csvReader, csvReader->variables[i]);
           if (yVals == NULL) {
             omc_free_csv_reader(csvReader);
-            throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
+            throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, csvReader->variables[i]);
           }
         }
       }
@@ -862,7 +863,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
 
       //Read the .mat file
       if(0 != (msg = omc_new_matlab4_reader(mFile.fileName().toStdString().c_str(), &reader)))
-        throw PlotException(msg);
+        throw PlotException(windowTitle(), msg);
 
       if (!editCase) {
         QFileInfo fileInfo(mFile);
@@ -873,7 +874,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
       var = omc_matlab4_find_var(&reader, xVariable.toStdString().c_str());
       if (!var) {
         omc_free_matlab4_reader(&reader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, xVariable);
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, xVariable);
       }
       // clear previous curve data
       pPlotCurve->clearXAxisVector();
@@ -884,7 +885,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
         double *xVals = omc_matlab4_read_vals(&reader,var->index);
         if (!xVals) {
           omc_free_matlab4_reader(&reader);
-          throw NoVariableException(ERROR_CORRUPTED_FILE, reader.nvar);
+          throw NoVariableException(windowTitle(), ERROR_CORRUPTED_FILE, reader.nvar);
         }
         for (uint32_t i = 0 ; i < reader.nrows ; i++)
           pPlotCurve->addXAxisValue(xVals[i]);
@@ -895,7 +896,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
         double xVal;
         if (omc_matlab4_val(&xVal,&reader,var,0.0)) {
           omc_free_matlab4_reader(&reader);
-          throw NoVariableException(ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, xVariable);
+          throw NoVariableException(windowTitle(), ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, xVariable);
         }
         for (uint32_t i = 0 ; i < reader.nrows ; i++)
           pPlotCurve->addXAxisValue(xVal);
@@ -904,7 +905,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
       var = omc_matlab4_find_var(&reader, yVariable.toStdString().c_str());
       if (!var) {
         omc_free_matlab4_reader(&reader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, yVariable);
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, yVariable);
       }
       // if variable is not a parameter then
       if (!var->isParam)
@@ -912,7 +913,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
         double *yVals = omc_matlab4_read_vals(&reader,var->index);
         if (!yVals) {
           omc_free_matlab4_reader(&reader);
-          throw NoVariableException(ERROR_CORRUPTED_FILE, reader.nvar);
+          throw NoVariableException(windowTitle(), ERROR_CORRUPTED_FILE, reader.nvar);
         }
         for (uint32_t i = 0 ; i < reader.nrows ; i++)
           pPlotCurve->addYAxisValue(yVals[i]);
@@ -923,7 +924,7 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
         double yVal;
         if (omc_matlab4_val(&yVal,&reader,var,0.0)) {
           omc_free_matlab4_reader(&reader);
-          throw NoVariableException(ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, yVariable);
+          throw NoVariableException(windowTitle(), ERROR_PARAMETER_DOES_NOT_HAVE_VALUE, yVariable);
         }
         for (uint32_t i = 0 ; i < reader.nrows ; i++)
           pPlotCurve->addYAxisValue(yVal);
@@ -936,7 +937,8 @@ void PlotWindow::plotParametric(PlotCurve *pPlotCurve)
   }
 }
 
-int setupInterp(double *vals, double val, int N, double &alpha){
+int PlotWindow::setupInterp(double *vals, double val, int N, double &alpha)
+{
   //given sorted values array of length N and val, returns pointer to i-th element so that
   //vals[i-1] < val <=  vals[i] and sets an interpolation coefficient alpha
   //if val is out of the array range, returns NULL
@@ -950,7 +952,8 @@ int setupInterp(double *vals, double val, int N, double &alpha){
   return p-vals;
 }
 
-int readPLTDataset(QTextStream *mpTextStream, QString variable, int N, double* valsOut){
+int PlotWindow::readPLTDataset(QString variable, int N, double *valsOut)
+{
   bool resetDone = false;
   QString currentLine;
   do { //find start of dataset of the varible
@@ -973,13 +976,14 @@ int readPLTDataset(QTextStream *mpTextStream, QString variable, int N, double* v
     currentLine = mpTextStream->readLine();
     QStringList values = currentLine.split(",");
     if (values.count() != 2)
-      throw NoVariableException(ERROR_FAILED_TO_LOAD_VARIABLE, variable);
+      throw NoVariableException(windowTitle(), ERROR_FAILED_TO_LOAD_VARIABLE, variable);
     valsOut[i] = QString(values[1]).toDouble();
   }
   return 0;
 }
 
-void readPLTArray(QTextStream *mpTextStream, QString variable, double alpha, int intervalSize, int it, QList<double> &arrLstOut){
+void PlotWindow::readPLTArray(QString variable, double alpha, int intervalSize, int it, QList<double> &arrLstOut)
+{
   int index = 1;
   auto vals = std::make_unique<double[]>(intervalSize);
   do  //loop over all indexes
@@ -992,9 +996,9 @@ void readPLTArray(QTextStream *mpTextStream, QString variable, double alpha, int
     } else {
       variableWithInd.append("["+QString::number(index)+"]");
     }
-    if (readPLTDataset(mpTextStream, variableWithInd, intervalSize, vals.get())){
+    if (readPLTDataset(variableWithInd, intervalSize, vals.get())){
       if (index == 1)
-        throw NoVariableException(ERROR_ARRAY_VARIABLE_DOES_NOT_EXIST, variable);
+        throw NoVariableException(windowTitle(), ERROR_ARRAY_VARIABLE_DOES_NOT_EXIST, variable);
       else
         break;
     }
@@ -1007,20 +1011,21 @@ void readPLTArray(QTextStream *mpTextStream, QString variable, double alpha, int
   return;
 }
 
-double getTimeUnitFactor(QString timeUnit)
+double PlotWindow::getTimeUnitFactor()
 {
+  QString timeUnit = getTimeUnit();
   if (timeUnit == "s") return 1.0;
   else if (timeUnit == "min") return 1.0/60.0;
   else if (timeUnit == "h") return 1.0/3600.0;
   else if (timeUnit == "d") return 1.0/86400.0;
-  else throw PlotException(ERROR_UNKNOWN_TIME_UNIT);
+  else throw PlotException(windowTitle(), ERROR_UNKNOWN_TIME_UNIT);
 }
 
 void PlotWindow::updateTimeText()
 {
   double time = getTime();
   QString timeUnit = getTimeUnit();
-  double timeUnitFactor = getTimeUnitFactor(timeUnit);
+  double timeUnitFactor = getTimeUnitFactor();
   QString timeString = QString::number(time * timeUnitFactor);
   mpPlot->setFooter(QString("t = %1 %2").arg(timeString).arg(timeUnit));
   mpPlot->replot();
@@ -1032,7 +1037,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
   QString currentLine;
   setTime(time);
   if (mVariablesList.isEmpty() && isPlotArray())
-    throw NoVariableException(ERROR_NO_VARIABLES_SPECIFIED);
+    throw NoVariableException(windowTitle(), ERROR_NO_VARIABLES_SPECIFIED);
   bool editCase = pPlotCurve ? true : false;
   //PLOT PLT
   //we presume time is the first dataset and array elements datasets are consequent
@@ -1040,7 +1045,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
   {
     /* open the file */
     if (!mFile.open(QIODevice::ReadOnly))
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
     mpTextStream = new QTextStream(&mFile);
     // read the interval size from the file
     int intervalSize = -1;
@@ -1055,18 +1060,18 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     }
     if (intervalSize == -1) {
       mFile.close();
-      throw PlotException(ERROR_INTERVAL_SIZE_NOT_SPECIFIED);
+      throw PlotException(windowTitle(), ERROR_INTERVAL_SIZE_NOT_SPECIFIED);
     }
     //    double vals[intervalSize];
     //Read in timevector
     auto timeVals = std::make_unique<double[]>(intervalSize);
-    readPLTDataset(mpTextStream, "time", intervalSize, timeVals.get());
+    readPLTDataset("time", intervalSize, timeVals.get());
     //Find indexes and alpha to interpolate data in particular time
     double alpha;
     int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
     if (it < 0) {
       mFile.close();
-      TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
+      TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
       if (mTimeOutOfBounds) {
         throw RecurringPlotException(timeOutOfBoundsException);
       }
@@ -1090,7 +1095,7 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
         mpPlot->addPlotCurve(pPlotCurve);
       }
       QList<double> arrLst;
-      readPLTArray(mpTextStream, currentVariable, alpha, intervalSize, it, arrLst);
+      readPLTArray(currentVariable, alpha, intervalSize, it, arrLst);
       for (int i = 0; i < arrLst.length(); i++)
       {
         pPlotCurve->addXAxisValue(i+1);
@@ -1109,19 +1114,19 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
     struct csv_data *csvReader;
     csvReader = read_csv(mFile.fileName().toStdString().c_str());
     if (csvReader == NULL)
-      throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+      throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
     //Read in timevector
     double *timeVals = read_csv_dataset(csvReader, "time");
     if (timeVals == NULL)
     {
       omc_free_csv_reader(csvReader);
-      throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+      throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
     }
     double alpha;
     int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
     if (it < 0) {
       omc_free_csv_reader(csvReader);
-      TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
+      TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
       if (mTimeOutOfBounds) {
         throw RecurringPlotException(timeOutOfBoundsException);
       }
@@ -1180,17 +1185,17 @@ void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
 
       //Read in mat file
       if(0 != (msg = omc_new_matlab4_reader(mFile.fileName().toStdString().c_str(), &reader)))
-        throw PlotException(msg);
+        throw PlotException(windowTitle(), msg);
       //calculate time
       double startTime = omc_matlab4_startTime(&reader);
       double stopTime =  omc_matlab4_stopTime(&reader);
       if (reader.nvar < 1) {
         omc_free_matlab4_reader(&reader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
-        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
+        TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), startTime, stopTime);
         if (mTimeOutOfBounds) {
           throw RecurringPlotException(timeOutOfBoundsException);
         }
@@ -1247,9 +1252,9 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
   int pair = 0;
   setTime(time);
   if (mVariablesList.isEmpty())
-    throw NoVariableException(ERROR_NO_VARIABLES_SPECIFIED);
+    throw NoVariableException(windowTitle(), ERROR_NO_VARIABLES_SPECIFIED);
   else if (mVariablesList.size()%2 != 0)
-    throw NoVariableException(ERROR_SPECIFY_VARIABLE_PAIRS);
+    throw NoVariableException(windowTitle(), ERROR_SPECIFY_VARIABLE_PAIRS);
 
   bool editCase = pPlotCurve ? true : false;
 
@@ -1274,7 +1279,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
     {
       /* open the file */
       if (!mFile.open(QIODevice::ReadOnly))
-        throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+        throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
       mpTextStream = new QTextStream(&mFile);
       // read the interval size from the file
       QString currentLine;
@@ -1290,17 +1295,17 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       }
       if (intervalSize == -1) {
         mFile.close();
-        throw PlotException(ERROR_INTERVAL_SIZE_NOT_SPECIFIED);
+        throw PlotException(windowTitle(), ERROR_INTERVAL_SIZE_NOT_SPECIFIED);
       }
       //Read in timevector
       auto timeVals = std::make_unique<double[]>(intervalSize);
-      readPLTDataset(mpTextStream, "time", intervalSize, timeVals.get());
+      readPLTDataset("time", intervalSize, timeVals.get());
       //Find indexes and alpha to interpolate data in particular time
       double alpha;
       int it = setupInterp(timeVals.get(), time, intervalSize, alpha);
       if (it < 0) {
         mFile.close();
-        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
+        TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), timeVals[0], timeVals[intervalSize - 1]);
         if (mTimeOutOfBounds) {
           throw RecurringPlotException(timeOutOfBoundsException);
         }
@@ -1319,12 +1324,12 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       }
       //Read the values
       QList<double> xValsLst;
-      readPLTArray(mpTextStream, xVariable, alpha, intervalSize, it, xValsLst);
+      readPLTArray(xVariable, alpha, intervalSize, it, xValsLst);
       QList<double> yValsLst;
-      readPLTArray(mpTextStream, yVariable, alpha, intervalSize, it, yValsLst);
+      readPLTArray(yVariable, alpha, intervalSize, it, yValsLst);
       if (xValsLst.length() != yValsLst.length()) {
         mFile.close();
-        throw PlotException(ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
+        throw PlotException(windowTitle(), ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
       }
       for (int i = 0; i < xValsLst.length(); i++){
         pPlotCurve->addXAxisValue(xValsLst[i]);
@@ -1342,19 +1347,19 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       struct csv_data *csvReader;
       csvReader = read_csv(mFile.fileName().toStdString().c_str());
       if (csvReader == NULL)
-        throw NoFileException(ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
+        throw NoFileException(windowTitle(), ERROR_FAILED_TO_OPEN_FILE, mFile.fileName());
       //Read in timevector
       double *timeVals = read_csv_dataset(csvReader, "time");
       if (timeVals == NULL)
       {
         omc_free_csv_reader(csvReader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
       }
       double alpha;
       int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
       if (it < 0) {
         omc_free_csv_reader(csvReader);
-        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
+        TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), timeVals[0], timeVals[csvReader->numsteps - 1]);
         if (mTimeOutOfBounds) {
           throw RecurringPlotException(timeOutOfBoundsException);
         }
@@ -1398,7 +1403,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
         else { //yVar
           if (pPlotCurve->getXAxisSize()!=res.count()) {
             omc_free_csv_reader(csvReader);
-            throw PlotException(ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
+            throw PlotException(windowTitle(), ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
           }
           for (int i = 0; i < res.count(); i++)
             pPlotCurve->addYAxisValue(res[i]);
@@ -1420,7 +1425,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
 
       //Read the .mat file
       if(0 != (msg = omc_new_matlab4_reader(mFile.fileName().toStdString().c_str(), &reader)))
-        throw PlotException(msg);
+        throw PlotException(windowTitle(), msg);
 
       if (!editCase) {
         QFileInfo fileInfo(mFile);
@@ -1432,11 +1437,11 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       double stopTime =  omc_matlab4_stopTime(&reader);
       if (reader.nvar < 1) {
         omc_free_matlab4_reader(&reader);
-        throw NoVariableException(ERROR_VARIABLE_DOES_NOT_EXIST, "time");
+        throw NoVariableException(windowTitle(), ERROR_VARIABLE_DOES_NOT_EXIST, "time");
       }
       if (time<startTime || stopTime<time) {
         omc_free_matlab4_reader(&reader);
-        TimeOutOfBoundsException timeOutOfBoundsException(QFileInfo(mFile), startTime, stopTime);
+        TimeOutOfBoundsException timeOutOfBoundsException(windowTitle(), QFileInfo(mFile), startTime, stopTime);
         if (mTimeOutOfBounds) {
           throw RecurringPlotException(timeOutOfBoundsException);
         }
@@ -1476,7 +1481,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
         else{
           if (pPlotCurve->getXAxisSize()!=vars.count()) {
             omc_free_matlab4_reader(&reader);
-            throw PlotException(ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
+            throw PlotException(windowTitle(), ERROR_ARRAYS_MUST_HAVE_SAME_LENGTH);
           }
           for (int i = 0; i < vars.count(); i++)
             pPlotCurve->addYAxisValue(res[i]);
@@ -1494,9 +1499,9 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
 QPair<QVector<double>*, QVector<double>*> PlotWindow::plotInteractive(PlotCurve *pPlotCurve)
 {
   if (mVariablesList.isEmpty() && isPlotInteractive()) {
-    throw NoVariableException(ERROR_NO_VARIABLES_SPECIFIED);
+    throw NoVariableException(windowTitle(), ERROR_NO_VARIABLES_SPECIFIED);
   } else if (mVariablesList.size() != 1) {
-    throw NoVariableException(ERROR_COULD_NOT_DETERMINE_VARIABLE_NAME);
+    throw NoVariableException(windowTitle(), ERROR_COULD_NOT_DETERMINE_VARIABLE_NAME);
   }
   QString variableName = mVariablesList.at(0);
   pPlotCurve = new PlotCurve(mInteractiveModelName, "", "time", getXUnit(), getXDisplayUnit(), variableName, getYUnit(), getYDisplayUnit(), mpPlot);
@@ -1781,7 +1786,7 @@ void PlotWindow::checkForErrors(QStringList variables, QStringList variablesPlot
   }
   if (!nonExistingVariables.isEmpty())
   {
-    throw NoVariableException(ERROR_VARIABLES_ARE_NOT_FOUND, nonExistingVariables.join(", "));
+    throw NoVariableException(windowTitle(), ERROR_VARIABLES_ARE_NOT_FOUND, nonExistingVariables.join(", "));
   }
 }
 
@@ -2055,33 +2060,33 @@ void PlotWindow::interactiveSimulationPaused()
   setInteractiveControls(true);
 }
 
-PlotException::PlotException(const QString &str)
-  : std::runtime_error(str.toStdString())
+PlotException::PlotException(const QString &windowTitle, const QString &str)
+  : std::runtime_error((windowTitle.isEmpty() ? QString() : QString("[%1] ").arg(windowTitle)).append(str).toStdString())
 {
 }
 
-InvalidInputException::InvalidInputException(const QString &argName)
-  : PlotException(QString("%1: %2").arg(QObject::tr("Invalid input")).arg(argName))
+InvalidInputException::InvalidInputException(const QString &windowTitle, const QString &argName)
+  : PlotException(windowTitle, QString("%1: %2").arg(QObject::tr("Invalid input")).arg(argName))
 {
 }
 
-NoFileException::NoFileException(const QString &error, const QString &fileName)
-  : PlotException(fileName.isEmpty() ? error : QString("%1: %2").arg(error).arg(fileName))
+NoFileException::NoFileException(const QString &windowTitle, const QString &error, const QString &fileName)
+  : PlotException(windowTitle, fileName.isEmpty() ? error : QString("%1: %2").arg(error).arg(fileName))
 {
 }
 
-NoVariableException::NoVariableException(const QString &error, const QString &varName)
-  : PlotException(varName.isEmpty() ? error : QString("%1: %2").arg(error).arg(varName))
+NoVariableException::NoVariableException(const QString &windowTitle, const QString &error, const QString &varName)
+  : PlotException(windowTitle, varName.isEmpty() ? error : QString("%1: %2").arg(error).arg(varName))
 {
 }
 
-NoVariableException::NoVariableException(const QString &error, uint32_t nbVars)
-  : PlotException(QString("%1: nvar = %2").arg(error).arg(nbVars))
+NoVariableException::NoVariableException(const QString &windowTitle, const QString &error, uint32_t nbVars)
+  : PlotException(windowTitle, QString("%1: nvar = %2").arg(error).arg(nbVars))
 {
 }
 
-TimeOutOfBoundsException::TimeOutOfBoundsException(const QFileInfo &fileInfo, double startTime, double stopTime)
-  : PlotException(QString("%1: %2. (StartTime = %3, StopTime = %4)")
+TimeOutOfBoundsException::TimeOutOfBoundsException(const QString &windowTitle, const QFileInfo &fileInfo, double startTime, double stopTime)
+  : PlotException(windowTitle, QString("%1: %2. (StartTime = %3, StopTime = %4)")
       .arg(fileInfo.fileName()).arg(QObject::tr("Time out of bounds")).arg(startTime).arg(stopTime))
 {
 }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -191,6 +191,7 @@ public:
   QString getYRightDisplayUnit() { return mYRightDisplayUnit; }
   void setTimeUnit(QString timeUnit) {mTimeUnit = timeUnit;}
   QString getTimeUnit() {return mTimeUnit;}
+  double getTimeUnitFactor();
   void setXRange(double min, double max);
   QString getXRangeMin();
   QString getXRangeMax();
@@ -224,6 +225,9 @@ public:
   void updatePlot();
   void emitPrefixUnitsChanged();
 private:
+  int setupInterp(double *vals, double val, int N, double &alpha);
+  int readPLTDataset(QString variable, int N, double *valsOut);
+  void readPLTArray(QString variable, double alpha, int intervalSize, int it, QList<double> &arrLstOut);
   void setInteractiveControls(bool enabled);
 signals:
   void closingDown();
@@ -254,32 +258,32 @@ public slots:
 class PlotException : public std::runtime_error
 {
 public:
-  PlotException(const QString &str);
+  PlotException(const QString &windowTitle, const QString &str);
 };
 
 class InvalidInputException : public PlotException
 {
 public:
-  InvalidInputException(const QString &argName);
+  InvalidInputException(const QString &windowTitle, const QString &argName);
 };
 
 class NoFileException : public PlotException
 {
 public:
-  NoFileException(const QString &error, const QString &fileName = QString());
+  NoFileException(const QString &windowTitle, const QString &error, const QString &fileName = QString());
 };
 
 class NoVariableException : public PlotException
 {
 public:
-  NoVariableException(const QString &error, const QString &varName = QString());
-  NoVariableException(const QString &error, uint32_t nbVars);
+  NoVariableException(const QString &windowTitle, const QString &error, const QString &varName = QString());
+  NoVariableException(const QString &windowTitle, const QString &error, uint32_t nbVars);
 };
 
 class TimeOutOfBoundsException : public PlotException
 {
 public:
-  TimeOutOfBoundsException(const QFileInfo &fileInfo, double startTime, double stopTime);
+  TimeOutOfBoundsException(const QString &windowTitle, const QFileInfo &fileInfo, double startTime, double stopTime);
 };
 
 class RecurringPlotException : public PlotException


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/pull/15137#issuecomment-4005838654

~~To be rebased on #15174.~~ [done]

### Purpose

With multiple plots open (and multiple simulation result files available), it was not always clear which plot an exception originated from. Generally it is the active window, however array (parametric) plots are updated even when they are not currently active (typically for side-by-side windows mode), thus the exception is not necessarily related to the active plot.

### Approach

Pass a reference to the current `PlotWindow`'s title to each plot exception. This allows the base class `PlotException` to write the title of the plot window at the beginning of the error message. Note that when running OMPlot directly the plot window has no title so in this case nothing is prepended to the message.

Also make error messages reusable by defining global constants.

To be reviewed commit by commit.
