### PR TITLE
Allow to re-simulate cancelled or failed simulation

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1799,6 +1799,11 @@ void VariablesWidget::findVariableAndUpdateValue(QDomDocument xmlDocument, QHash
   }
 }
 
+/*!
+ * \brief VariablesWidget::reSimulate
+ * Re-simulates the model with the given simulation options.
+ * \param showSetup
+ */
 void VariablesWidget::reSimulate(bool showSetup)
 {
   QModelIndexList indexes = mpVariablesTreeView->selectionModel()->selectedIndexes();
@@ -1813,17 +1818,32 @@ void VariablesWidget::reSimulate(bool showSetup)
   pVariablesTreeItem = pVariablesTreeItem->rootParent();
   SimulationOptions simulationOptions = pVariablesTreeItem->getSimulationOptions();
   if (simulationOptions.isValid()) {
-    MainWindow::instance()->getSimulationDialog()->removeInteractiveSimulation(simulationOptions.isInteractiveSimulation(), pVariablesTreeItem->getFileName(), false);
-    simulationOptions.setReSimulate(true);
-    updateInitXmlFile(pVariablesTreeItem, simulationOptions);
-    if (showSetup) {
-      MainWindow::instance()->getSimulationDialog()->show(0, true, simulationOptions);
-    } else {
-      MainWindow::instance()->getSimulationDialog()->reSimulate(simulationOptions);
-    }
+    reSimulate(simulationOptions, pVariablesTreeItem, showSetup);
   } else {
     QMessageBox::information(this, QString("%1 - %2").arg(Helper::applicationName, Helper::information),
                              tr("You cannot re-simulate this class.<br />This is just a result file loaded via menu <b>File->Open Result File(s)</b>."), QMessageBox::Ok);
+  }
+}
+
+/*!
+ * \brief VariablesWidget::reSimulate
+ * Re-simulates the model with the given simulation options and updates the model_init.xml file if needed.
+ * \param simulationOptions
+ * \param pVariablesTreeItem
+ * \param showSetup
+ */
+void VariablesWidget::reSimulate(SimulationOptions simulationOptions, VariablesTreeItem *pVariablesTreeItem, bool showSetup)
+{
+  simulationOptions.setReSimulate(true);
+  if (pVariablesTreeItem) {
+    MainWindow::instance()->getSimulationDialog()->removeInteractiveSimulation(simulationOptions.isInteractiveSimulation(), pVariablesTreeItem->getFileName(), false);
+    updateInitXmlFile(pVariablesTreeItem, simulationOptions);
+  }
+
+  if (showSetup) {
+    MainWindow::instance()->getSimulationDialog()->show(0, true, simulationOptions);
+  } else {
+    MainWindow::instance()->getSimulationDialog()->reSimulate(simulationOptions);
   }
 }
 

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -237,6 +237,7 @@ public:
                                  QHash<QString, QHash<QString, QString> > *variables);
   void findVariableAndUpdateValue(QDomDocument xmlDocument, QHash<QString, QHash<QString, QString> > variables);
   void reSimulate(bool showSetup);
+  void reSimulate(SimulationOptions simulationOptions, VariablesTreeItem *pVariablesTreeItem, bool showSetup);
   void updateInitXmlFile(VariablesTreeItem *pVariablesTreeItem, SimulationOptions simulationOptions);
   void initializeVisualization();
   void updateVisualization();

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -43,6 +43,7 @@
 #include "Editors/TextEditor.h"
 #include "SimulationDialog.h"
 #include "TransformationalDebugger/TransformationsWidget.h"
+#include "Plotting/VariablesWidget.h"
 
 #include <QApplication>
 #include <QObject>
@@ -240,6 +241,11 @@ SimulationOutputWidget::SimulationOutputWidget(SimulationOptions simulationOptio
   mpCancelButton = new QPushButton(tr("Cancel Compilation"));
   mpCancelButton->setEnabled(false);
   connect(mpCancelButton, SIGNAL(clicked()), SLOT(cancelCompilationOrSimulation()));
+  mpReSimulateSetuButton = new QToolButton;
+  mpReSimulateSetuButton->setIcon(QIcon(":/Resources/icons/re-simulation-center.svg"));
+  mpReSimulateSetuButton->setToolTip(Helper::reSimulateSetup);
+  mpReSimulateSetuButton->setEnabled(false);
+  connect(mpReSimulateSetuButton, SIGNAL(clicked()), SLOT(showReSimulateSetup()));
   mpOpenTransformationalDebuggerButton = new QToolButton;
   mpOpenTransformationalDebuggerButton->setIcon(QIcon(":/Resources/icons/equational-debugger.svg"));
   mpOpenTransformationalDebuggerButton->setToolTip(tr("Open Transformational Debugger"));
@@ -397,9 +403,10 @@ SimulationOutputWidget::SimulationOutputWidget(SimulationOptions simulationOptio
   pMainLayout->addWidget(mpProgressLabel, 0, 0);
   pMainLayout->addWidget(mpProgressBar, 0, 1);
   pMainLayout->addWidget(mpCancelButton, 0, 2);
-  pMainLayout->addWidget(mpOpenTransformationalDebuggerButton, 0, 3);
-  pMainLayout->addWidget(mpOpenOutputFileButton, 0, 4);
-  pMainLayout->addWidget(mpGeneratedFilesTabWidget, 1, 0, 1, 5);
+  pMainLayout->addWidget(mpReSimulateSetuButton, 0, 3);
+  pMainLayout->addWidget(mpOpenTransformationalDebuggerButton, 0, 4);
+  pMainLayout->addWidget(mpOpenOutputFileButton, 0, 5);
+  pMainLayout->addWidget(mpGeneratedFilesTabWidget, 1, 0, 1, 6);
   setLayout(pMainLayout);
   // create the ArchivedSimulationItem
   mpArchivedSimulationItem = new ArchivedSimulationItem(mSimulationOptions.getOutputFileName(), mSimulationOptions.getStartTime().toDouble(), mSimulationOptions.getStopTime().toDouble(), this);
@@ -921,6 +928,7 @@ void SimulationOutputWidget::simulationProcessFinishedHelper()
   mpProgressLabel->setText(progressStr);
   updateMessageTab(progressStr);
   mpCancelButton->setEnabled(false);
+  mpReSimulateSetuButton->setEnabled(true);
   MainWindow::instance()->getSimulationDialog()->simulationProcessFinished(mSimulationOptions, mResultFileLastModifiedDateTime);
   mpArchivedSimulationItem->setStatus(Helper::finished);
   if (mpSimulationOutputHandler) {
@@ -949,8 +957,6 @@ void SimulationOutputWidget::cancelCompilationOrSimulation()
     progressStr = tr("Compilation of %1 is cancelled.").arg(mSimulationOptions.getClassName());
     mpProgressBar->setRange(0, 1);
     mpProgressBar->setValue(0);
-    mpCancelButton->setEnabled(false);
-    mpArchivedSimulationItem->setStatus(Helper::finished);
   } else if (isPostCompilationProcessRunning()) {
     setPostCompilationProcessKilled(true);
     mpPostCompilationProcess->kill();
@@ -958,16 +964,15 @@ void SimulationOutputWidget::cancelCompilationOrSimulation()
     progressStr = tr("Post compilation of %1 is cancelled.").arg(mSimulationOptions.getClassName());
     mpProgressBar->setRange(0, 1);
     mpProgressBar->setValue(0);
-    mpCancelButton->setEnabled(false);
-    mpArchivedSimulationItem->setStatus(Helper::finished);
   } else if (isSimulationProcessRunning()) {
     setSimulationProcessKilled(true);
     mpSimulationProcess->kill();
     mIsSimulationProcessRunning = false;
     progressStr = tr("Simulation of %1 is cancelled.").arg(mSimulationOptions.getClassName());
-    mpCancelButton->setEnabled(false);
-    mpArchivedSimulationItem->setStatus(Helper::finished);
   }
+  mpCancelButton->setEnabled(false);
+  mpReSimulateSetuButton->setEnabled(true);
+  mpArchivedSimulationItem->setStatus(Helper::finished);
   mpProgressLabel->setText(progressStr);
   updateMessageTab(progressStr);
 }
@@ -986,6 +991,17 @@ void SimulationOutputWidget::openTransformationalDebugger()
   } else {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::FILE_NOT_FOUND).arg(fileName), QMessageBox::Ok);
   }
+}
+
+/*!
+ * \brief SimulationOutputWidget::showReSimulateSetup
+ * Slot activated when mpReSimulateSetuButton clicked SIGNAL is raised.\n
+ * Calls VariablesWidget::reSimulate which shows the re-simulation setup dialog.
+ */
+void SimulationOutputWidget::showReSimulateSetup()
+{
+  VariablesTreeItem *pVariablesTreeItem = MainWindow::instance()->getVariablesWidget()->getVariablesTreeModel()->findVariablesTreeItemOneLevel(mSimulationOptions.getFullResultFileName());
+  MainWindow::instance()->getVariablesWidget()->reSimulate(mSimulationOptions, pVariablesTreeItem, true);
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -116,6 +116,7 @@ private:
   QProgressBar *mpProgressBar;
   QPushButton *mpCancelButton;
   QToolButton *mpOpenTransformationalDebuggerButton;
+  QToolButton *mpReSimulateSetuButton;
   QPushButton *mpOpenOutputFileButton;
   QTabWidget *mpGeneratedFilesTabWidget;
   QList<QString> mGeneratedFilesList;
@@ -153,6 +154,7 @@ private:
   void simulationProcessFinishedHelper();
 private slots:
   void openTransformationalDebugger();
+  void showReSimulateSetup();
   void openSimulationLogFile();
   void createSimulationProgressSocket();
   void readSimulationProgress();


### PR DESCRIPTION
### Related Issues

#5472

### Purpose

Let the user re-simulate the cancelled or failed simulation.

### Approach

Added a re-simulate setup button next to cancel compilation/simulation. The user can launch the re-simulation setup and change the simulation settings.
