### PR TITLE
Use first cref for array start position

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5452,13 +5452,18 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
     let arrayType = type + "_array"
     let wrapperArray = tempDecl(arrayType, &varDecls)
     if crefSubIsScalar(cr) then
-      let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
       let dimsLenStr = listLength(dims)
       let dimsValuesStr = (dims |> dim => '(_index_t)<%dimension(dim, context, &preExp, &varDecls, &auxFunction)%>' ;separator=", ")
+      // Workaround for https://github.com/OpenModelica/OpenModelica/issues/14470
       let arrayData = if hasZeroDimension(dims) then
         'NULL'
-      else
+      else if Flags.getConfigBool(Flags.NEW_BACKEND) then
+        let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
         let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
+        '((modelica_<%type%>*)&(<%nosubname%>))'
+      else
+        let &sub = buffer ""
+        let nosubname = contextCref(crefArrayGetFirstCref(cr), context, &preExp, &varDecls, &auxFunction, &sub)
         '((modelica_<%type%>*)&(<%nosubname%>))'
       let t = '<%type%>_array_create(&<%wrapperArray%>, <%arrayData%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let &preExp += t

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4132,6 +4132,7 @@ package Flags
   constant ConfigFlag EXPORT_CLOCKS_IN_MODELDESCRIPTION;
   constant ConfigFlag OBFUSCATE;
   constant ConfigFlag MAX_SIZE_LINEARIZATION;
+  constant ConfigFlag NEW_BACKEND;
 
   function isSet
     input DebugFlag inFlag;

--- a/testsuite/simulation/modelica/arrays/Issue14470.mos
+++ b/testsuite/simulation/modelica/arrays/Issue14470.mos
@@ -1,0 +1,62 @@
+// name: Issue14470
+// keywords: array sub index
+// status: correct
+// teardown_command: rm -rf RecordTest.LabelArray*
+//
+// Test for https://github.com/OpenModelica/OpenModelica/issues/14470
+// Sub index of positionArray needs to be correct so that label[3].position
+// points to the correct memory.
+
+loadString("
+package RecordTest
+  model LabelArray
+    Real pos[2] = {time, time};
+    Label label[3](position = positionArray);
+  protected
+    Real positionArray[3, 2] = {
+      pos + {0, 11}, // 0 Can't be changed to non-zero or bug vanishes
+      pos + {0, 21}, // 0 Can't be changed to non-zero or bug vanishes
+      pos + {30, 31}
+    }; // positionArray can't be moved out of protected or bug vanishes
+  end LabelArray;
+
+  model Label
+    Real position[2] = {0, 0};
+  algorithm
+    when time > 0.5 then
+      printFunc(position);
+    end when;
+  end Label;
+
+  impure function printFunc
+    input Real position[2];
+  algorithm
+    Modelica.Utilities.Streams.print(\"Position: \" + String(position[1]) + \", \" + String(position[2]));
+  end printFunc;
+end RecordTest;
+"); getErrorString();
+
+// The order of the prints isn't deterministic.
+buildModel(RecordTest.LabelArray); getErrorString();
+system("./RecordTest.LabelArray", "RecordTest.LabelArray_systemCall.log"); getErrorString();
+system("grep 'Position:' RecordTest.LabelArray_systemCall.log | sort > RecordTest.LabelArray_systemCall.log.tmp && mv RecordTest.LabelArray_systemCall.log.tmp RecordTest.LabelArray_systemCall.log"); getErrorString();
+
+readFile("RecordTest.LabelArray_systemCall.log");
+
+// Result:
+// true
+// ""
+// {"RecordTest.LabelArray", "RecordTest.LabelArray_init.xml"}
+// "Notification: Automatically loaded package Complex 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.1.0 due to usage.
+// "
+// 0
+// ""
+// 0
+// ""
+// "LOG_STDOUT        | info    | Position: 0.5, 11.5
+// LOG_STDOUT        | info    | Position: 0.5, 21.5
+// LOG_STDOUT        | info    | Position: 30.5, 31.5
+// "
+// endResult

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -1,21 +1,21 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
-ABCDsystem.plt.mos \
 ABCDsystem.csv.mos \
 ABCDsystem.empty.mos \
+ABCDsystem.plt.mos \
 AlgorithmArrayEqn.mos \
 AppendElement.mos \
 ArrayAddSub1.mos \
 ArrayDivError.mos \
-ArrayExponentiation.mos \
 ArrayEquation.mos \
-ArrayMult.mos \
+ArrayExponentiation.mos \
 ArrayFromRange.mos \
+ArrayModel.mos \
+ArrayMult.mos \
+ArrayParameterSize.mos \
 ArrayReduce.mos \
 ArrayReturn.mos \
-ArrayParameterSize.mos \
-ArrayModel.mos \
 ArraySlice.mos \
 ArraySlice2.mos \
 ArraySliceAssigmentFunction.mos \
@@ -27,30 +27,31 @@ bug_2217.mos \
 bug_2911.mos \
 bug_3184.mos \
 Bug3187.mos \
+Bug3916.mos
 ConstructFunc.mos \
 crefIndex.mos \
+DimConvert.mos \
 gc.mos \
 gc2980.mos \
-DimConvert.mos \
+Issue14470.mos \
 NPendulum.mos \
-PolynomialEvaluatorA.mos \
-PolynomialEvaluatorB.mos \
 PolynomialEvaluator1.mos \
 PolynomialEvaluator2.mos \
 PolynomialEvaluator3.mos \
-ticket2336.mos \
-ticket5114.mos \
+PolynomialEvaluatorA.mos \
+PolynomialEvaluatorB.mos \
 ticket_5994.mos \
 ticket_6099.mos \
+ticket2336.mos \
+ticket5114.mos \
 VariableRangeSubscript.mos \
 VectorizeOneReturnValue.mos \
 Xpowers1.mos \
 Xpowers2.mos \
 Xpowers3.mos \
 ZeroSizeLoop.mos \
-Bug3916.mos
 
-# test that currently fail. Move up when fixed. 
+# test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES= \
 ArrayFieldSlice.mos \
@@ -79,8 +80,8 @@ test:
 	@echo
 	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
 	@$(TEST) $(TESTFILES)
-	
-# Cleans all files that are not listed as dependencies 
+
+# Cleans all files that are not listed as dependencies
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -f $(CLEAN)
@@ -89,11 +90,11 @@ clean :
 # do it after cleaning and updating the folder
 # then you can get a list of file names (which must be dependencies
 # since you got them from repository + your own new files)
-# then add them to the DEPENDENCIES. You can find the 
-# list in deps.txt 
-getdeps: 
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
-	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt	
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
 	@echo Dependency list saved in deps.txt.
 	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
 


### PR DESCRIPTION
### Related Issues

Different way than #15163 to fix #14470.

### Purpose

* Change CodeGeneration to not calculate start of array by using sub-scripts.
* Directly use position of cref as start.

### Approach

* Use first CREF to get memory location of array for `real_array_create`.
* Adding special case for New Backend. The NB has generic function evaluations with optional `$i0` arguments that need to start at the beginning of the array.
