### PR TITLE
Fix collection of functions when inlining Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -36,6 +36,7 @@ encapsulated uniontype NFFlatModel
 
 protected
   import Binding = NFBinding;
+  import Call = NFCall;
   import Class = NFClass;
   import ComplexType = NFComplexType;
   import Component = NFComponent;
@@ -250,10 +251,7 @@ public
     end if;
 
     if BaseModelica.inlineFunctions() then
-      // Try to inline all functions regardless of what Inline annotation they have.
-      flat_model := mapExp(flat_model, function Expression.map(func = function Inline.inlineCallExp(forceInline = true)));
-      // Re-collect the functions to avoid dumping functions that are no longer used.
-      funcs := FunctionTree.listValues(Flatten.collectFunctions(flat_model));
+      (flat_model, funcs) := inlineFunctions(flat_model);
     end if;
 
     if scalarize then
@@ -328,6 +326,48 @@ public
     s := IOStream.append(s, "  end " + name + ";\n");
     s := IOStream.append(s, "end " + name + ";\n");
   end appendFlatStream;
+
+  function inlineFunctions
+    "Tries to inline all function calls in the flat model, and returns the new
+     flat model and a list of functions that couldn't be inlined."
+    input output FlatModel flatModel;
+          output list<Function> remainingFuncs;
+  protected
+    UnorderedSet<Function> funcs;
+  algorithm
+    funcs := UnorderedSet.new(Function.nameHash, Function.nameEqual);
+    flatModel := mapExp(flatModel, function Expression.map(func = function inlineFunctions_traverser(funcs = funcs)));
+    remainingFuncs := UnorderedSet.toList(funcs);
+  end inlineFunctions;
+
+  function inlineFunctions_traverser
+    input Expression exp;
+    input UnorderedSet<Function> funcs;
+    output Expression outExp;
+  protected
+    Function fn;
+  algorithm
+    outExp := match exp
+      case Expression.CALL()
+        algorithm
+          fn := Call.typedFunction(exp.call);
+
+          if Function.hasBuiltinStatus(fn) then
+            outExp := exp;
+          else
+            outExp := Inline.inlineCallExp(exp, forceInline = true);
+
+            if referenceEq(exp, outExp) then
+              // If the call wasn't inlined, add it to the set of remaining functions.
+              UnorderedSet.add(fn, funcs);
+            end if;
+          end if;
+        then
+          outExp;
+
+      else exp;
+    end match;
+  end inlineFunctions_traverser;
 
   function collectFlatTypes
     input FlatModel flatModel;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -686,6 +686,11 @@ uniontype Function
     InstNode.setFuncCache(cls_node, cache);
   end mapCachedFuncs;
 
+  function hasBuiltinStatus
+    input Function fn;
+    output Boolean isBuiltin = Pointer.access(fn.status) == FunctionStatus.BUILTIN;
+  end hasBuiltinStatus;
+
   function isEvaluated
     input Function fn;
     output Boolean evaluated;
@@ -772,6 +777,17 @@ uniontype Function
       else fn.path;
     end match;
   end nameConsiderBuiltin;
+
+  function nameEqual
+    input Function fn1;
+    input Function fn2;
+    output Boolean equal = AbsynUtil.pathEqual(name(fn1), name(fn2));
+  end nameEqual;
+
+  function nameHash
+    input Function fn;
+    output Integer hash = AbsynUtil.pathHash(name(fn));
+  end nameHash;
 
   function signatureString
     "Constructs a signature string for a function, e.g. Real func(Real x, Real y)"

--- a/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
@@ -71,27 +71,29 @@ algorithm
           else forceInline;
         end match;
       then
-        if shouldInline then inlineCall(call, forceInline) else callExp;
+        if shouldInline then inlineCall(callExp, forceInline) else callExp;
 
     else callExp;
   end match;
 end inlineCallExp;
 
 function inlineCall
-  input Call call;
+  input Expression callExp;
   input Boolean forceInline = false;
   output Expression exp;
+protected
+  Call call;
+  Function fn;
+  Expression arg;
+  list<Expression> args;
+  list<InstNode> inputs, outputs, locals;
+  list<Statement> body;
+  Statement stmt;
+  Binding binding;
 algorithm
-  exp := match call
-    local
-      Function fn;
-      Expression arg;
-      list<Expression> args;
-      list<InstNode> inputs, outputs, locals;
-      list<Statement> body;
-      Statement stmt;
-      Binding binding;
+  Expression.CALL(call = call) := callExp;
 
+  exp := match call
     // Record constructor
     case Call.TYPED_CALL(fn = fn, arguments = args)
         guard InstNode.name(InstNode.parentScope(fn.node)) == "'constructor'"
@@ -127,7 +129,7 @@ algorithm
         // This function can so far only handle functions with at most one
         // statement and output and no local variables.
         if listLength(body) > 1 or listLength(outputs) <> 1 or not listEmpty(locals) then
-          exp := Expression.CALL(call);
+          exp := callExp;
           return;
         end if;
 
@@ -138,7 +140,7 @@ algorithm
         end if;
 
         if not Statement.isAssignment(stmt) then
-          exp := Expression.CALL(call);
+          exp := callExp;
           return;
         end if;
 
@@ -160,12 +162,12 @@ algorithm
           exp := getOutputExp(stmt, listHead(outputs), call);
           exp := inlineCallExp(exp, forceInline);
         else
-          exp := Expression.CALL(call);
+          exp := callExp;
         end try;
       then
         exp;
 
-    else Expression.CALL(call);
+    else callExp;
   end match;
 end inlineCall;
 

--- a/testsuite/openmodelica/basemodelica/Inline2.mo
+++ b/testsuite/openmodelica/basemodelica/Inline2.mo
@@ -1,0 +1,30 @@
+// name: Inline2
+// status: correct
+
+model Inline2
+  function f
+    input Real x;
+    output Real y;
+    external "C";
+  end f;
+
+  Real x = 1;
+  Real y = f(x);
+  annotation(__OpenModelica_commandLineOptions="-f --baseModelicaOptions=inlineFunctions");
+end Inline2;
+
+// Result:
+// //! base 0.1.0
+// package 'Inline2'
+//   function 'Inline2.f'
+//     input Real 'x';
+//     output Real 'y';
+//   external "C";
+//   end 'Inline2.f';
+//
+//   model 'Inline2'
+//     Real 'x' = 1.0;
+//     Real 'y' = 'Inline2.f'('x');
+//   end 'Inline2';
+// end 'Inline2';
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -16,6 +16,7 @@ TESTFILES = \
 	Expression1.mo \
 	Functional1.mo \
 	Inline1.mo \
+	Inline2.mo \
 	InStreamNominalThreshold.mo \
 	MoveBindings1.mo \
 	NonScalarizedWithRecords1.mo \


### PR DESCRIPTION
- Collect non-inlined functions while inlining functions for Base Modelica, instead of using `Flatten.collectFunctions` which doesn't collect functions already marked as collected.