### PR TITLE
Fix inlining for Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -48,6 +48,7 @@ protected
   import FlatModelicaUtil = NFFlatModelicaUtil;
   import Flatten = NFFlatten;
   import NFFlatten.FunctionTree;
+  import FunctionInverse = NFFunctionInverse;
   import Inline = NFInline;
   import InstContext = NFInstContext;
   import IOStream;
@@ -352,14 +353,17 @@ public
         algorithm
           fn := Call.typedFunction(exp.call);
 
-          if Function.hasBuiltinStatus(fn) then
+          if Function.isBuiltin(fn) then
             outExp := exp;
           else
             outExp := Inline.inlineCallExp(exp, forceInline = true);
 
             if referenceEq(exp, outExp) then
               // If the call wasn't inlined, add it to the set of remaining functions.
-              UnorderedSet.add(fn, funcs);
+              collectFunction(fn, funcs);
+            else
+              // Otherwise, collect any calls in the new expression that couldn't be inlined.
+              Expression.apply(outExp, function collectFunctions(funcs = funcs));
             end if;
           end if;
         then
@@ -368,6 +372,40 @@ public
       else exp;
     end match;
   end inlineFunctions_traverser;
+
+  function collectFunctions
+    input Expression exp;
+    input UnorderedSet<Function> funcs;
+  algorithm
+    () := match exp
+      case Expression.CALL()
+        algorithm
+          collectFunction(Call.typedFunction(exp.call), funcs);
+        then
+          ();
+
+      else ();
+    end match;
+  end collectFunctions;
+
+  function collectFunction
+    input Function fn;
+    input UnorderedSet<Function> funcs;
+  algorithm
+    if not Function.isBuiltin(fn) then
+      UnorderedSet.add(fn, funcs);
+
+      for fn_der in fn.derivatives loop
+        for der_fn in Function.getCachedFuncs(fn_der.derivativeFn) loop
+          UnorderedSet.add(der_fn, funcs);
+        end for;
+      end for;
+
+      for fn_inv in fn.inverses loop
+        UnorderedSet.add(FunctionInverse.getFunction(fn_inv), funcs);
+      end for;
+    end if;
+  end collectFunction;
 
   function collectFlatTypes
     input FlatModel flatModel;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -686,11 +686,6 @@ uniontype Function
     InstNode.setFuncCache(cls_node, cache);
   end mapCachedFuncs;
 
-  function hasBuiltinStatus
-    input Function fn;
-    output Boolean isBuiltin = Pointer.access(fn.status) == FunctionStatus.BUILTIN;
-  end hasBuiltinStatus;
-
   function isEvaluated
     input Function fn;
     output Boolean evaluated;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
@@ -38,6 +38,7 @@ encapsulated uniontype NFFunctionInverse
   import Type = NFType;
 
 protected
+  import Call = NFCall;
   import Inst = NFInst;
   import Lookup = NFLookup;
   import SCodeUtil;
@@ -104,6 +105,16 @@ public
     subMod := SCode.SubMod.NAMEMOD("inverse",
       SCode.Mod.MOD(SCode.Final.NOT_FINAL(), SCode.Each.NOT_EACH(), {inv_mod}, NONE(), NONE(), fnInv.info));
   end toSubMod;
+
+  function getFunction
+    input FunctionInverse fnInv;
+    output Function fn;
+  protected
+    Call call;
+  algorithm
+    Expression.CALL(call = call) := fnInv.inverseCall;
+    fn := Call.typedFunction(call);
+  end getFunction;
 
 protected
   function getInverseAnnotations

--- a/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
@@ -160,7 +160,7 @@ algorithm
           end for;
 
           exp := getOutputExp(stmt, listHead(outputs), call);
-          exp := inlineCallExp(exp, forceInline);
+          exp := Expression.map(exp, function inlineCallExp(forceInline = forceInline));
         else
           exp := callExp;
         end try;

--- a/testsuite/openmodelica/basemodelica/Inline3.mo
+++ b/testsuite/openmodelica/basemodelica/Inline3.mo
@@ -1,0 +1,32 @@
+// name: Inline3
+// status: correct
+
+model Inline3
+  function f
+    input Real x;
+    output Real y;
+  algorithm
+    y := 2 + x;
+  end f;
+
+  function f2
+    input Real x;
+    output Real y;
+  algorithm
+    y := x + 1;
+  end f2;
+
+  Real x = 1;
+  Real y = f2(f(x));
+  annotation(__OpenModelica_commandLineOptions="-f --baseModelicaOptions=inlineFunctions");
+end Inline3;
+
+// Result:
+// //! base 0.1.0
+// package 'Inline3'
+//   model 'Inline3'
+//     Real 'x' = 1.0;
+//     Real 'y' = 2.0 + 'x' + 1.0;
+//   end 'Inline3';
+// end 'Inline3';
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -17,6 +17,7 @@ TESTFILES = \
 	Functional1.mo \
 	Inline1.mo \
 	Inline2.mo \
+	Inline3.mo \
 	InStreamNominalThreshold.mo \
 	MoveBindings1.mo \
 	NonScalarizedWithRecords1.mo \


### PR DESCRIPTION
- Use `Expression.map` for recursion in `Inline.inlineCall` instead of just calling the function again on the inlined expression, since the inlined expression might contain subexpressions that should be inlined.
- Fix check for builtin functions in `FlatModel.inlineFunctions`.
- Collect functions also in the inlined expression, as well as derivative and inverse functions, in `FlatModel.inlineFunctions`.