### PR TITLE
Error on FMU export when --daeMode is active (#15226)

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4235,6 +4235,12 @@ algorithm
     Error.addMessage(Error.FMU_EXPORT_NOT_SUPPORTED_CPP, {FMUType});
     FMUType := "me";
   end if;
+  if Flags.getConfigBool(Flags.DAE_MODE) then
+    success := false;
+    outValue := Values.STRING("");
+    Error.addMessage(Error.FMU_EXPORT_DAE_MODE_NOT_SUPPORTED, {});
+    return;
+  end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename
   //       The scripting environment from a user's perspective is like that. fmuTargetName is the name of the .fmu in the templates, etc.
@@ -4342,6 +4348,11 @@ algorithm
   if Config.simCodeTarget() == "Cpp" and FMI.isFMICSType(FMUType) then
     Error.addMessage(Error.FMU_EXPORT_NOT_SUPPORTED_CPP, {FMUType});
     FMUType := "me";
+  end if;
+  if Flags.getConfigBool(Flags.DAE_MODE) then
+    outValue := Values.STRING("");
+    Error.addMessage(Error.FMU_EXPORT_DAE_MODE_NOT_SUPPORTED, {});
+    return;
   end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1310,6 +1310,8 @@ public constant ErrorTypes.Message DUPLICATE_VARIABLE_ERROR = ErrorTypes.MESSAGE
   Gettext.gettext("Duplicate elements:\n %s."));
 public constant ErrorTypes.Message ENCRYPTION_NOT_SUPPORTED = ErrorTypes.MESSAGE(7026, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("File not Found: %s. Compile OpenModelica with Encryption support."));
+public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_NOT_SUPPORTED = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("DAE mode (--daeMode) is not supported for FMU export. Please remove the --daeMode flag."));
 
 constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
+dae_fmu_export_error.mos \
 fmi_attributes_01.mos \
 fmi_attributes_02.mos \
 fmi_attributes_03.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/dae_fmu_export_error.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/dae_fmu_export_error.mos
@@ -1,0 +1,24 @@
+// name:     dae_fmu_export_error
+// keywords: FMU-Export, DAE-FMU, error
+// status:   correct
+// teardown_command: rm -rf DaeModeModel*
+
+loadString("
+model DaeModeModel
+  Real x, y;
+equation
+  der(x) = y;
+  y + x = 2;
+annotation(__OpenModelica_commandLineOptions = \"--daeMode\");
+end DaeModeModel;
+"); getErrorString();
+
+buildModelFMU(DaeModeModel, version = "2.0", fmuType = "me"); getErrorString();
+
+// Result:
+// true
+// ""
+// ""
+// "Error: DAE mode (--daeMode) is not supported for FMU export. Please remove the --daeMode flag.
+// "
+// endResult


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/15226.

### Purpose

Throw an error if FMU export is combined with DAE-mode.

### Approach

* Add a backend check that rejects FMU export when the `--daeMode` flag is set, since FMI is based on an ODE formulation and DAE mode is not supported.
* A new error message is emitted before code generation so the user gets a clear diagnostic instead of a C compilation failure.
