### PR TITLE
Dump functions when using --dumpFlatModel without -f

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -706,7 +706,7 @@ algorithm
   end match;
 end dumpVarParallelismStr;
 
-protected function dumpCommentStr
+public function dumpCommentStr
   "Dumps a comment to a string."
   input Option<SCode.Comment> inComment;
   output String outString;
@@ -725,14 +725,14 @@ algorithm
   end match;
 end dumpCommentStr;
 
-protected function dumpClassAnnotationStr
+public function dumpClassAnnotationStr
   input Option<SCode.Comment> inComment;
   output String outString;
 algorithm
   outString := dumpAnnotationStr(inComment, "  ", ";\n");
 end dumpClassAnnotationStr;
 
-protected function dumpCompAnnotationStr
+public function dumpCompAnnotationStr
   input Option<SCode.Comment> inComment;
   output String outString;
 algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -135,36 +135,45 @@ public
 
   function toString
     input FlatModel flatModel;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
-    output String str = IOStream.string(toStream(flatModel, printBindingTypes));
+    output String str = IOStream.string(toStream(flatModel, functions, printBindingTypes));
   end toString;
 
   function printString
     input FlatModel flatModel;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
   protected
     IOStream.IOStream s;
   algorithm
-    s := toStream(flatModel, printBindingTypes);
+    s := toStream(flatModel, functions, printBindingTypes);
     IOStream.print(s, IOStream.stdOutput);
   end printString;
 
   function toStream
     input FlatModel flatModel;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
     output IOStream.IOStream s;
   algorithm
     s := IOStream.create(getInstanceName(), IOStream.IOStreamType.LIST());
-    s := appendStream(flatModel, printBindingTypes, s);
+    s := appendStream(flatModel, functions, printBindingTypes, s);
   end toStream;
 
   function appendStream
     input FlatModel flatModel;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
     input output IOStream.IOStream s;
   protected
     String name = className(flatModel);
   algorithm
+    for fn in FunctionTree.listValues(functions) loop
+      s := Function.toStream(fn, "", s);
+      s := IOStream.append(s, ";\n\n");
+    end for;
+
     s := IOStream.append(s, "class " + name + "\n");
 
     for v in flatModel.variables loop
@@ -202,7 +211,7 @@ public
   function toFlatString
     "Returns a string containing the flat Modelica representation of the given model."
     input FlatModel flatModel;
-    input list<Function> functions;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
     output String str = IOStream.string(toFlatStream(flatModel, functions, printBindingTypes));
   end toFlatString;
@@ -210,7 +219,7 @@ public
   function printFlatString
     "Prints a flat Modelica representation of the given model to standard output."
     input FlatModel flatModel;
-    input list<Function> functions;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
   protected
     IOStream.IOStream s;
@@ -222,7 +231,7 @@ public
   function toFlatStream
     "Returns a new IOStream containing the flat Modelica representation of the given model."
     input FlatModel flatModel;
-    input list<Function> functions;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
     output IOStream.IOStream s;
   algorithm
@@ -233,7 +242,7 @@ public
   function appendFlatStream
     "Appends the flat Modelica representation of the given model to an existing IOStream."
     input FlatModel flatModel;
-    input list<Function> functions;
+    input FunctionTree functions;
     input Boolean printBindingTypes = false;
     input output IOStream.IOStream s;
   protected
@@ -241,7 +250,7 @@ public
     String name = Util.makeQuotedIdentifier(className(flatModel));
     BaseModelica.OutputFormat format;
     Boolean scalarize;
-    list<Function> funcs = functions;
+    list<Function> funcs = FunctionTree.listValues(functions);
   algorithm
     format := BaseModelica.formatFromFlags();
     scalarize := Flags.isConfigFlagSet(Flags.BASE_MODELICA_OPTIONS, "scalarize");

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -883,6 +883,74 @@ uniontype Function
     str := AbsynUtil.pathString(name(fn)) + "<function>(" + inputs + ") => " + outputs;
   end typeString;
 
+  function toStream
+    input Function fn;
+    input String indent;
+    input output IOStream.IOStream s;
+  protected
+    String fn_name;
+    Option<SCode.Comment> cmt;
+  algorithm
+    if isDefaultRecordConstructor(fn) then
+      s := Record.toDeclarationStream(fn.node, indent, s);
+    elseif isPartialDerivative(fn) then
+      fn_name := AbsynUtil.pathString(fn.path);
+      cmt := SCodeUtil.getElementComment(InstNode.definition(fn.node));
+
+      s := IOStream.append(s, indent);
+      s := IOStream.append(s, "function ");
+      s := IOStream.append(s, fn_name);
+      s := IOStream.append(s, " = der(");
+      s := IOStream.append(s, AbsynUtil.pathString(getDerivedFunctionName(fn)));
+      s := IOStream.append(s, ", ");
+      s := IOStream.append(s, stringDelimitList(getDerivedInputNames(fn), ", "));
+      s := IOStream.append(s, DAEDump.dumpCommentAnnotationStr(cmt));
+      s := IOStream.append(s, ")");
+    else
+      fn_name := AbsynUtil.pathString(fn.path);
+      cmt := SCodeUtil.getElementComment(InstNode.definition(fn.node));
+      s := IOStream.append(s, indent);
+
+      if InstNode.isPartial(fn.node) then
+        s := IOStream.append(s, "partial ");
+      end if;
+
+      s := IOStream.append(s, "function ");
+      s := IOStream.append(s, fn_name);
+      s := IOStream.append(s, DAEDump.dumpCommentStr(cmt));
+      s := IOStream.append(s, "\n");
+
+      for i in fn.inputs loop
+        s := IOStream.append(s, indent + "  ");
+        s := IOStream.append(s, InstNode.toString(i));
+        s := IOStream.append(s, ";\n");
+      end for;
+
+      for o in fn.outputs loop
+        s := IOStream.append(s, indent + "  ");
+        s := IOStream.append(s, InstNode.toString(o));
+        s := IOStream.append(s, ";\n");
+      end for;
+
+      if not listEmpty(fn.locals) then
+        s := IOStream.append(s, indent);
+        s := IOStream.append(s, "protected\n");
+
+        for l in fn.locals loop
+          s := IOStream.append(s, indent + "  ");
+          s := IOStream.append(s, InstNode.toString(l));
+          s := IOStream.append(s, ";\n");
+        end for;
+      end if;
+
+      s := Sections.toStream(InstNode.getSections(fn.node), indent, s);
+      s := IOStream.append(s, DAEDump.dumpClassAnnotationStr(cmt));
+      s := IOStream.append(s, indent);
+      s := IOStream.append(s, "end ");
+      s := IOStream.append(s, fn_name);
+    end if;
+  end toStream;
+
   function toFlatStream
     input Function fn;
     input BaseModelica.OutputFormat format;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -83,9 +83,9 @@ public
       print("\n########################################\n\n");
 
       if Flags.getConfigBool(Flags.BASE_MODELICA) then
-        FlatModel.printFlatString(flat_model, FunctionTree.listValues(functions));
+        FlatModel.printFlatString(flat_model, functions);
       else
-        FlatModel.printString(flat_model);
+        FlatModel.printString(flat_model, functions);
       end if;
 
       print("\n");
@@ -145,7 +145,7 @@ public
     FlatModel flat_model;
   algorithm
     flat_model := combineSubscripts(flatModel);
-    str := FlatModel.toFlatString(flat_model, FunctionTree.listValues(functions));
+    str := FlatModel.toFlatString(flat_model, functions);
   end dumpFlatModel;
 
   function replaceEmptyArrays

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -361,6 +361,18 @@ algorithm
   end for;
 end foldInputFields;
 
+function toDeclarationStream
+  input InstNode recordNode;
+  input String indent;
+  input output IOStream.IOStream s;
+protected
+  InstNode node;
+algorithm
+  node := getDeclarationNode(recordNode, evaluate = false);
+  s := IOStream.append(s, indent);
+  s := IOStream.append(s, InstNode.toString(node));
+end toDeclarationStream;
+
 function toFlatDeclarationStream
   input InstNode recordNode;
   input BaseModelica.OutputFormat format;
@@ -368,16 +380,28 @@ function toFlatDeclarationStream
   input output IOStream.IOStream s;
 protected
   InstNode node;
+algorithm
+  node := getDeclarationNode(recordNode, evaluate = true);
+  s := IOStream.append(s, InstNode.toFlatString(node, format, indent));
+end toFlatDeclarationStream;
+
+function getDeclarationNode
+  input InstNode recordNode;
+  input Boolean evaluate;
+  output InstNode declNode;
+protected
   InstNodeType node_ty;
 algorithm
   node_ty := InstNode.nodeType(recordNode);
-  node := instRecord(recordNode);
-  Typing.typeClass(node, NFInstContext.RELAXED);
+  declNode := instRecord(recordNode);
+  Typing.typeClass(declNode, NFInstContext.RELAXED);
   // Keep the node type from the original node to get the correct name.
-  node := InstNode.setNodeType(node_ty, node);
-  EvalConstants.evaluateRecordDeclaration(node);
-  s := IOStream.append(s, InstNode.toFlatString(node, format, indent));
-end toFlatDeclarationStream;
+  declNode := InstNode.setNodeType(node_ty, declNode);
+
+  if evaluate then
+    EvalConstants.evaluateRecordDeclaration(declNode);
+  end if;
+end getDeclarationNode;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFRecord;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSections.mo
@@ -36,9 +36,10 @@ encapsulated uniontype NFSections
   import Statement = NFStatement;
   import ComponentRef = NFComponentRef;
   import Expression = NFExpression;
-  import SCode.Annotation;
+  import SCode;
 
 protected
+  import DAEDump;
   import Sections = NFSections;
   import SCodeUtil;
   import IOStream;
@@ -56,7 +57,7 @@ public
     list<Expression> args;
     ComponentRef outputRef;
     String language;
-    Option<Annotation> ann;
+    Option<SCode.Annotation> ann;
     Boolean explicit;
     SourceInfo info;
   end EXTERNAL;
@@ -388,6 +389,54 @@ public
     end match;
   end isEmpty;
 
+  function toStream
+    input Sections sections;
+    input String indent;
+    input output IOStream.IOStream s;
+  algorithm
+    () := match sections
+      case SECTIONS()
+        algorithm
+          for alg in sections.algorithms loop
+            s := IOStream.append(s, indent);
+            s := IOStream.append(s, "algorithm\n");
+            s := Statement.toStreamList(alg.statements, indent + "  ", s);
+          end for;
+        then
+          ();
+
+      case EXTERNAL()
+        algorithm
+          s := IOStream.append(s, indent);
+          s := IOStream.append(s, "external \"");
+          s := IOStream.append(s, sections.language);
+          s := IOStream.append(s, "\"");
+
+          if sections.explicit then
+            if not ComponentRef.isEmpty(sections.outputRef) then
+              s := IOStream.append(s, " ");
+              s := IOStream.append(s, ComponentRef.toString(sections.outputRef));
+              s := IOStream.append(s, " =");
+            end if;
+            s := IOStream.append(s, " ");
+            s := IOStream.append(s, sections.name);
+            s := IOStream.append(s, "(");
+            s := IOStream.append(s, stringDelimitList(list(Expression.toString(e) for e in sections.args), ", "));
+            s := IOStream.append(s, ")");
+          end if;
+
+          if isSome(sections.ann) then
+            s := IOStream.append(s, DAEDump.dumpCompAnnotationStr(SOME(SCode.Comment.COMMENT(sections.ann, NONE()))));
+          end if;
+
+          s := IOStream.append(s, ";\n");
+        then
+          ();
+
+      else ();
+    end match;
+  end toStream;
+
   function toFlatStream
     input Sections sections;
     input Absyn.Path scopeName;
@@ -395,7 +444,7 @@ public
     input String indent;
     input output IOStream.IOStream s;
   protected
-    Annotation ann;
+    SCode.Annotation ann;
     SCode.Mod mod, modLib, modInc, modLibDir, modIncDir;
   algorithm
     () := match sections


### PR DESCRIPTION
- Dump functions when using the normal flat output with --dumpFlatModel, not just when using Base Modelica format.