### PR TITLE
CMake: Switch to qt6 default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,12 @@ omc_add_subdirectory(OMCompiler)
 
 if(OM_ENABLE_GUI_CLIENTS)
   # select qt version 5/6
-  set (OM_QT_MAJOR_VERSION 5 CACHE STRING "Qt version")
+  if (MINGW)
+    # qtwebengine is not available for mingw yet
+    set (OM_QT_MAJOR_VERSION 5 CACHE STRING "Qt version")
+  else ()
+    set (OM_QT_MAJOR_VERSION 6 CACHE STRING "Qt version")
+  endif ()
 
   omc_add_subdirectory(OMParser)
   omc_add_subdirectory(OMPlot)


### PR DESCRIPTION
Will help to move away from deprecated qtwebkit as qt6 gains momentum on many Linux distros + FreeBSD. 

Maybe a good time to merge this would be right after a new version is branched.

Closes #9592
Closes #7260
