### PR TITLE
Fix expansion of call arguments in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -268,12 +268,11 @@ public
       flat_model.variables := Scalarize.scalarizeVariables(flat_model.variables, forceScalarize = true);
       flat_model.equations := Equation.splitRecordEquations(flat_model.equations);
       flat_model.equations := Scalarize.scalarizeEquations(flat_model.equations, forceScalarize = true);
-      flat_model.equations := Equation.mapExpList(flat_model.equations, ExpandExp.expandCallArgs);
       flat_model.initialEquations := Equation.splitRecordEquations(flat_model.initialEquations);
       flat_model.initialEquations := Scalarize.scalarizeEquations(flat_model.initialEquations, forceScalarize = true);
-      flat_model.initialEquations := Equation.mapExpList(flat_model.initialEquations, ExpandExp.expandCallArgs);
       flat_model.algorithms := list(Flatten.unrollForStatementsInAlg(a) for a in flat_model.algorithms);
       flat_model.initialAlgorithms := list(Flatten.unrollForStatementsInAlg(a) for a in flat_model.initialAlgorithms);
+      flat_model := mapExp(flat_model, ExpandExp.expandCallArgs);
     else
       flat_model.variables := reconstructRecordInstances(flat_model.variables);
     end if;

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -44,6 +44,7 @@ TESTFILES = \
 	Scalarize5.mo \
 	Scalarize6.mo \
 	Scalarize7.mo \
+	Scalarize8.mo \
 	ScalarizeFor1.mo \
 	ScalarizedWithRecords1.mo \
 	ScalarizedWithoutRecords1.mo \

--- a/testsuite/openmodelica/basemodelica/Scalarize8.mo
+++ b/testsuite/openmodelica/basemodelica/Scalarize8.mo
@@ -1,0 +1,30 @@
+// name: Scalarize8
+// status: correct
+
+function f
+  input Real x[3];
+  output Real y = x[1]+x[2]+x[3];
+end f;
+
+model Scalarize8
+  Real x[3];
+  Real y = f(x);
+  annotation(__OpenModelica_commandLineOptions="-d=newInst -f --baseModelicaOptions=scalarize");
+end Scalarize8;
+
+// Result:
+// //! base 0.1.0
+// package 'Scalarize8'
+//   function 'f'
+//     input Real 'x'[3];
+//     output Real 'y' = 'x'[1] + 'x'[2] + 'x'[3];
+//   end 'f';
+//
+//   model 'Scalarize8'
+//     Real 'x[1]';
+//     Real 'x[2]';
+//     Real 'x[3]';
+//     Real 'y' = 'f'({'x[1]', 'x[2]', 'x[3]'});
+//   end 'Scalarize8';
+// end 'Scalarize8';
+// endResult


### PR DESCRIPTION
- Expand call arguments in the whole flat model when scalarizing, not just in equations.

Fixes #15235