### PR TITLE
[GBODE] consider NLS converged when absorption effects dominate

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
@@ -580,6 +580,23 @@ static double gbScalesNorm(GB_INTERNAL_NLS_DATA *nls, double *vec, int stack_siz
   return sqrt(sum / ((double)nls->size * (double)stack_size));
 }
 
+/** @brief Compute scaled norm of possible vector stack vec = (x + v1, x + v2, ..., x + v_{stacksize}). */
+static double gbScalesNormXPlusZ(GB_INTERNAL_NLS_DATA *nls, double *x, double *z, int stack_size)
+{
+  double sum = 0.0;
+  for (int j = 0; j < stack_size; j++)
+  {
+    double *vec_stride = &z[j * nls->size];
+    for (int i = 0; i < nls->size; i++)
+    {
+      double tmp = (x[i] + vec_stride[i]) * nls->scal[i];
+      sum += tmp * tmp;
+    }
+  }
+
+  return sqrt(sum / ((double)nls->size * (double)stack_size));
+}
+
 /** @brief Solve one stage of a DIRK method with the internal solve routine. */
 static NLS_SOLVER_STATUS gbInternalSolveNls_DIRK(DATA *data,
                                                  threadData_t *threadData,
@@ -960,12 +977,6 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
   // Newton iteration count - we start with newt_it = 1, because we need this for the step size selection and conditions below
   for (int newt_it = 1 ;; newt_it++)
   {
-    // Z = (T otimes I) * W
-    if (newt_it != 1)
-    {
-      dense_kron_id_vec(transform->size, size, transform->T, nls->W, nls->Z);
-    }
-
     // compute residuals: rhs := -1 / h (Lambda otimes I) * W + (T^{-1} * I) * F((T otimes I) * W) + Phi (Phi = T^{-1} A_part^{-1} * K_1 if (K_1 explicit else 0))
 
     // work[j] = F((T otimes I) * W)[j]
@@ -1030,11 +1041,14 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
     // Newton step (we must do W += dW)
     daxpy_(&w_size, &DBL_ONE, flat_res, &INT_ONE, nls->W, &INT_ONE);
 
+    // Z = (T otimes I) * W
+    dense_kron_id_vec(transform->size, size, transform->T, nls->W, nls->Z);
+
     nrm_delta_prev = fmax(DBL_EPSILON, nrm_delta);
     nrm_delta = gbScalesNorm(nls, flat_res, nls->tabl->t_transform->size);
 
     // handle absorption effects
-    nrm_x = gbScalesNorm(nls, x, nls->tabl->t_transform->size);
+    nrm_x = gbScalesNormXPlusZ(nls, x0, nls->Z, transform->size);
     modelica_boolean absorption = (nrm_delta <= DBL_ABSORPTION * nrm_x);
 
     if (newt_it > 1)
@@ -1073,9 +1087,6 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
       {
         nls->call_jac = TRUE;
       }
-
-      // Z = (T otimes I) * W
-      dense_kron_id_vec(transform->size, size, transform->T, nls->W, nls->Z);
 
       // set solution X[j] = X_0 + Z[j]
       int offset = transform->firstRowZero ? size : 0;


### PR DESCRIPTION
# Related
There is no really related issue, but I ping the main GBODE ticket: https://github.com/OpenModelica/OpenModelica/issues/14022

# PR
@bernhardbachmann and I studied the regression report https://libraries.openmodelica.org/branches/history/gbode/2026-03-10%2011:29:44..2026-03-13%2001:08:14.html (uses ESDIRK4). We came to the conclusion that at least some simulations terminate with step size below the minimal step size, because the Newton iteration is not achieving any more progress while already at a satsifactory point. This due to absorption effects $x_{i+1} = x_i  + \Delta x_i = x_i$, when the relative error between $|\Delta x_i| \leq \varepsilon |x_i|$. Thus, we effectively get the same Newton updates for every Newton iteration as the update is simply absorbed.

To prevent this behavior we claim that absorption effects in the Newton iteration dominate, if $|\Delta x_i| \leq 10 \varepsilon |x_i|$ and always terminate the nonlinear system iteration if this condition is met. If the accuracy of the solution is not satisfactory, the error control will repeat the step anyway, so there is no real downside.

This fixes at least AixLib.Fluid.Geothermal.Borefields.Examples.RectangularBorefield and we are certain that other models are also effected.