### PR TITLE
Set the transform on DynamicSelect reset

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -1153,7 +1153,7 @@ void ShapeAnnotation::resetDynamicSelect()
   mTextStyles.resetDynamicToStatic();
   mHorizontalAlignment.resetDynamicToStatic();
 
-  update();
+  applyTransformation();
 }
 
 /*!


### PR DESCRIPTION
### Related Issues

Fixes #15241

### Purpose

Reset `DynamicSelect` properly when user switch to Modeling perspective.

### Approach

Set the transform when resetting `DynamicSelect`.
