### PR TITLE
Improve typing of array slices

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2142,21 +2142,19 @@ algorithm
         e := evaluateEnd(subscript.exp, dimension, subscriptedExp, index, context, info);
         (e, ty, variability) := typeExp(e, context, info);
 
+        if Type.isArray(ty) and InstContext.inEquation(context) then
+          Structural.markExp(e);
+          e := Ceval.tryEvalExp(e);
+          ty := Expression.typeOf(e);
+        end if;
+
         if checkSubscript then
           (e, matched_ty) := checkSubscriptType(e, Type.arrayElementType(ty), dimension, info);
         else
           matched_ty := ty;
         end if;
 
-        if Type.isArray(ty) then
-          outSubscript := Subscript.SLICE(e);
-
-          if InstContext.inEquation(context) then
-            Structural.markExp(e);
-          end if;
-        else
-          outSubscript := Subscript.INDEX(e);
-        end if;
+        outSubscript := if Type.isArray(ty) then Subscript.SLICE(e) else Subscript.INDEX(e);
       then
         (matched_ty, variability);
 

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1136,6 +1136,7 @@ SizeInvalidType3.mo \
 SlicedCref1.mo \
 SlicedCref2.mo \
 SlicedCref3.mo \
+SlicedCref4.mo \
 StatementInvalidType1.mo \
 StateSelectVariability1.mo \
 StateSelect1.mo \

--- a/testsuite/flattening/modelica/scodeinst/SlicedCref4.mo
+++ b/testsuite/flattening/modelica/scodeinst/SlicedCref4.mo
@@ -1,0 +1,23 @@
+// name: SlicedCref4
+// keywords:
+// status: incorrect
+//
+
+model SlicedCref4
+  final parameter Integer a = 6;
+  final parameter Integer b = 7;
+  final parameter Integer c = 6;
+  Real v[a, b, c];
+equation
+  v[2:a-1, 2:b-1, 2:b-1] = zeros(a - 2, b - 2, c - 2);
+end SlicedCref4;
+
+// Result:
+// Error processing file: SlicedCref4.mo
+// [flattening/modelica/scodeinst/SlicedCref4.mo:12:3-12:54:writable] Error: Type mismatch in equation v[2:a - 1, 2:b - 1, 2:b - 1] = zeros(a - 2, b - 2, c - 2) of type Real[4, 5, 5] = Integer[4, 5, 4].
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/openmodelica/interactive-API/Obfuscation2.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation2.mos
@@ -5,7 +5,7 @@
 //
 
 setCommandLineOptions("--obfuscate=protected");
-loadModel(Modelica, {"3.2.3"}); getErrorString();
+loadModel(Modelica, {"4.0.0"}); getErrorString();
 instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString();
 
 // Result:
@@ -18,135 +18,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState\"
 //   input Real p;
@@ -249,7 +132,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -271,7 +154,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -421,135 +304,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState\"
 //   input Real p;
@@ -652,7 +418,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -674,7 +440,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -824,135 +590,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState\"
 //   input Real p;
@@ -1059,9 +708,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
@@ -1069,7 +718,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -1091,7 +740,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -1253,14 +902,14 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
 // algorithm
-//   eta := 1e-6 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   eta := 1e-6 * Modelica.Math.Polynomials.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.dynamicViscosity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
@@ -1419,32 +1068,31 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
-//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Delta;
-//   output Real lambda2;
-//   protected Real x1 = log10(Re1);
-//   protected Real y1 = log10(64.0 * Re1);
-//   protected Real yd1 = 1.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2 \"Cubic Hermite spline interpolation in transition region\"
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number (= independent variable)\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for laminar regime\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for turbulent regime\";
+//   input Real Delta \"Relative roughness\";
+//   output Real lambda2 \"Interpolated modified friction coefficient in transition regime\";
+//   protected Real x1 = log10(Re1) \"Lower abscissa value\";
+//   protected Real y1 = log10(64.0 * Re1) \"Lower ordinate value\";
+//   protected Real yd1 = 1.0 \"Left boundary slope\";
 //   protected Real aux1 = 1.1217826467560994;
 //   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
-//   protected Real x2 = log10(Re2);
-//   protected Real dx;
+//   protected Real x2 = log10(Re2) \"Upper abscissa value\";
+//   protected Real dx = log10(Re / Re1);
 //   protected Real aux3 = log10(aux2);
-//   protected Real diff_x = x2 - x1;
+//   protected Real diff_x = x2 - x1 \"Interval length\";
 //   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
-//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9) \"Right boundary slope\";
 //   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
-//   protected Real y2 = log10(L2);
+//   protected Real y2 = log10(L2) \"Upper ordinate value\";
 //   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
 //   protected Real m = (y2 - y1) / diff_x;
 //   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
 //   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   dx := log10(Re / Re1);
-//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (yd1 + dx * (c2 + dx * c3));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState\"
@@ -1467,135 +1115,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState\"
 //   input Real p;
@@ -1698,7 +1229,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -1720,7 +1251,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -1882,14 +1413,14 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
 // algorithm
-//   eta := 1e-6 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   eta := 1e-6 * Modelica.Math.Polynomials.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.dynamicViscosity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
@@ -2048,32 +1579,31 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
-//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Delta;
-//   output Real lambda2;
-//   protected Real x1 = log10(Re1);
-//   protected Real y1 = log10(64.0 * Re1);
-//   protected Real yd1 = 1.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2 \"Cubic Hermite spline interpolation in transition region\"
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number (= independent variable)\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for laminar regime\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for turbulent regime\";
+//   input Real Delta \"Relative roughness\";
+//   output Real lambda2 \"Interpolated modified friction coefficient in transition regime\";
+//   protected Real x1 = log10(Re1) \"Lower abscissa value\";
+//   protected Real y1 = log10(64.0 * Re1) \"Lower ordinate value\";
+//   protected Real yd1 = 1.0 \"Left boundary slope\";
 //   protected Real aux1 = 1.1217826467560994;
 //   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
-//   protected Real x2 = log10(Re2);
-//   protected Real dx;
+//   protected Real x2 = log10(Re2) \"Upper abscissa value\";
+//   protected Real dx = log10(Re / Re1);
 //   protected Real aux3 = log10(aux2);
-//   protected Real diff_x = x2 - x1;
+//   protected Real diff_x = x2 - x1 \"Interval length\";
 //   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
-//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9) \"Right boundary slope\";
 //   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
-//   protected Real y2 = log10(L2);
+//   protected Real y2 = log10(L2) \"Upper ordinate value\";
 //   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
 //   protected Real m = (y2 - y1) / diff_x;
 //   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
 //   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   dx := log10(Re / Re1);
-//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (yd1 + dx * (c2 + dx * c3));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState\"
@@ -2168,7 +1698,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
 // algorithm
-//   eta := 1e-6 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   eta := 1e-6 * Modelica.Math.Polynomials.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.dynamicViscosity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
@@ -2188,9 +1718,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.h_pTX_der \"Derivative function of h_pTX\"
@@ -2201,7 +1731,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -2321,7 +1851,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real lambda(quantity = \"ThermalConductivity\", unit = \"W/(m.K)\", min = 0.0, max = 500.0, start = 1.0, nominal = 1.0) \"Thermal conductivity\";
 // algorithm
-//   lambda := 0.001 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({6.569147081771781e-15, -3.402596192305051e-11, 5.327928484630316e-8, -4.534083928921947e-5, 0.07612967530903766, 24.16948108809705}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   lambda := 0.001 * Modelica.Math.Polynomials.evaluateWithRange({6.569147081771781e-15, -3.402596192305051e-11, 5.327928484630316e-8, -4.534083928921947e-5, 0.07612967530903766, 24.16948108809705}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.thermalConductivity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
@@ -2330,135 +1860,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState\"
 //   input Real p;
@@ -2565,9 +1978,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
@@ -2575,7 +1988,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -2597,7 +2010,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -2759,14 +2172,14 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
 // algorithm
-//   eta := 1e-6 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   eta := 1e-6 * Modelica.Math.Polynomials.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.dynamicViscosity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
@@ -2925,32 +2338,31 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
-//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Delta;
-//   output Real lambda2;
-//   protected Real x1 = log10(Re1);
-//   protected Real y1 = log10(64.0 * Re1);
-//   protected Real yd1 = 1.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2 \"Cubic Hermite spline interpolation in transition region\"
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number (= independent variable)\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for laminar regime\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for turbulent regime\";
+//   input Real Delta \"Relative roughness\";
+//   output Real lambda2 \"Interpolated modified friction coefficient in transition regime\";
+//   protected Real x1 = log10(Re1) \"Lower abscissa value\";
+//   protected Real y1 = log10(64.0 * Re1) \"Lower ordinate value\";
+//   protected Real yd1 = 1.0 \"Left boundary slope\";
 //   protected Real aux1 = 1.1217826467560994;
 //   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
-//   protected Real x2 = log10(Re2);
-//   protected Real dx;
+//   protected Real x2 = log10(Re2) \"Upper abscissa value\";
+//   protected Real dx = log10(Re / Re1);
 //   protected Real aux3 = log10(aux2);
-//   protected Real diff_x = x2 - x1;
+//   protected Real diff_x = x2 - x1 \"Interval length\";
 //   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
-//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9) \"Right boundary slope\";
 //   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
-//   protected Real y2 = log10(L2);
+//   protected Real y2 = log10(L2) \"Upper ordinate value\";
 //   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
 //   protected Real m = (y2 - y1) / diff_x;
 //   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
 //   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   dx := log10(Re / Re1);
-//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (yd1 + dx * (c2 + dx * c3));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState\"
@@ -2973,135 +2385,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
 //   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -1.342338281725291e7, 549760.6476280135, 1000.0, {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-6, 4.95504349e-9, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1.034972096e6, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-7, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+//   T := Modelica.Math.Nonlinear.solveOneNonlinearEquation(function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.f_nonlinear(#(p), #(h), #(X[1:1])), 190.0, 647.0, 1e-13);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear
-//   input Real x \"Independent variable of function\";
-//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
-//   output Real y \"= f_nonlinear(x)\";
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.f_nonlinear \"Solve h_pTX(p,T,X) for T with given h\"
+//   input Real u \"Independent variable\";
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real y \"Dependent variable y=f(u)\";
 // algorithm
-//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX(p, x, X);
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data\"
-//   input String name;
-//   input Real MM;
-//   input Real Hf;
-//   input Real H0;
-//   input Real Tlimit;
-//   input Real[7] alow;
-//   input Real[2] blow;
-//   input Real[7] ahigh;
-//   input Real[2] bhigh;
-//   input Real R;
-//   output f_nonlinear_Data res;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data;
-//
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve
-//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
-//   input Real x_min \"Minimum value of x\";
-//   input Real x_max \"Maximum value of x\";
-//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
-//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
-//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
-//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
-//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
-//   protected constant Real eps = 1e-15 \"Machine epsilon\";
-//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
-//   protected Real c \"Intermediate point a <= c <= b\";
-//   protected Real d;
-//   protected Real e \"b - a\";
-//   protected Real m;
-//   protected Real s;
-//   protected Real p;
-//   protected Real q;
-//   protected Real r;
-//   protected Real tol;
-//   protected Real fa \"= f_nonlinear(a) - y_zero\";
-//   protected Real fb \"= f_nonlinear(b) - y_zero\";
-//   protected Real fc;
-//   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
-//   protected Real a = x_min2 \"Current best minimum interval value\";
-//   protected Real b = x_max2 \"Current best maximum interval value\";
-// algorithm
-//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
-//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
-//   fc := fb;
-//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
-//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
-//     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(x_min2, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
-//     \" + \"fa and fb must have opposite sign which is not the case\");
-//   end if;
-//   c := a;
-//   fc := fa;
-//   e := b - a;
-//   d := e;
-//   while not found loop
-//     if abs(fc) < abs(fb) then
-//       a := b;
-//       b := c;
-//       c := a;
-//       fa := fb;
-//       fb := fc;
-//       fc := fa;
-//     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
-//     m := (c - b) / 2.0;
-//     if abs(m) <= tol or fb == 0.0 then
-//       found := true;
-//       x_zero := b;
-//     else
-//       if abs(e) < tol or abs(fa) <= abs(fb) then
-//         e := m;
-//         d := e;
-//       else
-//         s := fb / fa;
-//         if a == c then
-//           p := 2.0 * m * s;
-//           q := 1.0 - s;
-//         else
-//           q := fa / fc;
-//           r := fb / fc;
-//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
-//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
-//         end if;
-//         if p > 0.0 then
-//           q := -q;
-//         else
-//           p := -p;
-//         end if;
-//         s := e;
-//         e := d;
-//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
-//           d := p / q;
-//         else
-//           e := m;
-//           d := e;
-//         end if;
-//       end if;
-//       a := b;
-//       fa := fb;
-//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
-//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
-//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
-//         c := a;
-//         fc := fa;
-//         e := b - a;
-//         d := e;
-//       end if;
-//     end if;
-//   end while;
-// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX(p, u, X) - h;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.f_nonlinear;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState\"
 //   input Real p;
@@ -3208,9 +2503,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
@@ -3218,7 +2513,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -3240,7 +2535,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real dT(unit = \"K/s\") \"Temperature derivative\";
 //   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
 //   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
-//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
 //   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
 //   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
@@ -3402,14 +2697,14 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
 //   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
 // algorithm
-//   eta := 1e-6 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.SIunits.Conversions.to_degC(state.T));
+//   eta := 1e-6 * Modelica.Math.Polynomials.evaluateWithRange({9.739110288630587e-15, -3.1353724870333906e-11, 4.3004876595642225e-8, -3.822801629175824e-5, 0.05042787436718076, 17.23926013924253}, -149.99999999999997, 1000.0000000000001, Modelica.Units.Conversions.to_degC(state.T));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.dynamicViscosity;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
 //   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
-//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+//   output Real R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+//   R_s := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.gasConstant;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
@@ -3568,32 +2863,31 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
-//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real Delta;
-//   output Real lambda2;
-//   protected Real x1 = log10(Re1);
-//   protected Real y1 = log10(64.0 * Re1);
-//   protected Real yd1 = 1.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2 \"Cubic Hermite spline interpolation in transition region\"
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number (= independent variable)\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for laminar regime\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary Reynolds number for turbulent regime\";
+//   input Real Delta \"Relative roughness\";
+//   output Real lambda2 \"Interpolated modified friction coefficient in transition regime\";
+//   protected Real x1 = log10(Re1) \"Lower abscissa value\";
+//   protected Real y1 = log10(64.0 * Re1) \"Lower ordinate value\";
+//   protected Real yd1 = 1.0 \"Left boundary slope\";
 //   protected Real aux1 = 1.1217826467560994;
 //   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
-//   protected Real x2 = log10(Re2);
-//   protected Real dx;
+//   protected Real x2 = log10(Re2) \"Upper abscissa value\";
+//   protected Real dx = log10(Re / Re1);
 //   protected Real aux3 = log10(aux2);
-//   protected Real diff_x = x2 - x1;
+//   protected Real diff_x = x2 - x1 \"Interval length\";
 //   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
-//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9) \"Right boundary slope\";
 //   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
-//   protected Real y2 = log10(L2);
+//   protected Real y2 = log10(L2) \"Upper ordinate value\";
 //   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
 //   protected Real m = (y2 - y1) / diff_x;
 //   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
 //   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   dx := log10(Re / Re1);
-//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (yd1 + dx * (c2 + dx * c3));
 // end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
 // function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState\"
@@ -3675,7 +2969,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   output Real y \"Interpolated ordinate value\";
 //   output Real dy_dx \"Derivative dy/dx at abscissa value x\";
 //   protected Real h \"Distance between x1 and x2\";
-//   protected Real t \"abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]\";
+//   protected Real t \"Abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]\";
 //   protected Real h00 \"Basis function 00 of cubic Hermite spline\";
 //   protected Real h10 \"Basis function 10 of cubic Hermite spline\";
 //   protected Real h01 \"Basis function 01 of cubic Hermite spline\";
@@ -3804,6 +3098,161 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   end if;
 // end Modelica.Fluid.Utilities.regFun3;
 //
+// function Modelica.Math.Nonlinear.solveOneNonlinearEquation \"Solve f(u) = 0 in a very reliable and efficient way (f(u_min) and f(u_max) must have different signs)\"
+//   input f<function>(#Real u) => #Real f \"Function y = f(u); u is computed so that y=0\";
+//   input Real u_min \"Lower bound of search interval\";
+//   input Real u_max \"Upper bound of search interval\";
+//   input Real tolerance = 1e-13 \"Relative tolerance of solution u\";
+//   output Real u \"Value of independent variable u so that f(u) = 0\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected Real a = u_min \"Current best minimum interval value\";
+//   protected Real b = u_max \"Current best maximum interval value\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f(a)\";
+//   protected Real fb \"= f(b)\";
+//   protected Real fc;
+//   protected Boolean found = false;
+// algorithm
+//   fa := unbox(f(#(u_min)));
+//   fb := unbox(f(#(u_max)));
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments u_min and u_max provided in the function call
+//         solveOneNonlinearEquation(f,u_min,u_max)
+//     do not bracket the root of the single non-linear equation 0=f(u):
+//       u_min  = \" + String(u_min, 6, 0, true) + \"
+//     \" + \"  u_max  = \" + String(u_max, 6, 0, true) + \"
+//     \" + \"  fa = f(u_min) = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(u_max) = \" + String(fb, 6, 0, true) + \"
+//     \" + \"fa and fb must have opposite sign which is not the case\");
+//   end if;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
+//     end if;
+//     tol := 2.0 * eps * abs(b) + tolerance;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       u := b;
+//     else
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
+//       else
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
+//         else
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
+//         end if;
+//         if p > 0.0 then
+//           q := -q;
+//         else
+//           p := -p;
+//         end if;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
+//         else
+//           e := m;
+//           d := e;
+//         end if;
+//       end if;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := unbox(f(#(b)));
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
+//       end if;
+//     end if;
+//   end while;
+// end Modelica.Math.Nonlinear.solveOneNonlinearEquation;
+//
+// function Modelica.Math.Polynomials.evaluate \"Evaluate polynomial at a given abscissa value\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real u \"Abscissa value\";
+//   output Real y \"Value of polynomial at u\";
+// algorithm
+//   y := p[1];
+//   for j in 2:size(p, 1) loop
+//     y := p[j] + u * y;
+//   end for;
+// end Modelica.Math.Polynomials.evaluate;
+//
+// function Modelica.Math.Polynomials.evaluateWithRange \"Evaluate polynomial at a given abscissa value with linear extrapolation outside of the defined range\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
+//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
+//   input Real u \"Abscissa value\";
+//   output Real y \"Value of polynomial at u. Outside of uMin,uMax, linear extrapolation is used\";
+// algorithm
+//   if u < uMin then
+//     y := Modelica.Math.Polynomials.evaluate(p, uMin) - Modelica.Math.Polynomials.evaluate_der(p, uMin, uMin - u);
+//   elseif u > uMax then
+//     y := Modelica.Math.Polynomials.evaluate(p, uMax) + Modelica.Math.Polynomials.evaluate_der(p, uMax, u - uMax);
+//   else
+//     y := Modelica.Math.Polynomials.evaluate(p, u);
+//   end if;
+// end Modelica.Math.Polynomials.evaluateWithRange;
+//
+// function Modelica.Math.Polynomials.evaluateWithRange_der \"Evaluate derivative of polynomial at a given abscissa value with extrapolation outside of the defined range\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
+//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
+//   input Real u \"Abscissa value\";
+//   input Real du \"Delta of abscissa value\";
+//   output Real dy \"Value of derivative of polynomial at u\";
+// algorithm
+//   if u < uMin then
+//     dy := Modelica.Math.Polynomials.evaluate_der(p, uMin, du);
+//   elseif u > uMax then
+//     dy := Modelica.Math.Polynomials.evaluate_der(p, uMax, du);
+//   else
+//     dy := Modelica.Math.Polynomials.evaluate_der(p, u, du);
+//   end if;
+// end Modelica.Math.Polynomials.evaluateWithRange_der;
+//
+// function Modelica.Math.Polynomials.evaluate_der \"Evaluate derivative of polynomial at a given abscissa value\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real u \"Abscissa value\";
+//   input Real du \"Delta of abscissa value\";
+//   output Real dy \"Value of derivative of polynomial at u\";
+//   protected Integer n = size(p, 1);
+// algorithm
+//   dy := p[1] * /*Real*/(n - 1);
+//   for j in 2:size(p, 1) - 1 loop
+//     dy := p[j] * /*Real*/(n - j) + u * dy;
+//   end for;
+//   dy := dy * du;
+// end Modelica.Math.Polynomials.evaluate_der;
+//
 // function Modelica.Media.Air.MoistAir.Utilities.spliceFunction \"Spline interpolation of two functions\"
 //   input Real pos \"Returned value for x-deltax >= 0\";
 //   input Real neg \"Returned value for x+deltax <= 0\";
@@ -3867,7 +3316,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real[2] blow;
 //   input Real[7] ahigh;
 //   input Real[2] bhigh;
-//   input Real R;
+//   input Real R_s;
 //   output DataRecord res;
 // end Modelica.Media.IdealGases.Common.DataRecord;
 //
@@ -3876,16 +3325,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
 //   output Real cp(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Specific heat capacity at temperature T\";
 // algorithm
-//   cp := data.R * 1.0 / (T * T) * (data.alow[1] + T * (data.alow[2] + T * (data.alow[3] + T * (data.alow[4] + T * (data.alow[5] + T * (data.alow[6] + data.alow[7] * T))))));
+//   cp := data.R_s * 1.0 / (T * T) * (data.alow[1] + T * (data.alow[2] + T * (data.alow[3] + T * (data.alow[4] + T * (data.alow[5] + T * (data.alow[6] + data.alow[7] * T))))));
 // end Modelica.Media.IdealGases.Common.Functions.cp_Tlow;
 //
-// function Modelica.Media.IdealGases.Common.Functions.cp_Tlow_der \"Compute specific heat capacity at constant pressure, low T region\"
+// function Modelica.Media.IdealGases.Common.Functions.cp_Tlow_der \"Compute derivative of specific heat capacity at constant pressure, low T region\"
 //   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
-//   input Real dT \"Temperature derivative\";
-//   output Real cp_der \"Derivative of specific heat capacity\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   output Real cp_der(unit = \"J/(kg.K.s)\") \"Derivative of specific heat capacity\";
 // algorithm
-//   cp_der := dT * data.R / (T * T * T) * (T * (T * T * (data.alow[4] + T * (2.0 * data.alow[5] + T * (3.0 * data.alow[6] + 4.0 * data.alow[7] * T))) - data.alow[2]) - 2.0 * data.alow[1]);
+//   cp_der := dT * data.R_s / (T * T * T) * (T * (T * T * (data.alow[4] + T * (2.0 * data.alow[5] + T * (3.0 * data.alow[6] + 4.0 * data.alow[7] * T))) - data.alow[2]) - 2.0 * data.alow[1]);
 // end Modelica.Media.IdealGases.Common.Functions.cp_Tlow_der;
 //
 // function Modelica.Media.IdealGases.Common.Functions.h_Tlow \"Compute specific enthalpy, low T region; reference is decided by the
@@ -3897,10 +3346,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   input Real h_off(quantity = \"SpecificEnergy\", unit = \"J/kg\") = 0.0 \"User defined offset for reference enthalpy, if referenceChoice = UserDefined\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at temperature T\";
 // algorithm
-//   h := data.R * (T * (data.blow[1] + data.alow[2] * log(T) + T * (data.alow[3] + T * (0.5 * data.alow[4] + T * (0.3333333333333333 * data.alow[5] + T * (0.25 * data.alow[6] + 0.2 * data.alow[7] * T))))) - data.alow[1]) / T + (if exclEnthForm then -data.Hf else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.ZeroAt0K then data.H0 else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined then h_off else 0.0);
+//   h := data.R_s * (T * (data.blow[1] + data.alow[2] * log(T) + T * (data.alow[3] + T * (0.5 * data.alow[4] + T * (0.3333333333333333 * data.alow[5] + T * (0.25 * data.alow[6] + 0.2 * data.alow[7] * T))))) - data.alow[1]) / T + (if exclEnthForm then -data.Hf else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.ZeroAt0K then data.H0 else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined then h_off else 0.0);
 // end Modelica.Media.IdealGases.Common.Functions.h_Tlow;
 //
-// function Modelica.Media.IdealGases.Common.Functions.h_Tlow_der \"Compute specific enthalpy, low T region; reference is decided by the
+// function Modelica.Media.IdealGases.Common.Functions.h_Tlow_der \"Compute derivative of specific enthalpy, low T region; reference is decided by the
 //     refChoice input, or by the referenceChoice package constant by default\"
 //   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
 //   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
@@ -3913,77 +3362,19 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   h_der := dT * Modelica.Media.IdealGases.Common.Functions.cp_Tlow(data, T);
 // end Modelica.Media.IdealGases.Common.Functions.h_Tlow_der;
 //
-// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate \"Evaluate polynomial at a given abscissa value\"
-//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
-//   input Real u \"Abscissa value\";
-//   output Real y \"Value of polynomial at u\";
-// algorithm
-//   y := p[1];
-//   for j in 2:size(p, 1) loop
-//     y := p[j] + u * y;
-//   end for;
-// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate;
-//
-// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange \"Evaluate polynomial at a given abscissa value with linear extrapolation outside of the defined range\"
-//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
-//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
-//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
-//   input Real u \"Abscissa value\";
-//   output Real y \"Value of polynomial at u. Outside of uMin,uMax, linear extrapolation is used\";
-// algorithm
-//   if u < uMin then
-//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, uMin) - Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMin, uMin - u);
-//   elseif u > uMax then
-//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, uMax) + Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMax, u - uMax);
-//   else
-//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, u);
-//   end if;
-// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange;
-//
-// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange_der \"Evaluate derivative of polynomial at a given abscissa value with extrapolation outside of the defined range\"
-//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
-//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
-//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
-//   input Real u \"Abscissa value\";
-//   input Real du \"Delta of abscissa value\";
-//   output Real dy \"Value of derivative of polynomial at u\";
-// algorithm
-//   if u < uMin then
-//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMin, du);
-//   elseif u > uMax then
-//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMax, du);
-//   else
-//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, u, du);
-//   end if;
-// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange_der;
-//
-// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der \"Evaluate derivative of polynomial at a given abscissa value\"
-//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
-//   input Real u \"Abscissa value\";
-//   input Real du \"Delta of abscissa value\";
-//   output Real dy \"Value of derivative of polynomial at u\";
-//   protected Integer n = size(p, 1);
-// algorithm
-//   dy := p[1] * /*Real*/(n - 1);
-//   for j in 2:size(p, 1) - 1 loop
-//     dy := p[j] * /*Real*/(n - j) + u * dy;
-//   end for;
-//   dy := dy * du;
-// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der;
-//
-// function Modelica.SIunits.Conversions.to_bar \"Convert from Pascal to bar\"
-//   input Real Pa(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pascal value\";
-//   output Real bar(quantity = \"Pressure\", unit = \"bar\") \"bar value\";
+// function Modelica.Units.Conversions.to_bar \"Convert from Pascal to bar\"
+//   input Real Pa(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Value in Pascal\";
+//   output Real bar(quantity = \"Pressure\", unit = \"bar\") \"Value in bar\";
 // algorithm
 //   bar := Pa / 1e5;
-// end Modelica.SIunits.Conversions.to_bar;
+// end Modelica.Units.Conversions.to_bar;
 //
-// function Modelica.SIunits.Conversions.to_degC \"Convert from Kelvin to degCelsius\"
-//   input Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Kelvin value\";
-//   output Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Celsius value\";
+// function Modelica.Units.Conversions.to_degC \"Convert from kelvin to degree Celsius\"
+//   input Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Value in kelvin\";
+//   output Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Value in degree Celsius\";
 // algorithm
 //   Celsius := Kelvin - 273.15;
-// end Modelica.SIunits.Conversions.to_degC;
+// end Modelica.Units.Conversions.to_degC;
 //
 // function Modelica.Utilities.Streams.error \"Print error message and cancel all actions - in case of an unrecoverable error\"
 //   input String string \"String to be printed to error message window\";
@@ -4018,7 +3409,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary1.medium.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real boundary1.medium.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real boundary1.medium.u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real boundary1.medium.R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real boundary1.medium.R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real boundary1.medium.MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real boundary1.medium.state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real boundary1.medium.state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4026,8 +3417,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary1.medium.state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean boundary1.medium.preferredMediumStates = false \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean boundary1.medium.standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real boundary1.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(boundary1.medium.T) \"Temperature of medium in [degC]\";
-//   Real boundary1.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(boundary1.medium.p) \"Absolute pressure of medium in [bar]\";
+//   Real boundary1.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(boundary1.medium.T) \"Temperature of medium in [degC]\";
+//   Real boundary1.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(boundary1.medium.p) \"Absolute pressure of medium in [bar]\";
 //   Real boundary1.medium.x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real boundary1.medium.phi \"Relative humidity\";
 //   protected Real boundary1.medium.n1(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4035,7 +3426,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real boundary1.medium.n3(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real boundary1.medium.n4(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real boundary1.medium.n5(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real boundary1.medium.n6(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real boundary1.medium.n6(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real boundary1.ports[1].m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e60) \"Mass flow rate from the connection point into the component\";
 //   Real boundary1.ports[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
 //   Real boundary1.ports[1].h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific thermodynamic enthalpy close to the connection point if m_flow < 0\";
@@ -4049,10 +3440,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real boundary1.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = 293.15 \"Fixed value of temperature\";
 //   parameter Real boundary1.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01 \"Fixed value of composition\";
 //   parameter Real boundary1.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99 \"Fixed value of composition\";
-//   protected Real boundary1.n8 \"Needed to connect to conditional connector\";
-//   protected Real boundary1.n9 \"Needed to connect to conditional connector\";
-//   protected Real boundary1.n10[1] \"Needed to connect to conditional connector\";
-//   protected Real boundary1.n10[2] \"Needed to connect to conditional connector\";
+//   protected Real boundary1.n8(unit = \"Pa\") \"Needed to connect to conditional connector\";
+//   protected Real boundary1.n9(unit = \"K\") \"Needed to connect to conditional connector\";
+//   protected Real boundary1.n10[1](unit = \"1\") \"Needed to connect to conditional connector\";
+//   protected Real boundary1.n10[2](unit = \"1\") \"Needed to connect to conditional connector\";
 //   final parameter Boolean pipe1.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (port_a -> port_b)\";
 //   Real pipe1.port_a.m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5) \"Mass flow rate from the connection point into the component\";
 //   Real pipe1.port_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
@@ -4067,12 +3458,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected parameter Boolean pipe1.n13 = true \"= false to hide the arrow in the model icon\";
 //   parameter Real pipe1.nParallel(min = 1.0) = 1.0 \"Number of identical parallel pipes\";
 //   final parameter Real pipe1.length(quantity = \"Length\", unit = \"m\") = 50.0 \"Length\";
-//   final parameter Boolean pipe1.isCircular = true \"= true if cross sectional area is circular\";
+//   final parameter Boolean pipe1.isCircular = true \"= true, if cross sectional area is circular\";
 //   parameter Real pipe1.diameter(quantity = \"Length\", unit = \"m\", min = 0.0) = 0.0254 \"Diameter of circular pipe\";
 //   parameter Real pipe1.crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * pipe1.diameter * pipe1.diameter / 4.0 \"Inner cross section area\";
 //   parameter Real pipe1.perimeter(quantity = \"Length\", unit = \"m\", min = 0.0) = 3.141592653589793 * pipe1.diameter \"Inner perimeter\";
 //   parameter Real pipe1.roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-5 \"Average height of surface asperities (default: smooth steel pipe)\";
-//   final parameter Real pipe1.V(quantity = \"Volume\", unit = \"m3\") = pipe1.crossArea * 50.0 * pipe1.nParallel \"volume size\";
+//   final parameter Real pipe1.V(quantity = \"Volume\", unit = \"m3\") = pipe1.crossArea * 50.0 * pipe1.nParallel \"Volume size\";
 //   final parameter Real pipe1.height_ab(quantity = \"Length\", unit = \"m\") = 50.0 \"Height(port_b) - Height(port_a)\";
 //   final parameter Integer pipe1.n = 5 \"Number of discrete volumes\";
 //   final Real pipe1.fluidVolumes[1](quantity = \"Volume\", unit = \"m3\") \"Discretized volume, determine in inheriting class\";
@@ -4119,7 +3510,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[1].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[1].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[1].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe1.mediums[1].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe1.mediums[1].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe1.mediums[1].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe1.mediums[1].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[1].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4127,8 +3518,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe1.mediums[1].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe1.mediums[1].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe1.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[1].T) \"Temperature of medium in [degC]\";
-//   Real pipe1.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[1].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe1.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe1.mediums[1].T) \"Temperature of medium in [degC]\";
+//   Real pipe1.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe1.mediums[1].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe1.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe1.mediums[1].phi \"Relative humidity\";
 //   protected Real pipe1.mediums[1].n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4136,7 +3527,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe1.mediums[1].n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe1.mediums[1].n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe1.mediums[1].n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe1.mediums[1].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe1.mediums[1].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe1.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[2], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe1.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start) \"Specific enthalpy of medium\";
@@ -4145,7 +3536,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[2].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[2].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[2].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe1.mediums[2].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe1.mediums[2].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe1.mediums[2].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe1.mediums[2].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[2].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4153,8 +3544,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe1.mediums[2].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe1.mediums[2].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe1.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[2].T) \"Temperature of medium in [degC]\";
-//   Real pipe1.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[2].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe1.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe1.mediums[2].T) \"Temperature of medium in [degC]\";
+//   Real pipe1.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe1.mediums[2].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe1.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe1.mediums[2].phi \"Relative humidity\";
 //   protected Real pipe1.mediums[2].n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4162,7 +3553,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe1.mediums[2].n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe1.mediums[2].n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe1.mediums[2].n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe1.mediums[2].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe1.mediums[2].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe1.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[3], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe1.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start) \"Specific enthalpy of medium\";
@@ -4171,7 +3562,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[3].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[3].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[3].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe1.mediums[3].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe1.mediums[3].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe1.mediums[3].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe1.mediums[3].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[3].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4179,8 +3570,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe1.mediums[3].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe1.mediums[3].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe1.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[3].T) \"Temperature of medium in [degC]\";
-//   Real pipe1.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[3].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe1.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe1.mediums[3].T) \"Temperature of medium in [degC]\";
+//   Real pipe1.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe1.mediums[3].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe1.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe1.mediums[3].phi \"Relative humidity\";
 //   protected Real pipe1.mediums[3].n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4188,7 +3579,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe1.mediums[3].n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe1.mediums[3].n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe1.mediums[3].n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe1.mediums[3].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe1.mediums[3].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe1.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[4], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe1.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start) \"Specific enthalpy of medium\";
@@ -4197,7 +3588,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[4].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[4].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[4].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe1.mediums[4].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe1.mediums[4].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe1.mediums[4].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe1.mediums[4].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[4].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4205,8 +3596,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe1.mediums[4].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe1.mediums[4].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe1.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[4].T) \"Temperature of medium in [degC]\";
-//   Real pipe1.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[4].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe1.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe1.mediums[4].T) \"Temperature of medium in [degC]\";
+//   Real pipe1.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe1.mediums[4].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe1.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe1.mediums[4].phi \"Relative humidity\";
 //   protected Real pipe1.mediums[4].n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4214,7 +3605,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe1.mediums[4].n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe1.mediums[4].n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe1.mediums[4].n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe1.mediums[4].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe1.mediums[4].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe1.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[5], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe1.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start) \"Specific enthalpy of medium\";
@@ -4223,7 +3614,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[5].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[5].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe1.mediums[5].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe1.mediums[5].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe1.mediums[5].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe1.mediums[5].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe1.mediums[5].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.mediums[5].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4231,8 +3622,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe1.mediums[5].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe1.mediums[5].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe1.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[5].T) \"Temperature of medium in [degC]\";
-//   Real pipe1.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[5].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe1.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe1.mediums[5].T) \"Temperature of medium in [degC]\";
+//   Real pipe1.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe1.mediums[5].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe1.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe1.mediums[5].phi \"Relative humidity\";
 //   protected Real pipe1.mediums[5].n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4240,7 +3631,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe1.mediums[5].n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe1.mediums[5].n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe1.mediums[5].n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe1.mediums[5].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe1.mediums[5].n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe1.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe1.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe1.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
@@ -4267,21 +3658,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.Wb_flows[4](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   Real pipe1.Wb_flows[5](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   protected final parameter Boolean pipe1.n20 = true \"= true to set up initial equations for pressure\";
-//   final parameter Real pipe1.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe1.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe1.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe1.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe1.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe1.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe1.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe1.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe1.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe1.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe1.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe1.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe1.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe1.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe1.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"hydraulic diameters of flow segments\";
+//   final parameter Real pipe1.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe1.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe1.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe1.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe1.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe1.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe1.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe1.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe1.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe1.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe1.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe1.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe1.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe1.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe1.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe1.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe1.crossArea / pipe1.perimeter \"Hydraulic diameters of flow segments\";
 //   final parameter Real pipe1.roughnesses[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe1.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe1.roughnesses[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe1.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe1.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe1.roughness \"Average heights of surface asperities\";
@@ -4296,12 +3687,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe1.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.02 \"Start value for mass flow rate\";
 //   final parameter Integer pipe1.nNodes(min = 1) = 5 \"Number of discrete flow volumes\";
 //   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe1.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b \"Determines whether flow or volume models are present at the ports\";
-//   final parameter Boolean pipe1.useLumpedPressure = false \"=true to lump pressure states together\";
-//   final parameter Integer pipe1.nFM = 6 \"number of flow models in flowModel\";
-//   final parameter Integer pipe1.nFMDistributed = 6;
-//   final parameter Integer pipe1.nFMLumped = 2;
+//   final parameter Boolean pipe1.useLumpedPressure = false \"= true to lump pressure states together\";
+//   final parameter Integer pipe1.nFM = 6 \"Number of flow models in flowModel\";
+//   final parameter Integer pipe1.nFMDistributed = 6 \"Number of distributed flow models\";
+//   final parameter Integer pipe1.nFMLumped = 2 \"Number of lumped flow models\";
 //   final parameter Integer pipe1.iLumped = 3 \"Index of control volume with representative state if useLumpedPressure\";
-//   final parameter Boolean pipe1.useInnerPortProperties = false \"=true to take port properties for flow models from internal control volumes\";
+//   final parameter Boolean pipe1.useInnerPortProperties = false \"= true to take port properties for flow models from internal control volumes\";
 //   Real pipe1.state_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe1.state_a.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
 //   Real pipe1.state_a.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
@@ -4375,7 +3766,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.flowModel.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe1.flowModel.vs[6](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe1.flowModel.vs[7](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
-//   final parameter Real pipe1.flowModel.nParallel = pipe1.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe1.flowModel.nParallel = pipe1.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe1.flowModel.crossAreas[1](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe1.flowModel.crossAreas[2](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe1.flowModel.crossAreas[3](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
@@ -4404,7 +3795,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.flowModel.dheights[5](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final Real pipe1.flowModel.dheights[6](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final parameter Real pipe1.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g \"Constant gravity acceleration\";
-//   final parameter Boolean pipe1.flowModel.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (states[1] -> states[n+1])\";
+//   final parameter Boolean pipe1.flowModel.allowFlowReversal = true \"= true, if flow reversal is enabled, otherwise restrict flow to design direction (states[1] -> states[n+1])\";
 //   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial \"Formulation of momentum balance\";
 //   final parameter Real pipe1.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.02 \"Start value of mass flow rates\";
 //   final parameter Real pipe1.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) = pipe1.p_a_start \"Start value for p[1] at design inflow\";
@@ -4416,12 +3807,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.flowModel.pathLengths[4](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe1.flowModel.pathLengths[5](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe1.flowModel.pathLengths[6](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
-//   Real pipe1.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe1.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe1.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe1.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe1.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe1.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe1.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
 //   Real pipe1.flowModel.Is[1](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe1.flowModel.Is[2](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe1.flowModel.Is[3](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
@@ -4474,12 +3865,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.flowModel.mus_act[4](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe1.flowModel.mus_act[5](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe1.flowModel.mus_act[6](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
-//   Real pipe1.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe1.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe1.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe1.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe1.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe1.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe1.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
 //   final parameter Real pipe1.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Start of turbulent regime, depending on type of flow device\";
 //   final parameter Boolean pipe1.flowModel.show_Res = false \"= true, if Reynolds numbers are included for plotting\";
 //   protected final parameter Boolean pipe1.flowModel.n21 = false \"= true, if rho_nominal is used, otherwise computed from medium\";
@@ -4502,15 +3893,15 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe1.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe1.flowModel.m_flow_small \"Nominal mass flow rate\";
 //   parameter Real pipe1.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small \"Within regularization if |m_flows| < m_flow_small (may be wider for large discontinuities in static head)\";
 //   protected parameter Real pipe1.flowModel.n25(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 1e5) \"Within regularization if |dp| < dp_small (may be wider for large discontinuities in static head)\";
-//   protected final parameter Boolean pipe1.flowModel.n26 = false \"= true if the pressure loss does not depend on fluid states\";
-//   protected final parameter Boolean pipe1.flowModel.n27 = false \"= true if the pressure loss is continuous around zero flow\";
-//   protected Real pipe1.flowModel.n28[1](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n28[2](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n28[3](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n28[4](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n28[5](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n28[6](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe1.flowModel.n29(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[1], pipe1.flowModel.n28[1], (pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[2], pipe1.flowModel.n28[2], (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[3], pipe1.flowModel.n28[3], (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[4], pipe1.flowModel.n28[4], (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[5], pipe1.flowModel.n28[5], (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[6], pipe1.flowModel.n28[6], (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[6]) \"pressure loss for nominal conditions\";
+//   protected final parameter Boolean pipe1.flowModel.n26 = false \"= true, if the pressure loss does not depend on fluid states\";
+//   protected final parameter Boolean pipe1.flowModel.n27 = false \"= true, if the pressure loss is continuous around zero flow\";
+//   protected Real pipe1.flowModel.n28[1](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n28[2](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n28[3](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n28[4](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n28[5](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n28[6](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe1.flowModel.n29(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[1], pipe1.flowModel.n28[1], (pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[2], pipe1.flowModel.n28[2], (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[3], pipe1.flowModel.n28[3], (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[4], pipe1.flowModel.n28[4], (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[5], pipe1.flowModel.n28[5], (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.n22, pipe1.flowModel.n22, pipe1.flowModel.n24, pipe1.flowModel.n24, pipe1.flowModel.pathLengths_internal[6], pipe1.flowModel.n28[6], (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[6]) \"Pressure loss for nominal conditions\";
 //   Real pipe1.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe1.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe1.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
@@ -4529,11 +3920,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.H_flows[4](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe1.H_flows[5](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe1.H_flows[6](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
-//   Real pipe1.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe1.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe1.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe1.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe1.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
+//   Real pipe1.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe1.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe1.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe1.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe1.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
 //   protected Real pipe1.n30[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe1.n30[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe1.n30[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -4629,7 +4020,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.heatTransfer.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe1.heatTransfer.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe1.heatTransfer.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
-//   final parameter Real pipe1.heatTransfer.nParallel = pipe1.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe1.heatTransfer.nParallel = pipe1.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe1.heatTransfer.lengths[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe1.heatTransfer.lengths[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe1.heatTransfer.lengths[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -4645,11 +4036,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.heatTransfer.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe1.heatTransfer.roughnesses[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe1.heatTransfer.roughnesses[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
-//   final parameter Real pipe1.dxs[1] = 0.2;
-//   final parameter Real pipe1.dxs[2] = 0.2;
-//   final parameter Real pipe1.dxs[3] = 0.2;
-//   final parameter Real pipe1.dxs[4] = 0.2;
-//   final parameter Real pipe1.dxs[5] = 0.2;
+//   final parameter Real pipe1.dxs[1] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe1.dxs[2] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe1.dxs[3] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe1.dxs[4] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe1.dxs[5] = 0.2 \"Normalized lengths\";
 //   final parameter Boolean pipe2.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (port_a -> port_b)\";
 //   Real pipe2.port_a.m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5) \"Mass flow rate from the connection point into the component\";
 //   Real pipe2.port_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
@@ -4664,12 +4055,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected parameter Boolean pipe2.n38 = true \"= false to hide the arrow in the model icon\";
 //   parameter Real pipe2.nParallel(min = 1.0) = 1.0 \"Number of identical parallel pipes\";
 //   final parameter Real pipe2.length(quantity = \"Length\", unit = \"m\") = 50.0 \"Length\";
-//   final parameter Boolean pipe2.isCircular = true \"= true if cross sectional area is circular\";
+//   final parameter Boolean pipe2.isCircular = true \"= true, if cross sectional area is circular\";
 //   parameter Real pipe2.diameter(quantity = \"Length\", unit = \"m\", min = 0.0) = 0.0254 \"Diameter of circular pipe\";
 //   parameter Real pipe2.crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * pipe2.diameter * pipe2.diameter / 4.0 \"Inner cross section area\";
 //   parameter Real pipe2.perimeter(quantity = \"Length\", unit = \"m\", min = 0.0) = 3.141592653589793 * pipe2.diameter \"Inner perimeter\";
 //   parameter Real pipe2.roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-5 \"Average height of surface asperities (default: smooth steel pipe)\";
-//   final parameter Real pipe2.V(quantity = \"Volume\", unit = \"m3\") = pipe2.crossArea * 50.0 * pipe2.nParallel \"volume size\";
+//   final parameter Real pipe2.V(quantity = \"Volume\", unit = \"m3\") = pipe2.crossArea * 50.0 * pipe2.nParallel \"Volume size\";
 //   final parameter Real pipe2.height_ab(quantity = \"Length\", unit = \"m\") = 25.0 \"Height(port_b) - Height(port_a)\";
 //   final parameter Integer pipe2.n = 5 \"Number of discrete volumes\";
 //   final Real pipe2.fluidVolumes[1](quantity = \"Volume\", unit = \"m3\") \"Discretized volume, determine in inheriting class\";
@@ -4716,7 +4107,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[1].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[1].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[1].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe2.mediums[1].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe2.mediums[1].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe2.mediums[1].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe2.mediums[1].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[1].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4724,8 +4115,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe2.mediums[1].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe2.mediums[1].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe2.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[1].T) \"Temperature of medium in [degC]\";
-//   Real pipe2.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[1].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe2.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe2.mediums[1].T) \"Temperature of medium in [degC]\";
+//   Real pipe2.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe2.mediums[1].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe2.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe2.mediums[1].phi \"Relative humidity\";
 //   protected Real pipe2.mediums[1].n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4733,7 +4124,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.mediums[1].n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe2.mediums[1].n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe2.mediums[1].n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe2.mediums[1].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe2.mediums[1].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe2.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[2], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe2.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start) \"Specific enthalpy of medium\";
@@ -4742,7 +4133,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[2].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[2].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[2].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe2.mediums[2].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe2.mediums[2].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe2.mediums[2].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe2.mediums[2].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[2].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4750,8 +4141,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe2.mediums[2].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe2.mediums[2].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe2.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[2].T) \"Temperature of medium in [degC]\";
-//   Real pipe2.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[2].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe2.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe2.mediums[2].T) \"Temperature of medium in [degC]\";
+//   Real pipe2.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe2.mediums[2].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe2.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe2.mediums[2].phi \"Relative humidity\";
 //   protected Real pipe2.mediums[2].n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4759,7 +4150,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.mediums[2].n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe2.mediums[2].n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe2.mediums[2].n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe2.mediums[2].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe2.mediums[2].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe2.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[3], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe2.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start) \"Specific enthalpy of medium\";
@@ -4768,7 +4159,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[3].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[3].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[3].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe2.mediums[3].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe2.mediums[3].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe2.mediums[3].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe2.mediums[3].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[3].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4776,8 +4167,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe2.mediums[3].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe2.mediums[3].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe2.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[3].T) \"Temperature of medium in [degC]\";
-//   Real pipe2.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[3].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe2.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe2.mediums[3].T) \"Temperature of medium in [degC]\";
+//   Real pipe2.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe2.mediums[3].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe2.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe2.mediums[3].phi \"Relative humidity\";
 //   protected Real pipe2.mediums[3].n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4785,7 +4176,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.mediums[3].n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe2.mediums[3].n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe2.mediums[3].n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe2.mediums[3].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe2.mediums[3].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe2.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[4], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe2.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start) \"Specific enthalpy of medium\";
@@ -4794,7 +4185,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[4].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[4].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[4].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe2.mediums[4].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe2.mediums[4].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe2.mediums[4].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe2.mediums[4].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[4].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4802,8 +4193,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe2.mediums[4].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe2.mediums[4].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe2.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[4].T) \"Temperature of medium in [degC]\";
-//   Real pipe2.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[4].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe2.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe2.mediums[4].T) \"Temperature of medium in [degC]\";
+//   Real pipe2.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe2.mediums[4].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe2.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe2.mediums[4].phi \"Relative humidity\";
 //   protected Real pipe2.mediums[4].n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4811,7 +4202,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.mediums[4].n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe2.mediums[4].n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe2.mediums[4].n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe2.mediums[4].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe2.mediums[4].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe2.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[5], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe2.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start) \"Specific enthalpy of medium\";
@@ -4820,7 +4211,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[5].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[5].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe2.mediums[5].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe2.mediums[5].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe2.mediums[5].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe2.mediums[5].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe2.mediums[5].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.mediums[5].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -4828,8 +4219,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe2.mediums[5].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe2.mediums[5].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe2.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[5].T) \"Temperature of medium in [degC]\";
-//   Real pipe2.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[5].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe2.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe2.mediums[5].T) \"Temperature of medium in [degC]\";
+//   Real pipe2.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe2.mediums[5].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe2.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe2.mediums[5].phi \"Relative humidity\";
 //   protected Real pipe2.mediums[5].n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -4837,7 +4228,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.mediums[5].n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe2.mediums[5].n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe2.mediums[5].n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe2.mediums[5].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe2.mediums[5].n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe2.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe2.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe2.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
@@ -4864,21 +4255,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.Wb_flows[4](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   Real pipe2.Wb_flows[5](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   protected final parameter Boolean pipe2.n45 = true \"= true to set up initial equations for pressure\";
-//   final parameter Real pipe2.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe2.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe2.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe2.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe2.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe2.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe2.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe2.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe2.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe2.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe2.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe2.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe2.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe2.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe2.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"hydraulic diameters of flow segments\";
+//   final parameter Real pipe2.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe2.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe2.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe2.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe2.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe2.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe2.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe2.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe2.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe2.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe2.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe2.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe2.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe2.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe2.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe2.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe2.crossArea / pipe2.perimeter \"Hydraulic diameters of flow segments\";
 //   final parameter Real pipe2.roughnesses[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe2.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe2.roughnesses[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe2.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe2.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe2.roughness \"Average heights of surface asperities\";
@@ -4893,12 +4284,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe2.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.01 \"Start value for mass flow rate\";
 //   final parameter Integer pipe2.nNodes(min = 1) = 5 \"Number of discrete flow volumes\";
 //   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe2.modelStructure = Modelica.Fluid.Types.ModelStructure.av_vb \"Determines whether flow or volume models are present at the ports\";
-//   final parameter Boolean pipe2.useLumpedPressure = false \"=true to lump pressure states together\";
-//   final parameter Integer pipe2.nFM = 4 \"number of flow models in flowModel\";
-//   final parameter Integer pipe2.nFMDistributed = 4;
-//   final parameter Integer pipe2.nFMLumped = 1;
+//   final parameter Boolean pipe2.useLumpedPressure = false \"= true to lump pressure states together\";
+//   final parameter Integer pipe2.nFM = 4 \"Number of flow models in flowModel\";
+//   final parameter Integer pipe2.nFMDistributed = 4 \"Number of distributed flow models\";
+//   final parameter Integer pipe2.nFMLumped = 1 \"Number of lumped flow models\";
 //   final parameter Integer pipe2.iLumped = 3 \"Index of control volume with representative state if useLumpedPressure\";
-//   final parameter Boolean pipe2.useInnerPortProperties = false \"=true to take port properties for flow models from internal control volumes\";
+//   final parameter Boolean pipe2.useInnerPortProperties = false \"= true to take port properties for flow models from internal control volumes\";
 //   Real pipe2.state_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe2.state_a.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
 //   Real pipe2.state_a.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
@@ -4954,7 +4345,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.flowModel.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe2.flowModel.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe2.flowModel.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
-//   final parameter Real pipe2.flowModel.nParallel = pipe2.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe2.flowModel.nParallel = pipe2.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe2.flowModel.crossAreas[1](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe2.flowModel.crossAreas[2](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe2.flowModel.crossAreas[3](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
@@ -4975,7 +4366,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.flowModel.dheights[3](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final Real pipe2.flowModel.dheights[4](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final parameter Real pipe2.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g \"Constant gravity acceleration\";
-//   final parameter Boolean pipe2.flowModel.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (states[1] -> states[n+1])\";
+//   final parameter Boolean pipe2.flowModel.allowFlowReversal = true \"= true, if flow reversal is enabled, otherwise restrict flow to design direction (states[1] -> states[n+1])\";
 //   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial \"Formulation of momentum balance\";
 //   final parameter Real pipe2.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.01 \"Start value of mass flow rates\";
 //   final parameter Real pipe2.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) = pipe2.p_a_start \"Start value for p[1] at design inflow\";
@@ -4985,10 +4376,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.flowModel.pathLengths[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe2.flowModel.pathLengths[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe2.flowModel.pathLengths[4](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
-//   Real pipe2.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe2.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe2.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe2.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
+//   Real pipe2.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe2.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe2.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe2.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
 //   Real pipe2.flowModel.Is[1](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe2.flowModel.Is[2](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe2.flowModel.Is[3](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
@@ -5025,10 +4416,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.flowModel.mus_act[2](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe2.flowModel.mus_act[3](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe2.flowModel.mus_act[4](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
-//   Real pipe2.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"pressure drop between states\";
-//   Real pipe2.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"pressure drop between states\";
-//   Real pipe2.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"pressure drop between states\";
-//   Real pipe2.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"pressure drop between states\";
+//   Real pipe2.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"Pressure drop between states\";
+//   Real pipe2.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"Pressure drop between states\";
+//   Real pipe2.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"Pressure drop between states\";
+//   Real pipe2.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0) \"Pressure drop between states\";
 //   final parameter Real pipe2.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Start of turbulent regime, depending on type of flow device\";
 //   final parameter Boolean pipe2.flowModel.show_Res = false \"= true, if Reynolds numbers are included for plotting\";
 //   protected final parameter Boolean pipe2.flowModel.n46 = false \"= true, if rho_nominal is used, otherwise computed from medium\";
@@ -5047,13 +4438,13 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe2.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe2.flowModel.m_flow_small \"Nominal mass flow rate\";
 //   parameter Real pipe2.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small \"Within regularization if |m_flows| < m_flow_small (may be wider for large discontinuities in static head)\";
 //   protected parameter Real pipe2.flowModel.n50(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 1e5) \"Within regularization if |dp| < dp_small (may be wider for large discontinuities in static head)\";
-//   protected final parameter Boolean pipe2.flowModel.n51 = false \"= true if the pressure loss does not depend on fluid states\";
-//   protected final parameter Boolean pipe2.flowModel.n52 = false \"= true if the pressure loss is continuous around zero flow\";
-//   protected Real pipe2.flowModel.n53[1](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe2.flowModel.n53[2](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe2.flowModel.n53[3](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe2.flowModel.n53[4](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe2.flowModel.n54(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[1], pipe2.flowModel.n53[1], (pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[2], pipe2.flowModel.n53[2], (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[3], pipe2.flowModel.n53[3], (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[4], pipe2.flowModel.n53[4], (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[4]) \"pressure loss for nominal conditions\";
+//   protected final parameter Boolean pipe2.flowModel.n51 = false \"= true, if the pressure loss does not depend on fluid states\";
+//   protected final parameter Boolean pipe2.flowModel.n52 = false \"= true, if the pressure loss is continuous around zero flow\";
+//   protected Real pipe2.flowModel.n53[1](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe2.flowModel.n53[2](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe2.flowModel.n53[3](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe2.flowModel.n53[4](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe2.flowModel.n54(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[1], pipe2.flowModel.n53[1], (pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[2], pipe2.flowModel.n53[2], (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[3], pipe2.flowModel.n53[3], (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.n47, pipe2.flowModel.n47, pipe2.flowModel.n49, pipe2.flowModel.n49, pipe2.flowModel.pathLengths_internal[4], pipe2.flowModel.n53[4], (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[4]) \"Pressure loss for nominal conditions\";
 //   Real pipe2.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe2.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe2.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
@@ -5072,11 +4463,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.H_flows[4](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe2.H_flows[5](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe2.H_flows[6](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
-//   Real pipe2.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe2.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe2.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe2.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe2.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
+//   Real pipe2.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe2.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe2.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe2.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe2.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
 //   protected Real pipe2.n55[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe2.n55[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe2.n55[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -5170,7 +4561,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.heatTransfer.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe2.heatTransfer.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe2.heatTransfer.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
-//   final parameter Real pipe2.heatTransfer.nParallel = pipe2.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe2.heatTransfer.nParallel = pipe2.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe2.heatTransfer.lengths[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe2.heatTransfer.lengths[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe2.heatTransfer.lengths[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -5186,12 +4577,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.heatTransfer.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe2.heatTransfer.roughnesses[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe2.heatTransfer.roughnesses[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
-//   parameter Real pipe2.heatTransfer.alpha0(quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\") = 100.0 \"guess value for heat transfer coefficients\";
-//   Real pipe2.heatTransfer.alphas[1](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"CoefficientOfHeatTransfer\";
-//   Real pipe2.heatTransfer.alphas[2](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"CoefficientOfHeatTransfer\";
-//   Real pipe2.heatTransfer.alphas[3](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"CoefficientOfHeatTransfer\";
-//   Real pipe2.heatTransfer.alphas[4](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"CoefficientOfHeatTransfer\";
-//   Real pipe2.heatTransfer.alphas[5](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"CoefficientOfHeatTransfer\";
+//   parameter Real pipe2.heatTransfer.alpha0(quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\") = 100.0 \"Guess value for heat transfer coefficients\";
+//   Real pipe2.heatTransfer.alphas[1](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"Heat transfer coefficient\";
+//   Real pipe2.heatTransfer.alphas[2](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"Heat transfer coefficient\";
+//   Real pipe2.heatTransfer.alphas[3](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"Heat transfer coefficient\";
+//   Real pipe2.heatTransfer.alphas[4](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"Heat transfer coefficient\";
+//   Real pipe2.heatTransfer.alphas[5](quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\", start = pipe2.heatTransfer.alpha0) \"Heat transfer coefficient\";
 //   Real pipe2.heatTransfer.Res[1] \"Reynolds numbers\";
 //   Real pipe2.heatTransfer.Res[2] \"Reynolds numbers\";
 //   Real pipe2.heatTransfer.Res[3] \"Reynolds numbers\";
@@ -5248,11 +4639,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe2.heatTransfer.n65[3];
 //   protected Real pipe2.heatTransfer.n65[4];
 //   protected Real pipe2.heatTransfer.n65[5];
-//   final parameter Real pipe2.dxs[1] = 0.2;
-//   final parameter Real pipe2.dxs[2] = 0.2;
-//   final parameter Real pipe2.dxs[3] = 0.2;
-//   final parameter Real pipe2.dxs[4] = 0.2;
-//   final parameter Real pipe2.dxs[5] = 0.2;
+//   final parameter Real pipe2.dxs[1] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe2.dxs[2] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe2.dxs[3] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe2.dxs[4] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe2.dxs[5] = 0.2 \"Normalized lengths\";
 //   final parameter Boolean pipe3.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (port_a -> port_b)\";
 //   Real pipe3.port_a.m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5) \"Mass flow rate from the connection point into the component\";
 //   Real pipe3.port_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
@@ -5267,12 +4658,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected parameter Boolean pipe3.n68 = true \"= false to hide the arrow in the model icon\";
 //   parameter Real pipe3.nParallel(min = 1.0) = 1.0 \"Number of identical parallel pipes\";
 //   final parameter Real pipe3.length(quantity = \"Length\", unit = \"m\") = 25.0 \"Length\";
-//   final parameter Boolean pipe3.isCircular = true \"= true if cross sectional area is circular\";
+//   final parameter Boolean pipe3.isCircular = true \"= true, if cross sectional area is circular\";
 //   parameter Real pipe3.diameter(quantity = \"Length\", unit = \"m\", min = 0.0) = 0.0254 \"Diameter of circular pipe\";
 //   parameter Real pipe3.crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * pipe3.diameter * pipe3.diameter / 4.0 \"Inner cross section area\";
 //   parameter Real pipe3.perimeter(quantity = \"Length\", unit = \"m\", min = 0.0) = 3.141592653589793 * pipe3.diameter \"Inner perimeter\";
 //   parameter Real pipe3.roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-5 \"Average height of surface asperities (default: smooth steel pipe)\";
-//   final parameter Real pipe3.V(quantity = \"Volume\", unit = \"m3\") = pipe3.crossArea * 25.0 * pipe3.nParallel \"volume size\";
+//   final parameter Real pipe3.V(quantity = \"Volume\", unit = \"m3\") = pipe3.crossArea * 25.0 * pipe3.nParallel \"Volume size\";
 //   final parameter Real pipe3.height_ab(quantity = \"Length\", unit = \"m\") = 25.0 \"Height(port_b) - Height(port_a)\";
 //   final parameter Integer pipe3.n = 5 \"Number of discrete volumes\";
 //   final Real pipe3.fluidVolumes[1](quantity = \"Volume\", unit = \"m3\") \"Discretized volume, determine in inheriting class\";
@@ -5319,7 +4710,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[1].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[1].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[1].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe3.mediums[1].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe3.mediums[1].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe3.mediums[1].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe3.mediums[1].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[1].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5327,8 +4718,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe3.mediums[1].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe3.mediums[1].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe3.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[1].T) \"Temperature of medium in [degC]\";
-//   Real pipe3.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[1].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe3.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe3.mediums[1].T) \"Temperature of medium in [degC]\";
+//   Real pipe3.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe3.mediums[1].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe3.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe3.mediums[1].phi \"Relative humidity\";
 //   protected Real pipe3.mediums[1].n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5336,7 +4727,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe3.mediums[1].n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe3.mediums[1].n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe3.mediums[1].n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe3.mediums[1].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe3.mediums[1].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe3.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[2], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe3.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start) \"Specific enthalpy of medium\";
@@ -5345,7 +4736,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[2].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[2].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[2].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe3.mediums[2].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe3.mediums[2].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe3.mediums[2].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe3.mediums[2].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[2].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5353,8 +4744,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe3.mediums[2].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe3.mediums[2].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe3.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[2].T) \"Temperature of medium in [degC]\";
-//   Real pipe3.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[2].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe3.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe3.mediums[2].T) \"Temperature of medium in [degC]\";
+//   Real pipe3.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe3.mediums[2].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe3.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe3.mediums[2].phi \"Relative humidity\";
 //   protected Real pipe3.mediums[2].n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5362,7 +4753,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe3.mediums[2].n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe3.mediums[2].n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe3.mediums[2].n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe3.mediums[2].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe3.mediums[2].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe3.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[3], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe3.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start) \"Specific enthalpy of medium\";
@@ -5371,7 +4762,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[3].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[3].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[3].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe3.mediums[3].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe3.mediums[3].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe3.mediums[3].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe3.mediums[3].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[3].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5379,8 +4770,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe3.mediums[3].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe3.mediums[3].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe3.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[3].T) \"Temperature of medium in [degC]\";
-//   Real pipe3.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[3].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe3.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe3.mediums[3].T) \"Temperature of medium in [degC]\";
+//   Real pipe3.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe3.mediums[3].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe3.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe3.mediums[3].phi \"Relative humidity\";
 //   protected Real pipe3.mediums[3].n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5388,7 +4779,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe3.mediums[3].n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe3.mediums[3].n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe3.mediums[3].n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe3.mediums[3].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe3.mediums[3].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe3.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[4], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe3.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start) \"Specific enthalpy of medium\";
@@ -5397,7 +4788,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[4].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[4].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[4].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe3.mediums[4].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe3.mediums[4].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe3.mediums[4].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe3.mediums[4].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[4].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5405,8 +4796,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe3.mediums[4].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe3.mediums[4].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe3.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[4].T) \"Temperature of medium in [degC]\";
-//   Real pipe3.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[4].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe3.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe3.mediums[4].T) \"Temperature of medium in [degC]\";
+//   Real pipe3.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe3.mediums[4].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe3.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe3.mediums[4].phi \"Relative humidity\";
 //   protected Real pipe3.mediums[4].n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5414,7 +4805,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe3.mediums[4].n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe3.mediums[4].n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe3.mediums[4].n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe3.mediums[4].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe3.mediums[4].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe3.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[5], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe3.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start) \"Specific enthalpy of medium\";
@@ -5423,7 +4814,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[5].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[5].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe3.mediums[5].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe3.mediums[5].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe3.mediums[5].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe3.mediums[5].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe3.mediums[5].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.mediums[5].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5431,8 +4822,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe3.mediums[5].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe3.mediums[5].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe3.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[5].T) \"Temperature of medium in [degC]\";
-//   Real pipe3.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[5].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe3.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe3.mediums[5].T) \"Temperature of medium in [degC]\";
+//   Real pipe3.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe3.mediums[5].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe3.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe3.mediums[5].phi \"Relative humidity\";
 //   protected Real pipe3.mediums[5].n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5440,7 +4831,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe3.mediums[5].n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe3.mediums[5].n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe3.mediums[5].n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe3.mediums[5].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe3.mediums[5].n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe3.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe3.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe3.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
@@ -5467,21 +4858,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.Wb_flows[4](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   Real pipe3.Wb_flows[5](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   protected final parameter Boolean pipe3.n75 = true \"= true to set up initial equations for pressure\";
-//   final parameter Real pipe3.lengths[1](quantity = \"Length\", unit = \"m\") = 5.0 \"lengths of flow segments\";
-//   final parameter Real pipe3.lengths[2](quantity = \"Length\", unit = \"m\") = 5.0 \"lengths of flow segments\";
-//   final parameter Real pipe3.lengths[3](quantity = \"Length\", unit = \"m\") = 5.0 \"lengths of flow segments\";
-//   final parameter Real pipe3.lengths[4](quantity = \"Length\", unit = \"m\") = 5.0 \"lengths of flow segments\";
-//   final parameter Real pipe3.lengths[5](quantity = \"Length\", unit = \"m\") = 5.0 \"lengths of flow segments\";
-//   final parameter Real pipe3.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe3.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe3.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe3.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe3.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe3.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe3.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe3.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe3.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe3.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"hydraulic diameters of flow segments\";
+//   final parameter Real pipe3.lengths[1](quantity = \"Length\", unit = \"m\") = 5.0 \"Lengths of flow segments\";
+//   final parameter Real pipe3.lengths[2](quantity = \"Length\", unit = \"m\") = 5.0 \"Lengths of flow segments\";
+//   final parameter Real pipe3.lengths[3](quantity = \"Length\", unit = \"m\") = 5.0 \"Lengths of flow segments\";
+//   final parameter Real pipe3.lengths[4](quantity = \"Length\", unit = \"m\") = 5.0 \"Lengths of flow segments\";
+//   final parameter Real pipe3.lengths[5](quantity = \"Length\", unit = \"m\") = 5.0 \"Lengths of flow segments\";
+//   final parameter Real pipe3.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe3.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe3.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe3.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe3.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe3.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe3.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe3.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe3.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe3.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe3.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe3.crossArea / pipe3.perimeter \"Hydraulic diameters of flow segments\";
 //   final parameter Real pipe3.roughnesses[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe3.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe3.roughnesses[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe3.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe3.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe3.roughness \"Average heights of surface asperities\";
@@ -5496,12 +4887,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe3.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.01 \"Start value for mass flow rate\";
 //   final parameter Integer pipe3.nNodes(min = 1) = 5 \"Number of discrete flow volumes\";
 //   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe3.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b \"Determines whether flow or volume models are present at the ports\";
-//   final parameter Boolean pipe3.useLumpedPressure = false \"=true to lump pressure states together\";
-//   final parameter Integer pipe3.nFM = 6 \"number of flow models in flowModel\";
-//   final parameter Integer pipe3.nFMDistributed = 6;
-//   final parameter Integer pipe3.nFMLumped = 2;
+//   final parameter Boolean pipe3.useLumpedPressure = false \"= true to lump pressure states together\";
+//   final parameter Integer pipe3.nFM = 6 \"Number of flow models in flowModel\";
+//   final parameter Integer pipe3.nFMDistributed = 6 \"Number of distributed flow models\";
+//   final parameter Integer pipe3.nFMLumped = 2 \"Number of lumped flow models\";
 //   final parameter Integer pipe3.iLumped = 3 \"Index of control volume with representative state if useLumpedPressure\";
-//   final parameter Boolean pipe3.useInnerPortProperties = false \"=true to take port properties for flow models from internal control volumes\";
+//   final parameter Boolean pipe3.useInnerPortProperties = false \"= true to take port properties for flow models from internal control volumes\";
 //   Real pipe3.state_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe3.state_a.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
 //   Real pipe3.state_a.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
@@ -5575,7 +4966,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.flowModel.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe3.flowModel.vs[6](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe3.flowModel.vs[7](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
-//   final parameter Real pipe3.flowModel.nParallel = pipe3.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe3.flowModel.nParallel = pipe3.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe3.flowModel.crossAreas[1](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe3.flowModel.crossAreas[2](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe3.flowModel.crossAreas[3](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
@@ -5604,7 +4995,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.flowModel.dheights[5](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final Real pipe3.flowModel.dheights[6](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final parameter Real pipe3.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g \"Constant gravity acceleration\";
-//   final parameter Boolean pipe3.flowModel.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (states[1] -> states[n+1])\";
+//   final parameter Boolean pipe3.flowModel.allowFlowReversal = true \"= true, if flow reversal is enabled, otherwise restrict flow to design direction (states[1] -> states[n+1])\";
 //   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial \"Formulation of momentum balance\";
 //   final parameter Real pipe3.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.01 \"Start value of mass flow rates\";
 //   final parameter Real pipe3.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) = pipe3.p_a_start \"Start value for p[1] at design inflow\";
@@ -5616,12 +5007,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.flowModel.pathLengths[4](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe3.flowModel.pathLengths[5](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe3.flowModel.pathLengths[6](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
-//   Real pipe3.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe3.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe3.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe3.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe3.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe3.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe3.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
 //   Real pipe3.flowModel.Is[1](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe3.flowModel.Is[2](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe3.flowModel.Is[3](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
@@ -5674,12 +5065,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.flowModel.mus_act[4](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe3.flowModel.mus_act[5](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe3.flowModel.mus_act[6](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
-//   Real pipe3.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe3.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe3.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe3.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe3.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe3.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe3.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
 //   final parameter Real pipe3.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Start of turbulent regime, depending on type of flow device\";
 //   final parameter Boolean pipe3.flowModel.show_Res = false \"= true, if Reynolds numbers are included for plotting\";
 //   protected final parameter Boolean pipe3.flowModel.n76 = false \"= true, if rho_nominal is used, otherwise computed from medium\";
@@ -5702,15 +5093,15 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe3.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe3.flowModel.m_flow_small \"Nominal mass flow rate\";
 //   parameter Real pipe3.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small \"Within regularization if |m_flows| < m_flow_small (may be wider for large discontinuities in static head)\";
 //   protected parameter Real pipe3.flowModel.n80(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 1e5) \"Within regularization if |dp| < dp_small (may be wider for large discontinuities in static head)\";
-//   protected final parameter Boolean pipe3.flowModel.n81 = false \"= true if the pressure loss does not depend on fluid states\";
-//   protected final parameter Boolean pipe3.flowModel.n82 = false \"= true if the pressure loss is continuous around zero flow\";
-//   protected Real pipe3.flowModel.n83[1](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n83[2](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n83[3](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n83[4](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n83[5](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n83[6](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe3.flowModel.n84(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[1], pipe3.flowModel.n83[1], (pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[2], pipe3.flowModel.n83[2], (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[3], pipe3.flowModel.n83[3], (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[4], pipe3.flowModel.n83[4], (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[5], pipe3.flowModel.n83[5], (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[6], pipe3.flowModel.n83[6], (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[6]) \"pressure loss for nominal conditions\";
+//   protected final parameter Boolean pipe3.flowModel.n81 = false \"= true, if the pressure loss does not depend on fluid states\";
+//   protected final parameter Boolean pipe3.flowModel.n82 = false \"= true, if the pressure loss is continuous around zero flow\";
+//   protected Real pipe3.flowModel.n83[1](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n83[2](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n83[3](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n83[4](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n83[5](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n83[6](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe3.flowModel.n84(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[1], pipe3.flowModel.n83[1], (pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[2], pipe3.flowModel.n83[2], (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[3], pipe3.flowModel.n83[3], (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[4], pipe3.flowModel.n83[4], (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[5], pipe3.flowModel.n83[5], (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.n77, pipe3.flowModel.n77, pipe3.flowModel.n79, pipe3.flowModel.n79, pipe3.flowModel.pathLengths_internal[6], pipe3.flowModel.n83[6], (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[6]) \"Pressure loss for nominal conditions\";
 //   Real pipe3.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe3.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe3.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.01) \"Mass flow rates of fluid across segment boundaries\";
@@ -5729,11 +5120,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.H_flows[4](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe3.H_flows[5](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe3.H_flows[6](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
-//   Real pipe3.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe3.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe3.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe3.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe3.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
+//   Real pipe3.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe3.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe3.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe3.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe3.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
 //   protected Real pipe3.n85[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe3.n85[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe3.n85[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -5829,7 +5220,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.heatTransfer.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe3.heatTransfer.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe3.heatTransfer.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
-//   final parameter Real pipe3.heatTransfer.nParallel = pipe3.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe3.heatTransfer.nParallel = pipe3.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe3.heatTransfer.lengths[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe3.heatTransfer.lengths[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe3.heatTransfer.lengths[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -5845,11 +5236,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.heatTransfer.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe3.heatTransfer.roughnesses[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe3.heatTransfer.roughnesses[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
-//   final parameter Real pipe3.dxs[1] = 0.2;
-//   final parameter Real pipe3.dxs[2] = 0.2;
-//   final parameter Real pipe3.dxs[3] = 0.2;
-//   final parameter Real pipe3.dxs[4] = 0.2;
-//   final parameter Real pipe3.dxs[5] = 0.2;
+//   final parameter Real pipe3.dxs[1] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe3.dxs[2] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe3.dxs[3] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe3.dxs[4] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe3.dxs[5] = 0.2 \"Normalized lengths\";
 //   final parameter Boolean pipe4.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (port_a -> port_b)\";
 //   Real pipe4.port_a.m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5) \"Mass flow rate from the connection point into the component\";
 //   Real pipe4.port_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
@@ -5864,12 +5255,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected parameter Boolean pipe4.n93 = true \"= false to hide the arrow in the model icon\";
 //   parameter Real pipe4.nParallel(min = 1.0) = 1.0 \"Number of identical parallel pipes\";
 //   final parameter Real pipe4.length(quantity = \"Length\", unit = \"m\") = 50.0 \"Length\";
-//   final parameter Boolean pipe4.isCircular = true \"= true if cross sectional area is circular\";
+//   final parameter Boolean pipe4.isCircular = true \"= true, if cross sectional area is circular\";
 //   parameter Real pipe4.diameter(quantity = \"Length\", unit = \"m\", min = 0.0) = 0.0254 \"Diameter of circular pipe\";
 //   parameter Real pipe4.crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * pipe4.diameter * pipe4.diameter / 4.0 \"Inner cross section area\";
 //   parameter Real pipe4.perimeter(quantity = \"Length\", unit = \"m\", min = 0.0) = 3.141592653589793 * pipe4.diameter \"Inner perimeter\";
 //   parameter Real pipe4.roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-5 \"Average height of surface asperities (default: smooth steel pipe)\";
-//   final parameter Real pipe4.V(quantity = \"Volume\", unit = \"m3\") = pipe4.crossArea * 50.0 * pipe4.nParallel \"volume size\";
+//   final parameter Real pipe4.V(quantity = \"Volume\", unit = \"m3\") = pipe4.crossArea * 50.0 * pipe4.nParallel \"Volume size\";
 //   final parameter Real pipe4.height_ab(quantity = \"Length\", unit = \"m\") = 50.0 \"Height(port_b) - Height(port_a)\";
 //   final parameter Integer pipe4.n = 5 \"Number of discrete volumes\";
 //   final Real pipe4.fluidVolumes[1](quantity = \"Volume\", unit = \"m3\") \"Discretized volume, determine in inheriting class\";
@@ -5916,7 +5307,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[1].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[1].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[1].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe4.mediums[1].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe4.mediums[1].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe4.mediums[1].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe4.mediums[1].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[1].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5924,8 +5315,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe4.mediums[1].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe4.mediums[1].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe4.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[1].T) \"Temperature of medium in [degC]\";
-//   Real pipe4.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[1].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe4.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe4.mediums[1].T) \"Temperature of medium in [degC]\";
+//   Real pipe4.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe4.mediums[1].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe4.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe4.mediums[1].phi \"Relative humidity\";
 //   protected Real pipe4.mediums[1].n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5933,7 +5324,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe4.mediums[1].n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe4.mediums[1].n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe4.mediums[1].n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe4.mediums[1].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe4.mediums[1].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe4.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[2], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe4.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start) \"Specific enthalpy of medium\";
@@ -5942,7 +5333,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[2].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[2].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[2].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe4.mediums[2].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe4.mediums[2].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe4.mediums[2].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe4.mediums[2].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[2].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5950,8 +5341,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe4.mediums[2].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe4.mediums[2].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe4.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[2].T) \"Temperature of medium in [degC]\";
-//   Real pipe4.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[2].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe4.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe4.mediums[2].T) \"Temperature of medium in [degC]\";
+//   Real pipe4.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe4.mediums[2].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe4.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe4.mediums[2].phi \"Relative humidity\";
 //   protected Real pipe4.mediums[2].n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5959,7 +5350,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe4.mediums[2].n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe4.mediums[2].n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe4.mediums[2].n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe4.mediums[2].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe4.mediums[2].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe4.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[3], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe4.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start) \"Specific enthalpy of medium\";
@@ -5968,7 +5359,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[3].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[3].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[3].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe4.mediums[3].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe4.mediums[3].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe4.mediums[3].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe4.mediums[3].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[3].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -5976,8 +5367,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe4.mediums[3].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe4.mediums[3].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe4.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[3].T) \"Temperature of medium in [degC]\";
-//   Real pipe4.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[3].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe4.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe4.mediums[3].T) \"Temperature of medium in [degC]\";
+//   Real pipe4.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe4.mediums[3].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe4.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe4.mediums[3].phi \"Relative humidity\";
 //   protected Real pipe4.mediums[3].n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -5985,7 +5376,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe4.mediums[3].n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe4.mediums[3].n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe4.mediums[3].n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe4.mediums[3].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe4.mediums[3].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe4.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[4], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe4.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start) \"Specific enthalpy of medium\";
@@ -5994,7 +5385,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[4].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[4].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[4].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe4.mediums[4].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe4.mediums[4].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe4.mediums[4].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe4.mediums[4].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[4].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -6002,8 +5393,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe4.mediums[4].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe4.mediums[4].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe4.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[4].T) \"Temperature of medium in [degC]\";
-//   Real pipe4.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[4].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe4.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe4.mediums[4].T) \"Temperature of medium in [degC]\";
+//   Real pipe4.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe4.mediums[4].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe4.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe4.mediums[4].phi \"Relative humidity\";
 //   protected Real pipe4.mediums[4].n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -6011,7 +5402,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe4.mediums[4].n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe4.mediums[4].n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe4.mediums[4].n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe4.mediums[4].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe4.mediums[4].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe4.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[5], nominal = 1e5, stateSelect = StateSelect.prefer) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer) \"Structurally independent mass fractions\";
 //   Real pipe4.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start) \"Specific enthalpy of medium\";
@@ -6020,7 +5411,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[5].X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[5].X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real pipe4.mediums[5].u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real pipe4.mediums[5].R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real pipe4.mediums[5].R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real pipe4.mediums[5].MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real pipe4.mediums[5].state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.mediums[5].state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -6028,8 +5419,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean pipe4.mediums[5].preferredMediumStates = true \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean pipe4.mediums[5].standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real pipe4.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[5].T) \"Temperature of medium in [degC]\";
-//   Real pipe4.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[5].p) \"Absolute pressure of medium in [bar]\";
+//   Real pipe4.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(pipe4.mediums[5].T) \"Temperature of medium in [degC]\";
+//   Real pipe4.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(pipe4.mediums[5].p) \"Absolute pressure of medium in [bar]\";
 //   Real pipe4.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real pipe4.mediums[5].phi \"Relative humidity\";
 //   protected Real pipe4.mediums[5].n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -6037,7 +5428,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real pipe4.mediums[5].n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real pipe4.mediums[5].n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real pipe4.mediums[5].n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real pipe4.mediums[5].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real pipe4.mediums[5].n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real pipe4.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe4.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
 //   Real pipe4.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) \"Mass flow rate, source or sink\";
@@ -6064,21 +5455,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.Wb_flows[4](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   Real pipe4.Wb_flows[5](quantity = \"Power\", unit = \"W\") \"Mechanical power, p*der(V) etc.\";
 //   protected final parameter Boolean pipe4.n100 = true \"= true to set up initial equations for pressure\";
-//   final parameter Real pipe4.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe4.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe4.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe4.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe4.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"lengths of flow segments\";
-//   final parameter Real pipe4.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe4.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe4.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe4.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe4.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"cross flow areas of flow segments\";
-//   final parameter Real pipe4.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe4.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe4.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe4.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"hydraulic diameters of flow segments\";
-//   final parameter Real pipe4.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"hydraulic diameters of flow segments\";
+//   final parameter Real pipe4.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe4.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe4.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe4.lengths[4](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe4.lengths[5](quantity = \"Length\", unit = \"m\") = 10.0 \"Lengths of flow segments\";
+//   final parameter Real pipe4.crossAreas[1](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe4.crossAreas[2](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe4.crossAreas[3](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe4.crossAreas[4](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe4.crossAreas[5](quantity = \"Area\", unit = \"m2\") = pipe4.crossArea \"Cross flow areas of flow segments\";
+//   final parameter Real pipe4.dimensions[1](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe4.dimensions[2](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe4.dimensions[3](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe4.dimensions[4](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"Hydraulic diameters of flow segments\";
+//   final parameter Real pipe4.dimensions[5](quantity = \"Length\", unit = \"m\") = 4.0 * pipe4.crossArea / pipe4.perimeter \"Hydraulic diameters of flow segments\";
 //   final parameter Real pipe4.roughnesses[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe4.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe4.roughnesses[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe4.roughness \"Average heights of surface asperities\";
 //   final parameter Real pipe4.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = pipe4.roughness \"Average heights of surface asperities\";
@@ -6093,12 +5484,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe4.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.02 \"Start value for mass flow rate\";
 //   final parameter Integer pipe4.nNodes(min = 1) = 5 \"Number of discrete flow volumes\";
 //   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe4.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b \"Determines whether flow or volume models are present at the ports\";
-//   final parameter Boolean pipe4.useLumpedPressure = false \"=true to lump pressure states together\";
-//   final parameter Integer pipe4.nFM = 6 \"number of flow models in flowModel\";
-//   final parameter Integer pipe4.nFMDistributed = 6;
-//   final parameter Integer pipe4.nFMLumped = 2;
+//   final parameter Boolean pipe4.useLumpedPressure = false \"= true to lump pressure states together\";
+//   final parameter Integer pipe4.nFM = 6 \"Number of flow models in flowModel\";
+//   final parameter Integer pipe4.nFMDistributed = 6 \"Number of distributed flow models\";
+//   final parameter Integer pipe4.nFMLumped = 2 \"Number of lumped flow models\";
 //   final parameter Integer pipe4.iLumped = 3 \"Index of control volume with representative state if useLumpedPressure\";
-//   final parameter Boolean pipe4.useInnerPortProperties = false \"=true to take port properties for flow models from internal control volumes\";
+//   final parameter Boolean pipe4.useInnerPortProperties = false \"= true to take port properties for flow models from internal control volumes\";
 //   Real pipe4.state_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real pipe4.state_a.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
 //   Real pipe4.state_a.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
@@ -6172,7 +5563,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.flowModel.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe4.flowModel.vs[6](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
 //   final Real pipe4.flowModel.vs[7](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow\";
-//   final parameter Real pipe4.flowModel.nParallel = pipe4.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe4.flowModel.nParallel = pipe4.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe4.flowModel.crossAreas[1](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe4.flowModel.crossAreas[2](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
 //   final Real pipe4.flowModel.crossAreas[3](quantity = \"Area\", unit = \"m2\") \"Cross flow areas at segment boundaries\";
@@ -6201,7 +5592,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.flowModel.dheights[5](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final Real pipe4.flowModel.dheights[6](quantity = \"Length\", unit = \"m\") \"Height(states[2:n]) - Height(states[1:n-1])\";
 //   final parameter Real pipe4.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g \"Constant gravity acceleration\";
-//   final parameter Boolean pipe4.flowModel.allowFlowReversal = true \"= true to allow flow reversal, false restricts to design direction (states[1] -> states[n+1])\";
+//   final parameter Boolean pipe4.flowModel.allowFlowReversal = true \"= true, if flow reversal is enabled, otherwise restrict flow to design direction (states[1] -> states[n+1])\";
 //   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial \"Formulation of momentum balance\";
 //   final parameter Real pipe4.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e5, max = 1e5) = 0.02 \"Start value of mass flow rates\";
 //   final parameter Real pipe4.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) = pipe4.p_a_start \"Start value for p[1] at design inflow\";
@@ -6213,12 +5604,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.flowModel.pathLengths[4](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe4.flowModel.pathLengths[5](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe4.flowModel.pathLengths[6](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
-//   Real pipe4.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe4.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe4.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe4.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe4.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
-//   Real pipe4.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[4](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[5](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
+//   Real pipe4.flowModel.m_flows[6](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02, stateSelect = StateSelect.prefer) \"Mass flow rates between states\";
 //   Real pipe4.flowModel.Is[1](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe4.flowModel.Is[2](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
 //   Real pipe4.flowModel.Is[3](quantity = \"Momentum\", unit = \"kg.m/s\") \"Momenta of flow segments\";
@@ -6271,12 +5662,12 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.flowModel.mus_act[4](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe4.flowModel.mus_act[5](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
 //   Real pipe4.flowModel.mus_act[6](quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 1e8, start = 0.001, nominal = 0.001) \"Actual viscosity per segment\";
-//   Real pipe4.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe4.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe4.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe4.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe4.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
-//   Real pipe4.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[2](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[3](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
+//   Real pipe4.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0) \"Pressure drop between states\";
 //   final parameter Real pipe4.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Start of turbulent regime, depending on type of flow device\";
 //   final parameter Boolean pipe4.flowModel.show_Res = false \"= true, if Reynolds numbers are included for plotting\";
 //   protected final parameter Boolean pipe4.flowModel.n101 = false \"= true, if rho_nominal is used, otherwise computed from medium\";
@@ -6299,15 +5690,15 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe4.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe4.flowModel.m_flow_small \"Nominal mass flow rate\";
 //   parameter Real pipe4.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small \"Within regularization if |m_flows| < m_flow_small (may be wider for large discontinuities in static head)\";
 //   protected parameter Real pipe4.flowModel.n105(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 1e5) \"Within regularization if |dp| < dp_small (may be wider for large discontinuities in static head)\";
-//   protected final parameter Boolean pipe4.flowModel.n106 = false \"= true if the pressure loss does not depend on fluid states\";
-//   protected final parameter Boolean pipe4.flowModel.n107 = false \"= true if the pressure loss is continuous around zero flow\";
-//   protected Real pipe4.flowModel.n108[1](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n108[2](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n108[3](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n108[4](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n108[5](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n108[6](quantity = \"Length\", unit = \"m\") \"mean diameters between segments\";
-//   protected Real pipe4.flowModel.n109(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[1], pipe4.flowModel.n108[1], (pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[2], pipe4.flowModel.n108[2], (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[3], pipe4.flowModel.n108[3], (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[4], pipe4.flowModel.n108[4], (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[5], pipe4.flowModel.n108[5], (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[6], pipe4.flowModel.n108[6], (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[6]) \"pressure loss for nominal conditions\";
+//   protected final parameter Boolean pipe4.flowModel.n106 = false \"= true, if the pressure loss does not depend on fluid states\";
+//   protected final parameter Boolean pipe4.flowModel.n107 = false \"= true, if the pressure loss is continuous around zero flow\";
+//   protected Real pipe4.flowModel.n108[1](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n108[2](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n108[3](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n108[4](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n108[5](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n108[6](quantity = \"Length\", unit = \"m\") \"Mean diameters between segments\";
+//   protected Real pipe4.flowModel.n109(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[1], pipe4.flowModel.n108[1], (pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[2], pipe4.flowModel.n108[2], (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[3], pipe4.flowModel.n108[3], (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[4], pipe4.flowModel.n108[4], (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[5], pipe4.flowModel.n108[5], (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.n102, pipe4.flowModel.n102, pipe4.flowModel.n104, pipe4.flowModel.n104, pipe4.flowModel.pathLengths_internal[6], pipe4.flowModel.n108[6], (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[6]) \"Pressure loss for nominal conditions\";
 //   Real pipe4.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe4.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
 //   Real pipe4.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e5, start = 0.02) \"Mass flow rates of fluid across segment boundaries\";
@@ -6326,11 +5717,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.H_flows[4](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe4.H_flows[5](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
 //   Real pipe4.H_flows[6](quantity = \"EnthalpyFlowRate\", unit = \"W\", min = -1e8, max = 1e8, nominal = 1000.0) \"Enthalpy flow rates of fluid across segment boundaries\";
-//   Real pipe4.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe4.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe4.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe4.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
-//   Real pipe4.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"mean velocities in flow segments\";
+//   Real pipe4.vs[1](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe4.vs[2](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe4.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe4.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
+//   Real pipe4.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities in flow segments\";
 //   protected Real pipe4.n110[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe4.n110[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   protected Real pipe4.n110[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -6426,7 +5817,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.heatTransfer.vs[3](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe4.heatTransfer.vs[4](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
 //   final Real pipe4.heatTransfer.vs[5](quantity = \"Velocity\", unit = \"m/s\") \"Mean velocities of fluid flow in segments\";
-//   final parameter Real pipe4.heatTransfer.nParallel = pipe4.nParallel \"number of identical parallel flow devices\";
+//   final parameter Real pipe4.heatTransfer.nParallel = pipe4.nParallel \"Number of identical parallel flow devices\";
 //   final Real pipe4.heatTransfer.lengths[1](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe4.heatTransfer.lengths[2](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
 //   final Real pipe4.heatTransfer.lengths[3](quantity = \"Length\", unit = \"m\") \"Lengths along flow path\";
@@ -6442,11 +5833,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.heatTransfer.roughnesses[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe4.heatTransfer.roughnesses[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
 //   final Real pipe4.heatTransfer.roughnesses[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) \"Average heights of surface asperities\";
-//   final parameter Real pipe4.dxs[1] = 0.2;
-//   final parameter Real pipe4.dxs[2] = 0.2;
-//   final parameter Real pipe4.dxs[3] = 0.2;
-//   final parameter Real pipe4.dxs[4] = 0.2;
-//   final parameter Real pipe4.dxs[5] = 0.2;
+//   final parameter Real pipe4.dxs[1] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe4.dxs[2] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe4.dxs[3] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe4.dxs[4] = 0.2 \"Normalized lengths\";
+//   final parameter Real pipe4.dxs[5] = 0.2 \"Normalized lengths\";
 //   final parameter Integer boundary4.nPorts = 1 \"Number of ports\";
 //   Real boundary4.medium.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 1e5, stateSelect = StateSelect.default) \"Absolute pressure of medium\";
 //   Real boundary4.medium.Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = 0.01, stateSelect = StateSelect.default) \"Structurally independent mass fractions\";
@@ -6456,7 +5847,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary4.medium.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.01, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real boundary4.medium.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   Real boundary4.medium.u(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e8, max = 1e8, nominal = 1e6) \"Specific internal energy of medium\";
-//   Real boundary4.medium.R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
+//   Real boundary4.medium.R_s(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 1e7, start = 1000.0, nominal = 1000.0) \"Gas constant (of mixture if applicable)\";
 //   Real boundary4.medium.MM(quantity = \"MolarMass\", unit = \"kg/mol\", min = 0.001, max = 0.25, nominal = 0.032) \"Molar mass (of mixture or single fluid)\";
 //   Real boundary4.medium.state.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Absolute pressure of medium\";
 //   Real boundary4.medium.state.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature of medium\";
@@ -6464,8 +5855,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary4.medium.state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1) \"Mass fractions (= (component mass)/total mass  m_i/m)\";
 //   final parameter Boolean boundary4.medium.preferredMediumStates = false \"= true if StateSelect.prefer shall be used for the independent property variables of the medium\";
 //   final parameter Boolean boundary4.medium.standardOrderComponents = true \"If true, and reducedX = true, the last element of X will be computed from the other ones\";
-//   Real boundary4.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(boundary4.medium.T) \"Temperature of medium in [degC]\";
-//   Real boundary4.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(boundary4.medium.p) \"Absolute pressure of medium in [bar]\";
+//   Real boundary4.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.Units.Conversions.to_degC(boundary4.medium.T) \"Temperature of medium in [degC]\";
+//   Real boundary4.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.Units.Conversions.to_bar(boundary4.medium.p) \"Absolute pressure of medium in [bar]\";
 //   Real boundary4.medium.x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass of total water/mass of dry air\";
 //   Real boundary4.medium.phi \"Relative humidity\";
 //   protected Real boundary4.medium.n116(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of liquid or solid water\";
@@ -6473,7 +5864,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real boundary4.medium.n118(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Mass fraction of air\";
 //   protected Real boundary4.medium.n119(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass fraction of saturation boundary in kg_water/kg_moistair\";
 //   protected Real boundary4.medium.n120(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) \"Steam water mass content of saturation boundary in kg_water/kg_dryair\";
-//   protected Real boundary4.medium.n121(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"partial saturation pressure of steam\";
+//   protected Real boundary4.medium.n121(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Partial saturation pressure of steam\";
 //   Real boundary4.ports[1].m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -1e60, max = 1e60) \"Mass flow rate from the connection point into the component\";
 //   Real boundary4.ports[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 1e8, start = 1e5, nominal = 1e5) \"Thermodynamic pressure in the connection point\";
 //   Real boundary4.ports[1].h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -1e10, max = 1e10, nominal = 1e6) \"Specific thermodynamic enthalpy close to the connection point if m_flow < 0\";
@@ -6487,11 +5878,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real boundary4.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = 293.15 \"Fixed value of temperature\";
 //   parameter Real boundary4.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01 \"Fixed value of composition\";
 //   parameter Real boundary4.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99 \"Fixed value of composition\";
-//   Real boundary4.p_in \"Prescribed boundary pressure\";
-//   protected Real boundary4.n123 \"Needed to connect to conditional connector\";
-//   protected Real boundary4.n124 \"Needed to connect to conditional connector\";
-//   protected Real boundary4.n125[1] \"Needed to connect to conditional connector\";
-//   protected Real boundary4.n125[2] \"Needed to connect to conditional connector\";
+//   Real boundary4.p_in(unit = \"Pa\") \"Prescribed boundary pressure\";
+//   protected Real boundary4.n123(unit = \"Pa\") \"Needed to connect to conditional connector\";
+//   protected Real boundary4.n124(unit = \"K\") \"Needed to connect to conditional connector\";
+//   protected Real boundary4.n125[1](unit = \"1\") \"Needed to connect to conditional connector\";
+//   protected Real boundary4.n125[2](unit = \"1\") \"Needed to connect to conditional connector\";
 //   parameter Real ramp1.height = 1e5 \"Height of ramps\";
 //   parameter Real ramp1.duration(quantity = \"Time\", unit = \"s\", min = 0.0, start = 2.0) = 0.0 \"Duration of ramp (= 0.0 gives a Step)\";
 //   Real ramp1.y \"Connector of Real output signal\";
@@ -6672,9 +6063,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   boundary1.medium.n2 = boundary1.medium.Xi[1] - boundary1.medium.n1;
 //   boundary1.medium.n3 = 1.0 - boundary1.medium.Xi[1];
 //   boundary1.medium.h = Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy_pTX(boundary1.medium.p, boundary1.medium.T, boundary1.medium.Xi);
-//   boundary1.medium.R = 287.0512249529787 * boundary1.medium.n3 / (1.0 - boundary1.medium.n1) + 461.5233290850878 * boundary1.medium.n2 / (1.0 - boundary1.medium.n1);
-//   boundary1.medium.u = boundary1.medium.h - boundary1.medium.R * boundary1.medium.T;
-//   boundary1.medium.d = boundary1.medium.p / (boundary1.medium.R * boundary1.medium.T);
+//   boundary1.medium.R_s = 287.0512249529787 * boundary1.medium.n3 / (1.0 - boundary1.medium.n1) + 461.5233290850878 * boundary1.medium.n2 / (1.0 - boundary1.medium.n1);
+//   boundary1.medium.u = boundary1.medium.h - boundary1.medium.R_s * boundary1.medium.T;
+//   boundary1.medium.d = boundary1.medium.p / (boundary1.medium.R_s * boundary1.medium.T);
 //   boundary1.medium.state.p = boundary1.medium.p;
 //   boundary1.medium.state.T = boundary1.medium.T;
 //   boundary1.medium.state.X[1] = boundary1.medium.X[1];
@@ -6713,9 +6104,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.mediums[1].n15 = pipe1.mediums[1].Xi[1] - pipe1.mediums[1].n14;
 //   pipe1.mediums[1].n16 = 1.0 - pipe1.mediums[1].Xi[1];
 //   pipe1.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[1].p, pipe1.mediums[1].T, pipe1.mediums[1].Xi);
-//   pipe1.mediums[1].R = 287.0512249529787 * pipe1.mediums[1].n16 / (1.0 - pipe1.mediums[1].n14) + 461.5233290850878 * pipe1.mediums[1].n15 / (1.0 - pipe1.mediums[1].n14);
-//   pipe1.mediums[1].u = pipe1.mediums[1].h - pipe1.mediums[1].R * pipe1.mediums[1].T;
-//   pipe1.mediums[1].d = pipe1.mediums[1].p / (pipe1.mediums[1].R * pipe1.mediums[1].T);
+//   pipe1.mediums[1].R_s = 287.0512249529787 * pipe1.mediums[1].n16 / (1.0 - pipe1.mediums[1].n14) + 461.5233290850878 * pipe1.mediums[1].n15 / (1.0 - pipe1.mediums[1].n14);
+//   pipe1.mediums[1].u = pipe1.mediums[1].h - pipe1.mediums[1].R_s * pipe1.mediums[1].T;
+//   pipe1.mediums[1].d = pipe1.mediums[1].p / (pipe1.mediums[1].R_s * pipe1.mediums[1].T);
 //   pipe1.mediums[1].state.p = pipe1.mediums[1].p;
 //   pipe1.mediums[1].state.T = pipe1.mediums[1].T;
 //   pipe1.mediums[1].state.X[1] = pipe1.mediums[1].X[1];
@@ -6742,9 +6133,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.mediums[2].n15 = pipe1.mediums[2].Xi[1] - pipe1.mediums[2].n14;
 //   pipe1.mediums[2].n16 = 1.0 - pipe1.mediums[2].Xi[1];
 //   pipe1.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[2].p, pipe1.mediums[2].T, pipe1.mediums[2].Xi);
-//   pipe1.mediums[2].R = 287.0512249529787 * pipe1.mediums[2].n16 / (1.0 - pipe1.mediums[2].n14) + 461.5233290850878 * pipe1.mediums[2].n15 / (1.0 - pipe1.mediums[2].n14);
-//   pipe1.mediums[2].u = pipe1.mediums[2].h - pipe1.mediums[2].R * pipe1.mediums[2].T;
-//   pipe1.mediums[2].d = pipe1.mediums[2].p / (pipe1.mediums[2].R * pipe1.mediums[2].T);
+//   pipe1.mediums[2].R_s = 287.0512249529787 * pipe1.mediums[2].n16 / (1.0 - pipe1.mediums[2].n14) + 461.5233290850878 * pipe1.mediums[2].n15 / (1.0 - pipe1.mediums[2].n14);
+//   pipe1.mediums[2].u = pipe1.mediums[2].h - pipe1.mediums[2].R_s * pipe1.mediums[2].T;
+//   pipe1.mediums[2].d = pipe1.mediums[2].p / (pipe1.mediums[2].R_s * pipe1.mediums[2].T);
 //   pipe1.mediums[2].state.p = pipe1.mediums[2].p;
 //   pipe1.mediums[2].state.T = pipe1.mediums[2].T;
 //   pipe1.mediums[2].state.X[1] = pipe1.mediums[2].X[1];
@@ -6771,9 +6162,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.mediums[3].n15 = pipe1.mediums[3].Xi[1] - pipe1.mediums[3].n14;
 //   pipe1.mediums[3].n16 = 1.0 - pipe1.mediums[3].Xi[1];
 //   pipe1.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[3].p, pipe1.mediums[3].T, pipe1.mediums[3].Xi);
-//   pipe1.mediums[3].R = 287.0512249529787 * pipe1.mediums[3].n16 / (1.0 - pipe1.mediums[3].n14) + 461.5233290850878 * pipe1.mediums[3].n15 / (1.0 - pipe1.mediums[3].n14);
-//   pipe1.mediums[3].u = pipe1.mediums[3].h - pipe1.mediums[3].R * pipe1.mediums[3].T;
-//   pipe1.mediums[3].d = pipe1.mediums[3].p / (pipe1.mediums[3].R * pipe1.mediums[3].T);
+//   pipe1.mediums[3].R_s = 287.0512249529787 * pipe1.mediums[3].n16 / (1.0 - pipe1.mediums[3].n14) + 461.5233290850878 * pipe1.mediums[3].n15 / (1.0 - pipe1.mediums[3].n14);
+//   pipe1.mediums[3].u = pipe1.mediums[3].h - pipe1.mediums[3].R_s * pipe1.mediums[3].T;
+//   pipe1.mediums[3].d = pipe1.mediums[3].p / (pipe1.mediums[3].R_s * pipe1.mediums[3].T);
 //   pipe1.mediums[3].state.p = pipe1.mediums[3].p;
 //   pipe1.mediums[3].state.T = pipe1.mediums[3].T;
 //   pipe1.mediums[3].state.X[1] = pipe1.mediums[3].X[1];
@@ -6800,9 +6191,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.mediums[4].n15 = pipe1.mediums[4].Xi[1] - pipe1.mediums[4].n14;
 //   pipe1.mediums[4].n16 = 1.0 - pipe1.mediums[4].Xi[1];
 //   pipe1.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[4].p, pipe1.mediums[4].T, pipe1.mediums[4].Xi);
-//   pipe1.mediums[4].R = 287.0512249529787 * pipe1.mediums[4].n16 / (1.0 - pipe1.mediums[4].n14) + 461.5233290850878 * pipe1.mediums[4].n15 / (1.0 - pipe1.mediums[4].n14);
-//   pipe1.mediums[4].u = pipe1.mediums[4].h - pipe1.mediums[4].R * pipe1.mediums[4].T;
-//   pipe1.mediums[4].d = pipe1.mediums[4].p / (pipe1.mediums[4].R * pipe1.mediums[4].T);
+//   pipe1.mediums[4].R_s = 287.0512249529787 * pipe1.mediums[4].n16 / (1.0 - pipe1.mediums[4].n14) + 461.5233290850878 * pipe1.mediums[4].n15 / (1.0 - pipe1.mediums[4].n14);
+//   pipe1.mediums[4].u = pipe1.mediums[4].h - pipe1.mediums[4].R_s * pipe1.mediums[4].T;
+//   pipe1.mediums[4].d = pipe1.mediums[4].p / (pipe1.mediums[4].R_s * pipe1.mediums[4].T);
 //   pipe1.mediums[4].state.p = pipe1.mediums[4].p;
 //   pipe1.mediums[4].state.T = pipe1.mediums[4].T;
 //   pipe1.mediums[4].state.X[1] = pipe1.mediums[4].X[1];
@@ -6829,9 +6220,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.mediums[5].n15 = pipe1.mediums[5].Xi[1] - pipe1.mediums[5].n14;
 //   pipe1.mediums[5].n16 = 1.0 - pipe1.mediums[5].Xi[1];
 //   pipe1.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[5].p, pipe1.mediums[5].T, pipe1.mediums[5].Xi);
-//   pipe1.mediums[5].R = 287.0512249529787 * pipe1.mediums[5].n16 / (1.0 - pipe1.mediums[5].n14) + 461.5233290850878 * pipe1.mediums[5].n15 / (1.0 - pipe1.mediums[5].n14);
-//   pipe1.mediums[5].u = pipe1.mediums[5].h - pipe1.mediums[5].R * pipe1.mediums[5].T;
-//   pipe1.mediums[5].d = pipe1.mediums[5].p / (pipe1.mediums[5].R * pipe1.mediums[5].T);
+//   pipe1.mediums[5].R_s = 287.0512249529787 * pipe1.mediums[5].n16 / (1.0 - pipe1.mediums[5].n14) + 461.5233290850878 * pipe1.mediums[5].n15 / (1.0 - pipe1.mediums[5].n14);
+//   pipe1.mediums[5].u = pipe1.mediums[5].h - pipe1.mediums[5].R_s * pipe1.mediums[5].T;
+//   pipe1.mediums[5].d = pipe1.mediums[5].p / (pipe1.mediums[5].R_s * pipe1.mediums[5].T);
 //   pipe1.mediums[5].state.p = pipe1.mediums[5].p;
 //   pipe1.mediums[5].state.T = pipe1.mediums[5].T;
 //   pipe1.mediums[5].state.X[1] = pipe1.mediums[5].X[1];
@@ -6865,7 +6256,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.flowModel.pathLengths_internal = pipe1.flowModel.pathLengths;
 //   pipe1.flowModel.Res_turbulent_internal = {pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent};
 //   pipe1.flowModel.n28 = {0.5 * (pipe1.flowModel.dimensions[1] + pipe1.flowModel.dimensions[2]), 0.5 * (pipe1.flowModel.dimensions[2] + pipe1.flowModel.dimensions[3]), 0.5 * (pipe1.flowModel.dimensions[3] + pipe1.flowModel.dimensions[4]), 0.5 * (pipe1.flowModel.dimensions[4] + pipe1.flowModel.dimensions[5]), 0.5 * (pipe1.flowModel.dimensions[5] + pipe1.flowModel.dimensions[6]), 0.5 * (pipe1.flowModel.dimensions[6] + pipe1.flowModel.dimensions[7])};
-//   pipe1.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe1.flowModel.dps_fg[$i24], pipe1.flowModel.rhos[(1:6)[$i24]], pipe1.flowModel.rhos[(2:7)[$i24]], pipe1.flowModel.mus[(1:6)[$i24]], pipe1.flowModel.mus[(2:7)[$i24]], pipe1.flowModel.pathLengths_internal[$i24], pipe1.flowModel.n28[$i24], {pipe1.flowModel.g * pipe1.flowModel.dheights[1], pipe1.flowModel.g * pipe1.flowModel.dheights[2], pipe1.flowModel.g * pipe1.flowModel.dheights[3], pipe1.flowModel.g * pipe1.flowModel.dheights[4], pipe1.flowModel.g * pipe1.flowModel.dheights[5], pipe1.flowModel.g * pipe1.flowModel.dheights[6]}[$i24], {(pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0}[$i24], {(pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0}[$i24], pipe1.flowModel.n25 / 6.0, pipe1.flowModel.Res_turbulent_internal[$i24]) for $i24 in 1:6) * pipe1.flowModel.nParallel)[$i25], {pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[1] - pipe1.flowModel.g * pipe1.flowModel.dheights[1] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[2] - pipe1.flowModel.g * pipe1.flowModel.dheights[2] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[3] - pipe1.flowModel.g * pipe1.flowModel.dheights[3] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[4] - pipe1.flowModel.g * pipe1.flowModel.dheights[4] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[5] - pipe1.flowModel.g * pipe1.flowModel.dheights[5] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[6] - pipe1.flowModel.g * pipe1.flowModel.dheights[6] * pipe1.flowModel.n22)}[$i25]) for $i25 in 1:6);
+//   pipe1.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe1.flowModel.dps_fg[$i24], pipe1.flowModel.rhos[{1, 2, 3, 4, 5, 6}[$i24]], pipe1.flowModel.rhos[{2, 3, 4, 5, 6, 7}[$i24]], pipe1.flowModel.mus[{1, 2, 3, 4, 5, 6}[$i24]], pipe1.flowModel.mus[{2, 3, 4, 5, 6, 7}[$i24]], pipe1.flowModel.pathLengths_internal[$i24], pipe1.flowModel.n28[$i24], {pipe1.flowModel.g * pipe1.flowModel.dheights[1], pipe1.flowModel.g * pipe1.flowModel.dheights[2], pipe1.flowModel.g * pipe1.flowModel.dheights[3], pipe1.flowModel.g * pipe1.flowModel.dheights[4], pipe1.flowModel.g * pipe1.flowModel.dheights[5], pipe1.flowModel.g * pipe1.flowModel.dheights[6]}[$i24], {(pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0}[$i24], {(pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0}[$i24], pipe1.flowModel.n25 / 6.0, pipe1.flowModel.Res_turbulent_internal[$i24]) for $i24 in 1:6) * pipe1.flowModel.nParallel)[$i25], {pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[1] - pipe1.flowModel.g * pipe1.flowModel.dheights[1] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[2] - pipe1.flowModel.g * pipe1.flowModel.dheights[2] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[3] - pipe1.flowModel.g * pipe1.flowModel.dheights[3] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[4] - pipe1.flowModel.g * pipe1.flowModel.dheights[4] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[5] - pipe1.flowModel.g * pipe1.flowModel.dheights[5] * pipe1.flowModel.n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[6] - pipe1.flowModel.g * pipe1.flowModel.dheights[6] * pipe1.flowModel.n22)}[$i25]) for $i25 in 1:6);
 //   pipe1.flowModel.rhos_act[1] = noEvent(if pipe1.flowModel.m_flows[1] > 0.0 then pipe1.flowModel.rhos[1] else pipe1.flowModel.rhos[2]);
 //   pipe1.flowModel.mus_act[1] = noEvent(if pipe1.flowModel.m_flows[1] > 0.0 then pipe1.flowModel.mus[1] else pipe1.flowModel.mus[2]);
 //   pipe1.flowModel.rhos_act[2] = noEvent(if pipe1.flowModel.m_flows[2] > 0.0 then pipe1.flowModel.rhos[2] else pipe1.flowModel.rhos[3]);
@@ -6915,7 +6306,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.Qb_flows[3] = pipe1.heatTransfer.Q_flows[3];
 //   pipe1.Qb_flows[4] = pipe1.heatTransfer.Q_flows[4];
 //   pipe1.Qb_flows[5] = pipe1.heatTransfer.Q_flows[5];
-//   pipe1.Wb_flows[2:4] = array(pipe1.vs[i] * pipe1.crossAreas[i] * ((pipe1.mediums[i + 1].p - pipe1.mediums[i - 1].p) / 2.0 + (pipe1.flowModel.dps_fg[i] + pipe1.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 10.0 * pipe1.mediums[i].d) for i in 2:4) * pipe1.nParallel;
+//   pipe1.Wb_flows[{2, 3, 4}] = array(pipe1.vs[i] * pipe1.crossAreas[i] * ((pipe1.mediums[i + 1].p - pipe1.mediums[i - 1].p) / 2.0 + (pipe1.flowModel.dps_fg[i] + pipe1.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 10.0 * pipe1.mediums[i].d) for i in 2:4) * pipe1.nParallel;
 //   pipe1.Wb_flows[1] = pipe1.vs[1] * pipe1.crossAreas[1] * ((pipe1.mediums[2].p - pipe1.port_a.p) / 1.5 + pipe1.flowModel.dps_fg[1] + pipe1.flowModel.dps_fg[2] / 2.0 - system.g * 10.0 * pipe1.mediums[1].d) * pipe1.nParallel;
 //   pipe1.Wb_flows[5] = pipe1.vs[5] * pipe1.crossAreas[5] * ((pipe1.port_b.p - pipe1.mediums[4].p) / 1.5 + pipe1.flowModel.dps_fg[5] / 2.0 + pipe1.flowModel.dps_fg[6] - system.g * 10.0 * pipe1.mediums[5].d) * pipe1.nParallel;
 //   pipe1.n30[1] = 5.0;
@@ -7048,9 +6439,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.mediums[1].n40 = pipe2.mediums[1].Xi[1] - pipe2.mediums[1].n39;
 //   pipe2.mediums[1].n41 = 1.0 - pipe2.mediums[1].Xi[1];
 //   pipe2.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[1].p, pipe2.mediums[1].T, pipe2.mediums[1].Xi);
-//   pipe2.mediums[1].R = 287.0512249529787 * pipe2.mediums[1].n41 / (1.0 - pipe2.mediums[1].n39) + 461.5233290850878 * pipe2.mediums[1].n40 / (1.0 - pipe2.mediums[1].n39);
-//   pipe2.mediums[1].u = pipe2.mediums[1].h - pipe2.mediums[1].R * pipe2.mediums[1].T;
-//   pipe2.mediums[1].d = pipe2.mediums[1].p / (pipe2.mediums[1].R * pipe2.mediums[1].T);
+//   pipe2.mediums[1].R_s = 287.0512249529787 * pipe2.mediums[1].n41 / (1.0 - pipe2.mediums[1].n39) + 461.5233290850878 * pipe2.mediums[1].n40 / (1.0 - pipe2.mediums[1].n39);
+//   pipe2.mediums[1].u = pipe2.mediums[1].h - pipe2.mediums[1].R_s * pipe2.mediums[1].T;
+//   pipe2.mediums[1].d = pipe2.mediums[1].p / (pipe2.mediums[1].R_s * pipe2.mediums[1].T);
 //   pipe2.mediums[1].state.p = pipe2.mediums[1].p;
 //   pipe2.mediums[1].state.T = pipe2.mediums[1].T;
 //   pipe2.mediums[1].state.X[1] = pipe2.mediums[1].X[1];
@@ -7077,9 +6468,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.mediums[2].n40 = pipe2.mediums[2].Xi[1] - pipe2.mediums[2].n39;
 //   pipe2.mediums[2].n41 = 1.0 - pipe2.mediums[2].Xi[1];
 //   pipe2.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[2].p, pipe2.mediums[2].T, pipe2.mediums[2].Xi);
-//   pipe2.mediums[2].R = 287.0512249529787 * pipe2.mediums[2].n41 / (1.0 - pipe2.mediums[2].n39) + 461.5233290850878 * pipe2.mediums[2].n40 / (1.0 - pipe2.mediums[2].n39);
-//   pipe2.mediums[2].u = pipe2.mediums[2].h - pipe2.mediums[2].R * pipe2.mediums[2].T;
-//   pipe2.mediums[2].d = pipe2.mediums[2].p / (pipe2.mediums[2].R * pipe2.mediums[2].T);
+//   pipe2.mediums[2].R_s = 287.0512249529787 * pipe2.mediums[2].n41 / (1.0 - pipe2.mediums[2].n39) + 461.5233290850878 * pipe2.mediums[2].n40 / (1.0 - pipe2.mediums[2].n39);
+//   pipe2.mediums[2].u = pipe2.mediums[2].h - pipe2.mediums[2].R_s * pipe2.mediums[2].T;
+//   pipe2.mediums[2].d = pipe2.mediums[2].p / (pipe2.mediums[2].R_s * pipe2.mediums[2].T);
 //   pipe2.mediums[2].state.p = pipe2.mediums[2].p;
 //   pipe2.mediums[2].state.T = pipe2.mediums[2].T;
 //   pipe2.mediums[2].state.X[1] = pipe2.mediums[2].X[1];
@@ -7106,9 +6497,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.mediums[3].n40 = pipe2.mediums[3].Xi[1] - pipe2.mediums[3].n39;
 //   pipe2.mediums[3].n41 = 1.0 - pipe2.mediums[3].Xi[1];
 //   pipe2.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[3].p, pipe2.mediums[3].T, pipe2.mediums[3].Xi);
-//   pipe2.mediums[3].R = 287.0512249529787 * pipe2.mediums[3].n41 / (1.0 - pipe2.mediums[3].n39) + 461.5233290850878 * pipe2.mediums[3].n40 / (1.0 - pipe2.mediums[3].n39);
-//   pipe2.mediums[3].u = pipe2.mediums[3].h - pipe2.mediums[3].R * pipe2.mediums[3].T;
-//   pipe2.mediums[3].d = pipe2.mediums[3].p / (pipe2.mediums[3].R * pipe2.mediums[3].T);
+//   pipe2.mediums[3].R_s = 287.0512249529787 * pipe2.mediums[3].n41 / (1.0 - pipe2.mediums[3].n39) + 461.5233290850878 * pipe2.mediums[3].n40 / (1.0 - pipe2.mediums[3].n39);
+//   pipe2.mediums[3].u = pipe2.mediums[3].h - pipe2.mediums[3].R_s * pipe2.mediums[3].T;
+//   pipe2.mediums[3].d = pipe2.mediums[3].p / (pipe2.mediums[3].R_s * pipe2.mediums[3].T);
 //   pipe2.mediums[3].state.p = pipe2.mediums[3].p;
 //   pipe2.mediums[3].state.T = pipe2.mediums[3].T;
 //   pipe2.mediums[3].state.X[1] = pipe2.mediums[3].X[1];
@@ -7135,9 +6526,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.mediums[4].n40 = pipe2.mediums[4].Xi[1] - pipe2.mediums[4].n39;
 //   pipe2.mediums[4].n41 = 1.0 - pipe2.mediums[4].Xi[1];
 //   pipe2.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[4].p, pipe2.mediums[4].T, pipe2.mediums[4].Xi);
-//   pipe2.mediums[4].R = 287.0512249529787 * pipe2.mediums[4].n41 / (1.0 - pipe2.mediums[4].n39) + 461.5233290850878 * pipe2.mediums[4].n40 / (1.0 - pipe2.mediums[4].n39);
-//   pipe2.mediums[4].u = pipe2.mediums[4].h - pipe2.mediums[4].R * pipe2.mediums[4].T;
-//   pipe2.mediums[4].d = pipe2.mediums[4].p / (pipe2.mediums[4].R * pipe2.mediums[4].T);
+//   pipe2.mediums[4].R_s = 287.0512249529787 * pipe2.mediums[4].n41 / (1.0 - pipe2.mediums[4].n39) + 461.5233290850878 * pipe2.mediums[4].n40 / (1.0 - pipe2.mediums[4].n39);
+//   pipe2.mediums[4].u = pipe2.mediums[4].h - pipe2.mediums[4].R_s * pipe2.mediums[4].T;
+//   pipe2.mediums[4].d = pipe2.mediums[4].p / (pipe2.mediums[4].R_s * pipe2.mediums[4].T);
 //   pipe2.mediums[4].state.p = pipe2.mediums[4].p;
 //   pipe2.mediums[4].state.T = pipe2.mediums[4].T;
 //   pipe2.mediums[4].state.X[1] = pipe2.mediums[4].X[1];
@@ -7164,9 +6555,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.mediums[5].n40 = pipe2.mediums[5].Xi[1] - pipe2.mediums[5].n39;
 //   pipe2.mediums[5].n41 = 1.0 - pipe2.mediums[5].Xi[1];
 //   pipe2.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[5].p, pipe2.mediums[5].T, pipe2.mediums[5].Xi);
-//   pipe2.mediums[5].R = 287.0512249529787 * pipe2.mediums[5].n41 / (1.0 - pipe2.mediums[5].n39) + 461.5233290850878 * pipe2.mediums[5].n40 / (1.0 - pipe2.mediums[5].n39);
-//   pipe2.mediums[5].u = pipe2.mediums[5].h - pipe2.mediums[5].R * pipe2.mediums[5].T;
-//   pipe2.mediums[5].d = pipe2.mediums[5].p / (pipe2.mediums[5].R * pipe2.mediums[5].T);
+//   pipe2.mediums[5].R_s = 287.0512249529787 * pipe2.mediums[5].n41 / (1.0 - pipe2.mediums[5].n39) + 461.5233290850878 * pipe2.mediums[5].n40 / (1.0 - pipe2.mediums[5].n39);
+//   pipe2.mediums[5].u = pipe2.mediums[5].h - pipe2.mediums[5].R_s * pipe2.mediums[5].T;
+//   pipe2.mediums[5].d = pipe2.mediums[5].p / (pipe2.mediums[5].R_s * pipe2.mediums[5].T);
 //   pipe2.mediums[5].state.p = pipe2.mediums[5].p;
 //   pipe2.mediums[5].state.T = pipe2.mediums[5].T;
 //   pipe2.mediums[5].state.X[1] = pipe2.mediums[5].X[1];
@@ -7198,7 +6589,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.flowModel.pathLengths_internal = pipe2.flowModel.pathLengths;
 //   pipe2.flowModel.Res_turbulent_internal = {pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent};
 //   pipe2.flowModel.n53 = {0.5 * (pipe2.flowModel.dimensions[1] + pipe2.flowModel.dimensions[2]), 0.5 * (pipe2.flowModel.dimensions[2] + pipe2.flowModel.dimensions[3]), 0.5 * (pipe2.flowModel.dimensions[3] + pipe2.flowModel.dimensions[4]), 0.5 * (pipe2.flowModel.dimensions[4] + pipe2.flowModel.dimensions[5])};
-//   pipe2.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe2.flowModel.dps_fg[$i38], pipe2.flowModel.rhos[(1:4)[$i38]], pipe2.flowModel.rhos[(2:5)[$i38]], pipe2.flowModel.mus[(1:4)[$i38]], pipe2.flowModel.mus[(2:5)[$i38]], pipe2.flowModel.pathLengths_internal[$i38], pipe2.flowModel.n53[$i38], {pipe2.flowModel.g * pipe2.flowModel.dheights[1], pipe2.flowModel.g * pipe2.flowModel.dheights[2], pipe2.flowModel.g * pipe2.flowModel.dheights[3], pipe2.flowModel.g * pipe2.flowModel.dheights[4]}[$i38], {(pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0}[$i38], {(pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0}[$i38], pipe2.flowModel.n50 / 4.0, pipe2.flowModel.Res_turbulent_internal[$i38]) for $i38 in 1:4) * pipe2.flowModel.nParallel)[$i39], {pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[1] - pipe2.flowModel.g * pipe2.flowModel.dheights[1] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[2] - pipe2.flowModel.g * pipe2.flowModel.dheights[2] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[3] - pipe2.flowModel.g * pipe2.flowModel.dheights[3] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[4] - pipe2.flowModel.g * pipe2.flowModel.dheights[4] * pipe2.flowModel.n47)}[$i39]) for $i39 in 1:4);
+//   pipe2.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe2.flowModel.dps_fg[$i38], pipe2.flowModel.rhos[{1, 2, 3, 4}[$i38]], pipe2.flowModel.rhos[{2, 3, 4, 5}[$i38]], pipe2.flowModel.mus[{1, 2, 3, 4}[$i38]], pipe2.flowModel.mus[{2, 3, 4, 5}[$i38]], pipe2.flowModel.pathLengths_internal[$i38], pipe2.flowModel.n53[$i38], {pipe2.flowModel.g * pipe2.flowModel.dheights[1], pipe2.flowModel.g * pipe2.flowModel.dheights[2], pipe2.flowModel.g * pipe2.flowModel.dheights[3], pipe2.flowModel.g * pipe2.flowModel.dheights[4]}[$i38], {(pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0}[$i38], {(pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0}[$i38], pipe2.flowModel.n50 / 4.0, pipe2.flowModel.Res_turbulent_internal[$i38]) for $i38 in 1:4) * pipe2.flowModel.nParallel)[$i39], {pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[1] - pipe2.flowModel.g * pipe2.flowModel.dheights[1] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[2] - pipe2.flowModel.g * pipe2.flowModel.dheights[2] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[3] - pipe2.flowModel.g * pipe2.flowModel.dheights[3] * pipe2.flowModel.n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[4] - pipe2.flowModel.g * pipe2.flowModel.dheights[4] * pipe2.flowModel.n47)}[$i39]) for $i39 in 1:4);
 //   pipe2.flowModel.rhos_act[1] = noEvent(if pipe2.flowModel.m_flows[1] > 0.0 then pipe2.flowModel.rhos[1] else pipe2.flowModel.rhos[2]);
 //   pipe2.flowModel.mus_act[1] = noEvent(if pipe2.flowModel.m_flows[1] > 0.0 then pipe2.flowModel.mus[1] else pipe2.flowModel.mus[2]);
 //   pipe2.flowModel.rhos_act[2] = noEvent(if pipe2.flowModel.m_flows[2] > 0.0 then pipe2.flowModel.rhos[2] else pipe2.flowModel.rhos[3]);
@@ -7267,7 +6658,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.Qb_flows[3] = pipe2.heatTransfer.Q_flows[3];
 //   pipe2.Qb_flows[4] = pipe2.heatTransfer.Q_flows[4];
 //   pipe2.Qb_flows[5] = pipe2.heatTransfer.Q_flows[5];
-//   pipe2.Wb_flows[2:4] = array(pipe2.vs[i] * pipe2.crossAreas[i] * ((pipe2.mediums[i + 1].p - pipe2.mediums[i - 1].p) / 2.0 + (pipe2.flowModel.dps_fg[i - 1] + pipe2.flowModel.dps_fg[i]) / 2.0 - system.g * 5.0 * pipe2.mediums[i].d) for i in 2:4) * pipe2.nParallel;
+//   pipe2.Wb_flows[{2, 3, 4}] = array(pipe2.vs[i] * pipe2.crossAreas[i] * ((pipe2.mediums[i + 1].p - pipe2.mediums[i - 1].p) / 2.0 + (pipe2.flowModel.dps_fg[i - 1] + pipe2.flowModel.dps_fg[i]) / 2.0 - system.g * 5.0 * pipe2.mediums[i].d) for i in 2:4) * pipe2.nParallel;
 //   pipe2.Wb_flows[1] = pipe2.vs[1] * pipe2.crossAreas[1] * ((pipe2.mediums[2].p - pipe2.mediums[1].p) / 2.0 + pipe2.flowModel.dps_fg[1] / 2.0 - system.g * 5.0 * pipe2.mediums[1].d) * pipe2.nParallel;
 //   pipe2.Wb_flows[5] = pipe2.vs[5] * pipe2.crossAreas[5] * ((pipe2.mediums[5].p - pipe2.mediums[4].p) / 2.0 + pipe2.flowModel.dps_fg[4] / 2.0 - system.g * 5.0 * pipe2.mediums[5].d) * pipe2.nParallel;
 //   pipe2.n55[1] = 15.0;
@@ -7386,9 +6777,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.mediums[1].n70 = pipe3.mediums[1].Xi[1] - pipe3.mediums[1].n69;
 //   pipe3.mediums[1].n71 = 1.0 - pipe3.mediums[1].Xi[1];
 //   pipe3.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[1].p, pipe3.mediums[1].T, pipe3.mediums[1].Xi);
-//   pipe3.mediums[1].R = 287.0512249529787 * pipe3.mediums[1].n71 / (1.0 - pipe3.mediums[1].n69) + 461.5233290850878 * pipe3.mediums[1].n70 / (1.0 - pipe3.mediums[1].n69);
-//   pipe3.mediums[1].u = pipe3.mediums[1].h - pipe3.mediums[1].R * pipe3.mediums[1].T;
-//   pipe3.mediums[1].d = pipe3.mediums[1].p / (pipe3.mediums[1].R * pipe3.mediums[1].T);
+//   pipe3.mediums[1].R_s = 287.0512249529787 * pipe3.mediums[1].n71 / (1.0 - pipe3.mediums[1].n69) + 461.5233290850878 * pipe3.mediums[1].n70 / (1.0 - pipe3.mediums[1].n69);
+//   pipe3.mediums[1].u = pipe3.mediums[1].h - pipe3.mediums[1].R_s * pipe3.mediums[1].T;
+//   pipe3.mediums[1].d = pipe3.mediums[1].p / (pipe3.mediums[1].R_s * pipe3.mediums[1].T);
 //   pipe3.mediums[1].state.p = pipe3.mediums[1].p;
 //   pipe3.mediums[1].state.T = pipe3.mediums[1].T;
 //   pipe3.mediums[1].state.X[1] = pipe3.mediums[1].X[1];
@@ -7415,9 +6806,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.mediums[2].n70 = pipe3.mediums[2].Xi[1] - pipe3.mediums[2].n69;
 //   pipe3.mediums[2].n71 = 1.0 - pipe3.mediums[2].Xi[1];
 //   pipe3.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[2].p, pipe3.mediums[2].T, pipe3.mediums[2].Xi);
-//   pipe3.mediums[2].R = 287.0512249529787 * pipe3.mediums[2].n71 / (1.0 - pipe3.mediums[2].n69) + 461.5233290850878 * pipe3.mediums[2].n70 / (1.0 - pipe3.mediums[2].n69);
-//   pipe3.mediums[2].u = pipe3.mediums[2].h - pipe3.mediums[2].R * pipe3.mediums[2].T;
-//   pipe3.mediums[2].d = pipe3.mediums[2].p / (pipe3.mediums[2].R * pipe3.mediums[2].T);
+//   pipe3.mediums[2].R_s = 287.0512249529787 * pipe3.mediums[2].n71 / (1.0 - pipe3.mediums[2].n69) + 461.5233290850878 * pipe3.mediums[2].n70 / (1.0 - pipe3.mediums[2].n69);
+//   pipe3.mediums[2].u = pipe3.mediums[2].h - pipe3.mediums[2].R_s * pipe3.mediums[2].T;
+//   pipe3.mediums[2].d = pipe3.mediums[2].p / (pipe3.mediums[2].R_s * pipe3.mediums[2].T);
 //   pipe3.mediums[2].state.p = pipe3.mediums[2].p;
 //   pipe3.mediums[2].state.T = pipe3.mediums[2].T;
 //   pipe3.mediums[2].state.X[1] = pipe3.mediums[2].X[1];
@@ -7444,9 +6835,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.mediums[3].n70 = pipe3.mediums[3].Xi[1] - pipe3.mediums[3].n69;
 //   pipe3.mediums[3].n71 = 1.0 - pipe3.mediums[3].Xi[1];
 //   pipe3.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[3].p, pipe3.mediums[3].T, pipe3.mediums[3].Xi);
-//   pipe3.mediums[3].R = 287.0512249529787 * pipe3.mediums[3].n71 / (1.0 - pipe3.mediums[3].n69) + 461.5233290850878 * pipe3.mediums[3].n70 / (1.0 - pipe3.mediums[3].n69);
-//   pipe3.mediums[3].u = pipe3.mediums[3].h - pipe3.mediums[3].R * pipe3.mediums[3].T;
-//   pipe3.mediums[3].d = pipe3.mediums[3].p / (pipe3.mediums[3].R * pipe3.mediums[3].T);
+//   pipe3.mediums[3].R_s = 287.0512249529787 * pipe3.mediums[3].n71 / (1.0 - pipe3.mediums[3].n69) + 461.5233290850878 * pipe3.mediums[3].n70 / (1.0 - pipe3.mediums[3].n69);
+//   pipe3.mediums[3].u = pipe3.mediums[3].h - pipe3.mediums[3].R_s * pipe3.mediums[3].T;
+//   pipe3.mediums[3].d = pipe3.mediums[3].p / (pipe3.mediums[3].R_s * pipe3.mediums[3].T);
 //   pipe3.mediums[3].state.p = pipe3.mediums[3].p;
 //   pipe3.mediums[3].state.T = pipe3.mediums[3].T;
 //   pipe3.mediums[3].state.X[1] = pipe3.mediums[3].X[1];
@@ -7473,9 +6864,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.mediums[4].n70 = pipe3.mediums[4].Xi[1] - pipe3.mediums[4].n69;
 //   pipe3.mediums[4].n71 = 1.0 - pipe3.mediums[4].Xi[1];
 //   pipe3.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[4].p, pipe3.mediums[4].T, pipe3.mediums[4].Xi);
-//   pipe3.mediums[4].R = 287.0512249529787 * pipe3.mediums[4].n71 / (1.0 - pipe3.mediums[4].n69) + 461.5233290850878 * pipe3.mediums[4].n70 / (1.0 - pipe3.mediums[4].n69);
-//   pipe3.mediums[4].u = pipe3.mediums[4].h - pipe3.mediums[4].R * pipe3.mediums[4].T;
-//   pipe3.mediums[4].d = pipe3.mediums[4].p / (pipe3.mediums[4].R * pipe3.mediums[4].T);
+//   pipe3.mediums[4].R_s = 287.0512249529787 * pipe3.mediums[4].n71 / (1.0 - pipe3.mediums[4].n69) + 461.5233290850878 * pipe3.mediums[4].n70 / (1.0 - pipe3.mediums[4].n69);
+//   pipe3.mediums[4].u = pipe3.mediums[4].h - pipe3.mediums[4].R_s * pipe3.mediums[4].T;
+//   pipe3.mediums[4].d = pipe3.mediums[4].p / (pipe3.mediums[4].R_s * pipe3.mediums[4].T);
 //   pipe3.mediums[4].state.p = pipe3.mediums[4].p;
 //   pipe3.mediums[4].state.T = pipe3.mediums[4].T;
 //   pipe3.mediums[4].state.X[1] = pipe3.mediums[4].X[1];
@@ -7502,9 +6893,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.mediums[5].n70 = pipe3.mediums[5].Xi[1] - pipe3.mediums[5].n69;
 //   pipe3.mediums[5].n71 = 1.0 - pipe3.mediums[5].Xi[1];
 //   pipe3.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[5].p, pipe3.mediums[5].T, pipe3.mediums[5].Xi);
-//   pipe3.mediums[5].R = 287.0512249529787 * pipe3.mediums[5].n71 / (1.0 - pipe3.mediums[5].n69) + 461.5233290850878 * pipe3.mediums[5].n70 / (1.0 - pipe3.mediums[5].n69);
-//   pipe3.mediums[5].u = pipe3.mediums[5].h - pipe3.mediums[5].R * pipe3.mediums[5].T;
-//   pipe3.mediums[5].d = pipe3.mediums[5].p / (pipe3.mediums[5].R * pipe3.mediums[5].T);
+//   pipe3.mediums[5].R_s = 287.0512249529787 * pipe3.mediums[5].n71 / (1.0 - pipe3.mediums[5].n69) + 461.5233290850878 * pipe3.mediums[5].n70 / (1.0 - pipe3.mediums[5].n69);
+//   pipe3.mediums[5].u = pipe3.mediums[5].h - pipe3.mediums[5].R_s * pipe3.mediums[5].T;
+//   pipe3.mediums[5].d = pipe3.mediums[5].p / (pipe3.mediums[5].R_s * pipe3.mediums[5].T);
 //   pipe3.mediums[5].state.p = pipe3.mediums[5].p;
 //   pipe3.mediums[5].state.T = pipe3.mediums[5].T;
 //   pipe3.mediums[5].state.X[1] = pipe3.mediums[5].X[1];
@@ -7538,7 +6929,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.flowModel.pathLengths_internal = pipe3.flowModel.pathLengths;
 //   pipe3.flowModel.Res_turbulent_internal = {pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent};
 //   pipe3.flowModel.n83 = {0.5 * (pipe3.flowModel.dimensions[1] + pipe3.flowModel.dimensions[2]), 0.5 * (pipe3.flowModel.dimensions[2] + pipe3.flowModel.dimensions[3]), 0.5 * (pipe3.flowModel.dimensions[3] + pipe3.flowModel.dimensions[4]), 0.5 * (pipe3.flowModel.dimensions[4] + pipe3.flowModel.dimensions[5]), 0.5 * (pipe3.flowModel.dimensions[5] + pipe3.flowModel.dimensions[6]), 0.5 * (pipe3.flowModel.dimensions[6] + pipe3.flowModel.dimensions[7])};
-//   pipe3.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe3.flowModel.dps_fg[$i58], pipe3.flowModel.rhos[(1:6)[$i58]], pipe3.flowModel.rhos[(2:7)[$i58]], pipe3.flowModel.mus[(1:6)[$i58]], pipe3.flowModel.mus[(2:7)[$i58]], pipe3.flowModel.pathLengths_internal[$i58], pipe3.flowModel.n83[$i58], {pipe3.flowModel.g * pipe3.flowModel.dheights[1], pipe3.flowModel.g * pipe3.flowModel.dheights[2], pipe3.flowModel.g * pipe3.flowModel.dheights[3], pipe3.flowModel.g * pipe3.flowModel.dheights[4], pipe3.flowModel.g * pipe3.flowModel.dheights[5], pipe3.flowModel.g * pipe3.flowModel.dheights[6]}[$i58], {(pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0}[$i58], {(pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0}[$i58], pipe3.flowModel.n80 / 6.0, pipe3.flowModel.Res_turbulent_internal[$i58]) for $i58 in 1:6) * pipe3.flowModel.nParallel)[$i59], {pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[1] - pipe3.flowModel.g * pipe3.flowModel.dheights[1] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[2] - pipe3.flowModel.g * pipe3.flowModel.dheights[2] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[3] - pipe3.flowModel.g * pipe3.flowModel.dheights[3] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[4] - pipe3.flowModel.g * pipe3.flowModel.dheights[4] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[5] - pipe3.flowModel.g * pipe3.flowModel.dheights[5] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[6] - pipe3.flowModel.g * pipe3.flowModel.dheights[6] * pipe3.flowModel.n77)}[$i59]) for $i59 in 1:6);
+//   pipe3.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe3.flowModel.dps_fg[$i58], pipe3.flowModel.rhos[{1, 2, 3, 4, 5, 6}[$i58]], pipe3.flowModel.rhos[{2, 3, 4, 5, 6, 7}[$i58]], pipe3.flowModel.mus[{1, 2, 3, 4, 5, 6}[$i58]], pipe3.flowModel.mus[{2, 3, 4, 5, 6, 7}[$i58]], pipe3.flowModel.pathLengths_internal[$i58], pipe3.flowModel.n83[$i58], {pipe3.flowModel.g * pipe3.flowModel.dheights[1], pipe3.flowModel.g * pipe3.flowModel.dheights[2], pipe3.flowModel.g * pipe3.flowModel.dheights[3], pipe3.flowModel.g * pipe3.flowModel.dheights[4], pipe3.flowModel.g * pipe3.flowModel.dheights[5], pipe3.flowModel.g * pipe3.flowModel.dheights[6]}[$i58], {(pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0}[$i58], {(pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0}[$i58], pipe3.flowModel.n80 / 6.0, pipe3.flowModel.Res_turbulent_internal[$i58]) for $i58 in 1:6) * pipe3.flowModel.nParallel)[$i59], {pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[1] - pipe3.flowModel.g * pipe3.flowModel.dheights[1] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[2] - pipe3.flowModel.g * pipe3.flowModel.dheights[2] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[3] - pipe3.flowModel.g * pipe3.flowModel.dheights[3] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[4] - pipe3.flowModel.g * pipe3.flowModel.dheights[4] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[5] - pipe3.flowModel.g * pipe3.flowModel.dheights[5] * pipe3.flowModel.n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[6] - pipe3.flowModel.g * pipe3.flowModel.dheights[6] * pipe3.flowModel.n77)}[$i59]) for $i59 in 1:6);
 //   pipe3.flowModel.rhos_act[1] = noEvent(if pipe3.flowModel.m_flows[1] > 0.0 then pipe3.flowModel.rhos[1] else pipe3.flowModel.rhos[2]);
 //   pipe3.flowModel.mus_act[1] = noEvent(if pipe3.flowModel.m_flows[1] > 0.0 then pipe3.flowModel.mus[1] else pipe3.flowModel.mus[2]);
 //   pipe3.flowModel.rhos_act[2] = noEvent(if pipe3.flowModel.m_flows[2] > 0.0 then pipe3.flowModel.rhos[2] else pipe3.flowModel.rhos[3]);
@@ -7588,7 +6979,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.Qb_flows[3] = pipe3.heatTransfer.Q_flows[3];
 //   pipe3.Qb_flows[4] = pipe3.heatTransfer.Q_flows[4];
 //   pipe3.Qb_flows[5] = pipe3.heatTransfer.Q_flows[5];
-//   pipe3.Wb_flows[2:4] = array(pipe3.vs[i] * pipe3.crossAreas[i] * ((pipe3.mediums[i + 1].p - pipe3.mediums[i - 1].p) / 2.0 + (pipe3.flowModel.dps_fg[i] + pipe3.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 5.0 * pipe3.mediums[i].d) for i in 2:4) * pipe3.nParallel;
+//   pipe3.Wb_flows[{2, 3, 4}] = array(pipe3.vs[i] * pipe3.crossAreas[i] * ((pipe3.mediums[i + 1].p - pipe3.mediums[i - 1].p) / 2.0 + (pipe3.flowModel.dps_fg[i] + pipe3.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 5.0 * pipe3.mediums[i].d) for i in 2:4) * pipe3.nParallel;
 //   pipe3.Wb_flows[1] = pipe3.vs[1] * pipe3.crossAreas[1] * ((pipe3.mediums[2].p - pipe3.port_a.p) / 1.5 + pipe3.flowModel.dps_fg[1] + pipe3.flowModel.dps_fg[2] / 2.0 - system.g * 5.0 * pipe3.mediums[1].d) * pipe3.nParallel;
 //   pipe3.Wb_flows[5] = pipe3.vs[5] * pipe3.crossAreas[5] * ((pipe3.port_b.p - pipe3.mediums[4].p) / 1.5 + pipe3.flowModel.dps_fg[5] / 2.0 + pipe3.flowModel.dps_fg[6] - system.g * 5.0 * pipe3.mediums[5].d) * pipe3.nParallel;
 //   pipe3.n85[1] = 2.5;
@@ -7721,9 +7112,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.mediums[1].n95 = pipe4.mediums[1].Xi[1] - pipe4.mediums[1].n94;
 //   pipe4.mediums[1].n96 = 1.0 - pipe4.mediums[1].Xi[1];
 //   pipe4.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[1].p, pipe4.mediums[1].T, pipe4.mediums[1].Xi);
-//   pipe4.mediums[1].R = 287.0512249529787 * pipe4.mediums[1].n96 / (1.0 - pipe4.mediums[1].n94) + 461.5233290850878 * pipe4.mediums[1].n95 / (1.0 - pipe4.mediums[1].n94);
-//   pipe4.mediums[1].u = pipe4.mediums[1].h - pipe4.mediums[1].R * pipe4.mediums[1].T;
-//   pipe4.mediums[1].d = pipe4.mediums[1].p / (pipe4.mediums[1].R * pipe4.mediums[1].T);
+//   pipe4.mediums[1].R_s = 287.0512249529787 * pipe4.mediums[1].n96 / (1.0 - pipe4.mediums[1].n94) + 461.5233290850878 * pipe4.mediums[1].n95 / (1.0 - pipe4.mediums[1].n94);
+//   pipe4.mediums[1].u = pipe4.mediums[1].h - pipe4.mediums[1].R_s * pipe4.mediums[1].T;
+//   pipe4.mediums[1].d = pipe4.mediums[1].p / (pipe4.mediums[1].R_s * pipe4.mediums[1].T);
 //   pipe4.mediums[1].state.p = pipe4.mediums[1].p;
 //   pipe4.mediums[1].state.T = pipe4.mediums[1].T;
 //   pipe4.mediums[1].state.X[1] = pipe4.mediums[1].X[1];
@@ -7750,9 +7141,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.mediums[2].n95 = pipe4.mediums[2].Xi[1] - pipe4.mediums[2].n94;
 //   pipe4.mediums[2].n96 = 1.0 - pipe4.mediums[2].Xi[1];
 //   pipe4.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[2].p, pipe4.mediums[2].T, pipe4.mediums[2].Xi);
-//   pipe4.mediums[2].R = 287.0512249529787 * pipe4.mediums[2].n96 / (1.0 - pipe4.mediums[2].n94) + 461.5233290850878 * pipe4.mediums[2].n95 / (1.0 - pipe4.mediums[2].n94);
-//   pipe4.mediums[2].u = pipe4.mediums[2].h - pipe4.mediums[2].R * pipe4.mediums[2].T;
-//   pipe4.mediums[2].d = pipe4.mediums[2].p / (pipe4.mediums[2].R * pipe4.mediums[2].T);
+//   pipe4.mediums[2].R_s = 287.0512249529787 * pipe4.mediums[2].n96 / (1.0 - pipe4.mediums[2].n94) + 461.5233290850878 * pipe4.mediums[2].n95 / (1.0 - pipe4.mediums[2].n94);
+//   pipe4.mediums[2].u = pipe4.mediums[2].h - pipe4.mediums[2].R_s * pipe4.mediums[2].T;
+//   pipe4.mediums[2].d = pipe4.mediums[2].p / (pipe4.mediums[2].R_s * pipe4.mediums[2].T);
 //   pipe4.mediums[2].state.p = pipe4.mediums[2].p;
 //   pipe4.mediums[2].state.T = pipe4.mediums[2].T;
 //   pipe4.mediums[2].state.X[1] = pipe4.mediums[2].X[1];
@@ -7779,9 +7170,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.mediums[3].n95 = pipe4.mediums[3].Xi[1] - pipe4.mediums[3].n94;
 //   pipe4.mediums[3].n96 = 1.0 - pipe4.mediums[3].Xi[1];
 //   pipe4.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[3].p, pipe4.mediums[3].T, pipe4.mediums[3].Xi);
-//   pipe4.mediums[3].R = 287.0512249529787 * pipe4.mediums[3].n96 / (1.0 - pipe4.mediums[3].n94) + 461.5233290850878 * pipe4.mediums[3].n95 / (1.0 - pipe4.mediums[3].n94);
-//   pipe4.mediums[3].u = pipe4.mediums[3].h - pipe4.mediums[3].R * pipe4.mediums[3].T;
-//   pipe4.mediums[3].d = pipe4.mediums[3].p / (pipe4.mediums[3].R * pipe4.mediums[3].T);
+//   pipe4.mediums[3].R_s = 287.0512249529787 * pipe4.mediums[3].n96 / (1.0 - pipe4.mediums[3].n94) + 461.5233290850878 * pipe4.mediums[3].n95 / (1.0 - pipe4.mediums[3].n94);
+//   pipe4.mediums[3].u = pipe4.mediums[3].h - pipe4.mediums[3].R_s * pipe4.mediums[3].T;
+//   pipe4.mediums[3].d = pipe4.mediums[3].p / (pipe4.mediums[3].R_s * pipe4.mediums[3].T);
 //   pipe4.mediums[3].state.p = pipe4.mediums[3].p;
 //   pipe4.mediums[3].state.T = pipe4.mediums[3].T;
 //   pipe4.mediums[3].state.X[1] = pipe4.mediums[3].X[1];
@@ -7808,9 +7199,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.mediums[4].n95 = pipe4.mediums[4].Xi[1] - pipe4.mediums[4].n94;
 //   pipe4.mediums[4].n96 = 1.0 - pipe4.mediums[4].Xi[1];
 //   pipe4.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[4].p, pipe4.mediums[4].T, pipe4.mediums[4].Xi);
-//   pipe4.mediums[4].R = 287.0512249529787 * pipe4.mediums[4].n96 / (1.0 - pipe4.mediums[4].n94) + 461.5233290850878 * pipe4.mediums[4].n95 / (1.0 - pipe4.mediums[4].n94);
-//   pipe4.mediums[4].u = pipe4.mediums[4].h - pipe4.mediums[4].R * pipe4.mediums[4].T;
-//   pipe4.mediums[4].d = pipe4.mediums[4].p / (pipe4.mediums[4].R * pipe4.mediums[4].T);
+//   pipe4.mediums[4].R_s = 287.0512249529787 * pipe4.mediums[4].n96 / (1.0 - pipe4.mediums[4].n94) + 461.5233290850878 * pipe4.mediums[4].n95 / (1.0 - pipe4.mediums[4].n94);
+//   pipe4.mediums[4].u = pipe4.mediums[4].h - pipe4.mediums[4].R_s * pipe4.mediums[4].T;
+//   pipe4.mediums[4].d = pipe4.mediums[4].p / (pipe4.mediums[4].R_s * pipe4.mediums[4].T);
 //   pipe4.mediums[4].state.p = pipe4.mediums[4].p;
 //   pipe4.mediums[4].state.T = pipe4.mediums[4].T;
 //   pipe4.mediums[4].state.X[1] = pipe4.mediums[4].X[1];
@@ -7837,9 +7228,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.mediums[5].n95 = pipe4.mediums[5].Xi[1] - pipe4.mediums[5].n94;
 //   pipe4.mediums[5].n96 = 1.0 - pipe4.mediums[5].Xi[1];
 //   pipe4.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[5].p, pipe4.mediums[5].T, pipe4.mediums[5].Xi);
-//   pipe4.mediums[5].R = 287.0512249529787 * pipe4.mediums[5].n96 / (1.0 - pipe4.mediums[5].n94) + 461.5233290850878 * pipe4.mediums[5].n95 / (1.0 - pipe4.mediums[5].n94);
-//   pipe4.mediums[5].u = pipe4.mediums[5].h - pipe4.mediums[5].R * pipe4.mediums[5].T;
-//   pipe4.mediums[5].d = pipe4.mediums[5].p / (pipe4.mediums[5].R * pipe4.mediums[5].T);
+//   pipe4.mediums[5].R_s = 287.0512249529787 * pipe4.mediums[5].n96 / (1.0 - pipe4.mediums[5].n94) + 461.5233290850878 * pipe4.mediums[5].n95 / (1.0 - pipe4.mediums[5].n94);
+//   pipe4.mediums[5].u = pipe4.mediums[5].h - pipe4.mediums[5].R_s * pipe4.mediums[5].T;
+//   pipe4.mediums[5].d = pipe4.mediums[5].p / (pipe4.mediums[5].R_s * pipe4.mediums[5].T);
 //   pipe4.mediums[5].state.p = pipe4.mediums[5].p;
 //   pipe4.mediums[5].state.T = pipe4.mediums[5].T;
 //   pipe4.mediums[5].state.X[1] = pipe4.mediums[5].X[1];
@@ -7873,7 +7264,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.flowModel.pathLengths_internal = pipe4.flowModel.pathLengths;
 //   pipe4.flowModel.Res_turbulent_internal = {pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent};
 //   pipe4.flowModel.n108 = {0.5 * (pipe4.flowModel.dimensions[1] + pipe4.flowModel.dimensions[2]), 0.5 * (pipe4.flowModel.dimensions[2] + pipe4.flowModel.dimensions[3]), 0.5 * (pipe4.flowModel.dimensions[3] + pipe4.flowModel.dimensions[4]), 0.5 * (pipe4.flowModel.dimensions[4] + pipe4.flowModel.dimensions[5]), 0.5 * (pipe4.flowModel.dimensions[5] + pipe4.flowModel.dimensions[6]), 0.5 * (pipe4.flowModel.dimensions[6] + pipe4.flowModel.dimensions[7])};
-//   pipe4.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe4.flowModel.dps_fg[$i72], pipe4.flowModel.rhos[(1:6)[$i72]], pipe4.flowModel.rhos[(2:7)[$i72]], pipe4.flowModel.mus[(1:6)[$i72]], pipe4.flowModel.mus[(2:7)[$i72]], pipe4.flowModel.pathLengths_internal[$i72], pipe4.flowModel.n108[$i72], {pipe4.flowModel.g * pipe4.flowModel.dheights[1], pipe4.flowModel.g * pipe4.flowModel.dheights[2], pipe4.flowModel.g * pipe4.flowModel.dheights[3], pipe4.flowModel.g * pipe4.flowModel.dheights[4], pipe4.flowModel.g * pipe4.flowModel.dheights[5], pipe4.flowModel.g * pipe4.flowModel.dheights[6]}[$i72], {(pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0}[$i72], {(pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0}[$i72], pipe4.flowModel.n105 / 6.0, pipe4.flowModel.Res_turbulent_internal[$i72]) for $i72 in 1:6) * pipe4.flowModel.nParallel)[$i73], {pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[1] - pipe4.flowModel.g * pipe4.flowModel.dheights[1] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[2] - pipe4.flowModel.g * pipe4.flowModel.dheights[2] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[3] - pipe4.flowModel.g * pipe4.flowModel.dheights[3] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[4] - pipe4.flowModel.g * pipe4.flowModel.dheights[4] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[5] - pipe4.flowModel.g * pipe4.flowModel.dheights[5] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[6] - pipe4.flowModel.g * pipe4.flowModel.dheights[6] * pipe4.flowModel.n102)}[$i73]) for $i73 in 1:6);
+//   pipe4.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe4.flowModel.dps_fg[$i72], pipe4.flowModel.rhos[{1, 2, 3, 4, 5, 6}[$i72]], pipe4.flowModel.rhos[{2, 3, 4, 5, 6, 7}[$i72]], pipe4.flowModel.mus[{1, 2, 3, 4, 5, 6}[$i72]], pipe4.flowModel.mus[{2, 3, 4, 5, 6, 7}[$i72]], pipe4.flowModel.pathLengths_internal[$i72], pipe4.flowModel.n108[$i72], {pipe4.flowModel.g * pipe4.flowModel.dheights[1], pipe4.flowModel.g * pipe4.flowModel.dheights[2], pipe4.flowModel.g * pipe4.flowModel.dheights[3], pipe4.flowModel.g * pipe4.flowModel.dheights[4], pipe4.flowModel.g * pipe4.flowModel.dheights[5], pipe4.flowModel.g * pipe4.flowModel.dheights[6]}[$i72], {(pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0}[$i72], {(pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0}[$i72], pipe4.flowModel.n105 / 6.0, pipe4.flowModel.Res_turbulent_internal[$i72]) for $i72 in 1:6) * pipe4.flowModel.nParallel)[$i73], {pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[1] - pipe4.flowModel.g * pipe4.flowModel.dheights[1] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[2] - pipe4.flowModel.g * pipe4.flowModel.dheights[2] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[3] - pipe4.flowModel.g * pipe4.flowModel.dheights[3] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[4] - pipe4.flowModel.g * pipe4.flowModel.dheights[4] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[5] - pipe4.flowModel.g * pipe4.flowModel.dheights[5] * pipe4.flowModel.n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[6] - pipe4.flowModel.g * pipe4.flowModel.dheights[6] * pipe4.flowModel.n102)}[$i73]) for $i73 in 1:6);
 //   pipe4.flowModel.rhos_act[1] = noEvent(if pipe4.flowModel.m_flows[1] > 0.0 then pipe4.flowModel.rhos[1] else pipe4.flowModel.rhos[2]);
 //   pipe4.flowModel.mus_act[1] = noEvent(if pipe4.flowModel.m_flows[1] > 0.0 then pipe4.flowModel.mus[1] else pipe4.flowModel.mus[2]);
 //   pipe4.flowModel.rhos_act[2] = noEvent(if pipe4.flowModel.m_flows[2] > 0.0 then pipe4.flowModel.rhos[2] else pipe4.flowModel.rhos[3]);
@@ -7923,7 +7314,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.Qb_flows[3] = pipe4.heatTransfer.Q_flows[3];
 //   pipe4.Qb_flows[4] = pipe4.heatTransfer.Q_flows[4];
 //   pipe4.Qb_flows[5] = pipe4.heatTransfer.Q_flows[5];
-//   pipe4.Wb_flows[2:4] = array(pipe4.vs[i] * pipe4.crossAreas[i] * ((pipe4.mediums[i + 1].p - pipe4.mediums[i - 1].p) / 2.0 + (pipe4.flowModel.dps_fg[i] + pipe4.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 10.0 * pipe4.mediums[i].d) for i in 2:4) * pipe4.nParallel;
+//   pipe4.Wb_flows[{2, 3, 4}] = array(pipe4.vs[i] * pipe4.crossAreas[i] * ((pipe4.mediums[i + 1].p - pipe4.mediums[i - 1].p) / 2.0 + (pipe4.flowModel.dps_fg[i] + pipe4.flowModel.dps_fg[i + 1]) / 2.0 - system.g * 10.0 * pipe4.mediums[i].d) for i in 2:4) * pipe4.nParallel;
 //   pipe4.Wb_flows[1] = pipe4.vs[1] * pipe4.crossAreas[1] * ((pipe4.mediums[2].p - pipe4.port_a.p) / 1.5 + pipe4.flowModel.dps_fg[1] + pipe4.flowModel.dps_fg[2] / 2.0 - system.g * 10.0 * pipe4.mediums[1].d) * pipe4.nParallel;
 //   pipe4.Wb_flows[5] = pipe4.vs[5] * pipe4.crossAreas[5] * ((pipe4.port_b.p - pipe4.mediums[4].p) / 1.5 + pipe4.flowModel.dps_fg[5] / 2.0 + pipe4.flowModel.dps_fg[6] - system.g * 10.0 * pipe4.mediums[5].d) * pipe4.nParallel;
 //   pipe4.n110[1] = 5.0;
@@ -8055,9 +7446,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   boundary4.medium.n117 = boundary4.medium.Xi[1] - boundary4.medium.n116;
 //   boundary4.medium.n118 = 1.0 - boundary4.medium.Xi[1];
 //   boundary4.medium.h = Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy_pTX(boundary4.medium.p, boundary4.medium.T, boundary4.medium.Xi);
-//   boundary4.medium.R = 287.0512249529787 * boundary4.medium.n118 / (1.0 - boundary4.medium.n116) + 461.5233290850878 * boundary4.medium.n117 / (1.0 - boundary4.medium.n116);
-//   boundary4.medium.u = boundary4.medium.h - boundary4.medium.R * boundary4.medium.T;
-//   boundary4.medium.d = boundary4.medium.p / (boundary4.medium.R * boundary4.medium.T);
+//   boundary4.medium.R_s = 287.0512249529787 * boundary4.medium.n118 / (1.0 - boundary4.medium.n116) + 461.5233290850878 * boundary4.medium.n117 / (1.0 - boundary4.medium.n116);
+//   boundary4.medium.u = boundary4.medium.h - boundary4.medium.R_s * boundary4.medium.T;
+//   boundary4.medium.d = boundary4.medium.p / (boundary4.medium.R_s * boundary4.medium.T);
 //   boundary4.medium.state.p = boundary4.medium.p;
 //   boundary4.medium.state.T = boundary4.medium.T;
 //   boundary4.medium.state.X[1] = boundary4.medium.X[1];


### PR DESCRIPTION
- Evaluate slice subscripts during typing, rather than just marking them as structural, to allow determining the correct type for array slices.

Fixes #15264