### PR TITLE
Fix impure functions being constant-folded during elaboration

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -7430,7 +7430,7 @@ algorithm
   true := isValidWRTParallelScope(fn,builtin,funcParal,inEnv,info);
 
   const := List.fold(constlist, Types.constAnd, DAE.C_CONST());
-  const := if (Flags.isSet(Flags.RML) and not builtin) or purity == DAE.Purity.OM_IMPURE then DAE.C_VAR() else const "in RML no function needs to be ceval'ed; this speeds up compilation significantly when bootstrapping";
+  const := if (Flags.isSet(Flags.RML) and not builtin) or purity == DAE.Purity.OM_IMPURE or isImpure then DAE.C_VAR() else const "in RML no function needs to be ceval'ed; this speeds up compilation significantly when bootstrapping";
   (cache,const) := determineConstSpecialFunc(cache,inEnv,const,fn_1);
   tyconst := elabConsts(restype, const);
   prop := getProperties(restype, tyconst);


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/15310

### Purpose

Fix issue in CevalScript.

### Approach

In elabCallArgs3 (Static.mo), the constness of a function call with all-constant arguments was set to C_CONST even for functions declared with the Modelica 'impure' keyword. The existing guard only reset the constness to C_VAR for OM_IMPURE (the __OpenModelica_Impure annotation), not for standard Modelica IMPURE purity.

As a result, InstSection.mo:instAssignment2 would call cevalIfConstant on the elaborated expression — which has no isImpure guard — and eagerly evaluate the impure call at elaboration time, before the function's algorithm section ever ran. This caused statements like `ret := OpenModelica.Scripting.system(...)` to be pre-evaluated (and side-effecting calls like `writeFile` to be silently deferred), breaking sequential execution order in algorithm sections.

Fix: extend the constness override to also cover isImpure (purity == DAE.Purity.IMPURE), so that standard Modelica 'impure' functions correctly get C_VAR and are never constant-folded.