### PR TITLE
Fixing OMBootstrapping at 91938f0

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -7,7 +7,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz")
 else()
 #download and unpack the sources
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
-file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz
+file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/91938f0acbdc6e9ba91114376e3640ca6147b579.tar.gz
      ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz
      SHOW_PROGRESS
      STATUS status
@@ -17,7 +17,7 @@ list(GET status 0 status_code)
 list(GET status 1 status_string)
 # check the download status!
 if(NOT status_code EQUAL 0)
-message(FATAL_ERROR "error: downloading 'https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz' failed
+message(FATAL_ERROR "error: downloading 'https://github.com/OpenModelica/OMBootstrapping/archive/91938f0acbdc6e9ba91114376e3640ca6147b579.tar.gz' failed
         status_code: ${status_code}
         status_string: ${status_string}
         log: ${log}")


### PR DESCRIPTION
### Related Issues

Fixes build error in https://github.com/OpenModelica/OpenModelica/pull/15327.

### Purpose

* Use correct version of OMBootstrapping for CMake build.

### Approach

* Pin https://github.com/OpenModelica/OMBootstrapping/commit/91938f0acbdc6e9ba91114376e3640ca6147b579.
