### PR TITLE
[NB] update function differentiation

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -1484,7 +1484,7 @@ public
     protected
       Algorithm alg;
     algorithm
-      alg := Algorithm.ALGORITHM(stmts, {}, {}, InstNode.EMPTY_NODE(), DAE.emptyElementSource);
+      alg := Algorithm.ALGORITHM(stmts, {}, {}, NONE(), InstNode.EMPTY_NODE(), DAE.emptyElementSource);
       alg := Algorithm.setInputsOutputs(alg);
       eqn := BackendDAE.lowerAlgorithm(alg, init);
     end makeAlgorithm;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -1056,7 +1056,7 @@ protected
       // wrap no return call in algorithm
       case FEquation.NORETCALL() algorithm
         stmt := Statement.NORETCALL(frontend_equation.exp, frontend_equation.source);
-        alg  := Algorithm.ALGORITHM({stmt}, {}, {}, InstNode.EMPTY_NODE(), frontend_equation.source);
+        alg  := Algorithm.ALGORITHM({stmt}, {}, {}, NONE(), InstNode.EMPTY_NODE(), frontend_equation.source);
         alg  := Algorithm.setInputsOutputs(alg);
       then {lowerAlgorithm(alg, init)};
 
@@ -1227,7 +1227,7 @@ protected
       case FEquation.ASSERT(condition = Expression.CALL(call = call)) guard(Call.isNamed(call, "noEvent")) algorithm
         attr := EquationAttributes.default(EquationKind.EMPTY, init);
         alg := Algorithm.ALGORITHM({Statement.ASSERT(frontend_eq.condition, frontend_eq.message, frontend_eq.level, frontend_eq.source)},
-          {}, {}, frontend_eq.scope, frontend_eq.source);
+          {}, {}, NONE(), frontend_eq.scope, frontend_eq.source);
       then {lowerAlgorithm(alg, init)};
 
       case FEquation.ASSERT() algorithm

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -1102,7 +1102,7 @@ public
         Operator addOp, mulOp;
         list<tuple<Expression, InstNode>> arguments_inputs;
         InstNode inp;
-        Boolean isCont, isReal, isFunc;
+        Boolean isCont, isReal, isFunc, isSkipped;
         // interface map. If the map contains a variable it has a zero derivative
         // if the value is "true" it has to be stripped from the interface
         // (it is possible that a variable has a zero derivative, but still appears in the interface)
@@ -1131,7 +1131,6 @@ public
         if Util.isSome(func_opt) then
           // The function is in the function tree
           SOME(func) := func_opt;
-
           interface_map := UnorderedMap.new<Boolean>(stringHashDjb2, stringEqual);
 
           // build interface map to check if a function fits
@@ -1139,13 +1138,15 @@ public
           arguments_inputs := List.zip(call.arguments, func.inputs);
           for tpl in arguments_inputs loop
             (arg, inp) := tpl;
-            // do not check for continuous if it is for functions (differentiating a function inside a function)
-            // crefs are not lowered there! assume it is continuous
-            isCont := (diffArguments.diffType == DifferentiationType.FUNCTION) or BackendUtil.isContinuous(arg, false);
-            // input type has to be real value or a function pointer
-            isReal := Type.isReal(Type.arrayElementType(Expression.typeOf(arg)));
-            isFunc := InstNode.isFunction(inp);
-            if not (isFunc or (isCont and isReal)) then
+            // check if it is continuous
+            // do not check for continuous if it is for functions (differentiating a function inside a function) crefs are not lowered there! assume it is continuous
+            isCont := ((diffArguments.diffType == DifferentiationType.FUNCTION) or BackendUtil.isContinuous(arg, false));
+
+            // input type has to be real value or a function pointer, skip if its in the interface diff info
+            isReal    := Type.isReal(Type.arrayElementType(Expression.typeOf(arg)));
+            isFunc    := InstNode.isFunction(inp);
+            isSkipped := Util.applyOptionOrDefault(func.interfaceDiffInfo, function UnorderedSet.contains(key = inp), false);
+            if isSkipped or not (isFunc or (isCont and isReal)) then
               // add to map; if it is not Real also already set to true (always removed from interface)
               UnorderedMap.add(InstNode.name(inp), not (isFunc or isReal), interface_map);
             end if;
@@ -1161,9 +1162,11 @@ public
 
           for tpl in listReverse(arguments_inputs) loop
             (arg, inp) := tpl;
+            isSkipped := Util.applyOptionOrDefault(func.interfaceDiffInfo, function UnorderedSet.contains(key = inp), false);
             // only keep the arguments which are not in the map or have value false
-            if not UnorderedMap.getOrDefault(InstNode.name(inp), interface_map, false) then
+            if not (isSkipped or UnorderedMap.getOrDefault(InstNode.name(inp), interface_map, false)) then
               arguments := arg :: arguments;
+            else
             end if;
           end for;
 
@@ -2044,6 +2047,7 @@ public
         Class new_cls;
         DifferentiationArguments funcDiffArgs;
         UnorderedMap<ComponentRef, ComponentRef> diff_map = UnorderedMap.new<ComponentRef>(ComponentRef.hash, ComponentRef.isEqual);
+        UnorderedSet<InstNode> diffInfo;
         list<Algorithm> algorithms;
         FunctionDerivative funcDer;
         Function dummy_func;
@@ -2063,15 +2067,21 @@ public
             funcDiffArgs          := DifferentiationArguments.default();
             funcDiffArgs.diffType := DifferentiationType.FUNCTION;
             funcDiffArgs.funcMap  := diffArguments.funcMap;
+            // prepare interface diff info if the function
+            diffInfo := match der_func.interfaceDiffInfo
+              case SOME(diffInfo) then UnorderedSet.copy(diffInfo);
+              else UnorderedSet.new(InstNode.hash, InstNode.nameEqual);
+            end match;
+
             createInterfaceDerivatives(der_func.inputs, interface_map, diff_map);
             createInterfaceDerivatives(der_func.locals, interface_map, diff_map);
             createInterfaceDerivatives(der_func.outputs, interface_map, diff_map);
             funcDiffArgs.diff_map := SOME(diff_map);
 
             // differentiate interface arguments
-            (inputs, funcDiffArgs)  := differentiateFunctionInterfaceNodes(der_func.inputs, interface_map, diff_map, funcDiffArgs, true);
-            (locals, funcDiffArgs)  := differentiateFunctionInterfaceNodes(der_func.locals, interface_map, diff_map, funcDiffArgs, false);
-            (outputs, funcDiffArgs) := differentiateFunctionInterfaceNodes(der_func.outputs, interface_map, diff_map, funcDiffArgs, false);
+            (inputs, funcDiffArgs)  := differentiateFunctionInterfaceNodes(der_func.inputs, interface_map, diff_map, funcDiffArgs, diffInfo, true);
+            (locals, funcDiffArgs)  := differentiateFunctionInterfaceNodes(der_func.locals, interface_map, diff_map, funcDiffArgs, diffInfo, false);
+            (outputs, funcDiffArgs) := differentiateFunctionInterfaceNodes(der_func.outputs, interface_map, diff_map, funcDiffArgs, diffInfo, false);
 
             // update inputs, outputs and locals, add old outputs to locals as they might still be used as temporary variables
             der_func.inputs   := inputs;
@@ -2092,9 +2102,12 @@ public
             node.name       := der_func_name + "." + node.name;
             node.definition := SCodeUtil.setElementName(node.definition, node.name);
             // create "fake" function from new node, update cache to get correct derivative name
-            der_func.path   := AbsynUtil.prefixPath(der_func_name, der_func.path);
-            cachedData      := CachedData.FUNCTION({der_func}, true, false);
-            der_func.node   := InstNode.setFuncCache(node, cachedData);
+            der_func.path               := AbsynUtil.prefixPath(der_func_name, der_func.path);
+            der_func.derivatives        := {};
+            der_func.derivedInputs      := {};
+            der_func.interfaceDiffInfo  := SOME(diffInfo);
+            cachedData                  := CachedData.FUNCTION({der_func}, true, false);
+            der_func.node               := InstNode.newFuncCache(node, cachedData);
 
             // create fake derivative
             funcDer := FunctionDerivative.FUNCTION_DER(
@@ -2123,10 +2136,12 @@ public
               else funcDiffArgs;
             end match;
 
-            node.cls              := Pointer.create(new_cls);
-            cachedData            := CachedData.FUNCTION({der_func}, true, false);
-            der_func.node         := InstNode.setFuncCache(node, cachedData);
-            der_func.derivatives  := {};
+            node.cls                    := Pointer.create(new_cls);
+            der_func.derivatives        := {};
+            der_func.derivedInputs      := {};
+            der_func.interfaceDiffInfo  := SOME(diffInfo);
+            cachedData                  := CachedData.FUNCTION({der_func}, true, false);
+            der_func.node               := InstNode.newFuncCache(node, cachedData);
 
             // save the function tree
             diffArguments.funcMap := funcDiffArgs.funcMap;
@@ -2165,11 +2180,13 @@ public
     "differentiates function interface nodes (inputs, outputs, locals) and
     adds them to the diff_map used for differentiation. Also returns the new
     interface node lists for the differentiated function.
-    (outputs only have the differentiated and not the original interface nodes)"
+    Note1: outputs only have the differentiated and not the original interface nodes
+    Note2: for derivatives of higher orders skip the previously differentiated interface nodes"
     input output list<InstNode> interface_nodes;
     input UnorderedMap<String, Boolean> interface_map;
     input UnorderedMap<ComponentRef, ComponentRef> diff_map;
     input output DifferentiationArguments diffArgs;
+    input UnorderedSet<InstNode> diffInfo;
     input Boolean keepOld;
   protected
     list<InstNode> new_nodes;
@@ -2177,9 +2194,15 @@ public
   algorithm
     new_nodes := if keepOld then listReverse(interface_nodes) else {};
     for node in interface_nodes loop
+      // check if its part of the interface
       if not UnorderedMap.contains(InstNode.name(node), interface_map) then
-        (d_node, diffArgs) := differentiateFunctionInterfaceNode(node, diff_map, diffArgs);
-        new_nodes := d_node :: new_nodes;
+        // check if derivative of higher order skips this
+        if not UnorderedSet.contains(node, diffInfo) then
+          (d_node, diffArgs) := differentiateFunctionInterfaceNode(node, diff_map, diffArgs);
+          new_nodes := d_node :: new_nodes;
+          // add to skipped nodes if differentiated again because the derivative now already exists
+          UnorderedSet.add(node, diffInfo);
+        end if;
       end if;
     end for;
     interface_nodes := listReverse(new_nodes);
@@ -2289,12 +2312,14 @@ public
     UnorderedMap<ComponentRef, ComponentRef> diff_map = UnorderedMap.new<ComponentRef>(ComponentRef.hash, ComponentRef.isEqual);
     UnorderedMap<String, Boolean> interface_map;
     DifferentiationArguments diffArgs = DifferentiationArguments.default();
+    UnorderedSet<InstNode> diffInfo;
     list<Algorithm> algorithms;
     CachedData cachedData;
     InstNode diffVar;
     ComponentRef diffCref;
     list<InstNode> locals, outputs, local_outputs;
     Boolean changed = false;
+
   algorithm
     func := match func
       case der_func as Function.FUNCTION(node = InstNode.CLASS_NODE(cls = cls)) algorithm
@@ -2306,6 +2331,11 @@ public
                 // prepare differentiation arguments
                 diffArgs.diffType     := DifferentiationType.FUNCTION;
                 diffArgs.funcMap      := funcMap;
+                // prepare interface diff info if the function
+                diffInfo := match der_func.interfaceDiffInfo
+                  case SOME(diffInfo) then UnorderedSet.copy(diffInfo);
+                  else UnorderedSet.new(InstNode.hash, InstNode.nameEqual);
+                end match;
 
                 interface_map := UnorderedMap.fromLists(list(InstNode.name(var) for var in der_func.inputs), List.fill(false, listLength(der_func.inputs)), stringHashDjb2, stringEqual);
 
@@ -2323,12 +2353,13 @@ public
                   createInterfaceDerivatives(der_func.outputs, interface_map, diff_map);
                   diffArgs.diff_map   := SOME(diff_map);
 
-                  (locals, diffArgs)  := differentiateFunctionInterfaceNodes(der_func.locals, interface_map, diff_map, diffArgs, true);
-                  (outputs, diffArgs) := differentiateFunctionInterfaceNodes(der_func.outputs, interface_map, diff_map, diffArgs, false);
+                  (locals, diffArgs)  := differentiateFunctionInterfaceNodes(der_func.locals, interface_map, diff_map, diffArgs, diffInfo, true);
+                  (outputs, diffArgs) := differentiateFunctionInterfaceNodes(der_func.outputs, interface_map, diff_map, diffArgs, diffInfo, false);
 
-                  diffCref          := UnorderedMap.getSafe(ComponentRef.fromNode(var, InstNode.getType(var)), diff_map, sourceInfo());
-                  der_func.locals   := listAppend(locals, local_outputs);
-                  der_func.outputs  := outputs;
+                  diffCref                    := UnorderedMap.getSafe(ComponentRef.fromNode(var, InstNode.getType(var)), diff_map, sourceInfo());
+                  der_func.locals             := listAppend(locals, local_outputs);
+                  der_func.outputs            := outputs;
+                  der_func.interfaceDiffInfo  := SOME(diffInfo);
 
                   // differentiate function statements
                   (algorithms, diffArgs) := List.mapFold(algorithms, differentiateAlgorithm, diffArgs);
@@ -2338,15 +2369,17 @@ public
                 end for;
 
                 // add them to new node
-                sections.algorithms     := algorithms;
-                new_cls.sections        := sections;
-                new_cls.ty              := wrap_cls.ty;
-                new_cls.restriction     := wrap_cls.restriction;
-                node.cls                := Pointer.create(new_cls);
-                cachedData              := CachedData.FUNCTION({der_func}, true, false);
-                der_func.node           := InstNode.setFuncCache(node, cachedData);
-                der_func.derivatives    := {};
-                der_func.derivedInputs  := {};
+                sections.algorithms         := algorithms;
+                new_cls.sections            := sections;
+                new_cls.ty                  := wrap_cls.ty;
+                new_cls.restriction         := wrap_cls.restriction;
+                node.cls                    := Pointer.create(new_cls);
+                der_func.derivatives        := {};
+                der_func.derivedInputs      := {};
+                der_func.interfaceDiffInfo  := SOME(diffInfo);
+                cachedData                  := CachedData.FUNCTION({der_func}, true, false);
+                der_func.node               := InstNode.newFuncCache(node, cachedData);
+
 
                 changed := true;
               then new_cls;
@@ -2377,15 +2410,30 @@ public
     list<list<Statement>> statements;
     list<Statement> statements_flat;
     list<ComponentRef> inputs, outputs;
+    UnorderedSet<Statement> diffInfo;
   algorithm
-    (statements, diffArguments) := List.mapFold(alg.statements, differentiateStatement, diffArguments);
+    // store which statements are differentiated so they wont be differentiated again
+    diffInfo := match alg.stmtDiffInfo
+      case SOME(diffInfo) then UnorderedSet.copy(diffInfo);
+      else UnorderedSet.new(Statement.hash, Statement.isEqual);
+    end match;
+
+    // differentiate the statements
+    (statements, diffArguments) := List.mapFold(alg.statements, function differentiateStatement(diffInfo = diffInfo), diffArguments);
+
+    // add all original statements to the set of statements that should not be differentiated
+    for stmt in alg.statements loop
+      UnorderedSet.add(stmt, diffInfo);
+    end for;
+
     statements_flat := List.flatten(statements);
     (inputs, outputs) := Algorithm.getInputsOutputs(statements_flat);
-    alg := Algorithm.ALGORITHM(statements_flat, inputs, outputs, alg.scope, alg.source);
+    alg := Algorithm.ALGORITHM(statements_flat, inputs, outputs, SOME(diffInfo), alg.scope, alg.source);
   end differentiateAlgorithm;
 
   function differentiateStatement
     input Statement stmt;
+    input UnorderedSet<Statement> diffInfo;
     output list<Statement> diff_stmts "two statements for 'Real' assignments (diff; original) and else one";
     input output DifferentiationArguments diffArguments;
   algorithm
@@ -2397,6 +2445,9 @@ public
         list<list<Statement>> branch_stmts;
         list<tuple<Expression, list<Statement>>> branches = {};
 
+      // 0. do not differentiate if it already exists differentiated due to previous differentiation
+      case _ guard(UnorderedSet.contains(stmt, diffInfo)) then {stmt};
+
       // I. differentiate 'Real' assignment and return differentiated and original statement
       case diff_stmt as Statement.ASSIGNMENT() guard(Type.isReal(Type.arrayElementType(Expression.typeOf(diff_stmt.lhs)))) algorithm
         (lhs, diffArguments) := differentiateExpression(diff_stmt.lhs, diffArguments);
@@ -2407,24 +2458,24 @@ public
 
       // II. delegate differentiation to body and only return differentiated statement
       case diff_stmt as Statement.FOR() algorithm
-        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, differentiateStatement, diffArguments);
+        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, function differentiateStatement(diffInfo = diffInfo), diffArguments);
         diff_stmt.body := List.flatten(branch_stmts);
       then {diff_stmt};
 
       case diff_stmt as Statement.WHILE() algorithm
-        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, differentiateStatement, diffArguments);
+        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, function differentiateStatement(diffInfo = diffInfo), diffArguments);
         diff_stmt.body := List.flatten(branch_stmts);
       then {diff_stmt};
 
       case diff_stmt as Statement.FAILURE() algorithm
-        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, differentiateStatement, diffArguments);
+        (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, function differentiateStatement(diffInfo = diffInfo), diffArguments);
         diff_stmt.body := List.flatten(branch_stmts);
       then {diff_stmt};
 
       case diff_stmt as Statement.IF() algorithm
         for branch in diff_stmt.branches loop
           (exp, branch_stmts_flat) := branch;
-          (branch_stmts, diffArguments) := List.mapFold(branch_stmts_flat, differentiateStatement, diffArguments);
+          (branch_stmts, diffArguments) := List.mapFold(branch_stmts_flat, function differentiateStatement(diffInfo = diffInfo), diffArguments);
           branches := (exp, List.flatten(branch_stmts)) :: branches;
         end for;
         diff_stmt.branches := listReverse(branches);
@@ -2433,7 +2484,7 @@ public
       case diff_stmt as Statement.WHEN() algorithm
         for branch in diff_stmt.branches loop
           (exp, branch_stmts_flat) := branch;
-          (branch_stmts, diffArguments) := List.mapFold(branch_stmts_flat, differentiateStatement, diffArguments);
+          (branch_stmts, diffArguments) := List.mapFold(branch_stmts_flat, function differentiateStatement(diffInfo = diffInfo), diffArguments);
           branches := (exp, List.flatten(branch_stmts)) :: branches;
         end for;
         diff_stmt.branches := listReverse(branches);

--- a/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
@@ -53,6 +53,7 @@ public
     list<Statement> statements;
     list<ComponentRef> inputs;
     list<ComponentRef> outputs;
+    Option<UnorderedSet<Statement>> stmtDiffInfo;
     InstNode scope;
     DAE.ElementSource source;
   end ALGORITHM;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -140,7 +140,7 @@ constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
 constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
-  INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
+  INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, NONE(), {
     Slot.SLOT(ENUM_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
   }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}), Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
@@ -179,7 +179,7 @@ constant InstNode FORMAT_PARAM = InstNode.COMPONENT_NODE("format", NONE(),
 
 // String(r, significantDigits=d, minimumLength=0, leftJustified=true)
 constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
-  STRING_DUMMY_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, NONE(), {
     Slot.SLOT(R_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(SIGNIFICANT_DIGITS_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED),
@@ -189,7 +189,7 @@ constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
 
 // String(r, format="-0.6g")
 constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
-  STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, NONE(), {
     Slot.SLOT(R_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(FORMAT_PARAM, SlotType.NAMED, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
@@ -197,7 +197,7 @@ constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
 
 // String(i, minimumLength=0, leftJustified=true)
 constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
-  STRING_DUMMY_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, NONE(), {
     Slot.SLOT(I_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
@@ -206,7 +206,7 @@ constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
 
 // String(b, minimumLength=0, leftJustified=true)
 constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
-  STRING_DUMMY_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, NONE(), {
     Slot.SLOT(B_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
@@ -215,7 +215,7 @@ constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
 
 // String(e, minimumLength=0, leftJustified=true)
 constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
-  STRING_DUMMY_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, NONE(), {
     Slot.SLOT(E_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
@@ -244,212 +244,212 @@ constant ComponentRef STRING_CREF =
 
 // TODO: Sort these functions ...
 constant Function COS_REAL = Function.FUNCTION(Path.IDENT("cos"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SIN_REAL = Function.FUNCTION(Path.IDENT("sin"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function TAN_REAL = Function.FUNCTION(Path.IDENT("tan"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ACOS_REAL = Function.FUNCTION(Path.IDENT("acos"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ASIN_REAL = Function.FUNCTION(Path.IDENT("asin"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ATAN_REAL = Function.FUNCTION(Path.IDENT("atan"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function COSH_REAL = Function.FUNCTION(Path.IDENT("cosh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SINH_REAL = Function.FUNCTION(Path.IDENT("sinh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function TANH_REAL = Function.FUNCTION(Path.IDENT("tanh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ACOSH_REAL = Function.FUNCTION(Path.IDENT("acosh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ASINH_REAL = Function.FUNCTION(Path.IDENT("asinh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ATANH_REAL = Function.FUNCTION(Path.IDENT("atanh"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function EXP_REAL = Function.FUNCTION(Path.IDENT("exp"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function LOG_REAL = Function.FUNCTION(Path.IDENT("log"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function LOG10_REAL = Function.FUNCTION(Path.IDENT("log10"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SIGN = Function.FUNCTION(Path.IDENT("sign"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_INT = Function.FUNCTION(Path.IDENT("max"),
-  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MIN_INT = Function.FUNCTION(Path.IDENT("min"),
-  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MIN_REAL = Function.FUNCTION(Path.IDENT("min"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ARG_MIN_ARR_REAL = Function.FUNCTION(Path.IDENT("argmin"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ARG_MAX_ARR_REAL = Function.FUNCTION(Path.IDENT("argmax"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function DIV_INT = Function.FUNCTION(Path.IDENT("div"),
-  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function DIV_REAL = Function.FUNCTION(Path.IDENT("div"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FLOOR = Function.FUNCTION(Path.IDENT("floor"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_REAL = Function.FUNCTION(Path.IDENT("integer"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_ENUM = Function.FUNCTION(Path.IDENT("Integer"),
-  InstNode.EMPTY_NODE(), {ENUM_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {ENUM_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INSTREAM_DIV_REAL = Function.FUNCTION(Path.IDENT("$OMC$inStreamDiv"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function PROMOTE = Function.FUNCTION(Path.IDENT("promote"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function CAT = Function.FUNCTION(Path.IDENT("cat"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ARRAY_FUNC = Function.FUNCTION(Path.IDENT("array"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FILL_FUNC = Function.FUNCTION(Path.IDENT("fill"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SMOOTH = Function.FUNCTION(Path.IDENT("smooth"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function NO_EVENT = Function.FUNCTION(Path.IDENT("noEvent"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function PRE = Function.FUNCTION(Path.IDENT("pre"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SUM = Function.FUNCTION(Path.IDENT("sum"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FMU_LOAD_RESOURCE = Function.FUNCTION(Path.IDENT("OpenModelica_fmuLoadResource"),
-  InstNode.EMPTY_NODE(), {STRING_PARAM}, {STRING_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {STRING_PARAM}, {STRING_PARAM}, {}, NONE(), {},
     Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path.IDENT("sample")),
-  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function TRANSPOSE = Function.FUNCTION(Path.IDENT("transpose"),
-  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
@@ -468,7 +468,7 @@ constant InstNode CLOCK_DUMMY_NODE = NFInstNode.CLASS_NODE("Clock",
 
 // Clock() - inferred clock
 constant Function CLOCK_INFERRED = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {}, {CLOCK_PARAM}, {}, {}, Type.CLOCK(),
+  CLOCK_DUMMY_NODE, {}, {CLOCK_PARAM}, {}, NONE(), {}, Type.CLOCK(),
   DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
@@ -489,7 +489,7 @@ constant InstNode SOLVER_METHOD_PARAM = InstNode.COMPONENT_NODE("solverMethod", 
 
 // Clock(intervalCounter, resolution = 1) - clock with Integer interval
 constant Function CLOCK_INT = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {INT_PARAM, INT_PARAM}, {CLOCK_PARAM}, {}, {
+  CLOCK_DUMMY_NODE, {INT_PARAM, INT_PARAM}, {CLOCK_PARAM}, {}, NONE(), {
     Slot.SLOT(INTERVAL_COUNTER_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(RESOLUTION_PARAM, SlotType.GENERIC, SOME(Expression.INTEGER(1)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
@@ -497,14 +497,14 @@ constant Function CLOCK_INT = Function.FUNCTION(Path.IDENT("Clock"),
 
 // Clock(interval) - clock with Real interval
 constant Function CLOCK_REAL = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {REAL_PARAM}, {CLOCK_PARAM}, {}, {
+  CLOCK_DUMMY_NODE, {REAL_PARAM}, {CLOCK_PARAM}, {}, NONE(), {
     Slot.SLOT(INTERVAL_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(condition, startInterval = 0.0) - Event clock, triggered by zero-crossing events
 constant Function CLOCK_BOOL = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {BOOL_PARAM, REAL_PARAM}, {CLOCK_PARAM}, {}, {
+  CLOCK_DUMMY_NODE, {BOOL_PARAM, REAL_PARAM}, {CLOCK_PARAM}, {}, NONE(), {
     Slot.SLOT(CONDITION_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(START_INTERVAL_PARAM, SlotType.GENERIC, SOME(Expression.REAL(0.0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
@@ -512,7 +512,7 @@ constant Function CLOCK_BOOL = Function.FUNCTION(Path.IDENT("Clock"),
 
 // Clock(c, solverMethod) - Solver clock
 constant Function CLOCK_SOLVER = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {CLOCK_PARAM, STRING_PARAM}, {CLOCK_PARAM}, {}, {
+  CLOCK_DUMMY_NODE, {CLOCK_PARAM, STRING_PARAM}, {CLOCK_PARAM}, {}, NONE(), {
     Slot.SLOT(C_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(SOLVER_METHOD_PARAM, SlotType.GENERIC, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
@@ -540,27 +540,27 @@ constant ComponentRef CLOCK_CREF =
   ComponentRef.CREF(CLOCK_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant Function GET_PART_REAL = Function.FUNCTION(Path.IDENT("$getPart"),
-  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, NONE(), {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function GET_PART_INT = Function.FUNCTION(Path.IDENT("$getPart"),
-  InstNode.EMPTY_NODE(), {INT_PARAM}, {INT_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {INT_PARAM}, {INT_PARAM}, {}, NONE(), {},
     Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function GET_PART_BOOL = Function.FUNCTION(Path.IDENT("$getPart"),
-  InstNode.EMPTY_NODE(), {BOOL_PARAM}, {BOOL_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {BOOL_PARAM}, {BOOL_PARAM}, {}, NONE(), {},
     Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function GET_PART_CLOCK = Function.FUNCTION(Path.IDENT("$getPart"),
-  InstNode.EMPTY_NODE(), {CLOCK_PARAM}, {CLOCK_PARAM}, {}, {},
+  InstNode.EMPTY_NODE(), {CLOCK_PARAM}, {CLOCK_PARAM}, {}, NONE(), {},
     Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function CLOCK_FIRE = Function.FUNCTION(Path.IDENT("$_clkfire"),
-  InstNode.EMPTY_NODE(), {INT_PARAM}, {}, {}, {},
+  InstNode.EMPTY_NODE(), {INT_PARAM}, {}, {}, NONE(), {},
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1417,7 +1417,7 @@ algorithm
           body := {Statement.FOR(iter, SOME(range), body, Statement.ForType.NORMAL(), alg.source)};
         end while;
       then
-        Algorithm.ALGORITHM(body, alg.inputs, alg.outputs, alg.scope, alg.source); // ToDo: update inputs, outputs?
+        Algorithm.ALGORITHM(body, alg.inputs, alg.outputs, NONE(), alg.scope, alg.source); // ToDo: update inputs, outputs?
   end match;
 end vectorizeAlgorithm;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -262,13 +262,13 @@ type FunctionStatus = enumeration(
 );
 
 uniontype Function
-
   record FUNCTION
     Absyn.Path path;
     InstNode node;
     list<InstNode> inputs;
     list<InstNode> outputs;
     list<InstNode> locals;
+    Option<UnorderedSet<InstNode>> interfaceDiffInfo;
     list<Slot> slots;
     Type returnType;
     DAE.FunctionAttributes attributes;
@@ -295,7 +295,7 @@ uniontype Function
     attr := makeAttributes(node, inputs, outputs, comments);
     // Make sure builtin functions aren't added to the function tree.
     status := if isBuiltinAttr(attr) then FunctionStatus.COLLECTED else FunctionStatus.INITIAL;
-    fn := FUNCTION(path, node, inputs, outputs, locals, {}, Type.UNKNOWN(),
+    fn := FUNCTION(path, node, inputs, outputs, locals, NONE(), {}, Type.UNKNOWN(),
       attr, {}, {}, listArray({}), Pointer.create(status), Pointer.create(0));
   end new;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3509,7 +3509,7 @@ protected
 algorithm
   // collect inputs and outputs later when types are computed properly
   statements := instStatements(algorithmSection.statements, scope, context);
-  alg := Algorithm.ALGORITHM(statements, {}, {}, scope, DAE.emptyElementSource);
+  alg := Algorithm.ALGORITHM(statements, {}, {}, NONE(), scope, DAE.emptyElementSource);
 end instAlgorithmSection;
 
 function instStatements

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -195,8 +195,8 @@ uniontype CachedData
   function setFuncCache
     input array<CachedData> in_caches;
     input CachedData in_cache;
-    algorithm
-      arrayUpdate(in_caches, 1, in_cache);
+  algorithm
+    arrayUpdate(in_caches, 1, in_cache);
   end setFuncCache;
 
   function getPackageCache
@@ -1498,6 +1498,17 @@ uniontype InstNode
       else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end cacheAddFunc;
+
+  function newFuncCache
+    "overwrites the old cache. use only for entirely new inst nodes from cloning!"
+    input output InstNode node;
+    input CachedData in_func_cache;
+  algorithm
+    () := match node
+      case CLASS_NODE() algorithm node.caches := arrayCreate(1, in_func_cache); then ();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+    end match;
+  end newFuncCache;
 
   function getFuncCache
     input InstNode inNode;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -63,11 +63,10 @@ import EvalConstants = NFEvalConstants;
 import NFPrefixes.Direction;
 import NFPrefixes.Variability;
 import NFPrefixes.Visibility;
-import NFFunction.Function;
+import NFFunction.{Function, FunctionStatus};
 import NFClassTree.ClassTree;
 import ComplexType = NFComplexType;
 import ComponentRef = NFComponentRef;
-import NFFunction.FunctionStatus;
 import MetaModelica.Dangerous.listReverseInPlace;
 import UnorderedMap;
 import UnorderedSet;
@@ -176,8 +175,8 @@ algorithm
   // Create the constructor function and add it to the function cache.
   attr := DAE.FUNCTION_ATTRIBUTES_DEFAULT;
   status := Pointer.create(FunctionStatus.INITIAL);
-  InstNode.cacheAddFunc(node, Function.FUNCTION(path, ctor_node, inputs,
-    {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, {}, listArray({}), status, Pointer.create(0)), false);
+  InstNode.cacheAddFunc(node, Function.FUNCTION(path, ctor_node, inputs, {out_rec}, locals,
+  NONE(), {}, Type.UNKNOWN(), attr, {}, {}, listArray({}), status, Pointer.create(0)), false);
 end instDefaultConstructor;
 
 function checkLocalFieldOrder

--- a/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
@@ -171,6 +171,11 @@ public
     end match;
   end filterDiscrete;
 
+  function hash
+    input Statement stmt;
+    output Integer hash = stringHashDjb2(toString(stmt));
+  end hash;
+
   function isEqual
     input Statement stmt1;
     input Statement stmt2;


### PR DESCRIPTION
    [NB] update function differentiation
    
     - when a function is differentiated multiple times it has to be tracked which of the interface variables have already been differentiated
     - it is efficient to also do that for body statements
     - added sets to track which interface variables and which body statements have already been differentiated
     - do not differentiate them again when the function derivative is differentiated again
    [NF] add new function interface diff structure
