### PR TITLE
[NF] Add trailing ':' subscripts to partially-indexed arrays

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1113,7 +1113,9 @@ public
   end mapSubscripts;
 
   function fillSubscripts
-    "Fills in any unsubscripted dimensions in the cref with : subscripts."
+    "Fills in any unsubscripted dimensions in the cref with : subscripts,
+     appending them at the end to preserve subscript order.
+     E.g. a[i] for Real[10,2] becomes a[i,:]."
     input output ComponentRef cref;
   algorithm
     () := match cref
@@ -2406,6 +2408,22 @@ public
       else false;
     end match;
   end isSliced;
+
+  function hasImplicitTrailingIndex
+    "Returns true if the outermost cref component has fewer subscripts than
+     dimensions.
+     E.g. a[i] where a : Real[10,2] returns true, because
+     one scalar index is given but a second dimension is left implicit (:)."
+    input ComponentRef cref;
+    output Boolean res;
+  algorithm
+    res := match cref
+      case CREF(origin = Origin.CREF)
+        then not listEmpty(cref.subscripts) and
+             listLength(cref.subscripts) < Type.dimensionCount(cref.ty);
+      else false;
+    end match;
+  end hasImplicitTrailingIndex;
 
   function iterate
     input output ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -214,6 +214,22 @@ public
     functions := FunctionTree.map(functions, expandSlicedCrefsFunction);
   end expandSlicedCrefs;
 
+  function addTrailingWholeIndices
+    "Add implicit trailing subscripts to array expressions.
+    E.g. for Real[10,2] a this will replace a[i] with a[i,:]."
+    input output Expression exp;
+  algorithm
+    exp := match exp
+      case Expression.CREF()
+        guard ComponentRef.hasImplicitTrailingIndex(exp.cref)
+        algorithm
+          exp.cref := ComponentRef.fillSubscripts(exp.cref);
+        then exp;
+
+      else exp;
+    end match;
+  end addTrailingWholeIndices;
+
   function expandSlicedCrefsExp
     input output Expression exp;
   algorithm
@@ -252,8 +268,11 @@ public
     Expression e1, e2;
   algorithm
     eq := match eq
+      local
+        Equation eq2;
       case Equation.EQUALITY(rhs = e1)
         algorithm
+          e1:= Expression.map(e1, addTrailingWholeIndices);
           e2 := Expression.map(e1, expandSlicedCrefsExp);
 
           if not referenceEq(e1, e2) then
@@ -264,6 +283,7 @@ public
 
       case Equation.ARRAY_EQUALITY(rhs = e1)
         algorithm
+          e1 := Expression.map(e1, addTrailingWholeIndices);
           e2 := Expression.map(e1, expandSlicedCrefsExp);
 
           if not referenceEq(e1, e2) then
@@ -272,7 +292,10 @@ public
         then
           eq;
 
-      else Equation.mapExpShallow(eq, function Expression.map(func = expandSlicedCrefsExp));
+      else
+        algorithm
+          eq2 := Equation.mapExpShallow(eq, function Expression.map(func = addTrailingWholeIndices));
+        then Equation.mapExpShallow(eq2, function Expression.map(func = expandSlicedCrefsExp));
     end match;
   end expandSlicedCrefsEq;
 
@@ -288,8 +311,12 @@ public
     Expression e1, e2;
   algorithm
     stmt := match stmt
+      local
+        Statement stmt2;
       case Statement.ASSIGNMENT(rhs = e1)
         algorithm
+          stmt.lhs := Expression.map(stmt.lhs, addTrailingWholeIndices);
+          e1 := Expression.map(e1, addTrailingWholeIndices);
           e2 := Expression.map(e1, expandSlicedCrefsExp);
 
           if not referenceEq(e1, e2) then
@@ -298,7 +325,10 @@ public
         then
           stmt;
 
-      else Statement.mapExpShallow(stmt, function Expression.map(func = expandSlicedCrefsExp));
+      else
+        algorithm
+          stmt2 := Statement.mapExpShallow(stmt, function Expression.map(func = addTrailingWholeIndices));
+        then Statement.mapExpShallow(stmt2, function Expression.map(func = expandSlicedCrefsExp));
     end match;
   end expandSlicedCrefsStmt;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1995,6 +1995,12 @@ algorithm
   end if;
 
   (cref, subsVariability) := typeCref2(cref, context, info);
+
+  // Fill all implicit array subscripts with explicit `:`
+  if ComponentRef.hasImplicitTrailingIndex(cref) then
+    cref := ComponentRef.fillSubscripts(cref);
+  end if;
+
   ty := ComponentRef.getSubscriptedType(cref);
   nodeVariability := ComponentRef.nodeVariability(cref);
 end typeCref;

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorization2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorization2.mo
@@ -65,6 +65,6 @@ end FuncVectorization2;
 //   Integer g[2,2];
 //   Integer g[2,3];
 // equation
-//   g = array(array(FuncVectorization2.F(b[$i0,$i1], 1) for $i1 in 1:3) for $i0 in 1:2);
+//   g = array(array(FuncVectorization2.F(b[$i0,$i1,:], 1) for $i1 in 1:3) for $i0 in 1:2);
 // end FuncVectorization2;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorizationMap1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorizationMap1.mo
@@ -63,8 +63,8 @@ end FuncVectorizationMap1;
 //   Real g[2,2];
 //   Real g[2,3];
 // equation
-//   g = array(array(FuncVectorizationMap1.F(b[$i0,$i1], 1.0) for $i1 in 1:3) for $i0 in 1:2);
-//   g = array(array(FuncVectorizationMap1.F(b[i,$i2], 1.0) for $i2 in 1:3) for i in 1:2);
-//   g = array(array(FuncVectorizationMap1.F(b[i,j], 1.0) for j in 1:3) for i in 1:2);
+//   g = array(array(FuncVectorizationMap1.F(b[$i0,$i1,:], 1.0) for $i1 in 1:3) for $i0 in 1:2);
+//   g = array(array(FuncVectorizationMap1.F(b[i,$i2,:], 1.0) for $i2 in 1:3) for i in 1:2);
+//   g = array(array(FuncVectorizationMap1.F(b[i,j,:], 1.0) for j in 1:3) for i in 1:2);
 // end FuncVectorizationMap1;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript1.mo
@@ -1,0 +1,50 @@
+// name: ImplicitTrailingSubscript1
+// keywords: array subscript implicit trailing
+// status: correct
+//
+// Scalar index on a 2D array is implicitly adding trailing ':' subscripts.
+// Explicitly add them to only have one canonical form for arrays.
+
+function testFunc
+  input Real oldArray[3, 2];
+  output Real newArray[3, 2];
+algorithm
+  for i in 1:3 loop
+    newArray[i] := oldArray[i];
+  end for;
+end testFunc;
+
+model ImplicitTrailingSubscript1
+  Real a[3, 2];
+  Real b[3, 2];
+equation
+  b = testFunc(a);
+end ImplicitTrailingSubscript1;
+
+// Result:
+// function testFunc
+//   input Real[3, 2] oldArray;
+//   output Real[3, 2] newArray;
+// algorithm
+//   for i in 1:3 loop
+//     newArray[i,:] := oldArray[i,:];
+//   end for;
+// end testFunc;
+//
+// class ImplicitTrailingSubscript1
+//   Real a[1,1];
+//   Real a[1,2];
+//   Real a[2,1];
+//   Real a[2,2];
+//   Real a[3,1];
+//   Real a[3,2];
+//   Real b[1,1];
+//   Real b[1,2];
+//   Real b[2,1];
+//   Real b[2,2];
+//   Real b[3,1];
+//   Real b[3,2];
+// equation
+//   b = testFunc(a);
+// end ImplicitTrailingSubscript1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript2.mo
@@ -1,0 +1,74 @@
+// name: ImplicitTrailingSubscript2
+// keywords: array subscript implicit trailing
+// status: correct
+//
+// Scalar index on a 3D array is implicitly adding trailing ':' subscripts.
+// Explicitly add them to only have one canonical form for arrays.
+
+function testFunc
+  input Real oldArray[3, 3, 2];
+  output Real newArray[3, 3, 2];
+algorithm
+  for i in 1:3 loop
+    newArray[i] := oldArray[i];
+  end for;
+end testFunc;
+
+model ImplicitTrailingSubscript2
+  Real a[3, 3, 2];
+  Real b[3, 3, 2];
+equation
+  b = testFunc(a);
+end ImplicitTrailingSubscript2;
+
+// Result:
+// function testFunc
+//   input Real[3, 3, 2] oldArray;
+//   output Real[3, 3, 2] newArray;
+// algorithm
+//   for i in 1:3 loop
+//     newArray[i,:,:] := oldArray[i,:,:];
+//   end for;
+// end testFunc;
+//
+// class ImplicitTrailingSubscript2
+//   Real a[1,1,1];
+//   Real a[1,1,2];
+//   Real a[1,2,1];
+//   Real a[1,2,2];
+//   Real a[1,3,1];
+//   Real a[1,3,2];
+//   Real a[2,1,1];
+//   Real a[2,1,2];
+//   Real a[2,2,1];
+//   Real a[2,2,2];
+//   Real a[2,3,1];
+//   Real a[2,3,2];
+//   Real a[3,1,1];
+//   Real a[3,1,2];
+//   Real a[3,2,1];
+//   Real a[3,2,2];
+//   Real a[3,3,1];
+//   Real a[3,3,2];
+//   Real b[1,1,1];
+//   Real b[1,1,2];
+//   Real b[1,2,1];
+//   Real b[1,2,2];
+//   Real b[1,3,1];
+//   Real b[1,3,2];
+//   Real b[2,1,1];
+//   Real b[2,1,2];
+//   Real b[2,2,1];
+//   Real b[2,2,2];
+//   Real b[2,3,1];
+//   Real b[2,3,2];
+//   Real b[3,1,1];
+//   Real b[3,1,2];
+//   Real b[3,2,1];
+//   Real b[3,2,2];
+//   Real b[3,3,1];
+//   Real b[3,3,2];
+// equation
+//   b = testFunc(a);
+// end ImplicitTrailingSubscript2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript3.mo
@@ -1,0 +1,48 @@
+// name: ImplicitTrailingSubscript3
+// keywords: array subscript implicit trailing
+// status: correct
+//
+// Index on a 2D array is implicitly adding trailing ':' subscripts.
+// Explicitly add them to only have one canonical form for arrays.
+
+function initFunc
+  input Real oldArray[3, 2];
+  output Real newArray[3, 2];
+algorithm
+  newArray[1:2] := oldArray[2:3];
+end initFunc;
+
+model ImplicitTrailingSubscript3
+  Real a[3, 2] = fill({1,2}, 3);
+  Real b[3, 2] = fill({3,4}, 3);
+equation
+  b = initFunc(a);
+end ImplicitTrailingSubscript3;
+
+// Result:
+// function initFunc
+//   input Real[3, 2] oldArray;
+//   output Real[3, 2] newArray;
+// algorithm
+//   newArray[1:2, :] := oldArray[2:3, :];
+// end initFunc;
+//
+// class ImplicitTrailingSubscript3
+//   Real a[1,1];
+//   Real a[1,2];
+//   Real a[2,1];
+//   Real a[2,2];
+//   Real a[3,1];
+//   Real a[3,2];
+//   Real b[1,1];
+//   Real b[1,2];
+//   Real b[2,1];
+//   Real b[2,2];
+//   Real b[3,1];
+//   Real b[3,2];
+// equation
+//   a = {{1.0, 2.0}, {1.0, 2.0}, {1.0, 2.0}};
+//   b = {{3.0, 4.0}, {3.0, 4.0}, {3.0, 4.0}};
+//   b = initFunc(a);
+// end ImplicitTrailingSubscript3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImplicitTrailingSubscript3.mo
@@ -10,13 +10,12 @@ function initFunc
   output Real newArray[3, 2];
 algorithm
   newArray[1:2] := oldArray[2:3];
+  newArray[3] := {0,0};
 end initFunc;
 
 model ImplicitTrailingSubscript3
   Real a[3, 2] = fill({1,2}, 3);
-  Real b[3, 2] = fill({3,4}, 3);
-equation
-  b = initFunc(a);
+  Real b[3, 2] = initFunc(a);
 end ImplicitTrailingSubscript3;
 
 // Result:
@@ -24,7 +23,8 @@ end ImplicitTrailingSubscript3;
 //   input Real[3, 2] oldArray;
 //   output Real[3, 2] newArray;
 // algorithm
-//   newArray[1:2, :] := oldArray[2:3, :];
+//   newArray[1:2,:] := oldArray[2:3,:];
+//   newArray[3,:] := {0.0, 0.0};
 // end initFunc;
 //
 // class ImplicitTrailingSubscript3
@@ -42,7 +42,6 @@ end ImplicitTrailingSubscript3;
 //   Real b[3,2];
 // equation
 //   a = {{1.0, 2.0}, {1.0, 2.0}, {1.0, 2.0}};
-//   b = {{3.0, 4.0}, {3.0, 4.0}, {3.0, 4.0}};
 //   b = initFunc(a);
 // end ImplicitTrailingSubscript3;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -783,6 +783,9 @@ ImplicitRangeInvalid1.mo \
 ImplicitRangeInvalid2.mo \
 ImplicitRangeType1.mo \
 ImplicitRangeType2.mo \
+ImplicitTrailingSubscript1.mo \
+ImplicitTrailingSubscript2.mo \
+ImplicitTrailingSubscript3.mo \
 ImportComponent1.mo \
 ImportConflict1.mo \
 ImportConflict2.mo \

--- a/testsuite/flattening/modelica/scodeinst/SlicedCref5.mo
+++ b/testsuite/flattening/modelica/scodeinst/SlicedCref5.mo
@@ -26,7 +26,7 @@ end SlicedCref5;
 //   Real y[3,1];
 //   Real y[3,2];
 // algorithm
-//   x[1:2] := y[2:3];
-//   x[:] := y[3:-1:1];
+//   x[1:2,:] := y[2:3,:];
+//   x[:,:] := y[3:-1:1,:];
 // end SlicedCref5;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Subscript5.mo
+++ b/testsuite/flattening/modelica/scodeinst/Subscript5.mo
@@ -2,7 +2,7 @@
 // status: correct
 //
 // Checks that partially subscripted crefs are padded with :.
-// 
+//
 
 function f
   input Real x[:, :];
@@ -16,7 +16,7 @@ model Subscript5
   Real x[3, 3] = {{time, 1, 2}, {3, 4, 5}, {6, 7, 8}};
   Real y = f(x, x);
 end Subscript5;
-  
+
 
 // Result:
 // function f
@@ -24,7 +24,7 @@ end Subscript5;
 //   input Real[:, :] y;
 //   output Real z;
 // algorithm
-//   z := x[1] * y[2];
+//   z := x[1,:] * y[2,:];
 // end f;
 //
 // class Subscript5

--- a/testsuite/simulation/modelica/arrays/ArrayWithImplicitSubscripts.mos
+++ b/testsuite/simulation/modelica/arrays/ArrayWithImplicitSubscripts.mos
@@ -1,0 +1,37 @@
+// name: ArrayWithImplicitSubscripts
+// keywords: array index implicit
+// status: correct
+// teardown_command: rm -rf ImplicitArraySubscripts1*
+//
+// Test for https://github.com/OpenModelica/OpenModelica/issues/14038
+
+loadString("
+model ImplicitArraySubscripts1
+  Real array1[10,2]=fill({0,0}, 10);
+  Real array2[10,2]=foo(array1);
+
+  function foo
+    input  Real oldArray[10,2];
+    output Real newArray[10,2];
+  algorithm
+    for i in 1:10 loop
+      newArray[i]:={0,0};
+    end for;
+  end foo;
+end ImplicitArraySubscripts1;
+"); getErrorString();
+
+simulate(ImplicitArraySubscripts1); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ImplicitArraySubscripts1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ImplicitArraySubscripts1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -19,6 +19,7 @@ ArrayReturn.mos \
 ArraySlice.mos \
 ArraySlice2.mos \
 ArraySliceAssigmentFunction.mos \
+ArrayWithImplicitSubscripts.mos \
 AsubCrefExpType.mos \
 BooleanArray.mos \
 BooleanArray2.mos \


### PR DESCRIPTION
### Related Issues

Fixes #14038.

### Purpose

Per Modelica spec section 10.5.1, a scalar index on a multi-dimensional array reduces the dimensionality by one; remaining dimensions use an implicit ':'. E.g. newArray[i] for Real[10,2] is equivalent to newArray[i,:].

Without this fix the code generator treated newArray[i] as a scalar element access, producing incorrect C code (real_array_get instead of indexed_assign_real_array) and a compiler warning about incompatible pointer types.

### Approach

Changes:
- ComponentRef.hasImplicitTrailingIndex: detects when a cref has scalar
  INDEX subscripts but fewer subscripts than dimensions
- NFTyping.typeCref: Use ComponentRef.fillSubscripts to fill all implicit array subscripts with explicit `:`
- New tests:
  - scodeinst: ImplicitTrailingSubscript1 and ImplicitTrailingSubscript2
  - simulation: ArrayWithImplicitSubscripts
