### PR TITLE
Less skipped workflow noise

### DIFF
--- a/.github/workflows/build_bsd.yaml
+++ b/.github/workflows/build_bsd.yaml
@@ -2,10 +2,11 @@
 name: Build FreeBSD
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
   pull_request:
+    types:
+      - labeled
+      - synchronize
     paths-ignore:
       - 'doc/**'
 
@@ -39,4 +40,3 @@ jobs:
           cmake -S . -B build_cmake
           cmake --build build_cmake --target install --parallel 2
           ./build_cmake/install_cmake/bin/omc --help
-

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,11 +1,13 @@
 name: nightly-release
 
 on:
-  push
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
-  build: # run only on pushes to the default branch (master)
-    if: github.ref_name == github.event.repository.default_branch
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Related Issues

It looks like we get a GitHub notification for every commit on any OpenModelica branch with an active pull request because some workflow was skipped.
Like `Build FreeBSD workflow run skipped for issue-14038 branch` or `nightly-release workflow run skipped for issue-14038 branch`.

### Purpose

Reduce the noise.

### Approach

* Build FreeBSD workflow only triggered when there is any label on a PR, never on push to branch
* nightly-release workflow only triggers on push to master branch. Always skip forks (still noisy, but better. User's can disable workflows / actions on their fork)
