### PR TITLE
fmi: fix memory pool leak in internalEventUpdate and fmi2DoStep (#14509)

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -274,6 +274,7 @@ fmi2Status internalEventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "internalEventUpdate: Start Event Update! Next Sample Event %g", eventInfo->nextEventTime)
 
   setThreadData(comp);
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
   /* try */
   MMC_TRY_INTERNAL(simulationJumpBuffer)
 
@@ -370,6 +371,7 @@ fmi2Status internalEventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
 
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
+  omc_util_restore_pool_state(mem_pool_state);
   resetThreadData(comp);
 
   if (done) {
@@ -2225,6 +2227,8 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
   if (invalidState(comp, "fmi2DoStep", 0, model_state_cs_step_complete))
     return fmi2Error;
 
+  MemPoolState doStep_pool_state = omc_util_get_pool_state();
+
   eventInfo.newDiscreteStatesNeeded           = fmi2False;
   eventInfo.terminateSimulation               = fmi2False;
   eventInfo.nominalsOfContinuousStatesChanged = fmi2False;
@@ -2405,6 +2409,7 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
     }
   }
 
+  omc_util_restore_pool_state(doStep_pool_state);
   return status;
 }
 


### PR DESCRIPTION
### Related Issues

Fixes #14509

Related: #10790, #13991, #13905, #13488, #13336, #12225

### Purpose

Co-Simulation FMUs exported from OpenModelica (C runtime, FMI 2.0) suffer from a memory pool leak that causes a deterministic hang after a large number of `fmi2DoStep` calls. The FMU prints:

LOG_ASSERT | debug | .../sources/gc/memory_pool.c:100: pool_expand:
Assertion 0 && "Attempt to allocate an unusually large memory..." failed.


The call to `fmi2DoStep` never returns. The crash is deterministic by cumulative step count, independent of inputs or wall time, and occurs whether steps are taken in a single simulation or across multiple consecutive simulations.

The root cause is that `internalEventUpdate()` and `fmi2DoStep()` in `fmu2_model_interface.c` do not save/restore the memory pool state, while other internal functions (`updateIfNeeded`, `internalGetDerivatives`, `internalGetEventIndicators`, `internal_CompletedIntegratorStep`) correctly do.

`internalEventUpdate` calls model callbacks (`updateDiscreteSystem`, `functionDAE`, `storePreValues`, etc.) that allocate temporary arrays via `pool_malloc`. Without save/restore, these accumulate permanently. The pool grows geometrically until `pool_expand` hits the 1 GB assertion threshold.

### Approach

Add `omc_util_get_pool_state()` / `omc_util_restore_pool_state()` to `internalEventUpdate` and `fmi2DoStep`, following the same pattern already used by the other internal functions.

- **`internalEventUpdate`**: Save pool state after `setThreadData(comp)`, restore after `MMC_CATCH_INTERNAL`. This is the primary leak source — it directly wraps the callbacks that allocate temporary arrays.
- **`fmi2DoStep`**: Save pool state after the `invalidState` check, restore before `return status`. This provides a safety net — if any other sub-call within the integration loop leaks, the outer restore reclaims everything.

This is safe because `omc_util_restore_pool_state` only frees blocks allocated *after* the saved state. Permanent model data (states, parameters) is allocated during `fmi2Instantiate` / `fmi2EnterInitializationMode`, before any `fmi2DoStep`, and is never touched by these restores. Nesting is also safe: inner restores free their own allocations, the outer restore catches anything remaining.

Verified on three different FMUs exported from OpenModelica 1.26.x, recompiled from sources on Windows (MinGW GCC). Simulations ran 500,000+ steps with stable memory usage and no behavioral changes.