### PR TITLE
[NB] fix assignment of columnVars in NSimJacobian

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -333,7 +333,7 @@ public
               numberOfResultVars  = listLength(resVars),
               columnEqns          = columnEqns,
               constantEqns        = {},
-              columnVars          = resVars,
+              columnVars          = tmpVars,
               seedVars            = seedVars,
               sparsity            = sparsity,
               sparsityT           = sparsityT,

--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -100,15 +100,19 @@ public
             str := StringUtil.headline_2("[EMPTY] SimCode Jacobian " + simJac.name + "(idx = " + intString(simJac.jacobianIndex) + ", partition = " + intString(simJac.partitionIndex) + ")") + "\n";
           else
             str := StringUtil.headline_2("SimCode Jacobian " + simJac.name + "(idx = " + intString(simJac.jacobianIndex) + ", partition = " + intString(simJac.jacobianIndex) + ")") + "\n";
-            str := str + StringUtil.headline_4("ColumnVars (size = " + intString(simJac.numberOfResultVars) + ")");
-            for var in simJac.columnVars loop
-              str := str + SimVar.toString(var, "  ") + "\n";
-            end for;
-            str := str + "\n" + StringUtil.headline_4("SeedVars (size = " + intString(listLength(simJac.seedVars)) + ")");
+            str := str + StringUtil.headline_4("SeedVars (size = " + intString(listLength(simJac.seedVars)) + ")");
             for var in simJac.seedVars loop
               str := str + SimVar.toString(var, "  ") + "\n";
             end for;
-            str := str + "\n" + StringUtil.headline_3("Column Equations (size = " + intString(simJac.numberOfResultVars) + ")");
+            str := str + "\n" + StringUtil.headline_4("TmpVars (size = " + intString(listLength(simJac.columnVars)) + ")");
+            for var in simJac.columnVars loop
+              str := str + SimVar.toString(var, "  ") + "\n";
+            end for;
+            // TODO: print list of ResultVars
+            str := str + "\n" + StringUtil.headline_4("ResultVars (size = " + intString(simJac.numberOfResultVars) + ")");
+
+            // TODO: count equations properly, e.g. linear systems are falsely counted as a single equation
+            str := str + "\n" + StringUtil.headline_3("Column Equations (size = " + intString(listLength(simJac.columnEqns)) + ")");
             for eq in simJac.columnEqns loop
               str := str + SimStrongComponent.Block.toString(eq, "  ");
             end for;

--- a/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian1.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian1.mos
@@ -111,17 +111,20 @@ buildModel(scalarAdjointJacobian1); getErrorString();
 //   SimCode Jacobian ADJ(idx = 1, partition = 1)
 // ================================================
 //
-// ColumnVars (size = 2)
-// ***********************
-//   (0)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.i_L
-//   (1)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.V
-//
 // SeedVars (size = 2)
 // *********************
 //   (0)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.i_L
 //   (1)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.V
 //
-// Column Equations (size = 2)
+// TmpVars (size = 2)
+// ********************
+//   (0)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.i_C
+//   (1)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.i_R
+//
+// ResultVars (size = 2)
+// ***********************
+//
+// Column Equations (size = 4)
 // -----------------------------
 //   (14) $pDER_ODE_JAC_ADJ.i_C := $SEED_ODE_JAC_ADJ.$DER.V .* 1/(C)
 //   (13) $pDER_ODE_JAC_ADJ.i_R := -$pDER_ODE_JAC_ADJ.i_C
@@ -261,8 +264,8 @@ buildModel(scalarAdjointJacobian1); getErrorString();
 //
 // columnVars(2)
 // ----------------------
-// index:0: $pDER_ODE_JAC_ADJ.i_L (no alias)  initial: 	no arrCref index:(1) []
-// index:1: $pDER_ODE_JAC_ADJ.V (no alias)  initial: 	no arrCref index:(2) []
+// index:0: $pDER_ODE_JAC_ADJ.i_C (no alias)  initial: 	no arrCref index:(1) []
+// index:1: $pDER_ODE_JAC_ADJ.i_R (no alias)  initial: 	no arrCref index:(2) []
 //
 // modelInfo:
 // ========================================

--- a/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian2.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian2.mos
@@ -172,17 +172,6 @@ buildModel(AdjointJacobian2); getErrorString();
 //   SimCode Jacobian ADJ(idx = 1, partition = 1)
 // ================================================
 //
-// ColumnVars (size = 8)
-// ***********************
-//   (0)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.m
-//   (1)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.z
-//   (2)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.l
-//   (3)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.y
-//   (4)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.x
-//   (5)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.k[1]
-//   (6)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.k[2]
-//   (7)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.k[3]
-//
 // SeedVars (size = 8)
 // *********************
 //   (0)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.m
@@ -194,8 +183,18 @@ buildModel(AdjointJacobian2); getErrorString();
 //   (6)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.k[2]
 //   (7)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.k[3]
 //
-// Column Equations (size = 8)
-// -----------------------------
+// TmpVars (size = 4)
+// ********************
+//   (0)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.q
+//   (1)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.t
+//   (2)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.$FUN_1
+//   (3)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.$FUN_2
+//
+// ResultVars (size = 8)
+// ***********************
+//
+// Column Equations (size = 10)
+// ------------------------------
 //   (36) $pDER_ODE_JAC_ADJ.t := $SEED_ODE_JAC_ADJ.$DER.m
 //   (35) $pDER_ODE_JAC_ADJ.$FUN_1 := $SEED_ODE_JAC_ADJ.$DER.m .* $FUN_2
 //   (34) $pDER_ODE_JAC_ADJ.$FUN_2 := $SEED_ODE_JAC_ADJ.$DER.m .* $FUN_1
@@ -388,16 +387,12 @@ buildModel(AdjointJacobian2); getErrorString();
 // 	28: $pDER_ODE_JAC_ADJ.m=0.0 [Real]
 // 	27: $pDER_ODE_JAC_ADJ.k=transpose(A * B) * $SEED_ODE_JAC_ADJ.$DER.k [Real[3]]
 //
-// columnVars(8)
+// columnVars(4)
 // ----------------------
-// index:0: $pDER_ODE_JAC_ADJ.m (no alias)  initial: 	no arrCref index:(1) []
-// index:1: $pDER_ODE_JAC_ADJ.z (no alias)  initial: 	no arrCref index:(2) []
-// index:2: $pDER_ODE_JAC_ADJ.l (no alias)  initial: 	no arrCref index:(3) []
-// index:3: $pDER_ODE_JAC_ADJ.y (no alias)  initial: 	no arrCref index:(4) []
-// index:4: $pDER_ODE_JAC_ADJ.x (no alias)  initial: 	no arrCref index:(5) []
-// index:5: $pDER_ODE_JAC_ADJ.k[1] (no alias)  initial: 	arrCref:$pDER_ODE_JAC_ADJ.k index:(6) []
-// index:6: $pDER_ODE_JAC_ADJ.k[2] (no alias)  initial: 	no arrCref index:(7) []
-// index:7: $pDER_ODE_JAC_ADJ.k[3] (no alias)  initial: 	no arrCref index:(8) []
+// index:0: $pDER_ODE_JAC_ADJ.q (no alias)  initial: 	no arrCref index:(1) []
+// index:1: $pDER_ODE_JAC_ADJ.t (no alias)  initial: 	no arrCref index:(2) []
+// index:2: $pDER_ODE_JAC_ADJ.$FUN_1 (no alias)  initial: 	no arrCref index:(3) []
+// index:3: $pDER_ODE_JAC_ADJ.$FUN_2 (no alias)  initial: 	no arrCref index:(4) []
 //
 // modelInfo:
 // ========================================

--- a/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian3.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian3.mos
@@ -91,17 +91,20 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 //   SimCode Jacobian ADJ(idx = 1, partition = 1)
 // ================================================
 //
-// ColumnVars (size = 2)
-// ***********************
-//   (0)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.y
-//   (1)[JVAR] (1) Real $pDER_ODE_JAC_ADJ.x
-//
 // SeedVars (size = 2)
 // *********************
 //   (0)[SEED] (1) Real $SEED_ODE_LS_JAC_1.$DER.y
 //   (1)[SEED] (1) Real $SEED_ODE_LS_JAC_1.$DER.x
 //
-// Column Equations (size = 2)
+// TmpVars (size = 2)
+// ********************
+//   (0)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.$TMP_1
+//   (1)[JTMP] (1) Real $pDER_ODE_JAC_ADJ.$TMP_2
+//
+// ResultVars (size = 2)
+// ***********************
+//
+// Column Equations (size = 3)
 // -----------------------------
 //   (13) Nonlinear System (size = 2, homotopy = false, mixed = false, torn = true)
 //   --Iteration Vars:{$pDER_ODE_JAC_ADJ.$TMP_1, $pDER_ODE_JAC_ADJ.$TMP_2}
@@ -252,8 +255,8 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 //
 // columnVars(2)
 // ----------------------
-// index:0: $pDER_ODE_JAC_ADJ.y (no alias)  initial: 	no arrCref index:(1) []
-// index:1: $pDER_ODE_JAC_ADJ.x (no alias)  initial: 	no arrCref index:(2) []
+// index:0: $pDER_ODE_JAC_ADJ.$TMP_1 (no alias)  initial: 	no arrCref index:(1) []
+// index:1: $pDER_ODE_JAC_ADJ.$TMP_2 (no alias)  initial: 	no arrCref index:(2) []
 //
 // modelInfo:
 // ========================================

--- a/testsuite/simulation/modelica/NBackend/differentation/algebraicLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/algebraicLoop.mos
@@ -66,17 +66,18 @@ buildModel(algebraicLoop); getErrorString();
 //   SimCode Jacobian A(idx = 0, partition = 0)
 // ==============================================
 //
-// ColumnVars (size = 2)
-// ***********************
-//   (0)[JVAR] (1) Real $pDER_ODE_JAC.$DER.y
-//   (1)[JVAR] (1) Real $pDER_ODE_JAC.$DER.x
-//
 // SeedVars (size = 2)
 // *********************
 //   (0)[SEED] (1) Real $SEED_ODE_JAC.y
 //   (1)[SEED] (1) Real $SEED_ODE_JAC.x
 //
-// Column Equations (size = 2)
+// TmpVars (size = 0)
+// ********************
+//
+// ResultVars (size = 2)
+// ***********************
+//
+// Column Equations (size = 1)
 // -----------------------------
 //   (11) Nonlinear System (size = 2, homotopy = false, mixed = false, torn = true)
 //   --Iteration Vars:{$pDER_ODE_JAC.$DER.x, $pDER_ODE_JAC.$DER.y}
@@ -231,10 +232,6 @@ buildModel(algebraicLoop); getErrorString();
 // 	10: -(2.0 * $DER.x * $pDER_ODE_JAC.$DER.x + 3.0 * $DER.y ^ 2.0 * $pDER_ODE_JAC.$DER.y - ($SEED_ODE_JAC.x * y + x * $SEED_ODE_JAC.y)) (RESIDUAL)
 //
 //
-// columnVars(2)
-// ----------------------
-// index:0: $pDER_ODE_JAC.$DER.y (no alias)  initial: 	no arrCref index:(1) []
-// index:1: $pDER_ODE_JAC.$DER.x (no alias)  initial: 	no arrCref index:(2) []
 // 	Jacobian idx: 2
 //
 // 	Jacobian idx: 3


### PR DESCRIPTION
Reverts a change from [https://github.com/OpenModelica/OpenModelica/pull/12530](https://github.com/OpenModelica/OpenModelica/pull/12530).

The change caused an incorrect number of `tmpVars` in `initJacobian()`, leading to out-of-bounds writes. This corrupted the sparsity pattern and altered its members. On my example, the index array was overridden, which lead to bogus values and a consequent segfault.
