### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build_bsd.yaml
+++ b/.github/workflows/build_bsd.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -9,7 +9,7 @@ jobs:
   build: # run only on pushes to the default branch (master)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Build Assets


### PR DESCRIPTION
### Related Issues

Fixes deprecation warning:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

### Purpose

* Update GitHub action versions

### Approach

* `actions/checkout@v4` --> `actions/checkout@v6`
