### PR TITLE
[NF] Detect use of locals only assigned inside an if without else

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -3101,35 +3101,60 @@ protected
   protected
     Vector<InstNode> unassigned_branch;
     list<InstNode> assigned = {};
+    Boolean has_else = false;
     Integer index;
+    Expression last_cond;
   algorithm
     for b in branches loop
       checkUseBeforeAssignExp(unassigned, Util.tuple21(b), info);
     end for;
 
-    // Check each branch separately, then assume that any variables that were
-    // assigned (or incorrectly used) in at least one branch are assigned after
-    // the if-statement to avoid false positives.
-    for b in branches loop
-      unassigned_branch := Vector.copy(unassigned);
-      checkUseBeforeAssign2(unassigned_branch, Util.tuple22(b));
+    // An explicit else is lowered by the frontend to a trailing branch with
+    // the literal true as its condition. Without one, the implicit else
+    // assigns nothing, so a variable assigned inside the if may still be
+    // unassigned after it. See issue #7433.
+    if not listEmpty(branches) then
+      last_cond := Util.tuple21(List.last(branches));
+      has_else := match last_cond
+        case Expression.BOOLEAN(value = true) then true;
+        else false;
+      end match;
+    end if;
 
-      if Vector.size(unassigned) <> Vector.size(unassigned_branch) then
-        assigned := listAppend(
-          List.setDifferenceOnTrue(Vector.toList(unassigned), Vector.toList(unassigned_branch), InstNode.refEqual),
-          assigned);
-      end if;
-    end for;
+    // When an else branch is present, keep the permissive behaviour: treat
+    // variables assigned (or flagged as used-before-assigned) in any branch
+    // as assigned after the if, to avoid false positives in code where the
+    // author knows the branches together cover the reachable cases.
+    if has_else then
+      for b in branches loop
+        unassigned_branch := Vector.copy(unassigned);
+        checkUseBeforeAssign2(unassigned_branch, Util.tuple22(b));
 
-    if not listEmpty(assigned) then
-      assigned := List.uniqueOnTrue(assigned, InstNode.refEqual);
-
-      for a in assigned loop
-        (_, index) := Vector.find(unassigned, function InstNode.refEqual(node1 = a));
-
-        if index > 0 then
-          Vector.remove(unassigned, index);
+        if Vector.size(unassigned) <> Vector.size(unassigned_branch) then
+          assigned := listAppend(
+            List.setDifferenceOnTrue(Vector.toList(unassigned), Vector.toList(unassigned_branch), InstNode.refEqual),
+            assigned);
         end if;
+      end for;
+
+      if not listEmpty(assigned) then
+        assigned := List.uniqueOnTrue(assigned, InstNode.refEqual);
+
+        for a in assigned loop
+          (_, index) := Vector.find(unassigned, function InstNode.refEqual(node1 = a));
+
+          if index > 0 then
+            Vector.remove(unassigned, index);
+          end if;
+        end for;
+      end if;
+    else
+      // No else: analyse each branch for its own internal uses, but do not
+      // propagate any assignments out of the if. Keep the outer unassigned
+      // set intact so a later use after the if is flagged correctly.
+      for b in branches loop
+        unassigned_branch := Vector.copy(unassigned);
+        checkUseBeforeAssign2(unassigned_branch, Util.tuple22(b));
       end for;
     end if;
   end checkUseBeforeAssignIf;

--- a/testsuite/metamodelica/meta/Makefile
+++ b/testsuite/metamodelica/meta/Makefile
@@ -119,6 +119,7 @@ Try.mos \
 TryExtends.mos \
 TupleInteractive.mos \
 UnboundLocal.mo \
+UnboundLocalIf.mo \
 UnboxCond.mo \
 Uniontype1.mos \
 Uniontype2.mos \

--- a/testsuite/metamodelica/meta/UnboundLocalIf.mo
+++ b/testsuite/metamodelica/meta/UnboundLocalIf.mo
@@ -1,0 +1,60 @@
+// cflags: +g=MetaModelica
+// status: correct
+
+model UnboundLocalIf
+  function assignedInSingleBranch
+    input Boolean cond;
+    output Integer y;
+  protected
+    Integer x;
+  algorithm
+    if cond then
+      x := 1;
+    end if;
+    y := x;
+  end assignedInSingleBranch;
+
+  function assignedInIfElseifNoElse
+    input Boolean c1;
+    input Boolean c2;
+    output Integer y;
+  protected
+    Integer x;
+  algorithm
+    if c1 then
+      x := 1;
+    elseif c2 then
+      x := 2;
+    end if;
+    y := x;
+  end assignedInIfElseifNoElse;
+
+  function assignedInAllBranches
+    input Boolean c;
+    output Integer y;
+  protected
+    Integer x;
+  algorithm
+    if c then
+      x := 1;
+    else
+      x := 2;
+    end if;
+    y := x;
+  end assignedInAllBranches;
+
+  Integer r1 = assignedInSingleBranch(true);
+  Integer r2 = assignedInIfElseifNoElse(true, false);
+  Integer r3 = assignedInAllBranches(true);
+end UnboundLocalIf;
+
+// Result:
+// class UnboundLocalIf
+//   Integer r1 = 1;
+//   Integer r2 = 1;
+//   Integer r3 = 1;
+// end UnboundLocalIf;
+// [metamodelica/meta/UnboundLocalIf.mo:14:5-14:11:writable] Warning: x was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocalIf.mo:29:5-29:11:writable] Warning: x was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+//
+// endResult


### PR DESCRIPTION
## Summary

Fixes part of #7433: the new-frontend def/use analyser previously treated any variable assigned in at least one branch of an if-statement as assigned after the if, even when no else branch existed. A following read of such a variable produced no warning. The new behaviour:

```mo
function f
  input Boolean cond;
  output Integer y;
protected
  Integer x;
algorithm
  if cond then
    x := 1;
  end if;
  y := x;  // now: Warning: x was used before it was defined
end f;
```

## Root cause

`NFFunction.checkUseBeforeAssignIf` folded, across all branches, the set of variables that were assigned (or flagged) inside a branch and then removed them from the outer unassigned set. That is correct when an else branch is present and every branch contributes, but when there is no else the implicit else assigns nothing, so a variable assigned only inside the if should remain possibly unassigned after it.

The frontend lowers an explicit else to a trailing branch whose condition is the literal `Expression.BOOLEAN(true)` (see `NFInst.mo:3579`). The fix detects that shape and keeps the outer unassigned set intact when it is absent. Each branch is still analysed for its own internal use-before-assign warnings.

## What is intentionally unchanged

- **Classical frontend (`InstUtil.checkFunctionDefUseElse`).** I prototyped the same strict rule there but the 2-stage bootstrap flagged 9 distinct false positives in the first ~10% of retranslated files, including the common MetaModelica pattern where a boolean guard `b` invisibly implies a sibling variable has been assigned:

  ```mo
  case (BackendDAE.ASSIGN(left = e1, right = e2)::rest)
    equation
      if inCont then
        (_, b, extArg) = inFunc(e1, inTypeA);
      end if;
      if b then // only true if the first if assigned extArg
        (_, b, extArg) = inFunc(e2, extArg);
      end if;
      (b, extArg) = traverseExpsOfWhenOps_WithStop(rest, inFunc, extArg, b);
    then (b, extArg);
  ```

  The analyser cannot prove the invariant on `b`, so strictening the classical frontend would produce many warnings-treated-as-errors in `OMCompiler/Compiler/boot`'s compile step. The classical frontend keeps its existing permissive merge.

- **NF with an explicit else.** Variables assigned in some but not all branches of an if/else chain still count as assigned after the if. Strictening this case surfaces similar false positives (early-return, guarded-by-boolean) and is out of scope here.

## Test plan

- [x] New `testsuite/metamodelica/meta/UnboundLocalIf.mo` with three functions: a no-else if, a no-else if/elseif, and an if/else that assigns on every branch. The first two warn, the third does not.
- [x] `testsuite/metamodelica/meta/` full suite: 139 / 139 pass (138 pre-existing + the new test).
- [x] `testsuite/flattening/modelica/algorithms-functions/`: 117 / 117 pass.
- [x] `testsuite/openmodelica/instance-API/`: 96 / 96 pass.
- [x] Reproducer shows NF warns at lines 10 and 25 of the sample `UseBeforeAssign.mo` and does not warn on the all-branches-assign case.
- [x] Classical-FE path (via `-d=-newInst`) still produces no warning for the same sample, confirming the permissive behaviour is preserved where the bootstrap relies on it.
- [x] OMC rebuilds cleanly.

## Follow-ups

- Stricter NF merge for if/else (flagging variables assigned on some but not all branches) once the common early-return and guarded-by-boolean patterns in user Modelica libraries have been quantified.
- A separate pass to make the classical frontend stricter would require fixing or annotating a non-trivial number of patterns in OMC's own MetaModelica sources.

Refs #7433