### PR TITLE
Disable DynamicSelect workaround for getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2131,9 +2131,13 @@ protected
     try
       (arg2, ty2, var2) := Typing.typeExp(expDynamic, context, info);
     else
-      variability := var1;
-      callExp := arg1;
-      return;
+      if InstContext.inInstanceAPI(context) then
+        fail();
+      else
+        variability := var1;
+        callExp := arg1;
+        return;
+      end if;
     end try;
 
     arg2 := ExpandExp.expand(arg2);

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2356,7 +2356,8 @@ protected
       (args, named_args) := instArgs(functionArgs, scope, context, info);
     else
       // didn't work, is this DynamicSelect dynamic part?! #5631
-      if InstContext.inAnnotation(context) and stringEq(name, "DynamicSelect") then
+      if InstContext.inAnnotation(context) and not InstContext.inInstanceAPI(context) and
+         stringEq(name, "DynamicSelect") then
         // return just the first part of DynamicSelect
         callExp := match functionArgs
            case Absyn.FUNCTIONARGS() then

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -105,6 +105,7 @@ import Testsuite;
 import MetaModelica.Dangerous.listReverseInPlace;
 
 constant InstContext.Type ANNOTATION_CONTEXT = intBitOr(NFInstContext.RELAXED, NFInstContext.ANNOTATION);
+constant InstContext.Type INST_API_ANNOTATION_CONTEXT = intBitOr(ANNOTATION_CONTEXT, NFInstContext.INSTANCE_API);
 constant InstContext.Type FAST_CONTEXT = intBitOr(NFInstContext.RELAXED, NFInstContext.FAST_LOOKUP);
 
 public
@@ -1920,8 +1921,8 @@ protected
 algorithm
   ErrorExt.setCheckpoint(getInstanceName());
   try
-    exp := Inst.instExp(absynExp, scope, ANNOTATION_CONTEXT, info);
-    exp := Typing.typeExp(exp, ANNOTATION_CONTEXT, info);
+    exp := Inst.instExp(absynExp, scope, INST_API_ANNOTATION_CONTEXT, info);
+    exp := Typing.typeExp(exp, INST_API_ANNOTATION_CONTEXT, info);
     exp := SimplifyExp.simplify(exp);
     json := Expression.toJSON(exp);
   else

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation15.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation15.mos
@@ -1,0 +1,81 @@
+// name: GetModelInstanceAnnotation15
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+  annotation(
+    Icon(graphics = {Text(origin = {46, -66}, textColor = {238, 46, 47}, extent = {{-98, 88}, {0, 44}}, textString = DynamicSelect(\"P\", String(P, format=\"9.1f\")))}));
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"graphics\": [
+//         {
+//           \"$error\": \"[<interactive>:4:10-4:164:writable] Error: Variable P not found in scope M.\\n\",
+//           \"value\": {
+//             \"$kind\": \"call\",
+//             \"name\": \"Text\",
+//             \"namedArgs\": {
+//               \"origin\": [
+//                 46,
+//                 -66
+//               ],
+//               \"textColor\": [
+//                 238,
+//                 46,
+//                 47
+//               ],
+//               \"extent\": [
+//                 [
+//                   -98,
+//                   88
+//                 ],
+//                 [
+//                   0,
+//                   44
+//                 ]
+//               ],
+//               \"textString\": {
+//                 \"$kind\": \"call\",
+//                 \"name\": \"DynamicSelect\",
+//                 \"args\": [
+//                   \"P\",
+//                   {
+//                     \"$kind\": \"call\",
+//                     \"name\": \"String\",
+//                     \"args\": [
+//                       \"P\"
+//                     ],
+//                     \"namedArgs\": {
+//                       \"format\": \"9.1f\"
+//                     }
+//                   }
+//                 ]
+//               }
+//             }
+//           }
+//         }
+//       ]
+//     }
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 5,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -16,6 +16,7 @@ GetModelInstanceAnnotation11.mos \
 GetModelInstanceAnnotation12.mos \
 GetModelInstanceAnnotation13.mos \
 GetModelInstanceAnnotation14.mos \
+GetModelInstanceAnnotation15.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Don't silently return the first argument of erroneous DynamicSelect calls when using getModelInstance, treat it like any other call.