### PR TITLE
[GBODE] update error calculation for global steps in MR

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -1602,9 +1602,9 @@ int gbode_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
       if (gbData->multi_rate) {
         // Multi-rate integration enabled:
 
+        // TODO: how to work with this threshold rigorously?
         // Calculate the error threshold for slow states (used to separate slow and fast states).
-        err_states = getErrorThreshold(gbData);
-        err = err_states;
+        // err_states = getErrorThreshold(gbData);
 
         // Classify states into fast and slow based on the scaled error:
         // - States with error >= 1 are considered fast.
@@ -1628,6 +1628,23 @@ int gbode_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
             gbData->nSlowStates++;
             gbData->err_slow = fmax(gbData->err_slow, gbData->err[i]);
           }
+        }
+
+        if ((double) gbData->nFastStates > (double) gbData->nStates * gbData->percentage)
+        {
+          // too many fast states => reject
+          err = INFINITY;
+        }
+        else
+        {
+          // do scaled 2 norm as error measure of slow states error
+          err = 0.0;
+          for (int slow_idx = 0; slow_idx < gbData->nSlowStates; slow_idx++)
+          {
+            int full_idx = gbData->slowStatesIdx[slow_idx];
+            err += gbData->err[full_idx] * gbData->err[full_idx];
+          }
+          err = sqrt(err / (double) gbData->nSlowStates);
         }
       }
 


### PR DESCRIPTION
Co-authored with @phannebohm.

Previously, the slow state error was severely underestimated after partitioning a system into slow and fast state sets. The solver was incorrectly using the error threshold (e.g. the 10% / `gbratio` quantile) as the slow state error itself. This, however, is not a proper measure for the slow state error, as the slow states with the largest errors are ignored!!

For models like the InverterChain, this always resulted in an artificially low value of ~1e-10. By ignoring the slow states with the actual largest errors, the solver attempted giant new step sizes (2.5 times the previous step size). @casella, this underestimation was likely the main cause of the convergence failures we've been seeing all along. Because the new step size is just way too big for smooth convergence.

This PR implements a proper measure of the slow state error. We now implicitly build a vector from all slow states and calculate the scaled 2-norm of that vector. 

Together with my other open [[GBODE] perform zero-order hold for all fast states #15408](https://github.com/OpenModelica/OpenModelica/pull/15408), this change significantly reduces the convergence failures. The Radau IIA 3-stage MR now takes just 12 seconds for the InverterChain, while the SR version takes 21 seconds and IDA 19 seconds.

The MR has around ~4k convergence failures (instead of 11k to 17k depending on settings) just as the SR version with ~4k convergence failures. We cant hope for much more :D 