### PR TITLE
SimulationOutputWidget: track compilation stderr separately

### DIFF
--- a/OMEdit/OMEditLIB/MCP/MCPToolsSimulation.cpp
+++ b/OMEdit/OMEditLIB/MCP/MCPToolsSimulation.cpp
@@ -94,7 +94,7 @@ static QString waitAndCheckCompilation(SimulationOutputWidget *output)
     if (!compilationProc || compilationProc->exitCode() != 0) {
         return QString("Compilation failed (exit code %1):\n%2")
             .arg(compilationProc ? compilationProc->exitCode() : -1)
-            .arg(output->getCompilationOutput());
+            .arg(output->getCompilationStandardError());
     }
     return QString();
 }

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -251,6 +251,7 @@ SimulationOutputWidget::SimulationOutputWidget(SimulationOptions simulationOptio
   mpCompilationOutputTextBox = new OutputPlainTextEdit;
   mpCompilationOutputTextBox->setFont(QFont(Helper::monospacedFontInfo.family()));
   mpGeneratedFilesTabWidget->addTab(mpCompilationOutputTextBox, tr("Compilation"));
+  mCompilationStandardError.clear();
   mSimulationStandardOutput.clear();
   mSimulationStandardError.clear();
   // Simulation output handler
@@ -431,9 +432,9 @@ SimulationOutputWidget::~SimulationOutputWidget()
   }
 }
 
-QString SimulationOutputWidget::getCompilationOutput()
+QString SimulationOutputWidget::getCompilationStandardError()
 {
-  return mpCompilationOutputTextBox ? mpCompilationOutputTextBox->toPlainText() : QString();
+  return mCompilationStandardError;
 }
 
 /*!
@@ -613,7 +614,9 @@ void SimulationOutputWidget::readPostCompilationStandardOutput()
  */
 void SimulationOutputWidget::readPostCompilationStandardError()
 {
-  writeCompilationOutput(QString(mpPostCompilationProcess->readAllStandardError()), Qt::red);
+  QString output = QString(mpPostCompilationProcess->readAllStandardError());
+  mCompilationStandardError += output;
+  writeCompilationOutput(output, Qt::red);
 }
 
 /*!
@@ -629,7 +632,9 @@ void SimulationOutputWidget::postCompilationProcessError(QProcess::ProcessError 
   if (isPostCompilationProcessKilled()) {
     return;
   }
-  writeCompilationOutput(mpPostCompilationProcess->errorString(), Qt::red);
+  QString errorString = mpPostCompilationProcess->errorString();
+  mCompilationStandardError += errorString;
+  writeCompilationOutput(errorString, Qt::red);
 }
 
 /*!
@@ -1031,7 +1036,9 @@ void SimulationOutputWidget::readCompilationStandardOutput()
  */
 void SimulationOutputWidget::readCompilationStandardError()
 {
-  writeCompilationOutput(QString(mpCompilationProcess->readAllStandardError()), Qt::red);
+  QString output = QString(mpCompilationProcess->readAllStandardError());
+  mCompilationStandardError += output;
+  writeCompilationOutput(output, Qt::red);
 }
 
 /*!
@@ -1047,7 +1054,9 @@ void SimulationOutputWidget::compilationProcessError(QProcess::ProcessError erro
   if (isCompilationProcessKilled()) {
     return;
   }
-  writeCompilationOutput(mpCompilationProcess->errorString(), Qt::red);
+  QString errorString = mpCompilationProcess->errorString();
+  mCompilationStandardError += errorString;
+  writeCompilationOutput(errorString, Qt::red);
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -105,7 +105,7 @@ public:
   void setSimulationProcessKilled(bool killed) {mIsSimulationProcessKilled = killed;}
   bool isSimulationProcessKilled() {return mIsSimulationProcessKilled;}
   bool isSimulationProcessRunning() {return mIsSimulationProcessRunning;}
-  QString getCompilationOutput();
+  QString getCompilationStandardError();
   QString getSimulationStandardOutput() {return mSimulationStandardOutput;}
   QString getSimulationStandardError() {return mSimulationStandardError;}
   void writeSimulationMessage(StringHandler::SimulationMessageType type, QString text, QString index);
@@ -124,6 +124,7 @@ private:
   QTabWidget *mpGeneratedFilesTabWidget;
   QList<QString> mGeneratedFilesList;
   OutputPlainTextEdit *mpCompilationOutputTextBox;
+  QString mCompilationStandardError;
   QString mSimulationStandardOutput;
   QString mSimulationStandardError;
   SimulationOutputHandler *mpSimulationOutputHandler;


### PR DESCRIPTION
Replace getCompilationOutput() (which returned the full mixed stdout+stderr text box content) with getCompilationStandardError(), which accumulates only stderr from the compilation and post-compilation processes into mCompilationStandardError.