### PR TITLE
MCP: add getCoordinateSystem and setCoordinateSystem tools

### DIFF
--- a/OMEdit/OMEditLIB/MCP/MCPServer.cpp
+++ b/OMEdit/OMEditLIB/MCP/MCPServer.cpp
@@ -633,7 +633,8 @@ if (method == "tools/call") {
       toolName == "deleteComponent" || toolName == "listComponentParameters" ||
       toolName == "addRectangle" || toolName == "addEllipse" || toolName == "addLine" ||
       toolName == "addPolygon" || toolName == "addText" ||
-      toolName == "listShapes" || toolName == "removeShape") {
+      toolName == "listShapes" || toolName == "removeShape" ||
+      toolName == "getCoordinateSystem" || toolName == "setCoordinateSystem") {
         return handleDiagramTool(toolName, id, arguments);
       }
       if (toolName == "checkModel") {

--- a/OMEdit/OMEditLIB/MCP/MCPToolsDiagram.cpp
+++ b/OMEdit/OMEditLIB/MCP/MCPToolsDiagram.cpp
@@ -897,6 +897,108 @@ QHttpServerResponse MCPServer::handleDiagramTool(const QString &toolName, QJsonV
         QCoreApplication::processEvents();
         return makeMCPToolResponse(id, makeContent(QString("Shape removed from %1 view of class %2").arg(view, className)));
       }
+      if (toolName == "getCoordinateSystem") {
+        QString className = arguments.value("className").toString();
+        QString view = arguments.value("view").toString();
+        if (view != "icon" && view != "diagram")
+        return makeMCPError(id, QString("Invalid view: %1. Must be \"icon\" or \"diagram\".").arg(view));
+        MainWindow *mainWindow = MainWindow::instance();
+        LibraryTreeModel *pLibraryTreeModel = mainWindow->getLibraryWidget()->getLibraryTreeModel();
+        LibraryTreeItem *pLibraryTreeItem = pLibraryTreeModel->findLibraryTreeItem(className);
+        if (!pLibraryTreeItem)
+        return makeMCPError(id, QString("Class not found: %1").arg(className));
+        if (!pLibraryTreeItem->getModelWidget())
+        pLibraryTreeModel->showModelWidget(pLibraryTreeItem, false);
+        ModelWidget *pModelWidget = pLibraryTreeItem->getModelWidget();
+        if (view == "diagram" && !pModelWidget->isDiagramViewLoaded())
+        pModelWidget->loadDiagramViewNAPI();
+        GraphicsView *pGraphicsView = (view == "icon") ? pModelWidget->getIconGraphicsView() : pModelWidget->getDiagramGraphicsView();
+        const ModelInstance::CoordinateSystem &cs = pGraphicsView->mCoordinateSystem;
+        QJsonObject result;
+        if (cs.hasExtent()) {
+          const ExtentAnnotation &e = cs.getExtent();
+          QJsonObject extent;
+          extent["x1"] = e.at(0).x();
+          extent["y1"] = e.at(0).y();
+          extent["x2"] = e.at(1).x();
+          extent["y2"] = e.at(1).y();
+          result["extent"] = extent;
+        }
+        if (cs.hasPreserveAspectRatio())
+        result["preserveAspectRatio"] = (bool)cs.getPreserveAspectRatio();
+        if (cs.hasInitialScale())
+        result["initialScale"] = (double)(qreal)cs.getInitialScale();
+        if (cs.hasGrid()) {
+          QJsonObject grid;
+          grid["x"] = cs.getGrid().x();
+          grid["y"] = cs.getGrid().y();
+          result["grid"] = grid;
+        }
+        return makeMCPToolResponse(id, makeContent(result));
+      }
+      if (toolName == "setCoordinateSystem") {
+        QString className = arguments.value("className").toString();
+        QString view = arguments.value("view").toString();
+        if (view != "icon" && view != "diagram")
+        return makeMCPError(id, QString("Invalid view: %1. Must be \"icon\" or \"diagram\".").arg(view));
+        MainWindow *mainWindow = MainWindow::instance();
+        LibraryTreeModel *pLibraryTreeModel = mainWindow->getLibraryWidget()->getLibraryTreeModel();
+        LibraryTreeItem *pLibraryTreeItem = pLibraryTreeModel->findLibraryTreeItem(className);
+        if (!pLibraryTreeItem)
+        return makeMCPError(id, QString("Class not found: %1").arg(className));
+        if (isClassReadOnly(className, pLibraryTreeModel))
+        return makeMCPError(id, QString("Cannot modify class in a system library or read-only package: %1").arg(className));
+        if (!pLibraryTreeItem->getModelWidget())
+        pLibraryTreeModel->showModelWidget(pLibraryTreeItem, false);
+        ModelWidget *pModelWidget = pLibraryTreeItem->getModelWidget();
+        if (view == "diagram" && !pModelWidget->isDiagramViewLoaded())
+        pModelWidget->loadDiagramViewNAPI();
+        GraphicsView *pGraphicsView = (view == "icon") ? pModelWidget->getIconGraphicsView() : pModelWidget->getDiagramGraphicsView();
+        const ModelInstance::CoordinateSystem &cs = pGraphicsView->mCoordinateSystem;
+        // Build coordinate system annotation, merging current values with provided overrides
+        QStringList coSysList;
+        if (arguments.contains("extent")) {
+          QJsonObject ext = arguments.value("extent").toObject();
+          coSysList.append(QString("extent={{%1,%2},{%3,%4}}")
+            .arg(ext.value("x1").toDouble()).arg(ext.value("y1").toDouble())
+            .arg(ext.value("x2").toDouble()).arg(ext.value("y2").toDouble()));
+        } else if (cs.hasExtent()) {
+          const ExtentAnnotation &e = cs.getExtent();
+          coSysList.append(QString("extent={{%1,%2},{%3,%4}}").arg(e.at(0).x()).arg(e.at(0).y()).arg(e.at(1).x()).arg(e.at(1).y()));
+        }
+        if (arguments.contains("preserveAspectRatio")) {
+          coSysList.append(QString("preserveAspectRatio=%1").arg(arguments.value("preserveAspectRatio").toBool() ? "true" : "false"));
+        } else if (cs.hasPreserveAspectRatio()) {
+          coSysList.append(QString("preserveAspectRatio=%1").arg((bool)cs.getPreserveAspectRatio() ? "true" : "false"));
+        }
+        if (arguments.contains("initialScale")) {
+          coSysList.append(QString("initialScale=%1").arg(arguments.value("initialScale").toDouble()));
+        } else if (cs.hasInitialScale()) {
+          coSysList.append(QString("initialScale=%1").arg((qreal)cs.getInitialScale()));
+        }
+        if (arguments.contains("grid")) {
+          QJsonObject grid = arguments.value("grid").toObject();
+          coSysList.append(QString("grid={%1,%2}").arg(grid.value("x").toDouble()).arg(grid.value("y").toDouble()));
+        } else if (cs.hasGrid()) {
+          coSysList.append(QString("grid={%1,%2}").arg(cs.getGrid().x()).arg(cs.getGrid().y()));
+        }
+        QStringList dummyCoSysList, graphicsList;
+        pGraphicsView->getCoordinateSystemAndGraphics(dummyCoSysList, graphicsList);
+        QString viewName = (view == "icon") ? "Icon" : "Diagram";
+        QString annotationString;
+        if (!coSysList.isEmpty())
+        annotationString = QString("annotate=%1(coordinateSystem=CoordinateSystem(%2), graphics={%3})").arg(viewName, coSysList.join(","), graphicsList.join(","));
+        else
+        annotationString = QString("annotate=%1(graphics={%2})").arg(viewName, graphicsList.join(","));
+        if (!m_proxy->addClassAnnotation(className, annotationString))
+        return makeMCPError(id, QString("Failed to set coordinate system for %1 of class %2").arg(view, className));
+        pModelWidget->reDrawModelWidget();
+        if (view == "icon")
+        pLibraryTreeItem->handleIconUpdated();
+        pLibraryTreeModel->updateLibraryTreeItemClassText(pLibraryTreeItem);
+        QCoreApplication::processEvents();
+        return makeMCPToolResponse(id, makeContent(QString("Coordinate system updated for %1 view of class %2").arg(view, className)));
+      }
       return makeMCPError(id, QString("Tool not found: %1").arg(toolName));
     }
 

--- a/OMEdit/OMEditLIB/Resources/json/MCPTools.json
+++ b/OMEdit/OMEditLIB/Resources/json/MCPTools.json
@@ -323,11 +323,11 @@
                 },
                 "width": {
                     "type": "number",
-                    "description": "The width of the component in diagram coordinates."
+                    "description": "The width of the component in diagram coordinates. A negative number flips the component horizontally."
                 },
                 "height": {
                     "type": "number",
-                    "description": "The height of the component in diagram coordinates."
+                    "description": "The height of the component in diagram coordinates. A negative number flips the component vertically."
                 },
                 "visible": {
                     "type": "boolean",
@@ -827,5 +827,53 @@
             "required": ["className"]
         },
         "annotations": {"readOnlyHint": true, "destructiveHint": false}
+    },
+    {
+        "name": "getCoordinateSystem",
+        "description": "Returns the coordinate system of the icon or diagram view of a class. Only fields that are explicitly set in the class annotation are included in the result.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "className": {"type": "string", "description": "The fully-qualified name of the class."},
+                "view": {"type": "string", "description": "Which view to query: \"icon\" or \"diagram\"."}
+            },
+            "required": ["className", "view"]
+        },
+        "annotations": {"readOnlyHint": true, "destructiveHint": false}
+    },
+    {
+        "name": "setCoordinateSystem",
+        "description": "Sets the coordinate system of the icon or diagram view of a class. All fields are optional; omitted fields preserve their current values.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "className": {"type": "string", "description": "The fully-qualified name of the class."},
+                "view": {"type": "string", "description": "Which view to update: \"icon\" or \"diagram\"."},
+                "extent": {
+                    "type": "object",
+                    "description": "Bounding box of the coordinate system.",
+                    "properties": {
+                        "x1": {"type": "number", "description": "X coordinate of the first (lower-left) corner."},
+                        "y1": {"type": "number", "description": "Y coordinate of the first (lower-left) corner."},
+                        "x2": {"type": "number", "description": "X coordinate of the second (upper-right) corner."},
+                        "y2": {"type": "number", "description": "Y coordinate of the second (upper-right) corner."}
+                    },
+                    "required": ["x1", "y1", "x2", "y2"]
+                },
+                "preserveAspectRatio": {"type": "boolean", "description": "Whether to preserve the aspect ratio when the view is resized. Default true."},
+                "initialScale": {"type": "number", "description": "Initial scale factor for the diagram (e.g. 0.1). Default 0.1."},
+                "grid": {
+                    "type": "object",
+                    "description": "Snap grid spacing in x and y directions.",
+                    "properties": {
+                        "x": {"type": "number", "description": "Grid spacing in the x direction."},
+                        "y": {"type": "number", "description": "Grid spacing in the y direction."}
+                    },
+                    "required": ["x", "y"]
+                }
+            },
+            "required": ["className", "view"]
+        },
+        "annotations": {"readOnlyHint": false, "destructiveHint": false}
     }
 ]


### PR DESCRIPTION
Adds two new diagram MCP tools:
- getCoordinateSystem: returns the explicitly-set fields of the CoordinateSystem annotation (extent, preserveAspectRatio, initialScale, grid) for a given class view.
- setCoordinateSystem: updates any subset of those fields, preserving unspecified ones, then writes back via addClassAnnotation and redraws.