### PR TITLE
Add getTotalModel scripting API and MCP tool

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2321,6 +2321,30 @@ loaded with loadFile() or passing the file to the compiler on the command line.<
   preferredView="text");
 end saveTotalModel;
 
+
+function getTotalModel
+  "Saves a model and dependencies to a single string."
+  input TypeName className;
+  input Boolean stripAnnotations = false;
+  input Boolean stripComments = false;
+  input Boolean obfuscate = false;
+  output String result;
+external "builtin";
+annotation(Documentation(info="<html>
+<p>Save the <code>className</code> model in a single string, together with all the other classes
+that it depends upon, directly and indirectly. This file can be later reloaded
+with the <a href=\"modelica://OpenModelica.Scripting.loadString\">loadString()</a>
+API function, which loads <code>className</code> and all the other needed
+classes into memory.</p>
+<p>This is useful to allow third parties to run a certain model (e.g. for
+debugging) without worrying about all the library dependencies.</p>
+<p>Please note that the resulting file is not a valid Modelica .mo file according
+to the specification and cannot be loaded in OMEdit - it can only be
+loaded with loadFile() or passing the file to the compiler on the command line.</p>
+</html>"),
+  preferredView="text");
+end getTotalModel;
+
 function saveTotalModelDebug
   "Saves a model and dependencies to a single file using a heuristic."
   input String filename;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2566,6 +2566,29 @@ loaded with loadFile() or passing the file to the compiler on the command line.<
   preferredView="text");
 end saveTotalModel;
 
+function getTotalModel
+  "Saves a model and dependencies to a single string."
+  input TypeName className;
+  input Boolean stripAnnotations = false;
+  input Boolean stripComments = false;
+  input Boolean obfuscate = false;
+  output String result;
+external "builtin";
+annotation(Documentation(info="<html>
+<p>Save the <code>className</code> model in a single string, together with all the other classes
+that it depends upon, directly and indirectly. This file can be later reloaded
+with the <a href=\"modelica://OpenModelica.Scripting.loadString\">loadString()</a>
+API function, which loads <code>className</code> and all the other needed
+classes into memory.</p>
+<p>This is useful to allow third parties to run a certain model (e.g. for
+debugging) without worrying about all the library dependencies.</p>
+<p>Please note that the resulting file is not a valid Modelica .mo file according
+to the specification and cannot be loaded in OMEdit - it can only be
+loaded with loadFile() or passing the file to the compiler on the command line.</p>
+</html>"),
+  preferredView="text");
+end getTotalModel;
+
 function saveTotalModelDebug
   "Saves a model and dependencies to a single file using a heuristic."
   input String filename;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1899,6 +1899,24 @@ algorithm
       then
         Values.BOOL(false);
 
+    case ("getTotalModel",{Values.CODE(Absyn.C_TYPENAME(classpath)),
+                           Values.BOOL(b1), Values.BOOL(b2), Values.BOOL(b3)})
+      equation
+        access = Interactive.checkAccessAnnotationAndEncryption(classpath, SymbolTable.getAbsyn());
+        if access >= Access.all then
+          s1 = getTotalModel(classpath, b1, b2, b3);
+          b = true;
+        else
+          Error.addMessage(Error.SAVE_ENCRYPTED_CLASS_ERROR, {});
+          b = false;
+        end if;
+      then
+        Values.STRING(s1);
+
+    case ("getTotalModel",{Values.CODE(Absyn.C_TYPENAME(_)),
+                           Values.BOOL(_), Values.BOOL(_), Values.BOOL(_)})
+      then Values.STRING("");
+
     case ("saveTotalModel",{Values.STRING(filename),Values.CODE(Absyn.C_TYPENAME(classpath)),
                                     Values.BOOL(b1), Values.BOOL(b2), Values.BOOL(b3)})
       equation
@@ -7789,11 +7807,27 @@ protected function saveTotalModel
   input Boolean stripComments;
   input Boolean obfuscate;
 protected
+  String result, obfuscate_map;
+algorithm
+  (result, obfuscate_map) := getTotalModel(classpath, stripAnnotations, stripComments, obfuscate);
+  if obfuscate then
+    System.writeFile(StringUtil.stripFileExtension(filename) + "_mapping.json", obfuscate_map);
+  end if;
+  System.writeFile(filename, result);
+end saveTotalModel;
+
+protected function getTotalModel
+  input Absyn.Path classpath;
+  input Boolean stripAnnotations;
+  input Boolean stripComments;
+  input Boolean obfuscate;
+  output String result;
+  output String obfuscate_map;
+protected
   SCode.Program scodeP;
   String str,str1,str2,str3;
   NFSCodeEnv.Env env;
   SCode.Comment cmt;
-  String obfuscate_map;
   Absyn.Path cls_path = classpath;
 algorithm
   runFrontEndLoadProgram(cls_path);
@@ -7808,7 +7842,6 @@ algorithm
 
   if obfuscate then
     (scodeP, cls_path, cmt, obfuscate_map) := Obfuscate.obfuscateProgram(scodeP, cls_path, cmt);
-    System.writeFile(StringUtil.stripFileExtension(filename) + "_mapping.json", obfuscate_map);
   end if;
 
   str := SCodeDump.programStr(scodeP,SCodeDump.defaultOptions);
@@ -7818,8 +7851,8 @@ algorithm
   str3 := if stripAnnotations then "" else SCodeDump.printAnnotationStr(cmt,SCodeDump.defaultOptions);
   str3 := if stringEq(str3,"") then "" else (str3 + ";\n");
   str1 := "\nmodel " + str1 + str2 + "\n  extends " + AbsynUtil.pathString(cls_path) + ";\n" + str3 + "end " + str1 + ";\n";
-  System.writeFile(filename, str + str1);
-end saveTotalModel;
+  result := str + str1;
+end getTotalModel;
 
 protected function saveTotalModelDebug
   input String filename;

--- a/OMEdit/OMEditLIB/MCP/MCPServer.cpp
+++ b/OMEdit/OMEditLIB/MCP/MCPServer.cpp
@@ -519,6 +519,17 @@ if (method == "tools/call") {
     QString code = m_proxy->listFile(className);
     return makeMCPToolResponse(id, makeContent(code));
   }
+  if (toolName == "getTotalModel") {
+    QString className = arguments.value("className").toString(); // required
+    if (!m_proxy->existClass(className)) {
+      return makeMCPError(id, QString("Class not found: %1").arg(className));
+    }
+    bool stripAnnotations = arguments.value("stripAnnotations").toBool(false);
+    bool stripComments = arguments.value("stripComments").toBool(false);
+    bool obfuscate = arguments.value("obfuscate").toBool(false);
+    QString code = m_proxy->getTotalModel(className, stripAnnotations, stripComments, obfuscate);
+    return makeMCPToolResponse(id, makeContent(code));
+  }
   if (toolName == "setSourceCode") {
     QString className = arguments.value("className").toString(); // required
     QStringList parts = StringHandler::splitPath(className);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -1913,6 +1913,22 @@ QString OMCProxy::listFile(QString className, bool nestedClasses)
 }
 
 /*!
+ * \brief OMCProxy::getTotalModel
+ * Returns the class and all its dependencies as a single string.
+ * \param className
+ * \param stripAnnotations
+ * \param stripComments
+ * \param obfuscate
+ * \return
+ */
+QString OMCProxy::getTotalModel(QString className, bool stripAnnotations, bool stripComments, bool obfuscate)
+{
+  QString result = mpOMCInterface->getTotalModel(className, stripAnnotations, stripComments, obfuscate);
+  printMessagesStringInternal();
+  return result;
+}
+
+/*!
  * \brief OMCProxy::diffModelicaFileListings
  * Creates diffs of two strings corresponding to Modelica files.
  * \param before

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -177,6 +177,7 @@ public:
   bool saveTotalModel(QString fileName, QString className, bool stripAnnotations, bool stripComments, bool obfuscate, bool simplified);
   QString list(QString className);
   QString listFile(QString className, bool nestedClasses = true);
+  QString getTotalModel(QString className, bool stripAnnotations = false, bool stripComments = false, bool obfuscate = false);
   QString diffModelicaFileListings(const QString &before, const QString &after);
   QString instantiateModel(QString className);
   QString runScript(QString fileName);

--- a/OMEdit/OMEditLIB/Resources/json/MCPTools.json
+++ b/OMEdit/OMEditLIB/Resources/json/MCPTools.json
@@ -36,6 +36,21 @@
         }
     },
     {
+        "name": "getTotalModel",
+        "description": "Returns the Modelica source code for the given class together with all classes it depends on, as a single string. Useful for sharing a self-contained model. The result is not a valid .mo file per the specification, but can be reloaded with loadString().",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "className": {"type": "string", "description": "The fully-qualified name of the class."},
+                "stripAnnotations": {"type": "boolean", "description": "If true, remove all annotations from the output. Default false."},
+                "stripComments": {"type": "boolean", "description": "If true, remove all comments from the output. Default false."},
+                "obfuscate": {"type": "boolean", "description": "If true, obfuscate identifiers in the output. Default false."}
+            },
+            "required": ["className"]
+        },
+        "annotations": {"readOnlyHint": true, "destructiveHint": false}
+    },
+    {
         "name": "setSourceCode",
         "description": "Replaces the Modelica source code for the given class and reloads it in the GUI. Do not use this for editing diagrams - there are dedicated tools for that. Note that the source code changes each time the model is modified by other tool calls; you will remove icon and diagram annotations unless you read the code again before trying to edit it.",
         "inputSchema": {


### PR DESCRIPTION
Refactors the internal saveTotalModel helper into a getTotalModel function that returns the combined source as a string, then has saveTotalModel call it. Exposes getTotalModel as a builtin scripting function (ModelicaBuiltin.mo, NFModelicaBuiltin.mo, CevalScriptBackend.mo) and adds a corresponding MCP tool with optional stripAnnotations, stripComments, and obfuscate arguments.