### PR TITLE
More fixes for #13447

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -677,7 +677,7 @@ algorithm
       FMI.Info fmiInfo;
       list<String> strs,strs1,strs2;
       Real timeTotal,timeSimulation,linearizeTime,offset,offset1,offset2,scaleFactor,scaleFactor1,scaleFactor2;
-      Boolean bval, b, b1, b2, b3, b4, b5, showProtected, inputConnectors, outputConnectors, sanityCheckFailed;
+      Boolean bval, b, b1, b2, b3, b4, b5, showProtected, inputConnectors, outputConnectors, sanityCheckFailed, lineEndingIsCRLF;
       list<tuple<String,Values.Value>> resultValues;
       list<Values.Value> cvars;
       list<Absyn.Path> paths;
@@ -1035,6 +1035,14 @@ algorithm
         ExecStat.execStatReset();
 
         (s1, bom) := StringUtil.stripBOM(s1);
+        // Work internally with LF line endings only, so that lines coming from
+        // the original file (s1) and lines produced by the listing (s2, always LF)
+        // compare and merge uniformly. Remember the original (s1) convention and
+        // restore it on output, so we do not rewrite every line ending of a file
+        // that uses CRLF (e.g. on Windows checkouts). See #13447.
+        lineEndingIsCRLF := s1 <> System.stringReplace(s1, "\r\n", "\n"); // removing CRLF changed s1 => it originally contained CRLF
+        s1 := System.stringReplace(s1, "\r\n", "\n");
+        s1 := System.stringReplace(s1, "\r", "\n"); // also fold any remaining lone CR (old Mac) to LF
         (tokens1, errorTokens) := scanString(s1);
         reportErrors(errorTokens);
 
@@ -1059,6 +1067,8 @@ algorithm
         end if;
 
         (s2, bom) := StringUtil.stripBOM(s2);
+        s2 := System.stringReplace(s2, "\r\n", "\n");
+        s2 := System.stringReplace(s2, "\r", "\n");
         (tokens2, errorTokens) := scanString(s2);
         reportErrors(errorTokens);
         ExecStat.execStat("diffModelicaFileListings scan string 2");
@@ -1131,6 +1141,8 @@ algorithm
               Error.addInternalError("Unknown diffModelicaFileListings choice", sourceInfo());
             then fail();
         end matchcontinue;
+        // Restore the original file's line-ending convention (we processed as LF above).
+        str := if lineEndingIsCRLF then System.stringReplace(str, "\n", "\r\n") else str;
       then
         Values.STRING(bom + str);
 


### PR DESCRIPTION
Fix https://github.com/OpenModelica/OpenModelica/issues/13447: preserve original line endings in diffModelicaFileListings
Detect the source listing's line-ending convention (CRLF/LF), process
internally as LF so original-file lines and list() lines merge uniformly,
then restore CRLF on output when the source used it. This avoids rewriting
every line ending on Windows (CRLF) checkouts, which produced huge diffs.

This replaces the previous approach (strip all \r + append a fake trailing
newline at end of the token stream). Stripping \r forced LF-only output on
Windows, and the fake newline broke the primary file-vs-list() diff,
regressing testsuite test openmodelica/diff/PartialCoolingCapacity.mos.
The lexer (LexerModelicaDiff.mo, lexerModelicaDiff.l) and parser
(SimpleModelicaParser.mo) are therefore reverted to master; the fix now
lives entirely in CevalScriptBackend.mo:diffModelicaFileListings.
