### PR TITLE
Revert "Hide previous(v) in the result file (#8209)"

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1789,9 +1789,6 @@ algorithm
   cr := ComponentReference.makeCrefQual(DAE.previousNamePrefix, DAE.T_REAL_DEFAULT, {}, inVar.varName);
   outVar := copyVarNewName(cr,inVar);
   outVar := setVarKind(outVar,BackendDAE.JAC_TMP_VAR());
-
-  // HACK hide previous(v) in results because it's not calculated right
-  outVar := setHideResult(outVar, SOME(DAE.BCONST(true)));
 end createClockedState;
 
 public function createAliasDerVar

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -2735,7 +2735,7 @@ end checkComponentNames;
 
 protected function collectInitialClockedVarsEqns "author: rfranke
   This function creates initial equations for a clocked partition.
-  Previous states are initialized with the states."
+  Previous states are initialized with the respective states, states with their start values."
   input BackendDAE.Var inVar;
   input tuple<BackendDAE.Variables, BackendDAE.EquationArray> inTpl;
   output BackendDAE.Var outVar;
@@ -2767,10 +2767,6 @@ algorithm
           previousVar = BackendVariable.setBindExp(previousVar, NONE());
           previousVar = BackendVariable.setVarFixed(previousVar, true);
           previousVar = BackendVariable.setVarStartValueOption(previousVar, SOME(DAE.CREF(cr, ty)));
-
-          // HACK hide previous(v) in results because it's not calculated right
-          previousVar = BackendVariable.setHideResult(previousVar, SOME(DAE.BCONST(true)));
-
           previousExp = Expression.crefExp(previousCR);
           vars = BackendVariable.addVar(previousVar, vars);
           eqns = BackendEquation.add(BackendDAE.EQUATION(previousExp, crExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL), eqns);
@@ -2781,11 +2777,6 @@ algorithm
           then (vars, eqns);
         else (vars, eqns);
       end match;
-      // Note: don't add initial equations for start values as they are already set before initialization
-      // add clocked variable and initial equation
-      //startExp = BackendVariable.varStartValue(var);
-      //vars = BackendVariable.addVar(var, vars);
-      //eqns = BackendEquation.add(BackendDAE.EQUATION(crExp, startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL), eqns);
     then (var, (vars, eqns));
   end match;
 end collectInitialClockedVarsEqns;

--- a/testsuite/openmodelica/cppruntime/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/testArrayEquations.mos
@@ -211,10 +211,10 @@ val(y4, 1.0);
 // ========================================
 // algVars (104)
 // ----------------------
-// index:0: $CLKPRE.x1 (no alias)  hideResult  initial: x1	no arrCref index:(1) [10]
-// index:1: $CLKPRE.x2 (no alias)  hideResult  initial: x2	no arrCref index:(11) [10]
-// index:2: $CLKPRE.x3 (no alias)  hideResult  initial: x3	no arrCref index:(21) [10]
-// index:3: $CLKPRE.x4 (no alias)  hideResult  initial: x4	no arrCref index:(31) [10]
+// index:0: $CLKPRE.x1 (no alias)  initial: x1	no arrCref index:(1) [10]
+// index:1: $CLKPRE.x2 (no alias)  initial: x2	no arrCref index:(11) [10]
+// index:2: $CLKPRE.x3 (no alias)  initial: x3	no arrCref index:(21) [10]
+// index:3: $CLKPRE.x4 (no alias)  initial: x4	no arrCref index:(31) [10]
 // index:4: $DER.x4 (no alias)  initial: 	no arrCref index:(41) [10]
 // index:5: u (no alias)  initial: 1.0:10.0	no arrCref index:(51) [10]
 // index:6: x1 (no alias)  initial: 	no arrCref index:(61) [10]


### PR DESCRIPTION
This reverts commit 15cb39456e18a48ac09167d32f6cdb8d71d50693.

Previous states of synchronous models should be treated like derivatives of continuous-time models.

See also issue #15405.