### PR TITLE
Fix lookup of SimVar without FMI export

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15409,12 +15409,14 @@ algorithm
         local Integer index;
         case SOME(index)
         then SOME(index + getScalarElementIndex(subs, List.map(sv.numArrayElement, stringInt)) - 1);
+        else sv.variable_index;
       end match;
       // fix fmi_index when using nfScalarize
       sv.fmi_index := match sv.fmi_index
         local Integer fmiIndex;
         case SOME(fmiIndex)
         then SOME(fmiIndex + getScalarElementIndex(subs, List.map(sv.numArrayElement, stringInt)) - 1);
+        else sv.fmi_index;
       end match;
     end if;
     sv := match sv.aliasvar

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -23,6 +23,7 @@ mslElectricalMachinesTest.mos \
 mslElectricalMachinesTestDAE.mos \
 mslElectricalSensorsTest.mos \
 mslMathFFT1Test.mos \
+mslMechanicsTestProtectedVector \
 mslThermalMassesTestNB.mos \
 nameClashTest.mos \
 functionPointerTest.mos \

--- a/testsuite/openmodelica/cppruntime/mslMechanicsTestProtectedVector.mos
+++ b/testsuite/openmodelica/cppruntime/mslMechanicsTestProtectedVector.mos
@@ -1,0 +1,28 @@
+// name: mslMechanicsTestProtectedVector
+// keywords: protected body.Q_start
+// status: correct
+// teardown_command: rm -f *Pendulum*
+
+setCommandLineOptions("--simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+
+simulate(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum);
+val(body.w_a[3], 5);
+val(body.z_a[3], 5);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// -2.318178134998348
+// 3.045459364536539
+// ""
+// endResult


### PR DESCRIPTION
Without else branch, the function SimCodeUtil.simVarFromHT fails if there is no fmiIndex, e.g. as it was filtered out.
This lets cref2simvar assume that the variable would not exist. 
Bug was introduced with commit d4817cd on Sep 19, 2024.

Issue: #15427