### PR TITLE
Fix annotation handling when instantiating components

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -3572,6 +3572,16 @@ algorithm
   end match;
 end getModifierBinding;
 
+public function setModifierBinding
+  input Option<Absyn.Exp> binding;
+  input output SCode.Mod mod;
+algorithm
+  () := match mod
+    case SCode.Mod.MOD() algorithm mod.binding := binding; then ();
+    else ();
+  end match;
+end setModifierBinding;
+
 function getComponentCondition
   input SCode.Element element;
   output Option<Absyn.Exp> condition;
@@ -6395,6 +6405,95 @@ algorithm
     info
   );
 end makeMod;
+
+public function makeSingleAnnotation
+  "Creates an annotation(name = value) annotation."
+  input String name;
+  input Absyn.Exp value;
+  output SCode.Annotation ann;
+algorithm
+  ann := SCode.Annotation.ANNOTATION(SCode.Mod.MOD(
+    SCode.Final.NOT_FINAL(),
+    SCode.Each.NOT_EACH(),
+    {
+      SCode.SubMod.NAMEMOD(
+        name,
+        SCode.Mod.MOD(
+          SCode.Final.NOT_FINAL(),
+          SCode.Each.NOT_EACH(),
+          {},
+          SOME(value),
+          NONE(),
+          AbsynUtil.dummyInfo
+        )
+      )
+    },
+    NONE(),
+    NONE(),
+    AbsynUtil.dummyInfo
+  ));
+end makeSingleAnnotation;
+
+public function setAnnotationInComment
+  "Sets the value of an annotation in a comment. If the annotation doesn't already exist it's added."
+  input String name;
+  input Absyn.Exp value;
+  input output SCode.Comment cmt;
+  input Boolean replace = true "Whether to replace the value of an existing annotation or not";
+protected
+  SCode.Annotation ann;
+  SCode.Mod mod;
+algorithm
+  if isNone(cmt.annotation_) then
+    cmt.annotation_ := SOME(makeSingleAnnotation(name, value));
+    return;
+  else
+    cmt.annotation_ := SOME(setAnnotationValue(name, value, Util.getOption(cmt.annotation_), replace));
+  end if;
+end setAnnotationInComment;
+
+public function setAnnotationValue
+  "Sets the value of an annotation. If the annotation doesn't already exist it's added."
+  input String name;
+  input Absyn.Exp value;
+  input output SCode.Annotation ann;
+  input Boolean replace = true "Whether to replace the value of an existing annotation or not";
+protected
+  SCode.Mod mod;
+  list<SCode.SubMod> submods;
+  Boolean found;
+
+  function replace_mod
+    input String name;
+    input Absyn.Exp value;
+    input Boolean replace;
+    input output SCode.SubMod mod;
+          output Boolean found;
+  algorithm
+    found := mod.ident == name;
+    if found and replace then
+      mod.mod := setModifierBinding(SOME(value), mod.mod);
+    end if;
+  end replace_mod;
+algorithm
+  () := match ann
+    case SCode.Annotation.ANNOTATION(modification = mod as SCode.Mod.MOD())
+      algorithm
+        (submods, found) := List.findMap(mod.subModLst,
+          function replace_mod(name = name, value = value, replace = replace));
+
+        if not found then
+          submods := SCode.SubMod.NAMEMOD(name, makeMod(binding = SOME(value))) :: submods;
+        end if;
+
+        mod.subModLst := submods;
+        ann.modification := mod;
+      then
+        ();
+
+    else ();
+  end match;
+end setAnnotationValue;
 
 annotation(__OpenModelica_Interface="frontend");
 end SCodeUtil;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -1938,6 +1938,7 @@ algorithm
       SCode.Element elementDefinition;
       Boolean in_function;
       Restriction parent_res, res;
+      SCode.Comment cmt;
 
     case SCode.COMPONENT(info = info)
       algorithm
@@ -1991,12 +1992,14 @@ algorithm
           res := Class.restriction(ty);
 
           /* fix issue https://github.com/OpenModelica/OpenModelica/issues/12533
-           * check if restriction is TYPE and has named annotation absolulteValue=false, then copy the derived annotations to components annotation
+           * check if restriction is TYPE and has named annotation absoluteValue=false, if so set absoluteValue=false in the component's annotation too.
            * (e.g) type TemperatureDifference = Real (final quantity="ThermodynamicTemperature", final unit="K") annotation(absoluteValue=false);
           */
           elementDefinition := InstNode.definition(ty_node);
           if (Restriction.isType(res) and SCodeUtil.optCommentHasBooleanNamedAnnotationFalse(SCodeUtil.getElementComment(elementDefinition), "absoluteValue")) then
-            InstNode.componentApply(node, Component.setComment, Util.getOption(SCodeUtil.getElementComment(elementDefinition)));
+            cmt := Component.comment(InstNode.component(node));
+            cmt := SCodeUtil.setAnnotationInComment("absoluteValue", Absyn.Exp.BOOL(false), cmt, replace = false);
+            InstNode.componentApply(node, Component.setComment, cmt);
           end if;
 
           if not InstContext.inRedeclared(context) then

--- a/testsuite/flattening/modelica/declarations/Annotations.mo
+++ b/testsuite/flattening/modelica/declarations/Annotations.mo
@@ -3,7 +3,7 @@
 // status:   correct
 //
 // Checks that annotations are output correctly on the flat code when
-// +showAnnotations is used.
+// --showAnnotations is used.
 //
 
 function f "Some comment"
@@ -14,12 +14,12 @@ algorithm
   annotation(key = value);
 end f;
 
-class c
+model c
   Real x "x" annotation(key = value);
 equation
   x = f(time);
   annotation(key = value);
-  annotation(__OpenModelica_commandLineOptions="+showAnnotations -d=-newInst");
+  annotation(__OpenModelica_commandLineOptions="--showAnnotations");
 end c;
 
 // Result:
@@ -35,6 +35,6 @@ end c;
 //   Real x "x" annotation(key = value);
 // equation
 //   x = f(time);
-//   annotation(key = value, __OpenModelica_commandLineOptions = "+showAnnotations -d=-newInst");
+//   annotation(key = value, __OpenModelica_commandLineOptions = "--showAnnotations");
 // end c;
 // endResult

--- a/testsuite/flattening/modelica/declarations/Annotations2.mo
+++ b/testsuite/flattening/modelica/declarations/Annotations2.mo
@@ -1,0 +1,26 @@
+// name:     Annotations2
+// keywords: declaration annotations comments
+// status:   correct
+//
+// The frontend has special rules for absoluteValue, check that it doesn't
+// overwrite existing comments/annotations.
+//
+
+model Annotations2
+  type Power = Real;
+  type TemperatureDifference = Real annotation(absoluteValue = false);
+
+  parameter Power Test1 = 0 "test1";
+  parameter TemperatureDifference Test2 = 0 "test2" annotation(absoluteValue = true);
+  parameter TemperatureDifference Test3 = 0 "test3";
+  annotation(__OpenModelica_commandLineOptions="--showAnnotations");
+end Annotations2;
+
+// Result:
+// class Annotations2
+//   parameter Real Test1 = 0.0 "test1";
+//   parameter Real Test2 = 0.0 "test2" annotation(absoluteValue = true);
+//   parameter Real Test3 = 0.0 "test3" annotation(absoluteValue = false);
+//   annotation(__OpenModelica_commandLineOptions = "--showAnnotations");
+// end Annotations2;
+// endResult

--- a/testsuite/flattening/modelica/declarations/Makefile
+++ b/testsuite/flattening/modelica/declarations/Makefile
@@ -2,6 +2,7 @@ TEST=../../../rtest -v
 
 TESTFILES=\
 Annotations.mo \
+Annotations2.mo \
 BuiltinTime1.mo \
 BuiltinTimeInvalid1.mo \
 BuiltinTimeInvalid2.mo \


### PR DESCRIPTION
- Only copy the absoluteValue=false annotation from the type to the component, rather than overwriting the component's comment completely.
- Update old annotation test case to use the NF.

Fixes #15435