### PR TITLE
Update OMParser License

### DIFF
--- a/.CI/scripts/SimulationRuntime-license-exceptions.txt
+++ b/.CI/scripts/SimulationRuntime-license-exceptions.txt
@@ -290,7 +290,16 @@ OMEdit/OMEditLIB/TransformationalDebugger/diff_match_patch.*
 # =============================================================================
 # OMNotebook
 # =============================================================================
+
 OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
+
+# =============================================================================
+# OMParser
+# =============================================================================
+
+OMParser/3rdParty/
+OMParser/test/
+
 
 # =============================================================================
 # Submodules
@@ -301,7 +310,6 @@ libraries/
 OMCompiler/3rdParty/
 !OMCompiler/3rdParty/ryu/ryu/om_format.*
 OMOptim/
-OMParser/
 OMPlot/
 OMSens_Qt/
 OMSimulator/

--- a/.github/workflows/check-runtime-license.yml
+++ b/.github/workflows/check-runtime-license.yml
@@ -27,4 +27,5 @@ jobs:
             OMCompiler                                 \
             OMEdit                                     \
             OMNotebook                                 \
+            OMParser                                   \
             OMShell


### PR DESCRIPTION
### Related Issues

For https://github.com/OpenModelica/OpenModelica/issues/15397.

### Purpose

* Refined exception list for OMParser:
  * All 316 files are antlr4 third-party runtime or test code — no OSMC-authored sources.
  * Replaced blanket `OMParser/` exclusion with `OMParser/3rdParty/` and `OMParser/test/`.
  * Checked 0 files, skipped 316 (excluded), 0 failures.

### Approach

Run script `.CI/scripts/check_runtime_license.py`