### PR TITLE
Update OMSens_Qt License

### DIFF
--- a/.CI/scripts/SimulationRuntime-license-exceptions.txt
+++ b/.CI/scripts/SimulationRuntime-license-exceptions.txt
@@ -335,7 +335,6 @@ OMPlot/qwt/
 libraries/
 OMCompiler/3rdParty/
 !OMCompiler/3rdParty/ryu/ryu/om_format.*
-OMSens_Qt/
 OMSimulator/
 
 # =============================================================================

--- a/.github/workflows/check-runtime-license.yml
+++ b/.github/workflows/check-runtime-license.yml
@@ -30,4 +30,5 @@ jobs:
             OMOptim                                    \
             OMParser                                   \
             OMPlot                                     \
+            OMSens_Qt                                  \
             OMShell


### PR DESCRIPTION
### Related Issues

For https://github.com/OpenModelica/OpenModelica/issues/15397.

* Removed `OMSens_Qt/` blanket exclusion from exception list.
* Added `*/omc_config*.h.in` glob to exception list (build-generated config headers).
* Added `OMSens_Qt` to CI license check workflow.

License header changes are in the [OMSens_Qt submodule](https://github.com/OpenModelica/OMSens_Qt).

### Approach

Run script `.CI/scripts/check_runtime_license.py`