### PR TITLE
Update OMOptim License

### DIFF
--- a/.CI/scripts/SimulationRuntime-license-exceptions.txt
+++ b/.CI/scripts/SimulationRuntime-license-exceptions.txt
@@ -300,6 +300,25 @@ OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
 OMParser/3rdParty/
 OMParser/test/
 
+# =============================================================================
+# OMOptim
+# =============================================================================
+
+# [3rd-party] Thales group / INRIA / DOLPHIN — ParadisEO (LGPL 2.1 & CeCILL)
+OMOptim/ParadisEO-2.0.1/
+# [3rd-party] DOLPHIN Project-Team, INRIA Lille — CeCILL license
+OMOptim/OMOptim/Core/Optim/EA/SA1/SA1moFullEvalByCopy.h
+# CEP-ARMINES copyright — mixed OSMC-PL + CEP-ARMINES header
+OMOptim/OMOptim/GUI/Dialogs/AboutOMOptim.cpp
+# [3rd-party] Nokia Corporation — Qt Toolkit example (LGPL 2.1)
+OMOptim/OMOptim/GUI/Scene/arrow.cpp
+OMOptim/OMOptim/GUI/Scene/arrow.h
+OMOptim/OMOptim/GUI/Scene/diagramitem.cpp
+OMOptim/OMOptim/GUI/Scene/diagramitem.h
+OMOptim/OMOptim/GUI/Scene/diagramscene.cpp
+OMOptim/OMOptim/GUI/Scene/diagramscene.h
+OMOptim/OMOptim/GUI/Scene/diagramtextitem.cpp
+OMOptim/OMOptim/GUI/Scene/diagramtextitem.h
 
 # =============================================================================
 # Submodules
@@ -309,7 +328,6 @@ OMParser/test/
 libraries/
 OMCompiler/3rdParty/
 !OMCompiler/3rdParty/ryu/ryu/om_format.*
-OMOptim/
 OMPlot/
 OMSens_Qt/
 OMSimulator/

--- a/.github/workflows/check-runtime-license.yml
+++ b/.github/workflows/check-runtime-license.yml
@@ -27,5 +27,6 @@ jobs:
             OMCompiler                                 \
             OMEdit                                     \
             OMNotebook                                 \
+            OMOptim                                    \
             OMParser                                   \
             OMShell


### PR DESCRIPTION
### Related Issues

For https://github.com/OpenModelica/OpenModelica/issues/15397.

* Replaced blanket `OMOptim/` exclusion with specific entries:
  * `OMOptim/ParadisEO-2.0.1/` (LGPL 2.1 & CeCILL, third-party)
  * `OMOptim/OMOptim/Core/Optim/EA/SA1/SA1moFullEvalByCopy.h` (CeCILL, DOLPHIN/INRIA)
  * `OMOptim/OMOptim/GUI/Dialogs/AboutOMOptim.cpp` (mixed OSMC-PL + CEP-ARMINES)
  * `OMOptim/OMOptim/GUI/Scene/{arrow,diagramitem,diagramscene,diagramtextitem}.{cpp,h}` (Nokia Qt Diagram Scene example, LGPL 2.1)
* Added `*/omc_config*.h.in` glob to exception list (build-generated config headers).
* Added `OMOptim` to CI license check workflow.
* Updated OMOptim submodule pointer.

License header changes are in the [OMOptim submodule](https://github.com/OpenModelica/OMOptim).

### Approach

Run script `.CI/scripts/check_runtime_license.py`