### PR TITLE
Remove string comments on match expression input/pattern/else

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -283,7 +283,7 @@ algorithm
       Option<CrefExpTable> derConst;
     case (REPLACEMENTS(hashTable=ht),src,_) /* source dest */
       guard
-        isSome(UnorderedMap.getOrDefault(src, ht, NONE())) "if rule a->b exists, fail"
+        isSome(UnorderedMap.getOrDefault(src, ht, NONE())) // if rule a->b exists, fail
       then
         fail();
     case (REPLACEMENTS(ht,invHt,eht,iv,derConst),src,dst)

--- a/OMCompiler/Compiler/FrontEnd/Absyn.mo
+++ b/OMCompiler/Compiler/FrontEnd/Absyn.mo
@@ -557,7 +557,7 @@ uniontype Algorithm "The Algorithm type describes one algorithm statement in an
 
   // MetaModelica extensions
   record ALG_FAILURE
-    list<AlgorithmItem> equ;
+    list<AlgorithmItem> equ; // TODO: This is only 1 AlgorithmItem in the parser
   end ALG_FAILURE;
 
   record ALG_TRY
@@ -815,7 +815,7 @@ uniontype Exp "The Exp uniontype is the container of a Modelica expression.
     Exp inputExp                 " match expression of         ";
     list<ElementItem> localDecls " local declarations          ";
     list<Case> cases             " case list + else in the end ";
-    Option<String> comment       " match expr comment_optional ";
+    Option<String> comment       "TODO: Remove this as it was removed from the grammar";
   end MATCHEXP;
 
   // The following are only used internally in the compiler
@@ -849,20 +849,20 @@ uniontype Case "case in match or matchcontinue"
     Exp pattern " patterns to be matched ";
     Option<Exp> patternGuard;
     Info patternInfo "file information of the pattern";
-    list<ElementItem> localDecls " local decls ";
+    list<ElementItem> localDecls "TODO: Remove this as it was removed from the grammar";
     ClassPart classPart " equation or algorithm section ";
     Exp result " result ";
     Info resultInfo "file information of the result-exp";
-    Option<String> comment " comment after case like: case pattern string_comment ";
+    Option<String> comment "TODO: Remove this as it was removed from the grammar";
     Info info "file information of the whole case";
   end CASE;
 
   record ELSE "else in match or matchcontinue"
-    list<ElementItem> localDecls " local decls ";
+    list<ElementItem> localDecls "TODO: Remove this as it was removed from the grammar";
     ClassPart classPart " equation or algorithm section ";
     Exp result " result ";
     Info resultInfo "file information of the result-exp";
-    Option<String> comment " comment after case like: case pattern string_comment ";
+    Option<String> comment "TODO: Remove this as it was removed from the grammar";
     Info info "file information of the whole case";
   end ELSE;
 end Case;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -3605,7 +3605,7 @@ algorithm
       then explst;
 
     case (DAE.CALL(path=p1,expLst=explst,attr=DAE.CALL_ATTR(ty=DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p2)))),_)
-      guard AbsynUtil.pathEqual(p1,p2) "is record constructor"
+      guard AbsynUtil.pathEqual(p1,p2) // is record constructor
       then List.flatten(List.map1(explst, generateCrefsExpLstFromExp, inCrefPrefix));
 
     case (DAE.RECORD(path=p1,exps=explst),_)

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1053,7 +1053,7 @@ algorithm
 
     // simplify record constructor from one to another
     case (_,DAE.CALL(p1,exps,DAE.CALL_ATTR(ty=DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p2)))),DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p3)))
-      guard AbsynUtil.pathEqual(p1,p2) "It is a record constructor since it has the same path called as its output type"
+      guard AbsynUtil.pathEqual(p1,p2) // It is a record constructor since it has the same path called as its output type
       then DAE.CALL(p3,exps,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
 
     case (_,DAE.RECORD(_,exps,fieldNames,_),DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p3)))

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1916,7 +1916,7 @@ public
         then d;
 
       case WILD() then 0;
-      else "EMPTY_CREF" then 0;
+      else /* EMPTY_CREF */ then 0;
     end match;
   end depth;
 

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -2278,7 +2278,7 @@ match_expression returns [void* ast]
      END_MATCH)
   )
      {
-       ast = Absyn__MATCHEXP(ty->type==MATCHCONTINUE ? Absyn__MATCHCONTINUE : Absyn__MATCH, exp.ast, mmc_mk_nil(), cs, mmc_mk_none());
+       ast = Absyn__MATCHEXP(ty->type==MATCHCONTINUE ? Absyn__MATCHCONTINUE : Absyn__MATCH, exp.ast, or_nil(es), cs, mmc_mk_none());
      }
   ;
 

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -2267,18 +2267,18 @@ interactive_stmt_list returns [void* ast]
 
 /* MetaModelica */
 match_expression returns [void* ast]
-@init{ ty = 0; exp.ast = 0; cmt = 0; es = 0; cs = 0; } :
-  ( (ty=MATCHCONTINUE exp=expression[metamodelica_enabled()] cmt=string_comment
+@init{ ty = 0; exp.ast = 0; es = 0; cs = 0; } :
+  ( (ty=MATCHCONTINUE exp=expression[metamodelica_enabled()]
      es=local_clause
      cs=cases
      END_MATCHCONTINUE)
-  | (ty=MATCH exp=expression[metamodelica_enabled()] cmt=string_comment
+  | (ty=MATCH exp=expression[metamodelica_enabled()]
      es=local_clause
      cs=cases
      END_MATCH)
   )
      {
-       ast = Absyn__MATCHEXP(ty->type==MATCHCONTINUE ? Absyn__MATCHCONTINUE : Absyn__MATCH, exp.ast, or_nil(es), cs, mmc_mk_some_or_none(cmt));
+       ast = Absyn__MATCHEXP(ty->type==MATCHCONTINUE ? Absyn__MATCHCONTINUE : Absyn__MATCH, exp.ast, mmc_mk_nil(), cs, mmc_mk_none());
      }
   ;
 
@@ -2299,16 +2299,12 @@ cases returns [void* ast]
   ;
 
 cases2 returns [void* ast]
-@init{ el = 0; cmt = 0; es = 0; eqs = 0; th = 0; exp.ast = 0; c.ast = 0; cs.ast = 0; } :
-  ( (el=ELSE (cmt=string_comment es=local_clause ((EQUATION eqs=equation_list_then)|(al=T_ALGORITHM algs=algorithm_annotation_list[NULL,1]))? th=THEN)? exp=expression[metamodelica_enabled()] SEMICOLON)?
+@init{ el = 0; eqs = 0; th = 0; exp.ast = 0; c.ast = 0; cs.ast = 0; } :
+  ( (el=ELSE (((EQUATION eqs=equation_list_then)|(al=T_ALGORITHM algs=algorithm_annotation_list[NULL,1]))? th=THEN)? exp=expression[metamodelica_enabled()] SEMICOLON)?
     {
-      if (es != NULL)
-        c_add_source_message(NULL,2, ErrorType_syntax, ErrorLevel_warning, "case local declarations are deprecated. Move all case- and else-declarations to the match local declarations.",
-                             NULL, 0, $start->line, $start->charPosition+1, LT(1)->line, LT(1)->charPosition+1,
-                             ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
       if ($th) $el = $th;
       if (exp.ast) {
-       $ast = mmc_mk_cons_typed(Absyn_Case, Absyn__ELSE(or_nil(es),eqs ? Absyn__EQUATIONS(eqs) : (al ? Absyn__ALGORITHMS(algs.ast) : Absyn__EQUATIONS(mmc_mk_nil())),exp.ast,PARSER_INFO($el),mmc_mk_some_or_none(cmt),PARSER_INFO($start)),mmc_mk_nil());
+       $ast = mmc_mk_cons_typed(Absyn_Case, Absyn__ELSE(mmc_mk_nil(),eqs ? Absyn__EQUATIONS(eqs) : (al ? Absyn__ALGORITHMS(algs.ast) : Absyn__EQUATIONS(mmc_mk_nil())),exp.ast,PARSER_INFO($el),mmc_mk_none(),PARSER_INFO($start)),mmc_mk_nil());
       } else {
        $ast = mmc_mk_nil();
       }
@@ -2321,15 +2317,10 @@ cases2 returns [void* ast]
   ;
 
 onecase returns [void* ast]
-@init{ pat.ast = 0; guard.ast = 0; cmt = 0; es = 0; eqs = 0; th = 0; exp.ast = 0; } :
-  (CASE pat=pattern ((IF|GUARD) guard=expression[metamodelica_enabled()])? cmt=string_comment es=local_clause ((EQUATION eqs=equation_list_then)|(al=T_ALGORITHM algs=algorithm_annotation_list[NULL,1]))? th=THEN exp=expression[metamodelica_enabled()] SEMICOLON)
+@init{ pat.ast = 0; guard.ast = 0; eqs = 0; th = 0; exp.ast = 0; } :
+  (CASE pat=pattern ((IF|GUARD) guard=expression[metamodelica_enabled()])? ((EQUATION eqs=equation_list_then)|(al=T_ALGORITHM algs=algorithm_annotation_list[NULL,1]))? th=THEN exp=expression[metamodelica_enabled()] SEMICOLON)
     {
-        if (es != NULL) {
-          c_add_source_message(NULL,2, ErrorType_syntax, ErrorLevel_warning, "case local declarations are deprecated. Move all case- and else-declarations to the match local declarations.",
-                               NULL, 0, $start->line, $start->charPosition+1, LT(1)->line, LT(1)->charPosition+1,
-                               ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
-        }
-        $ast = Absyn__CASE(pat.ast,mmc_mk_some_or_none(guard.ast),pat.info,or_nil(es),eqs ? Absyn__EQUATIONS(eqs) : (al ? Absyn__ALGORITHMS(algs.ast) : Absyn__EQUATIONS(mmc_mk_nil())),exp.ast,PARSER_INFO($th),mmc_mk_some_or_none(cmt),PARSER_INFO($start));
+        $ast = Absyn__CASE(pat.ast,mmc_mk_some_or_none(guard.ast),pat.info,mmc_mk_nil(),eqs ? Absyn__EQUATIONS(eqs) : (al ? Absyn__ALGORITHMS(algs.ast) : Absyn__EQUATIONS(mmc_mk_nil())),exp.ast,PARSER_INFO($th),mmc_mk_none(),PARSER_INFO($start));
     }
   ;
 

--- a/testsuite/metamodelica/meta/MatchCaseInteractive1.mo
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive1.mo
@@ -83,11 +83,12 @@ package MatchCaseInteractive1
     output Real out;
   algorithm
     out := matchcontinue (tup)
+      local Real r;
       case (2,1.0,true,"abc") then 1;
       case (1,2.0,true,"abc") then 2;
       case (1,1.0,false,"abc") then 3;
       case (1,1.0,true,"abcd") then 4;
-      case (_,r,_,_) local Real r; then r;
+      case (_,r,_,_) then r;
       case _ then -1;
     end matchcontinue;
   end tupleFunc;

--- a/testsuite/metamodelica/meta/MatchCaseInteractive1.mos
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive1.mos
@@ -59,8 +59,7 @@ getErrorString();
 
 // Result:
 // true
-// "[metamodelica/meta/MatchCaseInteractive1.mo:90:7-91:7:writable] Warning: case local declarations are deprecated. Move all case- and else-declarations to the match local declarations.
-// "
+// ""
 // 2
 // ""
 // 4

--- a/testsuite/metamodelica/meta/MatchCaseInteractive3.mo
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive3.mo
@@ -43,6 +43,7 @@ algorithm
   _ := matchcontinue(selectVar)
     local
       String cmp1,cmp2;
+      Select c1, c2;
     case (FirstAlternative(cmp1, cmp2))
       equation
         print("FirstAlternative(");
@@ -56,8 +57,6 @@ algorithm
         print(")");
       then ();
     case (SecondAlternative(c1, c2))
-      local
-        Select c1, c2;
       equation
         print("SecondAlternative(");
         printSelect(c1);
@@ -66,8 +65,6 @@ algorithm
         print(")");
       then ();
     case ThirdAlternative(c1)
-      local
-        Select c1;
       equation
         print("ThirdAlternative(");
         printSelect(c1);

--- a/testsuite/metamodelica/meta/MatchCaseInteractive3.mos
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive3.mos
@@ -19,7 +19,5 @@ MatchCaseInteractive3.printSelect(MatchCaseInteractive3.mySelect);getErrorString
 //     x = 3
 // end MatchCaseInteractive3.UT.REC1;
 // ThirdAlternative(SecondAlternative(FirstAlternative("one", "First"), FirstAlternative("two", "Second")))
-// "[metamodelica/meta/MatchCaseInteractive3.mo:58:5-68:5:writable] Warning: case local declarations are deprecated. Move all case- and else-declarations to the match local declarations.
-// [metamodelica/meta/MatchCaseInteractive3.mo:68:5-76:3:writable] Warning: case local declarations are deprecated. Move all case- and else-declarations to the match local declarations.
-// "
+// ""
 // endResult

--- a/testsuite/openmodelica/parser/MetaModelicaMatchElse.mo
+++ b/testsuite/openmodelica/parser/MetaModelicaMatchElse.mo
@@ -15,14 +15,12 @@ algorithm
   _ := match (x) case 1 then fail(); else equation fail(); then 2; end match;
   _ := match (x) case 1 then fail(); else then 2; end match;
   _ := match (x) case 1 then fail(); else 2; end match;
-  _ := match (x) case 1 then fail(); else "comment" then 2; end match;
   _ := matchcontinue x case 1 then ();  end matchcontinue;
   _ := matchcontinue (x,y,z) case 1 then (); end matchcontinue;
   _ := matchcontinue () case 1 then (); end matchcontinue;
   _ := matchcontinue (x) case 1 then fail(); else equation fail(); then 2; end matchcontinue;
   _ := matchcontinue (x) case 1 then fail(); else then 2; end matchcontinue;
   _ := matchcontinue (x) case 1 then fail(); else 2; end matchcontinue;
-  _ := matchcontinue (x) case 1 then fail(); else "comment" then 2; end matchcontinue;
 end f1;
 
 class A


### PR DESCRIPTION
The code looked confusing with `else "abc" "def"` being possible, and it was barely used in the compiler.