### PR TITLE
Do not use quoted identifiers in MetaModelica code

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1777,7 +1777,7 @@ try
   varlst := BackendVariable.varList(v);
   knvarlst := BackendVariable.varList(globalKnownVars);
 
-  states := if Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+  states := if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
     BackendVariable.getAllClockedStatesFromVariables(v) else {};
 
   states := listAppend(BackendVariable.getAllStateVarFromVariables(v), states);
@@ -1957,7 +1957,7 @@ try
   eqSyst::{} := backendDAE.eqs;
   v := eqSyst.orderedVars;
   // get state var from simulation DAE
-  states := if Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+  states := if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
     BackendVariable.getAllClockedStatesFromVariables(v) else {};
   states := listAppend(BackendVariable.getAllStateVarFromVariables(v), states);
 

--- a/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
@@ -548,7 +548,7 @@ algorithm
 
         // If any matching modifiers were found, issue a warning and copy them to the external declaration.
         if not SCodeUtil.isEmptyMod(ann.modification) then
-          if Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+          if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
             Error.addSourceMessage(Error.MISPLACED_EXTERNAL_ANNOTATION, {}, info);
           end if;
           ext_decl.annotation_ := SOME(ann);

--- a/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
@@ -474,7 +474,7 @@ algorithm
   if expectPackage and not AbsynUtil.isParts(body) then
     Error.addSourceMessage(Error.LIBRARY_EXPECTED_PARTS, {pack}, info);
     fail();
-  elseif not (AbsynUtil.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.LanguageStandard.'2.x')) then
+  elseif not (AbsynUtil.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.LanguageStandard._2_x)) then
      s1 := AbsynUtil.withinString(w1);
      s2 := AbsynUtil.withinString(w2);
      if AbsynUtil.withinEqualCaseInsensitive(w1,w2) then

--- a/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
@@ -2790,7 +2790,7 @@ protected
   String error_str, flow_str, potential_str, class_str;
 algorithm
   // Don't check connector balance for language version 2.x and earlier.
-  if Config.languageStandardAtMost(Config.LanguageStandard.'2.x') then
+  if Config.languageStandardAtMost(Config.LanguageStandard._2_x) then
     return;
   end if;
 

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -2915,7 +2915,7 @@ algorithm
     Error.addSourceMessage(Error.IF_CONDITION_TYPE_ERROR,{Dump.printExpStr(aexp),Types.unparseType(ty)},info);
     fail();
   end try;
-  if Config.languageStandardAtLeast(Config.LanguageStandard.'3.2') then
+  if Config.languageStandardAtLeast(Config.LanguageStandard._3_2) then
     _ := match exp
       case DAE.CALL(path=Absyn.IDENT("initial")) then ();
       case DAE.CALL(path=Absyn.FULLYQUALIFIED(Absyn.IDENT("initial"))) then ();

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7221,7 +7221,7 @@ algorithm
 
         // In Modelica 3.2 and before, external functions with side-effects are not marked.
         if daePurity == DAE.Purity.UNDEFINED and SCodeUtil.isExternalFunctionRestriction(fres) and
-           not (hasOutVars or Config.languageStandardAtLeast(Config.LanguageStandard.'3.3')) then
+           not (hasOutVars or Config.languageStandardAtLeast(Config.LanguageStandard._3_3)) then
           daePurity := DAE.Purity.IMPURE;
         end if;
       then

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -715,7 +715,7 @@ protected
   SourceInfo cls_info, pre_info, info;
 algorithm
   if isSome(inInfo) and FGraph.isPartialScope(inEnv) and
-     Config.languageStandardAtLeast(Config.LanguageStandard.'3.2') then
+     Config.languageStandardAtLeast(Config.LanguageStandard._3_2) then
     FCore.N(data = FCore.CL(e = el, pre = pre)) :=
       FNode.fromRef(FGraph.lastScopeRef(inEnv));
     name := SCodeUtil.elementName(el);

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1765,7 +1765,7 @@ uniontype Function
     if Expression.isImpureCall(exp) then
       pure := false;
 
-      if Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+      if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
         Error.addSourceMessage(Error.PURE_FUNCTION_WITH_IMPURE_CALLS,
           {AbsynUtil.pathString(Function.name(fn)), Expression.getName(exp)},
           InstNode.info(fn.node));
@@ -2626,7 +2626,7 @@ protected
           inline_ty := InstUtil.commentIsInlineFunc(cmt);
 
           // Since Modelica 3.3, normal functions are pure by default and external functions are impure.
-          if purity == DAE.Purity.UNDEFINED and Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') then
+          if purity == DAE.Purity.UNDEFINED and Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
             purity := if SCodeUtil.isExternalFunctionRestriction(fres) then DAE.Purity.IMPURE else DAE.Purity.PURE;
           end if;
 

--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -51,7 +51,7 @@ import System;
 
 public
 
-type LanguageStandard = enumeration('1.x', '2.x', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', latest, experimental)
+type LanguageStandard = enumeration(_1_x, _2_x, _3_0, _3_1, _3_2, _3_3, _3_4, _3_5, _3_6, latest, experimental)
   "Defines the various modelica language versions that OMC can use.";
 
 public function typeinfo "+t"
@@ -458,15 +458,15 @@ protected function intLanguageStandard
   output LanguageStandard outStandard;
 algorithm
   outStandard := match(inValue)
-    case 10 then LanguageStandard.'1.x';
-    case 20 then LanguageStandard.'2.x';
-    case 30 then LanguageStandard.'3.0';
-    case 31 then LanguageStandard.'3.1';
-    case 32 then LanguageStandard.'3.2';
-    case 33 then LanguageStandard.'3.3';
-    case 34 then LanguageStandard.'3.4';
-    case 35 then LanguageStandard.'3.5';
-    case 36 then LanguageStandard.'3.6';
+    case 10 then LanguageStandard._1_x;
+    case 20 then LanguageStandard._2_x;
+    case 30 then LanguageStandard._3_0;
+    case 31 then LanguageStandard._3_1;
+    case 32 then LanguageStandard._3_2;
+    case 33 then LanguageStandard._3_3;
+    case 34 then LanguageStandard._3_4;
+    case 35 then LanguageStandard._3_5;
+    case 36 then LanguageStandard._3_6;
     case 1000 then LanguageStandard.latest;
     case 9999 then LanguageStandard.experimental;
   end match;
@@ -524,7 +524,7 @@ algorithm
   // If the old standard wasn't set by the user, then we consider it to have
   // changed only if the new standard is 3.0 or less. This is to avoid
   // printing a notice if the user loads e.g. MSL 3.1.
-  outHasChanged := languageStandardAtMost(LanguageStandard.'3.0');
+  outHasChanged := languageStandardAtMost(LanguageStandard._3_0);
 end hasLanguageStandardChanged;
 
 public function versionStringToStd
@@ -542,13 +542,13 @@ protected function versionStringToStd2
   output LanguageStandard outStandard;
 algorithm
   outStandard := match(inVersion)
-    case "1" :: _ then LanguageStandard.'1.x';
-    case "2" :: _ then LanguageStandard.'2.x';
-    case "3" :: "0" :: _ then LanguageStandard.'3.0';
-    case "3" :: "1" :: _ then LanguageStandard.'3.1';
-    case "3" :: _ then LanguageStandard.'3.2';
-    case "4" :: "0" :: _ then LanguageStandard.'3.4';
-    case "4" :: "1" :: _ then LanguageStandard.'3.6';
+    case "1" :: _ then LanguageStandard._1_x;
+    case "2" :: _ then LanguageStandard._2_x;
+    case "3" :: "0" :: _ then LanguageStandard._3_0;
+    case "3" :: "1" :: _ then LanguageStandard._3_1;
+    case "3" :: _ then LanguageStandard._3_2;
+    case "4" :: "0" :: _ then LanguageStandard._3_4;
+    case "4" :: "1" :: _ then LanguageStandard._3_6;
     case _ then LanguageStandard.latest;
   end match;
 end versionStringToStd2;
@@ -647,7 +647,7 @@ end replacedHomotopy;
 public function synchronousFeaturesAllowed
 "@autor: adrpo
  checks returns true if language standard is above or equal to Modelica 3.3"
-  output Boolean outRes = getLanguageStandard() >= LanguageStandard.'3.3';
+  output Boolean outRes = getLanguageStandard() >= LanguageStandard._3_3;
 end synchronousFeaturesAllowed;
 
 public function flatModelica


### PR DESCRIPTION
While the code looks nice with '3.3' as the enum literal, it is only used in this one place and really confuses AI when it sees it.