### PR TITLE
We need an arrayClearIndex

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -978,6 +978,13 @@ function arrayUpdateNoBoundsChecking<A> "O(1)"
 external "builtin";
 end arrayUpdateNoBoundsChecking;
 
+function arrayClearIndex<A> "O(1)"
+  input array<A> arr;
+  input Integer index;
+  output array<A> newArray;
+external "builtin";
+end arrayClearIndex;
+
 impure function arrayCreateNoInit<A>
   "Creates a new array where the elements are *not* initialized!. Any attempt to
    access an uninitialized elements may cause segmentation faults if you're

--- a/OMCompiler/Compiler/Util/Vector.mo
+++ b/OMCompiler/Compiler/Util/Vector.mo
@@ -233,11 +233,10 @@ public
      Does not change the capacity of the Vector."
     input Vector<T> v;
   protected
-    T null = null;
     array<T> data = Mutable.access(v.data);
     Integer sz = Mutable.access(v.size);
   algorithm
-    arrayUpdateNoBoundsChecking(data, sz, null);
+    arrayClearIndex(data, sz);
     Mutable.update(v.size, sz - 1);
   end pop;
 
@@ -246,11 +245,10 @@ public
      Does not change the capacity of the Vector."
     input Vector<T> v;
   protected
-    T null = null;
     array<T> data = Mutable.access(v.data);
   algorithm
     for i in 1:Mutable.access(v.size) loop
-      arrayUpdateNoBoundsChecking(data, i, null);
+      arrayClearIndex(data, i);
     end for;
 
     Mutable.update(v.size, 0);
@@ -264,13 +262,12 @@ public
     input Vector<T> v;
     input Integer newSize;
   protected
-    T null = null;
     array<T> data = Mutable.access(v.data);
     Integer sz = Mutable.access(v.size);
   algorithm
     if newSize < sz then
       for i in newSize:sz loop
-        arrayUpdateNoBoundsChecking(data, i, null);
+        arrayClearIndex(data, i);
       end for;
 
       Mutable.update(v.size, newSize);

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -161,6 +161,7 @@ static inline modelica_metatype arrayCreateNoInit(modelica_integer nelts, modeli
 #define arrayGetNoBoundsChecking(arr,ix) (MMC_STRUCTDATA((arr))[(ix)-1])
 #define arrayUpdate(X,Y,Z) boxptr_arrayUpdate(threadData,X,mmc_mk_icon(Y),Z)
 #define arrayUpdateNoBoundsChecking(X,Y,Z) boxptr_arrayUpdateNoBoundsChecking(threadData,X,mmc_mk_icon(Y),Z)
+#define arrayClearIndex(X,Y) boxptr_arrayUpdateNoBoundsChecking(threadData,X,mmc_mk_icon(Y),mmc_mk_icon(0))
 extern modelica_metatype arrayAppend(modelica_metatype, modelica_metatype);
 
 extern modelica_metatype boxptr_arrayGet(threadData_t *threadData,modelica_metatype,modelica_metatype);


### PR DESCRIPTION
Passing an uninitialized variable and hoping it is zero seems like a bad choice.