### PR TITLE
OMCompiler: Set relative compiler path hint

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
+++ b/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
@@ -40,8 +40,8 @@ target_link_libraries(omcfrontendcpp PUBLIC omc::simrt::runtime)
 
 target_include_directories(omcfrontendcpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(CC ${CMAKE_C_COMPILER})
-set(CXX ${CMAKE_CXX_COMPILER})
+get_filename_component(CC ${CMAKE_C_COMPILER} NAME)
+get_filename_component(CXX ${CMAKE_CXX_COMPILER} NAME)
 
 if (MSVC)
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -185,9 +185,9 @@ endif()
 
 set(host_short ${CMAKE_LIBRARY_ARCHITECTURE})
 
-set(RUNTIMECC ${CMAKE_C_COMPILER})
-set(CC ${CMAKE_C_COMPILER})
-set(CXX ${CMAKE_CXX_COMPILER})
+get_filename_component(RUNTIMECC ${CMAKE_C_COMPILER} NAME)
+get_filename_component(CC ${CMAKE_C_COMPILER} NAME)
+get_filename_component(CXX ${CMAKE_CXX_COMPILER} NAME)
 
 find_package(OpenMP)
 if(OpenMP_FOUND)


### PR DESCRIPTION
This helps making omcompiler relocatable since the base compiler toolchain location may change on conda-forge.
conda-forge provides its compiler and its location may change depending on the conda installation prefix.