### PR TITLE
OMCompiler: Bump buildproject cmake min version

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 set(FMU_NAME @FMU_NAME_IN@)
 


### PR DESCRIPTION
Silences this warning:
 `Compatibility with CMake < 3.10 will be removed from a future version of ...`
