### PR TITLE
CMake: Add macos bundle option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ omc_add_to_report(CMAKE_LIBRARY_ARCHITECTURE)
 ## OPTIONS #################################################################################################
 omc_option(OM_ENABLE_GUI_CLIENTS "Enable, build, and install the qt based GUI clients." ON)
 
+## On Conda-forge this should be disabled
+omc_option(OM_MACOS_APP_BUNDLE "Build GUI clients as application bundles on macOS" ON)
+mark_as_advanced(OM_MACOS_APP_BUNDLE)
+
 omc_option(OM_ENABLE_ENCRYPTION "Enable and build the OpenModelica Encryption support module. " OFF)
 
 ## Use ccache to speedup compilation! It is important to use ccache if you can.

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   set(app_icon_macos "")
 endif()
 
-add_executable(OMEdit WIN32 MACOSX_BUNDLE main.cpp rc_omedit.rc ${app_icon_macos})
+add_executable(OMEdit WIN32 main.cpp rc_omedit.rc ${app_icon_macos})
 target_link_libraries(OMEdit PRIVATE OMEditLib)
 
 if(APPLE)
@@ -69,7 +69,6 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
             DIRECTORIES ${MSYSTEM_PREFIX_ESCAPED}/bin ${RUNTIME_LIB_DIRS}
             PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
             POST_EXCLUDE_REGEXES ".*system32/.*\\.dll")
-else()
-  install(TARGETS OMEdit
-          BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
+else ()
+  omc_install_gui_client(OMEdit)
 endif()

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
   set(app_icon_macos "")
 endif()
 
-add_executable(OMNotebook WIN32 MACOSX_BUNDLE ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc ${app_icon_macos})
+add_executable(OMNotebook WIN32 ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc ${app_icon_macos})
 target_compile_definitions(OMNotebook PRIVATE OMNOTEBOOKLIB_MOC_INCLUDE)
 
 target_include_directories(OMNotebook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -116,13 +116,12 @@ endif ()
 target_link_libraries(OMNotebook PUBLIC OMPlotLib)
 target_link_libraries(OMNotebook PUBLIC OpenModelicaCompiler)
 
+omc_install_gui_client(OMNotebook)
 if(APPLE)
   set_target_properties(OMNotebook PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 endif()
 
 
-install(TARGETS OMNotebook
-        BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
 install(FILES stylesheet.xml
               commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/)

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -64,10 +64,8 @@ else()
   set(app_icon_macos "")
 endif()
 
-add_executable(OMPlot WIN32 MACOSX_BUNDLE main.cpp rc_omplot.rc ${app_icon_macos})
+add_executable(OMPlot WIN32 main.cpp rc_omplot.rc ${app_icon_macos})
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
 
-
 install(TARGETS OMPlotLib)
-install(TARGETS OMPlot
-        BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
+omc_install_gui_client(OMPlot)

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -27,17 +27,13 @@ else()
   set(app_icon_macos "")
 endif()
 
-add_executable(OMShell WIN32 MACOSX_BUNDLE ${OMSHELLL_SOURCES}
-                                           ${OMSHELLL_HEADERS}
-                                           ${app_icon_macos})
+add_executable(OMShell WIN32 ${OMSHELLL_SOURCES} ${OMSHELLL_HEADERS} ${app_icon_macos})
 
 target_link_libraries(OMShell PRIVATE OpenModelicaCompiler)
 target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::Xml)
 target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::Widgets)
 target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::PrintSupport)
 
-
-install(TARGETS OMShell
-        BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
+omc_install_gui_client(OMShell)
 install(FILES commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omshell)

--- a/cmake/omc_utils.cmake
+++ b/cmake/omc_utils.cmake
@@ -22,9 +22,10 @@ macro(omc_option var help_text value)
   omc_add_to_report(${var})
 endmacro(omc_option)
 
+omc_option(OM_MACOS_APP_BUNDLE "Build GUI clients as application bundles on macOS" ON)
+mark_as_advanced(OM_MACOS_APP_BUNDLE)
+
 macro(omc_install_gui_client target)
-  option(OM_MACOS_APP_BUNDLE "Build gui clients as application bundles on macos" ON)
-  mark_as_advanced(OM_MACOS_APP_BUNDLE)
   # On macOS we want BUNDLEs (.app) to go to an 'Applications/' directory instead of a 'bin/' directory
   if(APPLE AND OM_MACOS_APP_BUNDLE)
     set_target_properties(${target} PROPERTIES MACOSX_BUNDLE TRUE)

--- a/cmake/omc_utils.cmake
+++ b/cmake/omc_utils.cmake
@@ -22,9 +22,6 @@ macro(omc_option var help_text value)
   omc_add_to_report(${var})
 endmacro(omc_option)
 
-omc_option(OM_MACOS_APP_BUNDLE "Build GUI clients as application bundles on macOS" ON)
-mark_as_advanced(OM_MACOS_APP_BUNDLE)
-
 macro(omc_install_gui_client target)
   # On macOS we want BUNDLEs (.app) to go to an 'Applications/' directory instead of a 'bin/' directory
   if(APPLE AND OM_MACOS_APP_BUNDLE)

--- a/cmake/omc_utils.cmake
+++ b/cmake/omc_utils.cmake
@@ -21,3 +21,15 @@ macro(omc_option var help_text value)
   option(${var} ${help_text} ${value})
   omc_add_to_report(${var})
 endmacro(omc_option)
+
+macro(omc_install_gui_client target)
+  option(OM_MACOS_APP_BUNDLE "Build gui clients as application bundles on macos" ON)
+  mark_as_advanced(OM_MACOS_APP_BUNDLE)
+  # On macOS we want BUNDLEs (.app) to go to an 'Applications/' directory instead of a 'bin/' directory
+  if(APPLE AND OM_MACOS_APP_BUNDLE)
+    set_target_properties(${target} PROPERTIES MACOSX_BUNDLE TRUE)
+  endif ()
+  set(OM_MACOS_INSTALL_BUNDLEDIR "Applications")
+  install(TARGETS ${target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                            BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
+endmacro()


### PR DESCRIPTION
This adds a new cmake option  to decide whether gui clients are installed as application bundles.
On conda-forge we want to be able to disable that option as desktop integration is not the goal.
