### PR TITLE
CMake: Set revision from file

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -23,6 +23,7 @@ jobs:
         run: |
           export OMVERSION=`git describe --tags --match "v*.*" --always`
           echo Version: $OMVERSION
+          echo "$OMVERSION" > OMVERSION.txt
           cd ..
           ln -s ${{ github.event.repository.name }} ${{ github.event.repository.name }}-$OMVERSION
           zip ${{ github.event.repository.name }}/${{ github.event.repository.name }}-$OMVERSION-nightly.zip ${{ github.event.repository.name }}-$OMVERSION -r -x '*/.git/*'

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           export OMVERSION=`git describe --tags --match "v*.*" --always`
           echo Version: $OMVERSION
+          echo "$OMVERSION" > OMVERSION.txt
           cd ..
           ln -s ${{ github.event.repository.name }} ${{ github.event.repository.name }}-$OMVERSION
           zip ${{ github.event.repository.name }}/${{ github.event.repository.name }}-$OMVERSION-src-with-submodules.zip ${{ github.event.repository.name }}-$OMVERSION -r -x '*/.git/*'

--- a/cmake/omc_git_revision.cmake
+++ b/cmake/omc_git_revision.cmake
@@ -1,16 +1,22 @@
-## Get the revision info. The version is saved in the variable SOURCE_REVISION
-find_package(Git)
 
-if(Git_FOUND)
-  execute_process(COMMAND
-    ${GIT_EXECUTABLE} describe --match "v*.*" --always
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    OUTPUT_VARIABLE SOURCE_REVISION
-    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  set(SOURCE_REVISION "${SOURCE_REVISION}-cmake")
-else()
-  set(SOURCE_REVISION "unknown-cmake")
-endif()
+set(SOURCE_REVISION "unknown")
+
+if (EXISTS ${CMAKE_SOURCE_DIR}/OMVERSION.txt)
+  file(READ ${CMAKE_SOURCE_DIR}/OMVERSION.txt SOURCE_REVISION)
+  string(STRIP "${SOURCE_REVISION}" SOURCE_REVISION)
+else ()
+  ## Get the revision info. The version is saved in the variable SOURCE_REVISION
+  find_package(Git)
+  if(Git_FOUND)
+    execute_process(COMMAND
+      ${GIT_EXECUTABLE} describe --match "v*.*" --always
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      OUTPUT_VARIABLE SOURCE_REVISION
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+endif ()
+
+set(SOURCE_REVISION "${SOURCE_REVISION}-cmake")
 
 omc_add_to_report(SOURCE_REVISION)


### PR DESCRIPTION
### Related Issues

see #15337 

### Purpose

allows setting a proper version when building from source tarballs 

### Approach

write OMVERSION.txt at the root
