### PR TITLE
Fix compilation of SimulationRuntime/OMSICpp/runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/System/Base/SystemDefaultImplementation.cpp
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/System/Base/SystemDefaultImplementation.cpp
@@ -634,8 +634,8 @@ void SystemDefaultImplementation::storeTime(double time)
 {
     // delete up to last value < time - _delay_max
     buffer_type::iterator first = _time_buffer.begin();
-    buffer_type::iterator pos = find_if(first, _time_buffer.end(),
-                                        bind2nd(std::greater_equal<double>(),
+    buffer_type::iterator pos = boost::container::find_if(first, _time_buffer.end(),
+                                        boost::container::bind2nd(std::greater_equal<double>(),
                                                 time - _delay_max));
     if (pos != first && --pos != first)
     {
@@ -693,8 +693,8 @@ double SystemDefaultImplementation::delay(unsigned int expr_id, double expr_valu
             else
             {
                 //find posion in value buffer for queried time
-                buffer_type::iterator pos = find_if(_time_buffer.begin(), _time_buffer.end(),
-                                                    bind2nd(std::greater_equal<double>(), ts));
+                buffer_type::iterator pos = boost::container::find_if(_time_buffer.begin(), _time_buffer.end(),
+                                                    boost::container::bind2nd(std::greater_equal<double>(), ts));
 
                 if (pos != _time_buffer.end())
                 {


### PR DESCRIPTION
prepended `boost::container::` to `find_if` and `bind2nd` to avoid ambiguity error