### PR TITLE
Variable-lenght arrays error for GCC/Clang

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -68,13 +68,15 @@ target_include_directories(omc_config INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 omc_add_subdirectory(3rdParty)
 
 
-# We want to make sure include directories are handled properly by disabling implicit function
-# declaration so that we can be consistent and correct with our inclusions.
-# We do this after 3rdParty is added!! because some libs in FMILib use implicit function declaration
-# because of missing #defines due to bad configuration for now.
+# These flags are set after 3rdParty is added so they do not affect 3rdParty libraries.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  # Disallow implicit function declarations: ensures include directories are handled properly.
+  # Excluded from 3rdParty because FMILib uses implicit function declarations due to missing
+  # #defines from bad configuration.
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=incompatible-pointer-types>)
+  # VLAs are a C99/GCC extension not supported by MSVC; catching them prevents portability issues.
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=vla>)
 endif()
 
 omc_add_subdirectory(SimulationRuntime)

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
@@ -109,17 +109,20 @@ void debugeJac(OptData * optData, ipnumber* vopt){
   const int NRes = optData->dim.NRes;
   const int nReal = optData->dim.nReal;
   const int NV = optData->dim.NV;
-  ipnumber vopt_shift[NV];
-  long double h[nv][nsi][np];
+  ipnumber *vopt_shift = (ipnumber*)malloc(NV * sizeof(ipnumber));
+  long double *h = (long double*)malloc(nv * nsi * np * sizeof(long double));
+  #define H(k,i,j) h[(k)*nsi*np + (i)*np + (j)]
   long double hh;
   const modelica_real * const vmax = optData->bounds.vmax;
   const modelica_real * const vmin = optData->bounds.vmin;
   const modelica_real * vnom = optData->bounds.vnom;
-  modelica_real vv[nsi][np][nReal];
+  modelica_real *vv = (modelica_real*)malloc(nsi * np * nReal * sizeof(modelica_real));
+  #define VV(i,j,r) vv[(i)*np*nReal + (j)*nReal + (r)]
   FILE *pFile;
   char buffer[4096];
   long double *sdt;
-  modelica_real JJ[nsi][np][nv][nx];
+  modelica_real *JJ = (modelica_real*)malloc(nsi * np * nv * nx * sizeof(modelica_real));
+  #define JJM(a,b,c,d) JJ[(a)*np*nv*nx + (b)*nv*nx + (c)*nx + (d)]
   modelica_boolean **sJ;
   modelica_real tmpJ;
 
@@ -167,8 +170,8 @@ void debugeJac(OptData * optData, ipnumber* vopt){
          }
         }
         vopt_shift[jj] += hh;
-        h[k][i][j] = hh;
-        memcpy(vv[i][j] , optData->v[i][j], nReal*sizeof(modelica_real));
+        H(k,i,j) = hh;
+        memcpy(&VV(i,j,0), optData->v[i][j], nReal*sizeof(modelica_real));
       }
      }
 
@@ -179,10 +182,10 @@ void debugeJac(OptData * optData, ipnumber* vopt){
       sdt = optData->bounds.scaldt[i];
       for(j = 0; j < np; ++j){
         for(kk = 0, ii = nx; kk<nx;++kk, ++ii){
-           hh = h[k][i][j];
-           JJ[i][j][kk][k] = (optData->v[i][j][ii] - vv[i][j][ii])*sdt[kk]/hh;
+           hh = H(k,i,j);
+           JJM(i,j,kk,k) = (optData->v[i][j][ii] - VV(i,j,ii))*sdt[kk]/hh;
         }
-        memcpy(optData->v[i][j] , vv[i][j], nReal*sizeof(modelica_real));
+        memcpy(optData->v[i][j], &VV(i,j,0), nReal*sizeof(modelica_real));
       }
      }
    }
@@ -204,7 +207,7 @@ void debugeJac(OptData * optData, ipnumber* vopt){
       for(k = 0; k < nx; ++k){
         fprintf(pFile,"%s;%f;",optData->data->modelData->realVarsData[k].info.name,(float)optData->time.t[i][j]);
         for(jj = 0; jj < nv; ++jj){
-          tmpJ = (sJ[k][jj]) ? (JJ[i][j][k][jj]) : 0.0;
+          tmpJ = (sJ[k][jj]) ? (JJM(i,j,k,jj)) : 0.0;
           fprintf(pFile,"%lf;",tmpJ);
         }
         fprintf(pFile,"\n");
@@ -340,6 +343,9 @@ void debugeJac(OptData * optData, ipnumber* vopt){
 
     fclose(pFile);
   }
+
+  free(vopt_shift);
+  free(h);
+  free(vv);
+  free(JJ);
 }
-
-

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
@@ -181,8 +181,8 @@ static inline void pickUpTime(OptDataTime * time, OptDataDim * dim, DATA* data, 
   const int nsi = dim->nsi;
   const int np = dim->np;
   const int np1 = np - 1;
-  long double c[np];
-  long double dc[np];
+  long double *c = (long double*)malloc(np * sizeof(long double));
+  long double *dc = (long double*)malloc(np * sizeof(long double));
   int i, k;
   double t;
   char * cflags = NULL;
@@ -238,6 +238,9 @@ static inline void pickUpTime(OptDataTime * time, OptDataDim * dim, DATA* data, 
     overwriteTimeGridFile(time, cflags, c, np, nsi);
   if(time->model_grid)
     overwriteTimeGridModel(time, c, np, nsi);
+
+  free(c);
+  free(dc);
 }
 
 static int getNsi(char*filename, const int nsi, modelica_boolean * exTimeGrid){
@@ -268,7 +271,7 @@ static int getNsi(char*filename, const int nsi, modelica_boolean * exTimeGrid){
 
 static inline void overwriteTimeGridFile(OptDataTime * time, char* filename, long double c[], const int np, const int nsi){
   int i,k;
-  long double dc[np];
+  long double *dc = (long double*)malloc(np * sizeof(long double));
   const int np1 = np - 1;
   double t;
   FILE * pFile = NULL;
@@ -312,6 +315,7 @@ static inline void overwriteTimeGridFile(OptDataTime * time, char* filename, lon
   }
   time->tf = time->t[nsi-1][np1];
   fclose(pFile);
+  free(dc);
 }
 
 int cmp_modelica_real(const void *v1, const void *v2) {
@@ -335,7 +339,6 @@ static inline void overwriteTimeGridModel(OptDataTime * time, long double c[], c
   }
 
   free(time->tt);
-
 }
 
 /* pick up information(startTime, stopTime, dt) from model data to optimizer struct
@@ -600,7 +603,7 @@ void res2file(OptData *optData, SOLVER_INFO* solverInfo, double *vopt){
   const int nInteger = optData->data->modelData->nVariablesInteger;
   const int nRelations =  optData->data->modelData->nRelations;
   const int nvnp = nv*np;
-  long double a[np];
+  long double *a = (long double*)malloc(np * sizeof(long double));
   modelica_real *** v = optData->v;
   float tmp_u;
 
@@ -673,6 +676,7 @@ void res2file(OptData *optData, SOLVER_INFO* solverInfo, double *vopt){
     }
   }
   fclose(pFile);
+  free(a);
 }
 
 

--- a/OMCompiler/SimulationRuntime/c/optimization/eval_all/EvalF.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/eval_all/EvalF.c
@@ -56,7 +56,7 @@ Bool evalfF(ipindex n, ipnumber * vopt, Bool new_x, ipnumber *objValue, void * u
     const long double * const dt = optData->time.dt;
 
     modelica_real *** v = optData->v;
-    long double erg[np];
+    long double *erg = (long double*)malloc(np * sizeof(long double));
     int i,j;
 
     for(j = 0; j< np; ++j){
@@ -71,6 +71,7 @@ Bool evalfF(ipindex n, ipnumber * vopt, Bool new_x, ipnumber *objValue, void * u
 
     for(j = 0; j< np; ++j)
       lagrange += b[j]*erg[j];
+    free(erg);
   }
 
   if(ma){

--- a/OMCompiler/SimulationRuntime/c/optimization/eval_all/EvalG.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/eval_all/EvalG.c
@@ -81,7 +81,7 @@ Bool evalfG(ipindex n, double * vopt, Bool new_x, int m, ipnumber *g, void * use
   modelica_real ***v;
   long double a[5][5];
   long double *sdt;
-  double * vv[np+1];
+  double **vv = (double**)malloc((np+1) * sizeof(double*));
   int i, j, k, shift;
 
 
@@ -150,6 +150,7 @@ Bool evalfG(ipindex n, double * vopt, Bool new_x, int m, ipnumber *g, void * use
     const int nJ = optData->dim.nJ;
     printMaxError(g, m, nx, nJ, optData->time.t, np ,nsi ,optData->data, optData);
   }
+  free(vv);
   return TRUE;
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
@@ -284,7 +284,7 @@ static void gbInternal_evalJacobianMR(DATA* data,
   const SPARSE_PATTERN* fullSp  = fullJac->sparsePattern;
   const SPARSE_PATTERN* smallSp = nls->odePatternMR;
 
-  unsigned int* fast_idx = gbData->fastStatesIdx;
+  int* fast_idx = gbData->fastStatesIdx;
   unsigned int  size_fast = gbData->nFastStates;
 
   fullJac->evalSelection = NULL; // TODO: set evalSelection for Jacobian gbData->gbfData->jacobian->evalSelection;
@@ -337,7 +337,7 @@ static void gbInternal_evalNumericalJacobian(DATA *data,
 
   const SPARSE_PATTERN *sparsity;
   EVAL_SELECTION *selection = NULL;
-  unsigned int *state_map = NULL;
+  int *state_map = NULL;
 
   int size;
   unsigned int max_colors;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -303,7 +303,7 @@ int gbodef_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solve
   }
 
   if (OMC_ACTIVE_STREAM(OMC_LOG_GBODE_STATES)) {
-    const unsigned int bufSize = 4096;
+    enum { bufSize = 4096 };
     char filename[bufSize];
     snprintf(filename, bufSize, "%s_ActiveStates.txt", data->modelData->modelFilePrefix);
     gbfData->fastStatesDebugFile = omc_fopen(filename, "w");
@@ -536,7 +536,7 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
     }
   }
 
-  const unsigned int bufSize = 1024;
+  enum { bufSize = 1024 };
   char buffer[bufSize];
   if (gbData->multi_rate) {
     snprintf(buffer, bufSize, "%s", " and slow states interpolation");
@@ -803,7 +803,7 @@ static void updateEvalSelection(DATA* data, DATA_GBODE* gbData)
   /* debug print */
   if (OMC_ACTIVE_STREAM(OMC_LOG_GBODE_V)) {
     infoStreamPrint(OMC_LOG_GBODE_V, 1, "updateEvalSelection");
-    const unsigned int bufSize = 40960;
+    enum { bufSize = 40960 };
     char row_to_print[bufSize];
     unsigned int ct;
     ct = snprintf(row_to_print, bufSize, "%s (time=%g): =", "eqFunctions", data->localData[0]->timeValue);
@@ -839,7 +839,7 @@ static void updateEvalSelectionJacobian(DATA* data, DATA_GBODE* gbData)
   /* debug print */
   if (OMC_ACTIVE_STREAM(OMC_LOG_GBODE_V)) {
     infoStreamPrint(OMC_LOG_GBODE_V, 1, "updateEvalSelectionJacobian");
-    const unsigned int bufSize = 40960;
+    enum { bufSize = 40960 };
     char row_to_print[bufSize];
     unsigned int ct;
     ct = snprintf(row_to_print, bufSize, "%s (time=%g): =", "Jacobian eqFunctions", data->localData[0]->timeValue);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
@@ -629,7 +629,7 @@ void printVector_gb(enum OMC_LOG_STREAM stream, char name[], double* a, int n, d
 
   // This only works for number of states less than 10!
   // For large arrays, this is not a good output format!
-  const unsigned int bufSize = 40960;
+  enum { bufSize = 40960 };
   char row_to_print[bufSize];
   unsigned int ct;
   ct = snprintf(row_to_print, bufSize, "%s(%8g) =\t", name, time);
@@ -653,7 +653,7 @@ void printIntVector_gb(enum OMC_LOG_STREAM stream, char name[], int* a, int n, d
   // If stream is not active or size of vector to big do nothing
   if (!OMC_ACTIVE_STREAM(stream) || n>1000) return;
 
-  const unsigned int bufSize = 40960;
+  enum { bufSize = 40960 };
   char row_to_print[bufSize];
   unsigned int ct;
   ct = snprintf(row_to_print, bufSize, "%s(%8g) =\t", name, time);
@@ -681,7 +681,7 @@ void printVector_gbf(enum OMC_LOG_STREAM stream, char name[], double* a, int n, 
 
   // This only works for number of states less than 10!
   // For large arrays, this is not a good output format!
-  const unsigned int bufSize = 40960;
+  enum { bufSize = 40960 };
   char row_to_print[bufSize];
   unsigned int ct;
   ct = snprintf(row_to_print, bufSize, "%s(%8g) =\t", name, time);
@@ -741,7 +741,7 @@ void printSparseJacobianLocal(JACOBIAN* jacobian, const char* name)
  */
 void dumpFastStates_gb(DATA_GBODE* gbData, modelica_boolean event, double time, int rejectedType)
 {
-  const unsigned int bufSize = 4096;
+  enum { bufSize = 4096 };
   char fastStates_row[bufSize];
   unsigned int ct;
   ct = snprintf(fastStates_row, bufSize, "%15.10g %2d %15.10g %15.10g %15.10g", time, rejectedType, gbData->err_slow, gbData->err_int, gbData->err_fast);
@@ -768,7 +768,7 @@ void dumpFastStates_gb(DATA_GBODE* gbData, modelica_boolean event, double time, 
  */
 void dumpFastStates_gbf(DATA_GBODE* gbData, double time, int rejectedType)
 {
-  const unsigned int bufSize = 40960;
+  enum { bufSize = 40960 };
   char fastStates_row[bufSize];
   unsigned int ct;
   int i, ii;

--- a/OMCompiler/SimulationRuntime/c/util/utility.c
+++ b/OMCompiler/SimulationRuntime/c/util/utility.c
@@ -34,6 +34,7 @@
 #include "../simulation/options.h"
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 
 modelica_real real_int_pow(threadData_t *threadData, modelica_real base, modelica_integer n)
 {
@@ -68,20 +69,14 @@ extern int OpenModelica_regexImpl(const char* str, const char* re, const int max
   regex_t myregex;
   int nmatch=0,i,rc,res;
   int flags = (extended ? REG_EXTENDED : 0) | (ignoreCase ? REG_ICASE : 0) | (maxn ? 0 : REG_NOSUB);
-#if !defined(_MSC_VER)
-  regmatch_t matches[maxn < 1 ? 1 : maxn];
-#else
-  /* Stupid compiler */
   regmatch_t *matches;
   matches = (regmatch_t*)malloc(maxn*sizeof(regmatch_t));
   assert(matches != NULL);
-#endif
+
   memset(&myregex, 1, sizeof(regex_t));
   rc = regcomp(&myregex, re, flags);
   if (rc && maxn == 0) {
-#if defined(_MSC_VER)
     free(matches);
-#endif
     return 0;
   }
   if (rc) {
@@ -95,9 +90,8 @@ extern int OpenModelica_regexImpl(const char* str, const char* re, const int max
       for (i=1; i<maxn; i++)
         outMatches[i] = mystrdup("");
     }
-#if defined(_MSC_VER)
+
     free(matches);
-#endif
     return 0;
   }
   res = regexec(&myregex, str, maxn, matches, 0);
@@ -119,9 +113,8 @@ extern int OpenModelica_regexImpl(const char* str, const char* re, const int max
   }
 
   regfree(&myregex);
-#if defined(_MSC_VER)
   free(matches);
-#endif
+
   return nmatch;
 }
 
@@ -403,4 +396,3 @@ extern void uriToFilename(threadData_t *threadData)
 {
   abort();
 }
-


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/3790

### Purpose

* VLAs are a C99/GCC feature, MSVC doesn't allow it

### Approach

* Disallow it and make it a hard error on Linux.
