### PR TITLE
Fix some compiler warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSI/base/include/uthash.h
+++ b/OMCompiler/SimulationRuntime/OMSI/base/include/uthash.h
@@ -441,16 +441,27 @@ do {                                                                            
   hashv += keylen;                                                               \
   switch ( _hj_k ) {                                                             \
      case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                          \
+     /* fallthrough */                                                           \
      case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                           \
+     /* fallthrough */                                                           \
      case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                            \
+     /* fallthrough */                                                           \
      case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                           \
+     /* fallthrough */                                                           \
      case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                           \
+     /* fallthrough */                                                           \
      case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                            \
+     /* fallthrough */                                                           \
      case 5:  _hj_j += _hj_key[4];                                               \
+     /* fallthrough */                                                           \
      case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                           \
+     /* fallthrough */                                                           \
      case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                           \
+     /* fallthrough */                                                           \
      case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                            \
+     /* fallthrough */                                                           \
      case 1:  _hj_i += _hj_key[0];                                               \
+     /* fallthrough */                                                           \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
   bkt = hashv & (num_bkts-1);                                                    \

--- a/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
+++ b/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
@@ -713,15 +713,15 @@ void solver_print_data (solver_data*    solver,
         case solver_true:
             lin_callbacks = solver->solver_callbacks;
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_A_element?"yes":"no", (void*) lin_callbacks->get_A_element);
+                    "\t\t get_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_A_element?"yes":"no", lin_callbacks->get_A_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_A_element?"yes":"no", (void*) lin_callbacks->set_A_element);
+                    "\t\t set_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_A_element?"yes":"no", lin_callbacks->set_A_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_b_element?"yes":"no", (void*) lin_callbacks->get_b_element);
+                    "\t\t get_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_b_element?"yes":"no", lin_callbacks->get_b_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_b_element?"yes":"no", (void*) lin_callbacks->set_b_element);
+                    "\t\t set_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_b_element?"yes":"no", lin_callbacks->set_b_element);
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t solve_eq_system set: \t %s \t ( Address: %p )\n", lin_callbacks->solve_eq_system?"yes":"no", (void*) lin_callbacks->solve_eq_system);
+                    "\t\t solve_eq_system set: \t %s \t ( Address: %p )\n", lin_callbacks->solve_eq_system?"yes":"no", lin_callbacks->solve_eq_system);
             break;
         default:
 

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Solver/AlgLoopSolverDefaultImplementation.cpp
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Solver/AlgLoopSolverDefaultImplementation.cpp
@@ -60,6 +60,8 @@ bool* AlgLoopSolverDefaultImplementation::getConditionsWorkArray()
         return _conditions0;
     else
         ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
+
+    return nullptr;
 }
 
 bool* AlgLoopSolverDefaultImplementation::getConditions2WorkArray()
@@ -68,6 +70,8 @@ bool* AlgLoopSolverDefaultImplementation::getConditions2WorkArray()
         return _conditions1;
     else
         ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
+
+    return nullptr;
 }
 
 
@@ -77,6 +81,8 @@ double* AlgLoopSolverDefaultImplementation::getVariableWorkArray()
         return _algloopVars;
     else
         ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
+
+    return nullptr;
 }
 
 void AlgLoopSolverDefaultImplementation::initialize(int dimZeroFunc, int dimSys)

--- a/OMPlot/qwt/src/qwt_date.cpp
+++ b/OMPlot/qwt/src/qwt_date.cpp
@@ -14,6 +14,7 @@
 #include <qlocale.h>
 
 #include <limits>
+#include <QTimeZone>
 
 #if QT_VERSION >= 0x050000
 
@@ -132,7 +133,8 @@ static inline void qwtFloorTime(
     const Qt::TimeSpec timeSpec = dt.timeSpec();
 
     if ( timeSpec == Qt::LocalTime )
-        dt = dt.toTimeSpec( Qt::UTC );
+        dt = dt.toUTC();
+
 
     const QTime t = dt.time();
     switch( intervalType )
@@ -157,7 +159,7 @@ static inline void qwtFloorTime(
     }
 
     if ( timeSpec == Qt::LocalTime )
-        dt = dt.toTimeSpec( Qt::LocalTime );
+        dt = dt.toLocalTime();
 }
 
 static inline QDateTime qwtToTimeSpec(
@@ -175,11 +177,11 @@ static inline QDateTime qwtToTimeSpec(
         // for those dates
 
         QDateTime dt2 = dt;
-        dt2.setTimeSpec( spec );
+        dt2.setTimeZone( spec == Qt::LocalTime ? QTimeZone::systemTimeZone() : QTimeZone::utc() );
         return dt2;
     }
 
-    return dt.toTimeSpec( spec );
+    return spec == Qt::LocalTime ? dt.toLocalTime() : dt.toUTC();
 }
 
 #if 0
@@ -277,7 +279,7 @@ QDateTime QwtDate::toDateTime( double value, Qt::TimeSpec timeSpec )
 
     static const QTime timeNull( 0, 0, 0, 0 );
 
-    QDateTime dt( d, timeNull.addMSecs( msecs ), Qt::UTC );
+    QDateTime dt( d, timeNull.addMSecs( msecs ), QTimeZone::utc() );
 
     if ( timeSpec == Qt::LocalTime )
         dt = qwtToTimeSpec( dt, timeSpec );
@@ -653,7 +655,7 @@ int QwtDate::utcOffset( const QDateTime& dateTime )
         }
         default:
         {
-            const QDateTime dt1( dateTime.date(), dateTime.time(), Qt::UTC );
+            const QDateTime dt1( dateTime.date(), dateTime.time(), QTimeZone::utc() );
             seconds = dateTime.secsTo( dt1 );
         }
     }

--- a/OMPlot/qwt/src/qwt_date_scale_draw.cpp
+++ b/OMPlot/qwt/src/qwt_date_scale_draw.cpp
@@ -10,6 +10,8 @@
 #include "qwt_date_scale_draw.h"
 #include "qwt_text.h"
 
+#include <QTimeZone>
+
 class QwtDateScaleDraw::PrivateData
 {
   public:
@@ -272,7 +274,9 @@ QDateTime QwtDateScaleDraw::toDateTime( double value ) const
     if ( m_data->timeSpec == Qt::OffsetFromUTC )
     {
         dt = dt.addSecs( m_data->utcOffset );
-#if QT_VERSION >= 0x050200
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        dt.setTimeZone(QTimeZone::fromSecondsAheadOfUtc( m_data->utcOffset ) );
+#elif QT_VERSION >= 0x050200
         dt.setOffsetFromUtc( m_data->utcOffset );
 #else
         dt.setUtcOffset( m_data->utcOffset );


### PR DESCRIPTION
- Add fallthrough comments to silence implicit-fallthrough warnings.
- Remove unnecessary cast of function pointers to void*.
- Add return statements to silence warnings about them missing.
- Avoid deprecated QDateTime methods.