### PR TITLE
Make static analysis of the function easier

### DIFF
--- a/OMCompiler/Compiler/Template/TplParser.mo
+++ b/OMCompiler/Compiler/Template/TplParser.mo
@@ -4572,10 +4572,10 @@ algorithm
       end if;
     end while;
   else
-    outChars := {};
-    outLineInfo := parseError({}, inLineInfo, "Not able to parse the text template expression from the point.", true);
-    outExpressionBase := TplAbsyn.ERROR_EXP();
   end try;
+  outChars := {};
+  outLineInfo := parseError({}, inLineInfo, "Not able to parse the text template expression from the point.", true);
+  outExpressionBase := TplAbsyn.ERROR_EXP();
 
 //   //<# #> or $# #$
 //   /*


### PR DESCRIPTION
The loop never breaks; only returns or gives a failure. But the analysis might not realize that.
