### PR TITLE
Fix caching issue when compiling OMC

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -175,6 +175,7 @@ protected function instantiateClass_dispatch
   input SCode.Path inPath;
   input Boolean doSCodeDep "Do SCode dependency (if the debug flag is also enabled)";
   input Boolean relaxedFrontEnd=true "Do not check for illegal simulation models, so we allow instantation of packages, etc";
+  input Boolean clearCache = true "Clear the inst cache when done";
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
@@ -220,7 +221,9 @@ algorithm
         //Debug.fcall2(Flags.CHECK_MODEL_BALANCE, checkModelBalancing, SOME(path), dae2);
 
         // let the GC collect these as they are used only by Inst!
-        InstHashTable.release();
+        if clearCache then
+          InstHashTable.release();
+        end if;
       then
         (cache,env,ih,dae2);
 
@@ -290,7 +293,9 @@ algorithm
         //print("\nSetSource+DAE: " + realString(System.getTimerIntervalTime()));
 
         // let the GC collect these as they are used only by Inst!
-        InstHashTable.release();
+        if clearCache then
+          InstHashTable.release();
+        end if;
       then
         (cache, env, ih, dae);
 
@@ -311,6 +316,7 @@ public function instantiateClass
   input SCode.Path inPath;
   input Boolean doSCodeDep=true "Do SCode dependency (if the debug flag is also enabled)";
   input Boolean relaxedFrontEnd=true "Do not check for illegal simulation models, so we allow instantation of packages, etc";
+  input Boolean clearCache=true "Clear the inst cache when done";
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
@@ -334,7 +340,7 @@ algorithm
     // instantiate a class
     case (cache,ih,cdecls as _::_,path)
       algorithm
-        (outCache,outEnv,outIH,outDAElist) := instantiateClass_dispatch(cache,ih,cdecls,path,doSCodeDep,relaxedFrontEnd);
+        (outCache,outEnv,outIH,outDAElist) := instantiateClass_dispatch(cache,ih,cdecls,path,doSCodeDep,relaxedFrontEnd,clearCache);
         outDAElist := UnitCheck.checkUnits(outDAElist,FCore.getFunctionTree(outCache));
       then
         (outCache,outEnv,outIH,outDAElist);

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -99,6 +99,7 @@ import Global;
 import Graph;
 import HashSetString;
 import Inst;
+import InstHashTable;
 import InstFunction;
 import InteractiveUtil;
 import List;
@@ -2019,6 +2020,10 @@ algorithm
         end for;
 
         cache := instantiateDaeFunctions(cache, env, paths);
+        // The inst cache is normally released by Inst.instantiateClass, but
+        // since findFunctionToCompile might need to call it many times we want
+        // to keep the cache for performance and release it here instead.
+        InstHashTable.release();
         funcs := FCore.getFunctionTree(cache);
         d := List.map2(paths, DAEUtil.getNamedFunctionWithError, funcs, info);
         (_,(_,dependencies)) := DAEUtil.traverseDAEFunctions(d,Expression.traverseSubexpressionsHelper,(matchQualifiedCalls,{}));
@@ -2085,7 +2090,7 @@ algorithm
   if not skip then
   try
     ErrorExt.setCheckpoint("getNonPartialElementsForInstantiatedClass");
-    (, env) := Inst.instantiateClass(FCore.emptyCache(), InnerOuter.emptyInstHierarchy, sp, AbsynUtil.makeNotFullyQualified(p), doSCodeDep=false);
+    (, env) := Inst.instantiateClass(FCore.emptyCache(), InnerOuter.emptyInstHierarchy, sp, AbsynUtil.makeNotFullyQualified(p), doSCodeDep=false, clearCache = false);
     elts := FCore.RefTree.fold(FNode.children(FNode.fromRef(FGraph.lastScopeRef(env))),
       addNonPartialClassRef, {});
     ErrorExt.rollBack("getNonPartialElementsForInstantiatedClass");


### PR DESCRIPTION
- Clearing the inst cache in Inst.instantiateClass causes significant performance issues when compiling packages that contain a lot of functions using extends, such as in NBackend, since it causes the whole package to be instantiated over and over. Clear it in CevalScript.generateFunctions2 when it's no longer needed instead.