### PR TITLE
Util/StringUtil: fix four long-standing source-level bugs

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -593,6 +593,47 @@ algorithm
   end matchcontinue;
 end simOptionsAsString;
 
+protected function diffSanityCheckEqual
+  "Sanity check for the Modelica source diff/merge: returns true when s1 and
+   s2 represent the same Modelica program. Code tokens are compared strictly
+   (ignoring whitespace), while comments are compared as a multiset so the
+   merge step is free to relocate them."
+  input String s1;
+  input String s2;
+  output Boolean b;
+protected
+  import LexerModelicaDiff.{Token,tokenContent,scanString,isLineComment,isBlockComment,blockCommentCanonical,modelicaDiffTokenWhitespace};
+  list<Token> ts1, ts2;
+  list<String> comments1, comments2;
+algorithm
+  (ts1, _) := scanString(s1);
+  (ts2, _) := scanString(s2);
+  if stringAppendList(list(tokenContent(t) for t guard not modelicaDiffTokenWhitespace(t) in ts1)) <>
+     stringAppendList(list(tokenContent(t) for t guard not modelicaDiffTokenWhitespace(t) in ts2)) then
+    b := false;
+    return;
+  end if;
+  comments1 := List.sort(list(diffSanityCheckCommentStr(t)
+                              for t guard isLineComment(t) or isBlockComment(t) in ts1),
+                         Util.strcmpBool);
+  comments2 := List.sort(list(diffSanityCheckCommentStr(t)
+                              for t guard isLineComment(t) or isBlockComment(t) in ts2),
+                         Util.strcmpBool);
+  b := List.isEqualOnTrue(comments1, comments2, stringEq);
+end diffSanityCheckEqual;
+
+protected function diffSanityCheckCommentStr
+  "Canonical string form of a comment token. Block comments are normalised by
+   trimming each line, so that re-indented block comments compare equal."
+  input LexerModelicaDiff.Token t;
+  output String s;
+protected
+  import LexerModelicaDiff.{tokenContent,isBlockComment,blockCommentCanonical};
+algorithm
+  s := if isBlockComment(t) then stringDelimitList(blockCommentCanonical(t), "\n")
+                            else tokenContent(t);
+end diffSanityCheckCommentStr;
+
 public function cevalInteractiveFunctions3
 "defined in the interactive environment."
   input FCore.Cache inCache;
@@ -1057,7 +1098,7 @@ algorithm
             Error.addInternalError("Failed to parse merged string (see generated file SanityCheckFail.mo)\n", sourceInfo());
             fail();
           end try;
-          if not StringUtil.equalIgnoreSpace(s3, s4) then
+          if not diffSanityCheckEqual(s3, s4) then
             System.writeFile("SanityCheckFailBefore.mo", s3);
             System.writeFile("SanityCheckFailAfter.mo", s4);
             if b then

--- a/OMCompiler/Compiler/Util/StringUtil.mo
+++ b/OMCompiler/Compiler/Util/StringUtil.mo
@@ -334,6 +334,10 @@ algorithm
       b := false;
       for j2 in j:stringLength(s2) loop
         if MetaModelica.Dangerous.stringGetNoBoundsChecking(s2, j2) <> stringCharInt(" ") then
+          if MetaModelica.Dangerous.stringGetNoBoundsChecking(s2, j2) <>
+             MetaModelica.Dangerous.stringGetNoBoundsChecking(s1, i) then
+            return;
+          end if;
           j := j2+1;
           b := true;
           break;
@@ -420,10 +424,10 @@ algorithm
     return;
   end if;
   if stringGet(s,1) == 239 and
-     stringGet(s,2) == 187 and
-     stringGet(s,3) == 191 then
-    s := substring(s, 4, stringLength(s));
+    stringGet(s,2) == 187 and
+    stringGet(s,3) == 191 then
     bom := substring(s, 1, 3);
+    s := substring(s, 4, stringLength(s));
   end if;
 end stripBOM;
 

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -341,15 +341,17 @@ end tuple62;
 public function stringContainsChar "Returns true if a string contains a specified character"
   input String str;
   input String char;
-  output Boolean res;
+  output Boolean res = false;
+protected
+  Integer ch;
 algorithm
-  res := matchcontinue()
-    case ()
-      algorithm
-        _::_::_ := stringSplitAtChar(str,char);
-      then true;
-    else false;
-  end matchcontinue;
+  ch := stringCharInt(char);
+  for i in 1:stringLength(str) loop
+    if MetaModelica.Dangerous.stringGetNoBoundsChecking(str, i) == ch then
+      res := true;
+      return;
+    end if;
+  end for;
 end stringContainsChar;
 
 public function stringDelimitListPrintBuf "
@@ -1388,11 +1390,11 @@ public function nextPowerOf2
   output Integer v;
 algorithm
   v := i - 1;
-  v := intBitOr(v, intBitLShift(v, 1));
-  v := intBitOr(v, intBitLShift(v, 2));
-  v := intBitOr(v, intBitLShift(v, 4));
-  v := intBitOr(v, intBitLShift(v, 8));
-  v := intBitOr(v, intBitLShift(v, 16));
+  v := intBitOr(v, intBitRShift(v, 1));
+  v := intBitOr(v, intBitRShift(v, 2));
+  v := intBitOr(v, intBitRShift(v, 4));
+  v := intBitOr(v, intBitRShift(v, 8));
+  v := intBitOr(v, intBitRShift(v, 16));
   v := v + 1;
 end nextPowerOf2;
 


### PR DESCRIPTION
- Util.nextPowerOf2: the fill-bits algorithm requires right shifts; intBitLShift was producing 0 / negative values for any input > 1.
- Util.stringContainsChar: relied on stringSplitAtChar producing >=2 segments, but that helper drops the trailing empty segment, so a char appearing only at the end was reported as not present. Rewrite as a direct linear scan over the string.
- StringUtil.equalIgnoreSpace: the inner loop confirmed only that s2 had another non-space character, never comparing the actual values — any two strings with matching non-space character counts compared equal. Compare codepoints when both sides land on a non-space.
- StringUtil.stripBOM: captured the BOM *after* shortening s, so it both returned the wrong bytes and aborted when the content was shorter than three bytes. Swap the order.