### PR TITLE
Fix compilation for macOS

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -691,9 +691,10 @@ int SystemImpl__systemCall(const char* str, const char* outFile)
       dup2(fd, 2);
 #if defined(__APPLE_CC__)
       /* OSX likes to not redirect the Segmentation Fault: messages unless the command is in a subshell */
-      char command[strlen(str)+3];
+      char * command = (char*) omc_alloc_interface.malloc_atomic(strlen(str)+3);
       sprintf(command, "(%s)", str);
       execl("/bin/sh", "/bin/sh", "-c", command, NULL);
+      free(command);
 #else
       execl("/bin/sh", "/bin/sh", "-c", str, NULL);
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.c
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.c
@@ -34,7 +34,9 @@
 #include "../gc/omc_gc.h"
 #include <errno.h>
 #include "omc_error.h"
+#ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000L
+#endif
 
 /* If min_time is set, subtract this amount from measured times to avoid
  * including the time of measuring in reported statistics */


### PR DESCRIPTION
- avoid variable length array
- define `NSEC_PER_SEC` only if not already defined