### PR TITLE
Support dollar idents we generate in the compiler

### DIFF
--- a/OMCompiler/Parser/BaseModelica_Lexer.g
+++ b/OMCompiler/Parser/BaseModelica_Lexer.g
@@ -429,7 +429,7 @@ T_END : 'end' EAT_WS_COMMENT?;
 IDENT : QIDENT | IDENT2;
 
 fragment
-IDENT2 : NONDIGIT (NONDIGIT | DIGIT)* | '$cpuTime';
+IDENT2 : NONDIGIT (NONDIGIT | DIGIT)* | '$cpuTime' | '$Sensitivities' | '$DER';
 
 fragment
 QIDENT :


### PR DESCRIPTION
Maybe we need more of them, but at least you can now do:

```mos
setCommandLineOptions("--calculateSensitivities"); getErrorString();
loadString("
model LotkaVolterra
  Real y1(start=2, fixed=true);
  Real y2(start=3, fixed=true);
  parameter Real p1=0.05;
  parameter Real p2=1.4;
equation
  der(y1) = p1 * y1 - y2;
  der(y2) = -p2 * y2;
end LotkaVolterra;
"); getErrorString();
simulate(LotkaVolterra, method="ida", simflags="-idaSensitivity -idaScaling", stopTime=5); getErrorString();
plot({y1, 
      y2, 
      $Sensitivities.p1.y1,
      $Sensitivities.p1.y2,
      $Sensitivities.p2.y1,
      $Sensitivities.p2.y2}); getErrorString();
```