### PR TITLE
Improve checkForDiscreteChanges Boolean print

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
@@ -119,8 +119,8 @@ modelica_boolean checkForDiscreteChanges(DATA *data, threadData_t *threadData)
         needToIterate = TRUE;
         if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
         {
-          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %d to %d",
-                          modelData->booleanVarsData[i].info.name, v1, v2);
+          infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s",
+                          modelData->booleanVarsData[i].info.name, v1 ? "true" : "false", v2 ? "true" : "false");
         }
         else
         {

--- a/testsuite/openmodelica/cruntime/debugDumps/testDumpEvents.mos
+++ b/testsuite/openmodelica/cruntime/debugDumps/testDumpEvents.mos
@@ -38,7 +38,7 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // true
 // record SimulationResult
 //     resultFile = "bbTestDump_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'bbTestDump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_EVENTS'",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'bbTestDump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_EVENTS'",
 //     messages = "LOG_EVENTS        | info    | status of relations at time=0
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -308,7 +308,7 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // end SimulationResult;
 // record SimulationResult
 //     resultFile = "bbTestDump_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'bbTestDump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_EVENTS_V'",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'bbTestDump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_EVENTS_V'",
 //     messages = "LOG_EVENTS_V      | info    | Set tolerance for zero-crossing hysteresis to: 1.000000e-10
 // LOG_EVENTS_V      | info    | check for discrete changes at time=0
 // LOG_EVENTS        | info    | status of relations at time=0
@@ -326,10 +326,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=0.451523641008
 // |                 | |       | | discrete var changed: v_new from 0 to 3.10061
 // |                 | |       | | discrete var changed: n_bounce from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=0.451523641008
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -338,8 +338,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=0.451523641008
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=0.451523641008
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -351,8 +351,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=0.451523641072
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=0.451523641072
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=0.451523641072
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -371,10 +371,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.08365673842
 // |                 | |       | | discrete var changed: v_new from 3.10061 to 2.17043
 // |                 | |       | | discrete var changed: n_bounce from 1 to 2
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=1.08365673842
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -383,8 +383,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.08365673842
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.08365673842
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -396,8 +396,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=1.08365673851
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.08365673851
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.08365673851
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -416,10 +416,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.52614990659
 // |                 | |       | | discrete var changed: v_new from 2.17043 to 1.5193
 // |                 | |       | | discrete var changed: n_bounce from 2 to 3
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=1.52614990659
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -428,8 +428,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.52614990659
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.52614990659
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -441,8 +441,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=1.52614990673
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.52614990673
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.52614990673
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -461,10 +461,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.83589512431
 // |                 | |       | | discrete var changed: v_new from 1.5193 to 1.06351
 // |                 | |       | | discrete var changed: n_bounce from 3 to 4
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=1.83589512431
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -473,8 +473,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.83589512431
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.83589512431
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -486,8 +486,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=1.8358951245
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=1.8358951245
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=1.8358951245
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -506,10 +506,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.0527167767
 // |                 | |       | | discrete var changed: v_new from 1.06351 to 0.744457
 // |                 | |       | | discrete var changed: n_bounce from 4 to 5
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.0527167767
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -518,8 +518,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.0527167767
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.0527167767
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -531,8 +531,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.05271677697
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.05271677697
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.05271677697
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -551,10 +551,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.20449193337
 // |                 | |       | | discrete var changed: v_new from 0.744457 to 0.52112
 // |                 | |       | | discrete var changed: n_bounce from 5 to 6
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.20449193337
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -563,8 +563,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.20449193337
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.20449193337
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -576,8 +576,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.20449193375
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.20449193375
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.20449193375
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -596,10 +596,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.31073454302
 // |                 | |       | | discrete var changed: v_new from 0.52112 to 0.364784
 // |                 | |       | | discrete var changed: n_bounce from 6 to 7
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.31073454302
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -608,8 +608,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.31073454302
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.31073454302
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -621,8 +621,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.31073454357
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.31073454357
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.31073454357
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -641,10 +641,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.38510436977
 // |                 | |       | | discrete var changed: v_new from 0.364784 to 0.255349
 // |                 | |       | | discrete var changed: n_bounce from 7 to 8
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.38510436977
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -653,8 +653,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.38510436977
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.38510436977
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -666,8 +666,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.38510437055
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.38510437055
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.38510437055
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -686,10 +686,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.43716324847
 // |                 | |       | | discrete var changed: v_new from 0.255349 to 0.178744
 // |                 | |       | | discrete var changed: n_bounce from 8 to 9
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.43716324847
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -698,8 +698,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.43716324847
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.43716324847
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -711,8 +711,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.43716324959
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.43716324959
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.43716324959
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -731,10 +731,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.47360446354
 // |                 | |       | | discrete var changed: v_new from 0.178744 to 0.125121
 // |                 | |       | | discrete var changed: n_bounce from 9 to 10
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.47360446354
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -743,8 +743,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.47360446354
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.47360446354
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -756,8 +756,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.47360446513
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.47360446513
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.47360446513
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -776,10 +776,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.49911331406
 // |                 | |       | | discrete var changed: v_new from 0.125121 to 0.0875846
 // |                 | |       | | discrete var changed: n_bounce from 10 to 11
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.49911331406
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -788,8 +788,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.49911331406
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.49911331406
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -801,8 +801,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.49911331634
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.49911331634
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.49911331634
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -821,10 +821,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.51696950938
 // |                 | |       | | discrete var changed: v_new from 0.0875846 to 0.0613092
 // |                 | |       | | discrete var changed: n_bounce from 11 to 12
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.51696950938
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -833,8 +833,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.51696950938
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.51696950938
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -846,8 +846,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.51696951264
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.51696951264
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.51696951264
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -866,10 +866,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.52946884606
 // |                 | |       | | discrete var changed: v_new from 0.0613092 to 0.0429165
 // |                 | |       | | discrete var changed: n_bounce from 12 to 13
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.52946884606
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -878,8 +878,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.52946884606
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.52946884606
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -891,8 +891,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.52946885072
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.52946885072
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.52946885072
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -911,10 +911,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.53821838167
 // |                 | |       | | discrete var changed: v_new from 0.0429165 to 0.0300415
 // |                 | |       | | discrete var changed: n_bounce from 13 to 14
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.53821838167
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -923,8 +923,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.53821838167
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.53821838167
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -936,8 +936,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.53821838832
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.53821838832
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.53821838832
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -956,10 +956,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.5443430565
 // |                 | |       | | discrete var changed: v_new from 0.0300415 to 0.0210291
 // |                 | |       | | discrete var changed: n_bounce from 14 to 15
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.5443430565
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -968,8 +968,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.5443430565
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.5443430565
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -981,8 +981,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.54434306601
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.54434306601
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.54434306601
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1001,10 +1001,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.54863032877
 // |                 | |       | | discrete var changed: v_new from 0.0210291 to 0.0147203
 // |                 | |       | | discrete var changed: n_bounce from 15 to 16
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.54863032877
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1013,8 +1013,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.54863032877
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.54863032877
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1026,8 +1026,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.54863034235
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.54863034235
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.54863034235
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1046,10 +1046,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55163141919
 // |                 | |       | | discrete var changed: v_new from 0.0147203 to 0.0103042
 // |                 | |       | | discrete var changed: n_bounce from 16 to 17
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55163141919
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1058,8 +1058,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55163141919
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55163141919
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1071,8 +1071,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.5516314386
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.5516314386
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.5516314386
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1091,10 +1091,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55373218227
 // |                 | |       | | discrete var changed: v_new from 0.0103042 to 0.00721297
 // |                 | |       | | discrete var changed: n_bounce from 17 to 18
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55373218227
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1103,8 +1103,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55373218227
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55373218227
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1116,8 +1116,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55373221
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55373221
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55373221
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1136,10 +1136,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55520271612
 // |                 | |       | | discrete var changed: v_new from 0.00721297 to 0.00504908
 // |                 | |       | | discrete var changed: n_bounce from 18 to 19
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55520271612
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1148,8 +1148,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55520271612
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55520271612
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1161,8 +1161,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55520275574
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55520275574
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55520275574
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1181,10 +1181,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55623208942
 // |                 | |       | | discrete var changed: v_new from 0.00504908 to 0.00353435
 // |                 | |       | | discrete var changed: n_bounce from 19 to 20
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55623208942
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1193,8 +1193,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55623208942
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55623208942
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1206,8 +1206,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55623214602
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55623214602
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55623214602
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1226,10 +1226,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55695265019
 // |                 | |       | | discrete var changed: v_new from 0.00353435 to 0.00247404
 // |                 | |       | | discrete var changed: n_bounce from 20 to 21
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55695265019
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1238,8 +1238,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55695265019
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55695265019
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1251,8 +1251,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55695273106
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55695273106
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55695273106
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1271,10 +1271,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.557457042
 // |                 | |       | | discrete var changed: v_new from 0.00247404 to 0.00173183
 // |                 | |       | | discrete var changed: n_bounce from 21 to 22
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.557457042
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1283,8 +1283,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.557457042
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.557457042
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1296,8 +1296,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55745715755
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55745715755
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55745715755
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1316,10 +1316,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55781011528
 // |                 | |       | | discrete var changed: v_new from 0.00173183 to 0.00121227
 // |                 | |       | | discrete var changed: n_bounce from 22 to 23
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55781011528
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1328,8 +1328,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55781011528
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55781011528
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1341,8 +1341,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55781028041
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55781028041
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55781028041
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1361,10 +1361,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55805726525
 // |                 | |       | | discrete var changed: v_new from 0.00121227 to 0.000848586
 // |                 | |       | | discrete var changed: n_bounce from 23 to 24
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55805726525
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1373,8 +1373,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55805726525
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55805726525
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1386,8 +1386,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55805750132
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55805750132
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55805750132
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1406,10 +1406,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55823026845
 // |                 | |       | | discrete var changed: v_new from 0.000848586 to 0.000594002
 // |                 | |       | | discrete var changed: n_bounce from 24 to 25
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55823026845
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1418,8 +1418,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55823026845
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55823026845
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1431,8 +1431,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55823060619
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55823060619
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55823060619
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1451,10 +1451,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55835136827
 // |                 | |       | | discrete var changed: v_new from 0.000594002 to 0.000415791
 // |                 | |       | | discrete var changed: n_bounce from 25 to 26
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55835136827
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1463,8 +1463,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55835136827
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55835136827
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1476,8 +1476,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55835185227
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55835185227
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55835185227
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1496,10 +1496,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55843613483
 // |                 | |       | | discrete var changed: v_new from 0.000415791 to 0.000291038
 // |                 | |       | | discrete var changed: n_bounce from 26 to 27
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55843613483
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1508,8 +1508,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55843613483
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55843613483
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1521,8 +1521,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55843683061
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55843683061
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55843683061
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1541,10 +1541,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55849546686
 // |                 | |       | | discrete var changed: v_new from 0.000291038 to 0.000203706
 // |                 | |       | | discrete var changed: n_bounce from 27 to 28
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55849546686
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1553,8 +1553,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55849546686
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55849546686
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1566,8 +1566,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55849647374
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55849647374
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55849647374
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1586,10 +1586,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55853699312
 // |                 | |       | | discrete var changed: v_new from 0.000203706 to 0.000142567
 // |                 | |       | | discrete var changed: n_bounce from 28 to 29
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55853699312
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1598,8 +1598,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55853699312
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55853699312
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1611,8 +1611,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55853847233
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55853847233
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55853847233
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1631,10 +1631,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55856605309
 // |                 | |       | | discrete var changed: v_new from 0.000142567 to 9.97582e-05
 // |                 | |       | | discrete var changed: n_bounce from 29 to 30
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55856605309
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1643,8 +1643,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55856605309
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55856605309
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1656,8 +1656,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55856831036
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55856831036
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55856831036
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1676,10 +1676,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55858638353
 // |                 | |       | | discrete var changed: v_new from 9.97582e-05 to 6.97784e-05
 // |                 | |       | | discrete var changed: n_bounce from 30 to 31
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55858638353
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1688,8 +1688,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55858638353
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55858638353
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1701,8 +1701,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS        | info    | state event at time=2.55859037025
 // |                 | |       | | [2] h <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55859037025
-// |                 | |       | | discrete var changed: $whenCondition2 from 1 to 0
-// |                 | |       | | discrete var changed: impact from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition2 from true to false
+// |                 | |       | | discrete var changed: impact from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55859037025
 // |                 | |       | | [1] (pre: false) false = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1721,10 +1721,10 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55860059936
 // |                 | |       | | discrete var changed: v_new from 6.97784e-05 to 4.87753e-05
 // |                 | |       | | discrete var changed: n_bounce from 31 to 32
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition2 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: impact from 0 to 1
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition2 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: impact from false to true
 // LOG_EVENTS_V      | info    | status of relations at time=2.55860059936
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0
@@ -1733,8 +1733,8 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // |                 | |       | | [2] (pre: -1)  1 = h <= 0.0
 // |                 | |       | | [3] (pre:  1)  1 = v <= 0.0
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55860059936
-// |                 | |       | | discrete var changed: $whenCondition1 from 1 to 0
-// |                 | |       | | discrete var changed: $whenCondition3 from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from true to false
+// |                 | |       | | discrete var changed: $whenCondition3 from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55860059936
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre: false) false = v <= 0.0
@@ -1750,9 +1750,9 @@ simulate(bbTestDump, stopTime=3.0, simflags="-lv LOG_EVENTS_V");
 // LOG_EVENTS_V      | info    | check for discrete changes at time=2.55860557137
 // |                 | |       | | discrete var changed: v_new from 4.87753e-05 to 0
 // |                 | |       | | discrete var changed: n_bounce from 32 to 33
-// |                 | |       | | discrete var changed: $whenCondition1 from 0 to 1
-// |                 | |       | | discrete var changed: $whenCondition3 from 0 to 1
-// |                 | |       | | discrete var changed: flying from 1 to 0
+// |                 | |       | | discrete var changed: $whenCondition1 from false to true
+// |                 | |       | | discrete var changed: $whenCondition3 from false to true
+// |                 | |       | | discrete var changed: flying from true to false
 // LOG_EVENTS_V      | info    | status of relations at time=2.55860557137
 // |                 | |       | | [1] (pre:  true)  true = h <= 0.0
 // |                 | |       | | [2] (pre:  true)  true = v <= 0.0


### PR DESCRIPTION
### Related Issues

Updated while working on https://github.com/OpenModelica/OpenModelica/issues/15043.

### Purpose

* Print `true` and `false` when talking about bools in `checkForDiscreteChanges`

### Approach

* Convert 0/1 to true/false in the print
