### PR TITLE
Implement more of flow alias eliminiation

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -384,6 +384,17 @@ public
     end match;
   end variability;
 
+  function setVariability
+    input Variability var;
+    input output Binding binding;
+  algorithm
+    () := match binding
+      case TYPED_BINDING() algorithm binding.variability := var; then ();
+      case FLAT_BINDING()  algorithm binding.variability := var; then ();
+      else ();
+    end match;
+  end setVariability;
+
   function purity
     input Binding binding;
     output Purity purity;
@@ -881,6 +892,19 @@ public
       else Source.BINDING;
     end match;
   end source;
+
+  function setSource
+    input Source source;
+    input output Binding binding;
+  algorithm
+    () := match binding
+      case RAW_BINDING() algorithm binding.source := source; then ();
+      case UNTYPED_BINDING() algorithm binding.source := source; then ();
+      case TYPED_BINDING() algorithm binding.source := source; then ();
+      case FLAT_BINDING() algorithm binding.source := source; then ();
+      else ();
+    end match;
+  end setSource;
 
   function makeUntyped
     input Expression exp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -2630,6 +2630,7 @@ algorithm
   end match;
 end evalBuiltinMax;
 
+public
 function evalBuiltinMax2
   input Expression exp1;
   input Expression exp2;
@@ -2650,6 +2651,7 @@ algorithm
   end match;
 end evalBuiltinMax2;
 
+protected
 function evalPositiveMax
   input Expression flow_exp;
   input Expression eps;
@@ -2687,6 +2689,7 @@ algorithm
   end match;
 end evalBuiltinMin;
 
+public
 function evalBuiltinMin2
   input Expression exp1;
   input Expression exp2;
@@ -2707,6 +2710,7 @@ algorithm
   end match;
 end evalBuiltinMin2;
 
+protected
 function evalBuiltinMod
   input list<Expression> args;
   input EvalTarget target;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4680,6 +4680,12 @@ public
     exp := CREF(ComponentRef.getSubscriptedType(cref, includeScope), cref);
   end fromCref;
 
+  function fromTypedCref
+    input ComponentRef cref;
+    input Type ty;
+    output Expression exp = CREF(ty, cref);
+  end fromTypedCref;
+
   function toCref
     input Expression exp;
     output ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2501,7 +2501,7 @@ algorithm
   flatModel.equations := listAppend(conn_eql, flatModel.equations);
 
   if not listEmpty(unhandled_stream_sets) then
-    flatModel := StreamFlowAlias.removeAliases(flatModel);
+    flatModel := StreamFlowAlias.eliminateAliases(flatModel);
   end if;
 
   // add top-level IOs for unconnected local IOs

--- a/OMCompiler/Compiler/NFFrontEnd/NFStreamFlowAlias.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStreamFlowAlias.mo
@@ -48,8 +48,18 @@ encapsulated package NFStreamFlowAlias
   import Expression = NFExpression;
   import FlatModel = NFFlatModel;
   import NFInstNode.InstNode;
+  import NFPrefixes.Variability;
   import Operator = NFOperator;
   import Type = NFType;
+
+protected
+  import Binding = NFBinding;
+  import Ceval = NFCeval;
+  import Structural = NFStructural;
+  import Variable = NFVariable;
+  import MetaModelica.Dangerous.listReverseInPlace;
+
+public
 
   extends DisjointSets(redeclare type Entry = FlowAlias);
 
@@ -57,7 +67,13 @@ encapsulated package NFStreamFlowAlias
     record FLOW_ALIAS
       ComponentRef name;
       Boolean negative;
+      Option<Variable> variable;
     end FLOW_ALIAS;
+
+    function isFlow
+      input FlowAlias alias;
+      output Boolean isFlow = Util.applyOptionOrDefault(alias.variable, Variable.isFlow, false);
+    end isFlow;
   end FlowAlias;
 
   redeclare function extends EntryHash
@@ -67,8 +83,9 @@ encapsulated package NFStreamFlowAlias
 
   redeclare function extends EntryEqual
   algorithm
-    isEqual := entry1.negative == entry2.negative and
-               ComponentRef.isEqual(entry1.name, entry2.name);
+    // Only compare the names, not the signs, since an alias and its negative
+    // can't belong to different sets.
+    isEqual := ComponentRef.isEqual(entry1.name, entry2.name);
   end EntryEqual;
 
   redeclare function extends EntryString
@@ -79,21 +96,70 @@ encapsulated package NFStreamFlowAlias
     end if;
   end EntryString;
 
+  function eliminateAliases
+    "Performs alias eliminiation for flow variables defined in stream connectors."
+    input output FlatModel flatModel;
+  protected
+    Sets sets;
+    UnorderedMap<ComponentRef, Expression> replacements;
+    list<tuple<FlowAlias, list<FlowAlias>>> aliases;
+  algorithm
+    (flatModel, sets) := fromModel(flatModel);
+    (flatModel, aliases) := createAliases(sets, flatModel);
+    replacements := buildReplacements(aliases);
+    flatModel := applyReplacements(replacements, flatModel);
+  end eliminateAliases;
+
   function fromModel
+    "Returns the alias sets and equations found in the given model,
+     removing the alias equations from the model in the process."
     input output FlatModel flatModel;
     output Sets sets;
-    output list<Equation> aliasEqs;
   protected
-    list<Equation> other_eqs;
+    list<Equation> alias_eqs, other_eqs;
     list<list<FlowAlias>> flow_aliases;
+    list<Variable> vars = {};
+    Option<FlowAlias> opt_alias;
+    FlowAlias alias;
   algorithm
     sets := emptySets(0);
-    (aliasEqs, flow_aliases, other_eqs) := sortEquations(flatModel.equations);
+
+    // Find alias equations and add them to the alias sets.
+    (alias_eqs, flow_aliases, other_eqs) := sortEquations(flatModel.equations);
     flatModel.equations := other_eqs;
-    sets := List.threadFold(flow_aliases, aliasEqs, addAliasEquation, sets);
+    sets := List.threadFold(flow_aliases, alias_eqs, addAliasEquation, sets);
+
+    // Find alias binding equations and add them to the alias sets.
+    sets := List.fold(flatModel.variables, addAliasBinding, sets);
+
+    // Update the aliases with which Variable they're associated with.
+    for v in flatModel.variables loop
+      alias := FlowAlias.FLOW_ALIAS(v.name, false, NONE());
+      opt_alias := getEntry(alias, sets);
+
+      if isSome(opt_alias) then
+        SOME(alias) := opt_alias;
+        alias.variable := SOME(v);
+        UnorderedMap.updateKey(alias, sets.elements);
+      else
+        vars := v :: vars;
+      end if;
+    end for;
+
+    // Sanity check, all aliases should have an associated Variable now.
+    for alias in UnorderedMap.keyList(sets.elements) loop
+      if isNone(alias.variable) then
+        Error.addInternalError(getInstanceName() + ": " + ComponentRef.toString(alias.name) +
+          " has no associated variable", sourceInfo());
+      end if;
+    end for;
+
+    flatModel.variables := MetaModelica.Dangerous.listReverseInPlace(vars);
   end fromModel;
 
   function sortEquations
+    "Sorts a list of equations into alias equations and non-alias equations,
+     and also returns the aliases found in each alias equation."
     input list<Equation> eqs;
     output list<Equation> aliasEqs = {};
     output list<list<FlowAlias>> flowAliases = {};
@@ -122,6 +188,7 @@ encapsulated package NFStreamFlowAlias
   end sortEquations;
 
   function addAliasEquation
+    "Adds an alias equation to the sets."
     input list<FlowAlias> aliases;
     input Equation eq;
     input output Sets sets;
@@ -140,7 +207,29 @@ encapsulated package NFStreamFlowAlias
     end if;
   end addAliasEquation;
 
+  function addAliasBinding
+    "Adds a variable's binding equation to the sets if var = binding qualifies
+     as an alias equation."
+    input Variable var;
+    input output Sets sets;
+  protected
+    Expression bind_exp;
+    list<FlowAlias> aliases;
+    FlowAlias alias1, alias2;
+  algorithm
+    if Binding.hasExp(var.binding) then
+      bind_exp := Binding.getExp(var.binding);
+      aliases := getAliasVarsFromExpPair(Expression.fromTypedCref(var.name, var.ty), bind_exp);
+
+      if not listEmpty(aliases) then
+        {alias1, alias2} := aliases;
+        sets := addAliasPair(alias1, alias2, sets);
+      end if;
+    end if;
+  end addAliasBinding;
+
   function addAliasPair
+    "Adds the alias equation alias1 = alias2 to the sets."
     input FlowAlias alias1;
     input FlowAlias alias2;
     input output Sets sets;
@@ -149,23 +238,19 @@ encapsulated package NFStreamFlowAlias
     Boolean flipped_sign1, flipped_sign2;
 
     function find_set
-      "Returns the set that the alias or its negative belongs to."
+      "Returns the set that the alias or its negative belongs to,
+       as well as if it was the alias or its negative that was found."
       input FlowAlias alias;
             output Integer set;
       input output Sets sets;
             output Boolean flippedSign;
     protected
       FlowAlias negative_alias = alias;
+      FlowAlias entry;
     algorithm
-      negative_alias.negative := not negative_alias.negative;
-
-      if contains(negative_alias, sets) then
-        (set, sets) := findSet(negative_alias, sets);
-        flippedSign := true;
-      else
-        (set, sets) := findSet(alias, sets);
-        flippedSign := false;
-      end if;
+      (set, sets) := findSet(alias, sets);
+      SOME(entry) := getEntry(alias, sets);
+      flippedSign := entry.negative <> alias.negative;
     end find_set;
   algorithm
     // Find the sets the aliases or their negatives belong to.
@@ -175,6 +260,7 @@ encapsulated package NFStreamFlowAlias
     // If the negative of exactly one of the aliases was found, then all the
     // aliases in one of the sets need to be negated before merging the sets.
     if flipped_sign1 <> flipped_sign2 then
+      // TODO: If one of them got added as a new set, then we only need to flip that one.
       root1 := findRoot(set1, sets.nodes);
       root2 := findRoot(set2, sets.nodes);
 
@@ -199,18 +285,30 @@ encapsulated package NFStreamFlowAlias
     output list<FlowAlias> aliases = {};
   algorithm
     aliases := match eq
-      case Equation.EQUALITY()
-        algorithm
-          aliases := getAliasVarsFromExp(eq.lhs, eq.rhs, aliases);
-          aliases := getAliasVarsFromExp(eq.rhs, eq.lhs, aliases);
-        then
-          if listLength(aliases) == 2 and List.any(aliases, isStreamConnectorFlow) then aliases else {};
-
+      case Equation.EQUALITY() then getAliasVarsFromExpPair(eq.lhs, eq.rhs);
       else {};
     end match;
   end getAliasVarsFromEq;
 
+  function getAliasVarsFromExpPair
+    "Returns the alias variables found in the given expressions if exp1 = exp2
+     qualifies as an alias equation."
+    input Expression exp1;
+    input Expression exp2;
+    output list<FlowAlias> aliases;
+  algorithm
+    aliases := getAliasVarsFromExp(exp1, exp2, {});
+    aliases := getAliasVarsFromExp(exp2, exp1, aliases);
+
+    if listLength(aliases) <> 2 or List.none(aliases, isStreamConnectorFlow) then
+      aliases := {};
+    end if;
+  end getAliasVarsFromExpPair;
+
   function getAliasVarsFromExp
+    "Returns the alias variables for one side of an equation, with the other
+     side being used to check for e.g. zero equality but not contributing to
+     the list of aliases."
     input Expression exp;
     input Expression otherExp;
     input output list<FlowAlias> aliases;
@@ -220,8 +318,10 @@ encapsulated package NFStreamFlowAlias
     FlowAlias alias1, alias2;
   algorithm
     aliases := match exp
-      case Expression.CREF() then FlowAlias.FLOW_ALIAS(exp.cref, false) :: aliases;
-      case Expression.UNARY(exp = e as Expression.CREF()) then FlowAlias.FLOW_ALIAS(e.cref, true) :: aliases;
+      // a
+      case Expression.CREF() then FlowAlias.FLOW_ALIAS(exp.cref, false, NONE()) :: aliases;
+      // -a
+      case Expression.UNARY(exp = e as Expression.CREF()) then FlowAlias.FLOW_ALIAS(e.cref, true, NONE()) :: aliases;
 
       // a + b = 0 => a = -b;
       case Expression.BINARY(operator = Operator.OPERATOR(op = NFOperator.Op.ADD))
@@ -278,7 +378,7 @@ encapsulated package NFStreamFlowAlias
     crefs := MetaModelica.Dangerous.listReverseInPlace(crefs);
 
     for cr in crefs loop
-      scalarAliases := FLOW_ALIAS(cr, alias.negative) :: scalarAliases;
+      scalarAliases := FLOW_ALIAS(cr, alias.negative, NONE()) :: scalarAliases;
     end for;
   end scalarizeAlias;
 
@@ -306,34 +406,59 @@ encapsulated package NFStreamFlowAlias
     end for;
   end negateSet;
 
-  function removeAliases
+  function createAliases
+    "Extracts the alias sets and defines the representatives and their aliases."
+    input Sets sets;
     input output FlatModel flatModel;
+          output list<tuple<FlowAlias, list<FlowAlias>>> aliases = {};
   protected
-    Sets sets;
-    list<Equation> flow_eqs;
-    UnorderedMap<ComponentRef, Expression> replacements;
-    array<list<FlowAlias>> alias_sets;
+    array<list<FlowAlias>> extracted_sets;
+    FlowAlias representative;
+    Variable repr_var;
+    list<FlowAlias> rest_aliases, accum_aliases = {};
+    Binding repr_binding;
+    list<Variable> alias_vars = {};
+    list<Equation> alias_eqs = {};
   algorithm
-    (flatModel, sets, flow_eqs) := fromModel(flatModel);
-    replacements := buildReplacements(sets);
-    flatModel := applyReplacements(replacements, flatModel);
-    flatModel.equations := listAppend(flatModel.equations, flow_eqs);
-  end removeAliases;
+    extracted_sets := extractSets(sets);
+
+    for set in extracted_sets loop
+      // Define the representative for the alias set.
+      (representative, rest_aliases) := defineRepresentative(set);
+      SOME(repr_var) := representative.variable;
+      alias_vars := repr_var :: alias_vars;
+
+      // Create a '= representative' binding for the aliases, to show which
+      // variable they're aliases of.
+      repr_binding := Variable.asBinding(repr_var);
+
+      // Define the rest of the set as aliases of the representative.
+      for alias in rest_aliases loop
+        (alias, alias_eqs) := defineAlias(alias, repr_binding, alias_eqs);
+        alias_vars := Util.getOption(alias.variable) :: alias_vars;
+      end for;
+
+      aliases := (representative, rest_aliases) :: aliases;
+    end for;
+
+    aliases := listReverseInPlace(aliases);
+    flatModel.variables := listAppend(flatModel.variables, listReverseInPlace(alias_vars));
+    flatModel.equations := listAppend(flatModel.equations, listReverseInPlace(alias_eqs));
+  end createAliases;
 
   function buildReplacements
-    input Sets sets;
+    "Constructs an alias->representative map."
+    input list<tuple<FlowAlias, list<FlowAlias>>> aliases;
     output UnorderedMap<ComponentRef, Expression> replacements;
   protected
     FlowAlias representative;
     Expression exp, negative_exp;
     list<FlowAlias> rest_aliases;
-    array<list<FlowAlias>> extracted_sets;
   algorithm
     replacements := UnorderedMap.new<Expression>(ComponentRef.hash, ComponentRef.isEqual);
-    extracted_sets := extractSets(sets);
 
-    for set in extracted_sets loop
-      representative :: rest_aliases := set;
+    for set in aliases loop
+      (representative, rest_aliases) := set;
       exp := Expression.fromCref(representative.name);
       exp := if representative.negative then Expression.negate(exp) else exp;
       negative_exp := Expression.negate(exp);
@@ -345,6 +470,7 @@ encapsulated package NFStreamFlowAlias
   end buildReplacements;
 
   function applyReplacements
+    "Replaces aliases with the chosen representative variable in the model."
     input UnorderedMap<ComponentRef, Expression> replacements;
     input output FlatModel flatModel;
   algorithm
@@ -368,6 +494,206 @@ encapsulated package NFStreamFlowAlias
       else exp;
     end match;
   end applyReplacementsInExp;
+
+  function defineRepresentative
+    "Defines a representative for an alias set, by choosing one of the aliases
+     as the representative and determining the start/nominal/min/max attributes
+     for it."
+    input list<FlowAlias> aliases;
+    output FlowAlias representative;
+    output list<FlowAlias> restAliases;
+  protected
+    list<Binding> start_values = {}, nominal_values = {};
+    list<Expression> min_values = {}, max_values = {};
+    list<FlowAlias> accum_aliases = {};
+    Expression min_value, max_value;
+    Binding start_binding, nominal_binding, min_binding, max_binding;
+  algorithm
+    // Evaluate the start/nominal/min/max attributes of the aliases and sort them into lists.
+    for alias in aliases loop
+      (alias, start_values, nominal_values, min_values, max_values) :=
+        evalAliasAttributes(alias, start_values, nominal_values, min_values, max_values);
+      accum_aliases := alias :: accum_aliases;
+    end for;
+
+    // Select any flow variable in the set as the representative.
+    (representative, restAliases) := List.findAndRemove(aliases, FlowAlias.isFlow);
+
+    // Compute start/nominal/min/max attributes for the representative.
+    // start/nominal is chosen according to 8.6.2
+    start_binding := if listEmpty(start_values) then NFBinding.EMPTY_BINDING else listHead(start_values);
+    nominal_binding := if listEmpty(nominal_values) then NFBinding.EMPTY_BINDING else listHead(nominal_values);
+    // min/max is max(min_values) and min(max_values) respectively.
+    min_binding := computeLimit(min_values, Ceval.evalBuiltinMax2);
+    max_binding := computeLimit(max_values, Ceval.evalBuiltinMin2);
+
+    // Update the representative with the new attributes.
+    representative := setRepresentativeAttributes(representative, start_binding, nominal_binding,
+                                                  min_binding, max_binding);
+  end defineRepresentative;
+
+  function computeLimit
+    "Computes a min or max value for a representative, depending on the reduce function."
+    input list<Expression> values;
+    input ReduceFn reduceFn;
+    output Binding limit;
+  protected
+    partial function ReduceFn
+      input Expression exp1;
+      input Expression exp2;
+      output Expression result;
+    end ReduceFn;
+
+    Expression res;
+  algorithm
+    if listEmpty(values) then
+      limit := NFBinding.EMPTY_BINDING;
+    else
+      res := List.reduce(values, reduceFn);
+      limit := Binding.makeFlat(res, Variability.CONSTANT, NFBinding.Source.GENERATED);
+    end if;
+  end computeLimit;
+
+  function defineAlias
+    input output FlowAlias alias;
+    input Binding binding;
+    input output list<Equation> equations;
+  protected
+    Variable var;
+    Expression var_exp, bind_exp;
+    Equation bind_eq;
+  algorithm
+    SOME(var) := alias.variable;
+
+    // Move the variable's binding to an equation if it has one.
+    if Binding.isBound(var.binding) then
+      var_exp := Expression.fromTypedCref(var.name, var.ty);
+      bind_exp := Binding.getExp(var.binding);
+      bind_eq := Equation.makeEquality(var_exp, bind_exp, var.ty);
+      equations := bind_eq :: equations;
+    end if;
+
+    // Replace the variable's binding with the given representative binding and
+    // mark it as an alias with a comment.
+    var.binding := binding;
+    var.comment := SCode.Comment.COMMENT(var.comment.annotation_, SOME("Alias variable"));
+    alias.variable := SOME(var);
+  end defineAlias;
+
+  function evalAliasAttributes
+    "Evaluates the start, nominal, min, and max attributes for an alias and
+     appends them to the given lists if they're present.
+
+     Start/nominal values are returned as bindings since we need to know where
+     they come from, while for min/max we only need the values."
+    input output FlowAlias alias;
+    input output list<Binding> startValues;
+    input output list<Binding> nominalValues;
+    input output list<Expression> minValues;
+    input output list<Expression> maxValues;
+  protected
+    Variable var;
+    list<tuple<String, Binding>> attrs, accum_attrs = {};
+    String attr_name;
+    Binding attr_binding;
+    Expression attr_exp;
+  algorithm
+    SOME(var) := alias.variable;
+    attrs := var.typeAttributes;
+
+    for attr in attrs loop
+      (attr_name, attr_binding) := attr;
+
+      if Binding.hasExp(attr_binding) then
+        attr := match attr_name
+          case "start"
+            algorithm
+              attr_binding := evalAliasAttribute(attr_binding);
+              startValues := attr_binding :: startValues;
+            then
+              (attr_name, attr_binding);
+
+          case "nominal"
+            algorithm
+              attr_binding := evalAliasAttribute(attr_binding);
+              nominalValues := attr_binding :: nominalValues;
+            then
+              (attr_name, attr_binding);
+
+          case "min"
+            algorithm
+              (attr_binding, attr_exp) := evalAliasAttribute(attr_binding);
+              minValues := attr_exp :: minValues;
+            then
+              (attr_name, attr_binding);
+
+          case "max"
+            algorithm
+              (attr_binding, attr_exp) := evalAliasAttribute(attr_binding);
+              maxValues := attr_exp :: maxValues;
+            then
+              (attr_name, attr_binding);
+
+          else attr;
+        end match;
+      end if;
+
+      accum_attrs := attr :: accum_attrs;
+    end for;
+
+    attrs := listReverseInPlace(attrs);
+    var.typeAttributes := attrs;
+    alias.variable := SOME(var);
+  end evalAliasAttributes;
+
+  function evalAliasAttribute
+    "Helper function to evalAliasAttributes, evaluates an attribute's binding."
+    input output Binding binding;
+          output Expression bindingExp;
+  algorithm
+    bindingExp := Binding.getExp(binding);
+    Structural.markExp(bindingExp);
+    bindingExp := Ceval.evalExp(bindingExp);
+    binding := Binding.setExp(bindingExp, binding);
+  end evalAliasAttribute;
+
+  function setRepresentativeAttributes
+    "Sets the start, nominal, min, and max attributes for an alias set representative."
+    input output FlowAlias alias;
+    input Binding startValue;
+    input Binding nominalValue;
+    input Binding minValue;
+    input Binding maxValue;
+  protected
+    Variable var;
+    list<tuple<String, Binding>> attrs = {};
+    String attr_name;
+
+    function add_attribute
+      input String name;
+      input Binding binding;
+      input output list<tuple<String, Binding>> attrs;
+    algorithm
+      if Binding.isBound(binding) then
+        attrs := (name, binding) :: attrs;
+      end if;
+    end add_attribute;
+  algorithm
+    SOME(var) := alias.variable;
+
+    // Remove any existing attributes.
+    attrs := list(attr for attr guard not listMember(Util.tuple21(attr),
+                  {"start", "nominal", "min", "max"}) in var.typeAttributes);
+
+    // Add the new attributes if they have a binding.
+    attrs := add_attribute("max", maxValue, attrs);
+    attrs := add_attribute("min", minValue, attrs);
+    attrs := add_attribute("nominal", nominalValue, attrs);
+    attrs := add_attribute("start", startValue, attrs);
+
+    var.typeAttributes := attrs;
+    alias.variable := SOME(var);
+  end setRepresentativeAttributes;
 
 annotation(__OpenModelica_Interface="nf_frontend");
 end NFStreamFlowAlias;

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -752,6 +752,13 @@ public
     output Option<Expression> nominal = VariableAttributes.getNominal(getVariableAttributes(var));
   end getNominal;
 
+  function asBinding
+    input Variable var;
+    input Binding.Source source = NFBinding.Source.GENERATED;
+    output Binding binding;
+  algorithm
+    binding := Binding.FLAT_BINDING(Expression.fromTypedCref(var.name, var.ty), variability(var), source);
+  end asBinding;
 
   annotation(__OpenModelica_Interface="nf_frontend");
 end NFVariable;

--- a/OMCompiler/Compiler/Util/DisjointSets.mo
+++ b/OMCompiler/Compiler/Util/DisjointSets.mo
@@ -213,6 +213,14 @@ algorithm
   found := isSome(UnorderedMap.get(entry, sets.elements));
 end contains;
 
+function getEntry
+  input Entry entry;
+  input Sets sets;
+  output Option<Entry> outEntry;
+algorithm
+  outEntry := UnorderedMap.getKey(entry, sets.elements);
+end getEntry;
+
 function find
   "This function finds and returns the node associated with a given entry.
    If the entry does not a have a node in the forest, then a new node will be

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -4408,7 +4408,7 @@ public function deleteMemberOnTrue<T, VT>
   occurence of the value in the list for which the function returns true. It
   returns the new list and the deleted element, or only the original list if
   no element was removed.
-    Example: deleteMemberOnTrue({1,2,3,2},2,intEq) => {1,3,2}"
+    Example: deleteMemberOnTrue(2,{1,2,3,2},intEq) => ({1,3,2}, SOME(2))"
   input VT inValue;
   input list<T> inList;
   input CompareFunc inCompareFunc;

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -442,6 +442,16 @@ public
     outKey := if index > 0 then SOME(Vector.getNoBounds(map.keys, index)) else NONE();
   end getKey;
 
+  function updateKey
+    "Updates an existing key by replacing it with a new value.
+     This can be used to update properties of the key that does not affect its
+     hash or equivalence relation. Will fail if the key doesn't exist in the map."
+    input K key;
+    input UnorderedMap<K, V> map;
+  algorithm
+    Vector.update(map.keys, find(key, map), key);
+  end updateKey;
+
   function contains
     "Returns whether the given key exists in the map or not."
     input K key;

--- a/testsuite/openmodelica/basemodelica/FlowAlias1.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias1.mos
@@ -1,0 +1,41 @@
+// name: FlowAlias1
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test1); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test1'
+//   model 'Test1'
+//     Real 'pump.outlet.p';
+//     Real 'pump.outlet.h';
+//     parameter Real 'pump.T' = 20.0;
+//     Real 'pump.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'tank.port.w';
+//     Real 'pump.outlet.w' = 'tank.port.w' \"Alias variable\";
+//     Real 'pump.w' = 'tank.port.w' \"Alias variable\";
+//   equation
+//     'pump.outlet.p' = 'tank.port.p';
+//     'pump.outlet.h' = 4200.0 * 'pump.T';
+//     'pump.P' = if 'tank.port.w' > 0.0 then 'tank.port.w' * ('pump.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then 'pump.outlet.h' else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     'tank.port.w' = sin(time);
+//   end 'Test1';
+// end 'Test1';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias2.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias2.mos
@@ -1,0 +1,56 @@
+// name: FlowAlias2
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test2); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test2'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test2'
+//     Real 'source1.outlet.p';
+//     Real 'source1.outlet.h';
+//     parameter Real 'source1.T' = 30.0;
+//     Real 'source2.outlet.p';
+//     Real 'source2.outlet.h';
+//     parameter Real 'source2.T' = 30.0;
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'source1.outlet.w';
+//     parameter Real 'source1.w' = 'source1.outlet.w' \"Alias variable\" annotation(Evaluate = true);
+//     Real 'source2.outlet.w';
+//     parameter Real 'source2.w' = 'source2.outlet.w' \"Alias variable\" annotation(Evaluate = true);
+//   equation
+//     'source2.outlet.p' = 'tank.port.p';
+//     'source2.outlet.p' = 'source1.outlet.p';
+//     'tank.port.w' + 'source2.outlet.w' + 'source1.outlet.w' = 0.0;
+//     'source1.outlet.h' = 4200.0 * 'source1.T';
+//     'source2.outlet.h' = 4200.0 * 'source2.T';
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'source1.outlet.w', 1e-7) * 'source1.outlet.h' + '$OMC$PositiveMax'(-'source2.outlet.w', 1e-7) * 'source2.outlet.h') / ('$OMC$PositiveMax'(-'source1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'source2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'source1.outlet.w' = 1.0;
+//     -'source2.outlet.w' = 2.0;
+//   end 'Test2';
+// end 'Test2';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias3.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias3.mos
@@ -1,0 +1,56 @@
+// name: FlowAlias3
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test3); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test3'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test3'
+//     Real 'source1.outlet.p';
+//     Real 'source1.outlet.h';
+//     parameter Real 'source1.T' = 30.0;
+//     Real 'source2.outlet.p';
+//     Real 'source2.outlet.h';
+//     parameter Real 'source2.T' = 30.0;
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'source1.outlet.w';
+//     parameter Real 'source1.w' = 'source1.outlet.w' \"Alias variable\" annotation(Evaluate = true);
+//     Real 'source2.outlet.w';
+//     parameter Real 'source2.w' = 'source2.outlet.w' \"Alias variable\" annotation(Evaluate = true);
+//   equation
+//     'source2.outlet.p' = 'tank.port.p';
+//     'source2.outlet.p' = 'source1.outlet.p';
+//     'tank.port.w' + 'source2.outlet.w' + 'source1.outlet.w' = 0.0;
+//     'source1.outlet.h' = 4200.0 * 'source1.T';
+//     'source2.outlet.h' = 4200.0 * 'source2.T';
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'source1.outlet.w', 1e-7) * 'source1.outlet.h' + '$OMC$PositiveMax'(-'source2.outlet.w', 1e-7) * 'source2.outlet.h') / ('$OMC$PositiveMax'(-'source1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'source2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'source1.outlet.w' = 1.0;
+//     -'source2.outlet.w' = 0.0;
+//   end 'Test3';
+// end 'Test3';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias4.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias4.mos
@@ -1,0 +1,60 @@
+// name: FlowAlias4
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test4); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test4'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test4'
+//     Real 'pump.outlet.p';
+//     Real 'pump.outlet.h';
+//     parameter Real 'pump.T' = 20.0;
+//     Real 'pump.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'sensor.port.p';
+//     Real 'sensor.port.w'(min = 0.0);
+//     Real 'sensor.port.h';
+//     Real 'sensor.h';
+//     Real 'sensor.T';
+//     Real 'pump.outlet.w';
+//     Real 'pump.w' = 'pump.outlet.w' \"Alias variable\";
+//   equation
+//     'sensor.port.p' = 'tank.port.p';
+//     'sensor.port.p' = 'pump.outlet.p';
+//     'sensor.port.w' + 'tank.port.w' + 'pump.outlet.w' = 0.0;
+//     'pump.outlet.h' = 4200.0 * 'pump.T';
+//     'pump.P' = if (-'pump.outlet.w') > 0.0 then (-'pump.outlet.w') * ('pump.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then 'pump.outlet.h' else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     'sensor.port.w' = 0.0;
+//     'sensor.port.h' = 0.0;
+//     'sensor.h' = ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) * 'pump.outlet.h' + '$OMC$PositiveMax'(-'tank.port.w', 1e-7) * 'tank.port.h') / ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'tank.port.w', 1e-7));
+//     'sensor.h' = 4200.0 * 'sensor.T';
+//     -'pump.outlet.w' = sin(time);
+//   end 'Test4';
+// end 'Test4';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias5.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias5.mos
@@ -1,0 +1,65 @@
+// name: FlowAlias5
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test5); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test5'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test5'
+//     Real 'pump.outlet.p';
+//     Real 'pump.outlet.h';
+//     parameter Real 'pump.T' = 20.0;
+//     Real 'pump.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'wrapper.port.p';
+//     Real 'wrapper.port.h';
+//     Real 'wrapper.sensor.port.p';
+//     Real 'wrapper.sensor.port.h';
+//     Real 'wrapper.sensor.h';
+//     Real 'wrapper.sensor.T';
+//     Real 'wrapper.T' = 'wrapper.sensor.T';
+//     Real 'wrapper.sensor.port.w'(min = 0.0);
+//     Real 'wrapper.port.w' = 'wrapper.sensor.port.w' \"Alias variable\";
+//     Real 'pump.outlet.w';
+//     Real 'pump.w' = 'pump.outlet.w' \"Alias variable\";
+//   equation
+//     'wrapper.port.p' = 'wrapper.sensor.port.p';
+//     'wrapper.port.p' = 'tank.port.p';
+//     'wrapper.port.p' = 'pump.outlet.p';
+//     'wrapper.sensor.port.w' + 'tank.port.w' + 'pump.outlet.w' = 0.0;
+//     'pump.outlet.h' = 4200.0 * 'pump.T';
+//     'pump.P' = if (-'pump.outlet.w') > 0.0 then (-'pump.outlet.w') * ('pump.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) * 'pump.outlet.h' + '$OMC$PositiveMax'(-'wrapper.port.w', 1e-7) * 'wrapper.port.h') / ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'wrapper.port.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     'wrapper.sensor.port.w' = 0.0;
+//     'wrapper.sensor.port.h' = 0.0;
+//     'wrapper.sensor.h' = ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) * 'pump.outlet.h' + '$OMC$PositiveMax'(-'tank.port.w', 1e-7) * 'tank.port.h') / ('$OMC$PositiveMax'(-'pump.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'tank.port.w', 1e-7));
+//     'wrapper.sensor.h' = 4200.0 * 'wrapper.sensor.T';
+//     -'pump.outlet.w' = sin(time);
+//   end 'Test5';
+// end 'Test5';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias6.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias6.mos
@@ -1,0 +1,60 @@
+// name: FlowAlias6
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test6); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test6'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test6'
+//     Real 'pump1.outlet.p';
+//     Real 'pump1.outlet.h';
+//     parameter Real 'pump1.T' = 20.0;
+//     Real 'pump1.P';
+//     Real 'pump2.outlet.p';
+//     Real 'pump2.outlet.h';
+//     parameter Real 'pump2.T' = 20.0;
+//     Real 'pump2.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'pump1.outlet.w'(min = 0.0);
+//     Real 'pump1.w'(min = 0.0) = 'pump1.outlet.w' \"Alias variable\";
+//     Real 'pump2.outlet.w'(min = 0.0);
+//     Real 'pump2.w'(min = 0.0) = 'pump2.outlet.w' \"Alias variable\";
+//   equation
+//     'pump2.outlet.p' = 'tank.port.p';
+//     'pump2.outlet.p' = 'pump1.outlet.p';
+//     'tank.port.w' + 'pump2.outlet.w' + 'pump1.outlet.w' = 0.0;
+//     'pump1.outlet.h' = 4200.0 * 'pump1.T';
+//     'pump1.P' = if (-'pump1.outlet.w') > 0.0 then (-'pump1.outlet.w') * ('pump1.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     'pump2.outlet.h' = 4200.0 * 'pump2.T';
+//     'pump2.P' = if (-'pump2.outlet.w') > 0.0 then (-'pump2.outlet.w') * ('pump2.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) * 'pump1.outlet.h' + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7) * 'pump2.outlet.h') / ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'pump1.outlet.w' = max(1.0 - time, 0.0);
+//     -'pump2.outlet.w' = max(1.0 - 2.0 * time, 0.0);
+//   end 'Test6';
+// end 'Test6';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias7.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias7.mos
@@ -1,0 +1,60 @@
+// name: FlowAlias7
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test7); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test7'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test7'
+//     Real 'pump1.outlet.p';
+//     Real 'pump1.outlet.h';
+//     parameter Real 'pump1.T' = 20.0;
+//     Real 'pump1.P';
+//     Real 'pump2.outlet.p';
+//     Real 'pump2.outlet.h';
+//     parameter Real 'pump2.T' = 20.0;
+//     Real 'pump2.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'pump1.outlet.w'(min = 0.0);
+//     Real 'pump1.w'(min = 0.0) = 'pump1.outlet.w' \"Alias variable\";
+//     Real 'pump2.outlet.w'(min = 0.1);
+//     Real 'pump2.w'(min = 0.1) = 'pump2.outlet.w' \"Alias variable\";
+//   equation
+//     'pump2.outlet.p' = 'tank.port.p';
+//     'pump2.outlet.p' = 'pump1.outlet.p';
+//     'tank.port.w' + 'pump2.outlet.w' + 'pump1.outlet.w' = 0.0;
+//     'pump1.outlet.h' = 4200.0 * 'pump1.T';
+//     'pump1.P' = if (-'pump1.outlet.w') > 0.0 then (-'pump1.outlet.w') * ('pump1.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     'pump2.outlet.h' = 4200.0 * 'pump2.T';
+//     'pump2.P' = if (-'pump2.outlet.w') > 0.0 then (-'pump2.outlet.w') * ('pump2.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) * 'pump1.outlet.h' + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7) * 'pump2.outlet.h') / ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'pump1.outlet.w' = max(1.0 - time, 0.0);
+//     -'pump2.outlet.w' = max(1.0 - 2.0 * time, 0.1);
+//   end 'Test7';
+// end 'Test7';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias8.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias8.mos
@@ -1,0 +1,60 @@
+// name: FlowAlias8
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test8); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test8'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test8'
+//     Real 'pump1.outlet.p';
+//     Real 'pump1.outlet.h';
+//     parameter Real 'pump1.T' = 20.0;
+//     Real 'pump1.P';
+//     Real 'pump2.outlet.p';
+//     Real 'pump2.outlet.h';
+//     parameter Real 'pump2.T' = 20.0;
+//     Real 'pump2.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'pump1.outlet.w'(min = 0.0);
+//     Real 'pump1.w'(min = 0.0) = 'pump1.outlet.w' \"Alias variable\";
+//     Real 'pump2.outlet.w';
+//     Real 'pump2.w' = 'pump2.outlet.w' \"Alias variable\";
+//   equation
+//     'pump2.outlet.p' = 'tank.port.p';
+//     'pump2.outlet.p' = 'pump1.outlet.p';
+//     'tank.port.w' + 'pump2.outlet.w' + 'pump1.outlet.w' = 0.0;
+//     'pump1.outlet.h' = 4200.0 * 'pump1.T';
+//     'pump1.P' = if (-'pump1.outlet.w') > 0.0 then (-'pump1.outlet.w') * ('pump1.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     'pump2.outlet.h' = 4200.0 * 'pump2.T';
+//     'pump2.P' = if (-'pump2.outlet.w') > 0.0 then (-'pump2.outlet.w') * ('pump2.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) * 'pump1.outlet.h' + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7) * 'pump2.outlet.h') / ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'pump1.outlet.w' = max(1.0 - time, 0.0);
+//     -'pump2.outlet.w' = 0.1;
+//   end 'Test8';
+// end 'Test8';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/FlowAlias9.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias9.mos
@@ -1,0 +1,60 @@
+// name: FlowAlias9
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(TestAliasStream.Test9); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test9'
+//   function '$OMC$PositiveMax'
+//     input Real 'flowValue';
+//     input Real 'eps';
+//     output Real 'positiveMax';
+//   algorithm
+//     'positiveMax' := max('flowValue', 'eps');
+//   end '$OMC$PositiveMax';
+//
+//   model 'Test9'
+//     Real 'pump1.outlet.p';
+//     Real 'pump1.outlet.h';
+//     parameter Real 'pump1.T' = 20.0;
+//     Real 'pump1.P';
+//     Real 'pump2.outlet.p';
+//     Real 'pump2.outlet.h';
+//     parameter Real 'pump2.T' = 20.0;
+//     Real 'pump2.P';
+//     Real 'tank.port.p';
+//     Real 'tank.port.w';
+//     Real 'tank.port.h';
+//     parameter Real 'tank.A' = 0.001;
+//     Real 'tank.y'(fixed = true, start = 1.0);
+//     Real 'tank.T'(fixed = true, start = 20.0);
+//     Real 'pump1.outlet.w'(min = 0.0);
+//     Real 'pump1.w'(min = 0.0) = 'pump1.outlet.w' \"Alias variable\";
+//     Real 'pump2.outlet.w';
+//     Real 'pump2.w' = 'pump2.outlet.w' \"Alias variable\";
+//   equation
+//     'pump2.outlet.p' = 'tank.port.p';
+//     'pump2.outlet.p' = 'pump1.outlet.p';
+//     'tank.port.w' + 'pump2.outlet.w' + 'pump1.outlet.w' = 0.0;
+//     'pump1.outlet.h' = 4200.0 * 'pump1.T';
+//     'pump1.P' = if (-'pump1.outlet.w') > 0.0 then (-'pump1.outlet.w') * ('pump1.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     'pump2.outlet.h' = 4200.0 * 'pump2.T';
+//     'pump2.P' = if (-'pump2.outlet.w') > 0.0 then (-'pump2.outlet.w') * ('pump2.outlet.p' - 1e5) / 1000.0 else 0.0;
+//     1000.0 * 'tank.A' * der('tank.y') = 'tank.port.w';
+//     1000.0 * 'tank.A' * 4200.0 * der('tank.y' * 'tank.T') = smooth(0, 'tank.port.w' * (if 'tank.port.w' > 0.0 then ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) * 'pump1.outlet.h' + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7) * 'pump2.outlet.h') / ('$OMC$PositiveMax'(-'pump1.outlet.w', 1e-7) + '$OMC$PositiveMax'(-'pump2.outlet.w', 1e-7)) else 'tank.port.h'));
+//     'tank.port.h' = 4200.0 * 'tank.T';
+//     'tank.port.p' = 1e5 + 9810.0 * 'tank.y';
+//     -'pump1.outlet.w' = max(1.0 - time, 0.0);
+//     -'pump2.outlet.w' = sin(time);
+//   end 'Test9';
+// end 'Test9';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -17,6 +17,15 @@ TESTFILES = \
 	Enum1.mo \
 	EnumArraySubscript1.mo \
 	Expression1.mo \
+	FlowAlias1.mos \
+	FlowAlias2.mos \
+	FlowAlias3.mos \
+	FlowAlias4.mos \
+	FlowAlias5.mos \
+	FlowAlias6.mos \
+	FlowAlias7.mos \
+	FlowAlias8.mos \
+	FlowAlias9.mos \
 	Functional1.mo \
 	If1.mo \
 	If2.mo \

--- a/testsuite/openmodelica/basemodelica/TestAliasStream.mo
+++ b/testsuite/openmodelica/basemodelica/TestAliasStream.mo
@@ -1,0 +1,137 @@
+package TestAliasStream
+  constant Real c = 4200;
+  constant Real rho = 1000;
+  constant Real p_atm = 1e5;
+  constant Real g = 9.81;
+
+  connector FluidPort
+    Real p;
+    flow Real w;
+    stream Real h;
+  end FluidPort;
+
+  model Pump
+    FluidPort outlet;
+    parameter Real T = 20;
+    input Real w;
+    Real P;
+  equation
+    outlet.w = -w;
+    outlet.h = c*T;
+    P = if w > 0 then w*(outlet.p - p_atm)/rho else 0;
+  end Pump;
+
+  model FixedFlowSource
+    FluidPort outlet;
+    parameter Real w annotation(Evaluate = true);
+    parameter Real T = 30;
+  equation
+    outlet.w = -w;
+    outlet.h = c*T;
+  end FixedFlowSource;
+
+  model Tank
+    FluidPort port;
+    parameter Real A = 1e-3;
+    Real y(start = 1, fixed = true);
+    Real T(start = 20, fixed = true);
+  equation
+    rho*A*der(y) = port.w;
+    rho*A*c*der(y*T) = port.w*actualStream(port.h);
+    port.h = c*T;
+    port.p = p_atm + rho*g*y;
+  end Tank;
+
+  model TemperatureSensor
+    FluidPort port(w(min = 0));
+    Real h;
+    output Real T;
+  equation
+    port.w = 0;
+    port.h = 0;
+    h = inStream(port.h);
+    h = c*T;
+  end TemperatureSensor;
+
+  model TemperatureSensorWrapper
+    FluidPort port;
+    TemperatureSensor sensor;
+    Real T = sensor.T;
+  equation
+    connect(port, sensor.port);
+  end TemperatureSensorWrapper;
+
+  model Test1
+    Pump pump(w = sin(time));
+    Tank tank;
+  equation
+    connect(pump.outlet, tank.port);
+  end Test1;
+
+  model Test2
+    FixedFlowSource source1(w = 1);
+    FixedFlowSource source2(w = 2);
+    Tank tank;
+  equation
+    connect(source1.outlet, tank.port);
+    connect(source2.outlet, tank.port);
+  end Test2;
+
+  model Test3
+    extends Test2(source2(w = 0));
+  end Test3;
+
+  model Test4
+    Pump pump(w = sin(time));
+    Tank tank;
+    TemperatureSensor sensor;
+  equation
+    connect(pump.outlet, tank.port);
+    connect(sensor.port, tank.port);
+  end Test4;
+
+  model Test5
+    Pump pump(w = sin(time));
+    Tank tank;
+    TemperatureSensorWrapper wrapper;
+  equation
+    connect(pump.outlet, tank.port);
+    connect(wrapper.port, tank.port);
+  end Test5;
+
+  model Test6
+    Pump pump1(w(min = 0)=max(1 - time, 0));
+    Pump pump2(w(min = 0)=max(1 - 2*time, 0));
+    Tank tank;
+  equation
+    connect(pump1.outlet, tank.port);
+    connect(pump2.outlet, tank.port);
+  end Test6;
+
+  model Test7
+    Pump pump1(w(min = 0)=max(1 - time, 0));
+    Pump pump2(w(min = 0.1)=max(1 - 2*time, 0.1));
+    Tank tank;
+  equation
+    connect(pump1.outlet, tank.port);
+    connect(pump2.outlet, tank.port);
+  end Test7;
+
+  model Test8
+    Pump pump1(w(min = 0) = max(1 - time, 0));
+    Pump pump2(w = 0.1);
+    Tank tank;
+  equation
+    connect(pump1.outlet, tank.port);
+    connect(pump2.outlet, tank.port);
+  end Test8;
+
+  model Test9
+    Pump pump1(w(min = 0) = max(1 - time, 0));
+    Pump pump2(w = sin(time));
+    Tank tank;
+  equation
+    connect(pump1.outlet, tank.port);
+    connect(pump2.outlet, tank.port);
+  end Test9;
+end TestAliasStream;


### PR DESCRIPTION
- Don't compare signs when looking up aliases in the sets to avoid having to check if an alias already exists before looking it up.
- Define aliases as variables rather than equations, and generally improve how representatives and their aliases are defined.