### PR TITLE
Fix handling of positional only function slots

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1109,9 +1109,9 @@ uniontype Function
       // If we have too many positional arguments it can't possibly match.
       matching := false;
       return;
-    elseif pos_arg_count == slot_count and listEmpty(namedArgs) then
-      // If we have exactly as many positional arguments as slots and no named
-      // arguments we can just return the list of arguments as it is.
+    elseif pos_arg_count == slot_count and listEmpty(namedArgs) and List.all(slots, Slot.positional) then
+      // If we have exactly as many positional arguments as slots, no named arguments, and all slots
+      // accept positional arguments, then we can just return the list of arguments as it is.
       matching := true;
       return;
     end if;

--- a/testsuite/flattening/modelica/scodeinst/FuncStringInvalid2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncStringInvalid2.mo
@@ -7,12 +7,12 @@
 //
 
 model FuncStringInvalid2
-  String s = String(1, false, 3);
+  String s = String(1, 3, false);
 end FuncStringInvalid2;
 
 // Result:
 // Error processing file: FuncStringInvalid2.mo
-// [flattening/modelica/scodeinst/FuncStringInvalid2.mo:10:3-10:33:writable] Error: No matching function found for String(/*Integer*/ 1, /*Boolean*/ false, /*Integer*/ 3).
+// [flattening/modelica/scodeinst/FuncStringInvalid2.mo:10:3-10:33:writable] Error: No matching function found for String(/*Integer*/ 1, /*Integer*/ 3, /*Boolean*/ false).
 // Candidates are:
 //   String(enumeration(:) $e, Integer minimumLength = 0, Boolean leftJustified = true) => String
 //   String(Integer $i, Integer minimumLength = 0, Boolean leftJustified = true) => String


### PR DESCRIPTION
- Check that all slots accept positional arguments before returning early from `Function.fillArgs`.
- Fix the test case for calling String with only positional argument so that it fails for the right reason and not because the arguments are in the wrong order.

Fixes #15628
