### PR TITLE
Remove VLA from systemimpl MSYS case

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -75,10 +75,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clan
   # #defines from bad configuration.
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=incompatible-pointer-types>)
-if (NOT WIN32) # this doesn't seem to work with msys2/ucrt64 clang 22.1.4, it fails to compile systemimpl.c
   # VLAs are a C99/GCC extension not supported by MSVC; catching them prevents portability issues.
   add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=vla>)
-endif()
 endif()
 
 omc_add_subdirectory(SimulationRuntime)

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -1332,9 +1332,11 @@ static int file_select_moc(direntry entry)
 int setenv(const char* envname, const char* envvalue, int overwrite)
 {
   int res;
-  char *temp = (char*)omc_alloc_interface.malloc_atomic(strlen(envname)+strlen(envvalue)+2);
-  sprintf(temp,"%s=%s", envname, envvalue);
+  int len = strlen(envname)+strlen(envvalue)+2;
+  char *temp = (char*)malloc(len);
+  snprintf(temp, len, "%s=%s", envname, envvalue);
   res = _putenv(temp);
+  free(temp);
   return res;
 }
 #endif
@@ -2592,17 +2594,14 @@ void SystemImpl__gettextInit(const char *locale)
   int omlen;
 #if defined(__MINGW32__)
   if (*locale) {
-    char environment[strlen(locale)+9];
-    strcpy(environment, "LANGUAGE=");
-    putenv(strcat(environment, locale));
+    setenv("LANGUAGE", locale, 1);
   } else {
     LCID userLocaleId = GetUserDefaultLCID();
     int localeBufferSize = GetLocaleInfo(userLocaleId, LOCALE_SISO639LANGNAME, NULL, 0);
-    char userLocaleStr[localeBufferSize];
+    char *userLocaleStr = (char*)malloc(localeBufferSize);
     GetLocaleInfo(userLocaleId, LOCALE_SISO639LANGNAME, userLocaleStr, localeBufferSize);
-    char environment[localeBufferSize+9];
-    strcpy(environment, "LANGUAGE=");
-    putenv(strcat(environment, userLocaleStr));
+    setenv("LANGUAGE", userLocaleStr, 1);
+    free(userLocaleStr);
   }
 #else
   /* We might get sent sv_SE when only sv_SE.utf8 exists, etc */


### PR DESCRIPTION
### Related Issues

Removing left over variable length arrays (VLA) in systemimp and fixing buffer overflow.

### Purpose

* Remove VLA
* Re-add `-Werror=vla` flag for MSYS case

### Approach

* Fixing buffer overflow (`\0` not accounted in first branch)
* Use `setenv`
* `putenv_` doesn't take ownership of string, free `tmp` directly.
* Using `snprintf` is better practice

