### PR TITLE
Run include-what-you-use on FrontEndCpp

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.cpp
@@ -33,8 +33,11 @@
  *
  */
 
-#include "Util.h"
+#include <ostream>
+
+#include "Absyn/Statement.h"
 #include "Algorithm.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.h
@@ -36,6 +36,9 @@
 #ifndef ABSYN_ALGORITHM_H
 #define ABSYN_ALGORITHM_H
 
+#include <iosfwd>
+#include <vector>
+
 #include "MetaModelica.h"
 #include "Statement.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.cpp
@@ -35,7 +35,9 @@
 
 #include <ostream>
 
+#include "Absyn/Modifier.h"
 #include "Annotation.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.h
@@ -36,8 +36,8 @@
 #ifndef ABSYN_ANNOTATION_H
 #define ABSYN_ANNOTATION_H
 
-#include <string_view>
 #include <iosfwd>
+#include <string_view>
 
 #include "MetaModelica.h"
 #include "Modifier.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.cpp
@@ -34,9 +34,16 @@
  */
 
 #include <ostream>
+#include <string_view>
+#include <utility>
 
-#include "ElementVisitor.h"
+#include "Absyn/ClassDef.h"
+#include "Absyn/Comment.h"
+#include "Absyn/Element.h"
+#include "Absyn/ElementPrefixes.h"
 #include "Class.h"
+#include "ElementVisitor.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.h
@@ -36,14 +36,18 @@
 #ifndef ABSYN_CLASS_H
 #define ABSYN_CLASS_H
 
+#include <iosfwd>
+#include <memory>
 #include <string>
 
-#include "MetaModelica.h"
-#include "Element.h"
-#include "ElementPrefixes.h"
-#include "Restriction.h"
 #include "ClassDef.h"
 #include "Comment.h"
+#include "Element.h"
+#include "ElementPrefixes.h"
+#include "MetaModelica.h"
+#include "Prefixes.h"
+#include "Restriction.h"
+#include "SourceInfo.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.cpp
@@ -34,14 +34,20 @@
  */
 
 #include <ostream>
+#include <stdexcept>
 
-#include "Util.h"
-#include "Class.h"
-#include "ExternalDecl.h"
-#include "Equation.h"
+#include "Absyn/Comment.h"
+#include "Absyn/ElementAttributes.h"
+#include "Absyn/Modifier.h"
+#include "Absyn/TypeSpec.h"
 #include "Algorithm.h"
-#include "Element.h"
+#include "Class.h"
 #include "ClassDef.h"
+#include "Element.h"
+#include "Equation.h"
+#include "ExternalDecl.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 constexpr int PARTS = 0;
 constexpr int CLASS_EXTENDS = 1;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.h
@@ -36,24 +36,27 @@
 #ifndef ABSYN_CLASSDEF_H
 #define ABSYN_CLASSDEF_H
 
-#include <memory>
-#include <vector>
 #include <iosfwd>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include "MetaModelica.h"
-#include "TypeSpec.h"
-#include "Element.h"
-#include "Modifier.h"
-#include "ElementAttributes.h"
+#include "Absyn/Algorithm.h"
+#include "Absyn/Equation.h"
 #include "Comment.h"
+#include "Element.h"
+#include "ElementAttributes.h"
+#include "MetaModelica.h"
+#include "Modifier.h"
+#include "Path.h"
+#include "TypeSpec.h"
 #include "Util/IndirectForwardIterator.h"
 
 namespace OpenModelica::Absyn
 {
   class Class;
   class ExternalDecl;
-  class Equation;
-  class Algorithm;
   struct ClassDefVisitor;
 
   class ClassDef

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.cpp
@@ -34,8 +34,12 @@
  */
 
 #include <ostream>
+#include <utility>
 
+#include "Absyn/Annotation.h"
+#include "Absyn/Modifier.h"
 #include "Comment.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.h
@@ -36,11 +36,13 @@
 #ifndef ABSYN_COMMENT_H
 #define ABSYN_COMMENT_H
 
-#include <optional>
 #include <iosfwd>
+#include <optional>
+#include <string>
+#include <string_view>
 
-#include "MetaModelica.h"
 #include "Annotation.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.cpp
@@ -35,9 +35,17 @@
 
 #include <ostream>
 
+#include "Absyn/Comment.h"
+#include "Absyn/Element.h"
+#include "Absyn/ElementAttributes.h"
+#include "Absyn/ElementPrefixes.h"
+#include "Absyn/Subscript.h"
+#include "Absyn/TypeSpec.h"
+#include "Component.h"
 #include "ElementVisitor.h"
 #include "Expression.h"
-#include "Component.h"
+#include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.h
@@ -36,16 +36,20 @@
 #ifndef ABSYN_COMPONENT_H
 #define ABSYN_COMPONENT_H
 
-#include <string>
+#include <iosfwd>
+#include <memory>
 #include <optional>
+#include <string>
 
-#include "MetaModelica.h"
-#include "Element.h"
-#include "ElementPrefixes.h"
-#include "ElementAttributes.h"
-#include "TypeSpec.h"
+#include "Absyn/Modifier.h"
 #include "Comment.h"
+#include "Element.h"
+#include "ElementAttributes.h"
+#include "ElementPrefixes.h"
 #include "Expression.h"
+#include "MetaModelica.h"
+#include "Prefixes.h"
+#include "TypeSpec.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.cpp
@@ -33,12 +33,13 @@
  *
  */
 
-#include <sstream>
 #include <ostream>
+#include <stdexcept>
 
-#include "Util.h"
-#include "Subscript.h"
 #include "ComponentRef.h"
+#include "Subscript.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.h
@@ -36,17 +36,16 @@
 #ifndef ABSYN_COMPONENTREF_H
 #define ABSYN_COMPONENTREF_H
 
+#include <iosfwd>
 #include <string>
 #include <utility>
 #include <vector>
-#include <iosfwd>
 
 #include "MetaModelica.h"
+#include "Subscript.h"
 
 namespace OpenModelica::Absyn
 {
-  class Subscript;
-
   class ComponentRef
   {
     public:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.cpp
@@ -35,7 +35,10 @@
 
 #include <ostream>
 
+#include "Absyn/Comment.h"
+#include "Absyn/Modifier.h"
 #include "ConstrainingClass.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.h
@@ -38,10 +38,10 @@
 
 #include <iosfwd>
 
-#include "MetaModelica.h"
-#include "Path.h"
-#include "Modifier.h"
 #include "Comment.h"
+#include "MetaModelica.h"
+#include "Modifier.h"
+#include "Path.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.cpp
@@ -35,8 +35,12 @@
 
 #include <ostream>
 
-#include "ElementVisitor.h"
+#include "Absyn/Element.h"
 #include "DefineUnit.h"
+#include "ElementVisitor.h"
+#include "Prefixes.h"
+#include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.h
@@ -36,9 +36,14 @@
 #ifndef ABSYN_DEFINEUNIT_H
 #define ABSYN_DEFINEUNIT_H
 
-#include "MetaModelica.h"
-#include "Element.h"
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <string>
+
 #include "../Prefixes.h"
+#include "Element.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.cpp
@@ -33,14 +33,15 @@
  *
  */
 
-#include <ostream>
+#include <stdexcept>
+#include <utility>
 
-#include "Import.h"
-#include "Extends.h"
 #include "Class.h"
 #include "Component.h"
 #include "DefineUnit.h"
 #include "Element.h"
+#include "Extends.h"
+#include "Import.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.h
@@ -36,12 +36,12 @@
 #ifndef ABSYN_ELEMENT_H
 #define ABSYN_ELEMENT_H
 
-#include <memory>
 #include <iosfwd>
+#include <memory>
 
 #include "MetaModelica.h"
-#include "SourceInfo.h"
 #include "Prefixes.h"
+#include "SourceInfo.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.cpp
@@ -34,8 +34,11 @@
  */
 
 #include <ostream>
+#include <string_view>
 
+#include "Absyn/Subscript.h"
 #include "ElementAttributes.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.h
@@ -36,8 +36,8 @@
 #ifndef ABSYN_ELEMENTATTRIBUTES_H
 #define ABSYN_ELEMENTATTRIBUTES_H
 
-#include <vector>
 #include <iosfwd>
+#include <vector>
 
 #include "MetaModelica.h"
 #include "Prefixes.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.cpp
@@ -34,8 +34,11 @@
  */
 
 #include <ostream>
+#include <string_view>
 
+#include "Absyn/ConstrainingClass.h"
 #include "ElementPrefixes.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.h
@@ -38,9 +38,9 @@
 
 #include <iosfwd>
 
-#include "Prefixes.h"
 #include "ConstrainingClass.h"
 #include "MetaModelica.h"
+#include "Prefixes.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementVisitor.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementVisitor.cpp
@@ -33,6 +33,11 @@
  *
  */
 
+#include "Absyn/Class.h"
+#include "Absyn/Component.h"
+#include "Absyn/DefineUnit.h"
+#include "Absyn/Extends.h"
+#include "Absyn/Import.h"
 #include "ElementVisitor.h"
 
 using namespace OpenModelica;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementVisitor.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementVisitor.h
@@ -36,6 +36,7 @@
 #ifndef ELEMENTVISITOR_H
 #define ELEMENTVISITOR_H
 
+#include "Absyn/Element.h"
 #include "Class.h"
 #include "Component.h"
 #include "DefineUnit.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.cpp
@@ -35,9 +35,13 @@
 
 #include <cassert>
 #include <ostream>
+#include <stdexcept>
 
-#include "Util.h"
+#include "Absyn/Comment.h"
+#include "Absyn/ComponentRef.h"
+#include "Absyn/Expression.h"
 #include "Equation.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.h
@@ -36,13 +36,17 @@
 #ifndef ABSYN_EQUATION_H
 #define ABSYN_EQUATION_H
 
+#include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <iosfwd>
+#include <utility>
+#include <vector>
 
-#include "Expression.h"
 #include "Comment.h"
+#include "Expression.h"
+#include "MetaModelica.h"
 #include "SourceInfo.h"
 
 namespace OpenModelica::Absyn

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.cpp
@@ -34,13 +34,34 @@
  */
 
 #include <ostream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
 
-#include "Util.h"
-#include "Subscript.h"
+#include "Absyn/ComponentRef.h"
+#include "Absyn/FunctionArgs.h"
+#include "Absyn/Operator.h"
 #include "Expression.h"
+#include "Subscript.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+class SubscriptedExp : public Expression::Base
+{
+  public:
+    explicit SubscriptedExp(MetaModelica::Record value);
+
+    std::unique_ptr<Base> clone() const noexcept override;
+    MetaModelica::Value toAbsyn() const noexcept override;
+    void print(std::ostream &os) const noexcept override;
+
+  private:
+    Expression _exp;
+    std::vector<Subscript> _subscripts;
+};
 
 constexpr int INTEGER = 0;
 constexpr int REAL = 1;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
@@ -47,12 +47,9 @@
 #include "FunctionArgs.h"
 #include "MetaModelica.h"
 #include "Operator.h"
-#include "Path.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class Subscript;
 
   class Expression
   {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
@@ -36,17 +36,19 @@
 #ifndef ABSYN_EXPRESSION_H
 #define ABSYN_EXPRESSION_H
 
-#include <memory>
 #include <cstdint>
+#include <iosfwd>
+#include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-#include <iosfwd>
 
-#include "MetaModelica.h"
 #include "ComponentRef.h"
+#include "FunctionArgs.h"
+#include "MetaModelica.h"
 #include "Operator.h"
 #include "Path.h"
-#include "FunctionArgs.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
@@ -356,20 +358,6 @@ namespace OpenModelica::Absyn
     private:
       //std::unique_ptr<CodeNode> _code;
       MetaModelica::Value _value;
-  };
-
-  class SubscriptedExp : public Expression::Base
-  {
-    public:
-      explicit SubscriptedExp(MetaModelica::Record value);
-
-      std::unique_ptr<Base> clone() const noexcept override;
-      MetaModelica::Value toAbsyn() const noexcept override;
-      void print(std::ostream &os) const noexcept override;
-
-    private:
-      Expression _exp;
-      std::vector<Subscript> _subscripts;
   };
 
   class Break : public Expression::Base

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.cpp
@@ -34,9 +34,15 @@
  */
 
 #include <ostream>
+#include <string_view>
 
+#include "Absyn/Annotation.h"
+#include "Absyn/Element.h"
+#include "Absyn/Modifier.h"
 #include "ElementVisitor.h"
 #include "Extends.h"
+#include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.h
@@ -36,12 +36,15 @@
 #ifndef ABSYN_EXTENDS_H
 #define ABSYN_EXTENDS_H
 
-#include "MetaModelica.h"
+#include <iosfwd>
+#include <memory>
+
+#include "Annotation.h"
 #include "Element.h"
+#include "MetaModelica.h"
+#include "Modifier.h"
 #include "Path.h"
 #include "Prefixes.h"
-#include "Modifier.h"
-#include "Annotation.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.cpp
@@ -35,10 +35,12 @@
 
 #include <ostream>
 
-#include "Util.h"
+#include "Absyn/Annotation.h"
+#include "Absyn/ComponentRef.h"
 #include "Expression.h"
 #include "ExternalDecl.h"
-#include "Subscript.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
@@ -37,7 +37,6 @@
 #define ABSYN_EXTERNALDECL_H
 
 #include <iosfwd>
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -46,11 +45,9 @@
 #include "Annotation.h"
 #include "ComponentRef.h"
 #include "MetaModelica.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class Expression;
 
   class ExternalDecl
   {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
@@ -36,15 +36,17 @@
 #ifndef ABSYN_EXTERNALDECL_H
 #define ABSYN_EXTERNALDECL_H
 
-#include <string>
-#include <optional>
-#include <vector>
-#include <memory>
 #include <iosfwd>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
-#include "MetaModelica.h"
+#include "Absyn/Expression.h"
 #include "Annotation.h"
 #include "ComponentRef.h"
+#include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.cpp
@@ -33,11 +33,9 @@
  *
  */
 
-#include <ostream>
-
-#include "FunctionArgsList.h"
-#include "FunctionArgsIter.h"
 #include "FunctionArgs.h"
+#include "FunctionArgsIter.h"
+#include "FunctionArgsList.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
@@ -40,12 +40,9 @@
 #include <memory>
 
 #include "MetaModelica.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class Expression;
-
   class FunctionArgs
   {
     public:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
@@ -36,10 +36,11 @@
 #ifndef ABSYN_FUNCTIONARGS_H
 #define ABSYN_FUNCTIONARGS_H
 
-#include <memory>
 #include <iosfwd>
+#include <memory>
 
 #include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.cpp
@@ -33,9 +33,14 @@
  *
  */
 
-#include "Util.h"
-#include "Iterator.h"
+#include <ostream>
+
+#include "Absyn/Expression.h"
+#include "Absyn/FunctionArgs.h"
 #include "FunctionArgsIter.h"
+#include "Iterator.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
@@ -44,11 +44,9 @@
 #include "Expression.h"
 #include "FunctionArgs.h"
 #include "MetaModelica.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class Iterator;
 
   class FunctionArgsIter : public FunctionArgs::Base
   {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
@@ -36,10 +36,15 @@
 #ifndef ABSYN_FUNCTIONARGSITER_H
 #define ABSYN_FUNCTIONARGSITER_H
 
+#include <iosfwd>
+#include <memory>
 #include <vector>
 
+#include "Absyn/Iterator.h"
 #include "Expression.h"
 #include "FunctionArgs.h"
+#include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.cpp
@@ -35,9 +35,11 @@
 
 #include <ostream>
 
-#include "Util.h"
+#include "Absyn/FunctionArgs.h"
 #include "Expression.h"
 #include "FunctionArgsList.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
@@ -36,13 +36,16 @@
 #ifndef ABSYN_FUNCTIONARGSLIST_H
 #define ABSYN_FUNCTIONARGSLIST_H
 
-#include <string>
-#include <vector>
-#include <memory>
-#include <utility>
 #include <iosfwd>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "Absyn/Expression.h"
 #include "FunctionArgs.h"
+#include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
@@ -45,12 +45,9 @@
 #include "Absyn/Expression.h"
 #include "FunctionArgs.h"
 #include "MetaModelica.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class Expression;
-
   class FunctionArgsList : public FunctionArgs::Base
   {
     public:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.cpp
@@ -34,9 +34,15 @@
  */
 
 #include <ostream>
+#include <string_view>
 
+#include "Absyn/Element.h"
+#include "Absyn/ImportPath.h"
 #include "ElementVisitor.h"
 #include "Import.h"
+#include "Prefixes.h"
+#include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.h
@@ -37,11 +37,12 @@
 #define ABSYN_IMPORT_H
 
 #include <iosfwd>
+#include <memory>
 
-#include "MetaModelica.h"
+#include "../Prefixes.h"
 #include "Element.h"
 #include "ImportPath.h"
-#include "../Prefixes.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.cpp
@@ -33,12 +33,14 @@
  *
  */
 
-#include <utility>
-#include <stdexcept>
 #include <ostream>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
 
-#include "Util.h"
 #include "ImportPath.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.h
@@ -36,10 +36,10 @@
 #ifndef ABSYN_IMPORTPATH_H
 #define ABSYN_IMPORTPATH_H
 
-#include <optional>
-#include <vector>
-#include <string>
 #include <iosfwd>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "MetaModelica.h"
 #include "Path.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.cpp
@@ -35,7 +35,9 @@
 
 #include <ostream>
 
+#include "Absyn/Expression.h"
 #include "Iterator.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.h
@@ -36,11 +36,12 @@
 #ifndef ABSYN_ITERATOR_H
 #define ABSYN_ITERATOR_H
 
-#include <string>
+#include <iosfwd>
 #include <optional>
+#include <string>
 
-#include "MetaModelica.h"
 #include "Expression.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.cpp
@@ -33,12 +33,13 @@
  *
  */
 
-#include <stdexcept>
 #include <ostream>
 
-#include "Util.h"
+#include "Absyn/Expression.h"
 #include "Element.h"
 #include "Modifier.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.h
@@ -36,18 +36,18 @@
 #ifndef ABSYN_MODIFIER_H
 #define ABSYN_MODIFIER_H
 
-#include <vector>
-#include <utility>
-#include <string>
+#include <iosfwd>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
-#include <iosfwd>
+#include <utility>
+#include <vector>
 
-#include "MetaModelica.h"
-#include "Prefixes.h"
 #include "Element.h"
 #include "Expression.h"
+#include "MetaModelica.h"
+#include "Prefixes.h"
 #include "SourceInfo.h"
 
 namespace OpenModelica::Absyn

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.cpp
@@ -34,11 +34,11 @@
  */
 
 #include <array>
-#include <string>
 #include <stdexcept>
-#include <ostream>
+#include <string>
 
 #include "Operator.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
@@ -40,7 +40,7 @@
 #include <string_view>
 
 #include "MetaModelica.h"
-#include "meta_modelica.h"
+#include "omc_inline.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
@@ -36,10 +36,11 @@
 #ifndef ABSYN_OPERATOR_H
 #define ABSYN_OPERATOR_H
 
-#include <string_view>
 #include <ostream>
+#include <string_view>
 
 #include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
@@ -37,7 +37,7 @@
 #define ABSYN_OPERATOR_H
 
 #include <string_view>
-#include <iosfwd>
+#include <ostream>
 
 #include "MetaModelica.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.cpp
@@ -33,11 +33,13 @@
  *
  */
 
-#include <cassert>
 #include <ostream>
+#include <stdexcept>
 
-#include "Util.h"
+#include "Absyn/Comment.h"
+#include "Absyn/Expression.h"
 #include "Statement.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
@@ -48,11 +48,9 @@
 #include "Expression.h"
 #include "MetaModelica.h"
 #include "SourceInfo.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {
-  class StatementConcept;
 
   class Statement
   {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
@@ -36,17 +36,19 @@
 #ifndef ABSYN_STATEMENT_H
 #define ABSYN_STATEMENT_H
 
+#include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <optional>
-#include <vector>
 #include <utility>
-#include <iosfwd>
+#include <vector>
 
 #include "Comment.h"
-#include "SourceInfo.h"
 #include "Expression.h"
+#include "MetaModelica.h"
+#include "SourceInfo.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica::Absyn
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.cpp
@@ -35,9 +35,10 @@
 
 #include <ostream>
 
-#include "Util.h"
 #include "Expression.h"
 #include "Subscript.h"
+#include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
@@ -49,10 +50,26 @@ extern "C" record_description Absyn_Subscript_NOSUB__desc;
 extern "C" record_description Absyn_Subscript_SUBSCRIPT__desc;
 
 Subscript::Subscript(MetaModelica::Record value)
-  : _subscript{value.index() == SUBSCRIPT ? std::make_optional<Expression>(value[0]) : std::nullopt}
+  : _subscript{value.index() == SUBSCRIPT ? std::make_unique<Expression>(value[0]) : nullptr}
 {
 
 }
+
+Subscript::Subscript(const Subscript &other)
+  : _subscript{other._subscript ? std::make_unique<Expression>(*other._subscript) : nullptr}
+{
+
+}
+
+Subscript::Subscript(Subscript &&other) noexcept = default;
+
+Subscript& Subscript::operator=(const Subscript &other)
+{
+  _subscript = other._subscript ? std::make_unique<Expression>(*other._subscript) : nullptr;
+  return *this;
+}
+
+Subscript& Subscript::operator=(Subscript &&other) noexcept = default;
 
 Subscript::~Subscript() noexcept = default;
 
@@ -70,14 +87,14 @@ MetaModelica::Value Subscript::toAbsynList(const std::vector<Subscript> &subs) n
   return MetaModelica::List{subs, [](const auto &s) { return s.toAbsyn(); }};
 }
 
-const std::optional<Expression>& Subscript::expression() const noexcept
+const Expression* Subscript::expression() const noexcept
 {
-  return _subscript;
+  return _subscript.get();
 }
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream& os, const Subscript &subscript)
 {
-  auto &e = subscript.expression();
+  const Expression *e = subscript.expression();
 
   if (e) {
     os << *e;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.h
@@ -37,27 +37,32 @@
 #define ABSYN_SUBSCRIPT_H
 
 #include <iosfwd>
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "MetaModelica.h"
-#include "Expression.h"
 
 namespace OpenModelica::Absyn
 {
+  class Expression;
+
   class Subscript
   {
     public:
       Subscript(MetaModelica::Record value);
+      Subscript(const Subscript &other);
+      Subscript(Subscript &&other) noexcept;
+      Subscript& operator=(const Subscript &other);
+      Subscript& operator=(Subscript &&other) noexcept;
       ~Subscript() noexcept;
 
       MetaModelica::Value toAbsyn() const noexcept;
       static MetaModelica::Value toAbsynList(const std::vector<Subscript> &subs) noexcept;
 
-      const std::optional<Expression>& expression() const noexcept;
+      const Expression* expression() const noexcept;
 
     private:
-      std::optional<Expression> _subscript;
+      std::unique_ptr<Expression> _subscript;
   };
 
   std::ostream& operator<< (std::ostream& os, const Subscript &subscript);

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.cpp
@@ -35,7 +35,9 @@
 
 #include <ostream>
 
+#include "Absyn/Subscript.h"
 #include "TypeSpec.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.h
@@ -37,6 +37,7 @@
 #define ABSYN_TYPESPEC_H
 
 #include <iosfwd>
+#include <vector>
 
 #include "MetaModelica.h"
 #include "Path.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Attributes.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Attributes.cpp
@@ -36,6 +36,7 @@
 #include "Absyn/ElementAttributes.h"
 #include "Absyn/ElementPrefixes.h"
 #include "Attributes.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Attributes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Attributes.h
@@ -36,9 +36,9 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
-#include "Absyn/AbsynFwd.h"
-#include "MetaModelica.h"
+#include "Absyn/ElementPrefixes.h"
 #include "ConstrainingClass.h"
+#include "MetaModelica.h"
 #include "Prefixes.h"
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/Attributes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Attributes.h
@@ -36,6 +36,7 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
+#include "Absyn/ElementAttributes.h"
 #include "Absyn/ElementPrefixes.h"
 #include "ConstrainingClass.h"
 #include "MetaModelica.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Binding.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Binding.cpp
@@ -33,7 +33,10 @@
  *
  */
 
+#include <initializer_list>
+
 #include "Binding.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
+++ b/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
@@ -45,27 +45,3 @@ if (MSVC)
 else()
   target_compile_options(omcfrontendcpp PRIVATE -Wall -Wextra -Wpedantic)
 endif()
-
-# Include-what-you-use
-# Ensures all C++ files include all used headers, no transient includes
-find_program(IWYU_PATH NAMES include-what-you-use iwyu)
-find_program(IWYU_FIX_PATH NAMES fix_include)
-message(STATUS "IWYU: ${IWYU_PATH}")
-message(STATUS "IWYU fix: ${IWYU_FIX_PATH}")
-if(IWYU_PATH)
-  set(IWYU_COMMAND ${IWYU_PATH} -Xiwyu --no_fwd_decls --nosafe_headers)
-  set_property(TARGET omcfrontendcpp PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
-  set_property(TARGET omcfrontendcppabsyn PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
-endif()
-if(IWYU_PATH AND IWYU_FIX_PATH)
-  add_custom_target(iwyu-fix
-    COMMAND iwyu_tool -p ${CMAKE_BINARY_DIR}
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CMAKE_CURRENT_SOURCE_DIR}/Absyn
-      -- -Xiwyu --no_fwd_decls --nosafe_headers
-      | ${IWYU_FIX_PATH} --nosafe_headers
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "Running include-what-you-use and fixing includes"
-    VERBATIM
-  )
-endif()

--- a/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
+++ b/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
@@ -53,7 +53,7 @@ find_program(IWYU_FIX_PATH NAMES fix_include)
 message(STATUS "IWYU: ${IWYU_PATH}")
 message(STATUS "IWYU fix: ${IWYU_FIX_PATH}")
 if(IWYU_PATH)
-  set(IWYU_COMMAND ${IWYU_PATH} -Xiwyu --no_fwd_decls)
+  set(IWYU_COMMAND ${IWYU_PATH} -Xiwyu --no_fwd_decls --nosafe_headers)
   set_property(TARGET omcfrontendcpp PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
   set_property(TARGET omcfrontendcppabsyn PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
 endif()
@@ -62,9 +62,8 @@ if(IWYU_PATH AND IWYU_FIX_PATH)
     COMMAND iwyu_tool -p ${CMAKE_BINARY_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR}/Absyn
-      ${CMAKE_CURRENT_SOURCE_DIR}/Util
-      -- -Xiwyu --no_fwd_decls
-      | ${IWYU_FIX_PATH}
+      -- -Xiwyu --no_fwd_decls --nosafe_headers
+      | ${IWYU_FIX_PATH} --nosafe_headers
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running include-what-you-use and fixing includes"
     VERBATIM

--- a/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
+++ b/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
@@ -46,12 +46,27 @@ else()
   target_compile_options(omcfrontendcpp PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
-# Include what you see
+# Include-what-you-use
 # Ensures all C++ files include all used headers, no transient includes
 find_program(IWYU_PATH NAMES include-what-you-use iwyu)
+find_program(IWYU_FIX_PATH NAMES fix_include)
 message(STATUS "IWYU: ${IWYU_PATH}")
+message(STATUS "IWYU fix: ${IWYU_FIX_PATH}")
 if(IWYU_PATH)
   set(IWYU_COMMAND ${IWYU_PATH} -Xiwyu --no_fwd_decls)
-  set_property(TARGET omcfrontendcpp PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
-  set_property(TARGET omcfrontendcppabsyn PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+  set_property(TARGET omcfrontendcpp PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
+  set_property(TARGET omcfrontendcppabsyn PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
+endif()
+if(IWYU_PATH AND IWYU_FIX_PATH)
+  add_custom_target(iwyu-fix
+    COMMAND iwyu_tool -p ${CMAKE_BINARY_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/Absyn
+      ${CMAKE_CURRENT_SOURCE_DIR}/Util
+      -- -Xiwyu --no_fwd_decls
+      | ${IWYU_FIX_PATH}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running include-what-you-use and fixing includes"
+    VERBATIM
+  )
 endif()

--- a/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
+++ b/OMCompiler/Compiler/FrontEndCpp/CMakeLists.txt
@@ -45,3 +45,13 @@ if (MSVC)
 else()
   target_compile_options(omcfrontendcpp PRIVATE -Wall -Wextra -Wpedantic)
 endif()
+
+# Include what you see
+# Ensures all C++ files include all used headers, no transient includes
+find_program(IWYU_PATH NAMES include-what-you-use iwyu)
+message(STATUS "IWYU: ${IWYU_PATH}")
+if(IWYU_PATH)
+  set(IWYU_COMMAND ${IWYU_PATH} -Xiwyu --no_fwd_decls)
+  set_property(TARGET omcfrontendcpp PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+  set_property(TARGET omcfrontendcppabsyn PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+endif()

--- a/OMCompiler/Compiler/FrontEndCpp/Class.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Class.cpp
@@ -33,10 +33,13 @@
  *
  */
 
+#include <utility>
+
 #include "Absyn/Class.h"
 #include "Absyn/ClassDef.h"
-#include "InstNode.h"
 #include "Class.h"
+#include "InstNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Class.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Class.h
@@ -36,16 +36,24 @@
 #ifndef CLASS_H
 #define CLASS_H
 
+#include <memory>
 #include <optional>
+#include <vector>
 
 #include "Absyn/AbsynFwd.h"
+#include "Absyn/Class.h"
+#include "Absyn/ClassDef.h"
 #include "Absyn/ConstrainingClass.h"
-#include "Modifier.h"
 #include "Attributes.h"
+#include "ClassTree.h"
+#include "Dimension.h"
+#include "InstNode.h"
+#include "MetaModelica.h"
+#include "Modifier.h"
 #include "Prefixes.h"
 #include "Restriction.h"
 #include "Type.h"
-#include "ClassTree.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Class.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Class.h
@@ -40,7 +40,6 @@
 #include <optional>
 #include <vector>
 
-#include "Absyn/AbsynFwd.h"
 #include "Absyn/Class.h"
 #include "Absyn/ClassDef.h"
 #include "Absyn/ConstrainingClass.h"
@@ -53,12 +52,9 @@
 #include "Prefixes.h"
 #include "Restriction.h"
 #include "Type.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica
 {
-  class InstNode;
-
   class Class
   {
     public:

--- a/OMCompiler/Compiler/FrontEndCpp/ClassNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassNode.cpp
@@ -33,9 +33,14 @@
  *
  */
 
+#include <stdint.h>
+#include <utility>
+
 #include "Absyn/Class.h"
+#include "Absyn/ElementPrefixes.h"
 #include "Class.h"
 #include "ClassNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ClassNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassNode.h
@@ -36,9 +36,18 @@
 #ifndef CLASSNODE_H
 #define CLASSNODE_H
 
-#include "InstNode.h"
-
+#include <memory>
 #include <optional>
+#include <string>
+
+#include "Absyn/Class.h"
+#include "Absyn/Element.h"
+#include "Class.h"
+#include "InstNode.h"
+#include "InstNodeType.h"
+#include "MetaModelica.h"
+#include "Prefixes.h"
+#include "Util/MMCache.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/ClassTree.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassTree.cpp
@@ -33,13 +33,20 @@
  *
  */
 
-#include "MMAvlTree.h"
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+#include "Absyn/Element.h"
 #include "Absyn/ElementVisitor.h"
-#include "Util.h"
-#include "ClassNode.h"
 #include "Class.h"
-#include "Import.h"
+#include "ClassNode.h"
 #include "ClassTree.h"
+#include "Import.h"
+#include "MMAvlTree.h"
+#include "Util.h"
+#include "Util/IndirectForwardIterator.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ClassTree.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassTree.h
@@ -36,12 +36,24 @@
 #ifndef CLASSTREE_H
 #define CLASSTREE_H
 
+#include <memory>
+#include <optional>
+#include <stddef.h>
+#include <stdint.h>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "Absyn/AbsynFwd.h"
+#include "Absyn/Class.h"
+#include "Absyn/ClassDef.h"
+#include "Absyn/Component.h"
+#include "Absyn/Extends.h"
+#include "Absyn/Import.h"
+#include "Import.h"
+#include "InstNode.h"
 #include "MetaModelica.h"
+#include "meta_modelica.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/ClassTree.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ClassTree.h
@@ -44,7 +44,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Absyn/AbsynFwd.h"
 #include "Absyn/Class.h"
 #include "Absyn/ClassDef.h"
 #include "Absyn/Component.h"
@@ -53,12 +52,9 @@
 #include "Import.h"
 #include "InstNode.h"
 #include "MetaModelica.h"
-#include "meta_modelica.h"
 
 namespace OpenModelica
 {
-  class InstNode;
-  class Import;
 
   class ClassTree
   {

--- a/OMCompiler/Compiler/FrontEndCpp/ComplexType.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComplexType.cpp
@@ -37,6 +37,7 @@
 
 #include "ComplexType.h"
 #include "InstNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComplexType.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComplexType.cpp
@@ -33,8 +33,10 @@
  *
  */
 
-#include "InstNode.h"
+#include <utility>
+
 #include "ComplexType.h"
+#include "InstNode.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComplexType.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComplexType.h
@@ -44,7 +44,6 @@
 
 namespace OpenModelica
 {
-  class InstNode;
 
   class ComplexType
   {

--- a/OMCompiler/Compiler/FrontEndCpp/ComplexType.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComplexType.h
@@ -39,6 +39,7 @@
 #include <memory>
 #include <vector>
 
+#include "InstNode.h"
 #include "MetaModelica.h"
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/Component.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Component.cpp
@@ -33,9 +33,11 @@
  *
  */
 
+#include <utility>
+
 #include "Absyn/Component.h"
-#include "InstNode.h"
 #include "Component.h"
+#include "InstNode.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Component.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Component.cpp
@@ -38,6 +38,7 @@
 #include "Absyn/Component.h"
 #include "Component.h"
 #include "InstNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Component.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Component.h
@@ -38,7 +38,6 @@
 
 #include <memory>
 
-#include "Absyn/AbsynFwd.h"
 #include "Absyn/Comment.h"
 #include "Absyn/Component.h"
 #include "Attributes.h"
@@ -52,7 +51,6 @@
 
 namespace OpenModelica
 {
-  class InstNode;
 
   class Component
   {

--- a/OMCompiler/Compiler/FrontEndCpp/Component.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Component.h
@@ -39,10 +39,15 @@
 #include <memory>
 
 #include "Absyn/AbsynFwd.h"
+#include "Absyn/Comment.h"
+#include "Absyn/Component.h"
 #include "Attributes.h"
 #include "Binding.h"
+#include "InstNode.h"
+#include "MetaModelica.h"
 #include "Modifier.h"
 #include "Prefixes.h"
+#include "SourceInfo.h"
 #include "Type.h"
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
@@ -33,9 +33,12 @@
  *
  */
 
+#include <stdexcept>
+#include <stdint.h>
 #include <utility>
 
 #include "Absyn/Component.h"
+#include "Absyn/ElementPrefixes.h"
 #include "Component.h"
 #include "ComponentNode.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentNode.cpp
@@ -41,6 +41,7 @@
 #include "Absyn/ElementPrefixes.h"
 #include "Component.h"
 #include "ComponentNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentNode.h
@@ -38,10 +38,19 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "Absyn/AbsynFwd.h"
+#include "Absyn/Component.h"
+#include "Absyn/Element.h"
+#include "Component.h"
 #include "InstNode.h"
+#include "InstNodeType.h"
+#include "MetaModelica.h"
+#include "Path.h"
 #include "Prefixes.h"
+#include "Type.h"
+#include "Util/MMCache.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentNode.h
@@ -40,7 +40,6 @@
 #include <optional>
 #include <string>
 
-#include "Absyn/AbsynFwd.h"
 #include "Absyn/Component.h"
 #include "Absyn/Element.h"
 #include "Component.h"
@@ -54,7 +53,6 @@
 
 namespace OpenModelica
 {
-  class Component;
 
   class ComponentNode : public InstNode
   {

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentRef.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentRef.cpp
@@ -41,6 +41,7 @@
 #include "ComponentRef.h"
 #include "InstNode.h"
 #include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentRef.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentRef.cpp
@@ -33,14 +33,14 @@
  *
  */
 
-#include <sstream>
-#include <ostream>
 #include <algorithm>
 #include <cassert>
+#include <initializer_list>
+#include <sstream>
 
-#include "Util.h"
-#include "InstNode.h"
 #include "ComponentRef.h"
+#include "InstNode.h"
+#include "Util.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentRef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentRef.h
@@ -36,10 +36,16 @@
 #ifndef COMPONENTREF_H
 #define COMPONENTREF_H
 
+#include <algorithm>
+#include <cstddef>
 #include <iosfwd>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include "InstNode.h"
 #include "MetaModelica.h"
-
 #include "Subscript.h"
 #include "Type.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/ComponentRef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ComponentRef.h
@@ -48,10 +48,10 @@
 #include "MetaModelica.h"
 #include "Subscript.h"
 #include "Type.h"
+#include "omc_inline.h"
 
 namespace OpenModelica
 {
-  class InstNode;
 
   class ComponentRef
   {

--- a/OMCompiler/Compiler/FrontEndCpp/ConstrainingClass.h
+++ b/OMCompiler/Compiler/FrontEndCpp/ConstrainingClass.h
@@ -38,8 +38,8 @@
 
 #include <memory>
 
-#include "MetaModelica.h"
 #include "InstNode.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Dimension.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Dimension.cpp
@@ -35,10 +35,10 @@
 
 #include <ostream>
 #include <stdexcept>
-
-#include "Prefixes.h"
+#include <stdint.h>
 
 #include "Dimension.h"
+#include "Prefixes.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Dimension.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Dimension.cpp
@@ -39,6 +39,7 @@
 
 #include "Dimension.h"
 #include "Prefixes.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Dimension.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Dimension.h
@@ -36,9 +36,9 @@
 #ifndef DIMENSION_H
 #define DIMENSION_H
 
+#include <iosfwd>
 #include <memory>
 #include <optional>
-#include <iosfwd>
 
 #include "MetaModelica.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/Import.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Import.cpp
@@ -41,6 +41,7 @@
 #include "Import.h"
 #include "InstNode.h"
 #include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Import.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Import.cpp
@@ -34,10 +34,13 @@
  */
 
 #include <cassert>
+#include <string>
 
 #include "Absyn/Import.h"
-#include "InstNode.h"
+#include "Absyn/ImportPath.h"
 #include "Import.h"
+#include "InstNode.h"
+#include "SourceInfo.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Import.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Import.h
@@ -39,12 +39,12 @@
 #include <optional>
 
 #include "Absyn/AbsynFwd.h"
+#include "Absyn/Import.h"
+#include "InstNode.h"
 #include "MetaModelica.h"
 
 namespace OpenModelica
 {
-  class InstNode;
-
   class Import
   {
     public:

--- a/OMCompiler/Compiler/FrontEndCpp/Import.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Import.h
@@ -38,7 +38,6 @@
 
 #include <optional>
 
-#include "Absyn/AbsynFwd.h"
 #include "Absyn/Import.h"
 #include "InstNode.h"
 #include "MetaModelica.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Inst.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Inst.cpp
@@ -33,18 +33,23 @@
  *
  */
 
-#include <string>
-#include <vector>
+#include <bits/chrono.h>
 #include <iostream>
-#include <chrono>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
-#include "MetaModelica.h"
-#include "Absyn/Element.h"
 #include "Absyn/Class.h"
+#include "Absyn/ClassDef.h"
+#include "Absyn/Element.h"
+#include "Absyn/ElementPrefixes.h"
 #include "ClassNode.h"
-#include "Class.h"
 #include "Inst.h"
+#include "InstNodeType.h"
+#include "MetaModelica.h"
+#include "Prefixes.h"
+#include "Restriction.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
@@ -40,6 +40,7 @@
 #include "ComponentNode.h"
 #include "InstNode.h"
 #include "NameNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.cpp
@@ -36,10 +36,10 @@
 #include <stdexcept>
 #include <string>
 
-#include "ComponentNode.h"
 #include "ClassNode.h"
-#include "NameNode.h"
+#include "ComponentNode.h"
 #include "InstNode.h"
+#include "NameNode.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.h
@@ -40,7 +40,7 @@
 #include <string>
 #include <vector>
 
-#include "Absyn/AbsynFwd.h"
+#include "Absyn/Element.h"
 #include "InstNodeType.h"
 #include "MetaModelica.h"
 #include "Path.h"

--- a/OMCompiler/Compiler/FrontEndCpp/InstNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNode.h
@@ -37,17 +37,20 @@
 #define INSTNODE_H
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "Absyn/AbsynFwd.h"
-#include "Util/MMCache.h"
-#include "MetaModelica.h"
 #include "InstNodeType.h"
-#include "Type.h"
+#include "MetaModelica.h"
 #include "Path.h"
+#include "Type.h"
+#include "Util/MMCache.h"
 
 namespace OpenModelica
 {
   class Class;
+  class InstNode;
 
   std::unique_ptr<InstNode> node_from_mm(MetaModelica::Record value);
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNodeType.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNodeType.cpp
@@ -33,15 +33,14 @@
  *
  */
 
-extern "C" {
-#include "meta/meta_modelica_builtin.h"
-}
+#include <initializer_list>
 
-#include "MMUnorderedMap.h"
 #include "Absyn/Element.h"
-#include "Absyn/ElementVisitor.h"
 #include "InstNode.h"
 #include "InstNodeType.h"
+#include "MMUnorderedMap.h"
+#include "meta_modelica.h"
+#include "meta_modelica_builtin_boxvar.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/InstNodeType.h
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNodeType.h
@@ -46,11 +46,6 @@
 
 namespace OpenModelica
 {
-  namespace Absyn
-  {
-    class Element;
-  };
-
   class InstNode;
 
   class InstNodeType

--- a/OMCompiler/Compiler/FrontEndCpp/InstNodeType.h
+++ b/OMCompiler/Compiler/FrontEndCpp/InstNodeType.h
@@ -37,8 +37,11 @@
 #define INSTNODETYPE_H
 
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
 
+#include "Absyn/Element.h"
 #include "MetaModelica.h"
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/MMAvlTree.h
+++ b/OMCompiler/Compiler/FrontEndCpp/MMAvlTree.h
@@ -36,9 +36,9 @@
 #ifndef MMAVLTREE_H
 #define MMAVLTREE_H
 
+#include <algorithm>
 #include <ostream>
 #include <string>
-#include <algorithm>
 
 #include "MetaModelica.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
@@ -39,6 +39,12 @@
 
 #include "MetaModelica.h"
 #include "meta/meta_modelica.h"
+#include "meta_modelica_builtin.h"
+#include "meta_modelica_data.h"
+#include "meta_modelica_mk_box.h"
+#include "modelica_string.h"
+#include "omc_gc.h"
+#include "openmodelica_types.h"
 
 using namespace OpenModelica::MetaModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
@@ -34,14 +34,11 @@
  */
 
 #include <cassert>
-#include <stdexcept>
 #include <ostream>
-
-extern "C" {
-#include "meta/meta_modelica.h"
-}
+#include <stdexcept>
 
 #include "MetaModelica.h"
+#include "meta/meta_modelica.h"
 
 using namespace OpenModelica::MetaModelica;
 
@@ -1013,4 +1010,3 @@ template<> Tuple       Value::to() const { return toTuple(); }
 template<> Record      Value::to() const { return toRecord(); }
 template<> Pointer     Value::to() const { return toPointer(); }
 template<> Mutable     Value::to() const { return toMutable(); }
-

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
@@ -51,8 +51,6 @@
 
 #include "meta_modelica.h"
 
-struct record_description;
-
 namespace OpenModelica
 {
   namespace MetaModelica

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
@@ -36,18 +36,20 @@
 #ifndef METAMODELICA_H
 #define METAMODELICA_H
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <iosfwd>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <iosfwd>
-#include <optional>
-#include <functional>
-#include <memory>
-#include <initializer_list>
-#include <iterator>
-#include <vector>
 #include <type_traits>
+#include <vector>
+
+#include "meta_modelica.h"
 
 struct record_description;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Modifier.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Modifier.cpp
@@ -36,6 +36,7 @@
 #include <initializer_list>
 
 #include "Modifier.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Modifier.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Modifier.cpp
@@ -33,6 +33,8 @@
  *
  */
 
+#include <initializer_list>
+
 #include "Modifier.h"
 
 using namespace OpenModelica;

--- a/OMCompiler/Compiler/FrontEndCpp/NameNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/NameNode.cpp
@@ -36,6 +36,7 @@
 #include <utility>
 
 #include "NameNode.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/NameNode.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/NameNode.cpp
@@ -33,6 +33,8 @@
  *
  */
 
+#include <utility>
+
 #include "NameNode.h"
 
 using namespace OpenModelica;

--- a/OMCompiler/Compiler/FrontEndCpp/NameNode.h
+++ b/OMCompiler/Compiler/FrontEndCpp/NameNode.h
@@ -36,7 +36,11 @@
 #ifndef NAMENODE_H
 #define NAMENODE_H
 
+#include <memory>
+#include <string>
+
 #include "InstNode.h"
+#include "MetaModelica.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Path.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Path.cpp
@@ -35,10 +35,9 @@
 
 #include <cassert>
 #include <sstream>
-#include <ostream>
 
-#include "Util.h"
 #include "Path.h"
+#include "Util.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Path.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Path.cpp
@@ -38,6 +38,7 @@
 
 #include "Path.h"
 #include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Path.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Path.h
@@ -37,11 +37,11 @@
 #define PATH_H
 
 #include <cstddef>
-#include <string>
-#include <vector>
-#include <utility>
-#include <string_view>
 #include <iosfwd>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "MetaModelica.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
@@ -36,15 +36,16 @@
 #ifndef PREFIXES_H
 #define PREFIXES_H
 
+#include <functional>
 #include <iosfwd>
 #include <memory>
 #include <optional>
 #include <stdint.h>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "MetaModelica.h"
+#include "meta_modelica.h"
 
 extern "C" record_description SCode_Replaceable_REPLACEABLE__desc;
 extern "C" record_description SCode_Replaceable_NOT__REPLACEABLE__desc;

--- a/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
@@ -36,10 +36,13 @@
 #ifndef PREFIXES_H
 #define PREFIXES_H
 
-#include <string_view>
+#include <iosfwd>
 #include <memory>
 #include <optional>
-#include <iosfwd>
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "MetaModelica.h"
 

--- a/OMCompiler/Compiler/FrontEndCpp/Restriction.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Restriction.cpp
@@ -33,9 +33,6 @@
  *
  */
 
-#include <type_traits>
-#include <ostream>
-
 #include "Restriction.h"
 
 using namespace OpenModelica;

--- a/OMCompiler/Compiler/FrontEndCpp/Restriction.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Restriction.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "Restriction.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Restriction.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Restriction.h
@@ -36,13 +36,13 @@
 #ifndef RESTRICTION_H
 #define RESTRICTION_H
 
-#include <bitset>
 #include <iosfwd>
 #include <ostream>
 #include <string>
 
 #include "MetaModelica.h"
 #include "Prefixes.h"
+#include "omc_inline.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Restriction.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Restriction.h
@@ -38,6 +38,7 @@
 
 #include <bitset>
 #include <iosfwd>
+#include <ostream>
 #include <string>
 
 #include "MetaModelica.h"

--- a/OMCompiler/Compiler/FrontEndCpp/SourceInfo.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/SourceInfo.cpp
@@ -36,6 +36,7 @@
 #include <ostream>
 
 #include "SourceInfo.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/SourceInfo.h
+++ b/OMCompiler/Compiler/FrontEndCpp/SourceInfo.h
@@ -36,9 +36,11 @@
 #ifndef SOURCEINFO_H
 #define SOURCEINFO_H
 
-#include "MetaModelica.h"
-#include <string>
 #include <iosfwd>
+#include <stdint.h>
+#include <string>
+
+#include "MetaModelica.h"
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Subscript.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Subscript.cpp
@@ -38,6 +38,7 @@
 
 #include "Subscript.h"
 #include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Subscript.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Subscript.cpp
@@ -36,8 +36,8 @@
 #include <cassert>
 #include <ostream>
 
-#include "Util.h"
 #include "Subscript.h"
+#include "Util.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Subscript.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Subscript.h
@@ -36,7 +36,11 @@
 #ifndef SUBSCRIPT_H
 #define SUBSCRIPT_H
 
+#include <cstddef>
 #include <iosfwd>
+#include <stdint.h>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "MetaModelica.h"

--- a/OMCompiler/Compiler/FrontEndCpp/Type.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Type.cpp
@@ -33,16 +33,16 @@
  *
  */
 
-#include <sstream>
-#include <algorithm>
-#include <utility>
-#include <stdexcept>
 #include <cassert>
+#include <initializer_list>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
 
-#include "Util.h"
-#include "InstNode.h"
 #include "ComplexType.h"
+#include "InstNode.h"
 #include "Type.h"
+#include "Util.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Type.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Type.cpp
@@ -43,6 +43,7 @@
 #include "InstNode.h"
 #include "Type.h"
 #include "Util.h"
+#include "meta_modelica.h"
 
 using namespace OpenModelica;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Type.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Type.h
@@ -36,16 +36,18 @@
 #ifndef TYPE_H
 #define TYPE_H
 
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <stddef.h>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <optional>
-#include <memory>
-#include <iosfwd>
 
-#include "MetaModelica.h"
-
+#include "ComplexType.h"
 #include "Dimension.h"
+#include "InstNodeType.h"
+#include "MetaModelica.h"
 #include "Path.h"
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/Type.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Type.h
@@ -44,7 +44,6 @@
 #include <string_view>
 #include <vector>
 
-#include "ComplexType.h"
 #include "Dimension.h"
 #include "InstNodeType.h"
 #include "MetaModelica.h"
@@ -52,7 +51,6 @@
 
 namespace OpenModelica
 {
-  class InstNode;
   class ComplexType;
 
   class TypeData

--- a/OMCompiler/Compiler/FrontEndCpp/Util.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Util.h
@@ -38,8 +38,8 @@
 
 #include <cstdint>
 #include <iterator>
-#include <string_view>
 #include <ostream>
+#include <string_view>
 #include <vector>
 
 namespace OpenModelica

--- a/OMCompiler/Compiler/FrontEndCpp/Util/DisjointSets.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Util/DisjointSets.h
@@ -36,8 +36,8 @@
 #ifndef DISJOINTSETS_H
 #define DISJOINTSETS_H
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace OpenModelica
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Util/MMCache.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Util/MMCache.h
@@ -37,9 +37,9 @@
 #define MMCACHE_H
 
 #include <memory>
-#include <vector>
-#include <unordered_map>
 #include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 #include "MetaModelica.h"
 


### PR DESCRIPTION
### Related Issues

* I needed to update one include for MSVC.... aaannnndddd I found [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use).

Requirements:

  * Install iwyu: `apt-get install iwyu
  * You'll need to build with CMake and clang

How to run iwyu:

```bash
$ iwyu -p build_cmake OMCompiler/Compiler/FrontEndCpp/
$ iwyu -p build_cmake OMCompiler/Compiler/FrontEndCpp/Absyn OMCompiler/Compiler/FrontEndCpp/ -- -Xiwyu --no_fwd_decls --nosafe_headers | fix_include --nosafe_headers
```

### Purpose

* Include what you use in FrontEndCpp
* Playing around with iwyu to see what it can do

### Approach

* Broke some cyclic includes
* Sorted includes
