### PR TITLE
Fixing include in FrontEndCpp

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
@@ -37,7 +37,7 @@
 #define ABSYN_OPERATOR_H
 
 #include <string_view>
-#include <iosfwd>
+#include <ostream>
 
 #include "MetaModelica.h"
 


### PR DESCRIPTION
### Related Issues

* MSVC is complaining about a missing include in FrontEntCpp

### Purpose

* Fix MSVC build

### Approach

* Include `ostream` since `std::ostream&` is used.
