### PR TITLE
Split the frontend packages into smaller units

### DIFF
--- a/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
+++ b/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
@@ -19,15 +19,19 @@ end if;
 
 if not checkInterfaceOfPackages(class_typename, {
 // Also update Compiler/boot/CompileFile.mos if you change this file.
-  {"parser", "", "", "", "", "", "", "", ""},
-  {"backend", "frontend", "util", "susan", "nf_frontend", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump"},
-  {"frontend", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", ""},
-  {"frontend_types", "", "", "util_datatypes_basic", "parser", "", "", "", ""},
-  {"frontend_dump", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "", "", ""},
-  {"nf_frontend", "util", "susan", "frontend_types", "util_datatypes_basic", "parser", "frontend_dump", "", ""},
-  {"susan", "util", "util_datatypes_basic", "parser", "", "", "", "", ""},
-  {"util", "util_datatypes_basic", "", "", "", "", "", "", ""},
-  {"util_datatypes_basic", "", "", "", "", "", "", "", ""}
+  {"parser", "", "", "", "", "", "", "", "", "", "", "", ""},
+  {"backend", "frontend", "util", "susan", "nf_frontend", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "ast_collections", "dump_extra", "frontend_inst", "script_util"},
+  {"frontend", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "ast_collections", "frontend_inst", "script_util", "", "", ""},
+  {"frontend_types", "util_datatypes_basic", "parser", "", "", "", "", "", "", "", "", "", ""},
+  {"frontend_dump", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "", "", "", "", "", "", ""},
+  {"nf_frontend", "util", "susan", "frontend_types", "util_datatypes_basic", "parser", "frontend_dump", "", "", "", "", "", ""},
+  {"susan", "util", "util_datatypes_basic", "parser", "", "", "", "", "", "", "", "", ""},
+  {"util", "util_datatypes_basic", "", "", "", "", "", "", "", "", "", "", ""},
+  {"util_datatypes_basic", "", "", "", "", "", "", "", "", "", "", "", ""},
+  {"ast_collections", "util", "parser", "frontend_dump", "", "", "", "", "", "", "", "", ""},
+  {"dump_extra", "util", "susan", "parser", "frontend_dump", "", "", "", "", "", "", "", ""},
+  {"frontend_inst", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""},
+  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""}
 }) then
   print(getErrorString());
   exit(1);

--- a/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
+++ b/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
@@ -31,7 +31,7 @@ if not checkInterfaceOfPackages(class_typename, {
   {"ast_collections", "util", "parser", "frontend_dump", "", "", "", "", "", "", "", "", ""},
   {"dump_extra", "util", "susan", "parser", "frontend_dump", "", "", "", "", "", "", "", ""},
   {"frontend_inst", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""},
-  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""}
+  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "parser", "", "", "", "", "", "", ""}
 }) then
   print(getErrorString());
   exit(1);

--- a/OMCompiler/Compiler/FrontEnd/DumpGraphviz.mo
+++ b/OMCompiler/Compiler/FrontEnd/DumpGraphviz.mo
@@ -487,6 +487,6 @@ algorithm
   end match;
 end directionSymbol;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="dump_extra");
 end DumpGraphviz;
 

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplifyTypes.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplifyTypes.mo
@@ -58,5 +58,5 @@ end IntOp;
 
 constant Options optionSimplifyOnly = NO_EVAL();
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="frontend_inst");
 end ExpressionSimplifyTypes;

--- a/OMCompiler/Compiler/FrontEnd/InstTypes.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstTypes.mo
@@ -91,5 +91,5 @@ algorithm
   end match;
 end callingScopeStr;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="frontend_inst");
 end InstTypes;

--- a/OMCompiler/Compiler/FrontEnd/MMath.mo
+++ b/OMCompiler/Compiler/FrontEnd/MMath.mo
@@ -200,5 +200,5 @@ algorithm
   end matchcontinue;
 end testRational;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="util");
 end MMath;

--- a/OMCompiler/Compiler/FrontEnd/NFInstPrefix.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFInstPrefix.mo
@@ -417,5 +417,5 @@ algorithm
   end match;
 end toPackagePrefix;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="frontend_inst");
 end NFInstPrefix;

--- a/OMCompiler/Compiler/FrontEnd/SCodeInstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeInstUtil.mo
@@ -429,5 +429,5 @@ algorithm
   outSCodeElementLst := list(SCodeUtil.makeEnumType(e,info) for e in inEnumLst);
 end makeEnumComponents;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="frontend_inst");
 end SCodeInstUtil;

--- a/OMCompiler/Compiler/FrontEnd/UnitParserExt.mo
+++ b/OMCompiler/Compiler/FrontEnd/UnitParserExt.mo
@@ -110,5 +110,5 @@ with addBase or addDerived."
   external "C" UnitParserExtImpl__commit() annotation(Library = "omcruntime");
 end commit;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 end UnitParserExt;

--- a/OMCompiler/Compiler/Script/BlockCallRewrite.mo
+++ b/OMCompiler/Compiler/Script/BlockCallRewrite.mo
@@ -974,5 +974,5 @@ algorithm
   end match;
 end matchVarNamedArg;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="dump_extra");
 end BlockCallRewrite;

--- a/OMCompiler/Compiler/Script/GlobalScriptUtil.mo
+++ b/OMCompiler/Compiler/Script/GlobalScriptUtil.mo
@@ -40,6 +40,6 @@ encapsulated package GlobalScriptUtil
 
 "
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 
 end GlobalScriptUtil;

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -814,5 +814,5 @@ algorithm
   info := SOURCEINFO(fileName, true, 0, 0, 0, 0, 0.0);
 end makeSourceInfo;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 end PackageManagement;

--- a/OMCompiler/Compiler/Stubs/AbsynJLDumpTpl.mo
+++ b/OMCompiler/Compiler/Stubs/AbsynJLDumpTpl.mo
@@ -44,5 +44,5 @@ algorithm
   out_txt := txt;
 end dump;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="dump_extra");
 end AbsynJLDumpTpl;

--- a/OMCompiler/Compiler/Stubs/PackageManagement.mo
+++ b/OMCompiler/Compiler/Stubs/PackageManagement.mo
@@ -78,5 +78,5 @@ end upgradeInstalledPackages;
 function installCachedPackages
 end installCachedPackages;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 end PackageManagement;

--- a/OMCompiler/Compiler/Util/AvlSetPath.mo
+++ b/OMCompiler/Compiler/Util/AvlSetPath.mo
@@ -47,5 +47,5 @@ encapsulated package AvlSetPath
   algorithm
     outResult := AbsynUtil.pathCompare(inKey1, inKey2);
   end keyCompare;
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="ast_collections");
 end AvlSetPath;

--- a/OMCompiler/Compiler/Util/Curl.mo
+++ b/OMCompiler/Compiler/Util/Curl.mo
@@ -44,5 +44,5 @@ function multiDownload
   external "C" success = om_curl_multi_download(urlFileList, maxParallel);
 end multiDownload;
 
-annotation(__OpenModelica_Interface="util");
+annotation(__OpenModelica_Interface="script_util");
 end Curl;

--- a/OMCompiler/Compiler/Util/DynLoad.mo
+++ b/OMCompiler/Compiler/Util/DynLoad.mo
@@ -76,5 +76,5 @@ algorithm
   end if;
 end executeFunction;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 end DynLoad;

--- a/OMCompiler/Compiler/Util/HashTable5.mo
+++ b/OMCompiler/Compiler/Util/HashTable5.mo
@@ -109,5 +109,5 @@ algorithm
   hashTable := BaseHashTable.emptyHashTableWork(size,(hashFunc,AbsynUtil.crefEqual,Dump.printComponentRefStr,intString));
 end emptyHashTableSized;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="ast_collections");
 end HashTable5;

--- a/OMCompiler/Compiler/Util/HashTableStringToPath.mo
+++ b/OMCompiler/Compiler/Util/HashTableStringToPath.mo
@@ -103,5 +103,5 @@ algorithm
   hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2,stringEq,Util.id,AbsynUtil.pathStringDefault));
 end emptyHashTableSized;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="ast_collections");
 end HashTableStringToPath;

--- a/OMCompiler/Compiler/Util/HashTableStringToProgram.mo
+++ b/OMCompiler/Compiler/Util/HashTableStringToProgram.mo
@@ -109,5 +109,5 @@ function dummyStr
   output String str = "<dummy Absyn.Program string>";
 end dummyStr;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="ast_collections");
 end HashTableStringToProgram;

--- a/OMCompiler/Compiler/Util/SimulationResults.mo
+++ b/OMCompiler/Compiler/Util/SimulationResults.mo
@@ -159,5 +159,5 @@ public function filterSimulationResults
   external "C" result=SimulationResults_filterSimulationResults(inFile,outFile,vars,numberOfIntervals,removeDescription,hintReadAllVars) annotation(Library = "omcruntime");
 end filterSimulationResults;
 
-annotation(__OpenModelica_Interface="frontend");
+annotation(__OpenModelica_Interface="script_util");
 end SimulationResults;

--- a/OMCompiler/Compiler/Util/Unzip.mo
+++ b/OMCompiler/Compiler/Util/Unzip.mo
@@ -43,5 +43,5 @@ function unzipPath
   external "C" success = om_unzip(fileName, pathToExtract, destinationPath);
 end unzipPath;
 
-annotation(__OpenModelica_Interface="util");
+annotation(__OpenModelica_Interface="script_util");
 end Unzip;

--- a/OMCompiler/Compiler/boot/CompileFile.mos
+++ b/OMCompiler/Compiler/boot/CompileFile.mos
@@ -7,15 +7,19 @@ mkdir("build/tmp");
 cd("build/tmp");
 if not checkInterfaceOfPackages(mainClass, {
 // Also update Compiler/.cmake/mm_check_interface.in.mos if you change this file.
-  {"parser", "", "", "", "", "", "", "", ""},
-  {"backend", "frontend", "util", "susan", "nf_frontend", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump"},
-  {"frontend", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", ""},
-  {"frontend_types", "", "", "util_datatypes_basic", "parser", "", "", "", ""},
-  {"frontend_dump", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "", "", ""},
-  {"nf_frontend", "util", "susan", "frontend_types", "util_datatypes_basic", "parser", "frontend_dump", "", ""},
-  {"susan", "util", "util_datatypes_basic", "parser", "", "", "", "", ""},
-  {"util", "util_datatypes_basic", "", "", "", "", "", "", ""},
-  {"util_datatypes_basic", "", "", "", "", "", "", "", ""}
+  {"parser", "", "", "", "", "", "", "", "", "", "", "", ""},
+  {"backend", "frontend", "util", "susan", "nf_frontend", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "ast_collections", "dump_extra", "frontend_inst", "script_util"},
+  {"frontend", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "ast_collections", "frontend_inst", "script_util", "", "", ""},
+  {"frontend_types", "util_datatypes_basic", "parser", "", "", "", "", "", "", "", "", "", ""},
+  {"frontend_dump", "util", "susan", "util_datatypes_basic", "parser", "frontend_types", "", "", "", "", "", "", ""},
+  {"nf_frontend", "util", "susan", "frontend_types", "util_datatypes_basic", "parser", "frontend_dump", "", "", "", "", "", ""},
+  {"susan", "util", "util_datatypes_basic", "parser", "", "", "", "", "", "", "", "", ""},
+  {"util", "util_datatypes_basic", "", "", "", "", "", "", "", "", "", "", ""},
+  {"util_datatypes_basic", "", "", "", "", "", "", "", "", "", "", "", ""},
+  {"ast_collections", "util", "parser", "frontend_dump", "", "", "", "", "", "", "", "", ""},
+  {"dump_extra", "util", "susan", "parser", "frontend_dump", "", "", "", "", "", "", "", ""},
+  {"frontend_inst", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""},
+  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""}
 }) then
   print(getErrorString());
   exit(1);

--- a/OMCompiler/Compiler/boot/CompileFile.mos
+++ b/OMCompiler/Compiler/boot/CompileFile.mos
@@ -19,7 +19,7 @@ if not checkInterfaceOfPackages(mainClass, {
   {"ast_collections", "util", "parser", "frontend_dump", "", "", "", "", "", "", "", "", ""},
   {"dump_extra", "util", "susan", "parser", "frontend_dump", "", "", "", "", "", "", "", ""},
   {"frontend_inst", "util_datatypes_basic", "parser", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""},
-  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "", "", "", "", "", "", "", ""}
+  {"script_util", "util", "util_datatypes_basic", "frontend_types", "frontend_dump", "parser", "", "", "", "", "", "", ""}
 }) then
   print(getErrorString());
   exit(1);


### PR DESCRIPTION
This makes it more clear which packages depend on which parts of the compiler.