### PR TITLE
MM frontend: fix uninit-output bugs

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -4159,24 +4159,6 @@ public function lenVec
   len := Expression.makePureBuiltinCall("sqrt",{len},DAE.T_REAL_DEFAULT);
 end lenVec;
 
-public function addVec
-  input array<DAE.Exp> v;
-  input array<DAE.Exp> w;
-  output array<DAE.Exp> y;
-
-protected
-  Integer size1=arrayLength(v), size2= arrayLength(w);
-algorithm
-  if size1 <> size2 then
-    print("addVec fail.\n");
-    return ;
-  end if;
-  y := arrayCreate(size1, DAE.RCONST(0.0));
-  for i in 1:size1 loop
-    arrayUpdate(y,i,expAdd(arrayGet(v,i), arrayGet(w,i)));
-  end for;
-end addVec;
-
 public function subVec
   input array<DAE.Exp> v;
   input array<DAE.Exp> w;
@@ -4186,8 +4168,8 @@ protected
   Integer size1=arrayLength(v), size2= arrayLength(w);
 algorithm
   if size1 <> size2 then
-    print("addVec fail.\n");
-    return ;
+    print("subVec fail.\n");
+    fail();
   end if;
   y := arrayCreate(size1, DAE.RCONST(0.0));
   for i in 1:size1 loop

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -479,7 +479,7 @@ algorithm
   (cache, cond_exp, cond_prop) := elabExpInExpression(inCache,
     inEnv, cond_e, inImplicit, inDoVect, inPrefix, inInfo);
 
-  _ := matchcontinue()
+  (outCache, outExp, outProperties) := matchcontinue()
     case ()
       algorithm
         ErrorExt.setCheckpoint("Static.elabExp:IFEXP");
@@ -492,7 +492,7 @@ algorithm
           inPrefix, inInfo);
         ErrorExt.delCheckpoint("Static.elabExp:IFEXP");
       then
-        ();
+        (outCache, outExp, outProperties);
 
     case ()
       algorithm
@@ -505,7 +505,7 @@ algorithm
         ErrorExt.delCheckpoint("Static.elabExp:IFEXP:HACK");
         ErrorExt.rollBack("Static.elabExp:IFEXP");
       then
-        ();
+        (outCache, outExp, outProperties);
 
     else
       algorithm
@@ -1486,8 +1486,8 @@ public function deduceIterationRange
   input FCore.Graph inEnv;
   input FCore.Cache inCache;
   input Absyn.Info inInfo;
-  output DAE.Exp outRange;
-  output DAE.Properties outProperties;
+  output DAE.Exp outRange = DAE.ICONST(0);
+  output DAE.Properties outProperties = DAE.PROP(DAE.T_UNKNOWN_DEFAULT, DAE.C_UNKNOWN());
   output FCore.Cache outCache = inCache;
 protected
   Absyn.ComponentRef acref;


### PR DESCRIPTION
* Expression.addVec was unused (only Expression.subVec is called from ResolveLoops.mo). Remove addVec; the early-\`return;\` in its body reads back an uninitialised output array.

* Expression.subVec hit the same uninit-output bug on the size-mismatch path. Replace \`return;\` with \`fail();\` so an error message at the caller surfaces, matching the function's documented behaviour.

* Static.elabExp_If: rewrote the inner \`_ := matchcontinue()\` to return its values directly via \`(outCache, outExp, outProperties) := matchcontinue() … then (outCache, outExp, outProperties); \`. Returning the values explicitly makes the data flow direct and easier to analyze.

* Static.deduceIterationRange: initialise \`outRange\` and \`outProperties\` with neutral sentinels (\`DAE.ICONST(0)\` / \`DAE.PROP(T_UNKNOWN_DEFAULT, C_UNKNOWN)\`) to make the analysis easier. (It was safe before, just hard to prove)