### PR TITLE
Fix crash when using input cells in OMNotebook

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
@@ -112,9 +112,17 @@ namespace IAEX
     //TextCell interface.
     virtual QString text() = 0;
     virtual QString textHtml(){return QString();}  // Added 2005-10-27 AF
+    virtual QTextDocument* document() { return nullptr; }
     virtual QTextCursor textCursor();          // Added 2005-10-27 AF
     virtual QTextEdit* textEdit(){return 0;}      // Added 2005-10-27 AF
-    virtual void viewExpression(const bool){};
+    virtual void viewExpression(const bool){}
+    virtual void cutText() {}
+    virtual void copyText() {}
+    virtual void pasteText() {}
+    virtual bool findText(const QString &exp, QTextDocument::FindFlags options) { return false; }
+
+    virtual void clearSelection() {}
+    virtual void moveCursor(QTextCursor::MoveOperation operation) {}
 
     //Cellgroup interface.
     virtual void addChild(Cell *){}

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
@@ -737,10 +737,9 @@ namespace IAEX
         if( dynamic_cast<TextCell*>(cell) || dynamic_cast<InputCell*>(cell) )
         {
           // extraxt text
-          QTextEdit* editor = cell->textEdit();
-          if( editor )
+          QTextCursor cursor = cell->textCursor();
+          if( !cursor.isNull() )
           {
-            QTextCursor cursor = editor->textCursor();
             cursor.movePosition( QTextCursor::End, QTextCursor::KeepAnchor );
             QTextDocumentFragment text = cursor.selection();
             cursor.removeSelectedText();
@@ -763,11 +762,9 @@ namespace IAEX
             }
 
             // add text to new cell
-            QTextEdit* newEditor = document()->getCursor()->currentCell()->textEdit();
-            QTextCursor newCursor = newEditor->textCursor();
-            newCursor.insertFragment( text );
-            newCursor.movePosition( QTextCursor::Start );
-            newEditor->setTextCursor( newCursor );
+            auto currentCell = document()->getCursor()->currentCell();
+            currentCell->textCursor().insertFragment(text);
+            currentCell->moveCursor(QTextCursor::Start);
 
             // update document
             document()->setChanged( true );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.cpp
@@ -209,6 +209,14 @@ namespace IAEX{
     return false;
   }
 
+  QTextDocument* CellGroup::document()
+  {
+    if ( isClosed() && hasChilds() )
+      return child()->document();
+
+    return nullptr;
+  }
+
   /*!
    * \author Anders Fernström
    * \date 2005-08-24
@@ -224,6 +232,56 @@ namespace IAEX{
       return child()->textEdit();
     else
       return 0;
+  }
+
+  void CellGroup::cutText()
+  {
+    if (isClosed() && hasChilds())
+      child()->cutText();
+  }
+
+  void CellGroup::copyText()
+  {
+    if (isClosed() && hasChilds())
+      child()->copyText();
+  }
+
+  void CellGroup::pasteText()
+  {
+    if (isClosed() && hasChilds())
+      child()->pasteText();
+  }
+
+  bool CellGroup::findText(const QString &exp, QTextDocument::FindFlags options)
+  {
+    if (isClosed() && hasChilds()) {
+      return child()->findText(exp, options);
+    }
+
+    return false;
+  }
+
+  QTextCursor CellGroup::textCursor()
+  {
+    if (isClosed() && hasChilds()) {
+      return child()->textCursor();
+    }
+
+    return QTextCursor{};
+  }
+
+  void CellGroup::clearSelection()
+  {
+    if (isClosed() && hasChilds()) {
+      child()->clearSelection();
+    }
+  }
+
+  void CellGroup::moveCursor(QTextCursor::MoveOperation operation)
+  {
+    if (isClosed() && hasChilds()) {
+      child()->moveCursor(operation);
+    }
   }
 
   /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
@@ -89,8 +89,17 @@ namespace IAEX{
     bool isClosed() const;
     bool isEditable();                // Added 2005-10-28 AF
 
+    QTextDocument* document() override;
     QTextEdit* textEdit();              // Added 2006-08-24 AF
 
+    void cutText() override;
+    void copyText() override;
+    void pasteText() override;
+    bool findText(const QString &exp, QTextDocument::FindFlags options) override;
+
+    QTextCursor textCursor() override;
+    void clearSelection() override;
+    void moveCursor(QTextCursor::MoveOperation operation) override;
 
   public slots:
     virtual void setStyle( CellStyle style );    // Changed 2005-10-28 AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -939,6 +939,11 @@ namespace IAEX {
     return te.toHtml();
   }
 
+  QTextDocument* GraphCell::document()
+  {
+    return input_->document();
+  }
+
   /*!
   * \author Anders Fernström
   * \date 2005-11-23
@@ -983,19 +988,6 @@ namespace IAEX {
 
   /*!
   * \author Anders Fernström
-  * \date 2006-01-05
-  *
-  * \brief Return the input texteditor
-  *
-  * \return Texteditor for the inputpart of the GraphCell
-  */
-  QTextEdit *GraphCell::textEdit()
-  {
-    return (QTextEdit*)input_;
-  }
-
-  /*!
-  * \author Anders Fernström
   * \date 2006-02-03
   *
   * \brief Return the output texteditor
@@ -1005,6 +997,48 @@ namespace IAEX {
   QTextEdit* GraphCell::textEditOutput()
   {
     return output_;
+  }
+
+  void GraphCell::cutText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->copy();
+    } else {
+      input_->cut();
+    }
+  }
+
+  void GraphCell::copyText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->copy();
+    } else {
+      input_->copy();
+    }
+  }
+
+  void GraphCell::pasteText()
+  {
+    input_->paste();
+  }
+
+  bool GraphCell::findText(const QString &exp, QTextDocument::FindFlags options)
+  {
+    return input_->find(exp, options);
+  }
+
+  void GraphCell::clearSelection()
+  {
+    auto cursor = input_->textCursor();
+    cursor.clearSelection();
+    input_->setTextCursor(cursor);
+  }
+
+  void GraphCell::moveCursor(QTextCursor::MoveOperation operation)
+  {
+    auto cursor = input_->textCursor();
+    cursor.movePosition(operation);
+    input_->setTextCursor(cursor);
   }
 
   /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.h
@@ -67,12 +67,19 @@ namespace IAEX
 
     QString text();
     QString textHtml();            // Added 2005-10-27 AF
+    QTextDocument* document() override;
     virtual QString textOutput();      // Added 2005-11-23 AF
     virtual QString textOutputHtml();    // Added 2005-11-23 AF
     virtual QTextCursor textCursor();    // Added 2005-10-27 AF
-    virtual QTextEdit* textEdit();      // Added 2006-01-05 AF
     virtual QTextEdit* textEditOutput();  // Added 2006-02-03 AF
     virtual void viewExpression(const bool){}
+    void cutText() override;
+    void copyText() override;
+    void pasteText() override;
+    bool findText(const QString &exp, QTextDocument::FindFlags options) override;
+
+    void clearSelection() override;
+    void moveCursor(QTextCursor::MoveOperation operation) override;
 
     virtual void addCellWidgets();
     virtual void removeCellWidgets();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
@@ -520,6 +520,11 @@ namespace IAEX
     return input_->toHtml();
   }
 
+  QTextDocument* InputCell::document()
+  {
+    return input_->document();
+  }
+
   /*!
    * \author Anders Fernström
    * \date 2005-11-23
@@ -586,6 +591,57 @@ namespace IAEX
   QTextEdit* InputCell::textEditOutput()
   {
     return output_;
+  }
+
+  void InputCell::cutText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->copy();
+    } else {
+      input_->cut();
+    }
+  }
+
+  void InputCell::copyText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->copy();
+    } else {
+      input_->copy();
+    }
+  }
+
+  void InputCell::pasteText()
+  {
+    input_->paste();
+  }
+
+  bool InputCell::findText(const QString &exp, QTextDocument::FindFlags options)
+  {
+    if (input_->find(exp, options)) return true;
+    // Also look inside open input cells.
+    if (!isClosed()) return output_->find(exp, options);
+    return false;
+  }
+
+  void InputCell::clearSelection()
+  {
+    auto cursor = input_->textCursor();
+    cursor.clearSelection();
+    input_->setTextCursor(cursor);
+    cursor = output_->textCursor();
+    cursor.clearSelection();
+    output_->setTextCursor(cursor);
+  }
+
+  void InputCell::moveCursor(QTextCursor::MoveOperation operation)
+  {
+    auto cursor = input_->textCursor();
+    cursor.movePosition(operation);
+    input_->setTextCursor(cursor);
+    cursor = output_->textCursor();
+    cursor.movePosition(operation);
+    output_->setTextCursor(cursor);
   }
 
   /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.h
@@ -67,12 +67,20 @@ namespace IAEX
 
     QString text();
     QString textHtml();            // Added 2005-10-27 AF
+    QTextDocument* document() override;
     virtual QString textOutput();      // Added 2005-11-23 AF
     virtual QString textOutputHtml();    // Added 2005-11-23 AF
     virtual QTextCursor textCursor();    // Added 2005-10-27 AF
     virtual QTextEdit* textEdit();      // Added 2006-01-05 AF
     virtual QTextEdit* textEditOutput();  // Added 2006-02-03 AF
     virtual void viewExpression(const bool){}
+    void cutText() override;
+    void copyText() override;
+    void pasteText() override;
+    bool findText(const QString &exp, QTextDocument::FindFlags options) override;
+
+    void clearSelection() override;
+    void moveCursor(QTextCursor::MoveOperation operation) override;
 
     virtual void addCellWidgets();
     virtual void removeCellWidgets();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
@@ -426,6 +426,11 @@ namespace IAEX {
     return input_->toHtml();
   }
 
+  QTextDocument* LatexCell::document()
+  {
+    return input_->document();
+  }
+
   /*!
   * \brief Return the text inside the output part of the cell
   * as plain text
@@ -468,6 +473,25 @@ namespace IAEX {
     return input_;
   }
 
+  bool LatexCell::findText(const QString &exp, QTextDocument::FindFlags options)
+  {
+    return input_->find(exp, options);
+  }
+
+  void LatexCell::clearSelection()
+  {
+    auto cursor = input_->textCursor();
+    cursor.clearSelection();
+    input_->setTextCursor(cursor);
+  }
+
+  void LatexCell::moveCursor(QTextCursor::MoveOperation operation)
+  {
+    auto cursor = input_->textCursor();
+    cursor.movePosition(operation);
+    input_->setTextCursor(cursor);
+  }
+
   /*!
   * \brief Return the output texteditor
   * \return Texteditor for the output part of the LatexCell
@@ -475,6 +499,33 @@ namespace IAEX {
   QTextEdit* LatexCell::textEditOutput()
   {
     return output_;
+  }
+
+  void LatexCell::cutText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->cut();
+    } else {
+      input_->cut();
+    }
+  }
+
+  void LatexCell::copyText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->copy();
+    } else {
+      input_->copy();
+    }
+  }
+
+  void LatexCell::pasteText()
+  {
+    if (output_->hasFocus() && isEvaluated()) {
+      output_->paste();
+    } else {
+      input_->paste();
+    }
   }
 
   /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.h
@@ -59,12 +59,20 @@ namespace IAEX
     virtual ~LatexCell();
     QString text();
     QString textHtml();
+    QTextDocument* document() override;
     virtual QString textOutput();
     virtual QString textOutputHtml();
     virtual QTextCursor textCursor();
     virtual QTextEdit* textEdit();
     virtual QTextEdit* textEditOutput();
     virtual void viewExpression(const bool){}
+    void cutText() override;
+    void copyText() override;
+    void pasteText() override;
+    bool findText(const QString &exp, QTextDocument::FindFlags options) override;
+
+    void clearSelection() override;
+    void moveCursor(QTextCursor::MoveOperation operation) override;
 
     virtual void addCellWidgets();
     virtual void removeCellWidgets();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
@@ -1698,17 +1698,17 @@ void NotebookWindow::updateStyleMenu()
   */
 void NotebookWindow::updateEditMenu()
 {
-  QTextEdit *editor = subject_->getCursor()->currentCell()->textEdit();
-  if( editor )
+  QTextDocument *doc = subject_->getCursor()->currentCell()->document();
+  if( doc )
   {
     // undo
-    if( editor->document()->isUndoAvailable() )
+    if( doc->isUndoAvailable() )
       undoAction->setEnabled( true );
     else
       undoAction->setEnabled( false );
 
     // redo
-    if( editor->document()->isRedoAvailable() )
+    if( doc->isRedoAvailable() )
       redoAction->setEnabled( true );
     else
       redoAction->setEnabled( false );
@@ -1747,7 +1747,7 @@ void NotebookWindow::updateEditMenu()
       }
       else
       {
-        in_cursor = editor->textCursor();
+        in_cursor = subject_->getCursor()->currentCell()->textCursor();
       }
 
       if( in_cursor.hasSelection() ||
@@ -3332,11 +3332,8 @@ void NotebookWindow::changeWindow(QAction *action)
   */
 void NotebookWindow::undoEdit()
 {
-  QTextEdit *editor = subject_->getCursor()->currentCell()->textEdit();
-  if( editor )
-  {
-    editor->document()->undo();
-  }
+  QTextDocument *doc = subject_->getCursor()->currentCell()->document();
+  if( doc ) doc->undo();
 }
 
 /*!
@@ -3347,11 +3344,8 @@ void NotebookWindow::undoEdit()
   */
 void NotebookWindow::redoEdit()
 {
-  QTextEdit *editor = subject_->getCursor()->currentCell()->textEdit();
-  if( editor )
-  {
-    editor->document()->redo();
-  }
+  QTextDocument *doc = subject_->getCursor()->currentCell()->document();
+  if( doc ) doc->redo();
 }
 
 /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/replaceallvisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/replaceallvisitor.h
@@ -79,14 +79,13 @@ namespace IAEX
     // Visitor function - TEXTCELL
     void visitTextCellNodeBefore( TextCell *node )
     {
-      if( node->textEdit() )
+      auto cursor = node->textCursor();
+      if( !cursor.isNull() )
       {
         int options( 0 );
 
         // move cursor to start of text
-        QTextCursor cursor = node->textEdit()->textCursor();
-        cursor.movePosition( QTextCursor::Start );
-        node->textEdit()->setTextCursor( cursor );
+        node->moveCursor(QTextCursor::Start);
 
         // match case & match word
         if( matchCase_ && matchWord_ )
@@ -97,9 +96,8 @@ namespace IAEX
           options = QTextDocument::FindWholeWords;
 
         // replace all
-        while( node->textEdit()->find( findText_, (QTextDocument::FindFlag)options ))
-        {
-          node->textEdit()->textCursor().insertText( replaceText_ );
+        while (node->findText(findText_, (QTextDocument::FindFlag)options)) {
+          node->textCursor().insertText(replaceText_);
           if( count_ )
             (*count_)++;
         }
@@ -110,14 +108,13 @@ namespace IAEX
     // Visitor function - INPUTCELL
     void visitInputCellNodeBefore( InputCell *node )
     {
-      if( node->textEdit() )
+      auto cursor = node->textCursor();
+      if( !cursor.isNull() )
       {
         int options( 0 );
 
         // move cursor to start of text
-        QTextCursor cursor = node->textEdit()->textCursor();
-        cursor.movePosition( QTextCursor::Start );
-        node->textEdit()->setTextCursor( cursor );
+        node->moveCursor(QTextCursor::Start);
 
         // match case & match word
         if( matchCase_ && matchWord_ )
@@ -128,9 +125,8 @@ namespace IAEX
           options = QTextDocument::FindWholeWords;
 
         // replace all
-        while( node->textEdit()->find( findText_, (QTextDocument::FindFlag)options ))
-        {
-          node->textEdit()->textCursor().insertText( replaceText_ );
+        while (node->findText(findText_, (QTextDocument::FindFlag)options)) {
+          node->textCursor().insertText(replaceText_);
           if( count_ )
             (*count_)++;
         }
@@ -142,14 +138,13 @@ namespace IAEX
     // Visitor function - GRAPHCELL
     void visitGraphCellNodeBefore( GraphCell *node )
     {
-      if( node->textEdit() )
+      auto cursor = node->textCursor();
+      if( !cursor.isNull() )
       {
         int options( 0 );
 
         // move cursor to start of text
-        QTextCursor cursor = node->textEdit()->textCursor();
-        cursor.movePosition( QTextCursor::Start );
-        node->textEdit()->setTextCursor( cursor );
+        node->moveCursor(QTextCursor::Start);
 
         // match case & match word
         if( matchCase_ && matchWord_ )
@@ -160,9 +155,8 @@ namespace IAEX
           options = QTextDocument::FindWholeWords;
 
         // replace all
-        while( node->textEdit()->find( findText_, (QTextDocument::FindFlag)options ))
-        {
-          node->textEdit()->textCursor().insertText( replaceText_ );
+        while (node->findText(findText_, (QTextDocument::FindFlag)options)) {
+          node->textCursor().insertText(replaceText_);
           if( count_ )
             (*count_)++;
         }
@@ -172,14 +166,13 @@ namespace IAEX
 
     void visitLatexCellNodeBefore( LatexCell *node )
     {
-      if( node->textEdit() )
+      auto cursor = node->textCursor();
+      if( !cursor.isNull() )
       {
         int options( 0 );
 
         // move cursor to start of text
-        QTextCursor cursor = node->textEdit()->textCursor();
-        cursor.movePosition( QTextCursor::Start );
-        node->textEdit()->setTextCursor( cursor );
+        node->moveCursor(QTextCursor::Start);
 
         // match case & match word
         if( matchCase_ && matchWord_ )
@@ -190,9 +183,8 @@ namespace IAEX
           options = QTextDocument::FindWholeWords;
 
         // replace all
-        while( node->textEdit()->find( findText_, (QTextDocument::FindFlag)options ))
-        {
-          node->textEdit()->textCursor().insertText( replaceText_ );
+        while (node->findText(findText_, (QTextDocument::FindFlag)options)) {
+          node->textCursor().insertText(replaceText_);
           if( count_ )
             (*count_)++;
         }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/searchform.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/searchform.cpp
@@ -181,58 +181,25 @@ namespace IAEX
     while( !foundText )
     {
       // if cell have a editor, search in it.
-      QTextEdit* editor;
       if( currentCell )
       {
-        editor = currentCell->textEdit();
-        if( editor )
+        // FIND FUNCTION
+        if( searchDown )
         {
-          // FIND FUNCTION
-          if( searchDown )
+          if( currentCell->findText( searchText_, (QTextDocument::FindFlag)options ))
           {
-            if( editor->find( searchText_, (QTextDocument::FindFlag)options ))
-            {
-              // TODO: Activate Main Window, don't know if it is necessary
-              //parentWidget()->activateWindow();
-              break;
-            }
-          }
-          else
-          {
-            if( editor->find( searchText_, (QTextDocument::FindFlag)options | QTextDocument::FindBackward ))
-            {
-              // TODO: Activate Main Window, don't know if it is necessary
-              //parentWidget()->activateWindow();
-              break;
-            }
+            // TODO: Activate Main Window, don't know if it is necessary
+            //parentWidget()->activateWindow();
+            break;
           }
         }
-
-        // search inside inputcells
-        if( typeid( (*currentCell) ) == typeid( InputCell ) )
+        else
         {
-          InputCell* inputcell = dynamic_cast<InputCell*>( currentCell );
-          if( inputcell )
+          if( currentCell->findText( searchText_, (QTextDocument::FindFlag)options | QTextDocument::FindBackward ))
           {
-            // only look inside open inputcells
-            if( !inputcell->isClosed() )
-            {
-              editor = inputcell->textEditOutput();
-              if( editor )
-              {
-                // FIND FUNCTION
-                if( searchDown )
-                {
-                  if( editor->find( searchText_, (QTextDocument::FindFlag)options ))
-                    break;
-                }
-                else
-                {
-                  if( editor->find( searchText_, (QTextDocument::FindFlag)options | QTextDocument::FindBackward ))
-                    break;
-                }
-              }
-            }
+            // TODO: Activate Main Window, don't know if it is necessary
+            //parentWidget()->activateWindow();
+            break;
           }
         }
       }
@@ -286,23 +253,9 @@ namespace IAEX
         }
 
         // before moving, clear last cursor selection
-        if( currentCell->textEdit() )
+        if( currentCell )
         {
-          QTextCursor cursor = currentCell->textEdit()->textCursor();
-          cursor.clearSelection();
-          currentCell->textEdit()->setTextCursor( cursor );
-
-          // if inputcell, clear output also
-          if( typeid( (*currentCell) ) == typeid( InputCell ) )
-          {
-            InputCell* inputcell = dynamic_cast<InputCell*>( currentCell );
-            if( inputcell )
-            {
-              QTextCursor cursor = inputcell->textEditOutput()->textCursor();
-              cursor.clearSelection();
-              inputcell->textEditOutput()->setTextCursor( cursor );
-            }
-          }
+          currentCell->clearSelection();
         }
 
         if( document_->getCursor()->moveDown() )
@@ -316,29 +269,7 @@ namespace IAEX
           // if the new currentCell have a text editor, move the text cursor to pos 'start'
           if( currentCell )
           {
-            editor = currentCell->textEdit();
-            if( editor )
-            {
-              QTextCursor cursor = editor->textCursor();
-              cursor.movePosition( QTextCursor::Start );
-              editor->setTextCursor( cursor );
-            }
-
-            // if inputcell, also move the cursor of the output
-            if( typeid( (*currentCell) ) == typeid( InputCell ) )
-            {
-              InputCell* inputcell = dynamic_cast<InputCell*>( currentCell );
-              if( inputcell )
-              {
-                editor = inputcell->textEditOutput();
-                if( editor )
-                {
-                  QTextCursor cursor = editor->textCursor();
-                  cursor.movePosition( QTextCursor::Start );
-                  editor->setTextCursor( cursor );
-                }
-              }
-            }
+            currentCell->moveCursor(QTextCursor::Start);
           }
         }
         else
@@ -354,23 +285,9 @@ namespace IAEX
       {
         // UP
         // before moving, clear last cursor selection
-        if( currentCell->textEdit() )
+        if( currentCell )
         {
-          QTextCursor cursor = currentCell->textEdit()->textCursor();
-          cursor.clearSelection();
-          currentCell->textEdit()->setTextCursor( cursor );
-
-          // if inputcell, clear output also
-          if( typeid( (*currentCell) ) == typeid( InputCell ) )
-          {
-            InputCell* inputcell = dynamic_cast<InputCell*>( currentCell );
-            if( inputcell )
-            {
-              QTextCursor cursor = inputcell->textEditOutput()->textCursor();
-              cursor.clearSelection();
-              inputcell->textEditOutput()->setTextCursor( cursor );
-            }
-          }
+          currentCell->clearSelection();
         }
 
         // move
@@ -383,31 +300,7 @@ namespace IAEX
           currentCell = document_->getCursor()->currentCell();
           if( currentCell )
           {
-            // if the new currentCell have a text editor,
-            // move the text cursor to pos 'end'
-            editor = currentCell->textEdit();
-            if( editor )
-            {
-              QTextCursor cursor = editor->textCursor();
-              cursor.movePosition( QTextCursor::End );
-              editor->setTextCursor( cursor );
-            }
-
-            // if inputcell, also move the cursor of the output
-            if( typeid( (*currentCell) ) == typeid( InputCell ) )
-            {
-              InputCell* inputcell = dynamic_cast<InputCell*>( currentCell );
-              if( inputcell )
-              {
-                editor = inputcell->textEditOutput();
-                if( editor )
-                {
-                  QTextCursor cursor = editor->textCursor();
-                  cursor.movePosition( QTextCursor::End );
-                  editor->setTextCursor( cursor );
-                }
-              }
-            }
+            currentCell->moveCursor(QTextCursor::End);
 
             // if the new currentCell is closed and the option inside cells is set,
             // open the new cell
@@ -456,27 +349,23 @@ namespace IAEX
     Cell* currentCell = document_->getCursor()->currentCell();
     if( currentCell )
     {
-      QTextEdit* editor = currentCell->textEdit();
-      if( editor )
+      QTextCursor cursor = currentCell->textCursor();
+      if( cursor.hasSelection() )
       {
-        QTextCursor cursor = editor->textCursor();
-        if( cursor.hasSelection() )
-        {
-          // check if correct text is selected
-          int cs( 0 );
-          QString text = cursor.selectedText();
-          if( matchCase_ )
-            cs = Qt::CaseSensitive;
-          else
-            cs = Qt::CaseInsensitive;
+        // check if correct text is selected
+        int cs( 0 );
+        QString text = cursor.selectedText();
+        if( matchCase_ )
+          cs = Qt::CaseSensitive;
+        else
+          cs = Qt::CaseInsensitive;
 
-          if( text.startsWith( searchText_, ( Qt::CaseSensitivity)cs ) &&
-            text.endsWith( searchText_, ( Qt::CaseSensitivity)cs ))
-          {
-            // REPLACE
-            correct = true;
-            cursor.insertText( ui.replaceText_->text() );
-          }
+        if( text.startsWith( searchText_, ( Qt::CaseSensitivity)cs ) &&
+          text.endsWith( searchText_, ( Qt::CaseSensitivity)cs ))
+        {
+          // REPLACE
+          correct = true;
+          cursor.insertText( ui.replaceText_->text() );
         }
       }
     }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
@@ -69,53 +69,7 @@ namespace IAEX
   void TextCursorCutText::execute()
   {
     Cell *cell = document()->getCursor()->currentCell();
-    if( cell )
-    {
-      if( typeid(InputCell) == typeid(*cell) )
-      {
-        InputCell *inputcell = dynamic_cast<InputCell*>(cell);
-        if( inputcell->textEditOutput()->hasFocus() &&
-          inputcell->isEvaluated() )
-        {
-          inputcell->textEditOutput()->copy();
-        }
-        else
-          inputcell->textEdit()->cut();
-      }
-      else if( typeid(GraphCell) == typeid(*cell) )
-      {
-        GraphCell *graphcell = dynamic_cast<GraphCell*>(cell);
-        if( graphcell->textEditOutput()->hasFocus() &&
-          graphcell->isEvaluated() )
-        {
-          graphcell->textEditOutput()->copy();
-        }
-        else
-          graphcell->textEdit()->cut();
-      }
-
-      else if( typeid(LatexCell) == typeid(*cell) )
-      {
-        LatexCell *latexcell = dynamic_cast<LatexCell*>(cell);
-        if( latexcell->textEditOutput()->hasFocus() &&
-          latexcell->isEvaluated() )
-        {
-          latexcell->textEditOutput()->cut();
-        }
-        else
-          latexcell->textEdit()->cut();
-      }
-
-
-      else
-      {
-        QTextEdit *editor = cell->textEdit();
-        if( editor )
-        {
-          editor->cut();
-        }
-      }
-    }
+    if( cell ) cell->cutText();
   }
 
 
@@ -129,50 +83,7 @@ namespace IAEX
   void TextCursorCopyText::execute()
   {
     Cell *cell = document()->getCursor()->currentCell();
-    if( cell )
-    {
-      if( typeid(InputCell) == typeid(*cell) )
-      {
-        InputCell *inputcell = dynamic_cast<InputCell*>(cell);
-        if( inputcell->textEditOutput()->hasFocus() &&
-          inputcell->isEvaluated() )
-        {
-          inputcell->textEditOutput()->copy();
-        }
-        else
-          inputcell->textEdit()->copy();
-      }
-      else if( typeid(GraphCell) == typeid(*cell) )
-      {
-        GraphCell *graphcell = dynamic_cast<GraphCell*>(cell);
-        if( graphcell->textEditOutput()->hasFocus() &&
-          graphcell->isEvaluated() )
-        {
-          graphcell->textEditOutput()->copy();
-        }
-        else
-          graphcell->textEdit()->copy();
-      }
-      else if( typeid(LatexCell) == typeid(*cell) )
-      {
-        LatexCell *latexcell = dynamic_cast<LatexCell*>(cell);
-        if( latexcell->textEditOutput()->hasFocus() &&
-          latexcell->isEvaluated() )
-        {
-          latexcell->textEditOutput()->copy();
-        }
-        else
-          latexcell->textEdit()->copy();
-      }
-      else
-      {
-        QTextEdit *editor = cell->textEdit();
-        if( editor )
-        {
-          editor->copy();
-        }
-      }
-    }
+    if (cell) cell->copyText();
   }
 
 
@@ -186,37 +97,7 @@ namespace IAEX
   void TextCursorPasteText::execute()
   {
       Cell *cell = document()->getCursor()->currentCell();
-      if( cell )
-      {
-        if( typeid(LatexCell) == typeid(*cell) )
-        {
-          LatexCell *latexcell = dynamic_cast<LatexCell*>(cell);
-          if( latexcell->textEditOutput()->hasFocus() &&
-            latexcell->isEvaluated() )
-          {
-            latexcell->textEditOutput()->paste();
-          }
-          else
-          {
-            latexcell->textEdit()->paste();
-          }
-        }
-        else
-        {
-          QTextEdit *editor = cell->textEdit();
-          if( editor )
-          {
-            editor->paste();
-          }
-        }
-
-      }
-
-  /*  QTextEdit *editor = document()->getCursor()->currentCell()->textEdit();
-    if( editor )
-    {
-      editor->paste();
-    }*/
+      if ( cell ) cell->pasteText();
   }
 
 

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -93,7 +93,7 @@ private:
 	QComboBox* mpSimulationSpeedComboBox;
 	QFile mFile;
 	QStringList mVariablesList;
-	PlotType mPlotType;
+	PlotType mPlotType = PLOT;
 	QString mGridType;
 	QString mXLabel;
 	QString mYLabel;


### PR DESCRIPTION
- Remove GraphCell::textEdit since it doesn't have a QTextEdit to return.
- Implement various operations as virtual methods instead of directly accessing the text editor for a cell.
- Make sure PlotWindow::mPlotType is always initialized.

Fixes #15661