### PR TITLE
[NB] revert lbinaries change in events

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -1123,7 +1123,7 @@ protected
       then exp;
 
       // logical binarys: e.g. (a and b)
-      case Expression.LBINARY() guard(Expression.fold(exp, containsRelation, false)) algorithm
+      case Expression.LBINARY() algorithm
         (exp, bucket) := collectEventsCondition(exp, Pointer.access(bucket_ptr), iter, eqn, funcMap, createEqn);
         Pointer.update(bucket_ptr, bucket);
       then exp;
@@ -1225,15 +1225,6 @@ protected
       Pointer.update(b, true);
     end if;
   end containsTimeTraverseCref;
-
-  function containsRelation
-    input Expression exp;
-    input output Boolean b;
-  algorithm
-    if not b then
-      b := Expression.isRelation(exp);
-    end if;
-  end containsRelation;
 
 annotation(__OpenModelica_Interface="backend");
 end NBEvents;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -430,16 +430,6 @@ public
     end match;
   end isTrivialCref;
 
-  function isRelation
-    input Expression exp;
-    output Boolean b;
-  algorithm
-    b := match exp
-      case RELATION() then true;
-      else false;
-    end match;
-  end isRelation;
-
   function hash
     input Expression exp;
     output Integer hash = hashContinue(exp, Util.HASH_SEED);


### PR DESCRIPTION
 - do not restrict lbinaries to those that contain relations. when equations need to have a single cref representing the condition
- aims to fix [regressions](https://libraries.openmodelica.org/branches/history/newInst-newBackend/2026-05-28%2006:45:37..2026-05-28%2023:31:43.html)