### PR TITLE
[C/OMEdit] Handle NULL flag names/descriptions

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -306,7 +306,7 @@ static void readFlag(int *flag, int max, const char *value, const char *flagName
   }
 
   for (i=1; i<max; ++i) {
-    if (0 == strcmp(value, names[i])) {
+    if (names[i] != NULL && 0 == strcmp(value, names[i])) {
       *flag = i;
       return;
     }
@@ -314,7 +314,9 @@ static void readFlag(int *flag, int max, const char *value, const char *flagName
 
   warningStreamPrint(OMC_LOG_STDOUT, 1, "unrecognized option %s=%s, current options are:", flagName, value);
   for (i=1; i<max; ++i) {
-    warningStreamPrint(OMC_LOG_STDOUT, 0, "%-18s [%s]", names[i], desc[i]);
+    if (names[i] != NULL) {
+      warningStreamPrint(OMC_LOG_STDOUT, 0, "%-19s [%s]", names[i], desc[i] != NULL ? desc[i] : "");
+    }
   }
   messageCloseWarning(OMC_LOG_STDOUT);
   throwStreamPrint(NULL,"see last warning");

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
@@ -462,7 +462,7 @@ void freeRK_NLS_DATA(NONLINEAR_SYSTEM_DATA* nlsData)
     gbInternalNlsFree(dataSolver->ordinaryData);
     break;
   default:
-    throwStreamPrint(NULL, "Not handled NONLINEAR_SOLVER in gbode_freeData. Are we leaking memroy?");
+    throwStreamPrint(NULL, "Not handled NONLINEAR_SOLVER in gbode_freeData. Are we leaking memory?");
   }
   free(dataSolver);
   freeNlsDataGB(nlsData);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3119,8 +3119,10 @@ QStringList OMCProxy::getEnumerationLiterals(QString className)
 void OMCProxy::getSolverMethods(QStringList *methods, QStringList *descriptions)
 {
   for (int i = S_UNKNOWN + 1 ; i < S_MAX ; i++) {
-    *methods << SOLVER_METHOD_NAME[i];
-    *descriptions << SOLVER_METHOD_DESC[i];
+    if (SOLVER_METHOD_NAME[i] != NULL) {
+      *methods << SOLVER_METHOD_NAME[i];
+      *descriptions << (SOLVER_METHOD_DESC[i] != NULL ? SOLVER_METHOD_DESC[i] : "");
+    }
   }
 }
 
@@ -3133,8 +3135,10 @@ void OMCProxy::getSolverMethods(QStringList *methods, QStringList *descriptions)
 void OMCProxy::getJacobianMethods(QStringList *methods, QStringList *descriptions)
 {
   for (int i = JAC_UNKNOWN + 1 ; i < JAC_MAX ; i++) {
-    *methods << JACOBIAN_METHOD_NAME[i];
-    *descriptions << JACOBIAN_METHOD_DESC[i];
+    if (JACOBIAN_METHOD_NAME[i] != NULL) {
+      *methods << JACOBIAN_METHOD_NAME[i];
+      *descriptions << (JACOBIAN_METHOD_DESC[i] != NULL ? JACOBIAN_METHOD_DESC[i] : "");
+    }
   }
 }
 
@@ -3157,8 +3161,10 @@ QString OMCProxy::getJacobianFlagDetailedDescription()
 void OMCProxy::getInitializationMethods(QStringList *methods, QStringList *descriptions)
 {
   for (int i = IIM_UNKNOWN + 1 ; i < IIM_MAX ; i++) {
-    *methods << INIT_METHOD_NAME[i];
-    *descriptions << INIT_METHOD_DESC[i];
+    if (INIT_METHOD_NAME[i] != NULL) {
+      *methods << INIT_METHOD_NAME[i];
+      *descriptions << (INIT_METHOD_DESC[i] != NULL ? INIT_METHOD_DESC[i] : "");
+    }
   }
 }
 
@@ -3171,8 +3177,10 @@ void OMCProxy::getInitializationMethods(QStringList *methods, QStringList *descr
 void OMCProxy::getLinearSolvers(QStringList *methods, QStringList *descriptions)
 {
   for (int i = LS_NONE + 1 ; i < LS_MAX ; i++) {
-    *methods << LS_NAME[i];
-    *descriptions << LS_DESC[i];
+    if (LS_NAME[i] != NULL) {
+      *methods << LS_NAME[i];
+      *descriptions << (LS_DESC[i] != NULL ? LS_DESC[i] : "");
+    }
   }
 }
 
@@ -3185,8 +3193,10 @@ void OMCProxy::getLinearSolvers(QStringList *methods, QStringList *descriptions)
 void OMCProxy::getNonLinearSolvers(QStringList *methods, QStringList *descriptions)
 {
   for (int i = NLS_NONE + 1 ; i < NLS_MAX ; i++) {
-    *methods << NLS_NAME[i];
-    *descriptions << NLS_DESC[i];
+    if (NLS_NAME[i] != NULL) {
+      *methods << NLS_NAME[i];
+      *descriptions << (NLS_DESC[i] != NULL ? NLS_DESC[i] : "");
+    }
   }
 }
 
@@ -3199,8 +3209,10 @@ void OMCProxy::getNonLinearSolvers(QStringList *methods, QStringList *descriptio
 void OMCProxy::getLogStreams(QStringList *names, QStringList *descriptions)
 {
   for (int i = firstOMCErrorStream ; i < OMC_SIM_LOG_MAX ; i++) {
-    *names << OMC_LOG_STREAM_NAME[i];
-    *descriptions << OMC_LOG_STREAM_DESC[i];
+    if (OMC_LOG_STREAM_NAME[i] != NULL) {
+      *names << OMC_LOG_STREAM_NAME[i];
+      *descriptions << (OMC_LOG_STREAM_DESC[i] != NULL ? OMC_LOG_STREAM_DESC[i] : "");
+    }
   }
 }
 


### PR DESCRIPTION
### Related Issues

#15678

### Purpose

Fix segmentation fault in case `names[i]` or `desc[i]` is `NULL`.
Don't display settings with missing names in OMEdit:

<img width="1424" height="1207" alt="image" src="https://github.com/user-attachments/assets/df9a968f-91d3-44cf-b283-f5f1be9e426e" />

### Approach

* Handle `NULL` in `readFlags`
* Skip `NULL` names in get functions in OMCProxy.cpp.
