### PR TITLE
Add flag to dump confidence numbers

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/BaseModelica.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/BaseModelica.mo
@@ -54,12 +54,14 @@ public
       ScalarizeMode scalarizeMode;
       RecordMode recordMode;
       Boolean moveBindings;
+      Boolean showConfidence;
     end OUTPUT_FORMAT;
   end OutputFormat;
 
   constant OutputFormat defaultFormat = OutputFormat.OUTPUT_FORMAT(
       ScalarizeMode.PARTIALLY_SCALARIZED,
       RecordMode.WITH_RECORDS,
+      false,
       false
   );
 
@@ -80,6 +82,7 @@ public
         case "nonScalarized"       algorithm format.scalarizeMode := ScalarizeMode.NOT_SCALARIZED; then ();
         case "withRecords"         algorithm format.recordMode := RecordMode.WITH_RECORDS; then ();
         case "withoutRecords"      algorithm format.recordMode := RecordMode.WITHOUT_RECORDS; then ();
+        case "showConfidence"      algorithm format.showConfidence := true; then ();
         else ();
       end match;
     end for;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -494,6 +494,10 @@ public
       case INVALID_BINDING() then toFlatString(binding.binding, format, prefix);
       else "";
     end match;
+
+    if format.showConfidence then
+      string := string + " /* confidence = " + String(actualConfidence(binding)) + "*/";
+    end if;
   end toFlatString;
 
   function toDebugString

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -846,6 +846,12 @@ public
       s := IOStream.append(s, " = ");
       s := IOStream.append(s, Expression.toFlatString(bind_exp, format));
 
+      if format.showConfidence then
+        s := IOStream.append(s, " /* confidence = ");
+        s := IOStream.append(s, String(Binding.actualConfidence(binding)));
+        s := IOStream.append(s, "*/");
+      end if;
+
       ty_attrs := listRest(ty_attrs);
       if listEmpty(ty_attrs) then
         break;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1361,7 +1361,8 @@ constant ConfigFlag BASE_MODELICA_FORMAT = CONFIG_FLAG(153, "baseModelicaFormat"
     ("partiallyScalarized", Gettext.notrans("Include subscripts in the quoted identifiers, except for the last name ('a[1].x'[3]).")),
     ("nonScalarized", Gettext.notrans("Don't include subscripts in the quoted identifiers ('a'[1].'x'[3]).")),
     ("withRecords", Gettext.notrans("Keep records and don't expand them.")),
-    ("withoutRecords", Gettext.notrans("Expand records into separate components."))
+    ("withoutRecords", Gettext.notrans("Expand records into separate components.")),
+    ("showConfidence", Gettext.notrans("Add comments that show confidence numbers for binding equations."))
   })),
   Gettext.gettext("Formatting options for Base Modelica"));
 constant ConfigFlag BASE_MODELICA_OPTIONS = CONFIG_FLAG(154, "baseModelicaOptions",

--- a/testsuite/flattening/modelica/modification/Confidence1.mo
+++ b/testsuite/flattening/modelica/modification/Confidence1.mo
@@ -1,0 +1,28 @@
+// name:     Confidence1
+// keywords: modification confidence
+// status:   correct
+//
+
+model Confidence1
+  model M1
+    Real x(start = 4.0);
+    Real y(start = 5.0);
+  equation
+    x = y;
+  end M1;
+
+  M1 m1(x(start = 3.0));
+  annotation(__OpenModelica_commandLineOptions="-f --baseModelicaFormat=showConfidence");
+end Confidence1;
+
+// Result:
+// //! base 0.1.0
+// package 'Confidence1'
+//   model 'Confidence1'
+//     Real 'm1.x'(start = 3.0 /* confidence = 1*/);
+//     Real 'm1.y'(start = 5.0 /* confidence = 2*/);
+//   equation
+//     'm1.x' = 'm1.y';
+//   end 'Confidence1';
+// end 'Confidence1';
+// endResult

--- a/testsuite/flattening/modelica/modification/Confidence2.mo
+++ b/testsuite/flattening/modelica/modification/Confidence2.mo
@@ -1,0 +1,32 @@
+// name:     Confidence2
+// keywords: modification confidence
+// status:   correct
+//
+
+model Confidence2
+  model M2
+    parameter Real xStart = 4.0;
+    parameter Real yStart = 5.0;
+    Real x(start = xStart);
+    Real y(start = yStart);
+  equation
+    x = y;
+  end M2;
+
+  M2 m2(xStart = 3.0);
+  annotation(__OpenModelica_commandLineOptions="-f --baseModelicaFormat=showConfidence");
+end Confidence2;
+
+// Result:
+// //! base 0.1.0
+// package 'Confidence2'
+//   model 'Confidence2'
+//     parameter Real 'm2.xStart' = 3.0 /* confidence = 1*/;
+//     parameter Real 'm2.yStart' = 5.0 /* confidence = 2*/;
+//     Real 'm2.x'(start = 'm2.xStart' /* confidence = 1*/);
+//     Real 'm2.y'(start = 'm2.yStart' /* confidence = 2*/);
+//   equation
+//     'm2.x' = 'm2.y';
+//   end 'Confidence2';
+// end 'Confidence2';
+// endResult

--- a/testsuite/flattening/modelica/modification/Confidence3.mo
+++ b/testsuite/flattening/modelica/modification/Confidence3.mo
@@ -1,0 +1,39 @@
+// name:     Confidence3
+// keywords: modification confidence
+// status:   correct
+//
+
+model Confidence3
+  model M3
+    model MLocal
+      parameter Real xStart = 4.0;
+      Real x(start = xStart);
+    end MLocal;
+    model MLocalWrapped
+      parameter Real xStart = 4.0;
+      MLocal m(xStart = xStart);
+    end MLocalWrapped;
+    MLocal mx;
+    MLocalWrapped my(xStart = 3.0);
+  equation
+    mx.x = my.m.x;
+  end M3;
+
+  M3 m3;
+  annotation(__OpenModelica_commandLineOptions="-f --baseModelicaFormat=showConfidence");
+end Confidence3;
+
+// Result:
+// //! base 0.1.0
+// package 'Confidence3'
+//   model 'Confidence3'
+//     parameter Real 'm3.mx.xStart' = 4.0 /* confidence = 3*/;
+//     Real 'm3.mx.x'(start = 'm3.mx.xStart' /* confidence = 3*/);
+//     parameter Real 'm3.my.xStart' = 3.0 /* confidence = 2*/;
+//     parameter Real 'm3.my.m.xStart' = 'm3.my.xStart' /* confidence = 2*/;
+//     Real 'm3.my.m.x'(start = 'm3.my.m.xStart' /* confidence = 2*/);
+//   equation
+//     'm3.mx.x' = 'm3.my.m.x';
+//   end 'Confidence3';
+// end 'Confidence3';
+// endResult

--- a/testsuite/flattening/modelica/modification/Makefile
+++ b/testsuite/flattening/modelica/modification/Makefile
@@ -32,6 +32,9 @@ BreakConnectInvalid1.mo \
 BreakConnectInvalid2.mo \
 BreakConnectInvalid2.mo \
 Bug3817.mos \
+Confidence1.mo \
+Confidence2.mo \
+Confidence3.mo \
 DisturbedResistance1.mo \
 DisturbedResistance3.mo \
 DisturbedResistance4.mo \


### PR DESCRIPTION
- Add `--baseModelicaFormat=showConfidence` to add confidence numbers to Base Modelica models.
- Add the examples from the specification as test cases.
