### PR TITLE
Use windeployqt6 utility to copy required Qt binaries and resources

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -16,7 +16,60 @@ else # new OMDev, use clang
 	IS_NEW_OMDEV = true
 	CC = clang
 	CXX = clang++
-	QT_EXTRA_DLLS=libdouble-conversion.dll libzstd.dll libwoff2dec.dll libwoff2common.dll Qt6WebEngineCore.dll Qt6WebEngineWidgets.dll Qt6Positioning.dll Qt6Qml.dll Qt6Quick.dll Qt6QmlMeta.dll Qt6QmlWorkerScript.dll Qt6QmlModels.dll Qt6WebChannel.dll Qt6QuickWidgets.dll Qt6Widgets.dll Qt6Xml.dll libharfbuzz-subset-0.dll liblcms2-2.dll libminizip-1.dll libopenjp2-7.dll libopus-0.dll libsnappy.dll libdeflate.dll libjbig-0.dll libLerc.dll libwebpdemux-2.dll libwebpmux-3.dll libngtcp2-16.dll libngtcp2_crypto_ossl-0.dll libtiff*.dll libnghttp2-14.dll libgraphite2.dll libbrotlidec.dll libbrotlicommon.dll libfontconfig-1.dll
+	QT_EXTRA_DLLS = \
+    libdouble-conversion.dll \
+    libzstd.dll \
+    libharfbuzz-0.dll \
+    libharfbuzz-subset-0.dll \
+    liblcms2-2.dll \
+    libminizip-1.dll \
+    libopenjp2-7.dll \
+    libopus-0.dll \
+    libsnappy.dll \
+    libdeflate.dll \
+    libjbig-0.dll \
+    libLerc.dll \
+    libngtcp2-16.dll \
+    libngtcp2_crypto_ossl-0.dll \
+    libtiff*.dll \
+    libnghttp2-14.dll \
+    libgraphite2.dll \
+    libbrotlidec.dll \
+    libbrotlicommon.dll \
+    libfontconfig-1.dll \
+    libb2-1.dll \
+    libintl-8.dll \
+    libiconv-2.dll \
+    libxslt-1.dll \
+    liblzma-5.dll \
+    libxml2-*.dll \
+    libwebp-*.dll \
+    zlib1.dll \
+    libpng16-16.dll \
+    libjpeg-8.dll \
+    libfreetype-6.dll \
+    libglib-2.0-0.dll \
+    libbz2-1.dll \
+    libicuin*.dll \
+    libicuuc*.dll \
+    libicudt*.dll \
+    libpcre*.dll \
+    libOpenThreads.dll \
+    libosg.dll \
+    libosgViewer.dll \
+    libosgDB.dll \
+    libosgUtil.dll \
+    libosgGA.dll \
+    libosgText.dll \
+    libmd4c.dll \
+    libsharpyuv-0.dll \
+    libcurl-4.dll \
+    libcrypto-3-x64.dll \
+    libidn2-0.dll \
+    libunistring-5.dll \
+    libpsl-5.dll \
+    libssh2-1.dll \
+    libssl-3-x64.dll
 endif
 
 # CFLAGS=-g -O2
@@ -43,10 +96,6 @@ builddir_build=$(OMBUILDDIR)
 builddir_bin=$(OMBUILDDIR)/bin
 builddir_lib=$(OMBUILDDIR)/lib/omc
 builddir_inc=$(OMBUILDDIR)/include/omc
-builddir_bin_share_qt5_translations=$(OMBUILDDIR)/bin/share/qt5/translations
-builddir_bin_share_qt6_translations=$(OMBUILDDIR)/bin/share/qt6/translations
-builddir_bin_share_qt6_resources=$(OMBUILDDIR)/bin/share/qt6/resources
-builddir_bin_share_qt6_bin=$(OMBUILDDIR)/bin/share/qt6/bin
 
 PKG_CONFIG_PATH=$(OM_MSYS_ENV_DIR)/lib/pkgconfig
 
@@ -115,7 +164,6 @@ omsimulator:
 	cp -vpPR OMSimulator/install/share/OMSimulator/ $(OMBUILDDIR)/share
 	cp -vpPR OMSimulator/install/lib/* $(OMBUILDDIR)/lib/omc/
 
-
 omnotebook: omc omplot qtclientsDLLs
 	$(MAKE) -f $(defaultMakefileTarget) -C OMNotebook/OMNotebook/OMNotebookGUI OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" OM_QT_MAJOR_VERSION=$(OM_QT_MAJOR_VERSION)
 
@@ -133,91 +181,6 @@ qtclients: omplot omedit omnotebook omshell omoptim omsens_qt
 qtclientsDLLs:
 	echo Copying needed .dlls
 	mkdir -p $(builddir_bin)/
-
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libintl-8.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libiconv-2.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libxslt-1.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/liblzma-5.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libxml2-*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libwebp-*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libsqlite3-0.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/zlib1.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libsz*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libhdf5-*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libpng16-16.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libjpeg-8.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libfreetype-6.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libglib-2.0-0.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libbz2-1.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libicuin*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libicuuc*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libicudt*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libpcre*.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libharfbuzz-0.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libOpenThreads.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosg.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosgViewer.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosgDB.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosgUtil.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosgGA.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libosgText.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libmd4c.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libsharpyuv-0.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libcurl-4.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libcrypto-3-x64.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libidn2-0.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libunistring-5.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libpsl-5.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libssh2-1.dll  $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libssl-3-x64.dll  $(builddir_bin)/
-
-ifeq ($(OM_QT_MAJOR_VERSION),6)
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/libb2-1.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Core.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Gui.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Xml.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Widgets.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Core5Compat.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6PrintSupport.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Svg.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Network.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6OpenGLWidgets.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6OpenGL.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6Concurrent.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6HttpServer.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt6WebSockets.dll $(builddir_bin)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt6/plugins/* $(builddir_bin)/
-	mkdir -p $(builddir_bin_share_qt6_translations)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt6/translations/* $(builddir_bin_share_qt6_translations)/
-	mkdir -p $(builddir_bin_share_qt6_bin)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt6/bin/* $(builddir_bin_share_qt6_bin)/
-	mkdir -p $(builddir_bin_share_qt6_resources)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt6/resources/* $(builddir_bin_share_qt6_resources)/
-else
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Core.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Gui.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Network.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Svg.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5WebKit.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5WebKitWidgets.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Xml.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5XmlPatterns.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Widgets.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5PrintSupport.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Multimedia.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5MultimediaWidgets.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Positioning.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Qml.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Quick.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Sensors.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5WebChannel.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5Sql.dll $(builddir_bin)/
-	cp -puf $(OM_MSYS_ENV_DIR)/bin/Qt5OpenGL.dll $(builddir_bin)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt5/plugins/* $(builddir_bin)/
-	mkdir -p $(builddir_bin_share_qt5_translations)/
-	cp -pufr $(OM_MSYS_ENV_DIR)/share/qt5/translations/* $(builddir_bin_share_qt5_translations)/
-endif
-
 	for f in $(QT_EXTRA_DLLS); do cp -puf $(OM_MSYS_ENV_DIR)/bin/$$f $(builddir_bin)/; done
 	mkdir -p $(builddir_bin)/osgPlugins-3.6.5/
 	cp -pufr $(OM_MSYS_ENV_DIR)/bin/osgPlugins-3.6.5/* $(builddir_bin)/osgPlugins-3.6.5/

--- a/OMEdit/Makefile.omdev.mingw
+++ b/OMEdit/Makefile.omdev.mingw
@@ -49,6 +49,7 @@ mkbuilddirs:
 install: build OMEditLIB/Resources/nls/qm.stamp
 	cp -p $(resourcedir)/*.qm $(builddir_share)/omedit/nls/
 	cp -p bin/$(NAME)$(EXE) $(builddir_bin)
+	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(builddir_bin) $(builddir_bin)/$(NAME)$(EXE)
 
 OMEditLIB/Resources/nls/qm.stamp: OMEditLIB/OMEditLIB.pro OMEditLIB/Resources/nls/*.ts
 	lrelease $<

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -37,23 +37,6 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
     string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
   endif()
 
-  # Install the Qt5/Qt6 plugins directories
-  message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} plugins from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/")
-  install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/plugins/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/)
-  # Install the Qt5/Qt6 translation directories
-  message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} translation from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/")
-  install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/translations/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt${OM_QT_MAJOR_VERSION}/translations)
-  # Install the Qt5/Qt6 resources directories
-  message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} translation from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/resources/")
-  install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/resources/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt${OM_QT_MAJOR_VERSION}/resources)
-  # Install the Qt share/qtX/bin directory
-  message(STATUS "Installing QT${OM_QT_MAJOR_VERSION} translation from ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/bin/")
-  install(DIRECTORY ${MSYSTEM_PREFIX_ESCAPED}/share/qt${OM_QT_MAJOR_VERSION}/bin/    # Note the slash at the end!
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/share/qt${OM_QT_MAJOR_VERSION}/bin)
-
   # TODO: This is stupid, but I can't get install with RUNTIME_DEPENDENCIES to run.
   # It needs to link to libs that are installed to ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR},
   # but if I add that to DIRECTORIES it will throw errors on the second run.
@@ -80,6 +63,32 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
             DIRECTORIES ${MSYSTEM_PREFIX_ESCAPED}/bin ${RUNTIME_LIB_DIRS}
             PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
             POST_EXCLUDE_REGEXES ".*system32/.*\\.dll")
+
+  # Find windeployqt6
+  find_program(WINDEPLOYQT_EXECUTABLE
+    NAMES windeployqt windeployqt6
+    HINTS "${MSYSTEM_PREFIX_ESCAPED}/bin"
+    REQUIRED
+  )
+
+  install(CODE "
+    message(STATUS \"Running windeployqt6 on OMEdit...\")
+    execute_process(
+      COMMAND \"${WINDEPLOYQT_EXECUTABLE}\"
+        --no-compiler-runtime
+        --no-system-d3d-compiler
+        --no-quick-import
+        --libdir \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+        \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/OMEdit.exe\"
+      RESULT_VARIABLE WINDEPLOYQT_RESULT
+      OUTPUT_VARIABLE WINDEPLOYQT_OUTPUT
+      ERROR_VARIABLE  WINDEPLOYQT_ERROR
+    )
+    if(NOT WINDEPLOYQT_RESULT EQUAL 0)
+      message(FATAL_ERROR \"windeployqt6 failed:\n\${WINDEPLOYQT_OUTPUT}\n\${WINDEPLOYQT_ERROR}\")
+    endif()
+    message(STATUS \"windeployqt6 output: \${WINDEPLOYQT_OUTPUT}\")
+  ")
 else ()
   omc_install_gui_client(OMEdit)
 endif()

--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -191,22 +191,18 @@ int main(int argc, char *argv[])
   }
   MMC_INIT();
   MMC_TRY_TOP()
-#if defined(_MSC_VER) || defined(__MINGW32__)
-  const char *installationDirectoryPath = SettingsImpl__getInstallationDirectoryPath();
-  // make QtWebEngineProcess find the Qt dlls!
-  QString p = QString(installationDirectoryPath).replace("/", "\\");
-  qputenv("PATH", QByteArray(p.toUtf8()) + "\\bin;" + qgetenv("PATH"));
+#ifdef Q_OS_WIN
   // currently the sandbox does not work with qt6-webengine
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS", qgetenv("QTWEBENGINE_CHROMIUM_FLAGS") + " --no-sandbox");
+  // make QtWebEngineProcess find the Qt dlls!
   // Qt6Core.dll lives in <install>/bin, so Qt computes its prefix as <install>/ and
-  // looks for QtWebEngine resources/process/locales under <install>/share/qt6/...
-  // We install those under <install>/bin/share/qt6/... instead, so override the
+  // looks for QtWebEngine resources/locales under <install>/...
+  // We install those under <install>/bin/... instead, so override the
   // search paths here before any QtWebEngine subprocess is launched.
-  QByteArray qt6Share = QByteArray(installationDirectoryPath) + "/bin/share/qt6";
-  qputenv("QTWEBENGINEPROCESS_PATH",     qt6Share + "/bin/QtWebEngineProcess.exe");
-  qputenv("QTWEBENGINE_RESOURCES_PATH",  qt6Share + "/resources");
-  qputenv("QTWEBENGINE_LOCALES_PATH",    qt6Share + "/translations/qtwebengine_locales");
-#endif
+  const char *installationDirectoryPath = SettingsImpl__getInstallationDirectoryPath();
+  qputenv("QTWEBENGINE_RESOURCES_PATH",  QByteArray(installationDirectoryPath) + "/bin/resources");
+  qputenv("QTWEBENGINE_LOCALES_PATH",  QByteArray(installationDirectoryPath) + "/bin/translations/qtwebengine_locales");
+#endif // #ifdef Q_OS_WIN
   Q_INIT_RESOURCE(resource_omedit);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -191,18 +191,6 @@ int main(int argc, char *argv[])
   }
   MMC_INIT();
   MMC_TRY_TOP()
-#ifdef Q_OS_WIN
-  // currently the sandbox does not work with qt6-webengine
-  qputenv("QTWEBENGINE_CHROMIUM_FLAGS", qgetenv("QTWEBENGINE_CHROMIUM_FLAGS") + " --no-sandbox");
-  // make QtWebEngineProcess find the Qt dlls!
-  // Qt6Core.dll lives in <install>/bin, so Qt computes its prefix as <install>/ and
-  // looks for QtWebEngine resources/locales under <install>/...
-  // We install those under <install>/bin/... instead, so override the
-  // search paths here before any QtWebEngine subprocess is launched.
-  const char *installationDirectoryPath = SettingsImpl__getInstallationDirectoryPath();
-  qputenv("QTWEBENGINE_RESOURCES_PATH",  QByteArray(installationDirectoryPath) + "/bin/resources");
-  qputenv("QTWEBENGINE_LOCALES_PATH",  QByteArray(installationDirectoryPath) + "/bin/translations/qtwebengine_locales");
-#endif // #ifdef Q_OS_WIN
   Q_INIT_RESOURCE(resource_omedit);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -149,6 +149,24 @@ void dumpQtPaths()
 OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threadData, bool testsuiteRunning)
   : QApplication(argc, argv)
 {
+  const char *installationDirectoryPath = SettingsImpl__getInstallationDirectoryPath();
+  if (!installationDirectoryPath) {
+    QMessageBox::critical(0, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::INSTALLATIONDIRECTORY_NOT_FOUND), QMessageBox::Ok);
+    quit();
+    exit(1);
+  }
+#ifdef Q_OS_WIN
+  // currently the sandbox does not work with qt6-webengine
+  qputenv("QTWEBENGINE_CHROMIUM_FLAGS", qgetenv("QTWEBENGINE_CHROMIUM_FLAGS") + " --no-sandbox");
+  // make QtWebEngineProcess find the Qt dlls!
+  // Qt6Core.dll lives in <install>/bin, so Qt computes its prefix as <install>/ and
+  // looks for QtWebEngine resources/locales under <install>/...
+  // We install those under <install>/bin/... instead, so override the
+  // search paths here before any QtWebEngine subprocess is launched.
+  qputenv("QTWEBENGINE_RESOURCES_PATH",  QByteArray(installationDirectoryPath) + "/bin/resources");
+  qputenv("QTWEBENGINE_LOCALES_PATH",  QByteArray(installationDirectoryPath) + "/bin/translations/qtwebengine_locales");
+#endif // #ifdef Q_OS_WIN
+
 /* We need a better handling of ligth and dark themes.
  * For now just force light theme for Qt 6.8
  * The default color scheme is based on the system theme, so Qt will automatically use light or dark theme based on the user's system settings.
@@ -172,12 +190,6 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
 #endif // #ifdef Q_OS_WIN
   // Localization
   //*a.severin/ add localization
-  const char *installationDirectoryPath = SettingsImpl__getInstallationDirectoryPath();
-  if (!installationDirectoryPath) {
-    QMessageBox::critical(0, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::INSTALLATIONDIRECTORY_NOT_FOUND), QMessageBox::Ok);
-    quit();
-    exit(1);
-  }
   QSettings *pSettings = Utilities::getApplicationSettings();
   QLocale settingsLocale = QLocale(pSettings->value("language").toString());
   QString locale = settingsLocale.name() == "C" ? QLocale::system().name() : settingsLocale.name();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -121,6 +121,33 @@ if(APPLE)
   set_target_properties(OMNotebook PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 endif()
 
+if(MINGW)
+  # Find windeployqt6
+  find_program(WINDEPLOYQT_EXECUTABLE
+    NAMES windeployqt windeployqt6
+    HINTS "${MSYSTEM_PREFIX_ESCAPED}/bin"
+    REQUIRED
+  )
+
+  install(CODE "
+    message(STATUS \"Running windeployqt6 on OMNotebook...\")
+    execute_process(
+      COMMAND \"${WINDEPLOYQT_EXECUTABLE}\"
+        --no-compiler-runtime
+        --no-system-d3d-compiler
+        --no-quick-import
+        --libdir \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+        \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/OMNotebook.exe\"
+      RESULT_VARIABLE WINDEPLOYQT_RESULT
+      OUTPUT_VARIABLE WINDEPLOYQT_OUTPUT
+      ERROR_VARIABLE  WINDEPLOYQT_ERROR
+    )
+    if(NOT WINDEPLOYQT_RESULT EQUAL 0)
+      message(FATAL_ERROR \"windeployqt6 failed:\n\${WINDEPLOYQT_OUTPUT}\n\${WINDEPLOYQT_ERROR}\")
+    endif()
+    message(STATUS \"windeployqt6 output: \${WINDEPLOYQT_OUTPUT}\")
+  ")
+endif()
 
 install(FILES stylesheet.xml
               commands.xml

--- a/OMNotebook/OMNotebook/OMNotebookGUI/Makefile.omdev.mingw
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/Makefile.omdev.mingw
@@ -43,6 +43,7 @@ build: omc_config.h $(NAME) Resources/nls/qm.stamp
 	mkdir -p $(builddir_share)/omnotebook/drmodelica/ $(builddir_share)/omnotebook/drcontrol/ $(builddir_share)/omnotebook/nls/
 	cp -p $(resourcedir)/*.qm $(builddir_share)/omnotebook/nls/
 	cp -p ../bin/$(NAME)$(EXE) $(builddir_bin);
+	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(builddir_bin) $(builddir_bin)/$(NAME)$(EXE)
 	cp -p *.xml $(builddir_share)/omnotebook/
 	cp -p ../../OMNotebookHelp.onb $(OMBUILDDIR)/share/omnotebook/
 	(DRMODELICAPWD=`cd ../../DrModelica/ && pwd` && \

--- a/OMPlot/.gitignore
+++ b/OMPlot/.gitignore
@@ -15,7 +15,8 @@
 /OMPlot/OMPlotGUI/Makefile.lib.Release
 /OMPlot/OMPlotGUI/Makefile.Release
 /OMPlot/OMPlotGUI/Makefile.unix
-/OMPlot/OMPlotGUI/object_script.*
+/OMPlot/OMPlotGUI/debug/object_script.*
+/OMPlot/OMPlotGUI/release/object_script.*
 /OMPlot/OMPlotGUI/OMPlotGUI.config
 OMPlotGUI.pro.*
 OMPlotLib.pro.*

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -51,8 +51,6 @@ endif ()
 target_link_libraries(OMPlotLib PUBLIC omqwt)
 target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 
-
-
 if(APPLE)
   set(MACOSX_BUNDLE_ICON_FILE omplot.ico)
 
@@ -69,3 +67,31 @@ target_link_libraries(OMPlot PRIVATE OMPlotLib)
 
 install(TARGETS OMPlotLib)
 omc_install_gui_client(OMPlot)
+
+if(MINGW)
+  # Find windeployqt6
+  find_program(WINDEPLOYQT_EXECUTABLE
+    NAMES windeployqt windeployqt6
+    HINTS "${MSYSTEM_PREFIX_ESCAPED}/bin"
+    REQUIRED
+  )
+
+  install(CODE "
+    message(STATUS \"Running windeployqt6 on OMPlot...\")
+    execute_process(
+      COMMAND \"${WINDEPLOYQT_EXECUTABLE}\"
+        --no-compiler-runtime
+        --no-system-d3d-compiler
+        --no-quick-import
+        --libdir \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+        \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/OMPlot.exe\"
+      RESULT_VARIABLE WINDEPLOYQT_RESULT
+      OUTPUT_VARIABLE WINDEPLOYQT_OUTPUT
+      ERROR_VARIABLE  WINDEPLOYQT_ERROR
+    )
+    if(NOT WINDEPLOYQT_RESULT EQUAL 0)
+      message(FATAL_ERROR \"windeployqt6 failed:\n\${WINDEPLOYQT_OUTPUT}\n\${WINDEPLOYQT_ERROR}\")
+    endif()
+    message(STATUS \"windeployqt6 output: \${WINDEPLOYQT_OUTPUT}\")
+  ")
+endif()

--- a/OMPlot/OMPlot/OMPlotGUI/Makefile.omdev.mingw
+++ b/OMPlot/OMPlot/OMPlotGUI/Makefile.omdev.mingw
@@ -41,5 +41,5 @@ $(LIB): Makefile.lib
 
 build: $(NAME) $(LIB)
 	cp -p ../bin/$(NAME)$(EXE) $(OMBUILDDIR)/bin
-	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(builddir_bin) $(builddir_bin)/$(NAME)$(EXE)
+	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(OMBUILDDIR)/bin $(OMBUILDDIR)/bin/$(NAME)$(EXE)
 	cp -a *.h $(OMBUILDDIR)/include/omplot

--- a/OMPlot/OMPlot/OMPlotGUI/Makefile.omdev.mingw
+++ b/OMPlot/OMPlot/OMPlotGUI/Makefile.omdev.mingw
@@ -41,4 +41,5 @@ $(LIB): Makefile.lib
 
 build: $(NAME) $(LIB)
 	cp -p ../bin/$(NAME)$(EXE) $(OMBUILDDIR)/bin
+	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(builddir_bin) $(builddir_bin)/$(NAME)$(EXE)
 	cp -a *.h $(OMBUILDDIR)/include/omplot

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -35,5 +35,34 @@ target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::Widgets)
 target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::PrintSupport)
 
 omc_install_gui_client(OMShell)
+
+if(MINGW)
+  # Find windeployqt6
+  find_program(WINDEPLOYQT_EXECUTABLE
+    NAMES windeployqt windeployqt6
+    HINTS "${MSYSTEM_PREFIX_ESCAPED}/bin"
+    REQUIRED
+  )
+
+  install(CODE "
+    message(STATUS \"Running windeployqt6 on OMShell...\")
+    execute_process(
+      COMMAND \"${WINDEPLOYQT_EXECUTABLE}\"
+        --no-compiler-runtime
+        --no-system-d3d-compiler
+        --no-quick-import
+        --libdir \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+        \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/OMShell.exe\"
+      RESULT_VARIABLE WINDEPLOYQT_RESULT
+      OUTPUT_VARIABLE WINDEPLOYQT_OUTPUT
+      ERROR_VARIABLE  WINDEPLOYQT_ERROR
+    )
+    if(NOT WINDEPLOYQT_RESULT EQUAL 0)
+      message(FATAL_ERROR \"windeployqt6 failed:\n\${WINDEPLOYQT_OUTPUT}\n\${WINDEPLOYQT_ERROR}\")
+    endif()
+    message(STATUS \"windeployqt6 output: \${WINDEPLOYQT_OUTPUT}\")
+  ")
+endif()
+
 install(FILES commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omshell)

--- a/OMShell/OMShell/OMShellGUI/Makefile.omdev.mingw
+++ b/OMShell/OMShell/OMShellGUI/Makefile.omdev.mingw
@@ -31,6 +31,7 @@ $(NAME): Makefile
 build: $(NAME)
 	mkdir -p $(builddir_share)/omshell/nls/
 	cp -p ../bin/$(NAME)$(EXE) $(builddir_bin)
+	windeployqt6.exe --no-compiler-runtime --no-system-d3d-compiler --no-quick-import --libdir $(builddir_bin) $(builddir_bin)/$(NAME)$(EXE)
 	cp -p commands.xml $(builddir_share)/omshell/
 	cp -p OMShell_*.qm $(builddir_share)/omshell/nls/
 	cp -puf ../../../common/pre-commit.sh $(shell git rev-parse --git-dir)/hooks/pre-commit


### PR DESCRIPTION
No need to update paths when QtWebEngineProcess.exe is at the same location where OMEdit.exe is Updated corresponsing CMake compilation as well