### PR TITLE
Delete DocumentationWidget before closing OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -852,6 +852,8 @@ void MainWindow::beforeClosingMainWindow()
   GitCommands::destroy();
   // delete the searchwidget object to call the destructor, to cancel the search operation running on seperate thread
   delete mpSearchWidget;
+  // delete the DocumentationWidget object
+  delete mpDocumentationWidget;
   // if new api profiling file is open then close it.
   if (mpNewApiProfilingFile) {
     fclose(mpNewApiProfilingFile);


### PR DESCRIPTION
This makes Qt web engine happy and OMEdit closes successfully.
Otherwise we get "Release of profile requested but WebEnginePage still not deleted. Expect troubles !".