### PR TITLE
Handle named arguments better in FlatModelica::Expression

### DIFF
--- a/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
@@ -860,6 +860,9 @@ namespace FlatModelica
       void print(std::ostream &os) const override;
       QJsonValue serialize() const override;
 
+      std::string_view name() const { return _name; }
+      const Expression& value() const { return _value; }
+
     private:
       std::string _name;
       Expression _value;
@@ -2184,7 +2187,7 @@ namespace FlatModelica
 
   Expression NamedArg::eval(const Expression::VariableEvaluator &var_eval, int recursion_level) const
   {
-    return _value.evaluate(var_eval, recursion_level);
+    return Expression{std::make_unique<NamedArg>(_name, _value.evaluate(var_eval, recursion_level))};
   }
 
   void NamedArg::print(std::ostream &os) const
@@ -2829,6 +2832,33 @@ namespace FlatModelica
   const Expression& Expression::arg(size_t index) const
   {
     return args()[index];
+  }
+
+  /*!
+   * \brief Expression::argName
+   * Returns the name of a named argument, or an empty string.
+   * \return The name of the named argument.
+   */
+  std::string_view Expression::argName() const
+  {
+    auto p = dynamic_cast<const NamedArg*>(_value.get());
+    return p ? p->name() : std::string_view{};
+  }
+
+  /*!
+   * \brief Expression::args
+   * Returns the value of a named argument, or throws an error.
+   * \return The value of the named argument.
+   */
+  const Expression& Expression::argValue() const
+  {
+    auto p = dynamic_cast<const NamedArg*>(_value.get());
+
+    if (!p) {
+      throw std::runtime_error("Expression::argValue: not a named argument");
+    }
+
+    return p->value();
   }
 
   /*!

--- a/OMEdit/OMEditLIB/FlatModelica/Expression.h
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.h
@@ -38,6 +38,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <ostream>
 #include <functional>
 #include <vector>
@@ -134,6 +135,7 @@ namespace FlatModelica
       std::string enumValue() const;
       int enumIndex() const;
       QString QStringValue() const;
+      std::string_view name() const;
       QString functionName() const;
 
       int priority(bool lhs) const;
@@ -145,6 +147,8 @@ namespace FlatModelica
       const std::vector<Expression>& args() const;
       const Expression& arg(size_t index) const;
       void setArg(size_t index, const Expression &e);
+      std::string_view argName() const;
+      const Expression& argValue() const;
 
       Expression& operator+= (const Expression &other);
       Expression& operator-= (const Expression &other);

--- a/OMEdit/OMEditLIB/FlatModelica/ExpressionFuncs.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/ExpressionFuncs.cpp
@@ -84,35 +84,52 @@ namespace FlatModelica
 
   Expression evalString(const std::vector<Expression> &args)
   {
-    switch (args.size()) {
-      case 2: // String(r, format)
-        return Expression(format_string("%" + args[1].stringValue(), args[0].realValue()));
-
-      case 3: // String(i|b|e, minimumLength, leftJustified)
-        if (args[0].isInteger()) {
-          return Expression(format_string(
-              (args[2].boolValue() ? "%-" : "%") + args[1].toString() + "d",
-              args[0].intValue()
-            ));
-        } else {
-          // Boolean or enumeration, convert to string and pad with spaces if necessary.
-          auto str = args[0].toString();
-          auto len = args[1].intValue();
-          auto pad_len = len - str.size();
-          if (pad_len > 0) {
-            str.insert(args[2].boolValue() ? str.end() : str.begin(), pad_len, ' ');
-          }
-          return Expression(std::move(str));
-        }
-
-      case 4: // String(r, significantDigits, mininumLength, leftJustified)
-        return Expression(format_string(
-          (args[3].boolValue() ? "%-" : "%") + args[2].toString() + "." + args[1].toString() + "g",
-          args[0].realValue()
-        ));
+    if (args.size() == 2 && args[1].argName() == "format") {
+      // String(r, format)
+      return Expression(format_string("%" + args[1].argValue().stringValue(), args[0].realValue()));
     }
 
-    return Expression(args[0].toString());
+    int significant_digits = 6;
+    bool significant_digits_set = false;
+    int minimum_length = 0;
+    bool left_justified = false;
+
+    // Handle optional named arguments for String.
+    for (auto &arg: args) {
+      auto name = arg.argName();
+      if (name.empty()) continue;
+
+      if (name == "significantDigits") {
+        significant_digits = arg.argValue().intValue();
+        significant_digits_set = true;
+      } else if (name == "minimumLength") {
+        minimum_length = arg.argValue().intValue();
+      } else if (name == "leftJustified") {
+        left_justified = arg.argValue().boolValue();
+      }
+    }
+
+    if (significant_digits_set || args[0].isReal()) {
+      // String(r, significantDigits, minimumLength, leftJustified)
+      return Expression{format_string(
+          (left_justified ? "%-" : "%") + std::to_string(minimum_length) + "." +
+           std::to_string(significant_digits) + "g", args[0].realValue()
+        )};
+    } else if (args[0].isInteger()) {
+      // String(i, minimumLength, leftJustified)
+      return Expression{format_string(
+          (left_justified ? "%-" : "%") + std::to_string(minimum_length) + "d",
+          args[0].intValue()
+        )};
+    }
+
+    // String(b|e, minimumLength, leftJustified)
+    auto str = args[0].toString();
+    auto pad_len = minimum_length - str.size();
+    if (pad_len > 0) {
+      str.insert(left_justified ? str.end() : str.begin(), pad_len, ' ');
+    }
+    return Expression{std::move(str)};
   }
 
   Expression evalDiv(const Expression &x, const Expression &y)

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -79,11 +79,11 @@ void ExpressionTest::dynamicSelect_data()
     << "DynamicSelect({{-35,35},{35,-35}},{{0,0},{0,0}})";
 
   QTest::addRow("DynamicSelect3")
-    << "DynamicSelect(\"\", String(T - 273.15, \".1f\"))"
+    << "DynamicSelect(\"\", String(T - 273.15, format = \".1f\"))"
     << "DynamicSelect(\"\",\"-272.1\")";
 
   QTest::addRow("DynamicSelect4")
-    << "DynamicSelect(\"\", String((if use_T_in then T_in else T) - 273.15, \".1f\"))"
+    << "DynamicSelect(\"\", String((if use_T_in then T_in else T) - 273.15, format = \".1f\"))"
     << "DynamicSelect(\"\",\"-272.1\")";
 
   QTest::addRow("DynamicSelect5")


### PR DESCRIPTION
- Evaluate named arguments to named arguments, to make it possible to handle them properly when evaluating functions.
- Handle named arguments when evaluating String().

Fixes #15687