### PR TITLE
getModelInstanceReference: in-process model instance, no JSONstring

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -5488,6 +5488,35 @@ annotation(
    preferredView="text");
 end getModelInstanceAnnotation;
 
+function getModelInstanceReference
+  "Like getModelInstance, but returns an integer handle to an in-memory model
+   instance structure instead of a JSON string (see issue #15219). The handle is
+   intended to be read directly by an in-process client such as OMEdit and must
+   be released with releaseModelInstanceReference. Returns 0 on failure."
+  input TypeName className;
+  input TypeName context = $TypeName(__NoContext);
+  input String modifier = "";
+  output Integer handle;
+external "builtin";
+end getModelInstanceReference;
+
+function getModelInstanceAnnotationReference
+  "Like getModelInstanceAnnotation, but returns an integer handle to an
+   in-memory structure instead of a JSON string (see getModelInstanceReference)."
+  input TypeName className;
+  input String[:] filter = fill("", 0);
+  output Integer handle;
+external "builtin";
+end getModelInstanceAnnotationReference;
+
+function releaseModelInstanceReference
+  "Releases a handle returned by getModelInstanceReference or
+   getModelInstanceAnnotationReference. Returns true on success."
+  input Integer handle;
+  output Boolean success;
+external "builtin";
+end releaseModelInstanceReference;
+
 function modifierToJSON
   "Parses a modifier given as a string and dumps it as JSON."
   input String modifier;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -5732,6 +5732,35 @@ annotation(
    preferredView="text");
 end getModelInstanceAnnotation;
 
+function getModelInstanceReference
+  "Like getModelInstance, but returns an integer handle to an in-memory model
+   instance structure instead of a JSON string (see issue #15219). The handle is
+   intended to be read directly by an in-process client such as OMEdit and must
+   be released with releaseModelInstanceReference. Returns 0 on failure."
+  input TypeName className;
+  input TypeName context = $TypeName(__NoContext);
+  input String modifier = "";
+  output Integer handle;
+external "builtin";
+end getModelInstanceReference;
+
+function getModelInstanceAnnotationReference
+  "Like getModelInstanceAnnotation, but returns an integer handle to an
+   in-memory structure instead of a JSON string (see getModelInstanceReference)."
+  input TypeName className;
+  input String[:] filter = fill("", 0);
+  output Integer handle;
+external "builtin";
+end getModelInstanceAnnotationReference;
+
+function releaseModelInstanceReference
+  "Releases a handle returned by getModelInstanceReference or
+   getModelInstanceAnnotationReference. Returns true on success."
+  input Integer handle;
+  output Boolean success;
+external "builtin";
+end releaseModelInstanceReference;
+
 function modifierToJSON
   "Parses a modifier given as a string and dumps it as JSON."
   input String modifier;

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -212,6 +212,65 @@ algorithm
   outObj := if isNull(value) then obj else addPair(key, value, obj);
 end addPairNotNull;
 
+function toListForm
+  "Returns a JSON value where all OBJECT (hash-map backed) and ARRAY (vector
+   backed) nodes have been converted, recursively, into the list-based
+   LIST_OBJECT and LIST nodes. The result consists only of plain MetaModelica
+   lists, tuples and scalars, which can be traversed from C/C++ (e.g. from
+   OMEdit, see issue #15219) without knowing the internal layout of UnorderedMap
+   and Vector."
+  input JSON value;
+  output JSON outValue;
+algorithm
+  outValue := match value
+    local
+      list<tuple<String, JSON>> pairs;
+      list<JSON> elems;
+      String key;
+      JSON v;
+
+    case OBJECT()
+      algorithm
+        pairs := {};
+        for i in 1:UnorderedMap.size(value.values) loop
+          pairs := (UnorderedMap.keyAt(value.values, i),
+                    toListForm(UnorderedMap.valueAt(value.values, i))) :: pairs;
+        end for;
+      then
+        LIST_OBJECT(listReverse(pairs));
+
+    case LIST_OBJECT()
+      algorithm
+        pairs := {};
+        for p in value.values loop
+          (key, v) := p;
+          pairs := (key, toListForm(v)) :: pairs;
+        end for;
+      then
+        LIST_OBJECT(listReverse(pairs));
+
+    case ARRAY()
+      algorithm
+        elems := {};
+        for i in Vector.size(value.values):-1:1 loop
+          elems := toListForm(Vector.getNoBounds(value.values, i)) :: elems;
+        end for;
+      then
+        LIST(elems);
+
+    case LIST()
+      algorithm
+        elems := {};
+        for e in listReverse(value.values) loop
+          elems := toListForm(e) :: elems;
+        end for;
+      then
+        LIST(elems);
+
+    else value;
+  end match;
+end toListForm;
+
 function toString
   input JSON value;
   input Boolean prettyPrint = false;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3178,6 +3178,15 @@ algorithm
     case ("getModelInstanceAnnotation", {Values.CODE(Absyn.C_TYPENAME(classpath)), v as Values.ARRAY(), Values.BOOL(b)})
       then NFApi.getModelInstanceAnnotation(classpath, ValuesUtil.arrayValueStrings(v), b);
 
+    case ("getModelInstanceReference", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path)), Values.STRING(str)})
+      then NFApi.getModelInstanceReference(classpath, path, str);
+
+    case ("getModelInstanceAnnotationReference", {Values.CODE(Absyn.C_TYPENAME(classpath)), v as Values.ARRAY()})
+      then NFApi.getModelInstanceAnnotationReference(classpath, ValuesUtil.arrayValueStrings(v));
+
+    case ("releaseModelInstanceReference", {Values.INTEGER(i)})
+      then NFApi.releaseModelInstanceReference(i);
+
     case ("modifierToJSON", {Values.STRING(str), Values.BOOL(b)})
       then NFApi.modifierToJSON(str, b);
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -807,47 +807,10 @@ function getModelInstance
   input Boolean prettyPrint;
   output Values.Value res;
 protected
-  InstNode top, cls_node;
   JSON json;
-  InstContext.Type context;
-  InstanceTree inst_tree;
-  InstSettings inst_settings;
-  Modifier mod;
 algorithm
   try
-    context := InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
-    context := InstContext.set(context, NFInstContext.INSTANCE_API);
-    inst_settings := InstSettings.SETTINGS(mergeExtendsSections = false, resizableArrays = false);
-
-    (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(classPath));
-    mod := parseModifier(modifier, top);
-    cls_node := Inst.lookupRootClass(classPath, top, context);
-
-    if SCodeUtil.isFunction(InstNode.definition(cls_node)) then
-      context := InstContext.unset(context, NFInstContext.CLASS);
-      context := InstContext.set(context, NFInstContext.FUNCTION);
-    end if;
-
-    if AbsynUtil.pathFirstIdent(contextPath) <> "__NoContext" then
-      cls_node := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE(), SOME(contextPath)), cls_node);
-    end if;
-
-    cls_node := Inst.instantiateRootClass(cls_node, context, mod);
-    execStat("Inst.instantiateRootClass");
-    inst_tree := buildInstanceTree(cls_node);
-    execStat("NFApi.buildInstanceTree");
-    Inst.instExpressions(cls_node, context = context, settings = inst_settings);
-    Inst.updateImplicitVariability(cls_node, Flags.isSet(Flags.EVAL_PARAM), context);
-    execStat("Inst.instExpressions");
-
-    Typing.typeClassType(cls_node, NFBinding.EMPTY_BINDING, context, cls_node);
-    Typing.typeComponents(cls_node, context);
-    execStat("Typing.typeComponents");
-    Typing.typeBindings(cls_node, context);
-    execStat("Typing.typeBinding");
-
-    json := dumpJSONInstanceTree(inst_tree, cls_node);
-    execStat("NFApi.dumpJSONInstanceTree");
+    json := buildModelInstanceJSON(classPath, contextPath, modifier);
     res := Values.STRING(JSON.toString(json, prettyPrint));
     execStat("JSON.toString");
     Inst.clearCaches();
@@ -857,25 +820,45 @@ algorithm
   end try;
 end getModelInstance;
 
+function getModelInstanceReference
+  "Like getModelInstance, but instead of serializing the model instance to a
+   JSON string it stores the (boxed) JSON structure in memory and returns an
+   integer handle to it (see issue #15219). OMEdit, which links the compiler
+   in-process, can then read the structure directly via the C function
+   ModelInstanceReference_get, avoiding both JSON string generation here and
+   JSON string parsing in OMEdit. The handle must be freed with
+   releaseModelInstanceReference. A handle of 0 indicates failure."
+  input Absyn.Path classPath;
+  input Absyn.Path contextPath;
+  input String modifier;
+  output Values.Value res;
+protected
+  JSON json;
+  Integer handle;
+algorithm
+  try
+    json := buildModelInstanceJSON(classPath, contextPath, modifier);
+    json := JSON.toListForm(json);
+    execStat("NFApi.toListForm");
+    handle := storeModelInstanceReference(json);
+    res := Values.INTEGER(handle);
+    Inst.clearCaches();
+  else
+    Inst.clearCaches();
+    fail();
+  end try;
+end getModelInstanceReference;
+
 function getModelInstanceAnnotation
   input Absyn.Path classPath;
   input list<String> filter;
   input Boolean prettyPrint;
   output Values.Value res;
 protected
-  InstNode top, cls_node;
-  InstContext.Type context;
   JSON json;
 algorithm
   try
-    context := InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
-    context := InstContext.set(context, NFInstContext.INSTANCE_API);
-
-    (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(classPath));
-    cls_node := Inst.lookupRootClass(classPath, top, context);
-    cls_node := InstNode.resolveInner(cls_node);
-
-    json := dumpJSONInstanceAnnotation(cls_node, filter);
+    json := buildModelInstanceAnnotationJSON(classPath, filter);
     res := Values.STRING(JSON.toString(json, prettyPrint));
     Inst.clearCaches();
   else
@@ -883,6 +866,121 @@ algorithm
     fail();
   end try;
 end getModelInstanceAnnotation;
+
+function getModelInstanceAnnotationReference
+  "Like getModelInstanceAnnotation, but returns an integer handle to an
+   in-memory JSON structure instead of a JSON string (see
+   getModelInstanceReference and issue #15219)."
+  input Absyn.Path classPath;
+  input list<String> filter;
+  output Values.Value res;
+protected
+  JSON json;
+  Integer handle;
+algorithm
+  try
+    json := buildModelInstanceAnnotationJSON(classPath, filter);
+    json := JSON.toListForm(json);
+    handle := storeModelInstanceReference(json);
+    res := Values.INTEGER(handle);
+    Inst.clearCaches();
+  else
+    Inst.clearCaches();
+    fail();
+  end try;
+end getModelInstanceAnnotationReference;
+
+function releaseModelInstanceReference
+  "Releases a handle previously returned by getModelInstanceReference or
+   getModelInstanceAnnotationReference. Returns true on success."
+  input Integer handle;
+  output Values.Value res;
+algorithm
+  res := Values.BOOL(releaseModelInstanceReferenceImpl(handle));
+end releaseModelInstanceReference;
+
+function buildModelInstanceJSON
+  "Instantiates the given model and builds the JSON structure describing the
+   model instance. Shared by getModelInstance and getModelInstanceReference."
+  input Absyn.Path classPath;
+  input Absyn.Path contextPath;
+  input String modifier;
+  output JSON json;
+protected
+  InstNode top, cls_node;
+  InstContext.Type context;
+  InstanceTree inst_tree;
+  InstSettings inst_settings;
+  Modifier mod;
+algorithm
+  context := InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
+  context := InstContext.set(context, NFInstContext.INSTANCE_API);
+  inst_settings := InstSettings.SETTINGS(mergeExtendsSections = false, resizableArrays = false);
+
+  (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(classPath));
+  mod := parseModifier(modifier, top);
+  cls_node := Inst.lookupRootClass(classPath, top, context);
+
+  if SCodeUtil.isFunction(InstNode.definition(cls_node)) then
+    context := InstContext.unset(context, NFInstContext.CLASS);
+    context := InstContext.set(context, NFInstContext.FUNCTION);
+  end if;
+
+  if AbsynUtil.pathFirstIdent(contextPath) <> "__NoContext" then
+    cls_node := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE(), SOME(contextPath)), cls_node);
+  end if;
+
+  cls_node := Inst.instantiateRootClass(cls_node, context, mod);
+  execStat("Inst.instantiateRootClass");
+  inst_tree := buildInstanceTree(cls_node);
+  execStat("NFApi.buildInstanceTree");
+  Inst.instExpressions(cls_node, context = context, settings = inst_settings);
+  Inst.updateImplicitVariability(cls_node, Flags.isSet(Flags.EVAL_PARAM), context);
+  execStat("Inst.instExpressions");
+
+  Typing.typeClassType(cls_node, NFBinding.EMPTY_BINDING, context, cls_node);
+  Typing.typeComponents(cls_node, context);
+  execStat("Typing.typeComponents");
+  Typing.typeBindings(cls_node, context);
+  execStat("Typing.typeBinding");
+
+  json := dumpJSONInstanceTree(inst_tree, cls_node);
+  execStat("NFApi.dumpJSONInstanceTree");
+end buildModelInstanceJSON;
+
+function buildModelInstanceAnnotationJSON
+  "Instantiates the given model and builds the JSON structure describing its
+   annotation. Shared by getModelInstanceAnnotation and
+   getModelInstanceAnnotationReference."
+  input Absyn.Path classPath;
+  input list<String> filter;
+  output JSON json;
+protected
+  InstNode top, cls_node;
+  InstContext.Type context;
+algorithm
+  context := InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
+  context := InstContext.set(context, NFInstContext.INSTANCE_API);
+
+  (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(classPath));
+  cls_node := Inst.lookupRootClass(classPath, top, context);
+  cls_node := InstNode.resolveInner(cls_node);
+
+  json := dumpJSONInstanceAnnotation(cls_node, filter);
+end buildModelInstanceAnnotationJSON;
+
+function storeModelInstanceReference
+  "Stores a boxed JSON value and returns a 1-based handle (0 on failure)."
+  input JSON json;
+  output Integer handle;
+  external "C" handle = ModelInstanceReference_store(json) annotation(Library = "omcruntime");
+end storeModelInstanceReference;
+
+function releaseModelInstanceReferenceImpl
+  input Integer handle;
+  output Boolean success;
+  external "C" success = ModelInstanceReference_release(handle) annotation(Library = "omcruntime");
+end releaseModelInstanceReferenceImpl;
 
 function parseModifier
   input String modifierValue;

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ set(OMC_RUNTIIME_SOURCES
     Error_omc.cpp
     Dynload_omc.cpp
     Print_omc.c
+    ModelInstanceReference_omc.c
     ErrorMessage.cpp
     System_omc.c
     Lapack_omc.cpp

--- a/OMCompiler/Compiler/runtime/Makefile.common
+++ b/OMCompiler/Compiler/runtime/Makefile.common
@@ -22,6 +22,7 @@ endif
 
 OMC_OBJ_SHARED = Error_omc$(OBJEXT) \
   Print_omc.o \
+  ModelInstanceReference_omc.o \
   ErrorMessage$(OBJEXT) systemimplmisc.o System_omc$(OBJEXT) \
   Lapack_omc.o Settings_omc$(OBJEXT) \
   UnitParserExt_omc.o unitparser.o \

--- a/OMCompiler/Compiler/runtime/ModelInstanceReference_omc.c
+++ b/OMCompiler/Compiler/runtime/ModelInstanceReference_omc.c
@@ -1,0 +1,105 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * In-memory model-instance references (issue #15219).
+ *
+ * getModelInstanceReference()/getModelInstanceAnnotationReference() build the
+ * exact same MetaModelica JSON structure as getModelInstance()/
+ * getModelInstanceAnnotation(), but instead of serializing it to a string they
+ * store the boxed MetaModelica JSON value here and return an integer handle.
+ *
+ * OMEdit links libOpenModelicaCompiler in-process, so it can fetch the boxed
+ * value directly with ModelInstanceReference_get() and walk it, avoiding both
+ * the JSON string generation (in omc) and the JSON string parsing (in OMEdit)
+ * which, for large models, takes seconds.
+ *
+ * The values are kept in a static array which lives in the process data segment
+ * and is therefore scanned conservatively by the (Boehm) garbage collector, so
+ * the stored values are kept alive until they are released. Handles are 1-based;
+ * a handle of 0 means "no/invalid reference" and lets callers fall back to the
+ * string-based API.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "meta/meta_modelica.h"
+#include "omc_config.h"
+
+#define MODEL_INSTANCE_REFERENCE_MAX 256
+
+static void *modelInstanceReferences[MODEL_INSTANCE_REFERENCE_MAX];
+static int modelInstanceReferenceUsed[MODEL_INSTANCE_REFERENCE_MAX];
+
+/* Stores a boxed JSON value and returns a 1-based handle, or 0 if no slot is
+ * free. Called from MetaModelica (NFApi.storeModelInstanceReference). */
+extern int ModelInstanceReference_store(void *json)
+{
+  int i;
+  for (i = 0; i < MODEL_INSTANCE_REFERENCE_MAX; i++) {
+    if (!modelInstanceReferenceUsed[i]) {
+      modelInstanceReferenceUsed[i] = 1;
+      modelInstanceReferences[i] = json;
+      return i + 1; /* 1-based handle */
+    }
+  }
+  return 0; /* no free slot */
+}
+
+/* Returns the boxed JSON value for a handle, or NULL for an invalid handle.
+ * Called directly (as a C symbol) from OMEdit. */
+extern void* ModelInstanceReference_get(int handle)
+{
+  int i = handle - 1;
+  if (i < 0 || i >= MODEL_INSTANCE_REFERENCE_MAX || !modelInstanceReferenceUsed[i]) {
+    return NULL;
+  }
+  return modelInstanceReferences[i];
+}
+
+/* Releases a handle. Returns 1 on success, 0 for an invalid handle.
+ * Called from MetaModelica (NFApi.releaseModelInstanceReference) and may also be
+ * called directly from OMEdit. */
+extern int ModelInstanceReference_release(int handle)
+{
+  int i = handle - 1;
+  if (i < 0 || i >= MODEL_INSTANCE_REFERENCE_MAX || !modelInstanceReferenceUsed[i]) {
+    return 0;
+  }
+  modelInstanceReferenceUsed[i] = 0;
+  modelInstanceReferences[i] = NULL;
+  return 1;
+}

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -112,6 +112,8 @@ public:
   void setDebug(bool debug) {mDebug = debug;}
   bool isNewApiProfiling() const {return mNewApiProfiling;}
   void setNewApiProfiling(bool newApiProfiling);
+  bool isNewApiNoJson() const {return mNewApiNoJson;}
+  void setNewApiNoJson(bool newApiNoJson) {mNewApiNoJson = newApiNoJson;}
   bool isCRMLEnabled() const {return mCRMLEnabled;}
   void setCRMLEnabled(bool crmlEnabled) {mCRMLEnabled = crmlEnabled;}
   bool isTestsuiteRunning() const {return mTestsuiteRunning;}
@@ -272,6 +274,7 @@ private:
   bool mDebug;
   bool mNewApiProfiling = false;
   FILE *mpNewApiProfilingFile = nullptr;
+  bool mNewApiNoJson = false;
   bool mCRMLEnabled = false;
   bool mTestsuiteRunning = false;
   bool mSkipExpressionEvaluation = false;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -39,6 +39,7 @@
 
 #include <stdlib.h>
 #include <iostream>
+#include <cstring>
 
 #include "OMCProxy.h"
 #include "MainWindow.h"
@@ -3418,6 +3419,75 @@ QList<QString> OMCProxy::getAvailablePackageConversionsFrom(const QString &pkg, 
   return result;
 }
 
+/*
+ * Accessors exported by the compiler runtime (Compiler/runtime/ModelInstanceReference_omc.c)
+ * for the getModelInstanceReference (issue #15219) handle registry. They are linked in via
+ * OpenModelicaCompiler. _get returns the boxed (list-form) JSON value for a handle and
+ * _release frees the registry slot.
+ */
+extern "C" void* ModelInstanceReference_get(int handle);
+extern "C" int ModelInstanceReference_release(int handle);
+
+/*!
+ * \brief OMCProxy::jsonValueFromMM
+ * Recursively converts a boxed MetaModelica JSON value (as produced by
+ * getModelInstanceReference and normalised by NFApi to list form) into a QJsonValue,
+ * bypassing string serialization and QJsonDocument::fromJson (issue #15219).
+ * Only the list-form node kinds appear (LIST_OBJECT/LIST), never OBJECT/ARRAY.
+ * \param value boxed JSON uniontype value
+ * \return
+ */
+/* Converts a boxed MetaModelica string to a QString.
+ * MMC_STRINGDATA expands to a struct member declared as `char data[1]` (a flexible array
+ * member with a bogus size of 1), so its type is char[1], not char*. Passed directly to
+ * QString::fromUtf8 that array binds Qt's QByteArrayView overload using the *declared* size
+ * (1 byte), truncating every string to its first character. The explicit (const char*) cast
+ * forces array-to-pointer decay so the strlen-based fromUtf8(const char*) overload is used. */
+static QString stringFromMM(void *mmString)
+{
+  return QString::fromUtf8((const char*) MMC_STRINGDATA(mmString));
+}
+
+QJsonValue OMCProxy::jsonValueFromMM(void *value)
+{
+  // A boxed uniontype record stores its record_description in slot 0 and its fields in slots 1..n.
+  struct record_description *desc = (struct record_description*) MMC_STRUCTDATA(value)[0];
+  const char *name = desc->name;
+  if (strcmp(name, "JSON.LIST_OBJECT") == 0) {
+    QJsonObject object;
+    void *lst = MMC_STRUCTDATA(value)[1];
+    while (!MMC_NILTEST(lst)) {
+      // each element is a tuple<String, JSON>: slot 0 is the key, slot 1 is the value (tuples carry no descriptor).
+      void *pair = MMC_CAR(lst);
+      object.insert(stringFromMM(MMC_STRUCTDATA(pair)[0]), jsonValueFromMM(MMC_STRUCTDATA(pair)[1]));
+      lst = MMC_CDR(lst);
+    }
+    return object;
+  } else if (strcmp(name, "JSON.LIST") == 0) {
+    QJsonArray array;
+    void *lst = MMC_STRUCTDATA(value)[1];
+    while (!MMC_NILTEST(lst)) {
+      array.append(jsonValueFromMM(MMC_CAR(lst)));
+      lst = MMC_CDR(lst);
+    }
+    return array;
+  } else if (strcmp(name, "JSON.STRING") == 0) {
+    return QJsonValue(stringFromMM(MMC_STRUCTDATA(value)[1]));
+  } else if (strcmp(name, "JSON.INTEGER") == 0) {
+    // qint64 (not double) so the value is integer-typed, matching QJsonDocument::fromJson
+    // which parses whole numbers as integers (Qt distinguishes integer vs double QJsonValues).
+    return QJsonValue((qint64) MMC_UNTAGFIXNUM(MMC_STRUCTDATA(value)[1]));
+  } else if (strcmp(name, "JSON.NUMBER") == 0) {
+    return QJsonValue(mmc_prim_get_real(MMC_STRUCTDATA(value)[1]));
+  } else if (strcmp(name, "JSON.TRUE") == 0) {
+    return QJsonValue(true);
+  } else if (strcmp(name, "JSON.FALSE") == 0) {
+    return QJsonValue(false);
+  }
+  // JSON.NULL, and defensively JSON.OBJECT/JSON.ARRAY which should never reach here after normalisation.
+  return QJsonValue(QJsonValue::Null);
+}
+
 /*!
  * \brief OMCProxy::getModelInstance
  * \param className
@@ -3427,6 +3497,42 @@ QList<QString> OMCProxy::getAvailablePackageConversionsFrom(const QString &pkg, 
  */
 QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &context, const QString &modifier, bool prettyPrint, bool icon)
 {
+  // Reference path (issue #15219): fetch an in-memory handle and walk the boxed JSON tree directly,
+  // skipping JSON.toString (omc) and QJsonDocument::fromJson (OMEdit). Gated behind --NAPINoJson=true.
+  // mpOMCInterface is the in-process linked compiler library, so the boxed value's address is valid here.
+  // Falls back to the JSON-string path on failure (handle <= 0).
+  if (MainWindow::instance()->isNewApiNoJson()) {
+    QElapsedTimer refTimer;
+    if (MainWindow::instance()->isNewApiProfiling()) {
+      refTimer.start();
+    }
+    QString cnt = context.isEmpty() ? QString("__NoContext") : context;
+    int handle = 0;
+    if (icon) {
+      QList<QString> filter;
+      filter << "Icon" << "IconMap" << "Diagram" << "DiagramMap" << "experiment";
+      handle = mpOMCInterface->getModelInstanceAnnotationReference(className, filter);
+    } else {
+      handle = mpOMCInterface->getModelInstanceReference(className, cnt, modifier);
+    }
+    printMessagesStringInternal();
+    if (handle > 0) {
+      void *value = ModelInstanceReference_get(handle);
+      QJsonObject object;
+      if (value) {
+        object = jsonValueFromMM(value).toObject();
+      }
+      ModelInstanceReference_release(handle);
+      if (MainWindow::instance()->isNewApiProfiling()) {
+        const QString api = icon ? "getModelInstanceAnnotationReference" : "getModelInstanceReference";
+        double elapsed = (double)refTimer.elapsed() / 1000.0;
+        MainWindow::instance()->writeNewApiProfiling(QString("Time for %1(%2) + direct walk %3 secs").arg(api, className, QString::number(elapsed, 'f', 6)));
+      }
+      return object;
+    }
+    // handle <= 0: fall through to the JSON-string path below.
+  }
+
   QElapsedTimer timer;
   if (MainWindow::instance()->isNewApiProfiling()) {
     timer.start();

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -282,6 +282,7 @@ public:
   bool convertPackageToLibrary(const QString &packageToConvert, const QString &library, const QString &libraryVersion);
   QList<QString> getAvailablePackageConversionsFrom(const QString &pkg, const QString &version);
   QJsonObject getModelInstance(const QString &className, const QString &context = QString(""), const QString &modifier = QString(""), bool prettyPrint = false, bool icon = false);
+  static QJsonValue jsonValueFromMM(void *value);
   QJsonObject modifierToJSON(const QString &modifier, bool prettyPrint = false);
   int storeAST();
   bool restoreAST(int id);

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -221,6 +221,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   // if user has requested to open the file by passing it in argument then,
   bool debug = false;
   bool newApiProfiling = false;
+  bool newApiNoJson = false;
   QString fileName = "";
   QStringList fileNames, invalidFlags;
   if (arguments().size() > 1 && !testsuiteRunning) {
@@ -236,6 +237,12 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         napiProfilingArg.remove("--NAPIProfiling=");
         if (0 == strcmp("true", napiProfilingArg.toUtf8().constData())) {
           newApiProfiling = true;
+        }
+      } else if (strncmp(arguments().at(i).toUtf8().constData(), "--NAPINoJson=",13) == 0) {
+        QString napiNoJsonArg = arguments().at(i);
+        napiNoJsonArg.remove("--NAPINoJson=");
+        if (0 == strcmp("true", napiNoJsonArg.toUtf8().constData())) {
+          newApiNoJson = true;
         }
       } else if (strncmp(arguments().at(i).toUtf8().constData(), "--paths",7) == 0) {
         dumpQtPaths();
@@ -262,6 +269,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   MainWindow *pMainwindow = MainWindow::instance();
   pMainwindow->setDebug(debug);
   pMainwindow->setNewApiProfiling(newApiProfiling);
+  pMainwindow->setNewApiNoJson(newApiNoJson);
   pMainwindow->setTestsuiteRunning(testsuiteRunning);
   pMainwindow->setUpMainWindow(threadData);
   if (pMainwindow->getExitApplicationStatus()) {        // if there is some issue in running the application.

--- a/OMEdit/OMEditLIB/Options/OptionsDefaults.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDefaults.h
@@ -60,6 +60,7 @@ namespace OptionsDefaults
     int activateAccessAnnotationsIndex = 1;
     bool createBackupFile = true;
     bool displayNFAPIErrorsWarnings = false;
+    bool enableInstanceApiNoJson = false;
     bool enableCRMLSupport = false;
     int libraryIconSize = 24;
     int libraryIconMaximumTextLength = 3;

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -260,6 +260,16 @@ void OptionsDialog::readGeneralSettings()
   } else {
     mpGeneralSettingsPage->getDisplayNFAPIErrorsWarningsCheckBox()->setChecked(OptionsDefaults::GeneralSettings::displayNFAPIErrorsWarnings);
   }
+  // read read-model-instance-from-memory (no JSON) option (issue #15219)
+  if (mpSettings->contains("enableInstanceApiNoJson")) {
+    mpGeneralSettingsPage->getEnableInstanceApiNoJsonCheckBox()->setChecked(mpSettings->value("enableInstanceApiNoJson").toBool());
+  } else {
+    mpGeneralSettingsPage->getEnableInstanceApiNoJsonCheckBox()->setChecked(OptionsDefaults::GeneralSettings::enableInstanceApiNoJson);
+  }
+  // The option and the --NAPINoJson command-line flag both feed the same MainWindow flag; OR them
+  // so the command-line flag still forces the path on even when the option is off.
+  MainWindow::instance()->setNewApiNoJson(mpGeneralSettingsPage->getEnableInstanceApiNoJsonCheckBox()->isChecked()
+                                          || MainWindow::instance()->isNewApiNoJson());
   // read enable CRML support
   if (mpSettings->contains("enableCRMLSupport")) {
     mpGeneralSettingsPage->getEnableCRMLSupportCheckBox()->setChecked(mpSettings->value("enableCRMLSupport").toBool());
@@ -1611,6 +1621,15 @@ void OptionsDialog::saveGeneralSettings()
   } else {
     mpSettings->setValue("createBackupFile", createBackupFile);
   }
+  // save read-model-instance-from-memory (no JSON) option (issue #15219)
+  bool enableInstanceApiNoJson = mpGeneralSettingsPage->getEnableInstanceApiNoJsonCheckBox()->isChecked();
+  if (enableInstanceApiNoJson == OptionsDefaults::GeneralSettings::enableInstanceApiNoJson) {
+    mpSettings->remove("enableInstanceApiNoJson");
+  } else {
+    mpSettings->setValue("enableInstanceApiNoJson", enableInstanceApiNoJson);
+  }
+  // apply immediately so the change takes effect without restarting OMEdit
+  MainWindow::instance()->setNewApiNoJson(enableInstanceApiNoJson);
   // save enable CRML support
   bool enableCRMLSupport = mpGeneralSettingsPage->getEnableCRMLSupportCheckBox()->isChecked();
   if (enableCRMLSupport == OptionsDefaults::GeneralSettings::enableCRMLSupport) {
@@ -3576,6 +3595,9 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   mpCreateBackupFileCheckbox->setChecked(OptionsDefaults::GeneralSettings::createBackupFile);
   /* Display errors/warnings when new instantiation fails in evaluating graphical annotations */
   mpDisplayNFAPIErrorsWarningsCheckBox = new QCheckBox(tr("Display errors/warnings when instantiating the graphical annotations"));
+  /* Read the model instance directly from memory instead of via a JSON string (issue #15219) */
+  mpEnableInstanceApiNoJsonCheckBox = new QCheckBox(tr("Read the model instance directly from memory instead of JSON (faster for large models)"));
+  mpEnableInstanceApiNoJsonCheckBox->setChecked(OptionsDefaults::GeneralSettings::enableInstanceApiNoJson);
   // Enable CRML support
   mpEnableCRMLSupportCheckBox = new QCheckBox(tr("Enable CRML Support *"));
   mpEnableCRMLSupportCheckBox->setChecked(OptionsDefaults::GeneralSettings::enableCRMLSupport);
@@ -3600,7 +3622,8 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   pGeneralSettingsLayout->addWidget(mpActivateAccessAnnotationsComboBox, 7, 1, 1, 2);
   pGeneralSettingsLayout->addWidget(mpCreateBackupFileCheckbox, 8, 0, 1, 3);
   pGeneralSettingsLayout->addWidget(mpDisplayNFAPIErrorsWarningsCheckBox, 9, 0, 1, 3);
-  pGeneralSettingsLayout->addWidget(mpEnableCRMLSupportCheckBox, 10, 0, 1, 3);
+  pGeneralSettingsLayout->addWidget(mpEnableInstanceApiNoJsonCheckBox, 10, 0, 1, 3);
+  pGeneralSettingsLayout->addWidget(mpEnableCRMLSupportCheckBox, 11, 0, 1, 3);
   mpGeneralSettingsGroupBox->setLayout(pGeneralSettingsLayout);
   // Library Browser group box
   mpLibraryBrowserGroupBox = new QGroupBox(tr("Library Browser"));

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -295,6 +295,7 @@ public:
   ComboBox* getActivateAccessAnnotationsComboBox() {return mpActivateAccessAnnotationsComboBox;}
   QCheckBox* getCreateBackupFileCheckbox() {return mpCreateBackupFileCheckbox;}
   QCheckBox* getDisplayNFAPIErrorsWarningsCheckBox() {return mpDisplayNFAPIErrorsWarningsCheckBox;}
+  QCheckBox* getEnableInstanceApiNoJsonCheckBox() {return mpEnableInstanceApiNoJsonCheckBox;}
   SpinBox* getLibraryIconSizeSpinBox() {return mpLibraryIconSizeSpinBox;}
   SpinBox* getLibraryIconTextLengthSpinBox() {return mpLibraryIconTextLengthSpinBox;}
   void setShowProtectedClasses(bool value) {mpShowProtectedClasses->setChecked(value);}
@@ -332,6 +333,7 @@ private:
   ComboBox *mpActivateAccessAnnotationsComboBox;
   QCheckBox *mpCreateBackupFileCheckbox;
   QCheckBox *mpDisplayNFAPIErrorsWarningsCheckBox;
+  QCheckBox *mpEnableInstanceApiNoJsonCheckBox;
   QCheckBox *mpEnableCRMLSupportCheckBox;
   QGroupBox *mpLibraryBrowserGroupBox;
   Label *mpLibraryIconSizeLabel;

--- a/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
+++ b/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
@@ -42,6 +42,7 @@
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
 #include "Modeling/Model.h"
+#include "OMC/OMCProxy.h"
 
 OMEDITTEST_MAIN(ModelInstanceTest)
 
@@ -184,6 +185,40 @@ void ModelInstanceTest::isInput_data()
       << "RestrictedVariabilityParamDialog.InputByRedeclare"
       << "X"
       << true;
+}
+
+void ModelInstanceTest::referencePathEquivalence()
+{
+  MainWindow *pMainWindow = MainWindow::instance();
+  OMCProxy *pOMCProxy = pMainWindow->getOMCProxy();
+  const bool savedFlag = pMainWindow->isNewApiNoJson();
+
+  QStringList classes;
+  classes << "P.M"
+          << "RestrictedVariabilityParamDialog.Volume"
+          << "RestrictedVariabilityParamDialog.RestrictByRedeclare";
+
+  for (const QString &className : classes) {
+    // Diagram/model path (icon = false).
+    pMainWindow->setNewApiNoJson(false);
+    const QJsonObject jsonObject = pOMCProxy->getModelInstance(className, "", "", false, false);
+    pMainWindow->setNewApiNoJson(true);
+    const QJsonObject referenceObject = pOMCProxy->getModelInstance(className, "", "", false, false);
+    if (jsonObject != referenceObject) {
+      QFAIL(QString("Model instance for %1 differs between the JSON path and the reference path.").arg(className).toStdString().c_str());
+    }
+
+    // Annotation/icon path (icon = true).
+    pMainWindow->setNewApiNoJson(false);
+    const QJsonObject jsonIcon = pOMCProxy->getModelInstance(className, "", "", false, true);
+    pMainWindow->setNewApiNoJson(true);
+    const QJsonObject referenceIcon = pOMCProxy->getModelInstance(className, "", "", false, true);
+    if (jsonIcon != referenceIcon) {
+      QFAIL(QString("Annotation instance for %1 differs between the JSON path and the reference path.").arg(className).toStdString().c_str());
+    }
+  }
+
+  pMainWindow->setNewApiNoJson(savedFlag);
 }
 
 void ModelInstanceTest::cleanupTestCase()

--- a/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.h
+++ b/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.h
@@ -78,6 +78,13 @@ private slots:
    */
   void isInput();
   void isInput_data();
+  /*!
+   * \brief referencePathEquivalence
+   * Tests that getModelInstance returns an identical QJsonObject via the
+   * getModelInstanceReference path (--NAPINoJson, issue #15219) as via the
+   * legacy JSON-string + QJsonDocument::fromJson path.
+   */
+  void referencePathEquivalence();
   void cleanupTestCase();
 };
 


### PR DESCRIPTION
Play with #15219.

Add an in-process transfer path for the model instance between omc and OMEdit that skips JSON string serialization (omc) and parsing (OMEdit), which for large models takes seconds (issue #15219). First vertical slice, gated behind an option with the existing JSON-string path kept as the default.

Producer (OMCompiler):
- New builtins getModelInstanceReference / getModelInstanceAnnotationReference / releaseModelInstanceReference (ModelicaBuiltin.mo, NFModelicaBuiltin.mo, CevalScriptBackend.mo dispatch).
- NFApi runs the same pipeline as getModelInstance up to the JSON value, then JSON.toListForm (new, in JSON.mo: OBJECT->LIST_OBJECT and ARRAY->LIST recursively so the structure is plain MM lists/tuples/scalars walkable from C++) and stores the boxed value in a handle registry instead of JSON.toString.
- ModelInstanceReference_omc.c: handle registry (static array, GC-scanned) with C accessors ModelInstanceReference_store/_get/_release.

Consumer (OMEdit):
- OMCProxy::getModelInstance, when enabled, fetches the handle, reads the boxed JSON value via ModelInstanceReference_get and walks it into a QJsonObject with jsonValueFromMM (raw MMC macros), then releases it; falls back to the JSON string path on failure. Reuses the existing ModelInstance::Model unchanged.
- stringFromMM casts MMC_STRINGDATA to (const char*): MMC_STRINGDATA has type char[1], which would otherwise bind Qt6's QString::fromUtf8(QByteArrayView) overload by the declared array size and truncate every string to one character.
- JSON integers map to qint64-typed QJsonValue to match QJsonDocument::fromJson.

Enabling it:
- Command-line flag --NAPINoJson=true (MainWindow::isNewApiNoJson, default off).
- Tools->Options General checkbox "Read the model instance directly from memory instead of JSON", persisted via QSettings (enableInstanceApiNoJson, default off), applied immediately (no restart). The option drives the same MainWindow flag and ORs the command-line flag, so OMCProxy needs no separate plumbing.

Test:
- ModelInstanceTest::referencePathEquivalence asserts the reference path yields a QJsonObject identical to the JSON-string path (diagram and icon).

See also: #11920