### PR TITLE
Use builtin isSome/isNone instead of Util

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -214,13 +214,13 @@ algorithm
     // A non-parser error occured, display the error message.
     case (_, _)
       algorithm
-        true := isSome(inStatements) or Util.isSome(inProgram);
+        true := isSome(inStatements) or isSome(inProgram);
         result := Error.printMessagesStr(false);
       then result;
 
     else
       algorithm
-        true := isSome(inStatements) or Util.isSome(inProgram);
+        true := isSome(inStatements) or isSome(inProgram);
         Error.addMessage(Error.STACK_OVERFLOW, {inCommand});
       then "";
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -1068,7 +1068,7 @@ public
       protected
         list<ComponentRef> names;
       algorithm
-        if Util.isSome(map) then
+        if isSome(map) then
           (names, _) := getFrames(Util.getOption(map));
           str := str + " (" + ComponentRef.toString(listHead(names)) + ")";
         end if;
@@ -1095,7 +1095,7 @@ public
     algorithm
       iter := match iter
         case SINGLE() algorithm
-          if Util.isSome(funcCrefOpt) then
+          if isSome(funcCrefOpt) then
             funcCref := Util.getOption(funcCrefOpt);
             iter.name := funcCref(iter.name);
           end if;
@@ -1103,7 +1103,7 @@ public
         then iter;
 
         case NESTED() algorithm
-          if Util.isSome(funcCrefOpt) then
+          if isSome(funcCrefOpt) then
             funcCref := Util.getOption(funcCrefOpt);
             for i in 1:arrayLength(iter.names) loop
               iter.names[i] := funcCref(iter.names[i]);
@@ -3151,7 +3151,7 @@ public
       // referenceEq for lists?
       ifBody.then_eqns := List.map(ifBody.then_eqns, func);
 
-      if Util.isSome(ifBody.else_if) then
+      if isSome(ifBody.else_if) then
         old_else_if := Util.getOption(ifBody.else_if);
         else_if := mapEqnExpCref(old_else_if, func, funcExp, funcCrefOpt, mapFunc);
         if not referenceEq(else_if, old_else_if) then
@@ -3183,7 +3183,7 @@ public
       for eqn in body.then_eqns loop
         Equation.createName(eqn, idx, context);
       end for;
-      if Util.isSome(body.else_if) then
+      if isSome(body.else_if) then
         createNames(Util.getOption(body.else_if), idx, context);
       end if;
     end createNames;
@@ -3197,7 +3197,7 @@ public
       Expression condition = if Expression.isEnd(body.condition) then Expression.BOOLEAN(true) else body.condition;
     algorithm
       stmt := (condition, List.flatten(list(Equation.toStatement(Pointer.access(eqn)) for eqn in body.then_eqns)));
-      if Util.isSome(body.else_if) then
+      if isSome(body.else_if) then
         stmts := stmt :: toStatement(Util.getOption(body.else_if));
       else
         stmts := {stmt};
@@ -3253,7 +3253,7 @@ public
         case {eqn_ptr} algorithm
           SOME(new_exp) := Equation.getLHS(Pointer.access(eqn_ptr));
           if Expression.isEnd(exp) or Expression.isEqual(exp, new_exp) then
-            if Util.isSome(body.else_if) then
+            if isSome(body.else_if) then
               (new_exp, success) := getLHS(Util.getOption(body.else_if), new_exp);
             end if;
           else
@@ -3280,7 +3280,7 @@ public
       exp := match body.then_eqns
         case {eqn_ptr} algorithm
           SOME(new_exp) := Equation.getRHS(Pointer.access(eqn_ptr));
-          if Util.isSome(body.else_if) then
+          if isSome(body.else_if) then
             new_exp := Expression.IF(Expression.typeOf(new_exp), body.condition, new_exp, getRHS(Util.getOption(body.else_if)));
           end if;
         then new_exp;
@@ -3406,7 +3406,7 @@ public
         then_eqns[i] := eqn :: then_eqns[i];
         i := i + 1;
       end for;
-      if Util.isSome(body.else_if) then
+      if isSome(body.else_if) then
         (conditions, then_eqns) := splitCollect(Util.getOption(body.else_if), conditions, then_eqns);
       end if;
     end splitCollect;
@@ -3521,7 +3521,7 @@ public
       tuple<Expression, list<Statement>> stmt;
     algorithm
       stmt := (body.condition, list(WhenStatement.toStatement(st) for st in body.when_stmts));
-      if Util.isSome(body.else_when) then
+      if isSome(body.else_when) then
         stmts := stmt :: toStatement(Util.getOption(body.else_when));
       else
         stmts := {stmt};
@@ -3615,7 +3615,7 @@ public
           end for;
           // create body from flat list and add to new bodies
           new_body := fromFlatList(flat_new);
-          if Util.isSome(new_body) then
+          if isSome(new_body) then
             bodies := Util.getOption(new_body) :: bodies;
           else
             Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
@@ -3636,7 +3636,7 @@ public
           // if there is a statement: create the when body and combine with previous
           // conditions. if there is no statement in this branch, save the condition
           // negated for the next branch
-          if Util.isSome(stmt) then
+          if isSome(stmt) then
             condition := combineConditions(acc_condition, condition, false);
             acc_condition := Expression.EMPTY(Type.INTEGER());
             flat_new := (condition, {Util.getOption(stmt)}) :: flat_new;
@@ -3646,7 +3646,7 @@ public
         end for;
         // create body from flat list and add to new bodies
         new_body := fromFlatList(flat_new);
-        if Util.isSome(new_body) then
+        if isSome(new_body) then
           bodies := Util.getOption(new_body) :: bodies;
         else
           Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
@@ -3669,7 +3669,7 @@ public
           flat_new := (condition, stmts) :: flat_new;
           // create body from flat list and add to new bodies
           new_body := fromFlatList(flat_new);
-          if Util.isSome(new_body) then
+          if isSome(new_body) then
             bodies := Util.getOption(new_body) :: bodies;
           end if;
         else
@@ -3768,7 +3768,7 @@ public
     protected
       WhenEquationBody body;
     algorithm
-      if Util.isSome(body_opt) then
+      if isSome(body_opt) then
         body := Util.getOption(body_opt);
         for stmt in body.when_stmts loop
           () := match stmt
@@ -4192,7 +4192,7 @@ public
       output OldBackendDAE.EquationAttributes oldAttributes;
     algorithm
       oldAttributes := OldBackendDAE.EQUATION_ATTRIBUTES(
-        differentiated  = Util.isSome(attributes.derivative),
+        differentiated  = isSome(attributes.derivative),
         kind            = convertEquationKind(attributes.kind, attributes.clock_idx, attributes.exclusively_initial),
         evalStages      = Evaluation.Stages.convert(attributes.evalStages));
     end convert;
@@ -4260,7 +4260,7 @@ public
                                     else "[UKWN";
     end match;
     str := if exclusively_initial then "[INI]" + str else "[DAE]" + str;
-    if Util.isSome(clock_idx) then
+    if isSome(clock_idx) then
       str := str + "(" + intString(Util.getOption(clock_idx)) + ")]";
     else
       str := str + "]";
@@ -4283,8 +4283,8 @@ public
       Integer luI = lastUsedIndex(equations);
       Integer length, scal_start, current_index = 1;
       String index;
-      Boolean useMapping = Util.isSome(mapping_opt);
-      Boolean filterEqs = Util.isSome(filter_opt);
+      Boolean useMapping = isSome(mapping_opt);
+      Boolean filterEqs = isSome(filter_opt);
       array<tuple<Integer,Integer>> mapping;
       UnorderedSet<String> filter;
       Pointer<Equation> eqn;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBPartition.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBPartition.mo
@@ -106,7 +106,7 @@ public
     algorithm
       str := match association
         case CONTINUOUS() algorithm
-          if Util.isSome(association.jacobian) then
+          if isSome(association.jacobian) then
             str := BJacobian.toString(Util.getOption(association.jacobian), Partition.kindToString(association.kind));
             if (Flags.getConfigBool(Flags.MOO_DYNAMIC_OPTIMIZATION)) then
               str := "\n" + str + BJacobian.toString(Util.getOption(association.LFG_jacobian), Partition.kindToString(association.kind));
@@ -116,13 +116,13 @@ public
           else
             str := StringUtil.headline_1("No Jacobian");
           end if;
-          if Util.isSome(association.jacobianAdjoint) then
+          if isSome(association.jacobianAdjoint) then
             str := BJacobian.toString(Util.getOption(association.jacobianAdjoint), Partition.kindToString(association.kind) + " Adjoint") + "\n";
           end if;
         then str;
         case CLOCKED() algorithm
           str := BClock.toString(association.clock);
-          if Util.isSome(association.baseClock) then
+          if isSome(association.baseClock) then
             str := StringUtil.headline_1("Sub clock: " + str + " of base clock " + BClock.toString(Util.getOption(association.baseClock)));
           else
             str := StringUtil.headline_1("Base clock: " + str);
@@ -159,7 +159,7 @@ public
       clock_tpl := Pointer.access(clock_ptr);
       infer := Pointer.access(infer_ptr);
 
-      if Util.isSome(clock_tpl) then
+      if isSome(clock_tpl) then
         SOME((name, clock)) := clock_tpl;
 
         // throw an error if there are different clocks in this partition
@@ -172,7 +172,7 @@ public
         if BClock.isBaseClock(clock) then
           // if the clock is still an inferred clock without reference, update it to the default base clock and add to the base clocks
           if BClock.isInferredClock(clock) then
-            if Util.isNone(infer) then
+            if isNone(infer) then
               clock := NBPartitioning.DEFAULT_BASE_CLOCK;
               UnorderedMap.add(name, clock, info.baseClocks);
             else
@@ -628,7 +628,7 @@ public
       input Partition part;
       output list<Pointer<Variable>> residuals = {};
     algorithm
-      if Util.isSome(part.strongComponents) then
+      if isSome(part.strongComponents) then
         for comp in Util.getOption(part.strongComponents) loop
           residuals := listAppend(StrongComponent.getLoopResiduals(comp), residuals);
         end for;
@@ -664,7 +664,7 @@ public
     protected
       array<StrongComponent> comps;
     algorithm
-      if Util.isSome(partition.strongComponents) then
+      if isSome(partition.strongComponents) then
         SOME(comps) := partition.strongComponents;
         for i in 1:arrayLength(comps) loop
           comps[i] := func(comps[i]);
@@ -742,7 +742,7 @@ public
     protected
       array<StrongComponent> comps;
     algorithm
-      if Util.isSome(par.strongComponents) then
+      if isSome(par.strongComponents) then
         // no need to override comps afterwards since arrays are mutable
         comps := Util.getOption(par.strongComponents);
         for i in 1:arrayLength(comps) loop
@@ -770,13 +770,13 @@ public
       input Partition part2;
       input Boolean strict;
     algorithm
-      if Util.isSome(part1.daeUnknowns) or Util.isSome(part2.daeUnknowns) then
+      if isSome(part1.daeUnknowns) or isSome(part2.daeUnknowns) then
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed. Cannot merge DAE-Mode partitions."}); fail();
-      elseif Util.isSome(part1.strongComponents) or Util.isSome(part2.strongComponents) then
+      elseif isSome(part1.strongComponents) or isSome(part2.strongComponents) then
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed. Should not merge sorted partitions."}); fail();
-      elseif Util.isSome(part1.matching) or Util.isSome(part2.matching) then
+      elseif isSome(part1.matching) or isSome(part2.matching) then
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed. Should not merge matched partitions."}); fail();
-      elseif Util.isSome(part1.adjacencyMatrix) or Util.isSome(part2.adjacencyMatrix) then
+      elseif isSome(part1.adjacencyMatrix) or isSome(part2.adjacencyMatrix) then
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed. Should not merge partitions with adjacency matrix."}); fail();
       end if;
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -645,14 +645,14 @@ public
   function hasStartAttr
     extends checkVar;
   algorithm
-    b := Util.isSome(VariableAttributes.getStartAttribute(var.backendinfo.attributes));
+    b := isSome(VariableAttributes.getStartAttribute(var.backendinfo.attributes));
   end hasStartAttr;
 
   function hasPre
     "only returns true if the variable itself is not a pre() or previous() and has a pre() pointer set"
     extends checkVar;
   algorithm
-    b := not isPrevious(var_ptr) and Util.isSome(getVarPre(var_ptr));
+    b := not isPrevious(var_ptr) and isSome(getVarPre(var_ptr));
   end hasPre;
 
   function isJacobianResultVar
@@ -1766,7 +1766,7 @@ public
 
     // map start exp
     opt_start   := getStartAttribute(var_ptr);
-    if Util.isSome(opt_start) then
+    if isSome(opt_start) then
       SOME(start) := opt_start;
       new_start   := mapFunc(start, funcExp);
 
@@ -1942,7 +1942,7 @@ public
       Integer numberOfElements = VariablePointers.size(variables);
       Integer length, scal_start;
       String index;
-      Boolean useMapping = Util.isSome(mapping_opt);
+      Boolean useMapping = isSome(mapping_opt);
       array<tuple<Integer,Integer>> mapping;
     algorithm
       if useMapping then
@@ -2208,7 +2208,7 @@ public
       var_ptr := match UnorderedMap.get(cref, variables.map)
         case SOME(index) guard(index > 0) then ExpandableArray.get(index, variables.varArr);
         else algorithm
-          if Util.isSome(info) then
+          if isSome(info) then
             Error.addInternalError(getInstanceName() + " failed for " + ComponentRef.toString(cref), Util.getOption(info));
           end if;
         then fail();

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -410,7 +410,7 @@ public
         print(toString(bdae, "(" + name + ")"));
       end if;
 
-      if Util.isSome(eq_filter_opt) then
+      if isSome(eq_filter_opt) then
         debugFollowEquations(bdae, eq_filter_opt, "(" + name + ")");
       end if;
     end for;
@@ -1761,7 +1761,7 @@ public
           strongcomponentinfo("Simulation", {bdae.ode, bdae.algebraic, bdae.ode_event, bdae.alg_event});
           // collect strong component info initialization
           strongcomponentinfo("Initialization", {bdae.init});
-          if Util.isSome(bdae.init_0) then
+          if isSome(bdae.init_0) then
             strongcomponentinfo("Initialization (lambda=0)", {Util.getOption(bdae.init_0)});
           end if;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBCausalize.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBCausalize.mo
@@ -113,7 +113,7 @@ public
           end if;
           (partitions, varData, eqData) := applyModule(partitions, kind, varData, eqData, bdae.funcMap, func);
           bdae.init := partitions;
-          if Util.isSome(bdae.init_0) then
+          if isSome(bdae.init_0) then
             (partitions, varData, eqData) := applyModule(Util.getOption(bdae.init_0), kind, varData, eqData, bdae.funcMap, func);
             bdae.init_0 := SOME(partitions);
           end if;

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
@@ -317,7 +317,7 @@ public
     (cref, iter) := tpl;
     var_ptr := BVariable.getVarPointer(cref, sourceInfo());
     var_pre := BVariable.getVarPre(var_ptr);
-    if Util.isSome(var_pre) then
+    if isSome(var_pre) then
       pre := BVariable.getVarName(Util.getOption(var_pre));
       pre := ComponentRef.copySubscripts(cref, pre);
       kind := if BVariable.isContinuous(var_ptr, true) then EquationKind.CONTINUOUS else EquationKind.DISCRETE;
@@ -345,11 +345,11 @@ public
     Option<Pointer<Variable>> var_pre = BVariable.getVarPre(var_ptr);
     ComponentRef merged_name;
   algorithm
-    if BVariable.isPrevious(var_ptr) and Util.isSome(var_pre) then
+    if BVariable.isPrevious(var_ptr) and isSome(var_pre) then
       // for previous change the rhs to the start value of the discrete state
       merged_name := BVariable.getVarName(Util.getOption(var_pre));
       merged_name := ComponentRef.mergeSubscripts(subscripts, merged_name, true, true, true);
-    elseif Util.isSome(var_pre) then
+    elseif isSome(var_pre) then
       // for vars with previous change the lhs cref to the $PRE cref
       merged_name := ComponentRef.mergeSubscripts(subscripts, name, true, true, true);
       var_ptr := Util.getOption(var_pre);
@@ -513,7 +513,7 @@ public
       end match;
     end if;
 
-    if Util.isSome(start_eq) then
+    if isSome(start_eq) then
       // empty list indicates full array, slice otherwise
       if not listEmpty(var_slice.indices) then
         (sliced_eqn, _) := Equation.slice(Util.getOption(start_eq), var_slice.indices);
@@ -630,7 +630,7 @@ public
   algorithm
     if not BVariable.isPrevious(var_ptr) then
       pre := BVariable.getVarPre(var_ptr);
-      if Util.isSome(pre) then
+      if isSome(pre) then
         kind := if BVariable.isContinuous(var_ptr, true) then EquationKind.CONTINUOUS else EquationKind.DISCRETE;
         pre_eq := Equation.makeAssignment(Expression.fromCref(BVariable.getVarName(var_ptr)), Expression.fromCref(BVariable.getVarName(Util.getOption(pre))), idx, NBEquation.PRE_STR, Iterator.EMPTY(), EquationAttributes.default(kind, true));
         Pointer.update(ptr_pre_eqs, pre_eq :: Pointer.access(ptr_pre_eqs));
@@ -660,7 +660,7 @@ public
     var_ptr := Slice.getT(var_slice);
     if not BVariable.isPrevious(var_ptr) then
       pre := BVariable.getVarPre(var_ptr);
-      if Util.isSome(pre) then
+      if isSome(pre) then
         name    := BVariable.getVarName(var_ptr);
         dims    := Type.arrayDims(ComponentRef.getSubscriptedType(name));
         (iterators, ranges, subscripts) := Flatten.makeIterators(name, dims);
@@ -698,7 +698,7 @@ public
         bdae.algebraic  := list(Partition.mapEqn(par, function cleanupInitialCall(kind = Partition.getKind(par))) for par in bdae.algebraic);
         bdae.ode_event  := list(Partition.mapEqn(par, function cleanupInitialCall(kind = Partition.getKind(par))) for par in bdae.ode_event);
         bdae.alg_event  := list(Partition.mapEqn(par, function cleanupInitialCall(kind = Partition.getKind(par))) for par in bdae.alg_event);
-        if Util.isSome(bdae.dae) then
+        if isSome(bdae.dae) then
           bdae.dae := SOME(list(Partition.mapEqn(par, function cleanupInitialCall(kind = Partition.getKind(par))) for par in Util.getOption(bdae.dae)));
         end if;
         // homotopy(actual, simplified) -> actual
@@ -706,7 +706,7 @@ public
         bdae.algebraic  := list(Partition.mapExp(par, function cleanupHomotopy(kind = Partition.getKind(par))) for par in bdae.algebraic);
         bdae.ode_event  := list(Partition.mapExp(par, function cleanupHomotopy(kind = Partition.getKind(par))) for par in bdae.ode_event);
         bdae.alg_event  := list(Partition.mapExp(par, function cleanupHomotopy(kind = Partition.getKind(par))) for par in bdae.alg_event);
-        if Util.isSome(bdae.dae) then
+        if isSome(bdae.dae) then
           bdae.dae := SOME(list(Partition.mapExp(par, function cleanupHomotopy(kind = Partition.getKind(par))) for par in Util.getOption(bdae.dae)));
         end if;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
@@ -237,7 +237,7 @@ public
       try
         // parse the clock and see if it depends on another clock
         (clock, baseClock) := fromExp(exp);
-        if Util.isSome(baseClock) then
+        if isSome(baseClock) then
           // sub clock
           UnorderedMap.add(clock_name, clock, info.subClocks);
           UnorderedMap.add(clock_name, Util.getOption(baseClock), info.subToBase);
@@ -470,7 +470,7 @@ public
         UnorderedMap.add(clock_name, base_clock, info.subToBase);
 
         // also update and add the implicit clock
-        if Util.isSome(implicit_clock_opt) then
+        if isSome(implicit_clock_opt) then
           SOME(implicit_clock) := implicit_clock_opt;
           // add the implicit clock as a sub clock
           UnorderedMap.add(implicit_clock, dest, info.subClocks);
@@ -743,11 +743,11 @@ protected
       for eqn_name in UnorderedSet.toList(cluster.eqn_idnts) loop
         Equation.map(Pointer.access(EquationPointers.getEqnByName(equations, eqn_name)), function findClock(info = info, clock_ptr = clock_ptr), NONE(), Expression.fakeMap);
         clock_opt := Pointer.access(clock_ptr);
-        if Util.isSome(clock_opt) then break; end if;
+        if isSome(clock_opt) then break; end if;
       end for;
 
       // if a clock/clocked signal was found, add all a mapping for each variable in the cluster to the clock
-      if Util.isSome(clock_opt) then
+      if isSome(clock_opt) then
         SOME(clock) := clock_opt;
         for var_name in UnorderedSet.toList(cluster.variables) loop
           UnorderedMap.add(var_name, clock, clock_map);
@@ -1082,7 +1082,7 @@ protected
     // merge clocked partitions by baseclock, subclock
     for partition in clocked_partitions loop
       (clock, baseClock_opt, _)  := Partition.Partition.getClocks(partition);
-      if Util.isSome(baseClock_opt) then
+      if isSome(baseClock_opt) then
         // it is a sub clock
         SOME(baseClock) := baseClock_opt;
         baseClock       := BClock.baseClockInferrence(baseClock, base_clock_inferrence);
@@ -1230,7 +1230,7 @@ protected
           end for;
 
           // finalize last partition
-          if Util.isSome(collector) then
+          if isSome(collector) then
             SOME((vars, eqns, clock)) := collector;
             part := Partition.PARTITION(0, Partition.Association.CLOCKED(clock, baseClock, UnorderedSet.new(BClock.hash, BClock.isEqual), false),
               VariablePointers.fromList(vars), NONE(), EquationPointers.fromList(eqns), NONE(), NONE(), NONE());

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBSorting.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBSorting.mo
@@ -145,7 +145,7 @@ public
       // add each equation to a bucket if solved the same way
       for eqn_scal_idx in 1:arrayLength(eqn_to_var) loop
         mode_opt := UnorderedMap.get((eqn_scal_idx, eqn_to_var[eqn_scal_idx]), modes);
-        if Util.isSome(mode_opt) then
+        if isSome(mode_opt) then
           mode := Util.getOption(mode_opt);
           if Equation.isRecordOrTupleEquation(EquationPointers.getEqnAt(eqns, mapping.eqn_StA[eqn_scal_idx])) then
             // add the cref to the result, but remove it from the modes so all modes of a tuple equations are equal
@@ -171,7 +171,7 @@ public
       Option<Value> val_opt = UnorderedMap.get(mode, buckets);
       Value val;
     algorithm
-      if Util.isSome(val_opt) then
+      if isSome(val_opt) then
         SOME(val) := val_opt;
         val := Value.addEquation(val, eqn_scal_idx);
         UnorderedMap.add(mode, val, buckets);
@@ -190,7 +190,7 @@ public
       Option<Value> val_opt = UnorderedMap.get(mode, buckets);
       Value val;
     algorithm
-      if Util.isSome(val_opt) then
+      if isSome(val_opt) then
         SOME(val) := val_opt;
         val := Value.addCref(val, cref);
         val := Value.addEquation(val, eqn_scal_idx);

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -664,7 +664,7 @@ protected
 
       // fail for record elements for now
       case Expression.CREF()
-        guard(Util.isSome(BVariable.getParent(BVariable.getVarPointer(exp.cref, sourceInfo()))))
+        guard(isSome(BVariable.getParent(BVariable.getVarPointer(exp.cref, sourceInfo()))))
       then FAILED_CREF_TPL;
 
       // variable found
@@ -900,12 +900,12 @@ protected
   algorithm
   // function calls of different set functions in NBVariable.mo
     new_min := getMaximum(attrcollector.min_val_map);
-    if Util.isSome(new_min) then
+    if isSome(new_min) then
       Pointer.update(var_to_keep, BVariable.setMin(Pointer.access(var_to_keep), new_min, true));
       UnorderedMap.add(BVariable.getVarName(var_to_keep), Util.getOption(new_min), attrcollector.min_val_map); // update attribute collector
     end if;
     new_max := getMinimum(attrcollector.max_val_map);
-    if Util.isSome(new_max) then
+    if isSome(new_max) then
       Pointer.update(var_to_keep, BVariable.setMax(Pointer.access(var_to_keep), new_max, true));
       UnorderedMap.add(BVariable.getVarName(var_to_keep), Util.getOption(new_max), attrcollector.max_val_map); // update attribute collector
     end if;
@@ -921,7 +921,7 @@ protected
       UnorderedMap.add(BVariable.getVarName(var_to_keep), Util.getOption(new_start), attrcollector.start_map); // update attribute collector
     end if;
     (new_cref, new_stateSelect) := chooseStateSelect(attrcollector.stateSelect_map);
-    if Util.isSome(new_stateSelect) and Util.isSome(UnorderedMap.get(BVariable.getVarName(var_to_keep),attrcollector.stateSelect_map)) then // only update stateSelect value, if var_to_keep has a stateSelect value
+    if isSome(new_stateSelect) and isSome(UnorderedMap.get(BVariable.getVarName(var_to_keep),attrcollector.stateSelect_map)) then // only update stateSelect value, if var_to_keep has a stateSelect value
       Pointer.update(var_to_keep, BVariable.setStateSelect(Pointer.access(var_to_keep), Util.getOption(new_stateSelect), true));
       UnorderedMap.add(BVariable.getVarName(var_to_keep), Util.getOption(new_stateSelect), attrcollector.stateSelect_map); // update attribute collector
       if Util.getOption(new_stateSelect) == StateSelect.ALWAYS then // start value of var with StateSelect = always is stronger than start value of fixed var
@@ -931,7 +931,7 @@ protected
       end if;
     end if;
     new_tearingSelect := chooseTearingSelect(attrcollector.tearingSelect_map);
-    if Util.isSome(new_tearingSelect) and Util.isSome(UnorderedMap.get(BVariable.getVarName(var_to_keep),attrcollector.tearingSelect_map)) then // only update tearingSelect value, if var_to_keep has a tearingSelect value
+    if isSome(new_tearingSelect) and isSome(UnorderedMap.get(BVariable.getVarName(var_to_keep),attrcollector.tearingSelect_map)) then // only update tearingSelect value, if var_to_keep has a tearingSelect value
       Pointer.update(var_to_keep, BVariable.setTearingSelect(Pointer.access(var_to_keep), Util.getOption(new_tearingSelect), true));
       UnorderedMap.add(BVariable.getVarName(var_to_keep), Util.getOption(new_tearingSelect), attrcollector.tearingSelect_map); // update attribute collector
     end if;
@@ -1306,11 +1306,11 @@ protected
   protected
     Expression min_val, max_val;
   algorithm
-    if Util.isSome(attr_min) then
+    if isSome(attr_min) then
       min_val := Util.getOption(attr_min);
       UnorderedMap.add(BVariable.getVarName(var_ptr), min_val, attrcollector.min_val_map);
     end if;
-    if Util.isSome(attr_max) then
+    if isSome(attr_max) then
       max_val := Util.getOption(attr_max);
       UnorderedMap.add(BVariable.getVarName(var_ptr), max_val, attrcollector.max_val_map);
     end if;
@@ -1324,11 +1324,11 @@ protected
   protected
     Expression start_val, fixed_val;
   algorithm
-    if Util.isSome(attr_start) then
+    if isSome(attr_start) then
       start_val := Util.getOption(attr_start);
       UnorderedMap.add(BVariable.getVarName(var_ptr), start_val, attrcollector.start_map);
     end if;
-    if Util.isSome(attr_fixed) then
+    if isSome(attr_fixed) then
       fixed_val := Util.getOption(attr_fixed);
       UnorderedMap.add(BVariable.getVarName(var_ptr), fixed_val, attrcollector.fixed_map);
     end if;
@@ -1359,18 +1359,18 @@ protected
       case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_REAL())) algorithm
         attrcollector := optionMinMax(var_ptr, attr.min, attr.max, attrcollector);
         attrcollector := optionStartFixed(var_ptr, attr.start, attr.fixed, attrcollector);
-        if Util.isSome(attr.nominal) then
+        if isSome(attr.nominal) then
           nominal_val := Util.getOption(attr.nominal);
           UnorderedMap.add(BVariable.getVarName(var_ptr), nominal_val, attrcollector.nominal_map);
         end if;
-        if Util.isSome(attr.stateSelect) then
+        if isSome(attr.stateSelect) then
           stateSelect_val := Util.getOption(attr.stateSelect);
           if stateSelect_val == StateSelect.ALWAYS then
             rating := rating + 100;
           end if;
           UnorderedMap.add(BVariable.getVarName(var_ptr), stateSelect_val, attrcollector.stateSelect_map);
         end if;
-        if Util.isSome(attr.tearingSelect) then
+        if isSome(attr.tearingSelect) then
           tearingSelect_val := Util.getOption(attr.tearingSelect);
           UnorderedMap.add(BVariable.getVarName(var_ptr), tearingSelect_val, attrcollector.tearingSelect_map);
         end if;
@@ -1441,7 +1441,7 @@ protected
     algorithm
       SOME(rhs) := Equation.getRHS(solved_eq);
       // min:
-      if Util.isSome(min_val_opt) then
+      if isSome(min_val_opt) then
         UnorderedMap.add(var_cref, Util.getOption(min_val_opt), repl);
         new_rhs := Expression.map(rhs, function Replacements.applySimpleExp(replacements = repl));
         new_rhs := SimplifyExp.simplify(new_rhs);
@@ -1450,7 +1450,7 @@ protected
       end if;
 
       // max:
-      if Util.isSome(max_val_opt) then
+      if isSome(max_val_opt) then
         UnorderedMap.add(var_cref, Util.getOption(max_val_opt), repl);
         new_rhs := Expression.map(rhs, function Replacements.applySimpleExp(replacements = repl));
         new_rhs := SimplifyExp.simplify(new_rhs);
@@ -1469,13 +1469,13 @@ protected
       else
         swap_min_max := false;
       end if;
-      if swap_min_max and Util.isSome(min_val_opt) and Util.isSome(max_val_opt) then
+      if swap_min_max and isSome(min_val_opt) and isSome(max_val_opt) then
         UnorderedMap.add(var_cref, Util.getOption(max_val_opt), attrcollector.min_val_map);
         UnorderedMap.add(var_cref, Util.getOption(min_val_opt), attrcollector.max_val_map);
       end if;
 
       // start:
-      if Util.isSome(start_opt) then
+      if isSome(start_opt) then
         UnorderedMap.add(var_cref, Util.getOption(start_opt), repl);
         new_rhs := Expression.map(rhs, function Replacements.applySimpleExp(replacements = repl));
         new_rhs := SimplifyExp.simplify(new_rhs);
@@ -1483,7 +1483,7 @@ protected
       end if;
 
       // nominal:
-      if Util.isSome(nominal_opt) then
+      if isSome(nominal_opt) then
         UnorderedMap.add(var_cref, Util.getOption(nominal_opt), repl);
         new_rhs := Expression.map(rhs, function Replacements.applySimpleExp(replacements = repl));
         // normalize the nominal values (remove negations)

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
@@ -573,7 +573,7 @@ protected
     for eqn in body.then_eqns loop
       collectDiscreteStatesFromWhen(Pointer.access(eqn), acc_discrete_states, acc_previous, scalarized);
     end for;
-    if Util.isSome(body.else_if) then
+    if isSome(body.else_if) then
       collectDiscreteStatesFromWhenInIf(Util.getOption(body.else_if),  acc_discrete_states, acc_previous, scalarized);
     end if;
   end collectDiscreteStatesFromWhenInIf;
@@ -588,7 +588,7 @@ protected
     Option<Pointer<Variable>> pre = BVariable.getVarPre(var_ptr);
     Pointer<Variable> pre_var;
   algorithm
-    if Util.isSome(pre) then
+    if isSome(pre) then
       SOME(pre_var) := pre;
       pre_cref := BVariable.getVarName(pre_var);
       pre_cref := ComponentRef.copySubscripts(var_cref, pre_cref);

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -253,7 +253,7 @@ public
       Condition cond;
       ComponentRef aux;
     algorithm
-      if Util.isSome(bucket.aux_stmts) then
+      if isSome(bucket.aux_stmts) then
         // add all new statements to the algorithm body
         for tpl in Util.getOption(bucket.aux_stmts) loop
           (cond, aux) := tpl;
@@ -706,7 +706,7 @@ public
       end if;
 
       sev_opt := UnorderedMap.get(condition, bucket.state_map);
-      if Util.isSome(sev_opt) then
+      if isSome(sev_opt) then
         // if the state event already exist update the equations it belongs to
         SOME(sev) := sev_opt;
         UnorderedSet.add(eqn, sev.eqns);
@@ -895,7 +895,7 @@ public
       end if;
 
       cev_opt := UnorderedMap.get(condition, bucket.time_map);
-      if Util.isSome(cev_opt) then
+      if isSome(cev_opt) then
         // time event already exists, just get the identifier
         SOME(cev) := cev_opt;
         aux_cref := BVariable.getVarName(cev.auxiliary);

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
@@ -648,7 +648,7 @@ protected
         then Expression.fromCref(name);
       end match;
 
-      if Util.isNone(aux_opt) then
+      if isNone(aux_opt) then
         // create auxilliary and add to map if there was none before
         aux := CALL_AUX(exp, if Type.isDiscrete(ty) then EquationKind.DISCRETE else EquationKind.CONTINUOUS, false);
         UnorderedMap.add(id, aux, map);

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBInline.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBInline.mo
@@ -1080,7 +1080,7 @@ protected
           Option<InlineRating> iro;
         case Expression.CREF() algorithm
           iro := UnorderedMap.get(exp.cref, local_map);
-          if Util.isSome(iro) then
+          if isSome(iro) then
             Pointer.update(irp, add(Pointer.access(irp), multiply(Util.getOption(iro), i)));
           end if;
         then ();
@@ -1159,7 +1159,7 @@ protected
           case Expression.CALL() guard(functionInlineable(Call.typedFunction(exp.call))) algorithm
             fn  := Call.typedFunction(exp.call);
             lir := UnorderedMap.get(fn, func_map);
-            if Util.isSome(lir) then
+            if isSome(lir) then
               // add the found rating to the overall rating
               Pointer.update(irp, addMapped(Pointer.access(irp), Util.getOption(lir), listArray(Call.arguments(exp.call)), local_map));
               cont := false;

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -144,7 +144,7 @@ public
           bdae.algebraic := applyToPartitions(bdae.algebraic, bdae.funcMap, knowns, name, func);
           bdae.alg_event := applyToPartitions(bdae.alg_event, bdae.funcMap, knowns, name, func);
           bdae.init := applyToPartitions(bdae.init, bdae.funcMap, knowns, name, func);
-          if Util.isSome(bdae.init_0) then
+          if isSome(bdae.init_0) then
             bdae.init_0 := SOME(applyToPartitions(Util.getOption(bdae.init_0), bdae.funcMap, knowns, name, func));
           end if;
       then bdae;
@@ -1069,7 +1069,7 @@ protected
         (LFG_jacobian, MRF_jacobian, R0_jacobian) := partJacobianDynamicOptimization(part, knowns, name, func, funcMap);
       end if;
 
-      if Util.isSome(jacobian) then
+      if isSome(jacobian) then
         if BackendDAE.getIsAdjoint(Util.getOption(jacobian)) then
           part.association := Partition.Association.CONTINUOUS(kind, NONE(), jacobian, LFG_jacobian, MRF_jacobian, R0_jacobian);
         else
@@ -1142,7 +1142,7 @@ protected
 
     BVariable.checkVar func = getTmpFilterFunction(jacType);
   algorithm
-    if Util.isSome(strongComponents) then
+    if isSome(strongComponents) then
       // filter all discrete strong components and differentiate the others
       // todo: mixed algebraic loops should be here without the discrete subsets
       comps := list(comp for comp guard(not StrongComponent.isDiscrete(comp)) in Util.getOption(strongComponents));
@@ -1201,7 +1201,7 @@ protected
       seedVars      = VariablePointers.fromList(seed_vars)
     );
 
-    if Util.isSome(full) then
+    if isSome(full) then
       //sparsity := Adjacency.Matrix.fullToSparsity(Util.getOption(full), comps);
     else
       Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because full adjacency matrix to create sparsity pattern is missing."});
@@ -1444,7 +1444,7 @@ protected
     Option<ComponentRef> o_pDerCref;
   algorithm
     newName := name + "_ADJ";
-    if Util.isSome(strongComponents) then
+    if isSome(strongComponents) then
       comps := list(comp for comp guard(not StrongComponent.isDiscrete(comp)) in Util.getOption(strongComponents));
       // only allow single components and algebraic loops
       for c in comps loop
@@ -1944,7 +1944,7 @@ protected
       vstr := "[" + stringDelimitList(list(Expression.toString(e) for e in elst), ", ") + "]";
     end valueToString;
   algorithm
-    if Util.isNone(adjoint_map) then
+    if isNone(adjoint_map) then
       str := "{}";
       return;
     end if;

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -102,10 +102,10 @@ public
         // The order here is important. Whatever comes first is declared the "original", same components afterwards will be alias
         // Has to be the same order as in SimCode!
         bdae.init       := list(solvePartition(par, bdae.funcMap, implicit_index_ptr, duplicate_map, bdae.varData, bdae.eqData) for par in bdae.init);
-        if Util.isSome(bdae.init_0) then
+        if isSome(bdae.init_0) then
           bdae.init_0   := SOME(list(solvePartition(par, bdae.funcMap, implicit_index_ptr, duplicate_map, bdae.varData, bdae.eqData) for par in Util.getOption(bdae.init_0)));
         end if;
-        if Util.isSome(bdae.dae) then
+        if isSome(bdae.dae) then
           bdae.dae      := SOME(list(solvePartition(par, bdae.funcMap, implicit_index_ptr, duplicate_map, bdae.varData, bdae.eqData) for par in Util.getOption(bdae.dae)));
         end if;
         bdae.ode        := list(solvePartition(par, bdae.funcMap, implicit_index_ptr, duplicate_map, bdae.varData, bdae.eqData) for par in bdae.ode);
@@ -138,7 +138,7 @@ public
     ComponentRef name;
     list<Pointer<Equation>> sliced_eqns;
   algorithm
-    if Util.isSome(partition.strongComponents) then
+    if isSome(partition.strongComponents) then
       for comp in Util.getOption(partition.strongComponents) loop
         solved_comps := match UnorderedMap.get(comp, duplicate_map)
           local list<StrongComponent> alias_comps;
@@ -717,7 +717,7 @@ public
     end for;
     body.then_eqns := listReverse(new_then_eqns);
     // if there is an else branch -> go deeper
-    if Util.isSome(body.else_if) then
+    if isSome(body.else_if) then
       (else_if, status, implicit_index) := solveIfBody(Util.getOption(body.else_if), vars, funcMap, kind, implicit_index, slicing_map, iter, varData, eqData);
       body.else_if := SOME(else_if);
     else
@@ -864,7 +864,7 @@ protected
     IfEquationBody else_if;
     Equation eqn;
   algorithm
-    if Util.isSome(body.else_if) then
+    if isSome(body.else_if) then
       (else_if, status, _) := solveSimpleIf(Util.getOption(body.else_if), cref);
       if status == Status.EXPLICIT then
         body.else_if := SOME(else_if);
@@ -1571,7 +1571,7 @@ protected
     else
       // check if the record parents occur (todo: vice versa?)
       record_parent := BVariable.getParent(BVariable.getVarPointer(var_cref, sourceInfo()));
-      if Util.isSome(record_parent) then
+      if isSome(record_parent) then
         (var_cref, solve_status) := getVarSlice(BVariable.getVarName(Util.getOption(record_parent)), eqn);
       else
         // todo: choose best slice of list if more than one.

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -125,7 +125,7 @@ public
     str := str + "### Iteration Variables:\n" + Slice.lstToString(set.iteration_vars, BVariable.pointerToString);
     str := str + "\n### Residual Equations:\n" + Slice.lstToString(set.residual_eqns, function Equation.pointerToString(str = ""));
     str := str + "\n### Inner Equations:\n" + Array.toString(set.innerEquations, function StrongComponent.toString(index = -1), "", "\t", "\n\t", "");
-    if Util.isSome(set.jac) then
+    if isSome(set.jac) then
       str := str + "\n" + BJacobian.toString(Util.getOption(set.jac), "NLS");
     end if;
   end toString;
@@ -155,7 +155,7 @@ public
       case (_, BackendDAE.MAIN(eqData = BEquation.EQ_DATA_SIM(uniqueIndex = eq_index))) guard(Partition.kindIsInitial(kind))
         algorithm
           bdae.init := tearingTraverser(bdae.init, funcs, bdae.funcMap, eq_index, kind);
-          if Util.isSome(bdae.init_0) then
+          if isSome(bdae.init_0) then
             bdae.init_0 := SOME(tearingTraverser(Util.getOption(bdae.init_0), funcs, bdae.funcMap, eq_index, kind));
           end if;
       then bdae;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -1473,7 +1473,7 @@ public
         end match;
       end makeNewKinds;
     algorithm
-      if Util.isSome(opt_dep) then
+      if isSome(opt_dep) then
         SOME(dep) := opt_dep;
 
         // turn to reductions
@@ -1508,7 +1508,7 @@ public
       Option<Dependency> opt_dep = UnorderedMap.get(cref, map);
       Dependency dep;
     algorithm
-      if Util.isSome(opt_dep) then
+      if isSome(opt_dep) then
         SOME(dep) := opt_dep;
         if arrayLength(dep.skips) >= depth then
           // this might scale badly, try to unique the lists in the end or always use sets here
@@ -1539,7 +1539,7 @@ public
       Integer rest = num;
       Integer i, len;
     algorithm
-      if Util.isSome(opt_dep) then
+      if isSome(opt_dep) then
         SOME(dep) := opt_dep;
         if num < 0 then
           // remove all skips
@@ -1689,7 +1689,7 @@ public
         case UNSOLVABLE()         then "XX";
         case IMPLICIT()           then "II";
         case EXPLICIT_NONLINEAR() then "N" + (if sol.unique then "+" else "-");
-        case EXPLICIT_LINEAR()    then "L" + (if Util.isSome(sol.vars) then "V" elseif Util.isSome(sol.pars) then "P" else "C");
+        case EXPLICIT_LINEAR()    then "L" + (if isSome(sol.vars) then "V" elseif isSome(sol.pars) then "P" else "C");
         case UNKNOWN()            then "||";
         else algorithm
           Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of unknown solvability kind."});
@@ -2001,7 +2001,7 @@ public
       // in the size() operator nothing is solvable
       case Expression.SIZE() algorithm
         set  := collectDependencies(exp.exp, depth, kind, map, dep_map, sol_map, rep_set);
-        if Util.isSome(exp.dimIndex) then
+        if isSome(exp.dimIndex) then
           set2  := collectDependencies(Util.getOption(exp.dimIndex), depth, kind, map, dep_map, sol_map, rep_set);
           set := UnorderedSet.union(set, set2);
         end if;
@@ -2083,7 +2083,7 @@ public
       // nothing is solvable from ranges
       case Expression.RANGE() algorithm
         sets := collectDependencies(exp.start, depth, kind, map, dep_map, sol_map, rep_set) :: sets;
-        if Util.isSome(exp.step) then
+        if isSome(exp.step) then
           sets := collectDependencies(Util.getOption(exp.step), depth, kind, map, dep_map, sol_map, rep_set) :: sets;
         end if;
         sets := collectDependencies(exp.stop, depth, kind, map, dep_map, sol_map, rep_set) :: sets;
@@ -2174,7 +2174,7 @@ public
     if isInitialException(body.condition) then
       // branches only in the initial system are ignored
       // only look at the 'else' branch if it exists
-      if Util.isSome(body.else_if) then
+      if isSome(body.else_if) then
         set := collectDependenciesIf(Util.getOption(body.else_if), kind, map, dep_map, sol_map, rep_set);
       end if;
     else
@@ -2189,7 +2189,7 @@ public
       end for;
 
       // if there is an 'else' branch, mark those not occuring in both as implicit (maybe it should be unsolvable?)
-      if Util.isSome(body.else_if) then
+      if isSome(body.else_if) then
         set1 := UnorderedSet.union_list(sets1, ComponentRef.hash, ComponentRef.isEqual);
         set2 := collectDependenciesIf(Util.getOption(body.else_if), kind, map, dep_map, sol_map, rep_set);
         diff  := UnorderedSet.sym_difference(set1, set2);
@@ -2223,7 +2223,7 @@ public
     if isInitialException(body.condition) then
       // branches only in the initial system are ignored
       // traverse else when if it exists
-      if Util.isSome(body.else_when) then
+      if isSome(body.else_when) then
         lst := collectDependenciesWhen(Util.getOption(body.else_when), kind, map, dep_map, sol_map, rep_set) :: lst;
       end if;
       set := UnorderedSet.union_list(lst, ComponentRef.hash, ComponentRef.isEqual);
@@ -2252,7 +2252,7 @@ public
       Solvability.updateList(UnorderedSet.toList(diff), Solvability.UNSOLVABLE(), sol_map);
 
       // traverse else when if it exists
-      if Util.isSome(body.else_when) then
+      if isSome(body.else_when) then
         lst := collectDependenciesWhen(Util.getOption(body.else_when), kind, map, dep_map, sol_map, rep_set) :: lst;
       end if;
       set := UnorderedSet.union_list(set :: set1 :: set2 :: lst, ComponentRef.hash, ComponentRef.isEqual);

--- a/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
@@ -351,7 +351,7 @@ public
     input output String str;
     input Option<Integer> i_opt = NONE();
   protected
-    String i = if Util.isSome(i_opt) then intString(Util.getOption(i_opt)) else "";
+    String i = if isSome(i_opt) then intString(Util.getOption(i_opt)) else "";
   algorithm
     str := NBVariable.FUNCTION_DERIVATIVE_STR + i + "_" + str;
   end makeFDerString;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -427,7 +427,7 @@ public
       case Equation.ARRAY_EQUATION() algorithm
         (lhs, diffArguments) := differentiateExpressionNoCollect(eq.lhs, diffArguments);
         // Only do per-element reverse seeding for explicit element-wise array assembly on RHS
-        if Util.isSome(diffArguments.adjoint_map) and
+        if isSome(diffArguments.adjoint_map) and
           diffArguments.diffType == DifferentiationType.JACOBIAN and
           Expression.isArray(eq.rhs) then
 
@@ -625,7 +625,7 @@ public
         list<list<Expression>> new_matrix_elements = {};
         array<Expression> arr;
         ComponentRef d_fn;
-        Boolean isReverse = Util.isSome(diffArguments.adjoint_map);
+        Boolean isReverse = isSome(diffArguments.adjoint_map);
 
       // differentiation of constant expressions results in zero
       case Expression.INTEGER()   then (Expression.INTEGER(0), diffArguments);
@@ -797,7 +797,7 @@ public
   protected
     Boolean oldCollect;
   algorithm
-    if Util.isSome(diffArguments.adjoint_map) then
+    if isSome(diffArguments.adjoint_map) then
       oldCollect := diffArguments.collectAdjoints;
       diffArguments.collectAdjoints := false;
       (expr, diffArguments) := differentiateExpression(expr, diffArguments);
@@ -831,7 +831,7 @@ public
         + " | diffType=" + DifferentiationArguments.diffTypeStr(diffArguments.diffType)
         + " | scalarized=" + boolString(diffArguments.scalarized)
         + " | collectAdjoints=" + boolString(diffArguments.collectAdjoints));
-    if Util.isSome(diffArguments.adjoint_map) then
+    if isSome(diffArguments.adjoint_map) then
       dbg("[dCREF] current_grad=" + Expression.toString(diffArguments.current_grad));
     end if;
 
@@ -1007,14 +1007,14 @@ public
                 algorithm
                   dbg("[dCREF:JAC] adjoint via INDEX[" + intString(iidx) + "]");
                   onehotOpt := buildOneHotVectorAdjoint(derCref, iidx, diffArguments.current_grad);
-                then (if Util.isSome(onehotOpt) then Util.getOption(onehotOpt) else diffArguments.current_grad);
+                then (if isSome(onehotOpt) then Util.getOption(onehotOpt) else diffArguments.current_grad);
 
               // Single slice/range -> multi-hot scatter
               case {Subscript.SLICE()}
                 algorithm
                   dbg("[dCREF:JAC] adjoint via SLICE " + Subscript.toString(listHead(expCrefSubscripts)));
                   multiOpt := buildMultiHotVectorAdjoint(derCref, listHead(expCrefSubscripts), diffArguments.current_grad);
-                then (if Util.isSome(multiOpt) then Util.getOption(multiOpt) else diffArguments.current_grad);
+                then (if isSome(multiOpt) then Util.getOption(multiOpt) else diffArguments.current_grad);
 
               // Whole dimension -> pass upstream as-is
               case {Subscript.WHOLE()}
@@ -1048,7 +1048,7 @@ public
   protected
     Boolean oldCollect;
   algorithm
-    if Util.isSome(diffArguments.adjoint_map) then
+    if isSome(diffArguments.adjoint_map) then
       oldCollect := diffArguments.collectAdjoints;
       diffArguments.collectAdjoints := false;
       (exp, diffArguments) := differentiateComponentRef(exp, diffArguments);
@@ -1132,7 +1132,7 @@ public
       // user defined functions
       case Expression.CALL(call = call as Call.TYPED_CALL()) algorithm
         func_opt := UnorderedMap.get(call.fn.path, diffArguments.funcMap);
-        if Util.isSome(func_opt) then
+        if isSome(func_opt) then
           // The function is in the function tree
           SOME(func) := func_opt;
           interface_map := UnorderedMap.new<Boolean>(stringHashDjb2, stringEqual);
@@ -1158,7 +1158,7 @@ public
 
           // try to get a fitting function from derivatives -> if none is found, differentiate
           der_func_opt := Function.getDerivative(func, interface_map);
-          if Util.isSome(der_func_opt) then
+          if isSome(der_func_opt) then
             SOME(der_func) := der_func_opt;
             der_func := addDiffInfo(func, der_func, diffArguments);
           else
@@ -1246,7 +1246,7 @@ public
         Type ty;
         DifferentiationType diffType;
         Integer rY, rX;
-        Boolean isReverse = Util.isSome(diffArguments.adjoint_map);
+        Boolean isReverse = isSome(diffArguments.adjoint_map);
 
         Type elTy;
         // sumG = G + Gᵀ
@@ -2557,7 +2557,7 @@ public
         Type ty1, ty2;
         Integer r1, r2;
         list<Integer> dim1, dim2;
-        Boolean isReverse = Util.isSome(diffArguments.adjoint_map);
+        Boolean isReverse = isSome(diffArguments.adjoint_map);
 
       // Addition calculations (ADD, ADD_EW, ...)
       // (f + g)' = f' + g'
@@ -2851,7 +2851,7 @@ public
     input output Expression exp "Has to be Expression.MULTARY()";
     input output DifferentiationArguments diffArguments;
   protected
-    Boolean isReverse = Util.isSome(diffArguments.adjoint_map);
+    Boolean isReverse = isSome(diffArguments.adjoint_map);
   algorithm
     if Flags.isSet(Flags.DEBUG_ADJOINT) then
       print("differentiateMultary: " + Expression.toString(exp) + "\n");
@@ -3103,7 +3103,7 @@ public
     Array<List<Expression>> diff_lists;
     List<Expression> arg_products, restArgs;
     Integer idx = 1;
-    Boolean isReverse = Util.isSome(diffArguments.adjoint_map);
+    Boolean isReverse = isSome(diffArguments.adjoint_map);
     Operator mulEWOp = Operator.fromClassification(
       (NFOperator.MathClassification.MULTIPLICATION, NFOperator.SizeClassification.ELEMENT_WISE),
       operator.ty);
@@ -3195,7 +3195,7 @@ public
     Expression exp;
   algorithm
     opt_exp := Binding.getExpOpt(binding);
-    if Util.isSome(opt_exp) then
+    if isSome(opt_exp) then
       (exp, diffArgs) := differentiateExpression(Util.getOption(opt_exp), diffArgs);
       binding := Binding.setExp(exp, binding);
     end if;
@@ -3525,7 +3525,7 @@ protected
       //             else seed;
 
       //           ohOpt := buildOneHotVectorAdjoint(derBaseCref, Expression.toInteger(elems[j]), seedElem);
-      //           if Util.isSome(ohOpt) then
+      //           if isSome(ohOpt) then
       //             acc := Expression.MULTARY({acc, Util.getOption(ohOpt)}, {}, addOp);
       //           else
       //             scatter := NONE(); return;
@@ -3557,8 +3557,8 @@ protected
                 then Expression.applySubscripts({Subscript.INDEX(Expression.INTEGER(j+1))}, seed, true)
                 else seed
             );
-            if Util.isSome(ohOpt) then
-              if Util.isSome(accOpt) then
+            if isSome(ohOpt) then
+              if isSome(accOpt) then
                 acc := Util.getOption(accOpt);
                 term := Util.getOption(ohOpt);
                 accOpt := SOME(Expression.MULTARY({acc, term}, {}, addOp));
@@ -3570,7 +3570,7 @@ protected
             end if;
           end for;
 
-          scatter := if Util.isSome(accOpt) then accOpt else SOME(Expression.makeZero(arrTy));
+          scatter := if isSome(accOpt) then accOpt else SOME(Expression.makeZero(arrTy));
         then scatter;
 
       else NONE();

--- a/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
@@ -263,7 +263,7 @@ public
     Option<ComponentRef> cref;
   algorithm
     cref := UnorderedMap.get(BVariable.getVarName(var_ptr), replacements);
-    if Util.isSome(cref) then
+    if isSome(cref) then
       var_ptr := BVariable.getVarPointer(Util.getOption(cref), sourceInfo());
     end if;
   end replaceVarPtr;
@@ -351,7 +351,7 @@ public
             for local_node in fn.locals loop
               local_cref      := ComponentRef.fromNode(local_node, InstNode.getType(local_node));
               binding_exp_opt := InstNode.getBindingExpOpt(local_node);
-              if Util.isSome(binding_exp_opt) then
+              if isSome(binding_exp_opt) then
                 // replace binding expression with already gathered input replacements
                 binding_exp := Expression.map(Util.getOption(binding_exp_opt), function applySimpleExp(replacements = local_replacements));
               else

--- a/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
@@ -360,9 +360,9 @@ protected
       (name, range) := tpl;
       () := match range
         case Expression.RANGE() algorithm
-          if Util.isSome(range.step) and Expression.isNegative(Util.getOption(range.step)) then
+          if isSome(range.step) and Expression.isNegative(Util.getOption(range.step)) then
             UnorderedMap.add(name, range.start, replacements);
-          elseif Util.isNone(range.step) or Expression.isPositive(Util.getOption(range.step)) then
+          elseif isNone(range.step) or Expression.isPositive(Util.getOption(range.step)) then
             UnorderedMap.add(name, range.stop, replacements);
           else
             max_call := Expression.CALL(Call.makeTypedCall(
@@ -549,7 +549,7 @@ protected
     diff := SimplifyExp.simplify(diff);
     factor := Expression.integerValueOrDefault(diff, 0);
 
-    if Util.isSome(opt_factor) and factor <> Util.getOption(opt_factor) then
+    if isSome(opt_factor) and factor <> Util.getOption(opt_factor) then
       factor := 0;
     end if;
   end getFactor;
@@ -574,7 +574,7 @@ protected
     Expression shift;
     Integer factor, distance;
   algorithm
-    if Util.isNone(opt_factor) or Util.getOption(opt_factor) <> 0 then
+    if isNone(opt_factor) or Util.getOption(opt_factor) <> 0 then
       factor := getFactor(exp, args, opt_factor);
 
       if factor <> 0 then
@@ -583,7 +583,7 @@ protected
         try
           // the shift has to be a single integer value
           Expression.INTEGER(distance) := shift;
-          if Util.isNone(opt_factor) then
+          if isNone(opt_factor) then
             min_distance := distance;
             max_distance := distance;
             opt_factor := SOME(factor);
@@ -661,7 +661,7 @@ protected
     DifferentiationArguments args;
     UnorderedMap<ComponentRef, Expression> zero_replacements;
   algorithm
-    if Util.isSome(replacements) then
+    if isSome(replacements) then
       const := Expression.map(old_const, function Replacements.applySimpleExp(replacements = Util.getOption(replacements)));
     else
       const := old_const;
@@ -770,12 +770,12 @@ protected
       value := match var
         case Variable.VARIABLE(backendinfo = BackendInfo.BACKEND_INFO(attributes = attributes as VariableAttributes.VAR_ATTR_INT())) algorithm
           if UnorderedSet.contains(cref, min_parameters) then
-            if Util.isSome(attributes.min) then
+            if isSome(attributes.min) then
               SOME(value) := attributes.min;
             else
               value := Expression.INTEGER(0);
             end if;
-          elseif Util.isSome(attributes.max) then
+          elseif isSome(attributes.max) then
             SOME(value) := attributes.max;
           else
             value := Expression.INTEGER(0);

--- a/OMCompiler/Compiler/Template/CodegenCppInit.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppInit.tpl
@@ -214,7 +214,7 @@ template ScalarVariableType(SimCode simCode, DAE.ComponentRef simVarCref, AliasV
     case T_REAL(__) then
       let start_  = ScalarVariableTypeStartAttribute(simCode, simVarCref, simVarAlias, startValue, "Real", complexStartExpressions, stateDerVectorName)
       let fixed_  = ' fixed="<%isFixed%>"'
-      let nom_    = ' useNominal="<%Util.isSome(nominalValue)%>"<%attributeOptionString(nominalValue, "nominal")%>'
+      let nom_    = ' useNominal="<%isSome(nominalValue)%>"<%attributeOptionString(nominalValue, "nominal")%>'
       let min_    = attributeOptionString(minValue, "min")
       let max_    = attributeOptionString(maxValue, "max")
       let unit_   = unitString(unit, "unit")

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -267,6 +267,12 @@ package builtin
     end SOURCEINFO;
   end SourceInfo;
 
+  function isSome
+    replaceable type Type_a subtypeof Any;
+    input Option<Type_a> inOption;
+    output Boolean out;
+  end isSome;
+
 end builtin;
 
 package SimCodeVar
@@ -3591,12 +3597,6 @@ package Util
     input String str;
     output Boolean b;
   end isCIdentifier;
-
-  function isSome
-    replaceable type Type_a subtypeof Any;
-    input Option<Type_a> inOption;
-    output Boolean out;
-  end isSome;
 
   function getOption
     replaceable type Type_a subtypeof Any;


### PR DESCRIPTION
Util has no isSome/isNone function; these calls only resolved because OpenModelica's name resolution falls back to the builtin operator even when a package prefix that doesn't contain the name is given. Call the builtins directly so the code does not rely on that lenient resolution.