### PR TITLE
SimCodeUtil: call Dangerous.listReverseInPlace, not List

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -2870,7 +2870,7 @@ algorithm
     (eqCrefs, newExp, lhsExpLstRes, rhsExpLstRes, lhsExpLstAss, rhsExpLstAss) := createTmpCrefExpsForComplexEqnSys_work(e, crPrefix, eqCrefs, callCrefs, lhsExpLstRes, rhsExpLstRes, lhsExpLstAss, rhsExpLstAss);
     outExpList := newExp::outExpList;
   end for;
-  outExpList := List.listReverseInPlace(outExpList);
+  outExpList := Dangerous.listReverseInPlace(outExpList);
 end createTmpCrefExpsForComplexEqnSys;
 
 protected function createTmpCrefExpsForComplexEqnSys_work


### PR DESCRIPTION
createTmpCrefExpsForComplexEqnSys called `List.listReverseInPlace`, but List does not export that name — it imports it from MetaModelica.Dangerous for its own use. Every other listReverseInPlace call site in this file (and the codebase) qualifies it as Dangerous.listReverseInPlace; this one is an inconsistency that only resolves under lenient import lookup. Use the Dangerous qualification (already imported at the top of the file) to match.