### PR TITLE
SimCodeVar: initialise all SimVars fields in emptySimVars

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeVar.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeVar.mo
@@ -79,7 +79,8 @@ uniontype SimVars "Container for metadata about variables in a Modelica model."
 end SimVars;
 
 public constant SimVars emptySimVars = SIMVARS({}, {}, {}, {}, {}, {}, {}, {},
-  {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
+  {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+  {}, {});
 
 public uniontype SimVar "Information about a variable in a Modelica model."
   record SIMVAR


### PR DESCRIPTION
The SIMVARS record has 30 list<SimVar> fields, but the emptySimVars constant only supplied 28 positional arguments — the trailing dataReconinputVars and dataReconSetBVars (added to the record later) were omitted. Supply the two missing {} so the constant initialises the record in full.