### PR TITLE
Fix crash when editing legends in OMPlot

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
@@ -133,8 +133,12 @@ void Legend::switchAxis(bool checked)
 void Legend::showSetupDialog()
 {
   if (mpPlotCurve) {
-    mpPlot->getParentPlotWindow()->showSetupDialog(mpPlotCurve->getNameStructure());
+    auto name = mpPlotCurve->getNameStructure();
+    // Clear the curve before showing the setup dialog, because this Legend
+    // might be destroyed when the setup dialog applies the settings so doing
+    // anything after showing the dialog is unsafe.
     mpPlotCurve = 0;
+    mpPlot->getParentPlotWindow()->showSetupDialog(std::move(name));
   }
 }
 


### PR DESCRIPTION
- Make sure `Legend::showSetupDialog` exists immediately after showing the setup dialog, since the setup dialog might delete the legend that called it.