### PR TITLE
Updating to build-deps:v1.22.3

### DIFF
--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.22.2
+FROM ghcr.io/openmodelica/build-deps:v1.22.3
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -25,7 +25,7 @@ pipeline {
         stage('autoconf-jammy-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +

--- a/.devcontainer/build-deps/Dockerfile
+++ b/.devcontainer/build-deps/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=docker.openmodelica.org/build-deps:v1.22.3
 FROM ${BASE_IMAGE}
 
 ENV SHELL=/bin/bash

--- a/.devcontainer/build-deps/devcontainer.json
+++ b/.devcontainer/build-deps/devcontainer.json
@@ -7,7 +7,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "BASE_IMAGE": "docker.openmodelica.org/build-deps:v1.22.2",
+        "BASE_IMAGE": "docker.openmodelica.org/build-deps:v1.22.3",
         // On Windows USERNAME is set, on Linux USER is set
         // We hope only one is set
         "USERNAME": "${localEnv:USER}${localEnv:USERNAME}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -550,7 +550,7 @@ pipeline {
         stage('11 build-gui-clang-qt6') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.6-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -795,7 +795,7 @@ pipeline {
         stage('clang-qt6-omedit-testsuite') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.6-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         stage('gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args '''
@@ -75,7 +75,7 @@ pipeline {
         stage('clang') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args '''
@@ -124,7 +124,7 @@ pipeline {
         stage('cmake-jammy-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args '''
@@ -206,7 +206,7 @@ pipeline {
         stage('checks') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args '''
@@ -533,7 +533,7 @@ pipeline {
         stage('10 build-gui-clang-qt5') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -567,7 +567,7 @@ pipeline {
         stage('12 testsuite-clang-parmod') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
               alwaysPull true
               // No runtest.db cache necessary; the tests run in serial and do not load libraries!
@@ -589,7 +589,7 @@ pipeline {
         stage('13 testsuite-clang-metamodelica') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
             }
           }
@@ -607,7 +607,7 @@ pipeline {
         stage('14 testsuite-matlab-translator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
             }
@@ -629,7 +629,7 @@ pipeline {
         stage('15 test-clang-icon-generator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               args '''
                 --mount type=volume,source=runtest-clang-icon-generator,target=/cache/runtest \
@@ -659,7 +659,7 @@ pipeline {
         stage('16 testsuite-unit-test-C') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2-qttools'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args '''
@@ -776,7 +776,7 @@ pipeline {
         stage('clang-qt5-omedit-testsuite') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -818,7 +818,7 @@ pipeline {
         stage('fmuchecker-results') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
             }
@@ -845,7 +845,7 @@ pipeline {
         stage('upload-compliance') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
             }
@@ -863,7 +863,7 @@ pipeline {
         stage('upload-doc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'ghcr.io/openmodelica/build-deps:v1.22.3'
               label 'linux'
               alwaysPull true
             }

--- a/doc/UsersGuide/README.md
+++ b/doc/UsersGuide/README.md
@@ -5,7 +5,7 @@ OpenModelica User's Guide using Sphinx (Python Documentation Generator).
 ## Dependencies
 
 Getting all dependencies right is a nightmare. Just use the dev container
-`build-deps:v1.22.0` from
+`build-deps` from
 [.devcontainer/README.md](./../../.devcontainer/README.md) and set
 `GITHUB_AUTH`.
 


### PR DESCRIPTION
### Related Issues

The Ubuntu Focal based Docker image has an outdated GPG key.

### Purpose

* Update GPG key
* Use only one image with Qt5 and Qt6

### Approach

* Use [ghcr.io/openmodelica/build-deps:v1.22.3](https://github.com/OpenModelica/build-deps/pkgs/container/build-deps/907491742?tag=v1.22.3) everywhere.
* See https://github.com/OpenModelica/build-deps/releases/tag/v1.22.3
* Updated GPG key, Qt5 and Qt6 tool chains in one image
* Image is signed
* [docker.openmodelica.org/build-deps:v1.22.3](https://nexus.openmodelica.org/#browse/browse:openmodelica:v2%2Fbuild-deps%2Ftags%2Fv1.22.3) is also available. It's the same image but not signed.
