### PR TITLE
Matching: use arrayUpdateNoBoundsChecking in fillnadjacency loop

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -6811,7 +6811,7 @@ algorithm
   else
     true := n <= arrayLength(arrIx);
     for i in 1:n loop
-      Dangerous.arrayUpdateNoBoundsChecking(arr, Dangerous.arrayGetNoBoundsChecking(arrIx, i), false);
+      arrayUpdate(arr, Dangerous.arrayGetNoBoundsChecking(arrIx, i), false);
     end for;
   end if;
   if debug then

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -6811,7 +6811,7 @@ algorithm
   else
     true := n <= arrayLength(arrIx);
     for i in 1:n loop
-      Dangerous.arrayUpdate(arr, Dangerous.arrayGetNoBoundsChecking(arrIx, i), false);
+      Dangerous.arrayUpdateNoBoundsChecking(arr, Dangerous.arrayGetNoBoundsChecking(arrIx, i), false);
     end for;
   end if;
   if debug then


### PR DESCRIPTION
`fillnadjacency`'s else-branch wrote `Dangerous.arrayUpdate` (the bounds-checked builtin) while indexing with `Dangerous.arrayGetNoBoundsChecking` on the same line. The loop is already guarded by `n <= arrayLength(arrIx)` and operates on a freshly sized array, so the bounds check is unintended — use the NoBoundsChecking variant to match the surrounding accesses.