### PR TITLE
NBackEnd: fix two cross-scope visibility/qualification errors

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
@@ -332,6 +332,7 @@ public
       end match;
     end fromExp;
 
+  public
     function updateSubClock
       "adding the sub clock src to the sub clock dest. not symmetrical/commutative"
       input output BClock dest;

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -618,7 +618,7 @@ protected
     linear := match full
       case Adjacency.Matrix.FULL() then UnorderedMap.all(e, function eqnIsLinear(occ = full.occurrences, sol = full.solvabilities, v = v));
       else algorithm
-        Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " expected type full, got type " + Adjacency.Matrix.strictnessString(Adjacency.Matrix.getStrictness(full)) + "."});
+        Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " expected type full, got type " + Adjacency.strictnessString(Adjacency.Matrix.getStrictness(full)) + "."});
       then fail();
     end match;
   end checkLinearity;


### PR DESCRIPTION
- NBPartitioning.BClock.updateSubClock was declared in a protected section but is called from ClockedInfo.resolveSubClock (outside BClock). Move it to a public section so the cross-scope call is legal.
- NBTearing referenced Adjacency.Matrix.strictnessString, but strictnessString is a top-level function of NBAdjacency, not a member of the Matrix uniontype (only getStrictness is). Qualify it as Adjacency.strictnessString.