### PR TITLE
Remove redundant self-qualified type/function references

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendInline.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendInline.mo
@@ -1153,7 +1153,7 @@ protected function replaceArgs
   output DAE.Exp outExp;
   output tuple<list<tuple<DAE.ComponentRef,DAE.Exp>>,HashTableCG.HashTable,Boolean> outTuple;
 algorithm
-  (outExp,outTuple) := Expression.Expression.traverseExpBottomUp(inExp,Inline.replaceArgs,inTuple);
+  (outExp,outTuple) := Expression.traverseExpBottomUp(inExp,Inline.replaceArgs,inTuple);
   if not Util.tuple33(outTuple) then
     if Flags.isSet(Flags.FAILTRACE) then
       Debug.traceln("BackendInline.replaceArgs failed");

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -1939,8 +1939,8 @@ protected
   protected
     Integer m1 = listLength(itVarPtrs);
     Integer m2 = listLength(resEqnPtrs);
-    list<NBSlice.Slice<NBVariable.VariablePointer>> itVars_s;
-    list<NBSlice.Slice<Pointer<NBEquation.Equation>>> res_s;
+    list<NBSlice<NBVariable.VariablePointer>> itVars_s;
+    list<NBSlice<Pointer<NBEquation.Equation>>> res_s;
     NBTearing.Tearing tearingSet;
   algorithm
     // sanity

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -1864,7 +1864,7 @@ public
         // gather unsolvables from iterator
         occ2 := UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
         filter := function Slice.getDependentCref(map = map, pseudo = true);
-        Iterator.map(eqn.iter, function Slice.Slice.filterExp(filter = filter, acc = occ2),
+        Iterator.map(eqn.iter, function Slice.filterExp(filter = filter, acc = occ2),
           SOME(function filter(acc = occ2)), Expression.mapShallow);
         // update unsolvables
         Solvability.updateList(UnorderedSet.toList(occ2), Solvability.UNSOLVABLE(), sol_map);


### PR DESCRIPTION
`NBSlice.Slice<T>`, `Slice.Slice.filterExp` and `Expression.Expression. traverseExpBottomUp` rely on a protected self-import (`import Slice = NBSlice;` inside the NBSlice uniontype, and likewise for Expression) to double-qualify a name through itself. Reaching a module's own protected self-import alias from outside the module is not something callers should depend on since it is not allowed in Modelica; reference thetype/function directly:

  NBSlice.Slice<T>                     -> NBSlice<T>
  Slice.Slice.filterExp(...)           -> Slice.filterExp(...)
  Expression.Expression.traverseExp... -> Expression.traverseExp...