### PR TITLE
NBModule: import Matching = NBMatching

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
@@ -79,6 +79,7 @@ protected
   import Jacobian = NBackendDAE;
   import NBJacobian.JacobianType;
   import StrongComponent = NBStrongComponent;
+  import Matching = NBMatching;
   import Partition = NBPartition;
   import NBPartitioning.ClockedInfo;
   import BVariable = NBVariable;


### PR DESCRIPTION
The resolveSingularitiesInterface partial function references the Matching type (input Matching matching;) but NBModule never imported it. OMC tolerates this because the interface's types are only looked up at the redeclaration site (NBResolveSingularities, which does import Matching), but the name is genuinely out of scope in NBModule itself. Add the import so the interface is well-formed in its own scope.