### PR TITLE
[Cpp,FMI] extend FMI export with optional custom annotations

### DIFF
--- a/OMCompiler/Compiler/Makefile.in
+++ b/OMCompiler/Compiler/Makefile.in
@@ -29,7 +29,7 @@ CORBAHOME = @CORBAHOME@
 
 PROG = omc
 
-SCRIPT_FILES = openmodelica.lefty default_profiling.xsl replace-startValue.sh replace-startValue.xsl simcodedump.xsl ngspicetoModelica.py
+SCRIPT_FILES = openmodelica.lefty default_profiling.xsl replace-startValue.sh replace-startValue.xsl simcodedump.xsl ngspicetoModelica.py filter-annotations.jq
 
 SUBDIRS	= FrontEndCpp runtime Script
 

--- a/OMCompiler/Compiler/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/Makefile.omdev.mingw
@@ -16,7 +16,7 @@ LIBSOCKET = -lwsock32
 
 SHELL	= /bin/sh
 
-SCRIPT_FILES = Compile.bat Prompt.bat openmodelica.lefty default_profiling.xsl replace-startValue.* simcodedump.xsl ngspicetoModelica.py
+SCRIPT_FILES = Compile.bat Prompt.bat openmodelica.lefty default_profiling.xsl replace-startValue.* simcodedump.xsl ngspicetoModelica.py filter-annotations.jq
 
 SUBDIRS	= runtime Script
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4455,6 +4455,11 @@ algorithm
   dir := fmutmp+"/sources/";
 
   if Config.simCodeTarget() == "Cpp" then
+    // dump modelInstance.json so the FMU makefile can filter out the
+    // requested extra annotations (see flag --fmiExtraAnnotations)
+    if Flags.getConfigString(Flags.FMI_EXTRA_ANNOTATIONS) <> "" then
+      System.writeFile(filenameprefix + "_modelInstance.json", ValuesUtil.extractValueString(NFApi.getModelInstance(className, className, "", true)));
+    end if;
     System.removeDirectory("binaries");
     for platform in platforms loop
       if platform == "dynamic" or platform == "static" then

--- a/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
@@ -108,6 +108,8 @@ case SIMCODE(modelInfo=modelInfo as MODELINFO(__)) then
   let numBoolVars = numBoolvars(modelInfo)
   let numStringVars = numStringvars(modelInfo)
 
+  let extraAnnotations = Flags.getConfigString(FMI_EXTRA_ANNOTATIONS)
+
   let _ = FlagsUtil.set(Flags.HARDCODED_START_VALUES, true)
   let cpp = CodegenCpp.translateModel(simCode)
   let()= textFile(fmuWriteOutputHeaderFile(simCode , &extraFuncs , &extraFuncsDecl, ""),'OMCpp<%fileNamePrefix%>WriteOutput.h')
@@ -116,7 +118,7 @@ case SIMCODE(modelInfo=modelInfo as MODELINFO(__)) then
   let()= textFile((if isFMIVersion10(FMUVersion) then CodegenCppInit.modelInitXMLFile(simCode, numRealVars, numIntVars, numBoolVars, numStringVars, FMUVersion, FMUType, guid, true, "cpp-runtime", complexStartExpressions, stateDerVectorName) else
                    CodegenFMU.fmuModelDescriptionFile(simCode, guid, FMUVersion, FMUType, sourceFiles)), 'modelDescription.xml')
   let()= textFile(fmudeffile(simCode, FMUVersion), '<%fileNamePrefix%>.def')
-  let()= textFile(fmuMakefile(target,simCode, extraFuncs, extraFuncsDecl, "", FMUVersion, "", "", "", ""), '<%fileNamePrefix%>_FMU.makefile')
+  let()= textFile(fmuMakefile(target, simCode, extraFuncs, extraFuncsDecl, "", FMUVersion, "", "", "", "", extraAnnotations), '<%fileNamePrefix%>_FMU.makefile')
   let()= textFile(fmuCalcHelperMainfile(simCode), 'OMCpp<%fileNamePrefix%>CalcHelperMain.cpp')
   let _ = FlagsUtil.set(Flags.HARDCODED_START_VALUES, false)
 
@@ -708,7 +710,7 @@ case SIMCODE(modelInfo=MODELINFO(), modelStructure=fmiModelStructure) then
 end directionalDerivativeFunction;
 
 template fmuMakefile(String target, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, String FMUVersion, String additionalLinkerFlags_GCC,
-                            String additionalLinkerFlags_MSVC, String additionalCFlags_GCC, String additionalCFlags_MSVC)
+                     String additionalLinkerFlags_MSVC, String additionalCFlags_GCC, String additionalCFlags_MSVC, String extraAnnotations)
  "Generates the contents of the makefile for the simulation case. Copy libexpat & correct linux fmu"
 ::=
 match getGeneralTarget(target)
@@ -907,14 +909,22 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   <%\t%>zip -r "<%fmuTargetName%>.fmu" modelDescription.xml binaries sources
   endif
   endif
+  ifneq ("<%extraAnnotations%>","")
+  <%\t%><%mkdir%> -p extra/org.openmodelica
+  <%\t%>jq --arg regex "<%extraAnnotations%>" -f "$(OMHOME)/share/omc/scripts/filter-annotations.jq" <%fileNamePrefix%>_modelInstance.json > extra/org.openmodelica/modelAnnotations.json
+  ifeq ($(ZIP_FMU),ON)
+  <%\t%>zip -ur "<%fmuTargetName%>.fmu" extra
+  endif
+  endif
 
   ifeq ($(ZIP_FMU),OFF)
   <%\t%>rm -f OMCpp<%fileNamePrefix%>* <%fileNamePrefix%>_FMU.* <%fileNamePrefix%>.def <%fileNamePrefix%>.sh <%fileNamePrefix%>.bat <%fileNamePrefix%>.makefile <%fileNamePrefix%>_init.xml
+  <%\t%>rm -f <%fileNamePrefix%>_modelInstance.json
   endif
 
   clean:
   <%\t%>rm -f OMCpp<%fileNamePrefix%>* <%fileNamePrefix%>_FMU.* <%fileNamePrefix%>.def <%fileNamePrefix%>.sh <%fileNamePrefix%>.bat <%fileNamePrefix%>.makefile <%fileNamePrefix%>_init.xml
-  <%\t%>rm -rf modelDescription.xml binaries sources documentation
+  <%\t%>rm -rf modelDescription.xml binaries sources documentation extra <%fileNamePrefix%>_modelInstance.json
 
   >>
 end fmuMakefile;

--- a/OMCompiler/Compiler/Template/CodegenFMUCppHpcom.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCppHpcom.tpl
@@ -152,7 +152,7 @@ template fmuMakefile(String target, SimCode simCode, Text& extraFuncs, Text& ext
 
   <<
   <%CodegenCppHpcom.getAdditionalMakefileFlags(additionalCFlags_GCC, additionalCFlags_MSVC, additionalLinkerFlags_GCC, additionalLinkerFlags_MSVC)%>
-  <%CodegenFMUCpp.fmuMakefile(target, simCode, extraFuncs, extraFuncsDecl, extraFuncsNamespace, FMUVersion, additionalLinkerFlags_GCC, additionalLinkerFlags_MSVC, additionalCFlags_GCC, additionalCFlags_MSVC)%>
+  <%CodegenFMUCpp.fmuMakefile(target, simCode, extraFuncs, extraFuncsDecl, extraFuncsNamespace, FMUVersion, additionalLinkerFlags_GCC, additionalLinkerFlags_MSVC, additionalCFlags_GCC, additionalCFlags_MSVC, "")%>
   >>
 end fmuMakefile;
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4172,6 +4172,7 @@ package Flags
   constant ConfigFlag OBFUSCATE;
   constant ConfigFlag MAX_SIZE_LINEARIZATION;
   constant ConfigFlag NEW_BACKEND;
+  constant ConfigFlag FMI_EXTRA_ANNOTATIONS;
 
   function isSet
     input DebugFlag inFlag;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1404,6 +1404,9 @@ constant ConfigFlag EXECUTE_COMMAND = CONFIG_FLAG(162, "cmd",
 constant ConfigFlag MOO_DYNAMIC_OPTIMIZATION = CONFIG_FLAG(163, "moo",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generate code for dynamic optimization library MOO."));
+constant ConfigFlag FMI_EXTRA_ANNOTATIONS = CONFIG_FLAG(164, "fmiExtraAnnotations",
+  NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
+  Gettext.gettext("Export annotations matching the given regex to extra/org.openmodelica/modelAnnotations.json."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -429,7 +429,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.CAUSALIZE_DAE_MODE,
   Flags.SIM_CODE_SCALARIZE,
   Flags.EXECUTE_COMMAND,
-  Flags.MOO_DYNAMIC_OPTIMIZATION
+  Flags.MOO_DYNAMIC_OPTIMIZATION,
+  Flags.FMI_EXTRA_ANNOTATIONS
 };
 
 public function new

--- a/OMCompiler/Compiler/runtime/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/runtime/Makefile.omdev.mingw
@@ -48,6 +48,6 @@ SHELL	= /bin/sh
 CC	= gcc
 CXX = g++
 override CFLAGS += $(CORBA_C_CLFAGS) $(USE_METIS) -Werror=implicit-function-declaration -Wall -Wno-unused-variable -I$(OMC_CONFIG_INC) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc $(CORBAINCL) $(GCINCLUDE) -I$(FMIINCLUDE) -I$(CJSONINCLUDE) -I$(GRAPHINCLUDE) -I$(SQLITE3INCLUDE) -I$(ZMQINCLUDE) -I"$(TOP_DIR)/3rdParty/zlib" -I"$(TOP_DIR)/3rdParty/libffi/install/include/" -DWIN32_LEAN_AND_MEAN
-override CXXFLAGS += -std=c++11 $(CFLAGS)
+override CXXFLAGS += -std=c++17 $(CFLAGS)
 
 include Makefile.common

--- a/OMCompiler/Compiler/scripts/filter-annotations.jq
+++ b/OMCompiler/Compiler/scripts/filter-annotations.jq
@@ -1,0 +1,43 @@
+# Filter annotations of interest out of a modelInstance.json file produced by
+# the OpenModelica getModelInstance API. Used by the Cpp FMU export when the
+# --fmiExtraAnnotations=<regex> flag is set.
+#
+# Usage:
+#   jq --arg regex "__Optimization|__Estimation" -f filter-annotations.jq Model_modelInstance.json > modelAnnotations.json
+def keep_annotation:
+  if type == "object" then
+    if (.prefixes? | type) == "object" and (.prefixes.outer? // false) then
+      null
+    else
+      (
+        . as $obj
+        # place dims first to know them when parsing a name or type in one pass
+        # | reduce ($obj | keys_unsorted[]) as $k
+        | reduce ((if has("dims") then {dims} else {} end)
+                  + with_entries(select(.key != "dims")) | keys_unsorted[]) as $k
+            ({};
+              if $k | test($regex) then
+                . + {($k): $obj[$k]}
+              elif ($k == "name" or $k == "restriction" or $k == "dims")
+                    and ($obj | any(.. | objects; .annotation? | objects | keys | any(test($regex)))) then
+                . + if $k == "dims" then {($k): $obj[$k]["typed"]} else {($k): $obj[$k]} end
+              else
+                ($obj[$k] | keep_annotation) as $v
+                | if $v == null or $v == {} or $v == [] then
+                    .
+                  else
+                    . + {($k): $v}
+                  end
+              end
+            )
+      )
+      | if . == {} then null else . end
+    end
+  elif type == "array" then
+    map(keep_annotation)
+    | map(select(. != null and . != {} and . != []))
+    | if length == 0 then null else . end
+  else null
+  end;
+
+keep_annotation

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -7,6 +7,7 @@ exposeLocalIOs.mos \
 exposeLocalIOsArray.mos \
 solveOneNonlinearEquationTest.mos \
 testArrayEquations.mos \
+testExtraAnnotations.mos \
 testFMU2MatrixIO.mos \
 testModelDescription.mos \
 testClockDescription.mos \

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testExtraAnnotations.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testExtraAnnotations.mos
@@ -1,0 +1,257 @@
+// name:  testExtraAnnotations
+// keywords: FMI 2.0 export multiple clocks and sub-clocks
+// status: correct
+// teardown_command: rm -rf binaries sources modelAnnotations.json *ModelWithAnnotations*
+//
+
+setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
+setCommandLineOptions("--exposeLocalIOs=2"); getErrorString();
+setCommandLineOptions("--fmiExtraAnnotations=__Optimization|__Estimation"); getErrorString();
+
+loadString("
+package ExtraAnnotationsTest
+  connector RealInput = input Real;
+  connector ActiveInput = RealInput annotation(__Optimization(u_min = 0, u_active = true));
+  connector RealOutput = output Real;
+
+  model M
+    parameter Real p = 1 annotation(__Estimation(p_min=0));
+    ActiveInput u;
+    RealOutput y annotation(__Optimization(y_soft_min = 0, y_soft_weight1 = 100));
+  equation
+    y = p*u;
+    annotation(__Optimization(y(y_order = 1)));
+  end M;
+
+  model MM
+    M[2] m;
+  end MM;
+
+  model ModelWithAnnotations
+    MM[3] m1;
+    M[3,2] m2;
+    M m3;
+    parameter Real[5] s = zeros(5) annotation(__Estimation(p_max=1));
+    annotation(
+      __Estimation(m3(p(p_min = 1))),
+      __Optimization(m3(y(y_soft_max = 10, y_soft_weight1 = 1000), u(u_connection = \"MyInputSignal\"))));
+  end ModelWithAnnotations;
+end ExtraAnnotationsTest;
+");
+getErrorString();
+
+buildModelFMU(ExtraAnnotationsTest.ModelWithAnnotations, version="2.0");
+getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq ModelWithAnnotations.fmu extra/org.openmodelica/modelAnnotations.json > modelAnnotations.json");
+readFile("modelAnnotations.json");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// "ModelWithAnnotations.fmu"
+// ""
+// 0
+// "{
+//   \"name\": \"ExtraAnnotationsTest.ModelWithAnnotations\",
+//   \"restriction\": \"model\",
+//   \"annotation\": {
+//     \"__Estimation\": {
+//       \"m3\": {
+//         \"p\": {
+//           \"p_min\": 1
+//         }
+//       }
+//     },
+//     \"__Optimization\": {
+//       \"m3\": {
+//         \"y\": {
+//           \"y_soft_max\": 10,
+//           \"y_soft_weight1\": 1000
+//         },
+//         \"u\": {
+//           \"u_connection\": \"MyInputSignal\"
+//         }
+//       }
+//     }
+//   },
+//   \"elements\": [
+//     {
+//       \"dims\": [
+//         \"3\"
+//       ],
+//       \"name\": \"m1\",
+//       \"type\": {
+//         \"name\": \"ExtraAnnotationsTest.MM\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"dims\": [
+//               \"2\"
+//             ],
+//             \"name\": \"m\",
+//             \"type\": {
+//               \"name\": \"ExtraAnnotationsTest.M\",
+//               \"restriction\": \"model\",
+//               \"annotation\": {
+//                 \"__Optimization\": {
+//                   \"y\": {
+//                     \"y_order\": 1
+//                   }
+//                 }
+//               },
+//               \"elements\": [
+//                 {
+//                   \"name\": \"p\",
+//                   \"annotation\": {
+//                     \"__Estimation\": {
+//                       \"p_min\": 0
+//                     }
+//                   }
+//                 },
+//                 {
+//                   \"name\": \"u\",
+//                   \"type\": {
+//                     \"name\": \"ExtraAnnotationsTest.ActiveInput\",
+//                     \"restriction\": \"connector\",
+//                     \"annotation\": {
+//                       \"__Optimization\": {
+//                         \"u_min\": 0,
+//                         \"u_active\": true
+//                       }
+//                     }
+//                   }
+//                 },
+//                 {
+//                   \"name\": \"y\",
+//                   \"annotation\": {
+//                     \"__Optimization\": {
+//                       \"y_soft_min\": 0,
+//                       \"y_soft_weight1\": 100
+//                     }
+//                   }
+//                 }
+//               ]
+//             }
+//           }
+//         ]
+//       }
+//     },
+//     {
+//       \"dims\": [
+//         \"3\",
+//         \"2\"
+//       ],
+//       \"name\": \"m2\",
+//       \"type\": {
+//         \"name\": \"ExtraAnnotationsTest.M\",
+//         \"restriction\": \"model\",
+//         \"annotation\": {
+//           \"__Optimization\": {
+//             \"y\": {
+//               \"y_order\": 1
+//             }
+//           }
+//         },
+//         \"elements\": [
+//           {
+//             \"name\": \"p\",
+//             \"annotation\": {
+//               \"__Estimation\": {
+//                 \"p_min\": 0
+//               }
+//             }
+//           },
+//           {
+//             \"name\": \"u\",
+//             \"type\": {
+//               \"name\": \"ExtraAnnotationsTest.ActiveInput\",
+//               \"restriction\": \"connector\",
+//               \"annotation\": {
+//                 \"__Optimization\": {
+//                   \"u_min\": 0,
+//                   \"u_active\": true
+//                 }
+//               }
+//             }
+//           },
+//           {
+//             \"name\": \"y\",
+//             \"annotation\": {
+//               \"__Optimization\": {
+//                 \"y_soft_min\": 0,
+//                 \"y_soft_weight1\": 100
+//               }
+//             }
+//           }
+//         ]
+//       }
+//     },
+//     {
+//       \"name\": \"m3\",
+//       \"type\": {
+//         \"name\": \"ExtraAnnotationsTest.M\",
+//         \"restriction\": \"model\",
+//         \"annotation\": {
+//           \"__Optimization\": {
+//             \"y\": {
+//               \"y_order\": 1
+//             }
+//           }
+//         },
+//         \"elements\": [
+//           {
+//             \"name\": \"p\",
+//             \"annotation\": {
+//               \"__Estimation\": {
+//                 \"p_min\": 0
+//               }
+//             }
+//           },
+//           {
+//             \"name\": \"u\",
+//             \"type\": {
+//               \"name\": \"ExtraAnnotationsTest.ActiveInput\",
+//               \"restriction\": \"connector\",
+//               \"annotation\": {
+//                 \"__Optimization\": {
+//                   \"u_min\": 0,
+//                   \"u_active\": true
+//                 }
+//               }
+//             }
+//           },
+//           {
+//             \"name\": \"y\",
+//             \"annotation\": {
+//               \"__Optimization\": {
+//                 \"y_soft_min\": 0,
+//                 \"y_soft_weight1\": 100
+//               }
+//             }
+//           }
+//         ]
+//       }
+//     },
+//     {
+//       \"dims\": [
+//         \"5\"
+//       ],
+//       \"name\": \"s\",
+//       \"annotation\": {
+//         \"__Estimation\": {
+//           \"p_max\": 1
+//         }
+//       }
+//     }
+//   ]
+// }
+// "
+// endResult


### PR DESCRIPTION
This is particularly interesting for applications that go beyond simulation, like optimization, to specify additional things like constraints via custom annotations in a Modelica model.

### Approach

- new flag --fmiExtraAnnotations=`<`regex for annotations of interest`>`
- FMI export calls API function getModelInstance and filters out annotations
- FMI export adds file extra/org.openmodelica/modelAnnotations.json to FMU

See the added testExtraAnnotations.mos for an example.