### PR TITLE
Added a message handler based on QtMsgType

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -49,16 +49,34 @@
 
 extern "C" {
 #include "meta/meta_modelica_data.h"
-#include "../../OMCompiler/Compiler/runtime/settingsimpl.h"
 }
 
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
 
-#include <QMessageBox>
-
 #ifdef QT_NO_DEBUG
+#include <QMutex>
+
+static QMutex mutex;
+void messageHandler(QtMsgType type, const QMessageLogContext &ctx, const QString &msg)
+{
+  Q_UNUSED(ctx);
+  QMutexLocker lock(&mutex);
+
+  QString line;
+  switch (type) {
+    case QtDebugMsg:    line = QStringLiteral("[QtDebug]  ") + msg; break;
+    case QtInfoMsg:     line = QStringLiteral("[QtInfo] ") + msg; break;
+    case QtWarningMsg:  line = QStringLiteral("[QtWarning] ") + msg; break;
+    case QtCriticalMsg: line = QStringLiteral("[QtCritical] ") + msg; break;
+    case QtFatalMsg:    line = QStringLiteral("[QtFatal]") + msg; break;
+  }
+
+  FILE *out = (type == QtDebugMsg || type == QtInfoMsg) ? stdout : stderr;
+  fprintf(out, "%s\n", qPrintable(line));
+}
+
 #include "CrashReport/CrashReportDialog.h"
 
 #ifdef Q_OS_WIN
@@ -160,7 +178,7 @@ void printOMEditUsage()
   fprintf(stderr, "  --NAPIProfiling=[true|false]  Enable profiling for the new JSON-based API.\n");
   fprintf(stderr, "                                Default: false.\n\n");
 
-  fprintf(stderr, "  --paths                       Dumps the Qt paths in /tmp/qt-paths.txt.\n\n");
+  fprintf(stderr, "  --paths                       Prints the Qt paths.\n\n");
 
   fprintf(stderr, "files                           List of Modelica files (*.mo) to open.\n");
 }
@@ -175,16 +193,20 @@ static int execution_failed()
 
 int main(int argc, char *argv[])
 {
-  // if user asks for --help
-  for(int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "--help") == 0) {
 #ifdef Q_OS_WIN
-      /// Re-attach to the parent console (the cmd.exe that launched us)
-      if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-        freopen("CONOUT$", "w", stdout);
-        freopen("CONOUT$", "w", stderr);
-      }
+  /// Re-attach to the parent console (the cmd.exe that launched us)
+  if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+    freopen("CONOUT$", "w", stdout);
+    freopen("CONOUT$", "w", stderr);
+  }
 #endif // #ifdef Q_OS_WIN
+#ifdef QT_NO_DEBUG
+  // install the message handler before creating the application object so that we can catch all messages
+  qInstallMessageHandler(messageHandler);
+#endif // #ifdef QT_NO_DEBUG
+  // if user asks for --help
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--help") == 0) {
       printOMEditUsage();
       return 0;
     }

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -99,41 +99,38 @@ QFont getWindowsUIFont()
 
 void dumpQtPaths()
 {
-  QString fname = QDir::tempPath() + QDir::separator() + QString("qt-paths.txt");
-  FILE *fout = fopen(fname.toUtf8(), "w");
-  fprintf(fout, "Qt location/paths:\n");
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::PrefixPath) = \n\t%s\n",
+  fprintf(stdout, "Qt location/paths:\n");
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::PrefixPath) = \n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::PrefixPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::DocumentationPath) = \n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::DocumentationPath) = \n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::DocumentationPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::HeadersPath) = \n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::HeadersPath) = \n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::HeadersPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::LibrariesPath) = \n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::LibrariesPath) = \n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::LibrariesPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::LibraryExecutablesPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::LibraryExecutablesPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::LibraryExecutablesPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::BinariesPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::BinariesPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::BinariesPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::PluginsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::PluginsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::PluginsPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::PluginsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::PluginsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::PluginsPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::QmlImportsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::QmlImportsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QT_LIBRRY_INFO_QMLIP)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::ArchDataPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::ArchDataPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::ArchDataPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::DataPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::DataPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::DataPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::TranslationsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::TranslationsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::TranslationsPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::ExamplesPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::ExamplesPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::ExamplesPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::TestsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::TestsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::TestsPath)));
-  fprintf(fout, "QLibraryInfo::location|path(QLibraryInfo::SettingsPath) =\n\t%s\n",
+  fprintf(stdout, "QLibraryInfo::location|path(QLibraryInfo::SettingsPath) =\n\t%s\n",
     qPrintable(QT_LIBRRY_INFO_PATH_OR_LOCATION(QLibraryInfo::SettingsPath)));
   fflush(NULL);
-  fclose(fout);
 }
 
 /*!


### PR DESCRIPTION
Always attach the console on Windows.
Print Qt paths to console instead of dumping to a tmp file.