### PR TITLE
omedit: add stylesheet override option

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -178,6 +178,9 @@ void printOMEditUsage()
   fprintf(stderr, "  --NAPIProfiling=[true|false]  Enable profiling for the new JSON-based API.\n");
   fprintf(stderr, "                                Default: false.\n\n");
 
+  fprintf(stderr, "  --StyleSheet=<file>           Load an additional Qt stylesheet after\n");
+  fprintf(stderr, "                                OMEdit's default stylesheet.\n\n");
+
   fprintf(stderr, "  --paths                       Prints the Qt paths.\n\n");
 
   fprintf(stderr, "files                           List of Modelica files (*.mo) to open.\n");

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -116,12 +116,7 @@ namespace {
 
   bool styleSheetArgumentValue(const QString &argument, QString *pFileName)
   {
-    QString optionPrefix = "--StyleSheet=";
-    if (argument.startsWith(optionPrefix)) {
-      *pFileName = argument.mid(optionPrefix.length());
-      return true;
-    }
-    optionPrefix = "--stylesheet=";
+    const QString optionPrefix = "--StyleSheet=";
     if (argument.startsWith(optionPrefix)) {
       *pFileName = argument.mid(optionPrefix.length());
       return true;
@@ -196,7 +191,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   if (!defaultStyleSheetLoaded) {
     styleSheetLoadErrors.append(defaultStyleSheetLoadError);
   }
-  if (arguments().size() > 1 && !testsuiteRunning) {
+  if (defaultStyleSheetLoaded && arguments().size() > 1 && !testsuiteRunning) {
     for (int i = 1; i < arguments().size(); i++) {
       QString styleSheetFileName;
       if (styleSheetArgumentValue(arguments().at(i), &styleSheetFileName)) {
@@ -204,9 +199,6 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         QString customStyleSheet;
         QString customStyleSheetLoadError;
         if (readStyleSheetFile(absoluteStyleSheetFileName, &customStyleSheet, &customStyleSheetLoadError)) {
-          if (!defaultStyleSheetLoaded) {
-            continue;
-          }
           appendStyleSheet(&applicationStyleSheet, customStyleSheet);
         } else {
           styleSheetLoadErrors.append(customStyleSheetLoadError);
@@ -270,6 +262,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   QStringList fileNames, invalidFlags;
   if (arguments().size() > 1 && !testsuiteRunning) {
     for (int i = 1; i < arguments().size(); i++) {
+      QString styleSheetFileName;
       if (strncmp(arguments().at(i).toUtf8().constData(), "--Debug=",8) == 0) {
         QString debugArg = arguments().at(i);
         debugArg.remove("--Debug=");
@@ -284,7 +277,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         }
       } else if (strncmp(arguments().at(i).toUtf8().constData(), "--paths",7) == 0) {
         dumpQtPaths();
-      } else if (styleSheetArgumentValue(arguments().at(i), &fileName)) {
+      } else if (styleSheetArgumentValue(arguments().at(i), &styleSheetFileName)) {
         // The stylesheet option is handled before MainWindow initialization.
       } else {
         fileName = arguments().at(i);

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -48,6 +48,9 @@
 #include "Simulation/TranslationFlagsWidget.h"
 
 #include <locale.h>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QTextCodec>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
@@ -100,6 +103,45 @@ void dumpQtPaths()
   fflush(NULL);
 }
 
+namespace {
+  QString absolutePath(const QString &fileName)
+  {
+    QFileInfo fileInfo(fileName);
+    QString absoluteFileName = fileName;
+    if (fileInfo.isRelative()) {
+      absoluteFileName = QString("%1/%2").arg(QDir::currentPath()).arg(fileName);
+    }
+    return absoluteFileName.replace("\\", "/");
+  }
+
+  bool styleSheetArgumentValue(const QString &argument, QString *pFileName)
+  {
+    QString optionPrefix = "--StyleSheet=";
+    if (argument.startsWith(optionPrefix)) {
+      *pFileName = argument.mid(optionPrefix.length());
+      return true;
+    }
+    optionPrefix = "--stylesheet=";
+    if (argument.startsWith(optionPrefix)) {
+      *pFileName = argument.mid(optionPrefix.length());
+      return true;
+    }
+    return false;
+  }
+
+  bool readStyleSheetFile(const QString &fileName, QString *pStyleSheet, QString *pErrorString)
+  {
+    QFile styleSheetFile(fileName);
+    if (!styleSheetFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      *pErrorString = QString("Failed to load stylesheet file %1: %2").arg(fileName, styleSheetFile.errorString());
+      return false;
+    }
+    *pStyleSheet = QString::fromUtf8(styleSheetFile.readAll());
+    pErrorString->clear();
+    return true;
+  }
+}
+
 /*!
  * \class OMEditApplication
  * \brief It is a subclass for QApplication so that we can handle QFileOpenEvent sent by OSX at startup.
@@ -139,7 +181,30 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   styleHints()->setColorScheme(Qt::ColorScheme::Light);  // must be before setStyleSheet
 #endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   // set the stylesheet
-  setStyleSheet("file:///:/Resources/css/stylesheet.qss");
+  QString applicationStyleSheet;
+  QString styleSheetLoadError;
+  if (readStyleSheetFile(":/Resources/css/stylesheet.qss", &applicationStyleSheet, &styleSheetLoadError)) {
+    setStyleSheet(applicationStyleSheet);
+  } else {
+    setStyleSheet("file:///:/Resources/css/stylesheet.qss");
+    styleSheetLoadError.clear();
+  }
+  if (arguments().size() > 1 && !testsuiteRunning) {
+    for (int i = 1; i < arguments().size(); i++) {
+      QString styleSheetFileName;
+      if (styleSheetArgumentValue(arguments().at(i), &styleSheetFileName)) {
+        const QString absoluteStyleSheetFileName = absolutePath(styleSheetFileName);
+        QString customStyleSheet;
+        if (readStyleSheetFile(absoluteStyleSheetFileName, &customStyleSheet, &styleSheetLoadError)) {
+          if (!applicationStyleSheet.isEmpty()) {
+            applicationStyleSheet.append("\n");
+          }
+          applicationStyleSheet.append(customStyleSheet);
+          setStyleSheet(applicationStyleSheet);
+        }
+      }
+    }
+  }
 #ifndef WIN32
   QTextCodec::setCodecForLocale(QTextCodec::codecForName(Helper::utf8.toUtf8().constData()));
 #endif // #ifndef WIN32
@@ -207,16 +272,13 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         }
       } else if (strncmp(arguments().at(i).toUtf8().constData(), "--paths",7) == 0) {
         dumpQtPaths();
+      } else if (styleSheetArgumentValue(arguments().at(i), &fileName)) {
+        // The stylesheet option is handled before MainWindow initialization.
       } else {
         fileName = arguments().at(i);
         if (!fileName.isEmpty()) {
           // if path is relative make it absolute
-          QFileInfo file (fileName);
-          QString absoluteFileName = fileName;
-          if (file.isRelative()) {
-            absoluteFileName = QString("%1/%2").arg(QDir::currentPath()).arg(fileName);
-          }
-          absoluteFileName = absoluteFileName.replace("\\", "/");
+          const QString absoluteFileName = absolutePath(fileName);
           if (QFile::exists(absoluteFileName)) {
             fileNames << absoluteFileName;
           } else {
@@ -240,6 +302,10 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   if (!invalidFlags.isEmpty()) {
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, QString("Invalid command line argument(s): %1").arg(invalidFlags.join(", ")),
                                                           Helper::scriptingKind, Helper::errorLevel));
+  }
+  // show stylesheet load error
+  if (!styleSheetLoadError.isEmpty()) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, styleSheetLoadError, Helper::scriptingKind, Helper::errorLevel));
   }
   // show qt translator load error
   if (!qtTranslatorLoadError.isEmpty()) {

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -140,6 +140,14 @@ namespace {
     pErrorString->clear();
     return true;
   }
+
+  void appendStyleSheet(QString *pStyleSheet, const QString &styleSheet)
+  {
+    if (!pStyleSheet->isEmpty()) {
+      pStyleSheet->append("\n");
+    }
+    pStyleSheet->append(styleSheet);
+  }
 }
 
 /*!
@@ -182,12 +190,13 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
 #endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   // set the stylesheet
   QString applicationStyleSheet;
-  QString styleSheetLoadError;
-  if (readStyleSheetFile(":/Resources/css/stylesheet.qss", &applicationStyleSheet, &styleSheetLoadError)) {
+  QStringList styleSheetLoadErrors;
+  QString defaultStyleSheetLoadError;
+  const bool defaultStyleSheetLoaded = readStyleSheetFile(":/Resources/css/stylesheet.qss", &applicationStyleSheet, &defaultStyleSheetLoadError);
+  if (defaultStyleSheetLoaded) {
     setStyleSheet(applicationStyleSheet);
   } else {
-    setStyleSheet("file:///:/Resources/css/stylesheet.qss");
-    styleSheetLoadError.clear();
+    styleSheetLoadErrors.append(defaultStyleSheetLoadError);
   }
   if (arguments().size() > 1 && !testsuiteRunning) {
     for (int i = 1; i < arguments().size(); i++) {
@@ -195,12 +204,15 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
       if (styleSheetArgumentValue(arguments().at(i), &styleSheetFileName)) {
         const QString absoluteStyleSheetFileName = absolutePath(styleSheetFileName);
         QString customStyleSheet;
-        if (readStyleSheetFile(absoluteStyleSheetFileName, &customStyleSheet, &styleSheetLoadError)) {
-          if (!applicationStyleSheet.isEmpty()) {
-            applicationStyleSheet.append("\n");
+        QString customStyleSheetLoadError;
+        if (readStyleSheetFile(absoluteStyleSheetFileName, &customStyleSheet, &customStyleSheetLoadError)) {
+          if (!defaultStyleSheetLoaded) {
+            continue;
           }
-          applicationStyleSheet.append(customStyleSheet);
+          appendStyleSheet(&applicationStyleSheet, customStyleSheet);
           setStyleSheet(applicationStyleSheet);
+        } else {
+          styleSheetLoadErrors.append(customStyleSheetLoadError);
         }
       }
     }
@@ -304,8 +316,8 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
                                                           Helper::scriptingKind, Helper::errorLevel));
   }
   // show stylesheet load error
-  if (!styleSheetLoadError.isEmpty()) {
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, styleSheetLoadError, Helper::scriptingKind, Helper::errorLevel));
+  if (!styleSheetLoadErrors.isEmpty()) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, styleSheetLoadErrors.join("\n"), Helper::scriptingKind, Helper::errorLevel));
   }
   // show qt translator load error
   if (!qtTranslatorLoadError.isEmpty()) {

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -193,9 +193,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   QStringList styleSheetLoadErrors;
   QString defaultStyleSheetLoadError;
   const bool defaultStyleSheetLoaded = readStyleSheetFile(":/Resources/css/stylesheet.qss", &applicationStyleSheet, &defaultStyleSheetLoadError);
-  if (defaultStyleSheetLoaded) {
-    setStyleSheet(applicationStyleSheet);
-  } else {
+  if (!defaultStyleSheetLoaded) {
     styleSheetLoadErrors.append(defaultStyleSheetLoadError);
   }
   if (arguments().size() > 1 && !testsuiteRunning) {
@@ -210,12 +208,14 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
             continue;
           }
           appendStyleSheet(&applicationStyleSheet, customStyleSheet);
-          setStyleSheet(applicationStyleSheet);
         } else {
           styleSheetLoadErrors.append(customStyleSheetLoadError);
         }
       }
     }
+  }
+  if (defaultStyleSheetLoaded) {
+    setStyleSheet(applicationStyleSheet);
   }
 #ifndef WIN32
   QTextCodec::setCodecForLocale(QTextCodec::codecForName(Helper::utf8.toUtf8().constData()));


### PR DESCRIPTION
## Summary
- load OMEdit default resource stylesheet explicitly
- add `--StyleSheet=<file>` and `--stylesheet=<file>` command-line options that append a custom Qt stylesheet after OMEdit default stylesheet
- keep the stylesheet option out of the Modelica file argument path and report stylesheet load failures in OMEdit Messages

## Rationale
Qt standard `-stylesheet` handling can be overwritten when OMEdit applies its own application stylesheet during startup. This gives OMEdit a small explicit override surface that is applied after the built-in stylesheet.

## Testing
- `git diff --check`
- GitHub/Jenkins PR checks are green on commit `5f779c3`:
  - `continuous-integration/jenkins/pr-merge`
  - `Runtime license headers`
  - `license/cla`
- Local macOS configure attempt for the PR branch, after expanding the sparse checkout and initializing the required submodules:
  - `cmake -S . -B build-pr15766-qt5-submodules -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOM_USE_CCACHE=OFF -DOM_QT_MAJOR_VERSION=5 -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt@5 -DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_OPTIMIZATION=OFF -DOM_OMC_ENABLE_MOO=OFF`
  - configuration did not reach the OMEdit build; it stopped earlier at `OMCompiler/Parser` because this local macOS environment does not have a Java runtime installed (`Could NOT find Java`).

Not run locally:
- full OMEdit build/runtime test; the local macOS OpenModelica build environment is still incomplete. The current PR checks are passing in CI.