### PR TITLE
OMEdit: document local rebuild dependencies

### DIFF
--- a/OMEdit/README.md
+++ b/OMEdit/README.md
@@ -14,6 +14,70 @@ Follow the instructions matching your OS:
   - [OMCompiler/README.Linux.md](../OMCompiler/README.Linux.md)
   - [OMCompiler/README.Windows.md](../OMCompiler/README.Windows.md)
 
+### Rebuilding OMEdit only
+
+The full OpenModelica build is the recommended way to prepare OMEdit and its
+dependencies. For small OMEdit changes it is also possible to rebuild only
+OMEdit, but the build still expects generated files and libraries from other
+parts of the source tree to be available.
+
+Use a complete source checkout, including `OMParser`, `OMPlot`,
+`OMCompiler/3rdParty`, and `OMCompiler/Compiler/runtime`. Set `OMBUILDDIR` to
+the OpenModelica build or install prefix that contains the compiler libraries
+and headers. For example, this is often `../build` in a source build and `/usr`
+inside a release Docker image.
+
+Build `OMParser` before building OMEdit:
+
+```sh
+make -C OMParser \
+  OMBUILDDIR=/path/to/openmodelica/build-or-install-prefix \
+  host_short="$(gcc -dumpmachine)"
+```
+
+This generates the Modelica parser sources, including `modelicaLexer.h`, and
+installs `libOMParser.a` and `libantlr4-runtime.a` under
+`$OMBUILDDIR/lib/$host_short/omc`.
+
+On Debian or Ubuntu based environments, make sure the Qt and parser tool
+dependencies needed by OMEdit are installed. Package names vary by distribution,
+but the following packages are commonly needed:
+
+```sh
+apt-get install -y \
+  qtbase5-dev qttools5-dev-tools \
+  libqt5webkit5-dev libqt5svg5-dev libqt5opengl5-dev \
+  libopenscenegraph-dev \
+  default-jre-headless antlr3 libantlr3-runtime-java
+```
+
+Then configure and build OMEdit against the same build or install prefix:
+
+```sh
+cd OMEdit
+autoconf
+./configure \
+  --with-openmodelicahome=/path/to/openmodelica/build-or-install-prefix \
+  --with-ombuilddir=/path/to/openmodelica/build-or-install-prefix
+
+make -f Makefile.unix \
+  ANTLRJAR=/usr/share/java/antlr3.jar:/usr/share/java/antlr3-runtime.jar:/usr/share/java/stringtemplate4.jar
+```
+
+Common partial rebuild failures usually mean that one of the generated artifacts
+or source-tree dependencies above is missing:
+
+  - `modelicaLexer.h: No such file or directory`: build `OMParser` first.
+  - `/usr/bin/ld: cannot find -lOMParser`: check that `libOMParser.a` was
+    installed under `$OMBUILDDIR/lib/$host_short/omc`.
+  - `antlr-3.2.jar` or similar ANTLR jar errors: pass a valid `ANTLRJAR` value
+    when invoking `make -f Makefile.unix`.
+  - `OMPlot.h`, `fmilib.h`, or `settingsimpl.h` missing: use a complete source
+    checkout and matching OpenModelica development headers.
+  - `#include_next <stdlib.h>` errors from system headers: inspect the generated
+    qmake flags and make sure `/usr/include` is not treated as an added
+    third-party include directory.
+
 ### Compile/Debug from Qt Creator
 
 Compile OMEdit once using the build instructions above so all dependencies of OMEdit are ready. Then follow these steps,


### PR DESCRIPTION
## Summary

- Document the assumptions for rebuilding only OMEdit after the full OpenModelica dependencies are already available.

- Add a short build sequence covering `OMParser`, common Debian/Ubuntu packages, `configure`, and `Makefile.unix` with `ANTLRJAR`.

- Add troubleshooting notes for common partial rebuild failures such as missing `modelicaLexer.h`, `libOMParser`, ANTLR jars, OMPlot/FMIl/runtime headers, and system include path issues.

## Motivation

Small OMEdit changes are often easier to validate with an OMEdit-only rebuild, but that path still requires generated parser artifacts and libraries from other parts of the source tree. This README addition makes those dependencies explicit and gives contributors searchable error messages and next steps.

## Validation

- `git diff --check`