### PR TITLE
Susan: generate iterative for-loops for list maps instead of recursion

### DIFF
--- a/OMCompiler/Compiler/Template/TplAbsyn.mo
+++ b/OMCompiler/Compiler/Template/TplAbsyn.mo
@@ -407,6 +407,13 @@ uniontype MMExp
     Ident eltName;
     list<MMExp> statements;
   end MM_FOR_LOOP;
+
+  record MM_LIST_FOR_LOOP "iterative list map: for eltName in listName loop match eltName ... end for;"
+    Ident eltName;
+    Ident listName;
+    TypedIdents matchLocals "pattern and body locals of the per-element match";
+    list<MMMatchCase> matchCases "the matched case plus an optional skip (else) case";
+  end MM_LIST_FOR_LOOP;
 end MMExp;
 
 public type MMMatchCase = tuple<list<MatchingExp>, list<MMExp>>;
@@ -2574,7 +2581,7 @@ algorithm
       TypeSignature argtype, oftype;
       ScopeEnv scEnv;
       Ident intxt, outtxt, fname,   idxName, freshIdxName, arrName, eltName;
-      TypedIdents locals,  localArgs, encodedExtargs, maplocals, caseLocals,   iargs, oargs;
+      TypedIdents locals,  localArgs, encodedExtargs, maplocals, caseLocals,   iargs, oargs, matchLocals;
       MapContext mapctx;
       TemplPackage tplPackage;
       list<MMDeclaration> accMMDecls;
@@ -2584,7 +2591,7 @@ algorithm
       Expression mapexp;
       list<MMEscOption> iopts;
       list<ASTDef> astDefs;
-      MMMatchCase mmmcEmptyList, mmmcCons, mmFailCons;
+      MMMatchCase mmmcEmptyList, mmmcCons, mmFailCons, mmmcMatched;
       Boolean isfirst, useiter,  isUsed;
       MMDeclaration mmFun;
       list<tuple<MatchingExp, TypedIdents, list<MMExp>>> elabcases;
@@ -2653,43 +2660,35 @@ algorithm
         //oargs = List.filterOnTrue(extargs, isText);
         oargs := List.filter1OnTrue(encodedExtargs, isAssignedText, assignedIdents);
         oargs := imlicitTxtArg :: oargs;
-        lhsArgs := List.map(oargs, Util.tuple21);
-        inMapExtargvals :=  List.map(encodedExtargs, makeMMArgValue);
-        rhsMMArgs := List.map(inMapExtargvals, Util.tuple31);
-        //recursive call
-        mmRecCall := MM_ASSIGN(
-            lhsArgs,
-            MM_FN_CALL(IDENT(fname), MM_IDENT(IDENT(imlicitTxt)) :: MM_IDENT(IDENT("rest")) :: rhsMMArgs)
-        );
-        //add the recursive call for the "rest" and revese statemnts
-        mapstmts := listReverse(mmRecCall :: mapstmts);
+        //reverse the per-element statements into source order
+        mapstmts := listReverse(mapstmts);
         //add indexed value if needed
         (mapstmts, maplocals)
           := addGetIndex(isUsed, freshIdxName, mapstmts, imlicitTxt, maplocals);
 
-        //make the empty case, cons case and a failing cons case (only recusive call for the rest)
-        mmmcEmptyList := makeMMMatchCase( (LIST_MATCH({}), {},{}), encodedExtargs, oargs);
-        mmmcCons := makeMMMatchCase(
-          (LIST_CONS_MATCH(mexp, BIND_MATCH("rest")), encodedExtargs, mapstmts),
-          encodedExtargs, oargs);
-        //TODO: the fail recursive call could be made conditional, only when the mexp can fail
-        // or, maybe, always like it is, to make easier location of failing of (badly)imported functions(they should not fail)
-        mmFailCons := makeMMMatchCase(
-          (LIST_CONS_MATCH(REST_MATCH(), BIND_MATCH("rest")), encodedExtargs, {mmRecCall}),
-          encodedExtargs, oargs);
-        mmmcases := if isAlwaysMatchedBool(mexp) then { mmmcEmptyList, mmmcCons } else { mmmcEmptyList, mmmcCons, mmFailCons };
-         //  listAppend({ mmmcEmptyList, mmmcCons },
-         //  { makeMMMatchCase(
-         // (LIST_CONS_MATCH(REST_MATCH(), BIND_MATCH("rest")), encodedExtargs, {mmRecCall}),
-         // encodedExtargs, oargs) } );
+        // The element-pattern bindings and per-element temporaries become the
+        // locals of the per-element match; the threaded text accumulators stay
+        // as the function's input/output arguments (iargs/oargs above).
+        matchLocals := maplocals;
+
+        // fresh loop variable bound to each list element (the match scrutinee)
+        eltName := "lstElt_" + intString(listLength(accMMDecls));
+
+        // The matched case runs the per-element body; the empty list is handled
+        // by the for-loop itself. When the element pattern may fail to match,
+        // add a skip case that leaves the accumulators unchanged.
+        mmmcMatched := ({mexp}, mapstmts);
+        mmmcases := if isAlwaysMatchedBool(mexp) then { mmmcMatched }
+                    else { mmmcMatched, ({REST_MATCH()}, {}) };
 
         mapctx := MAP_CONTEXT(ofbind, mapexp, iopts, hasIndexIdentOpt, useiter);
-        maplocals := listAppend(encodedExtargs, maplocals);
-        maplocals := imlicitTxtArg :: ("rest",argtype) :: maplocals;
 
-        // make fun
-        mmFun := MM_FUN(false,fname, iargs, oargs, maplocals,
-                        { MM_MATCH( mmmcases /*{ mmmcEmptyList, mmmcCons, mmFailCons } */ ) },
+        // make fun: an iterative for-loop over the list rather than a
+        // self-recursive helper. The recursion is a tail call (the C backend
+        // tail-call-optimises it), but a straight loop avoids deep call stacks
+        // for large models in every backend.
+        mmFun := MM_FUN(false, fname, iargs, oargs, {},
+                        { MM_LIST_FOR_LOOP(eltName, "items", matchLocals, mmmcases) },
                         GI_MAP_FUN(argtype, mapctx)
                 );
 
@@ -2903,6 +2902,17 @@ algorithm
   (outIntersection, outList1Rest, outList2Rest) := List.intersection1OnTrue(inList1, inList2, areTypedIdentsEqual);
   outIntersectionAndRests := (outIntersection, outList1Rest, outList2Rest);
 end intersectInOutArgs;
+
+public function isTupleListMember "True when an identifier names one of the typed idents in the list."
+  input Ident inId;
+  input TypedIdents inList;
+  output Boolean outIsMember;
+algorithm
+  outIsMember := matchcontinue ()
+    case () algorithm lookupTupleList(inList, inId); then true;
+    else false;
+  end matchcontinue;
+end isTupleListMember;
 
 /*
 function isIndexArg
@@ -6845,6 +6855,7 @@ algorithm
     case MM_FN_CALL() then List.foldr(exp.args, addExpToSet, addPathIdentToSet(set, exp.fnName));
     case MM_IDENT() then addPathIdentToSet(set, exp.ident);
     case MM_MATCH() then List.foldr(exp.matchCases, addMatchCaseToSet, set);
+    case MM_LIST_FOR_LOOP() then List.foldr(exp.matchCases, addMatchCaseToSet, set);
     else set;
   end match;
 end addExpToSet;

--- a/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
+++ b/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
@@ -50,6 +50,8 @@ template mmDeclaration(MMDeclaration it) ::=
        mmMatchFunBody(mf.inArgs, mf.outArgs, mf.locals, c.matchCases)
      case {c as MM_FOR_LOOP(__)} then //for-loop function
        mmForLoopFunBody(mf.inArgs, mf.outArgs, mf.locals, c.idxName, c.arrName, c.eltName, c.statements)
+     case {c as MM_LIST_FOR_LOOP(__)} then //iterative list-map for-loop function
+       mmListForLoopFunBody(mf.inArgs, mf.outArgs, mf.locals, c.eltName, c.listName, c.matchLocals, c.matchCases)
      case sts then //simple assignment functions
        <<
          <%typedIdentsEx(mf.inArgs, "input", "")%>
@@ -149,6 +151,53 @@ end try;
 %>
 >>
 end mmForLoopFunBody;
+
+template mmListForLoopFunBody(TypedIdents inArgs, TypedIdents outArgs, TypedIdents locals, Ident eltName, Ident listName, TypedIdents matchLocals, list<MMMatchCase> matchCases) ::=
+<<
+  <%inArgs |> (nm, ts) => '<%if isTupleListMember(nm, outArgs) then "input output" else "input"%> <%typeSig(ts)%> <%nm%>;' ;separator="\n"%>
+<%if locals then <<
+protected
+  <%typedIdents(locals)%>
+>>%>
+algorithm<% if debugSusan() then
+<<
+
+try
+>>
+%>
+  for <%eltName%> in <%listName%> loop
+    <%match outArgs
+     case {(nm,_)} then nm
+     case oas      then '(<%oas |> (nm,_)=> nm ;separator=", "%>)'
+    %> := match <%eltName%><%if matchLocals then <<
+
+      local
+        <%typedIdents(matchLocals)%>
+    >>%>
+  <%matchCases |> (mexps, statements) =>
+  <<
+
+    case <%mexps |> it => mmMatchingExp(it) ;separator=",\n"; anchor%>
+      <%if statements then <<
+      algorithm
+        <%statements |> it => '<%mmExp(it, ":=")%>;' ;separator="\n"%>
+      >>%>
+      then <%match outArgs
+            case {(nm,_)} then nm
+            case oas then '(<%oas |> (nm,_)=> nm ;separator=", "%>)'
+           %>;
+  >>;separator="\n"%>
+    end match;
+  end for;<% if debugSusan() then
+<<
+
+else
+  Tpl.fakeStackOverflow();
+end try;
+>>
+%>
+>>
+end mmListForLoopFunBody;
 
 template inOutArgs(TypedIdents inArgs, TypedIdents outArgs) ::=
   match intersectInOutArgs(inArgs, outArgs)

--- a/OMCompiler/Compiler/susan_codegen/TplCodegenTV.mo
+++ b/OMCompiler/Compiler/susan_codegen/TplCodegenTV.mo
@@ -209,6 +209,13 @@ package TplAbsyn
       Ident eltName;
       list<MMExp> statements;
     end MM_FOR_LOOP;
+
+    record MM_LIST_FOR_LOOP
+      Ident eltName;
+      Ident listName;
+      TypedIdents matchLocals;
+      list<MMMatchCase> matchCases;
+    end MM_LIST_FOR_LOOP;
   end MMExp;
 
   // **** types for dumping purposes ... i.e. Susan input AST
@@ -362,6 +369,12 @@ package TplAbsyn
     input TypedIdents inList2;
     output tuple<TypedIdents, TypedIdents, TypedIdents> outIntersectionAndRests;
   end intersectInOutArgs;
+
+  function isTupleListMember
+    input Ident inId;
+    input TypedIdents inList;
+    output Boolean outIsMember;
+  end isTupleListMember;
 
 end TplAbsyn;
 


### PR DESCRIPTION
The list-map elaboration in TplAbsyn (the `lm_*` helpers) emitted a self-recursive match function per `<list |> elt => ...>` template iteration. This only works when the MetaModelica compiler manages tail-call-optimization of that recursion into a loop and otherwise overflows.

Emit a `for elt in items loop () := match elt ... end match; end for;` instead — the array-map path already produced a for-loop (MM_FOR_LOOP), this brings list-map in line. A new MM_LIST_FOR_LOOP node carries the per-element match (with a skip/else case when the element pattern may fail); the threaded text accumulators stay as input/output arguments in the original argument order so existing call sites are unchanged.