### PR TITLE
BackendDump: drop debug SIMULATION/INITIALSYSTEM print in dumpLoops

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -1235,12 +1235,6 @@ protected
   Integer isyst = 1;
   Boolean firstComp = true; // used to print header only if there is actually an algebraic loop
 algorithm
-    _ := match outDAE.shared
-            case BackendDAE.SHARED(backendDAEType=BackendDAE.SIMULATION()) then print("SIMULATION\n");
-            case BackendDAE.SHARED(backendDAEType=BackendDAE.INITIALSYSTEM()) then print("INITIALSYSTEM\n");
-            else print("UNKNOWN\n");
-            end match;
-
    for syst in inDAE.eqs loop
      firstComp := true;
      BackendDAE.EQSYSTEM(orderedVars=vars,orderedEqs=eqns, matching=BackendDAE.MATCHING(comps=comps)) := syst;


### PR DESCRIPTION
The code actually never executes because OMC drops `then print("abc");`, so the code never did anything.