### PR TITLE
CodegenC.tpl: emit headers for WHEN generic-call loop bodies

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -7666,7 +7666,8 @@ template genericCallHeaders(list<SimGenericCall> genericCalls, Context context)
   let sub_name = match context case JACOBIAN_CONTEXT() then "jac_" else ""
   (genericCalls |> call => match call
     case SINGLE_GENERIC_CALL()
-    case IF_GENERIC_CALL() then
+    case IF_GENERIC_CALL()
+    case WHEN_GENERIC_CALL() then
       let &sub = buffer ""
       let &preExp = buffer ""
       let &varDecls = buffer ""


### PR DESCRIPTION
genericCallHeaders only handled SINGLE_GENERIC_CALL/IF_GENERIC_CALL, so a when-equation inside a for-loop produced a genericCall_N definition with no prototype, tripping clang's -Werror=implicit-function-declaration. Add WHEN_GENERIC_CALL to the header case.