### PR TITLE
Fix string corruption in reverse-order StringAllocator fills

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1222,8 +1222,9 @@ algorithm
         then (p,count+stringLength(p.name),false);
       case Absyn.QUALIFIED()
         algorithm
-          System.stringAllocatorStringCopy(sb, p.name, if reverse then len-count-dlen-stringLength(p.name) else count);
-          System.stringAllocatorStringCopy(sb, delimiter, if reverse then len-count-dlen else count+stringLength(p.name));
+          // In reverse order the delimiter goes to the left of the name
+          System.stringAllocatorStringCopy(sb, p.name, if reverse then len-count-stringLength(p.name) else count);
+          System.stringAllocatorStringCopy(sb, delimiter, if reverse then len-count-stringLength(p.name)-dlen else count+stringLength(p.name));
         then (p.path,count+stringLength(p.name)+dlen,true);
       case Absyn.FULLYQUALIFIED()
         algorithm

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1352,10 +1352,16 @@ class StringAllocator
   external "C" str=StringAllocator_constructor(sz) annotation(Include="
 void* StringAllocator_constructor(int sz)
 {
+  void *res;
   if (sz < 0) {
     MMC_THROW();
   }
-  return mmc_alloc_scon(sz);
+  res = mmc_alloc_scon(sz);
+  if (sz > 0) {
+    /* mmc_alloc_scon does not terminate the string and the copies below do not either */
+    ((char*)MMC_STRINGDATA(res))[sz] = '\\0';
+  }
+  return res;
 }
 ");
   end constructor;
@@ -1372,12 +1378,14 @@ function stringAllocatorStringCopy
   input Integer destOffset=0;
 external "C" om_stringAllocatorStringCopy(dest,source,destOffset) annotation(Include="
 void om_stringAllocatorStringCopy(void *dest, char *source, int destOffset) {
-  if (*source) {
-    strcpy(MMC_STRINGDATA(dest)+destOffset, source);
+  /* memcpy without the terminator so copies at later offsets are not clobbered when filling the string in reverse order */
+  size_t n = strlen(source);
+  if (n > 0) {
+    memcpy(MMC_STRINGDATA(dest)+destOffset, source, n);
   }
 }
 ", Documentation(info="<html>
-<p>Does a strcpy into the (input) destination. This is dangerous and not valid Modelica.</p>
+<p>Copies the source string (without its terminator) into the (input) destination at the given offset. This is dangerous and not valid Modelica.</p>
 <p>Make sure the String has been allocated properly and is not shared. The input lengths are not validated, so this function can write out of bounds if called incorrectly.</p>
 </html>"));
 end stringAllocatorStringCopy;


### PR DESCRIPTION
Two related bugs that corrupted every pathString(reverse=true) result (used by Inst.generatePrefixStr to print reversed-stored prefixes in source order for instantiation-cache keys):

- AbsynUtil.pathStringWork placed the delimiter to the right of each qualified segment in reverse mode, yielding "ab$c$" instead of "a$b$c" for the stored path c.b.a.

- om_stringAllocatorStringCopy used strcpy, whose terminating NUL lands one byte past the copied segment. Forward fills overwrite that byte with the next copy (or it lands in the terminator slot), but in reverse-order fills it lands inside the already-written region and zeroes a byte that is never written again. Single-character segments vanished entirely, so distinct prefixes could produce identical cache keys. Copy with memcpy (no terminator) instead, and NUL-terminate the buffer once in StringAllocator_constructor since the copies no longer do it and mmc_alloc_scon only zeroes data[0].