### PR TITLE
parser: report invalid-escape warning at the real source position

### DIFF
--- a/OMCompiler/Parser/BaseModelica_Lexer.g
+++ b/OMCompiler/Parser/BaseModelica_Lexer.g
@@ -395,18 +395,22 @@ SESCAPE : esc='\\' ('\'' | '"' | '\\' | '?' | 'a' | 'b' | 'f' | 'n' | 'r' | 't' 
   {
     char chars[2] = {LA(1),'\0'};
     const char *str = chars;
-    int len = strlen((char*)$text->chars);
+    /* End the span at the real position of the offending byte (LA(1), the
+       current lexer position) rather than tokenStart + strlen, which produced
+       a nonsensical column on the string's first line when the string spans
+       several lines. GETCHARPOSITIONINLINE() is the 0-based column of LA(1);
+       +2 makes it the 1-based column just past it. */
     if (((chars[0] & 0xE0) == 0xC0) || ((chars[0] & 0xF0) == 0xE0) || ((chars[0] & 0xF8) == 0xF0) ) {
       c_add_source_message(NULL,2, ErrorType_syntax, ErrorLevel_warning, "Lexer treating \\ as \\\\, since the next byte is the start of a UTF-8 character and thus not a valid Modelica escape sequence.",
-          &str, 0, $line, $pos+1, $line, $pos+len+1,
+          &str, 0, $line, $pos+1, GETLINE(), GETCHARPOSITIONINLINE()+2,
           ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
     } else if ((chars[0] & 0x80)) {
       c_add_source_message(NULL,2, ErrorType_syntax, ErrorLevel_warning, "Lexer treating \\ as \\\\, since the next byte is an invalid UTF-8 character and thus not a valid Modelica escape sequence.",
-          &str, 0, $line, $pos+1, $line, $pos+len+1,
+          &str, 0, $line, $pos+1, GETLINE(), GETCHARPOSITIONINLINE()+2,
           ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
     } else {
       c_add_source_message(NULL,2, ErrorType_syntax, ErrorLevel_warning, "Lexer treating \\ as \\\\, since \\\%s is not a valid Modelica escape sequence.",
-          &str, 1, $line, $pos+1, $line, $pos+len+1,
+          &str, 1, $line, $pos+1, GETLINE(), GETCHARPOSITIONINLINE()+2,
           ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
     }
   });

--- a/testsuite/openmodelica/parser/DocumentationBackslash.mo
+++ b/testsuite/openmodelica/parser/DocumentationBackslash.mo
@@ -14,7 +14,7 @@ end DocumentationBackslash;
 // Result:
 // class DocumentationBackslash
 // end DocumentationBackslash;
-// [openmodelica/parser/DocumentationBackslash.mo:9:158-9:172:writable] Warning: Lexer treating \ as \\, since \L is not a valid Modelica escape sequence.
-// [openmodelica/parser/DocumentationBackslash.mo:9:158-9:182:writable] Warning: Lexer treating \ as \\, since \C is not a valid Modelica escape sequence.
+// [openmodelica/parser/DocumentationBackslash.mo:9:158-10:14:writable] Warning: Lexer treating \ as \\, since \L is not a valid Modelica escape sequence.
+// [openmodelica/parser/DocumentationBackslash.mo:9:158-10:24:writable] Warning: Lexer treating \ as \\, since \C is not a valid Modelica escape sequence.
 //
 // endResult


### PR DESCRIPTION
The SESCAPE action in BaseModelica_Lexer.g built the warning's end position as tokenStart + strlen(token text) on the string's *first* line, ignoring newlines inside the string. For a multi-line documentation string this gave a column far past the end of line 1 instead of the real location of the bad escape. Use the lexer's current position (GETLINE()/GETCHARPOSITIONINLINE()) so the span ends at the offending byte. Update DocumentationBackslash.mo's expected output accordingly.