### PR TITLE
SimulationRuntime cpp: don't re-prefix raw -l flags in LAPACK_LIBRARIES

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Modelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Modelica/CMakeLists.txt
@@ -220,9 +220,15 @@ endif()
 
 set(LAPACK_LIBRARIES_ "")
 foreach(lib ${LAPACK_LIBRARIES})
-  get_filename_component(libNew "${lib}" NAME_WE)
-  string(REGEX REPLACE "^lib" "" libNew ${libNew})
-  set(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${LINKER_LIB_PREFIX}${libNew}")
+  # FindLAPACK/FindBLAS may return raw linker flags (e.g. "-lm;-ldl") mixed in
+  # with library paths; pass those through instead of prefixing another "-l".
+  if("${lib}" MATCHES "^-")
+    set(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${lib}")
+  else()
+    get_filename_component(libNew "${lib}" NAME_WE)
+    string(REGEX REPLACE "^lib" "" libNew ${libNew})
+    set(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${LINKER_LIB_PREFIX}${libNew}")
+  endif()
 endforeach(lib ${LAPACK_LIBRARIES})
 
 set(INTEL_TBB_LIBS "")

--- a/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
@@ -203,9 +203,15 @@ ENDFOREACH(lib ${SUNDIALS_LIBRARIES})
 
 SET(LAPACK_LIBRARIES_ "")
 FOREACH(lib ${LAPACK_LIBRARIES})
-	GET_FILENAME_COMPONENT(libNew "${lib}" NAME_WE)
-	STRING(REGEX REPLACE "^lib" "" libNew ${libNew})
-	SET(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${LINKER_LIB_PREFIX}${libNew}")
+	# FindLAPACK/FindBLAS may return raw linker flags (e.g. "-lm;-ldl") mixed in
+	# with library paths; pass those through instead of prefixing another "-l".
+	IF("${lib}" MATCHES "^-")
+		SET(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${lib}")
+	ELSE()
+		GET_FILENAME_COMPONENT(libNew "${lib}" NAME_WE)
+		STRING(REGEX REPLACE "^lib" "" libNew ${libNew})
+		SET(LAPACK_LIBRARIES_ "${LAPACK_LIBRARIES_} ${LINKER_LIB_PREFIX}${libNew}")
+	ENDIF()
 ENDFOREACH(lib ${LAPACK_LIBRARIES})
 
 SET(INTEL_TBB_LIBS "")


### PR DESCRIPTION
FindLAPACK/FindBLAS can return raw linker flags such as -lm and -ldl mixed in with the library paths (e.g. when OpenBLAS is found on Debian).  The ModelicaConfig_gcc.inc generation blindly prefixed every entry with -l, producing '-l-lm -l-ldl' and breaking the link of every Cpp-target model.