### PR TITLE
[SimCode] Fix codegen for nested initialization nonlinear systems (#15433)

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1253,10 +1253,19 @@ algorithm
 end crefPrefixAux;
 
 public function crefRemovePrePrefix
+  "Strips a leading $PRE or $START qualifier from a cref. Used by the code
+   generation templates before looking up a SimVar (cref2simvar) to obtain
+   index/nominal/min/max info: $PRE.x and $START.x are not SimVars of their
+   own, they share the storage of x, so they must resolve to x's SimVar.
+   Without stripping $START the lookup fails and emits the -2
+   ERROR_simVarFromHT_failed sentinel, which crashes at runtime when used as
+   a scalar index (ticket #15433, nested initialization nonlinear systems
+   iterating over $START.<var>)."
   input output DAE.ComponentRef cref;
 algorithm
   cref := match cref
     case DAE.CREF_QUAL(ident=DAE.preNamePrefix) then cref.componentRef;
+    case DAE.CREF_QUAL(ident=DAE.startNamePrefix) then cref.componentRef;
     else cref;
   end match;
 end crefRemovePrePrefix;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -1237,6 +1237,11 @@ Adds algebraic loops from list of SimEqSystem into ModelInfo
 and SimEqSystem equation algebraic system index."
   input output list<SimCode.SimEqSystem> eqns;
   input output SimCode.ModelInfo modelInfo;
+  input Boolean addNLSToModelInfo = true "If false, nonlinear systems found here are indexed but not added to
+    modelInfo.nonLinearSystems. Used when recursing into the inner equations of a nonlinear system, because the
+    code generation templates already emit those nested nonlinear systems from within their parent (see
+    generateNonLinearResidualFunction / generateNonLinearSystemData in CodegenC.tpl). Adding them here as well
+    leads to duplicate residualFunc/initializeStaticDataNLS/... definitions and a C compiler error (#15433).";
   output list<SimCode.JacobianMatrix> symJacs = {};
 protected
   list<SimCode.SimEqSystem> resEqns = {};
@@ -1263,7 +1268,12 @@ algorithm
           optNlSyst := SOME(altNlSyst);
         end if;
         system := SimCode.SES_NONLINEAR(nlSyst, optNlSyst, eqAttr);
-        modelInfo.nonLinearSystems := system::modelInfo.nonLinearSystems;
+        // Only add top-level nonlinear systems to modelInfo. Nested ones (inner equations of another
+        // nonlinear system) are emitted by the templates from within their parent, so adding them here
+        // too would generate duplicate C functions (ticket #15433).
+        if addNLSToModelInfo then
+          modelInfo.nonLinearSystems := system::modelInfo.nonLinearSystems;
+        end if;
       then system;
 
       // linear case
@@ -1321,7 +1331,10 @@ algorithm
   end if;
 
   // proceed inSyst.eqs
-  (eqs, modelInfo, tmpSymJacs) := addAlgebraicLoopsModelInfo(inSyst.eqs, modelInfo);
+  // Index the inner (nested) systems, but do NOT add nested nonlinear systems to modelInfo.nonLinearSystems:
+  // the templates emit them from within this parent nonlinear system (ticket #15433). Nested linear systems
+  // are still added because the linear templates do not recurse into inner equations.
+  (eqs, modelInfo, tmpSymJacs) := addAlgebraicLoopsModelInfo(inSyst.eqs, modelInfo, addNLSToModelInfo = false);
   inSyst.eqs := eqs;
   allSymJacs := listAppend(tmpSymJacs, allSymJacs);
 
@@ -1364,6 +1377,8 @@ algorithm
   end if;
 
   // proceed inSyst.eqs
+  // Keep addNLSToModelInfo = true (default) here: the linear templates do not recurse into inner equations,
+  // so any nonlinear system nested inside this linear system must stay in modelInfo.nonLinearSystems.
   (eqs, modelInfo, tmpSymJacs) := addAlgebraicLoopsModelInfo(inSyst.residual, modelInfo);
   inSyst.residual := eqs;
   allSymJacs := listAppend(tmpSymJacs, allSymJacs);


### PR DESCRIPTION
Parallel mounted cables in the Cables library produced a non-compilable model (actual issue #15433). Two distinct code-generation bugs, both triggered when a torn nonlinear system has *nested* nonlinear systems among its inner equations (here the scalar systems solving $START.cableX.cableElement[50].cableFrame_b.r_0[i]):

1. Duplicate C functions -> "redefinition" compile error. The templates emit nested nonlinear systems from within their parent (generateNonLinearResidualFunction / generateNonLinearSystemData in CodegenC.tpl), but addAlgebraicLoopsModelInfo *also* added them as separate top-level entries to modelInfo.nonLinearSystems, so each nested residualFunc/initializeStaticDataNLS/... was emitted twice. Add an addNLSToModelInfo flag: when updateNonLinearSyst recurses into the inner equations of a nonlinear system it now indexes the nested systems but does not add them to the flat list. updateLinearSyst keeps the default (true) because the linear templates do not recurse into inner equations.

2. Out-of-bounds at runtime (getNominalFromScalarIdx scalar_idx = -2). The nested systems iterate over $START.<var>. crefRemovePrePrefix, used by the templates before cref2simvar to fetch index/nominal/min/max, only stripped $PRE, so the $START.<var> lookup failed and emitted the -2 ERROR_simVarFromHT_failed sentinel, crashing when used as a scalar index. $START.x (like $PRE.x) shares x's storage, so also strip a leading $START there, matching how crefToCStr already resolves $START.

After this the model compiles, links and runs. (A separate numerical initialization convergence issue remains and is not addressed here.)

