### PR TITLE
Parser: named arguments after positional needs a comma

### DIFF
--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -2004,19 +2004,30 @@ component_reference2 returns [void* ast, int isNone]
   finally{ OM_POP(2); }
 
 function_call returns [void* ast]
-@init { OM_PUSHZ1(fa); } :
-  LPAR fa=function_arguments RPAR { ast = fa; }
+@init { OM_PUSHZ1(fa.ast); } :
+  LPAR fa=function_arguments RPAR { $ast = fa.ast; }
   ;
   finally{ OM_POP(1); }
 
 function_arguments returns [void* ast]
 @init{ OM_PUSHZ2(for_or_el.ast, namel); for_or_el.isFor = 0; } :
-  for_or_el=for_or_expression_list (namel=named_arguments)?
+  for_or_el=for_or_expression_list (COMMA namel=named_arguments)?
     {
-      if (for_or_el.isFor)
-        ast = for_or_el.ast;
-      else
-        ast = Absyn__FUNCTIONARGS(for_or_el.ast, or_nil(namel));
+      if (for_or_el.isFor) {
+        if (namel) {
+          ModelicaParser_lexerError = ANTLR3_TRUE;
+          c_add_source_message(NULL, 2, ErrorType_syntax, ErrorLevel_error, "Named arguments cannot be combined with for-indices.",
+              NULL, 0, $start->line, $start->charPosition+1, LT(1)->line, LT(1)->charPosition,
+              ModelicaParser_readonly, ModelicaParser_filename_C_testsuiteFriendly);
+        }
+        $ast = for_or_el.ast;
+      } else {
+        $ast = Absyn__FUNCTIONARGS(for_or_el.ast, or_nil(namel));
+      }
+    }
+  | namel=named_arguments
+    {
+      $ast = Absyn__FUNCTIONARGS(mmc_mk_nil(), namel);
     }
   ;
   finally{ OM_POP(2); }
@@ -2025,9 +2036,9 @@ for_or_expression_list returns [void* ast, int isFor]
 @init{ OM_PUSHZ3(e.ast, el, forind); } :
   ( {LA(1)==IDENT || (LA(1)==OPERATOR && LA(2) == EQUALS) || LA(1) == RPAR || LA(1) == RBRACE}? { $ast = mmc_mk_nil(); $isFor = 0; }
   | ( e=expression[1]
-      ( ({LA(1)==COMMA}? el=for_or_expression_list2)
+      ( el=for_or_expression_list2
       | (threaded=THREADED? FOR forind=for_indices)
-      )?
+      )
     )
     {
       if (el != NULL) {

--- a/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
+++ b/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
@@ -18,14 +18,14 @@ buildModel(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler); getErrorString();
 system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=dassl -jacobian=symbolical", "out.log"); getErrorString();
 readFile("out.log"); remove("out.log");
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
-                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff"
+                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
 system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=dassl -jacobian=coloredSymbolical", "out.log"); getErrorString();
 readFile("out.log"); remove("out.log");
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
-                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff"
+                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
@@ -33,14 +33,14 @@ getErrorString();
 system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=symbolical", "out.log"); getErrorString();
 readFile("out.log"); remove("out.log");
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
-                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff"
+                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
 system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=coloredSymbolical", "out.log"); getErrorString();
 readFile("out.log"); remove("out.log");
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
-                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff"
+                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 


### PR DESCRIPTION
Previously, the RPAR was enforced after the for-indices - this now requires an explicit error-message.