### PR TITLE
Fix codegen for record types with quoted dotted identifiers (#13009)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -90,9 +90,14 @@ import ExpressionDumpTpl.*;
 end symbolName;
 
 template replaceDotAndUnderscore(String str)
- "Replace _ with __ and dot in identifiers with _"
+ "Replace _ with __ and dot in identifiers with _.
+  For quoted identifiers (those starting with a single quote) the dots are
+  part of the name itself (e.g. 'Modelica.Media.X') and must be sanitized by
+  unquoteIdentifier (-> _2E), not treated as path separators (-> _5F_5F).
+  Otherwise the generated name diverges from the record type name built by
+  AbsynUtil.pathStringUnquoteReplaceDot and the C code fails to compile. See #13009."
 ::=
-  let str_dots = System.stringReplace(str,".", "_")
+  let str_dots = if stringEq(System.substring(str,1,1), "'") then str else System.stringReplace(str,".", "_")
   let str_underscores = System.stringReplace(str_dots, "_", "__")
   System.unquoteIdentifier(str_underscores)
 end replaceDotAndUnderscore;

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -11,6 +11,7 @@ RecordConstructor1.mos \
 TestComplexSum1.mos \
 TestComplexSum2.mos \
 Ticket5134.mos \
+Ticket13009.mos \
 Ticket14485.mos \
 
 # test that currently fail. Move up when fixed. 

--- a/testsuite/simulation/modelica/records/Ticket13009.mos
+++ b/testsuite/simulation/modelica/records/Ticket13009.mos
@@ -1,0 +1,39 @@
+// name:     Ticket13009.mos
+// keywords: record quoted identifier dot codegen
+// status:   correct
+// teardown_command: rm -rf P.M* _P.M* output.log
+
+// Quoted identifiers that contain a dot (e.g. the record name 'fluid.R')
+// must be mangled consistently between the generated record typedef and the
+// places where that type is used. Previously the use sites replaced the dot
+// inside the quoted identifier with __ (-> _5F_5F) while the typedef kept it
+// as part of the name (-> _2E), so the C code failed to compile. See #13009.
+
+loadString("
+package 'P'
+  record 'fluid.R'
+    Real x;
+  end 'fluid.R';
+
+  model 'M'
+    'fluid.R' r;
+  equation
+    r = 'fluid.R'(time);
+  end 'M';
+end 'P';
+"); getErrorString();
+
+simulate('P'.'M'); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "_omcQ_27P_27._omcQ_27M_27_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = '_omcQ_27P_27._omcQ_27M_27', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
For quoted identifiers containing a dot (e.g. the record name 'fluid.R'), replaceDotAndUnderscore treated the dot as a path separator and replaced it with __ (-> _5F_5F at use sites), while the record typedef kept the dot as part of the name (-> _2E via unquoteIdentifier). The mismatched names made the generated C code fail to compile.

Skip the dot-to-underscore replacement for quoted identifiers so the name is sanitized only by unquoteIdentifier, matching the typedef produced by AbsynUtil.pathStringUnquoteReplaceDot.

Add testsuite/simulation/modelica/records/Ticket13009.mos.

Fixes #13009
Ticket: https://github.com/OpenModelica/OpenModelica/issues/13009