### PR TITLE
Port stuff on maintenace

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -5076,6 +5076,7 @@ AboutOMEditDialog::AboutOMEditDialog(MainWindow *pMainWindow)
      "<h2>%1 - %2</h2>"
      "<b>Connected to %3 %4 encryption support</b><br />"
      "<b>Connected to %5</b><br /><br />"
+     "Compiled with <b>Qt %7</b>, running with <b>Qt %8</b>.<br /><br />"
      "Installation path <b>%6</b><br /><br />"
      "Copyright <b>Open Source Modelica Consortium (OSMC)</b>.<br />"
      "Distributed under OSMC-PL and GPL, see <u><a href=\"http://www.openmodelica.org\">www.openmodelica.org</a></u>."
@@ -5092,7 +5093,9 @@ AboutOMEditDialog::AboutOMEditDialog(MainWindow *pMainWindow)
           "without",
 #endif
           oms_getVersion(),
-          Helper::OpenModelicaHome);
+          Helper::OpenModelicaHome,
+          QStringLiteral(QT_VERSION_STR),
+          QString::fromLatin1(qVersion()));
   // about text label
   Label *pAboutTextLabel = new Label(aboutText);
   pAboutTextLabel->setWordWrap(true);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -7992,7 +7992,7 @@ bool ModelWidgetContainer::eventFilter(QObject *object, QEvent *event)
     if (pAction->shortcut() != QKeySequence("Ctrl+q")) {
       shouldValidateText = true;
     }
-  } else if (event->type() == QEvent::ContextMenu && object->parent() && qobject_cast<LibraryTreeView*>(object->parent())) {
+  } else if (event->type() == QEvent::MouseButtonPress && object->parent() && qobject_cast<LibraryTreeView*>(object->parent())) {
     shouldValidateText = true;
   } else if ((event->type() == QEvent::MouseButtonPress && qobject_cast<QMenuBar*>(object)) ||
              (event->type() == QEvent::MouseButtonPress && qobject_cast<QToolButton*>(object)) ||


### PR DESCRIPTION
[OMEdit] Add Qt version in the About dialog (#15778)
 Fixes #15777
-----
Validate text when user clicks on the Library Browser (#15797)
Fixes #15792
Use QEvent::MouseButtonPress instead of QEvent::ContextMenu
-----
