### PR TITLE
[Cpp, FMI] move generation of modelInstance.json to SimCodeMain (#15801) (#15803)

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4456,11 +4456,6 @@ algorithm
   dir := fmutmp+"/sources/";
 
   if Config.simCodeTarget() == "Cpp" then
-    // dump modelInstance.json so the FMU makefile can filter out the
-    // requested extra annotations (see flag --fmiExtraAnnotations)
-    if Flags.getConfigString(Flags.FMI_EXTRA_ANNOTATIONS) <> "" then
-      System.writeFile(filenameprefix + "_modelInstance.json", ValuesUtil.extractValueString(NFApi.getModelInstance(className, className, "", true)));
-    end if;
     System.removeDirectory("binaries");
     for platform in platforms loop
       if platform == "dynamic" or platform == "static" then

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -91,6 +91,7 @@ import Flags;
 import FlatModel = NFFlatModel;
 import NFFunction;
 import NFFlatten.{FunctionTree, FunctionTreeImpl};
+import NFApi;
 import FMI;
 import GCExt;
 import HashTable;
@@ -1078,6 +1079,11 @@ algorithm
           Tpl.tplNoret3(CodegenFMUCppHpcom.translateModel, simCode, FMUVersion, FMUType);
         else
           Tpl.tplNoret(function CodegenFMUCpp.translateModel(in_a_FMUVersion=FMUVersion, in_a_FMUType=FMUType, in_a_sourceFiles={}), simCode);
+          // dump modelInstance.json so the FMU makefile can filter out the
+          // requested extra annotations (see flag --fmiExtraAnnotations)
+          if Flags.getConfigString(Flags.FMI_EXTRA_ANNOTATIONS) <> "" then
+            System.writeFile(simCode.fileNamePrefix + "_modelInstance.json", ValuesUtil.extractValueString(NFApi.getModelInstance(simCode.modelInfo.name, simCode.modelInfo.name, "", true)));
+          end if;
         end if;
       then ();
     else

--- a/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
@@ -911,7 +911,9 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   endif
   ifneq ("<%extraAnnotations%>","")
   <%\t%><%mkdir%> -p extra/org.openmodelica
+  ifneq ("$(wildcard <%fileNamePrefix%>_modelInstance.json)","")
   <%\t%>jq --arg regex "<%extraAnnotations%>" -f "$(OMHOME)/share/omc/scripts/filter-annotations.jq" <%fileNamePrefix%>_modelInstance.json > extra/org.openmodelica/modelAnnotations.json
+  endif
   ifeq ($(ZIP_FMU),ON)
   <%\t%>zip -ur "<%fmuTargetName%>.fmu" extra
   endif


### PR DESCRIPTION
This makes it work with OMEdit.
SimCodeMain.callTargetTemplatesFMU is used by buildModelFMU (omc) and translateModelFMU (OMEdit).
