### PR TITLE
Refactored matchcontinue to match

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1572,7 +1572,7 @@ protected function setMinMaxFromEnumeration
   input Option<DAE.VariableAttributes> inVarAttr;
   output Option<DAE.VariableAttributes> outVarAttr;
 algorithm
-  outVarAttr := matchcontinue inType
+  outVarAttr := match inType
     local
       Option<DAE.Exp> min, max;
       list<String> names;
@@ -1583,7 +1583,7 @@ algorithm
       then
         setMinMaxFromEnumeration1(min, max, inVarAttr, path, names);
     else inVarAttr;
-  end matchcontinue;
+  end match;
 end setMinMaxFromEnumeration;
 
 protected function setMinMaxFromEnumeration1
@@ -1724,7 +1724,7 @@ protected function lowerType
   input  DAE.Type inType;
   output BackendDAE.Type outType;
 algorithm
-  outType := matchcontinue inType
+  outType := match inType
     local
     case DAE.T_REAL() then DAE.T_REAL_DEFAULT;
     case DAE.T_INTEGER() then DAE.T_INTEGER_DEFAULT;
@@ -1737,7 +1737,7 @@ algorithm
     case DAE.T_ARRAY() then inType;
     case DAE.T_FUNCTION() then inType;
     else algorithm print("lowerType: " + TypesDump.printTypeStr(inType) + " failed\n"); then fail();
-  end matchcontinue;
+  end match;
 end lowerType;
 
 protected function lowerExtObjVar

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -757,7 +757,7 @@ protected function traverseExpVisitorWrapper "help function to replaceFinalVarTr
   output DAE.Exp exp;
   output BackendVarTransform.VariableReplacements repl;
 algorithm
-  (exp,repl) := matchcontinue(inExp,inRepl)
+  (exp,repl) := match(inExp,inRepl)
     local
 
     case (exp as DAE.CREF(_,_),repl) algorithm
@@ -765,7 +765,7 @@ algorithm
     then (exp,repl);
 
     else (inExp,inRepl);
-  end matchcontinue;
+  end match;
 end traverseExpVisitorWrapper;
 
 

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -2060,7 +2060,7 @@ public function printCallFunction2StrDIVISION
     output String outString;
   end strongComponentStringRefStrFunc;
 algorithm
-  outString := matchcontinue inExp
+  outString := match inExp
     local
       String s,s_1,s_2,fs,argstr;
       Absyn.Path fcn;
@@ -2092,7 +2092,7 @@ algorithm
         s_2 := stringAppend(s_1, ")");
       then
         s_2;
-  end matchcontinue;
+  end match;
 end printCallFunction2StrDIVISION;
 
 // protected function printVarsStatistics "author: PA

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -470,7 +470,7 @@ protected function makeTransitive2 "
   output DAE.Exp outDst;
 algorithm
   (outRepl,outSrc,outDst):=
-  matchcontinue inFuncTypeExpExpToBooleanOption
+  match inFuncTypeExpExpToBooleanOption
     local
       DAE.Exp dst_1;
       // for rule a->b1+..+bn, replace all b1 to bn's in the expression;
@@ -481,7 +481,7 @@ algorithm
         (repl,src,dst_1);
         // replace Exp failed, keep old rule.
     case _ then (repl,src,dst);  /* dst has no own replacement, return */
-  end matchcontinue;
+  end match;
 end makeTransitive2;
 
 protected function addExtendReplacement
@@ -2374,7 +2374,7 @@ protected function replaceTimeEvents
   output BackendDAE.TimeEvent teOut;
 
 algorithm
-  teOut := matchcontinue teIn
+  teOut := match teIn
     local
       Integer index;
       DAE.Exp startExp, intervalExp;
@@ -2385,7 +2385,7 @@ algorithm
     then BackendDAE.SAMPLE_TIME_EVENT(index, startExp, intervalExp, teIn.iter);
   else
     then teIn;
-  end matchcontinue;
+  end match;
 end replaceTimeEvents;
 
 protected function replaceZeroCrossing"replaces the exp in the BackendDAE.ZeroCrossing"
@@ -2395,7 +2395,7 @@ protected function replaceZeroCrossing"replaces the exp in the BackendDAE.ZeroCr
   output BackendDAE.ZeroCrossing zcOut;
 
 algorithm
-  zcOut := matchcontinue zcIn
+  zcOut := match zcIn
     local
       DAE.Exp relation_;
   case BackendDAE.ZERO_CROSSING(relation_ = relation_)
@@ -2404,7 +2404,7 @@ algorithm
     then BackendDAE.ZERO_CROSSING(zcIn.index, relation_, zcIn.occurEquLst, zcIn.iter);
   else
     then zcIn;
-  end matchcontinue;
+  end match;
 end replaceZeroCrossing;
 
 

--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -2440,7 +2440,7 @@ protected function getTopLevelFactors"Gets factors(crefs only) of the exp"
   input list<DAE.Exp> lstIn;
   output list<DAE.Exp> lstOut;
 algorithm
-  lstOut := matchcontinue exp
+  lstOut := match exp
     local
       DAE.Exp e1,e2;
       list<DAE.Exp> eLst;
@@ -2457,7 +2457,7 @@ algorithm
    then e1::lstIn;
   else
     then lstIn;
-  end matchcontinue;
+  end match;
 end getTopLevelFactors;
 
 protected function printCSE"prints a CSE tuple string.

--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -2735,7 +2735,7 @@ protected function expType "gets the type of an expression"
   input DAE.Exp eIn;
   output DAE.Type tOut;
 algorithm
-  tOut := matchcontinue eIn
+  tOut := match eIn
     local
       DAE.Type t;
     case DAE.CREF(ty=t)
@@ -2746,7 +2746,7 @@ algorithm
       print("expType failed for: "+ExpressionBasics.printExpStr(eIn)+"\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end expType;
 
 protected function getScalarsForComplexVar "gets the list<ComponentRef> for the scalar values of complex vars and multidimensional vars (at least real) .

--- a/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
@@ -859,7 +859,7 @@ protected function updateIndicesInComp "author: Waurich TUD 2013-09
   input Integer eqOffset;
   output BackendDAE.StrongComponent compOut;
 algorithm
-  compOut := matchcontinue compIn
+  compOut := match compIn
     local
       Integer varIdx;
       Integer eqIdx;
@@ -876,7 +876,7 @@ algorithm
         print("updateVarEqIndices failed\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end updateIndicesInComp;
 
 protected function buildNewResidualEquation "author: Waurich TUD 2013-09
@@ -1282,7 +1282,7 @@ protected function varInFrontList "author: Waurich TUD 2013-08
   input list<list<BackendDAE.Var>> lstLstIn;
   output list<list<BackendDAE.Var>> lstLstOut;
 algorithm
-  lstLstOut := matchcontinue lstLstIn
+  lstLstOut := match lstLstIn
     local
       list<BackendDAE.Var> varLst;
     case {}
@@ -1295,7 +1295,7 @@ algorithm
         lstLstOut := List.replaceAt(varLst, 1, lstLstIn);
       then
         lstLstOut;
-  end matchcontinue;
+  end match;
 end varInFrontList;
 
 
@@ -1305,7 +1305,7 @@ protected function eqInFrontList "author: Waurich TUD 2013-08
   input list<list<BackendDAE.Equation>> lstLstIn;
   output list<list<BackendDAE.Equation>> lstLstOut;
 algorithm
-  lstLstOut := matchcontinue lstLstIn
+  lstLstOut := match lstLstIn
     local
       list<BackendDAE.Equation> eqLst;
     case {}
@@ -1318,7 +1318,7 @@ algorithm
         lstLstOut := List.replaceAt(eqLst, 1, lstLstIn);
       then
         lstLstOut;
-  end matchcontinue;
+  end match;
 end eqInFrontList;
 
 
@@ -1558,14 +1558,14 @@ protected function getCallExpLst "author: Waurich TUD 2015-08
   output DAE.Exp eOut;
   output list<DAE.Exp> eLstOut;
 algorithm
-  (eOut,eLstOut) := matchcontinue eIn
+  (eOut,eLstOut) := match eIn
     local
       list<DAE.Exp> expLst;
     case DAE.CALL(expLst=expLst)
       then (eIn,listAppend(expLst,eLstIn));
     else
       then (eIn,eLstIn);
-  end matchcontinue;
+  end match;
 end getCallExpLst;
 
 protected function getSummands "gets all sum-terms in the equation.

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -4950,7 +4950,7 @@ protected function setThreadIdxInTask "
   input Integer threadIdx;
   output HpcOmSimCode.Task taskOut;
 algorithm
-  taskOut := matchcontinue taskIn
+  taskOut := match taskIn
     local
     Integer weighting, index;
     Real calcTime, timeFinished;
@@ -4959,7 +4959,7 @@ algorithm
   then HpcOmSimCode.CALCTASK(weighting,index,calcTime,timeFinished,threadIdx,eqIdc);
   else
     then taskIn;
-  end matchcontinue;
+  end match;
 end setThreadIdxInTask;
 
 protected function tasksEqual "author: marcusw

--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -879,12 +879,12 @@ protected function isWhenEquation "author: Waurich TUD 2013-06
   input BackendDAE.StrongComponent inComp;
   output Boolean isWhenEq;
 algorithm
-  isWhenEq := matchcontinue inComp
+  isWhenEq := match inComp
   local    case BackendDAE.SINGLEWHENEQUATION()
     then
       true;
   else false;
-  end matchcontinue;
+  end match;
 end isWhenEquation;
 
 protected function fillRequiredSccs
@@ -3218,7 +3218,7 @@ protected
   list<list<Integer>> critPath, critPathWoC;
   Real costPath, costPathWoC;
 algorithm
-  oString := matchcontinue(iCriticalPaths,iCriticalPathsWoC)
+  oString := match(iCriticalPaths,iCriticalPathsWoC)
   case(({},_),_)
     algorithm
     then
@@ -3231,7 +3231,7 @@ algorithm
       tmpString := tmpString + dumpCriticalPathInfo1(critPathWoC,1);
   then
     tmpString;
-  end matchcontinue;
+  end match;
 end dumpCriticalPathInfo;
 
 protected function dumpCriticalPathInfo1 "author: marcusw
@@ -3248,7 +3248,7 @@ protected function printCriticalPathInfo "author: Waurich TUD 2013-07
   input list<list<Integer>> criticalPathsIn;
   input Real cpCosts;
 algorithm
-  () := matchcontinue criticalPathsIn
+  () := match criticalPathsIn
   case {}
     algorithm
     then
@@ -3262,7 +3262,7 @@ algorithm
     printCriticalPathInfo1(criticalPathsIn,1);
   then
     ();
-  end matchcontinue;
+  end match;
 end printCriticalPathInfo;
 
 protected function printCriticalPathInfo1 "author: Waurich TUD 2013-07
@@ -4537,7 +4537,7 @@ public function calculateCosts "author: Waurich TUD 2014-12
   input BackendDAE.CompInfo compInfo;
   output tuple<Integer,Real> exeCost;
 algorithm
-  exeCost := matchcontinue compInfo
+  exeCost := match compInfo
     local
       Integer numAdds,numMul,numDiv,numOth,numTrig,numRel,numLog,numFuncs, costs, ops,ops1, offset,size;
       Real allOpCosts,tornCosts,otherCosts,dens;
@@ -4578,7 +4578,7 @@ algorithm
         algorithm
           print("calculate costs failed!\n");
         then (-1,-1.0);
-  end matchcontinue;
+  end match;
 end calculateCosts;
 
 public function copyCosts "author: marcusw

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -6614,7 +6614,7 @@ protected function testMatchingAlgorithm
   input BackendDAE.MatchingOptions inMatchingOptions;
 algorithm
   () :=
-  matchcontinue index
+  match index
     local
       BackendDAE.StructurallySingularSystemHandlerArg arg;
     case 0
@@ -6626,7 +6626,7 @@ algorithm
         testMatchingAlgorithm(index-1,matchingAlgorithm,isyst,ishared,inMatchingOptions);
       then
         ();
-  end matchcontinue;
+  end match;
 end testMatchingAlgorithm;
 
 public function testExternMatchingAlgorithms1
@@ -6664,7 +6664,7 @@ public function testExternMatchingAlgorithm
   input Integer ne;
 algorithm
   () :=
-  matchcontinue index
+  match index
     case 0
       then ();
     else
@@ -6673,7 +6673,7 @@ algorithm
         testExternMatchingAlgorithm(index-1,matchingAlgorithm,cheapId,nv,ne);
       then
         ();
-  end matchcontinue;
+  end match;
 end testExternMatchingAlgorithm;
 
 protected function randSortSystem

--- a/OMCompiler/Compiler/BackEnd/MathematicaDump.mo
+++ b/OMCompiler/Compiler/BackEnd/MathematicaDump.mo
@@ -857,7 +857,7 @@ protected function getStartAttribute "returns the start attribute of a variable"
    input Option<DAE.VariableAttributes> inVariableAttributesOption;
    output Option<DAE.Exp> out;
 algorithm
-out:=matchcontinue inVariableAttributesOption
+out:=match inVariableAttributesOption
    local
      Option<DAE.Exp> e;
     case SOME(DAE.VAR_ATTR_REAL(start=e))
@@ -870,7 +870,7 @@ out:=matchcontinue inVariableAttributesOption
       then e;
     case _
       then NONE();
-   end matchcontinue;
+   end match;
 end getStartAttribute;
 
 annotation(__OpenModelica_Interface="backend_tools");

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -1378,7 +1378,7 @@ public function sortLoop "author:Waurich TUD 2014-01
   input list<Integer> sortLoopIn;
   output list<Integer> sortLoopOut;
 algorithm
-  sortLoopOut := matchcontinue(loopIn, sortLoopIn)
+  sortLoopOut := match(loopIn, sortLoopIn)
     local
       Integer start, next;
       list<Integer> rest, vars, eqs;
@@ -1401,7 +1401,7 @@ algorithm
         end if;
         rest := List.deleteMemberOnTrue(next,loopIn,intEq);
       then sortLoop(rest,m,mT,next::sortLoopIn);
-  end matchcontinue;
+  end match;
 end sortLoop;
 
 protected function closePathDirectly "author:Waurich TUD 2014-01

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -3105,7 +3105,7 @@ protected function hasEqnNonDiffParts
   output Boolean cont;
   output tuple<list<DAE.Exp>, Boolean, Boolean> outTpl;
 algorithm
-  (outExp, cont, outTpl) := matchcontinue(inExp, inTpl)
+  (outExp, cont, outTpl) := match(inExp, inTpl)
   local
     list<DAE.Exp> expLst;
     Boolean b, insideCall;
@@ -3129,7 +3129,7 @@ algorithm
 */
 
     case (outExp, (_, b, _)) then (outExp, b, inTpl);
-  end matchcontinue;
+  end match;
 end hasEqnNonDiffParts;
 
 protected function isRecordInvoled

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -1901,7 +1901,7 @@ protected function unknowsMatchingToMathematicaGrid2
   input list<String> eqns;
   output list<String> out;
 algorithm
-out:=matchcontinue(vars,eqns)
+out:=match(vars,eqns)
   local
     String var,eqn,s;
     list<String> var_t,eqn_t,r;
@@ -1919,7 +1919,7 @@ out:=matchcontinue(vars,eqns)
         s := var+","+eqn;
         r := unknowsMatchingToMathematicaGrid2(var_t,eqn_t);
       then s::r;
-  end matchcontinue;
+  end match;
 end unknowsMatchingToMathematicaGrid2;
 
 protected function getEquationStringOrNothing
@@ -2205,7 +2205,7 @@ protected function getEquationsForUnknownsSystem
   output list<Integer> eqnsOut;
   output list<Integer> varsOut;
 algorithm
-(eqnsOut,varsOut):=matchcontinue unknowns
+(eqnsOut,varsOut):=match unknowns
   local
     ExtAdjacencyMatrix unknownsSystem;
     list<Integer> yEqMap,yVarMap,setS;
@@ -2236,7 +2236,7 @@ algorithm
         vars := yVarMap;
         setS := restoreIndicesEquivalence(List.filter1OnTrue(arrayList(ass2),intGt,-1),yEqMap);
     then (setS,vars);
-end matchcontinue;
+end match;
 end getEquationsForUnknownsSystem;
 
 protected function getEquationsForKnownsSystem

--- a/OMCompiler/Compiler/BackEnd/Vectorization.mo
+++ b/OMCompiler/Compiler/BackEnd/Vectorization.mo
@@ -286,7 +286,7 @@ public function replaceSubscriptInCrefExp"exp-traverse-function to replace the f
   output DAE.Exp expOut;
   output list<DAE.Subscript> subsOut;
 algorithm
-  (expOut,subsOut) := matchcontinue expIn
+  (expOut,subsOut) := match expIn
     local
       DAE.ComponentRef cref;
       DAE.Type ty;
@@ -296,7 +296,7 @@ algorithm
     then (DAE.CREF(cref,ty),subsIn);
   else
     then(expIn,subsIn);
-  end matchcontinue;
+  end match;
 end replaceSubscriptInCrefExp;
 
 
@@ -1002,7 +1002,7 @@ protected function crefPartlyEqual
   input DAE.ComponentRef cref1;
   output Boolean partlyEq;
 algorithm
-  partlyEq := matchcontinue(cref0,cref1)
+  partlyEq := match(cref0,cref1)
     local
       Boolean b;
       DAE.ComponentRef cref01, cref11;
@@ -1020,7 +1020,7 @@ algorithm
       then cref0.ident ==cref1.ident;
   else
     then false;
-  end matchcontinue;
+  end match;
 end crefPartlyEqual;
 
 public function reduceLoopExpressions "strip the higher indexes in accumulated iterations"
@@ -1109,7 +1109,7 @@ public function replaceFirstSubsInCref"replaces the first occuring subscript in 
   input list<DAE.Subscript> subs;
   output DAE.ComponentRef crefOut;
 algorithm
-  crefOut := matchcontinue crefIn
+  crefOut := match crefIn
     local
       DAE.Ident ident;
       DAE.Type identType;
@@ -1126,7 +1126,7 @@ algorithm
     then DAE.CREF_IDENT(ident, identType, subscriptLst);
   else
     then crefIn;
-  end matchcontinue;
+  end match;
 end replaceFirstSubsInCref;
 
 annotation(__OpenModelica_Interface="backend");

--- a/OMCompiler/Compiler/BackEnd/VisualXML.mo
+++ b/OMCompiler/Compiler/BackEnd/VisualXML.mo
@@ -832,7 +832,7 @@ function isVisualizationVar
   input BackendDAE.Var var;
   output Boolean isVisVar;
 algorithm
-  isVisVar := matchcontinue var
+  isVisVar := match var
     local
       DAE.ElementSource source;
       String obj;
@@ -848,7 +848,7 @@ algorithm
         Util.stringNotEqual(obj, "");
 
     else false;
-  end matchcontinue;
+  end match;
 end isVisualizationVar;
 
 function isVisualizationVarFold
@@ -894,7 +894,7 @@ function hasVisPath
   output String visPath;
   output Integer numOut;
 algorithm
-  (visPath, numOut) := matchcontinue pathsIn
+  (visPath, numOut) := match pathsIn
     local
       String name;
       Absyn.Path path;
@@ -919,7 +919,7 @@ algorithm
         (name, numIn);
 
     case _::rest then hasVisPath(rest,numIn+1);
-  end matchcontinue;
+  end match;
 end hasVisPath;
 
 function dumpVis

--- a/OMCompiler/Compiler/BackEnd/XMLDump.mo
+++ b/OMCompiler/Compiler/BackEnd/XMLDump.mo
@@ -690,14 +690,14 @@ The output is something like:
   input Integer eoffset;
 algorithm
   ():=
-  matchcontinue l
+  match l
     case {}
         then();
     case _
       algorithm
         dumpComponents2(l,1+voffset,eoffset);
       then();
-  end matchcontinue;
+  end match;
 end dumpComponents1;
 
 
@@ -821,7 +821,7 @@ content of the list. The output could be something like:
   input DAE.InstDims arry_Dim;
   input String Content;
 algorithm
-    () := matchcontinue arry_Dim
+    () := match arry_Dim
    local    case {}
       then ();
     else
@@ -830,7 +830,7 @@ algorithm
         dumpDAEInstDims2(arry_Dim);
         dumpStrCloseTag(Content);
       then();
-  end matchcontinue;
+  end match;
 end dumpDAEInstDims;
 
 
@@ -2140,7 +2140,7 @@ This function dumps a list of functions
 "
   input list<DAE.Function> funcelems;
 algorithm
-  () := matchcontinue funcelems
+  () := match funcelems
     local
     case {} then();
     case _
@@ -2149,7 +2149,7 @@ algorithm
         dumpFunctions2(funcelems);
         dumpStrCloseTag(FUNCTIONS);
       then();
-  end matchcontinue;
+  end match;
 end dumpFunctions;
 
 
@@ -2415,7 +2415,7 @@ the XML delimiters tag of the list.
   input String inContent;
   input String inElementContent;
 algorithm
-  ():= matchcontinue (lst,inContent,inElementContent)
+  ():= match (lst,inContent,inElementContent)
   local
     list<Integer> l;
     String inLst,inEl;
@@ -2426,7 +2426,7 @@ algorithm
         dumpLstInt(l,inEl);
         dumpStrCloseTag(inLst);
       then();
-  end matchcontinue;
+  end match;
 end dumpLstIntAttr;
 
 protected function dumpMatching
@@ -2679,7 +2679,7 @@ protected function dumpStrCloseTag "
   input String inContent;
 algorithm
   ():=
-  matchcontinue inContent
+  match inContent
       local String inString;
   case ""
     algorithm
@@ -2688,7 +2688,7 @@ algorithm
     algorithm
       Print.printBuf("\n</");Print.printBuf(transformModelicaIdentifierToXMLElementTag(inString));Print.printBuf(">");
     then ();
-  end matchcontinue;
+  end match;
 end dumpStrCloseTag;
 
 protected function dumpStreamStr "
@@ -2850,7 +2850,7 @@ protected function dumpStrTagContent "
   input String inContent;
 algorithm
   ():=
-  matchcontinue (inElementName,inContent)
+  match (inElementName,inContent)
       local String inTagString,inTagContent;
   case ("",_)  then ();
   case (_,"")  then ();
@@ -2860,7 +2860,7 @@ algorithm
       Print.printBuf("\n");Print.printBuf(inTagContent);
       dumpStrCloseTag(inTagString);
     then ();
-  end matchcontinue;
+  end match;
 end dumpStrTagContent;
 
 
@@ -2873,7 +2873,7 @@ print on a new line an XML code like:
 "
   input String inElementName;
 algorithm
-  ():=matchcontinue inElementName
+  ():=match inElementName
   local String ElementName;
     case "" then();
     case ElementName
@@ -2882,7 +2882,7 @@ algorithm
          Print.printBuf(transformModelicaIdentifierToXMLElementTag(ElementName));
          Print.printBuf("/>");
       then();
-  end matchcontinue;
+  end match;
 end dumpStrVoidTag;
 
 protected function dumpDimension "
@@ -3960,7 +3960,7 @@ function: unparseCommentOptionNoAnnotation
   output String outString;
 algorithm
   outString:=
-  matchcontinue inAbsynCommentOption
+  match inAbsynCommentOption
     local String str,cmt;
     case SOME(SCode.COMMENT(_,SOME(cmt)))
       algorithm
@@ -3969,7 +3969,7 @@ algorithm
       then
         str;
     case _ then "";
-  end matchcontinue;
+  end match;
 end unparseCommentOptionNoAnnotation;
 
 annotation(__OpenModelica_Interface="backend");

--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
@@ -1044,7 +1044,7 @@ protected function analyseCref
   input Graph inGraph;
   output Graph outGraph;
 algorithm
-  outGraph := matchcontinue(inCref, inGraph)
+  outGraph := match(inCref, inGraph)
     local
       Graph g;
 
@@ -1056,7 +1056,7 @@ algorithm
       then
         g;
 
-  end matchcontinue;
+  end match;
 end analyseCref;
 
 protected function analyseExpTraverserExit

--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
@@ -1026,7 +1026,7 @@ protected function analyseCref
   input Graph inGraph;
   output Graph outGraph;
 algorithm
-  outGraph := matchcontinue(inCref, inGraph)
+  outGraph := match(inCref, inGraph)
     local
       Graph g;
 
@@ -1038,7 +1038,7 @@ algorithm
       then
         g;
 
-  end matchcontinue;
+  end match;
 end analyseCref;
 
 protected function analyseExpTraverserExit

--- a/OMCompiler/Compiler/FFrontEnd/FNode.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FNode.mo
@@ -1232,7 +1232,7 @@ public function lookupRef
   input Scope inScope;
   output Ref outRef;
 algorithm
-  outRef := matchcontinue inScope
+  outRef := match inScope
     local
       Scope s;
       Ref r;
@@ -1248,7 +1248,7 @@ algorithm
         r := lookupRef_dispatch(inRef, s);
       then
         r;
-  end matchcontinue;
+  end match;
 end lookupRef;
 
 public function lookupRef_dispatch

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -5754,14 +5754,14 @@ protected function eltsHasLocalClass
   input list<Absyn.ElementItem> inElts;
   output Boolean res;
 algorithm
-  res := matchcontinue inElts
+  res := match inElts
     local
       list<Absyn.ElementItem> elts;
 
     case Absyn.ELEMENTITEM(Absyn.ELEMENT(specification=Absyn.CLASSDEF())) :: _ then true;
     case _ :: elts then eltsHasLocalClass(elts);
     else false;
-  end matchcontinue;
+  end match;
 end eltsHasLocalClass;
 
 protected function traverseInnerClass<Arg>

--- a/OMCompiler/Compiler/FrontEnd/Algorithm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Algorithm.mo
@@ -715,7 +715,7 @@ public function makeParFor "This function creates a DAE.STMT_PARFOR construct, c
   input DAE.ElementSource source;
   output DAE.Statement outStatement;
 algorithm
-  outStatement := matchcontinue (inIdent, inExp, inProperties, inStatementLst)
+  outStatement := match (inIdent, inExp, inProperties, inStatementLst)
     local
       Boolean isArray;
       String i, e_str, t_str;
@@ -737,7 +737,7 @@ algorithm
         Error.addSourceMessage(Error.FOR_EXPRESSION_TYPE_ERROR, {e_str, t_str}, ElementSource.getElementSourceFileInfo(source));
       then
         fail();
-  end matchcontinue;
+  end match;
 end makeParFor;
 
 public function makeWhile "This function creates a DAE.STMT_WHILE construct, checking that the types
@@ -749,7 +749,7 @@ public function makeWhile "This function creates a DAE.STMT_WHILE construct, che
   output DAE.Statement outStatement;
 algorithm
   outStatement:=
-  matchcontinue (inExp, inProperties, inStatementLst)
+  match (inExp, inProperties, inStatementLst)
     local
       DAE.Exp e;
       list<DAE.Statement> stmts;
@@ -763,7 +763,7 @@ algorithm
         Error.addSourceMessage(Error.WHILE_CONDITION_TYPE_ERROR, {e_str, t_str}, ElementSource.getElementSourceFileInfo(source));
       then
         fail();
-  end matchcontinue;
+  end match;
 end makeWhile;
 
 public function makeWhenA "This function creates a DAE.STMT_WHEN algorithm construct,
@@ -776,7 +776,7 @@ public function makeWhenA "This function creates a DAE.STMT_WHEN algorithm const
   output DAE.Statement outStatement;
 algorithm
   outStatement:=
-  matchcontinue (inExp, inProperties, inStatementLst, elseWhenStmt)
+  match (inExp, inProperties, inStatementLst, elseWhenStmt)
     local
       DAE.Exp e;
       list<DAE.Statement> stmts;
@@ -792,7 +792,7 @@ algorithm
         Error.addSourceMessage(Error.WHEN_CONDITION_TYPE_ERROR, {e_str, t_str}, ElementSource.getElementSourceFileInfo(source));
       then
         fail();
-  end matchcontinue;
+  end match;
 end makeWhenA;
 
 public function makeReinit " creates a reinit statement in an algorithm
@@ -837,7 +837,7 @@ public function makeAssert "Creates an assert statement from two expressions.
   input DAE.ElementSource source;
   output list<DAE.Statement> outStatement;
 algorithm
-  outStatement := matchcontinue (cond, inProperties3, inProperties4, inProperties5)
+  outStatement := match (cond, inProperties3, inProperties4, inProperties5)
     local
       SourceInfo info;
       DAE.Type t1, t2, t3;
@@ -860,7 +860,7 @@ algorithm
         strTy := TypesDump.unparseType(t3);
         Error.assertionOrAddSourceMessage(Types.isString(t3), Error.EXP_TYPE_MISMATCH, {strExp, "AssertionLevel", strTy}, info);
       then fail();
-  end matchcontinue;
+  end match;
 end makeAssert;
 
 public function makeTerminate "

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1107,7 +1107,7 @@ Function for extracting the name and type out of the first cref of a componentRe
   output DAE.Type res;
 algorithm
   (id,res) :=
-  matchcontinue inRef
+  match inRef
     local
       DAE.Type t2;
       DAE.Ident name;
@@ -1125,7 +1125,7 @@ algorithm
         Debug.traceln(s);
       then
         fail();
-  end matchcontinue;
+  end match;
 end crefNameType;
 
 public function getArrayCref
@@ -1772,7 +1772,7 @@ A function for replacing any occurance of DAE.SLICE or DAE.WHOLEDIM with new sub
   input list<DAE.Subscript> inSub;
   output list<DAE.Subscript> osubs;
 algorithm
-  osubs := matchcontinue inSubs
+  osubs := match inSubs
     local
       list<DAE.Subscript> subs;
       DAE.Subscript sub;
@@ -1798,7 +1798,7 @@ algorithm
         subs := replaceSliceSub(subs,inSub);
       then
         (sub::subs);
-  end matchcontinue;
+  end match;
 end replaceSliceSub;
 
 public function stripCrefIdentSliceSubs "
@@ -1984,7 +1984,7 @@ public function crefStripLastIdent
   input DAE.ComponentRef inCr;
   output DAE.ComponentRef outCr;
 algorithm
-  outCr := matchcontinue inCr
+  outCr := match inCr
     local
       DAE.Ident id;
       list<DAE.Subscript> subs;
@@ -2000,7 +2000,7 @@ algorithm
         cr1 := crefStripLastIdent(cr);
       then
         ComponentReferenceBasics.makeCrefQual(id,t2,subs,cr1);
-  end matchcontinue;
+  end match;
 end crefStripLastIdent;
 
 public function crefStripIterSub
@@ -2273,7 +2273,7 @@ public function firstNCrefs
   output DAE.ComponentRef outFirstCrefs;
 
 algorithm
-  outFirstCrefs := matchcontinue(inCref,nIn)
+  outFirstCrefs := match(inCref,nIn)
     local
       DAE.Ident id;
       DAE.Type ty;
@@ -2297,7 +2297,7 @@ algorithm
       else
         then (inCref);
 
-  end matchcontinue;
+  end match;
 end firstNCrefs;
 
 public function splitCrefFirst
@@ -2389,7 +2389,7 @@ public function expandCref
   input Boolean expandRecord;
   output list<DAE.ComponentRef> outCref;
 algorithm
-  outCref := matchcontinue expandRecord
+  outCref := match expandRecord
     case _ then expandCref_impl(inCref,expandRecord);
 
     else
@@ -2400,7 +2400,7 @@ algorithm
       then
         fail();
 
-  end matchcontinue;
+  end match;
 end expandCref;
 
 public function expandCref_impl

--- a/OMCompiler/Compiler/FrontEnd/ConnectionGraph.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectionGraph.mo
@@ -670,7 +670,7 @@ protected function findResultGraph
   output DaeEdges outConnectedConnections;
   output DaeEdges outBrokenConnections;
 algorithm
-  (outRoots, outConnectedConnections, outBrokenConnections) := matchcontinue inGraph
+  (outRoots, outConnectedConnections, outBrokenConnections) := match inGraph
     local
       DefiniteRoots definiteRoots, finalRoots;
       PotentialRoots potentialRoots, orderedPotentialRoots;
@@ -742,7 +742,7 @@ algorithm
       then
         (finalRoots, connected, broken);
 
-  end matchcontinue;
+  end match;
 end findResultGraph;
 
 protected function orderConnectsGuidedByUser
@@ -957,7 +957,7 @@ protected function evalConnectionsOperators
   input list<DAE.Element> inDae;
   output list<DAE.Element> outDae;
 algorithm
-  outDae := matchcontinue inDae
+  outDae := match inDae
     local
       HashTable.HashTable rooted;
       HashTable3.HashTable table;
@@ -984,7 +984,7 @@ algorithm
         (outDae, _) := DAEUtil.traverseDAEElementList(inDae, evalConnectionsOperatorsHelper, (rooted,inRoots,graph));
       then outDae;
 
-  end matchcontinue;
+  end match;
 end evalConnectionsOperators;
 
 protected function evalConnectionsOperatorsHelper
@@ -1772,7 +1772,7 @@ public function addBrokenEqualityConstraintEquations
   input DaeEdges inBroken;
   output DAE.DAElist outDAE;
 algorithm
-  outDAE := matchcontinue inBroken
+  outDAE := match inBroken
     local
       list<DAE.Element> equalityConstraintElements;
       DAE.DAElist dae;
@@ -1786,7 +1786,7 @@ algorithm
       then
         dae;
 
-  end matchcontinue;
+  end match;
 end addBrokenEqualityConstraintEquations;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -134,12 +134,12 @@ protected function funcGreaterThan "sorting function for two DAE.Element that ar
   input DAE.Function func2;
   output Boolean res;
 algorithm
-  res := matchcontinue func2
+  res := match func2
     case _ algorithm
       res := stringCompare(functionNameStr(func1),functionNameStr(func2)) > 0;
     then res;
     else true;
-  end matchcontinue;
+  end match;
 end funcGreaterThan;
 
 public function dumpOperatorString "
@@ -1823,7 +1823,7 @@ protected function indent "
   input Integer inInteger;
 algorithm
   ():=
-  matchcontinue inInteger
+  match inInteger
     local Integer i_1,i;
     case 0 then ();
     case i
@@ -1833,7 +1833,7 @@ algorithm
         indent(i_1);
       then
         ();
-  end matchcontinue;
+  end match;
 end indent;
 
 protected function indentStr "
@@ -1843,7 +1843,7 @@ protected function indentStr "
   output String outString;
 algorithm
   outString:=
-  matchcontinue inInteger
+  match inInteger
     local
       Integer i_1,i;
       String s1,str;
@@ -1855,7 +1855,7 @@ algorithm
         str := stringAppend(" ", s1);
       then
         str;
-  end matchcontinue;
+  end match;
 end indentStr;
 
 public function dumpDebug "
@@ -2244,7 +2244,7 @@ protected function buildGrVars "Helper function to build_graphviz.
   input list<DAE.Element> inElementLst;
   output list<Graphviz.Node> outGraphvizNodeLst;
 algorithm
-  outGraphvizNodeLst := matchcontinue inElementLst
+  outGraphvizNodeLst := match inElementLst
     local
       list<String> strlist;
       list<DAE.Element> vars;
@@ -2254,7 +2254,7 @@ algorithm
         (strlist,_) := buildGrStrlist(vars, buildGrVarStr, 10);
       then
         {Graphviz.LNODE("VARS",strlist,{Graphviz.box},{})};
-  end matchcontinue;
+  end match;
 end buildGrVars;
 
 public function buildGrStrlist "Helper function to build_graphviz.
@@ -2327,7 +2327,7 @@ protected function printExpStrSpecial "
   output String outString;
 algorithm
   outString:=
-  matchcontinue inExp
+  match inExp
     local
       String s_1,s_2,s,str;
       DAE.Exp exp;
@@ -2342,7 +2342,7 @@ algorithm
         str := ExpressionBasics.printExpStr(exp);
       then
         str;
-  end matchcontinue;
+  end match;
 end printExpStrSpecial;
 
 protected function buildGrElement "
@@ -2457,7 +2457,7 @@ public function unparseDimensions
   input Boolean printTypeDimension "use true here when printing components in functions as these are not vectorized! Otherwise, use false";
   output String dimsStr;
 algorithm
-  dimsStr := matchcontinue(dims, printTypeDimension)
+  dimsStr := match(dims, printTypeDimension)
     local
       String str;
 
@@ -2472,7 +2472,7 @@ algorithm
        str := "[" + stringDelimitList(List.map(dims, ExpressionBasics.dimensionString), ", ") + "]";
      then
        str;
-  end matchcontinue;
+  end match;
 end unparseDimensions;
 
 public function dumpStr "This function prints the DAE to a string."
@@ -3654,7 +3654,7 @@ public function cmtListToString
   input list<SCode.Comment> inCmtLst;
   output String outStr;
 algorithm
-  outStr := matchcontinue inCmtLst
+  outStr := match inCmtLst
     local
       SCode.Comment c;
       list<SCode.Comment> rest;
@@ -3677,7 +3677,7 @@ algorithm
 
     else "";
 
-  end matchcontinue;
+  end match;
 end cmtListToString;
 
 public function clockKindString

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -230,7 +230,7 @@ public function getDerivativePaths " collects all paths representing derivative 
   input list<DAE.FunctionDefinition> inFuncDefs;
   output list<Absyn.Path> paths;
 algorithm
-  paths := matchcontinue inFuncDefs
+  paths := match inFuncDefs
     local
       list<Absyn.Path> pLst1,pLst2;
       Absyn.Path p1,p2;
@@ -253,7 +253,7 @@ algorithm
         paths;
 
     case _::funcDefs then getDerivativePaths(funcDefs);
-  end matchcontinue;
+  end match;
 end getDerivativePaths;
 
 public function addEquationBoundString "
@@ -2895,7 +2895,7 @@ public function getStatement
   output list<DAE.Statement> outStatements;
 algorithm
   outStatements:=
-  matchcontinue inElement
+  match inElement
     local
       list<DAE.Statement> stmts;
     case DAE.ALGORITHM(algorithm_ = DAE.ALGORITHM_STMTS(statementLst = stmts))
@@ -2907,7 +2907,7 @@ algorithm
         Debug.trace("- Differentiatte.getStatement failed\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end getStatement;
 
 public function getTupleSize "gets the size of a DAE.TUPLE"
@@ -4748,7 +4748,7 @@ public function joinDaeLst "joins a list of daes by using joinDaes"
   input list<DAE.DAElist> idaeLst;
   output DAE.DAElist outDae;
 algorithm
-  outDae := matchcontinue idaeLst
+  outDae := match idaeLst
     local
       DAE.DAElist dae,dae1;
       list<DAE.DAElist> daeLst;
@@ -4758,7 +4758,7 @@ algorithm
         dae1 := joinDaeLst(daeLst);
         dae := joinDaes(dae,dae1);
       then dae;
-  end matchcontinue;
+  end match;
 end joinDaeLst;
 
 public function splitElements
@@ -6690,7 +6690,7 @@ protected
 algorithm
   DAE.CREF(componentRef = cref) := crefExp;
   DAE.CREF(componentRef = baseCref) := baseExp;
-  safe := matchcontinue (cref, baseCref)
+  safe := match (cref, baseCref)
     // Wholesale c -- always disqualify if any field already written.
     case (DAE.CREF_IDENT(ident = headIdent), DAE.CREF_IDENT(ident = baseIdent))
       then not (stringEq(headIdent, baseIdent) and not listEmpty(writtenFields));
@@ -6703,7 +6703,7 @@ algorithm
     case (DAE.CREF_QUAL(ident = headIdent), DAE.CREF_IDENT(ident = baseIdent))
       then not (stringEq(headIdent, baseIdent) and not listEmpty(writtenFields));
     else true;
-  end matchcontinue;
+  end match;
 end optMRFACheckCrefRead;
 annotation(__OpenModelica_Interface="frontend_base");
 end DAEUtil;

--- a/OMCompiler/Compiler/FrontEnd/Dump.mo
+++ b/OMCompiler/Compiler/FrontEnd/Dump.mo
@@ -580,7 +580,7 @@ public function printSubscriptsStr "Prettyprint a Subscript list to a string."
   input list<Absyn.Subscript> inAbsynSubscriptLst;
   output String outString;
 algorithm
-  outString := matchcontinue inAbsynSubscriptLst
+  outString := match inAbsynSubscriptLst
     local
       String s,s_1,s_2;
       list<Absyn.Subscript> l;
@@ -594,7 +594,7 @@ algorithm
         s_2 := stringAppend(s_1, "]");
       then
         s_2;
-  end matchcontinue;
+  end match;
 end printSubscriptsStr;
 
 public function printFunctionArgsStr "

--- a/OMCompiler/Compiler/FrontEnd/DumpGraphviz.mo
+++ b/OMCompiler/Compiler/FrontEnd/DumpGraphviz.mo
@@ -429,7 +429,7 @@ protected function printAlgorithmitem "Create a Node from an AlgorithmItem."
   input Absyn.AlgorithmItem inAlgorithmItem;
   output Graphviz.Node outNode;
 algorithm
-  outNode := matchcontinue inAlgorithmItem
+  outNode := match inAlgorithmItem
     local
       Graphviz.Node node;
       Absyn.Algorithm alg;
@@ -440,19 +440,19 @@ algorithm
       then
         node;
     else Graphviz.NODE("ALG_ERROR",{},{});
-  end matchcontinue;
+  end match;
 end printAlgorithmitem;
 
 protected function printAlgorithm "Create a Node from an Algorithm."
   input Absyn.Algorithm inAlgorithm;
   output Graphviz.Node outNode;
 algorithm
-  outNode := matchcontinue inAlgorithm
+  outNode := match inAlgorithm
     local
 
     case Absyn.ALG_ASSIGN() then Graphviz.NODE("ALG_ASSIGN",{},{});
     else Graphviz.NODE(" DumpGraphviz.printAlgorithm ALG_ERROR",{},{});
-  end matchcontinue;
+  end match;
 end printAlgorithm;
 
 protected function variabilitySymbol "Return Variability as a string."

--- a/OMCompiler/Compiler/FrontEnd/ExpressionDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionDump.mo
@@ -1497,7 +1497,7 @@ protected function genStringNTime
   input Integer inInteger;
   output String outString;
 algorithm
-  outString := matchcontinue (inString,inInteger)
+  outString := match (inString,inInteger)
     local
       String str,new_str,res_str;
       Integer new_level,level;
@@ -1511,7 +1511,7 @@ algorithm
         res_str := stringAppend(str, new_str);
       then
         res_str;
-  end matchcontinue;
+  end match;
 end genStringNTime;
 
 public function dumpExp
@@ -1536,7 +1536,7 @@ public function printArraySizes "Function: printArraySizes"
   input list<Option <Integer>> inLst;
   output String out;
 algorithm
-  out := matchcontinue inLst
+  out := match inLst
     local
       Integer x;
       list<Option<Integer>> lst;
@@ -1555,7 +1555,7 @@ algorithm
       algorithm
         s := printArraySizes(lst);
       then s;
-  end matchcontinue;
+  end match;
 end printArraySizes;
 
 public function typeOfString

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -429,7 +429,7 @@ public function inlineAlgorithm
   output DAE.Algorithm outAlgorithm;
   output Boolean inlined;
 algorithm
-  (outAlgorithm,inlined) := matchcontinue(inAlgorithm,inElementList)
+  (outAlgorithm,inlined) := match(inAlgorithm,inElementList)
     local
       list<DAE.Statement> stmts,stmts_1;
       Functiontuple fns;
@@ -444,7 +444,7 @@ algorithm
         Debug.trace("Inline.inlineAlgorithm failed\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end inlineAlgorithm;
 
 public function inlineStatements
@@ -1247,7 +1247,7 @@ Author: Frenkel TUD, 2010-05"
   input Functiontuple fns;
   output Boolean outb;
 algorithm
-  outb := matchcontinue(inIT,fns)
+  outb := match(inIT,fns)
     local
       DAE.InlineType it;
       list<DAE.InlineType> itlst;
@@ -1257,7 +1257,7 @@ algorithm
        b := listMember(it,itlst);
       then b;
     else false;
-  end matchcontinue;
+  end match;
 end checkInlineType;
 
 // TODO: mahge: This needs to be rewritten completely.

--- a/OMCompiler/Compiler/FrontEnd/InstBasics.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBasics.mo
@@ -51,7 +51,7 @@ public function commentIsInlineFunc
   input SCode.Comment cmt;
   output DAE.InlineType outInlineType;
 algorithm
-  outInlineType := matchcontinue cmt
+  outInlineType := match cmt
     local
       list<SCode.SubMod> smlst;
 
@@ -59,7 +59,7 @@ algorithm
       then isInlineFunc2(smlst);
 
     else DAE.DEFAULT_INLINE();
-  end matchcontinue;
+  end match;
 end commentIsInlineFunc;
 
 protected function isInlineFunc2

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -825,7 +825,7 @@ protected function potentialRootArguments
   output Absyn.ComponentRef outCref;
   output Integer outPriority;
 algorithm
-  (outCref, outPriority) := matchcontinue inFunctionArgs
+  (outCref, outPriority) := match inFunctionArgs
     local
       Absyn.ComponentRef cr;
       Integer p;
@@ -841,7 +841,7 @@ algorithm
         Error.addSourceMessage(Error.WRONG_TYPE_OR_NO_OF_ARGS, {s1, s2}, info);
       then
         fail();
-  end matchcontinue;
+  end match;
 end potentialRootArguments;
 
 protected function uniqueRootArguments
@@ -852,7 +852,7 @@ protected function uniqueRootArguments
   output Absyn.ComponentRef outCref;
   output Absyn.Exp outMessage;
 algorithm
-  (outCref, outMessage) := matchcontinue inFunctionArgs
+  (outCref, outMessage) := match inFunctionArgs
     local
       Absyn.ComponentRef cr;
       Absyn.Exp msg;
@@ -868,7 +868,7 @@ algorithm
         Error.addSourceMessage(Error.WRONG_TYPE_OR_NO_OF_ARGS, {s1, s2}, info);
       then
         fail();
-  end matchcontinue;
+  end match;
 end uniqueRootArguments;
 
 protected function checkReinitType
@@ -1061,7 +1061,7 @@ The expand adds the elements at the end and they are containing Absyn.WILD() exp
   output Absyn.Exp outExp;
   output DAE.Properties oprop;
 algorithm
-  (outExp,oprop) := matchcontinue(inExp,propCall,propTuple)
+  (outExp,oprop) := match(inExp,propCall,propTuple)
   local
     list<Absyn.Exp> aexpl,aexpl2;
     list<DAE.Type> typeList;
@@ -1109,7 +1109,7 @@ algorithm
     then
       fail();
 
-  end matchcontinue;
+  end match;
 end expandTupleEquationWithWild;
 
 protected function instEquationCommonCiTrans

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -1430,7 +1430,7 @@ protected function printGraph
   input list<tuple<Element, list<Element>>> cycles;
   type Element = tuple<SCode.Element, DAE.Mod>;
 algorithm
-  () := matchcontinue g
+  () := match g
     // nothing for empty graph
     case {} then ();
     // show me something!
@@ -1440,7 +1440,7 @@ algorithm
         print("Element order:\n\t" + stringDelimitList(List.map(order, elementName), "\n\t") + "\n");
         print("Cycles:\n" + Graph.printGraph(cycles, elementName) + "\n");
       then ();
-  end matchcontinue;
+  end match;
 end printGraph;
 
 protected function getDepsFromExps
@@ -6959,7 +6959,7 @@ protected function mergeClassComments
   input SCode.Comment comment2;
   output SCode.Comment outComment;
 algorithm
-  outComment := matchcontinue(comment1, comment2)
+  outComment := match(comment1, comment2)
     local
       Option<SCode.Annotation> ann1,ann2,ann;
       Option<String> str1,str2,str;
@@ -6975,7 +6975,7 @@ algorithm
         str := if isSome(str1) then str1 else str2;
         ann := if isSome(ann1) then ann1 else ann2;
       then SCode.COMMENT(ann,str);
-  end matchcontinue;
+  end match;
 end mergeClassComments;
 
 public function makeNonExpSubscript

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -1353,7 +1353,7 @@ if variable is not constant."
   input DAE.Type tp;
   input DAE.ComponentRef cref;
 algorithm
-  () := matchcontinue attr
+  () := match attr
     local
       String s1,s2;
 
@@ -1378,7 +1378,7 @@ algorithm
         true := Flags.isSet(Flags.FAILTRACE);
         Debug.traceln("- Lookup.checkPackageVariableConstant failed: " + s1 + " in " + s2);
       then fail();
-  end matchcontinue;
+  end match;
 end checkPackageVariableConstant;
 
 public function lookupVarInternal "Helper function to lookupVar. Searches the frames for variables."
@@ -2533,10 +2533,10 @@ protected function selectModifier
   input DAE.Mod inModNoID;
   output DAE.Mod outMod;
 algorithm
-  outMod := matchcontinue inModID
+  outMod := match inModID
     case DAE.NOMOD() then inModNoID;
     else inModID;
-  end matchcontinue;
+  end match;
 end selectModifier;
 
 protected function buildRecordConstructorElts

--- a/OMCompiler/Compiler/FrontEnd/Mod.mo
+++ b/OMCompiler/Compiler/FrontEnd/Mod.mo
@@ -1094,7 +1094,7 @@ protected function mergeModifiers
   input SCode.Mod inSMod;
   output DAE.Mod outMod;
 algorithm
-  outMod := matchcontinue inSMod
+  outMod := match inSMod
     local
       DAE.Mod m;
       list<SCode.SubMod> sl;
@@ -1109,7 +1109,7 @@ algorithm
 
     else inMod;
 
-  end matchcontinue;
+  end match;
 end mergeModifiers;
 
 protected function mergeSubMods
@@ -2862,7 +2862,7 @@ public function addEachOneLevel
   input DAE.Mod inMod;
   output DAE.Mod outMod;
 algorithm
-  outMod := matchcontinue inMod
+  outMod := match inMod
     local
       SCode.Final finalPrefix;
       SCode.Element el;
@@ -2887,7 +2887,7 @@ algorithm
       then
         fail();
 
-  end matchcontinue;
+  end match;
 end addEachOneLevel;
 
 public function addEachToSubsIfNeeded

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
@@ -347,7 +347,7 @@ protected function analyseItemIfRedeclares
   input Item inItem;
   input Env inEnv;
 algorithm
-  () := matchcontinue inRepls
+  () := match inRepls
     local
       Env env;
     // no replacements happened on the environemnt! do nothing
@@ -358,7 +358,7 @@ algorithm
         //i = NFSCodeEnv.setItemEnv(inItem, {cls_frm});
         analyseItemNoStopOnUsed(inItem, env);
       then ();
-  end matchcontinue;
+  end match;
 end analyseItemIfRedeclares;
 
 protected function analyseItemNoStopOnUsed

--- a/OMCompiler/Compiler/FrontEnd/OperatorOverloading.mo
+++ b/OMCompiler/Compiler/FrontEnd/OperatorOverloading.mo
@@ -1948,7 +1948,7 @@ function replaceOperatorWithFcall "Replaces a userdefined operator expression wi
   input DAE.Const inConst;
   output DAE.Exp outExp;
 algorithm
-  outExp := matchcontinue (AbExp, inExp1, inOper, inExp2)
+  outExp := match (AbExp, inExp1, inOper, inExp2)
     local
       DAE.Exp e1,e2;
       Absyn.Path funcname;
@@ -1983,7 +1983,7 @@ algorithm
     case (Absyn.RELATION(_,_,_), e1, _, SOME(e2))
       then DAE.RELATION(e1, inOper, e2, -1, NONE());
 
-  end matchcontinue;
+  end match;
 end replaceOperatorWithFcall;
 
 function warnUnsafeRelations "Check if we have Real == Real or Real != Real, if so give a warning."

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -2122,7 +2122,7 @@ protected function elabResultExp
   output Option<DAE.Type> resType;
 algorithm
   (outCache,outBody,resExp,resultInfo,resType) :=
-  matchcontinue (inCache,inEnv,inBody,AbsynUtil.stripCommentExpressions(exp))
+  match (inCache,inEnv,inBody,AbsynUtil.stripCommentExpressions(exp))
     local
       DAE.Exp elabExp;
       DAE.Properties prop;
@@ -2142,7 +2142,7 @@ algorithm
         (elabExp,ty) := makeTupleFromMetaTuple(elabExp,ty);
         (body,elabExp,info) := elabResultExp2(not Flags.isSet(Flags.PATTERNM_MOVE_LAST_EXP),body,elabExp,inInfo);
       then (cache,body,SOME(elabExp),info,SOME(ty));
-  end matchcontinue;
+  end match;
 end elabResultExp;
 
 protected function elabPatternGuard

--- a/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
@@ -241,7 +241,7 @@ public function prefixLast "Returns the last NONPRE Prefix of a prefix"
   input DAE.Prefix inPrefix;
   output DAE.Prefix outPrefix;
 algorithm
-  outPrefix := matchcontinue inPrefix
+  outPrefix := match inPrefix
     local
       DAE.ComponentPrefix p;
       DAE.Prefix res;
@@ -254,7 +254,7 @@ algorithm
         res := prefixLast(DAE.PREFIX(p,cp));
       then
         res;
-  end matchcontinue;
+  end match;
 end prefixLast;
 
 public function prefixStripLast
@@ -478,7 +478,7 @@ public function makeCrefFromPrefixNoFail
   input DAE.Prefix pre;
   output DAE.ComponentRef cref;
 algorithm
-  cref := matchcontinue pre
+  cref := match pre
     local
       DAE.ComponentRef c;
 
@@ -499,7 +499,7 @@ algorithm
         c := prefixToCref(pre);
       then
         c;
-  end matchcontinue;
+  end match;
 end makeCrefFromPrefixNoFail;
 
 protected function prefixSubscriptsInCref "help function to prefixToCrefOpt2, deals with prefixing expressions in subscripts"
@@ -1228,13 +1228,13 @@ public function makePrefixString "helper function for Mod.verifySingleMod, prett
   input DAE.Prefix pre;
   output String str;
 algorithm
-  str := matchcontinue pre
+  str := match pre
     case DAE.NOPRE() then "from top scope";
     case _
       algorithm
         str := "from calling scope: " + printPrefixStr(pre);
       then str;
-  end matchcontinue;
+  end match;
 end makePrefixString;
 
 public function prefixExpressionsInType

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -249,7 +249,7 @@ function countParts
   input SCode.Element inClass;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inClass
+  outInteger := match inClass
     local
       Integer res;
       list<SCode.Element> elts;
@@ -269,7 +269,7 @@ algorithm
 
     else 0;
 
-  end matchcontinue;
+  end match;
 end countParts;
 
 function componentNames
@@ -4145,7 +4145,7 @@ public function mergeModifiers
   input SCode.Mod inOldMod;
   output SCode.Mod outMod;
 algorithm
-  outMod := matchcontinue(inNewMod, inOldMod)
+  outMod := match(inNewMod, inOldMod)
     local
       SCode.Final f1, f2;
       SCode.Each e1, e2;
@@ -4176,7 +4176,7 @@ algorithm
 
     else inNewMod;
 
-  end matchcontinue;
+  end match;
 end mergeModifiers;
 
 protected function mergeSubMods

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -10236,7 +10236,7 @@ protected function lookupFunctionsInEnvNoError
   output FCore.Cache outCache;
   output list<DAE.Type> outTypesTypeLst;
 algorithm
-  (outCache, outTypesTypeLst) := matchcontinue inInfo
+  (outCache, outTypesTypeLst) := match inInfo
 
     case _
       algorithm
@@ -10253,7 +10253,7 @@ algorithm
         ErrorExt.rollBack("Static.lookupFunctionsInEnvNoError");
       then
         fail();
-  end matchcontinue;
+  end match;
 end lookupFunctionsInEnvNoError;
 
 
@@ -10316,7 +10316,7 @@ public function fixEnumerationType
   input DAE.Type inType;
   output DAE.Type outType;
 algorithm
-  outType := matchcontinue inType
+  outType := match inType
     local
       Absyn.Path p;
       list<String> n;
@@ -10326,7 +10326,7 @@ algorithm
       then DAE.T_ENUMERATION(NONE(), p, n, v, al);
 
     else inType;
-  end matchcontinue;
+  end match;
 end fixEnumerationType;
 
 public function applySubscriptsVariability
@@ -10376,7 +10376,7 @@ protected function fillCrefSubscripts
   input DAE.Type inType;
   output DAE.ComponentRef outComponentRef;
 algorithm
-  outComponentRef := matchcontinue (inComponentRef,inType/*,slicedExp*/)
+  outComponentRef := match (inComponentRef,inType/*,slicedExp*/)
     local
       DAE.ComponentRef e,cref_1,cref;
       DAE.Type t;
@@ -10400,7 +10400,7 @@ algorithm
         cref_1 := fillCrefSubscripts(cref, t);
       then
         ComponentReferenceBasics.makeCrefQual(id,ty2,subs,cref_1);
-  end matchcontinue;
+  end match;
 end fillCrefSubscripts;
 
 protected function stripPrefixType

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -112,7 +112,7 @@ end isDiscreteType;
 public function propsAnd "Function for merging a list of properties, currently only working on DAE.PROP() and not TUPLE_DAE.PROP()."
   input list<DAE.Properties> inProps;
   output DAE.Properties outProp;
-algorithm outProp := matchcontinue inProps
+algorithm outProp := match inProps
   local
     Properties prop;
     Const c,c2;
@@ -127,7 +127,7 @@ algorithm outProp := matchcontinue inProps
       true := equivtypes(ty,ty2);
     then
       DAE.PROP(ty,c);
-end matchcontinue;
+end match;
 end propsAnd;
 
 public function makePropsNotConst
@@ -871,7 +871,7 @@ public function numberOfDimensions "Return the number of dimensions of a Type."
   input DAE.Type inType;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inType
+  outInteger := match inType
     local
       Integer n;
       Type t;
@@ -888,7 +888,7 @@ algorithm
         n := numberOfDimensions(t);
       then n;
     else 0;
-  end matchcontinue;
+  end match;
 end numberOfDimensions;
 
 public function dimensionsKnown
@@ -1792,7 +1792,7 @@ public function makeArray "This function makes an array type given a Type and an
   input Absyn.ArrayDim inArrayDim;
   output DAE.Type outType;
 algorithm
-  outType := matchcontinue (inType,inArrayDim)
+  outType := match (inType,inArrayDim)
     local
       Type t;
       Integer len;
@@ -1803,7 +1803,7 @@ algorithm
         len := listLength(l);
       then
         DAE.T_ARRAY(t,{DAE.DIM_INTEGER(len)});
-  end matchcontinue;
+  end match;
 end makeArray;
 
 public function makeArraySubscripts " This function makes an array type given a Type and a list of DAE.Subscript"
@@ -3919,7 +3919,7 @@ type."
  input DAE.Dimension dim;
  output DAE.Exp res;
 algorithm
-  res := matchcontinue ie
+  res := match ie
     local DAE.Type ty,ty1; DAE.Exp e;
     case DAE.CAST(ty,e)
       algorithm
@@ -3927,7 +3927,7 @@ algorithm
       then DAE.CAST(ty1,e);
 
     case e then e;
-  end matchcontinue;
+  end match;
 end liftExpType;
 
 public function typeConvertArray

--- a/OMCompiler/Compiler/FrontEnd/TypesDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/TypesDump.mo
@@ -604,7 +604,7 @@ public function printParamsStr "Prints function arguments to a string."
   input list<DAE.FuncArg> inFuncArgLst;
   output String str;
 algorithm
-  str := matchcontinue inFuncArgLst
+  str := match inFuncArgLst
     local
       String n;
       DAE.Type t;
@@ -624,7 +624,7 @@ algorithm
         str := stringAppendList({n," :: ",s1, " * ",s2});
       then
        str;
-  end matchcontinue;
+  end match;
 end printParamsStr;
 
 public function unparseVarAttr "
@@ -680,12 +680,12 @@ public function connectorTypeStr
   input DAE.ConnectorType ct;
   output String str;
 algorithm
-  str := matchcontinue ct
+  str := match ct
     local    case DAE.POTENTIAL() then "";
     case DAE.FLOW() then "flow ";
     case DAE.STREAM(_) then "stream ";
     else "";
-  end matchcontinue;
+  end match;
 end connectorTypeStr;
 
 protected function unparseParam "Prints a function argument to a string."

--- a/OMCompiler/Compiler/FrontEnd/UnitAbsynBuilder.mo
+++ b/OMCompiler/Compiler/FrontEnd/UnitAbsynBuilder.mo
@@ -70,7 +70,7 @@ in the scopes of the classLst for each variable"
  protected
  list<Absyn.Path> paths; list<SCode.Element> du;
 algorithm
-   () := matchcontinue dae
+   () := match dae
    local
      list<DAE.Element> elts;
    case _ algorithm
@@ -87,7 +87,7 @@ algorithm
        du := List.unionList(List.map1(paths,retrieveUnitsFromEnv,(cache,env)));
        registerUnitWeightDefineunits(du);
    then ();
-   end matchcontinue;
+   end match;
 end registerUnitWeights;
 
 protected function retrieveUnitsFromEnv "help function to registerUnitWeights"
@@ -116,7 +116,7 @@ end retrieveUnitsFromEnv;
 protected function registerUnitWeightDefineunits "help function to registerUnitWeightForClass"
   input list<SCode.Element> du;
 algorithm
-   () := matchcontinue du
+   () := match du
      /* No defineunits found, for backward compatibility, use default implementation:
      SI system ,with lower cost on Hz and Bq */
      case {} algorithm
@@ -151,14 +151,14 @@ algorithm
        SCode.DEFINEUNIT("kat",SCode.PUBLIC(),SOME("s-1.mol"),NONE(), SCodeUtil.dummyInfo)
        });   then ();
      else algorithm registerUnitWeightDefineunits2(du); then ();
-  end matchcontinue;
+  end match;
 end registerUnitWeightDefineunits;
 
 
 protected function registerUnitWeightDefineunits2 "help function to registerUnitWeightDefineunits"
   input list<SCode.Element> idu;
 algorithm
-   () := matchcontinue idu
+   () := match idu
      local String n; Real w; list<SCode.Element> du;
      case SCode.DEFINEUNIT(name=n,weight = SOME(w))::du algorithm
        UnitParserExt.registerWeight(n,w);
@@ -172,7 +172,7 @@ algorithm
      then ();
      case {} then ();
 
-  end matchcontinue;
+  end match;
 end registerUnitWeightDefineunits2;
 
 public function registerUnits "traverses the Absyn.Program and registers all defineunits.
@@ -181,7 +181,7 @@ are referenced in the model are picked up
 "
   input Absyn.Program prg;
 algorithm
-  () := matchcontinue prg
+  () := match prg
     case _
       algorithm
         // phi: very old unit checking
@@ -195,7 +195,7 @@ algorithm
       algorithm
         false := Flags.getConfigBool(Flags.UNIT_CHECKING);
       then ();
-  end matchcontinue;
+  end match;
 end registerUnits;
 
 protected function registerUnitInClass " help function to registerUnits"
@@ -554,7 +554,7 @@ protected function printBaseUnitsStr "help function to printUnit"
   input list<MMath.Rational> lst;
   output String str;
 algorithm
-  str := matchcontinue lst
+  str := match lst
   local Integer i1,i2,i3,i4;
     case MMath.RATIONAL(i1,i2)::MMath.RATIONAL(i3,i4)::_ algorithm
     str := "m^("+intString(i1)+"/"+intString(i2)+")"
@@ -562,7 +562,7 @@ algorithm
     then str;
     case {} then "";
     else "printBaseUnitsStr failed len:" + intString(listLength(lst)) + "\n";
-  end matchcontinue;
+  end match;
 end printBaseUnitsStr;
 
 protected function printTypeParameterStr "help function to printUnit"

--- a/OMCompiler/Compiler/FrontEnd/UnitChecker.mo
+++ b/OMCompiler/Compiler/FrontEnd/UnitChecker.mo
@@ -399,7 +399,7 @@ public function hasUnknown
   input UnitAbsyn.SpecUnit su;
   output Boolean res;
 algorithm
-  res := matchcontinue su
+  res := match su
     case UnitAbsyn.SPECUNIT({},_) then false;
     case UnitAbsyn.SPECUNIT(_,_) then true;
     else
@@ -407,7 +407,7 @@ algorithm
         true := Flags.isSet(Flags.FAILTRACE);
         Debug.trace("UnitChecker::hasUnknown() failed\n");
       then fail();
-  end matchcontinue;
+  end match;
 end hasUnknown;
 
 public function unitHasUnknown

--- a/OMCompiler/Compiler/FrontEnd/ValuesDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesDump.mo
@@ -570,7 +570,7 @@ protected function unparseDimSizes "
   output String outString;
 algorithm
   outString:=
-  matchcontinue inValueLst
+  match inValueLst
     local
       Integer i1,len;
       String s1,s2,s3,res;
@@ -590,7 +590,7 @@ algorithm
         res := intString(len);
       then
         res;
-  end matchcontinue;
+  end match;
 end unparseDimSizes;
 
 annotation(__OpenModelica_Interface="frontend_dump");

--- a/OMCompiler/Compiler/FrontEnd/ValuesMake.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesMake.mo
@@ -108,7 +108,7 @@ public function makeArray "
   output Values.Value outValue;
 algorithm
   outValue:=
-  matchcontinue inValueLst
+  match inValueLst
     local
       Integer i1;
       list<Integer> il;
@@ -121,7 +121,7 @@ algorithm
       algorithm
         i1 := listLength(vlst);
       then Values.ARRAY(vlst,{i1});
-  end matchcontinue;
+  end match;
 end makeArray;
 
 function makeEmptyArray

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -866,7 +866,7 @@ public function valueReals "
   output list<Real> outReal;
 algorithm
   outReal:=
-  matchcontinue inValue
+  match inValue
     local
       Real r;
       list<Values.Value> rest;
@@ -889,7 +889,7 @@ algorithm
         res := valueReals(rest);
       then
         res;
-  end matchcontinue;
+  end match;
 end valueReals;
 
 public function valueString

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -1338,7 +1338,7 @@ function merge
   input NFOCConnectionGraph inGraph2;
   output NFOCConnectionGraph outGraph;
 algorithm
-  outGraph := matchcontinue(inGraph1, inGraph2)
+  outGraph := match(inGraph1, inGraph2)
     local
       Boolean updateGraph, updateGraph1, updateGraph2;
       DefiniteRoots definiteRoots, definiteRoots1, definiteRoots2;
@@ -1379,7 +1379,7 @@ algorithm
         connections    := List.union(connections1, connections2);
       then
         GRAPH(updateGraph,definiteRoots,potentialRoots,uniqueRoots,branches,connections);
-  end matchcontinue;
+  end match;
 end merge;
 
 /***********************************************************************************************************************/

--- a/OMCompiler/Compiler/Script/Binding.mo
+++ b/OMCompiler/Compiler/Script/Binding.mo
@@ -633,7 +633,7 @@ protected function applyModifiers
   input Boolean newName;
   output list<Absyn.ElementItem> out_elems;
   algorithm
-  out_elems := matchcontinue exp
+  out_elems := match exp
    local
      list<tuple<Absyn.Exp, String>> rest;
     list<Absyn.ComponentItem> cnew;
@@ -647,7 +647,7 @@ protected function applyModifiers
         then enew::applyModifiers(comps, rest, instance_name, counter+1, finalPrefix,redeclareKeywords ,innerOuter, info , constrainClass, attributes,tSpec, newName);
     case _::rest
         then applyModifiers(comps, rest, instance_name, counter, finalPrefix,redeclareKeywords ,innerOuter, info , constrainClass, attributes,tSpec, newName);
-   end matchcontinue;
+   end match;
 end applyModifiers;
 
 protected function applyModifier
@@ -853,7 +853,7 @@ protected function applyTemplate
   input list<tuple<Absyn.Exp, String>>  in_es;
   output list<tuple<Absyn.Exp, String>>  out_es;
   algorithm
-  out_es := matchcontinue comps
+  out_es := match comps
    local
      list<Absyn.ComponentItem> clist;
      list<tuple<list<Absyn.ComponentItem>, String>>  rest;
@@ -868,7 +868,7 @@ protected function applyTemplate
     case _::rest
        algorithm
         then applyTemplate(exp, rest, in_es);
-   end matchcontinue;
+   end match;
 end applyTemplate;
 
 protected function applyTemplate2
@@ -878,7 +878,7 @@ protected function applyTemplate2
   input String pathInClass;
   output list<tuple<Absyn.Exp, String>>  out_es;
   algorithm
-  out_es := matchcontinue comps
+  out_es := match comps
    local
      list<Absyn.ComponentItem> rest;
      Absyn.Ident name, newName;
@@ -893,7 +893,7 @@ protected function applyTemplate2
     case _::rest
        algorithm
         then applyTemplate2(exp, rest, in_es, pathInClass);
-   end matchcontinue;
+   end match;
 end applyTemplate2;
 
 protected function parseExpression
@@ -957,7 +957,7 @@ protected function updateCRF
   input Absyn.Ident name;
   output Absyn.ComponentRef out_componentRef;
   algorithm
-  out_componentRef := matchcontinue componentRef
+  out_componentRef := match componentRef
   local
      Absyn.ComponentRef cRef, new_cRef;
      list<Absyn.Subscript> subscripts;
@@ -971,7 +971,7 @@ protected function updateCRF
        then Absyn.CREF_QUAL(id, subscripts, new_cRef);
   case Absyn.CREF_IDENT("getPath", subscripts) then Absyn.CREF_IDENT(name, subscripts);
   case _ then    componentRef;
-  end matchcontinue;
+  end match;
 end updateCRF;
 
 protected function getAllProviderInstances
@@ -1030,7 +1030,7 @@ input list<tuple<list<Absyn.ComponentItem>, String>> in_components;
 input String pathInClass;
 output list<tuple<list<Absyn.ComponentItem>, String>> out_components;
 algorithm
-  out_components:= matchcontinue components
+  out_components:= match components
    local
     list<Absyn.ComponentItem> rest;
      Absyn.Ident name ;
@@ -1044,7 +1044,7 @@ algorithm
         then parseComponents(className, template, e_items, env, rest, tmp, pathInClass);
     case _::rest
         then parseComponents(className, template, e_items, env, rest, in_components, pathInClass);
-   end matchcontinue;
+   end match;
 end parseComponents;
 
 

--- a/OMCompiler/Compiler/Script/BlockCallRewrite.mo
+++ b/OMCompiler/Compiler/Script/BlockCallRewrite.mo
@@ -890,7 +890,7 @@ protected function matchParamNamedArg
   output list<Absyn.ElementArg> newModif "modifiers to add to component";
   output Boolean found;
 algorithm
-  (newModif, found) := matchcontinue comps
+  (newModif, found) := match comps
     local
       list<Absyn.ComponentItem>  r_comps;
       Absyn.Ident cName;
@@ -908,7 +908,7 @@ algorithm
       then
         matchParamNamedArg(argName, argValue, r_comps, oldModif);
 
-  end matchcontinue;
+  end match;
 end matchParamNamedArg;
 
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -6669,7 +6669,7 @@ protected function getAlgorithmsInClassParts
   input list<Absyn.ClassPart> inAbsynClassPartLst;
   output list<Absyn.ClassPart> outList;
 algorithm
-  outList := matchcontinue inAbsynClassPartLst
+  outList := match inAbsynClassPartLst
     local
       list<Absyn.ClassPart> algsList;
       list<Absyn.ClassPart> xs;
@@ -6685,7 +6685,7 @@ algorithm
       then
         algsList;
     case {} then {};
-  end matchcontinue;
+  end match;
 end getAlgorithmsInClassParts;
 
 protected function getNthAlgorithm
@@ -6745,7 +6745,7 @@ protected function getInitialAlgorithmsInClassParts
   input list<Absyn.ClassPart> inAbsynClassPartLst;
   output list<Absyn.ClassPart> outList;
 algorithm
-  outList := matchcontinue inAbsynClassPartLst
+  outList := match inAbsynClassPartLst
     local
       list<Absyn.ClassPart> algsList;
       list<Absyn.ClassPart> xs;
@@ -6761,7 +6761,7 @@ algorithm
       then
         algsList;
     case {} then {};
-  end matchcontinue;
+  end match;
 end getInitialAlgorithmsInClassParts;
 
 protected function getNthInitialAlgorithm
@@ -6821,7 +6821,7 @@ protected function getAlgorithmItemsCountInClassParts
  input list<Absyn.ClassPart> inAbsynClassPartLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynClassPartLst
+  outInteger := match inAbsynClassPartLst
     local
       list<Absyn.AlgorithmItem> algs;
       list<Absyn.ClassPart> xs;
@@ -6838,7 +6838,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getAlgorithmItemsCountInClassParts;
 
 protected function getAlgorithmItemsCountInAlgorithmItems
@@ -6846,7 +6846,7 @@ protected function getAlgorithmItemsCountInAlgorithmItems
   input list<Absyn.AlgorithmItem> inAbsynAlgorithmItemLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynAlgorithmItemLst
+  outInteger := match inAbsynAlgorithmItemLst
     local
       list<Absyn.AlgorithmItem> xs;
       Integer c1, res;
@@ -6861,7 +6861,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getAlgorithmItemsCountInAlgorithmItems;
 
 protected function getNthAlgorithmItem
@@ -6974,7 +6974,7 @@ protected function getInitialAlgorithmItemsCountInClassParts
  input list<Absyn.ClassPart> inAbsynClassPartLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynClassPartLst
+  outInteger := match inAbsynClassPartLst
     local
       list<Absyn.AlgorithmItem> algs;
       list<Absyn.ClassPart> xs;
@@ -6991,7 +6991,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getInitialAlgorithmItemsCountInClassParts;
 
 protected function getNthInitialAlgorithmItem
@@ -7080,7 +7080,7 @@ protected function getEquationsInClassParts
   input list<Absyn.ClassPart> inAbsynClassPartLst;
   output list<Absyn.ClassPart> outList;
 algorithm
-  outList := matchcontinue inAbsynClassPartLst
+  outList := match inAbsynClassPartLst
     local
       list<Absyn.ClassPart> eqsList;
       list<Absyn.ClassPart> xs;
@@ -7096,7 +7096,7 @@ algorithm
       then
         eqsList;
     case {} then {};
-  end matchcontinue;
+  end match;
 end getEquationsInClassParts;
 
 protected function getNthEquation
@@ -7156,7 +7156,7 @@ protected function getInitialEquationsInClassParts
   input list<Absyn.ClassPart> inAbsynClassPartLst;
   output list<Absyn.ClassPart> outList;
 algorithm
-  outList := matchcontinue inAbsynClassPartLst
+  outList := match inAbsynClassPartLst
     local
       list<Absyn.ClassPart> eqsList;
       list<Absyn.ClassPart> xs;
@@ -7172,7 +7172,7 @@ algorithm
       then
         eqsList;
     case {} then {};
-  end matchcontinue;
+  end match;
 end getInitialEquationsInClassParts;
 
 protected function getNthInitialEquation
@@ -7232,7 +7232,7 @@ protected function getEquationItemsCountInClassParts
  input list<Absyn.ClassPart> inAbsynClassPartLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynClassPartLst
+  outInteger := match inAbsynClassPartLst
     local
       list<Absyn.EquationItem> eqs;
       list<Absyn.ClassPart> xs;
@@ -7249,7 +7249,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getEquationItemsCountInClassParts;
 
 protected function getEquationItemsCountInEquationItems
@@ -7257,7 +7257,7 @@ protected function getEquationItemsCountInEquationItems
   input list<Absyn.EquationItem> inAbsynEquationItemLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynEquationItemLst
+  outInteger := match inAbsynEquationItemLst
     local
       list<Absyn.EquationItem> xs;
       Integer c1, res;
@@ -7272,7 +7272,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getEquationItemsCountInEquationItems;
 
 protected function getNthEquationItem
@@ -7393,7 +7393,7 @@ protected function getInitialEquationItemsCountInClassParts
  input list<Absyn.ClassPart> inAbsynClassPartLst;
   output Integer outInteger;
 algorithm
-  outInteger := matchcontinue inAbsynClassPartLst
+  outInteger := match inAbsynClassPartLst
     local
       list<Absyn.EquationItem> eqs;
       list<Absyn.ClassPart> xs;
@@ -7410,7 +7410,7 @@ algorithm
       then
         res;
     case {} then 0;
-  end matchcontinue;
+  end match;
 end getInitialEquationItemsCountInClassParts;
 
 protected function getNthInitialEquationItem
@@ -7572,7 +7572,7 @@ protected function unparseGroupImport
   input list<Absyn.GroupImport> inAbsynGroupImportLst;
   output list<String> outList;
 algorithm
-  outList := matchcontinue inAbsynGroupImportLst
+  outList := match inAbsynGroupImportLst
   local
     list<Absyn.GroupImport> rest;
     list<String> lst;
@@ -7588,7 +7588,7 @@ algorithm
         lst := unparseGroupImport(rest);
       then
         lst;
-  end matchcontinue;
+  end match;
 end unparseGroupImport;
 
 public function isShortDefinition

--- a/OMCompiler/Compiler/Script/Figaro.mo
+++ b/OMCompiler/Compiler/Script/Figaro.mo
@@ -809,14 +809,14 @@ protected function scanDeclaration "Scans a declaration."
   input list<String> inStringList "string sequence to scan";
   output list<String> outStringList "string sequence to continue scanning";
 algorithm
-  outStringList := matchcontinue inStringList
+  outStringList := match inStringList
     local
       list<String> rest;
     case "?" :: ">" :: rest
       then rest;
     case _ :: rest
       then scanDeclaration(rest);
-  end matchcontinue;
+  end match;
 end scanDeclaration;
 
 protected function scanTagName "Scans a tag name."
@@ -825,7 +825,7 @@ protected function scanTagName "Scans a tag name."
   output list<String> outStringList "string sequence to continue scanning";
   output String outTagName;
 algorithm
-  (outStringList, outTagName) := matchcontinue inStringList
+  (outStringList, outTagName) := match inStringList
     local
       String first;
       list<String> rest;
@@ -833,7 +833,7 @@ algorithm
       then (rest, inTagName);
     case first :: rest
       then scanTagName(rest, inTagName + first);
-  end matchcontinue;
+  end match;
 end scanTagName;
 
 protected function scanText "Greedy. Scans text until some kind of tag begins."
@@ -842,7 +842,7 @@ protected function scanText "Greedy. Scans text until some kind of tag begins."
   output list<String> outStringList "string sequence to continue scanning";
   output String outText;
 algorithm
-  (outStringList, outText) := matchcontinue inStringList
+  (outStringList, outText) := match inStringList
     local
       String first;
       list<String> rest;
@@ -852,7 +852,7 @@ algorithm
       then (inStringList, inText);
     case first :: rest
       then scanText(rest, inText + first);
-  end matchcontinue;
+  end match;
 end scanText;
 
 /* These functions walk over the token sequence from the lexer and throw away tokens that will not

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -2246,7 +2246,7 @@ protected function extractComponentsFromClass
   output InteractiveTypes.Components outComponents;
 algorithm
   outComponents:=
-  matchcontinue (inClass,inPath,inComponents,inEnv)
+  match (inClass,inPath,inComponents,inEnv)
     local
       InteractiveTypes.Components comps_1,comps;
       Absyn.ClassDef classdef;
@@ -2262,7 +2262,7 @@ algorithm
         print("-extract_components_from_class failed\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end extractComponentsFromClass;
 
 protected function extractComponentsFromClassdef
@@ -4096,7 +4096,7 @@ protected
   Boolean c;
 algorithm
   for item in items loop
-    (outItems, changed) := matchcontinue item
+    (outItems, changed) := match item
       case Absyn.ElementItem.ELEMENTITEM(element = elem as Absyn.Element.ELEMENT())
         algorithm
           (spec, c) := renameClassInElementSpec(elem.specification, oldName, newName, env);
@@ -4106,7 +4106,7 @@ algorithm
           (item :: outItems, changed or c);
 
       else (item :: outItems, changed);
-    end matchcontinue;
+    end match;
   end for;
 
   outItems := Dangerous.listReverseInPlace(outItems);
@@ -7734,7 +7734,7 @@ protected function getPackagesInParts
   output list<String> outStringLst;
 algorithm
   outStringLst:=
-  matchcontinue inAbsynClassPartLst
+  match inAbsynClassPartLst
     local
       list<String> l1,l2,res;
       list<Absyn.ElementItem> elts;
@@ -7764,7 +7764,7 @@ algorithm
       then
         res;
 
-  end matchcontinue;
+  end match;
 end getPackagesInParts;
 
 protected function getPackagesInElts
@@ -7773,7 +7773,7 @@ protected function getPackagesInElts
   output list<String> outStringLst;
 algorithm
   outStringLst:=
-  matchcontinue inAbsynElementItemLst
+  match inAbsynElementItemLst
     local
       list<String> res;
       String id;
@@ -7789,7 +7789,7 @@ algorithm
         res := getPackagesInElts(rest);
       then
         res;
-  end matchcontinue;
+  end match;
 end getPackagesInElts;
 
 public function getClassnamesInPath
@@ -8528,7 +8528,7 @@ protected function getConnectionsInClassparts
   input list<Absyn.ClassPart> inAbsynClassPartLst;
   output list<Absyn.EquationItem> outList;
 algorithm
-  outList := matchcontinue inAbsynClassPartLst
+  outList := match inAbsynClassPartLst
     local
       list<Absyn.EquationItem> eqlist1, eqlist2;
       list<Absyn.ClassPart> xs;
@@ -8548,7 +8548,7 @@ algorithm
 
     case {} then {};
 
-  end matchcontinue;
+  end match;
 end getConnectionsInClassparts;
 
 protected function getConnectionsInEquations
@@ -9935,7 +9935,7 @@ protected function getDefinitionComponents
   input list<Absyn.ComponentItem> components;
   output list<String> res;
 algorithm
-  res := matchcontinue components
+  res := match components
   local
     list<Absyn.ComponentItem> rest;
     String ident;
@@ -9950,7 +9950,7 @@ algorithm
       res := getDefinitionComponents(typeStr,dirStr,numDim,rest);
     then ident :: res;
     case rest then getDefinitionComponents(typeStr,dirStr,numDim,rest);
-  end matchcontinue;
+  end match;
 end getDefinitionComponents;
 
 protected function getDefinitionTypeVars

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -109,7 +109,7 @@ public function getExtendsElementspecInClass
   output list<Absyn.ElementSpec> outAbsynElementSpecLst;
 algorithm
   outAbsynElementSpecLst:=
-  matchcontinue inClass
+  match inClass
     local
       list<Absyn.ElementSpec> ext;
       list<Absyn.ClassPart> parts;
@@ -134,7 +134,7 @@ algorithm
         // Note: the array dimensions of DERIVED are lost. They must be
         // queried by another api-function
     else {};
-  end matchcontinue;
+  end match;
 end getExtendsElementspecInClass;
 
 protected function getExtendsElementspecInClassparts
@@ -143,7 +143,7 @@ protected function getExtendsElementspecInClassparts
   output list<Absyn.ElementSpec> outAbsynElementSpecLst;
 algorithm
   outAbsynElementSpecLst:=
-  matchcontinue inAbsynClassPartLst
+  match inAbsynClassPartLst
     local
       list<Absyn.ElementSpec> lst1,lst2,res;
       list<Absyn.ElementItem> elts;
@@ -173,7 +173,7 @@ algorithm
       then
         res;
 
-  end matchcontinue;
+  end match;
 end getExtendsElementspecInClassparts;
 
 protected function getExtendsElementspecInElementitems

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -328,7 +328,7 @@ protected
 algorithm
   // handle the annotations
   for i in inElements loop
-   elArgs := matchcontinue i
+   elArgs := match i
       case Absyn.ELEMENT(specification = Absyn.COMPONENTS(components = items), constrainClass = cc)
         algorithm
           el := AbsynUtil.getAnnotationsFromItems(items, AbsynUtil.getAnnotationsFromConstraintClass(cc));
@@ -358,7 +358,7 @@ algorithm
 
 
       else elArgs;
-    end matchcontinue;
+    end match;
   end for;
 
   for l in elArgs loop
@@ -764,10 +764,10 @@ algorithm
 
   cls := InstNode.getClass(cls_node);
 
-  exts := matchcontinue cls
+  exts := match cls
     case Class.EXPANDED_DERIVED() then listArray({cls.baseClass});
     else ClassTree.getExtends(Class.classTree(cls));
-  end matchcontinue;
+  end match;
 
   if index < 1 or index > arrayLength(exts) then
     result := ValuesMake.makeBoolean(false);

--- a/OMCompiler/Compiler/Script/ProgramUtil.mo
+++ b/OMCompiler/Compiler/Script/ProgramUtil.mo
@@ -1049,7 +1049,7 @@ public function mergeElements
    input  list<Absyn.ElementItem> inEls2;
    output list<Absyn.ElementItem> outEls;
   algorithm
-    outEls := matchcontinue(inEls1, inEls2)
+    outEls := match(inEls1, inEls2)
     local
       list<Absyn.ElementItem> rest, merged;
       Absyn.ElementItem e2;
@@ -1060,7 +1060,7 @@ public function mergeElements
           merged := mergeElement(inEls1, e2);
           merged := mergeElements(merged, rest);
         then merged;
-    end matchcontinue;
+    end match;
 end mergeElements;
 public function excludeElementsFromFile
 "exclude all elements which are part of the given file"

--- a/OMCompiler/Compiler/Script/Refactor.mo
+++ b/OMCompiler/Compiler/Script/Refactor.mo
@@ -333,7 +333,7 @@ protected function refactorGraphAnnInAlgItem"Helper function to refactorGraphAnn
   input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.AlgorithmItem outItem;
 algorithm
-  outItem := matchcontinue inItem
+  outItem := match inItem
     local
       Absyn.Algorithm alg;
       Option<String> com;
@@ -349,7 +349,7 @@ algorithm
 
     else inItem;
 
-  end matchcontinue;
+  end match;
 
 end refactorGraphAnnInAlgItem;
 

--- a/OMCompiler/Compiler/Script/RewriteRules.mo
+++ b/OMCompiler/Compiler/Script/RewriteRules.mo
@@ -949,7 +949,7 @@ protected function operatorMatches
   input DAE.Operator op2;
   output Boolean b;
 algorithm
-  b := matchcontinue(op1, op2)
+  b := match(op1, op2)
     local
 
     case (DAE.UMINUS_ARR(),DAE.UMINUS()) then true;
@@ -972,7 +972,7 @@ algorithm
     // all other forward to Expression.operatorEqual
     else Expression.operatorEqual(op1, op2);
 
-  end matchcontinue;
+  end match;
 end operatorMatches;
 
 public function loadRules

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -163,7 +163,7 @@ public function buildCrefExpFromAsub
   input list<DAE.Exp> subs;
   output DAE.Exp cRefOut;
 algorithm
-  cRefOut := matchcontinue(cref, subs)
+  cRefOut := match(cref, subs)
     local
       DAE.Exp crefExp;
       DAE.Type ty;
@@ -178,7 +178,7 @@ algorithm
         crefExp := Expression.makeCrefExp(crNew, ty);
       then
         crefExp;
-  end matchcontinue;
+  end match;
 end buildCrefExpFromAsub;
 
 public function buildCrefExpFromSubs
@@ -188,7 +188,7 @@ public function buildCrefExpFromSubs
   input list<DAE.Subscript> subs;
   output DAE.Exp cRefOut;
 algorithm
-  cRefOut := matchcontinue(cref, subs)
+  cRefOut := match(cref, subs)
     local
       DAE.Exp crefExp;
       DAE.Type ty;
@@ -201,7 +201,7 @@ algorithm
         crefExp := Expression.makeCrefExp(crNew, ty);
       then
         crefExp;
-  end matchcontinue;
+  end match;
 end buildCrefExpFromSubs;
 
 public function incrementInt
@@ -2009,7 +2009,7 @@ protected
 algorithm
   installationDir := Settings.getInstallationDirectoryPath();
 
-  () := matchcontinue(uri,path,inLibs)
+  () := match(uri,path,inLibs)
     local
   case(_, _,{"-lWinmm"}) guard Autoconf.os=="Windows_NT"
     algorithm
@@ -2032,7 +2032,7 @@ algorithm
       end if;
 
     then ();
-  end matchcontinue;
+  end match;
 end getLinkerLibraryPaths;
 
 protected function generateExtFunctionLibraryDirectoryFlags
@@ -2736,7 +2736,7 @@ function twodigit
   output String outS;
 algorithm
   outS :=
-  matchcontinue i
+  match i
     local String s;
     case _ guard i < 10
       algorithm
@@ -2745,7 +2745,7 @@ algorithm
       then
         s;
     else intString(i);
-  end matchcontinue;
+  end match;
 end twodigit;
 
 public function generateSubPalceholders

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -11106,7 +11106,7 @@ public function countDynamicExternalFunctions
   input list<SimCodeFunction.Function> inFncLst;
   output Integer outDynLoadFuncs;
 algorithm
-  outDynLoadFuncs:= matchcontinue inFncLst
+  outDynLoadFuncs:= match inFncLst
   local
      list<SimCodeFunction.Function> rest;
      Integer i;
@@ -11123,7 +11123,7 @@ algorithm
       i := countDynamicExternalFunctions(rest);
     then
       i;
-end matchcontinue;
+end match;
 end countDynamicExternalFunctions;
 
 protected function getFilesFromSimVar

--- a/OMCompiler/Compiler/Template/TplAbsyn.mo
+++ b/OMCompiler/Compiler/Template/TplAbsyn.mo
@@ -4474,7 +4474,7 @@ public function checkTextType
   input SourceInfo inInfo;
   output TypeSignature outType;
 algorithm
-  outType := matchcontinue (inType, inUnresolvedMsg)
+  outType := match (inType, inUnresolvedMsg)
     local
       String msg;
       TypeSignature ts;
@@ -4493,7 +4493,7 @@ algorithm
       then
         UNRESOLVED_TYPE(msg);
 
-  end matchcontinue;
+  end match;
 end checkTextType;
 
 
@@ -4504,7 +4504,7 @@ public function makeMMExpFromTemplateConstant
   output MMExp outMMExp;
   output TypeSignature outConstType;
 algorithm
-  (outMMExp, outConstType) := matchcontinue (inTplDef, inTemplIdent)
+  (outMMExp, outConstType) := match (inTplDef, inTemplIdent)
     local
       Ident ident;
       TypeSignature idtype, lt;
@@ -4538,7 +4538,7 @@ algorithm
         true := Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!makeMMExpFromTemplateConstant failed\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end makeMMExpFromTemplateConstant;
 
 public function prepareMatchArgument
@@ -4548,7 +4548,7 @@ public function prepareMatchArgument
   output Ident outIdent;
   output MatchingExp outMExp;
 algorithm
-  (outIdent, outMExp) := matchcontinue inMExp
+  (outIdent, outMExp) := match inMExp
     local
       MatchingExp mexp;
       Ident ident;
@@ -4570,7 +4570,7 @@ algorithm
     //no need to addToLocals because it is already in the locals
     else (inMatchArgName, BIND_AS_MATCH(inMatchArgName, inMExp) );
 
-  end matchcontinue;
+  end match;
 end prepareMatchArgument;
 
 

--- a/OMCompiler/Compiler/Template/TplParser.mo
+++ b/OMCompiler/Compiler/Template/TplParser.mo
@@ -319,7 +319,7 @@ public function mergeErrors
   input LineInfo inLineInfoToAddErrorsFrom;
   output LineInfo outLineInfo;
 algorithm
-  outLineInfo := matchcontinue (inLineInfo, inLineInfoToAddErrorsFrom)
+  outLineInfo := match (inLineInfo, inLineInfoToAddErrorsFrom)
     local
       list<String>  solchars, errLst, errLstToAdd;
       String fname;
@@ -342,7 +342,7 @@ algorithm
         Debug.trace("- !!! TplParser.mergeErrors failed.\n");
       then fail();
 
-  end matchcontinue;
+  end match;
 end mergeErrors;
 
 
@@ -4129,7 +4129,7 @@ public function makeStrTokFromRevStrList
   input list<String> inRevStrList;
   output Tpl.StringToken outStringToken;
 algorithm
-  outStringToken := matchcontinue inRevStrList
+  outStringToken := match inRevStrList
     local
       list<String> strList;
       String str;
@@ -4160,7 +4160,7 @@ algorithm
         Debug.trace("Parse invalid operation error - TplParser.makeStrTokFromRevStrList failed (an empty string list passed?) .\n");
       then fail();
 
-  end matchcontinue;
+  end match;
 end makeStrTokFromRevStrList;
 
 /*
@@ -4634,7 +4634,7 @@ public function makeTemplateFromExpList
   output TplAbsyn.ExpressionBase outExpressionBase;
 algorithm
   outExpressionBase
-  := matchcontinue (inExpressionList, inLeftQuote,inRightQuote)
+  := match (inExpressionList, inLeftQuote,inRightQuote)
     local
       String lquote, rquote;
       TplAbsyn.ExpressionBase expB;
@@ -4652,7 +4652,7 @@ algorithm
        expLst := listReverse(expLst);
      then TplAbsyn.TEMPLATE(expLst, lquote, rquote);
 
-  end matchcontinue;
+  end match;
 end makeTemplateFromExpList;
 
 


### PR DESCRIPTION
These were detected using fallibility analysis. The code never calls fail(), so match captures the same semantics as matchcontinue (but can skip calling setjmp).