### PR TITLE
CodegenUtil: substring is a builtin, not System.substring

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -97,7 +97,7 @@ template replaceDotAndUnderscore(String str)
   Otherwise the generated name diverges from the record type name built by
   AbsynUtil.pathStringUnquoteReplaceDot and the C code fails to compile. See #13009."
 ::=
-  let str_dots = if stringEq(System.substring(str,1,1), "'") then str else System.stringReplace(str,".", "_")
+  let str_dots = if stringEq(substring(str,1,1), "'") then str else System.stringReplace(str,".", "_")
   let str_underscores = System.stringReplace(str_dots, "_", "__")
   System.unquoteIdentifier(str_underscores)
 end replaceDotAndUnderscore;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -227,6 +227,13 @@ package builtin
     output Integer ch;
   end stringGet;
 
+  function substring
+    input String str;
+    input Integer start;
+    input Integer stop;
+    output String out;
+  end substring;
+
   function listHead
     replaceable type TypeVar subtypeof Any;
     input list<TypeVar> lst;
@@ -1883,12 +1890,6 @@ package BackendDAE
 end BackendDAE;
 
 package System
-  function substring
-    input String inString;
-    input Integer start;
-    input Integer stop;
-    output String outString;
-  end substring;
 
   function stringFind
     input String str;


### PR DESCRIPTION
`substring(str, start, stop)` is a MetaModelica builtin.

Declare `substring` in SimCodeTV's `builtin` package and call it bare so Susan emits the builtin `substring(...)` in the generated `.mo`.