### PR TITLE
Let -override win over -iif imported start values (#15807)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -209,6 +209,12 @@ typedef hash_string_long omc_CommandLineOverridesUses;
 // function to handle command line settings override
 void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override, const char *overrideFile);
 
+/* Persistent map of all quantities given via -override/-overrideFile.
+ * Kept alive after doOverride() so that other parts of the runtime (e.g.
+ * importStartValues() for -iif) can tell which quantities the user explicitly
+ * overrode and must therefore not be clobbered by imported values. See #15807. */
+static omc_CommandLineOverrides *gCommandLineOverrides = NULL;
+
 static const double REAL_MIN = -DBL_MAX;
 static const double REAL_MAX = DBL_MAX;
 static const double INTEGER_MIN = (double)MODELICA_INT_MIN;
@@ -1463,6 +1469,10 @@ void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override,
       free(overrideStr2);
     }
 
+    /* remember the overridden quantities so importStartValues() (-iif) does not
+     * clobber values the user explicitly set via -override/-overrideFile (#15807) */
+    gCommandLineOverrides = mOverrides;
+
     // override all found!
     for(i=0; i<modelData->nStatesArray; i++) {
       singleOverride(mOverrides, &mOverridesUses, mi->rSta, i, 0);
@@ -1520,6 +1530,20 @@ void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override,
   } else {
     infoStreamPrint(OMC_LOG_SOLVER, 0, "NO override given on the command line.");
   }
+}
+
+/**
+ * @brief Check whether a quantity was overridden on the command line.
+ *
+ * Used to make sure that values explicitly set via -override/-overrideFile are
+ * not clobbered when importing start values from a file given with -iif (#15807).
+ *
+ * @param name   Fully qualified name of the variable or parameter.
+ * @return int   1 if the quantity was given via -override/-overrideFile, 0 otherwise.
+ */
+int isQuantityOverridden(const char *name)
+{
+  return (gCommandLineOverrides != NULL) && (findHashStringStringNull(gCommandLineOverrides, name) != NULL);
 }
 
 void parseVariableStr(char* variableStr)

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.h
@@ -45,6 +45,7 @@ void read_input_xml(MODEL_DATA* modelData,
                     SIMULATION_INFO* simulationData,
                     threadData_t* threadData);
 void parseVariableStr(char* variableStr);
+int isQuantityOverridden(const char *name);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -35,6 +35,7 @@
 #include "../../../openmodelica.h"
 #include "../../../openmodelica_func.h"
 #include "../../../simulation/options.h"
+#include "../../simulation_input_xml.h"
 #include "../../arrayIndex.h"
 #include "../model_help.h"
 #if !defined(OMC_MINIMAL_RUNTIME)
@@ -581,6 +582,10 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
         throwStreamPrint(NULL, "Support for array variables not yet implemented!");
         // TODO: Implement reading of array variables with omc_matlab4_read_vars_val (?)
       }
+      if (isQuantityOverridden(mData->realVarsData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of real variable %s: overridden on command line", mData->realVarsData[i].info.name);
+        continue;
+      }
       pVar = omc_matlab4_find_var(&reader, mData->realVarsData[i].info.name);
 
       if(!pVar) {
@@ -602,6 +607,10 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
 
     infoStreamPrint(OMC_LOG_INIT, 0, "import integer variables");
     for(i=0; i<mData->nVariablesInteger; ++i) {
+      if (isQuantityOverridden(mData->integerVarsData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of integer variable %s: overridden on command line", mData->integerVarsData[i].info.name);
+        continue;
+      }
       pVar = omc_matlab4_find_var(&reader, mData->integerVarsData[i].info.name);
 
       if(!pVar) {
@@ -623,6 +632,10 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
 
     infoStreamPrint(OMC_LOG_INIT, 0, "import boolean variables");
     for(i=0; i<mData->nVariablesBoolean; ++i) {
+      if (isQuantityOverridden(mData->booleanVarsData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of boolean variable %s: overridden on command line", mData->booleanVarsData[i].info.name);
+        continue;
+      }
       pVar = omc_matlab4_find_var(&reader, mData->booleanVarsData[i].info.name);
 
       if(!pVar) {
@@ -649,6 +662,11 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
         // TODO: Implement reading of array parameters
       }
 
+      if (isQuantityOverridden(mData->realParameterData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of real parameter %s: overridden on command line", mData->realParameterData[i].info.name);
+        continue;
+      }
+
       pVar = omc_matlab4_find_var(&reader, mData->realParameterData[i].info.name);
 
       if(!pVar) {
@@ -670,6 +688,10 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
     infoStreamPrint(OMC_LOG_INIT, 0, "import integer parameters");
     for(i=0; i<mData->nParametersInteger; ++i)
     {
+      if (isQuantityOverridden(mData->integerParameterData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of integer parameter %s: overridden on command line", mData->integerParameterData[i].info.name);
+        continue;
+      }
       pVar = omc_matlab4_find_var(&reader, mData->integerParameterData[i].info.name);
 
       if (!pVar) {
@@ -690,6 +712,10 @@ int importStartValues(DATA *data, threadData_t *threadData, const char *pInitFil
 
     infoStreamPrint(OMC_LOG_INIT, 0, "import boolean parameters");
     for(i=0; i<mData->nParametersBoolean; ++i) {
+      if (isQuantityOverridden(mData->booleanParameterData[i].info.name)) {
+        infoStreamPrint(OMC_LOG_INIT_V, 0, "| skip import of boolean parameter %s: overridden on command line", mData->booleanParameterData[i].info.name);
+        continue;
+      }
       pVar = omc_matlab4_find_var(&reader, mData->booleanParameterData[i].info.name);
 
       if(!pVar) {

--- a/testsuite/simulation/modelica/start_value_selection/Makefile
+++ b/testsuite/simulation/modelica/start_value_selection/Makefile
@@ -9,6 +9,7 @@ TESTFILES = \
 	overrideLiteralStartFromFile_alg.mos \
 	overrideParamStartFromFile_alg.mos \
 	overrideParamStartFromFile_param.mos \
+	overrideParamWithIif.mos \
 
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/simulation/modelica/start_value_selection/overrideParamWithIif.mos
+++ b/testsuite/simulation/modelica/start_value_selection/overrideParamWithIif.mos
@@ -1,0 +1,50 @@
+// name:     overrideParamWithIif.mos [BUG: #15807]
+// keywords: start value selection, -iif, -override
+// status:   correct
+// teardown_command: rm -rf *overrideParamWithIif_model* ref_overrideParamWithIif.mat res_overrideParamWithIif.mat
+// cflags:
+
+// A parameter explicitly set with -override must win over the value imported
+// from an initialization file given with -iif (ticket #15807). Before the fix
+// the imported value (J=2) silently clobbered the override (J=10).
+
+loadString("
+model overrideParamWithIif_model
+  parameter Real J = 2.0;
+  Real x(start = 1.0, fixed = true);
+equation
+  der(x) = -J*x;
+  annotation(experiment(StopTime = 1));
+end overrideParamWithIif_model;
+");getErrorString();
+
+// first run with J = 2 to create an initialization file
+simulate(overrideParamWithIif_model, simflags="-r=ref_overrideParamWithIif.mat");getErrorString();
+
+// second run: initialize from the file but override J = 10. The override must
+// win, so J must be 10 (not 2 from the file).
+simulate(overrideParamWithIif_model, simflags="-iif=ref_overrideParamWithIif.mat -override=J=10 -r=res_overrideParamWithIif.mat");getErrorString();
+val(J, 0.0);getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ref_overrideParamWithIif.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamWithIif_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=ref_overrideParamWithIif.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "res_overrideParamWithIif.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'overrideParamWithIif_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif=ref_overrideParamWithIif.mat -override=J=10 -r=res_overrideParamWithIif.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 10.0
+// ""
+// endResult


### PR DESCRIPTION
Fix for #15807.

When a simulation was initialized from a file via -iif, importStartValues() overwrote every matching quantity with the value from the file, silently clobbering values the user had explicitly set with -override/-overrideFile.

Remember the set of command-line overrides in doOverride() and skip importing those quantities in importStartValues(), so -override and -iif can be combined.

Adds testsuite/.../start_value_selection/overrideParamWithIif.mos.

