### PR TITLE
[C] Fix result file output for non-scalarized array variables

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -106,6 +106,52 @@ void csvEscapedString(const char* original, char* replaced, size_t n, threadData
 }
 
 /**
+ * @brief Write the (escaped, quoted) flattened name(s) of a result variable.
+ *
+ * For scalar variables a single name is written. For array variables (used when
+ * sim code scalarization is disabled) one name per scalar element is written in
+ * the form `"<name>[i,j,...]"`, using the same Modelica structured naming as the
+ * .mat result files and val(). Without this an array variable would only emit a
+ * single header entry while the data row emits one value per scalar element.
+ *
+ * @param fout        Output file.
+ * @param format      printf format with a single `%s`, e.g. `",\"%s\""`.
+ * @param name        Variable name.
+ * @param dimension   Dimension of the variable. `NULL` or 0 dimensions for scalars.
+ * @param threadData  Thread data for error handling.
+ */
+static void csvWriteArrayNames(FILE* fout, const char* format, const char* name,
+                               const DIMENSION_INFO* dimension, threadData_t* threadData)
+{
+  char escaped[MAX_IDENT_LENGTH];
+
+  if (dimension == NULL || dimension->numberOfDimensions == 0) {
+    csvEscapedString(name, escaped, MAX_IDENT_LENGTH, threadData);
+    fprintf(fout, format, escaped);
+    return;
+  }
+
+  char nameBuffer[MAX_IDENT_LENGTH];
+  for (size_t linear = 0; linear < dimension->scalar_length; linear++) {
+    /* compute multi-dimensional 1-based indices for this linear index (row-major) */
+    size_t rem = linear;
+    size_t written = snprintf(nameBuffer, MAX_IDENT_LENGTH, "%s", name);
+    for (size_t k = 0; k < dimension->numberOfDimensions; k++) {
+      size_t stride = 1;
+      for (size_t j = k + 1; j < dimension->numberOfDimensions; j++) {
+        stride *= (size_t)dimension->dimensions[j].start;
+      }
+      size_t idx = rem / stride + 1;
+      rem = rem % stride;
+      written += snprintf(nameBuffer + written, MAX_IDENT_LENGTH - written, (k == 0) ? "[%zu" : ",%zu", idx);
+    }
+    snprintf(nameBuffer + written, MAX_IDENT_LENGTH - written, "]");
+    csvEscapedString(nameBuffer, escaped, MAX_IDENT_LENGTH, threadData);
+    fprintf(fout, format, escaped);
+  }
+}
+
+/**
  * @brief Write CSV data row.
  *
  * @param self        Simulation result.
@@ -131,39 +177,44 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   fprintf(fout, "%.16g", data->localData[0]->timeValue);
   if(self->cpuTime)
     fprintf(fout, format, cpuTimeValue);
-  for(i = 0; i < data->modelData->nVariablesReal; i++) if(!data->modelData->realVarsData[i].filterOutput)
-    fprintf(fout, format, (data->localData[0])->realVars[i]);
-  for(i = 0; i < data->modelData->nVariablesInteger; i++) if(!data->modelData->integerVarsData[i].filterOutput)
-    fprintf(fout, formatint, (data->localData[0])->integerVars[i]);
-  for(i = 0; i < data->modelData->nVariablesBoolean; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
-    fprintf(fout, formatbool, (data->localData[0])->booleanVars[i]);
+  for(i = 0; i < data->modelData->nVariablesRealArray; i++) if(!data->modelData->realVarsData[i].filterOutput)
+    for(size_t k = 0; k < data->modelData->realVarsData[i].dimension.scalar_length; k++)
+      fprintf(fout, format, (data->localData[0])->realVars[data->simulationInfo->realVarsIndex[i] + k]);
+  for(i = 0; i < data->modelData->nVariablesIntegerArray; i++) if(!data->modelData->integerVarsData[i].filterOutput)
+    for(size_t k = 0; k < data->modelData->integerVarsData[i].dimension.scalar_length; k++)
+      fprintf(fout, formatint, (data->localData[0])->integerVars[data->simulationInfo->integerVarsIndex[i] + k]);
+  for(i = 0; i < data->modelData->nVariablesBooleanArray; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
+    for(size_t k = 0; k < data->modelData->booleanVarsData[i].dimension.scalar_length; k++)
+      fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->simulationInfo->booleanVarsIndex[i] + k]);
   //for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
   //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
 
-  for(i = 0; i < data->modelData->nAliasReal; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+  for(i = 0; i < data->modelData->nAliasRealArray; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
     if (data->modelData->realAlias[i].aliasType == ALIAS_TYPE_TIME) {
-      value = (data->localData[0])->timeValue;
+      fprintf(fout, format, (data->localData[0])->timeValue);
     } else {
-      value = (data->localData[0])->realVars[data->modelData->realAlias[i].nameID];
-    }
-    if (data->modelData->realAlias[i].negate) {
-      fprintf(fout, format, -value);
-    } else {
-      fprintf(fout, format, value);
-    }
-  }
-  for(i = 0; i < data->modelData->nAliasInteger; i++) if(!data->modelData->integerAlias[i].filterOutput && data->modelData->integerAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-    if (data->modelData->integerAlias[i].negate) {
-      fprintf(fout, formatint, -(data->localData[0])->integerVars[data->modelData->integerAlias[i].nameID]);
-    } else {
-      fprintf(fout, formatint, (data->localData[0])->integerVars[data->modelData->integerAlias[i].nameID]);
+      const int nameID = data->modelData->realAlias[i].nameID;
+      const modelica_boolean negate = data->modelData->realAlias[i].negate;
+      for(size_t k = 0; k < data->modelData->realVarsData[nameID].dimension.scalar_length; k++) {
+        value = (data->localData[0])->realVars[data->simulationInfo->realVarsIndex[nameID] + k];
+        fprintf(fout, format, negate ? -value : value);
+      }
     }
   }
-  for(i = 0; i < data->modelData->nAliasBoolean; i++) if(!data->modelData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-    if (data->modelData->booleanAlias[i].negate) {
-      fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->modelData->booleanAlias[i].nameID]==1?0:1);
-    } else {
-      fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->modelData->booleanAlias[i].nameID]);
+  for(i = 0; i < data->modelData->nAliasIntegerArray; i++) if(!data->modelData->integerAlias[i].filterOutput && data->modelData->integerAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+    const int nameID = data->modelData->integerAlias[i].nameID;
+    const modelica_boolean negate = data->modelData->integerAlias[i].negate;
+    for(size_t k = 0; k < data->modelData->integerVarsData[nameID].dimension.scalar_length; k++) {
+      modelica_integer ivalue = (data->localData[0])->integerVars[data->simulationInfo->integerVarsIndex[nameID] + k];
+      fprintf(fout, formatint, negate ? -ivalue : ivalue);
+    }
+  }
+  for(i = 0; i < data->modelData->nAliasBooleanArray; i++) if(!data->modelData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+    const int nameID = data->modelData->booleanAlias[i].nameID;
+    const modelica_boolean negate = data->modelData->booleanAlias[i].negate;
+    for(size_t k = 0; k < data->modelData->booleanVarsData[nameID].dimension.scalar_length; k++) {
+      modelica_boolean bvalue = (data->localData[0])->booleanVars[data->simulationInfo->booleanVarsIndex[nameID] + k];
+      fprintf(fout, formatbool, negate ? (bvalue==1?0:1) : bvalue);
     }
   }
   //for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
@@ -188,7 +239,6 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
 
   const char* format = ",\"%s\"";
   FILE *fout = omc_fopen(self->filename, "w");
-  char escapedNameBuffer[MAX_IDENT_LENGTH];
 
   assertStreamPrint(threadData, 0!=fout, "Error, couldn't create output file: [%s] because of %s", self->filename, strerror(errno));
 
@@ -196,39 +246,35 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
   if(self->cpuTime) {
     fprintf(fout, format, "$cpuTime");
   }
-  for(i = 0; i < mData->nVariablesReal; i++) if(!mData->realVarsData[i].filterOutput) {
-    csvEscapedString(mData->realVarsData[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-    fprintf(fout, format, escapedNameBuffer);
+  for(i = 0; i < mData->nVariablesRealArray; i++) if(!mData->realVarsData[i].filterOutput) {
+    csvWriteArrayNames(fout, format, mData->realVarsData[i].info.name, &mData->realVarsData[i].dimension, threadData);
   }
-  for(i = 0; i < mData->nVariablesInteger; i++) {
+  for(i = 0; i < mData->nVariablesIntegerArray; i++) {
     if(!mData->integerVarsData[i].filterOutput) {
-      csvEscapedString(mData->integerVarsData[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-      fprintf(fout, format, escapedNameBuffer);
+      csvWriteArrayNames(fout, format, mData->integerVarsData[i].info.name, &mData->integerVarsData[i].dimension, threadData);
     }
   }
-  for(i = 0; i < mData->nVariablesBoolean; i++) {
+  for(i = 0; i < mData->nVariablesBooleanArray; i++) {
     if(!mData->booleanVarsData[i].filterOutput) {
-      csvEscapedString(mData->booleanVarsData[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-      fprintf(fout, format, escapedNameBuffer);
+      csvWriteArrayNames(fout, format, mData->booleanVarsData[i].info.name, &mData->booleanVarsData[i].dimension, threadData);
     }
   }
 
-  for(i = 0; i < mData->nAliasReal; i++) {
+  for(i = 0; i < mData->nAliasRealArray; i++) {
     if(!mData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-      csvEscapedString(mData->realAlias[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-      fprintf(fout, format, escapedNameBuffer);
+      /* time aliases are scalar, other aliases inherit the dimension of the aliased variable */
+      const DIMENSION_INFO *aliasDim = (mData->realAlias[i].aliasType == ALIAS_TYPE_TIME) ? NULL : &mData->realVarsData[mData->realAlias[i].nameID].dimension;
+      csvWriteArrayNames(fout, format, mData->realAlias[i].info.name, aliasDim, threadData);
     }
   }
-  for(i = 0; i < mData->nAliasInteger; i++) {
+  for(i = 0; i < mData->nAliasIntegerArray; i++) {
     if(!mData->integerAlias[i].filterOutput && data->modelData->integerAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-      csvEscapedString(mData->integerAlias[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-      fprintf(fout, format, escapedNameBuffer);
+      csvWriteArrayNames(fout, format, mData->integerAlias[i].info.name, &mData->integerVarsData[mData->integerAlias[i].nameID].dimension, threadData);
     }
   }
-  for(i = 0; i < mData->nAliasBoolean; i++) {
+  for(i = 0; i < mData->nAliasBooleanArray; i++) {
     if(!mData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-      csvEscapedString(mData->booleanAlias[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
-      fprintf(fout, format, escapedNameBuffer);
+      csvWriteArrayNames(fout, format, mData->booleanAlias[i].info.name, &mData->booleanVarsData[mData->booleanAlias[i].nameID].dimension, threadData);
     }
   }
   fprintf(fout, "\n");

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -376,12 +376,12 @@ struct variableCount count_name_description_signals(const MODEL_DATA *mData,
  * @brief Print name(s) of scalar or array variable.
  *
  * For array variables names for all array elements are printed in the form
- * `"<name>[dim1][dim2]...[dimN]"` and for state derivatives in
- * `"der(<name>[dim1][dim2]...[dimN])"`.
+ * `"<name>[dim1,dim2,...,dimN]"` and for state derivatives in
+ * `"der(<name>[dim1,dim2,...,dimN])"`.
  *
  * If array variable is a state derivative assumes that `name` has format
  * `"der(<name>)"`. Will overwrite last character of `name` with array suffix
- * `"[dim1][dim2]...[dimN])"`.
+ * `"[dim1,dim2,...,dimN])"`.
  *
  * TODO: Move to a place where CSV can use it as well.
  *
@@ -435,8 +435,12 @@ char *printArrayName(char *buffer,
     }
     for (size_t k = 0; k < dimension->numberOfDimensions; ++k)
     {
-      written += snprintf(buffer + written, maxlen - written, "[%zu]", idx[k]);
+      /* Modelica uses comma separated subscripts inside a single pair of
+         brackets, e.g. "m[1,2]", so that names match the ones used by val()
+         and the scalarized code path. */
+      written += snprintf(buffer + written, maxlen - written, (k == 0) ? "[%zu" : ",%zu", idx[k]);
     }
+    written += snprintf(buffer + written, maxlen - written, "]");
     if (isStateDerivative)
     {
       written += snprintf(buffer + written, maxlen - written, ")");

--- a/testsuite/simulation/modelica/NBackend/array_handling/Makefile
+++ b/testsuite/simulation/modelica/NBackend/array_handling/Makefile
@@ -2,6 +2,7 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 array_start_vector.mos\
+arrayResultFile.mos\
 simple_for.mos\
 simple_nested_for.mos\
 irregular_for.mos\

--- a/testsuite/simulation/modelica/NBackend/array_handling/arrayResultFile.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/arrayResultFile.mos
@@ -1,0 +1,73 @@
+// name: arrayResultFile
+// keywords: NewBackend
+// status: correct
+//
+// Without sim code scalarization array variables are stored whole and are
+// expanded into their scalar elements when the result file is written. Check
+// that mat and csv result files use the Modelica structured names "m[i,j]" and
+// that the csv writer emits one column per scalar element, for array variables
+// as well as for array aliases.
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+loadString("
+  model arrayResultFile
+    Real[2,2] m;
+    Real[2,2] mAlias;
+    Integer[2] k;
+    Boolean[2] b;
+    Real tr;
+  equation
+    m = {{time, 2*time},{3*time, 4*time}};
+    mAlias = m;
+    k = {1, 2};
+    b = {true, false};
+    tr = m[1,1] + m[2,2];
+  end arrayResultFile;
+"); getErrorString();
+
+simulate(arrayResultFile, stopTime=1.0); getErrorString();
+val(m[1,1], 1.0);
+val(m[1,2], 1.0);
+val(m[2,1], 1.0);
+val(m[2,2], 1.0);
+val(mAlias[2,1], 1.0);
+val(tr, 1.0);
+
+simulate(arrayResultFile, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
+readFile("arrayResultFile_res.csv");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "arrayResultFile_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'arrayResultFile', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 2.0
+// 3.0
+// 4.0
+// 3.0
+// 5.0
+// record SimulationResult
+//     resultFile = "arrayResultFile_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'arrayResultFile', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "\"time\",\"mAlias[1,1]\",\"mAlias[1,2]\",\"mAlias[2,1]\",\"mAlias[2,2]\",\"tr\",\"k[1]\",\"k[2]\",\"b[1]\",\"b[2]\",\"m[1,1]\",\"m[1,2]\",\"m[2,1]\",\"m[2,2]\"
+// 0,0,0,0,0,0,1,2,1,0,0,0,0,0
+// 0.5,0.5,1,1.5,2,2.5,1,2,1,0,0.5,1,1.5,2
+// 1,1,2,3,4,5,1,2,1,0,1,2,3,4
+// 1,1,2,3,4,5,1,2,1,0,1,2,3,4
+// "
+// endResult


### PR DESCRIPTION
### Related Issues

Related to https://github.com/OpenModelica/OpenModelica/issues/14918.

There seems to be a bug in `OpenModelicaScripting.val`:

```modelica
setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
loadString("
  model array2D
    Real[2,2] m;
    Real tr;
  equation
    m = {{time, 2*time},{3*time, 4*time}};
    tr = m[1,1] + m[2,2];
  end array2D;
"); getErrorString();
simulate(array2D, stopTime=1.0); getErrorString();
val(m[1,1], 1.0);
val(m[1,2], 1.0);
val(m[2,1], 1.0);
val(m[2,2], 1.0);
val(tr, 1.0);
```

```
  val(m[1,1], 1.0);   // -> NaN  (expected 1.0)
  val(m[1,2], 1.0);   // -> NaN  (expected 2.0)
  val(m[2,1], 1.0);   // -> NaN  (expected 3.0)
  val(m[2,2], 1.0);   // -> NaN  (expected 4.0)
  val(tr,     1.0);   // -> 5.0  (correct: time + 4*time = 5 at t=1)
```

### Purpose

Without sim code scalarization array variables are stored whole and expanded to scalar elements when writing the result file.

### Approach

- MAT: printArrayName emitted element names as "m[1][2]" (one bracket pair per dimension) instead of the Modelica structured name "m[1,2]" used by val() and the scalarized code path, so val() returned NaN for every element of a multi dimensional array. Emit comma separated subscripts inside a single bracket pair.
- CSV: the writer was never made array aware. It iterated the scalar variable counts while indexing the array sized *VarsData/*Alias arrays, reading out of bounds and crashing in omc_csv_init. Iterate the array variable counts and expand each array variable into its scalar elements using *VarsIndex/scalar_length for the values and "name[i,j,...]" for the header, mirroring the MAT writer.


### Tests

Added `testsuite/simulation/modelica/NBackend/array_handling/arrayResultFile.mos`, simulating a model with a 2D Real array, an array alias, an Integer array and a Boolean array with `--simCodeScalarize=false`:

- mat: `val()` on each `m[i,j]` element.
- csv: the full result file, checking that header and data row agree and that arrays and array aliases are expanded into one column per scalar element.

Without the fix the test returns `NaN` from every `val()` call and segfaults on the csv run.