### PR TITLE
[BackEnd] BackendDump.dumpMatching2: loop instead of recursion (fix stack overflow)

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -3144,29 +3144,15 @@ algorithm
 end dumpMatching;
 
 protected function dumpMatching2 "author: PA
-  Helper function to dumpMatching."
+  Helper function to dumpMatching. Uses a loop rather than recursion to avoid a stack overflow on
+  large models (the matching array has one entry per scalar variable)."
   input array<Integer> v;
   input Integer i;
   input Integer len;
 algorithm
-  () := matchcontinue len
-    local
-      Integer eqn;
-      String s,s2;
-    case _
-      algorithm
-        true := intLe(i,len);
-        s := intString(i);
-        eqn := v[i];
-        s2 := intString(eqn);
-        print("var " + s + " is solved in eqn " + s2 + "\n");
-        dumpMatching2(v, i+1, len);
-      then
-        ();
-    else
-      then
-        ();
-  end matchcontinue;
+  for j in i:len loop
+    print("var " + intString(j) + " is solved in eqn " + intString(v[j]) + "\n");
+  end for;
 end dumpMatching2;
 
 public function dumpMatchingVars "Prints matching information on stdout."


### PR DESCRIPTION

dumpMatching2 recursed once per matched variable - the matching array has one entry per scalar variable - so dumping the matching of a large model (e.g. via -d=dumpindxdae) overflowed the stack. On an ~25000-variable model (parallel cable initialization) it crashed with the default 8 MB stack: the backtrace showed 1024+ frames in BackendDump.dumpMatching2. The matchcontinue form prevented tail-call optimization.

Convert it to a simple for-loop; the printed output is unchanged.