### PR TITLE
Fix some OMNotebook issues

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/ModelicaTextHighlighter.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/ModelicaTextHighlighter.cpp
@@ -52,6 +52,14 @@
 namespace IAEX
 {
 
+enum BlockState
+{
+  DefaultState,
+  SingleLineComment,
+  MultiLineComment,
+  QuotedString
+};
+
 //  ModelicaTextHighlighter implementation
 ModelicaTextHighlighter::ModelicaTextHighlighter(QTextDocument *pTextDocument)
     : QSyntaxHighlighter(pTextDocument)
@@ -151,31 +159,31 @@ void ModelicaTextHighlighter::highlightMultiLine(const QString &text)
 {
     /* Hand‑written recogniser beats the crap known as QRegEx ;) */
     int index = 0, startIndex = 0;
-    int blockState = previousBlockState();
+    BlockState blockState = static_cast<BlockState>(previousBlockState());
 
     while (index < text.length()) {
         switch (blockState) {
-        case 1: // inside a single‑line comment
+        case BlockState::SingleLineComment:
             if (text[index] == '/' && index + 1 < text.length() && text[index + 1] == '/') {
-                ++index;               // stay in the comment state
-                blockState = 1;
+                ++index;
+                blockState = BlockState::SingleLineComment; // stay in the comment state
             }
             break;
 
-        case 2: // inside a multi‑line comment
+        case BlockState::MultiLineComment:
             if (text[index] == '*' && index + 1 < text.length() && text[index + 1] == '/') {
                 ++index;
                 setFormat(startIndex, index - startIndex + 1, mMultiLineCommentFormat);
-                blockState = 0;
+                blockState = BlockState::DefaultState;
             }
             break;
 
-        case 3: // inside a quoted string
+        case BlockState::QuotedString:
             if (text[index] == '\\') {
                 ++index;               // escape sequence – skip next char
             } else if (text[index] == '"') {
                 setFormat(startIndex, index - startIndex + 1, mQuotationFormat);
-                blockState = 0;
+                blockState = BlockState::DefaultState;
             }
             break;
 
@@ -183,13 +191,13 @@ void ModelicaTextHighlighter::highlightMultiLine(const QString &text)
             if (text[index] == '/' && index + 1 < text.length() && text[index + 1] == '/') {
                 startIndex = index++;
                 setFormat(startIndex, text.length() - startIndex, mSingleLineCommentFormat);
-                blockState = 1;
+                blockState = BlockState::SingleLineComment;
             } else if (text[index] == '/' && index + 1 < text.length() && text[index + 1] == '*') {
                 startIndex = index++;
-                blockState = 2;
+                blockState = BlockState::MultiLineComment;
             } else if (text[index] == '"') {
                 startIndex = index;
-                blockState = 3;
+                blockState = BlockState::QuotedString;
             }
             break;
         }
@@ -197,13 +205,13 @@ void ModelicaTextHighlighter::highlightMultiLine(const QString &text)
     }
 
     switch (blockState) {
-    case 2:
+      case BlockState::MultiLineComment:
         setFormat(startIndex, text.length() - startIndex, mMultiLineCommentFormat);
-        setCurrentBlockState(2);
+        setCurrentBlockState(BlockState::MultiLineComment);
         break;
-    case 3:
+      case BlockState::QuotedString:
         setFormat(startIndex, text.length() - startIndex, mQuotationFormat);
-        setCurrentBlockState(3);
+        setCurrentBlockState(BlockState::QuotedString);
         break;
     }
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -451,7 +451,7 @@ namespace IAEX
 
       // refresh all window menus
       for (DocumentView *dv : documentViewList())
-          static_cast<NotebookWindow*>(dv)->updateWindowMenu();
+        dv->updateWindowMenu();
   }
 
   //  DrModelica conversion (unchanged – never called)

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellstyle.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellstyle.h
@@ -85,13 +85,8 @@ namespace IAEX
       textFormat_.setFontPointSize( 12 );
 
       textFormat_.setForeground( QBrush( QColor(0,0,0) ));
-
-      // defalut visibliity
-      visible_ = true;
-
-      // defalut chapter level
-      chapterLevel_ = 0;
     }
+
     virtual ~CellStyle(){}
 
     QString name(){ return name_; }
@@ -111,11 +106,10 @@ namespace IAEX
   private:
     QString name_;
     QTextCharFormat textFormat_;
-        QTextFrameFormat frameFormat_;
-    int alignment_;
-
-    bool visible_;
-    int chapterLevel_;
+    QTextFrameFormat frameFormat_;
+    int alignment_ = Qt::AlignLeft;
+    bool visible_ = true;
+    int chapterLevel_ = 0;
   };
 }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/documentview.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/documentview.h
@@ -63,12 +63,13 @@ namespace IAEX
       Q_OBJECT
    public:
       DocumentView(QWidget *parent=0)
-   : QMainWindow(parent){ setAttribute(Qt::WA_DeleteOnClose); }
+        : QMainWindow(parent){ setAttribute(Qt::WA_DeleteOnClose); }
       virtual ~DocumentView(){}
 
       virtual void update() = 0;
-    virtual Document* document() = 0;
+      virtual Document* document() = 0;
 
+      virtual void updateWindowMenu() = 0;
    };
 };
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
@@ -80,8 +80,8 @@ public:
                  QWidget *parent=0);
   virtual ~NotebookWindow();
 
-  virtual void update();
-  virtual Document* document();
+  virtual void update() override;
+  virtual Document* document() override;
   CellApplication *application();
 
 public slots:
@@ -99,7 +99,7 @@ public slots:
   void updateBorderMenu();
   void updateMarginMenu();
   void updatePaddingMenu();
-  void updateWindowMenu();
+  void updateWindowMenu() override;
   void updateWindowTitle();
   void updateChapterCounters();
   void setStatusMessage( QString msg );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
@@ -58,7 +58,6 @@
 #include <QtWidgets>
 #include <QDomNode>
 #include <QtCore/QRegularExpression>
-#define fromAscii fromLatin1
 
 // IAEX Headers
 #include "xmlparser.h"
@@ -413,46 +412,15 @@ namespace IAEX
           QRegularExpression rx(pattern, QRegularExpression::CaseInsensitiveOption);
 #else
           QRegularExpression rx(pattern);
-rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption | QRegularExpression::InvertedGreedinessOption);
-
+          rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption | QRegularExpression::InvertedGreedinessOption);
 #endif
           if (!rx.isValid())
           {
-            fprintf(stderr, "Invalid QRegExp(%s)\n", rx.pattern().toStdString().c_str());
-          }
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-          QRegularExpressionMatch match = rx.match(text);
-          while (match.hasMatch())
-          {
-            text = text.replace(rx, match.captured(1) + QString::fromAscii("/") + match.captured(2));
-            match = rx.match(text);
+            fprintf(stderr, "Invalid QRegularExpression(%s)\n", rx.pattern().toStdString().c_str());
           }
 
+          text.replace(rx, QStringLiteral("\1/\2"));
           textcell->setTextHtml(text);
-#else
-          QRegularExpressionMatch match = rx.match(text);
-          if (match.hasMatch())
-          {
-              while (match.hasMatch())
-              {
-                  // int numX = match.lastCapturedIndex(); 
-                  // QString s1 = match.captured(1);
-                  // QString s2 = match.captured(2);
-                  
-                  // Ersetzt das erste Vorkommen des Treffers im Text
-                  text.replace(match.capturedStart(0), match.capturedLength(0), 
-                              match.captured(1) + QStringLiteral("/") + match.captured(2));
-                  
-                  // Suche erneut im modifizierten Text
-                  match = rx.match(text);
-              }
-              textcell->setTextHtml(text);
-          }
-          else // Keine Treffer gefunden
-          {
-              textcell->setTextHtml(text);
-          }
-#endif
         }
         else if( e.tagName() == XML_RULE )
         {


### PR DESCRIPTION
- Replace magic numbers in ModelicaTextHighlighter with an enum.
- Add virtual DocumentView::updateWindowMenu method to avoid dangerous casts.
- Make sure everything is initialized in CellStyle.
- Remove fromAscii macro in XMLParser that was used for Qt4 compatibility.
- Degermanise comments.
