### PR TITLE
Set QSG_RHI_BACKEND to opengl on Windows

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -218,6 +218,10 @@ int main(int argc, char *argv[])
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+#ifdef Q_OS_WIN
+  // Set this before creating QApplication. Avoids web engine switch to Direct3DSurface. See issue #15822.
+  qputenv("QSG_RHI_BACKEND", "opengl");
+#endif // #ifdef Q_OS_WIN
   OMEditApplication a(argc, argv, threadData);
 // Do not use the signal handler OR exception filter if user is building a debug version.
 // Perhaps the user wants to use gdb.

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -104,7 +104,8 @@ ViewerWidget::ViewerWidget(QWidget* parent, Qt::WindowFlags flags)
   camera->setGraphicsContext(mpGraphicsWindow.get());
   camera->setClearColor(osg::Vec4(0.95, 0.95, 0.95, 1.0));
   camera->setViewport(new osg::Viewport(0, 0, width(), height()));
-  camera->setProjectionMatrixAsPerspective(30.0f, static_cast<double>(width()/2) / static_cast<double>(height()/2), 1.0f, 10000.0f);
+  double aspect = height() > 0 ? static_cast<double>(width()) / static_cast<double>(height()) : 1.0;
+  camera->setProjectionMatrixAsPerspective(30.0f, aspect, 1.0f, 10000.0f);
   mpSceneView->addEventHandler(new osgViewer::StatsHandler());
   // reverse the mouse wheel zooming
   osgGA::MultiTouchTrackballManipulator *pMultiTouchTrackballManipulator = new osgGA::MultiTouchTrackballManipulator();
@@ -114,7 +115,6 @@ ViewerWidget::ViewerWidget(QWidget* parent, Qt::WindowFlags flags)
   mpViewer->setThreadingModel(osgViewer::CompositeViewer::SingleThreaded);
   // disable the default setting of viewer.done() by pressing Escape.
   mpViewer->setKeyEventSetsDone(0);
-  mpViewer->realize();
   // This ensures that the widget will receive keyboard events. This focus
   // policy is not set by default. The default, Qt::NoFocus, will result in
   // keyboard events that are ignored.
@@ -127,13 +127,12 @@ ViewerWidget::ViewerWidget(QWidget* parent, Qt::WindowFlags flags)
 }
 
 /*!
- * \brief ViewerWidget::paintEvent
- * Reimplementation of QOpenGLWidget::paintEvent().
- * \sa ViewerWidget::paintGL()
+ * \brief ViewerWidget::initializeGL
+ * Reimplementation of QOpenGLWidget::initializeGL()
  */
-void ViewerWidget::paintEvent(QPaintEvent* /* paintEvent */)
+void ViewerWidget::initializeGL()
 {
-  paintGL();
+  mpViewer->realize();
 }
 
 /*!
@@ -149,9 +148,13 @@ void ViewerWidget::paintEvent(QPaintEvent* /* paintEvent */)
  */
 void ViewerWidget::paintGL()
 {
-  mpFrameMutex->lock();
-  frame();
-  mpFrameMutex->unlock();
+  if (!context()) {
+    qDebug() << "No OpenGL context";
+    return;
+  }
+
+  OpenThreads::ScopedLock<OpenThreads::Mutex> lock(*mpFrameMutex);
+  mpViewer->frame();
   MessagesWidget::instance()->showPendingMessages();
 }
 

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.h
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.h
@@ -48,13 +48,9 @@
 
 #include <OpenThreads/Mutex>
 
-#include <iostream>
-
 #include <QMenu>
 
 #include "AbstractAnimationWindow.h"
-#include "AnimationUtil.h"
-#include "Util/Helper.h"
 
 /*!
  * \note We need to create two files with same class name since Qt meta object compiler doesn't handle ifdef.
@@ -90,7 +86,7 @@ public:
   void pickVisualizer(int x, int y);
   void frame();
 protected:
-  virtual void paintEvent(QPaintEvent *paintEvent) override;
+  virtual void initializeGL() override;
   virtual void paintGL() override;
   virtual void resizeGL(int width, int height) override;
   virtual void keyPressEvent(QKeyEvent *event) override;


### PR DESCRIPTION
Qt web engine forces the surface to direct3Dsurface which is not compatble with OSG. The animation window is shown blank as a result.

Clean up the ViewerWidget code.
Use initializeGL() instead of calling realize() directly. Use paintGL() instead of paintEvent().

### Related Issues

#15822