### PR TITLE
[BackEnd] Fail getWhenEquationExpr instead of returning uninitialized

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -332,8 +332,9 @@ public function getWhenEquationExpr "Get the left and right hand parts from an e
 algorithm
   try
     BackendDAE.WHEN_STMTS(whenStmtLst={BackendDAE.ASSIGN(left=DAE.CREF(componentRef = outComponentRef), right=outExp)}) := inWhenEquation;
-else
+  else
     Error.addInternalError("BackendEquation.getWhenEquationExpr failed\n", sourceInfo());
+    fail();
   end try;
 end getWhenEquationExpr;
 


### PR DESCRIPTION
The try/else branch reported an internal error but then returned normally, leaving both outputs uninitialized.