### PR TITLE
Add -d=checkDefUse: warn when variables are not provably defined before use

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -3559,13 +3559,13 @@ algorithm
     case DAE.CALL(path=Absyn.IDENT(name = "change"), expLst={e})
       algorithm
         ty := Expression.typeof(e);
-      then (DAE.RELATION(e, DAE.NEQUAL(ty), DAE.CALL(Absyn.IDENT("pre"), {e}, DAE.CALL_ATTR(ty, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL())), -1, NONE()), true);
+      then (DAE.RELATION(e, DAE.NEQUAL(ty), DAE.CALL(Absyn.IDENT("pre"), {e}, DAE.CALL_ATTR(ty, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS)), -1, NONE()), true);
 
     // edge(b) = b and not pre(b)
     case DAE.CALL(path=Absyn.IDENT(name = "edge"), expLst={e})
       algorithm
         ty := Expression.typeof(e);
-      then (DAE.LBINARY(e, DAE.AND(ty), DAE.LUNARY(DAE.NOT(ty), DAE.CALL(Absyn.IDENT("pre"), {e}, DAE.CALL_ATTR(ty, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL())))), true);
+      then (DAE.LBINARY(e, DAE.AND(ty), DAE.LUNARY(DAE.NOT(ty), DAE.CALL(Absyn.IDENT("pre"), {e}, DAE.CALL_ATTR(ty, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS)))), true);
 
     else (inExp,inB);
   end matchcontinue;

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1074,7 +1074,7 @@ algorithm
       algorithm
         expl := List.map1(varLst,Expression.generateCrefsExpFromExpVar,cr);
         (expl_1, outFunctionTree) := List.map3Fold(expl, function differentiateExp(maxIter=maxIter), inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
-        res := DAE.CALL(path,expl_1,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+        res := DAE.CALL(path,expl_1,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
       then
         (res, outFunctionTree);
 
@@ -1164,7 +1164,7 @@ algorithm
       algorithm
         //({BackendDAE.VAR(varKind = BackendDAE.STATE(index=_))},_) = BackendVariable.getVar(cr, timevars);
         BackendVariable.getVarSingle(cr, timevars);
-        res := DAE.CALL(Absyn.IDENT("der"),{e},DAE.CALL_ATTR(tp,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+        res := DAE.CALL(Absyn.IDENT("der"),{e},DAE.CALL_ATTR(tp,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
       then
         (res, inFunctionTree);
 
@@ -2203,7 +2203,7 @@ algorithm
         (dexpl, outFunctionTree) := List.map3Fold(expl1, function differentiateExp(maxIter=maxIter), inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
         expl1 := listAppend(expl,dexpl);
       then
-        (DAE.CALL(dpath,expl1,DAE.CALL_ATTR(ty,b,c,isImpure,false,dinl,tc)),outFunctionTree);
+        (DAE.CALL(dpath,expl1,DAE.CALL_ATTR(ty,b,c,isImpure,false,dinl,tc,DAE.NoReturn.RETURNS)),outFunctionTree);
 
     case (DAE.CALL(path=path,expLst=expl), BackendDAE.DIFFERENTIATION_TIME())
       algorithm
@@ -2345,7 +2345,7 @@ algorithm
           print("Diffed ExpList: \n");
           print(stringDelimitList(List.map(dexpl, ExpressionBasics.printExpStr), ", ") + "\n");
         end if;
-        e := DAE.CALL(dpath,expl1,DAE.CALL_ATTR(ty,b,c,isImpure,false,dinl,tc));
+        e := DAE.CALL(dpath,expl1,DAE.CALL_ATTR(ty,b,c,isImpure,false,dinl,tc,DAE.NoReturn.RETURNS));
         e := createPartialArguments(ty, dexpl, dexplZero, expl, e);
       then
         (e,functions);
@@ -2434,10 +2434,10 @@ algorithm
         // try to create zero expression to fill up the arguments, if it fails use the total differentiation
         (dexplZero, functions, success) := tryZeroDiff(expl1, functions, maxIter);
         if success then
-          e := DAE.CALL(dpath,dexpl,DAE.CALL_ATTR(dtp,b,false,isImpure,false,DAE.NO_INLINE(),tc));
+          e := DAE.CALL(dpath,dexpl,DAE.CALL_ATTR(dtp,b,false,isImpure,false,DAE.NO_INLINE(),tc,DAE.NoReturn.RETURNS));
           exp := createPartialArguments(ty, dexpl, dexplZero, expl, e);
         else
-          exp := DAE.CALL(dpath,listAppend(expl,dexpl),DAE.CALL_ATTR(dtp,b,false,isImpure,false,DAE.NO_INLINE(),tc));
+          exp := DAE.CALL(dpath,listAppend(expl,dexpl),DAE.CALL_ATTR(dtp,b,false,isImpure,false,DAE.NO_INLINE(),tc,DAE.NoReturn.RETURNS));
         end if;
 
         if Flags.isSet(Flags.DEBUG_DIFFERENTIATION_VERBOSE) then

--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -1547,7 +1547,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " failed", sourceInfo());
+        Error.terminate(getInstanceName() + " failed", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -3326,7 +3326,7 @@ protected
   DAE.Type tp;
 algorithm
   tp := Expression.typeof(inExp);
-  outExp := DAE.CALL(Absyn.IDENT("der"), {inExp}, DAE.CALL_ATTR(tp, false, true, false, false, DAE.NO_INLINE(),DAE.NO_TAIL()));
+  outExp := DAE.CALL(Absyn.IDENT("der"), {inExp}, DAE.CALL_ATTR(tp, false, true, false, false, DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
 end makeder;
 
 protected function adjacencyMatrixfromEnhancedStrict

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4561,7 +4561,7 @@ uniontype LinearJacobian
         then ();
 
         else algorithm
-          Error.assertion(false, getInstanceName() + " key does not have an element in pivot row.", sourceInfo());
+          Error.terminate(getInstanceName() + " key does not have an element in pivot row.", sourceInfo());
         then ();
        end match;
     end for;

--- a/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
@@ -1983,7 +1983,7 @@ protected function substGetPartition
 protected
   DAE.CallAttributes attrs;
 algorithm
-  attrs := DAE.CALL_ATTR(Expression.typeof(inExp), false, true, true, false, DAE.NO_INLINE(), DAE.NO_TAIL());
+  attrs := DAE.CALL_ATTR(Expression.typeof(inExp), false, true, true, false, DAE.NO_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS);
   outExp := DAE.CALL(Absyn.IDENT("$getPart"), {inExp}, attrs);
 end substGetPartition;
 

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -13,6 +13,11 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(GEN_DEBUG_SYMBOLS "-d=gendebugsymbols")
 endif()
 
+# Compile the compiler against itself with the def-use static analysis enabled so that
+# conditionally-assigned variables are caught at build time. -d= is additive and survives
+# the setCommandLineOptions("-d=rml") in mm_compile.in.mos.
+set(CHECK_DEF_USE "-d=checkDefUse")
+
 # list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.cmake")
 # enable_language(MODELICA)
 
@@ -90,7 +95,7 @@ macro(add_compile_step mo_source_file)
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.stamp
                 ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos
 
-        COMMAND ${OMC_EXE} -g=MetaModelica -n=1 ${GEN_DEBUG_SYMBOLS} ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos
+        COMMAND ${OMC_EXE} -g=MetaModelica -n=1 ${GEN_DEBUG_SYMBOLS} ${CHECK_DEF_USE} ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos
 
         OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/c_files/${file_name_no_ext}.c
                 ${CMAKE_CURRENT_BINARY_DIR}/c_files/${file_name_no_ext}_records.c

--- a/OMCompiler/Compiler/FFrontEnd/FNode.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FNode.mo
@@ -397,9 +397,71 @@ protected
 algorithm
   FCore.N(n, id, p, c, FCore.FT(tys)) := fromRef(ref);
   tys := List.unique(listAppend(inTys, tys));
+  // A type-only instantiation cannot run the body analysis that marks a
+  // function no-return, so it yields a returning variant, while a full
+  // instantiation yields the no-return variant. Both would otherwise be kept
+  // here (they differ only in the NoReturn marker), leaving two types for a
+  // single function and breaking single-type function lookups. Drop the
+  // returning variant when a no-return variant of the same function is present.
+  tys := list(t for t guard not isReturningFunctionWithNoReturnVariant(t, tys) in tys);
   // update the child
   r := updateRef(ref, FCore.N(n, id, p, c, FCore.FT(tys)));
 end addTypesToRef;
+
+protected function isReturningFunctionWithNoReturnVariant
+  "True if ty is a returning function type for which the list also holds an
+   otherwise identical no-return function type."
+  input DAE.Type ty;
+  input list<DAE.Type> tys;
+  output Boolean b;
+algorithm
+  b := match ty
+    case DAE.T_FUNCTION(functionAttributes = DAE.FUNCTION_ATTRIBUTES(noReturn = DAE.NoReturn.RETURNS))
+      then List.isMemberOnTrue(ty, tys, isNoReturnVariantOf);
+    else false;
+  end match;
+end isReturningFunctionWithNoReturnVariant;
+
+protected function isNoReturnVariantOf
+  "True if cand is a no-return function type equal to the given returning
+   function type apart from the NoReturn marker."
+  input DAE.Type returning;
+  input DAE.Type cand;
+  output Boolean b;
+algorithm
+  b := match (returning, cand)
+    local
+      list<DAE.FuncArg> fargs1, fargs2;
+      DAE.Type ret1, ret2;
+      Absyn.Path path1, path2;
+      DAE.FunctionAttributes attr1, attr2;
+    case (DAE.T_FUNCTION(fargs1, ret1, attr1, path1),
+          DAE.T_FUNCTION(fargs2, ret2, attr2 as DAE.FUNCTION_ATTRIBUTES(noReturn = DAE.NoReturn.NORETURN), path2))
+      then AbsynUtil.pathEqual(path1, path2) and valueEq(ret1, ret2)
+       and valueEq(fargs1, fargs2) and functionAttributesEqualModNoReturn(attr1, attr2);
+    else false;
+  end match;
+end isNoReturnVariantOf;
+
+protected function functionAttributesEqualModNoReturn
+  "Compares two function attribute records ignoring their NoReturn marker."
+  input DAE.FunctionAttributes a1;
+  input DAE.FunctionAttributes a2;
+  output Boolean equal;
+algorithm
+  equal := match (a1, a2)
+    local
+      DAE.InlineType inl1, inl2;
+      Boolean omp1, omp2, fp1, fp2;
+      DAE.Purity pu1, pu2;
+      DAE.FunctionBuiltin bi1, bi2;
+      DAE.FunctionParallelism par1, par2;
+    case (DAE.FUNCTION_ATTRIBUTES(inl1, omp1, pu1, fp1, bi1, par1, _),
+          DAE.FUNCTION_ATTRIBUTES(inl2, omp2, pu2, fp2, bi2, par2, _))
+      then valueEq(inl1, inl2) and valueEq(omp1, omp2) and valueEq(pu1, pu2)
+       and valueEq(fp1, fp2) and valueEq(bi1, bi2) and valueEq(par1, par2);
+  end match;
+end functionAttributesEqualModNoReturn;
 
 public function addIteratorsToRef
   input Ref ref;

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -7137,7 +7137,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown element.", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown element.", sourceInfo());
       then
         fail();
 
@@ -7277,7 +7277,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown equation.", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown equation.", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
@@ -2326,7 +2326,8 @@ algorithm
         false,
         false,
         DAE.NO_INLINE(),
-        DAE.NO_TAIL()));
+        DAE.NO_TAIL(),
+        DAE.NoReturn.RETURNS));
 
   setGlobalRoot(Global.isInStream, SOME(true));
 end makePositiveMaxCall;

--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -1074,16 +1074,21 @@ partial function EvaluateSingletonTypeFunction
   output Type ty;
 end EvaluateSingletonTypeFunction;
 
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.PURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_DEFAULT = FUNCTION_ATTRIBUTES(DEFAULT_INLINE(),false,Purity.PURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.IMPURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL());
-public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.IMPURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL());
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.PURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL(),NoReturn.RETURNS);
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_DEFAULT = FUNCTION_ATTRIBUTES(DEFAULT_INLINE(),false,Purity.PURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL(),NoReturn.RETURNS);
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.IMPURE,false,FUNCTION_NOT_BUILTIN(),FP_NON_PARALLEL(),NoReturn.RETURNS);
+public constant FunctionAttributes FUNCTION_ATTRIBUTES_BUILTIN_IMPURE = FUNCTION_ATTRIBUTES(NO_INLINE(),false,Purity.IMPURE,false,FUNCTION_BUILTIN(NONE(), false),FP_NON_PARALLEL(),NoReturn.RETURNS);
 
 public type Purity = enumeration(
   PURE,      // Function with pure prefix
   IMPURE,    // Function with impure prefix
   UNDEFINED, // Function with neither pure nor impure prefix
   OM_IMPURE  // Function with __OpenModelica_Impure=true annotation (only used by the OF)
+);
+
+public type NoReturn = enumeration(
+  RETURNS,  // The function may return normally to its caller
+  NORETURN  // The function never returns normally (always fails, e.g. via fail(), assert(false) or terminate)
 );
 
 public
@@ -1095,6 +1100,7 @@ uniontype FunctionAttributes
     Boolean isFunctionPointer "if the function is a local variable";
     FunctionBuiltin isBuiltin;
     FunctionParallelism functionParallelism;
+    NoReturn noReturn "whether the function ever returns normally";
   end FUNCTION_ATTRIBUTES;
 end FunctionAttributes;
 
@@ -1558,16 +1564,16 @@ public uniontype TailCall
   end TAIL;
 end TailCall;
 
-public constant CallAttributes callAttrBuiltinBool = CALL_ATTR(T_BOOL_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinInteger = CALL_ATTR(T_INTEGER_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinReal = CALL_ATTR(T_REAL_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinString = CALL_ATTR(T_STRING_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinOther = CALL_ATTR(T_UNKNOWN_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinImpureBool = CALL_ATTR(T_BOOL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinImpureInteger = CALL_ATTR(T_INTEGER_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinImpureReal = CALL_ATTR(T_REAL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrBuiltinImpureString = CALL_ATTR(T_STRING_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
-public constant CallAttributes callAttrOther = CALL_ATTR(T_UNKNOWN_DEFAULT,false,false,false,false,NO_INLINE(),NO_TAIL());
+public constant CallAttributes callAttrBuiltinBool = CALL_ATTR(T_BOOL_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinInteger = CALL_ATTR(T_INTEGER_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinReal = CALL_ATTR(T_REAL_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinString = CALL_ATTR(T_STRING_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinOther = CALL_ATTR(T_UNKNOWN_DEFAULT,false,true,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinImpureBool = CALL_ATTR(T_BOOL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinImpureInteger = CALL_ATTR(T_INTEGER_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinImpureReal = CALL_ATTR(T_REAL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrBuiltinImpureString = CALL_ATTR(T_STRING_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
+public constant CallAttributes callAttrOther = CALL_ATTR(T_UNKNOWN_DEFAULT,false,false,false,false,NO_INLINE(),NO_TAIL(),NoReturn.RETURNS);
 
 public
 uniontype CallAttributes
@@ -1579,6 +1585,7 @@ uniontype CallAttributes
     Boolean isFunctionPointerCall;
     InlineType inlineType;
     TailCall tailCall "Input variables of the function if the call is tail-recursive";
+    NoReturn noReturn "whether the called function ever returns normally";
   end CALL_ATTR;
 end CallAttributes;
 

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -4034,7 +4034,7 @@ protected
   Type tp;
 algorithm
   tp := typeof(e1);
-  outExp := DAE.CALL(Absyn.IDENT("max"),{e1,e2},DAE.CALL_ATTR(tp,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+  outExp := DAE.CALL(Absyn.IDENT("max"),{e1,e2},DAE.CALL_ATTR(tp,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
 end expMaxScalar;
 
 public function expOptMaxScalar
@@ -4061,7 +4061,7 @@ protected
   Type tp;
 algorithm
   tp := typeof(e1);
-  outExp := DAE.CALL(Absyn.IDENT("min"),{e1,e2},DAE.CALL_ATTR(tp, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL()));
+  outExp := DAE.CALL(Absyn.IDENT("min"),{e1,e2},DAE.CALL_ATTR(tp, false, true, false, false, DAE.NO_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS));
 end expMinScalar;
 
 public function expOptMinScalar
@@ -10032,7 +10032,7 @@ public function makeBuiltinCall
   output DAE.Exp call;
   annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  call := DAE.CALL(Absyn.IDENT(name),args,DAE.CALL_ATTR(result_type,false,true,isImpure,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+  call := DAE.CALL(Absyn.IDENT(name),args,DAE.CALL_ATTR(result_type,false,true,isImpure,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
 end makeBuiltinCall;
 
 public function makePureBuiltinCall

--- a/OMCompiler/Compiler/FrontEnd/ExpressionBasics.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionBasics.mo
@@ -341,7 +341,7 @@ algorithm
     j := min(listHead(d) for d in dimsLst);
 
     if j <> max(listHead(d) for d in dimsLst) then
-      Error.assertion(false, getInstanceName() + ": cat got uneven dimensions for dim=" + String(i) + " " + stringDelimitList(list(toString(e) for e in exps), ", "), sourceInfo());
+      Error.terminate(getInstanceName() + ": cat got uneven dimensions for dim=" + String(i) + " " + stringDelimitList(list(toString(e) for e in exps), ", "), sourceInfo());
     end if;
 
     firstDims := j :: firstDims;
@@ -402,7 +402,7 @@ algorithm
     if listEmpty(outDims) then
       outDims := dims;
     elseif not valueEq(dims, outDims) then
-      Error.assertion(false, getInstanceName() + ": Got unbalanced array from " + toString(e), sourceInfo());
+      Error.terminate(getInstanceName() + ": Got unbalanced array from " + toString(e), sourceInfo());
     end if;
     outExps := listAppend(arr, outExps);
     i := i+1;

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1042,7 +1042,7 @@ algorithm
     // simplify record constructor from one to another
     case (DAE.CALL(p1,exps,DAE.CALL_ATTR(ty=DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p2)))), DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p3)))
       guard AbsynUtil.pathEqual(p1,p2) // It is a record constructor since it has the same path called as its output type
-      then DAE.CALL(p3,exps,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+      then DAE.CALL(p3,exps,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
 
     case (DAE.RECORD(_,exps,fieldNames,_), DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(p3)))
       then DAE.RECORD(p3,exps,fieldNames,tp);

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -1546,7 +1546,7 @@ algorithm
         // We have something like v[i].re and v is in the inputs... So we fail to inline.
       then (inExp,(argmap,checkcr,false));
 
-    case (DAE.UNBOX(DAE.CALL(path,expLst,DAE.CALL_ATTR(_,tuple_,false,isImpure,_,inlineType,tc)),ty),(argmap,_,true))
+    case (DAE.UNBOX(DAE.CALL(path,expLst,DAE.CALL_ATTR(_,tuple_,false,isImpure,_,inlineType,tc,_)),ty),(argmap,_,true))
       algorithm
         cref := ComponentReference.pathToCref(path);
         e as DAE.CREF(componentRef=cref,ty=ty2) := getExpFromArgMap(argmap,cref);
@@ -1554,7 +1554,7 @@ algorithm
         expLst := List.map(expLst,Expression.unboxExp);
         b := Expression.isBuiltinFunctionReference(e);
         isFunctionPointerCall := Types.isFunctionReferenceVar(ty2);
-        e := DAE.CALL(path,expLst,DAE.CALL_ATTR(ty,tuple_,b,isImpure,isFunctionPointerCall,inlineType,tc));
+        e := DAE.CALL(path,expLst,DAE.CALL_ATTR(ty,tuple_,b,isImpure,isFunctionPointerCall,inlineType,tc,DAE.NoReturn.RETURNS));
         (e,_) := ExpressionSimplify.simplify(e);
       then (e,inTuple);
 
@@ -1565,7 +1565,7 @@ algorithm
       then (e,(argmap,checkcr,false));
 
     // TODO: Use the inlineType of the function reference!
-    case (DAE.CALL(path,expLst,DAE.CALL_ATTR(DAE.T_METATYPE(),tuple_,false,isImpure,_,_,tc)),(argmap,_,true))
+    case (DAE.CALL(path,expLst,DAE.CALL_ATTR(DAE.T_METATYPE(),tuple_,false,isImpure,_,_,tc,_)),(argmap,_,true))
       algorithm
         cref := ComponentReference.pathToCref(path);
         e as DAE.CREF(componentRef=cref,ty=ty) := getExpFromArgMap(argmap,cref);
@@ -1574,7 +1574,7 @@ algorithm
         b := Expression.isBuiltinFunctionReference(e);
         (ty2,inlineType) := functionReferenceType(ty);
         isFunctionPointerCall := Types.isFunctionReferenceVar(ty2);
-        e := DAE.CALL(path,expLst,DAE.CALL_ATTR(ty2,tuple_,b,isImpure,isFunctionPointerCall,inlineType,tc));
+        e := DAE.CALL(path,expLst,DAE.CALL_ATTR(ty2,tuple_,b,isImpure,isFunctionPointerCall,inlineType,tc,DAE.NoReturn.RETURNS));
         e := boxIfUnboxedFunRef(e,ty);
         (e,_) := ExpressionSimplify.simplify(e);
       then (e,inTuple);
@@ -1799,7 +1799,7 @@ algorithm
       algorithm
         crs := List.map1(List.map(vars,TypesDump.getVarName),ComponentReference.appendStringCref,cr);
         exps := List.map1r(crs, VarTransform.getReplacement, repl);
-      then DAE.CALL(path,exps,DAE.CALL_ATTR(ty,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+      then DAE.CALL(path,exps,DAE.CALL_ATTR(ty,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
   end matchcontinue;
 
 end getReplacementCheckComplex;

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -801,7 +801,7 @@ algorithm
     // Assemble the binding for the record.
     ety := Types.simplifyType(Types.arrayElementType(inRecordType));
     exp := DAE.CALL(inRecordName, listReverse(accum_exps),
-      DAE.CALL_ATTR(ety, false, false, false, false, DAE.NORM_INLINE(), DAE.NO_TAIL()));
+      DAE.CALL_ATTR(ety, false, false, false, false, DAE.NORM_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS));
     val := Values.RECORD(inRecordName, listReverse(accum_vals), listReverse(accum_names), -1);
     (exp, val) := InstUtil.liftRecordBinding(inRecordType, exp, val);
     outBinding := DAE.EQBOUND(exp, SOME(val), DAE.C_CONST(), DAE.BINDING_FROM_RECORD_SUBMODS());

--- a/OMCompiler/Compiler/FrontEnd/InstFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstFunction.mo
@@ -371,6 +371,12 @@ algorithm
 
         ty1 := InstUtil.setFullyQualifiedTypename(ty,fpath);
         checkExtObjOutput(ty1,info);
+        // Mark functions whose body always fails as no-return before adding the
+        // type to the environment, so that calls to them get an isNoReturn call
+        // attribute and the def-use analysis treats those calls as terminating.
+        if InstUtil.functionAlwaysFails(daeElts) then
+          ty1 := Types.setFunctionNoReturn(ty1);
+        end if;
         env_1 := FGraph.mkTypeNode(env_1, n, ty1);
 
         // set the source of this element
@@ -379,7 +385,7 @@ algorithm
         partialPrefixBool := SCodeUtil.partialBool(partialPrefix);
 
         daeElts := InstUtil.optimizeFunctionCheckForLocals(fpath,daeElts,NONE(),{},{},{});
-        InstUtil.checkFunctionDefUse(daeElts,info);
+        InstUtil.checkFunctionDefUse(daeElts, info);
         /* Not working 100% yet... Also, a lot of code has unused inputs :( */
         if false and Config.acceptMetaModelicaGrammar() and not instFunctionTypeOnly then
           InstUtil.checkFunctionInputUsed(daeElts,NONE(),AbsynUtil.pathString(fpath));

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -4248,7 +4248,7 @@ algorithm
                         DAE.CALL(fpath1,{crefExp1, crefExp2},
                                  DAE.CALL_ATTR(
                                    equalityConstraintFunctionReturnType,
-                                   false, false, false, false, inlineType1, DAE.NO_TAIL())), // use the inline type
+                                   false, false, false, false, inlineType1, DAE.NO_TAIL(), DAE.NoReturn.RETURNS)), // use the inline type
                         source // set the origin of the element
                         )};
         graph := ConnectionGraph.addConnection(graph, c1_1, c2_1, breakDAEElements);
@@ -4291,7 +4291,7 @@ algorithm
                         DAE.CALL(fpath1,{crefExp1, crefExp2},
                                  DAE.CALL_ATTR(
                                    equalityConstraintFunctionReturnType,
-                                   false, false, false, false, inlineType1, DAE.NO_TAIL())), // use the inline type
+                                   false, false, false, false, inlineType1, DAE.NO_TAIL(), DAE.NoReturn.RETURNS)), // use the inline type
                         source // set the origin of the element
                         )};
         graph := ConnectionGraph.addConnection(graph, ComponentReferenceBasics.crefStripLastSubs(c1_1), ComponentReferenceBasics.crefStripLastSubs(c2_1), breakDAEElements);

--- a/OMCompiler/Compiler/FrontEnd/InstStateMachineUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstStateMachineUtil.mo
@@ -336,7 +336,7 @@ Create RHS expression of merging equation.
   input DAE.Type ty "type of inner cref (inner cref type expected to the same as outer crefs type)";
   output DAE.Exp res;
 protected
-  DAE.CallAttributes callAttributes = DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  DAE.CallAttributes callAttributes = DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
 algorithm
   res := match inOuterCrefs
     local
@@ -421,7 +421,7 @@ Create RHS expression of merging equation.
   input DAE.Type ty "type of inner cref (inner cref type expected to the same as outer crefs type)";
   output DAE.Exp res;
 protected
-  DAE.CallAttributes callAttributes = DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  DAE.CallAttributes callAttributes = DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
 algorithm
   res := match inOuterCrefs
     local

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7004,6 +7004,7 @@ protected
   SCode.Restriction restriction;
   SCode.FunctionRestriction fres;
   Boolean isOpenModelicaPure, isImpure, hasOutVars, unboxArgs;
+  DAE.NoReturn noReturn;
   DAE.FunctionBuiltin isBuiltin;
   DAE.InlineType inlineType;
   String name;
@@ -7014,6 +7015,7 @@ algorithm
   restriction := SCodeUtil.getClassRestriction(cl);
   SCode.Restriction.R_FUNCTION(functionRestriction = fres) := restriction;
   daePurity := InstBasics.getFunctionRestrictionPurity(SCodeUtil.getFunctionRestrictionPurity(fres), inheritedComment, newFrontend = false);
+  noReturn := if SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment, "__OpenModelica_NoReturn") then DAE.NoReturn.NORETURN else DAE.NoReturn.RETURNS;
 
   attr := matchcontinue fres
     case SCode.FR_EXTERNAL_FUNCTION(purity)
@@ -7024,7 +7026,7 @@ algorithm
         name := SCodeUtil.isBuiltinFunction(cl,List.map(inVars,TypesDump.getVarName),List.map(outVars,TypesDump.getVarName));
         inlineType := InstBasics.commentIsInlineFunc(inheritedComment);
         unboxArgs := SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment, "__OpenModelica_UnboxArguments");
-      then (DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_NON_PARALLEL()));
+      then (DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_NON_PARALLEL(),noReturn));
 
     //parallel functions: There are some builtin functions.
     case SCode.FR_PARALLEL_FUNCTION()
@@ -7035,7 +7037,7 @@ algorithm
         inlineType := InstBasics.commentIsInlineFunc(inheritedComment);
         isOpenModelicaPure := not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
         unboxArgs := SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment, "__OpenModelica_UnboxArguments");
-      then (DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_PARALLEL_FUNCTION()));
+      then (DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,DAE.FUNCTION_BUILTIN(SOME(name), unboxArgs),DAE.FP_PARALLEL_FUNCTION(),noReturn));
 
     //parallel functions: non-builtin
     case SCode.FR_PARALLEL_FUNCTION()
@@ -7043,11 +7045,11 @@ algorithm
         inlineType := InstBasics.commentIsInlineFunc(inheritedComment);
         isBuiltin := if SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_BuiltinPtr") then DAE.FUNCTION_BUILTIN_PTR() else DAE.FUNCTION_NOT_BUILTIN();
         isOpenModelicaPure := not SCodeUtil.commentHasBooleanNamedAnnotation(inheritedComment,"__OpenModelica_Impure");
-      then DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,isBuiltin,DAE.FP_PARALLEL_FUNCTION());
+      then DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,isBuiltin,DAE.FP_PARALLEL_FUNCTION(),noReturn);
 
     //kernel functions: never builtin and never inlined.
     case SCode.FR_KERNEL_FUNCTION()
-      then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(),false,daePurity, false, DAE.FUNCTION_NOT_BUILTIN(),DAE.FP_KERNEL_FUNCTION());
+      then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(),false,daePurity, false, DAE.FUNCTION_NOT_BUILTIN(),DAE.FP_KERNEL_FUNCTION(),noReturn);
 
     else
       algorithm
@@ -7061,7 +7063,7 @@ algorithm
           daePurity := DAE.Purity.IMPURE;
         end if;
       then
-        DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,isBuiltin,DAE.FP_NON_PARALLEL());
+        DAE.FUNCTION_ATTRIBUTES(inlineType,false,daePurity,false,isBuiltin,DAE.FP_NON_PARALLEL(),noReturn);
   end matchcontinue;
 end getFunctionAttributes;
 
@@ -7515,6 +7517,97 @@ algorithm
   i := listLength(lst);
 end numStructuralParameterScopes;
 
+public function functionAlwaysFails
+  "True if every execution of the function body reaches a guaranteed failure
+   (fail(), assert(false), terminate()) before any normal return. Such functions
+   are marked no-return so that calls to them can be treated as terminating."
+  input list<DAE.Element> elts;
+  output Boolean alwaysFails;
+protected
+  list<list<DAE.Statement>> sections = {};
+algorithm
+  for e in elts loop
+    _ := match e
+      local list<DAE.Statement> ss;
+      case DAE.ALGORITHM(algorithm_=DAE.ALGORITHM_STMTS(ss))
+        algorithm sections := ss :: sections; then ();
+      else ();
+    end match;
+  end for;
+  alwaysFails := stmtsAlwaysFail(List.flatten(listReverse(sections)));
+end functionAlwaysFails;
+
+protected function stmtsAlwaysFail
+  "Scan a statement sequence: it always fails if a guaranteed-fail statement is
+   reached while every preceding statement merely falls through."
+  input list<DAE.Statement> stmts;
+  output Boolean alwaysFails = false;
+algorithm
+  for s in stmts loop
+    if statementGuaranteesFail(s) then
+      alwaysFails := true;
+      return;
+    elseif not statementIsTransparent(s) then
+      // a statement that may complete some other way (return, loop, try, ...);
+      // we cannot prove the function always fails
+      return;
+    end if;
+  end for;
+end stmtsAlwaysFail;
+
+protected function statementGuaranteesFail
+  "True if executing this single statement always leads to a failure."
+  input DAE.Statement s;
+  output Boolean b;
+algorithm
+  b := match s
+    local list<DAE.Statement> ss; DAE.Else el; Boolean b1,b2;
+    case DAE.STMT_NORETCALL(exp=DAE.CALL(path=Absyn.IDENT("fail"),expLst={})) then true;
+    case DAE.STMT_ASSERT(cond=DAE.BCONST(false)) then true;
+    case DAE.STMT_TERMINATE() then true;
+    case DAE.STMT_IF(statementLst=ss, else_=el)
+      algorithm
+        b1 := stmtsAlwaysFail(ss);
+        b2 := elseGuaranteesFail(el);
+      then b1 and b2;
+    else false;
+  end match;
+end statementGuaranteesFail;
+
+protected function elseGuaranteesFail
+  input DAE.Else inElse;
+  output Boolean b;
+algorithm
+  b := match inElse
+    local list<DAE.Statement> ss; DAE.Else el; Boolean b1,b2;
+    case DAE.NOELSE() then false;
+    case DAE.ELSE(statementLst=ss) then stmtsAlwaysFail(ss);
+    case DAE.ELSEIF(statementLst=ss, else_=el)
+      algorithm
+        b1 := stmtsAlwaysFail(ss);
+        b2 := elseGuaranteesFail(el);
+      then b1 and b2;
+  end match;
+end elseGuaranteesFail;
+
+protected function statementIsTransparent
+  "True if the statement always completes normally and falls through, so the
+   scan for a guaranteed failure may continue past it. Treating a maybe-failing
+   assign/call as transparent is sound: reaching a later guaranteed failure
+   means the function fails either way."
+  input DAE.Statement s;
+  output Boolean b;
+algorithm
+  b := match s
+    case DAE.STMT_ASSIGN() then true;
+    case DAE.STMT_TUPLE_ASSIGN() then true;
+    case DAE.STMT_ASSIGN_ARR() then true;
+    case DAE.STMT_ARRAY_INIT() then true;
+    case DAE.STMT_NORETCALL() then true;
+    else false;
+  end match;
+end statementIsTransparent;
+
 public function checkFunctionDefUse
   "Finds any variable that might be used without first being defined"
   input list<DAE.Element> elts;
@@ -7545,8 +7638,8 @@ algorithm
   outUnbound := match (elts, alg, inUnbound, inOutputs)
     local
       list<DAE.Element> rest;
-      list<DAE.Statement> stmts;
-      list<String> unbound,outputs,names,outNames;
+      list<DAE.Statement> stmts,prevStmts;
+      list<String> unbound,maybeUnbound,outputs,names,outNames;
       String name;
       DAE.InstDims dims;
       DAE.VarDirection dir;
@@ -7558,8 +7651,19 @@ algorithm
       then inUnbound;
     case ({}, SOME(stmts), unbound, outputs)
       algorithm
-        (_,_,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, false, (false,false,unbound));
+        (_,_,unbound,maybeUnbound) := List.fold1(stmts, checkFunctionDefUseStmt, false, (false,false,unbound,{}));
         unbound := List.fold1(outputs, checkOutputDefUse, inInfo, unbound);
+        // Outputs that are only assigned on some control flow paths cannot be
+        // proven to be initialized; the specification recommends a warning when
+        // the static check is not possible. Only enabled on request to avoid
+        // flooding existing code with warnings.
+        if Flags.isSet(Flags.CHECK_DEF_USE) then
+          for name in outputs loop
+            if listMember(name, maybeUnbound) then
+              Error.addSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT_UNPROVEN, {name}, inInfo);
+            end if;
+          end for;
+        end if;
       then unbound;
     case (DAE.VAR(direction=DAE.INPUT())::rest, _, unbound, _)
       algorithm
@@ -7589,6 +7693,11 @@ algorithm
       algorithm
         unbound := checkFunctionDefUse2(rest,SOME(stmts),unbound,inOutputs,inInfo);
       then unbound;
+    // Several algorithm sections run in sequence; analyse them as one body.
+    case (DAE.ALGORITHM(algorithm_=DAE.ALGORITHM_STMTS(stmts))::rest, SOME(prevStmts), unbound, _)
+      algorithm
+        unbound := checkFunctionDefUse2(rest,SOME(listAppend(prevStmts,stmts)),unbound,inOutputs,inInfo);
+      then unbound;
     case (_::rest, _, unbound, _)
       algorithm
         unbound := checkFunctionDefUse2(rest,alg,unbound,inOutputs,inInfo);
@@ -7610,11 +7719,14 @@ algorithm
 end checkOutputDefUse;
 
 protected function checkFunctionDefUseStmt
-  "Find any variable that might be used in the statement without prior definition. Any defined variables are removed from undefined."
+  "Find any variable that might be used in the statement without prior definition. Any defined variables are removed from undefined.
+  The fourth element of the state tuple tracks variables that are assigned on
+  some but not all control flow paths: uses of those cannot be proven to be
+  defined (reported separately, only for MetaModelica)."
   input DAE.Statement inStmt;
   input Boolean inLoop;
-  input tuple<Boolean,Boolean,list<String>> inUnbound "Return or Break ; Returned for sure ; Unbound";
-  output tuple<Boolean,Boolean,list<String>> outUnbound "";
+  input tuple<Boolean,Boolean,list<String>,list<String>> inUnbound "Return or Break ; Returned for sure ; Unbound ; Possibly unbound";
+  output tuple<Boolean,Boolean,list<String>,list<String>> outUnbound "";
 algorithm
   outUnbound := match (inStmt, inUnbound)
     local
@@ -7622,96 +7734,141 @@ algorithm
       String str,iter;
       DAE.Exp exp,lhs,rhs,exp1,exp2;
       list<DAE.Exp> lhss;
-      list<String> unbound;
+      list<String> unbound,maybe,maybeBody,unboundBefore,lhsNames,guaranteed;
       Boolean b,b1,b2;
       DAE.Else else_;
       list<DAE.Statement> stmts;
       SourceInfo info;
 
-    case (_, (true,_,_)) then inUnbound;
-    case (_, (false,true,_))
+    case (_, (true,_,_,_)) then inUnbound;
+    case (_, (false,true,_,_))
       algorithm
         info := ElementSource.getElementSourceFileInfo(ElementSource.getStatementSource(inStmt));
         Error.addSourceMessage(Error.INTERNAL_ERROR,
           {"InstUtil.checkFunctionDefUseStmt failed"}, info);
       then fail();
-    case (DAE.STMT_ASSIGN(exp1=lhs,exp=rhs,source=source), (_,_,unbound))
+    case (DAE.STMT_ASSIGN(exp1=lhs,exp=rhs,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,info));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,maybe,info));
         // Traverse subs too! arr[x] := ..., x unbound
-        unbound := traverseCrefSubs(lhs,info,unbound);
+        (unbound,maybe) := traverseCrefSubs(lhs,info,unbound,maybe);
         unbound := crefFiltering(lhs,unbound);
-      then ((false,false,unbound));
-    case (DAE.STMT_TUPLE_ASSIGN(expExpLst=lhss,exp=rhs,source=source), (_,_,unbound))
+        maybe := crefFiltering(lhs,maybe);
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_TUPLE_ASSIGN(expExpLst=lhss,exp=rhs,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,info));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,maybe,info));
         // Traverse subs too! arr[x] := ..., x unbound
-        unbound := List.fold1(lhss,traverseCrefSubs,info,unbound);
+        for l in lhss loop
+          (unbound,maybe) := traverseCrefSubs(l,info,unbound,maybe);
+        end for;
         unbound := List.fold(lhss,crefFiltering,unbound);
-      then ((false,false,unbound));
-    case (DAE.STMT_ASSIGN_ARR(lhs=lhs,exp=rhs,source=source), (_,_,unbound))
+        maybe := List.fold(lhss,crefFiltering,maybe);
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_ASSIGN_ARR(lhs=lhs,exp=rhs,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,info));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(rhs,findUnboundVariableUse,(unbound,maybe,info));
         // Traverse subs too! arr[x] := ..., x unbound
-        unbound := traverseCrefSubs(lhs,info,unbound);
+        (unbound,maybe) := traverseCrefSubs(lhs,info,unbound,maybe);
         unbound := crefFiltering(lhs,unbound);
-      then ((false,false,unbound));
-    case (DAE.STMT_IF(exp,stmts,else_,source), (_,_,unbound))
+        maybe := crefFiltering(lhs,maybe);
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_IF(exp,stmts,else_,source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (b1,b2,unbound) := checkFunctionDefUseElse(DAE.ELSEIF(exp,stmts,else_),unbound,inLoop,info);
-      then ((b1,b2,unbound));
-    case (DAE.STMT_FOR(iter=iter,range=exp,statementLst=stmts,source=source), (_,_,unbound))
-      algorithm
-        info := ElementSource.getElementSourceFileInfo(source);
-        unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,iter);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-        (_,b,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound));
-      then ((b,b,unbound));
-    case (DAE.STMT_PARFOR(iter=iter,range=exp,statementLst=stmts,source=source), (_,_,unbound))
+        (b1,b2,unbound,maybe) := checkFunctionDefUseElse(DAE.ELSEIF(exp,stmts,else_),unbound,maybe,inLoop,info);
+      then ((b1,b2,unbound,maybe));
+    case (DAE.STMT_FOR(iter=iter,range=exp,statementLst=stmts,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
         unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,iter);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-        (_,b,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound));
-      then ((b,b,unbound));
-    case (DAE.STMT_WHILE(exp=exp,statementLst=stmts,source=source), (_,_,unbound))
+        maybe := List.filter1OnTrue(maybe,Util.stringNotEqual,iter);
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+        unboundBefore := unbound;
+        (_,b,unbound,maybeBody) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound,maybe));
+        // the loop body may run zero times, so anything assigned in it cannot
+        // be proven to be assigned afterwards
+        maybe := List.unionOnTrue(maybe, maybeBody, stringEq);
+        maybe := List.unionOnTrue(maybe, List.setDifferenceOnTrue(unboundBefore, unbound, stringEq), stringEq);
+      then ((b,b,unbound,maybe));
+    case (DAE.STMT_PARFOR(iter=iter,range=exp,statementLst=stmts,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-        (_,b,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound));
-      then ((b,b,unbound));
+        unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,iter);
+        maybe := List.filter1OnTrue(maybe,Util.stringNotEqual,iter);
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+        unboundBefore := unbound;
+        (_,b,unbound,maybeBody) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound,maybe));
+        maybe := List.unionOnTrue(maybe, maybeBody, stringEq);
+        maybe := List.unionOnTrue(maybe, List.setDifferenceOnTrue(unboundBefore, unbound, stringEq), stringEq);
+      then ((b,b,unbound,maybe));
+    case (DAE.STMT_WHILE(exp=DAE.BCONST(true),statementLst=stmts), (_,_,unbound,maybe))
+      algorithm
+        guaranteed := whileTrueBreakAssigned(stmts, unbound);
+        unboundBefore := unbound;
+        (_,_,unbound,maybeBody) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound,maybe));
+        maybe := List.unionOnTrue(maybe, maybeBody, stringEq);
+        maybe := List.unionOnTrue(maybe, List.setDifferenceOnTrue(unboundBefore, unbound, stringEq), stringEq);
+        maybe := List.setDifferenceOnTrue(maybe, guaranteed, stringEq);
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_WHILE(exp=exp,statementLst=stmts,source=source), (_,_,unbound,maybe))
+      algorithm
+        info := ElementSource.getElementSourceFileInfo(source);
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+        unboundBefore := unbound;
+        (_,b,unbound,maybeBody) := List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound,maybe));
+        // the loop body may run zero times, so anything assigned in it cannot
+        // be proven to be assigned afterwards
+        maybe := List.unionOnTrue(maybe, maybeBody, stringEq);
+        maybe := List.unionOnTrue(maybe, List.setDifferenceOnTrue(unboundBefore, unbound, stringEq), stringEq);
+      then ((b,b,unbound,maybe));
     case (DAE.STMT_ASSERT(cond=DAE.BCONST(false)), _) // TODO: Re-write these earlier from assert(false,msg) to terminate(msg)
-      then ((true,true,{}));
-    case (DAE.STMT_ASSERT(cond=exp1,msg=exp2,source=source), (_,_,unbound))
+      then ((true,true,{},{}));
+    case (DAE.STMT_ASSERT(cond=exp1,msg=exp2,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp1,findUnboundVariableUse,(unbound,info));
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp2,findUnboundVariableUse,(unbound,info));
-      then ((false,false,unbound));
-    case (DAE.STMT_TERMINATE(msg=exp,source=source), (_,_,unbound))
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp1,findUnboundVariableUse,(unbound,maybe,info));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp2,findUnboundVariableUse,(unbound,maybe,info));
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_TERMINATE(msg=exp,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-      then ((true,true,unbound));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+      then ((true,true,unbound,maybe));
     case (DAE.STMT_NORETCALL(exp=DAE.CALL(path=Absyn.IDENT("fail"),expLst={})), _)
-      then ((true,true,{}));
-    case (DAE.STMT_NORETCALL(exp=exp,source=source), (_,_,unbound))
+      then ((true,true,{},{}));
+    // a call to a function that never returns normally terminates this path
+    case (DAE.STMT_NORETCALL(exp=DAE.CALL(attr=DAE.CALL_ATTR(noReturn=DAE.NoReturn.NORETURN))), _)
+      then ((true,true,{},{}));
+    case (DAE.STMT_NORETCALL(exp=exp as DAE.CALL(attr=DAE.CALL_ATTR(tailCall=DAE.TAIL(outVars=lhsNames))),source=source), (_,_,unbound,maybe))
+      algorithm
+        // a tail call assigns its TAIL output variables
+        info := ElementSource.getElementSourceFileInfo(source);
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+        unbound := List.setDifferenceOnTrue(unbound,lhsNames,stringEq);
+        maybe := List.setDifferenceOnTrue(maybe,lhsNames,stringEq);
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_NORETCALL(exp=exp,source=source), (_,_,unbound,maybe))
       algorithm
         info := ElementSource.getElementSourceFileInfo(source);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-      then ((false,false,unbound));
-    case (DAE.STMT_BREAK(), (_,_,unbound)) then ((true,false,unbound));
-    case (DAE.STMT_RETURN(), (_,_,unbound)) then ((true,true,unbound));
-    case (DAE.STMT_CONTINUE(), (_,_,unbound)) then ((false,false,unbound));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+      then ((false,false,unbound,maybe));
+    case (DAE.STMT_BREAK(), (_,_,unbound,maybe)) then ((true,false,unbound,maybe));
+    case (DAE.STMT_RETURN(), (_,_,unbound,maybe)) then ((true,true,unbound,maybe));
+    case (DAE.STMT_CONTINUE(), (_,_,unbound,maybe)) then ((false,false,unbound,maybe));
     case (DAE.STMT_ARRAY_INIT(), _) then inUnbound;
-    case (DAE.STMT_FAILURE(body=stmts), (_,_,unbound))
+    case (DAE.STMT_FAILURE(body=stmts), (_,_,unbound,maybe))
       algorithm
-        (_,b,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound));
-      then ((b,b,unbound));
+        unboundBefore := unbound;
+        (_,b,unbound,maybeBody) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound,maybe));
+        // the failure body is expected to fail partway through, so anything
+        // assigned in it cannot be proven to be assigned afterwards
+        maybe := List.unionOnTrue(maybe, maybeBody, stringEq);
+        maybe := List.unionOnTrue(maybe, List.setDifferenceOnTrue(unboundBefore, unbound, stringEq), stringEq);
+      then ((b,b,unbound,maybe));
 
     // STMT_WHEN not in functions
     // STMT_REINIT not in functions
@@ -7725,37 +7882,194 @@ algorithm
   end match;
 end checkFunctionDefUseStmt;
 
+protected function whileTrueBreakAssigned
+  "Variables definitely assigned on every control-flow path that leaves a
+   'while true' loop via break; those are defined after the loop. Nested loops
+   and failure blocks are conservatively credited with nothing assigned."
+  input list<DAE.Statement> stmts;
+  input list<String> entryUnbound;
+  output list<String> assigned;
+protected
+  Option<list<String>> atBreak;
+algorithm
+  (_, _, atBreak) := walkBreakAssigned(stmts, entryUnbound);
+  assigned := match atBreak
+    local list<String> u;
+    // u holds the variables possibly still unbound at some break
+    case SOME(u) then List.setDifferenceOnTrue(entryUnbound, u, stringEq);
+    // no break: the loop never falls through, so code after it is unreachable
+    else entryUnbound;
+  end match;
+end whileTrueBreakAssigned;
+
+protected function walkBreakAssigned
+  "Walk a statement sequence tracking which of the entry variables are still
+   unbound. Returns the fall-through unbound set, whether the sequence always
+   exits (break/return), and the union of the unbound sets seen at each break."
+  input list<DAE.Statement> stmts;
+  input list<String> inUnbound;
+  output list<String> outUnbound = inUnbound;
+  output Boolean exits = false;
+  output Option<list<String>> atBreak = NONE();
+protected
+  list<String> ub, ue;
+  Boolean xt, xe;
+  Option<list<String>> bt, be, ifBreak;
+algorithm
+  for s in stmts loop
+    _ := match s
+      local
+        DAE.Exp lhs;
+        list<DAE.Exp> lhss;
+        list<DAE.Statement> ss;
+        DAE.Else el;
+      case DAE.STMT_ASSIGN(exp1=lhs)
+        algorithm outUnbound := crefFiltering(lhs, outUnbound); then ();
+      case DAE.STMT_ASSIGN_ARR(lhs=lhs)
+        algorithm outUnbound := crefFiltering(lhs, outUnbound); then ();
+      case DAE.STMT_TUPLE_ASSIGN(expExpLst=lhss)
+        algorithm outUnbound := List.fold(lhss, crefFiltering, outUnbound); then ();
+      case DAE.STMT_BREAK()
+        algorithm
+          atBreak := mergeBreakUnbound(atBreak, SOME(outUnbound));
+          exits := true;
+        then ();
+      case DAE.STMT_RETURN() algorithm exits := true; then ();
+      case DAE.STMT_TERMINATE() algorithm exits := true; then ();
+      case DAE.STMT_NORETCALL(exp=DAE.CALL(path=Absyn.IDENT("fail"),expLst={}))
+        algorithm exits := true; then ();
+      case DAE.STMT_IF(statementLst=ss, else_=el)
+        algorithm
+          (ub, xt, bt) := walkBreakAssigned(ss, outUnbound);
+          (ue, xe, be) := walkBreakAssignedElse(el, outUnbound);
+          (outUnbound, exits, ifBreak) := mergeBranches(outUnbound, ub, xt, bt, ue, xe, be);
+          atBreak := mergeBreakUnbound(atBreak, ifBreak);
+        then ();
+      else ();
+    end match;
+    if exits then break; end if;
+  end for;
+end walkBreakAssigned;
+
+protected function walkBreakAssignedElse
+  input DAE.Else inElse;
+  input list<String> inUnbound;
+  output list<String> outUnbound;
+  output Boolean exits;
+  output Option<list<String>> atBreak;
+protected
+  list<String> ub, ue;
+  Boolean xt, xe;
+  Option<list<String>> bt, be;
+algorithm
+  (outUnbound, exits, atBreak) := match inElse
+    local
+      list<DAE.Statement> ss;
+      DAE.Else el;
+    case DAE.NOELSE() then (inUnbound, false, NONE());
+    case DAE.ELSE(statementLst=ss) then walkBreakAssigned(ss, inUnbound);
+    case DAE.ELSEIF(statementLst=ss, else_=el)
+      algorithm
+        (ub, xt, bt) := walkBreakAssigned(ss, inUnbound);
+        (ue, xe, be) := walkBreakAssignedElse(el, inUnbound);
+      then mergeBranches(inUnbound, ub, xt, bt, ue, xe, be);
+  end match;
+end walkBreakAssignedElse;
+
+protected function mergeBranches
+  "Combine the then- and else-branch results of an if into the state after the
+   if. A variable is assigned afterwards only if assigned in both fall-through
+   branches; the if exits only if both branches exit."
+  input list<String> entryUnbound;
+  input list<String> thenUnbound;
+  input Boolean thenExits;
+  input Option<list<String>> thenBreak;
+  input list<String> elseUnbound;
+  input Boolean elseExits;
+  input Option<list<String>> elseBreak;
+  output list<String> outUnbound;
+  output Boolean exits;
+  output Option<list<String>> atBreak;
+algorithm
+  atBreak := mergeBreakUnbound(thenBreak, elseBreak);
+  if thenExits and elseExits then
+    exits := true;
+    outUnbound := entryUnbound;
+  elseif thenExits then
+    exits := false;
+    outUnbound := elseUnbound;
+  elseif elseExits then
+    exits := false;
+    outUnbound := thenUnbound;
+  else
+    exits := false;
+    outUnbound := List.unionOnTrue(thenUnbound, elseUnbound, stringEq);
+  end if;
+end mergeBranches;
+
+protected function mergeBreakUnbound
+  "A variable is possibly unbound at a break if it is so on either path."
+  input Option<list<String>> a;
+  input Option<list<String>> b;
+  output Option<list<String>> res;
+algorithm
+  res := match (a, b)
+    local list<String> la, lb;
+    case (NONE(), _) then b;
+    case (_, NONE()) then a;
+    case (SOME(la), SOME(lb)) then SOME(List.unionOnTrue(la, lb, stringEq));
+  end match;
+end mergeBreakUnbound;
+
 protected function checkFunctionDefUseElse
   input DAE.Else inElse;
   input list<String> inUnbound;
+  input list<String> inMaybeUnbound;
   input Boolean inLoop;
   input SourceInfo info;
-  output tuple<Boolean,Boolean,list<String>> outUnbound;
+  output tuple<Boolean,Boolean,list<String>,list<String>> outUnbound;
 algorithm
   outUnbound := match (inElse, inUnbound, inLoop)
     local
       DAE.Exp exp;
       list<DAE.Statement> stmts;
       DAE.Else else_;
-      list<String> unbound,unboundBranch;
-      Boolean b1,b2,b3,b4,iloop;
-    case (DAE.NOELSE(), _, _) then ((false,false,inUnbound));
-    case (DAE.ELSEIF(exp,stmts,else_), unbound, iloop)
+      list<String> unbound,unboundBranch,maybe,maybeBranch,assignedThen,assignedElse,proven,entryUnbound;
+      Boolean b1,b2,b3,b4;
+    case (DAE.NOELSE(), _, _) then ((false,false,inUnbound,inMaybeUnbound));
+    case (DAE.ELSEIF(exp,stmts,else_), unbound, _)
       algorithm
-        (_,(unbound,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
-        (b1,b2,unboundBranch) := checkFunctionDefUseElse(else_,unbound,inLoop,info);
-        (b3,b4,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound));
-        iloop := true "We find a few false positives if we are too conservative, so let's do it non-exact";
-        unbound := if iloop then List.intersectionOnTrue(unboundBranch, unbound, stringEq) else unbound;
-        unbound := if not (iloop or b1) then List.union(unboundBranch, unbound) else unbound;
+        maybe := inMaybeUnbound;
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,maybe,info));
+        entryUnbound := unbound;
+        (b1,b2,unboundBranch,maybeBranch) := checkFunctionDefUseElse(else_,unbound,maybe,inLoop,info);
+        (b3,b4,unbound,maybe) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound,maybe));
+        // Pessimistic bookkeeping: anything that is assigned in only some of
+        // the branches (ignoring branches that surely return or fail) cannot
+        // be proven to be assigned after the if-statement.
+        assignedThen := if b4 then {} else List.setDifferenceOnTrue(entryUnbound, unbound, stringEq);
+        assignedElse := if b2 then {} else List.setDifferenceOnTrue(entryUnbound, unboundBranch, stringEq);
+        if b2 and not b4 then
+          proven := assignedThen; // only the then-branch continues
+        elseif b4 and not b2 then
+          proven := assignedElse; // only the else-branch continues
+        else
+          proven := List.intersectionOnTrue(assignedThen, assignedElse, stringEq);
+        end if;
+        maybe := List.unionOnTrue(if b4 then {} else maybe, if b2 then {} else maybeBranch, stringEq);
+        maybe := List.unionOnTrue(maybe,
+          List.setDifferenceOnTrue(List.unionOnTrue(assignedThen, assignedElse, stringEq), proven, stringEq), stringEq);
+        // Optimistic merge for the hard warnings: a variable assigned in any
+        // branch is treated as assigned afterwards to avoid false positives.
+        unbound := List.intersectionOnTrue(unboundBranch, unbound, stringEq);
         /* Merge the state of the two branches. Either they can break/return or not */
         b1 := b1 and b3;
         b2 := b2 and b4;
-      then ((b1,b2,unbound));
+      then ((b1,b2,unbound,maybe));
     case (DAE.ELSE(stmts), unbound, _)
       algorithm
-        (b1,b2,unbound) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound));
-      then ((b1,b2,unbound));
+        (b1,b2,unbound,maybe) := List.fold1(stmts, checkFunctionDefUseStmt, inLoop, (false,false,unbound,inMaybeUnbound));
+      then ((b1,b2,unbound,maybe));
   end match;
 end checkFunctionDefUseElse;
 
@@ -7816,70 +8130,143 @@ protected function traverseCrefSubs
   input DAE.Exp exp;
   input SourceInfo info;
   input list<String> inUnbound;
+  input list<String> inMaybeUnbound;
   output list<String> outUnbound;
+  output list<String> outMaybeUnbound;
 algorithm
-  outUnbound := match (exp, inUnbound)
+  (outUnbound,outMaybeUnbound) := match (exp, inUnbound)
     local
-      list<String> unbound;
+      list<String> unbound,maybe;
       DAE.ComponentRef cr;
     case (DAE.CREF(componentRef=cr), unbound)
       algorithm
-        (_,(unbound,_)) := Expression.traverseExpTopDownCrefHelper(cr,findUnboundVariableUse,(unbound,info));
-      then unbound;
-    else inUnbound;
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDownCrefHelper(cr,findUnboundVariableUse,(unbound,inMaybeUnbound,info));
+      then (unbound,maybe);
+    else (inUnbound,inMaybeUnbound);
   end match;
 end traverseCrefSubs;
 
 protected function findUnboundVariableUse "Check if the expression is used before it is defined"
   input DAE.Exp inExp;
-  input tuple<list<String>,SourceInfo> inTpl;
+  input tuple<list<String>,list<String>,SourceInfo> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<list<String>,SourceInfo> outTpl;
+  output tuple<list<String>,list<String>,SourceInfo> outTpl;
 algorithm
   (outExp,cont,outTpl) := match (inExp,inTpl)
     local
       DAE.Exp exp;
-      list<String> unbound,unboundLocal;
+      list<String> unbound,maybe,unboundLocal,assigned,assignedUnion,proven,maybeMerged,caseUnbound,caseMaybe;
       SourceInfo info;
       String str,name;
       DAE.ComponentRef cr;
-      Boolean b;
-      tuple<list<String>,SourceInfo> arg;
+      Boolean b,caseReturns,provenInit;
+      tuple<list<String>,list<String>,SourceInfo> arg;
       list<DAE.Exp> inputs;
       list<DAE.Element> localDecls;
       list<DAE.MatchCase> cases;
-      list<list<String>> unbounds;
+      list<tuple<list<String>,list<String>,Boolean>> caseResults;
+      DAE.Exp redExpr,iterExp;
+      DAE.ReductionIterators iterators;
+      Option<DAE.Exp> guardExp;
+      list<String> iterUnbound,iterMaybe;
     case (exp as DAE.SIZE(),arg) then (exp,false,arg);
     case (exp as DAE.CALL(path=Absyn.IDENT("isPresent"), attr = DAE.CALL_ATTR(builtin = true)),arg)
       then (exp,false,arg);
-    case (DAE.CREF(componentRef = DAE.WILD()), (_, info))
+    case (DAE.CREF(componentRef = DAE.WILD()), (_, _, info))
       algorithm
         // _ shouldn't be allowed to be used like a variable, but until that's
         // enforced just give an error message here instead of just failing.
         Error.addSourceMessage(Error.WARNING_DEF_USE, {"_"}, info);
       then (inExp, true, inTpl);
-    case (exp as DAE.CREF(componentRef=cr),(unbound,info))
+    case (exp as DAE.CREF(componentRef=cr),(unbound,maybe,info))
       algorithm
-        b := listMember(ComponentReferenceBasics.crefFirstIdent(cr),unbound);
         str := ComponentReferenceBasics.crefFirstIdent(cr);
-        Error.assertionOrAddSourceMessage(not b, Error.WARNING_DEF_USE, {str}, info);
-        unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,str);
-      then (exp,true,(unbound,info));
-    case (exp as DAE.CALL(path=Absyn.IDENT(name)),(unbound,info))
+        if listMember(str,unbound) then
+          Error.addSourceMessage(Error.WARNING_DEF_USE, {str}, info);
+          unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,str);
+        elseif listMember(str,maybe) then
+          // assigned on some but not all control flow paths leading here
+          if Flags.isSet(Flags.CHECK_DEF_USE) then
+            Error.addSourceMessage(Error.WARNING_DEF_USE_UNPROVEN, {str}, info);
+          end if;
+          maybe := List.filter1OnTrue(maybe,Util.stringNotEqual,str);
+        end if;
+      then (exp,true,(unbound,maybe,info));
+    case (exp as DAE.CALL(path=Absyn.IDENT(name)),(unbound,maybe,info))
       algorithm
-        b := listMember(name,unbound);
-        Error.assertionOrAddSourceMessage(not b, Error.WARNING_DEF_USE, {name}, info);
-        unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,name);
-      then (exp,true,(unbound,info));
-    case (exp as DAE.MATCHEXPRESSION(inputs=inputs,localDecls=localDecls,cases=cases),(unbound,info))
+        if listMember(name,unbound) then
+          Error.addSourceMessage(Error.WARNING_DEF_USE, {name}, info);
+          unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,name);
+        elseif listMember(name,maybe) then
+          if Flags.isSet(Flags.CHECK_DEF_USE) then
+            Error.addSourceMessage(Error.WARNING_DEF_USE_UNPROVEN, {name}, info);
+          end if;
+          maybe := List.filter1OnTrue(maybe,Util.stringNotEqual,name);
+        end if;
+      then (exp,true,(unbound,maybe,info));
+    case (exp as DAE.MATCHEXPRESSION(inputs=inputs,localDecls=localDecls,cases=cases),(unbound,maybe,info))
       algorithm
-        (_,(unbound,_)) := Expression.traverseExpTopDown(DAE.LIST(inputs),findUnboundVariableUse,(unbound,info));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(DAE.LIST(inputs),findUnboundVariableUse,(unbound,maybe,info));
         unboundLocal := checkFunctionDefUse2(localDecls,NONE(),unbound,{},info);
-        unbounds := List.map1(cases,findUnboundVariableUseInCase,unboundLocal);
+        caseResults := list(findUnboundVariableUseInCase(c,unboundLocal,maybe) for c in cases);
         // Find variables assigned in a case, like: _ = match () case () equation o = 1.5; then ();
-        unbound := List.fold1r(unbounds, List.intersectionOnTrue, stringEq, unbound);
-      then (exp,false,(unbound,info));
+        unbound := List.fold1r(list(Util.tuple31(t) for t in caseResults), List.intersectionOnTrue, stringEq, unbound);
+        // Pessimistic bookkeeping: only variables that are assigned in every
+        // case that can reach the code after the match-expression are proven
+        // to be assigned; the rest cannot be proven to be initialized.
+        provenInit := true;
+        proven := {};
+        assignedUnion := {};
+        maybeMerged := {};
+        for t in caseResults loop
+          (caseUnbound,caseMaybe,caseReturns) := t;
+          if not caseReturns then
+            assigned := List.setDifferenceOnTrue(unboundLocal, caseUnbound, stringEq);
+            proven := if provenInit then assigned else List.intersectionOnTrue(proven, assigned, stringEq);
+            provenInit := false;
+            assignedUnion := List.unionOnTrue(assignedUnion, assigned, stringEq);
+            maybeMerged := List.unionOnTrue(maybeMerged, caseMaybe, stringEq);
+          end if;
+        end for;
+        if not provenInit then
+          maybe := List.unionOnTrue(maybeMerged,
+            List.setDifferenceOnTrue(assignedUnion, proven, stringEq), stringEq);
+        end if;
+      then (exp,false,(unbound,maybe,info));
+    case (exp as DAE.REDUCTION(expr=redExpr,iterators=iterators),(unbound,maybe,info))
+      algorithm
+        // The iterator ranges are evaluated in the enclosing scope.
+        for it in iterators loop
+          DAE.REDUCTIONITER(exp=iterExp) := it;
+          (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(iterExp,findUnboundVariableUse,(unbound,maybe,info));
+        end for;
+        // The iterator variables are bound within the reduction guard/body, so
+        // they shadow any enclosing variable of the same name. Remember whether
+        // each name was (maybe) unbound outside so the enclosing state can be
+        // restored afterwards, and remove them while traversing the body.
+        iterUnbound := {};
+        iterMaybe := {};
+        for it in iterators loop
+          DAE.REDUCTIONITER(id=name) := it;
+          if listMember(name,unbound) then
+            iterUnbound := name :: iterUnbound;
+            unbound := List.filter1OnTrue(unbound,Util.stringNotEqual,name);
+          end if;
+          if listMember(name,maybe) then
+            iterMaybe := name :: iterMaybe;
+            maybe := List.filter1OnTrue(maybe,Util.stringNotEqual,name);
+          end if;
+        end for;
+        for it in iterators loop
+          DAE.REDUCTIONITER(guardExp=guardExp) := it;
+          (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(DAE.META_OPTION(guardExp),findUnboundVariableUse,(unbound,maybe,info));
+        end for;
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(redExpr,findUnboundVariableUse,(unbound,maybe,info));
+        // Restore the enclosing scope's status for the iterator names.
+        unbound := listAppend(iterUnbound,unbound);
+        maybe := listAppend(iterMaybe,maybe);
+      then (exp,false,(unbound,maybe,info));
     case (exp,arg) then (exp,true,arg);
   end match;
 end findUnboundVariableUse;
@@ -7887,21 +8274,29 @@ end findUnboundVariableUse;
 protected function findUnboundVariableUseInCase "Check if the expression is used before it is defined"
   input DAE.MatchCase case_;
   input list<String> inUnbound;
-  output list<String> unbound;
+  input list<String> inMaybeUnbound;
+  output tuple<list<String>,list<String>,Boolean> outResult "Unbound ; Possibly unbound ; Surely returns or fails";
 algorithm
-  unbound := match (case_,inUnbound)
+  outResult := match (case_,inUnbound)
     local
       SourceInfo info,resultInfo;
       Option<DAE.Exp> patternGuard,result;
       list<DAE.Pattern> patterns;
       list<DAE.Statement> body;
+      list<String> unbound,maybe;
+      Boolean returned;
     case (DAE.CASE(patterns=patterns,patternGuard=patternGuard,body=body,result=result,info=info,resultInfo=resultInfo),unbound)
       algorithm
+        maybe := inMaybeUnbound;
         (_,unbound) := Patternm.traversePatternList(patterns,patternFiltering,unbound);
-        (_,(unbound,_)) := Expression.traverseExpTopDown(DAE.META_OPTION(patternGuard),findUnboundVariableUse,(unbound,info));
-        (_,_,unbound) := List.fold1(body, checkFunctionDefUseStmt, true, (false,false,unbound));
-        (_,(unbound,_)) := Expression.traverseExpTopDown(DAE.META_OPTION(result),findUnboundVariableUse,(unbound,resultInfo));
-      then unbound;
+        (_,maybe) := Patternm.traversePatternList(patterns,patternFiltering,maybe);
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(DAE.META_OPTION(patternGuard),findUnboundVariableUse,(unbound,maybe,info));
+        (_,returned,unbound,maybe) := List.fold1(body, checkFunctionDefUseStmt, true, (false,false,unbound,maybe));
+        (_,(unbound,maybe,_)) := Expression.traverseExpTopDown(DAE.META_OPTION(result),findUnboundVariableUse,(unbound,maybe,resultInfo));
+        // a case without a result expression is 'then fail()': it never
+        // continues past the match-expression
+        returned := returned or not isSome(result);
+      then ((unbound,maybe,returned));
   end match;
 end findUnboundVariableUseInCase;
 

--- a/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
+++ b/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
@@ -761,7 +761,7 @@ algorithm
 
   // a.active and (smOf.fsm_of_a.activeReset or smOf.fsm_of_a.activeResetStates[i])
   andExp := DAE.LBINARY(activeExp, DAE.AND(DAE.T_BOOL_DEFAULT), orExp);
-  //callAttributes := DAE.CALL_ATTR(inLHSty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  //callAttributes := DAE.CALL_ATTR(inLHSty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
   // pre(activeExp)
   //preExp := DAE.CALL(Absyn.IDENT("pre"), {activeExp}, callAttributes);
   //andExp := DAE.LBINARY(activeExp, DAE.AND(DAE.T_BOOL_DEFAULT),  DAE.LUNARY(DAE.NOT(DAE.T_BOOL_DEFAULT), preExp));
@@ -868,7 +868,7 @@ algorithm
   // a.active and (smOf.fsm_of_a.activeReset or smOf.fsm_of_a.activeResetStates[i])
   andExp := DAE.LBINARY(activeExp, DAE.AND(DAE.T_BOOL_DEFAULT), orExp);
 
-  callAttributes := DAE.CALL_ATTR(inLHSty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  callAttributes := DAE.CALL_ATTR(inLHSty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
   // previous(a.x)
   previousExp := DAE.CALL(Absyn.IDENT("previous"), {DAE.CREF(inLHSCref, inLHSty)}, callAttributes);
 
@@ -941,7 +941,7 @@ algorithm
   end try;
   // reference the active indicator for this state
   activeRef := DAE.CREF(qCref("active", DAE.T_BOOL_DEFAULT, {}, inStateCref), DAE.T_BOOL_DEFAULT);
-  callAttributes := DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  callAttributes := DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
   if isResetEquation then // x_previous
     expElse := DAE.CREF(ComponentReference.appendStringLastIdent("_previous", cref), ty);
   else                    // previous(x)
@@ -977,7 +977,7 @@ algorithm
   end try;
   // reference the active indicator for this state
   activeRef := DAE.CREF(qCref("active", DAE.T_BOOL_DEFAULT, {}, inStateCref), DAE.T_BOOL_DEFAULT);
-  callAttributes := DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+  callAttributes := DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
   expElse := DAE.RCONST(0);
   scalar1 := DAE.IFEXP(activeRef, scalar, expElse);
   // state.x = if state.active then .. else expElse

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -5821,7 +5821,7 @@ algorithm
       then
         (cache,
         DAE.CALL(Absyn.QUALIFIED("Connections", Absyn.IDENT("uniqueRootIndices")), {exp1, exp2, exp3},
-                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL())),
+                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS)),
         DAE.PROP(ty, DAE.C_VAR()));
 
     case (cache, env, {aexp1,aexp2,_}, {}, pre)
@@ -5834,7 +5834,7 @@ algorithm
       then
         (cache,
         DAE.CALL(Absyn.QUALIFIED("Connections", Absyn.IDENT("uniqueRootIndices")), {exp1, exp2, exp3},
-                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL())),
+                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS)),
         DAE.PROP(ty, DAE.C_VAR()));
 
     case (cache, env, {aexp1,aexp2}, {Absyn.NAMEDARG("message", _)}, pre)
@@ -5847,7 +5847,7 @@ algorithm
       then
         (cache,
         DAE.CALL(Absyn.QUALIFIED("Connections", Absyn.IDENT("uniqueRootIndices")), {exp1, exp2, exp3},
-                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL())),
+                 DAE.CALL_ATTR(ty,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS)),
         DAE.PROP(ty, DAE.C_VAR()));
 
   end match;
@@ -7047,7 +7047,7 @@ algorithm
 
         tp := complexTypeFromSlots(newslots2,ClassInf.UNKNOWN(Absyn.IDENT("")));
       then
-        (cache,SOME((DAE.CALL(fn,args_2,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL())),DAE.PROP(DAE.T_UNKNOWN_DEFAULT,DAE.C_CONST()))));
+        (cache,SOME((DAE.CALL(fn,args_2,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS)),DAE.PROP(DAE.T_UNKNOWN_DEFAULT,DAE.C_CONST()))));
 
     // Record constructors, user defined or implicit, try the hard stuff first
     case (cache,env,fn,args,nargs,impl,pre)
@@ -7073,7 +7073,7 @@ algorithm
         tyconst := elabConsts(outtype, const);
         prop := getProperties(outtype, tyconst);
 
-        callExp := DAE.CALL(path,args_2,DAE.CALL_ATTR(outtype,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
+        callExp := DAE.CALL(path,args_2,DAE.CALL_ATTR(outtype,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
 
         (call_exp,prop_1) := vectorizeCall(callExp, vect_dims, newslots2, prop, info);
         expProps := SOME((call_exp,prop_1));
@@ -7261,6 +7261,7 @@ protected
   DAE.FunctionBuiltin isBuiltin;
   DAE.FunctionParallelism funcParal;
   Boolean tuple_,builtin,isImpure;
+  DAE.NoReturn noReturn;
   DAE.InlineType inlineType;
   Absyn.Path fn_1;
   DAE.Properties prop,prop_1;
@@ -7283,7 +7284,8 @@ algorithm
    functype as DAE.T_FUNCTION(functionAttributes=DAE.FUNCTION_ATTRIBUTES(purity=purity,
                                                                          inline=inlineType,
                                                                          isFunctionPointer=isFunctionPointer,
-                                                                         functionParallelism=funcParal)),
+                                                                         functionParallelism=funcParal,
+                                                                         noReturn=noReturn)),
    vect_dims,
    slots) := elabTypes(inCache, inEnv, args, nargs, typeVars, typelist, onlyOneFunction, true/* Check types*/, impl,pre,info)
    "The constness of a function depends on the inputs. If all inputs are constant the call itself is constant.";
@@ -7307,7 +7309,7 @@ algorithm
   (args_2, slots2) := addDefaultArgs(slots, info);
   // DO NOT CHECK IF ALL SLOTS ARE FILLED!
   true := List.fold(slots2, slotAnd, true);
-  callExp := DAE.CALL(fn_1,args_2,DAE.CALL_ATTR(tp,tuple_,builtin,isImpure or purity == DAE.Purity.OM_IMPURE,isFunctionPointer,inlineType,DAE.NO_TAIL()));
+  callExp := DAE.CALL(fn_1,args_2,DAE.CALL_ATTR(tp,tuple_,builtin,isImpure or purity == DAE.Purity.OM_IMPURE,isFunctionPointer,inlineType,DAE.NO_TAIL(),noReturn));
   // ExpressionDump.dumpExpWithTitle("function elabCallArgs3: ", callExp);
 
   // create a replacement for input variables -> their binding

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -2080,6 +2080,27 @@ algorithm
   outType := DAE.T_FUNCTION(newfargs,rettype,functionAttributes,tysrc);
 end extendsFunctionTypeArgs;
 
+public function setFunctionNoReturn
+  "Marks a function type as never returning normally, so that callers can treat
+   calls to it as terminating."
+  input output DAE.Type ty;
+algorithm
+  ty := match ty
+    local
+      list<DAE.FuncArg> fargs;
+      DAE.Type rettype;
+      Absyn.Path p;
+      DAE.InlineType inl;
+      Boolean ge, fp;
+      DAE.Purity pu;
+      DAE.FunctionBuiltin bi;
+      DAE.FunctionParallelism par;
+    case DAE.T_FUNCTION(fargs, rettype, DAE.FUNCTION_ATTRIBUTES(inl,ge,pu,fp,bi,par,_), p)
+      then DAE.T_FUNCTION(fargs, rettype, DAE.FUNCTION_ATTRIBUTES(inl,ge,pu,fp,bi,par,DAE.NoReturn.NORETURN), p);
+    else ty;
+  end match;
+end setFunctionNoReturn;
+
 protected function makeElementReturnType "
   Create a return type from a list of Element output variables.
   Depending on the length of the output variable list, different
@@ -3907,7 +3928,7 @@ algorithm
         (e_1,_) := matchType(e,t1,t2,printFailtrace);
         t := simplifyType(t2);
       then
-        (DAE.CALL(Absyn.IDENT("mmc_unbox_record"),{e_1},DAE.CALL_ATTR(t,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL())),t2);
+        (DAE.CALL(Absyn.IDENT("mmc_unbox_record"),{e_1},DAE.CALL_ATTR(t,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS)),t2);
 
   end matchcontinue;
 end typeConvert;
@@ -6991,7 +7012,7 @@ algorithm
   isT := isTuple(ty);
   isB := isBuiltin(attr.isBuiltin);
   isImpure := attr.purity == DAE.Purity.IMPURE;
-  callAttr := DAE.CALL_ATTR(ty,isT,isB,isImpure,false,attr.inline,DAE.NO_TAIL());
+  callAttr := DAE.CALL_ATTR(ty,isT,isB,isImpure,false,attr.inline,DAE.NO_TAIL(),DAE.NoReturn.RETURNS);
 end makeCallAttr;
 
 public function builtinName

--- a/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
@@ -240,7 +240,7 @@ protected
 
         else
           algorithm
-            Error.assertion(false, getInstanceName() + " got unknown equation " +
+            Error.terminate(getInstanceName() + " got unknown equation " +
                                    Equation.toString(eq) + "\n", sourceInfo());
           then
             fail();
@@ -747,7 +747,7 @@ protected
         outExpl := e :: outExpl;
         flowRange := true;
       else
-        Error.assertion(false, getInstanceName() + " got invalid intervals.", sourceInfo());
+        Error.terminate(getInstanceName() + " got invalid intervals.", sourceInfo());
       end if;
     end for;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -1008,7 +1008,7 @@ public
         case VAR_ATTR_RECORD() then {attributes};
 
         else algorithm
-          Error.assertion(false, getInstanceName() + "failed. Not yet handled: " + toString(attributes), sourceInfo());
+          Error.terminate(getInstanceName() + "failed. Not yet handled: " + toString(attributes), sourceInfo());
         then fail();
       end match;
     end scalarize;
@@ -1025,7 +1025,7 @@ public
         case VAR_ATTR_STRING()  then Type.STRING();
         // should probably add enumeration but currently the needed info is not stored here
         else algorithm
-          Error.assertion(false, getInstanceName() + " cannot create type from attributes: " + toString(attr), sourceInfo());
+          Error.terminate(getInstanceName() + " cannot create type from attributes: " + toString(attr), sourceInfo());
         then fail();
       end match;
     end elemType;
@@ -1157,7 +1157,7 @@ public
           // unknown attributes here.
           else
             algorithm
-              Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+              Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
             then
               fail();
         end match;
@@ -1196,7 +1196,7 @@ public
             // unknown attributes here.
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+                Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
               then
                 fail();
           end match;
@@ -1232,7 +1232,7 @@ public
             // unknown attributes here.
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+                Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
               then
                 fail();
           end match;
@@ -1267,7 +1267,7 @@ public
             // unknown attributes here.
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+                Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
               then
                 fail();
           end match;
@@ -1305,7 +1305,7 @@ public
             // unknown attributes here.
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+                Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
               then
                 fail();
           end match;
@@ -1377,13 +1377,13 @@ public
         case Expression.ARRAY() algorithm
           arg :: rest := arrayList(exp.elements);
           if not (listEmpty(rest) or List.all(rest, function Expression.isEqual(exp2=arg))) then
-            Error.assertion(false, getInstanceName() +
+            Error.terminate(getInstanceName() +
               " cannot handle array StateSelect with different values yet:" + Expression.toString(exp), sourceInfo());
             fail();
           end if;
         then getStateSelectName(arg);
         else algorithm
-          Error.assertion(false, getInstanceName() +
+          Error.terminate(getInstanceName() +
             " got invalid StateSelect expression " + Expression.toString(exp), sourceInfo());
         then fail();
       end match;
@@ -1401,7 +1401,7 @@ public
         case "always"   then StateSelect.ALWAYS;
         else
           algorithm
-            Error.assertion(false, getInstanceName() + " got unknown StateSelect literal " + name, sourceInfo());
+            Error.terminate(getInstanceName() + " got unknown StateSelect literal " + name, sourceInfo());
           then
             fail();
       end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -384,7 +384,7 @@ public
       case FLAT_BINDING() then binding.variability;
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown binding", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown binding", sourceInfo());
         then
           fail();
     end match;
@@ -556,7 +556,7 @@ public
           fail();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got untyped binding", sourceInfo());
+          Error.terminate(getInstanceName() + " got untyped binding", sourceInfo());
         then
           fail();
     end match;
@@ -586,7 +586,7 @@ public
       case CEVAL_BINDING() then NONE();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got untyped binding", sourceInfo());
+          Error.terminate(getInstanceName() + " got untyped binding", sourceInfo());
         then
           fail();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -96,7 +96,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown call: " +
+          Error.terminate(getInstanceName() + " got unknown call: " +
             Call.toString(call), sourceInfo());
         then
           fail();
@@ -168,7 +168,7 @@ public
       case "zeros" then typeZerosOnesCall("zeros", call, next_context, info);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unhandled builtin function: " + Call.toString(call), sourceInfo());
+          Error.terminate(getInstanceName() + " got unhandled builtin function: " + Call.toString(call), sourceInfo());
         then
           fail();
     end match;
@@ -1059,7 +1059,7 @@ protected
       args := Expression.arrayScalarElements(arg);
 
       if listLength(args) <> 1 then
-        Error.assertion(false, getInstanceName() + " failed to expand scalar(" +
+        Error.terminate(getInstanceName() + " failed to expand scalar(" +
           Expression.toString(arg) + ") correctly", info);
       end if;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -153,7 +153,7 @@ public
       case Absyn.FOR_ITER_FARG() then instIteratorCall(functionName, functionArgs, scope, context, info);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown call type", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown call type", sourceInfo());
         then
           fail();
     end match;
@@ -236,7 +236,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + ": " + Expression.toString(callExp), sourceInfo());
+          Error.terminate(getInstanceName() + ": " + Expression.toString(callExp), sourceInfo());
         then fail();
     end match;
   end typeCall;
@@ -299,7 +299,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid function call expression", sourceInfo());
         then
           fail();
     end match;
@@ -455,7 +455,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid function call expression", sourceInfo());
         then
           fail();
     end match;
@@ -525,7 +525,7 @@ public
       case TYPED_ARRAY_CONSTRUCTOR() then call.var;
       case TYPED_REDUCTION() then call.var;
       else algorithm
-        Error.assertion(false, getInstanceName() + " got untyped call", sourceInfo());
+        Error.terminate(getInstanceName() + " got untyped call", sourceInfo());
         then fail();
     end match;
   end variability;
@@ -773,7 +773,7 @@ public
       case TYPED_REDUCTION() then call.fn;
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got untyped function", sourceInfo());
+          Error.terminate(getInstanceName() + " got untyped function", sourceInfo());
         then
           fail();
     end match;
@@ -867,7 +867,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown call", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown call", sourceInfo());
         then
           fail();
 
@@ -1233,7 +1233,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown call", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown call", sourceInfo());
         then
           fail();
     end match;
@@ -1315,7 +1315,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got untyped call", sourceInfo());
+          Error.terminate(getInstanceName() + " got untyped call", sourceInfo());
         then
           fail();
     end match;
@@ -2490,7 +2490,7 @@ protected
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown function args", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown function args", sourceInfo());
         then
           fail();
     end match;
@@ -2660,7 +2660,7 @@ protected
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid function call expression", sourceInfo());
         then
           fail();
     end match;
@@ -2714,7 +2714,7 @@ protected
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid reduction call", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid reduction call", sourceInfo());
         then
           fail();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCallAttributes.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCallAttributes.mo
@@ -53,7 +53,7 @@ public
     output DAE.CallAttributes fattr;
   algorithm
     fattr := DAE.CALL_ATTR(NFType.toDAE(returnType), attr.tuple_, attr.builtin,
-      attr.isImpure, attr.isFunctionPointerCall, attr.inlineType, attr.tailCall);
+      attr.isImpure, attr.isFunctionPointerCall, attr.inlineType, attr.tailCall, DAE.NoReturn.RETURNS);
   end toDAE;
 
 annotation(__OpenModelica_Interface="nf_frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -3384,7 +3384,7 @@ algorithm
     case "max" then (evalBuiltinMax2, Expression.makeMinValue(ty));
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown reduction function " +
+        Error.terminate(getInstanceName() + " got unknown reduction function " +
           AbsynUtil.pathString(Function.name(fn)), sourceInfo());
       then
         fail();
@@ -3468,7 +3468,7 @@ algorithm
     result := Expression.mapSplitExpressions(e,
       function Expression.nthRecordElement(index = index));
   else
-    Error.assertion(false, getInstanceName() + " could not evaluate " +
+    Error.terminate(getInstanceName() + " could not evaluate " +
       Expression.toString(exp), sourceInfo());
   end try;
 end evalRecordElement;

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -440,7 +440,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
           ();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got non-modifiable class", sourceInfo());
+          Error.terminate(getInstanceName() + " got non-modifiable class", sourceInfo());
         then
           fail();
     end match;
@@ -473,7 +473,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
           ();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got non-modifiable class", sourceInfo());
+          Error.terminate(getInstanceName() + " got non-modifiable class", sourceInfo());
         then
           fail();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -402,7 +402,7 @@ public
 
           else
             algorithm
-              Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
+              Error.terminate(getInstanceName() + " got invalid component", sourceInfo());
             then
               fail();
         end match;
@@ -598,12 +598,12 @@ public
 
             // Sanity check.
             if comp_idx <> compCount + 1 then
-              Error.assertion(false, getInstanceName() + " miscounted components in " +
+              Error.terminate(getInstanceName() + " miscounted components in " +
                 InstNode.name(clsNode), sourceInfo());
             end if;
 
             if cls_idx <> classCount + 1 then
-              Error.assertion(false, getInstanceName() + " miscounted classes in " +
+              Error.terminate(getInstanceName() + " miscounted classes in " +
                 InstNode.name(clsNode), sourceInfo());
             end if;
 
@@ -651,7 +651,7 @@ public
 
         else
           algorithm
-            Error.assertion(false, getInstanceName() + " got invalid class", sourceInfo());
+            Error.terminate(getInstanceName() + " got invalid class", sourceInfo());
           then
             fail();
 
@@ -769,7 +769,7 @@ public
               ();
 
           else algorithm
-            Error.assertion(false, getInstanceName() + " failed for non-instantiated tree.", sourceInfo());
+            Error.terminate(getInstanceName() + " failed for non-instantiated tree.", sourceInfo());
           then fail();
         end match;
       end if;
@@ -792,7 +792,7 @@ public
               ();
 
           else algorithm
-            Error.assertion(false, getInstanceName() + " failed for non-flat tree.", sourceInfo());
+            Error.terminate(getInstanceName() + " failed for non-flat tree.", sourceInfo());
           then fail();
         end match;
       end if;
@@ -1403,7 +1403,7 @@ public
           node := resolveEntry(entry.entry, tree);
         end if;
       else
-        Error.assertion(false, getInstanceName() + " failed on " + name, sourceInfo());
+        Error.terminate(getInstanceName() + " failed on " + name, sourceInfo());
       end try;
     end getRedeclaredNode;
 
@@ -1722,7 +1722,7 @@ public
 
         else
           algorithm
-            Error.assertion(false, getInstanceName() + " got invalid entry", sourceInfo());
+            Error.terminate(getInstanceName() + " got invalid entry", sourceInfo());
           then
             fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -709,7 +709,7 @@ public
   algorithm
     (new_subscripts, cref) := mergeSubscripts2(subscripts, cref, applyToScope, backend, reverse);
     if not listEmpty(new_subscripts) then
-      Error.assertion(false, getInstanceName() + " failed because the subscripts "
+      Error.terminate(getInstanceName() + " failed because the subscripts "
         + List.toString(subscripts, Subscript.toString) + " could not be fully merged onto "
         + ComponentRef.toString(old_cref) + ".\nResult: " + ComponentRef.toString(cref)
         + " with leftover: " + List.toString(new_subscripts, Subscript.toString) + ".", sourceInfo());
@@ -1062,7 +1062,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " failed", sourceInfo());
+          Error.terminate(getInstanceName() + " failed", sourceInfo());
         then
           fail();
     end match;
@@ -1253,7 +1253,7 @@ public
       case (EMPTY(), _)       then -1;
       case (WILD(), _)        then -1;
       else algorithm
-        Error.assertion(false, getInstanceName() + " failed", sourceInfo());
+        Error.terminate(getInstanceName() + " failed", sourceInfo());
       then fail();
     end match;
   end compare;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnection.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnection.mo
@@ -135,7 +135,7 @@ protected
     input Connection conn;
   algorithm
     if listLength(leftConnectors) <> listLength(rightConnectors) then
-      Error.assertion(false, getInstanceName() + " got unbalanced connection " + toString(conn) + ":" +
+      Error.terminate(getInstanceName() + " got unbalanced connection " + toString(conn) + ":" +
         List.toString(leftConnectors, Connector.toString, "\n  lhs: ", "{", ", ", "}", true) +
         List.toString(rightConnectors, Connector.toString, "\n  rhs: ", "{", ", ", "}", true), sourceInfo());
       fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -229,7 +229,7 @@ public
     else
       // Connectors should only have structural parameter subscripts, so it
       // should always be possible to expand them.
-      Error.assertion(false, getInstanceName() + " failed to expand connector `" +
+      Error.terminate(getInstanceName() + " failed to expand connector `" +
         ComponentRef.toString(cref) + "\n", ElementSource.getInfo(source));
     end if;
   end makeConnectors;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -117,7 +117,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression " +
+          Error.terminate(getInstanceName() + " got unknown expression " +
             Expression.toString(exp), sourceInfo());
         then
           fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -287,7 +287,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
         then
           fail();
     end match;
@@ -323,7 +323,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
         then
           fail();
     end match;
@@ -357,7 +357,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
         then
           fail();
     end match;
@@ -390,7 +390,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
         then
           fail();
     end match;
@@ -425,7 +425,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type attribute " + name, sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type attribute " + name, sourceInfo());
         then
           fail();
     end match;
@@ -462,7 +462,7 @@ algorithm
     case Expression.CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR(exp = e)) then getStateSelectName(e);
     else
       algorithm
-        Error.assertion(false, getInstanceName() +
+        Error.terminate(getInstanceName() +
           " got invalid StateSelect expression " + Expression.toString(exp), sourceInfo());
       then
         fail();
@@ -481,7 +481,7 @@ algorithm
     case "always" then DAE.StateSelect.ALWAYS();
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown StateSelect literal " + name, sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown StateSelect literal " + name, sourceInfo());
       then
         fail();
   end match;
@@ -500,7 +500,7 @@ algorithm
     case Expression.CREF(cref = ComponentRef.CREF(node = node)) then InstNode.name(node);
     else
       algorithm
-        Error.assertion(false, getInstanceName() +
+        Error.terminate(getInstanceName() +
           " got invalid Uncertainty expression " + Expression.toString(exp), sourceInfo());
       then
         fail();
@@ -520,7 +520,7 @@ algorithm
     case "propagate" then DAE.Uncertainty.PROPAGATE();
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown Uncertainty literal " + name, sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown Uncertainty literal " + name, sourceInfo());
       then
         fail();
   end match;
@@ -603,7 +603,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown equation " + Equation.toString(eq), sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown equation " + Equation.toString(eq), sourceInfo());
       then
         fail();
   end match;
@@ -759,7 +759,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown equation " + Equation.toString(eq), sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown equation " + Equation.toString(eq), sourceInfo());
       then
         fail();
   end match;
@@ -847,7 +847,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown statement " + Statement.toString(stmt), sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown statement " + Statement.toString(stmt), sourceInfo());
       then
         fail();
   end match;
@@ -1107,7 +1107,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown function", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown function", sourceInfo());
       then
         fail();
 
@@ -1153,7 +1153,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got invalid component.", sourceInfo());
+        Error.terminate(getInstanceName() + " got invalid component.", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -116,7 +116,7 @@ public
             case Type.ENUMERATION() then ENUM(ty);
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got invalid typename", sourceInfo());
+                Error.terminate(getInstanceName() + " got invalid typename", sourceInfo());
               then
                 fail();
           end match;
@@ -170,7 +170,7 @@ public
                             stop  = Expression.INTEGER(stop))
       then (start, step, stop);
       else algorithm
-        Error.assertion(false, getInstanceName() + " got non-range expression: " + Expression.toString(range), sourceInfo());
+        Error.terminate(getInstanceName() + " got non-range expression: " + Expression.toString(range), sourceInfo());
       then fail();
     end match;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -501,7 +501,7 @@ algorithm
           outExp := Expression.applySubscripts(ComponentRef.getSubscripts(cr), outExp);
         end for;
       else
-        Error.assertion(false, getInstanceName() + " could not find replacement for " +
+        Error.terminate(getInstanceName() + " could not find replacement for " +
           ComponentRef.toString(cref), sourceInfo());
       end try;
     end if;
@@ -750,13 +750,13 @@ algorithm
     case Statement.BREAK()      then FlowControl.BREAK;
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " failed on " + anyString(stmt) + "\n", sourceInfo());
+        Error.terminate(getInstanceName() + " failed on " + anyString(stmt) + "\n", sourceInfo());
       then
         fail();
 
   end match;
   //else
-  //   Error.assertion(false, getInstanceName() + " failed to evaluate statement " + Statement.toString(stmt) + "\n", sourceInfo());
+  //   Error.terminate(getInstanceName() + " failed to evaluate statement " + Statement.toString(stmt) + "\n", sourceInfo());
   //   fail();
   //end try;
 end evaluateStatement;
@@ -813,7 +813,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " failed on " +
+        Error.terminate(getInstanceName() + " failed on " +
           Expression.toString(variable) + " := " + Expression.toString(value), sourceInfo());
       then
         fail();
@@ -899,7 +899,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + ": unimplemented case for " +
+        Error.terminate(getInstanceName() + ": unimplemented case for " +
           Expression.toString(arrayExp) +
           Subscript.toStringList(subscripts) + " = " +
           Expression.toString(value), sourceInfo());
@@ -1066,7 +1066,7 @@ algorithm
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " failed to evaluate assert(false, " +
+          Error.terminate(getInstanceName() + " failed to evaluate assert(false, " +
             Expression.toString(msg) + ", " + Expression.toString(lvl) + ")", sourceInfo());
         then
           fail();
@@ -1555,7 +1555,7 @@ algorithm
     exp := Expression.makeRecord(InstNode.fullPath(cls_node),
       InstNode.getType(cls_node), listReverseInPlace(expl));
   else
-    Error.assertion(false, getInstanceName() +
+    Error.terminate(getInstanceName() +
       " failed to find return value for output " + InstNode.name(outputNode), sourceInfo());
   end if;
 end getExternalOutputResult;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1011,7 +1011,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown expression.", sourceInfo());
         then
           fail();
 
@@ -1480,12 +1480,12 @@ public
             step := if start > stop then -1 else 1;
           end if;
         else
-          Error.assertion(false, getInstanceName() + " range could not be parsed to integer values: " + toString(range), sourceInfo());
+          Error.terminate(getInstanceName() + " range could not be parsed to integer values: " + toString(range), sourceInfo());
           fail();
         end try;
       then (start, step, stop);
       else algorithm
-        Error.assertion(false, getInstanceName() + " expression not RANGE(): " + toString(range), sourceInfo());
+        Error.terminate(getInstanceName() + " expression not RANGE(): " + toString(range), sourceInfo());
       then fail();
     end match;
   end getIntegerRange;
@@ -1505,7 +1505,7 @@ public
     i := match SimplifyExp.simplify(e)
       case INTEGER(i) then i;
       else algorithm
-        Error.assertion(false, getInstanceName() + " cannot be parsed to an integer: " + toString(exp), sourceInfo());
+        Error.terminate(getInstanceName() + " cannot be parsed to an integer: " + toString(exp), sourceInfo());
       then fail();
     end match;
   end getInteger;
@@ -1809,7 +1809,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown subscript '" + Subscript.toString(sub) + "'", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown subscript '" + Subscript.toString(sub) + "'", sourceInfo());
         then
           fail();
 
@@ -2001,7 +2001,7 @@ public
 
     // Check that the expression has enough dimensions to be subscripted.
     if not listEmpty(extra_subs) then
-      Error.assertion(false, getInstanceName() + ": too few dimensions in " +
+      Error.terminate(getInstanceName() + ": too few dimensions in " +
         toString(exp) + " to apply subscripts " + Subscript.toStringList(subscripts), sourceInfo());
     end if;
 
@@ -2632,7 +2632,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression '" + toString(exp) + "'", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown expression '" + toString(exp) + "'", sourceInfo());
         then
           fail();
 
@@ -2753,7 +2753,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression '" + toString(exp) + "'", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown expression '" + toString(exp) + "'", sourceInfo());
         then
           fail();
 
@@ -2825,7 +2825,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unhandled expression " + toString(exp), sourceInfo());
+          Error.terminate(getInstanceName() + " got unhandled expression " + toString(exp), sourceInfo());
         then
           fail();
     end match;
@@ -5714,7 +5714,7 @@ public
       case INSTANCE_NAME() then Variability.CONSTANT;
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown expression.", sourceInfo());
         then
           fail();
     end match;
@@ -5795,7 +5795,7 @@ public
       case INSTANCE_NAME() then Purity.PURE;
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown expression.", sourceInfo());
         then
           fail();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -108,7 +108,7 @@ public
           (e, expanded) := ExpandExp.expand(exp, backend, resize);
 
           if not expanded then
-            Error.assertion(false, getInstanceName() + " got unexpandable expression `" +
+            Error.terminate(getInstanceName() + " got unexpandable expression `" +
               Expression.toString(exp) + "`", sourceInfo());
           end if;
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -504,7 +504,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got non-instantiated component " + Prefix.toString(prefix) + "\n", sourceInfo());
+        Error.terminate(getInstanceName() + " got non-instantiated component " + Prefix.toString(prefix) + "\n", sourceInfo());
       then
         ();
 
@@ -567,7 +567,7 @@ algorithm
 
           else
             algorithm
-              Error.assertion(false, getInstanceName() + " got unknown component", sourceInfo());
+              Error.terminate(getInstanceName() + " got unknown component", sourceInfo());
             then
               fail();
         end match;
@@ -583,7 +583,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown component", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown component", sourceInfo());
       then
         fail();
 
@@ -909,7 +909,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got non-record binding " +
+        Error.terminate(getInstanceName() + " got non-record binding " +
           Expression.toString(binding_exp), sourceInfo());
       then
         fail();
@@ -1597,7 +1597,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got untyped binding.", sourceInfo());
+        Error.terminate(getInstanceName() + " got untyped binding.", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1611,7 +1611,7 @@ uniontype Function
       case ComponentRef.CREF() then typeNodeCache(functionRef.node, context);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid function call reference", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid function call reference", sourceInfo());
         then
           fail();
     end match;
@@ -2413,7 +2413,7 @@ protected
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got non-instantiated function " + AbsynUtil.pathString(InstNode.scopePath(node)), sourceInfo());
+          Error.terminate(getInstanceName() + " got non-instantiated function " + AbsynUtil.pathString(InstNode.scopePath(node)), sourceInfo());
         then
           fail();
     end match;
@@ -2510,7 +2510,7 @@ protected
 
       slot := SLOT(component, SlotType.GENERIC, default, NONE(), index, SlotEvalStatus.NOT_EVALUATED);
     else
-      Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
+      Error.terminate(getInstanceName() + " got invalid component", sourceInfo());
     end try;
   end makeSlot;
 
@@ -2597,7 +2597,7 @@ protected
           has_unbox_args := hasUnboxArgsAnnotation(cmt);
         then
           DAE.FUNCTION_ATTRIBUTES(inline_ty, generateEvents, purity, is_partial,
-            DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_NON_PARALLEL());
+            DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_NON_PARALLEL(), DAE.NoReturn.RETURNS);
 
       // Parallel function: there are some builtin functions.
       case SCode.FunctionRestriction.FR_PARALLEL_FUNCTION()
@@ -2610,7 +2610,7 @@ protected
           has_unbox_args := hasUnboxArgsAnnotation(cmt);
         then
           DAE.FUNCTION_ATTRIBUTES(inline_ty, generateEvents, purity, is_partial,
-            DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_PARALLEL_FUNCTION());
+            DAE.FUNCTION_BUILTIN(SOME(name), has_unbox_args), DAE.FP_PARALLEL_FUNCTION(), DAE.NoReturn.RETURNS);
 
       // Parallel function: non-builtin.
       case SCode.FunctionRestriction.FR_PARALLEL_FUNCTION()
@@ -2619,12 +2619,12 @@ protected
           generateEvents := InstBasics.commentGenerateEvents(cmt);
         then
           DAE.FUNCTION_ATTRIBUTES(inline_ty, generateEvents, purity, is_partial,
-            getBuiltinPtr(cmt), DAE.FP_PARALLEL_FUNCTION());
+            getBuiltinPtr(cmt), DAE.FP_PARALLEL_FUNCTION(), DAE.NoReturn.RETURNS);
 
       // Kernel functions: never builtin and never inlined.
       case SCode.FunctionRestriction.FR_KERNEL_FUNCTION()
         then DAE.FUNCTION_ATTRIBUTES(DAE.NO_INLINE(), false, purity, is_partial,
-          DAE.FUNCTION_NOT_BUILTIN(), DAE.FP_KERNEL_FUNCTION());
+          DAE.FUNCTION_NOT_BUILTIN(), DAE.FP_KERNEL_FUNCTION(), DAE.NoReturn.RETURNS);
 
       // Normal function.
       else
@@ -2641,7 +2641,7 @@ protected
             purity := DAE.Purity.PURE;
           end if;
         then
-          DAE.FUNCTION_ATTRIBUTES(inline_ty, generateEvents, purity, is_partial, getBuiltinPtr(cmt), DAE.FP_NON_PARALLEL());
+          DAE.FUNCTION_ATTRIBUTES(inline_ty, generateEvents, purity, is_partial, getBuiltinPtr(cmt), DAE.FP_NON_PARALLEL(), DAE.NoReturn.RETURNS);
 
     end matchcontinue;
   end makeAttributes;
@@ -2751,17 +2751,17 @@ protected
       case Sections.EMPTY() then {};
       case Sections.EXTERNAL()
         algorithm
-          Error.assertion(false, getInstanceName() + " got function with external section (not algorithm section)", sourceInfo());
+          Error.terminate(getInstanceName() + " got function with external section (not algorithm section)", sourceInfo());
         then fail();
 
       case Sections.SECTIONS()
         algorithm
-          Error.assertion(false, getInstanceName() + " got function with multiple algorithm sections", sourceInfo());
+          Error.terminate(getInstanceName() + " got function with multiple algorithm sections", sourceInfo());
         then fail();
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown sections", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown sections", sourceInfo());
         then fail();
 
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
@@ -293,7 +293,7 @@ protected
       // translating Absyn to SCode, and redeclare isn't allowed by the syntax.
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid modifier", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid modifier", sourceInfo());
         then
           fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
@@ -155,7 +155,7 @@ protected
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid modifier", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid modifier", sourceInfo());
         then
           fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFImport.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFImport.mo
@@ -182,7 +182,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid class tree", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid class tree", sourceInfo());
         then
           ();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -704,7 +704,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown class:\n" + SCodeDump.unparseElementStr(def), sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown class:\n" + SCodeDump.unparseElementStr(def), sourceInfo());
       then
         fail();
 
@@ -1277,7 +1277,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown class.", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown class.", sourceInfo());
       then
         ();
 
@@ -1780,7 +1780,7 @@ algorithm
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown classes", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown classes", sourceInfo());
         then
           fail();
     end match;
@@ -1794,7 +1794,7 @@ algorithm
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown classes", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown classes", sourceInfo());
         then
           fail();
     end match;
@@ -2237,7 +2237,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown components", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown components", sourceInfo());
       then
         fail();
 
@@ -2574,7 +2574,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got invalid class", sourceInfo());
+        Error.terminate(getInstanceName() + " got invalid class", sourceInfo());
       then
         fail();
 
@@ -2739,7 +2739,7 @@ algorithm
     else
       algorithm
         if not InstContext.inRelaxed(context) then
-          Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
+          Error.terminate(getInstanceName() + " got invalid component", sourceInfo());
           fail();
         end if;
       then
@@ -2926,7 +2926,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown expression: " + Dump.printExpStr(absynExp), sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown expression: " + Dump.printExpStr(absynExp), sourceInfo());
       then
         fail();
 
@@ -2964,7 +2964,7 @@ algorithm
                    instCrefTypename(cref, cref.node, info);
           else
             algorithm
-              Error.assertion(false, getInstanceName() + " got invalid instance node", sourceInfo());
+              Error.terminate(getInstanceName() + " got invalid instance node", sourceInfo());
             then
               fail();
         end match;
@@ -3038,7 +3038,7 @@ algorithm
     case Type.ENUMERATION() then Type.ARRAY(ty, {Dimension.ENUM(ty)});
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown class node " +
+        Error.terminate(getInstanceName() + " got unknown class node " +
          InstNode.name(node), sourceInfo());
       then
         fail();
@@ -3459,7 +3459,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown equation", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown equation", sourceInfo());
       then
         fail();
 
@@ -3676,7 +3676,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown statement", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown statement", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -183,7 +183,7 @@ uniontype CachedData
                                     func_cache.specialBuiltin or specialBuiltin);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + ": Invalid cache for function", sourceInfo());
+          Error.terminate(getInstanceName() + ": Invalid cache for function", sourceInfo());
         then
           fail();
     end match;
@@ -1258,7 +1258,7 @@ uniontype InstNode
         then scopeList(parent(clsNode), includeRoot, accumScopes);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown node type", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown node type", sourceInfo());
         then
           fail();
     end match;
@@ -1377,7 +1377,7 @@ uniontype InstNode
         then scopePath2(classParent(node), scopeType, accumPath);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown node type", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown node type", sourceInfo());
         then
           fail();
     end match;
@@ -1488,7 +1488,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.initFunc(node.caches); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end cacheInitFunc;
 
@@ -1499,7 +1499,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.addFunc(fn, specialBuiltin, node.caches); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end cacheAddFunc;
 
@@ -1510,7 +1510,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm node.caches := arrayCreate(1, in_func_cache); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end newFuncCache;
 
@@ -1520,7 +1520,7 @@ uniontype InstNode
   algorithm
     func_cache := match inNode
       case CLASS_NODE() then CachedData.getFuncCache(inNode.caches);
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end getFuncCache;
 
@@ -1530,7 +1530,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.setFuncCache(node.caches, in_func_cache); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setFuncCache;
 
@@ -1540,7 +1540,7 @@ uniontype InstNode
   algorithm
     pack_cache := match inNode
       case CLASS_NODE() then CachedData.getPackageCache(inNode.caches);
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end getPackageCache;
 
@@ -1551,7 +1551,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.setPackageCache(node.caches, CachedData.PACKAGE(packageNode, state)); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setPackageCache;
 
@@ -1560,7 +1560,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.clearPackageCache(node.caches); then ();
-      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+      else algorithm Error.terminate(getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end clearPackageCache;
 
@@ -2174,7 +2174,7 @@ uniontype InstNode
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " did not get an instanced class", sourceInfo());
+          Error.terminate(getInstanceName() + " did not get an instanced class", sourceInfo());
         then fail();
     end match;
   end getSections;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -730,7 +730,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " was called with an invalid path.", sourceInfo());
+        Error.terminate(getInstanceName() + " was called with an invalid path.", sourceInfo());
       then
         fail();
   end match;
@@ -789,7 +789,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " was called with an invalid path.", sourceInfo());
+        Error.terminate(getInstanceName() + " was called with an invalid path.", sourceInfo());
       then
         fail();
   end match;
@@ -1096,7 +1096,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got invalid top node", sourceInfo());
+        Error.terminate(getInstanceName() + " got invalid top node", sourceInfo());
       then
         fail();
 
@@ -1137,7 +1137,7 @@ algorithm
 
             else
               algorithm
-                Error.assertion(false, getInstanceName() + " got unknown component", sourceInfo());
+                Error.terminate(getInstanceName() + " got unknown component", sourceInfo());
               then
                 fail();
           end match;
@@ -1146,7 +1146,7 @@ algorithm
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown node", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown node", sourceInfo());
         then
           fail();
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -490,7 +490,7 @@ uniontype LookupState
       case SCode.CLASS() then CLASS();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown element.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown element.", sourceInfo());
         then
           fail();
     end match;
@@ -575,7 +575,7 @@ uniontype LookupState
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " failed on unknown transition for element " + InstNode.name(node), sourceInfo());
+          Error.terminate(getInstanceName() + " failed on unknown transition for element " + InstNode.name(node), sourceInfo());
         then
           fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
@@ -185,7 +185,7 @@ public
       case ((TypeRestriction.MATRIX, _), (TypeRestriction.MATRIX, ty))  then (SizeClassification.ELEMENT_WISE, ty);
       case ((TypeRestriction.ARRAY,  _), (TypeRestriction.ARRAY,  ty))  then (SizeClassification.ELEMENT_WISE, ty);
       else algorithm
-        Error.assertion(false, getInstanceName() + " failed because the multary arguments have incompatible sizes: "
+        Error.terminate(getInstanceName() + " failed because the multary arguments have incompatible sizes: "
         + List.toString(types, Type.toString), sourceInfo());
       then fail();
     end match;
@@ -211,7 +211,7 @@ public
       case (TypeRestriction.MATRIX, TypeRestriction.VECTOR)               then (SizeClassification.MATRIX_VECTOR, ty2);
       case (r1, r2) guard(r1 == r2)                                       then (getSizeClassification(operator), ty1);
       else algorithm
-        Error.assertion(false, getInstanceName() + " failed because the binary arguments have incompatible sizes: "
+        Error.terminate(getInstanceName() + " failed because the binary arguments have incompatible sizes: "
           + Type.toString(ty1) + ", " + Type.toString(ty2), sourceInfo());
       then fail();
     end match;
@@ -331,7 +331,7 @@ public
       case Op.NEQUAL            then Absyn.Operator.NEQUAL();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;
@@ -384,7 +384,7 @@ public
       case Op.NEQUAL            then DAE.NEQUAL(ty);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type: " + opToString(op.op), sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type: " + opToString(op.op), sourceInfo());
         then
           fail();
     end match;
@@ -458,7 +458,7 @@ public
       //case Op.USERDEFINED      then "Userdefined:" + AbsynUtil.pathString(op.fqName);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -116,7 +116,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got non-instantiated function", sourceInfo());
+          Error.terminate(getInstanceName() + " got non-instantiated function", sourceInfo());
         then
           fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
@@ -186,7 +186,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown dim", sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown dim", sourceInfo());
         then
           fail();
 
@@ -228,7 +228,7 @@ public
 
       case INVALID_RANGE()
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid range " +
+          Error.terminate(getInstanceName() + " got invalid range " +
             Expression.toString(iterator.exp), sourceInfo());
         then
           fail();
@@ -247,7 +247,7 @@ public
       case ARRAY_RANGE() then iterator.index <= arrayLength(iterator.values);
       case INVALID_RANGE()
         algorithm
-          Error.assertion(false, getInstanceName() + " got invalid range " +
+          Error.terminate(getInstanceName() + " got invalid range " +
             Expression.toString(iterator.exp), sourceInfo());
         then
           fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -252,7 +252,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got non-instantiated function", sourceInfo());
+        Error.terminate(getInstanceName() + " got non-instantiated function", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFSBGraphUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSBGraphUtil.mo
@@ -79,7 +79,7 @@ public
 
       for dim in dims loop
         if not Dimension.isKnown(dim) then
-          Error.assertion(false, getInstanceName() + ": unknown dimension " + Dimension.toString(dim),
+          Error.terminate(getInstanceName() + ": unknown dimension " + Dimension.toString(dim),
                                  sourceInfo());
         end if;
 
@@ -195,7 +195,7 @@ public
       case Expression.RANGE() then intervalFromRange(e);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown expression " +
+          Error.terminate(getInstanceName() + " got unknown expression " +
                                  Expression.toString(e), sourceInfo());
         then
           fail();
@@ -236,13 +236,13 @@ public
         case Op.MUL then SBInterval.new(llo * rlo, llo * step, lhi * rhi);
         else
           algorithm
-            Error.assertion(false, getInstanceName() +
+            Error.terminate(getInstanceName() +
               " got unknown operator " + Operator.symbol(op), sourceInfo());
           then
             fail();
       end match;
     else
-      Error.assertion(false, getInstanceName() + " got unknown expression " +
+      Error.terminate(getInstanceName() + " got unknown expression " +
         Expression.toString(Expression.BINARY(lhs, op, rhs)) + "\n", sourceInfo());
     end if;
   end intervalFromBinaryExp;
@@ -304,7 +304,7 @@ public
 
     if SBMultiInterval.ndim(mi1) <> SBMultiInterval.ndim(mi2) and
        mi1_sz <> 1 and mi2_sz <> 1 then
-      Error.assertion(false, getInstanceName() + " got incompatible connect", sourceInfo());
+      Error.terminate(getInstanceName() + " got incompatible connect", sourceInfo());
     end if;
 
     sz := arrayLength(ints1);
@@ -320,7 +320,7 @@ public
       sz2 := SBInterval.size(ints2[i]);
 
       if sz1 <> sz2 and sz1 <> 1 and sz2 <> 1 then
-        Error.assertion(false, getInstanceName() + " got incompatible connect", sourceInfo());
+        Error.terminate(getInstanceName() + " got incompatible connect", sourceInfo());
       end if;
 
       count := max(sz1, sz2);

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -194,7 +194,7 @@ algorithm
         vars := Variable.VARIABLE(cr, elem_ty, binding, vis, attr, ty_attr, {}, cmt, info, binfo) :: vars;
       end for;
     else
-      Error.assertion(false, getInstanceName() + " failed on " +
+      Error.terminate(getInstanceName() + " failed on " +
         Variable.toString(var, printBindingType = true), var.info);
     end try;
   else
@@ -251,7 +251,7 @@ algorithm
       vars := List.keepPositions(vars, indices, zeroBased = true);
     end if;
   else
-    Error.assertion(false, getInstanceName() + " failed for: " + Variable.toString(var), sourceInfo());
+    Error.terminate(getInstanceName() + " failed for: " + Variable.toString(var), sourceInfo());
   end try;
 end scalarizeBackendVariable;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFSections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSections.mo
@@ -134,7 +134,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() +
+          Error.terminate(getInstanceName() +
             " got invalid Sections to prepend equation to", sourceInfo());
         then
           fail();
@@ -163,7 +163,7 @@ public
 
       else
         algorithm
-          Error.assertion(false, getInstanceName() +
+          Error.terminate(getInstanceName() +
             " got invalid Sections to prepend algorithm to", sourceInfo());
         then
           fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -860,7 +860,7 @@ algorithm
       elseif mcl == NFOperator.MathClassification.MULTIPLICATION then
         (new_const, neutralConst) := Ceval.evalMultaryMulDiv(const_args, inv_const_args, Operator.typeOf(operator));
       else
-        Error.assertion(false, getInstanceName() + " detected non-commutative operator in MULTARY(): [" + Operator.mathSymbol(mcl) +
+        Error.terminate(getInstanceName() + " detected non-commutative operator in MULTARY(): [" + Operator.mathSymbol(mcl) +
           "]\n with following arguments: " + stringDelimitList(list(Expression.toString(e) for e in const_args), ", ") +
           "\n and following inverse arguments: " + stringDelimitList(list(Expression.toString(e) for e in inv_const_args), ", "),
           sourceInfo());
@@ -1491,7 +1491,7 @@ algorithm
     then res;
 
     else algorithm
-      Error.assertion(false, getInstanceName() + " detected non-commutative operator in MULTARY(): [" + Operator.mathSymbol(mcl) +
+      Error.terminate(getInstanceName() + " detected non-commutative operator in MULTARY(): [" + Operator.mathSymbol(mcl) +
        "]\n with following arguments: " + stringDelimitList(list(Expression.toString(e) for e in const), ", ") +
        "\n and following inverse arguments: " + stringDelimitList(list(Expression.toString(e) for e in inv_const), ", "),
        sourceInfo());

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -176,7 +176,7 @@ public
       then List.intRange2(start, stop);
 
       else algorithm
-        Error.assertion(false, getInstanceName() + " got an incorrect subscript type " + toString(subscript) + ".", sourceInfo());
+        Error.terminate(getInstanceName() + " got an incorrect subscript type " + toString(subscript) + ".", sourceInfo());
       then fail();
     end match;
   end toIndexList;
@@ -197,7 +197,7 @@ public
     if isValidIndexType(ty) then
       subscript := INDEX(exp);
     else
-      Error.assertion(false, getInstanceName() + " got a non integer type exp to make an index sub", sourceInfo());
+      Error.terminate(getInstanceName() + " got a non integer type exp to make an index sub", sourceInfo());
       fail();
     end if;
   end makeIndex;
@@ -208,7 +208,7 @@ public
     output Subscript subscript = SPLIT_INDEX(node, dimIndex);
   algorithm
     if dimIndex < 1 then
-      Error.assertion(false, getInstanceName() + " got invalid index " + String(dimIndex), sourceInfo());
+      Error.terminate(getInstanceName() + " got invalid index " + String(dimIndex), sourceInfo());
     end if;
   end makeSplitIndex;
 
@@ -754,7 +754,7 @@ public
       case WHOLE() then Absyn.Subscript.NOSUB();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " failed on unknown subscript", sourceInfo());
+          Error.terminate(getInstanceName() + " failed on unknown subscript", sourceInfo());
         then
           fail();
     end match;
@@ -770,7 +770,7 @@ public
       case WHOLE() then DAE.WHOLEDIM();
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " failed on unknown subscript " + toString(subscript), sourceInfo());
+          Error.terminate(getInstanceName() + " failed on unknown subscript " + toString(subscript), sourceInfo());
         then
           fail();
     end match;
@@ -938,7 +938,7 @@ public
       case WHOLE() then Dimension.UNKNOWN();
       case SPLIT_INDEX() then Dimension.fromInteger(1);
       else algorithm
-        Error.assertion(false, getInstanceName() + " got wrong subscript " + toString(subscript) + "\n", sourceInfo());
+        Error.terminate(getInstanceName() + " got wrong subscript " + toString(subscript) + "\n", sourceInfo());
       then fail();
     end match;
   end toDimension;
@@ -1250,7 +1250,7 @@ public
       case Dimension.ENUM()                   then INDEX(Expression.nthEnumLiteral(dim.enumType, i));
       case Dimension.RESIZABLE()              then INDEX(Expression.INTEGER(i));
       else algorithm
-        Error.assertion(false, getInstanceName() + " got an incorrect dimension type " + Dimension.toString(dim) + ".", sourceInfo());
+        Error.terminate(getInstanceName() + " got an incorrect dimension type " + Dimension.toString(dim) + ".", sourceInfo());
       then fail();
     end match;
   end nth;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1027,7 +1027,7 @@ public
       case Type.UNTYPED() then Array.toString(ty.dimensions, Dimension.toString, InstNode.name(ty.typeNode), "[", ", ", "]", false);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;
@@ -1061,7 +1061,7 @@ public
       case Type.UNTYPED() then Array.toString(ty.dimensions, function Dimension.toFlatString(format = format), InstNode.name(ty.typeNode), "[", ", ", "]", false);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;
@@ -1076,7 +1076,7 @@ public
       case Type.ARRAY() then stringDelimitList(List.map(ty.dimensions, function Dimension.toFlatString(format = format)), ", ");
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown or not array type: " + anyString(ty), sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown or not array type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;
@@ -1179,7 +1179,7 @@ public
       case Type.ANY() then DAE.T_ANYTYPE(NONE());
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
+          Error.terminate(getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;
@@ -1215,7 +1215,7 @@ public
               case Subscript.WHOLE() then dim :: subbed_dims;
               case Subscript.SPLIT_INDEX() then subbed_dims;
               else algorithm
-                Error.assertion(false, getInstanceName() + " got wrong subscript " + Subscript.toString(sub) + "\n", sourceInfo());
+                Error.terminate(getInstanceName() + " got wrong subscript " + Subscript.toString(sub) + "\n", sourceInfo());
               then fail();
             end match;
           end for;
@@ -1238,7 +1238,7 @@ public
       else
         algorithm
           if failOnError then
-            Error.assertion(false, getInstanceName() +
+            Error.terminate(getInstanceName() +
               " got unsubscriptable type " + toString(ty) + "\n", sourceInfo());
             fail();
           end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1593,7 +1593,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown type.", sourceInfo());
       then
         fail();
 
@@ -1695,7 +1695,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown type.", sourceInfo());
       then
         fail();
 
@@ -2968,7 +2968,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got untyped binding " + Binding.toString(binding), sourceInfo());
+        Error.terminate(getInstanceName() + " got untyped binding " + Binding.toString(binding), sourceInfo());
       then
         fail();
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -210,7 +210,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
       then
         fail();
 
@@ -308,7 +308,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got noninstantiated class " +
+        Error.terminate(getInstanceName() + " got noninstantiated class " +
           InstNode.name(clsNode), sourceInfo());
       then
         fail();
@@ -424,7 +424,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() +
+        Error.terminate(getInstanceName() +
           " got record type without constructor", sourceInfo());
       then
         fail();
@@ -498,7 +498,7 @@ algorithm
     // Any other type of component shouldn't show up here.
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got noninstantiated component " + InstNode.name(component), sourceInfo());
+        Error.terminate(getInstanceName() + " got noninstantiated component " + InstNode.name(component), sourceInfo());
       then
         fail();
 
@@ -578,7 +578,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got non-iterator " + InstNode.name(iterator), sourceInfo());
+        Error.terminate(getInstanceName() + " got non-iterator " + InstNode.name(iterator), sourceInfo());
       then
         fail();
 
@@ -990,7 +990,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
       then
         fail();
 
@@ -1122,7 +1122,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got invalid node " + InstNode.name(node), sourceInfo());
+        Error.terminate(getInstanceName() + " got invalid node " + InstNode.name(node), sourceInfo());
       then
         fail();
 
@@ -1195,7 +1195,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated binding", sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated binding", sourceInfo());
       then
         fail();
 
@@ -2192,7 +2192,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown subscript", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown subscript", sourceInfo());
       then
         fail();
   end match;
@@ -2783,7 +2783,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(classNode), sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated class " + InstNode.name(classNode), sourceInfo());
       then
         fail();
   end match;
@@ -2845,7 +2845,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(classNode), sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated class " + InstNode.name(classNode), sourceInfo());
       then
         fail();
   end match;
@@ -3028,7 +3028,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got uninstantiated component " + InstNode.name(component), sourceInfo());
+        Error.terminate(getInstanceName() + " got uninstantiated component " + InstNode.name(component), sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -190,7 +190,7 @@ public
         // list of binding expression until they match.
         if expl_len < crefs_len then
           if intMod(crefs_len, expl_len) <> 0 then
-            Error.assertion(false, getInstanceName() + " failed to expand " +
+            Error.terminate(getInstanceName() + " failed to expand " +
               ComponentRef.toString(var.name), sourceInfo());
           end if;
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1054,7 +1054,7 @@ algorithm
           // Debugging code. Make sure the scanner works before debugging the diff.
           System.writeFile("string.before", s1);
           System.writeFile("string.after", stringAppendList(list(tokenContent(t) for t in tokens1)));
-          Error.assertion(false, "Lexed string does not match the original. See files string.before and string.after", sourceInfo());
+          Error.terminate("Lexed string does not match the original. See files string.before and string.after", sourceInfo());
           fail();
         end if;
 
@@ -1066,7 +1066,7 @@ algorithm
           // Debugging code. Make sure the parser works before debugging the diff.
           System.writeFile("string.before", s1);
           System.writeFile("string.after", SimpleModelicaParser.parseTreeStr(parseTree1));
-          Error.assertion(false, "Parsed string does not match the original. See files string.before and string.after", sourceInfo());
+          Error.terminate("Parsed string does not match the original. See files string.before and string.after", sourceInfo());
           fail();
         end if;
 
@@ -1083,7 +1083,7 @@ algorithm
           // Debugging code. Make sure the parser works before debugging the diff.
           System.writeFile("string.before", s2);
           System.writeFile("string.after", SimpleModelicaParser.parseTreeStr(parseTree2));
-          Error.assertion(false, "Parsed string does not match the original. See files string.before and string.after", sourceInfo());
+          Error.terminate("Parsed string does not match the original. See files string.before and string.after", sourceInfo());
           fail();
         end if;
 

--- a/OMCompiler/Compiler/Script/Conversion.mo
+++ b/OMCompiler/Compiler/Script/Conversion.mo
@@ -412,7 +412,7 @@ protected
     input SourceInfo info;
     input output ConversionRules rules;
   algorithm
-    Error.assertion(false, getInstanceName() + ": not implemented", info);
+    Error.terminate(getInstanceName() + ": not implemented", info);
   end parseConvertClassIf;
 
   function parseConvertElement

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1044,7 +1044,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown class tree", sourceInfo());
+        Error.terminate(getInstanceName() + " got unknown class tree", sourceInfo());
       then
         fail();
   end match;
@@ -1495,7 +1495,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got unknown component " +
+        Error.terminate(getInstanceName() + " got unknown component " +
           InstNode.name(node), sourceInfo());
       then
         fail();

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -3391,7 +3391,7 @@ algorithm
         end for;
         outSimEqn := listReverse(outSimEqn);
       else
-        Error.assertion(false, getInstanceName() + " failed because expression "
+        Error.terminate(getInstanceName() + " failed because expression "
           + ExpressionBasics.printExpStr(right) + " could not be scalarized.", sourceInfo());
       end try;
     then (outSimEqn, ouniqueEqIndex);

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1166,6 +1166,10 @@ public constant ErrorTypes.Message GENERATED_FUNCTION_UNASSIGNED_OUTPUT = ErrorT
   "Output %s of the generated function %s is never assigned a value. Using an uninitialized variable is an error; this indicates an error in the symbolic differentiation, please report it.");
 public constant ErrorTypes.Message GENERATED_FUNCTION_DEFAULT_INIT = ErrorTypes.MESSAGE(623, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   "Variable %s of the generated function %s will be initialized to %s because it could not be proven that it is always assigned before it is used.");
+public constant ErrorTypes.Message WARNING_DEF_USE_UNPROVEN = ErrorTypes.MESSAGE(624, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  "%s was possibly used before it was defined (given a value): it is not defined on all control flow paths leading to the use. Per the Modelica specification using an uninitialized variable is an error.");
+public constant ErrorTypes.Message UNASSIGNED_FUNCTION_OUTPUT_UNPROVEN = ErrorTypes.MESSAGE(625, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  "Output parameter %s was possibly not assigned a value: it is not assigned on all control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
 
 public constant ErrorTypes.Message MATCH_SHADOWING = ErrorTypes.MESSAGE(5001, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   "Local variable '%s' shadows another variable.");
@@ -1501,6 +1505,7 @@ public function addSourceMessageAndFail
 algorithm
   addSourceMessage(inErrorMsg, inMessageTokens, inInfo);
   fail();
+  annotation(__OpenModelica_NoReturn = true);
 end addSourceMessageAndFail;
 
 public function addMultiSourceMessage
@@ -1743,6 +1748,18 @@ algorithm
     then fail();
   end match;
 end assertion;
+
+public function terminate "
+  Unconditionally reports a compiler-internal error and fails. Equivalent to
+  assertion(false, message, info); used for code paths that must never be
+  reached, and recognized by the def-use analysis as never returning."
+  input String message;
+  input SourceInfo info;
+algorithm
+  addSourceMessage(INTERNAL_ERROR, {message}, info);
+  fail();
+  annotation(__OpenModelica_NoReturn = true);
+end terminate;
 
 public function assertionOrAddSourceMessage "
   Used to make assertions. These messages are meant to be shown to a user when

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -564,6 +564,8 @@ constant DebugFlag FLOW_ALIAS_ELIMINATION = DEBUG_FLAG(198, "flowAliasEliminatio
   "Enables simple alias elimination of flow variables in stream connectors.");
 constant DebugFlag DUMP_CHECK_MODEL = DEBUG_FLAG(199, "dumpCheckModel", false,
   "Dumps the variables and equations found by checkModel.");
+constant DebugFlag CHECK_DEF_USE = DEBUG_FLAG(200, "checkDefUse", false,
+  "Warns about variables in functions that cannot statically be proven to be defined (given a value) before they are used, e.g. variables only assigned on some control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -259,7 +259,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.FORCE_SCALARIZE,
   Flags.DEBUG_ADJOINT,
   Flags.FLOW_ALIAS_ELIMINATION,
-  Flags.DUMP_CHECK_MODEL
+  Flags.DUMP_CHECK_MODEL,
+  Flags.CHECK_DEF_USE
 };
 
 protected

--- a/OMCompiler/Compiler/Util/SBGraph.mo
+++ b/OMCompiler/Compiler/Util/SBGraph.mo
@@ -290,7 +290,7 @@ public
         then Vector.size(il.U_vertices);
 
         else algorithm
-          Error.assertion(false, getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
+          Error.terminate(getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
         then fail();
       end match;
     end addVertex;
@@ -311,7 +311,7 @@ public
         case SetType.F algorithm (_, index) := Vector.find(il.F_vertices, predFn); then index;
         case SetType.U algorithm (_, index) := Vector.find(il.U_vertices, predFn); then index;
         else algorithm
-          Error.assertion(false, getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
+          Error.terminate(getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
         then fail();
       end match;
       od := if index > 0 then SOME(index) else NONE();
@@ -327,7 +327,7 @@ public
         case SetType.F  then Vector.get(il.F_vertices, d);
         case SetType.U  then Vector.get(il.U_vertices, d);
         else algorithm
-          Error.assertion(false, getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
+          Error.terminate(getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: F,U", sourceInfo());
         then fail();
       end match;
     end getVertex;
@@ -413,7 +413,7 @@ public
         case SetType.F then Vector.size(il.F_vertices);
         case SetType.U then Vector.size(il.U_vertices);
         else algorithm
-          Error.assertion(false, getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: V,F,U", sourceInfo());
+          Error.terminate(getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: V,F,U", sourceInfo());
         then fail();
       end match;
     end vertexCount;
@@ -433,7 +433,7 @@ public
         case SetType.F then Vector.toList(il.F_vertices);
         case SetType.U then Vector.toList(il.U_vertices);
         else algorithm
-          Error.assertion(false, getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: V,F,U", sourceInfo());
+          Error.terminate(getInstanceName() + " failed for wrong SetType: " + setTypeString(ST) + "\nAllowed: V,F,U", sourceInfo());
         then fail();
       end match;
     end vertices;

--- a/OMCompiler/Compiler/boot/Makefile.common
+++ b/OMCompiler/Compiler/boot/Makefile.common
@@ -66,7 +66,7 @@ bootstrap-from-tarball2:
 	#$(PATCH_SOURCES)
 	# We have not compiled OpenModelicaScriptingAPI.mo yet
 	touch build/OpenModelicaScriptingAPI.h
-	$(MAKE) -f $(defaultMakefileTarget) install INCLUDESOURCES=1 OMC=.omc BOOTSTRAP_STAGE_1=1 CPPFLAGS="$(CPPFLAGS) -DOMC_BOOTSTRAPPING_STAGE_1"
+	$(MAKE) -f $(defaultMakefileTarget) install INCLUDESOURCES=1 OMC=.omc OMC_EXTRA_FLAGS= BOOTSTRAP_STAGE_1=1 CPPFLAGS="$(CPPFLAGS) -DOMC_BOOTSTRAPPING_STAGE_1"
 	@echo "Bootstrapping phase 1/3 completed"
 	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory clean OMC="$(BOOTSTRAP_OMC)"
 	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory runtime-depends OMBUILDDIR=$(OMBUILDDIR) OMC="$(BOOTSTRAP_OMC)"

--- a/OMCompiler/Compiler/boot/Makefile.in
+++ b/OMCompiler/Compiler/boot/Makefile.in
@@ -30,7 +30,11 @@ CORBALIBS=@CORBALIBS@
 ULIMIT_CMD=true
 SHREXT=@DLLEXT@
 OMC=@OMC@
-OMC_EXTRA_FLAGS=
+# Compile the compiler against itself with the def-use static analysis enabled so
+# that conditionally-assigned variables are caught at build time. -d= is additive and
+# survives the setCommandLineOptions("-d=rml") in CompileFile.mos. Bootstrap stages that
+# run an older compiler (which does not know the flag) override this to empty.
+OMC_EXTRA_FLAGS=-d=checkDefUse
 RPATH=@RPATH@
 STATIC=@BOOTSTRAP_STATIC@
 BOOTSTRAP_OMC=@OMBUILDDIR@/bin/omc

--- a/OMCompiler/README.Linux.md
+++ b/OMCompiler/README.Linux.md
@@ -122,7 +122,7 @@ sudo apt-get install ccache flex
 ```bash
 cd OpenModelica
 # Configure CMake, create Makefiles in build_cmake
-cmake -S . -B build_cmake
+cmake -S . -B build_cmake -DCMAKE_INSTALL_PREFIX=build
 # Compile with generated Makefiles
 cmake --build build_cmake --parallel <Nr. of cores> --target install
 ```


### PR DESCRIPTION
The old frontend's checkFunctionDefUse deliberately merges branches optimistically: a variable assigned in any if-branch or match-case counts as assigned afterwards, so uses of variables that are only assigned on some control flow paths pass silently. This adds a pessimistic second tier that tracks such variables (if-without-else, some-but-not-all match cases, loop and failure() bodies; branches that surely return or fail and 'then fail()' cases are excluded) and warns on their use, and warns about outputs that are not provably assigned on all paths.

Off by default and enabled with -d=checkDefUse: running it over the compiler's own sources yields ~317 findings (a mix of real bugs and patterns guarded by correlated conditions that no flow-insensitive analysis can prove), and the bootstrapping build treats warnings as errors. The default behavior is unchanged.