### PR TITLE
Improve handling of dimensions with cyclic dependencies

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -235,9 +235,12 @@ public
   function getType
     input Component component;
     output Type ty;
+  protected
+    Type t;
   algorithm
     ty := match component
-      case COMPONENT(ty = Type.UNTYPED()) then InstNode.getType(component.classInst);
+      case COMPONENT(ty = t as Type.UNTYPED())
+        then Type.liftArrayLeftList(InstNode.getType(component.classInst), arrayList(t.dimensions));
       case COMPONENT() then component.ty;
       case ITERATOR() then component.ty;
       case TYPE_ATTRIBUTE() then component.ty;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -800,7 +800,16 @@ algorithm
   if isSome(ty) then
     // If the type is known, take the dimension directly from it.
     (dim, error) := nthDimensionBoundsChecked(Util.getOption(ty), dim_index);
-    oe := NONE();
+
+    if Dimension.isUnknown(dim) then
+      // Fall back to typing the expression if the dimension we got from the
+      // type is unknown, which can happen when the type of the binding isn't
+      // fully typed yet due to cyclic dependencies.
+      (dim, oe, error) := typeExpDim(exp, dim_index,
+        InstContext.set(context, NFInstContext.DIMENSION), info);
+    else
+      oe := NONE();
+    end if;
   else
     // If the type is unknown, try to type the expression only as much as is
     // needed to get the dimension we're looking for.

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown19.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown19.mo
@@ -1,0 +1,48 @@
+// name: DimUnknown19
+// keywords:
+// status: correct
+//
+//
+
+record flowParameters
+  parameter Real V_flow[:];
+end flowParameters;
+
+record Generic
+  parameter flowParameters pressure(V_flow = {0, 0});
+end Generic;
+
+record PumpMultiple
+  parameter Integer nPum;
+  parameter Generic per[nPum](pressure(V_flow = fill({0, 1, 2}, nPum)));
+end PumpMultiple;
+
+model Multiple
+  parameter Integer nPum;
+  parameter PumpMultiple dat(final nPum = nPum);
+end Multiple;
+
+model DimUnknown19
+  parameter PumpMultiple datPumMul(final nPum = pumMul.nPum);
+  Multiple pumMul(nPum = 2, final dat = datPumMul);
+end DimUnknown19;
+
+// Result:
+// class DimUnknown19
+//   final parameter Integer datPumMul.nPum = 2;
+//   parameter Real datPumMul.per[1].pressure.V_flow[1] = 0.0;
+//   parameter Real datPumMul.per[1].pressure.V_flow[2] = 1.0;
+//   parameter Real datPumMul.per[1].pressure.V_flow[3] = 2.0;
+//   parameter Real datPumMul.per[2].pressure.V_flow[1] = 0.0;
+//   parameter Real datPumMul.per[2].pressure.V_flow[2] = 1.0;
+//   parameter Real datPumMul.per[2].pressure.V_flow[3] = 2.0;
+//   final parameter Integer pumMul.nPum = 2;
+//   final parameter Integer pumMul.dat.nPum = 2;
+//   final parameter Real pumMul.dat.per[1].pressure.V_flow[1] = datPumMul.per[1].pressure.V_flow[1];
+//   final parameter Real pumMul.dat.per[1].pressure.V_flow[2] = datPumMul.per[1].pressure.V_flow[2];
+//   final parameter Real pumMul.dat.per[1].pressure.V_flow[3] = datPumMul.per[1].pressure.V_flow[3];
+//   final parameter Real pumMul.dat.per[2].pressure.V_flow[1] = datPumMul.per[2].pressure.V_flow[1];
+//   final parameter Real pumMul.dat.per[2].pressure.V_flow[2] = datPumMul.per[2].pressure.V_flow[2];
+//   final parameter Real pumMul.dat.per[2].pressure.V_flow[3] = datPumMul.per[2].pressure.V_flow[3];
+// end DimUnknown19;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -384,6 +384,7 @@ DimUnknown15.mo \
 DimUnknown16.mo \
 DimUnknown17.mo \
 DimUnknown18.mo \
+DimUnknown19.mo \
 dim1.mo \
 dim13.mo \
 dim16.mo \


### PR DESCRIPTION
- Add the dimensions to the type when returning a type for an untyped component in Component.getType.
- Fall back to using typeExpDim in Typing.deduceDimensionFromExp if we get a type whose dimensions aren't known yet.

Fixes #13115 and #13116