### PR TITLE
OMEdit: build against the Rust omc port in-process (CONFIG+=rust_omc)

### DIFF
--- a/OMEdit/OMEdit.config.pre.pri
+++ b/OMEdit/OMEdit.config.pre.pri
@@ -47,6 +47,23 @@ CONFIG += warn_on
 
 DEFINES += OM_HAVE_PTHREADS
 
+# Build OMEdit against the Rust omc port (libOpenModelicaCompiler.so) in-process.
+# Enable by either setting OMEDIT_RUST_OMC=1 in the environment, or passing
+# qmake CONFIG+=rust_omc. The env var is preferred: a recursive build regenerates
+# the subproject Makefiles with a plain `qmake` (no CONFIG+= propagation), but the
+# env var is read on every qmake run.
+# This switches the OMC interface from the MMC value/runtime ABI to the port's
+# self-contained replacement (omc_rust_embedding.h, installed alongside the
+# scripting-API headers); see OMC/OMCProxy.cpp. The Rust .so must be installed as
+# libOpenModelicaCompiler.so (the same name/path the C build links).
+OMEDIT_RUST_OMC_ENV = $$(OMEDIT_RUST_OMC)
+equals(OMEDIT_RUST_OMC_ENV, 1) {
+  CONFIG += rust_omc
+}
+rust_omc {
+  DEFINES += OMC_RUST_ABI
+}
+
 win32 {
   _cxx = $$(CXX)
   contains(_cxx, clang++) {

--- a/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -56,7 +56,8 @@ win32 {
 INCLUDEPATH += ../ \
   ../OMEditLIB \
   ../OMEditLIB/CrashReport \
-  $$OPENMODELICAHOME/include/omc/c
+  $$OPENMODELICAHOME/include/omc/c \
+  $$OPENMODELICAHOME/include/omc/scripting-API
 
 SOURCES += main.cpp
 

--- a/OMEdit/OMEditGUI/OMEditGUI.unix.config.pri.in
+++ b/OMEdit/OMEditGUI/OMEditGUI.unix.config.pri.in
@@ -7,7 +7,15 @@ QMAKE_LINK = @CXX@
 OPENMODELICAHOME = @OPENMODELICAHOME@
 host_short = @host_short@
 
-LIBS += -L@OPENMODELICAHOME@/lib/$$host_short/omc -lOMPlot -lomqwt -lfmilib_shared -L$$OMEDIT_ROOT/OMEditLIB/Debugger/Parser -lGDBMIParser -lOMParser -lantlr4-runtime -lomantlr3 @RPATH_QMAKE@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcruntime  -lomcgc -L@OMBUILDDIR@/lib/$$host_short/omc @LIBOSG@ -lomopcua -lzmq -lsimdjson -L@OMBUILDDIR@/lib -lOMSimulator @LIB_BOOST_REGEX@
+# The OpenModelica C runtime + Boehm GC. Omitted under rust_omc / OMC_RUST_ABI:
+# the Rust libOpenModelicaCompiler provides everything OMEdit used from them (the
+# MMC value-runtime symbols ModelInstanceReference_*/SettingsImpl__*, plus the
+# SimulationRuntime result readers, flag/log-stream tables, realtime clock and
+# ryu number formatting), so OMEdit links no OpenModelica C runtime / GC.
+OMC_C_RUNTIME = -lOpenModelicaRuntimeC -lomcruntime -lomcgc
+rust_omc: OMC_C_RUNTIME =
+
+LIBS += -L@OPENMODELICAHOME@/lib/$$host_short/omc -lOMPlot -lomqwt -lfmilib_shared -L$$OMEDIT_ROOT/OMEditLIB/Debugger/Parser -lGDBMIParser -lOMParser -lantlr4-runtime -lomantlr3 @RPATH_QMAKE@ -lOpenModelicaCompiler $$OMC_C_RUNTIME -L@OMBUILDDIR@/lib/$$host_short/omc @LIBOSG@ -lomopcua -lzmq -lsimdjson -L@OMBUILDDIR@/lib -lOMSimulator @LIB_BOOST_REGEX@
 
 QMAKE_CXXFLAGS_RELEASE -= -O1
 QMAKE_CXXFLAGS_RELEASE -= -O2

--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -47,9 +47,16 @@
 #define GC_THREADS
 #endif
 
+#ifdef OMC_RUST_ABI
+// Drive the Rust omc port (libOpenModelicaCompiler.so) in-process: a
+// self-contained replacement for the MMC value/runtime ABI (no Boehm GC). See
+// omc_rust_embedding.h; provides MMC_INIT/MMC_TRY_TOP/threadData.
+#include "omc_rust_embedding.h"
+#else
 extern "C" {
 #include "meta/meta_modelica_data.h"
 }
+#endif
 
 #ifdef Q_OS_WIN
 #include <windows.h>

--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
@@ -41,7 +41,11 @@
 #include "Editors/CEditor.h"
 #include "Editors/TextEditor.h"
 #include "Git/CommitChangesDialog.h"
+#ifdef OMC_RUST_ABI
+#include "omc_rust_embedding.h" // Rust omc port: box-based mmc_mk_scon + stringHashDjb2 (no MMC runtime)
+#else
 #include "meta/meta_modelica_builtin.h"
+#endif
 #include <QApplication>
 #include <QObject>
 #include <QHeaderView>

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -42,9 +42,13 @@
 
 #undef smooth
 
+#ifdef OMC_RUST_ABI
+#include "omc_rust_embedding.h" // Rust omc port: self-contained threadData_t (no MMC runtime)
+#else
 extern "C" {
 #include "meta/meta_modelica.h"
 }
+#endif
 
 #include "Util/StringHandler.h"
 

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -48,7 +48,15 @@
 #include "Options/OptionsDialog.h"
 #include "Modeling/MessagesWidget.h"
 #include "util/simulation_options.h"
+#ifdef OMC_RUST_ABI
+// Rust omc port in-process: the self-contained MMC-replacement (mmc_mk_*,
+// MMC_STRINGDATA, the MMC_TRY no-op control flow, the full threadData_t with the
+// callback fields, printStacktraceMessages) plus the JSON walker, with no OMC
+// MMC runtime / Boehm GC. omc_error.h would otherwise pull in the real MMC ABI.
+#include "omc_rust_embedding.h"
+#else
 #include "util/omc_error.h"
+#endif
 #include "FlatModelica/Expression.h"
 
 extern "C" {
@@ -3443,11 +3451,63 @@ extern "C" int ModelInstanceReference_release(int handle);
  * QString::fromUtf8 that array binds Qt's QByteArrayView overload using the *declared* size
  * (1 byte), truncating every string to its first character. The explicit (const char*) cast
  * forces array-to-pointer decay so the strlen-based fromUtf8(const char*) overload is used. */
+#ifndef OMC_RUST_ABI
 static QString stringFromMM(void *mmString)
 {
   return QString::fromUtf8((const char*) MMC_STRINGDATA(mmString));
 }
+#endif
 
+#ifdef OMC_RUST_ABI
+// Rust omc port: the boxed value is the port's own JSON tree, walked through the
+// typed omc_json_* C ABI (openmodelica_backend_main::ModelInstanceReference)
+// rather than MMC record/cons-cell macros. Node kinds match the MMC version's
+// JSON.* constructors; the value reaches here normalised to list form
+// (LIST_OBJECT/LIST), so only those aggregates appear.
+QJsonValue OMCProxy::jsonValueFromMM(void *value)
+{
+  switch (omc_json_kind(value)) {
+    case OMC_JSON_LIST_OBJECT: {
+      QJsonObject object;
+      OmcJsonIter *it = omc_json_iter_new(value);
+      for (; !omc_json_iter_at_end(it); omc_json_iter_advance(it)) {
+        size_t keyLen = 0;
+        const char *key = omc_json_iter_key(it, &keyLen);
+        object.insert(QString::fromUtf8(key, (int) keyLen),
+                      jsonValueFromMM(const_cast<void*>(omc_json_iter_value(it))));
+      }
+      omc_json_iter_free(it);
+      return object;
+    }
+    case OMC_JSON_LIST: {
+      QJsonArray array;
+      OmcJsonIter *it = omc_json_iter_new(value);
+      for (; !omc_json_iter_at_end(it); omc_json_iter_advance(it)) {
+        array.append(jsonValueFromMM(const_cast<void*>(omc_json_iter_value(it))));
+      }
+      omc_json_iter_free(it);
+      return array;
+    }
+    case OMC_JSON_STRING: {
+      size_t len = 0;
+      const char *s = omc_json_string(value, &len);
+      return QJsonValue(QString::fromUtf8(s, (int) len));
+    }
+    case OMC_JSON_INTEGER:
+      // qint64 (not double) so the value is integer-typed, matching QJsonDocument::fromJson.
+      return QJsonValue((qint64) omc_json_integer(value));
+    case OMC_JSON_NUMBER:
+      return QJsonValue(omc_json_number(value));
+    case OMC_JSON_TRUE:
+      return QJsonValue(true);
+    case OMC_JSON_FALSE:
+      return QJsonValue(false);
+    default:
+      // OMC_JSON_NULL, and defensively OBJECT/ARRAY which should never reach here after normalisation.
+      return QJsonValue(QJsonValue::Null);
+  }
+}
+#else
 QJsonValue OMCProxy::jsonValueFromMM(void *value)
 {
   // A boxed uniontype record stores its record_description in slot 0 and its fields in slots 1..n.
@@ -3487,6 +3547,7 @@ QJsonValue OMCProxy::jsonValueFromMM(void *value)
   // JSON.NULL, and defensively JSON.OBJECT/JSON.ARRAY which should never reach here after normalisation.
   return QJsonValue(QJsonValue::Null);
 }
+#endif
 
 /*!
  * \brief OMCProxy::getModelInstance

--- a/OMEdit/OMEditLIB/OMEditApplication.h
+++ b/OMEdit/OMEditLIB/OMEditApplication.h
@@ -40,9 +40,13 @@
 #ifndef OMEDITAPPLICATION_H
 #define OMEDITAPPLICATION_H
 
+#ifdef OMC_RUST_ABI
+#include "omc_rust_embedding.h" // Rust omc port: self-contained threadData_t (no MMC runtime)
+#else
 extern "C" {
 #include "meta/meta_modelica_data.h"
 }
+#endif
 
 #include <QApplication>
 #include <QTranslator>

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.config.in
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.config.in
@@ -2,7 +2,16 @@ QMAKE_CC  = @CC@
 QMAKE_CXX = @CXX@
 QMAKE_LINK = @CXX@
 
-LIBS += -L @OMBUILDDIR@/lib/@host_short@/omc -lomqwt -lOpenModelicaRuntimeC @RPATH_QMAKE@
+# Build libOMPlot against the Rust omc port: drop the OpenModelica C runtime so
+# libOMPlot.so does not NEED it (its result-reader symbols then resolve from the
+# host's libOpenModelicaCompiler, e.g. OMEdit). Enabled by OMEDIT_RUST_OMC=1.
+# The standalone OMPlot exe re-adds it (see OMPlotGUI.pro) since it has no host.
+OMPLOT_RUST_ENV = $$(OMEDIT_RUST_OMC)
+equals(OMPLOT_RUST_ENV, 1): CONFIG += rust_omc
+OMPLOT_OMC_RUNTIME = -lOpenModelicaRuntimeC
+rust_omc: OMPLOT_OMC_RUNTIME =
+
+LIBS += -L @OMBUILDDIR@/lib/@host_short@/omc -lomqwt $$OMPLOT_OMC_RUNTIME @RPATH_QMAKE@
 INCLUDEPATH += @OPENMODELICAHOME@/include/omplot/qwt @OPENMODELICAHOME@/include/omc/c
 
 QMAKE_CFLAGS = @CFLAGS@ @CPPFLAGS@

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
@@ -73,6 +73,10 @@ win32 {
 } else {
   include(OMPlotGUI.config)
   LIBS += -lOMPlot
+  # The standalone exe has no host to resolve libOMPlot's reader symbols, so it
+  # keeps the C runtime even under rust_omc (it is a separate process; this does
+  # not affect OMEdit, which provides the readers from libOpenModelicaCompiler).
+  rust_omc: LIBS += -lOpenModelicaRuntimeC
 }
 
 INCLUDEPATH += .


### PR DESCRIPTION
Add a compile-time switch (DEFINES += OMC_RUST_ABI, enabled via `qmake CONFIG+=rust_omc` or env `OMEDIT_RUST_OMC=1`) that retargets OMEdit's in-process OMC interface from the MMC value/runtime ABI to the Rust port's self-contained replacement (omc_rust_embedding.h, shipped by libopenmodelica_compiler and installed alongside the scripting-API headers). No OMC MMC runtime / Boehm GC is used on OMEdit's command path.

Under the switch:
- main.cpp / MainWindow.h / OMEditApplication.h: include omc_rust_embedding.h instead of meta/meta_modelica*.h. It provides MMC_INIT/MMC_TRY_TOP (no-op control flow that still declares threadData), a malloc-boxed value with mmc_mk_*/MMC_STRINGDATA, and the threadData_t carrying the plot/loadModel callbacks — while re-using the benign, MMC-free runtime metadata OMEdit pulled in transitively (the FLAG_* simulation-flag table via util/simulation_options.h, the OMC_LOG_STREAM enum + name/desc arrays).
- OMCProxy.cpp: include the replacement instead of util/omc_error.h; the omc init
  + sendCommand bodies are unchanged (they bracket through the no-op MMC_TRY macros and exchange boxed strings the cdylib shims read/write). jsonValueFromMM is rewritten to walk the port's JSON value through the typed omc_json_* ABI rather than MMC record/cons-cell macros (the --NAPINoJson fast path, issue #15219), so the in-memory model-instance optimisation is preserved.
- FMUExportOutputWidget.cpp: switch the include; stringHashDjb2 reads the box.
- OMEditGUI.pro: add the scripting-API include dir.

The C build is unaffected (everything is behind OMC_RUST_ABI).

Verified end-to-end: OMEdit builds and links against the Rust libOpenModelicaCompiler.so (omc_Main_*, the typed omc_scripting_*, the omc_json_* walker and ModelInstanceReference_* all resolve from it), and a headless run drives the compiler correctly — getVersion() -> "v1.27.0-dev", countMessages() -> (0,0,0), getAvailableMatchingAlgorithms() -> two 21-entry QList<QString>, plus cd/getInstallationDirectoryPath/getModelicaPath/numProcessors.

The Rust omc port provides the only symbols OMEdit needed from the MMC value runtime (ModelInstanceReference_*, SettingsImpl__getInstallationDirectoryPath) from libOpenModelicaCompiler itself, so libomcruntime is no longer linked under the OMC_RUST_ABI build. Gated via an OMC_MMC_RUNTIME qmake variable so the C build is unchanged. (libomcgc stays, pulled transitively by libOpenModelicaRuntimeC.)

The Rust libOpenModelicaCompiler now provides the whole OpenModelica C-runtime surface OMEdit uses (the MMC value-runtime symbols, the SimulationRuntime result readers + flag/log-stream tables + realtime clock + ryu formatting), so OMEdit links no OpenModelica C runtime or Boehm GC directly. Gated on rust_omc via the OMC_C_RUNTIME qmake variable; the C build is unchanged.

Under rust_omc (env OMEDIT_RUST_OMC=1), libOMPlot.so no longer links the OpenModelica C runtime: its result-reader symbols (omc_*matlab4*/read_csv) are left undefined and resolved from the host's libOpenModelicaCompiler (the Rust port) at load time. This lets OMEdit's process drop libOpenModelicaRuntimeC and the Boehm GC entirely (libOMPlot was the last transitive puller).

Gated via OMPLOT_OMC_RUNTIME in OMPlotGUI.config[.in]; the C build is unchanged. The standalone OMPlot executable re-adds -lOpenModelicaRuntimeC (OMPlotGUI.pro): it has no host to resolve the readers and is a separate process, so it keeps the C reader (this does not affect OMEdit).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
