### PR TITLE
Utilities::tempDirectory(): recreate directory if it was removed

### DIFF
--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -636,13 +636,14 @@ QString& Utilities::tempDirectory()
     tmpPath = QDir::tempPath() + "/OpenModelica_" + QString(user ? user : "nobody") + "/OMEdit/";
 #endif
     tmpPath.remove("\"");
-    if (!QDir().exists(tmpPath)) {
-      if (!QDir().mkpath(tmpPath)) {
-        qDebug() << "Failed to create the tempDirectory" << tmpPath
-                 << "will use" << QDir::tempPath() << "instead.";
-        tmpPath = QDir::tempPath();
-        tmpPath.remove("\"");
-      }
+  }
+  // Recreate on every call if it has been removed (e.g. by tmpfiles cleanup on long-running sessions)
+  if (!QDir().exists(tmpPath)) {
+    if (!QDir().mkpath(tmpPath)) {
+      qDebug() << "Failed to create the tempDirectory" << tmpPath
+               << "will use" << QDir::tempPath() << "instead.";
+      tmpPath = QDir::tempPath();
+      tmpPath.remove("\"");
     }
   }
   return tmpPath;


### PR DESCRIPTION
Periodic /tmp cleanup can remove the OMEdit temp directory during a long-running session. Since it was only created once on first call, later calls returned a stale path, causing mkdir/file creation under it to fail. Now recreate it on every call if missing.