### PR TITLE
Fixing zero-length format string

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/arrayIndex.c
@@ -428,7 +428,10 @@ void printMultiDimArrayIndex(DIMENSION_INFO *dimension_info,
 {
   if (dimension_info == NULL || dimension_info->numberOfDimensions == 0)
   {
-    snprintf(buffer, buffer_size - 1, "");
+    if (buffer_size > 0)
+    {
+      buffer[0] = '\0';
+    }
     return;
   }
 


### PR DESCRIPTION
### Related Issues


Warning when building a 3.0 FMU with array variables:

```bash
/var/lib/jenkins/ws/OpenModelica_PR-15692/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_directional_derivatives.mos_temp7288/193.fmutmp/sources/simulation/arrayIndex.c:431:39: warning: zero-length gnu_printf format string [-Wformat-zero-length]
  431 |     snprintf(buffer, buffer_size - 1, \"\");
```

### Purpose

* Fix warning

### Approach

* Directly write an empty string
