### PR TITLE
[FMI] Fix FMI 1.0 model-exchange CVODE build + direct-feedthrough outputs (#15862)

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -881,8 +881,23 @@ algorithm
         copyFiles(RuntimeSources.cminpack_sources, source=install_fmu_sources_dir, destination=fmu_tmp_sources_dir);
         cminpack_sources := RuntimeSources.cminpack_sources;
 
-        // Check if the sundials files are needed
-        if SimCodeUtil.cvodeFmiFlagIsSet(simCode.fmiSimulationFlags) then
+        // Check if the sundials files are needed.
+        // The in-FMU CVODE integrator (s:cvode) is a Co-Simulation feature: cvode_solver_fmi_step()
+        // drives the fmi2 ModelInstance / fmi2DoStep API and cvode_solver.h includes
+        // fmu2_model_interface.h. OpenModelica only exports FMI 1.0 as Model Exchange (CS export
+        // requires FMI 2.0, see FMI.canExportFMU); a model-exchange FMU is integrated by the
+        // importer, and the FMI 1.0 export only ships fmu1_model_interface.h, so copying the
+        // sundials sources there breaks compilation (fatal error:
+        // 'fmi-export/fmu2_model_interface.h' file not found). See issue #15838.
+        if FMUVersion == "1.0" then
+          // The in-FMU CVODE integrator does not apply to a model-exchange FMU; warn that the
+          // 's:cvode' flag is ignored and do not pull in the sundials sources (they would not
+          // compile for FMI 1.0).
+          if SimCodeUtil.cvodeFmiFlagIsSet(simCode.fmiSimulationFlags) then
+            Error.addCompilerWarning("OpenModelica exports FMI 1.0 as Model Exchange only (Co-Simulation export requires FMI 2.0). A model-exchange FMU is integrated by the importer, so the in-FMU CVODE integrator does not apply. The 's:cvode' simulation flag is ignored for this FMI 1.0 export.");
+          end if;
+          simrt_c_sundials_sources := {};
+        elseif SimCodeUtil.cvodeFmiFlagIsSet(simCode.fmiSimulationFlags) then
           // The sundials headers are in the include directory.
           copyFiles(RuntimeSources.sundials_headers, source=install_include_omc_dir, destination=fmu_tmp_sources_dir);
           copyFiles(RuntimeSources.simrt_c_sundials_sources, source=install_fmu_sources_dir, destination=fmu_tmp_sources_dir);
@@ -1016,7 +1031,14 @@ algorithm
 
         // Add external libraries and includes
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMI_INTERFACE_HEADER_FILES_DIRECTORY@", "\"" + Settings.getInstallationDirectoryPath() + "/include/omc/c/fmi" + "\"");
-        (needCvode, cvodeDirectory) := SimCodeUtil.getCmakeSundialsLinkCode(simCode.fmiSimulationFlags);
+        // FMI 1.0 (Model Exchange only) never links CVODE into the FMU (see note above where the
+        // sundials sources are skipped for FMI 1.0); keep NEED_CVODE=OFF so cvode_solver.c and
+        // sundials_error.c are not compiled. See issue #15838.
+        if FMUVersion == "1.0" then
+          (needCvode, cvodeDirectory) := ("OFF", "\"\"");
+        else
+          (needCvode, cvodeDirectory) := SimCodeUtil.getCmakeSundialsLinkCode(simCode.fmiSimulationFlags);
+        end if;
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@NEED_CVODE@", needCvode);
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@CVODE_DIRECTORY@", cvodeDirectory);
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_LIBS@", SimCodeUtil.getCmakeLinkLibrariesCode(simCode.makefileParams.libs));

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu1_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu1_model_interface.c.inc
@@ -161,6 +161,7 @@ fmiComponent fmiInstantiateModel(fmiString instanceName, fmiString GUID, fmiCall
     comp->functions = functions;
     comp->loggingOn = loggingOn;
     comp->state = modelInstantiated;
+    comp->_need_update = 1;
     comp->instanceName = functions.allocateMemory(1 + strlen(instanceName), sizeof(char));
     comp->GUID = functions.allocateMemory(1 + strlen(GUID), sizeof(char));
     /* Cannot use functions.allocateMemory since the pointer might not be stored on the stack of the parent */
@@ -285,6 +286,7 @@ fmiStatus fmiSetReal(fmiComponent c, const fmiValueReference vr[], size_t nvr, c
     if (setReal(comp, vr[i],value[i]) != fmiOK) // to be implemented by the includer of this file
       return fmiError;
   }
+  comp->_need_update = 1;
 
   return fmiOK;
 }
@@ -309,6 +311,7 @@ fmiStatus fmiSetInteger(fmiComponent c, const fmiValueReference vr[], size_t nvr
     if (setInteger(comp, vr[i],value[i]) != fmiOK) // to be implemented by the includer of this file
       return fmiError;
   }
+  comp->_need_update = 1;
 
   return fmiOK;
 }
@@ -333,6 +336,7 @@ fmiStatus fmiSetBoolean(fmiComponent c, const fmiValueReference vr[], size_t nvr
     if (setBoolean(comp, vr[i],value[i]) != fmiOK) // to be implemented by the includer of this file
       return fmiError;
   }
+  comp->_need_update = 1;
 
   return fmiOK;
 }
@@ -357,6 +361,7 @@ fmiStatus fmiSetString(fmiComponent c, const fmiValueReference vr[], size_t nvr,
     if (setString(comp, vr[i],value[i]) != fmiOK) // to be implemented by the includer of this file
       return fmiError;
   }
+  comp->_need_update = 1;
   return fmiOK;
 }
 
@@ -368,6 +373,7 @@ fmiStatus fmiSetTime(fmiComponent c, fmiReal t)
   if (comp->loggingOn) comp->functions.logger(c, comp->instanceName, fmiOK, "log",
       "fmiSetTime: time=%.16g", t);
   comp->fmuData->localData[0]->timeValue = t;
+  comp->_need_update = 1;
   return fmiOK;
 }
 
@@ -391,12 +397,45 @@ fmiStatus fmiSetContinuousStates(fmiComponent c, const fmiReal x[], size_t nx)
     }
   }
 #endif
+  comp->_need_update = 1;
   return fmiOK;
 }
 
 // ---------------------------------------------------------------------------
 // FMI functions: get variable values from the FMU
 // ---------------------------------------------------------------------------
+
+/* Re-evaluate the model if an input (or time/state) changed since the last evaluation, so that
+   fmiGet* returns up-to-date direct-feedthrough outputs. Mirrors updateIfNeeded() in
+   fmu2_model_interface.c. Before initialization the start values stand, so we only evaluate once
+   the model is initialized. See #15838. */
+static fmiStatus updateIfNeeded(ModelInstance* comp, const char* func)
+{
+  threadData_t *threadData = comp->threadData;
+  if (!comp->_need_update)
+    return fmiOK;
+  if (comp->state != modelInitialized) {
+    /* nothing has been computed yet; fmiInitialize will do the first evaluation */
+    return fmiOK;
+  }
+
+  /* try */
+  MMC_TRY_INTERNAL(simulationJumpBuffer)
+
+    comp->fmuData->callback->functionODE(comp->fmuData, threadData);
+    comp->fmuData->callback->functionAlgebraics(comp->fmuData, threadData);
+    comp->fmuData->callback->output_function(comp->fmuData, threadData);
+    comp->fmuData->callback->function_storeDelayed(comp->fmuData, threadData);
+    storePreValues(comp->fmuData);
+    comp->_need_update = 0;
+    return fmiOK;
+
+  /* catch */
+  MMC_CATCH_INTERNAL(simulationJumpBuffer)
+
+    comp->functions.logger(comp, comp->instanceName, fmiError, "error", "%s: terminated by an assertion.", func);
+    return fmiError;
+}
 
 fmiStatus fmiGetReal(fmiComponent c, const fmiValueReference vr[], size_t nvr, fmiReal value[])
 {
@@ -407,6 +446,8 @@ fmiStatus fmiGetReal(fmiComponent c, const fmiValueReference vr[], size_t nvr, f
   if (nvr>0 && nullPointer(comp, "fmiGetReal", "vr[]", vr))
     return fmiError;
   if (nvr>0 && nullPointer(comp, "fmiGetReal", "value[]", value))
+    return fmiError;
+  if (updateIfNeeded(comp, "fmiGetReal") != fmiOK)
     return fmiError;
 #if NUMBER_OF_REALS>0
   for (i=0; i<nvr; i++) {
@@ -432,6 +473,8 @@ fmiStatus fmiGetInteger(fmiComponent c, const fmiValueReference vr[], size_t nvr
     return fmiError;
   if (nvr>0 && nullPointer(comp, "fmiGetInteger", "value[]", value))
     return fmiError;
+  if (updateIfNeeded(comp, "fmiGetInteger") != fmiOK)
+    return fmiError;
 #if NUMBER_OF_INTEGERS>0
   for (i=0; i<nvr; i++) {
     if (vrOutOfRange(comp, "fmiGetInteger", vr[i], NUMBER_OF_INTEGERS))
@@ -456,6 +499,8 @@ fmiStatus fmiGetBoolean(fmiComponent c, const fmiValueReference vr[], size_t nvr
     return fmiError;
   if (nvr>0 && nullPointer(comp, "fmiGetBoolean", "value[]", value))
     return fmiError;
+  if (updateIfNeeded(comp, "fmiGetBoolean") != fmiOK)
+    return fmiError;
 #if NUMBER_OF_BOOLEANS>0
   for (i=0; i<nvr; i++) {
     if (vrOutOfRange(comp, "fmiGetBoolean", vr[i], NUMBER_OF_BOOLEANS))
@@ -479,6 +524,8 @@ fmiStatus fmiGetString(fmiComponent c, const fmiValueReference vr[], size_t nvr,
   if (nvr>0 && nullPointer(comp, "fmiGetString", "vr[]", vr))
     return fmiError;
   if (nvr>0 && nullPointer(comp, "fmiGetString", "value[]", value))
+    return fmiError;
+  if (updateIfNeeded(comp, "fmiGetString") != fmiOK)
     return fmiError;
 #if NUMBER_OF_STRINGS>0
   for (i=0; i<nvr; i++) {
@@ -569,6 +616,8 @@ fmiStatus fmiGetDerivatives(fmiComponent c, fmiReal derivatives[], size_t nx)
   MMC_TRY_INTERNAL(simulationJumpBuffer)
 
     comp->fmuData->callback->functionODE(comp->fmuData, comp->threadData);
+    /* the continuous system has just been evaluated; a following fmiGetReal need not redo it */
+    comp->_need_update = 0;
   #if (NUMBER_OF_STATES>0)
     for (i=0; i<nx; i++) {
       fmiValueReference vr = vrStatesDerivatives[i];
@@ -671,6 +720,9 @@ fmiStatus fmiInitialize(fmiComponent c, fmiBoolean toleranceControlled, fmiReal 
 
     /* due to an event overwrite old values */
     overwriteOldSimulationData(comp->fmuData);
+
+    /* the model has just been evaluated by initialization() above */
+    comp->_need_update = 0;
 
     eventInfo->iterationConverged = fmiTrue;
     eventInfo->stateValueReferencesChanged = fmiFalse;
@@ -797,6 +849,9 @@ fmiStatus fmiEventUpdate(fmiComponent c, fmiBoolean intermediateResults, fmiEven
     /* due to an event overwrite old values */
     overwriteOldSimulationData(comp->fmuData);
 
+    /* the model has just been re-evaluated during the event update */
+    comp->_need_update = 0;
+
     if (comp->loggingOn)
       comp->functions.logger(c, comp->instanceName, fmiOK, "log", "fmiEventUpdate: intermediateResults = %d", intermediateResults);
 
@@ -859,6 +914,8 @@ fmiStatus fmiCompletedIntegratorStep(fmiComponent c, fmiBoolean* callEventUpdate
      *       in the whole ringbuffer
      */
     overwriteOldSimulationData(comp->fmuData);
+    /* the model has just been re-evaluated for the completed step */
+    comp->_need_update = 0;
     return fmiOK;
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu1_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu1_model_interface.h
@@ -55,6 +55,11 @@ typedef struct {
   fmiBoolean loggingOn;
   fmiEventInfo eventInfo;
   ModelState state;
+  /* Set by the fmiSetReal/Integer/Boolean/String, fmiSetTime and fmiSetContinuousStates functions
+     and cleared once the model has been re-evaluated, so that fmiGetReal/Integer/Boolean/String
+     recompute direct-feedthrough outputs after an input changed (mirrors fmu2_model_interface.c).
+     Without it a stateless algebraic model such as y = 2*u never updates its output. See #15838. */
+  fmiBoolean _need_update;
   DATA* fmuData;
   threadData_t *threadData;
 } ModelInstance;

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEInputOutput.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEInputOutput.mos
@@ -1,0 +1,37 @@
+// name:     FMI1MEInputOutput
+// keywords: fmu export fmi 1.0 model exchange input output
+// status: correct
+// teardown_command: rm -rf binaries sources modelDescription.xml *.fmu *_FMU.* *.fmutmp *.libs *.lib *.so *.dll *_res.mat *_info.json test_fmu_me_1_0*
+// cflags: -d=-newInst
+//
+// Regression test for #15838: exporting an FMI 1.0 Model-Exchange FMU for a
+// model with a Real input and Real output (a Modelica.Blocks gain). This is the
+// original reproducer from the issue and makes sure an FMU with causal
+// connectors builds as FMI 1.0 ME.
+//
+
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+
+loadString("
+model test_fmu_me_1_0
+  Modelica.Blocks.Interfaces.RealInput u;
+  Modelica.Blocks.Interfaces.RealOutput y;
+  Modelica.Blocks.Math.Gain gain(k = 2);
+equation
+  connect(gain.u, u);
+  connect(gain.y, y);
+  annotation(uses(Modelica(version = \"4.1.0\")));
+end test_fmu_me_1_0;
+"); getErrorString();
+
+// Export must succeed (FMU compiles).
+buildModelFMU(test_fmu_me_1_0, version="1.0", fmuType="me"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "test_fmu_me_1_0.fmu"
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEcvodeFlag.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEcvodeFlag.mos
@@ -1,0 +1,51 @@
+// name:     FMI1MEcvodeFlag
+// keywords: fmu export fmi 1.0 model exchange cvode fmiFlags
+// status: correct
+// teardown_command: rm -rf binaries sources modelDescription.xml *.fmu *_FMU.* *.fmutmp *.libs *.lib *.so *.dll *_res.mat *_info.json ExpDecayCvode* ExpDecayCvode_cmake.txt
+// cflags: -d=-newInst
+//
+// Regression test for #15838: exporting an FMI 1.0 Model-Exchange FMU with the
+// in-FMU CVODE integrator requested (--fmiFlags=s:cvode) used to break the FMU
+// build, because the sundials sources (cvode_solver.c/sundials_error.c) were
+// copied in and cvode_solver.h includes the FMI 2.0 header
+// fmi-export/fmu2_model_interface.h, which does not exist in an FMI 1.0 export.
+//
+// CVODE-in-FMU is a Co-Simulation feature and OpenModelica only exports FMI 1.0
+// as Model Exchange, so the 's:cvode' flag must be ignored (with a warning) and
+// the FMU must still compile.
+//
+
+setCommandLineOptions("--fmiFlags=s:cvode"); getErrorString();
+
+loadString("
+model ExpDecayCvode
+  Real x(start=1);
+equation
+  der(x) = -x;
+end ExpDecayCvode;
+"); getErrorString();
+
+// Export must succeed (FMU compiles) and emit a warning that s:cvode is ignored.
+buildModelFMU(ExpDecayCvode, version="1.0", fmuType="me"); getErrorString();
+
+// The generated FMU CMake project must keep NEED_CVODE OFF, so the sundials
+// sources are not compiled into the FMI 1.0 FMU.
+system("unzip -p ExpDecayCvode.fmu sources/CMakeLists.txt | grep -A1 'set(NEED_CVODE' > ExpDecayCvode_cmake.txt"); getErrorString();
+readFile("ExpDecayCvode_cmake.txt"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "ExpDecayCvode.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// Warning: OpenModelica exports FMI 1.0 as Model Exchange only (Co-Simulation export requires FMI 2.0). A model-exchange FMU is integrated by the importer, so the in-FMU CVODE integrator does not apply. The 's:cvode' simulation flag is ignored for this FMI 1.0 export.
+// "
+// 0
+// ""
+// "set(NEED_CVODE
+//     OFF
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos
@@ -1,7 +1,7 @@
 // name:     FMI1MEfmpy
 // keywords: fmu export fmi 1.0 model exchange fmpy
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml *.fmu *_FMU.* *.fmutmp *.libs *.lib *.so *.dll *_res.mat *_fmpy.csv *_diff.*.csv *_info.json ExpDecay* SampleCount* Oscillator* StateEvent*
+// teardown_command: rm -rf binaries sources modelDescription.xml *.fmu *_FMU.* *.fmutmp *.libs *.lib *.so *.dll *_res.mat *_fmpy.csv *_diff.*.csv *_info.json ExpDecay* SampleCount* Oscillator* StateEvent* DirectFeedthrough*
 // cflags: -d=-newInst
 //
 // Exports a few FMI 1.0 Model-Exchange FMUs and validates them with an
@@ -48,6 +48,12 @@ equation
   y = sin(time);
   b = x > 0.5;
 end StateEvent;
+
+model DirectFeedthrough
+  Real y;
+equation
+  y = 2*time;
+end DirectFeedthrough;
 "); getErrorString();
 
 // ExpDecay: a single continuous state.
@@ -73,6 +79,15 @@ buildModelFMU(StateEvent, version="1.0", fmuType="me"); getErrorString();
 simulate(StateEvent, stopTime=2.0); getErrorString();
 system("python3 ../../simulate_fmu_fmpy.py StateEvent.fmu StateEvent_fmpy.csv 2.0 x y"); getErrorString();
 diffSimulationResults("StateEvent_fmpy.csv", "StateEvent_res.mat", "StateEvent_diff", vars={"x","y"}); getErrorString();
+
+// DirectFeedthrough: a stateless algebraic output y = 2*time. With no continuous states an FMI 1.0
+// ME importer never calls fmiGetDerivatives, so the output is only correct if fmiGetReal
+// re-evaluates the model after fmiSetTime (the _need_update mechanism). Without it FMPy would read
+// y = 0 for all time. See #15838.
+buildModelFMU(DirectFeedthrough, version="1.0", fmuType="me"); getErrorString();
+simulate(DirectFeedthrough, stopTime=1.0); getErrorString();
+system("python3 ../../simulate_fmu_fmpy.py DirectFeedthrough.fmu DirectFeedthrough_fmpy.csv 1.0 y"); getErrorString();
+diffSimulationResults("DirectFeedthrough_fmpy.csv", "DirectFeedthrough_res.mat", "DirectFeedthrough_diff", vars={"y"}); getErrorString();
 // Result:
 // true
 // ""
@@ -136,6 +151,20 @@ diffSimulationResults("StateEvent_fmpy.csv", "StateEvent_res.mat", "StateEvent_d
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
+// 0
+// ""
+// (true, {})
+// ""
+// "DirectFeedthrough.fmu"
+// ""
+// record SimulationResult
+//     resultFile = "DirectFeedthrough_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DirectFeedthrough', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
 // 0
 // ""
 // (true, {})

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
@@ -2,6 +2,8 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 FMI1MEfmpy.mos \
+FMI1MEcvodeFlag.mos \
+FMI1MEInputOutput.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing


### PR DESCRIPTION

Two follow-up fixes to #15838 for the FMI 1.0 model-exchange export.

1. Don't pull CVODE into FMI 1.0 exports. Exporting with --fmiFlags=s:cvode copied the sundials sources (cvode_solver.c/sundials_error.c) into the FMU and compiled them, but cvode_solver.h includes the FMI 2.0 header fmi-export/fmu2_model_interface.h, which does not exist in an FMI 1.0 export (it only ships fmu1_model_interface.h):

     cvode_solver.h:34:12: fatal error:
     'fmi-export/fmu2_model_interface.h' file not found

   The in-FMU CVODE integrator drives the fmi2 ModelInstance / fmi2DoStep API, i.e. it is a Co-Simulation feature, and OpenModelica only exports FMI 1.0 as Model Exchange (CS export requires FMI 2.0, see FMI.canExportFMU). A model-exchange FMU is integrated by the importer, so an in-FMU integrator does not apply.

   SimCode/SimCodeMain.mo: for FMUVersion == "1.0" skip copying the sundials sources, keep NEED_CVODE=OFF in the generated FMU CMakeLists, and warn that the 's:cvode' flag is ignored.

2. Re-evaluate direct-feedthrough outputs on fmiGetReal. A stateless algebraic model (e.g. y = 2\*u) exported as FMI 1.0 ME always reported y = 0: with no continuous states an importer never calls fmiGetDerivatives, and fmiGetReal returned the stored value without re-evaluating the model after fmiSetReal/fmiSetTime. Ported the _need_update dirty-flag mechanism from fmu2_model_interface.c to the FMI 1.0 interface: the fmiSet* functions mark the model dirty and fmiGet* re-evaluate it (functionODE/algebraics/output) before reading, clearing the flag in fmiInitialize/fmiEventUpdate/fmiCompletedIntegratorStep/ fmiGetDerivatives. Verified with FMPy: the gain model now returns y = 2\*u.

Tests (testsuite ModelExchange/1.0):
- FMI1MEcvodeFlag.mos: exports an FMI 1.0 ME FMU with --fmiFlags=s:cvode, checks it builds, the warning is emitted, and NEED_CVODE is OFF.
- FMI1MEInputOutput.mos: exports the issue's reproducer (a Modelica.Blocks gain with a Real input and output) as FMI 1.0 ME.
- FMI1MEfmpy.mos: adds a stateless DirectFeedthrough (y = 2*time) model and validates it through FMPy; without fix 2 FMPy reads y = 0.

Follow-up to #15838.

