### PR TITLE
[Template,NB] set variable when setting start value

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -7552,8 +7552,18 @@ template genericCallLhsRhs(DAE.Exp lhs, DAE.Exp rhs, Context context, Text &preE
 ::= match lhs
     case CREF(componentRef=cr, ty = T_ARRAY()) then
       let rhs_ = daeExp(rhs, context, &preExp, &varDecls, &auxFunction)
+      let start_ = if isStartCref(cr) then genericCallLhsRhs(makeCrefExp(popCref(cr), crefTypeFull(cr)), lhs, context, &preExp, &varDecls, &auxFunction) else ""
       <<
       <%algStmtAssignArrWithRhsExpStr(lhs, rhs_, context, &preExp, &varDecls, &auxFunction)%>
+      <%start_%>
+      >>
+    case CREF(componentRef=cr) then
+      let lhs_ = daeExp(lhs, context, &preExp, &varDecls, &auxFunction)
+      let rhs_ = daeExp(rhs, context, &preExp, &varDecls, &auxFunction)
+      let start_ = if isStartCref(cr) then genericCallLhsRhs(makeCrefExp(popCref(cr), crefTypeFull(cr)), lhs, context, &preExp, &varDecls, &auxFunction) else ""
+      <<
+      <%lhs_%> = <%rhs_%>;
+      <%start_%>
       >>
     else
       let lhs_ = daeExp(lhs, context, &preExp, &varDecls, &auxFunction)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4033,6 +4033,12 @@ package Expression
     input Boolean allow_arrays;
     output Boolean b;
   end isSimpleLiteralValue;
+
+  function makeCrefExp
+    input DAE.ComponentRef inCref;
+    input DAE.Type inExpType;
+    output DAE.Exp outExp;
+  end makeCrefExp;
 end Expression;
 
 package ExpressionDump


### PR DESCRIPTION
 - when assigning to a start value during initialization, also set the variable itself
 - sorting makes sure that the start value is evaluated before evaluating the variable
 - important if the start value is computed by system variables and is needed for an algebraic loop