### PR TITLE
checkDefUse: initialize or fail-terminate conditionally-assigned variables

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -450,7 +450,7 @@ protected
   DAE.ComponentRef cref;
   DAE.ComponentRef rec_cref;
   ArrayBindingList arrayBindingExpList;
-  list<Integer> subscriptLst;
+  list<Integer> subscriptLst = {};
   DAE.Exp binding;
   DAE.Exp scalarBinding;
   list<DAE.Exp> expLst;

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -4251,7 +4251,7 @@ protected
   BackendDAE.EquationArray eqns;
   BackendDAE.Variables vars;
   Integer n, size, idx = 1, m, j;
-  BackendDAE.Equation eqn, eqn1;
+  BackendDAE.Equation eqn = BackendDAE.DUMMY_EQUATION(), eqn1;
   DAE.Exp left, right, e1, e2, e, e3;
   list<DAE.Exp> left_lst, right_lst;
   list<Integer> indRemove;

--- a/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
+++ b/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
@@ -84,19 +84,19 @@ protected
   list<BackendDAE.Equation> setC_Eq, setS_Eq, residualEquations, complexEquationList, swappedEquationList;
   BackendDAE.AdjacencyMatrix adjacencyMatrix;
   array<list<Integer>> mapEqnIncRow;
-  array<Integer> mapIncRowEqn, match1, match2;
-  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo;
+  array<Integer> mapIncRowEqn = listArray({}), match1, match2;
+  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo = {};
   Integer varCount, eqCount;
-  list<Integer> ebltEqsLst, matchedEqsLst, approximatedEquations, setC, tempSetS, setS, boundaryConditionEquations, bindingEquations;
-  ExtAdjacencyMatrix sBltAdjacencyMatrix;
+  list<Integer> ebltEqsLst = {}, matchedEqsLst, approximatedEquations = {}, setC, tempSetS = {}, setS, boundaryConditionEquations, bindingEquations = {};
+  ExtAdjacencyMatrix sBltAdjacencyMatrix = {};
   list<BackendDAE.Var> paramVars, residualVars, unMeasuredVariables;
   BackendDAE.Jacobian simCodeJacobian;
   BackendDAE.Shared shared;
   String str, modelicaOutput, modelicaFileName, modelName, auxillaryConditionsFilename, auxillaryEquations, intermediateEquationsFilename, intermediateEquations, csvfileName;
-  list<tuple<Integer, list<Integer>>> mappedEbltSetS;
+  list<tuple<Integer, list<Integer>>> mappedEbltSetS = {};
   list<tuple<Integer, BackendDAE.Equation, list<Integer>>> setBFailedBoundaryConditionEquations;
 
-  list<Integer> allVarsList, knowns, boundaryConditionVars, exactEquationVars, extractedVarsfromSetS, boundaryConditionTaggedEquationSolvedVars, unMeasuredVariablesOfInterest;
+  list<Integer> allVarsList, knowns = {}, boundaryConditionVars = {}, exactEquationVars = {}, extractedVarsfromSetS, boundaryConditionTaggedEquationSolvedVars, unMeasuredVariablesOfInterest = {};
   BackendDAE.Variables inputVars, outDiffVars, outOtherVars, outResidualVars;
   Integer procedureCount;
   list<tuple<String, String>> measurementcsvData;
@@ -499,11 +499,11 @@ protected
   list<BackendDAE.Equation> setS_Eq, failedboundaryConditionEquations;
   BackendDAE.AdjacencyMatrix adjacencyMatrix;
   array<list<Integer>> mapEqnIncRow;
-  array<Integer> mapIncRowEqn, match1, match2;
-  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo;
+  array<Integer> mapIncRowEqn = listArray({}), match1, match2;
+  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo = {};
   Integer varCount, eqCount;
-  list<Integer> ebltEqsLst, matchedEqsLst, approximatedEquations, tempSetS, setS, boundaryConditionEquations, bindingEquations, setSPrime;
-  ExtAdjacencyMatrix sBltAdjacencyMatrix;
+  list<Integer> ebltEqsLst = {}, matchedEqsLst, approximatedEquations = {}, tempSetS, setS, boundaryConditionEquations, bindingEquations = {}, setSPrime;
+  ExtAdjacencyMatrix sBltAdjacencyMatrix = {};
   list<BackendDAE.Var> paramVars, setSVars, knownVars, failedboundaryConditionVars, extraVarsinSetSPrime, unMeasuredVariables;
   BackendDAE.Jacobian simCodeJacobian;
   BackendDAE.Shared shared;
@@ -511,7 +511,7 @@ protected
   list<tuple<Integer, list<Integer>>> mappedEbltSetS;
   list<tuple<Integer, BackendDAE.Equation, list<Integer>>> setBFailedBoundaryConditionEquations;
 
-  list<Integer> allVarsList, knowns, boundaryConditionVars, exactEquationVars, boundaryConditionTaggedEquationSolvedVars, unMeasuredVariablesOfInterest;
+  list<Integer> allVarsList, knowns = {}, boundaryConditionVars = {}, exactEquationVars, boundaryConditionTaggedEquationSolvedVars, unMeasuredVariablesOfInterest = {};
   BackendDAE.Variables inputVars, outDiffVars, outOtherVars, outBoundaryConditionVars;
   Integer procedureCount;
   list<tuple<String, String>> measurementcsvData;
@@ -763,11 +763,11 @@ protected
   list<BackendDAE.Equation> setC_Eq, setS_Eq, setSPrime_Eq, residualEquations, failedboundaryConditionEquations, allDaeEqs;
   BackendDAE.AdjacencyMatrix adjacencyMatrix;
   array<list<Integer>> mapEqnIncRow;
-  array<Integer> mapIncRowEqn, match1, match2;
-  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo;
+  array<Integer> mapIncRowEqn = listArray({}), match1, match2;
+  list<tuple<Integer,Integer>> solvedEqsAndVarsInfo = {};
   Integer varCount, eqCount;
-  list<Integer> ebltEqsLst, matchedEqsLst, approximatedEquations, setC, tempSetS, setS, boundaryConditionEquations, bindingEquations, setSPrime, unMeasuredEqsLst;
-  ExtAdjacencyMatrix sBltAdjacencyMatrix;
+  list<Integer> ebltEqsLst = {}, matchedEqsLst, approximatedEquations = {}, setC, tempSetS = {}, setS, boundaryConditionEquations, bindingEquations = {}, setSPrime, unMeasuredEqsLst;
+  ExtAdjacencyMatrix sBltAdjacencyMatrix = {};
   list<BackendDAE.Var> paramVars, setSVars, residualVars, knownVars, failedboundaryConditionVars, extraVarsinSetSPrime, unMeasuredVariables;
   BackendDAE.Jacobian simCodeJacobian, simCodeJacobianH;
   BackendDAE.Shared shared;
@@ -775,7 +775,7 @@ protected
   list<tuple<Integer, list<Integer>>> mappedEbltSetS;
   list<tuple<Integer, BackendDAE.Equation, list<Integer>>> setBFailedBoundaryConditionEquations;
 
-  list<Integer> allVarsList, knowns, unMeasuredVariablesOfInterest, failedboundaryConditionEquationIndex, boundaryConditionVars, exactEquationVars, extractedVarsfromSetS, boundaryConditionTaggedEquationSolvedVars;
+  list<Integer> allVarsList, knowns = {}, unMeasuredVariablesOfInterest = {}, failedboundaryConditionEquationIndex, boundaryConditionVars = {}, exactEquationVars = {}, extractedVarsfromSetS, boundaryConditionTaggedEquationSolvedVars;
   BackendDAE.Variables inputVars, outDiffVars, outOtherVars, outResidualVars, outBoundaryConditionVars, outOtherVarsSetSPrime;
   Integer procedureCount, numRelatedBoundaryConditions;
   list<tuple<String, String>> measurementcsvData;
@@ -2358,9 +2358,10 @@ algorithm
     (index, eq) := eqs;
     if intEq(eBLTIndex, index) then
       outEquations := eq;
-      break;
+      return;
     end if;
   end for;
+  fail();
 end getEquationsFromEBLT;
 
 protected function getAbsoluteIndexHelper
@@ -2774,6 +2775,7 @@ algorithm
       return;
     end if;
   end for;
+  fail();
 end getSolvedVariableNumber;
 
 public function getSolvedEquationNumber
@@ -2790,6 +2792,7 @@ algorithm
       return;
     end if;
   end for;
+  fail();
 end getSolvedEquationNumber;
 
 public function getSolvedEquationAndVarsInfo
@@ -3091,7 +3094,7 @@ public function getDependencyequation
   input list<tuple<Integer,Integer>> solvedvariables;
   input ExtAdjacencyMatrix m;
   output list<Integer> outSBLT;
-  output list<Integer> outEBLT;
+  output list<Integer> outEBLT = {};
 protected
   list<Integer> t={}, nonsq;
   Integer eqnumber, varnumber;

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -3243,6 +3243,7 @@ algorithm
   else
     true := Flags.isSet(Flags.FAILTRACE);
     Debug.traceln("- Differentiate.lowerVarsElementVars failed.");
+    fail();
   end try;
 end lowerVarsElementVars;
 

--- a/OMCompiler/Compiler/BackEnd/DynamicOptimization.mo
+++ b/OMCompiler/Compiler/BackEnd/DynamicOptimization.mo
@@ -747,13 +747,13 @@ public function simplifyConstraints
 protected
   list<BackendDAE.EqSystem> systlst, new_systlst = {};
   BackendDAE.Shared shared;
-  BackendDAE.Equation eqn_;
+  BackendDAE.Equation eqn_ = BackendDAE.DUMMY_EQUATION();
   BackendDAE.Var var_, var_con;
   BackendDAE.StrongComponents comps;
   Integer eindex,vindx;
   DAE.ComponentRef cr;
   list<BackendDAE.Var> var_lst, var_lst_opt, var_lst1;
-  DAE.Exp e1, e2, e, c;
+  DAE.Exp e1, e2 = DAE.ICONST(0), e, c;
   BackendDAE.Variables vars, globalKnownVars;
   BackendDAE.EquationArray eqns;
   AvlTreePathFunction.Tree funcs;

--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -372,7 +372,7 @@ algorithm
       Boolean b1,b2, changed1;
       BackendDAE.Equation eq;
       BackendDAE.EquationAttributes attr;
-      DAE.Exp exp1,exp2,lhsExp,rhsExp;
+      DAE.Exp exp1,exp2,lhsExp = DAE.ICONST(0),rhsExp = DAE.ICONST(0);
       DAE.ElementSource source;
       AvlTreePathFunction.Tree funcs;
       list<BackendDAE.Equation> addEqs1, addEqs2;
@@ -2234,7 +2234,7 @@ protected
   list<DAE.ComponentRef> outputs;
   list<DAE.Exp> lhsExps;
   list<list<DAE.Exp>> lhsExpLst;
-  list<DAE.Statement> stmts,stmtsIn;
+  list<DAE.Statement> stmts = {},stmtsIn;
 algorithm
   DAE.STMT_FOR(iter=iter, range=range, statementLst=stmtsIn) :=  stmtIn;
   try

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -1776,7 +1776,7 @@ algorithm
         true := Flags.isSet(Flags.FAILTRACE);
         print(DAEDump.ppStatementStr(x));
         print("Warning, not allowed to set the componentRef to a expression in FindZeroCrossings.traverseStmtsExps for ZeroCrosssing\n");
-      then (DAE.STMT_ASSIGN_ARR(tp, e_2, e_1, source), extraArg);
+      then fail();
 
       case DAE.STMT_IF(exp=e, statementLst=stmts, else_=algElse, source=source) algorithm
         (algElse, extraArg) := traverseStmtsElseExps(algElse, extraArg, inKnvars);

--- a/OMCompiler/Compiler/BackEnd/HpcOmMemory.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmMemory.mo
@@ -1069,7 +1069,7 @@ import Util;
     output list<CacheLineMap> oCacheLinesFloat;
     output list<CacheLineMap> oCacheLinesInt;
     output list<CacheLineMap> oCacheLinesBool;
-    output list<CacheLineMap> oVarCacheLines; //one of the 3 types above
+    output list<CacheLineMap> oVarCacheLines = {}; //one of the 3 types above
   algorithm
     (oCacheLinesFloat,oCacheLinesInt,oCacheLinesBool) := iCacheLinesForTypes;
     if(intEq(iVarDataType, VARDATATYPE_FLOAT)) then
@@ -1098,7 +1098,7 @@ import Util;
     input list<CacheLineMap> iCacheLinesInt;
     input list<CacheLineMap> iCacheLinesBool;
     input list<CacheLineMap> iVarCacheLines;
-    output CacheLines oContractedCacheLines;
+    output CacheLines oContractedCacheLines = (iCacheLinesFloat, iCacheLinesInt, iCacheLinesBool);
   algorithm
     if(intEq(iVarDataType, VARDATATYPE_FLOAT)) then
       oContractedCacheLines := (iVarCacheLines, iCacheLinesInt, iCacheLinesBool);

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -6628,6 +6628,7 @@ algorithm
     end if;
   end for;
 
+  fail();
 end findInIntTuple1;
 
 

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -206,6 +206,7 @@ algorithm
       enabledModules := if Config.adaptiveHomotopy() then {"inlineHomotopy", "generateHomotopyComponents"} else {};
       disabledModules := {};
     else
+      initsyst0 := initsyst;
       enabledModules := {};
       disabledModules := {"inlineHomotopy", "generateHomotopyComponents"};
     end if;
@@ -1435,17 +1436,17 @@ protected
   Integer nVars, nEqns, nAddEqs, nAddVars;
   list<Integer> stateIndices, range, redundantEqns;
   list<BackendDAE.Var> initVarList;
-  array<Integer> ass1, ass2;
+  array<Integer> ass1 = listArray({}), ass2 = listArray({});
   BackendDAE.AdjacencyMatrix m "adjacency matrix of modified system";
   BackendDAE.AdjacencyMatrix m_ "adjacency matrix of original system (TODO: fix this one)";
-  BackendDAE.EqSystem syst;
+  BackendDAE.EqSystem syst = BackendDAEUtil.createEqSystem(inEqSystem.orderedVars, inEqSystem.orderedEqs);
   AvlTreePathFunction.Tree funcs;
   BackendDAE.AdjacencyMatrixEnhanced me;
-  array<Integer> mapIncRowEqn;
+  array<Integer> mapIncRowEqn = listArray({});
   Boolean perfectMatching;
   Integer maxMixedDeterminedIndex = intMax(0, Flags.getConfigInt(Flags.MAX_MIXED_DETERMINED_INDEX));
 
-  array<Boolean> eMarks, vMarks;
+  array<Boolean> eMarks = arrayCreate(0, false), vMarks = arrayCreate(0, false);
   list<Integer> singular_eqns_idx, singular_vars_idx;
   Integer overDetIndex, underDetIndex, scalarEqnSize;
   BackendDAE.Equation eq;

--- a/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -5396,7 +5396,7 @@ algorithm
   local
     DAE.ComponentRef cr1;
     list<DAE.ComponentRef> cr_lst;
-    DAE.Exp res, e, e1, e2;
+    DAE.Exp res, e, e1 = DAE.ICONST(0), e2;
     BackendDAE.Var v;
     list<tuple<DAE.ComponentRef,BackendDAE.Equation>> cr_eq_rest;
     Integer j, j1;
@@ -5456,7 +5456,7 @@ pick the expression with lowest integer value, if two
 integer values are equal, take the first occurring one.
 "
   input list<tuple<DAE.Exp,Integer>> tplExpIndList;
-  output DAE.Exp outE;
+  output DAE.Exp outE = DAE.ICONST(0);
 protected
   DAE.Exp e;
   tuple<DAE.Exp,Integer> tpl;

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2074,8 +2074,8 @@ protected function generateGenericJacobian "author: wbraun"
   input Boolean daeMode = false;
   output Option<BackendDAE.SymbolicJacobian> outJacobian;
   output AvlTreePathFunction.Tree outFunctionTree;
-  output BackendDAE.SparsePattern outSparsePattern;
-  output BackendDAE.SparseColoring outSparseColoring;
+  output BackendDAE.SparsePattern outSparsePattern = BackendDAE.emptySparsePattern;
+  output BackendDAE.SparseColoring outSparseColoring = {};
   output BackendDAE.NonlinearPattern nonlinearPattern;
 protected
   BackendDAE.SymbolicJacobian symbolicJacobian;
@@ -2196,7 +2196,7 @@ algorithm
       BackendDAE.BackendDAE backendDAE, backendDAE2;
       BackendDAE.EqSystem syst;
       BackendDAE.Shared shared;
-      Boolean b;
+      Boolean b = false;
       list<String> strPostOptModules;
 
       case (BackendDAE.DAE(syst::{}, shared), {}, _)

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -172,7 +172,7 @@ protected function callTearingMethod
   output Boolean outRunMatching;
 protected
   constant Boolean debug = false;
-  list<Integer> userTVars, userResiduals;
+  list<Integer> userTVars = {}, userResiduals = {};
   TearingMethod tearingMethod = inTearingMethod;
 algorithm
 
@@ -4094,9 +4094,9 @@ protected function getNextSolvableEqn " finds equation that can be matched with 
   input array<list<Integer>> mapEqnIncRow;
   input array<Integer> mapIncRowEqn;
   input array<Integer> eqnNonlinPoints;
-  output Integer eqOut;
-  output list<Integer> eqnsOut;
-  output list<Integer> varsOut;
+  output Integer eqOut = 0;
+  output list<Integer> eqnsOut = {};
+  output list<Integer> varsOut = {};
 protected
   Boolean solvable = false;
   list<Integer> eqns = assEq_coll;

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -1775,6 +1775,7 @@ algorithm
       return;
     end if;
   end for;
+  fail();
 end getSolvedVariableNumber;
 
 
@@ -1792,6 +1793,7 @@ algorithm
       return;
     end if;
   end for;
+  fail();
 end getSolvedEquationNumber;
 
 public function dumpMatching

--- a/OMCompiler/Compiler/BackEnd/VisualXML.mo
+++ b/OMCompiler/Compiler/BackEnd/VisualXML.mo
@@ -226,6 +226,7 @@ algorithm
     end matchcontinue;
   else
     Error.addInternalError("VisualXMl.getConstCrefBinding failed for "+ComponentReference.crefStr(cr)+"\n", sourceInfo());
+    fail();
   end try;
 end getConstCrefBinding;
 

--- a/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
@@ -222,7 +222,7 @@ algorithm
       Option<Absyn.Class> cl;
       list<String> filenames;
       LoadFileStrategy strategy;
-      Boolean lveStarted;
+      Boolean lveStarted = false;
       Option<Integer> lveInstance;
 
     case false

--- a/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
@@ -2461,6 +2461,7 @@ algorithm
     true := Flags.isSet(Flags.FAILTRACE);
     Debug.traceln("- ConnectUtil.evaluateInStream failed for " +
       ComponentReference.crefStr(streamCref) + "\n");
+    fail();
   end try;
 end evaluateInStream;
 

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -6060,7 +6060,7 @@ public function mergeAlgorithmSections
 protected
   list<DAE.Element> els, newEls = {}, dAElist;
   list<DAE.Statement> istmts = {}, stmts = {}, s;
-  DAE.ElementSource source, src;
+  DAE.ElementSource source = DAE.emptyElementSource, src;
   DAE.Ident ident;
   Option<SCode.Comment> comment;
 algorithm

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -5307,15 +5307,16 @@ public function traverseExpList<ArgT> "Calls traverseExpBottomUp for each elemen
   end FuncExpType;
 protected
   DAE.Exp e1;
-  Boolean allEq=true;
   DoubleEnded.MutableList<DAE.Exp> delst;
+  list<DAE.Exp> rest = inExpl;
   Integer nEq=0;
 algorithm
-  for e in inExpl loop
-    (e1, ext_arg) := traverseExpBottomUp(e, rel, ext_arg);
-    // Preserve reference equality without any allocation if nothing changed
-    if (if allEq then not referenceEq(e, e1) else false) then
-      allEq:=false;
+  // Preserve reference equality without any allocation if nothing changed.
+  expl := inExpl;
+  while not listEmpty(rest) loop
+    (e1, ext_arg) := traverseExpBottomUp(listHead(rest), rel, ext_arg);
+    if not referenceEq(listHead(rest), e1) then
+      // First change: switch to building a new list with a DoubleEnded list.
       delst := DoubleEnded.empty(e1);
       for elt in inExpl loop
         if nEq < 1 then
@@ -5324,14 +5325,17 @@ algorithm
         DoubleEnded.push_back(delst, elt);
         nEq := nEq-1;
       end for;
-    end if;
-    if allEq then
-      nEq := nEq + 1;
-    else
       DoubleEnded.push_back(delst, e1);
+      for e in listRest(rest) loop
+        (e1, ext_arg) := traverseExpBottomUp(e, rel, ext_arg);
+        DoubleEnded.push_back(delst, e1);
+      end for;
+      expl := DoubleEnded.toListAndClear(delst);
+      return;
     end if;
-  end for;
-  expl := if allEq then inExpl else DoubleEnded.toListAndClear(delst);
+    nEq := nEq + 1;
+    rest := listRest(rest);
+  end while;
 end traverseExpList;
 
 public function traverseExpTopDown
@@ -6789,15 +6793,16 @@ public function traverseExpListBidir<ArgT>
   end FuncType;
 protected
   DAE.Exp e1;
-  Boolean allEq=true;
   DoubleEnded.MutableList<DAE.Exp> delst;
+  list<DAE.Exp> rest = inExpl;
   Integer nEq=0;
 algorithm
-  for e in inExpl loop
-    (e1, outArg) := traverseExpBidir(e, inEnterFunc, inExitFunc, outArg);
-    // Preserve reference equality without any allocation if nothing changed
-    if (if allEq then not referenceEq(e, e1) else false) then
-      allEq:=false;
+  // Preserve reference equality without any allocation if nothing changed.
+  outExpl := inExpl;
+  while not listEmpty(rest) loop
+    (e1, outArg) := traverseExpBidir(listHead(rest), inEnterFunc, inExitFunc, outArg);
+    if not referenceEq(listHead(rest), e1) then
+      // First change: switch to building a new list with a DoubleEnded list.
       delst := DoubleEnded.empty(e1);
       for elt in inExpl loop
         if nEq < 1 then
@@ -6806,14 +6811,17 @@ algorithm
         DoubleEnded.push_back(delst, elt);
         nEq := nEq-1;
       end for;
-    end if;
-    if allEq then
-      nEq := nEq + 1;
-    else
       DoubleEnded.push_back(delst, e1);
+      for e in listRest(rest) loop
+        (e1, outArg) := traverseExpBidir(e, inEnterFunc, inExitFunc, outArg);
+        DoubleEnded.push_back(delst, e1);
+      end for;
+      outExpl := DoubleEnded.toListAndClear(delst);
+      return;
     end if;
-  end for;
-  outExpl := if allEq then inExpl else DoubleEnded.toListAndClear(delst);
+    nEq := nEq + 1;
+    rest := listRest(rest);
+  end while;
 end traverseExpListBidir;
 
 public function traverseExpBidir<ArgT>
@@ -7393,12 +7401,15 @@ public function traverseExpTopDownSubs
   replaceable type Argument subtypeof Any;
 protected
   DAE.Exp exp;
-  DAE.Subscript nsub;
-  Boolean allEq=true;
+  DAE.Subscript sub, nsub;
   DoubleEnded.MutableList<DAE.Subscript> delst;
+  list<DAE.Subscript> rest = inSubscript;
   Integer nEq=0;
 algorithm
-  for sub in inSubscript loop
+  // Preserve reference equality without any allocation if nothing changed.
+  outSubscript := inSubscript;
+  while not listEmpty(rest) loop
+    sub := listHead(rest);
     nsub := match sub
       case DAE.WHOLEDIM() then sub;
       case DAE.SLICE()
@@ -7414,9 +7425,8 @@ algorithm
           (exp,arg) := traverseExpTopDown(sub.exp, rel, arg);
         then if referenceEq(sub.exp, exp) then sub else DAE.WHOLE_NONEXP(exp);
     end match;
-    // Preserve reference equality without any allocation if nothing changed
-    if (if allEq then not referenceEq(nsub, sub) else false) then
-      allEq:=false;
+    if not referenceEq(nsub, sub) then
+      // First change: switch to building a new list with a DoubleEnded list.
       delst := DoubleEnded.empty(nsub);
       for elt in inSubscript loop
         if nEq < 1 then
@@ -7425,14 +7435,32 @@ algorithm
         DoubleEnded.push_back(delst, elt);
         nEq := nEq-1;
       end for;
-    end if;
-    if allEq then
-      nEq := nEq + 1;
-    else
       DoubleEnded.push_back(delst, nsub);
+      for sub2 in listRest(rest) loop
+        sub := sub2;
+        nsub := match sub
+          case DAE.WHOLEDIM() then sub;
+          case DAE.SLICE()
+            algorithm
+              (exp,arg) := traverseExpTopDown(sub.exp, rel, arg);
+            then if referenceEq(sub.exp, exp) then sub else DAE.SLICE(exp);
+          case DAE.INDEX()
+            algorithm
+              (exp,arg) := traverseExpTopDown(sub.exp, rel, arg);
+            then if referenceEq(sub.exp, exp) then sub else DAE.INDEX(exp);
+          case DAE.WHOLE_NONEXP()
+            algorithm
+              (exp,arg) := traverseExpTopDown(sub.exp, rel, arg);
+            then if referenceEq(sub.exp, exp) then sub else DAE.WHOLE_NONEXP(exp);
+        end match;
+        DoubleEnded.push_back(delst, nsub);
+      end for;
+      outSubscript := DoubleEnded.toListAndClear(delst);
+      return;
     end if;
-  end for;
-  outSubscript := if allEq then inSubscript else DoubleEnded.toListAndClear(delst);
+    nEq := nEq + 1;
+    rest := listRest(rest);
+  end while;
 end traverseExpTopDownSubs;
 
 /***************************************************/

--- a/OMCompiler/Compiler/FrontEnd/FUnitCheck.mo
+++ b/OMCompiler/Compiler/FrontEnd/FUnitCheck.mo
@@ -371,7 +371,7 @@ protected function foldEquation2 "help-function"
   input output HashTableStringToUnit.HashTable htS2U;
   input output HashTableUnitToString.HashTable htU2S;
   input list<Functionargs> args;
-        output list<list<tuple<DAE.Exp, Unit.Unit>>> inconsistentUnits;
+        output list<list<tuple<DAE.Exp, Unit.Unit>>> inconsistentUnits = {};
 algorithm
   inconsistentUnits := match eq
     local

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -432,6 +432,7 @@ algorithm
     outBinding := instBinding(inMod, varLst, expected_type, inIndices, inName, useConstValue);
   else
     Error.addMessage(Error.TYPE_ERROR, {inName, "enumeration type"});
+    fail();
   end try;
 end instEnumerationBinding;
 

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -2781,7 +2781,7 @@ protected function instWhenEqBranch
   input Boolean inUnrollLoops;
   input ConnectionGraph.ConnectionGraph inGraph;
   input SourceInfo info;
-  output FCore.Cache outCache;
+  output FCore.Cache outCache = inCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
   output DAE.Exp outCondition;

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -3586,7 +3586,7 @@ public function isArrayType
   input FCore.Cache inCache;
   input FCore.Graph inEnv;
   input Absyn.Path inPath;
-  output FCore.Cache outCache;
+  output FCore.Cache outCache = inCache;
   output Boolean outIsArray;
 protected
   SCode.Element el;

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -2879,6 +2879,7 @@ algorithm
   else
     true := Flags.isSet(Flags.FAILTRACE);
     Debug.traceln("- Static.elabMatrixCatTwoExp failed");
+    fail();
   end try;
 end elabMatrixCatTwoExp;
 
@@ -2988,6 +2989,7 @@ algorithm
   else
     true := Flags.isSet(Flags.FAILTRACE);
     Debug.traceln("- Static.promoteExp failed");
+    fail();
   end try;
 end promoteExp;
 
@@ -8382,13 +8384,13 @@ protected function elabTypes
   input Boolean inImplicit;
   input DAE.Prefix inPrefix;
   input SourceInfo inInfo;
-  output FCore.Cache outCache;
-  output list<DAE.Exp> outArgs;
-  output list<DAE.Const> outConsts;
-  output DAE.Type outResultType;
-  output DAE.Type outFunctionType;
-  output DAE.Dimensions outDimensions;
-  output list<Slot> outSlots;
+  output FCore.Cache outCache = inCache;
+  output list<DAE.Exp> outArgs = {};
+  output list<DAE.Const> outConsts = {};
+  output DAE.Type outResultType = DAE.T_UNKNOWN_DEFAULT;
+  output DAE.Type outFunctionType = DAE.T_UNKNOWN_DEFAULT;
+  output DAE.Dimensions outDimensions = {};
+  output list<Slot> outSlots = {};
 protected
   list<DAE.FuncArg> params;
   DAE.Type res_ty, func_ty;

--- a/OMCompiler/Compiler/MidCode/DAEToMid.mo
+++ b/OMCompiler/Compiler/MidCode/DAEToMid.mo
@@ -1071,7 +1071,7 @@ protected
   Integer labelFin, labelMux, labelInit, labelFail, labelFin2, labelOut, caseLabel;
   list<Integer> caseLabels;
   MidCode.Var muxState, one, midvar,midvar2;
-  MidCode.VarBufPtr muxOldBuf;
+  MidCode.VarBufPtr muxOldBuf = MidCode.VARBUFPTR("");
   MidCode.VarBuf muxNewBuf;
   MidCode.OutVar outvar;
   Boolean matchContinue;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -823,7 +823,7 @@ public
         [...]"
       input output Iterator iter;
       input Expression condition;
-      output Solve.Status status;
+      output Solve.Status status = NBSolve.Status.UNSOLVABLE;
     protected
       type IterOpt = Option<Iterator>; // needed for the map
       list<ComponentRef> names;
@@ -2786,6 +2786,8 @@ public
           slicing_status  := if Equation.size(eqn_ptr) == listLength(indices) then SlicingStatus.TRIVIAL else SlicingStatus.NONTRIVIAL;
           if slicing_status == SlicingStatus.NONTRIVIAL then
             sliced_eqn := sliceFor(listHead(eqn.body), getForIterator(eqn), sizes, listReverse(getForFrames(eqn)), indices);
+          else
+            sliced_eqn := {Pointer.create(eqn)};
           end if;
         then (sliced_eqn, slicing_status);
 
@@ -2875,7 +2877,7 @@ public
       input UnorderedMap<ComponentRef, Expression> replacements   "prepared replacement map";
       output Equation sliced_eqn                                  "scalar sliced equation";
       input UnorderedMap<Path, Function> funcMap                  "func map for solving";
-      output Solve.Status solve_status                            "solve success status";
+      output Solve.Status solve_status = NBSolve.Status.EXPLICIT  "solve success status";
     protected
       Equation eqn;
       list<Integer> location;
@@ -4191,6 +4193,7 @@ public
         SOME(residualVar) := attr.residualVar;
       else
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of missing residualVar!"});
+        fail();
       end try;
     end getResidualVar;
 
@@ -4292,8 +4295,8 @@ public
       String index;
       Boolean useMapping = isSome(mapping_opt);
       Boolean filterEqs = isSome(filter_opt);
-      array<tuple<Integer,Integer>> mapping;
-      UnorderedSet<String> filter;
+      array<tuple<Integer,Integer>> mapping = listArray({});
+      UnorderedSet<String> filter = UnorderedSet.new(stringHashDjb2, stringEq);
       Pointer<Equation> eqn;
     algorithm
       // check if mapping is used
@@ -4470,11 +4473,8 @@ public
       Equation eq, new_eq;
       list<String> followEquations = Flags.getConfigStringList(Flags.DEBUG_FOLLOW_EQUATIONS);
       Boolean debug = not listEmpty(followEquations);
-      UnorderedSet<String> debug_eqns;
+      UnorderedSet<String> debug_eqns = UnorderedSet.fromList(followEquations, stringHashDjb2, stringEq);
     algorithm
-      if debug then
-        debug_eqns := UnorderedSet.fromList(followEquations, stringHashDjb2, stringEq);
-      end if;
 
       for i in 1:ExpandableArray.getLastUsedIndex(equations.eqArr) loop
         if ExpandableArray.occupied(i, equations.eqArr) then

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -572,7 +572,7 @@ public
     input Pointer<Integer> uniqueIndex;
     input UnorderedSet<ComponentRef> slice_set;
     output list<StrongComponent> new_residuals;
-    output DAEType dae_type;
+    output DAEType dae_type = DAEType.RESIDUAL;
   protected
     Pointer<Equation> eqn;
     ComponentRef eqn_name;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -2036,7 +2036,7 @@ function isJacobianResultVar
       Integer length, scal_start;
       String index;
       Boolean useMapping = isSome(mapping_opt);
-      array<tuple<Integer,Integer>> mapping;
+      array<tuple<Integer,Integer>> mapping = listArray({});
     algorithm
       if useMapping then
         length := 15;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -363,7 +363,7 @@ public
     output list<tuple<String, Real>> module_clocks = {};
   protected
     Module.wrapper func;
-    String name, debugStr;
+    String name, debugStr = "";
     Real clock_time;
     tuple<Integer, Integer> varSizes, eqnSizes;
   algorithm

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -349,8 +349,8 @@ protected
     Integer nVars = arrayLength(mT), nEqns = arrayLength(m);
     array<Integer> var_to_eqn;
     array<Integer> eqn_to_var;
-    array<Boolean> var_marks;
-    array<Boolean> eqn_marks;
+    array<Boolean> var_marks = arrayCreate(0, false);
+    array<Boolean> eqn_marks = arrayCreate(0, false);
     Boolean pathFound;
   algorithm
     var_to_eqn := arrayCreate(nVars, -1);

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -1251,6 +1251,7 @@ protected
       chosen_val := SOME(sval);
       chosen_cref := SOME(compref);
     else
+      (compref, state_select) := listHead(lst_values);
       for tpl in lst_values loop
         (cref,sval) := tpl;
         if sval > state_select then

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -690,7 +690,7 @@ public
       Option<StateEvent> sev_opt;
       StateEvent sev;
       Pointer<Variable> aux_var;
-      ComponentRef aux_cref;
+      ComponentRef aux_cref = ComponentRef.EMPTY();
       Pointer<Boolean> clocked = Pointer.create(false);
     algorithm
       // collect possible sample events from exp

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
@@ -285,10 +285,10 @@ protected
     UnorderedMap<Call_Id, Call_Aux> map = UnorderedMap.new<Call_Aux>(Call_Id.hash, Call_Id.isEqual);
     VariablePointers variables = VarData.getVariables(varData);
     UnorderedSet<VariablePointer> set = UnorderedSet.new(BVariable.hash, BVariable.equalName) "new iterators";
-    UnorderedMap<BClock, ComponentRef> clock_map, infer_map;
+    UnorderedMap<BClock, ComponentRef> clock_map = UnorderedMap.new<ComponentRef>(BClock.hash, BClock.isEqual), infer_map = UnorderedMap.new<ComponentRef>(BClock.hash, BClock.isEqual);
     Pointer<Integer> aux_index = Pointer.create(1);
-    list<Pointer<Variable>> new_vars_disc = {}, new_vars_cont = {}, new_vars_init = {}, new_vars_recd = {}, new_vars_clck, new_vars_infr;
-    list<Pointer<Equation>> new_eqns_disc = {}, new_eqns_cont = {}, new_eqns_init = {}, new_eqns_clck, new_eqns_infr;
+    list<Pointer<Variable>> new_vars_disc = {}, new_vars_cont = {}, new_vars_init = {}, new_vars_recd = {}, new_vars_clck = {}, new_vars_infr = {};
+    list<Pointer<Equation>> new_eqns_disc = {}, new_eqns_cont = {}, new_eqns_init = {}, new_eqns_clck = {}, new_eqns_infr = {};
     list<tuple<Call_Id, Call_Aux>> debug_lst_sim = {}, debug_lst_ini;
   algorithm
     () := match (eqData, varData)

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -200,7 +200,7 @@ public
     input String name;
     output BackendDAE jacobian;
   protected
-    JacobianType jacType;
+    JacobianType jacType = JacobianType.NLS;
     list<Pointer<Variable>> variables = {}, unknowns = {}, auxiliaryVars = {}, aliasVars = {};
     list<Pointer<Variable>> diffVars = {}, dependencies = {}, resultVars = {}, tmpVars = {}, seedVars = {};
     list<StrongComponent> comps = {};
@@ -1122,6 +1122,7 @@ protected
       comps := list(comp for comp guard(not StrongComponent.isDiscrete(comp)) in Util.getOption(strongComponents));
     else
       Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because no strong components were given!"});
+      fail();
     end if;
 
     // create seed vars

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -542,7 +542,7 @@ public
     input list<Slice<Pointer<Variable>>> var_slices;
     output Equation solved_eqn = eqn;
     input UnorderedMap<Path, Function> funcMap;
-    output Status status;
+    output Status status = Status.UNPROCESSED;
   protected
     list<Pointer<Variable>> vars = list(Slice.getT(v) for v in var_slices);
     Expression lhs = Util.getOption(Equation.getLHS(eqn));
@@ -837,7 +837,7 @@ protected
     input ComponentRef cref;
     input Equation eqn;
     output Equation eqnOut = eqn "don't change the equation";
-    output Status status;
+    output Status status = Status.UNSOLVABLE;
     output RelationInversion invertRelation = RelationInversion.FALSE;
   algorithm
     for stmt in body.when_stmts loop
@@ -1048,7 +1048,7 @@ protected
     input ComponentRef cref;
     input output Boolean crefFound;
     input output list<Expression> inverseInstructions;
-    output Status status;
+    output Status status = Status.EXPLICIT; // just set this per default, since the algorithm detects implicit equations
   protected
     list<Expression> argList = {}, invargList = {};
     Boolean crefFoundInRecursion;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -849,7 +849,7 @@ public
         local
           DifferentiationArguments diffArgs = DifferentiationArguments.default(NBDifferentiate.DifferentiationType.SIMPLE, funcMap);
           Pointer<Equation> eqn_ptr;
-          Expression residual, exp;
+          Expression residual = Expression.EMPTY(Type.REAL()), exp;
           Solve.Status status;
           Solvability sol;
           UnorderedSet<ComponentRef> linear_set, param_set, var_set;
@@ -2200,7 +2200,7 @@ public
     input UnorderedMap<ComponentRef, Dependency> dep_map;
     input UnorderedMap<ComponentRef, Solvability> sol_map;
     input UnorderedSet<ComponentRef> rep_set;
-    output UnorderedSet<ComponentRef> set;
+    output UnorderedSet<ComponentRef> set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
   protected
     list<UnorderedSet<ComponentRef>> sets1 = {};
     UnorderedSet<ComponentRef> set1, set2, diff;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -1241,7 +1241,7 @@ public
     exp := match exp
       local
         Integer i;
-        Expression ret, ret1, ret2, arg1, arg2, arg3, diffArg1, diffArg2, diffArg3, current_grad, cond1, cond2, cond, zero1, zero2, grad_x, grad_y, old_grad;
+        Expression ret, ret1, ret2, arg1, arg2, arg3, diffArg1, diffArg2, diffArg3, current_grad = diffArguments.current_grad, cond1, cond2, cond, zero1, zero2, grad_x, grad_y, old_grad;
         list<Expression> rest, diffRest;
         Type ty;
         DifferentiationType diffType;
@@ -2560,7 +2560,7 @@ public
         Expression exp1, exp2, diffExp1, diffExp2, e1, e2, e3, res;
         Operator operator, addOp, mulOp, powOp, divOp;
         Operator.SizeClassification sizeClass, powSizeClass;
-        Expression current_grad;
+        Expression current_grad = diffArguments.current_grad;
         // Local reverse grads (to assign before recursing)
         Expression grad_exp1, grad_exp2, denom2, numUF;
         Boolean isVec1, isVec2, isMat1, isMat2;
@@ -2874,9 +2874,9 @@ public
         list<Expression> diff_arguments, diff_inv_arguments;
         Operator operator, addOp, powOp, mulEWOp;
         Operator.SizeClassification sizeClass, powSizeClass;
-        Expression current_grad, upstream, e_over_f, e_over_g, numProd, denomProd;
+        Expression current_grad = diffArguments.current_grad, upstream, e_over_f, e_over_g, numProd, denomProd;
         List<Expression> arg_rest;
-        Boolean hasArray, hasArrayNum;
+        Boolean hasArray = false, hasArrayNum;
         Expression local_grad, localUpF, localUpG;
         Integer i;
         Type powTy;
@@ -3109,9 +3109,9 @@ public
     input output DifferentiationArguments diffArguments;
     input Operator operator;
   protected
-    Expression diff_arg, current_grad, localUp, restProd;
-    Array<List<Expression>> diff_lists;
-    List<Expression> arg_products, restArgs;
+    Expression diff_arg, current_grad = diffArguments.current_grad, localUp, restProd;
+    Array<List<Expression>> diff_lists = listArray({});
+    List<Expression> arg_products = {}, restArgs;
     Integer idx = 1;
     Boolean isReverse = isSome(diffArguments.adjoint_map);
     Operator mulEWOp = Operator.fromClassification(

--- a/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
@@ -148,7 +148,7 @@ public
     "this function detects if an equation is resizable"
     input Equation eqn;
     input ComponentRef cref_to_solve;
-    output UnorderedMap<ComponentRef, EvalOrder> order;
+    output UnorderedMap<ComponentRef, EvalOrder> order = UnorderedMap.new<EvalOrder>(ComponentRef.hash, ComponentRef.isEqual);
   protected
     Pointer<Variable> var_ptr = BVariable.getVarPointer(cref_to_solve, sourceInfo());
     UnorderedSet<ComponentRef> var_occurences = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
@@ -851,6 +851,7 @@ protected
     // traversing constraints
     for tpl in UnorderedMap.toList(c2p) loop
       (constraint, crefs) := tpl;
+      failed := false;
       () := match checkConstraint(constraint, optimal_values)
         // this constraint is not violated
         case SOME(value) guard(func(value)) algorithm

--- a/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
@@ -496,6 +496,7 @@ public
       Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
         + " failed because the equation size " + intString(eqn_size)
         + " could not be divided by the iterator size " + intString(iter_size) + " without rest."});
+      fail();
     end if;
 
     // create unique array for each equation
@@ -562,6 +563,7 @@ public
       Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
         + " failed because the equation size " + intString(eqn_size)
         + " could not be divided by the iterator size " + intString(iter_size) + " without rest."});
+      fail();
     end if;
 
     // get row cref lst
@@ -1599,18 +1601,16 @@ protected
       UnorderedMap.add(scal, getCrefInFrameIndices(scal, frames, mapping, map, true), map3);
     end for;
 
-    // if its repeated, use the same cref always
+    // if its repeated, use the same cref always; otherwise use local cref
     if repeated then
       mode := Mode.create(eqn_name, {original_cref}, false);
+    else
+      mode := Mode.create(eqn_name, {original_cref}, true);
     end if;
 
     for i in skip_idx:iter_size:skip_idx+size-iter_size loop
       shift := 0;
       for scal in scalarized loop
-        // if its not repeated use local cref
-        if not repeated then
-          mode := Mode.create(eqn_name, {original_cref}, true);
-        end if;
         for scal_idx in UnorderedMap.getSafe(scal, map3, sourceInfo()) loop
           if intMod(shift, iter_size) == 0 then shift := 0; end if;
           addMatrixEntry(m, modes, i + shift, scal_idx, mode);

--- a/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
@@ -213,6 +213,7 @@ public
       outputs_lst := UnorderedSet.toList(outputs_set);
     else
       Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed."});
+      fail();
     end try;
   end getInputsOutputs;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -486,7 +486,7 @@ public
 
   function variability
     input NFCall call;
-    output Variability var;
+    output Variability var = Variability.CONTINUOUS;
   algorithm
     var := match call
       local
@@ -505,6 +505,8 @@ public
               case "cardinality" then Variability.PARAMETER;
               else algorithm var_set := false; then Variability.CONTINUOUS;
             end match;
+          else
+            var_set := false;
           end if;
 
           if not var_set then

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -1679,7 +1679,7 @@ public
        partial class tree."
       input LookupTree.Entry entry;
       input ClassTree classTree;
-      output InstNode node;
+      output InstNode node = InstNode.EMPTY_NODE();
     algorithm
       node := match entry
         local

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -726,7 +726,7 @@ public
   algorithm
     (subscripts, cref) := match cref
       local
-        ComponentRef rest_cref;
+        ComponentRef rest_cref = EMPTY();
         list<Subscript> cref_subs;
 
       case CREF(subscripts = cref_subs)

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -340,7 +340,7 @@ protected
   Expression lhs_exp, rhs_exp, exp;
   Type ty, elem_ty;
   list<InstNode> iterators = {};
-  list<Expression> ranges;
+  list<Expression> ranges = {};
   list<Subscript> subs;
 algorithm
   source := ElementSource.mergeSources(lhsSource, rhsSource);

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -185,7 +185,7 @@ function evaluateExpTraverser
   input SourceInfo info;
   input Boolean changed = false;
   output Expression outExp;
-  output Boolean outChanged;
+  output Boolean outChanged = changed;
 protected
   Expression e;
   ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1264,7 +1264,7 @@ function loadLibraryFunction
   input Option<SCode.Annotation> extAnnotation;
   input Boolean debug;
   input SourceInfo info;
-  output Integer fnHandle;
+  output Integer fnHandle = -1;
 protected
   Integer lib_handle;
   SCode.Annotation ann;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -875,7 +875,7 @@ public
   function expandBinaryPowMatrix
     input Expression exp;
     input Boolean resize;
-    output Expression outExp;
+    output Expression outExp = exp;
     output Boolean expanded;
   protected
     Expression exp1, exp2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5595,7 +5595,7 @@ public
     input Boolean isArray;
     input Integer dims;
     input list<Type> types;
-    output Expression outExp;
+    output Expression outExp = exp;
   algorithm
     outExp := match (exp, types)
       local

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1145,13 +1145,13 @@ uniontype Function
     Slot s;
     String arg_name;
   algorithm
+    SOME(arg_name) := arg.name;
+
     // Try to find a slot and fill it with the argument expression.
     // Positional arguments fill the slots from the start of the array, so
     // searching backwards will generally be a bit more efficient.
     for i in arrayLength(slots):-1:1 loop
       s := slots[i];
-
-      SOME(arg_name) := arg.name;
 
       if Slot.name(s) == arg_name then
         if not Slot.named(s) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInline.mo
@@ -274,7 +274,7 @@ function convertIfToAssignment
 protected
   list<tuple<Expression, list<Statement>>> branches;
   Expression cond, if_exp, output_exp, lhs, rhs;
-  Type ty;
+  Type ty = Type.UNKNOWN();
   list<Statement> body;
   Statement s;
   DAE.ElementSource source;

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -1648,7 +1648,7 @@ algorithm
     local
       ComponentRef lhs, rhs;
       list<Equation> eql = {};
-      Boolean isThere;
+      Boolean isThere = false;
       String str;
       DAE.ElementSource source;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -59,7 +59,7 @@ public
     input InstContext.Type context;
     input SourceInfo info;
   protected
-    ComponentRef ctor_ref;
+    ComponentRef ctor_ref = ComponentRef.EMPTY();
     Absyn.Path ctor_path;
     Boolean ctor_overloaded;
     InstNode ctor_node;
@@ -140,7 +140,7 @@ public
     output list<Function> functions;
   protected
     InstNode node;
-    ComponentRef fn_ref;
+    ComponentRef fn_ref = ComponentRef.EMPTY();
     Boolean is_defined;
   algorithm
     functions := match Type.arrayElementType(ty)

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -135,7 +135,7 @@ protected
   list<tuple<String, Binding>> ty_attr;
   SCode.Comment cmt;
   SourceInfo info;
-  ExpressionIterator binding_iter;
+  ExpressionIterator binding_iter = ExpressionIterator.NONE_ITERATOR();
   list<ComponentRef> crefs;
   Expression exp;
   list<AttributeIterator> ty_attr_iters;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -864,6 +864,7 @@ algorithm
           "]\n with following arguments: " + stringDelimitList(list(Expression.toString(e) for e in const_args), ", ") +
           "\n and following inverse arguments: " + stringDelimitList(list(Expression.toString(e) for e in inv_const_args), ", "),
           sourceInfo());
+        fail();
       end if;
 
       // remove expressions that are in both arguments and inv_arguments
@@ -1507,6 +1508,7 @@ algorithm
     value := Expression.realValue(Ceval.evalExp(exp));
   else
     Error.addInternalError(getInstanceName() + " expression is not known to be a constant number: " + Expression.toString(exp), sourceInfo());
+    fail();
   end try;
 end getConstantValue;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
@@ -135,7 +135,7 @@ public
 
   function isDiscrete
     input Statement stmt;
-    output Boolean b;
+    output Boolean b = false;
   algorithm
     b := match stmt
       case ASSIGNMENT()           then Type.isDiscrete(stmt.ty);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -313,6 +313,7 @@ algorithm
         end match;
       else
         printUnresolvableTypeError(Expression.BINARY(exp1, op, exp2), {type1, type2}, info, showErrors);
+        fail();
       end if;
     end try;
   elseif listLength(exactMatches) == 1 then
@@ -373,8 +374,8 @@ function checkConditionalBinaryOperator
   output Expression outExp;
   output Type outType;
 protected
-  Type tty1, fty1, tty2, fty2, ty1, ty2;
-  Expression e1, e2;
+  Type tty1, fty1, tty2, fty2, ty1 = Type.UNKNOWN(), ty2 = Type.UNKNOWN();
+  Expression e1 = exp1, e2 = exp2;
   Boolean valid1, valid2;
   NFType.Branch branch;
 algorithm
@@ -412,6 +413,7 @@ algorithm
     outExp := e2;
   else
     printUnresolvableTypeError(exp1, {type1, type2}, info);
+    fail();
   end if;
 
   outExp := Expression.setType(outType, outExp);
@@ -470,6 +472,7 @@ algorithm
 
     case (Expression.ARRAY(elements = arr1), Expression.ARRAY(elements = arr2))
       algorithm
+        ty := Type.UNKNOWN();
         if arrayEmpty(arr1) then
           // If the arrays are empty, match against the element types to get the expected return type.
           ty1 := Type.arrayElementType(type1);
@@ -614,6 +617,7 @@ algorithm
             exp1, type1, var1, op, Expression.EMPTY(type2), ty, var2, candidates, context, info, showErrors = false);
         else
           printUnresolvableTypeError(Expression.BINARY(exp1, op, exp2), {type1, exp2.ty}, info);
+          fail();
         end try;
 
         outType := Type.setArrayElementType(exp2.ty, outType);
@@ -685,6 +689,7 @@ algorithm
             Expression.EMPTY(type1), ty, var1, op, exp2, type2, var2, candidates, context, info, showErrors = false);
         else
           printUnresolvableTypeError(Expression.BINARY(exp1, op, exp2), {type1, exp1.ty}, info);
+          fail();
         end try;
 
         outType := Type.setArrayElementType(exp1.ty, outType);
@@ -728,6 +733,7 @@ algorithm
     (outExp, outType) := checkOverloadedBinaryArrayScalar(exp1, type1, var1, op, exp2, type2, var2, candidates, context, info);
   else
     printUnresolvableTypeError(Expression.BINARY(exp1, op, exp2), {type1, type2}, info);
+    fail();
   end if;
 end checkOverloadedBinaryArrayDiv;
 
@@ -783,7 +789,7 @@ protected
   Expression e1, e2;
   list<Expression> expl;
   array<Expression> expl1, expl2;
-  Type ty, ty1, ty2;
+  Type ty = Type.UNKNOWN(), ty1, ty2;
   Boolean is_array1, is_array2;
 algorithm
   is_array1 := Type.isArray(type1);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1660,7 +1660,7 @@ function typeSubscriptedExp2
   input InstContext.Type context;
   input SourceInfo info;
   output Expression outExp;
-  output Type ty;
+  output Type ty = Type.UNKNOWN();
   output Variability variability;
   output Purity purity;
 protected

--- a/OMCompiler/Compiler/Parsers/SimpleModelicaParser.mo
+++ b/OMCompiler/Compiler/Parsers/SimpleModelicaParser.mo
@@ -1979,12 +1979,13 @@ function treeDiffWork
   input list<ParseTree> t1, t2;
   input Integer depth;
   input CmpParseTreeFunc compare;
-  output list<tuple<Diff,list<ParseTree>>> res, resLocal;
+  output list<tuple<Diff,list<ParseTree>>> res;
 protected
+  list<tuple<Diff,list<ParseTree>>> resLocal;
   list<ParseTree> t2_strip, before, middle, after, addedTrees, deletedTrees, ts;
-  list<String> addList, delList;
+  list<String> addList = {}, delList = {};
   Integer nadd, ndel;
-  ParseTree addedTree, deletedTree, deleted;
+  ParseTree addedTree, deletedTree, deleted = EMPTY();
   Boolean addedBeforeDeleted, joinTrees, tryFind;
   String str, debugString1="", debugString2="";
   Diff d;
@@ -2901,10 +2902,10 @@ end getNodes;
 
 function extractSingleAddDiffBeforeAndAfter "Ignores whitespace"
   input list<tuple<Diff,list<ParseTree>>> diffs;
-  output ParseTree addedTree;
-  output ParseTree deletedTree;
-  output list<ParseTree> before, middle, after;
-  output Boolean addedBeforeDeleted;
+  output ParseTree addedTree = EMPTY();
+  output ParseTree deletedTree = EMPTY();
+  output list<ParseTree> before = {}, middle = {}, after;
+  output Boolean addedBeforeDeleted = false;
 protected
   Boolean foundAdded=false;
   Boolean foundDeleted=false;

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -3389,7 +3389,7 @@ function generateSeparateCode
   input FCore.Cache cache;
   input FCore.Graph env;
   output Values.Value res;
-  output FCore.Cache outCache;
+  output FCore.Cache outCache = cache;
 protected
   Values.Value v;
   Boolean b;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1484,6 +1484,7 @@ algorithm
            result_file := "";
            resI := 1;
            timeSimulation := 0.0;
+           logFile := "";
          end if;
 
         timeTotal := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
@@ -1648,6 +1649,7 @@ algorithm
           result_file := "";
           timeSimulation := 0.0;
           resI := 1;
+          logFile := "";
         end if;
         timeTotal := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
         (outCache,simValue) := createSimulationResultFromcallModelExecutable(b,resI,timeTotal,timeSimulation,resultValues,outCache,className,vals,result_file,logFile);
@@ -1699,6 +1701,7 @@ algorithm
           result_file := "";
           timeSimulation := 0.0;
           resI := 1;
+          logFile := "";
         end if;
         timeTotal := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
         (outCache,simValue) := createSimulationResultFromcallModelExecutable(b,resI,timeTotal,timeSimulation,resultValues,outCache,className,vals,result_file,logFile);
@@ -1956,6 +1959,7 @@ algorithm
           s1 := getTotalModel(classpath, b1, b2, b3);
         else
           Error.addMessage(Error.SAVE_ENCRYPTED_CLASS_ERROR, {});
+          s1 := "";
         end if;
       then
         Values.STRING(s1);
@@ -3640,6 +3644,7 @@ algorithm
     SymbolTable.setAbsyn(p);
     // Always update the SCode structure; otherwise the cache plays tricks on us
     SymbolTable.clearSCode();
+    success := true;
   end try;
 end loadProgram;
 
@@ -3725,7 +3730,7 @@ public function runFrontEndWorkNF
   output String flatString;
 protected
   SCode.Program builtin_p, scode_p, annotation_p;
-  Boolean nf_api, inst_failed;
+  Boolean nf_api;
   Absyn.Path cls_name = className;
   Obfuscate.Mapping obfuscate_map;
   String obfuscate_mode;
@@ -3754,21 +3759,17 @@ algorithm
   // make sure we don't run the default instantiateModel using -d=nfAPI
   // only the stuff going via NFApi.mo should have this flag activated
   nf_api := FlagsUtil.set(Flags.NF_API, false);
-  inst_failed := false;
 
   try
     (flatModel, functions, flatString) :=
       NFInst.instClassInProgram(cls_name, scode_p, annotation_p, relaxedFrontend, dumpFlat);
   else
-    inst_failed := true;
     NFInst.clearCaches();
+    FlagsUtil.set(Flags.NF_API, nf_api);
+    fail();
   end try;
 
   FlagsUtil.set(Flags.NF_API, nf_api);
-
-  if inst_failed then
-    fail();
-  end if;
 end runFrontEndWorkNF;
 
 public function translateModel
@@ -4255,7 +4256,7 @@ protected function translateModelFMU
   input Boolean addDummy "if true, add a dummy state";
   input list<String> platforms = {"static"};
   input Option<SimCode.SimulationSettings> inSimSettings = NONE();
-  output Boolean success;
+  output Boolean success = false;
   output FCore.Cache cache;
   output Values.Value outValue;
 protected
@@ -4543,7 +4544,7 @@ protected function buildEncryptedPackage
   input Absyn.Path className "path for the model";
   input Boolean encrypt;
   input Absyn.Program inProgram;
-  output Boolean success;
+  output Boolean success = false;
 protected
   Absyn.Class cls;
   String fileName, logFile, omhome, pd, ext, packageTool, packageToolArgs, command;
@@ -4568,8 +4569,8 @@ algorithm
         command := stringAppendList({"\"",packageTool,"\""," ",packageToolArgs});
       else
         Error.addMessage(Error.ENCRYPTION_NOT_SUPPORTED, {packageTool});
-        success := false;
         runCommand := false;
+        command := "";
       end if;
     else
       molName := AbsynUtil.pathString(className) + ".mol";
@@ -4603,7 +4604,6 @@ algorithm
     end if;
   else
     Error.addMessage(Error.FILE_NOT_FOUND_ERROR, {fileName});
-    success := false;
   end if;
 end buildEncryptedPackage;
 
@@ -5181,7 +5181,7 @@ algorithm
   // Insert the class again if it was moved within this class part. Otherwise it needs
   // to be moved into another class part, which is handled by moveClassInClassParts.
   if outRemainingOffset == 0 then
-    elements := e :: elements;
+    elements := Util.getOption(outClass) :: elements;
   end if;
 
   outElements := List.append_reverse(acc, elements);
@@ -7747,7 +7747,7 @@ protected function getTotalModel
   input Boolean stripComments;
   input Boolean obfuscate;
   output String result;
-  output String obfuscate_map;
+  output String obfuscate_map = "";
 protected
   SCode.Program scodeP;
   String str,str1,str2,str3;
@@ -8330,7 +8330,7 @@ protected function addInitialStateWithAnnotation
   input Absyn.Annotation inAnnotation;
   input Absyn.Program inProgram;
   output Boolean b;
-  output Absyn.Program outProgram;
+  output Absyn.Program outProgram = inProgram;
 protected
   Absyn.Path package_;
   Absyn.Class cdef, newcdef;

--- a/OMCompiler/Compiler/Script/Conversion.mo
+++ b/OMCompiler/Compiler/Script/Conversion.mo
@@ -620,7 +620,7 @@ protected
     "Looks up a node in the conversion rules structure."
     input Absyn.Path path;
     input ConversionRules rules;
-    output Option<ConversionRules> outNode;
+    output Option<ConversionRules> outNode = NONE();
   protected
     ConversionRules node = rules;
   algorithm

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -3676,7 +3676,7 @@ public function getModificationValue
    expression, or fails if no modifier is found."
   input list<Absyn.ElementArg> args;
   input Absyn.Path path;
-  output Absyn.Exp value;
+  output Absyn.Exp value = Absyn.INTEGER(0);
 protected
   String name;
   list<Absyn.ElementArg> rest_args = args;
@@ -5317,6 +5317,7 @@ algorithm
                   res := Absyn.ELEMENTITEM(elt)::xs;
                   successResult := true;
                 else
+                  eltold := elt;
                   /* We need to split the old component into two parts: one with the renamed typename */
                   spec.components := list(c for c
                     guard match c
@@ -6157,7 +6158,7 @@ protected
   Access access;
   Absyn.Class cls;
   Interactive.GraphicEnvCache env;
-  Boolean silent;
+  Boolean silent = false;
   list<Values.Value> infos = {};
   list<Absyn.Element> elems;
 algorithm
@@ -6213,7 +6214,7 @@ protected
     output Values.Value result;
   protected
     Absyn.Class cdef;
-    list<Absyn.Element> comps;
+    list<Absyn.Element> comps = {};
 
   algorithm
     cdef := ProgramUtil.getPathedClassInProgram(classPath, program);
@@ -6245,7 +6246,7 @@ protected
     output Values.Value result;
   protected
     Absyn.Class cdef;
-    list<Absyn.Element> elts;
+    list<Absyn.Element> elts = {};
   algorithm
     cdef := ProgramUtil.getPathedClassInProgram(classPath, program);
 

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -1748,8 +1748,8 @@ protected function buildEnvForGraphicProgramFull
    instantiating the currently used class."
   input Absyn.Program inProgram;
   input Absyn.Path inModelPath;
-  output FCore.Cache outCache;
-  output FCore.Graph outEnv;
+  output FCore.Cache outCache = FCore.emptyCache();
+  output FCore.Graph outEnv = FGraph.empty();
   output Absyn.Program outProgram;
 protected
   Boolean check_model, eval_param, failed = false, graphics_mode;
@@ -3532,7 +3532,7 @@ protected function transformPathedElementInClassDef
   input Absyn.Path path;
   input Func func;
   input output Absyn.ClassDef def;
-        output Option<Absyn.Element> element;
+        output Option<Absyn.Element> element = NONE();
         output Boolean success;
 
   partial function Func
@@ -3572,7 +3572,7 @@ protected function transformPathedElementInClassPart
   input Absyn.Path path;
   input Func func;
   input output Absyn.ClassPart part;
-        output Option<Absyn.Element> element;
+        output Option<Absyn.Element> element = NONE();
         output Boolean success;
 
   partial function Func
@@ -3612,7 +3612,7 @@ protected function transformPathedElementInElementItem
   input Absyn.Path path;
   input Func func;
   input output Absyn.ElementItem item;
-        output Option<Absyn.Element> outElement;
+        output Option<Absyn.Element> outElement = NONE();
         output Boolean success;
 
   partial function Func
@@ -3647,7 +3647,7 @@ protected function transformPathedElementInElement
   input Absyn.Path path;
   input Func func;
   input output Absyn.Element element;
-        output Option<Absyn.Element> outElement;
+        output Option<Absyn.Element> outElement = NONE();
         output Boolean success;
 
   partial function Func
@@ -3675,7 +3675,7 @@ protected function transformPathedElementInElementSpec
   input Absyn.Path path;
   input Func func;
   input output Absyn.ElementSpec spec;
-        output Option<Absyn.Element> element;
+        output Option<Absyn.Element> element = NONE();
         output Boolean success;
 
   partial function Func
@@ -4878,7 +4878,7 @@ public function accessClass
   end Fn;
 protected
   Access access;
-  Boolean silent, eval_params, graphics_exp_mode;
+  Boolean silent = false, eval_params, graphics_exp_mode;
 algorithm
   eval_params := Config.getEvaluateParametersInAnnotations();
   graphics_exp_mode := Config.getGraphicsExpMode();

--- a/OMCompiler/Compiler/Script/MMToJuliaUtil.mo
+++ b/OMCompiler/Compiler/Script/MMToJuliaUtil.mo
@@ -302,7 +302,7 @@ function explicitReturnInClassPart
   "@author:johti17
    Only works for Algorithms!"
   input list<Absyn.ClassPart> classParts;
-  output Boolean existsImplicitReturn;
+  output Boolean existsImplicitReturn = false;
 algorithm
   for cp in classParts loop
     existsImplicitReturn := match cp
@@ -316,7 +316,7 @@ end explicitReturnInClassPart;
 function algorithmItemsContainsReturn
   "@author: johti17"
   input list<Absyn.AlgorithmItem> contents;
-  output Boolean existsReturn;
+  output Boolean existsReturn = false;
 algorithm
   for item in contents loop
     existsReturn := match item

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -508,23 +508,18 @@ protected
   SCode.Program scode_builtin, graphicProgramSCode;
   Absyn.Program placementProgram;
   list<tuple<Absyn.Program, tuple<SCode.Program, InstNode>>> cache;
-  Boolean update = true;
+  Boolean reuse;
 algorithm
   cache := getGlobalRoot(Global.instNFNodeCacheIndex);
-  if not listEmpty(cache) then
-    // if absyn is the same, all fine, reuse
-    if referenceEq(absynProgram, Util.tuple21(listHead(cache))) then
-      (program, top) := Util.tuple22(listHead(cache));
-      InstNode.clearGeneratedInners(top);
-      update := false;
-    else
-      update := true;
-      cache := {};
-      setGlobalRoot(Global.instNFNodeCacheIndex, cache);
+  // if absyn is the same, all fine, reuse
+  reuse := if listEmpty(cache) then false else referenceEq(absynProgram, Util.tuple21(listHead(cache)));
+  if reuse then
+    (program, top) := Util.tuple22(listHead(cache));
+    InstNode.clearGeneratedInners(top);
+  else
+    if not listEmpty(cache) then
+      setGlobalRoot(Global.instNFNodeCacheIndex, {});
     end if;
-  end if;
-
-  if update then
     (_, scode_builtin) := FBuiltin.getInitialFunctions();
     program := AbsynToSCode.translateAbsyn2SCode(absynProgram);
     program := listAppend(scode_builtin, program);
@@ -540,8 +535,7 @@ algorithm
       execStat("NFApi.mkTop("+ name +")");
     end if;
 
-    cache := {(absynProgram, (program, top))};
-    setGlobalRoot(Global.instNFNodeCacheIndex, cache);
+    setGlobalRoot(Global.instNFNodeCacheIndex, {(absynProgram, (program, top))});
   end if;
 end mkTop;
 

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -631,7 +631,7 @@ protected
   SemanticVersion.Version semverToInstall, semver;
   JSON index, versionObj, versionsObj, usesObj;
   Boolean indexHasPkg;
-  PackageInstallInfo packageToInstall;
+  Option<PackageInstallInfo> packageToInstall = NONE();
 algorithm
   candidates := versionsThatProvideTheWanted(pkg, version, printError=true);
   candidatesSemver := list(SemanticVersion.parse(candidate) for candidate in candidates);
@@ -683,7 +683,7 @@ algorithm
       else
         zip := "";
       end if;
-      packageToInstall := PKG_INSTALL_INFO(false, pkg, semverToInstall, zip, path, sha, false, JSON.emptyObject());
+      packageToInstall := SOME(PKG_INSTALL_INFO(false, pkg, semverToInstall, zip, path, sha, false, JSON.emptyObject()));
       indexHasPkg := JSON.hasKey(JSON.get(index, "libs"), pkg);
     end if;
   end if;
@@ -704,25 +704,25 @@ algorithm
   end if;
 
   if not indexHasPkg then
-    packagesToInstall := packageToInstall :: packagesToInstall;
+    packagesToInstall := Util.getOption(packageToInstall) :: packagesToInstall;
     return;
   end if;
 
   versionsObj := JSON.get(JSON.get(JSON.get(index, "libs"), pkg), "versions");
   if success and not JSON.hasKey(versionsObj, versionToInstall) then
-    packagesToInstall := packageToInstall :: packagesToInstall;
+    packagesToInstall := Util.getOption(packageToInstall) :: packagesToInstall;
     return;
   end if;
   versionObj := JSON.get(versionsObj, versionToInstall);
 
   if (not success) or (sha <> "" and sha <> getShaOrZipfile(versionObj)) then
     success := true;
-    packageToInstall := PKG_INSTALL_INFO(true, pkg, semverToInstall, JSON.getString(JSON.get(versionObj, "zipfile")), JSON.getString(JSON.get(versionObj, "path")), getShaOrZipfile(versionObj), JSON.getBoolean(JSON.getOrDefault(versionObj, "singleFileStructureCopyAllFiles", JSON.FALSE())), versionObj);
+    packageToInstall := SOME(PKG_INSTALL_INFO(true, pkg, semverToInstall, JSON.getString(JSON.get(versionObj, "zipfile")), JSON.getString(JSON.get(versionObj, "path")), getShaOrZipfile(versionObj), JSON.getBoolean(JSON.getOrDefault(versionObj, "singleFileStructureCopyAllFiles", JSON.FALSE())), versionObj));
   end if;
 
   usesObj := JSON.getOrDefault(versionObj, "uses", JSON.emptyObject());
 
-  packagesToInstall := packageToInstall :: packagesToInstall;
+  packagesToInstall := Util.getOption(packageToInstall) :: packagesToInstall;
 
   for usesPackage in JSON.getKeys(usesObj) loop
     JSON.STRING(usedVersion) := JSON.get(usesObj, usesPackage);

--- a/OMCompiler/Compiler/SimCode/SerializeTaskSystemInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeTaskSystemInfo.mo
@@ -92,7 +92,8 @@ algorithm
     // file.close();
     success := true;
   else
-    Error.addInternalError("SerializeTaskSystemInfo.serializeParModWork failed", sourceInfo());
+    fileName := "SerializeTaskSystemInfo.serializeParModWork failed";
+    Error.addInternalError(fileName, sourceInfo());
     success := false;
   end try;
 end serializeParModWork;

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -658,8 +658,9 @@ algorithm
         b := stringEq(fname, name);
         if not b then
           (fn, includes, includeDirs, libs,libPaths) := elaborateFunction(program, fel, includes, includeDirs, libs,libPaths, recDeclsMap);
+          accfns := fn :: accfns;
         end if;
-        (fns, includes, includeDirs, libs,libPaths) := elaborateFunctions2(program, rest, List.consOnTrue(not b, fn, accfns), includes, includeDirs, libs,libPaths, recDeclsMap);
+        (fns, includes, includeDirs, libs,libPaths) := elaborateFunctions2(program, rest, accfns, includes, includeDirs, libs,libPaths, recDeclsMap);
       then
         (fns, includes, includeDirs, libs,libPaths);
 
@@ -670,8 +671,9 @@ algorithm
         b := listMember(name, SCodeUtil.knownExternalCFunctions) and stringEq(fname, name);
         if not b then
           (fn, includes, includeDirs, libs,libPaths) := elaborateFunction(program, fel, includes, includeDirs, libs,libPaths, recDeclsMap);
+          accfns := fn :: accfns;
         end if;
-        (fns, includes, includeDirs, libs,libPaths) := elaborateFunctions2(program, rest, List.consOnTrue(not b, fn, accfns), includes, includeDirs, libs,libPaths, recDeclsMap);
+        (fns, includes, includeDirs, libs,libPaths) := elaborateFunctions2(program, rest, accfns, includes, includeDirs, libs,libPaths, recDeclsMap);
       then
         (fns, includes, includeDirs, libs,libPaths);
 

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1412,9 +1412,9 @@ algorithm
         ExecStat.execStat("Serialize dlow");
       end if;
 
-      isFMI2 := match kind
-        case TranslateModelKind.FMU(fmuType) then FMI.isFMIVersion20();
-        else false;
+      (isFMI2,fmuType) := match kind
+        case TranslateModelKind.FMU(fmuType) then (FMI.isFMIVersion20(),fmuType);
+        else (false,"");
       end match;
       // FMI 2.0: enable postOptModule to create alias variables for output states
       strPreOptModules := if (isFMI2) then SOME("introduceOutputAliases"::BackendDAEUtil.getPreOptModulesString()) else NONE();

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -312,7 +312,7 @@ protected
   Integer numRelatedBoundaryConditions;
   String fullPathPrefix, fileNamePrefixHash, iterationVarsStr;
 
-  SimCode.OMSIFunction omsiInitEquations, omsiSimEquations;
+  SimCode.OMSIFunction omsiInitEquations = SimCode.emptyOMSIFunction, omsiSimEquations;
   Option<SimCode.OMSIData> omsiOptData;
   SimCode.SimulationSettings theSettings;
 
@@ -683,7 +683,8 @@ algorithm
     // Generates c code for setC-results which calculates c(x,y) for dataReconciliation
     if isSome(shared.dataReconciliationData) then
         tmpSimVars := modelInfo.vars;
-        //BackendDAE.DATA_RECON(dataReconJac,setcVars) := Util.getOption(shared.dataReconciliationData);
+        BackendDAE.DATA_RECON(setcVars=setcVars, datareconinputs=datareconinputvars, setBVars=setBVars, relatedBoundaryConditions=numRelatedBoundaryConditions) := Util.getOption(shared.dataReconciliationData);
+        emptyVars := BackendVariable.emptyVars();
        (tmpsetcVars, _) :=  BackendVariable.traverseBackendDAEVars(setcVars, traversingdlowvarToSimvar, ({}, emptyVars));
         tmpsetcVars := rewriteIndex(tmpsetcVars, 0);
         tmpSimVars.dataReconSetcVars := tmpsetcVars;
@@ -2397,13 +2398,8 @@ algorithm
         varexp := Expression.crefExp(cr);
         varexp := if BackendVariable.isStateVar(v) then Expression.expDer(varexp) else varexp;
         BackendDAE.SHARED(functionTree = funcs) := shared;
-        b := true;
         try
           (exp_, asserts, solveEqns, solveCr) := ExpressionSolve.solve2(e1, e2, varexp, SOME(funcs), SOME(iuniqueEqIndex), true, BackendDAEUtil.isSimulationDAE(shared));
-        else
-          b := false;
-        end try;
-        if b then
           solveEqns := listReverse(solveEqns);
           solveCr := listReverse(solveCr);
           cr := if BackendVariable.isStateVar(v) then ComponentReference.crefPrefixDer(cr) else cr;
@@ -2424,7 +2420,7 @@ algorithm
           (_, homotopySupport) := BackendEquation.traverseExpsOfEquation(eqn, BackendDAEUtil.containsHomotopyCall, false);
           eqSystlst := {SimCode.SES_NONLINEAR(SimCode.NONLINEARSYSTEM(uniqueEqIndex, resEqs, {cr}, 0, 1, NONE(), homotopySupport, false, false, partitionKindToClockIndex(partitionKind)), NONE(), eqAttr)};
           uniqueEqIndex := uniqueEqIndex+1;
-        end if;
+        end try;
       then (eqSystlst, uniqueEqIndex,tempvars);
 
     // Algorithm for single variable.
@@ -9400,7 +9396,7 @@ end subPartitionString;
 
 public function dumpSimCodeDAEmodeDataString
   input Option<SimCode.DaeModeData> inDaeModedata;
-  output String str;
+  output String str = "";
 algorithm
   () := match inDaeModedata
   local
@@ -9826,6 +9822,7 @@ algorithm
     outHT := List.fold(vars.realOptimizeFinalConstraintsVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
   else
     Error.addInternalError("function createCrefToSimVarHT failed", sourceInfo());
+    fail();
   end try;
 end createCrefToSimVarHT;
 
@@ -12145,14 +12142,14 @@ protected function getVarIndexInfosByMapping "author: marcusw
   input Boolean iColumnMajor; //true if the subscripts should be evaluated in column major
   input String iIndexForUndefinedReferences;
   output list<String> oVarIndexList; //if the variable is part of an array, all array indices are returned in this list (the list contains one element if the variable is a scalar)
-  output String oConcreteVarIndex; //the scalar index of the variable (this value is always part of oVarIndexList)
+  output String oConcreteVarIndex = ""; //the scalar index of the variable (this value is always part of oVarIndexList)
 protected
   DAE.ComponentRef varName = iVarName;
   Integer arrayIdx, idx, arraySize, concreteVarIndex;
   array<Integer> varIndices;
   list<String> tmpVarIndexListNew = {};
   list<DAE.Subscript> arraySubscripts;
-  list<Integer> arrayDimensions, arrayDimensionsReverse;
+  list<Integer> arrayDimensions, arrayDimensionsReverse = {};
   Boolean toColumnMajor;
   Boolean isContiguous;
 algorithm

--- a/OMCompiler/Compiler/Util/UnorderedSet.mo
+++ b/OMCompiler/Compiler/Util/UnorderedSet.mo
@@ -221,10 +221,10 @@ public
     output T val;
   algorithm
     for b in Mutable.access(set.buckets) loop
-      for k in b loop
-        val := k;
+      if not listEmpty(b) then
+        val := listHead(b);
         return;
-      end for;
+      end if;
     end for;
 
     fail();


### PR DESCRIPTION
Restructure the compiler sources so they pass -d=checkDefUse with no findings. Variables that were only assigned on some control-flow paths are given a definite value before use: default-initialized, restructured so every branch of the match/if assigns them, or guarded with fail()/Error.terminate on the paths that cannot occur; outputs are likewise assigned on every path. Covers the frontend, backend, new backend (NB*), scripting and SimCode modules.