### PR TITLE
[3rdParty] Update SuiteSparse to v7.12.2

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -346,7 +346,7 @@ if(RUST_OMC_ENABLE_SUNDIALS)
       -DSUITESPARSE_USE_STRICT=OFF
       -DKLU_USE_CHOLMOD=OFF
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_suitesparse_ep_build} --parallel
-      --target klu amd colamd btf suitesparseconfig
+      --target KLU_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
     EXCLUDE_FROM_ALL ON)
@@ -368,11 +368,14 @@ if(RUST_OMC_ENABLE_SUNDIALS)
       -DSUNDIALS_KLU_ENABLE=ON
       -DSUNDIALS_INDEX_SIZE=32
       -DKLU_INCLUDE_DIR=${_suitesparse_sources}/KLU/Include
-      -DKLU_LIBRARY=${_suitesparse_ep_build}/libklu.a
-      -DAMD_LIBRARY=${_suitesparse_ep_build}/libamd.a
-      -DCOLAMD_LIBRARY=${_suitesparse_ep_build}/libcolamd.a
-      -DBTF_LIBRARY=${_suitesparse_ep_build}/libbtf.a
-      -DSUITESPARSECONFIG_LIBRARY=${_suitesparse_ep_build}/libsuitesparseconfig.a
+      # v7 builds each project in its own subdirectory of the build tree, so the
+      # archives are not at the top of ${_suitesparse_ep_build} the way the
+      # 5.8.1 wrapper left them.
+      -DKLU_LIBRARY=${_suitesparse_ep_build}/KLU/libklu.a
+      -DAMD_LIBRARY=${_suitesparse_ep_build}/AMD/libamd.a
+      -DCOLAMD_LIBRARY=${_suitesparse_ep_build}/COLAMD/libcolamd.a
+      -DBTF_LIBRARY=${_suitesparse_ep_build}/BTF/libbtf.a
+      -DSUITESPARSECONFIG_LIBRARY=${_suitesparse_ep_build}/SuiteSparse_config/libsuitesparseconfig.a
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_sundials_ep_build} --parallel
       --target
       sundials_kinsol_static sundials_ida_static sundials_cvode_static
@@ -388,11 +391,11 @@ if(RUST_OMC_ENABLE_SUNDIALS)
   add_custom_target(rust_sundials_collect
     COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_WASM_DIR}/lib
     COMMAND ${CMAKE_COMMAND} -E copy
-      ${_suitesparse_ep_build}/libklu.a
-      ${_suitesparse_ep_build}/libamd.a
-      ${_suitesparse_ep_build}/libcolamd.a
-      ${_suitesparse_ep_build}/libbtf.a
-      ${_suitesparse_ep_build}/libsuitesparseconfig.a
+      ${_suitesparse_ep_build}/KLU/libklu.a
+      ${_suitesparse_ep_build}/AMD/libamd.a
+      ${_suitesparse_ep_build}/COLAMD/libcolamd.a
+      ${_suitesparse_ep_build}/BTF/libbtf.a
+      ${_suitesparse_ep_build}/SuiteSparse_config/libsuitesparseconfig.a
       ${_sundials_ep_build}/src/kinsol/libsundials_kinsol.a
       ${_sundials_ep_build}/src/ida/libsundials_ida.a
       ${_sundials_ep_build}/src/cvode/libsundials_cvode.a

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -368,9 +368,6 @@ if(RUST_OMC_ENABLE_SUNDIALS)
       -DSUNDIALS_KLU_ENABLE=ON
       -DSUNDIALS_INDEX_SIZE=32
       -DKLU_INCLUDE_DIR=${_suitesparse_sources}/KLU/Include
-      # v7 builds each project in its own subdirectory of the build tree, so the
-      # archives are not at the top of ${_suitesparse_ep_build} the way the
-      # 5.8.1 wrapper left them.
       -DKLU_LIBRARY=${_suitesparse_ep_build}/KLU/libklu.a
       -DAMD_LIBRARY=${_suitesparse_ep_build}/AMD/libamd.a
       -DCOLAMD_LIBRARY=${_suitesparse_ep_build}/COLAMD/libcolamd.a

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -311,7 +311,7 @@ option(RUST_OMC_ENABLE_SUNDIALS "Build SUNDIALS/KLU for wasm32-wasip1 (sparse so
 
 if(RUST_OMC_ENABLE_SUNDIALS)
   set(_sundials_sources ${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0)
-  set(_suitesparse_sources ${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1)
+  set(_suitesparse_sources ${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse)
 
   # SuiteSparse toolchain: base wasi toolchain + include dirs for KLU headers.
   # CMAKE_C_FLAGS_INIT is a STRING (not list) so no semicolon issues.
@@ -470,7 +470,7 @@ endif()
 if(RUST_OMC_ENABLE_SUNDIALS)
   list(APPEND CARGO_ENV
        "OMC_SUNDIALS_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0"
-       "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1")
+       "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse")
 endif()
 
 # Always via ${CARGO_BUILD} so target/ is never the in-source default.

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -334,9 +334,17 @@ if(RUST_OMC_ENABLE_SUNDIALS)
   ExternalProject_Add(rust_suitesparse_wasm
     SOURCE_DIR ${_suitesparse_sources}
     BINARY_DIR ${_suitesparse_ep_build}
+    LIST_SEPARATOR |
     CMAKE_ARGS
       -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
       -DBUILD_SHARED_LIBS=OFF
+      -DSUITESPARSE_ENABLE_PROJECTS=suitesparse_config|amd|colamd|btf|klu
+      -DSUITESPARSE_USE_FORTRAN=OFF
+      -DSUITESPARSE_USE_OPENMP=OFF
+      -DSUITESPARSE_USE_CUDA=OFF
+      -DSUITESPARSE_DEMOS=OFF
+      -DSUITESPARSE_USE_STRICT=OFF
+      -DKLU_USE_CHOLMOD=OFF
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_suitesparse_ep_build} --parallel
       --target klu amd colamd btf suitesparseconfig
     INSTALL_COMMAND ""

--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -228,6 +228,10 @@ colpack-clean:
 	if test -f $(OMC_COLPACK_ROOT)/build/Makefile; then $(MAKE) -C $(OMC_COLPACK_ROOT)/build/ clean; fi
 	rm -rf $(OMC_COLPACK_ROOT)/build
 
+# Build only the SuiteSparse projects the OMC runtime needs. Building "all"
+# pulls in SPEX (needs GMP/MPFR), SPQR, GraphBLAS, ... which we do not use.
+# Keep these options in sync with 3rdParty/CMakeLists.txt, which applies the
+# same settings when SuiteSparse is built through the CMake build system.
 suitesparse:
 	mkdir -p 3rdParty/SuiteSparse/build
 	cd 3rdParty/SuiteSparse/build && $(CMAKE_NO_CHECK_UNDEFINED) .. -G $(CMAKE_TARGET) \
@@ -235,6 +239,14 @@ suitesparse:
 		-DCMAKE_INSTALL_PREFIX:PATH="$(OMBUILDDIR)" \
 		-DCMAKE_INSTALL_LIBDIR="$(LIB_OMC)" \
 		-DCMAKE_INSTALL_INCLUDEDIR="$(OMBUILDDIR)/include/omc/c/" \
+		-DSUITESPARSE_ENABLE_PROJECTS="suitesparse_config;amd;colamd;btf;klu;umfpack" \
+		-DSUITESPARSE_USE_OPENMP:Bool=OFF \
+		-DSUITESPARSE_USE_CUDA:Bool=OFF \
+		-DSUITESPARSE_USE_FORTRAN:Bool=OFF \
+		-DSUITESPARSE_DEMOS:Bool=OFF \
+		-DSUITESPARSE_USE_STRICT:Bool=OFF \
+		-DKLU_USE_CHOLMOD:Bool=OFF \
+		-DUMFPACK_USE_CHOLMOD:Bool=OFF \
 		-DBUILD_SHARED_LIBS:Bool=$(SUITESPARSE_SHARED)
 	$(MAKE) -C 3rdParty/SuiteSparse/build install
 	test ! `uname` = Darwin || install_name_tool -id @rpath/libamd.dylib               "$(builddir_lib_omc)/libamd.dylib"

--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -229,14 +229,14 @@ colpack-clean:
 	rm -rf $(OMC_COLPACK_ROOT)/build
 
 suitesparse:
-	mkdir -p 3rdParty/SuiteSparse-5.8.1/build
-	cd 3rdParty/SuiteSparse-5.8.1/build && $(CMAKE_NO_CHECK_UNDEFINED) .. -G $(CMAKE_TARGET) \
+	mkdir -p 3rdParty/SuiteSparse/build
+	cd 3rdParty/SuiteSparse/build && $(CMAKE_NO_CHECK_UNDEFINED) .. -G $(CMAKE_TARGET) \
 		-DCMAKE_VERBOSE_MAKEFILE:Bool=ON \
 		-DCMAKE_INSTALL_PREFIX:PATH="$(OMBUILDDIR)" \
 		-DCMAKE_INSTALL_LIBDIR="$(LIB_OMC)" \
 		-DCMAKE_INSTALL_INCLUDEDIR="$(OMBUILDDIR)/include/omc/c/" \
 		-DBUILD_SHARED_LIBS:Bool=$(SUITESPARSE_SHARED)
-	$(MAKE) -C 3rdParty/SuiteSparse-5.8.1/build install
+	$(MAKE) -C 3rdParty/SuiteSparse/build install
 	test ! `uname` = Darwin || install_name_tool -id @rpath/libamd.dylib               "$(builddir_lib_omc)/libamd.dylib"
 	test ! `uname` = Darwin || install_name_tool -id @rpath/libbtf.dylib               "$(builddir_lib_omc)/libbtf.dylib"
 	test ! `uname` = Darwin || install_name_tool -id @rpath/libcolamd.dylib            "$(builddir_lib_omc)/libcolamd.dylib"
@@ -251,8 +251,8 @@ suitesparse:
 
 
 suitesparse-clean:
-	$(MAKE) -C 3rdParty/SuiteSparse-5.8.1 distclean
-	rm -rf 3rdParty/SuiteSparse-5.8.1/build 3rdParty/SuiteSparse-5.8.1/build_msvc
+	$(MAKE) -C 3rdParty/SuiteSparse distclean
+	rm -rf 3rdParty/SuiteSparse/build 3rdParty/SuiteSparse/build_msvc
 
 $(OMBUILDDIR)/$(LIB_OMC)/libopenblas_openmodelica.a:
 	$(MAKE) -C 3rdParty/OpenBLAS-0.2.8 CC="$(CC)" CXX="$(CXX)" FC="$(FC)" FCFLAGS="$(FCFLAGS)" USE_THREAD=0 NO_LAPACKE=1 LIBNAMESUFFIX=openmodelica $(OPENBLAS_EXTRA_ARGS)

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -417,6 +417,14 @@ $(OMBUILDDIR)/lib/omc/msvc/umfpack.lib: getMSVCversion 3rdParty/SuiteSparse/CMak
 	echo '%OMDEV%\\bin\\cmake\\bin\\cmake -DCMAKE_VERBOSE_MAKEFILE:Bool=ON ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
 	echo '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$(OMBUILDDIR_MSVC)" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
 	echo '-DCMAKE_INSTALL_LIBDIR="lib\\omc\\msvc" -DCMAKE_INSTALL_INCLUDEDIR="$(OMBUILDDIR_MSVC)\\include\\omc\\msvc" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	# Build only the projects the OMC runtime needs; "all" pulls in SPEX
+	# (needs GMP/MPFR), SPQR, GraphBLAS, ... Keep in sync with the suitesparse
+	# target in Makefile.common and with 3rdParty/CMakeLists.txt.
+	echo '-DSUITESPARSE_ENABLE_PROJECTS="suitesparse_config;amd;colamd;btf;klu;umfpack" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DSUITESPARSE_USE_OPENMP:Bool=OFF -DSUITESPARSE_USE_CUDA:Bool=OFF -DSUITESPARSE_USE_FORTRAN:Bool=OFF ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DSUITESPARSE_DEMOS:Bool=OFF -DSUITESPARSE_USE_STRICT:Bool=OFF ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DKLU_USE_CHOLMOD:Bool=OFF -DUMFPACK_USE_CHOLMOD:Bool=OFF ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DSUITESPARSE_C_TO_FORTRAN="(name,NAME) name##_" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
 	echo '../ -G  "NMake Makefiles JOM" -D"CMAKE_MAKE_PROGRAM:PATH=%OMDEV%\\tools\\jom\\jom.exe"' >> 3rdParty/SuiteSparse/build_msvc/build.bat
 	echo echo Building SuiteSparse >> 3rdParty/SuiteSparse/build_msvc/build.bat
 	echo @echo on >> 3rdParty/SuiteSparse/build_msvc/build.bat

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -398,34 +398,34 @@ $(OMBUILDDIR)/lib/omc/msvc/cminpack.lib: getMSVCversion
 	(cp -puf 3rdParty/CMinpack/install_msvc/lib/cminpack.lib $(OMBUILDDIR)/lib/omc/msvc/)
 
 suitesparse_msvc: $(OMBUILDDIR)/lib/omc/msvc/umfpack.lib
-$(OMBUILDDIR)/lib/omc/msvc/umfpack.lib: getMSVCversion 3rdParty/SuiteSparse-5.8.1/CMakeLists.txt
+$(OMBUILDDIR)/lib/omc/msvc/umfpack.lib: getMSVCversion 3rdParty/SuiteSparse/CMakeLists.txt
 	rm -f $(OMBUILDDIR)/lib/omc/msvc/amd.lib $(OMBUILDDIR)/lib/omc/msvc/klu.lib $(OMBUILDDIR)/lib/omc/msvc/btf.lib $(OMBUILDDIR)/lib/omc/msvc/colamd.lib $(OMBUILDDIR)/lib/omc/msvc/umfpack.lib $(OMBUILDDIR)/lib/omc/msvc/suitesparseconfig.lib
 	rm -rf $(OMBUILDDIR)/include/omc/msvc/suitesparse
-	rm -rf 3rdParty/SuiteSparse-5.8.1/build_msvc
-	rm -rf 3rdParty/SuiteSparse-5.8.1/install_msvc
+	rm -rf 3rdParty/SuiteSparse/build_msvc
+	rm -rf 3rdParty/SuiteSparse/install_msvc
 	mkdir -p $(OMBUILDDIR)/lib/omc/msvc/
 	# Goto build msvc directory
-	test -d 3rdParty/SuiteSparse-5.8.1
-	mkdir -p 3rdParty/SuiteSparse-5.8.1/build_msvc
+	test -d 3rdParty/SuiteSparse
+	mkdir -p 3rdParty/SuiteSparse/build_msvc
 
 	# Create batch file, that builds with CMake and Visual Studio
 	test -f """${VSCOMNTOOLS}/../../VC/vcvarsall.bat"""
 	echo 'Building SuiteSparse with MSVC'
-	echo @echo on > 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo call '"${VSCOMNTOOLS}\\..\\..\\VC\\vcvarsall.bat" ${VCVARS_PARAMS}' >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo echo Calling CMake >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo '%OMDEV%\\bin\\cmake\\bin\\cmake -DCMAKE_VERBOSE_MAKEFILE:Bool=ON ^' >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$(OMBUILDDIR_MSVC)" ^' >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo '-DCMAKE_INSTALL_LIBDIR="lib\\omc\\msvc" -DCMAKE_INSTALL_INCLUDEDIR="$(OMBUILDDIR_MSVC)\\include\\omc\\msvc" ^' >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo '../ -G  "NMake Makefiles JOM" -D"CMAKE_MAKE_PROGRAM:PATH=%OMDEV%\\tools\\jom\\jom.exe"' >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo echo Building SuiteSparse >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo @echo on >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo set MAKE= >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo set MAKEFLAGS= >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
-	echo %OMDEV%\\tools\\jom\\jom.exe /f Makefile install >> 3rdParty/SuiteSparse-5.8.1/build_msvc/build.bat
+	echo @echo on > 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo call '"${VSCOMNTOOLS}\\..\\..\\VC\\vcvarsall.bat" ${VCVARS_PARAMS}' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo echo Calling CMake >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '%OMDEV%\\bin\\cmake\\bin\\cmake -DCMAKE_VERBOSE_MAKEFILE:Bool=ON ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$(OMBUILDDIR_MSVC)" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '-DCMAKE_INSTALL_LIBDIR="lib\\omc\\msvc" -DCMAKE_INSTALL_INCLUDEDIR="$(OMBUILDDIR_MSVC)\\include\\omc\\msvc" ^' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo '../ -G  "NMake Makefiles JOM" -D"CMAKE_MAKE_PROGRAM:PATH=%OMDEV%\\tools\\jom\\jom.exe"' >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo echo Building SuiteSparse >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo @echo on >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo set MAKE= >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo set MAKEFLAGS= >> 3rdParty/SuiteSparse/build_msvc/build.bat
+	echo %OMDEV%\\tools\\jom\\jom.exe /f Makefile install >> 3rdParty/SuiteSparse/build_msvc/build.bat
 
 	# Change into directory and run batch file
-	cd ./3rdParty/SuiteSparse-5.8.1/build_msvc; echo "change to 3rdParty/SuiteSparse-5.8.1/build_msvc";\
+	cd ./3rdParty/SuiteSparse/build_msvc; echo "change to 3rdParty/SuiteSparse/build_msvc";\
 	cmd "/c build.bat"
 
 # build sundials

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.h
@@ -37,7 +37,6 @@
 #include "simulation_data.h"
 
 #include "umfpack.h"
-#include "umfpack_get_numeric.h"
 
 typedef struct DATA_UMFPACK
 {


### PR DESCRIPTION
## Summary
Bump `OMCompiler/3rdParty` submodule to pull in SuiteSparse v7.12.2 (replacing the in-tree 5.8.1 copy) and adjust the OMC C runtime for the v7 header layout.

Depends on OpenModelica/OMCompiler-3rdParty#218. CI on this PR will fail submodule init until the 3rdParty PR is merged (or its branch pulled into a CI-visible location), since the submodule SHA only exists on the fork right now.

## Root cause / motivation
Fixes #15595. Per AnHeuermann's direction on the issue, scope is: replace the vendored copy with a submodule pointing at upstream, do all special handling in `OMCompiler/3rdParty/CMakeLists.txt`, target Linux CI green; Windows is a follow-up that can come after the SUNDIALS bump.

## Change details
- `OMCompiler/3rdParty` submodule SHA bumped to the companion 3rdParty PR head.
- `OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.h`: drop obsolete `#include "umfpack_get_numeric.h"`. SuiteSparse 7 collapsed the per-function UMFPACK headers into the unified `umfpack.h`; `umfpack_di_get_numeric` (the only symbol used here) is still declared there.

## Tested
- Full Debug build of `omc` on Linux passes.
- SimulationRuntime ctest unit tests: 13/13 green locally.
- Sundials 5.4 `sundials_sunlinsolklu_static` links cleanly against the new `KLU_static` target.

## Follow-ups not covered
- Windows build and possibly Sundials bump (per the plan agreed on the issue).
- Autoconf+Makefile build still works enough to compile; not extensively re-tested since it is on the way out.