### PR TITLE
Fix codegen for record fields with quoted identifier names

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2087,7 +2087,7 @@ case T_COMPLEX(complexClassType = RECORD(path = path), varLst = vars) then
     <<
     <%untagTmp%> = (MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(<%recordVar%>), <%offset%>)));
     <%unboxBuf%>
-    <%tmpVar%>._<%compname%> = <%unboxStr%>;
+    <%tmpVar%>._<%System.unquoteIdentifier(compname)%> = <%unboxStr%>;
     >>
     ;separator="\n")
   tmpVar
@@ -6338,7 +6338,7 @@ template daeExpRecord(Exp rec, Context context, Text &preExp, Text &varDecls, Te
   match rec
   case RECORD(__) then
   let name = tempDecl(underscorePath(path), &varDecls)
-  let ass = List.zip(exps,comp) |>  (exp,compn) => '<%name%>._<%compn%> = <%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>;<%\n%>'
+  let ass = List.zip(exps,comp) |>  (exp,compn) => '<%name%>._<%System.unquoteIdentifier(compn)%> = <%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>;<%\n%>'
   let &preExp += ass
   name
 end daeExpRecord;

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -11,6 +11,7 @@ RecordConstructor1.mos \
 TestComplexSum1.mos \
 TestComplexSum2.mos \
 Ticket5134.mos \
+Ticket12135.mos \
 Ticket13009.mos \
 Ticket14485.mos \
 

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -12,6 +12,7 @@ TestComplexSum1.mos \
 TestComplexSum2.mos \
 Ticket5134.mos \
 Ticket12135.mos \
+Ticket12135_inline.mos \
 Ticket13009.mos \
 Ticket14485.mos \
 

--- a/testsuite/simulation/modelica/records/Ticket12135.mos
+++ b/testsuite/simulation/modelica/records/Ticket12135.mos
@@ -1,0 +1,40 @@
+// name:     Ticket12135.mos
+// keywords: record quoted identifier field codegen
+// status:   correct
+// teardown_command: rm -rf _omcQ_27P_27.* output.log
+
+// Quoted record field names must be unquoted when emitted as C struct
+// member access in record literal expansion and in record constructor
+// bodies. Previously CodegenCFunctions.tpl printed the field name
+// verbatim ('w'), producing tmp._'w' = ... which is invalid C. See
+// issue #12135.
+
+loadString("
+package 'P'
+  record R
+    Real 'w';
+    Real 'T';
+  end R;
+
+  model 'M'
+    R r;
+  equation
+    r = R('w' = time, 'T' = 2*time);
+  end 'M';
+end 'P';
+"); getErrorString();
+
+simulate('P'.'M', stopTime=0.1); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "_omcQ_27P_27._omcQ_27M_27_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = '_omcQ_27P_27._omcQ_27M_27', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/records/Ticket12135_inline.mos
+++ b/testsuite/simulation/modelica/records/Ticket12135_inline.mos
@@ -1,0 +1,49 @@
+// name:     Ticket12135_inline.mos
+// keywords: record quoted identifier field codegen
+// status:   correct
+// teardown_command: rm -rf _omcQ_27P_27.* output.log
+
+// Companion regression test for #12135 that specifically exercises
+// CodegenCFunctions.tpl's daeExpRecord: a record literal with quoted
+// field names is inlined as a sub-expression (here, the argument to a
+// function call) rather than appearing on the right-hand side of an
+// equation. The inline path emits the struct member assignments
+// directly instead of going through the record constructor function.
+// Without the fix this produced tmp0._'w' = ... which is invalid C.
+
+loadString("
+package 'P'
+  record R
+    Real 'w';
+    Real 'T';
+  end R;
+
+  function f
+    input R rr;
+    output Real y;
+  algorithm
+    y := rr.'w' + rr.'T';
+  end f;
+
+  model 'M'
+    Real y;
+  equation
+    y = f(R('w' = time, 'T' = 2*time));
+  end 'M';
+end 'P';
+"); getErrorString();
+
+simulate('P'.'M', stopTime=0.1); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "_omcQ_27P_27._omcQ_27M_27_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = '_omcQ_27P_27._omcQ_27M_27', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
## Summary
Apply `System.unquoteIdentifier` to record field names in the two `CodegenCFunctions.tpl` templates that emit struct-field assignments (`daeExpRecord` and `unboxRecord`). Without this, a record field named `'w'` was rendered verbatim into C as `tmp._'w' = ...`, while the matching struct typedef declared the field as `__omcQ_27w_27`. The mismatch produced "no member named '_'" / "expected ';' before 'w'" compiler errors.

## Root cause
`daeExpRecord` (line 6327) and `unboxRecord` (line 2090) printed `_<%compn%>` / `_<%compname%>` raw. Other call sites already feed the field name through `crefStrNoUnderscore` or `System.unquoteIdentifier` before emitting; these two were the gap.

## Reproducer
The DoublePendulumTest model attached to #12135 (Pendulums.zip, `doublePendulumScalarQuoted.mo`) requires `--std=experimental` and triggers the bad codegen at multiple call sites in the initial-bindings file and again in the record constructor body. Both files compiled before and after the change.

Before:
```
_omcQ_27...Orientation_27' has no member named '_'
  217 |   tmp18._'w' = _OMC_LIT1;
```

After:
```
LOG_SUCCESS       | info    | The simulation finished successfully.
```

The companion `doublePendulumScalarNoQuotes.mo` still simulates successfully (regression check).

## Test
`testsuite/simulation/modelica/records/Ticket12135.mos` exercises a minimal package with a record whose fields are quoted (`'w'`, `'T'`) and constructs it via a record literal in an equation. Verified locally via `rtest`.

Fixes #12135