### PR TITLE
Reset ExecStat at the start of checkModel

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -6160,6 +6160,7 @@ algorithm
     // handle normal models
     case ()
       algorithm
+        ExecStat.execStatReset();
         flags := loadCommandLineOptionsFromModel(className);
 
         try


### PR DESCRIPTION
## Summary
Reset the `ExecStat` profiling counter at the start of `checkModel`, mirroring the existing unconditional reset in `instantiateModel`.

## Background
This is the rebased successor to @JKRT's #13773 (April 2025). That PR sat for 14 months on a maintainer question raised by @adrpo: should the reset be guarded behind a `checkModel` option? @sjoelund's reply pointed out that no such option exists for `simulate`, `buildModel`, or `instantiateModel`. I think Sjölund's count argument is the right read: there is no precedent for an opt-out, and `instantiateModel` (line 8715) already does the same reset unconditionally. Matching that convention for `checkModel` is the simplest and most consistent fix.

The original #13773 conflicts with master because `checkModel`'s body was refactored from the `case (env,_,_) equation` form into a `case () algorithm` form. This PR places the call at the equivalent post-refactor location.

## Root cause
`ExecStat` keeps a running counter across the session. Without a reset, `checkModel`'s profiling output accumulates timings from earlier calls in the same omc session and reports inflated values.

## Fix
One-line addition: `ExecStat.execStatReset();` at the very top of the `checkModel` main case, right before `loadCommandLineOptionsFromModel`. Matches the pattern in `instantiateModel`.

## Tested
Full Debug build green. Two back-to-back `checkModel` calls on a small model behave correctly.

Refs #13773