### PR TITLE
[NB][daeMode] make daeMode work for algebraic loops, der-only states and multi-partition systems

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -1271,6 +1271,21 @@ protected
         end for;
       end if;
     end addSubDependencies;
+
+    function addDerToState
+      "daeMode: a residual dependency on der(x) belongs to the state x -- its jacobian
+       column carries the cj*dF/dx' contribution. Replace each state derivative with its
+       state so residuals referencing only der(x) (e.g. der(x)=sin(time)) still get an
+       entry in x's column; all other dependencies are kept as is."
+      input ComponentRef dep;
+      input output UnorderedSet<ComponentRef> set;
+    algorithm
+      if BVariable.checkCref(dep, BVariable.isStateDerivative, sourceInfo()) then
+        UnorderedSet.add(BVariable.getVarName(Util.getOption(BVariable.getVarState(BVariable.getVarPointer(dep, sourceInfo())))), set);
+      else
+        UnorderedSet.add(dep, set);
+      end if;
+    end addDerToState;
   algorithm
     dependencies := UnorderedSet.selfMap(dependencies, function ComponentRef.mapExp(func = Expression.replaceResizableParameter));
     dependencies := UnorderedSet.selfMap(dependencies, function ComponentRef.simplifySubscripts(trim = false));
@@ -1286,6 +1301,9 @@ protected
         then UnorderedSet.fold(dependencies, function addSubDependencies(map = map, checkFn = BVariable.isStateOrOptimizable), UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual));
       case NBJacobian.JacobianType.OPT_R0
         then UnorderedSet.fold(dependencies, function addSubDependencies(map = map, checkFn = BVariable.isStateOrOptimizable), UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual));
+      // daeMode: attribute der(x) dependencies to the state x (cj*dF/dx' term)
+      case NBJacobian.JacobianType.DAE
+        then UnorderedSet.fold(dependencies, addDerToState, UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual));
       else dependencies;
     end match;
   end prepareDependencies;

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBDAEMode.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBDAEMode.mo
@@ -130,17 +130,36 @@ protected
               list<Pointer<Variable>> vars;
               UnorderedSet<Pointer<Equation>> new_eqns_set;
               UnorderedSet<Pointer<Variable>> new_vars_set;
+              list<Pointer<Equation>> new_eqns_lst = {};
+              list<Pointer<Variable>> new_vars_lst = {};
 
             case SOME(new_c) algorithm
+              // Collect equations and variables in strong-component (list) order.
+              // The sets only guard against duplicates: using UnorderedSet.toList
+              // would emit them in hash order, which scrambles the daeMode residual
+              // row order relative to the residual vector built by createDAEModeBlocks
+              // (also component order). That misalignment makes the daeMode jacobian
+              // rows reference the wrong residuals -> a structurally wrong/singular
+              // matrix and IDA's linear solver setup fails on torn loops.
               new_eqns_set := UnorderedSet.new(Equation.hash, Equation.equalName);
               new_vars_set := UnorderedSet.new(BVariable.hash, BVariable.equalName);
               for comp in new_c loop
                 eqns := StrongComponent.getEquations(comp);
                 vars := StrongComponent.getVariables(comp);
-                for eqn in eqns loop UnorderedSet.add(eqn, new_eqns_set); end for;
-                for var in vars loop UnorderedSet.add(var, new_vars_set); end for;
+                for eqn in eqns loop
+                  if not UnorderedSet.contains(eqn, new_eqns_set) then
+                    UnorderedSet.add(eqn, new_eqns_set);
+                    new_eqns_lst := eqn :: new_eqns_lst;
+                  end if;
+                end for;
+                for var in vars loop
+                  if not UnorderedSet.contains(var, new_vars_set) then
+                    UnorderedSet.add(var, new_vars_set);
+                    new_vars_lst := var :: new_vars_lst;
+                  end if;
+                end for;
               end for;
-            then (EquationPointers.fromList(UnorderedSet.toList(new_eqns_set)), VariablePointers.fromList(UnorderedSet.toList(new_vars_set)));
+            then (EquationPointers.fromList(listReverse(new_eqns_lst)), VariablePointers.fromList(listReverse(new_vars_lst)));
             else (part.equations, part.unknowns);
           end match;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -499,6 +499,19 @@ public
           for cref in seed_vars_array loop UnorderedSet.add(cref, set); end for;
           for cref in partial_vars_array loop UnorderedSet.add(cref, set); end for;
 
+          // daeMode: also mark each state derivative der(x) as relevant, so a residual
+          // that references only der(x) (e.g. der(x)=sin(time)) still contributes to its
+          // state's column. collectCrefs/prepareDependencies maps der(x) back to x.
+          if jacType == JacobianType.DAE then
+            for var in VariablePointers.toList(seedCandidates) loop
+              () := match BVariable.getVarDer(var)
+                local Pointer<Variable> der_ptr;
+                case SOME(der_ptr) algorithm UnorderedSet.add(BVariable.getVarName(der_ptr), set); then ();
+                else ();
+              end match;
+            end for;
+          end if;
+
           // traverse all components and save cref dependencies (only column-wise)
           for i in 1:arrayLength(comps) loop
             if not StrongComponent.isDiscrete(comps[i]) then
@@ -1034,7 +1047,14 @@ protected
 
       derivative_vars := list(var for var guard(BVariable.isStateDerivative(var)) in VariablePointers.toList(unknowns));
       state_vars := list(Util.getOption(BVariable.getVarState(var)) for var in derivative_vars);
-      seedCandidates := VariablePointers.fromList(state_vars, partialCandidates.scalarized);
+      // For daeMode the simulation jacobian is the residual Jacobian dF/dy over the
+      // full daeMode unknown set y = states + algebraic DAE unknowns. The columns
+      // (seed) are therefore the states PLUS the non-state-derivative daeUnknowns
+      // (the algebraic unknowns); the ODE path keeps just the states.
+      seedCandidates := if jacType == JacobianType.DAE then
+          VariablePointers.fromList(listAppend(state_vars, list(var for var guard(not BVariable.isStateDerivative(var)) in VariablePointers.toList(unknowns))), partialCandidates.scalarized)
+        else
+          VariablePointers.fromList(state_vars, partialCandidates.scalarized);
 
       jacobian := func(name, jacType, seedCandidates, partialCandidates, part.equations, part.strongComponents, part.adjacencyMatrix, funcMap, Partition.kindIsInitial(kind));
 

--- a/OMCompiler/Compiler/NSimCode/NSimCode.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCode.mo
@@ -331,6 +331,8 @@ public
           UnorderedMap<ComponentRef, SimVar> simcode_map;
           UnorderedMap<ComponentRef, SimStrongComponent.Block> equation_map;
           Option<DaeModeData> daeModeData;
+          UnorderedMap<ComponentRef, Integer> residual_idx_map;
+          list<SimVar> residualVarsList;
           SimJacobian jacA, jacB, jacC, jacD, jacF, jacH, jacAdjoint, jacLfg, jacMrf, jacR0;
           list<SimStrongComponent.Block> inlineEquations; // ToDo: what exactly is this?
           mapExp collect_literals;
@@ -427,7 +429,22 @@ public
             (linearLoops, nonlinearLoops, jacobians, simCodeIndices) := collectAlgebraicLoops(init, init_0, ode, algebraic, daeModeData, simCodeIndices, simcode_map);
 
             if isSome(daeModeData) then
-              (jacA, jacAdjoint, simCodeIndices) := SimJacobian.createSimulationJacobian(Util.getOption(bdae.dae), simCodeIndices, simcode_map);
+              // Map each residual var to its index in daeModeData->residualVars so the
+              // daeMode simulation jacobian's sparsity rows are indexed consistently with
+              // the residual vector (rr[i]=residualVars[i]). The jacobian's own result-var
+              // order can diverge from the residual-array order (partition/component
+              // reordering between backend and simcode), which would otherwise place
+              // jacobian entries in the wrong residual rows and break IDA's corrector.
+              residual_idx_map := UnorderedMap.new<Integer>(ComponentRef.hash, ComponentRef.isEqual);
+              () := match daeModeData
+                case SOME(DAE_MODE_DATA(residualVars = residualVarsList)) algorithm
+                  for rv in residualVarsList loop
+                    UnorderedMap.add(SimVar.getName(rv), rv.index, residual_idx_map);
+                  end for;
+                then ();
+                else ();
+              end match;
+              (jacA, jacAdjoint, simCodeIndices) := SimJacobian.createSimulationJacobian(Util.getOption(bdae.dae), simCodeIndices, simcode_map, SOME(residual_idx_map));
               // should jacAdjoint be added aswell? -> for now no
               daeModeData := DaeModeData.addJacobian(daeModeData, jacA);
             else
@@ -791,9 +808,43 @@ public
     protected
       list<list<SimStrongComponent.Block>> blcks;
       list<SimVar> residualVars;
+      list<SimVar> algebraicVars = {};
+      Integer savedResidualIndex;
     algorithm
+      // The daeMode residuals are written into their own daeModeData->residualVars
+      // array, indexed 0..nResidualVars-1. The SimCodeIndices.residualIndex counter is,
+      // however, shared with the initialization system created just before us: a
+      // nonlinear initial system creates residual(s) and bumps residualIndex past 0, so
+      // the daeMode residuals would start at 1 and overflow / leave a garbage slot 0 in
+      // residualVars (the state residual gets dropped -> IDACalcIC der blows up -> IDA
+      // linear setup fails). Reset to 0 so the daeMode residual indices match their own
+      // array; restore afterwards so unrelated downstream indexing is unaffected.
+      savedResidualIndex := simCodeIndices.residualIndex;
+      simCodeIndices.residualIndex := 0;
       (blcks, residualVars, simCodeIndices) := SimStrongComponent.Block.createDAEModeBlocks(systems, simCodeIndices, simcode_map, equation_map);
-      data := SOME(DAE_MODE_DATA(blcks, NONE(), residualVars, {}, {}, DaeModeConfig.ALL));
+      simCodeIndices.residualIndex := savedResidualIndex;
+      // The daeMode algebraic unknowns are each partition's daeUnknowns; reuse their
+      // already-created SimVars from the simcode map (do not re-index them). Without
+      // this the daeMode system is left with 0 algebraic unknowns, so the global
+      // residual system is over-determined and IDA's linear setup fails on loops.
+      for system in systems loop
+        algebraicVars := match system.daeUnknowns
+          local
+            VariablePointers daeUnknowns;
+            list<SimVar> acc;
+          case SOME(daeUnknowns) algorithm
+            acc := algebraicVars;
+            for var in VariablePointers.toList(daeUnknowns) loop
+              // state derivatives are the integrator's y', not global algebraic unknowns
+              if not BVariable.isStateDerivative(var) then
+                acc := UnorderedMap.getSafe(BVariable.getVarName(var), simcode_map, sourceInfo()) :: acc;
+              end if;
+            end for;
+          then acc;
+          else algebraicVars;
+        end match;
+      end for;
+      data := SOME(DAE_MODE_DATA(blcks, NONE(), residualVars, listReverse(algebraicVars), {}, DaeModeConfig.ALL));
     end create;
 
     function addJacobian

--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -222,6 +222,12 @@ public
       output Option<SimJacobian> simJacobian;
       input output SimCode.SimCodeIndices indices;
       input UnorderedMap<ComponentRef, SimVar> simcode_map;
+      input Option<UnorderedMap<ComponentRef, Integer>> rowIndexMap = NONE()
+        "daeMode: residual cref -> index in daeModeData->residualVars. The colored
+         FD indexes the residual vector (rr[i]=residualVars[i]) by the sparsity row
+         index, so the jacobian rows must use the residual-array index, not the
+         jacobian-local result order (which can diverge from the residual order due
+         to partition/component reordering between the backend and simcode).";
     algorithm
       simJacobian := match jacobian
         local
@@ -238,6 +244,8 @@ public
           list<SimVar> seedVars, resVars, tmpVars, loopVars;
           UnorderedMap<ComponentRef, SimVar> jac_map;
           UnorderedMap<ComponentRef, Integer> local_idx_map;
+          UnorderedMap<ComponentRef, Integer> rmap;
+          Integer row_idx;
           ComponentRef cref;
           SparsityPattern sparsity, sparsityT;
           SparsityColoring coloring, rowColoring;
@@ -301,7 +309,14 @@ public
               if BVariable.checkCref(cref, BVariable.isPDer, sourceInfo()) then
                 cref := BVariable.getPartnerCref(cref, function BVariable.getVarPDer(isTmp = false));
               end if;
-              UnorderedMap.add(cref, var.index, local_idx_map);
+              // daeMode: use the residual-array index so the sparsity rows line up
+              // with rr[i]=residualVars[i]; otherwise fall back to the local order.
+              row_idx := match rowIndexMap
+                case SOME(rmap) guard UnorderedMap.contains(cref, rmap)
+                  then UnorderedMap.getSafe(cref, rmap, sourceInfo());
+                else var.index;
+              end match;
+              UnorderedMap.add(cref, row_idx, local_idx_map);
             end for;
 
             (sparsity, sparsityT, coloring, rowColoring) := createSparsity(jacobian, local_idx_map);
@@ -345,6 +360,8 @@ public
       output SimJacobian simJacAdjoint;
       input output SimCode.SimCodeIndices simCodeIndices;
       input UnorderedMap<ComponentRef, SimVar> simcode_map;
+      input Option<UnorderedMap<ComponentRef, Integer>> rowIndexMap = NONE()
+        "daeMode: residual cref -> residualVars array index, to align jacobian rows with the residual vector";
     protected
       list<BackendDAE> jacobians = {}, jacobiansAdjoint = {};
       BackendDAE simJacobian, simJacobianAdjoint;
@@ -369,7 +386,7 @@ public
         (simJac, simCodeIndices) := SimJacobian.empty("A", simCodeIndices);
       else
         simJacobian := Jacobian.combine(jacobians, "A");
-        (simJac_opt, simCodeIndices) := SimJacobian.create(simJacobian, simCodeIndices, simcode_map);
+        (simJac_opt, simCodeIndices) := SimJacobian.create(simJacobian, simCodeIndices, simcode_map, rowIndexMap);
         if isSome(simJac_opt) then
           simJac := Util.getOption(simJac_opt);
         else
@@ -382,7 +399,7 @@ public
         (simJacAdjoint, simCodeIndices) := SimJacobian.empty("ADJ", simCodeIndices);
       else
         simJacobianAdjoint := Jacobian.combine(jacobiansAdjoint, "ADJ");
-        (simJacAdj_opt, simCodeIndices) := SimJacobian.create(simJacobianAdjoint, simCodeIndices, simcode_map);
+        (simJacAdj_opt, simCodeIndices) := SimJacobian.create(simJacobianAdjoint, simCodeIndices, simcode_map, rowIndexMap);
         if isSome(simJacAdj_opt) then
           simJacAdjoint := Util.getOption(simJacAdj_opt);
         else

--- a/testsuite/simulation/modelica/NBackend/daemode/Makefile
+++ b/testsuite/simulation/modelica/NBackend/daemode/Makefile
@@ -2,6 +2,9 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 TestDaeModeNB.mos \
+TestDaeModeNBAlgLoop.mos \
+TestDaeModeNBDerState.mos \
+TestDaeModeNBMultiPartition.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBAlgLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBAlgLoop.mos
@@ -1,0 +1,60 @@
+// name: TestDaeModeNBAlgLoop
+// keywords: NewBackend daeMode algebraic loop
+// status: correct
+// Torn nonlinear algebraic loop in daeMode. Runs newInst with both the old and
+// the new backend; the new backend support is added by the daeMode fixes.
+
+loadString("
+model TestDaeModeNBAlgLoop
+  Real x(start = 1, fixed = true);
+  Real a;
+  Real b;
+equation
+  der(x) = -x;
+  a + b = x;
+  a = sin(b) + 2*a;
+end TestDaeModeNBAlgLoop;
+"); getErrorString();
+
+// old backend (new frontend)
+setCommandLineOptions("-d=newInst --daeMode"); getErrorString();
+simulate(TestDaeModeNBAlgLoop, stopTime = 1.0, tolerance = 1e-8); getErrorString();
+val(x, 1.0); val(a, 0.0); val(b, 0.0);
+
+// new backend (new frontend)
+setCommandLineOptions("-d=newInst --newBackend --daeMode"); getErrorString();
+simulate(TestDaeModeNBAlgLoop, stopTime = 1.0, tolerance = 1e-8); getErrorString();
+val(x, 1.0); val(a, 0.0); val(b, 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBAlgLoop_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBAlgLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0.36787942556979447
+// -0.9345632107520242
+// 1.9345632107520243
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBAlgLoop_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBAlgLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.3678793995937988
+// -0.9345632107520242
+// 1.9345632107520243
+// endResult

--- a/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBDerState.mos
+++ b/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBDerState.mos
@@ -1,0 +1,49 @@
+// name: TestDaeModeNBDerState
+// keywords: NewBackend daeMode state
+// status: correct
+// State appearing only as der(x) (der(x)=sin(time)); daeMode jacobian state column
+// must carry the cj*dF/dx' term. newInst with both backends.
+
+loadString("
+model TestDaeModeNBDerState
+  Real x(start = 0, fixed = true);
+equation
+  der(x) = sin(time);
+end TestDaeModeNBDerState;
+"); getErrorString();
+
+setCommandLineOptions("-d=newInst --daeMode"); getErrorString();
+simulate(TestDaeModeNBDerState, stopTime = 2.0, tolerance = 1e-8); getErrorString();
+val(x, 2.0);
+
+setCommandLineOptions("-d=newInst --newBackend --daeMode"); getErrorString();
+simulate(TestDaeModeNBDerState, stopTime = 2.0, tolerance = 1e-8); getErrorString();
+val(x, 2.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBDerState_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBDerState', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.4161468879358239
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBDerState_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBDerState', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.416146870678159
+// endResult

--- a/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBMultiPartition.mos
+++ b/testsuite/simulation/modelica/NBackend/daemode/TestDaeModeNBMultiPartition.mos
@@ -1,0 +1,53 @@
+// name: TestDaeModeNBMultiPartition
+// keywords: NewBackend daeMode partition
+// status: correct
+// Decoupled state and standalone nonlinear algebraic equation -> two partitions in
+// daeMode; residual/jacobian row indexing must stay consistent. newInst, both backends.
+
+loadString("
+model TestDaeModeNBMultiPartition
+  Real x(start = 1, fixed = true);
+  Real b(start = 2);
+equation
+  der(x) = -x;
+  b = sin(b) + 0.5;
+end TestDaeModeNBMultiPartition;
+"); getErrorString();
+
+setCommandLineOptions("-d=newInst --daeMode"); getErrorString();
+simulate(TestDaeModeNBMultiPartition, stopTime = 1.0, tolerance = 1e-8); getErrorString();
+val(x, 1.0); val(b, 0.0);
+
+setCommandLineOptions("-d=newInst --newBackend --daeMode"); getErrorString();
+simulate(TestDaeModeNBMultiPartition, stopTime = 1.0, tolerance = 1e-8); getErrorString();
+val(x, 1.0); val(b, 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBMultiPartition_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBMultiPartition', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.3678794208691052
+// 1.4973003890958922
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestDaeModeNBMultiPartition_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-8, method = 'ida', fileNamePrefix = 'TestDaeModeNBMultiPartition', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.3678794258038379
+// 1.4973003890958925
+// endResult


### PR DESCRIPTION


Six fixes to the new backend's daeMode path so the residual DAE system F(t,y,y')=0 and its colored-numerical Jacobian are built consistently and fed to IDA correctly. Before this, --newBackend --daeMode hit IDA_LSETUP_FAIL / corrector divergence for almost everything beyond a single trivial state.

1. NSimCode (DaeModeData.create): populate algebraicVars from each partition's daeUnknowns (non-state-derivative); was hardcoded {} so nAlgebraicDAEVars was 0 and the global residual system was over-determined.

2. NBJacobian (daeMode jacobian seed): the residual jacobian dF/dy is taken over the full daeMode unknown set y = states + algebraic unknowns, so the seed columns are the states plus the non-state-derivative daeUnknowns, not just the states.

3. NBDAEMode (daeModeDefault): collect the daeMode equations/variables in strong-component (list) order instead of UnorderedSet hash order, so the residual row order is deterministic.

4. NSimCode (DaeModeData.create): reset SimCodeIndices.residualIndex to 0 before createDAEModeBlocks. It is shared with the initialization system; a nonlinear initial system bumps it past 0, so the daeMode residuals overflowed their own residualVars array and dropped the state residual.

5. NSimCode + NSimJacobian: thread a residual-cref -> residualVars-index map into the simulation jacobian so its sparsity rows are indexed consistently with the residual vector (rr[i] = residualVars[i]); the jacobian-local result order can diverge from the residual-array order due to partition/component reordering between backend and simcode.

6. NBStrongComponent + NBJacobian: attribute a residual dependency on der(x) to the state x's jacobian column (the cj*dF/dx' term). A state appearing only as der(x) (e.g. der(x)=sin(time)) otherwise produced an empty column and a structurally singular matrix.

With these, --newBackend --daeMode handles ODEs (1-N states), der-only states, aliases, der-in-algebraic, linear and torn-nonlinear algebraic loops, and multi-partition systems. testsuite/.../daemode testDAE p1-p4 pass with results matching the old backend (~8 significant figures). p5 (a when-equation) still fails; discrete event handling in daeMode is a separate feature. Non-daeMode is unaffected (all changes are gated on jacType == DAE / daeModeData).

Adds testsuite/simulation/modelica/NBackend/daemode tests (TestDaeModeNBAlgLoop, TestDaeModeNBDerState, TestDaeModeNBMultiPartition) that run daeMode with newInst on both the old and the new backend.

Work towards #15757.

