### PR TITLE
[NewBackend] Fix element-wise start values of non-scalarized arrays

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -390,7 +390,7 @@ public
             start := varAttr.start;
             nominal := varAttr.nominal;
             // FIXME parameters have default fixed = true
-            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.booleanValue, false);
+            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.isAllTrue, false);
             isDiscrete := match varKind
               case VariableKind.DISCRETE()        then true;
               case VariableKind.DISCRETE_STATE()  then true;
@@ -408,7 +408,7 @@ public
             min := varAttr.min;
             max := varAttr.max;
             start := varAttr.start;
-            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.booleanValue, false);
+            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.isAllTrue, false);
             isDiscrete := true;
             isProtected := Util.getOptionOrDefault(varAttr.isProtected, false);
         then ();
@@ -416,7 +416,7 @@ public
         case BackendInfo.BACKEND_INFO(varKind = varKind, attributes = varAttr as VariableAttributes.VAR_ATTR_BOOL())
           algorithm
             start := varAttr.start;
-            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.booleanValue, false);
+            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.isAllTrue, false);
             isDiscrete := true;
             isProtected := Util.getOptionOrDefault(varAttr.isProtected, false);
         then ();
@@ -430,7 +430,7 @@ public
         case BackendInfo.BACKEND_INFO(varKind = varKind, attributes = varAttr as VariableAttributes.VAR_ATTR_STRING())
           algorithm
             start := varAttr.start;
-            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.booleanValue, false);
+            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.isAllTrue, false);
             isDiscrete := true;
             isProtected := Util.getOptionOrDefault(varAttr.isProtected, false);
         then ();
@@ -440,7 +440,7 @@ public
             min := varAttr.min;
             max := varAttr.max;
             start := varAttr.start;
-            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.booleanValue, false);
+            isFixed := Util.applyOptionOrDefault(varAttr.fixed, Expression.isAllTrue, false);
             isDiscrete := true;
             isProtected := Util.getOptionOrDefault(varAttr.isProtected, false);
         then ();

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5511,11 +5511,12 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
       let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
       // let cast = typeCastContextInt(context, ty)
       '<%nosubname%>'
-    else if boolAnd(boolAnd(Flags.getConfigBool(Flags.NEW_BACKEND), boolNot(Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE))), boolNot(isStartCref(cr))) then
+    else if boolAnd(Flags.getConfigBool(Flags.NEW_BACKEND), boolNot(Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE))) then
       // Without sim code scalarization array elements like arr[2] are not
       // standalone simvars and have to be addressed relative to the first
       // element of the array using a flattened index. $START crefs address the
-      // (array valued) start attribute and keep the regular handling.
+      // (array valued) start attribute and the flattened index selects the
+      // matching start element (see varArrayNameValues).
       match crefSubs(crefArrayGetFirstCref(cr))
       case {} then
         let &sub = buffer ""
@@ -7982,10 +7983,25 @@ template varArrayNameValues(SimVar var, Integer ix, Boolean isPre, Boolean isSta
           let c_comment = CodegenUtil.crefCCommentWithVariability(var)
           let ty = crefShortType(name)
           if isStart then
-            // TODO: How to handle array case?
+            // The start attribute of a (non-scalarized) array variable can be
+            // either an array (start = {1,2,3}: one start.data element per array
+            // element, selected by the flattened index in &sub) or a single
+            // broadcast value (each start = 1: start.data has exactly one
+            // element). A scalar start variable has no subscript at all. Use the
+            // flattened index only when the start attribute actually holds one
+            // value per element, otherwise broadcast element [0] (issue #15686).
+            // Select the element via the address of the chosen lvalue so the
+            // whole expression stays an lvalue: $START crefs may appear in
+            // array-building contexts (real_array_create(&tmp, &<expr>, ...)),
+            // and a plain ?: ternary is an rvalue whose address cannot be taken.
             match ty
               case "real" then
-                '((modelica_real *)(<%varAttributes(var, &sub)%>.start.data))[0]'
+                let &nosub = buffer ""
+                let attr = varAttributes(var, &nosub)
+                if stringEq(&sub, "") then
+                  '((modelica_real *)(<%attr%>.start.data))[0]'
+                else
+                  '(*(real_array_nr_of_elements(<%attr%>.start) == 1 ? &((modelica_real *)(<%attr%>.start.data))[0] : &((modelica_real *)(<%attr%>.start.data))<%&sub%>))'
               else
                 '<%varAttributes(var, &sub)%>.start'
           else if isPre then

--- a/testsuite/simulation/modelica/NBackend/array_handling/Makefile
+++ b/testsuite/simulation/modelica/NBackend/array_handling/Makefile
@@ -1,47 +1,48 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
-simple_for.mos\
-simple_nested_for.mos\
-irregular_for.mos\
-diagonal_slice_for.mos\
-simple_der_for.mos\
-slice_for.mos\
-for_exp.mos\
-for_list.mos\
-for_if.mos\
-Resizable_HeatTransfer_equations.mos\
-testVectorizedSolarSystem.mos\
-testVectorizedPowerSystem.mos\
-exemplary.mos\
-MultiDimensionalArrays1.mos\
-MultiDimensionalArrays2.mos\
-MultiDimensionalArrays3.mos\
-MultiDimensionalArrays4.mos\
-subscripted_expression.mos\
-matrix_vector_product.mos\
-scalar_product.mos\
-EnumIndex.mos\
-BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder1.mos\
-BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder2.mos\
-BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder3.mos\
-BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder4.mos\
-BenchmarksForResizeableArrays.ArrayEquations.WaterHammer.mos\
-BenchmarksForResizeableArrays.ArrayEquationsWithIndexReduction.SlidingMass3D.mos\
-BenchmarksForResizeableArrays.ForLoops.CascadedFirstOrder.mos\
-BenchmarksForResizeableArrays.ForLoops.CocurrentHeatExchanger.mos\
-BenchmarksForResizeableArrays.ComponentArrays.FiltersInSeries.mos\
-BenchmarksForResizeableArrays.ComponentArrays.TransmissionLine.mos\
-BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.LinearSystemOfEquations.mos\
-BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.WrongNumberOfArrayEquations.mos\
-BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.MixedAlgebraicAndStatesArray.mos\
-BenchmarksForResizeableArrays.ErrorsIfArraysNotExpandedCorrected.FailedConsistencyCheckCorrected.mos\
-BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder1_Resizable.mos\
-BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder2_Resizable.mos\
-BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder3_Resizable.mos\
-BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder4_Resizable.mos\
-BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder_Resizable.mos\
-BenchmarksForResizeableArrays.Resizable.FiltersInSeries_Resizable.mos\
+array_start_vector.mos \
+BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder1.mos \
+BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder2.mos \
+BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder3.mos \
+BenchmarksForResizeableArrays.ArrayEquations.CascadedFirstOrder4.mos \
+BenchmarksForResizeableArrays.ArrayEquations.WaterHammer.mos \
+BenchmarksForResizeableArrays.ArrayEquationsWithIndexReduction.SlidingMass3D.mos \
+BenchmarksForResizeableArrays.ComponentArrays.FiltersInSeries.mos \
+BenchmarksForResizeableArrays.ComponentArrays.TransmissionLine.mos \
+BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.LinearSystemOfEquations.mos \
+BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.MixedAlgebraicAndStatesArray.mos \
+BenchmarksForResizeableArrays.ErrorsIfArraysNotExpanded.WrongNumberOfArrayEquations.mos \
+BenchmarksForResizeableArrays.ErrorsIfArraysNotExpandedCorrected.FailedConsistencyCheckCorrected.mos \
+BenchmarksForResizeableArrays.ForLoops.CascadedFirstOrder.mos \
+BenchmarksForResizeableArrays.ForLoops.CocurrentHeatExchanger.mos \
+BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder_Resizable.mos \
+BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder1_Resizable.mos \
+BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder2_Resizable.mos \
+BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder3_Resizable.mos \
+BenchmarksForResizeableArrays.Resizable.CascadedFirstOrder4_Resizable.mos \
+BenchmarksForResizeableArrays.Resizable.FiltersInSeries_Resizable.mos \
+diagonal_slice_for.mos \
+EnumIndex.mos \
+exemplary.mos \
+for_exp.mos \
+for_if.mos \
+for_list.mos \
+irregular_for.mos \
+matrix_vector_product.mos \
+MultiDimensionalArrays1.mos \
+MultiDimensionalArrays2.mos \
+MultiDimensionalArrays3.mos \
+MultiDimensionalArrays4.mos \
+Resizable_HeatTransfer_equations.mos \
+scalar_product.mos \
+simple_der_for.mos \
+simple_for.mos \
+simple_nested_for.mos \
+slice_for.mos \
+subscripted_expression.mos \
+testVectorizedPowerSystem.mos \
+testVectorizedSolarSystem.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/array_handling/array_start_vector.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/array_start_vector.mos
@@ -1,0 +1,47 @@
+// name: array_start_vector
+// keywords: NewBackend array start fixed
+// status: correct
+//
+// Non-scalarized array state with element-wise start values
+// (start = {1,2,3}, each fixed = true). The initial values of the array
+// elements must be 1.0, 2.0 and 3.0 respectively. Regression test for the
+// non-scalarized $START cref handling that previously broadcast the first
+// start element to all array elements.
+
+loadString("
+model array_start_vector
+  Real x[3](start = {1.0, 2.0, 3.0}, each fixed = true);
+  parameter Real a = 2.0;
+equation
+  der(x) = -a*x;
+end array_start_vector;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+simulate(array_start_vector, stopTime=0.0); getErrorString();
+
+val(x[1], 0.0);
+val(x[2], 0.0);
+val(x[3], 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "array_start_vector_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'array_start_vector', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: NSimJacobian.SimJacobian.createSparsityPattern: column cref not found in Jacobian local_idx_map: x[1]
+// 	Available keys: x, $DER.x
+// Warning: NSimJacobian.SimJacobian.create could not generate sparsity pattern of Jacobian [ODE].
+// "
+// 1.0
+// 2.0
+// 3.0
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/14468

### Purpose

For array variables in the non-scalarized new backend (--newBackend --simCodeScalarize=false), element-wise start values such as start = {1,2,3} were collapsed to the first element:

### Approach

- CodegenCFunctions.tpl expanded a $START.x[i] cref to the start attribute's data pointer with a hard-coded index [0], so every array element was initialized to the first start value (1,1,1 instead of 1,2,3). $START crefs now use the same flattened-index handling as regular array element crefs. The index is applied only when the start attribute actually holds one value per element; a single broadcast value (each start = 1) is still distributed to all elements, decided at runtime via real_array_nr_of_elements(). The element is selected through the address of the chosen lvalue so the expression stays addressable when a $START cref appears in an array-building context (real_array_create(&tmp, &<expr>, ...)).

- NSimVar.mo read the fixed attribute with Expression.booleanValue, which returns false for the non-scalar expression produced by 'each fixed = true', so array states were never marked fixed. Use Expression.isAllTrue (as NBVariable.isFixed already does).

Add a NBackend array_handling simulation test asserting the element-wise start values.
