### PR TITLE
Clean up OMNotebook graph/text cell

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
@@ -92,8 +92,7 @@ namespace IAEX
     next_(0),
     last_(0),
     previous_(0),
-    child_(0),
-    references_(0)
+    child_(0)
   {
     setMouseTracking(true);
     setEnabled(true);
@@ -144,15 +143,10 @@ namespace IAEX
    */
   Cell::~Cell()
   {
-    //Delete if there are no references to this cell.
-    if(references_ <= 0)
-    {
-      setMouseTracking(false);
-
-      delete treeView_;
-      delete mainWidget_;
-      delete label_;
-    }
+    setMouseTracking(false);
+    delete treeView_;
+    delete mainWidget_;
+    delete label_;
   }
 
   /*!
@@ -888,14 +882,4 @@ namespace IAEX
       printCell(current->child());
     }
   }
-
-  //    void Cell::retain(s)
-  //    {
-  //       references_ += 1;
-  //    }
-
-  //    void Cell::release()
-  //    {
-  //       references_ -= 1;
-  //    }
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
@@ -223,8 +223,6 @@ namespace IAEX
     Cell *last_;
     Cell *previous_;
     Cell *child_;
-
-    int references_;
   };
 }
 #endif

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -202,13 +202,6 @@ namespace IAEX {
     }
   }
 
-  MyTextEdit2a::~MyTextEdit2a()
-  {
-    for(QMap<int, IndentationState*>::iterator i = indentationStates.begin(); i != indentationStates.end(); ++i) {
-      delete i.value();
-    }
-  }
-
   void MyTextEdit2a::mousePressEvent(QMouseEvent *event)
   {
     inCommand = false;
@@ -437,19 +430,10 @@ namespace IAEX {
           k = b.userState();
         }
         Indent i(tmp);
-        if(indentationStates.contains(k))
+        auto s = indentationStates.find(k);
+        if (s != indentationStates.end())
         {
-          IndentationState* s = indentationStates[k];
-          i.ism.level = s->level;
-          i.ism.equation = s->equation;
-          i.ism.equationSection = s->equationSection;
-          i.ism.lMod = s->lMod;
-          i.ism.loopBlock = s->loopBlock;
-          i.ism.nextMod = s->nextMod;
-          i.ism.skipNext = s->skipNext;
-          i.ism.state = s->state;
-          i.current = s->current;
-          i.next = s->next;
+          i.setState(*s);
         }
 
         i.indentedText();
@@ -519,10 +503,9 @@ namespace IAEX {
   {
     if( source->hasText() )
     {
-      QMimeData *newSource = new QMimeData();
-      newSource->setText( source->text() );
-      QPlainTextEdit::insertFromMimeData( newSource );
-      delete newSource;
+      QMimeData newSource;
+      newSource.setText( source->text() );
+      QPlainTextEdit::insertFromMimeData( &newSource );
     }
     else
       QPlainTextEdit::insertFromMimeData( source );
@@ -642,18 +625,17 @@ namespace IAEX {
   * \author Anders Fernström
   * \date 2006-01-23
   *
-  * \brief If the mimedata that should be insertet contain text,
+  * \brief If the mimedata that should be inserted contains text,
   * create a new mimedata object that only contains text, otherwise
-  * text format is insertet also - don't want that for GraphCells.
+  * text format is inserted also - don't want that for GraphCells.
   */
   void MyTextEdit2::insertFromMimeData(const QMimeData *source)
   {
     if( source->hasText() )
     {
-      QMimeData *newSource = new QMimeData();
-      newSource->setText( source->text() );
-      QTextBrowser::insertFromMimeData( newSource );
-      delete newSource;
+      QMimeData newSource;
+      newSource.setText( source->text() );
+      QTextBrowser::insertFromMimeData( &newSource );
     }
     else
       QTextBrowser::insertFromMimeData( source );
@@ -723,22 +705,6 @@ namespace IAEX {
 
     connect(output_, SIGNAL(anchorClicked(const QUrl&)), input_, SLOT(goToPos(const QUrl&)));
     connect(this, SIGNAL(plotVariables(QStringList)), this, SLOT(plotVariablesSlot(QStringList)));
-
-    imageFile=0;
-  }
-
-  /*!
-  * \author Ingemar Axelsson and Anders Fernström
-  *
-  * \brief The class destructor
-  */
-  GraphCell::~GraphCell()
-  {
-    delete mpPlotWindow;
-    delete input_;
-    delete output_;
-    if(imageFile)
-      delete imageFile;
   }
 
   /*!
@@ -1566,9 +1532,9 @@ namespace IAEX {
   *
   */
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-  QRecursiveMutex* guard = new QRecursiveMutex();
+  QRecursiveMutex guard;
 #else // QT_VERSION_CHECK
-  QMutex* guard = new QMutex(QMutex::Recursive);
+  QMutex guard(QMutex::Recursive);
 #endif // QT_VERSION_CHECK
 
   void GraphCell::eval()
@@ -1612,7 +1578,7 @@ namespace IAEX {
       }
 
       {
-        guard->lock();
+        guard.lock();
         // adrpo:FIXME! WRONG! TODO! this is wrong!
         //       the commands should be sent to OMC in the same sequence
         //       they appear in the notebook, otherwise a simulate command
@@ -1639,7 +1605,7 @@ namespace IAEX {
     int errorLevel= delegate->getErrorLevel();
 
     //delete sender();
-    guard->unlock();
+    guard.unlock();
 
     if( res.isEmpty() && (error.isEmpty() || error.size() == 0) ) {
       res = "[done]";

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.h
@@ -42,12 +42,11 @@
 
 // IAEX headers
 #include "cell.h"
+#include "indent.h"
 #include "inputcelldelegate.h"
 #include "document.h"
 #include "PlotWindow.h"
 #include "ModelicaTextHighlighter.h"
-
-class IndentationState;
 
 namespace IAEX {
 
@@ -64,7 +63,6 @@ class GraphCell : public Cell
     Q_OBJECT
 public:
     explicit GraphCell(Document *doc, QWidget *parent = nullptr);
-    ~GraphCell() override;
 
     /* ----- Cell‑interface (override virtuals from Cell) ----- */
     QString          text()               override;
@@ -166,7 +164,6 @@ private:
 public:
     OMPlot::PlotWindow*      mpPlotWindow    = nullptr;
     QPushButton*             variableButton  = nullptr;
-    QTemporaryFile*          imageFile       = nullptr;
 
     /* ----- Plot callback (static) ----- */
     static void PlotCallbackFunction(void *p,
@@ -233,7 +230,6 @@ class MyTextEdit2a : public QPlainTextEdit
     Q_OBJECT
 public:
     explicit MyTextEdit2a(QWidget *parent = nullptr);
-    ~MyTextEdit2a() override;
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int  lineNumberAreaWidth();
@@ -276,7 +272,7 @@ protected:
 private:
     bool                     inCommand      = false;
     bool                     autoIndent     = true;
-    QMap<int, IndentationState*> indentationStates;
+    QMap<int, IndentationState> indentationStates;
     QWidget*                 lineNumberArea = nullptr;
 
     int indentationLevel(const QString &, bool = true);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/indent.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/indent.cpp
@@ -38,20 +38,6 @@
 #include <QMessageBox>
 #include <QDebug>
 
-IndentationState::~IndentationState() {
-}
-
-Indent::ISM::ISM() {
-  level = 0;
-  state = 0;
-  skipNext = false;
-  lMod = false;
-  nextMod = 0;
-}
-
-Indent::ISM::~ISM() {
-}
-
 void Indent::ISM::newToken(QString s, QString s2) {
   if(skipNext) {
     skipNext = false;
@@ -208,12 +194,23 @@ Indent::Indent(QString s, bool aggressive_) {
   lineModifiers = 0;
 }
 
-Indent::~Indent() {
-}
-
 void Indent::setText(QString s) {
   ts.reset();
   ts << s;
+}
+
+void Indent::setState(const IndentationState &state)
+{
+  ism.level = state.level;
+  ism.state = state.state;
+  ism.nextMod = state.nextMod;
+  ism.equation = state.equation;
+  ism.equationSection = state.equationSection;
+  ism.loopBlock = state.loopBlock;
+  ism.skipNext = state.skipNext;
+  ism.lMod = state.lMod;
+  current = state.current;
+  next = state.next;
 }
 
 int Indent::level() {
@@ -224,7 +221,7 @@ bool Indent::lMod() {
   return lmod;
 }
 
-QString Indent::indentedText(QMap<int, IndentationState*>* states) {
+QString Indent::indentedText(QMap<int, IndentationState>* states) {
   buffer1 = buffer1.replace(QRegularExpression("(==|:=|<=|>=|<>|=|<|>)"), " \\1 ");
   buffer1 = buffer1.replace('\n', " <newLine> ") + " <newLine> " + " <newLine> ";
   buffer1 = buffer1.replace("//", " //");
@@ -309,7 +306,7 @@ QString Indent::indentedText(QMap<int, IndentationState*>* states) {
         if(states->find(N) != states->end()) {
           states->remove(N);
         }
-        (*states)[N] = new IndentationState(ism.state, ism.level, ism.nextMod, current, next, ism.skipNext, ism.lMod, ism.equation, ism.equationSection, ism.loopBlock);
+        states->insert(N, IndentationState{ism.state, ism.level, ism.nextMod, current, next, ism.skipNext, ism.lMod, ism.equation, ism.equationSection, ism.loopBlock});
       }
     } else {
       tmp +=  current.trimmed() +  QString(current.size()?1:0, ' ') ;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/indent.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/indent.h
@@ -39,13 +39,13 @@
 #include <QTextStream>
 #include <QMap>
 
-class IndentationState {
-public:
-  IndentationState(int state_, int level_, int nextMod_, QString current_, QString next_, bool skipNext_, bool lMod_, bool equation_, bool equationSection_, bool loopBlock_):
-    state(state_), level(level_), nextMod(nextMod_), current(current_), next(next_), skipNext(skipNext_), lMod(lMod_), equation(equation_), equationSection(equationSection_), loopBlock(loopBlock_) {
-    }
-
-    ~IndentationState();
+struct IndentationState {
+  IndentationState(int state, int level, int nextMod, QString current, QString next, bool skipNext,
+                   bool lMod, bool equation, bool equationSection, bool loopBlock)
+    : level(level), state(state), nextMod(nextMod), current(current), next(next), skipNext(skipNext),
+      lMod(lMod), equation(equation), equationSection(equationSection), loopBlock(loopBlock)
+  {
+  }
 
   int level, state, nextMod;
   QString current, next;
@@ -54,11 +54,11 @@ public:
 
 class Indent {
 public:
-  Indent(QString t = QString(), bool a = false);
-  ~Indent();
+  Indent(QString s = QString(), bool aggressive = false);
 
-  QString indentedText(QMap<int, IndentationState*>* states = 0);
+  QString indentedText(QMap<int, IndentationState>* states = 0);
   void setText(QString);
+  void setState(const IndentationState &state);
   int level();
   bool lMod();
 
@@ -69,20 +69,22 @@ private:
   bool aggressive, lmod;
   QString buffer1, buffer2;
 
-  class ISM {
-  public:
-    ISM();
-    ~ISM();
-
+  struct ISM {
+    ISM() = default;
     void newToken(QString, QString);
-    int level, lineModifiers, state, nextMod;
-    bool equation, equationSection, loopBlock;
-    bool skipNext;
-    bool lMod;
-    int oldState;
+
+    int level = 0;
+    int lineModifiers = 0;
+    int state = 0;
+    int nextMod = 0;
+    bool equation = false;
+    bool equationSection = false;
+    bool loopBlock = false;
+    bool skipNext = false;
+    bool lMod = false;
+    int oldState = 0;
   };
 
-public:
   ISM ism;
   QString current, next;
 };

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
@@ -142,10 +142,9 @@ namespace IAEX
   {
     if( source->hasText() && !source->hasImage() )
     {
-      QMimeData *newSource = new QMimeData();
-      newSource->setText( source->text() );
-      QTextBrowser::insertFromMimeData( newSource );
-      delete newSource;
+      QMimeData newSource;
+      newSource.setText( source->text() );
+      QTextBrowser::insertFromMimeData( &newSource );
     }
     else
       QTextBrowser::insertFromMimeData( source );
@@ -266,8 +265,6 @@ namespace IAEX
    */
   TextCell::~TextCell()
   {
-    setMainWidget(0);
-    delete text_;
   }
 
   /*!
@@ -411,6 +408,21 @@ namespace IAEX
   QTextEdit* TextCell::textEdit()
   {
     return text_;
+  }
+
+  void TextCell::cutText()
+  {
+    text_->cut();
+  }
+
+  void TextCell::copyText()
+  {
+    text_->copy();
+  }
+
+  void TextCell::pasteText()
+  {
+    text_->paste();
   }
 
   /*!

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcell.h
@@ -71,6 +71,9 @@ namespace IAEX
     QString textHtml();
     QTextCursor textCursor();
     QTextEdit* textEdit();
+    void cutText() override;
+    void copyText() override;
+    void pasteText() override;
 
     void clear();
     virtual void accept(Visitor &v);


### PR DESCRIPTION
- Implement cut/copy/paste for text cells.
- Refactor Indent/IndentationState to avoid exposing internal state.
- Remove unused reference counting in Cell.
- Remove unnecessary heap allocations.
- Remove unnecessary deletes of widgets.