### PR TITLE
[NB,Cpp] Support non-scalarized array variables in the C++ runtime

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -48,6 +48,7 @@ protected
   import NFBackendExtension.{BackendInfo, VariableAttributes, VariableKind};
   import Binding = NFBinding;
   import ComponentRef = NFComponentRef;
+  import Dimension = NFDimension;
   import Expression = NFExpression;
   import NFInstNode.InstNode;
   import Operator = NFOperator;
@@ -104,7 +105,7 @@ public
       Option<Causality> causality;
       Option<Integer> variable_index "valueReference";
       Option<Integer> fmi_index "index of variable in modelDescription.xml";
-      list<String> numArrayElement;
+      list<Expression> numArrayElement;
       Boolean isValueChangeable;
       Boolean isProtected;
       Boolean hideResult;
@@ -190,7 +191,7 @@ public
             causality           = SOME(causality),
             variable_index      = SOME(uniqueIndex),
             fmi_index           = SOME(typeIndex),
-            numArrayElement     = {},
+            numArrayElement     = list(Dimension.sizeExp(dim) for dim in Type.arrayDims(var.ty)),
             isValueChangeable   = isValueChangeable,
             isProtected         = isProtected,
             hideResult          = var.backendinfo.annotations.hideResult,
@@ -333,7 +334,7 @@ public
         causality           = NONE(),  //ToDo update this!
         variable_index      = simVar.variable_index,
         fmi_index           = simVar.fmi_index,
-        numArrayElement     = simVar.numArrayElement,
+        numArrayElement     = list(Expression.toString(e) for e in simVar.numArrayElement),
         isValueChangeable   = simVar.isValueChangeable,
         isProtected         = simVar.isProtected,
         hideResult          = SOME(simVar.hideResult),

--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -1262,6 +1262,28 @@ public
       Integer numRelatedBoundaryConditions;
     end VAR_INFO;
 
+    function scalarSize
+      "Number of scalar elements a simvar occupies in the per-type storage vectors.
+       With simCodeScalarize=false arrays are kept un-expanded (one simvar per array),
+       but the C++ runtime sizes its var vectors and value references per scalar element,
+       so counts must sum the array sizes rather than just counting simvars (#15496)."
+      input SimVar v;
+      output Integer sz = 1;
+    algorithm
+      for e in v.numArrayElement loop
+        sz := sz * Expression.integerValueOrDefault(e, 1);
+      end for;
+    end scalarSize;
+
+    function listScalarSize
+      input list<SimVar> vars;
+      output Integer sz = 0;
+    algorithm
+      for v in vars loop
+        sz := sz + scalarSize(v);
+      end for;
+    end listScalarSize;
+
     function create
       input SimVars vars;
       input EventInfo eventInfo;
@@ -1273,23 +1295,23 @@ public
         numTimeEvents                = UnorderedSet.size(eventInfo.time_set),
         numRelations                 = sum(Condition.size(cond) for cond in UnorderedMap.keyList(eventInfo.state_map)),
         numMathEventFunctions        = eventInfo.numberMathEvents,
-        numStateVars                 = listLength(vars.stateVars),
-        numAlgVars                   = listLength(vars.algVars),
-        numDiscreteReal              = listLength(vars.discreteAlgVars),
-        numIntAlgVars                = listLength(vars.intAlgVars),
-        numBoolAlgVars               = listLength(vars.boolAlgVars),
-        numAlgAliasVars              = listLength(vars.aliasVars),
-        numIntAliasVars              = listLength(vars.intAliasVars),
-        numBoolAliasVars             = listLength(vars.boolAliasVars),
-        numParams                    = listLength(vars.paramVars),
-        numIntParams                 = listLength(vars.intParamVars),
-        numBoolParams                = listLength(vars.boolParamVars),
+        numStateVars                 = listScalarSize(vars.stateVars),
+        numAlgVars                   = listScalarSize(vars.algVars),
+        numDiscreteReal              = listScalarSize(vars.discreteAlgVars),
+        numIntAlgVars                = listScalarSize(vars.intAlgVars),
+        numBoolAlgVars               = listScalarSize(vars.boolAlgVars),
+        numAlgAliasVars              = listScalarSize(vars.aliasVars),
+        numIntAliasVars              = listScalarSize(vars.intAliasVars),
+        numBoolAliasVars             = listScalarSize(vars.boolAliasVars),
+        numParams                    = listScalarSize(vars.paramVars),
+        numIntParams                 = listScalarSize(vars.intParamVars),
+        numBoolParams                = listScalarSize(vars.boolParamVars),
         numOutVars                   = listLength(vars.outputVars),
         numInVars                    = listLength(vars.inputVars),
         numExternalObjects           = listLength(vars.extObjVars),
-        numStringAlgVars             = listLength(vars.stringAlgVars),
-        numStringParamVars           = listLength(vars.stringParamVars),
-        numStringAliasVars           = listLength(vars.stringAliasVars),
+        numStringAlgVars             = listScalarSize(vars.stringAlgVars),
+        numStringParamVars           = listScalarSize(vars.stringParamVars),
+        numStringAliasVars           = listScalarSize(vars.stringAliasVars),
         numEquations                 = simCodeIndices.equationIndex,
         numLinearSystems             = simCodeIndices.linearSystemIndex,
         numNonLinearSystems          = simCodeIndices.nonlinearSystemIndex,

--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -78,6 +78,7 @@ protected
   import NSimCode.SimCodeIndices;
 
   // Util imports
+  import Config;
   import Error;
   import Pointer;
   import StringUtil;
@@ -1262,26 +1263,19 @@ public
       Integer numRelatedBoundaryConditions;
     end VAR_INFO;
 
-    function scalarSize
-      "Number of scalar elements a simvar occupies in the per-type storage vectors.
-       With simCodeScalarize=false arrays are kept un-expanded (one simvar per array),
-       but the C++ runtime sizes its var vectors and value references per scalar element,
-       so counts must sum the array sizes rather than just counting simvars (#15496)."
-      input SimVar v;
-      output Integer sz = 1;
-    algorithm
-      for e in v.numArrayElement loop
-        sz := sz * Expression.integerValueOrDefault(e, 1);
-      end for;
-    end scalarSize;
-
     function listScalarSize
+      "Var-vector size for a simvar list. The C++ target keeps arrays un-expanded
+       but sizes its var vectors and value references per scalar element, so the
+       array sizes are summed. Every other target (notably the C runtime, which
+       also supports simCodeScalarize=false) keeps one slot per simvar."
       input list<SimVar> vars;
-      output Integer sz = 0;
+      output Integer sz;
     algorithm
-      for v in vars loop
-        sz := sz + scalarSize(v);
-      end for;
+      if stringEqual(Config.simCodeTarget(), "Cpp") then
+        sz := sum(product(Expression.integerValueOrDefault(e, 1) for e in v.numArrayElement) for v in vars);
+      else
+        sz := listLength(vars);
+      end if;
     end listScalarSize;
 
     function create

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -89,6 +89,7 @@ import ErrorExt;
 import ExecStat;
 import FGraph;
 import Flags;
+import FlagsUtil;
 import FlatModel = NFFlatModel;
 import NFFunction;
 import NFFlatten.{FunctionTree, FunctionTreeImpl};
@@ -1214,6 +1215,14 @@ algorithm
 
   // new backend - also activates new frontend by default
   if Flags.getConfigBool(Flags.NEW_BACKEND) then
+    // The C++ runtime keeps arrays un-expanded (StatArrayDim members) and cannot
+    // use the scalarized var layout; the C runtime does not yet support
+    // non-scalarized arrays. Force simCodeScalarize=false for the C++ target only,
+    // leaving the default (true) for the C target (issue #15496). Must happen
+    // before any scalarize-dependent decision in the pipeline.
+    if stringEqual(Config.simCodeTarget(), "Cpp") then
+      FlagsUtil.setConfigBool(Flags.SIM_CODE_SCALARIZE, false);
+    end if;
     // ToDo: set permanently matching -> SBGraphs
     System.realtimeTick(ClockIndexes.RT_CLOCK_FRONTEND);
     ExecStat.execStatReset();
@@ -1318,6 +1327,13 @@ algorithm
   file_name_prefix := if fileNamePrefix == "<default>" then AbsynUtil.pathString(className) else fileNamePrefix;
 
   if Flags.getConfigBool(Flags.NEW_BACKEND) then
+    // The C++ runtime keeps arrays un-expanded (StatArrayDim members) and cannot
+    // use the scalarized var layout; the C runtime, on the other hand, does not
+    // yet support non-scalarized arrays. So force simCodeScalarize=false for the
+    // C++ target only, leaving the default (true) for the C target (issue #15496).
+    if stringEqual(Config.simCodeTarget(), "Cpp") then
+      FlagsUtil.setConfigBool(Flags.SIM_CODE_SCALARIZE, false);
+    end if;
     func_map := UnorderedMap.fromLists(FunctionTree.listKeys(functions), FunctionTree.listValues(functions), AbsynUtil.pathHash, AbsynUtil.pathEqual);
     (outLibs, outFileDir, resultValues, _) := translateModelCallBackendNB(flatModel, func_map, className, file_name_prefix, simSettings);
   else

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -8170,8 +8170,16 @@ template memberVariableDefine2(SimVar simVar, HashTableCrIListArray.HashTable va
           else
             '<%variableType(type_)%> <%cref(name,useFlatArrayNotation)%>;'
 
-    case v as SIMVAR(name=CREF_IDENT(__),arrayCref=SOME(_),numArrayElement=num)
-    case v as SIMVAR(name=CREF_QUAL(__),arrayCref=SOME(_),numArrayElement=num) then
+    /* newInst with arrays */
+    case v as SIMVAR(type_ = T_ARRAY()) then
+      let& dims = buffer "" /*BUFD*/
+      let varName = arraycref2(name, dims)
+      let typeString = expTypeShort(type_)
+      <<
+      StatArrayDim<%listLength(v.numArrayElement)%><<%typeString%>, <%v.numArrayElement;separator=","%>, <%createRefVar%>> <%varName%>;
+      >>
+    case v as SIMVAR(name=CREF_IDENT(__),arrayCref=SOME(_))
+    case v as SIMVAR(name=CREF_QUAL(__),arrayCref=SOME(_)) then
       let &dims = buffer "" /*BUFD*/
       let arrayName = arraycref2(name,dims)
       let typeString = variableType(type_)
@@ -8200,14 +8208,6 @@ template memberVariableDefine2(SimVar simVar, HashTableCrIListArray.HashTable va
           <<
           RefArrayDim<%dims%><<%typeString%>, <%array_dimensions%>> <%arrayName%>;
           >>
-    /* newInst with arrays */
-    case v as SIMVAR(type_ = T_ARRAY()) then
-      let& dims = buffer "" /*BUFD*/
-      let varName = arraycref2(name, dims)
-      let typeString = expTypeShort(type_)
-      <<
-      StatArrayDim<%listLength(v.numArrayElement)%><<%typeString%>, <%List.lastN(v.numArrayElement, listLength(v.numArrayElement));separator=","%>, <%createRefVar%>> <%varName%>;
-      >>
    /*special case for variables that marked as array but are not arrays */
     case SIMVAR(numArrayElement=_::_) then
       let& dims = buffer "" /*BUFD*/

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -7901,6 +7901,16 @@ template memberVariableInitialize2(SimVar simVar, HashTableCrIListArray.HashTabl
           let &additionalConstructorVariables += ',<%cref(name,useFlatArrayNotation)%>(getSimVars()->init<%type%>Var(<%index%>))<%\n%>'
           ""
         else ""
+    /* newInst with arrays: a non-scalarized whole-array var (T_ARRAY) has no
+       subscripts on its cref, so the arrayCref=SOME path below would see dims="0"
+       and skip the init. Handle it here first (mirrors memberVariableDefine2). */
+    case v as SIMVAR(type_ = T_ARRAY()) then
+      let& dims = buffer "" /*BUFD*/
+      let varName = arraycref2(name, dims)
+      let arrayHeadIdx = listHead(SimCodeUtil.getVarIndexListByMapping(varToArrayIndexMapping,name,true,indexForUndefinedReferences))
+       <<
+       <%varName%>.init(&_pointerTo<%type%>Vars[<%arrayHeadIdx%>]);
+       >>
     case v as SIMVAR(name=CREF_IDENT(__),arrayCref=SOME(_),numArrayElement=num)
     case v as SIMVAR(name=CREF_QUAL(__),arrayCref=SOME(_),numArrayElement=num) then
       let &dims = buffer "" /*BUFD*/
@@ -7933,15 +7943,6 @@ template memberVariableInitialize2(SimVar simVar, HashTableCrIListArray.HashTabl
               getSimVars()->init<%type%>AliasArray(LIST_OF <%arrayIndices%> LIST_END, <%arrayName%>_ref_data);
               <%arrayName%> = RefArrayDim<%dims%><<%typeString%>, <%arrayextentDims(name, v.numArrayElement)%>>(<%arrayName%>_ref_data);
               >>
-    /* newInst with arrays */
-    case v as SIMVAR(type_ = T_ARRAY()) then
-      let& dims = buffer "" /*BUFD*/
-      let varName = arraycref2(name, dims)
-      let typeString = expTypeShort(type_)
-      let arrayHeadIdx = listHead(SimCodeUtil.getVarIndexListByMapping(varToArrayIndexMapping,name,true,indexForUndefinedReferences))
-       <<
-       <%varName%>.init(&_pointerTo<%type%>Vars[<%arrayHeadIdx%>]);
-       >>
    /*special case for variables that marked as array but are not arrays */
     case SIMVAR(numArrayElement=_::_) then
 
@@ -9558,6 +9559,8 @@ template equationString(SimEqSystem eq, Context context, Text &varDecls, SimCode
     then equationWhen(e, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   case e as SES_ARRAY_CALL_ASSIGN(__)
     then equationArrayCallAssign(e, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation, assignToStartValues)
+  case e as SES_RESIZABLE_ASSIGN(__)
+    then equationResizableAssign(e, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   case e as SES_LINEAR(lSystem = ls as LINEARSYSTEM(__))
     then
       let i = ls.index
@@ -9858,6 +9861,9 @@ template equation_function_create_single_body(SimEqSystem eq, Context context, S
     case e as SES_ARRAY_CALL_ASSIGN(__)
       then
       equationArrayCallAssign(e, context, &varDeclsLocal, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation, assignToStartValues)
+    case e as SES_RESIZABLE_ASSIGN(__)
+      then
+      equationResizableAssign(e, context, &varDeclsLocal, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     case e as SES_LINEAR(__)
     case e as SES_NONLINEAR(__)
       then
@@ -10929,6 +10935,108 @@ case eqn as SES_ARRAY_CALL_ASSIGN(lhs=lhs as CREF(__)) then
     <%lhsStr%>.assign(<%expPart%>);
     >>
 end equationArrayCallAssign;
+
+template equationResizableAssign(SimEqSystem eq, Context context, Text &varDecls, SimCode simCode, Text& extraFuncs,
+                                 Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+ "Generates a non-scalarized resizable array assignment (NewBackend) as an inline,
+  possibly nested, C++ for-loop. The actual lhs:=rhs body lives in a SINGLE_GENERIC_CALL
+  referenced by call_index; we look it up in simCode.generic_loop_calls and inline it.
+  The C runtime emits a separate genericCall_<n>() function for this; in the C++ runtime
+  equations are model-class members operating on _<var> fields, so inlining fits better."
+::=
+match eq
+case SES_RESIZABLE_ASSIGN(__) then
+  let &preExp = buffer "" /*BUFD*/
+  let header = (iters |> it => cppForIterHeader(it, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ; separator="\n")
+  let tail   = (iters |> it => "}" ; separator="\n")
+  let body   = resizableGenericCallBody(call_index, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  <<
+  <%preExp%>
+  <%header%>
+  <%body%>
+  <%tail%>
+  >>
+end equationResizableAssign;
+
+template cppForIterHeader(SimIterator iter, Context context, Text &preExp, Text &varDecls, SimCode simCode, Text& extraFuncs,
+                          Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+ "One C++ for-loop header for a resizable iterator, including any derived sub-iterators."
+::=
+match iter
+case SIM_ITERATOR_RANGE(__) then
+  let iterName = localCref(name, useFlatArrayNotation)
+  let startVal = daeExp(start, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let stepVal  = daeExp(step, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let stopVal  = daeExp(stop, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let subIts   = (sub_iter |> si => cppSubIter(si, iterName, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ; separator="\n")
+  <<
+  for (modelica_integer <%iterName%> = <%startVal%>; ((<%stepVal%>) >= 0 ? <%iterName%> <= (<%stopVal%>) : <%iterName%> >= (<%stopVal%>)); <%iterName%> += (<%stepVal%>)) {
+    <%subIts%>
+  >>
+case SIM_ITERATOR_LIST(__) then
+  let iterName = localCref(name, useFlatArrayNotation)
+  let arr      = (lst |> e => '<%e%>' ; separator=", ")
+  let subIts   = (sub_iter |> si => cppSubIter(si, iterName, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ; separator="\n")
+  <<
+  static const modelica_integer <%iterName%>_lst[<%size%>] = {<%arr%>};
+  for (int <%iterName%>_i = 0; <%iterName%>_i < <%size%>; <%iterName%>_i++) {
+    modelica_integer <%iterName%> = <%iterName%>_lst[<%iterName%>_i];
+    <%subIts%>
+  >>
+end cppForIterHeader;
+
+template cppSubIter(tuple<DAE.ComponentRef, array<DAE.Exp>> sit, Text parentIter, Context context, Text &preExp, Text &varDecls,
+                    SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+ "A derived (sub) iterator, used when a multi-dimensional array loop is flattened: the
+  derived index is a constant table indexed by the (1-based) parent iterator value."
+::=
+match sit
+case (sname, srange) then
+  let snm   = localCref(sname, useFlatArrayNotation)
+  let svals = (arrayList(srange) |> se => daeExp(se, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ; separator=", ")
+  let ssize = listLength(arrayList(srange))
+  <<
+  static const modelica_integer <%snm%>_arr[<%ssize%>] = {<%svals%>};
+  modelica_integer <%snm%> = <%snm%>_arr[<%parentIter%>-1];
+  >>
+end cppSubIter;
+
+template resizableGenericCallBody(Integer callIndex, Context context, Text &varDecls, SimCode simCode, Text& extraFuncs,
+                                  Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+ "Find the SINGLE_GENERIC_CALL whose index == callIndex in simCode.generic_loop_calls and inline its lhs:=rhs."
+::=
+match simCode
+case SIMCODE(__) then
+  (generic_loop_calls |> call =>
+    match call
+    case SINGLE_GENERIC_CALL(index=ci) then
+      if intEq(ci, callIndex) then resizableLhsRhs(call, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+   ; separator="")
+end resizableGenericCallBody;
+
+template resizableLhsRhs(SimGenericCall call, Context context, Text &varDecls, SimCode simCode, Text& extraFuncs,
+                         Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+ "Inline body of a single generic call: lhs := rhs, with the iterator crefs rendered as the loop variables."
+::=
+match call
+case SINGLE_GENERIC_CALL(__) then
+  let &preExp = buffer "" /*BUFD*/
+  let rhsPart = daeExp(rhs, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let assign = match lhs
+    case CREF(ty = T_ARRAY(__)) then
+      let lhsPart = daeExpCref(true, lhs, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+      '<%lhsPart%>.assign(<%rhsPart%>);'
+    case CREF(__) then
+      let lhsPart = daeExpCref(true, lhs, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+      '<%lhsPart%> = <%rhsPart%>;'
+    else
+      let lhsPart = daeExp(lhs, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+      '<%lhsPart%> = <%rhsPart%>;'
+  <<
+  <%preExp%>
+  <%assign%>
+  >>
+end resizableLhsRhs;
 
 template assignDerArray(Context context, String arr, Exp lhs_ecr, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
  "Assign array considering special treatment of states and Jacobian vars"

--- a/OMCompiler/Compiler/Template/CodegenCppInit.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppInit.tpl
@@ -186,6 +186,7 @@ template scalarVariableAttributeXML(SimVar simVar, SimCode simCode, String index
 ::=
   match simVar
     case SIMVAR(source = SOURCE(info = info)) then
+      let valueReference = SimCodeUtil.getValueReference(simVar, simCode, true)
       let alias = getAliasAttribute(aliasvar)
       let causalityAtt = CodegenFMUCommon.getCausality(causality)
       let variability = getVariablity(varKind)
@@ -193,7 +194,7 @@ template scalarVariableAttributeXML(SimVar simVar, SimCode simCode, String index
       let hr = match hideResult case SOME(bval) then '<%bval%>'
       let additionalAttributes = if generateFMUModelDescription then '' else 'isProtected="<%isProtected%>" hideResult="<%hr%>" isDiscrete="<%isDiscrete%>" isValueChangeable="<%isValueChangeable%>"'
       <<
-      name="<%System.stringReplace(Util.escapeModelicaStringToXmlString(crefStrNoUnderscore(name)),"$", "_D_")%>" valueReference="<%index%>" <%description%> variability="<%variability%>" causality="<%causalityAtt%>" alias="<%alias%>" <%additionalAttributes%>
+      name="<%System.stringReplace(Util.escapeModelicaStringToXmlString(crefStrNoUnderscore(name)),"$", "_D_")%>" valueReference="<%valueReference%>" <%description%> variability="<%variability%>" causality="<%causalityAtt%>" alias="<%alias%>" <%additionalAttributes%>
       >>
 end scalarVariableAttributeXML;
 

--- a/OMCompiler/Compiler/Template/CodegenCppInit.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppInit.tpl
@@ -153,6 +153,15 @@ template scalarVariableXML(SimCode simCode, SimVar simVar, HashTableCrIListArray
  "Generates code for ScalarVariable file for FMU target."
 ::=
   match simVar
+    case SIMVAR(type_ = T_ARRAY(), arrayCref = SOME(__)) then
+      let variableCode = if generateFMUModelDescription then CodegenFMUCommon.ScalarVariableType(simVar) else
+                                                             ScalarVariableType(simCode, name, aliasvar, unit, displayUnit, minValue, maxValue, initialValue, nominalValue, isFixed, type_, complexStartExpressions, stateDerVectorName)
+      <<
+      <ArrayVariable <%scalarVariableAttributeXML(simVar, simCode, indexForUndefinedReferences, generateFMUModelDescription)%>>
+        <%variableCode%>
+        <%simVar.numArrayElement |> dim => '<Dimension start="<%dim%>"/>'; separator="\n"%>
+      </ArrayVariable>
+      >>
     case SIMVAR(type_ = T_ARRAY()) then
       /* call ScalarVariableType for array to update complexStartExpressions */
       let _ = if not generateFMUModelDescription then
@@ -177,7 +186,6 @@ template scalarVariableAttributeXML(SimVar simVar, SimCode simCode, String index
 ::=
   match simVar
     case SIMVAR(source = SOURCE(info = info)) then
-      let valueReference = SimCodeUtil.getValueReference(simVar, simCode, true)
       let alias = getAliasAttribute(aliasvar)
       let causalityAtt = CodegenFMUCommon.getCausality(causality)
       let variability = getVariablity(varKind)
@@ -185,7 +193,7 @@ template scalarVariableAttributeXML(SimVar simVar, SimCode simCode, String index
       let hr = match hideResult case SOME(bval) then '<%bval%>'
       let additionalAttributes = if generateFMUModelDescription then '' else 'isProtected="<%isProtected%>" hideResult="<%hr%>" isDiscrete="<%isDiscrete%>" isValueChangeable="<%isValueChangeable%>"'
       <<
-      name="<%System.stringReplace(Util.escapeModelicaStringToXmlString(crefStrNoUnderscore(name)),"$", "_D_")%>" valueReference="<%valueReference%>" <%description%> variability="<%variability%>" causality="<%causalityAtt%>" alias="<%alias%>" <%additionalAttributes%>
+      name="<%System.stringReplace(Util.escapeModelicaStringToXmlString(crefStrNoUnderscore(name)),"$", "_D_")%>" valueReference="<%index%>" <%description%> variability="<%variability%>" causality="<%causalityAtt%>" alias="<%alias%>" <%additionalAttributes%>
       >>
 end scalarVariableAttributeXML;
 
@@ -202,7 +210,7 @@ end getAliasAttribute;
 template ScalarVariableType(SimCode simCode, DAE.ComponentRef simVarCref, AliasVariable simVarAlias, String unit, String displayUnit, Option<DAE.Exp> minValue, Option<DAE.Exp> maxValue, Option<DAE.Exp> startValue, Option<DAE.Exp> nominalValue, Boolean isFixed, DAE.Type type_, Text& complexStartExpressions, Text stateDerVectorName)
  "Generates code for ScalarVariable Type file for FMU target."
 ::=
-  match type_
+  match Types.arrayElementType(type_)
     case T_INTEGER(__) then
       let start_  = ScalarVariableTypeStartAttribute(simCode, simVarCref, simVarAlias, startValue, "Int", complexStartExpressions, stateDerVectorName)
       let fixed_  = ' fixed="<%isFixed%>"'

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1400,7 +1400,9 @@ constant ConfigFlag CAUSALIZE_DAE_MODE = CONFIG_FLAG(160, "causalizeDaeMode",
 /* please remove me once this is supported */
 constant ConfigFlag SIM_CODE_SCALARIZE = CONFIG_FLAG(161, "simCodeScalarize",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
-  "Scalarizes variables during simcode phase.");
+  "Scalarizes variables during simcode phase. Only consulted by the new backend.
+   Defaults to true; the C++ target (simCodeTarget=Cpp) forces it false so arrays
+   are kept un-expanded as StatArrayDim members (see SimCodeMain, issue #15496).");
 constant ConfigFlag EXECUTE_COMMAND = CONFIG_FLAG(162, "cmd",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   "Executes the string argument as a script before any other operation.");

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1400,9 +1400,7 @@ constant ConfigFlag CAUSALIZE_DAE_MODE = CONFIG_FLAG(160, "causalizeDaeMode",
 /* please remove me once this is supported */
 constant ConfigFlag SIM_CODE_SCALARIZE = CONFIG_FLAG(161, "simCodeScalarize",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
-  "Scalarizes variables during simcode phase. Only consulted by the new backend.
-   Defaults to true; the C++ target (simCodeTarget=Cpp) forces it false so arrays
-   are kept un-expanded as StatArrayDim members (see SimCodeMain, issue #15496).");
+  "Scalarizes variables during simcode phase.");
 constant ConfigFlag EXECUTE_COMMAND = CONFIG_FLAG(162, "cmd",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   "Executes the string argument as a script before any other operation.");

--- a/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -74,7 +74,7 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
       LOGGER_WRITE_BEGIN("Initialize start values:", LC_INIT, LL_DEBUG);
       FOREACH(ptree::value_type const& vars, modelDescription.get_child("ModelVariables"))
       {
-        if (vars.first == "ScalarVariable")
+        if (vars.first == "ScalarVariable" || vars.first == "ArrayVariable")
         {
           refIdxOpt = vars.second.get_optional<int>("<xmlattr>.valueReference");
 
@@ -114,7 +114,7 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
 
           FOREACH(ptree::value_type const& var, vars.second.get_child(""))
           {
-             if ((var.first == "Real") /* Todo: this is needed for reduce dae method but breaks tests*/ /*&& (name.substr(0, 3) != "der")*/)
+            if ((var.first == "Real") /* Todo: this is needed for reduce dae method but breaks tests*/ /*&& (name.substr(0, 3) != "der")*/)
             {
                //If a start value is given for the alias and the referred variable, skip the alias declaration
               if (!(isAlias || isNegatedAlias))
@@ -211,7 +211,7 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
     {
       std::stringstream sstream;
       sstream << "Could not read start values. Current variable reference is " << refIdx;
-      throw ModelicaSimulationError(UTILITY,sstream.str());
+      throw ModelicaSimulationError(UTILITY, sstream.str());
     }
     _isInitialized = true;
     file.close();

--- a/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -36,6 +36,23 @@
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <sstream>
+#include <vector>
+
+// Build the Modelica name of a scalar element of a row-major array,
+// e.g. arrayElementName("a", {2,3}, 4) -> "a[2,2]". Used to expose the
+// elements of a non-scalarized array variable as individual result signals.
+static std::string arrayElementName(const std::string& base, const std::vector<int>& dims, int linearOffset)
+{
+  std::vector<int> idx(dims.size());
+  int rem = linearOffset;
+  for (int k = (int)dims.size() - 1; k >= 0; k--) { idx[k] = rem % dims[k]; rem /= dims[k]; }
+  std::stringstream ss;
+  ss << base << "[";
+  for (size_t k = 0; k < idx.size(); k++) { if (k) ss << ","; ss << (idx[k] + 1); }
+  ss << "]";
+  return ss.str();
+}
 
 XmlPropertyReader::XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile)
   : IPropertyReader()
@@ -98,6 +115,25 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
           bool isAlias = aliasInfo.compare("alias") == 0;
           bool isNegatedAlias = aliasInfo.compare("negatedAlias") == 0;
 
+          // For a non-scalarized array (kept un-expanded with simCodeScalarize=false),
+          // collect the per-dimension sizes so each scalar element a[i,j,...] can be
+          // registered as its own result signal at the contiguous reference refIdx+offset.
+          bool isArray = (vars.first == "ArrayVariable");
+          std::vector<int> arrayDims;
+          int arraySize = 1;
+          if (isArray)
+          {
+            FOREACH(ptree::value_type const& dimNode, vars.second.get_child(""))
+            {
+              if (dimNode.first == "Dimension")
+              {
+                boost::optional<int> d = dimNode.second.get_optional<int>("<xmlattr>.start");
+                if (d) { arrayDims.push_back(*d); arraySize *= *d; }
+              }
+            }
+            if (arrayDims.empty()) { arrayDims.push_back(1); }
+          }
+
           bool emitResult = false;
           if (emitResults != EMIT_NONE) {
             emitResult = std::regex_match(name, filterRegex);
@@ -123,17 +159,33 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
                 if (v) {
                   double value = *v;
                   LOGGER_WRITE("XMLPropertyReader: Setting real variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value), LC_INIT, LL_DEBUG);
-                  system.setRealStartValue(realVars[refIdx], value);
+                  for (int off = 0; off < (isArray ? arraySize : 1); off++)
+                    system.setRealStartValue(realVars[refIdx + off], value);
                 }
               }
-              const double& realVar = sim_vars->getRealVar(refIdx);
-              const double* realVarPtr = &realVar;
               if (emitResult)
               {
-                if (isParameter)
-                  _realVars.addParameter(name, descripton, realVarPtr);
+                if (isArray)
+                {
+                  // expose each scalar element a[i,j,...] as its own result signal
+                  for (int off = 0; off < arraySize; off++)
+                  {
+                    const double* p = &sim_vars->getRealVar(refIdx + off);
+                    std::string elname = arrayElementName(name, arrayDims, off);
+                    if (isParameter)
+                      _realVars.addParameter(elname, descripton, p);
+                    else
+                      _realVars.addOutputVar(elname, descripton, p, isNegatedAlias);
+                  }
+                }
                 else
-                  _realVars.addOutputVar(name, descripton, realVarPtr, isNegatedAlias);
+                {
+                  const double* realVarPtr = &sim_vars->getRealVar(refIdx);
+                  if (isParameter)
+                    _realVars.addParameter(name, descripton, realVarPtr);
+                  else
+                    _realVars.addOutputVar(name, descripton, realVarPtr, isNegatedAlias);
+                }
               }
             }
             else if (var.first == "Integer")

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -60,6 +60,7 @@ simulationdaemode.log \
 simulationnewbackend-alias.log \
 simulationnewbackend-arrayhandling.log \
 simulationnewbackend-basics.log \
+simulationnewbackend-cpp.log \
 simulationnewbackend-differentation.log \
 simulationnewbackend-event_handling.log \
 simulationnewbackend-functions.log \
@@ -350,6 +351,9 @@ simulationnewbackend-arrayhandling.log: omc-diff
 	@echo $@ done
 simulationnewbackend-basics.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/basics/ -f Makefile test > $@
+	@echo $@ done
+simulationnewbackend-cpp.log: omc-diff
+	$(MAKE) -C simulation/modelica/NBackend/cpp/ -f Makefile test > $@
 	@echo $@ done
 simulationnewbackend-clocked.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/clocked/ -f Makefile test > $@

--- a/testsuite/simulation/modelica/NBackend/cpp/Makefile
+++ b/testsuite/simulation/modelica/NBackend/cpp/Makefile
@@ -1,0 +1,50 @@
+TEST = ../../../../rtest -v
+
+TESTFILES = \
+ParArray.mos\
+der_for_array.mos\
+
+# test that currently fail. Move up when fixed.
+# Run make failingtest
+FAILINGTESTFILES = \
+
+# Dependency files that are not .mo .mos or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.mo \
+*.mos \
+Makefile \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@echo
+	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@rm -f $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/simulation/modelica/NBackend/cpp/ParArray.mos
+++ b/testsuite/simulation/modelica/NBackend/cpp/ParArray.mos
@@ -1,0 +1,50 @@
+// name: ParArray
+// keywords: NewBackend, Cpp, array variables, non-scalarized, ticket:15496
+// status: correct
+//
+// New Backend + C++ runtime with arrays kept un-expanded (simCodeScalarize is
+// forced false for the Cpp target). Exact MWE from issue #15496: a degenerate
+// parameter-array start with der(a) = 0. Exercises the value-reference mapping,
+// element-aware var sizing, StatArrayDim member init and result element export.
+
+setCommandLineOptions("--newBackend --simCodeTarget=Cpp"); getErrorString();
+
+loadString("
+model ParArray
+  function getArr
+    input Real u;
+    output Real[3] y;
+  algorithm
+    y := fill(u, 3);
+  end getArr;
+  parameter Real p = 1;
+protected
+  parameter Real[3] a_start = getArr(p);
+  Real[3] a(start = a_start);
+equation
+  der(a) = zeros(3);
+end ParArray;
+"); getErrorString();
+
+simulate(ParArray, stopTime = 1.0); getErrorString();
+val(a[1], 1.0);
+val(a[2], 1.0);
+val(a[3], 1.0);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ParArray_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ParArray', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// "Warning: NSimJacobian.SimJacobian.createSparsityPattern: column cref not found in Jacobian local_idx_map: a[1]
+// 	Available keys: a, $DER.a
+// Warning: NSimJacobian.SimJacobian.create could not generate sparsity pattern of Jacobian [ODE].
+// "
+// 1.0
+// 1.0
+// 1.0
+// endResult

--- a/testsuite/simulation/modelica/NBackend/cpp/der_for_array.mos
+++ b/testsuite/simulation/modelica/NBackend/cpp/der_for_array.mos
@@ -1,0 +1,39 @@
+// name: der_for_array
+// keywords: NewBackend, Cpp, array variables, non-scalarized, for-equation, ticket:15496
+// status: correct
+//
+// New Backend + C++ runtime, non-scalarized array with a resizable for-equation
+// SES_RESIZABLE_ASSIGN: der(x[i]) = -x[i], x(0) = 1, so x[i](t) = exp(-t).
+
+setCommandLineOptions("--newBackend --simCodeTarget=Cpp"); getErrorString();
+
+loadString("
+model der_for_array
+  Real[3] x(each start = 1, each fixed = true);
+equation
+  for i in 1:3 loop
+    der(x[i]) = -x[i];
+  end for;
+end der_for_array;
+"); getErrorString();
+
+simulate(der_for_array, stopTime = 1.0); getErrorString();
+val(x[1], 1.0);
+val(x[3], 1.0);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "der_for_array_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'der_for_array', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// "Warning: NSimJacobian.SimJacobian.createSparsityPattern: column cref not found in Jacobian local_idx_map: x[1]
+// 	Available keys: x, $DER.x
+// Warning: NSimJacobian.SimJacobian.create could not generate sparsity pattern of Jacobian [ODE].
+// "
+// 0.3678796919078512
+// 0.3678796919078512
+// endResult


### PR DESCRIPTION
### Related Issues

Closes #15496.
Supersedes #15587 — this branch is stacked on it and carries its commit, so #15587 can be closed once this lands.

### Purpose

Make the New Backend **C++ target** compile and simulate models whose array
variables are kept un-expanded (`simCodeScalarize=false`), instead of failing
with `GetVarIndexListByMapping: No Element for a found`, `NOT IMPLEMENTED
EQUATION` (SES_RESIZABLE_ASSIGN), `init xml file has not been read`, or a
segfault.

The C++ runtime keeps arrays as `StatArrayDim` members and equations live in
model-class methods over those members, so non-scalarized arrays need an
element-aware var/value-reference layout, an equation case for the resizable
for-loop assignment, the array members actually pointed into the var pool, and
the result file expanded to scalar element signals.

### Approach

- **CodegenCppInit.tpl** — restore `getValueReference()` on the common scalar
  path; #15587 had replaced it with the raw `SimVar.index`, corrupting the
  valueReference of *every* C++ scalar variable (the ~112 cppruntime
  regressions).
- **CodegenCpp.tpl**
  - Add a `SES_RESIZABLE_ASSIGN` case to both equation dispatchers
    (`equationString` and `equation_function_create_single_body`). Implemented
    inline as a nested for-loop (`equationResizableAssign` + helpers), looking up
    the `lhs := rhs` body from `simCode.generic_loop_calls`. Inlining fits the
    C++ runtime better than the C runtime's separate `genericCall_<n>()`
    functions.
  - Reorder `memberVariableInitialize2` so the `T_ARRAY` case runs before the
    `arrayCref=SOME` case (mirrors `memberVariableDefine2`): a non-scalarized
    array cref has no subscripts, so the old order hit the `dims="0"` branch and
    emitted no `.init()`, leaving the `StatArrayDim` ref-array pointing at null →
    segfault in `setRealStartValue`.
- **NSimVar.mo** — `VarInfo.create` counts scalar **elements** (`listScalarSize`)
  instead of simvars, so the var vectors are sized to match the (element-aware)
  value-reference space.
- **SimCodeMain.mo** — force `simCodeScalarize=false` for the **Cpp target only**
  (set before the frontend on the main NB path and the residuals path). The C
  runtime does not yet support non-scalarized arrays, so its default (`true`) is
  unchanged.
- **XmlPropertyReader.cpp** — expand a non-scalarized `ArrayVariable` into one
  result signal per scalar element, named `a[i,j,...]` (row-major), matching the
  names used by `val()` and the C-side writer in #15823.

### Tests

New `testsuite/simulation/modelica/NBackend/cpp/` (wired in as
`simulationnewbackend-cpp.log`):
- `ParArray.mos` — the exact #15496 MWE (`der(a)=zeros(3)` from a degenerate
  parameter-array start) → `a[1..3] = 1.0`
- `der_for_array.mos` — resizable for-equation `der(x[i]) = -x[i]` → `x[i] = exp(-1)`

Both run with `--newBackend --simCodeTarget=Cpp`. Manually verified the default
**C** runtime is unaffected (scalar and array models still simulate).

### Follow-up

The C runtime non-scalarized path (init-XML var-index map, result output) is a
separate effort, tracked alongside #15823 and the other array PRs (#14336,
#14518, #14593, #11485). The NB Jacobian sparsity warning for non-scalarized
crefs is likewise left to the Jacobian-side PRs (the two test baselines capture
it for now).

