### PR TITLE
Fix resolveLoops folding array elements with non-constant indices

### DIFF
--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -2049,10 +2049,12 @@ algorithm
       BackendDAE.Variables vars;
       DAE.Exp exp,exp1,exp2;
       DAE.ComponentRef cref;
-    case (DAE.CREF(),(true,vars))
+    case (DAE.CREF(componentRef=cref),(true,vars))
       algorithm
-        //x
-      then (inExp,(true,vars));
+        //x, but reject array elements with non-constant indices since
+        //resolveLoops cannot map them to a single scalar variable
+        b := Expression.subscriptConstants(ComponentReferenceBasics.crefSubs(cref));
+      then (inExp,(b,vars));
 
     case (DAE.UNARY(exp=exp1),(true,vars))
       algorithm

--- a/testsuite/simulation/modelica/resolveLoops/Issue15901.mo
+++ b/testsuite/simulation/modelica/resolveLoops/Issue15901.mo
@@ -1,0 +1,17 @@
+model Issue15901
+  "Regression test for #15901: resolveLoops must not fold equations that
+   contain array elements indexed by a non-constant subscript"
+  Real u[2];
+  Integer f(start = 1);
+  Real y(start = 20), z(start = 0);
+equation
+  when time > 0.5 then
+    f = 0;
+  end when;
+  u[1] = 10 + time;
+  u[2] = 20 + time;
+  // y and z form a 2x2 loop. The first equation indexes u by the
+  // non-constant subscript f+1, so resolveLoops must stay away from it.
+  y = u[f+1] - z;
+  y = u[2] + z;
+end Issue15901;

--- a/testsuite/simulation/modelica/resolveLoops/Issue15901.mos
+++ b/testsuite/simulation/modelica/resolveLoops/Issue15901.mos
@@ -1,0 +1,40 @@
+// name:      Issue15901
+// keywords:  resolveLoops
+// status:    correct
+//
+// Regression test for #15901: resolveLoops wrongly folded equations that
+// contain an array element indexed by a non-constant subscript (u[f+1]) into
+// a loop, producing a bogus equation and hence wrong results. With f=1 the
+// correct solution is y=u[2]=20.25, z=0; with f=0 it is y=16, z=-5.
+//
+
+loadFile("Issue15901.mo"); getErrorString();
+
+simulate(Issue15901, startTime=0.0, stopTime=1.0, numberOfIntervals=4); getErrorString();
+
+val(f, 0.25);
+val(y, 0.25);
+val(z, 0.25);
+val(f, 1.0);
+val(y, 1.0);
+val(z, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Issue15901_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 4, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue15901', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 1.0
+// 20.25
+// 0.0
+// 0.0
+// 16.0
+// -5.0
+// endResult

--- a/testsuite/simulation/modelica/resolveLoops/Makefile
+++ b/testsuite/simulation/modelica/resolveLoops/Makefile
@@ -14,6 +14,7 @@ ElectricalCircuit4.mos \
 ElectricalCircuit5.mos \
 ElectricalCircuit6.mos \
 Issue13292.mos \
+Issue15901.mos \
 NPendulum2.mos \
 NPendulum3.mos
 #AmplifierWithOpAmpDetailed.mos \


### PR DESCRIPTION
Fixes #15901.

resolveLoops classified equations as simple linear equations via isAddOrSubExp, whose DAE.CREF case accepted any component reference unconditionally. An array element indexed by a non-constant subscript such as u[f+1] cannot be mapped to a single scalar variable in the adjacency matrix, so loop resolution fabricated a bogus equation (e.g. multiswitch.switch.y := u[f+1] + u[2]) and produced wrong results.

isAddOrSubExp now rejects component references that carry non-constant subscripts, so resolveLoops leaves such equations untouched. Plain scalars and constant-index elements like u[2] are unaffected.

Adds a self-contained regression test under simulation/modelica/resolveLoops.

