### PR TITLE
[CMake] Detect BLAS/LAPACK once and cache to skip per-call vendor sweep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,44 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 # issues after it.
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "unknown-install-component")
 
+## BLAS/LAPACK detection ###################################################################################
+## Detect BLAS and LAPACK once, here at the top level, before descending into the subprojects.
+##
+## When no BLA_VENDOR is pinned, CMake's stock FindBLAS/FindLAPACK modules sweep *every* known vendor
+## (Intel MKL, ACML, ARMPL, Apple, OpenBLAS, BLIS, ATLAS, Goto, Generic, ...), issuing hundreds of
+## find_library() calls. On a machine without a vendor BLAS this all-vendor sweep dominates the configure
+## (see issue #15904: ~200s of a ~285s configure). There are 18+ find_package(BLAS|LAPACK) call sites across
+## the tree (SimulationRuntime/c, Compiler/runtime, sundials, primme, CMinpack, Ipopt/MUMPS, OMSI, OMSICpp,
+## ...), and each one can re-trigger the full sweep, compounding the cost.
+##
+## FindBLAS/FindLAPACK clear the *normal* variables BLAS_LIBRARIES/LAPACK_LIBRARIES at entry, then guard
+## their all-vendor sweep with `if(NOT BLAS_LIBRARIES)` / `if(NOT LAPACK_LIBRARIES)`. A plain normal variable
+## inherited by a child scope is therefore wiped before the guard runs, so propagation alone does NOT prevent
+## a re-sweep. A *cache* entry of the same name, however, shows through `set(<var>)` (which only unsets the
+## normal variable) and trips the guard -- skipping the sweep entirely.
+##
+## So: detect once here, and (when found) publish the results as cache entries. Every subsequent
+## find_package(BLAS|LAPACK) anywhere in the tree -- including inside the OMCompiler/3rdParty and OMSimulator
+## submodules, which we cannot edit from this repository -- then short-circuits to the cached libraries. The
+## expensive vendor sweep runs at most once per configure instead of once per call site. Autodetection is
+## preserved (we don't pin BLA_VENDOR); if nothing is found here, the cache stays empty and a REQUIRED child
+## call still re-runs and errors exactly as before.
+## Detect and cache BLAS first: find_package(LAPACK) internally re-runs find_package(BLAS), so publishing
+## the BLAS cache up front lets LAPACK's own BLAS lookup short-circuit too -- otherwise the vendor sweep
+## would still run twice here.
+find_package(BLAS)
+if(BLAS_FOUND AND BLAS_LIBRARIES)
+  set(BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE STRING "BLAS libraries (detected once at the top level)" FORCE)
+  set(BLAS_LINKER_FLAGS "${BLAS_LINKER_FLAGS}" CACHE STRING "BLAS linker flags (detected once at the top level)" FORCE)
+  mark_as_advanced(BLAS_LIBRARIES BLAS_LINKER_FLAGS)
+endif()
+find_package(LAPACK)
+if(LAPACK_FOUND AND LAPACK_LIBRARIES)
+  set(LAPACK_LIBRARIES "${LAPACK_LIBRARIES}" CACHE STRING "LAPACK libraries (detected once at the top level)" FORCE)
+  set(LAPACK_LINKER_FLAGS "${LAPACK_LINKER_FLAGS}" CACHE STRING "LAPACK linker flags (detected once at the top level)" FORCE)
+  mark_as_advanced(LAPACK_LIBRARIES LAPACK_LINKER_FLAGS)
+endif()
+
 ## Subdirectories ##########################################################################################
 # If asked for encryption support, add and configure the OMEncryption directory.
 if(OM_ENABLE_ENCRYPTION)


### PR DESCRIPTION
This will mostly help WSL builds.

With no BLA_VENDOR pinned, CMake's FindBLAS/FindLAPACK sweep every known vendor (MKL, ACML, ARMPL, OpenBLAS, BLIS, ATLAS, Generic, ...) via hundreds of find_library() calls. With 18+ find_package(BLAS|LAPACK) call sites across the tree, each one re-triggers the full sweep and it dominates configure time (issue #15904: ~200s of a ~285s configure).

The modules clear the normal BLAS_LIBRARIES/LAPACK_LIBRARIES at entry, so variable propagation alone cannot short-circuit a later call. Instead, detect once at the top level and publish the results as cache entries: a cache entry shows through the modules' set(<var>) (which only unsets the normal variable), tripping their `if(NOT <var>)` guard and skipping the sweep. This also reaches the OMCompiler/3rdParty and OMSimulator submodule call sites, which cannot be edited from this repository. Autodetection is preserved (BLA_VENDOR is not pinned); if nothing is found the cache stays empty and REQUIRED child calls still error as before. BLAS is cached before find_package(LAPACK) so LAPACK's internal BLAS lookup short-circuits too.

Measured on a full superproject configure: the all-vendor find_library sweep drops from 156 calls to 1, and configure wall-clock roughly halves.

Fixes #15904

