### PR TITLE
fix: allow fmi2Get/Set/FreeFMUstate in Continuous-Time Mode

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1320,8 +1320,8 @@ fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
   ModelInstance *comp = (ModelInstance *) c;
   fmi2CallbackFunctions* functions = (fmi2CallbackFunctions*) comp->functions;
 
-  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode;
-  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete;
+  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error;
+  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_cs_step_failed|model_state_cs_step_canceled|model_state_terminated|model_state_error;
 
   if (invalidState(comp, "fmi2GetFMUstate", meStates, csStates))
     return fmi2Error;
@@ -1404,10 +1404,10 @@ fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
 {
   ModelInstance *comp = (ModelInstance *) c;
 
-  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode;
-  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete;
+  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error;
+  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_cs_step_failed|model_state_cs_step_canceled|model_state_terminated|model_state_error;
 
-  if (invalidState(comp, "fmi2GetFMUstate", meStates, csStates))
+  if (invalidState(comp, "fmi2SetFMUstate", meStates, csStates))
     return fmi2Error;
 
   INTERNAL_FMU_STATE * internal_state = (INTERNAL_FMU_STATE *) FMUstate;
@@ -1455,8 +1455,8 @@ fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
   ModelInstance *comp = (ModelInstance *) c;
   fmi2CallbackFunctions* functions = (fmi2CallbackFunctions*) comp->functions;
 
-  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode;
-  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete;
+  int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error;
+  int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_cs_step_failed|model_state_cs_step_canceled|model_state_terminated|model_state_error;
 
   if (invalidState(comp, "fmi2FreeFMUstate", meStates, csStates))
     return fmi2Error;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1455,7 +1455,7 @@ fmi3Status omcSetFMUstate(ModelInstance* c, fmi3FMUState FMUstate)
   int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated;
   int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_terminated;
 
-  if (invalidState(comp, "omcGetFMUstate", meStates, csStates))
+  if (invalidState(comp, "omcSetFMUstate", meStates, csStates))
     return fmi3Error;
 
   INTERNAL_FMU_STATE * internal_state = (INTERNAL_FMU_STATE *) FMUstate;


### PR DESCRIPTION
The FMI 2.0 spec allows the get/set/free FMU state functions to be called in Continuous-Time Mode and Terminated state. The state masks in the C runtime were missing these states, so any call to these functions after a simulation (where the FMU remains in Continuous-Time Mode) was rejected with fmi2Error.

This affects users who call get_fmu_state() after simulate(), e.g. when splitting long simulations into chunks with serialize/deserialize.

Changes in fmu2_model_interface.c:
- fmi2GetFMUstate: add me_continuous_time_mode, terminated, error to ME mask; add cs_step_failed, cs_step_canceled, terminated, error to CS mask
- fmi2SetFMUstate: same state mask fix + fix function name in error message ("fmi2GetFMUstate" -> "fmi2SetFMUstate")
- fmi2FreeFMUstate: same state mask fix

Changes in fmu3_model_interface.c:
- omcSetFMUstate: fix function name in error message ("omcGetFMUstate" -> "omcSetFMUstate")

Related: #7939, #15216

/cc @arun3688 @lochel 
