### PR TITLE
fix: enable canGetAndSetFMUstate by default in FMI 2.0 export

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -187,8 +187,8 @@ case SIMCODE(__) then
     canRunAsynchronuously = "false"
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"
-    <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canGetAndSetFMUstate="true"' else 'canGetAndSetFMUstate="false"'%>
-    <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canSerializeFMUstate="true"' else 'canSerializeFMUstate="false"'%>
+    canGetAndSetFMUstate="true"
+    canSerializeFMUstate="true"
     <% if Flags.isSet(FMU_EXPERIMENTAL) then 'providesDirectionalDerivative="true"' else 'providesDirectionalDerivative="false"'%>>
     <%SourceFiles(sourceFiles)%>
   </CoSimulation>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -98,8 +98,8 @@ case SIMCODE(__) then
     completedIntegratorStepNotNeeded="false"
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"
-    <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canGetAndSetFMUstate="true"' else 'canGetAndSetFMUstate="false"'%>
-    <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canSerializeFMUstate="true"' else 'canSerializeFMUstate="false"'%>
+    canGetAndSetFMUstate="true"
+    canSerializeFMUstate="true"
     <% if providesDirectionalDerivative(simCode) then 'providesDirectionalDerivative="true"' else 'providesDirectionalDerivative="false"'%>>
     <%SourceFiles(sourceFiles)%>
   </ModelExchange>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -129,8 +129,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <LogCategories>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOsArray.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOsArray.mos
@@ -55,8 +55,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <LogCategories>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
@@ -85,8 +85,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <TypeDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -73,8 +73,8 @@ getErrorString();
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
 //   <UnitDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
@@ -71,8 +71,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <TypeDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -72,8 +72,8 @@ val(evaporator_qm_S, 100);
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
 //   <UnitDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
@@ -56,8 +56,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <TypeDefinitions>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_25.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_25.mos
@@ -51,8 +51,8 @@ readFile("fmi_attributes_25.xml"); getErrorString();
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //   </ModelExchange>
 //   <LogCategories>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
@@ -52,8 +52,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //     <SourceFiles>
 //       <File name=\"test_Bug2764.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -43,8 +43,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //     <SourceFiles>
 //       <File name=\"test_Bug3049.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
@@ -61,8 +61,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"false\">
 //     <SourceFiles>
 //       <File name=\"testDID.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
@@ -57,8 +57,8 @@ readFile("modelDescription.tmp.xml");
 //     completedIntegratorStepNotNeeded=\"false\"
 //     canBeInstantiatedOnlyOncePerProcess=\"false\"
 //     canNotUseMemoryManagementFunctions=\"false\"
-//     canGetAndSetFMUstate=\"false\"
-//     canSerializeFMUstate=\"false\"
+//     canGetAndSetFMUstate=\"true\"
+//     canSerializeFMUstate=\"true\"
 //     providesDirectionalDerivative=\"true\">
 //     <SourceFiles>
 //       <File name=\"testDID.c\" />


### PR DESCRIPTION
The get/set/serialize FMU state functions are fully implemented in the C runtime and work reliably. FMI 3.0 already advertises them as enabled by default. FMI 2.0 was kept behind the +d=fmuExperimental flag for no technical reason - remove the gate so users get state save/restore without needing to discover a non-obvious compiler flag.

Fixes #7939

/cc @arun3688 @lochel 