### PR TITLE
Fix documentation generation: unset HOME and missing systemoverview.png

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -513,6 +513,10 @@ pipeline {
             }
             sh '''
             export OPENMODELICAHOME=$PWD/build
+            # omc invoked while building the docs needs a writable HOME holding the
+            # libraries, otherwise it tries to write to //.openmodelica and fails to
+            # load Modelica (same as the compliance stage).
+            export HOME=$PWD/libraries
             test ! -d $PWD/build/lib/omlibrary
             cp -a libraries/.openmodelica/libraries $PWD/build/lib/omlibrary
             for target in html pdf epub; do

--- a/doc/UsersGuide/Makefile
+++ b/doc/UsersGuide/Makefile
@@ -255,7 +255,7 @@ OMEDIT_ICONS=$(OMEDIT_ICONS_SVG) $(OMEDIT_ICONS_PNG) $(OMEDIT_ICONS_PDF)
 OMOPTIM_ICONS_BASE=Add.png
 OMOPTIM_ICONS=$(OMOPTIM_ICONS_BASE:%=source/media/omoptim-icons/%)
 
-all-dep: $(ALLDEP) source/media/mathematica-notebooks.pdf source/media/mdt-create-project.png source/media/mdt-build-prompt.png source/simoptions.inc source/omchelptext.rst source/githubreleases.rst source/tracreleases.inc
+all-dep: $(ALLDEP) source/media/systemoverview.png source/media/mathematica-notebooks.pdf source/media/mdt-create-project.png source/media/mdt-build-prompt.png source/simoptions.inc source/omchelptext.rst source/githubreleases.rst source/tracreleases.inc
 
 source/media/omedit-icons/%.svg: $(OPENMODELICA_ROOT)/OMEdit/OMEditLIB/Resources/icons/%.svg
 	@mkdir -p source/media/omedit-icons


### PR DESCRIPTION
Fixes #15919

The User's Guide build had two independent problems:

### 1. omc fails to load Modelica during the docs build (unset `HOME`)

`doc/UsersGuide/source/introduction.rst` runs `omc TestScript.mos` through Sphinx's `command-output` directive. `TestScript.mos` does `loadModel(Modelica)` + simulates `Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum`.

In the Jenkins `09 build-usersguide` stage, `HOME` was never set inside the docker container. With an empty `HOME`, omc's `MODELICAPATH` collapses to `/.openmodelica/libraries` and it cannot write its package index:

```
Error: Failed to open file for writing: //.openmodelica/libraries/index.json.tmp1
Error: Failed to download package index https://libraries.openmodelica.org/index/v1/index.json ...
Error: Failed to load package Modelica (default) using MODELICAPATH /.openmodelica/libraries/.
... Failed to build model: Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum
```

Reproduced locally with `env -i HOME= omc TestScript.mos` (fails identically) and confirmed it simulates successfully once `HOME` points at a writable dir containing the libraries.

**Fix:** export `HOME=$PWD/libraries` in the `build-usersguide` stage, the same approach already used by the `compliance` stage. `libraries/.openmodelica/libraries` is already populated by `makeLibsAndCache()`.

### 2. Missing `media/systemoverview.png` in the HTML/EPUB docs

`systemoverview.png` is generated from `systemoverview.svg` (it's gitignored), but its make rule was only listed as a dependency of the `latex` target. So `html` and `epub` builds referenced an image that was never generated.

**Fix:** add `source/media/systemoverview.png` to `all-dep`, which every Sphinx builder depends on. Verified the existing inkscape rule produces a valid 1075x497 PNG.

Both changes are CI/build-only and require no omc rebuild.

generated by Claude Code
