### PR TITLE
[FMI] Fix array-attribute init crash in scalarized FMU export

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -3539,12 +3539,16 @@ template ScalarVariableFMU(SimVar simVar, String classType)
 end ScalarVariableFMU;
 
 template DimensionsFMU(SimVar simVar, String classType, String ci)
- "Sets the runtime array dimensions of a non-scalarized variable so that
+ "Sets the runtime array dimensions of a non-scalarized array variable so that
   calculateAllScalarLength / computeVarIndices size the value vectors correctly.
-  Emits nothing for scalars (numberOfDimensions defaults to 0)."
+  Emits nothing for scalars (numberOfDimensions defaults to 0). Only genuine
+  array variables (type_ = T_ARRAY) are dimensioned: a scalarized array element
+  still carries the parent numArrayElement but is a scalar and must keep
+  numberOfDimensions 0, otherwise the start/min/max/nominal bound-attribute
+  update treats it as an array."
 ::=
 match simVar
-case SIMVAR(numArrayElement = dims) then
+case SIMVAR(type_ = T_ARRAY(), numArrayElement = dims) then
   if listEmpty(dims) then '' else
   <<
   modelData-><%classType%>[<%ci%>].dimension.numberOfDimensions = <%listLength(dims)%>;

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -2,6 +2,7 @@ TEST = ../../../../../rtest -v
 
 
 TESTFILES = \
+fmi2_array_cpp.mos \
 DIC_FMU2_CPP.mos \
 exposeLocalIOs.mos \
 exposeLocalIOsArray.mos \

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/fmi2_array_cpp.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/fmi2_array_cpp.mos
@@ -1,0 +1,46 @@
+// name: fmi2_array_cpp
+// keywords: FMI 2.0 export array Cpp
+// status: correct
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml fmi2_array_cpp.fmu fmi2_array_cpp.fmutmp fmi2_array_cpp.log fmi2_array_cpp_info.json output.log index.html
+// cflags: -d=-newInst
+//
+// #15926, FMI 2.0 export with the C++ (Cpp) simulation runtime and an array
+// variable carrying a parameter-bound nominal/min attribute. The FMU must build
+// and the array elements appear scalarized in the modelDescription.
+
+setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
+
+loadString("
+model fmi2_array_cpp
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  Real x[3](nominal = x_nom, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi2_array_cpp;
+"); getErrorString();
+
+buildModelFMU(fmi2_array_cpp, version="2.0", fmuType="me"); getErrorString();
+
+system("unzip -cqq fmi2_array_cpp.fmu modelDescription.xml | grep -E 'name=\"(x\\[|der\\(x|y\")' > modelDescription.tmp.xml"); getErrorString();
+readFile("modelDescription.tmp.xml"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi2_array_cpp.fmu"
+// ""
+// 0
+// ""
+// " name=\"x[1]\"
+// name=\"x[2]\"
+// name=\"x[3]\"
+// name=\"der(x[1])\"
+// name=\"der(x[2])\"
+// name=\"der(x[3])\"
+// name=\"y\"
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/3.0/Makefile
@@ -1,7 +1,8 @@
 TEST = ../../../../../rtest -v
 
 TESTFILES = \
-testCppFMI3.mos
+testCppFMI3.mos \
+fmi3_array_cpp.mos
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/3.0/fmi3_array_cpp.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/3.0/fmi3_array_cpp.mos
@@ -1,0 +1,50 @@
+// name: fmi3_array_cpp
+// keywords: FMI 3.0 export array Cpp
+// status: correct
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml fmi3_array_cpp.fmu fmi3_array_cpp.fmutmp fmi3_array_cpp.log fmi3_array_cpp_info.json output.log index.html
+// cflags: -d=-newInst
+//
+// #15926, FMI 3.0 export with the C++ (Cpp) simulation runtime and an array
+// variable carrying a parameter-bound nominal attribute. The FMU must build and
+// the array's typed Float64 elements appear in the modelDescription.
+
+setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
+
+loadString("
+model fmi3_array_cpp
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  Real x[3](nominal = x_nom, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi3_array_cpp;
+"); getErrorString();
+
+buildModelFMU(fmi3_array_cpp, version="3.0", fmuType="me"); getErrorString();
+
+system("unzip -cqq fmi3_array_cpp.fmu modelDescription.xml | grep -E \"<Float64 name\" > modelDescription.tmp.xml"); getErrorString();
+readFile("modelDescription.tmp.xml"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi3_array_cpp.fmu"
+// ""
+// 0
+// ""
+// " <Float64 name=\"time\" valueReference=\"11\" causality=\"independent\" variability=\"continuous\" description=\"Simulation time\"/>
+// <Float64 name=\"x[1]\" valueReference=\"0\" initial=\"exact\"  start=\"1.0\"/>
+// <Float64 name=\"x[2]\" valueReference=\"1\" initial=\"exact\"  start=\"2.0\"/>
+// <Float64 name=\"x[3]\" valueReference=\"2\" initial=\"exact\"  start=\"3.0\"/>
+// <Float64 name=\"der(x[1])\" valueReference=\"3\"  derivative=\"0\"/>
+// <Float64 name=\"der(x[2])\" valueReference=\"4\"  derivative=\"1\"/>
+// <Float64 name=\"der(x[3])\" valueReference=\"5\"  derivative=\"2\"/>
+// <Float64 name=\"y\" valueReference=\"6\" causality=\"output\" />
+// <Float64 name=\"x_nom[1]\" valueReference=\"7\" causality=\"parameter\" variability=\"fixed\"  start=\"10.0\"/>
+// <Float64 name=\"x_nom[2]\" valueReference=\"8\" causality=\"parameter\" variability=\"fixed\"  start=\"20.0\"/>
+// <Float64 name=\"x_nom[3]\" valueReference=\"9\" causality=\"parameter\" variability=\"fixed\"  start=\"30.0\"/>
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -2,6 +2,9 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 dae_fmu_export_error.mos \
+fmi2_array_attributes.mos \
+fmi2_array_attributes_nb.mos \
+fmi2_array_nonscalarized.mos \
 fmi2_arrays_initial_unknowns.mos \
 fmi_attributes_01.mos \
 fmi_attributes_02.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes.mos
@@ -1,0 +1,67 @@
+// name: fmi2_array_attributes
+// keywords: FMI 2.0 export array nominal scalarized
+// status: correct
+// teardown_command: rm -rf fmi2_array_attributes.fmu fmi2_array_attributes.fmutmp/ fmi2_array_attributes.dims fmi2_array_attributes.log fmi2_array_attributes_info.json fmi2_array_attributes_me_FMU* fmi2_array_attributes_res.mat index.html
+//
+// Regression test for #15926. A scalarized array variable whose nominal/min
+// attribute is bound to a parameter must not be marked as a runtime array in
+// the exported FMU (numberOfDimensions stays 0). Otherwise the start/min/max/
+// nominal bound-attribute update throws "Not yet implemented for array nominal"
+// during FMU initialization (fmi2ExitInitializationMode fails). The exported
+// FMU must initialize and simulate. Old backend, scalarized (default), C runtime.
+
+setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
+
+loadString("
+model fmi2_array_attributes
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  parameter Real x_min[3] = {-100.0, -100.0, -100.0};
+  Real x[3](nominal = x_nom, min = x_min, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi2_array_attributes;
+"); getErrorString();
+
+buildModelFMU(fmi2_array_attributes, version="2.0", fmuType="me"); getErrorString();
+
+// Scalarized elements must not be dimensioned in the generated FMU init
+// (empty result = no scalar element wrongly marked as an array).
+system("unzip -cqq fmi2_array_attributes.fmu sources/fmi2_array_attributes_init_fmu.c | grep -n 'numberOfDimensions = [1-9]' > fmi2_array_attributes.dims || true"); getErrorString();
+readFile("fmi2_array_attributes.dims"); getErrorString();
+
+// The exported FMU must initialize and simulate without the array-attribute throw.
+importFMU("fmi2_array_attributes.fmu"); getErrorString();
+loadFile("fmi2_array_attributes_me_FMU.mo"); getErrorString();
+simulate(fmi2_array_attributes_me_FMU, stopTime=1.0); getErrorString();
+val(y, 0.0); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi2_array_attributes.fmu"
+// ""
+// 0
+// ""
+// ""
+// ""
+// "fmi2_array_attributes_me_FMU.mo"
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "fmi2_array_attributes_me_FMU_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'fmi2_array_attributes_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Notification: Automatically loaded package Complex 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.1.0 due to usage.
+// "
+// 6.0
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes_nb.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes_nb.mos
@@ -1,0 +1,39 @@
+// name: fmi2_array_attributes_nb
+// keywords: FMI 2.0 export array nominal scalarized NewBackend
+// status: correct
+// teardown_command: rm -rf fmi2_array_attributes_nb.fmu fmi2_array_attributes_nb.fmutmp/ fmi2_array_attributes_nb.dims fmi2_array_attributes_nb.log fmi2_array_attributes_nb_info.json index.html
+//
+// #15926, new backend, scalarized (default), C runtime. A scalarized array
+// element must not be dimensioned in the exported FMU init (numberOfDimensions
+// stays 0), otherwise the nominal bound-attribute update throws at FMU init.
+
+setCommandLineOptions("--newBackend"); getErrorString();
+
+loadString("
+model fmi2_array_attributes_nb
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  Real x[3](nominal = x_nom, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi2_array_attributes_nb;
+"); getErrorString();
+
+buildModelFMU(fmi2_array_attributes_nb, version="2.0", fmuType="me"); getErrorString();
+
+// Scalarized elements must not be dimensioned (empty result).
+system("unzip -cqq fmi2_array_attributes_nb.fmu sources/fmi2_array_attributes_nb_init_fmu.c | grep -n 'numberOfDimensions = [1-9]' > fmi2_array_attributes_nb.dims || true"); getErrorString();
+readFile("fmi2_array_attributes_nb.dims"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi2_array_attributes_nb.fmu"
+// ""
+// 0
+// ""
+// ""
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_nonscalarized.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_nonscalarized.mos
@@ -1,0 +1,44 @@
+// name: fmi2_array_nonscalarized
+// keywords: FMI 2.0 export array non-scalarized NewBackend
+// status: correct
+// teardown_command: rm -rf fmi2_array_nonscalarized.fmu fmi2_array_nonscalarized.fmutmp/ fmi2_array_nonscalarized.dims fmi2_array_nonscalarized.log fmi2_array_nonscalarized_info.json index.html
+//
+// #15926, new backend, non-scalarized arrays (--simCodeScalarize=false), C
+// runtime. Here the array variable IS a runtime array and must be dimensioned
+// in the exported FMU init (numberOfDimensions = 1). Confirms the native-array
+// FMU export still dimensions genuine arrays.
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+loadString("
+model fmi2_array_nonscalarized
+  Real x[3](start = {1.0, 2.0, 3.0}, each fixed = true, each nominal = 5.0);
+  parameter Real a = 2.0;
+  output Real y = sum(x);
+equation
+  der(x) = -a*x;
+end fmi2_array_nonscalarized;
+"); getErrorString();
+
+buildModelFMU(fmi2_array_nonscalarized, version="2.0", fmuType="me"); getErrorString();
+
+// The genuine array variable must be dimensioned (non-empty result).
+system("unzip -cqq fmi2_array_nonscalarized.fmu sources/fmi2_array_nonscalarized_init_fmu.c | grep -c 'numberOfDimensions = [1-9]' > fmi2_array_nonscalarized.dims || true"); getErrorString();
+readFile("fmi2_array_nonscalarized.dims"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi2_array_nonscalarized.fmu"
+// "Warning: NSimJacobian.SimJacobian.createSparsityPattern: column cref not found in Jacobian local_idx_map: x[1]
+// Available keys: x, $DER.x
+// Warning: NSimJacobian.SimJacobian.create could not generate sparsity pattern of Jacobian [ODE].
+// "
+// 0
+// ""
+// "2
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -1,6 +1,9 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
+fmi3_array_attributes.mos \
+fmi3_array_attributes_nb.mos \
+fmi3_array_nonscalarized.mos \
 fmi3_arrays.mos \
 fmi3_arrays_approx.mos \
 fmi3_arrays_start_vector.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes.mos
@@ -1,0 +1,33 @@
+// name: fmi3_array_attributes
+// keywords: FMI 3.0 export array nominal scalarized
+// status: correct
+// teardown_command: rm -rf fmi3_array_attributes.fmu fmi3_array_attributes.fmutmp/ fmi3_array_attributes.dims fmi3_array_attributes.log fmi3_array_attributes_info.json index.html
+//
+// #15926, FMI 3.0, old backend, scalarized (default), C runtime. A scalarized
+// array element must not be dimensioned in the exported FMU init.
+
+loadString("
+model fmi3_array_attributes
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  Real x[3](nominal = x_nom, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi3_array_attributes;
+"); getErrorString();
+
+buildModelFMU(fmi3_array_attributes, version="3.0", fmuType="me"); getErrorString();
+
+system("unzip -cqq fmi3_array_attributes.fmu sources/fmi3_array_attributes_init_fmu.c | grep -n 'numberOfDimensions = [1-9]' > fmi3_array_attributes.dims || true"); getErrorString();
+readFile("fmi3_array_attributes.dims"); getErrorString();
+
+// Result:
+// true
+// ""
+// "fmi3_array_attributes.fmu"
+// ""
+// 0
+// ""
+// ""
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes_nb.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes_nb.mos
@@ -1,0 +1,37 @@
+// name: fmi3_array_attributes_nb
+// keywords: FMI 3.0 export array nominal scalarized NewBackend
+// status: correct
+// teardown_command: rm -rf fmi3_array_attributes_nb.fmu fmi3_array_attributes_nb.fmutmp/ fmi3_array_attributes_nb.dims fmi3_array_attributes_nb.log fmi3_array_attributes_nb_info.json index.html
+//
+// #15926, FMI 3.0, new backend, scalarized (default), C runtime. A scalarized
+// array element must not be dimensioned in the exported FMU init.
+
+setCommandLineOptions("--newBackend"); getErrorString();
+
+loadString("
+model fmi3_array_attributes_nb
+  parameter Real x_nom[3] = {10.0, 20.0, 30.0};
+  Real x[3](nominal = x_nom, start = {1.0, 2.0, 3.0}, each fixed = true);
+  output Real y = sum(x);
+equation
+  der(x) = -x;
+end fmi3_array_attributes_nb;
+"); getErrorString();
+
+buildModelFMU(fmi3_array_attributes_nb, version="3.0", fmuType="me"); getErrorString();
+
+system("unzip -cqq fmi3_array_attributes_nb.fmu sources/fmi3_array_attributes_nb_init_fmu.c | grep -n 'numberOfDimensions = [1-9]' > fmi3_array_attributes_nb.dims || true"); getErrorString();
+readFile("fmi3_array_attributes_nb.dims"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi3_array_attributes_nb.fmu"
+// ""
+// 0
+// ""
+// ""
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_nonscalarized.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_nonscalarized.mos
@@ -1,0 +1,63 @@
+// name: fmi3_array_nonscalarized
+// keywords: FMI 3.0 export array non-scalarized NewBackend
+// status: correct
+// teardown_command: rm -rf fmi3_array_nonscalarized.fmu fmi3_array_nonscalarized.fmutmp/ fmi3_array_nonscalarized.dims fmi3_array_nonscalarized.xml fmi3_array_nonscalarized_tmp.xml fmi3_array_nonscalarized.log fmi3_array_nonscalarized_info.json index.html
+//
+// #15926, FMI 3.0, new backend, non-scalarized arrays (--simCodeScalarize=false),
+// C runtime. The array is exported as one native FMI 3.0 Float64 with a
+// <Dimension> and IS dimensioned in the FMU init (numberOfDimensions = 1).
+
+setCommandLineOptions("--newBackend --simCodeScalarize=false"); getErrorString();
+
+loadString("
+model fmi3_array_nonscalarized
+  Real x[3](start = {1.0, 2.0, 3.0}, each fixed = true, each nominal = 5.0);
+  parameter Real a = 2.0;
+  output Real y = sum(x);
+equation
+  der(x) = -a*x;
+end fmi3_array_nonscalarized;
+"); getErrorString();
+
+buildModelFMU(fmi3_array_nonscalarized, version="3.0", fmuType="me"); getErrorString();
+
+// genuine array is dimensioned in the FMU init (non-empty count)
+system("unzip -cqq fmi3_array_nonscalarized.fmu sources/fmi3_array_nonscalarized_init_fmu.c | grep -c 'numberOfDimensions = [1-9]' > fmi3_array_nonscalarized.dims || true"); getErrorString();
+readFile("fmi3_array_nonscalarized.dims"); getErrorString();
+
+// native FMI 3.0 array variable with a Dimension child
+system("unzip -cqq fmi3_array_nonscalarized.fmu modelDescription.xml > fmi3_array_nonscalarized_tmp.xml"); getErrorString();
+system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" fmi3_array_nonscalarized_tmp.xml > fmi3_array_nonscalarized.xml"); getErrorString();
+readFile("fmi3_array_nonscalarized.xml"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi3_array_nonscalarized.fmu"
+// "Warning: NSimJacobian.SimJacobian.createSparsityPattern: column cref not found in Jacobian local_idx_map: x[1]
+// Available keys: x, $DER.x
+// Warning: NSimJacobian.SimJacobian.create could not generate sparsity pattern of Jacobian [ODE].
+// "
+// 0
+// ""
+// "2
+// "
+// ""
+// 0
+// ""
+// 0
+// ""
+// " <ModelVariables>
+// <Float64 name=\"time\" valueReference=\"9\" causality=\"independent\" variability=\"continuous\" description=\"Simulation time\"/>
+// <Float64 name=\"x\" valueReference=\"0\" initial=\"exact\"  start=\"1.0 2.0 3.0\"><Dimension start=\"3\"/></Float64>
+// <Float64 name=\"der(x)\" valueReference=\"3\"  derivative=\"0\"><Dimension start=\"3\"/></Float64>
+// <Float64 name=\"y\" valueReference=\"6\" causality=\"output\" >
+// <Alias name=\"_D_FUN_1\"/>
+// </Float64>
+// <Float64 name=\"a\" valueReference=\"7\" causality=\"parameter\" variability=\"fixed\"  start=\"2.0\"/>
+// </ModelVariables>
+// "
+// ""
+// endResult


### PR DESCRIPTION
DimensionsFMU marked scalarized array elements as runtime arrays because a scalarized element still carries the parent array's numArrayElement even though its own type is scalar. The exported FMU then set dimension.numberOfDimensions != 0 for such an element, so the start/min/max/nominal bound-attribute update took its "else" branch and threw "Not yet implemented for array nominal" during fmi2ExitInitializationMode. This made ~530 FMI library-coverage models (array-carrying IBPSA-derived models: trace substances and similar) fail at FMU initialization, while plain simulation was unaffected (it does not generate the FMU _init_fmu.c).

Gate DimensionsFMU on type_ = T_ARRAY() so only genuinely non-scalarized array variables are dimensioned, consistent with getNumElems / numScalarElems. Scalarized elements keep numberOfDimensions 0 and take the scalar put_real_element branch; the non-scalarized FMI 3.0 array export is unaffected.

Add a test matrix exercising scalarized and non-scalarized array FMU export across FMI 2.0 and 3.0, the old and new backend, and the C and C++ runtimes.

Fixes #15926.

---- 

Generated by Claude.