### PR TITLE
[3D] Visualize shapes used directly from ModelicaServices.Animation

### DIFF
--- a/OMCompiler/Compiler/BackEnd/VisualXML.mo
+++ b/OMCompiler/Compiler/BackEnd/VisualXML.mo
@@ -887,8 +887,11 @@ algorithm
 end isVisualizationVarFold;
 
 function hasVisPath
-  "checks if the path is Modelica.Mechanics.MultiBody.Visualizers.Advanced.* and
-   outputs * if true. outputs which path is the vis path
+  "checks if the path is a known visualization type and outputs its name if true.
+   These are Modelica.Mechanics.MultiBody.Visualizers.Advanced.{Shape,Vector,Surface}
+   and the underlying ModelicaServices.Animation.{Shape,Vector,Surface} they extend,
+   so that shapes instantiated directly from ModelicaServices are visualized as well.
+   outputs which path is the vis path
    author:Waurich TUD 2015-04"
   input  list<Absyn.Path> pathsIn;
   input Integer numIn;
@@ -910,18 +913,33 @@ algorithm
             path=Absyn.QUALIFIED(name="Visualizers",
               path=Absyn.QUALIFIED(name="Advanced",
                 path=Absyn.IDENT(name=name))))))::_
-        guard match name
-          case "Shape" then true;
-          case "Vector" then true;
-          case "Surface" then true;
-          else false;
-        end match
+        guard isVisualizerName(name)
+      then
+        (name, numIn);
+
+    case Absyn.QUALIFIED(name="ModelicaServices",
+        path=Absyn.QUALIFIED(name="Animation",
+          path=Absyn.IDENT(name=name)))::_
+        guard isVisualizerName(name)
       then
         (name, numIn);
 
     case _::rest then hasVisPath(rest,numIn+1);
   end match;
 end hasVisPath;
+
+function isVisualizerName
+  "true if the name is one of the supported visualization types"
+  input String name;
+  output Boolean isVisualizer;
+algorithm
+  isVisualizer := match name
+    case "Shape" then true;
+    case "Vector" then true;
+    case "Surface" then true;
+    else false;
+  end match;
+end isVisualizerName;
 
 function dumpVis
   "author: waurich TUD

--- a/testsuite/openmodelica/visualization/Makefile
+++ b/testsuite/openmodelica/visualization/Makefile
@@ -2,6 +2,7 @@ TEST=../../rtest -v
 
 TESTFILES= \
 ForceAndTorque.mos \
+ModelicaServicesShapeAnimation.mos \
 Surfaces.mos \
 
 

--- a/testsuite/openmodelica/visualization/ModelicaServicesShapeAnimation.mos
+++ b/testsuite/openmodelica/visualization/ModelicaServicesShapeAnimation.mos
@@ -1,0 +1,78 @@
+// name:     ModelicaServicesShapeAnimation
+// keywords: visualization
+// status:   correct
+// cflags: -d=newInst
+//
+// A Shape instantiated directly from ModelicaServices.Animation (not via
+// Modelica.Mechanics.MultiBody.Visualizers.Advanced) must be picked up for
+// visualization as well. See #15940.
+//
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+loadString("model ModelicaServicesShapeAnimation
+  ModelicaServices.Animation.Shape box(length = 1, width = 0.2, height = 0.1, r = {time, 0, 0});
+  annotation(experiment(StopTime = 1.1));
+end ModelicaServicesShapeAnimation;"); getErrorString();
+setDebugFlags("visxml"); getErrorString();
+translateModel(ModelicaServicesShapeAnimation); getErrorString();
+readFile("ModelicaServicesShapeAnimation_visual.xml");
+getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>
+// <visualization>
+//   <shape>
+//       <ident>box</ident>
+//       <type>box</type>
+//       <T>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>1.0</exp>
+//       </T>
+//       <r>
+//           <cref>box.r[1]</cref>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </r>
+//       <r_shape>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </r_shape>
+//       <lengthDir>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </lengthDir>
+//       <widthDir>
+//           <exp>0.0</exp>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//       </widthDir>
+//       <length><exp>1.0</exp></length>
+//       <width><exp>0.2</exp></width>
+//       <height><exp>0.1</exp></height>
+//       <extra><exp>0.0</exp></extra>
+//       <color>
+//           <exp>255.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </color>
+//       <specCoeff><exp>0.7</exp></specCoeff>
+//   </shape>
+// </visualization>"
+// ""
+// endResult


### PR DESCRIPTION
## Visualize shapes used directly from ModelicaServices.Animation

Fixes #15940

### Problem

A model that instantiates `ModelicaServices.Animation.Shape` directly shows no animation in OMEdit:

```modelica
model ShapeDoesNotAnimate
  ModelicaServices.Animation.Shape box(length = 1, width = 0.2, height = 0.1, r = {time, 0, 0});
  annotation(experiment(StopTime = 1.1));
end ShapeDoesNotAnimate;
```

The simulation runs, but an empty `_visual.xml` is produced, so nothing is drawn.

### Cause

`VisualXML.hasVisPath` only recognized visualization objects whose element-source type was `Modelica.Mechanics.MultiBody.Visualizers.Advanced.{Shape,Vector,Surface}`. The MultiBody `Advanced.Shape` itself extends `ModelicaServices.Animation.Shape`, so when a model uses the `ModelicaServices` class directly the MultiBody path never appears in the type list and the shape is skipped.

### Fix

Extend `hasVisPath` to also match `ModelicaServices.Animation.{Shape,Vector,Surface}` (name test factored into `isVisualizerName`). The MultiBody path keeps matching first in the type list, so existing behavior is unchanged — verified that `ModelicaServices.Animation.Shape` now produces a `_visual.xml` byte-identical to the MultiBody equivalent.

### Test

Added `testsuite/openmodelica/visualization/ModelicaServicesShapeAnimation.mos`. New test passes; existing `ForceAndTorque` and `Surfaces` tests still pass.

---

generated by Claude Code
