### PR TITLE
[FrontEnd] Fix noEvent not respected when a relation is shared by removeEqualRHS

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -1068,7 +1068,9 @@ algorithm
   e := inExp;
   (ops, (se, te, i)) := inTpl;
   // BackendDump.debugStrExpStrExpStr(("Repalce ", se, " with ", te, "\n"));
-  (e1, j) := Expression.replaceExp(e, se, te);
+  // use the noEvent-aware variant: a relation inside noEvent()/smooth() is
+  // continuous and must not be substituted by an event-based variable
+  (e1, j) := Expression.replaceExpNoEvent(e, se, te);
   ops := if j>0 then DAE.SUBSTITUTION({e1}, e)::ops else ops;
   // BackendDump.debugStrExpStrExpStr(("Old ", e, " new ", e1, "\n"));
   outTpl := (ops, (se, te, i+j));

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -4777,6 +4777,48 @@ algorithm
   end match;
 end replaceExpWork;
 
+public function replaceExpNoEvent
+"Like replaceExp, but does not descend into noEvent() or smooth() calls.
+ Relations inside such operators are evaluated continuously (without state
+ events), so replacing them by an (event-based, discrete) variable would
+ change the model semantics. Replacing a whole noEvent()/smooth() expression
+ is still possible, since the equality check happens before the descent stop."
+  input DAE.Exp inExp;
+  input DAE.Exp inSourceExp;
+  input DAE.Exp inTargetExp;
+  output DAE.Exp exp;
+  output Integer i;
+algorithm
+  (exp,(_,_,i)) := traverseExpTopDown(inExp,replaceExpWorkNoEvent,(inSourceExp,inTargetExp,0));
+end replaceExpNoEvent;
+
+protected function replaceExpWorkNoEvent
+  input DAE.Exp inExp;
+  input tuple<DAE.Exp,DAE.Exp,Integer> inTpl;
+  output DAE.Exp outExp;
+  output Boolean cont;
+  output tuple<DAE.Exp,DAE.Exp,Integer> otpl;
+algorithm
+  (outExp,cont,otpl) := match (inExp, inTpl)
+    local
+      DAE.Exp source,target;
+      Integer c;
+    case (_, (source,target,c))
+      guard ExpressionBasics.expEqual(inExp, source)
+      then (target,false,(source,target,c+1));
+
+    // do not replace inside noEvent()/smooth(): expressions there are
+    // continuous, substituting them by an event-based variable is unsound
+    case (DAE.CALL(path=Absyn.IDENT(name="noEvent")), _)
+      then (inExp,false,inTpl);
+
+    case (DAE.CALL(path=Absyn.IDENT(name="smooth")), _)
+      then (inExp,false,inTpl);
+
+    else (inExp,true,inTpl);
+  end match;
+end replaceExpWorkNoEvent;
+
 public function expressionCollector
    input DAE.Exp exp;
    input list<DAE.Exp> acc;

--- a/testsuite/simulation/modelica/NBackend/tickets/15936.mos
+++ b/testsuite/simulation/modelica/NBackend/tickets/15936.mos
@@ -1,0 +1,75 @@
+// name: 15936
+// keywords: NewBackend, event, noEvent, common subexpression elimination
+// status: correct
+//
+// A relation (h < 0) used both as an event-generating relation
+// (isPenetrating = h < 0) and inside noEvent(..) must not be merged by
+// common-subexpression elimination: the occurrence inside noEvent is
+// continuous and must not be replaced by the discrete event variable.
+// Otherwise sqrt(delta) is evaluated with a negative argument during event
+// iteration and the simulation aborts.
+//
+// Companion model cseOutsideNoEvent checks that sharing the same relation
+// *outside* any noEvent still works (a and b stay equal).
+
+loadString("
+model noEventNotRespected
+  parameter Real m=1;
+  parameter Real g=10;
+  parameter Real d=0.1;
+  parameter Real c=1e5;
+
+  Real h(start=1, fixed=true);
+  Real v(start=0, fixed=true);
+  Real f_n;
+  Real delta \"penetration depth\";
+  Real derDelta;
+  Boolean isPenetrating;
+equation
+  der(h) = v;
+  m*der(v) = -m*g + f_n;
+  isPenetrating = h < 0;
+  delta = noEvent(if h < 0 then -h else 0);
+  derDelta = -v;
+  f_n = max(0, c*sqrt(delta)*(1+d*derDelta));
+  annotation(experiment(StopTime=3));
+end noEventNotRespected;
+
+model cseOutsideNoEvent
+  Real h(start=1, fixed=true);
+  Boolean a;
+  Boolean b;
+equation
+  der(h) = -1;
+  a = h < 0.5;
+  b = h < 0.5;
+  assert(a == b, \"a and b must be equal\");
+end cseOutsideNoEvent;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend");
+
+simulate(noEventNotRespected, stopTime=3.0); getErrorString();
+simulate(cseOutsideNoEvent, stopTime=1.0); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// record SimulationResult
+//     resultFile = "noEventNotRespected_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'noEventNotRespected', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "cseOutsideNoEvent_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'cseOutsideNoEvent', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/tickets/Makefile
+++ b/testsuite/simulation/modelica/NBackend/tickets/Makefile
@@ -5,6 +5,7 @@ TESTFILES = \
 13144.mos \
 13788.mos \
 14530.mos \
+15936.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/events/Makefile
+++ b/testsuite/simulation/modelica/events/Makefile
@@ -12,6 +12,7 @@ bug4419.mos \
 ChatteringEventsTest1.mos \
 ChatteringEventsTest2.mos \
 CheckEvents.mos \
+cseOutsideNoEvent.mos \
 discreteRelations.mos \
 EventDelay.mos \
 EventIteration.mos \
@@ -23,6 +24,7 @@ IntegerZeroCrossings.mos \
 MathEventFuncs1.mos \
 MathEventFuncs2.mos \
 noEventEmit.mos \
+noEventNotRespected.mos \
 Reinit.mos \
 sample1.mos \
 sample2.mos \

--- a/testsuite/simulation/modelica/events/cseOutsideNoEvent.mos
+++ b/testsuite/simulation/modelica/events/cseOutsideNoEvent.mos
@@ -1,0 +1,38 @@
+// name: cseOutsideNoEvent
+// keywords: event, noEvent, common subexpression elimination
+// status: correct
+//
+// Companion of noEventNotRespected.mos: when the same relation (h < 0.5) is
+// shared between two equations *outside* any noEvent(..), the removeEqualRHS
+// common-subexpression optimization must still apply (b = a). The fix that
+// stops substitution inside noEvent(..)/smooth(..) must not disable this
+// legitimate case. See ticket #15936.
+
+loadString("
+model cseOutsideNoEvent
+  Real h(start=1, fixed=true);
+  Boolean a;
+  Boolean b;
+equation
+  der(h) = -1;
+  a = h < 0.5;
+  b = h < 0.5;
+  // a and b are the same relation, so they must always be equal
+  assert(a == b, \"a and b must be equal\");
+end cseOutsideNoEvent;
+"); getErrorString();
+
+simulate(cseOutsideNoEvent, stopTime=1.0); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "cseOutsideNoEvent_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'cseOutsideNoEvent', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/events/noEventNotRespected.mos
+++ b/testsuite/simulation/modelica/events/noEventNotRespected.mos
@@ -1,0 +1,49 @@
+// name: noEventNotRespected
+// keywords: event, noEvent, common subexpression elimination
+// status: correct
+//
+// A relation (h < 0) used both as an event-generating relation
+// (isPenetrating = h < 0) and inside noEvent(..) must not be merged by the
+// removeEqualRHS common-subexpression optimization: the occurrence inside
+// noEvent is continuous and must not be replaced by the discrete event
+// variable. Otherwise sqrt(delta) is evaluated with a negative argument
+// during event iteration and the simulation aborts. See ticket #15936.
+
+loadString("
+model noEventNotRespected
+  parameter Real m=1;
+  parameter Real g=10;
+  parameter Real d=0.1;
+  parameter Real c=1e5;
+
+  Real h(start=1, fixed=true);
+  Real v(start=0, fixed=true);
+  Real f_n;
+  Real delta \"penetration depth\";
+  Real derDelta;
+  Boolean isPenetrating;
+equation
+  der(h) = v;
+  m*der(v) = -m*g + f_n;
+  isPenetrating = h < 0;
+  delta = noEvent(if h < 0 then -h else 0);
+  derDelta = -v;
+  f_n = max(0, c*sqrt(delta)*(1+d*derDelta));
+  annotation(experiment(StopTime=3));
+end noEventNotRespected;
+"); getErrorString();
+
+simulate(noEventNotRespected, stopTime=3.0); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "noEventNotRespected_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'noEventNotRespected', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
## Fix noEvent(..) not respected when a relation is shared by removeEqualRHS

Fixes #15936

## Problem

When a relation such as `h < 0` is used both as an event-generating relation
and inside `noEvent(..)`, the `noEvent` was silently ignored and the
simulation aborted. Minimal example from the ticket:

```modelica
model NoEventNotRespected
  parameter Real m=1, g=10, d=0.1, c=1e5;
  Real h(start=1, fixed=true);
  Real v(start=0, fixed=true);
  Real f_n, delta, derDelta;
  Boolean isPenetrating;
equation
  der(h) = v;
  m*der(v) = -m*g + f_n;
  isPenetrating = h < 0;                       // event-generating relation
  delta = noEvent(if h < 0 then -h else 0);    // continuous relation
  derDelta = -v;
  f_n = max(0, c*sqrt(delta)*(1+d*derDelta));
  annotation(experiment(StopTime=3));
end NoEventNotRespected;
```

```
The following assertion has been violated at time 0.449317
Model error: Argument of sqrt(delta) was -4.17883e-06 should be >= 0
```

As reported, the failure disappears if the unrelated `isPenetrating = h < 0`
is removed, or if a different variable is used for the relation.

## Root cause

The pre-optimization module `removeEqualRHS`
(`BackendDAEOptimize.removeEqualFunctionCall`) detects equations `a=<exp>`
and `b=<exp>` with equal right-hand sides and substitutes the shared
expression by the variable. It used `Expression.replaceExp`, which descends
into `noEvent(..)` and `smooth(..)`.

For the model above it found `isPenetrating = h < 0` and replaced the inner,
continuous `h < 0` inside the `noEvent` with the discrete event variable
`isPenetrating`:

```
delta = if noEvent(isPenetrating) then -h else 0.0
```

`isPenetrating` is only updated at events, so during event iteration the
`noEvent` branch was evaluated with a stale relation value. `delta` then
became a small negative number and `sqrt(delta)` aborted the simulation.

This was confirmed by tracing the DAE through each optimization module: the
substitution happens exactly in `removeEqualRHS`, before any other CSE pass.

## Fix

Add `Expression.replaceExpNoEvent`, a variant of `replaceExp` that does not
descend into `noEvent(..)` / `smooth(..)` calls — mirroring how
`FindZeroCrossings.collectZC` already treats these operators — and use it in
`removeEqualRHS`. Replacing a whole `noEvent(..)` / `smooth(..)` expression
still works, because the equality check runs before the descent stop; only
substitution strictly *inside* these operators is suppressed.

The change is strictly more conservative: it can only prevent unsound
substitutions inside event-protected contexts. Legitimate sharing of
relations outside `noEvent` is unchanged (verified: `b = a` still happens).

Only the old (default) backend is affected — the new backend already skips
`noEvent`/`smooth` in its CSE modules and simulates the model correctly.

## Tests

- `testsuite/simulation/modelica/events/noEventNotRespected.mos` — shared
  relation inside `noEvent` must simulate (the `sqrt` is the guard).
- `testsuite/simulation/modelica/events/cseOutsideNoEvent.mos` — sharing the
  same relation outside `noEvent` must still apply.
- `testsuite/simulation/modelica/NBackend/tickets/15936.mos` — both scenarios
  under `--newBackend` (regression guard for the new backend).

All three pass via `rtest`.

---
generated by Claude Code
