### PR TITLE
[NF] Fix vector start value assigned with an if-expression (#15937)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1608,13 +1608,21 @@ public function flattenExp
   input output Expression exp;
   input Prefix prefix;
   input SourceInfo info;
+protected
+  Boolean had_split;
 algorithm
   exp := match exp
     case Expression.CREF(cref = ComponentRef.CREF())
       algorithm
         exp.cref := ComponentRef.mapExpShallow(exp.cref, function flattenExp(prefix = prefix, info = info));
+        had_split := ComponentRef.hasSplitSubscripts(exp.cref);
         exp.cref := flattenCref(exp.cref, prefix, info);
-        exp.ty := flattenType(exp.ty, prefix, info);
+        // Flattening split subscripts can change the dimensions of the cref
+        // (e.g. a vector value indexed by a split index that expands back to the
+        // whole array), so recompute the expression's type from the cref in that
+        // case to avoid keeping a stale (scalar) type (#15937).
+        exp.ty := if had_split then ComponentRef.getSubscriptedType(exp.cref)
+                  else flattenType(exp.ty, prefix, info);
       then
         exp;
 
@@ -1625,6 +1633,19 @@ algorithm
 
     case Expression.IF(ty = Type.CONDITIONAL_ARRAY())
       then flattenConditionalArrayIfExp(exp, prefix, info);
+
+    case Expression.IF()
+      algorithm
+        exp.condition := flattenExp(exp.condition, prefix, info);
+        exp.trueBranch := flattenExp(exp.trueBranch, prefix, info);
+        exp.falseBranch := flattenExp(exp.falseBranch, prefix, info);
+        // Recompute the type from the branches, since flattening split indices
+        // can turn scalar branches back into arrays (e.g. a vector start value
+        // assigned with an if-expression), and the stored type would otherwise
+        // be stale (#15937).
+        exp.ty := Expression.typeOf(exp.trueBranch);
+      then
+        exp;
 
     case Expression.INSTANCE_NAME()
       then Expression.STRING(Prefix.instanceName(prefix));

--- a/testsuite/flattening/modelica/scodeinst/IfExpression18.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression18.mo
@@ -1,0 +1,32 @@
+// name: IfExpression18
+// keywords: if-expression start array
+// status: correct
+//
+// Tests scalarization of a vector start value assigned with an if-expression
+// with a non-constant condition. See
+// https://github.com/OpenModelica/OpenModelica/issues/15937
+//
+
+model IfExpression18
+  parameter Boolean useStart = true;
+  parameter Real rot_start[3] = {0, 1, 0};
+  Real rot[3](start = if useStart then rot_start else 2 * rot_start, each fixed = true);
+equation
+  der(rot) = -rot;
+end IfExpression18;
+
+// Result:
+// class IfExpression18
+//   parameter Boolean useStart = true;
+//   parameter Real rot_start[1] = 0.0;
+//   parameter Real rot_start[2] = 1.0;
+//   parameter Real rot_start[3] = 0.0;
+//   Real rot[1](start = if useStart then rot_start[1] else 2.0 * rot_start[1], fixed = true);
+//   Real rot[2](start = if useStart then rot_start[2] else 2.0 * rot_start[2], fixed = true);
+//   Real rot[3](start = if useStart then rot_start[3] else 2.0 * rot_start[3], fixed = true);
+// equation
+//   der(rot[1]) = -rot[1];
+//   der(rot[2]) = -rot[2];
+//   der(rot[3]) = -rot[3];
+// end IfExpression18;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -769,6 +769,7 @@ IfExpression14.mo \
 IfExpression15.mo \
 IfExpression16.mo \
 IfExpression17.mo \
+IfExpression18.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
 ih2.mo \

--- a/testsuite/simulation/modelica/NBackend/tickets/15937.mos
+++ b/testsuite/simulation/modelica/NBackend/tickets/15937.mos
@@ -1,0 +1,44 @@
+// name: 15937
+// keywords: NewBackend, if-expression, start, array
+// status: correct
+// cflags: --newBackend
+//
+// Vector start value assigned with an if-expression with a non-constant
+// condition. The new backend should keep the array unexpanded.
+// See https://github.com/OpenModelica/OpenModelica/issues/15937
+
+loadString("
+model StartWithVectorIf
+  parameter Boolean useStart = true;
+  parameter Real rot_start[3] = {0, 1, 0};
+  Real rot[3](start = if useStart then rot_start else 2 * rot_start, each fixed = true);
+equation
+  der(rot) = -rot;
+  annotation(experiment(StopTime = 1.1));
+end StartWithVectorIf;
+"); getErrorString();
+
+simulate(StartWithVectorIf, stopTime = 1.1); getErrorString();
+
+val(rot[1], 0.0); getErrorString();
+val(rot[2], 0.0); getErrorString();
+val(rot[3], 0.0); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "StartWithVectorIf_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.1, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'StartWithVectorIf', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// ""
+// 1.0
+// ""
+// 0.0
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/tickets/Makefile
+++ b/testsuite/simulation/modelica/NBackend/tickets/Makefile
@@ -6,6 +6,7 @@ TESTFILES = \
 13788.mos \
 14530.mos \
 15936.mos \
+15937.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest


### PR DESCRIPTION
A vector type attribute (e.g. `start`) given as an if-expression with a non-constant condition is stored with split-index subscripts, which makes the if-expression scalar-typed per element, e.g.

 ```mo
   rot[3](start = if useStart then rot_start[<rot,1>]
                                else (2*rot_start)[<rot,1>])  // type Real
```

When `flattenExp` resolves the split indices of an array variable that is left unscalarized in the frontend, the subscripted branches expand back to full arrays (`rot_start`, `2*rot_start` -> Real[3]), but the cref expression and the enclosing if-expression kept their stale scalar `Real` type. As a result `NFScalarize` treated the start value as a scalar and crashed with

    Internal error NFScalarize.scalarizeVariable failed on Real[3] rot(...)

Fix `flattenExp` so the type is recomputed when a split subscript expands a cref back to an array, and so an if-expression's type is recomputed from its branches after flattening. With the new backend the array is correctly kept unexpanded with the right type.

Adds a frontend scalarization test (IfExpression18) and a new backend simulation test (NBackend/tickets/15937).

Fixes #15937

---

generated by Claude