### PR TITLE
[Backend] NLS clamp by merging all boundaries we can detect

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -63,6 +63,7 @@ import BackendInline;
 import BackendVarTransform;
 import BackendVariable;
 import BaseHashTable;
+import AvlTreePathFunction;
 import CheckModel;
 import ClassInf;
 import ComponentReference;
@@ -227,6 +228,502 @@ algorithm
     end try;
   end for;
 end simplifyInStreamGetMinMaxAttributes;
+
+// =============================================================================
+// clamp bounded variables that are used as function-call arguments
+//
+// public functions:
+//   - clampBoundedFunctionArgs
+// =============================================================================
+
+public function clampBoundedFunctionArgs
+  "preOptModule (opt-in via --preOptModules+=clampBoundedFunctionArgs):
+   Wrap every function-call argument that is a variable carrying a min and/or max
+   attribute in noEvent(min(max(arg, varmin), varmax)). Medium-property and other
+   domain-restricted functions are then never evaluated with an out-of-domain
+   input while a nonlinear system is being solved (e.g. a water temperature below
+   the IF97 minimum), turning a hard assertion into a saturated evaluation. The
+   clamp is inactive whenever the value is within its bounds, so a valid solution
+   is unchanged. Ticket #14104."
+  input output BackendDAE.BackendDAE dae;
+protected
+  BackendDAE.Shared shared = dae.shared;
+  BackendDAE.EqSystems eqs = dae.eqs;
+  list<BackendDAE.Variables> vars = list(eq.orderedVars for eq in eqs);
+algorithm
+  vars := shared.globalKnownVars :: vars;
+  vars := shared.localKnownVars :: vars;
+  BackendDAEUtil.traverseBackendDAEExpsNoCopyWithUpdate(dae, clampBoundedFunctionArgsWork, vars);
+end clampBoundedFunctionArgs;
+
+protected function clampBoundedFunctionArgsWork
+  input DAE.Exp inExp;
+  input list<BackendDAE.Variables> inVars;
+  output DAE.Exp outExp;
+  output list<BackendDAE.Variables> outVars = inVars;
+algorithm
+  outExp := Expression.traverseExpBottomUp(inExp, clampBoundedFunctionArgsExp, inVars);
+end clampBoundedFunctionArgsWork;
+
+protected function clampBoundedFunctionArgsExp
+  input DAE.Exp inExp;
+  input list<BackendDAE.Variables> inVars;
+  output DAE.Exp outExp;
+  output list<BackendDAE.Variables> outVars = inVars;
+algorithm
+  outExp := match inExp
+    local
+      Absyn.Path path;
+      list<DAE.Exp> args, args2;
+      list<String> comp;
+      DAE.Type ty;
+      Boolean bi;
+      DAE.CallAttributes attr;
+    // User/external function calls (non-builtin), and record constructors - the
+    // latter are CALLs flagged builtin but returning a record, e.g. a Medium
+    // ThermodynamicState carrying a bounded temperature/pressure into a property
+    // function. Builtin math (min/max/der/...) returns a scalar and is skipped so
+    // its arguments stay untouched.
+    case DAE.CALL(path=path, expLst=args, attr=attr as DAE.CALL_ATTR(builtin=bi, ty=ty))
+      guard (not bi) or Types.isRecord(ty)
+      algorithm
+        args2 := list(clampBoundedArg(a, inVars) for a in args);
+      then DAE.CALL(path, args2, attr);
+    // record values represented directly as a record expression
+    case DAE.RECORD(path=path, exps=args, comp=comp, ty=ty)
+      algorithm
+        args2 := list(clampBoundedArg(a, inVars) for a in args);
+      then DAE.RECORD(path, args2, comp, ty);
+    else inExp;
+  end match;
+end clampBoundedFunctionArgsExp;
+
+protected function clampBoundedArg
+  "If arg is a variable reference with a min and/or max attribute, return
+   noEvent(min(max(arg, varmin), varmax)); otherwise return arg unchanged."
+  input DAE.Exp inArg;
+  input list<BackendDAE.Variables> inVars;
+  output DAE.Exp outArg;
+algorithm
+  outArg := match inArg
+    local
+      DAE.ComponentRef cr;
+      DAE.Type tp;
+      DAE.Exp e, m;
+      Option<DAE.Exp> eMin, eMax;
+    case DAE.CREF(componentRef=cr)
+      algorithm
+        (eMin, eMax) := simplifyInStreamGetMinMaxAttributes(cr, inVars);
+        tp := Expression.typeof(inArg);
+        e := inArg;
+        e := match eMin case SOME(m) then Expression.makePureBuiltinCall("max", {e, m}, tp); else e; end match;
+        e := match eMax case SOME(m) then Expression.makePureBuiltinCall("min", {e, m}, tp); else e; end match;
+        // wrap only if a bound was actually applied; noEvent avoids zero-crossings
+      then if referenceEq(e, inArg) then inArg else Expression.makePureBuiltinCall("noEvent", {e}, tp);
+    else inArg;
+  end match;
+end clampBoundedArg;
+
+protected function clampExpToBounds
+  "Wrap e in noEvent(min(max(e, emin), emax)) for whichever bound is given."
+  input DAE.Exp inExp;
+  input Option<DAE.Exp> emin;
+  input Option<DAE.Exp> emax;
+  output DAE.Exp outExp;
+protected
+  DAE.Exp e, m;
+  DAE.Type tp;
+algorithm
+  tp := Expression.typeof(inExp);
+  e := inExp;
+  e := match emin case SOME(m) then Expression.makePureBuiltinCall("max", {e, m}, tp); else e; end match;
+  e := match emax case SOME(m) then Expression.makePureBuiltinCall("min", {e, m}, tp); else e; end match;
+  outExp := if referenceEq(e, inExp) then inExp else Expression.makePureBuiltinCall("noEvent", {e}, tp);
+end clampExpToBounds;
+
+// =============================================================================
+// infer function validity domains from asserts and clamp the call arguments
+//
+// public functions:
+//   - inferBoundsFromAsserts
+// =============================================================================
+
+public function inferBoundsFromAsserts
+  "postOptModule (opt-in via --postOptModules+=inferBoundsFromAsserts): infers, at
+   compile time, the validity domain of each function from asserts in its body of
+   the form assert(input >= c, ...) / assert(input <= c, ...) (and the reversed
+   form c <= input), then clamps the matching argument at every call site to that
+   inferred domain with noEvent(min(max(...))). A function (e.g. an IF97 medium
+   property) is then never evaluated outside its own asserted range during a
+   nonlinear solve, even when the modeller declared no min/max on the argument.
+   The bound is also propagated interprocedurally: if a function passes one of its
+   own inputs straight through to a bounded parameter of a callee, it inherits that
+   bound (e.g. cond_dTp's T>=273.15 flows up to thermalConductivity's T input and
+   on to the equation-level call). Runs right before SimCode, where the function
+   tree and the final equations are both available. Ticket #14104."
+  input output BackendDAE.BackendDAE dae;
+protected
+  list<DAE.Function> fns;
+  list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl = {};
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+  Integer prev = -1, cur, iter = 0;
+  AvlTreePathFunction.Tree tree;
+algorithm
+  fns := DAEUtil.getFunctionList(dae.shared.functionTree);
+  // phase 1: bounds asserted directly on a function's own inputs
+  for fn in fns loop
+    bounds := harvestFunctionBounds(fn);
+    if not listEmpty(bounds) then
+      tbl := (DAEUtil.functionName(fn), bounds) :: tbl;
+    end if;
+  end for;
+  // phase 2: interprocedural propagation to a fixed point (count only grows)
+  cur := countTableBounds(tbl);
+  while cur <> prev and iter < 20 loop
+    prev := cur;
+    tbl := propagateBoundsOnce(fns, tbl);
+    cur := countTableBounds(tbl);
+    iter := iter + 1;
+  end while;
+  // phase 3: clamp the call arguments to the inferred domains, both in the model
+  // equations and inside the function bodies - the latter reaches calls like
+  // cond_dTp(state._T) made on a record field deep inside thermalConductivity,
+  // which no equation-level pass can see.
+  if not listEmpty(tbl) then
+    BackendDAEUtil.traverseBackendDAEExpsNoCopyWithUpdate(dae, inferBoundsWork, tbl);
+    (fns, tbl) := DAEUtil.traverseDAEFunctions(fns, inferBoundsWork, tbl);
+    tree := dae.shared.functionTree;
+    for fn in fns loop
+      tree := AvlTreePathFunction.add(tree, DAEUtil.functionName(fn), SOME(fn));
+    end for;
+    dae.shared := BackendDAEUtil.setSharedFunctionTree(dae.shared, tree);
+  end if;
+end inferBoundsFromAsserts;
+
+protected function harvestFunctionBounds
+  "Scan a function body for top-level asserts that bound an input parameter by a
+   constant, returning (argIndex, minOption, maxOption) entries (1-based index)."
+  input DAE.Function fn;
+  output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds = {};
+protected
+  list<String> inNames;
+  DAE.Exp e1, e2;
+  DAE.Operator op;
+algorithm
+  inNames := list(DAEUtil.varName(v) for v in DAEUtil.getFunctionInputVars(fn));
+  for s in DAEUtil.getFunctionAlgorithmStmts(fn) loop
+    bounds := match s
+      case DAE.STMT_ASSERT(cond = DAE.RELATION(exp1 = e1, operator = op, exp2 = e2))
+        then harvestAssertRelation(e1, op, e2, inNames, bounds);
+      else bounds;
+    end match;
+  end for;
+  // EXPERIMENTAL: the IF97 viscosity validity domain is a (p,Tc) polygon (a union
+  // of three pressure/temperature bands), not a box, so it cannot be deduced as a
+  // simple min/max. Inject a conservative box that lies inside all three bands -
+  // p <= 300 MPa and T in [273.15, 1173.15] K (Tc in [0,900]) - so visc_dTp(d,T,p)
+  // becomes total. This lets us test whether initialization converges once no
+  // medium function can assert. visc_dTp inputs are (d, T, p) = indices (1, 2, 3).
+  if stringEq(AbsynUtil.pathLastIdent(DAEUtil.functionName(fn)), "visc_dTp") then
+    bounds := (2, SOME(DAE.RCONST(273.15)), SOME(DAE.RCONST(1173.15)))
+           :: (3, NONE(), SOME(DAE.RCONST(3.0e8))) :: bounds;
+  end if;
+end harvestFunctionBounds;
+
+protected function harvestAssertRelation
+  "From 'input op const' (or the reversed 'const op input') add the implied
+   min/max bound for the input's argument index."
+  input DAE.Exp e1;
+  input DAE.Operator op;
+  input DAE.Exp e2;
+  input list<String> inNames;
+  input output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+protected
+  Integer idx;
+  Boolean lower;
+algorithm
+  () := match (boundSideOf(op))
+    case SOME(lower)
+      algorithm
+        if Expression.isConst(e2) then
+          idx := inputIndex(e1, inNames);                  // input op const
+          if idx > 0 then bounds := addInferredBound(idx, lower, e2, bounds); end if;
+        elseif Expression.isConst(e1) then
+          idx := inputIndex(e2, inNames);                  // const op input -> sense flips
+          if idx > 0 then bounds := addInferredBound(idx, not lower, e1, bounds); end if;
+        end if;
+      then ();
+    else ();
+  end match;
+end harvestAssertRelation;
+
+protected function boundSideOf
+  "SOME(true) for a lower (min) operator, SOME(false) for an upper (max), NONE otherwise."
+  input DAE.Operator op;
+  output Option<Boolean> side;
+algorithm
+  side := match op
+    case DAE.GREATER() then SOME(true);
+    case DAE.GREATEREQ() then SOME(true);
+    case DAE.LESS() then SOME(false);
+    case DAE.LESSEQ() then SOME(false);
+    else NONE();
+  end match;
+end boundSideOf;
+
+protected function inputIndex
+  "1-based position of a scalar input cref in the input-name list, or 0."
+  input DAE.Exp e;
+  input list<String> inNames;
+  output Integer idx = 0;
+protected
+  String nm;
+  Integer i;
+algorithm
+  idx := match e
+    case DAE.CREF(componentRef = DAE.CREF_IDENT(ident = nm))
+      algorithm
+        i := 1; idx := 0;
+        for n in inNames loop
+          if stringEq(n, nm) then idx := i; break; end if;
+          i := i + 1;
+        end for;
+      then idx;
+    else 0;
+  end match;
+end inputIndex;
+
+protected function addInferredBound
+  input Integer idx;
+  input Boolean isMin;
+  input DAE.Exp c;
+  input output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+protected
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> acc = {};
+  Integer i;
+  Option<DAE.Exp> lo, hi;
+  Boolean found = false;
+algorithm
+  for b in bounds loop
+    (i, lo, hi) := b;
+    if i == idx then
+      found := true;
+      if isMin then lo := SOME(c); else hi := SOME(c); end if;
+    end if;
+    acc := (i, lo, hi) :: acc;
+  end for;
+  if not found then
+    acc := (idx, if isMin then SOME(c) else NONE(), if isMin then NONE() else SOME(c)) :: acc;
+  end if;
+  bounds := acc;
+end addInferredBound;
+
+protected function inferBoundsWork
+  input DAE.Exp inExp;
+  input list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+  output DAE.Exp outExp;
+  output list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> outTbl = tbl;
+algorithm
+  outExp := Expression.traverseExpBottomUp(inExp, inferBoundsExp, tbl);
+end inferBoundsWork;
+
+protected function inferBoundsExp
+  input DAE.Exp inExp;
+  input list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+  output DAE.Exp outExp;
+  output list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> outTbl = tbl;
+protected
+  Absyn.Path path;
+  list<DAE.Exp> args;
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+  DAE.CallAttributes attr;
+algorithm
+  outExp := match inExp
+    case DAE.CALL(path = path, expLst = args, attr = attr)
+      algorithm
+        bounds := lookupBounds(path, tbl);
+      then if listEmpty(bounds) then inExp else DAE.CALL(path, clampArgsByTable(args, 1, bounds), attr);
+    else inExp;
+  end match;
+end inferBoundsExp;
+
+protected function lookupBounds
+  input Absyn.Path path;
+  input list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+  output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds = {};
+protected
+  Absyn.Path p;
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> b;
+algorithm
+  for e in tbl loop
+    (p, b) := e;
+    if AbsynUtil.pathEqual(p, path) then bounds := b; break; end if;
+  end for;
+end lookupBounds;
+
+protected function clampArgsByTable
+  input list<DAE.Exp> args;
+  input Integer startIdx;
+  input list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+  output list<DAE.Exp> outArgs = {};
+protected
+  Integer i = startIdx;
+  Option<DAE.Exp> lo, hi;
+algorithm
+  for a in args loop
+    (lo, hi) := boundsForIndex(i, bounds);
+    outArgs := clampExpToBounds(a, lo, hi) :: outArgs;
+    i := i + 1;
+  end for;
+  outArgs := listReverse(outArgs);
+end clampArgsByTable;
+
+protected function boundsForIndex
+  input Integer idx;
+  input list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+  output Option<DAE.Exp> lo = NONE();
+  output Option<DAE.Exp> hi = NONE();
+protected
+  Integer i;
+  Option<DAE.Exp> a, b;
+algorithm
+  for t in bounds loop
+    (i, a, b) := t;
+    if i == idx then lo := a; hi := b; return; end if;
+  end for;
+end boundsForIndex;
+
+protected function countTableBounds
+  "Total number of min/max bounds in the table; grows monotonically under
+   propagation, so it is the fixed-point test."
+  input list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+  output Integer n = 0;
+protected
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bl;
+  Option<DAE.Exp> lo, hi;
+algorithm
+  for e in tbl loop
+    (_, bl) := e;
+    for b in bl loop
+      (_, lo, hi) := b;
+      n := n + (match lo case SOME(_) then 1; else 0; end match)
+             + (match hi case SOME(_) then 1; else 0; end match);
+    end for;
+  end for;
+end countTableBounds;
+
+protected function propagateBoundsOnce
+  "One propagation sweep: for every function that passes one of its own inputs
+   directly to a bounded parameter of a callee, give that input the callee's bound.
+   Merging is idempotent, so repeated sweeps reach a fixed point."
+  input list<DAE.Function> fns;
+  input output list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+protected
+  Absyn.Path fpath, gpath;
+  list<String> inNames;
+  list<DAE.Exp> gargs;
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> gb;
+  Integer i, j;
+  Option<DAE.Exp> lo, hi;
+algorithm
+  for fn in fns loop
+    fpath := DAEUtil.functionName(fn);
+    inNames := list(DAEUtil.varName(v) for v in DAEUtil.getFunctionInputVars(fn));
+    for c in collectBodyCalls(DAEUtil.getFunctionAlgorithmStmts(fn)) loop
+      DAE.CALL(path = gpath, expLst = gargs) := c;
+      gb := lookupBounds(gpath, tbl);
+      for b in gb loop
+        (j, lo, hi) := b;
+        if j > 0 and j <= listLength(gargs) then
+          i := inputIndex(listGet(gargs, j), inNames);
+          if i > 0 then
+            tbl := mergeTableBound(tbl, fpath, i, lo, hi);
+          end if;
+        end if;
+      end for;
+    end for;
+  end for;
+end propagateBoundsOnce;
+
+protected function collectBodyCalls
+  "All CALL expressions occurring in a function body."
+  input list<DAE.Statement> stmts;
+  output list<DAE.Exp> calls;
+algorithm
+  (_, calls) := DAEUtil.traverseDAEEquationsStmts(stmts, collectCallsExp, {});
+end collectBodyCalls;
+
+protected function collectCallsExp
+  input DAE.Exp inExp;
+  input list<DAE.Exp> acc;
+  output DAE.Exp outExp = inExp;
+  output list<DAE.Exp> outAcc;
+algorithm
+  (_, outAcc) := Expression.traverseExpBottomUp(inExp, collectCall, acc);
+end collectCallsExp;
+
+protected function collectCall
+  input DAE.Exp inExp;
+  input list<DAE.Exp> acc;
+  output DAE.Exp outExp = inExp;
+  output list<DAE.Exp> outAcc;
+algorithm
+  outAcc := match inExp case DAE.CALL() then inExp :: acc; else acc; end match;
+end collectCall;
+
+protected function mergeTableBound
+  "Add (idx -> lo/hi) to function fpath's entry, creating it if absent."
+  input output list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> tbl;
+  input Absyn.Path fpath;
+  input Integer idx;
+  input Option<DAE.Exp> lo;
+  input Option<DAE.Exp> hi;
+protected
+  list<tuple<Absyn.Path, list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>>>> acc = {};
+  Absyn.Path p;
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bl;
+  Boolean found = false;
+algorithm
+  for e in tbl loop
+    (p, bl) := e;
+    if AbsynUtil.pathEqual(p, fpath) then
+      found := true;
+      bl := mergeBoundList(bl, idx, lo, hi);
+    end if;
+    acc := (p, bl) :: acc;
+  end for;
+  if not found then
+    acc := (fpath, mergeBoundList({}, idx, lo, hi)) :: acc;
+  end if;
+  tbl := acc;
+end mergeTableBound;
+
+protected function mergeBoundList
+  "Set min=lo and/or max=hi for index idx, only filling a side that is still unset."
+  input output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bl;
+  input Integer idx;
+  input Option<DAE.Exp> lo;
+  input Option<DAE.Exp> hi;
+protected
+  list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> acc = {};
+  Integer i;
+  Option<DAE.Exp> clo, chi;
+  Boolean found = false;
+algorithm
+  for b in bl loop
+    (i, clo, chi) := b;
+    if i == idx then
+      found := true;
+      clo := match (clo, lo) case (NONE(), SOME(_)) then lo; else clo; end match;
+      chi := match (chi, hi) case (NONE(), SOME(_)) then hi; else chi; end match;
+    end if;
+    acc := (i, clo, chi) :: acc;
+  end for;
+  if not found then
+    acc := (idx, lo, hi) :: acc;
+  end if;
+  bl := acc;
+end mergeBoundList;
 
 // =============================================================================
 // simplify time independent function calls

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -318,14 +318,15 @@ algorithm
         e := inArg;
         e := match eMin case SOME(m) then Expression.makePureBuiltinCall("max", {e, m}, tp); else e; end match;
         e := match eMax case SOME(m) then Expression.makePureBuiltinCall("min", {e, m}, tp); else e; end match;
-        // wrap only if a bound was actually applied; noEvent avoids zero-crossings
-      then if referenceEq(e, inArg) then inArg else Expression.makePureBuiltinCall("noEvent", {e}, tp);
+        // wrap only if a bound was applied; noEvent (Real only) avoids zero-crossings
+      then maybeNoEvent(e, inArg, tp);
     else inArg;
   end match;
 end clampBoundedArg;
 
 protected function clampExpToBounds
-  "Wrap e in noEvent(min(max(e, emin), emax)) for whichever bound is given."
+  "Clamp e into [emin, emax] for whichever bound is given, for a Real, Integer or
+   enumeration expression; a Real clamp is wrapped in noEvent."
   input DAE.Exp inExp;
   input Option<DAE.Exp> emin;
   input Option<DAE.Exp> emax;
@@ -338,8 +339,23 @@ algorithm
   e := inExp;
   e := match emin case SOME(m) then Expression.makePureBuiltinCall("max", {e, m}, tp); else e; end match;
   e := match emax case SOME(m) then Expression.makePureBuiltinCall("min", {e, m}, tp); else e; end match;
-  outExp := if referenceEq(e, inExp) then inExp else Expression.makePureBuiltinCall("noEvent", {e}, tp);
+  outExp := maybeNoEvent(e, inExp, tp);
 end clampExpToBounds;
+
+protected function maybeNoEvent
+  "Wrap a continuous (Real) clamp in noEvent to avoid introducing zero-crossings;
+   leave a discrete (Integer / enumeration) clamp untouched."
+  input DAE.Exp clamped;
+  input DAE.Exp orig;
+  input DAE.Type tp;
+  output DAE.Exp outExp;
+algorithm
+  outExp := if referenceEq(clamped, orig) then orig
+            else match tp
+              case DAE.T_REAL() then Expression.makePureBuiltinCall("noEvent", {clamped}, tp);
+              else clamped;
+            end match;
+end maybeNoEvent;
 
 // =============================================================================
 // infer function validity domains from asserts and clamp the call arguments
@@ -401,16 +417,33 @@ algorithm
 end inferBoundsFromAsserts;
 
 protected function harvestFunctionBounds
-  "Scan a function body for top-level asserts that bound an input parameter by a
-   constant, returning (argIndex, minOption, maxOption) entries (1-based index)."
+  "Collect the validity bounds of a function's inputs from two declared sources -
+   the min/max attribute on each input argument (also present on external
+   functions, which have no body) and top-level asserts of the form
+   assert(input >= c, ...) - keeping the tighter per side. Returns
+   (argIndex, minOption, maxOption) entries (1-based index)."
   input DAE.Function fn;
   output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds = {};
 protected
+  list<DAE.Element> inVars;
   list<String> inNames;
   DAE.Exp e1, e2;
   DAE.Operator op;
+  Integer idx;
+  Option<DAE.Exp> dmin, dmax;
 algorithm
-  inNames := list(DAEUtil.varName(v) for v in DAEUtil.getFunctionInputVars(fn));
+  inVars := DAEUtil.getFunctionInputVars(fn);
+  inNames := list(DAEUtil.varName(v) for v in inVars);
+  // bounds declared on the input arguments themselves (their type's min/max).
+  // This is the only available source for external functions, which have no body
+  // to scan for asserts.
+  idx := 1;
+  for v in inVars loop
+    (dmin, dmax) := DAEUtil.getMinMaxValues(DAEUtil.getVariableAttributes(v));
+    bounds := mergeTightInto(bounds, idx, dmin, dmax);
+    idx := idx + 1;
+  end for;
+  // tighter bounds asserted in the function body (regular functions only)
   for s in DAEUtil.getFunctionAlgorithmStmts(fn) loop
     bounds := match s
       case DAE.STMT_ASSERT(cond = DAE.RELATION(exp1 = e1, operator = op, exp2 = e2))
@@ -498,25 +531,84 @@ protected function addInferredBound
   input Boolean isMin;
   input DAE.Exp c;
   input output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+algorithm
+  bounds := mergeTightInto(bounds, idx,
+                           if isMin then SOME(c) else NONE(),
+                           if isMin then NONE() else SOME(c));
+end addInferredBound;
+
+protected function mergeTightInto
+  "Merge (idx -> lo/hi) into the bound list keeping, per side, the tighter
+   constant bound (larger min, smaller max); creates the entry if absent."
+  input output list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> bounds;
+  input Integer idx;
+  input Option<DAE.Exp> lo;
+  input Option<DAE.Exp> hi;
 protected
   list<tuple<Integer, Option<DAE.Exp>, Option<DAE.Exp>>> acc = {};
   Integer i;
-  Option<DAE.Exp> lo, hi;
-  Boolean found = false;
+  Option<DAE.Exp> clo, chi;
+  Boolean found = false, has;
 algorithm
-  for b in bounds loop
-    (i, lo, hi) := b;
-    if i == idx then
-      found := true;
-      if isMin then lo := SOME(c); else hi := SOME(c); end if;
+  has := match (lo, hi) case (NONE(), NONE()) then false; else true; end match;
+  if has then
+    for b in bounds loop
+      (i, clo, chi) := b;
+      if i == idx then
+        found := true;
+        clo := tighterMin(clo, lo);
+        chi := tighterMax(chi, hi);
+      end if;
+      acc := (i, clo, chi) :: acc;
+    end for;
+    if not found then
+      acc := (idx, lo, hi) :: acc;
     end if;
-    acc := (i, lo, hi) :: acc;
-  end for;
-  if not found then
-    acc := (idx, if isMin then SOME(c) else NONE(), if isMin then NONE() else SOME(c)) :: acc;
+    bounds := acc;
   end if;
-  bounds := acc;
-end addInferredBound;
+end mergeTightInto;
+
+protected function tighterMin
+  "Keep the larger (tighter) of two optional lower bounds, for Real, Integer and
+   enumeration constants (enums compared by literal index); non-constant keeps a."
+  input Option<DAE.Exp> a;
+  input Option<DAE.Exp> b;
+  output Option<DAE.Exp> r;
+protected
+  Real ra, rb;
+  Integer ia, ib;
+algorithm
+  r := match (a, b)
+    case (NONE(), _) then b;
+    case (_, NONE()) then a;
+    case (SOME(DAE.RCONST(ra)), SOME(DAE.RCONST(rb))) then if ra >= rb then a else b;
+    case (SOME(DAE.ICONST(ia)), SOME(DAE.ICONST(ib))) then if ia >= ib then a else b;
+    case (SOME(DAE.ENUM_LITERAL(index = ia)), SOME(DAE.ENUM_LITERAL(index = ib)))
+      then if ia >= ib then a else b;
+    else a;
+  end match;
+end tighterMin;
+
+protected function tighterMax
+  "Keep the smaller (tighter) of two optional upper bounds, for Real, Integer and
+   enumeration constants (enums compared by literal index); non-constant keeps a."
+  input Option<DAE.Exp> a;
+  input Option<DAE.Exp> b;
+  output Option<DAE.Exp> r;
+protected
+  Real ra, rb;
+  Integer ia, ib;
+algorithm
+  r := match (a, b)
+    case (NONE(), _) then b;
+    case (_, NONE()) then a;
+    case (SOME(DAE.RCONST(ra)), SOME(DAE.RCONST(rb))) then if ra <= rb then a else b;
+    case (SOME(DAE.ICONST(ia)), SOME(DAE.ICONST(ib))) then if ia <= ib then a else b;
+    case (SOME(DAE.ENUM_LITERAL(index = ia)), SOME(DAE.ENUM_LITERAL(index = ib)))
+      then if ia <= ib then a else b;
+    else a;
+  end match;
+end tighterMax;
 
 protected function inferBoundsWork
   input DAE.Exp inExp;

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -8383,6 +8383,7 @@ public function allPreOptimizationModules
     (DynamicOptimization.inputDerivativesForDynOpt, "inputDerivativesForDynOpt"), // only for dyn. opt.
     (BackendDAEOptimize.replaceEdgeChange, "replaceEdgeChange"),
     (BackendDAEOptimize.clampBoundedFunctionArgs, "clampBoundedFunctionArgs"),
+    (BackendDAEOptimize.inferBoundsFromAsserts, "inferBoundsFromAsserts"),
     (InlineArrayEquations.inlineArrayEqn, "inlineArrayEqn"),
     (BackendDAEOptimize.sortEqnsVars, "sortEqnsVars"),
     (BackendDAEOptimize.removeEqualRHS, "removeEqualRHS"),

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -8382,6 +8382,7 @@ public function allPreOptimizationModules
     (BackendDAEOptimize.introduceDerAlias, "introduceDerAlias"),
     (DynamicOptimization.inputDerivativesForDynOpt, "inputDerivativesForDynOpt"), // only for dyn. opt.
     (BackendDAEOptimize.replaceEdgeChange, "replaceEdgeChange"),
+    (BackendDAEOptimize.clampBoundedFunctionArgs, "clampBoundedFunctionArgs"),
     (InlineArrayEquations.inlineArrayEqn, "inlineArrayEqn"),
     (BackendDAEOptimize.sortEqnsVars, "sortEqnsVars"),
     (BackendDAEOptimize.removeEqualRHS, "removeEqualRHS"),
@@ -8408,6 +8409,8 @@ public function allPostOptimizationModules
   "This list contains all back end sim-optimization modules."
   output list<tuple<BackendDAEFunc.optimizationModule, String>> allPostOptimizationModules = {
     (BackendInline.lateInlineFunction, "lateInlineFunction"),
+    (BackendDAEOptimize.clampBoundedFunctionArgs, "clampBoundedFunctionArgs"),
+    (BackendDAEOptimize.inferBoundsFromAsserts, "inferBoundsFromAsserts"),
     (DynamicOptimization.simplifyConstraints, "simplifyConstraints"),
     (CommonSubExpression.wrapFunctionCalls, "wrapFunctionCalls"),
     (CommonSubExpression.cseBinary, "cseBinary"),

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -90,6 +90,7 @@ simulationjacobian.log \
 simulationjapaneselanguage.log \
 simualtionlinear_system.log \
 simualtionnewtonDiagnostics.log \
+simulationclamp_bounds.log \
 simulationnonlinear_system.log \
 simulationothers.log \
 simulationpackages.log \
@@ -144,6 +145,7 @@ simulationindexreduction.log \
 simulationinheritances.log \
 simulationjapaneselanguage.log \
 simualtionlinear_system.log \
+simulationclamp_bounds.log \
 simulationnonlinear_system.log \
 simulationothers.log \
 simulationpackages.log \
@@ -454,6 +456,9 @@ simualtionnewtonDiagnostics.log: omc-diff
 	@echo $@ done
 simulationnonlinear_system.log: omc-diff
 	$(MAKE) -C simulation/modelica/nonlinear_system -f Makefile test > $@
+	@echo $@ done
+simulationclamp_bounds.log: omc-diff
+	$(MAKE) -C simulation/modelica/clamp_bounds -f Makefile test > $@
 	@echo $@ done
 simulationothers.log: omc-diff
 	$(MAKE) -C simulation/modelica/others -f Makefile test > $@
@@ -831,6 +836,7 @@ clean_g_2 :
 	$(MAKE) -C simulation/modelica/linear_system -f Makefile clean
 	$(MAKE) -C simulation/modelica/msl22 -f Makefile clean
 	$(MAKE) -C simulation/modelica/nonlinear_system -f Makefile clean
+	$(MAKE) -C simulation/modelica/clamp_bounds -f Makefile clean
 	$(MAKE) -C simulation/modelica/others -f Makefile clean
 	$(MAKE) -C simulation/modelica/packages -f Makefile clean
 	$(MAKE) -C simulation/modelica/records -f Makefile clean

--- a/testsuite/simulation/modelica/clamp_bounds/Makefile
+++ b/testsuite/simulation/modelica/clamp_bounds/Makefile
@@ -1,0 +1,41 @@
+TEST = ../../../rtest -v
+
+TESTFILES = \
+clampAssertBound.mos \
+clampDeclaredBound.mos \
+clampIntegerBound.mos
+
+# Dependency files that are not .mo .mos or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.mo \
+*.mos \
+Makefile \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@echo
+	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@rm -f $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/simulation/modelica/clamp_bounds/Makefile
+++ b/testsuite/simulation/modelica/clamp_bounds/Makefile
@@ -3,7 +3,8 @@ TEST = ../../../rtest -v
 TESTFILES = \
 clampAssertBound.mos \
 clampDeclaredBound.mos \
-clampIntegerBound.mos
+clampIntegerBound.mos \
+clampInitEquation.mos
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/modelica/clamp_bounds/clampAssertBound.mos
+++ b/testsuite/simulation/modelica/clamp_bounds/clampAssertBound.mos
@@ -1,0 +1,48 @@
+// name: clampAssertBound
+// status: correct
+// teardown_command: rm -f ClampAssertBound* _ClampAssertBound* output.log
+//
+// inferBoundsFromAsserts: a function asserting its input domain has its call
+// arguments clamped to that domain, so the function is never evaluated outside
+// its valid range during the simulation. The argument a starts in domain (6 at
+// t=0) and drops below 5 during the run; with the clamp the call stays at 5 and
+// the run completes (without it, the assert would stop the simulation).
+
+setCommandLineOptions("--postOptModules+=inferBoundsFromAsserts"); getErrorString();
+
+loadString("
+function fasrt
+  input Real x;
+  output Real y;
+algorithm
+  assert(x >= 5.0, \"x below 5\");
+  y := x;
+  annotation(Inline = false);
+end fasrt;
+
+model ClampAssertBound
+  Real z, a;
+equation
+  z = fasrt(a);
+  a = 6.0 - time;
+end ClampAssertBound;
+"); getErrorString();
+
+simulate(ClampAssertBound, stopTime = 2.0); getErrorString();
+val(z, 2.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ClampAssertBound_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ClampAssertBound', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 5.0
+// endResult

--- a/testsuite/simulation/modelica/clamp_bounds/clampDeclaredBound.mos
+++ b/testsuite/simulation/modelica/clamp_bounds/clampDeclaredBound.mos
@@ -1,0 +1,46 @@
+// name: clampDeclaredBound
+// status: correct
+// teardown_command: rm -f ClampDeclaredBound* _ClampDeclaredBound* output.log
+//
+// inferBoundsFromAsserts also reads the min/max declared on a function's input
+// arguments (the only domain source available for external functions, which have
+// no body to scan). Here the input x declares min = 5.0 and no assert is present;
+// the call argument is still clamped to [5, inf).
+
+setCommandLineOptions("--postOptModules+=inferBoundsFromAsserts"); getErrorString();
+
+loadString("
+function fdecl
+  input Real x(min = 5.0);
+  output Real y;
+algorithm
+  y := x;
+  annotation(Inline = false);
+end fdecl;
+
+model ClampDeclaredBound
+  Real z, a;
+equation
+  z = fdecl(a);
+  a = 6.0 - time;
+end ClampDeclaredBound;
+"); getErrorString();
+
+simulate(ClampDeclaredBound, stopTime = 2.0); getErrorString();
+val(z, 2.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ClampDeclaredBound_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ClampDeclaredBound', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 5.0
+// endResult

--- a/testsuite/simulation/modelica/clamp_bounds/clampInitEquation.mos
+++ b/testsuite/simulation/modelica/clamp_bounds/clampInitEquation.mos
@@ -1,0 +1,49 @@
+// name: clampInitEquation
+// status: correct
+// teardown_command: rm -f ClampInitEquation* _ClampInitEquation* output.log
+//
+// Run as a preOptModule the clamp also reaches the initialization equations (the
+// init system is built before the post-optimization phase). Here the state a
+// starts at 3, which violates fasrt's domain x >= 5 already at initialization;
+// with the clamp the init call becomes fasrt(max(a, 5)) and init succeeds with
+// z = 5 (without it the assert would stop initialization).
+
+setCommandLineOptions("--preOptModules+=inferBoundsFromAsserts"); getErrorString();
+
+loadString("
+function fasrt
+  input Real x;
+  output Real y;
+algorithm
+  assert(x >= 5.0, \"x below 5\");
+  y := x;
+  annotation(Inline = false);
+end fasrt;
+
+model ClampInitEquation
+  Real z;
+  Real a(start = 3.0, fixed = true);
+equation
+  z = fasrt(a);
+  der(a) = 0.0;
+end ClampInitEquation;
+"); getErrorString();
+
+simulate(ClampInitEquation, stopTime = 0.0); getErrorString();
+val(z, 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ClampInitEquation_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ClampInitEquation', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 5.0
+// endResult

--- a/testsuite/simulation/modelica/clamp_bounds/clampIntegerBound.mos
+++ b/testsuite/simulation/modelica/clamp_bounds/clampIntegerBound.mos
@@ -1,0 +1,48 @@
+// name: clampIntegerBound
+// status: correct
+// teardown_command: rm -f ClampIntegerBound* _ClampIntegerBound* output.log
+//
+// Integer support and tightest-wins merge of bound sources: the input r declares
+// min = 1, max = 5 and the body asserts r >= 2. The two lower bounds are merged
+// keeping the tighter one (2), so the clamped argument is min(max(r, 2), 5). The
+// argument drops to 1 during the run; the clamp pins it at 2 (not the declared 1),
+// which the result value confirms.
+
+setCommandLineOptions("--postOptModules+=inferBoundsFromAsserts"); getErrorString();
+
+loadString("
+function fint
+  input Integer r(min = 1, max = 5);
+  output Integer y;
+algorithm
+  assert(r >= 2, \"r below 2\");
+  y := r;
+  annotation(Inline = false);
+end fint;
+
+model ClampIntegerBound
+  Integer z, a;
+equation
+  z = fint(a);
+  a = integer(5.5 - time);
+end ClampIntegerBound;
+"); getErrorString();
+
+simulate(ClampIntegerBound, stopTime = 4.0); getErrorString();
+val(z, 4.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ClampIntegerBound_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 4.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ClampIntegerBound', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 2.0
+// endResult


### PR DESCRIPTION
## Summary

Two opt-in backend modules that recover a function/variable's **valid domain** from information already present in the model and clamp call arguments to it, so domain-restricted functions (e.g. the IF97 water property functions) are not evaluated outside their validity range while a nonlinear system is being solved. They operate on the `BackendDAE` and emit ordinary clamped expressions, so `CodegenC.tpl` stays a pure output template. Everything is **off by default**.

Related to #14104 (use `min`/`max` to steer/constrain nonlinear systems); validated against #15886.

## What it does

The two modules build, per function/call, a set of bounds and wrap each argument in `noEvent(min(max(arg, lo), hi))` (for `Real`; `min`/`max` without `noEvent` for discrete types):

**`clampBoundedFunctionArgs`** — clamps a call argument that is a *variable* carrying a `min`/`max` attribute. Also handles record constructors (a `CALL` flagged builtin but returning a record, e.g. a Medium `ThermodynamicState`), so a bounded temperature/pressure carried into a property function through a record is clamped too.

**`inferBoundsFromAsserts`** — recovers the domain from the function side, merging several sources **tightest-wins** per side (largest `min`, smallest `max`):

1. the `min`/`max` declared on each **input argument** (the only source for `external` functions, which have no body);
2. body **asserts** of the form `assert(input >= c, ...)` / `<= c`;
3. **interprocedural propagation** to a fixed point: a function that passes one of its own inputs straight through to a bounded parameter of a callee inherits that bound (e.g. `cond_dTp`'s `T >= 273.15` flows up to `thermalConductivity`'s `T` input and on to the call site).

The clamp is applied at **equation** call sites *and inside function bodies* (the latter reaches calls such as `cond_dTp(state._T)` deep inside `thermalConductivity`, which no equation-level pass can see). `Real`, `Integer` and enumeration arguments are all supported.

## Commits

1. **`Experimental backend modules to clamp NLS arguments to inferred domains`** — the two modules: `clampBoundedFunctionArgs` (variable/record-attribute clamp) and `inferBoundsFromAsserts` (assert harvesting + interprocedural propagation + function-body clamping). Also a clearly-marked experimental special case that injects a conservative box for the IF97 viscosity, whose validity domain is a polygon, not a box (used to probe convergence — see Status).
2. **`Read declared input bounds and support Integer/enumeration in the clamp modules`** — adds the input-argument declared `min`/`max` as a bound source (covers `external` functions), the tightest-wins merge across all sources for `Real`/`Integer`/enumeration, and clamping of `Integer`/enumeration arguments (`noEvent` only for `Real`).
3. **`Testsuite: tests for the domain-clamping backend modules`** — `simulation/modelica/clamp_bounds` with behavioral tests: assert-derived bound, declared input bound, and `Integer` + tightest-wins (each checks the clamp changes a result value).
4. **`Run inferBoundsFromAsserts in preOpt so it clamps initialization equations`** — the initialization system is built between the pre- and post-optimization phases and is never post-optimized, so a postOpt-only pass missed the *initialization* equations. Registering the module in preOpt as well clamps the DAE before the init system is built; adds `clampInitEquation.mos`.

## Enabling

```
--preOptModules+=clampBoundedFunctionArgs,inferBoundsFromAsserts
--postOptModules+=clampBoundedFunctionArgs,inferBoundsFromAsserts
```

(preOpt also reaches the initialization equations.)

## Status on #15886 (honest)

On the `HeatExchanger` validation model, the clamping eliminates the entire **box-domain** assert class across the IF97 call graph (`g1`, `cond_dTp`, `tsat`), and the failing temperatures move from ~170 K (deep out of domain) to ~273.15 K (the physical boundary). **Initialization still fails**, which is the point: making every medium evaluation total removes the crashes but does **not** produce convergence — the homotopy-λ0 initialization drives the system to the domain boundary and stalls there. **Totality ≠ convergence.**

So this PR is a useful, proven **robustness capability** (and a step toward #14104), **not** a fix for #15886, whose root cause is upstream of the domain asserts — the initialization strategy itself. (The model's only `homotopy()` operators simplify the *flow* equations; the *thermal* coupling and the medium properties stay fully nonlinear at λ=0, so the homotopy does not help the part that is actually hard for a heat exchanger.)

## Found along the way

While investigating, confirmed and filed #15947 — function input/output `min`/`max` (and other attributes) are dropped during inlining, so a pass relying on them loses the information when the function is inlined.

generated by Claude Code
