### PR TITLE
[FrontEnd] Record extends chain so inherited shapes are visualized

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -48,6 +48,7 @@ protected
 
 import Algorithm = NFAlgorithm;
 import Attributes = NFAttributes;
+import AbsynUtil;
 import AvlTreePathFunction;
 import Call = NFCall;
 import ComponentReferenceBasics;
@@ -214,14 +215,94 @@ algorithm
   source := match cref
     case ComponentRef.CREF()
       algorithm
-        source := ElementSource.addElementSourceType(source,
-          InstNode.scopePath(InstNode.classScope(InstNode.getDerivedNode(InstNode.parent(cref.node)))));
+        source := addComponentLevelTypeToSource(InstNode.parent(cref.node), source);
       then
         addComponentTypeToSource(cref.restCref, source);
 
     else source;
   end match;
 end addComponentTypeToSource;
+
+function addComponentLevelTypeToSource
+  "Records the type(s) of the class that owns the component referenced at one
+   level of a cref into the element source. For a regular component this is a
+   single class (the class in which the component is declared). When a component
+   is inherited through one or more `extends` of a visualization type, e.g.
+
+     model MyShape
+       extends ModelicaServices.Animation.Shape;
+     end MyShape;
+
+   getDerivedNode collapses the whole extends chain down to the most derived
+   class (MyShape), so the visualization base class (Shape) would be lost and
+   the backend (VisualXML) could no longer recognize it. In that case we record
+   the full extends chain, with the visualization base class kept in the primary
+   slot of this level so that the identifier prefix computed from the type index
+   in VisualXML.isVisualizationVarFold still points at the right component.
+
+   This is only reached when the element source types are recorded at all, i.e.
+   under -d=visxml (animation) or infoXmlOperations; otherwise the original
+   single most derived class entry is kept."
+  input InstNode parentNode;
+  input output DAE.ElementSource source;
+protected
+  InstNode concrete, n;
+  Absyn.Path concretePath, p;
+  list<Absyn.Path> chain = {};
+  Option<Absyn.Path> visPath = NONE();
+algorithm
+  // the collapsed, most derived class (default behaviour)
+  concrete := InstNode.classScope(InstNode.getDerivedNode(parentNode));
+  concretePath := InstNode.scopePath(concrete);
+
+  // Skip the chain walk when the most derived class is itself a visualization
+  // type (direct ModelicaServices/MultiBody shapes already match as a single
+  // entry); only an inherited shape needs the base classes recorded.
+  if not isVisualizerLeafName(concretePath) then
+    // walk the extends chain from where the component is actually declared up
+    // to the most derived class, collecting the intermediate base classes
+    n := InstNode.classScope(parentNode);
+    while InstNode.isBaseClass(n) loop
+      p := InstNode.scopePath(n, ignoreBaseClass = true);
+      chain := p :: chain;
+      if isNone(visPath) and isVisualizerLeafName(p) then
+        visPath := SOME(p);
+      end if;
+      n := InstNode.classScope(InstNode.getDerivedNode(n, recursive = false));
+    end while;
+  end if;
+
+  if isSome(visPath) then
+    // a visualization type appears as a base class -> record the whole chain
+    // with the visualization base class in the primary slot of this level
+    SOME(p) := visPath;
+    chain := listAppend(list(c for c guard not AbsynUtil.pathEqual(c, p) in chain),
+                        {concretePath});
+    for c in listReverse(chain) loop
+      source := ElementSource.addElementSourceType(source, c);
+    end for;
+    source := ElementSource.addElementSourceType(source, p);
+  else
+    // default (unchanged): single most derived class entry
+    source := ElementSource.addElementSourceType(source, concretePath);
+  end if;
+end addComponentLevelTypeToSource;
+
+function isVisualizerLeafName
+  "Returns true if the last identifier of the path is one of the visualization
+   type names (Shape, Vector, Surface). This is only used to position the type
+   in the element source; VisualXML.hasVisPath remains the authority on whether
+   a fully qualified path is actually a visualization type."
+  input Absyn.Path path;
+  output Boolean isVisualizer;
+algorithm
+  isVisualizer := match AbsynUtil.pathLastIdent(path)
+    case "Shape" then true;
+    case "Vector" then true;
+    case "Surface" then true;
+    else false;
+  end match;
+end isVisualizerLeafName;
 
 function convertVarAttributes
   input list<tuple<String, Binding>> attrs;

--- a/testsuite/openmodelica/visualization/Makefile
+++ b/testsuite/openmodelica/visualization/Makefile
@@ -3,6 +3,7 @@ TEST=../../rtest -v
 TESTFILES= \
 ForceAndTorque.mos \
 ModelicaServicesShapeAnimation.mos \
+ModelicaServicesShapeExtends.mos \
 Surfaces.mos \
 
 

--- a/testsuite/openmodelica/visualization/ModelicaServicesShapeExtends.mos
+++ b/testsuite/openmodelica/visualization/ModelicaServicesShapeExtends.mos
@@ -1,0 +1,90 @@
+// name:     ModelicaServicesShapeExtends
+// keywords: visualization
+// status:   correct
+// cflags: -d=newInst
+//
+// A model that inherits (via `extends`) from ModelicaServices.Animation.Shape
+// must be picked up for visualization as well. The extends chain is collapsed
+// to the most derived class during instantiation, so the Shape base class has
+// to be recorded in the element source for the backend to recognize it.
+// OpenModelicaBugs.ShapeDoesNotAnimate4 is the failing case from the report,
+// the other models are the variants that already worked. See #15940.
+//
+
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+loadModel(ModelicaServices, {"4.1.0"}); getErrorString();
+loadFile("OpenModelicaBugs.mo"); getErrorString();
+setDebugFlags("visxml"); getErrorString();
+translateModel(OpenModelicaBugs.ShapeDoesNotAnimate1); getErrorString();
+translateModel(OpenModelicaBugs.ShapeDoesNotAnimate2); getErrorString();
+translateModel(OpenModelicaBugs.ShapeDoesNotAnimate3); getErrorString();
+translateModel(OpenModelicaBugs.ShapeDoesNotAnimate4); getErrorString();
+readFile("OpenModelicaBugs.ShapeDoesNotAnimate4_visual.xml");
+getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>
+// <visualization>
+//   <shape>
+//       <ident>box</ident>
+//       <type>box</type>
+//       <T>
+//           <cref>box.R.T[1,1]</cref>
+//           <cref>box.R.T[1,2]</cref>
+//           <cref>box.R.T[1,3]</cref>
+//           <cref>box.R.T[2,1]</cref>
+//           <cref>box.R.T[2,2]</cref>
+//           <cref>box.R.T[2,3]</cref>
+//           <cref>box.R.T[3,1]</cref>
+//           <cref>box.R.T[3,2]</cref>
+//           <cref>box.R.T[3,3]</cref>
+//       </T>
+//       <r>
+//           <cref>box.r[1]</cref>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </r>
+//       <r_shape>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </r_shape>
+//       <lengthDir>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </lengthDir>
+//       <widthDir>
+//           <exp>0.0</exp>
+//           <exp>1.0</exp>
+//           <exp>0.0</exp>
+//       </widthDir>
+//       <length><exp>1.0</exp></length>
+//       <width><exp>0.2</exp></width>
+//       <height><exp>0.1</exp></height>
+//       <extra><exp>0.0</exp></extra>
+//       <color>
+//           <exp>255.0</exp>
+//           <exp>0.0</exp>
+//           <exp>0.0</exp>
+//       </color>
+//       <specCoeff><exp>0.7</exp></specCoeff>
+//   </shape>
+// </visualization>"
+// ""
+// endResult

--- a/testsuite/openmodelica/visualization/OpenModelicaBugs.mo
+++ b/testsuite/openmodelica/visualization/OpenModelicaBugs.mo
@@ -1,0 +1,61 @@
+within ;
+package OpenModelicaBugs "Models from the #15940 report exercising ModelicaServices.Animation.Shape"
+
+  model ShapeDoesNotAnimate1 "Shape used directly from ModelicaServices.Animation"
+    ModelicaServices.Animation.Shape box(length = 1, width = 0.2, height = 0.1, r = {time,0,0});
+    annotation(experiment(StopTime = 1.1));
+  end ShapeDoesNotAnimate1;
+
+  model ShapeDoesNotAnimate2 "Shape used directly, orientation given via a local record"
+    record Orientation
+      Real T[3,3];
+      Real w[3] = zeros(3);
+    end Orientation;
+    ModelicaServices.Animation.Shape box(shapeType = "box", length = 1, width = 0.2, height = 0.1, r = {time,0,0}, R = Orientation(T = identity(3)));
+    annotation(experiment(StopTime = 1.1));
+  end ShapeDoesNotAnimate2;
+
+  model ShapeDoesNotAnimate3 "Shape wrapped in a component (work-around hierarchy)"
+    OpenModelicaBugs.BaseShape1 box(shapeType = "box", length = 1, width = 0.2, height = 0.1, r = {time,0,0}, T = identity(3));
+    annotation(experiment(StopTime = 1.1));
+  end ShapeDoesNotAnimate3;
+
+  model ShapeDoesNotAnimate4 "Shape inherited via extends (the failing case in #15940)"
+    OpenModelicaBugs.BaseShape2 box(shapeType = "box", length = 1, width = 0.2, height = 0.1, r = {time,0,0}, T = identity(3));
+    annotation(experiment(StopTime = 1.1));
+  end ShapeDoesNotAnimate4;
+
+  model BaseShape1 "Wraps a ModelicaServices.Animation.Shape as a component"
+    import Modelica.Units.SI;
+    parameter String shapeType = "box";
+    input SI.Position r_shape[3] = {0,0,0} annotation(Dialog);
+    input Real lengthDirection[3] = {1,0,0} annotation(Dialog);
+    input Real widthDirection[3] = {0,1,0} annotation(Dialog);
+    input SI.Length length = 0 annotation(Dialog);
+    input SI.Length width = 0 annotation(Dialog);
+    input SI.Length height = 0 annotation(Dialog);
+    input Real extra = 0.0 annotation(Dialog);
+    input Real color[3] = {255,0,0} annotation(Dialog(colorSelector = true));
+    input Real specularCoefficient = 0.7 annotation(Dialog);
+    input SI.Position r[3] = {0,0,0} annotation(Dialog);
+    input Real T[3,3] annotation(Dialog);
+    record Orientation
+      Real T[3,3];
+      Real w[3] = zeros(3);
+    end Orientation;
+    ModelicaServices.Animation.Shape shape(shapeType = shapeType, r_shape = r_shape, lengthDirection = lengthDirection,
+      widthDirection = widthDirection, length = length, width = width, height = height, extra = extra, color = color,
+      specularCoefficient = specularCoefficient, r = r, R = Orientation(T = T));
+  end BaseShape1;
+
+  model BaseShape2 "Inherits a ModelicaServices.Animation.Shape via extends"
+    extends ModelicaServices.Animation.Shape(R = Orientation(T = T));
+    input Real T[3,3];
+    record Orientation
+      Real T[3,3];
+      Real w[3] = zeros(3);
+    end Orientation;
+  end BaseShape2;
+
+  annotation(uses(Modelica(version = "4.1.0"), ModelicaServices(version = "4.1.0")));
+end OpenModelicaBugs;


### PR DESCRIPTION
Fixes #15940

A model that inherits a visualization type via `extends`, e.g.

```mo
model BaseShape
  extends ModelicaServices.Animation.Shape;
end BaseShape;
```

did not animate. When converting the flat model to a DAE, the type of the class owning each component is recorded in the element source (used by the visxml backend to recognize shapes). For an inherited component, getDerivedNode collapses the whole extends chain down to the most derived class, so the ModelicaServices.Animation.Shape base class was lost and VisualXML produced an empty _visual.xml.

NFConvertDAE.addComponentLevelTypeToSource now walks the extends chain and, when a visualization base class is found, records the full chain with the visualization base class kept in the primary slot of that cref level, so the identifier prefix VisualXML derives from the type index still points at the right component. Components that do not involve a visualization type keep the previous single-entry behaviour, so existing models (including the direct ModelicaServices and MultiBody Advanced shapes) are unchanged.

Add a regression test (OpenModelicaBugs.mo with the models from the report) covering both the direct, the wrapped and the inherited (extends) variants.

---

generated by Claude Code

