### PR TITLE
Load a previously compiled simulation executable

### DIFF
--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -18,12 +18,12 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 set(OMEDITLIB_SOURCES Util/Helper.cpp
-                      Search/FindUsageWidget.cpp
                       Util/Utilities.cpp
                       Util/StringHandler.cpp
                       Util/OutputPlainTextEdit.cpp
                       Util/DirectoryOrFileSelector.cpp
                       MainWindow.cpp
+                      LoadCompiledModelDialog.cpp
                       OMC/OMCProxy.cpp
                       Modeling/Model.cpp
                       Modeling/MessagesWidget.cpp
@@ -77,9 +77,6 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       Element/ElementProperties.cpp
                       Element/Transformation.cpp
                       Modeling/DocumentationWidget.cpp
-                      MCP/MCPServer.cpp
-                      MCP/MCPToolsSimulation.cpp
-                      MCP/MCPToolsDiagram.cpp
                       Simulation/TranslationFlagsWidget.cpp
                       Simulation/SimulationDialog.cpp
                       Simulation/SimulationOutputWidget.cpp
@@ -133,6 +130,10 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       FlatModelica/Expression.cpp
                       FlatModelica/ExpressionFuncs.cpp
                       FlatModelica/Parser.cpp
+                      MCP/MCPServer.cpp
+                      MCP/MCPToolsSimulation.cpp
+                      MCP/MCPToolsDiagram.cpp
+                      Search/FindUsageWidget.cpp
                       Animation/OpenGLWidget.cpp
                       Animation/AbstractAnimationWindow.cpp
                       Animation/ViewerWidget.cpp
@@ -149,14 +150,13 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       Animation/Vector.cpp
                       resource_omedit.qrc)
 
-set(OMEDITLIB_HEADERS MCP/MCPServer.h
-                      Util/Helper.h
-                      Search/FindUsageWidget.h
+set(OMEDITLIB_HEADERS Util/Helper.h
                       Util/Utilities.h
                       Util/StringHandler.h
                       Util/OutputPlainTextEdit.h
                       Util/DirectoryOrFileSelector.h
                       MainWindow.h
+                      LoadCompiledModelDialog.h
                       OMC/OMCProxy.h
                       Modeling/Model.h
                       Modeling/MessagesWidget.h
@@ -268,6 +268,9 @@ set(OMEDITLIB_HEADERS MCP/MCPServer.h
                       FlatModelica/Expression.h
                       FlatModelica/ExpressionFuncs.h
                       FlatModelica/Parser.h
+                      MCP/MCPServer.h
+                      MCP/MCPServerPrivate.h
+                      Search/FindUsageWidget.h
                       Animation/OpenGLWidget.h
                       Animation/AbstractAnimationWindow.h
                       Animation/ViewerWidget.h

--- a/OMEdit/OMEditLIB/LoadCompiledModelDialog.cpp
+++ b/OMEdit/OMEditLIB/LoadCompiledModelDialog.cpp
@@ -1,0 +1,204 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#include "LoadCompiledModelDialog.h"
+#include "Util/Helper.h"
+#include "Util/Utilities.h"
+#include "Util/StringHandler.h"
+#include "MainWindow.h"
+
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QGridLayout>
+
+/*!
+ * \class LoadCompiledModelDialog
+ * \brief This class is used to load the compiled model.
+ */
+/*!
+ * \brief LoadCompiledModelDialog::LoadCompiledModelDialog
+ * \param pParent
+ */
+LoadCompiledModelDialog::LoadCompiledModelDialog(QWidget *pParent)
+  : QDialog(pParent)
+{
+  setAttribute(Qt::WA_DeleteOnClose);
+  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName).arg(Helper::loadCompiledModel));
+  setMinimumWidth(400);
+  // create executable label, textbox and browse button
+  Label *pExecutableLabel = new Label(tr("Executable"));
+  mpExecutableTextBox = new QLineEdit;
+  QPushButton *pExecutableBrowseButton = new QPushButton(Helper::browse);
+  connect(pExecutableBrowseButton, &QPushButton::clicked, this, &LoadCompiledModelDialog::browseExecutable);
+  // create model init file label, combobox and browse button
+  Label *pModelInitFileLabel = new Label(tr("Model init file"));
+  mpModelInitFileComboBox = new QComboBox;
+  mpModelInitFileComboBox->setEditable(true);
+  QPushButton *pModelInitFileBrowseButton = new QPushButton(Helper::browse);
+  connect(pModelInitFileBrowseButton, &QPushButton::clicked, this, &LoadCompiledModelDialog::browseModelInitFile);
+  // create result file label, combobox and browse button
+  Label *pResultFileLabel = new Label(tr("Result file"));
+  mpResultFileComboBox = new QComboBox;
+  mpResultFileComboBox->setEditable(true);
+  QPushButton *pResultFileBrowseButton = new QPushButton(Helper::browse);
+  connect(pResultFileBrowseButton, &QPushButton::clicked, this, &LoadCompiledModelDialog::browseResultFile);
+  // Create the buttons
+  QPushButton *pOkButton = new QPushButton(Helper::ok);
+  pOkButton->setAutoDefault(true);
+  connect(pOkButton, SIGNAL(clicked()), SLOT(loadCompiledModel()));
+  QPushButton *pCancelButton = new QPushButton(Helper::cancel);
+  pCancelButton->setAutoDefault(false);
+  connect(pCancelButton, SIGNAL(clicked()), SLOT(reject()));
+  // create buttons box
+  QDialogButtonBox *pButtonBox = new QDialogButtonBox(Qt::Horizontal);
+  pButtonBox->addButton(pOkButton, QDialogButtonBox::ActionRole);
+  pButtonBox->addButton(pCancelButton, QDialogButtonBox::ActionRole);
+  // Create a layout
+  QGridLayout *pMainLayout = new QGridLayout;
+  pMainLayout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  pMainLayout->addWidget(pExecutableLabel, 0, 0);
+  pMainLayout->addWidget(mpExecutableTextBox, 0, 1);
+  pMainLayout->addWidget(pExecutableBrowseButton, 0, 2);
+  pMainLayout->addWidget(pModelInitFileLabel, 1, 0);
+  pMainLayout->addWidget(mpModelInitFileComboBox, 1, 1);
+  pMainLayout->addWidget(pModelInitFileBrowseButton, 1, 2);
+  pMainLayout->addWidget(pResultFileLabel, 2, 0);
+  pMainLayout->addWidget(mpResultFileComboBox, 2, 1);
+  pMainLayout->addWidget(pResultFileBrowseButton, 2, 2);
+  pMainLayout->addWidget(pButtonBox, 3, 0, 1, 3, Qt::AlignRight);
+  setLayout(pMainLayout);
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::fetchModelInitFiles
+ * Fetches the model init files from the executable path and populates the model init file combobox.
+ */
+void LoadCompiledModelDialog::fetchModelInitFiles()
+{
+  mpModelInitFileComboBox->clear();
+  QString executablePath = mpExecutableTextBox->text();
+  if (executablePath.isEmpty()) {
+    return;
+  }
+  QDir dir(QFileInfo(executablePath).absolutePath());
+  QStringList filters;
+  filters << "*_init.xml";
+  QStringList initFiles = dir.entryList(filters, QDir::Files, QDir::Name);
+  for (const QString &initFile : initFiles) {
+    mpModelInitFileComboBox->addItem(dir.absoluteFilePath(initFile));
+  }
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::fetchResultFiles
+ * Fetches the result files from the executable path and populates the result file combobox.
+ */
+void LoadCompiledModelDialog::fetchResultFiles()
+{
+  mpResultFileComboBox->clear();
+  QString executablePath = mpExecutableTextBox->text();
+  if (executablePath.isEmpty()) {
+    return;
+  }
+  QDir dir(QFileInfo(executablePath).absolutePath());
+  QStringList filters;
+  QStringList extList = Helper::ModelicaSimulationOutputFormats.split(",", Qt::SkipEmptyParts);
+  for (const QString &ext : extList) {
+    filters << QString("*.%1").arg(ext.trimmed());
+  }
+  QStringList resultFiles = dir.entryList(filters, QDir::Files, QDir::Name);
+  for (const QString &resultFile : resultFiles) {
+    mpResultFileComboBox->addItem(dir.absoluteFilePath(resultFile));
+  }
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::browseExecutable
+ * Browses for the executable file and sets the path in the executable textbox.
+ */
+void LoadCompiledModelDialog::browseExecutable()
+{
+  QString executableFilePath = StringHandler::getOpenFileName(this, QString("%1 - %2").arg(Helper::applicationName).arg(Helper::chooseFile), NULL, "", NULL);
+  if (executableFilePath.isEmpty()) {
+    return;
+  }
+  mpExecutableTextBox->setText(executableFilePath);
+  fetchModelInitFiles();
+  fetchResultFiles();
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::browseModelInitFile
+ * Browses for the model init file and sets the path in the model init file combobox.
+ */
+void LoadCompiledModelDialog::browseModelInitFile()
+{
+  QString modelInitFilePath = StringHandler::getOpenFileName(this, QString("%1 - %2").arg(Helper::applicationName).arg(Helper::chooseFile), NULL, Helper::xmlFileTypes, NULL);
+  if (modelInitFilePath.isEmpty()) {
+    return;
+  }
+  mpModelInitFileComboBox->lineEdit()->setText(modelInitFilePath);
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::browseResultFile
+ * Browses for the result file and sets the path in the result file combobox.
+ */
+void LoadCompiledModelDialog::browseResultFile()
+{
+  QString resultFilePath = StringHandler::getOpenFileName(this, QString("%1 - %2").arg(Helper::applicationName).arg(Helper::chooseFile), NULL, Helper::omResultFileTypes, NULL);
+  if (resultFilePath.isEmpty()) {
+    return;
+  }
+  mpResultFileComboBox->lineEdit()->setText(resultFilePath);
+}
+
+/*!
+ * \brief LoadCompiledModelDialog::loadCompiledModel
+ * Loads the compiled model using the provided executable file path, model init file path, and result file path.
+ */
+void LoadCompiledModelDialog::loadCompiledModel()
+{
+  const QString executableFilePath = mpExecutableTextBox->text();
+  const QString modelInitFilePath = mpModelInitFileComboBox->currentText();
+  const QString resultFilePath = mpResultFileComboBox->currentText();
+
+  MainWindow::instance()->loadCompiledModel(executableFilePath, modelInitFilePath, resultFilePath);
+  accept();
+}

--- a/OMEdit/OMEditLIB/LoadCompiledModelDialog.h
+++ b/OMEdit/OMEditLIB/LoadCompiledModelDialog.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#ifndef LOADCOMPILEDMODELDIALOG_H
+#define LOADCOMPILEDMODELDIALOG_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QComboBox>
+
+class LoadCompiledModelDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit LoadCompiledModelDialog(QWidget *pParent = nullptr);
+private:
+  QLineEdit *mpExecutableTextBox;
+  QComboBox *mpModelInitFileComboBox;
+  QComboBox *mpResultFileComboBox;
+
+  void fetchModelInitFiles();
+  void fetchResultFiles();
+private slots:
+  void browseExecutable();
+  void browseModelInitFile();
+  void browseResultFile();
+  void loadCompiledModel();
+};
+
+#endif // LOADCOMPILEDMODELDIALOG_H

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -83,6 +83,7 @@
 #include "CrashReport/CrashReportDialog.h"
 #include "FMI/FMUExportOutputWidget.h"
 #include "PlotCurve.h"
+#include "LoadCompiledModelDialog.h"
 #include <QtSvg/QSvgGenerator>
 #include <QOpenGLWidget>
 #include <QNetworkProxyFactory>
@@ -497,6 +498,19 @@ void MainWindow::setNewApiProfiling(bool newApiProfiling)
 }
 
 /*!
+ * \brief MainWindow::getSimulationDialog
+ * Returns the SimulationDialog instance.
+ * \return
+ */
+SimulationDialog* MainWindow::getSimulationDialog()
+{
+  if (!mpSimulationDialog) {
+    mpSimulationDialog = new SimulationDialog(this);
+  }
+  return mpSimulationDialog;
+}
+
+/*!
  * \brief MainWindow::isModelingPerspectiveActive
  * Returns true if the Modeling perspective is active.
  * \return
@@ -890,6 +904,116 @@ void MainWindow::openDroppedFile(const QMimeData *pMimeData)
     }
   }
   hideProgressBar();
+}
+
+/*!
+ * \brief MainWindow::loadCompiledModel
+ * Loads the compiled model and switches to plotting perspective.
+ * \param executableFilePath
+ * \param modelInitFilePath
+ * \param resultFilePath
+ */
+void MainWindow::loadCompiledModel(const QString &executableFilePath, const QString &modelInitFilePath, const QString &resultFilePath)
+{
+  // check if all files belong to the same directory
+  const QString executableDir = QFileInfo(executableFilePath).absolutePath();
+  const QString modelInitDir = QFileInfo(modelInitFilePath).absolutePath();
+  const QString resultDir = QFileInfo(resultFilePath).absolutePath();
+  if (executableDir != modelInitDir || executableDir != resultDir) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica,
+                                                          tr("All files must be in the same directory."),
+                                                          Helper::scriptingKind, Helper::errorLevel));
+    return;
+  }
+  // check if files exists
+  auto checkFileExists = [](const QString &fileName) -> bool {
+    if (QFileInfo::exists(fileName)) {
+      return true;
+    }
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica,
+                                                          GUIMessages::getMessage(GUIMessages::FILE_NOT_FOUND).arg(fileName),
+                                                          Helper::scriptingKind, Helper::errorLevel));
+    return false;
+  };
+
+  // check if the executable file exists
+  if (!checkFileExists(executableFilePath)) {
+    return;
+  }
+  // check if the model init file exists
+  if (!checkFileExists(modelInitFilePath)) {
+    return;
+  }
+  // check if the result file exists
+  if (!checkFileExists(resultFilePath)) {
+    return;
+  }
+
+  mpStatusBar->showMessage(QString("%1: %2").arg(Helper::loading, resultFilePath));
+  QFileInfo resultFileInfo(resultFilePath);
+  QStringList list = mpOMCProxy->readSimulationResultVars(resultFileInfo.absoluteFilePath());
+  // if result file contains variables then switch to plotting perspective and add the variables to the variables tree.
+  if (list.size() > 0) {
+    // build SimulationOptions object from the model init file.
+    // Parse model_init.xml to extract DefaultExperiment values
+    SimulationOptions simulationOptions;
+    QFile initFile(modelInitFilePath);
+    if (initFile.open(QIODevice::ReadOnly)) {
+      QXmlStreamReader xml(&initFile);
+      while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() == QXmlStreamReader::StartElement) {
+          if (xml.name() == QStringLiteral("fmiModelDescription")) {
+            simulationOptions.setClassName(xml.attributes().value("modelIdentifier").toString());
+          }
+          if (xml.name() == QStringLiteral("DefaultExperiment")) {
+            auto a = xml.attributes();
+            if (!a.value("startTime").isEmpty()) {
+              simulationOptions.setStartTime(a.value("startTime").toString());
+            }
+            if (!a.value("stopTime").isEmpty()) {
+              simulationOptions.setStopTime(a.value("stopTime").toString());
+            }
+            if (!a.value("stepSize").isEmpty()) {
+              simulationOptions.setStepSize(a.value("stepSize").toDouble());
+            }
+            if (!a.value("tolerance").isEmpty()) {
+              simulationOptions.setTolerance(a.value("tolerance").toString());
+            }
+            if (!a.value("solver").isEmpty()) {
+              simulationOptions.setMethod(a.value("solver").toString());
+            }
+            if (!a.value("outputFormat").isEmpty()) {
+              simulationOptions.setOutputFormat(a.value("outputFormat").toString());
+            }
+            if (!a.value("variableFilter").isEmpty()) {
+              simulationOptions.setVariableFilter(a.value("variableFilter").toString());
+            }
+          }
+        }
+      }
+    }
+    simulationOptions.setWorkingDirectory(resultFileInfo.absoluteDir().absolutePath());
+    simulationOptions.setResultFileName(resultFileInfo.fileName());
+
+    QStringList simulationFlags;
+    simulationFlags.append(QString("-startTime=").append(simulationOptions.getStartTime()));
+    simulationFlags.append(QString("-stopTime=").append(simulationOptions.getStopTime()));
+    simulationFlags.append(QString("-stepSize=").append(QString::number(simulationOptions.getStepSize())));
+    simulationFlags.append(QString("-tolerance=").append(simulationOptions.getTolerance()));
+    simulationFlags.append(QString("-s=").append(simulationOptions.getMethod()));
+    simulationFlags.append(QString("-outputFormat=").append(simulationOptions.getOutputFormat()));
+    simulationFlags.append(QString("-variableFilter=").append(simulationOptions.getVariableFilter()));
+    simulationFlags.append(QString("-r=%1/%2").arg(simulationOptions.getWorkingDirectory(), simulationOptions.getFullResultFileName()));
+    simulationFlags.append(QString("-inputPath=%1").arg(simulationOptions.getWorkingDirectory()));
+    simulationFlags.append(QString("-outputPath=%1").arg(simulationOptions.getWorkingDirectory()));
+
+    simulationOptions.setSimulationFlags(simulationFlags);
+    simulationOptions.setIsValid(true);
+
+    switchToPlottingPerspectiveSlot();
+    mpVariablesWidget->insertVariablesItemsToTree(resultFileInfo.fileName(), resultFileInfo.absoluteDir().absolutePath(), list, simulationOptions);
+  }
+  mpStatusBar->clearMessage();
 }
 
 /*!
@@ -2074,6 +2198,16 @@ void MainWindow::loadEncryptedLibrary()
 #else // OM_ENABLE_ENCRYPTION
   showEncryptionSupportMessage();
 #endif // OM_ENABLE_ENCRYPTION
+}
+
+/*!
+ * \brief MainWindow::loadCompiledModel
+ * Opens the LoadCompiledModelDialog.
+ */
+void MainWindow::loadCompiledModel()
+{
+  LoadCompiledModelDialog *pLoadCompiledModelDialog = new LoadCompiledModelDialog(this);
+  pLoadCompiledModelDialog->exec();
 }
 
 /*!
@@ -3796,6 +3930,10 @@ void MainWindow::createActions()
   mpLoadEncryptedLibraryAction = new QAction(tr("Load Encrypted Library"), this);
   mpLoadEncryptedLibraryAction->setStatusTip(tr("Loads the encrypted Modelica library"));
   connect(mpLoadEncryptedLibraryAction, SIGNAL(triggered()), SLOT(loadEncryptedLibrary()));
+  // open compiled model action
+  mpLoadCompiledModelAction = new QAction(Helper::loadCompiledModel, this);
+  mpLoadCompiledModelAction->setStatusTip(tr("Loads the compiled model"));
+  connect(mpLoadCompiledModelAction, SIGNAL(triggered()), SLOT(loadCompiledModel()));
   // open result file action
   mpOpenResultFileAction = new QAction(tr("Open Result File(s)"), this);
   mpOpenResultFileAction->setShortcut(QKeySequence("Ctrl+shift+o"));
@@ -4284,6 +4422,7 @@ void MainWindow::createMenus()
   mpFileMenu->addAction(mpOpenModelicaFileWithEncodingAction);
   mpFileMenu->addAction(mpLoadModelicaLibraryAction);
   mpFileMenu->addAction(mpLoadEncryptedLibraryAction);
+  mpFileMenu->addAction(mpLoadCompiledModelAction);
   mpFileMenu->addAction(mpOpenResultFileAction);
   mpFileMenu->addAction(mpOpenTransformationFileAction);
   mpFileMenu->addSeparator();

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -144,7 +144,7 @@ public:
   QDockWidget* getVariablesDockWidget() {return mpVariablesDockWidget;}
   QDockWidget* getFindUsageDockWidget() {return mpFindUsageDockWidget;}
   SearchWidget* getSearchWidget() {return mpSearchWidget;}
-  SimulationDialog* getSimulationDialog() {return mpSimulationDialog;}
+  SimulationDialog* getSimulationDialog();
   OMSSimulationDialog* getOMSSimulationDialog() {return mpOMSSimulationDialog;}
   ModelWidgetContainer* getModelWidgetContainer() {return mpModelWidgetContainer;}
   WelcomePageWidget* getWelcomePageWidget() {return mpWelcomePageWidget;}
@@ -233,6 +233,7 @@ public:
   int askForExit();
   void beforeClosingMainWindow();
   void openDroppedFile(const QMimeData *pMimeData);
+  void loadCompiledModel(const QString &executableFilePath, const QString &modelInitFilePath, const QString &resultFilePath);
   void openResultFile(const QString &fileName);
   void simulate(LibraryTreeItem *pLibraryTreeItem);
   void simulateBuildOnly(LibraryTreeItem *pLibraryTreeItem);
@@ -336,6 +337,7 @@ private:
   QAction *mpOpenModelicaFileWithEncodingAction;
   QAction *mpLoadModelicaLibraryAction;
   QAction *mpLoadEncryptedLibraryAction;
+  QAction *mpLoadCompiledModelAction;
   QAction *mpOpenResultFileAction;
   QAction *mpOpenTransformationFileAction;
   QAction *mpUnloadAllAction;
@@ -502,6 +504,7 @@ public slots:
   void showOpenModelicaFileDialog();
   void loadModelicaLibrary();
   void loadEncryptedLibrary();
+  void loadCompiledModel();
   void showOpenResultFileDialog();
   void showOpenTransformationFileDialog();
   void unloadAll(bool onlyModelicaClasses = false);

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -88,12 +88,12 @@ INCLUDEPATH += . ../ \
   $$OPENMODELICAHOME/../OMParser/3rdParty/antlr4/runtime/Cpp/runtime/src
 
 SOURCES += Util/Helper.cpp \
-  Search/FindUsageWidget.cpp \
   Util/Utilities.cpp \
   Util/StringHandler.cpp \
   Util/OutputPlainTextEdit.cpp \
   Util/DirectoryOrFileSelector.cpp \
   MainWindow.cpp \
+  LoadCompiledModelDialog.cpp \
   $$OPENMODELICAHOME/include/omc/scripting-API/OpenModelicaScriptingAPIQt.cpp \
   OMC/OMCProxy.cpp \
   Modeling/Model.cpp \
@@ -203,15 +203,16 @@ SOURCES += Util/Helper.cpp \
   FlatModelica/Parser.cpp \
   MCP/MCPServer.cpp \
   MCP/MCPToolsDiagram.cpp \
-  MCP/MCPToolsSimulation.cpp
+  MCP/MCPToolsSimulation.cpp \
+  Search/FindUsageWidget.cpp
 
 HEADERS  += Util/Helper.h \
-  Search/FindUsageWidget.h \
   Util/Utilities.h \
   Util/StringHandler.h \
   Util/OutputPlainTextEdit.h \
   Util/DirectoryOrFileSelector.h \
   MainWindow.h \
+  LoadCompiledModelDialog.h \
   $$OPENMODELICAHOME/include/omc/scripting-API/OpenModelicaScriptingAPIQt.h \
   OMC/OMCProxy.h \
   Modeling/Model.h \
@@ -325,7 +326,8 @@ HEADERS  += Util/Helper.h \
   FlatModelica/ExpressionFuncs.h \
   FlatModelica/Parser.h \
   MCP/MCPServer.h \
-  MCP/MCPServerPrivate.h
+  MCP/MCPServerPrivate.h \
+  Search/FindUsageWidget.h
 
 CONFIG(osg) {
 

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -146,6 +146,7 @@ QString Helper::newModelicaClassLibraryBrowser;
 QString Helper::createNewModelicaClass;
 QString Helper::openModelicaFiles;
 QString Helper::openConvertModelicaFiles;
+QString Helper::loadCompiledModel;
 QString Helper::newCRMLModel;
 QString Helper::newCRMLModelTip;
 QString Helper::newMOSScript;
@@ -478,6 +479,7 @@ void Helper::initHelperVariables()
   Helper::createNewModelicaClass = tr("Creates a new Modelica Class");
   Helper::openModelicaFiles = tr("Open Model/Library File(s)");
   Helper::openConvertModelicaFiles = tr("Open/Convert Modelica File(s) With Encoding");
+  Helper::loadCompiledModel = tr("Load Compiled Model");
   Helper::newCRMLModel = tr("CRML Model");
   Helper::newCRMLModelTip = tr("Creates a new CRML Model");
   Helper::newMOSScript = tr("Modelica Script");

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -152,6 +152,7 @@ public:
   static QString createNewModelicaClass;
   static QString openModelicaFiles;
   static QString openConvertModelicaFiles;
+  static QString loadCompiledModel;
   static QString newCRMLModel;
   static QString newCRMLModelTip;
   static QString newMOSScript;


### PR DESCRIPTION
### Related Issues

#14111

### Purpose

Allow OMEdit to re-simulate a model from compiled artifacts without requiring Modelica source code.

### Approach

Load the previously simulated model executable, result file and model_init.xml file.
