### PR TITLE
[Runtime] Automatic clean-restart fallback to no-homotopy initialization (#14104)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -384,15 +384,73 @@ int initializeModel(DATA* data, threadData_t *threadData, const char* init_initM
   /* try */
   {
     int success = 0;
-#if !defined(OMC_EMCC)
-    MMC_TRY_INTERNAL(simulationJumpBuffer)
-#endif
-    if(initialization(data, threadData, init_initMethod, init_file, init_time))
+    int attempt;
+    /* The configured (by default: homotopy) initialization is attempt 0. If it
+     * fails, automatically RESTART CLEANLY and retry once without homotopy
+     * (attempt 1): the failed homotopy attempt leaves per-nonlinear-system
+     * initial-guess state that cannot be reset in place, so we re-allocate the
+     * nonlinear systems to get a pristine solver state. The fallback is skipped
+     * if the user already requested -noHomotopyOnFirstTry or the model has no
+     * homotopy operator. #14104 / #15886 */
+    int allowFallback = !omc_flag[FLAG_NO_HOMOTOPY_ON_FIRST_TRY];
+    modelica_boolean hasHomotopy = FALSE;
+#if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
     {
-      warningStreamPrint(OMC_LOG_STDOUT, 0, "Error in initialization. Storing results and exiting.\nUse -lv=LOG_INIT -w for more information.");
-      simInfo->stopTime = simInfo->startTime;
-      retValue = -1;
+      long hi;
+      for (hi = 0; hi < data->modelData->nNonLinearSystems; hi++) {
+        if (data->simulationInfo->nonlinearSystemData[hi].homotopySupport) { hasHomotopy = TRUE; break; }
+      }
     }
+#endif
+
+    for (attempt = 0; attempt < 2; attempt++)
+    {
+      retValue = 0;
+      success = 0;
+#if !defined(OMC_EMCC)
+      MMC_TRY_INTERNAL(simulationJumpBuffer)
+#endif
+      if(initialization(data, threadData, init_initMethod, init_file, init_time))
+      {
+        retValue = -1;
+      }
+      success = 1;
+#if !defined(OMC_EMCC)
+      MMC_CATCH_INTERNAL(simulationJumpBuffer)
+#endif
+
+      if (success && !retValue) {
+        break;   /* initialized successfully */
+      }
+
+      /* failed (assertion or unsolved). Try the clean no-homotopy restart once. */
+      if (attempt == 0 && allowFallback && hasHomotopy)
+      {
+        warningStreamPrint(OMC_LOG_STDOUT, 0,
+          "Initialization failed; restarting the nonlinear solvers and retrying automatically without homotopy (equivalent to -noHomotopyOnFirstTry).");
+        omc_flag[FLAG_HOMOTOPY_ON_FIRST_TRY]    = 0;
+        omc_flag[FLAG_NO_HOMOTOPY_ON_FIRST_TRY] = 1;
+#if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
+        /* pristine solver state: re-create the nonlinear systems in the same
+         * (non-initial) configuration as at start-up */
+        data->simulationInfo->initial = 0;
+        freeNonlinearSystems(data, threadData);
+        initializeNonlinearSystems(data, threadData);
+#endif
+        continue;
+      }
+
+      /* no (more) fallback available -> report failure as before */
+      retValue = -1;
+      simInfo->stopTime = simInfo->startTime;
+      if (!success) {
+        infoStreamPrint(OMC_LOG_ASSERT, 0, "simulation terminated by an assertion at initialization");
+      } else {
+        warningStreamPrint(OMC_LOG_STDOUT, 0, "Error in initialization. Storing results and exiting.\nUse -lv=LOG_INIT -w for more information.");
+      }
+      break;
+    }
+
     if (!retValue)
     {
       if (data->simulationInfo->homotopySteps == 0) {
@@ -402,17 +460,6 @@ int initializeModel(DATA* data, threadData_t *threadData, const char* init_initM
         usedLocal = data->callback->homotopyMethod == LOCAL_EQUIDISTANT_HOMOTOPY || data->callback->homotopyMethod == LOCAL_ADAPTIVE_HOMOTOPY ;
         infoStreamPrint(OMC_LOG_SUCCESS, 0, "The initialization finished successfully with %d %shomotopy steps.", data->simulationInfo->homotopySteps, usedLocal? "local ":"");
       }
-    }
-
-    success = 1;
-#if !defined(OMC_EMCC)
-    MMC_CATCH_INTERNAL(simulationJumpBuffer)
-#endif
-
-    if (!success)
-    {
-      retValue =  -1;
-      infoStreamPrint(OMC_LOG_ASSERT, 0, "simulation terminated by an assertion at initialization");
     }
   }
 

--- a/testsuite/simulation/modelica/initialization/HeatExchangerHomotopyFallback.mos
+++ b/testsuite/simulation/modelica/initialization/HeatExchangerHomotopyFallback.mos
@@ -1,0 +1,30 @@
+// name:      HeatExchangerHomotopyFallback
+// keywords:  initialization, homotopy, fallback
+// status:    correct
+//
+// Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation does not
+// initialize with the default global homotopy method (it stalls at lambda=0).
+// The automatic clean-restart fallback re-allocates the nonlinear systems and
+// retries the initialization once without homotopy, after which the model
+// initializes and simulates successfully.
+//
+// Regression test for the init fallback (#14104 / #15886). A non-empty result
+// file means the fallback recovered the failed homotopy initialization; without
+// the fallback the simulation produces no result.
+
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+// echo(false) suppresses the (numerically volatile) homotopy-failure log of the
+// first initialization attempt, so the test only checks the stable outcome.
+echo(false);
+sr := simulate(Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation, stopTime = 1.0);
+echo(true);
+// A non-empty result file means the fallback recovered the failed homotopy
+// initialization and the model simulated to completion.
+sr.resultFile <> "";
+
+// Result:
+// true
+// ""
+// true
+//
+// endResult

--- a/testsuite/simulation/modelica/initialization/Makefile
+++ b/testsuite/simulation/modelica/initialization/Makefile
@@ -33,6 +33,7 @@ eventTest2.mos \
 filterBlock1.mos \
 fullRobot.mos \
 gaspropreties.mos \
+HeatExchangerHomotopyFallback.mos \
 homotopy1.mos \
 homotopy2.mos \
 homotopy3.mos \


### PR DESCRIPTION
## Automatic clean-restart fallback to no-homotopy initialization

Fixes the initialization of
`Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation`
(#15886, referenced from #14104).

## Problem

Some media-heavy models that contain a `homotopy` operator fail to initialize
with the default *global homotopy* method: the homotopy path stalls at
`lambda = 0` and the nonlinear solver never reaches a solution, so
initialization aborts even though the plain (no-homotopy) initialization of the
very same model converges without trouble.

`HeatExchangerSimulation` is the reference case:

```mo
model Check
  extends Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation;
end Check;
```

Baseline `omc` (no flags) cannot initialize it; passing `-noHomotopyOnFirstTry`
by hand already does. The global homotopy was the *sole* blocker.

## Fix

Keep homotopy as the **default**, but add an automatic, opt-out-able **fallback**:
when the configured initialization fails for a model that actually uses
`homotopy`, restart the nonlinear solvers cleanly and retry the initialization
once *without* homotopy.

A failed homotopy attempt leaves per-nonlinear-system initial-guess state
(`nlsxOld` / extrapolation) that cannot be reset in place, so the nonlinear
systems are re-allocated before the retry:

```c
data->simulationInfo->initial = 0;        /* pristine start-up configuration */
freeNonlinearSystems(data, threadData);
initializeNonlinearSystems(data, threadData);
```

The fallback:

- only fires after a **genuine initialization failure** (assertion or unsolved
  system) — never on a model that initializes normally;
- is **skipped** when the user already passed `-noHomotopyOnFirstTry`, or when
  the model contains **no** `homotopy` operator;
- is isolated to `solver_main.c::initializeModel()` (a 2-attempt loop), reusing
  the existing, tested no-homotopy machinery rather than introducing a new path.

So the default behaviour and normal models are unaffected; only the
previously-failing homotopy-stuck class now recovers.

## Result

`HeatExchangerSimulation`, no flags:

```
LOG_ASSERT  | error | Failed to solve the initialization problem with global homotopy ...
LOG_STDOUT  | warning | Initialization failed; restarting the nonlinear solvers and
                        retrying automatically without homotopy (equivalent to
                        -noHomotopyOnFirstTry).
LOG_SUCCESS | info  | The initialization finished successfully without homotopy method.
LOG_SUCCESS | info  | The simulation finished successfully.
```

`Modelica.Electrical.Analog.Examples.CauerLowPassAnalog` (normal homotopy model)
initializes and simulates as before — the fallback does **not** fire.

## Test

Adds `testsuite/simulation/modelica/initialization/HeatExchangerHomotopyFallback.mos`:
it simulates `HeatExchangerSimulation` and asserts a result file is produced
(`sr.resultFile <> ""`). `echo(false)` is used around `simulate` to suppress the
numerically-volatile homotopy-failure log so the reference stays stable and
CI-portable (`true / "" / true`). Without the fallback the model produces no
result and the test fails.

---
generated by Claude Code
