### PR TITLE
[OMEdit] Fix #15965: bound DynamicSelect evaluation to stop infinite recursion

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -254,7 +254,7 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
                                                             bool readFromResultFileForDynamicSelect, double time, bool value)
 {
   try {
-    auto expression = pExpression->evaluate([&](std::string name) -> auto {
+    auto var_eval = [&](std::string name) -> FlatModelica::Expression {
       auto vname = QString::fromStdString(name);
       if (readFromResultFileForDynamicSelect) {
         QPair<double, bool> value = MainWindow::instance()->getVariablesWidget()->readVariableValue(vname, time, false);
@@ -272,15 +272,24 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
           return *valueOrBindingExpression;
         }
       }
-    });
+    };
 
-    if (!value && !expression.isLiteral() && !expression.isNull()) {
-      // qDebug() << "Expression is not literal:" << expression.toQString();
-      return evaluate_helper(&expression, pModel, readFromResultFileForDynamicSelect, time, value);
-    } else {
-      // qDebug() << "Expression is literal:" << expression.toQString() << expression.isNull();
-      return expression;
+    // Keep evaluating until the expression reduces to a literal. Some DynamicSelect
+    // expressions (e.g. a function call that evaluates to another non-literal call)
+    // never reach a literal; without a bound this recurses until the stack overflows
+    // and OMEdit hangs. Loop with a depth cap and stop early if evaluation no longer
+    // makes progress (a non-literal fixed point).
+    const int maxIterations = 100;
+    FlatModelica::Expression expression = pExpression->evaluate(var_eval);
+    for (int i = 0; !value && !expression.isLiteral() && !expression.isNull() && i < maxIterations; ++i) {
+      FlatModelica::Expression next = expression.evaluate(var_eval);
+      if (next.toQString() == expression.toQString()) {
+        // Fixed point that is not a literal: further evaluation is pointless.
+        break;
+      }
+      expression = std::move(next);
     }
+    return expression;
   } catch (const std::exception &e) {
     if (MainWindow::instance()->isDebug()) {
       qDebug() << "Failed to evaluate expression.";

--- a/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
+++ b/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
@@ -67,6 +67,13 @@ void DynamicAnnotationTest::initTestCase()
   if (!MainWindow::instance()->getOMCProxy()->existClass("EnableInReplaceable1")) {
     QFAIL(QString("Failed to load file %1").arg(enableInReplaceable1FileName).toStdString().c_str());
   }
+
+  // load EnableNonLiteral.mo (regression model for #15965)
+  const QString enableNonLiteralFileName = QFINDTESTDATA("EnableNonLiteral.mo");
+  MainWindow::instance()->getLibraryWidget()->openFile(enableNonLiteralFileName);
+  if (!MainWindow::instance()->getOMCProxy()->existClass("EnableNonLiteral")) {
+    QFAIL(QString("Failed to load file %1").arg(enableNonLiteralFileName).toStdString().c_str());
+  }
 }
 
 void DynamicAnnotationTest::evaluate()
@@ -122,6 +129,17 @@ void DynamicAnnotationTest::evaluate_data()
   QTest::newRow("Evaluate Dialog(enable = booleanParam) in record")
       << "EnableInReplaceable.ClassWithInstances"
       << "mainRecord"
+      << "realParam"
+      << true;
+
+  // Regression test for #15965: enable is a call to a user function that the
+  // FlatModelica evaluator cannot reduce, so it evaluates to the non-literal
+  // fixed point userPredicate(true). This used to make evaluate_helper recurse
+  // until the stack overflowed. It must now terminate; the non-literal result
+  // leaves the enable at its default (true).
+  QTest::newRow("Evaluate Dialog(enable = userPredicate(booleanParam)) does not recurse")
+      << "EnableNonLiteral.ClassWithInstances"
+      << "mainClass"
       << "realParam"
       << true;
 }

--- a/OMEdit/Testsuite/DynamicAnnotation/EnableNonLiteral.mo
+++ b/OMEdit/Testsuite/DynamicAnnotation/EnableNonLiteral.mo
@@ -1,0 +1,44 @@
+within ;
+package EnableNonLiteral
+  "Regression model for #15965.
+
+   OpenIPSL components (e.g. OpenIPSL.Interfaces.Generator, OpenIPSL.Electrical.Buses.*)
+   display power on the diagram with a DynamicSelect whose dynamic part calls a
+   user function, e.g.
+
+     textString = DynamicSelect(\"0.0 MW\", OpenIPSL.NonElectrical.Functions.displayPower(P, \" MW\"))
+
+   The OMEdit FlatModelica evaluator can only reduce builtin operators/functions,
+   so a call to a user function evaluates to itself: a non-literal fixed point.
+   DynamicAnnotation::evaluate_helper used to re-evaluate such an expression
+   recursively until the stack overflowed, and OMEdit hung inside the SIGSEGV
+   handler instead of crashing.
+
+   This model reproduces the same non-reducible user-function-call situation
+   through the Dialog(enable=...) evaluation path, which the test harness can
+   drive without a simulation result file. Evaluating it must terminate."
+
+  function userPredicate
+    "Stand-in for a user function the FlatModelica evaluator cannot execute
+     (like OpenIPSL.NonElectrical.Functions.displayPower). A call to it stays a
+     non-literal expression."
+    input Boolean b;
+    output Boolean r;
+  algorithm
+    r := b;
+  end userPredicate;
+
+  model MainClass
+    parameter Boolean booleanParam = true annotation(choices(checkBox = true));
+    // enable is a call to a user function, so it evaluates to the non-literal
+    // fixed point userPredicate(true) instead of a Boolean literal.
+    parameter Real realParam = 5 annotation(Dialog(enable = userPredicate(booleanParam)));
+  end MainClass;
+
+  model ClassWithInstances
+    MainClass mainClass annotation(
+      Placement(transformation(origin = {10, 10}, extent = {{-10, -10}, {10, 10}})));
+  end ClassWithInstances;
+
+  annotation(uses(Modelica(version="4.0.0")));
+end EnableNonLiteral;

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -129,6 +129,30 @@ void ExpressionTest::dynamicSelect_data()
   QTest::addRow("DynamicSelect15")
     << "DynamicSelect({0, 127, 255}, {min(1.0, max(0.0, 1.0 - ((if use_T_in then T_in else T) - 273.15) / 50.0)) * 28.0 + min(1.0, max(0.0, ((if use_T_in then T_in else T) - 273.15) / 50.0)) * 255.0, min(1.0, max(0.0, 1.0 - ((if use_T_in then T_in else T) - 273.15) / 50.0)) * 108.0, min(1.0, max(0.0, 1.0 - ((if use_T_in then T_in else T) - 273.15) / 50.0)) * 200.0})"
     << "DynamicSelect({0,127,255},{28,108,200})";
+
+  // Exact DynamicSelect expressions from OpenIPSL 3.1.0 that triggered #15965.
+  // The dynamic part is a call to a user function (displayPower), which the
+  // FlatModelica evaluator cannot execute, so it stays a non-literal call. The
+  // whole DynamicSelect is likewise not a reducible builtin, so evaluation
+  // leaves it as a non-literal expression (a fixed point). It must NOT loop; the
+  // fix that matters is in DynamicAnnotation::evaluate_helper (see the
+  // DynamicAnnotation testsuite), but this documents why the expression does not
+  // reduce to a literal.
+  // The real expression uses the qualified name
+  // OpenIPSL.NonElectrical.Functions.displayPower; the string parser used here
+  // only handles simple names, but the evaluation behaviour (a user-function
+  // call that stays non-literal) is identical.
+  QTest::addRow("OpenIPSL Generator P")
+    << "DynamicSelect(\"0.0 MW\", displayPower(P, \" MW\"))"
+    << "DynamicSelect(\"0.0 MW\",displayPower(1,\" MW\"))";
+
+  QTest::addRow("OpenIPSL Bus voltage")
+    << "DynamicSelect(\"Vpu\", String(v, significantDigits=3))"
+    << "DynamicSelect(\"Vpu\",\"1\")";
+
+  QTest::addRow("OpenIPSL Bus angle")
+    << "DynamicSelect(\"Angle\", String(angleDisplay, significantDigits=3) + \"°\")"
+    << "DynamicSelect(\"Angle\",\"1°\")";
 }
 
 void ExpressionTest::operators()


### PR DESCRIPTION
Opening a diagram window for a simulated OpenIPSL model hung OMEdit.

Root cause: OpenIPSL components display power on the diagram with a DynamicSelect whose dynamic part is a call to a user function, e.g.

    textString = DynamicSelect("0.0 MW", OpenIPSL.NonElectrical.Functions.displayPower(P, " MW"))

When the diagram shows live values, DynamicAnnotation::update evaluates this dynamic part. The OMEdit FlatModelica evaluator can only reduce builtin operators/functions, so a call to a user function (displayPower) evaluates to itself: a non-literal fixed point. DynamicAnnotation::evaluate_helper re-evaluated the result until it became a literal, calling itself with no depth limit, so it recursed forever until the stack overflowed. On the Qt main thread the resulting SIGSEGV lands inside the OMC signal handler, which is not async-signal-safe and deadlocks, so OMEdit hung instead of crashing.

Fix: replace the self-recursion in evaluate_helper with a bounded loop that caps the number of evaluation steps and stops early when re-evaluation no longer changes the expression (a non-literal fixed point). The variable-evaluator lambda is hoisted so it can be reused across iterations.

Tests:
- OMEdit/Testsuite/DynamicAnnotation: EnableNonLiteral.mo drives evaluate_helper with a non-reducible user-function call through the Dialog(enable=...) path. Without the fix this test overflows the stack (same Call::eval recursion_level=0 signature as the reported hang); with the fix it terminates.
- OMEdit/Testsuite/Expression: the exact OpenIPSL DynamicSelect expressions, documenting that the user-function dynamic part stays a non-literal expression.

Fixes #15965
