### PR TITLE
[FMI] Remove spaces around '=' for canRunAsynchronuosly attribute

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -184,7 +184,7 @@ case SIMCODE(__) then
     canHandleVariableCommunicationStepSize="true"
     canInterpolateInputs="true"
     maxOutputDerivativeOrder="1"
-    canRunAsynchronously="false"
+    canRunAsynchronuously="false"
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"
     canGetAndSetFMUstate="true"

--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -184,7 +184,7 @@ case SIMCODE(__) then
     canHandleVariableCommunicationStepSize="true"
     canInterpolateInputs="true"
     maxOutputDerivativeOrder="1"
-    canRunAsynchronuously = "false"
+    canRunAsynchronously="false"
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"
     canGetAndSetFMUstate="true"


### PR DESCRIPTION
While the XML specification allows spaces around the equal sign in attributes it's common convention to omit them for readability/consistency/file size.

Also some consumers might be strict about it, e.g. fmi-sim from the rust-fmi project throws an error because of it:

> fmi-sim --model model.fmu co-simulation
> Error: unknown field "canRunAsynchronuously =" in element "CoSimulation

Remove the spaces around '=' to be consistent with all other attributes