### PR TITLE
Support dynamicselect user functions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -4035,6 +4035,34 @@ algorithm
   end match;
 end getElementComment;
 
+public function collectModBindings
+  "Recursively collects all Absyn expression bindings in a modifier tree."
+  input SCode.Mod mod;
+  input output list<Absyn.Exp> acc;
+protected
+  list<SCode.SubMod> submods;
+  Option<Absyn.Exp> binding;
+algorithm
+  acc := match mod
+    case SCode.MOD(subModLst = submods, binding = binding)
+      algorithm
+        if isSome(binding) then
+          acc := Util.getOption(binding) :: acc;
+        end if;
+
+        for sm in submods loop
+          acc := match sm
+            case SCode.NAMEMOD() then collectModBindings(sm.mod, acc);
+            else acc;
+          end match;
+        end for;
+      then
+        acc;
+
+    else acc;
+  end match;
+end collectModBindings;
+
 public function stripAnnotationFromComment
   "Removes the annotation from a comment."
   input Option<SCode.Comment> inComment;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2129,7 +2129,6 @@ protected
 
     {expStatic, expDynamic} := list(Expression.unbox(arg) for arg in args);
     (arg1, ty1, var1) := Typing.typeExp(expStatic, context, info);
-    arg1 := ExpandExp.expand(arg1);
 
     // if we cannot typecheck the dynamic part, ignore it!
     // https://trac.openmodelica.org/OpenModelica/ticket/5631
@@ -2144,8 +2143,6 @@ protected
         return;
       end if;
     end try;
-
-    arg2 := ExpandExp.expand(arg2);
 
     // #15969: OMEdit's annotation evaluator cannot call Modelica user functions.
     // Replace each user function call in the dynamic expression with a reference

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2146,18 +2146,106 @@ protected
     end try;
 
     arg2 := ExpandExp.expand(arg2);
+
+    // #15969: OMEdit's annotation evaluator cannot call Modelica user functions.
+    // Replace each user function call in the dynamic expression with a reference
+    // to an auxiliary result-file variable (synthesized during flattening under
+    // the same deterministic name), keeping the rest of the expression so OMEdit
+    // can still evaluate it.
+    if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) and InstContext.inInstanceAPI(context) then
+      (arg2, _) := replaceDynamicSelectUserFunctions(arg2);
+    end if;
+
     ty := ty1;
     variability := var2;
 
     {fn} := Function.typeRefCache(fn_ref);
 
-    if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT) then
-      callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, variability, purity, ty1));
-    else
-      variability := var1;
-      callExp := arg1;
-    end if;
+    // Always keep both arguments; OMEdit selects the static or dynamic part.
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, variability, purity, ty1));
   end typeDynamicSelectCall;
+
+public
+  function dynamicSelectAuxName
+    "Deterministic name (issue #15969) for the auxiliary variable bound to a
+     DynamicSelect user function call. Derived purely from the content of the
+     call so that the instance API annotation rewrite and the flattening pass
+     agree on the name without any shared state (both hash the same call)."
+    input Expression callExp;
+    output String name =
+      "$DynamicSelect$" + intString(stringHashDjb2Mod(Expression.toString(callExp), 1073741789));
+  end dynamicSelectAuxName;
+
+  function replaceDynamicSelectUserFunctions
+    "#15969: Replaces every user (non-builtin) function call in the expression
+     with a reference to an auxiliary variable, keeping the surrounding
+     expression intact, and returns the rewritten expression together with the
+     list of (auxiliary name, binding call) pairs. Shared by the instance API
+     annotation rewrite (NFBuiltinCall.typeDynamicSelectCall) and the flattening
+     synthesis (NFInst)."
+    input Expression exp;
+    output Expression outExp;
+    output list<tuple<String, Expression>> auxVars;
+  algorithm
+    (outExp, auxVars) := replaceDynamicSelectUserFunctions2(exp, {});
+  end replaceDynamicSelectUserFunctions;
+
+protected
+  function replaceDynamicSelectUserFunctions2
+    input output Expression exp;
+    input output list<tuple<String, Expression>> auxVars;
+  protected
+    Function fn;
+    String name;
+    Type ty;
+  algorithm
+    (exp, auxVars) := match exp
+      // A user function call: replace the whole call (with its original
+      // arguments) by a reference to an auxiliary variable, and do not descend
+      // into it (so its arguments stay in the binding).
+      case Expression.CALL(call = Call.TYPED_CALL(fn = fn))
+        guard not Function.isBuiltin(fn)
+        algorithm
+          ty := Expression.typeOf(exp);
+          name := dynamicSelectAuxName(exp);
+
+          if not List.exist1(auxVars, dynamicSelectAuxExists, name) then
+            auxVars := (name, exp) :: auxVars;
+          end if;
+        then
+          (Expression.CREF(ty, ComponentRef.fromNode(InstNode.NAME_NODE(name), ty)), auxVars);
+
+      // Anything else: descend into the direct subexpressions.
+      else Expression.mapFoldShallow(exp, replaceDynamicSelectUserFunctions2, auxVars);
+    end match;
+  end replaceDynamicSelectUserFunctions2;
+
+  function dynamicSelectAuxExists
+    input tuple<String, Expression> auxVar;
+    input String name;
+    output Boolean res = Util.tuple21(auxVar) == name;
+  end dynamicSelectAuxExists;
+
+public
+  function containsUserFunctionCall
+    "Returns true if the expression contains a call to a non-builtin (user
+     defined) function."
+    input Expression exp;
+    output Boolean res = Expression.contains(exp, isUserFunctionCall);
+  end containsUserFunctionCall;
+
+protected
+  function isUserFunctionCall
+    input Expression exp;
+    output Boolean res;
+  algorithm
+    res := match exp
+      local
+        Function fn;
+      case Expression.CALL(call = Call.TYPED_CALL(fn = fn)) then not Function.isBuiltin(fn);
+      else false;
+    end match;
+  end isUserFunctionCall;
 
   function typeBackSampleCall
     input Call call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2168,14 +2168,66 @@ protected
 
 public
   function dynamicSelectAuxName
-    "Deterministic name for the auxiliary variable bound to a
-     DynamicSelect user function call. Derived purely from the content of the
-     call so that the instance API annotation rewrite and the flattening pass
-     agree on the name without any shared state (both hash the same call)."
+    "Deterministic name for the auxiliary variable bound to a DynamicSelect user
+     function call, derived from the content of the call so that the instance API
+     annotation rewrite and the flattening pass agree on the name without any
+     shared state. The class/package path that prefixes each component reference
+     is stripped first, leaving the reference relative to the component's own
+     class, so that the name does not depend on the instantiation context: the
+     same call is typed as 'scaleVal(u)' when the class is instantiated on its own
+     (as the instance API does per component when drawing an icon) but as
+     'scaleVal(A.B.u)' once flattened inside an enclosing model. Both must yield
+     the same auxiliary variable name so a component's icon animates when shown in
+     an enclosing model's diagram. Only the class path is stripped (not component
+     prefixes), so e.g. scaleVal(a.u) and scaleVal(b.u) in the same class stay
+     distinct."
     input Expression callExp;
     output String name =
-      "$DynamicSelect$" + intString(stringHashDjb2Mod(Expression.toString(callExp), 1073741789));
+      "$DynamicSelect$" +
+      intString(stringHashDjb2Mod(Expression.toString(Expression.map(callExp, stripCrefPrefixForName)), 1073741789));
   end dynamicSelectAuxName;
+
+  function stripCrefPrefixForName
+    "Strips the leading class/package path from every component reference in the
+     expression (see dynamicSelectAuxName)."
+    input output Expression exp;
+  algorithm
+    exp := match exp
+      case Expression.CREF()
+        then Expression.CREF(exp.ty, stripCrefClassPrefix(exp.cref));
+      else exp;
+    end match;
+  end stripCrefPrefixForName;
+
+  function stripCrefClassPrefix
+    "Cuts the class/package path prefixing a component reference so only the part
+     relative to the component's own class remains, e.g. A.B.a.u -> a.u."
+    input ComponentRef cref;
+    output ComponentRef outCref;
+  algorithm
+    outCref := match cref
+      case ComponentRef.CREF()
+        algorithm
+          if restCrefStartsWithClass(cref.restCref) then
+            outCref := ComponentRef.CREF(cref.node, cref.subscripts, cref.ty, cref.origin, ComponentRef.EMPTY());
+          else
+            outCref := ComponentRef.CREF(cref.node, cref.subscripts, cref.ty, cref.origin, stripCrefClassPrefix(cref.restCref));
+          end if;
+        then
+          outCref;
+      else cref;
+    end match;
+  end stripCrefClassPrefix;
+
+  function restCrefStartsWithClass
+    input ComponentRef cref;
+    output Boolean res;
+  algorithm
+    res := match cref
+      case ComponentRef.CREF() then InstNode.isClass(cref.node);
+      else false;
+    end match;
+  end restCrefStartsWithClass;
 
   function replaceDynamicSelectUserFunctions
     "Replaces every user (non-builtin) function call in the expression

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2144,7 +2144,7 @@ protected
       end if;
     end try;
 
-    // #15969: OMEdit's annotation evaluator cannot call Modelica user functions.
+    // OMEdit's annotation evaluator cannot call Modelica user functions.
     // Replace each user function call in the dynamic expression with a reference
     // to an auxiliary result-file variable (synthesized during flattening under
     // the same deterministic name), keeping the rest of the expression so OMEdit
@@ -2164,7 +2164,7 @@ protected
 
 public
   function dynamicSelectAuxName
-    "Deterministic name (issue #15969) for the auxiliary variable bound to a
+    "Deterministic name for the auxiliary variable bound to a
      DynamicSelect user function call. Derived purely from the content of the
      call so that the instance API annotation rewrite and the flattening pass
      agree on the name without any shared state (both hash the same call)."
@@ -2174,7 +2174,7 @@ public
   end dynamicSelectAuxName;
 
   function replaceDynamicSelectUserFunctions
-    "#15969: Replaces every user (non-builtin) function call in the expression
+    "Replaces every user (non-builtin) function call in the expression
      with a reference to an auxiliary variable, keeping the surrounding
      expression intact, and returns the rewritten expression together with the
      list of (auxiliary name, binding call) pairs. Shared by the instance API
@@ -2222,27 +2222,6 @@ protected
     input String name;
     output Boolean res = Util.tuple21(auxVar) == name;
   end dynamicSelectAuxExists;
-
-public
-  function containsUserFunctionCall
-    "Returns true if the expression contains a call to a non-builtin (user
-     defined) function."
-    input Expression exp;
-    output Boolean res = Expression.contains(exp, isUserFunctionCall);
-  end containsUserFunctionCall;
-
-protected
-  function isUserFunctionCall
-    input Expression exp;
-    output Boolean res;
-  algorithm
-    res := match exp
-      local
-        Function fn;
-      case Expression.CALL(call = Call.TYPED_CALL(fn = fn)) then not Function.isBuiltin(fn);
-      else false;
-    end match;
-  end isUserFunctionCall;
 
   function typeBackSampleCall
     input Call call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2167,37 +2167,74 @@ protected
   end typeDynamicSelectCall;
 
 public
+  constant String DYNAMIC_SELECT_AUX_PREFIX = "$DynamicSelect$";
+
   function dynamicSelectAuxName
     "Deterministic name for the auxiliary variable bound to a DynamicSelect user
      function call, derived from the content of the call so that the instance API
      annotation rewrite and the flattening pass agree on the name without any
-     shared state. The class/package path that prefixes each component reference
-     is stripped first, leaving the reference relative to the component's own
-     class, so that the name does not depend on the instantiation context: the
-     same call is typed as 'scaleVal(u)' when the class is instantiated on its own
-     (as the instance API does per component when drawing an icon) but as
-     'scaleVal(A.B.u)' once flattened inside an enclosing model. Both must yield
+     shared state. Both the class/package path and the instance scope prefixing
+     every component reference are stripped first, leaving the reference relative
+     to the component's own class, so that the name does not depend on the
+     instantiation context: the same call is typed as 'scaleVal(u)' when the class
+     is flattened on its own, but as 'scaleVal(display.u)' when the instance API
+     types the annotation in an enclosing model's component scope. Both must yield
      the same auxiliary variable name so a component's icon animates when shown in
-     an enclosing model's diagram. Only the class path is stripped (not component
-     prefixes), so e.g. scaleVal(a.u) and scaleVal(b.u) in the same class stay
-     distinct."
+     an enclosing model's diagram. Only the class path and the scope prefix are
+     stripped (both marked accordingly), not references written in the source, so
+     e.g. scaleVal(a.u) and scaleVal(b.u) in the same class stay distinct."
     input Expression callExp;
     output String name =
-      "$DynamicSelect$" +
+      DYNAMIC_SELECT_AUX_PREFIX +
       intString(stringHashDjb2Mod(Expression.toString(Expression.map(callExp, stripCrefPrefixForName)), 1073741789));
   end dynamicSelectAuxName;
 
   function stripCrefPrefixForName
-    "Strips the leading class/package path from every component reference in the
-     expression (see dynamicSelectAuxName)."
+    "Strips the leading class/package path and the instance scope prefix from
+     every component reference in the expression (see dynamicSelectAuxName)."
     input output Expression exp;
   algorithm
     exp := match exp
       case Expression.CREF()
-        then Expression.CREF(exp.ty, stripCrefClassPrefix(exp.cref));
+        then Expression.CREF(exp.ty, stripCrefContextPrefix(exp.cref));
       else exp;
     end match;
   end stripCrefPrefixForName;
+
+  function stripCrefContextPrefix
+    "Like stripCrefClassPrefix but also removes the instance scope prefix, i.e.
+     the nodes added when a reference is prefixed with its enclosing scope (marked
+     Origin.SCOPE), e.g. the component prefix 'display' in display.u. The result is
+     relative to the component's own class, so the auxiliary name is the same
+     whether the DynamicSelect call is typed in the component's scope (instance
+     API, giving display.u) or in the class scope (flattening, giving u)."
+    input ComponentRef cref;
+    output ComponentRef outCref;
+  algorithm
+    outCref := match cref
+      case ComponentRef.CREF()
+        algorithm
+          if restCrefIsClassOrScope(cref.restCref) then
+            outCref := ComponentRef.CREF(cref.node, cref.subscripts, cref.ty, cref.origin, ComponentRef.EMPTY());
+          else
+            outCref := ComponentRef.CREF(cref.node, cref.subscripts, cref.ty, cref.origin, stripCrefContextPrefix(cref.restCref));
+          end if;
+        then
+          outCref;
+      else cref;
+    end match;
+  end stripCrefContextPrefix;
+
+  function restCrefIsClassOrScope
+    input ComponentRef cref;
+    output Boolean res;
+  algorithm
+    res := match cref
+      case ComponentRef.CREF(origin = NFComponentRef.Origin.SCOPE) then true;
+      case ComponentRef.CREF() then InstNode.isClass(cref.node);
+      else false;
+    end match;
+  end restCrefIsClassOrScope;
 
   function stripCrefClassPrefix
     "Cuts the class/package path prefixing a component reference so only the part
@@ -2242,6 +2279,34 @@ public
   algorithm
     (outExp, auxVars) := replaceDynamicSelectUserFunctions2(exp, {});
   end replaceDynamicSelectUserFunctions;
+
+  function prefixDynamicSelectAuxRefs
+    "Prefixes every synthesized DynamicSelect auxiliary reference in the
+     expression with the given instance scope, so a sub-component's auxiliary
+     variable is referenced by its full instance path (e.g.
+     display.$DynamicSelect$H), matching the name the variable is given in the
+     result file after flattening. typeDynamicSelectCall creates the references
+     without a scope because it does not know the annotation's owning instance;
+     the instance API applies the scope here, where it is available."
+    input output Expression exp;
+    input InstNode scope;
+  algorithm
+    exp := Expression.map(exp, function prefixDynamicSelectAuxRef(scope = scope));
+  end prefixDynamicSelectAuxRefs;
+
+  function prefixDynamicSelectAuxRef
+    input output Expression exp;
+    input InstNode scope;
+  protected
+    String nm;
+  algorithm
+    exp := match exp
+      case Expression.CREF(cref = ComponentRef.CREF(node = InstNode.NAME_NODE(name = nm)))
+        guard 0 == System.strncmp(nm, DYNAMIC_SELECT_AUX_PREFIX, stringLength(DYNAMIC_SELECT_AUX_PREFIX))
+        then Expression.CREF(exp.ty, ComponentRef.appendScope(scope, exp.cref));
+      else exp;
+    end match;
+  end prefixDynamicSelectAuxRef;
 
 protected
   function replaceDynamicSelectUserFunctions2

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -65,6 +65,7 @@ protected
   import Typing = NFTyping;
   import Util;
   import ExpandExp = NFExpandExp;
+  import SimplifyExp = NFSimplifyExp;
   import Operator = NFOperator;
   import Component = NFComponent;
   import NFPrefixes.ConnectorType;
@@ -2148,8 +2149,11 @@ protected
     // Replace each user function call in the dynamic expression with a reference
     // to an auxiliary result-file variable (synthesized during flattening under
     // the same deterministic name), keeping the rest of the expression so OMEdit
-    // can still evaluate it.
+    // can still evaluate it. The expression is simplified first so that the
+    // auxiliary name (a hash of the call) matches the one computed on the
+    // flattening side, which also simplifies before hashing.
     if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) and InstContext.inInstanceAPI(context) then
+      arg2 := SimplifyExp.simplify(arg2);
       (arg2, _) := replaceDynamicSelectUserFunctions(arg2);
     end if;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1902,6 +1902,9 @@ uniontype Function
           // argument should be a cref?
           case "change" then true;
           case "der" then true;
+          // The two arguments may have different types (arrays, expressions,
+          // literals), so they are typed and cast individually. #15969
+          case "DynamicSelect" then true;
           // Function should not be used in function context.
           case "edge" then true;
           // can have variable number of arguments

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1902,8 +1902,9 @@ uniontype Function
           // argument should be a cref?
           case "change" then true;
           case "der" then true;
-          // The two arguments may have different types (arrays, expressions,
-          // literals), so they are typed and cast individually. #15969
+          // The dynamic argument is allowed to fail to typecheck (it is then
+          // ignored), and both arguments are kept in the typed call so OMEdit
+          // can pick the static or dynamic part, so it needs custom typing.
           case "DynamicSelect" then true;
           // Function should not be used in function context.
           case "edge" then true;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -88,6 +88,8 @@ import SCodeDump;
 import SCodeUtil;
 import System;
 import Call = NFCall;
+import BuiltinCall = NFBuiltinCall;
+import SimplifyExp = NFSimplifyExp;
 import Absyn.Path;
 import NFClassTree.ClassTree;
 import NFSections.Sections;
@@ -201,8 +203,23 @@ algorithm
   // Type the class.
   Typing.typeClass(inst_cls, context);
 
+  // #15969: Synthesize auxiliary variables bound to DynamicSelect dynamic
+  // expressions that call user functions, so their values reach the result file
+  // and OMEdit can display them without calling the function itself.
+  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
+    synthesizeDynamicSelectAux(inst_cls, context);
+  end if;
+
   // Flatten the model and evaluate constants in it.
   flatModel := Flatten.flatten(inst_cls, classPath);
+
+  // #15969: Give synthesized DynamicSelect auxiliary String variables an empty
+  // start value so the runtime can initialize them (a String variable without a
+  // start attribute would otherwise be a null pointer at the first output).
+  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
+    flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
+  end if;
+
   flatModel := EvalConstants.evaluate(flatModel, context);
 
   InstUtil.dumpFlatModelDebug("eval", flatModel);
@@ -4199,6 +4216,301 @@ algorithm
     fail();
   end if;
 end checkInstanceRestriction;
+
+public
+function synthesizeDynamicSelectAux
+  "#15969: Walks the instance tree and, for every class whose graphical
+   annotations contain a DynamicSelect whose dynamic expression calls a user
+   function, injects an auxiliary component bound to that dynamic expression.
+   Flattening then emits it as a result-file variable named exactly the way the
+   instance API rewrites the annotation (see NFApi.rewriteDynamicSelectAux and
+   NFBuiltinCall.dynamicSelectAuxName), so OMEdit can read the value from the
+   result file instead of calling the user function itself."
+  input InstNode clsNode;
+  input InstContext.Type context;
+algorithm
+  synthesizeDynamicSelectAuxNode(clsNode, context);
+end synthesizeDynamicSelectAux;
+
+protected
+function synthesizeDynamicSelectAuxNode
+  input InstNode clsNode;
+  input InstContext.Type context;
+protected
+  Class cls;
+  array<InstNode> comps;
+  InstNode comp_cls;
+algorithm
+  if InstNode.isEmpty(clsNode) or not InstNode.isClass(clsNode) then
+    return;
+  end if;
+
+  cls := InstNode.getClass(clsNode);
+
+  if Class.isOnlyBuiltin(cls) then
+    return;
+  end if;
+
+  // Snapshot the components before injecting any auxiliary ones.
+  comps := Class.getComponents(cls);
+
+  // Process this class' own graphical annotations.
+  injectClassDynamicSelectAux(clsNode, context);
+
+  // Recurse into the classes of the (original) components.
+  for c in comps loop
+    if InstNode.isComponent(c) then
+      comp_cls := Component.classInstance(InstNode.component(c));
+      synthesizeDynamicSelectAuxNode(comp_cls, context);
+    end if;
+  end for;
+end synthesizeDynamicSelectAuxNode;
+
+function injectClassDynamicSelectAux
+  input InstNode clsNode;
+  input InstContext.Type context;
+protected
+  list<Absyn.Exp> bindings;
+  list<Absyn.Exp> dyns;
+  list<InstNode> aux_comps = {};
+  list<tuple<String, Expression>> aux_vars;
+  Expression exp, binding;
+  Class cls;
+  ClassTree tree;
+  String name;
+algorithm
+  bindings := dynamicSelectAnnotationBindings(clsNode);
+
+  if listEmpty(bindings) then
+    return;
+  end if;
+
+  for b in bindings loop
+    // Collect the dynamic (second) arguments of any DynamicSelect calls in this
+    // annotation binding, then type each one in the *model* context (not an
+    // annotation context) so that any user functions it references are fully
+    // instantiated with their bodies. The same user function calls are what the
+    // instance API rewrite hashes for the auxiliary variable names.
+    (_, dyns) := AbsynUtil.traverseExp(b, collectDynamicSelectDynExp, {});
+
+    for dyn in dyns loop
+      ErrorExt.setCheckpoint(getInstanceName());
+      try
+        exp := instExp(dyn, clsNode, context, Absyn.dummyInfo);
+        exp := Typing.typeExp(exp, context, Absyn.dummyInfo);
+        exp := SimplifyExp.simplify(exp);
+
+        // Synthesize one auxiliary variable per user function call.
+        (_, aux_vars) := BuiltinCall.replaceDynamicSelectUserFunctions(exp);
+
+        for aux_var in aux_vars loop
+          (name, binding) := aux_var;
+          if not List.exist1(aux_comps, isNamedComponent, name) then
+            aux_comps := makeDynamicSelectAuxComponent(name, binding, clsNode) :: aux_comps;
+          end if;
+        end for;
+      else
+      end try;
+      ErrorExt.rollBack(getInstanceName());
+    end for;
+  end for;
+
+  if not listEmpty(aux_comps) then
+    cls := InstNode.getClass(clsNode);
+    tree := ClassTree.appendComponentsToFlatTree(aux_comps, Class.classTree(cls));
+    InstNode.updateClass(Class.setClassTree(tree, cls), clsNode);
+  end if;
+end injectClassDynamicSelectAux;
+
+function dynamicSelectAnnotationBindings
+  "Collects the Absyn expressions of a class' Icon and Diagram graphical
+   annotations, which are the ones that may contain DynamicSelect."
+  input InstNode clsNode;
+  output list<Absyn.Exp> bindings = {};
+protected
+  SCode.Element def;
+  Option<SCode.Comment> ocmt;
+  list<SCode.SubMod> submods;
+  SCode.Mod m;
+algorithm
+  try
+    def := InstNode.definition(clsNode);
+  else
+    return;
+  end try;
+
+  ocmt := SCodeUtil.getElementComment(def);
+
+  submods := match ocmt
+    case SOME(SCode.COMMENT(annotation_ = SOME(SCode.ANNOTATION(
+        modification = SCode.MOD(subModLst = submods))))) then submods;
+    else {};
+  end match;
+
+  for sm in submods loop
+    bindings := match sm
+      case SCode.NAMEMOD(ident = "Icon", mod = m) then collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Diagram", mod = m) then collectModBindings(m, bindings);
+      else bindings;
+    end match;
+  end for;
+end dynamicSelectAnnotationBindings;
+
+function collectModBindings
+  "Recursively collects all Absyn expression bindings in a modifier tree."
+  input SCode.Mod mod;
+  input output list<Absyn.Exp> acc;
+protected
+  list<SCode.SubMod> submods;
+  Option<Absyn.Exp> binding;
+algorithm
+  acc := match mod
+    case SCode.MOD(subModLst = submods, binding = binding)
+      algorithm
+        if isSome(binding) then
+          acc := Util.getOption(binding) :: acc;
+        end if;
+
+        for sm in submods loop
+          acc := match sm
+            case SCode.NAMEMOD() then collectModBindings(sm.mod, acc);
+            else acc;
+          end match;
+        end for;
+      then
+        acc;
+
+    else acc;
+  end match;
+end collectModBindings;
+
+function collectDynamicSelectDynExp
+  "Absyn traversal function that collects the dynamic (second) argument of every
+   DynamicSelect(static, dynamic) call."
+  input output Absyn.Exp exp;
+  input output list<Absyn.Exp> dyns;
+protected
+  Absyn.Exp dyn;
+algorithm
+  () := match exp
+    case Absyn.CALL(function_ = Absyn.CREF_IDENT(name = "DynamicSelect"),
+        functionArgs = Absyn.FUNCTIONARGS(args = {_, dyn}))
+      algorithm
+        dyns := dyn :: dyns;
+      then
+        ();
+
+    else ();
+  end match;
+end collectDynamicSelectDynExp;
+
+function isNamedComponent
+  input InstNode node;
+  input String name;
+  output Boolean res = InstNode.name(node) == name;
+end isNamedComponent;
+
+function makeDynamicSelectAuxComponent
+  "Builds a typed auxiliary component named `name`, bound to `dynExp`, as a public
+   member of the class `parent`."
+  input String name;
+  input Expression dynExp;
+  input InstNode parent;
+  output InstNode node;
+protected
+  Type ty = Expression.typeOf(dynExp);
+  Type elem_ty = Type.arrayElementType(ty);
+  InstNode cls_inst;
+  Variability var = Expression.variability(dynExp);
+  Binding binding;
+  Component comp;
+  Attributes attr = NFAttributes.DEFAULT_ATTR;
+  SCode.Element def;
+  String type_name;
+algorithm
+  cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  type_name := InstNode.name(cls_inst);
+
+  // Integer, Boolean and enumeration variables cannot be continuous, so clamp
+  // them to discrete. Real and String variables are left with the variability of
+  // the expression: a String bound to a continuous expression becomes an
+  // algebraic ("variable" kind) string that is re-evaluated at every output
+  // point, which is exactly what we want for a display value.
+  if Type.isInteger(elem_ty) or Type.isBoolean(elem_ty) or Type.isEnumeration(elem_ty) then
+    var := Prefixes.variabilityMin(var, Variability.DISCRETE);
+  end if;
+
+  binding := NFBinding.TYPED_BINDING(dynExp, ty, var, Expression.purity(dynExp),
+    NFBinding.EachType.NOT_EACH, Mutable.create(NFBinding.EvalState.NOT_EVALUATED),
+    false, NFBinding.Source.GENERATED, NFBinding.NO_CONFIDENCE, Absyn.dummyInfo);
+
+  attr.variability := var;
+
+  def := SCode.COMPONENT(name, SCode.defaultPrefixes, SCode.defaultVarAttr,
+    Absyn.TPATH(Absyn.IDENT(type_name), NONE()), SCode.NOMOD(), SCode.noComment,
+    NONE(), Absyn.dummyInfo);
+
+  comp := Component.COMPONENT(cls_inst, ty, binding, NFBinding.EMPTY_BINDING, attr,
+    SCode.noComment, ComponentState.Typed, Absyn.dummyInfo);
+
+  node := InstNode.COMPONENT_NODE(name, SOME(def), Visibility.PUBLIC,
+    Pointer.create(comp), parent, InstNodeType.NORMAL_COMP());
+end makeDynamicSelectAuxComponent;
+
+function addDynamicSelectAuxStringStart
+  "Ensures a synthesized DynamicSelect auxiliary String variable has a start
+   attribute (defaulting to the empty string)."
+  input output Variable var;
+protected
+  Boolean has_start = false;
+algorithm
+  if Type.isString(Type.arrayElementType(var.ty)) and
+     System.stringFind(ComponentRef.toString(var.name), "$DynamicSelect$") >= 0 then
+    for a in var.typeAttributes loop
+      if Util.tuple21(a) == "start" then
+        has_start := true;
+      end if;
+    end for;
+
+    if not has_start then
+      var.typeAttributes := ("start",
+        NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED))
+        :: var.typeAttributes;
+    end if;
+  end if;
+end addDynamicSelectAuxStringStart;
+
+function dynamicSelectAuxClassNode
+  "Returns the class node to use for an auxiliary variable bound to the given
+   user function call, taken from the function's (single) output component so
+   that any return type is handled correctly (basic types, enumerations,
+   records). Falls back to the builtin node for the element type if the binding
+   is not a user function call."
+  input Expression exp;
+  input Type elemTy;
+  output InstNode node;
+protected
+  Function fn;
+algorithm
+  node := match exp
+    case Expression.CALL(call = Call.TYPED_CALL(fn = fn))
+      guard not listEmpty(fn.outputs)
+      then Component.classInstance(InstNode.component(listHead(fn.outputs)));
+    else builtinTypeNode(elemTy);
+  end match;
+end dynamicSelectAuxClassNode;
+
+function builtinTypeNode
+  input Type ty;
+  output InstNode node;
+algorithm
+  node := match ty
+    case Type.INTEGER() then NFBuiltin.INTEGER_NODE;
+    case Type.BOOLEAN() then NFBuiltin.BOOLEAN_NODE;
+    case Type.STRING() then NFBuiltin.STRING_NODE;
+    else NFBuiltin.REAL_NODE;
+  end match;
+end builtinTypeNode;
 
 annotation(__OpenModelica_Interface="nf_frontend");
 end NFInst;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -4223,17 +4223,21 @@ function synthesizeDynamicSelectAux
   input InstNode clsNode;
   input InstContext.Type context;
 algorithm
-  synthesizeDynamicSelectAuxNode(clsNode, context);
+  synthesizeDynamicSelectAuxNode(clsNode, ComponentRef.EMPTY(), context);
 end synthesizeDynamicSelectAux;
 
 protected
 function synthesizeDynamicSelectAuxNode
   input InstNode clsNode;
+  input ComponentRef prefix
+    "The component instance path from the flat model root down to this class, so
+     that the synthesized bindings can reference the instance's variables.";
   input InstContext.Type context;
 protected
   Class cls;
   array<InstNode> comps;
   InstNode comp_cls;
+  ComponentRef comp_prefix;
 algorithm
   if InstNode.isEmpty(clsNode) or not InstNode.isClass(clsNode) then
     return;
@@ -4249,19 +4253,22 @@ algorithm
   comps := Class.getComponents(cls);
 
   // Process this class' own graphical annotations.
-  injectClassDynamicSelectAux(clsNode, context);
+  injectClassDynamicSelectAux(clsNode, prefix, context);
 
-  // Recurse into the classes of the (original) components.
+  // Recurse into the classes of the (original) components, extending the prefix
+  // with each component so its bindings resolve to the right instance.
   for c in comps loop
     if InstNode.isComponent(c) then
       comp_cls := Component.classInstance(InstNode.component(c));
-      synthesizeDynamicSelectAuxNode(comp_cls, context);
+      comp_prefix := ComponentRef.prefixCref(c, InstNode.getType(c), {}, prefix);
+      synthesizeDynamicSelectAuxNode(comp_cls, comp_prefix, context);
     end if;
   end for;
 end synthesizeDynamicSelectAuxNode;
 
 function injectClassDynamicSelectAux
   input InstNode clsNode;
+  input ComponentRef prefix;
   input InstContext.Type context;
 protected
   list<Absyn.Exp> bindings;
@@ -4300,6 +4307,11 @@ algorithm
         for aux_var in aux_vars loop
           (name, binding) := aux_var;
           if not List.exist1(aux_comps, isNamedComponent, name) then
+            // The binding's component references are typed relative to this
+            // class (e.g. A.B.u); rewrite them to the instance path (e.g. c.u)
+            // so that they are valid once the class is flattened as a component,
+            // since flattening does not prefix binding references.
+            binding := Expression.map(binding, function instanceDynamicSelectBindingCref(prefix = prefix));
             aux_comps := makeDynamicSelectAuxComponent(name, binding, clsNode) :: aux_comps;
           end if;
         end for;
@@ -4375,6 +4387,21 @@ function isNamedComponent
   input String name;
   output Boolean res = InstNode.name(node) == name;
 end isNamedComponent;
+
+function instanceDynamicSelectBindingCref
+  "Rewrites a component reference in a synthesized DynamicSelect binding from the
+   class-relative form to the instance path: the class/package prefix is stripped
+   and the instance prefix is appended, so e.g. A.B.u with prefix c becomes c.u."
+  input ComponentRef prefix;
+  input output Expression exp;
+algorithm
+  exp := match exp
+    case Expression.CREF()
+      then Expression.CREF(exp.ty,
+        ComponentRef.append(BuiltinCall.stripCrefClassPrefix(exp.cref), prefix));
+    else exp;
+  end match;
+end instanceDynamicSelectBindingCref;
 
 function makeDynamicSelectAuxComponent
   "Builds a typed auxiliary component named `name`, bound to `dynExp`, as a public

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -4250,17 +4250,21 @@ function synthesizeDynamicSelectAux
   input InstNode clsNode;
   input InstContext.Type context;
 algorithm
-  synthesizeDynamicSelectAuxNode(clsNode, context);
+  synthesizeDynamicSelectAuxNode(clsNode, ComponentRef.EMPTY(), context);
 end synthesizeDynamicSelectAux;
 
 protected
 function synthesizeDynamicSelectAuxNode
   input InstNode clsNode;
+  input ComponentRef prefix
+    "The component instance path from the flat model root down to this class, so
+     that the synthesized bindings can reference the instance's variables.";
   input InstContext.Type context;
 protected
   Class cls;
   array<InstNode> comps;
   InstNode comp_cls;
+  ComponentRef comp_prefix;
 algorithm
   if InstNode.isEmpty(clsNode) or not InstNode.isClass(clsNode) then
     return;
@@ -4276,19 +4280,22 @@ algorithm
   comps := Class.getComponents(cls);
 
   // Process this class' own graphical annotations.
-  injectClassDynamicSelectAux(clsNode, context);
+  injectClassDynamicSelectAux(clsNode, prefix, context);
 
-  // Recurse into the classes of the (original) components.
+  // Recurse into the classes of the (original) components, extending the prefix
+  // with each component so its bindings resolve to the right instance.
   for c in comps loop
     if InstNode.isComponent(c) then
       comp_cls := Component.classInstance(InstNode.component(c));
-      synthesizeDynamicSelectAuxNode(comp_cls, context);
+      comp_prefix := ComponentRef.prefixCref(c, InstNode.getType(c), {}, prefix);
+      synthesizeDynamicSelectAuxNode(comp_cls, comp_prefix, context);
     end if;
   end for;
 end synthesizeDynamicSelectAuxNode;
 
 function injectClassDynamicSelectAux
   input InstNode clsNode;
+  input ComponentRef prefix;
   input InstContext.Type context;
 protected
   list<Absyn.Exp> bindings;
@@ -4327,6 +4334,11 @@ algorithm
         for aux_var in aux_vars loop
           (name, binding) := aux_var;
           if not List.exist1(aux_comps, isNamedComponent, name) then
+            // The binding's component references are typed relative to this
+            // class (e.g. A.B.u); rewrite them to the instance path (e.g. c.u)
+            // so that they are valid once the class is flattened as a component,
+            // since flattening does not prefix binding references.
+            binding := Expression.map(binding, function instanceDynamicSelectBindingCref(prefix = prefix));
             aux_comps := makeDynamicSelectAuxComponent(name, binding, clsNode) :: aux_comps;
           end if;
         end for;
@@ -4402,6 +4414,21 @@ function isNamedComponent
   input String name;
   output Boolean res = InstNode.name(node) == name;
 end isNamedComponent;
+
+function instanceDynamicSelectBindingCref
+  "Rewrites a component reference in a synthesized DynamicSelect binding from the
+   class-relative form to the instance path: the class/package prefix is stripped
+   and the instance prefix is appended, so e.g. A.B.u with prefix c becomes c.u."
+  input ComponentRef prefix;
+  input output Expression exp;
+algorithm
+  exp := match exp
+    case Expression.CREF()
+      then Expression.CREF(exp.ty,
+        ComponentRef.append(BuiltinCall.stripCrefClassPrefix(exp.cref), prefix));
+    else exp;
+  end match;
+end instanceDynamicSelectBindingCref;
 
 function makeDynamicSelectAuxComponent
   "Builds a typed auxiliary component named `name`, bound to `dynExp`, as a public

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -88,6 +88,8 @@ import SCodeDump;
 import SCodeUtil;
 import System;
 import Call = NFCall;
+import BuiltinCall = NFBuiltinCall;
+import SimplifyExp = NFSimplifyExp;
 import Absyn.Path;
 import NFClassTree.ClassTree;
 import NFSections.Sections;
@@ -226,9 +228,24 @@ algorithm
   Error.checkCancel();
   Typing.typeClass(inst_cls, context);
 
+  // #15969: Synthesize auxiliary variables bound to DynamicSelect dynamic
+  // expressions that call user functions, so their values reach the result file
+  // and OMEdit can display them without calling the function itself.
+  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
+    synthesizeDynamicSelectAux(inst_cls, context);
+  end if;
+
   // Flatten the model and evaluate constants in it.
   Error.checkCancel();
   flatModel := Flatten.flatten(inst_cls, classPath);
+
+  // #15969: Give synthesized DynamicSelect auxiliary String variables an empty
+  // start value so the runtime can initialize them (a String variable without a
+  // start attribute would otherwise be a null pointer at the first output).
+  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
+    flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
+  end if;
+
   flatModel := EvalConstants.evaluate(flatModel, context);
 
   InstUtil.dumpFlatModelDebug("eval", flatModel);
@@ -4226,6 +4243,301 @@ algorithm
     fail();
   end if;
 end checkInstanceRestriction;
+
+public
+function synthesizeDynamicSelectAux
+  "#15969: Walks the instance tree and, for every class whose graphical
+   annotations contain a DynamicSelect whose dynamic expression calls a user
+   function, injects an auxiliary component bound to that dynamic expression.
+   Flattening then emits it as a result-file variable named exactly the way the
+   instance API rewrites the annotation (see NFApi.rewriteDynamicSelectAux and
+   NFBuiltinCall.dynamicSelectAuxName), so OMEdit can read the value from the
+   result file instead of calling the user function itself."
+  input InstNode clsNode;
+  input InstContext.Type context;
+algorithm
+  synthesizeDynamicSelectAuxNode(clsNode, context);
+end synthesizeDynamicSelectAux;
+
+protected
+function synthesizeDynamicSelectAuxNode
+  input InstNode clsNode;
+  input InstContext.Type context;
+protected
+  Class cls;
+  array<InstNode> comps;
+  InstNode comp_cls;
+algorithm
+  if InstNode.isEmpty(clsNode) or not InstNode.isClass(clsNode) then
+    return;
+  end if;
+
+  cls := InstNode.getClass(clsNode);
+
+  if Class.isOnlyBuiltin(cls) then
+    return;
+  end if;
+
+  // Snapshot the components before injecting any auxiliary ones.
+  comps := Class.getComponents(cls);
+
+  // Process this class' own graphical annotations.
+  injectClassDynamicSelectAux(clsNode, context);
+
+  // Recurse into the classes of the (original) components.
+  for c in comps loop
+    if InstNode.isComponent(c) then
+      comp_cls := Component.classInstance(InstNode.component(c));
+      synthesizeDynamicSelectAuxNode(comp_cls, context);
+    end if;
+  end for;
+end synthesizeDynamicSelectAuxNode;
+
+function injectClassDynamicSelectAux
+  input InstNode clsNode;
+  input InstContext.Type context;
+protected
+  list<Absyn.Exp> bindings;
+  list<Absyn.Exp> dyns;
+  list<InstNode> aux_comps = {};
+  list<tuple<String, Expression>> aux_vars;
+  Expression exp, binding;
+  Class cls;
+  ClassTree tree;
+  String name;
+algorithm
+  bindings := dynamicSelectAnnotationBindings(clsNode);
+
+  if listEmpty(bindings) then
+    return;
+  end if;
+
+  for b in bindings loop
+    // Collect the dynamic (second) arguments of any DynamicSelect calls in this
+    // annotation binding, then type each one in the *model* context (not an
+    // annotation context) so that any user functions it references are fully
+    // instantiated with their bodies. The same user function calls are what the
+    // instance API rewrite hashes for the auxiliary variable names.
+    (_, dyns) := AbsynUtil.traverseExp(b, collectDynamicSelectDynExp, {});
+
+    for dyn in dyns loop
+      ErrorExt.setCheckpoint(getInstanceName());
+      try
+        exp := instExp(dyn, clsNode, context, Absyn.dummyInfo);
+        exp := Typing.typeExp(exp, context, Absyn.dummyInfo);
+        exp := SimplifyExp.simplify(exp);
+
+        // Synthesize one auxiliary variable per user function call.
+        (_, aux_vars) := BuiltinCall.replaceDynamicSelectUserFunctions(exp);
+
+        for aux_var in aux_vars loop
+          (name, binding) := aux_var;
+          if not List.exist1(aux_comps, isNamedComponent, name) then
+            aux_comps := makeDynamicSelectAuxComponent(name, binding, clsNode) :: aux_comps;
+          end if;
+        end for;
+      else
+      end try;
+      ErrorExt.rollBack(getInstanceName());
+    end for;
+  end for;
+
+  if not listEmpty(aux_comps) then
+    cls := InstNode.getClass(clsNode);
+    tree := ClassTree.appendComponentsToFlatTree(aux_comps, Class.classTree(cls));
+    InstNode.updateClass(Class.setClassTree(tree, cls), clsNode);
+  end if;
+end injectClassDynamicSelectAux;
+
+function dynamicSelectAnnotationBindings
+  "Collects the Absyn expressions of a class' Icon and Diagram graphical
+   annotations, which are the ones that may contain DynamicSelect."
+  input InstNode clsNode;
+  output list<Absyn.Exp> bindings = {};
+protected
+  SCode.Element def;
+  Option<SCode.Comment> ocmt;
+  list<SCode.SubMod> submods;
+  SCode.Mod m;
+algorithm
+  try
+    def := InstNode.definition(clsNode);
+  else
+    return;
+  end try;
+
+  ocmt := SCodeUtil.getElementComment(def);
+
+  submods := match ocmt
+    case SOME(SCode.COMMENT(annotation_ = SOME(SCode.ANNOTATION(
+        modification = SCode.MOD(subModLst = submods))))) then submods;
+    else {};
+  end match;
+
+  for sm in submods loop
+    bindings := match sm
+      case SCode.NAMEMOD(ident = "Icon", mod = m) then collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Diagram", mod = m) then collectModBindings(m, bindings);
+      else bindings;
+    end match;
+  end for;
+end dynamicSelectAnnotationBindings;
+
+function collectModBindings
+  "Recursively collects all Absyn expression bindings in a modifier tree."
+  input SCode.Mod mod;
+  input output list<Absyn.Exp> acc;
+protected
+  list<SCode.SubMod> submods;
+  Option<Absyn.Exp> binding;
+algorithm
+  acc := match mod
+    case SCode.MOD(subModLst = submods, binding = binding)
+      algorithm
+        if isSome(binding) then
+          acc := Util.getOption(binding) :: acc;
+        end if;
+
+        for sm in submods loop
+          acc := match sm
+            case SCode.NAMEMOD() then collectModBindings(sm.mod, acc);
+            else acc;
+          end match;
+        end for;
+      then
+        acc;
+
+    else acc;
+  end match;
+end collectModBindings;
+
+function collectDynamicSelectDynExp
+  "Absyn traversal function that collects the dynamic (second) argument of every
+   DynamicSelect(static, dynamic) call."
+  input output Absyn.Exp exp;
+  input output list<Absyn.Exp> dyns;
+protected
+  Absyn.Exp dyn;
+algorithm
+  () := match exp
+    case Absyn.CALL(function_ = Absyn.CREF_IDENT(name = "DynamicSelect"),
+        functionArgs = Absyn.FUNCTIONARGS(args = {_, dyn}))
+      algorithm
+        dyns := dyn :: dyns;
+      then
+        ();
+
+    else ();
+  end match;
+end collectDynamicSelectDynExp;
+
+function isNamedComponent
+  input InstNode node;
+  input String name;
+  output Boolean res = InstNode.name(node) == name;
+end isNamedComponent;
+
+function makeDynamicSelectAuxComponent
+  "Builds a typed auxiliary component named `name`, bound to `dynExp`, as a public
+   member of the class `parent`."
+  input String name;
+  input Expression dynExp;
+  input InstNode parent;
+  output InstNode node;
+protected
+  Type ty = Expression.typeOf(dynExp);
+  Type elem_ty = Type.arrayElementType(ty);
+  InstNode cls_inst;
+  Variability var = Expression.variability(dynExp);
+  Binding binding;
+  Component comp;
+  Attributes attr = NFAttributes.DEFAULT_ATTR;
+  SCode.Element def;
+  String type_name;
+algorithm
+  cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  type_name := InstNode.name(cls_inst);
+
+  // Integer, Boolean and enumeration variables cannot be continuous, so clamp
+  // them to discrete. Real and String variables are left with the variability of
+  // the expression: a String bound to a continuous expression becomes an
+  // algebraic ("variable" kind) string that is re-evaluated at every output
+  // point, which is exactly what we want for a display value.
+  if Type.isInteger(elem_ty) or Type.isBoolean(elem_ty) or Type.isEnumeration(elem_ty) then
+    var := Prefixes.variabilityMin(var, Variability.DISCRETE);
+  end if;
+
+  binding := NFBinding.TYPED_BINDING(dynExp, ty, var, Expression.purity(dynExp),
+    NFBinding.EachType.NOT_EACH, Mutable.create(NFBinding.EvalState.NOT_EVALUATED),
+    false, NFBinding.Source.GENERATED, NFBinding.NO_CONFIDENCE, Absyn.dummyInfo);
+
+  attr.variability := var;
+
+  def := SCode.COMPONENT(name, SCode.defaultPrefixes, SCode.defaultVarAttr,
+    Absyn.TPATH(Absyn.IDENT(type_name), NONE()), SCode.NOMOD(), SCode.noComment,
+    NONE(), Absyn.dummyInfo);
+
+  comp := Component.COMPONENT(cls_inst, ty, binding, NFBinding.EMPTY_BINDING, attr,
+    SCode.noComment, ComponentState.Typed, Absyn.dummyInfo);
+
+  node := InstNode.COMPONENT_NODE(name, SOME(def), Visibility.PUBLIC,
+    Pointer.create(comp), parent, InstNodeType.NORMAL_COMP());
+end makeDynamicSelectAuxComponent;
+
+function addDynamicSelectAuxStringStart
+  "Ensures a synthesized DynamicSelect auxiliary String variable has a start
+   attribute (defaulting to the empty string)."
+  input output Variable var;
+protected
+  Boolean has_start = false;
+algorithm
+  if Type.isString(Type.arrayElementType(var.ty)) and
+     System.stringFind(ComponentRef.toString(var.name), "$DynamicSelect$") >= 0 then
+    for a in var.typeAttributes loop
+      if Util.tuple21(a) == "start" then
+        has_start := true;
+      end if;
+    end for;
+
+    if not has_start then
+      var.typeAttributes := ("start",
+        NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED))
+        :: var.typeAttributes;
+    end if;
+  end if;
+end addDynamicSelectAuxStringStart;
+
+function dynamicSelectAuxClassNode
+  "Returns the class node to use for an auxiliary variable bound to the given
+   user function call, taken from the function's (single) output component so
+   that any return type is handled correctly (basic types, enumerations,
+   records). Falls back to the builtin node for the element type if the binding
+   is not a user function call."
+  input Expression exp;
+  input Type elemTy;
+  output InstNode node;
+protected
+  Function fn;
+algorithm
+  node := match exp
+    case Expression.CALL(call = Call.TYPED_CALL(fn = fn))
+      guard not listEmpty(fn.outputs)
+      then Component.classInstance(InstNode.component(listHead(fn.outputs)));
+    else builtinTypeNode(elemTy);
+  end match;
+end dynamicSelectAuxClassNode;
+
+function builtinTypeNode
+  input Type ty;
+  output InstNode node;
+algorithm
+  node := match ty
+    case Type.INTEGER() then NFBuiltin.INTEGER_NODE;
+    case Type.BOOLEAN() then NFBuiltin.BOOLEAN_NODE;
+    case Type.STRING() then NFBuiltin.STRING_NODE;
+    else NFBuiltin.REAL_NODE;
+  end match;
+end builtinTypeNode;
 
 annotation(__OpenModelica_Interface="nf_frontend");
 end NFInst;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -59,6 +59,7 @@ import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
 import NFModifier.Modifier;
 import NFModifier.ModifierScope;
+import NFModifier.ModTable;
 import Operator = NFOperator;
 import Equation = NFEquation;
 import Statement = NFStatement;
@@ -212,15 +213,6 @@ algorithm
 
   // Flatten the model and evaluate constants in it.
   flatModel := Flatten.flatten(inst_cls, classPath);
-
-  // Give synthesized DynamicSelect auxiliary String variables an empty start
-  // value so the runtime can initialize them (a String variable without a start
-  // attribute would otherwise be a null pointer at the first output). The start
-  // is added here because a builtin type's attributes are taken from its class
-  // during flattening, which the directly-synthesized component bypasses.
-  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
-    flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
-  end if;
 
   flatModel := EvalConstants.evaluate(flatModel, context);
 
@@ -4402,7 +4394,15 @@ protected
   SCode.Element def;
   String type_name;
 algorithm
-  cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  // A String variable without a start attribute is a null pointer at the first
+  // output, so give String auxiliaries a class whose start is the empty string.
+  // The start is set here, when the component is created, because a basic type's
+  // attributes are taken from its class during flattening.
+  if Type.isString(elem_ty) then
+    cls_inst := makeStringAuxClassNode();
+  else
+    cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  end if;
   type_name := InstNode.name(cls_inst);
 
   // Integer, Boolean and enumeration variables cannot be continuous, so clamp
@@ -4431,28 +4431,41 @@ algorithm
     Pointer.create(comp), parent, InstNodeType.NORMAL_COMP());
 end makeDynamicSelectAuxComponent;
 
-function addDynamicSelectAuxStringStart
-  "Ensures a synthesized DynamicSelect auxiliary String variable has a start
-   attribute (defaulting to the empty string)."
-  input output Variable var;
+function makeStringAuxClassNode
+  "Returns a copy of the builtin String type node whose start attribute is bound
+   to the empty string, used as the class of a synthesized DynamicSelect String
+   auxiliary variable so that flattening emits start=\"\" for it."
+  output InstNode node = NFBuiltin.STRING_NODE;
 protected
-  Boolean has_start = false;
+  Class cls;
+  ClassTree tree;
+  array<InstNode> comps;
+  Modifier start_mod;
 algorithm
-  if Type.isString(Type.arrayElementType(var.ty)) and
-     System.stringFind(ComponentRef.toString(var.name), "$DynamicSelect$") >= 0 then
-    for a in var.typeAttributes loop
-      if Util.tuple21(a) == "start" then
-        has_start := true;
-      end if;
-    end for;
+  cls := InstNode.getClass(node);
+  tree := Class.classTree(cls);
+  comps := arrayCopy(ClassTree.getComponents(tree));
 
-    if not has_start then
-      var.typeAttributes := ("start",
-        NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED))
-        :: var.typeAttributes;
+  start_mod := Modifier.MODIFIER("start", SCode.NOT_FINAL(), SCode.NOT_EACH(),
+    NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED),
+    ModTable.EMPTY(), Absyn.dummyInfo);
+
+  for i in 1:arrayLength(comps) loop
+    if InstNode.name(comps[i]) == "start" then
+      comps[i] := InstNode.COMPONENT_NODE("start", NONE(), Visibility.PUBLIC,
+        Pointer.create(Component.TYPE_ATTRIBUTE(Type.STRING(), start_mod)),
+        InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
     end if;
-  end if;
-end addDynamicSelectAuxStringStart;
+  end for;
+
+  tree := match tree
+    case ClassTree.FLAT_TREE()
+      then ClassTree.FLAT_TREE(tree.tree, tree.classes, comps, tree.imports, tree.duplicates);
+    else tree;
+  end match;
+
+  node := InstNode.replaceClass(Class.setClassTree(tree, cls), node);
+end makeStringAuxClassNode;
 
 function dynamicSelectAuxClassNode
   "Returns the class node to use for an auxiliary variable bound to the given

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -59,6 +59,7 @@ import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
 import NFModifier.Modifier;
 import NFModifier.ModifierScope;
+import NFModifier.ModTable;
 import Operator = NFOperator;
 import Equation = NFEquation;
 import Statement = NFStatement;
@@ -238,15 +239,6 @@ algorithm
   // Flatten the model and evaluate constants in it.
   Error.checkCancel();
   flatModel := Flatten.flatten(inst_cls, classPath);
-
-  // Give synthesized DynamicSelect auxiliary String variables an empty start
-  // value so the runtime can initialize them (a String variable without a start
-  // attribute would otherwise be a null pointer at the first output). The start
-  // is added here because a builtin type's attributes are taken from its class
-  // during flattening, which the directly-synthesized component bypasses.
-  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
-    flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
-  end if;
 
   flatModel := EvalConstants.evaluate(flatModel, context);
 
@@ -4429,7 +4421,15 @@ protected
   SCode.Element def;
   String type_name;
 algorithm
-  cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  // A String variable without a start attribute is a null pointer at the first
+  // output, so give String auxiliaries a class whose start is the empty string.
+  // The start is set here, when the component is created, because a basic type's
+  // attributes are taken from its class during flattening.
+  if Type.isString(elem_ty) then
+    cls_inst := makeStringAuxClassNode();
+  else
+    cls_inst := dynamicSelectAuxClassNode(dynExp, elem_ty);
+  end if;
   type_name := InstNode.name(cls_inst);
 
   // Integer, Boolean and enumeration variables cannot be continuous, so clamp
@@ -4458,28 +4458,41 @@ algorithm
     Pointer.create(comp), parent, InstNodeType.NORMAL_COMP());
 end makeDynamicSelectAuxComponent;
 
-function addDynamicSelectAuxStringStart
-  "Ensures a synthesized DynamicSelect auxiliary String variable has a start
-   attribute (defaulting to the empty string)."
-  input output Variable var;
+function makeStringAuxClassNode
+  "Returns a copy of the builtin String type node whose start attribute is bound
+   to the empty string, used as the class of a synthesized DynamicSelect String
+   auxiliary variable so that flattening emits start=\"\" for it."
+  output InstNode node = NFBuiltin.STRING_NODE;
 protected
-  Boolean has_start = false;
+  Class cls;
+  ClassTree tree;
+  array<InstNode> comps;
+  Modifier start_mod;
 algorithm
-  if Type.isString(Type.arrayElementType(var.ty)) and
-     System.stringFind(ComponentRef.toString(var.name), "$DynamicSelect$") >= 0 then
-    for a in var.typeAttributes loop
-      if Util.tuple21(a) == "start" then
-        has_start := true;
-      end if;
-    end for;
+  cls := InstNode.getClass(node);
+  tree := Class.classTree(cls);
+  comps := arrayCopy(ClassTree.getComponents(tree));
 
-    if not has_start then
-      var.typeAttributes := ("start",
-        NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED))
-        :: var.typeAttributes;
+  start_mod := Modifier.MODIFIER("start", SCode.NOT_FINAL(), SCode.NOT_EACH(),
+    NFBinding.makeFlat(Expression.STRING(""), Variability.CONSTANT, NFBinding.Source.GENERATED),
+    ModTable.EMPTY(), Absyn.dummyInfo);
+
+  for i in 1:arrayLength(comps) loop
+    if InstNode.name(comps[i]) == "start" then
+      comps[i] := InstNode.COMPONENT_NODE("start", NONE(), Visibility.PUBLIC,
+        Pointer.create(Component.TYPE_ATTRIBUTE(Type.STRING(), start_mod)),
+        InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
     end if;
-  end if;
-end addDynamicSelectAuxStringStart;
+  end for;
+
+  tree := match tree
+    case ClassTree.FLAT_TREE()
+      then ClassTree.FLAT_TREE(tree.tree, tree.classes, comps, tree.imports, tree.duplicates);
+    else tree;
+  end match;
+
+  node := InstNode.replaceClass(Class.setClassTree(tree, cls), node);
+end makeStringAuxClassNode;
 
 function dynamicSelectAuxClassNode
   "Returns the class node to use for an auxiliary variable bound to the given

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -203,7 +203,7 @@ algorithm
   // Type the class.
   Typing.typeClass(inst_cls, context);
 
-  // #15969: Synthesize auxiliary variables bound to DynamicSelect dynamic
+  // Synthesize auxiliary variables bound to DynamicSelect dynamic
   // expressions that call user functions, so their values reach the result file
   // and OMEdit can display them without calling the function itself.
   if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
@@ -213,9 +213,11 @@ algorithm
   // Flatten the model and evaluate constants in it.
   flatModel := Flatten.flatten(inst_cls, classPath);
 
-  // #15969: Give synthesized DynamicSelect auxiliary String variables an empty
-  // start value so the runtime can initialize them (a String variable without a
-  // start attribute would otherwise be a null pointer at the first output).
+  // Give synthesized DynamicSelect auxiliary String variables an empty start
+  // value so the runtime can initialize them (a String variable without a start
+  // attribute would otherwise be a null pointer at the first output). The start
+  // is added here because a builtin type's attributes are taken from its class
+  // during flattening, which the directly-synthesized component bypasses.
   if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
     flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
   end if;
@@ -4219,13 +4221,13 @@ end checkInstanceRestriction;
 
 public
 function synthesizeDynamicSelectAux
-  "#15969: Walks the instance tree and, for every class whose graphical
-   annotations contain a DynamicSelect whose dynamic expression calls a user
-   function, injects an auxiliary component bound to that dynamic expression.
-   Flattening then emits it as a result-file variable named exactly the way the
-   instance API rewrites the annotation (see NFApi.rewriteDynamicSelectAux and
-   NFBuiltinCall.dynamicSelectAuxName), so OMEdit can read the value from the
-   result file instead of calling the user function itself."
+  "Walks the instance tree and, for every class whose graphical annotations
+   contain a DynamicSelect whose dynamic expression calls a user function,
+   injects an auxiliary component bound to that dynamic expression. Flattening
+   then emits it as a result-file variable named exactly the way the instance
+   API rewrites the annotation (see NFBuiltinCall.dynamicSelectAuxName), so
+   OMEdit can read the value from the result file instead of calling the user
+   function itself."
   input InstNode clsNode;
   input InstContext.Type context;
 algorithm
@@ -4349,40 +4351,12 @@ algorithm
 
   for sm in submods loop
     bindings := match sm
-      case SCode.NAMEMOD(ident = "Icon", mod = m) then collectModBindings(m, bindings);
-      case SCode.NAMEMOD(ident = "Diagram", mod = m) then collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Icon", mod = m) then SCodeUtil.collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Diagram", mod = m) then SCodeUtil.collectModBindings(m, bindings);
       else bindings;
     end match;
   end for;
 end dynamicSelectAnnotationBindings;
-
-function collectModBindings
-  "Recursively collects all Absyn expression bindings in a modifier tree."
-  input SCode.Mod mod;
-  input output list<Absyn.Exp> acc;
-protected
-  list<SCode.SubMod> submods;
-  Option<Absyn.Exp> binding;
-algorithm
-  acc := match mod
-    case SCode.MOD(subModLst = submods, binding = binding)
-      algorithm
-        if isSome(binding) then
-          acc := Util.getOption(binding) :: acc;
-        end if;
-
-        for sm in submods loop
-          acc := match sm
-            case SCode.NAMEMOD() then collectModBindings(sm.mod, acc);
-            else acc;
-          end match;
-        end for;
-      then
-        acc;
-
-    else acc;
-  end match;
-end collectModBindings;
 
 function collectDynamicSelectDynExp
   "Absyn traversal function that collects the dynamic (second) argument of every

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -228,7 +228,7 @@ algorithm
   Error.checkCancel();
   Typing.typeClass(inst_cls, context);
 
-  // #15969: Synthesize auxiliary variables bound to DynamicSelect dynamic
+  // Synthesize auxiliary variables bound to DynamicSelect dynamic
   // expressions that call user functions, so their values reach the result file
   // and OMEdit can display them without calling the function itself.
   if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
@@ -239,9 +239,11 @@ algorithm
   Error.checkCancel();
   flatModel := Flatten.flatten(inst_cls, classPath);
 
-  // #15969: Give synthesized DynamicSelect auxiliary String variables an empty
-  // start value so the runtime can initialize them (a String variable without a
-  // start attribute would otherwise be a null pointer at the first output).
+  // Give synthesized DynamicSelect auxiliary String variables an empty start
+  // value so the runtime can initialize them (a String variable without a start
+  // attribute would otherwise be a null pointer at the first output). The start
+  // is added here because a builtin type's attributes are taken from its class
+  // during flattening, which the directly-synthesized component bypasses.
   if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
     flatModel.variables := list(addDynamicSelectAuxStringStart(v) for v in flatModel.variables);
   end if;
@@ -4246,13 +4248,13 @@ end checkInstanceRestriction;
 
 public
 function synthesizeDynamicSelectAux
-  "#15969: Walks the instance tree and, for every class whose graphical
-   annotations contain a DynamicSelect whose dynamic expression calls a user
-   function, injects an auxiliary component bound to that dynamic expression.
-   Flattening then emits it as a result-file variable named exactly the way the
-   instance API rewrites the annotation (see NFApi.rewriteDynamicSelectAux and
-   NFBuiltinCall.dynamicSelectAuxName), so OMEdit can read the value from the
-   result file instead of calling the user function itself."
+  "Walks the instance tree and, for every class whose graphical annotations
+   contain a DynamicSelect whose dynamic expression calls a user function,
+   injects an auxiliary component bound to that dynamic expression. Flattening
+   then emits it as a result-file variable named exactly the way the instance
+   API rewrites the annotation (see NFBuiltinCall.dynamicSelectAuxName), so
+   OMEdit can read the value from the result file instead of calling the user
+   function itself."
   input InstNode clsNode;
   input InstContext.Type context;
 algorithm
@@ -4376,40 +4378,12 @@ algorithm
 
   for sm in submods loop
     bindings := match sm
-      case SCode.NAMEMOD(ident = "Icon", mod = m) then collectModBindings(m, bindings);
-      case SCode.NAMEMOD(ident = "Diagram", mod = m) then collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Icon", mod = m) then SCodeUtil.collectModBindings(m, bindings);
+      case SCode.NAMEMOD(ident = "Diagram", mod = m) then SCodeUtil.collectModBindings(m, bindings);
       else bindings;
     end match;
   end for;
 end dynamicSelectAnnotationBindings;
-
-function collectModBindings
-  "Recursively collects all Absyn expression bindings in a modifier tree."
-  input SCode.Mod mod;
-  input output list<Absyn.Exp> acc;
-protected
-  list<SCode.SubMod> submods;
-  Option<Absyn.Exp> binding;
-algorithm
-  acc := match mod
-    case SCode.MOD(subModLst = submods, binding = binding)
-      algorithm
-        if isSome(binding) then
-          acc := Util.getOption(binding) :: acc;
-        end if;
-
-        for sm in submods loop
-          acc := match sm
-            case SCode.NAMEMOD() then collectModBindings(sm.mod, acc);
-            else acc;
-          end match;
-        end for;
-      then
-        acc;
-
-    else acc;
-  end match;
-end collectModBindings;
 
 function collectDynamicSelectDynExp
   "Absyn traversal function that collects the dynamic (second) argument of every

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/omedit_runtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/omedit_runtime.rs
@@ -29,6 +29,9 @@ pub struct ModelicaMatVariable_t {
     name: *mut c_char,
     descr: *mut c_char,
     isParam: c_int,
+    /// Non-zero for a time-varying String variable, whose value lives in the
+    /// `stringData` matrix and whose `index` is a string-signal number.
+    isString: c_int,
     index: c_int,
 }
 
@@ -55,6 +58,12 @@ struct ModelicaMatReader {
     readAll: c_int,
     vars: *mut *mut c_double,
     doublePrecision: c_char,
+    /// String result support; consumers reach the values through
+    /// [`omc_matlab4_read_string_val`], so these stay null/zero here.
+    stringData: *mut c_char,
+    stringMaxLen: u32,
+    nStringSignals: u32,
+    nStringRows: u32,
 }
 
 struct ReaderState {
@@ -66,6 +75,10 @@ struct ReaderState {
     /// returns a reader-owned `double*` the caller does not free), keyed by the
     /// requested column index.
     cached: HashMap<c_int, Vec<f64>>,
+    /// String values handed out by `omc_matlab4_read_string_val`, kept alive for
+    /// the reader's lifetime as the C reader's `stringData` is, keyed by
+    /// (variable, requested time).
+    strings: HashMap<(usize, u64), CString>,
 }
 
 thread_local! {
@@ -98,13 +111,19 @@ pub extern "C" fn omc_new_matlab4_reader(
                     name: unsafe { dup_cstr(&v.name) },
                     descr: unsafe { dup_cstr(&v.descr) },
                     isParam: v.isParam as c_int,
+                    isString: v.isString as c_int,
                     index: v.index,
                 })
                 .collect();
             let (nall, nparam, nvar, nrows) =
                 (vars.len() as u32, mr.nparam as u32, mr.nvar as u32, mr.nrows as u32);
             let (start, stop) = (mr.start_time(), mr.stop_time());
-            let state = Box::new(ReaderState { reader: mr, vars, cached: HashMap::new() });
+            let state = Box::new(ReaderState {
+                reader: mr,
+                vars,
+                cached: HashMap::new(),
+                strings: HashMap::new(),
+            });
             let p = Box::into_raw(state);
             // Populate exactly the fields consumers read directly; the rest is
             // reached only through the accessor functions (which use `file`).
@@ -127,6 +146,10 @@ pub extern "C" fn omc_new_matlab4_reader(
                 r.readAll = 0;
                 r.vars = ptr::null_mut();
                 r.doublePrecision = 0;
+                r.stringData = ptr::null_mut();
+                r.stringMaxLen = 0;
+                r.nStringSignals = 0;
+                r.nStringRows = 0;
             }
             ptr::null()
         }
@@ -251,6 +274,37 @@ pub extern "C" fn omc_matlab4_val(
     }
 }
 
+/// The value of a time-varying String variable at `time`, as a reader-owned C
+/// string (valid until the reader is freed, as the C reader's pointer into
+/// `stringData` is), or null when `var` is not a String variable. A String is a
+/// step-like display value, so this is the value at the row at or just before
+/// `time`, not an interpolation.
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_matlab4_read_string_val(
+    reader: *mut ModelicaMatReader,
+    var: *mut ModelicaMatVariable_t,
+    time: c_double,
+) -> *const c_char {
+    let Some(st) = (unsafe { state(reader) }) else { return ptr::null() };
+    if var.is_null() {
+        return ptr::null();
+    }
+    // `var` points into `st.vars`; recover its index by offset.
+    let base = st.vars.as_ptr();
+    let i = (var as usize).wrapping_sub(base as usize)
+        / std::mem::size_of::<ModelicaMatVariable_t>();
+    if i >= st.vars.len() {
+        return ptr::null();
+    }
+    let key = (i, time.to_bits());
+    if !st.strings.contains_key(&key) {
+        let Some(s) = st.reader.read_string_val(i, time) else { return ptr::null() };
+        let Ok(c) = CString::new(s) else { return ptr::null() };
+        st.strings.insert(key, c);
+    }
+    st.strings.get(&key).unwrap().as_ptr()
+}
+
 /// Interpolate `n` variables at `time` into `res[0..n]` (libOMPlot's parametric
 /// path). Returns 0 on success, non-zero if any lookup fails.
 #[unsafe(no_mangle)]
@@ -309,15 +363,37 @@ pub extern "C" fn omc_matlab4_stopTime(reader: *mut ModelicaMatReader) -> c_doub
 
 // ─────────────────────────────── CSV reader ──────────────────────────────────
 
-/// Open a CSV result file. Returns an opaque `struct csv_data*` (a boxed
-/// [`CsvReader`]) or null on failure, matching the C `read_csv`.
-#[unsafe(no_mangle)]
-pub extern "C" fn read_csv(filename: *const c_char) -> *mut c_void {
+/// What the opaque `struct csv_data*` points at: the reader plus the `char**`
+/// arrays [`read_csv_dataset_str`] hands out, which the C ABI keeps alive for
+/// the reader's lifetime.
+struct CsvState {
+    reader: CsvReader,
+    strings: HashMap<String, (Vec<CString>, Vec<*mut c_char>)>,
+}
+
+fn csv_open(filename: *const c_char, keep_strings: bool) -> *mut c_void {
     let fname = unsafe { CStr::from_ptr(filename) }.to_string_lossy().into_owned();
-    match catch_unwind(|| CsvReader::open(&fname)) {
-        Ok(Ok(r)) => Box::into_raw(Box::new(r)) as *mut c_void,
+    let open = || if keep_strings { CsvReader::open_all(&fname) } else { CsvReader::open(&fname) };
+    match catch_unwind(open) {
+        Ok(Ok(reader)) => {
+            Box::into_raw(Box::new(CsvState { reader, strings: HashMap::new() })) as *mut c_void
+        }
         _ => ptr::null_mut(),
     }
+}
+
+/// Open a CSV result file. Returns an opaque `struct csv_data*` (a boxed
+/// [`CsvState`]) or null on failure, matching the C `read_csv`.
+#[unsafe(no_mangle)]
+pub extern "C" fn read_csv(filename: *const c_char) -> *mut c_void {
+    csv_open(filename, false)
+}
+
+/// `read_csv_all`: like [`read_csv`] but keeps the String columns readable
+/// through [`read_csv_dataset_str`] instead of failing on them.
+#[unsafe(no_mangle)]
+pub extern "C" fn read_csv_all(filename: *const c_char) -> *mut c_void {
+    csv_open(filename, true)
 }
 
 /// Return the trajectory of `var` as a reader-owned `double*` (the caller does
@@ -327,19 +403,39 @@ pub extern "C" fn read_csv_dataset(data: *mut c_void, var: *const c_char) -> *mu
     if data.is_null() {
         return ptr::null_mut();
     }
-    let reader = unsafe { &*(data as *const CsvReader) };
+    let st = unsafe { &*(data as *const CsvState) };
     let name = unsafe { CStr::from_ptr(var) }.to_string_lossy();
-    match reader.dataset(&name) {
+    match st.reader.dataset(&name) {
         Some(s) => s.as_ptr() as *mut c_double,
         None => ptr::null_mut(),
     }
 }
 
-/// Free a reader returned by [`read_csv`].
+/// The `numsteps` String values of a String column as a reader-owned `char**`
+/// (the caller frees neither), or null when `var` is not a String column or the
+/// file was opened with [`read_csv`]. Mirrors the C `read_csv_dataset_str`.
+#[unsafe(no_mangle)]
+pub extern "C" fn read_csv_dataset_str(data: *mut c_void, var: *const c_char) -> *mut *mut c_char {
+    if data.is_null() {
+        return ptr::null_mut();
+    }
+    let st = unsafe { &mut *(data as *mut CsvState) };
+    let name = unsafe { CStr::from_ptr(var) }.to_string_lossy().into_owned();
+    if !st.strings.contains_key(&name) {
+        let Some(vals) = st.reader.dataset_str(&name) else { return ptr::null_mut() };
+        let owned: Vec<CString> =
+            vals.iter().map(|v| CString::new(v.as_str()).unwrap_or_default()).collect();
+        let ptrs: Vec<*mut c_char> = owned.iter().map(|c| c.as_ptr() as *mut c_char).collect();
+        st.strings.insert(name.clone(), (owned, ptrs));
+    }
+    st.strings.get_mut(&name).unwrap().1.as_mut_ptr()
+}
+
+/// Free a reader returned by [`read_csv`] / [`read_csv_all`].
 #[unsafe(no_mangle)]
 pub extern "C" fn omc_free_csv_reader(data: *mut c_void) {
     if !data.is_null() {
-        unsafe { drop(Box::from_raw(data as *mut CsvReader)) };
+        unsafe { drop(Box::from_raw(data as *mut CsvState)) };
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_plot.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_plot.rs
@@ -159,11 +159,17 @@ fn render(a: &PlotArgs) -> Result<String, String> {
         let all = SimulationResults::readVariables(filename.clone(), false, false)
             .map_err(|e| e.to_string())?;
         // Drop the independent variable and internal helper variables.
-        list_to_vec(&all)
+        let mut names: Vec<String> = list_to_vec(&all)
             .into_iter()
             .map(|s| s.to_string())
             .filter(|s| s != "time" && !s.starts_with('$'))
-            .collect()
+            .collect();
+        // A String variable has no numeric trajectory to draw, so it is not a
+        // curve — OMPlot skips them by `allInfo[i].isString` for the same reason.
+        if let Ok(reader) = openmodelica_result_files::ResultReader::open(filename.as_str()) {
+            names.retain(|n| !reader.is_string_var(n));
+        }
+        names
     };
     if names.is_empty() {
         return Err("no variables to plot".into());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -238,6 +238,11 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]
     // here regardless of the filter); `keep` is applied to `series` at the end.
     let mut series_keep: Vec<bool> = Vec::new();
     for (v, &keep) in model.result_vars.iter().zip(keep) {
+        // A String signal has no numeric trajectory to plot, and OMPlot skips
+        // String variables in a result file for the same reason.
+        if matches!(v.kind, ResultKind::StringColumn { .. }) {
+            continue;
+        }
         if !matches!(v.kind, ResultKind::Time) {
             series_keep.push(keep);
         }
@@ -272,6 +277,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]
                 alias: false,
                 values: vec![*value],
             }),
+            ResultKind::StringColumn { .. } => unreachable!("skipped above"),
         }
     }
     // A start value shows the state's t0 value; a plain parameter shows its slot.
@@ -1384,6 +1390,13 @@ mod session {
                 Ok(SessionBackend::InWasm(sim_runtime::build_inwasm_session(&model)?))
             } else {
                 let (mut engine, sim_data) = sim_runtime::build_engine(&model, &meta)?;
+                // `drive()` arms the String capture for a one-shot run; this
+                // resumable session drives the chunks itself, so it arms it here.
+                let has_strings = meta
+                    .vars
+                    .iter()
+                    .any(|v| matches!(v.kind, ResultKind::StringColumn { .. }));
+                sim_driver::strings::begin(if has_strings { meta.layout.n_str_alg() } else { 0 });
                 let made = sim_driver::make_driver(&mut *engine, &meta, sim_data, meta.method.as_str())
                     .map_err(|err| sim_driver::enrich_trap_init(&mut *engine, err, meta.start_time));
                 let (driver, _label) = match made {
@@ -1485,6 +1498,7 @@ mod session {
                                 params,
                                 stats,
                                 lin,
+                                strings: sim_driver::strings::take(),
                             };
                             if log_stats {
                                 stats_block = openmodelica_sim_meta::stats::log_stats_block(&run.stats);
@@ -3826,9 +3840,13 @@ fn result_name(raw: &str) -> Option<String> {
 /// The `$`-prefixed variables C's result file *does* carry: an `optimization`
 /// model's objective terms (`BackendDAE.optimization{Mayer,Lagrange}TermName`) and
 /// its constraint residuals (`DynamicOptimization`'s `$con$` / `$finalCon$` /
-/// `$EqCon$`). The rest of the `$` namespace is the backend's own bookkeeping,
-/// which C hides through `hideResult` and this port drops by name.
-const OPT_RESULT_PREFIXES: [&str; 4] = ["$OMC$object", "$con$", "$finalCon$", "$EqCon$"];
+/// `$EqCon$`), plus the `DynamicSelect` auxiliaries the frontend synthesizes for a
+/// dynamic annotation expression that calls a user function — OMEdit reads them
+/// back out of the result file by name. The rest of the `$` namespace is the
+/// backend's own bookkeeping, which C hides through `hideResult` and this port
+/// drops by name.
+const OPT_RESULT_PREFIXES: [&str; 5] =
+    ["$OMC$object", "$con$", "$finalCon$", "$EqCon$", "$DynamicSelect$"];
 
 /// Evaluate a constant variable's binding to a scalar, for the `*ConstVars`
 /// lists (which have no SimData slot). Handles the literal forms model constants
@@ -3855,7 +3873,14 @@ pub(crate) fn const_value(exp: &Option<Arc<DAE::Exp>>) -> Option<f64> {
 /// captured per row) and string variables have no numeric result column.
 fn kind_from_slot(off: u32, wty: WTy, negate: Neg, heap: bool, layout: &SimLayout) -> Option<ResultKind> {
     if heap {
-        return None; // strings are not stored as numeric result data
+        // A string *variable* is a result signal, but not a numeric one: its text
+        // is captured per output row and written to the `.mat`'s `stringData`
+        // matrix / its own quoted CSV column. String parameters and external
+        // objects are not in the result file at all, as in C.
+        if off >= layout.str_off && off < layout.sparam_off {
+            return Some(ResultKind::StringColumn { idx: (off - layout.str_off) / 4 });
+        }
+        return None;
     }
     if off >= REAL_OFF && off < layout.rparam_off {
         // realVars region (states | derivatives | algebraics) -> data_2 column.
@@ -4249,8 +4274,11 @@ fn build_var_map(
         push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
         push_editable(sv, &name, off, WTy::I32);
     }
+    // String variables: an i32 runtime-String handle slot, and a result signal
+    // whose text the driver captures beside the numeric row (C's `stringVars`).
     for (i, sv) in lst(&vars.stringAlgVars).enumerate() {
-        insert_var(&mut map, sv, layout.str_off + (i as u32) * 4, WTy::I32, true)?;
+        let name = cref_display(&sv.name)?;
+        push_primary(&mut map, &mut result_vars, sv, layout.str_off + (i as u32) * 4, WTy::I32, true, name)?;
     }
     for (k, sv) in lst(&vars.stringParamVars).enumerate() {
         let off = layout.sparam_off + (k as u32) * 4;
@@ -4319,7 +4347,10 @@ fn build_var_map(
     let alias_lists = lst(&vars.aliasVars)
         .map(|v| (v, false))
         .chain(lst(&vars.intAliasVars).map(|v| (v, false)))
-        .chain(lst(&vars.boolAliasVars).map(|v| (v, true)));
+        .chain(lst(&vars.boolAliasVars).map(|v| (v, true)))
+        // A String alias shares the target's handle slot and its string column;
+        // there is no negation of a String.
+        .chain(lst(&vars.stringAliasVars).map(|v| (v, false)));
     for (av, is_bool) in alias_lists {
         let (target, negate) = match &av.aliasvar {
             SimCodeVar::AliasVariable::ALIAS { varName } => (varName.clone(), false),
@@ -11308,6 +11339,7 @@ fn write_result(
         run.n_reals,
         &run.params,
         keep,
+        &run.strings,
         precision,
     ) else {
         return Ok(());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/model_ctx.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/model_ctx.rs
@@ -138,6 +138,8 @@ pub(crate) fn write(path: &str) -> Result<(), &'static str> {
         &rows,
         model.layout.n_row_total(),
         &params,
+        // One guessed point, no run: nothing captured a String value.
+        &[],
         Precision::Double,
     );
     std::fs::write(path, bytes).map_err(|_| "cannot write the initial guess file")

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -219,6 +219,10 @@ struct Session {
     stats: SolveStats,
     /// `-l`'s linearized model as `<file name>\0<content>`, for the host to write.
     lin: Vec<u8>,
+    /// The captured String result values, one `u32` length prefix plus the UTF-8
+    /// bytes per value, in the driver's row-major order. Length-prefixed rather
+    /// than NUL-separated so an empty value stays unambiguous.
+    strings: Vec<u8>,
     /// `+profiling`'s collected state (`profiling::snapshot`), for the host to
     /// render into the report once it has written the result file.
     prof: Vec<u8>,
@@ -388,6 +392,12 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
         Err(_) => return -2,
     };
 
+    // `drive()` arms the String capture for the host drivers; this path builds its
+    // driver directly, so it arms it here.
+    let has_strings =
+        model.vars.iter().any(|v| matches!(v.kind, openmodelica_sim_meta::MetaKind::StringColumn { .. }));
+    driver::strings::begin(if has_strings { model.layout.n_str_alg() } else { 0 });
+
     *session() = Some(Session {
         engine,
         driver,
@@ -399,6 +409,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
         params: Vec::new(),
         stats: SolveStats::default(),
         lin: Vec::new(),
+        strings: Vec::new(),
         prof: Vec::new(),
     });
     // What C's `NLS_USERDATA` carries as `DATA*`: the run's model and `SimData`,
@@ -466,6 +477,10 @@ fn finish(s: &mut Session) {
         s.lin.push(0);
         s.lin.extend_from_slice(f.content.as_bytes());
     }
+    for v in driver::strings::take() {
+        s.strings.extend_from_slice(&(v.len() as u32).to_le_bytes());
+        s.strings.extend_from_slice(v.as_bytes());
+    }
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
     use openmodelica_sim_meta::rtclock;
     openmodelica_sim_meta::parmod::finish();
@@ -509,6 +524,17 @@ pub extern "C" fn rt_sim_lin_ptr() -> u32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_sim_lin_len() -> u32 {
     session().as_ref().map_or(0, |s| s.lin.len() as u32)
+}
+
+/// The captured String result values: per value a `u32` byte length followed by
+/// its UTF-8 bytes, in the same row-major order as the numeric rows.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_strings_ptr() -> u32 {
+    session().as_ref().map_or(0, |s| s.strings.as_ptr() as u32)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_strings_len() -> u32 {
+    session().as_ref().map_or(0, |s| s.strings.len() as u32)
 }
 
 /// `+profiling`'s collected state, valid once the run is done.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -260,6 +260,7 @@ fn run() {
         result.n_reals,
         &result.params,
         &keep,
+        &result.strings,
         precision,
     ) else {
         return;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
@@ -219,6 +219,8 @@ fn write_result_file(m: &meta::SimMeta, result: &driver::RunResult) -> Vec<u8> {
         let precision = simflags::with_flags(|f| {
             if f.single_precision { Precision::Single } else { Precision::Double }
         });
+        let n_rows = if result.n_reals == 0 { 0 } else { result.rows.len() / result.n_reals as usize };
+        let str_cols = meta::result::string_columns(m, &keep, &result.strings, n_rows);
         openmodelica_mat_writer::write_mat4(
             &matvars,
             m.start_time,
@@ -226,6 +228,7 @@ fn write_result_file(m: &meta::SimMeta, result: &driver::RunResult) -> Vec<u8> {
             &result.rows,
             result.n_reals,
             &kept_params,
+            &str_cols,
             precision,
         )
     } else {
@@ -240,13 +243,17 @@ fn write_result_file(m: &meta::SimMeta, result: &driver::RunResult) -> Vec<u8> {
             MetaKind::Column { col, negate } => PltKind::Column { col: *col, negate: neg(negate) },
             MetaKind::Param { negate, .. } => PltKind::Param { negate: neg(negate) },
             MetaKind::Const { value } => PltKind::Const { value: *value },
+            // Filtered out below: C's plt writer has no String channel.
+            MetaKind::StringColumn { .. } => PltKind::Const { value: 0.0 },
         };
         let mut signals: Vec<PltVar> = Vec::new();
         for (v, &keep) in m.vars.iter().zip(&keep) {
             let is_param = matches!(v.kind, MetaKind::Param { .. });
             // C's plt writer omits integer/boolean parameters (`nParameters*`).
             let is_int_bool_param = matches!(v.kind, MetaKind::Param { wty: meta::WTy::I32, .. });
-            let emit = keep && !is_int_bool_param;
+            // A String signal has no numeric data for the plt format to carry.
+            let is_string = matches!(v.kind, MetaKind::StringColumn { .. });
+            let emit = keep && !is_int_bool_param && !is_string;
             if is_param && emit {
                 kept_params.push(result.params.get(param_idx).copied().unwrap_or(0.0));
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
@@ -353,6 +353,8 @@ impl Recorder {
             &self.rows,
             self.columns.len() as u32 + 1,
             &params,
+            // An FMU recording has no String channel.
+            &[],
             mat::Precision::Double,
         )
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_files/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_files/src/lib.rs
@@ -28,7 +28,9 @@ impl ResultReader {
         } else if filename.ends_with(".plt") {
             PltReader::open(filename).map(ResultReader::Plt).map_err(OpenError::Failed)
         } else if filename.ends_with(".csv") {
-            CsvReader::open(filename).map(ResultReader::Csv).map_err(OpenError::Failed)
+            // The scripting readers tolerate String columns; a result file may
+            // carry them beside the numeric ones.
+            CsvReader::open_all(filename).map(ResultReader::Csv).map_err(OpenError::Failed)
         } else {
             Err(OpenError::UnknownSuffix)
         }
@@ -74,6 +76,18 @@ impl ResultReader {
         }
     }
 
+    /// Whether `varname` is a time-varying String variable: it has no numeric
+    /// trajectory, so a plot skips it (OMPlot's `reader.allInfo[i].isString`).
+    pub fn is_string_var(&self, varname: &str) -> bool {
+        match self {
+            ResultReader::Mat(reader) => {
+                reader.find_var(varname).is_some_and(|i| reader.allInfo[i].isString)
+            }
+            ResultReader::Csv(reader) => reader.is_string_var(varname),
+            ResultReader::Plt(_) => false,
+        }
+    }
+
     /// C `SimulationResultsImpl__readVarsFilterAliases`: for MATLAB4 the names
     /// of all real (non-negated-alias) variables and parameters, one per storage
     /// index, in `allInfo` order; the other formats fall through to
@@ -87,6 +101,13 @@ impl ResultReader {
                 for info in reader.allInfo.iter().rev() {
                     if info.index <= 0 {
                         continue; // negated aliases always have a real variable
+                    }
+                    // A String variable indexes `stringData`, not data_1/data_2,
+                    // so its index says nothing about the numeric storage it
+                    // would collide with here. It is not numerically comparable
+                    // either, which is what this list feeds.
+                    if info.isString {
+                        continue;
                     }
                     let seen = if info.isParam { &mut seen_param } else { &mut seen_var };
                     if !seen.insert(info.index) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_files/src/readers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_files/src/readers.rs
@@ -20,13 +20,31 @@ pub struct CsvReader {
     pub variables: Vec<String>,
     /// Var-major trajectories: `data[var][step]`.
     data: Vec<Vec<f64>>,
+    /// Var-major raw text, filled only by [`CsvReader::open_all`] and only for
+    /// the String columns; empty for every numeric column, as C frees theirs.
+    strdata: Vec<Vec<String>>,
+    /// Per-variable: true where a tolerant read saw a non-numeric cell.
+    is_string: Vec<bool>,
     pub numsteps: usize,
 }
 
 impl CsvReader {
     /// `read_csv`: returns `Err` with a short reason wherever the C reader
     /// returns NULL (caller turns that into the scripting error message).
+    /// Non-numeric cells are an error, as they are for a `-csvInput` file.
     pub fn open(filename: &str) -> Result<CsvReader, String> {
+        Self::read(filename, false)
+    }
+
+    /// `read_csv_all`: like [`CsvReader::open`] but tolerates String columns —
+    /// a non-numeric cell is kept as text ([`CsvReader::dataset_str`]) and
+    /// stored as NaN in the numeric matrix, so the numeric variables of a
+    /// result file that also carries Strings stay readable.
+    pub fn open_all(filename: &str) -> Result<CsvReader, String> {
+        Self::read(filename, true)
+    }
+
+    fn read(filename: &str, keep_strings: bool) -> Result<CsvReader, String> {
         let bytes = read_result_bytes(filename)?;
         // Optional `"sep=X"` first line selects the cell delimiter; the
         // data then starts at offset 8 (`"sep=X"␊`), as in read_csv.c.
@@ -42,6 +60,9 @@ impl CsvReader {
         };
         let numvars = variables.len();
         let mut data: Vec<Vec<f64>> = vec![Vec::new(); numvars];
+        let mut strdata: Vec<Vec<String>> =
+            if keep_strings { vec![Vec::new(); numvars] } else { Vec::new() };
+        let mut is_string = vec![false; numvars];
         for (rownum, row) in rows.enumerate() {
             if row.len() != numvars {
                 // Mirrors add_row's complaint (rows are 1-based and the
@@ -50,16 +71,53 @@ impl CsvReader {
                 return Err("row length mismatch".to_owned());
             }
             for (col, cell) in row.iter().enumerate() {
-                let Some(v) = parse_csv_cell(cell) else {
-                    // add_cell prints the offending cell to stderr.
-                    eprintln!("Found non-double data in csv result-file: {cell}");
-                    return Err("non-double data".to_owned());
+                let v = match parse_csv_cell(cell) {
+                    Some(v) => v,
+                    // A non-numeric cell is a String value where the caller
+                    // allows one, and an error where it does not.
+                    None if keep_strings => {
+                        is_string[col] = true;
+                        f64::NAN
+                    }
+                    None => {
+                        // add_cell prints the offending cell to stderr.
+                        eprintln!("Found non-double data in csv result-file: {cell}");
+                        return Err("non-double data".to_owned());
+                    }
                 };
                 data[col].push(v);
+                if keep_strings {
+                    strdata[col].push(cell.clone());
+                }
+            }
+        }
+        // The text of a numeric column is not worth keeping (C frees it).
+        for (col, keep) in is_string.iter().enumerate() {
+            if !keep && col < strdata.len() {
+                strdata[col] = Vec::new();
             }
         }
         let numsteps = data.first().map(|c| c.len()).unwrap_or(0);
-        Ok(CsvReader { variables, data, numsteps })
+        Ok(CsvReader { variables, data, strdata, is_string, numsteps })
+    }
+
+    /// `read_csv_dataset_str`: the `numsteps` un-escaped String values of a
+    /// String column, or `None` when the variable is not one (or the file was
+    /// opened with [`CsvReader::open`]).
+    pub fn dataset_str(&self, var: &str) -> Option<&[String]> {
+        let idx = self.variables.iter().position(|v| v == var)?;
+        if !self.is_string.get(idx).copied().unwrap_or(false) {
+            return None;
+        }
+        self.strdata.get(idx).map(Vec::as_slice)
+    }
+
+    /// Whether `var` is a String column of this file.
+    pub fn is_string_var(&self, var: &str) -> bool {
+        self.variables
+            .iter()
+            .position(|v| v == var)
+            .is_some_and(|i| self.is_string.get(i).copied().unwrap_or(false))
     }
 
     /// `read_csv_dataset`: the trajectory of `var` (exact name match), or

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_web/src/lib.rs
@@ -161,7 +161,9 @@ impl ResultFile {
             }
         }
         let mat_vars: Vec<MatVar> = signals.iter().map(|(name, comment, kind)| MatVar { name, comment, kind: *kind }).collect();
-        Ok(write_mat4(&mat_vars, start, stop, &rows, n_reals as u32, &params, Precision::Double))
+        // Resampled numeric channels only; a String signal has no numeric data
+        // to resample, so it is not carried over.
+        Ok(write_mat4(&mat_vars, start, stop, &rows, n_reals as u32, &params, &[], Precision::Double))
     }
 
     /// The file as CSV with `vars` (all of them when empty): one `time` column

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1315,6 +1315,8 @@ pub struct InWasmSession {
     stat_f: wasmer::TypedFunction<u32, u64>,
     lin_ptr: wasmer::TypedFunction<(), u32>,
     lin_len: wasmer::TypedFunction<(), u32>,
+    strings_ptr: wasmer::TypedFunction<(), u32>,
+    strings_len: wasmer::TypedFunction<(), u32>,
     prof_ptr: wasmer::TypedFunction<(), u32>,
     prof_len: wasmer::TypedFunction<(), u32>,
     sys_ptr: wasmer::TypedFunction<(), u32>,
@@ -1385,6 +1387,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_stat"))?,
         lin_ptr: gf(&store, "rt_sim_lin_ptr")?,
         lin_len: gf(&store, "rt_sim_lin_len")?,
+        strings_ptr: gf(&store, "rt_sim_strings_ptr")?,
+        strings_len: gf(&store, "rt_sim_strings_len")?,
         prof_ptr: gf(&store, "rt_sim_prof_ptr")?,
         prof_len: gf(&store, "rt_sim_prof_len")?,
         sys_ptr: gf(&store, "rt_sys_stats_ptr")?,
@@ -1481,7 +1485,19 @@ impl InWasmSession {
         stats.lin_solves = stat(7)?;
         openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
-        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+        // The String values were captured in the module's own buffer; decode the
+        // length-prefixed blob `rt_sim_strings_ptr` points at.
+        let sn2 = wt(self.strings_len.call(&mut self.store))? as usize;
+        let mut blob = vec![0u8; sn2];
+        if sn2 > 0 {
+            let sp2 = wt(self.strings_ptr.call(&mut self.store))?;
+            self.memory
+                .view(&self.store)
+                .read(sp2 as u64, &mut blob)
+                .map_err(|_| "CodegenWasmJit: strings read")?;
+        }
+        let strings = sim_driver::decode_string_blob(&blob);
+        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin, strings })
     }
 
     /// `+profiling`'s collected state, for the host's `profiling::adopt`: the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1730,6 +1730,8 @@ pub struct InWasmSession {
     stat_f: wasmtime::TypedFunc<u32, u64>,
     lin_ptr: wasmtime::TypedFunc<(), u32>,
     lin_len: wasmtime::TypedFunc<(), u32>,
+    strings_ptr: wasmtime::TypedFunc<(), u32>,
+    strings_len: wasmtime::TypedFunc<(), u32>,
     prof_ptr: wasmtime::TypedFunc<(), u32>,
     prof_len: wasmtime::TypedFunc<(), u32>,
     sys_ptr: wasmtime::TypedFunc<(), u32>,
@@ -1796,6 +1798,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.get_typed_func::<u32, u64>(&mut store, "rt_sim_stat"))?,
         lin_ptr: gf(&mut store, "rt_sim_lin_ptr")?,
         lin_len: gf(&mut store, "rt_sim_lin_len")?,
+        strings_ptr: gf(&mut store, "rt_sim_strings_ptr")?,
+        strings_len: gf(&mut store, "rt_sim_strings_len")?,
         prof_ptr: gf(&mut store, "rt_sim_prof_ptr")?,
         prof_len: gf(&mut store, "rt_sim_prof_len")?,
         sys_ptr: gf(&mut store, "rt_sys_stats_ptr")?,
@@ -1893,7 +1897,18 @@ impl InWasmSession {
         stats.lin_solves = stat(7)?;
         openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
-        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+        // The String values were captured in the module's own buffer; decode the
+        // length-prefixed blob `rt_sim_strings_ptr` points at.
+        let n = wt(self.strings_len.call(&mut self.store, ()))? as usize;
+        let mut blob = vec![0u8; n];
+        if n > 0 {
+            let p = wt(self.strings_ptr.call(&mut self.store, ()))?;
+            self.memory
+                .read(&self.store, p as usize, &mut blob)
+                .map_err(|_| "CodegenWasmJit: strings read")?;
+        }
+        let strings = sim_driver::decode_string_blob(&blob);
+        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin, strings })
     }
 
     /// `+profiling`'s collected state, for the host's `profiling::adopt`: the

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -65,6 +65,7 @@ import InstContext = NFInstContext;
 
 import Absyn.Path;
 import AbsynToSCode;
+import BuiltinCall = NFBuiltinCall;
 import CevalScriptBackend;
 import Config;
 import ConvertDAE = NFConvertDAE;
@@ -1965,6 +1966,16 @@ algorithm
     exp := Inst.instExp(absynExp, scope, INST_API_ANNOTATION_CONTEXT, info);
     exp := Typing.typeExp(exp, INST_API_ANNOTATION_CONTEXT, info);
     exp := SimplifyExp.simplify(exp);
+
+    // Reference each DynamicSelect auxiliary variable by its full instance path,
+    // relative to the annotation's owning scope. typeDynamicSelectCall creates
+    // the reference without a scope (it does not know the owning instance), so a
+    // sub-component's auxiliary (display.$DynamicSelect$H in the result file) is
+    // otherwise referenced as a bare $DynamicSelect$H and not found by OMEdit.
+    if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT_AUX) then
+      exp := BuiltinCall.prefixDynamicSelectAuxRefs(exp, scope);
+    end if;
+
     json := Expression.toJSON(exp);
   else
     if failOnError then

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -566,6 +566,8 @@ constant DebugFlag DUMP_CHECK_MODEL = DEBUG_FLAG(199, "dumpCheckModel", false,
   "Dumps the variables and equations found by checkModel.");
 constant DebugFlag CHECK_DEF_USE = DEBUG_FLAG(200, "checkDefUse", false,
   "Warns about variables in functions that cannot statically be proven to be defined (given a value) before they are used, e.g. variables only assigned on some control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
+constant DebugFlag NF_API_DYNAMIC_SELECT_AUX = DEBUG_FLAG(201, "nfAPIDynamicSelectAux", false,
+  "Synthesize auxiliary result-file variables bound to user-function calls inside DynamicSelect dynamic expressions so OMEdit can display them.");
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -575,6 +575,8 @@ constant DebugFlag TEARING_COST = DEBUG_FLAG(201, "tearingCost", false,
   "Dumps the estimated cost of every torn system against solving it untorn.");
 constant DebugFlag OMEDIT = DEBUG_FLAG(202, "omedit", false,
   "Set by OMEdit, so the compiler can emit output only a GUI consumes.");
+constant DebugFlag NF_API_DYNAMIC_SELECT_AUX = DEBUG_FLAG(203, "nfAPIDynamicSelectAux", false,
+  "Synthesize auxiliary result-file variables bound to user-function calls inside DynamicSelect dynamic expressions so OMEdit can display them.");
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -260,7 +260,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DEBUG_ADJOINT,
   Flags.FLOW_ALIAS_ELIMINATION,
   Flags.DUMP_CHECK_MODEL,
-  Flags.CHECK_DEF_USE
+  Flags.CHECK_DEF_USE,
+  Flags.NF_API_DYNAMIC_SELECT_AUX
 };
 
 protected

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -263,7 +263,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DUMP_CHECK_MODEL,
   Flags.CHECK_DEF_USE,
   Flags.TEARING_COST,
-  Flags.OMEDIT
+  Flags.OMEDIT,
+  Flags.NF_API_DYNAMIC_SELECT_AUX
 };
 
 protected

--- a/OMCompiler/Compiler/runtime/SimulationResults.c
+++ b/OMCompiler/Compiler/runtime/SimulationResults.c
@@ -134,7 +134,7 @@ static PlotFormat SimulationResultsImpl__openFile(const char *filename, Simulati
     }
     break;
   case CSV:
-    simresglob->csvReader = read_csv(filename);
+    simresglob->csvReader = read_csv_all(filename);
     if (simresglob->csvReader==NULL) {
       msg[1] = filename;
       c_add_message(NULL,-1, ErrorType_scripting, ErrorLevel_error, gettext("Failed to open simulation result %s: %s"), msg, 2);

--- a/OMCompiler/Compiler/runtime/SimulationResults.c
+++ b/OMCompiler/Compiler/runtime/SimulationResults.c
@@ -327,6 +327,10 @@ static void* SimulationResultsImpl__readVarsFilterAliases(const char *filename, 
     int *vars = (int*) calloc(simresglob->matReader.nvar+1,sizeof(int));
     for (i=simresglob->matReader.nall-1; i>=0; i--) {
       if (0 >= simresglob->matReader.allInfo[i].index) continue; /* Negated aliases always have a real variable, so skip it */
+      /* String variables index the stringData matrix, not data_1/data_2, so their
+       * index is unrelated to nparam/nvar and must not be used with the params/vars
+       * arrays. They are not numerically comparable, so skip them here. */
+      if (simresglob->matReader.allInfo[i].isString) continue;
       if (simresglob->matReader.allInfo[i].isParam && params[simresglob->matReader.allInfo[i].index]) continue;
       if (!simresglob->matReader.allInfo[i].isParam && vars[simresglob->matReader.allInfo[i].index]) continue;
       if (simresglob->matReader.allInfo[i].isParam) {

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -137,8 +137,10 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
     fprintf(fout, formatint, (data->localData[0])->integerVars[i]);
   for(i = 0; i < data->modelData->nVariablesBoolean; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
     fprintf(fout, formatbool, (data->localData[0])->booleanVars[i]);
-  //for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
-  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
+  for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput) {
+    modelica_string sv = (data->localData[0])->stringVars[i];
+    fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+  }
 
   for(i = 0; i < data->modelData->nAliasReal; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
     if (data->modelData->realAlias[i].aliasType == ALIAS_TYPE_TIME) {
@@ -166,10 +168,11 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
       fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->modelData->booleanAlias[i].nameID]);
     }
   }
-  //for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-  //  /* there would no negation of a string happen */
-  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
-  //}
+  for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+    /* there would no negation of a string happen */
+    modelica_string sv = (data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID];
+    fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+  }
   fprintf(fout, "\n");
   rt_accumulate(SIM_TIMER_OUTPUT);
 }
@@ -212,6 +215,12 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
       fprintf(fout, format, escapedNameBuffer);
     }
   }
+  for(i = 0; i < mData->nVariablesString; i++) {
+    if(!mData->stringVarsData[i].filterOutput) {
+      csvEscapedString(mData->stringVarsData[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
+      fprintf(fout, format, escapedNameBuffer);
+    }
+  }
 
   for(i = 0; i < mData->nAliasReal; i++) {
     if(!mData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
@@ -228,6 +237,12 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
   for(i = 0; i < mData->nAliasBoolean; i++) {
     if(!mData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
       csvEscapedString(mData->booleanAlias[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
+      fprintf(fout, format, escapedNameBuffer);
+    }
+  }
+  for(i = 0; i < mData->nAliasString; i++) {
+    if(!mData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+      csvEscapedString(mData->stringAlias[i].info.name, escapedNameBuffer, MAX_IDENT_LENGTH, threadData);
       fprintf(fout, format, escapedNameBuffer);
     }
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -41,6 +41,7 @@
 #include "util/rtclock.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 #include <time.h>
@@ -152,6 +153,33 @@ static void csvWriteArrayNames(FILE* fout, const char* format, const char* name,
 }
 
 /**
+ * @brief Write a String value as an escaped, quoted CSV field.
+ *
+ * A String value can be anything (it may come from a user function), so it has
+ * to be escaped just like an identifier before it is written. A stack buffer is
+ * used for short values and a heap buffer for longer ones.
+ *
+ * @param fout        Output file.
+ * @param sv          String value (may be NULL).
+ * @param threadData  Thread data for error handling.
+ */
+static void csvEmitStringValue(FILE* fout, modelica_string sv, threadData_t* threadData)
+{
+  const char* raw = sv ? MMC_STRINGDATA(sv) : "";
+  /* Worst case every character is a double-quote and gets doubled. */
+  size_t bufSize = 2 * strlen(raw) + 1;
+  char stackBuf[MAX_IDENT_LENGTH];
+  char* buf = (bufSize <= MAX_IDENT_LENGTH) ? stackBuf : (char*)malloc(bufSize);
+
+  csvEscapedString(raw, buf, bufSize, threadData);
+  fprintf(fout, ",\"%s\"", buf);
+
+  if (buf != stackBuf) {
+    free(buf);
+  }
+}
+
+/**
  * @brief Write CSV data row.
  *
  * @param self        Simulation result.
@@ -164,7 +192,6 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   const char* format = ",%.16g";
   const char* formatint = ",%i";
   const char* formatbool = ",%i";
-  const char* formatstring = ",\"%s\"";
   int i;
   modelica_real value = 0;
   double cpuTimeValue = 0;
@@ -188,8 +215,7 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
       fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->simulationInfo->booleanVarsIndex[i] + k]);
   for(i = 0; i < data->modelData->nVariablesStringArray; i++) if(!data->modelData->stringVarsData[i].filterOutput)
     for(size_t k = 0; k < data->modelData->stringVarsData[i].dimension.scalar_length; k++) {
-      modelica_string sv = (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[i] + k];
-      fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+      csvEmitStringValue(fout, (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[i] + k], threadData);
     }
 
   for(i = 0; i < data->modelData->nAliasRealArray; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
@@ -221,11 +247,10 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
   for(i = 0; i < data->modelData->nAliasStringArray; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-    /* there would no negation of a string happen */
+    /* String alias variables/parameters don't have negation */
     const int nameID = data->modelData->stringAlias[i].nameID;
     for(size_t k = 0; k < data->modelData->stringVarsData[nameID].dimension.scalar_length; k++) {
-      modelica_string sv = (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[nameID] + k];
-      fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+      csvEmitStringValue(fout, (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[nameID] + k], threadData);
     }
   }
   fprintf(fout, "\n");

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -186,8 +186,11 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   for(i = 0; i < data->modelData->nVariablesBooleanArray; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
     for(size_t k = 0; k < data->modelData->booleanVarsData[i].dimension.scalar_length; k++)
       fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->simulationInfo->booleanVarsIndex[i] + k]);
-  //for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
-  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
+  for(i = 0; i < data->modelData->nVariablesStringArray; i++) if(!data->modelData->stringVarsData[i].filterOutput)
+    for(size_t k = 0; k < data->modelData->stringVarsData[i].dimension.scalar_length; k++) {
+      modelica_string sv = (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[i] + k];
+      fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+    }
 
   for(i = 0; i < data->modelData->nAliasRealArray; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
     if (data->modelData->realAlias[i].aliasType == ALIAS_TYPE_TIME) {
@@ -217,10 +220,14 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
       fprintf(fout, formatbool, negate ? (bvalue==1?0:1) : bvalue);
     }
   }
-  //for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-  //  /* there would no negation of a string happen */
-  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
-  //}
+  for(i = 0; i < data->modelData->nAliasStringArray; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+    /* there would no negation of a string happen */
+    const int nameID = data->modelData->stringAlias[i].nameID;
+    for(size_t k = 0; k < data->modelData->stringVarsData[nameID].dimension.scalar_length; k++) {
+      modelica_string sv = (data->localData[0])->stringVars[data->simulationInfo->stringVarsIndex[nameID] + k];
+      fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+    }
+  }
   fprintf(fout, "\n");
   rt_accumulate(SIM_TIMER_OUTPUT);
 }
@@ -259,6 +266,11 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
       csvWriteArrayNames(fout, format, mData->booleanVarsData[i].info.name, &mData->booleanVarsData[i].dimension, threadData);
     }
   }
+  for(i = 0; i < mData->nVariablesStringArray; i++) {
+    if(!mData->stringVarsData[i].filterOutput) {
+      csvWriteArrayNames(fout, format, mData->stringVarsData[i].info.name, &mData->stringVarsData[i].dimension, threadData);
+    }
+  }
 
   for(i = 0; i < mData->nAliasRealArray; i++) {
     if(!mData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
@@ -275,6 +287,11 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
   for(i = 0; i < mData->nAliasBooleanArray; i++) {
     if(!mData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
       csvWriteArrayNames(fout, format, mData->booleanAlias[i].info.name, &mData->booleanVarsData[mData->booleanAlias[i].nameID].dimension, threadData);
+    }
+  }
+  for(i = 0; i < mData->nAliasStringArray; i++) {
+    if(!mData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
+      csvWriteArrayNames(fout, format, mData->stringAlias[i].info.name, &mData->stringVarsData[mData->stringAlias[i].nameID].dimension, threadData);
     }
   }
   fprintf(fout, "\n");

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -41,6 +41,7 @@
 #include "util/rtclock.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 #include <time.h>
@@ -106,6 +107,33 @@ void csvEscapedString(const char* original, char* replaced, size_t n, threadData
 }
 
 /**
+ * @brief Write a String value as an escaped, quoted CSV field.
+ *
+ * A String value can be anything (it may come from a user function), so it has
+ * to be escaped just like an identifier before it is written. A stack buffer is
+ * used for short values and a heap buffer for longer ones.
+ *
+ * @param fout        Output file.
+ * @param sv          String value (may be NULL).
+ * @param threadData  Thread data for error handling.
+ */
+static void csvEmitStringValue(FILE* fout, modelica_string sv, threadData_t* threadData)
+{
+  const char* raw = sv ? MMC_STRINGDATA(sv) : "";
+  /* Worst case every character is a double-quote and gets doubled. */
+  size_t bufSize = 2 * strlen(raw) + 1;
+  char stackBuf[MAX_IDENT_LENGTH];
+  char* buf = (bufSize <= MAX_IDENT_LENGTH) ? stackBuf : (char*)malloc(bufSize);
+
+  csvEscapedString(raw, buf, bufSize, threadData);
+  fprintf(fout, ",\"%s\"", buf);
+
+  if (buf != stackBuf) {
+    free(buf);
+  }
+}
+
+/**
  * @brief Write CSV data row.
  *
  * @param self        Simulation result.
@@ -118,7 +146,6 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   const char* format = ",%.16g";
   const char* formatint = ",%i";
   const char* formatbool = ",%i";
-  const char* formatstring = ",\"%s\"";
   int i;
   modelica_real value = 0;
   double cpuTimeValue = 0;
@@ -138,8 +165,7 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   for(i = 0; i < data->modelData->nVariablesBoolean; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
     fprintf(fout, formatbool, (data->localData[0])->booleanVars[i]);
   for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput) {
-    modelica_string sv = (data->localData[0])->stringVars[i];
-    fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+    csvEmitStringValue(fout, (data->localData[0])->stringVars[i], threadData);
   }
 
   for(i = 0; i < data->modelData->nAliasReal; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
@@ -169,9 +195,8 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
   for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != ALIAS_TYPE_PARAMETER) {
-    /* there would no negation of a string happen */
-    modelica_string sv = (data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID];
-    fprintf(fout, formatstring, sv ? MMC_STRINGDATA(sv) : "");
+    /* String alias variables/parameters don't have negation */
+    csvEmitStringValue(fout, (data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID], threadData);
   }
   fprintf(fout, "\n");
   rt_accumulate(SIM_TIMER_OUTPUT);

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 #include <utility>
 
 extern "C"
@@ -58,6 +59,8 @@ typedef struct mat_data
   size_t sync;        /* Number of emity until mat file header get's sinced. See falg `-mat_sync` */
   void *data_2;       /* Time variant data */
   MatVer4Type_t type; /* Level of precision for result storage */
+  size_t nStringSignals; /* #15969: number of (scalar) string signals */
+  void *stringValues;    /* #15969: std::vector<std::string>*, nStringSignals strings appended per emit */
 } mat_data;
 
 struct variableCount
@@ -71,7 +74,8 @@ enum channel_t : int32_t
 {
   CHANNEL_TIME = 0,           /* Special case: Variable is time */
   CHANNEL_TIME_INVARIANT = 1, /* Variable stored in data_1 matrix */
-  CHANNEL_TIME_VARIANT = 2    /* Variable stored in data_2 matrix */
+  CHANNEL_TIME_VARIANT = 2,   /* Variable stored in data_2 matrix */
+  CHANNEL_STRING = 3          /* #15969: time-varying String; value is the 1-based string signal index into the stringData matrix */
 };
 
 enum interpolation_t : int32_t
@@ -259,6 +263,18 @@ struct variableCount count_name_description_signals(const MODEL_DATA *mData,
       count.maxLengthName = fmax(lengthName(mData->booleanVarsData[i].info.name, &mData->booleanVarsData[i].dimension), count.maxLengthName);
       count.maxLengthDesc = fmax(lengthDescription(mData->booleanVarsData[i].info.comment, NULL), count.maxLengthDesc);
       count.nSignals += mData->booleanVarsData[i].dimension.scalar_length;
+    }
+  }
+
+  /* String variables (#15969): time-varying strings are stored via a separate
+   * stringData matrix; here we only reserve name/description/dataInfo slots. */
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      count.maxLengthName = fmax(lengthName(mData->stringVarsData[i].info.name, &mData->stringVarsData[i].dimension), count.maxLengthName);
+      count.maxLengthDesc = fmax(lengthDescription(mData->stringVarsData[i].info.comment, NULL), count.maxLengthDesc);
+      count.nSignals += mData->stringVarsData[i].dimension.scalar_length;
     }
   }
 
@@ -537,6 +553,17 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
   size_t maxLengthDesc = count.maxLengthDesc;
   matData->nSignals = count.nSignals;
 
+  /* #15969: count the scalar string signals that are actually written. */
+  matData->nStringSignals = 0;
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      matData->nStringSignals += mData->stringVarsData[i].dimension.scalar_length;
+    }
+  }
+  matData->stringValues = matData->nStringSignals > 0 ? new std::vector<std::string>() : NULL;
+
   /* Copy all the var names and descriptions to "name" and "description". */
   char *name = (char *)calloc(maxLengthName * matData->nSignals, sizeof(char));
   char *description = (char *)calloc(maxLengthDesc * matData->nSignals, sizeof(char));
@@ -658,6 +685,24 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
                                                maxLengthDesc,
                                                mData->booleanVarsData[i].info.comment,
                                                &mData->booleanVarsData[i].dimension,
+                                               NULL);
+    }
+  }
+
+  /* String variables (#15969) */
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      name_head = printArrayName(name_head,
+                                 maxLengthName,
+                                 mData->stringVarsData[i].info.name,
+                                 &mData->stringVarsData[i].dimension,
+                                 FALSE);
+      description_head = printArrayDescription(description_head,
+                                               maxLengthDesc,
+                                               mData->stringVarsData[i].info.comment,
+                                               &mData->stringVarsData[i].dimension,
                                                NULL);
     }
   }
@@ -988,6 +1033,26 @@ void writeDataInfo(simulation_result *self,
         dataInfo[cur].interpolation = INTERPOLATION_LINEAR;
         dataInfo[cur].extrapolation = EXTRAPOLATION_CONSTANT;
         cur++;
+      }
+    }
+  }
+
+  /* String variables (#15969): stored in the separate stringData matrix. The
+   * index is a 1-based string signal index (the column base in stringData). */
+  {
+    int stringSignalIndex = 0;
+    for (int arrayIdx = 0; arrayIdx < modelData->nVariablesStringArray; arrayIdx++)
+    {
+      if (!modelData->stringVarsData[arrayIdx].filterOutput)
+      {
+        for (int i = 0; i < modelData->stringVarsData[arrayIdx].dimension.scalar_length; i++)
+        {
+          dataInfo[cur].channel = CHANNEL_STRING;
+          dataInfo[cur].index = ++stringSignalIndex;
+          dataInfo[cur].interpolation = INTERPOLATION_LINEAR;
+          dataInfo[cur].extrapolation = EXTRAPOLATION_CONSTANT;
+          cur++;
+        }
       }
     }
   }
@@ -1488,6 +1553,24 @@ void mat4_emit4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
+  /* #15969: buffer the current string values (written as the stringData matrix
+   * when the file is closed). */
+  if (matData->stringValues != NULL)
+  {
+    std::vector<std::string> *sv = (std::vector<std::string> *)matData->stringValues;
+    for (int arrayIdx = 0; arrayIdx < mData->nVariablesStringArray; arrayIdx++)
+    {
+      if (!mData->stringVarsData[arrayIdx].filterOutput)
+      {
+        for (int i = 0; i < mData->stringVarsData[arrayIdx].dimension.scalar_length; i++)
+        {
+          modelica_string s = data->localData[0]->stringVars[data->simulationInfo->stringVarsIndex[arrayIdx] + i];
+          sv->push_back(s ? std::string(MMC_STRINGDATA(s)) : std::string());
+        }
+      }
+    }
+  }
+
   fwrite(matData->data_2, sizeofMatVer4Type(matData->type), matData->nData2, matData->pFile);
   matData->nEmits++;
 
@@ -1526,6 +1609,37 @@ void mat4_free4(simulation_result *self, DATA *data, threadData_t *threadData)
   {
     updateHeader_matVer4(matData->pFile, matData->data2HdrPos, "data_2", matData->nData2, matData->nEmits, matData->type);
     matData->nEmits = 0;
+  }
+
+  /* #15969: write the stringData matrix holding all time-varying string values.
+   * It is a character matrix with maxLen rows and (nStringSignals * nEmits)
+   * columns; column (emit * nStringSignals + signal) holds one string. */
+  if (matData->stringValues != NULL)
+  {
+    std::vector<std::string> *sv = (std::vector<std::string> *)matData->stringValues;
+    size_t total = sv->size();
+    if (total > 0)
+    {
+      size_t maxLen = 1;
+      for (size_t k = 0; k < total; k++)
+      {
+        if ((*sv)[k].size() + 1 > maxLen) maxLen = (*sv)[k].size() + 1;
+      }
+      char *sbuf = (char *)calloc(maxLen * total, sizeof(char));
+      if (sbuf)
+      {
+        for (size_t c = 0; c < total; c++)
+        {
+          const std::string &s = (*sv)[c];
+          memcpy(sbuf + c * maxLen, s.data(), s.size());
+        }
+        fseek(matData->pFile, 0, SEEK_END);
+        writeMatrix_matVer4(matData->pFile, "stringData", maxLen, total, sbuf, MatVer4Type_CHAR);
+        free(sbuf);
+      }
+    }
+    delete sv;
+    matData->stringValues = NULL;
   }
 
   if (matData->data_2)

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -59,8 +59,8 @@ typedef struct mat_data
   size_t sync;        /* Number of emity until mat file header get's sinced. See falg `-mat_sync` */
   void *data_2;       /* Time variant data */
   MatVer4Type_t type; /* Level of precision for result storage */
-  size_t nStringSignals; /* #15969: number of (scalar) string signals */
-  void *stringValues;    /* #15969: std::vector<std::string>*, nStringSignals strings appended per emit */
+  size_t nStringSignals; /* number of (scalar) string signals */
+  void *stringValues;    /* std::vector<std::string>*, nStringSignals strings appended per emit */
 } mat_data;
 
 struct variableCount
@@ -75,7 +75,7 @@ enum channel_t : int32_t
   CHANNEL_TIME = 0,           /* Special case: Variable is time */
   CHANNEL_TIME_INVARIANT = 1, /* Variable stored in data_1 matrix */
   CHANNEL_TIME_VARIANT = 2,   /* Variable stored in data_2 matrix */
-  CHANNEL_STRING = 3          /* #15969: time-varying String; value is the 1-based string signal index into the stringData matrix */
+  CHANNEL_STRING = 3          /* time-varying String; value is the 1-based string signal index into the stringData matrix */
 };
 
 enum interpolation_t : int32_t
@@ -266,7 +266,7 @@ struct variableCount count_name_description_signals(const MODEL_DATA *mData,
     }
   }
 
-  /* String variables (#15969): time-varying strings are stored via a separate
+  /* String variables: time-varying strings are stored via a separate
    * stringData matrix; here we only reserve name/description/dataInfo slots. */
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
@@ -557,7 +557,7 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
   size_t maxLengthDesc = count.maxLengthDesc;
   matData->nSignals = count.nSignals;
 
-  /* #15969: count the scalar string signals that are actually written. */
+  /* count the scalar string signals that are actually written. */
   matData->nStringSignals = 0;
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
@@ -693,7 +693,7 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
-  /* String variables (#15969) */
+  /* String variables */
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
     if (!mData->stringVarsData[i].filterOutput)
@@ -1041,7 +1041,7 @@ void writeDataInfo(simulation_result *self,
     }
   }
 
-  /* String variables (#15969): stored in the separate stringData matrix. The
+  /* String variables: stored in the separate stringData matrix. The
    * index is a 1-based string signal index (the column base in stringData). */
   {
     int stringSignalIndex = 0;
@@ -1557,7 +1557,7 @@ void mat4_emit4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
-  /* #15969: buffer the current string values (written as the stringData matrix
+  /* buffer the current string values (written as the stringData matrix
    * when the file is closed). */
   if (matData->stringValues != NULL)
   {
@@ -1615,7 +1615,7 @@ void mat4_free4(simulation_result *self, DATA *data, threadData_t *threadData)
     matData->nEmits = 0;
   }
 
-  /* #15969: write the stringData matrix holding all time-varying string values.
+  /* write the stringData matrix holding all time-varying string values.
    * It is a character matrix with maxLen rows and (nStringSignals * nEmits)
    * columns; column (emit * nStringSignals + signal) holds one string. */
   if (matData->stringValues != NULL)

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -59,8 +59,8 @@ typedef struct mat_data
   size_t sync;        /* Number of emity until mat file header get's sinced. See falg `-mat_sync` */
   void *data_2;       /* Time variant data */
   MatVer4Type_t type; /* Level of precision for result storage */
-  size_t nStringSignals; /* #15969: number of (scalar) string signals */
-  void *stringValues;    /* #15969: std::vector<std::string>*, nStringSignals strings appended per emit */
+  size_t nStringSignals; /* number of (scalar) string signals */
+  void *stringValues;    /* std::vector<std::string>*, nStringSignals strings appended per emit */
 } mat_data;
 
 struct variableCount
@@ -75,7 +75,7 @@ enum channel_t : int32_t
   CHANNEL_TIME = 0,           /* Special case: Variable is time */
   CHANNEL_TIME_INVARIANT = 1, /* Variable stored in data_1 matrix */
   CHANNEL_TIME_VARIANT = 2,   /* Variable stored in data_2 matrix */
-  CHANNEL_STRING = 3          /* #15969: time-varying String; value is the 1-based string signal index into the stringData matrix */
+  CHANNEL_STRING = 3          /* time-varying String; value is the 1-based string signal index into the stringData matrix */
 };
 
 enum interpolation_t : int32_t
@@ -266,7 +266,7 @@ struct variableCount count_name_description_signals(const MODEL_DATA *mData,
     }
   }
 
-  /* String variables (#15969): time-varying strings are stored via a separate
+  /* String variables: time-varying strings are stored via a separate
    * stringData matrix; here we only reserve name/description/dataInfo slots. */
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
@@ -553,7 +553,7 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
   size_t maxLengthDesc = count.maxLengthDesc;
   matData->nSignals = count.nSignals;
 
-  /* #15969: count the scalar string signals that are actually written. */
+  /* count the scalar string signals that are actually written. */
   matData->nStringSignals = 0;
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
@@ -689,7 +689,7 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
-  /* String variables (#15969) */
+  /* String variables */
   for (int i = 0; i < mData->nVariablesStringArray; i++)
   {
     if (!mData->stringVarsData[i].filterOutput)
@@ -1037,7 +1037,7 @@ void writeDataInfo(simulation_result *self,
     }
   }
 
-  /* String variables (#15969): stored in the separate stringData matrix. The
+  /* String variables: stored in the separate stringData matrix. The
    * index is a 1-based string signal index (the column base in stringData). */
   {
     int stringSignalIndex = 0;
@@ -1553,7 +1553,7 @@ void mat4_emit4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
-  /* #15969: buffer the current string values (written as the stringData matrix
+  /* buffer the current string values (written as the stringData matrix
    * when the file is closed). */
   if (matData->stringValues != NULL)
   {
@@ -1611,7 +1611,7 @@ void mat4_free4(simulation_result *self, DATA *data, threadData_t *threadData)
     matData->nEmits = 0;
   }
 
-  /* #15969: write the stringData matrix holding all time-varying string values.
+  /* write the stringData matrix holding all time-varying string values.
    * It is a character matrix with maxLen rows and (nStringSignals * nEmits)
    * columns; column (emit * nStringSignals + signal) holds one string. */
   if (matData->stringValues != NULL)

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 #include <utility>
 
 extern "C"
@@ -58,6 +59,8 @@ typedef struct mat_data
   size_t sync;        /* Number of emity until mat file header get's sinced. See falg `-mat_sync` */
   void *data_2;       /* Time variant data */
   MatVer4Type_t type; /* Level of precision for result storage */
+  size_t nStringSignals; /* #15969: number of (scalar) string signals */
+  void *stringValues;    /* #15969: std::vector<std::string>*, nStringSignals strings appended per emit */
 } mat_data;
 
 struct variableCount
@@ -71,7 +74,8 @@ enum channel_t : int32_t
 {
   CHANNEL_TIME = 0,           /* Special case: Variable is time */
   CHANNEL_TIME_INVARIANT = 1, /* Variable stored in data_1 matrix */
-  CHANNEL_TIME_VARIANT = 2    /* Variable stored in data_2 matrix */
+  CHANNEL_TIME_VARIANT = 2,   /* Variable stored in data_2 matrix */
+  CHANNEL_STRING = 3          /* #15969: time-varying String; value is the 1-based string signal index into the stringData matrix */
 };
 
 enum interpolation_t : int32_t
@@ -259,6 +263,18 @@ struct variableCount count_name_description_signals(const MODEL_DATA *mData,
       count.maxLengthName = fmax(lengthName(mData->booleanVarsData[i].info.name, &mData->booleanVarsData[i].dimension), count.maxLengthName);
       count.maxLengthDesc = fmax(lengthDescription(mData->booleanVarsData[i].info.comment, NULL), count.maxLengthDesc);
       count.nSignals += mData->booleanVarsData[i].dimension.scalar_length;
+    }
+  }
+
+  /* String variables (#15969): time-varying strings are stored via a separate
+   * stringData matrix; here we only reserve name/description/dataInfo slots. */
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      count.maxLengthName = fmax(lengthName(mData->stringVarsData[i].info.name, &mData->stringVarsData[i].dimension), count.maxLengthName);
+      count.maxLengthDesc = fmax(lengthDescription(mData->stringVarsData[i].info.comment, NULL), count.maxLengthDesc);
+      count.nSignals += mData->stringVarsData[i].dimension.scalar_length;
     }
   }
 
@@ -541,6 +557,17 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
   size_t maxLengthDesc = count.maxLengthDesc;
   matData->nSignals = count.nSignals;
 
+  /* #15969: count the scalar string signals that are actually written. */
+  matData->nStringSignals = 0;
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      matData->nStringSignals += mData->stringVarsData[i].dimension.scalar_length;
+    }
+  }
+  matData->stringValues = matData->nStringSignals > 0 ? new std::vector<std::string>() : NULL;
+
   /* Copy all the var names and descriptions to "name" and "description". */
   char *name = (char *)calloc(maxLengthName * matData->nSignals, sizeof(char));
   char *description = (char *)calloc(maxLengthDesc * matData->nSignals, sizeof(char));
@@ -662,6 +689,24 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
                                                maxLengthDesc,
                                                mData->booleanVarsData[i].info.comment,
                                                &mData->booleanVarsData[i].dimension,
+                                               NULL);
+    }
+  }
+
+  /* String variables (#15969) */
+  for (int i = 0; i < mData->nVariablesStringArray; i++)
+  {
+    if (!mData->stringVarsData[i].filterOutput)
+    {
+      name_head = printArrayName(name_head,
+                                 maxLengthName,
+                                 mData->stringVarsData[i].info.name,
+                                 &mData->stringVarsData[i].dimension,
+                                 FALSE);
+      description_head = printArrayDescription(description_head,
+                                               maxLengthDesc,
+                                               mData->stringVarsData[i].info.comment,
+                                               &mData->stringVarsData[i].dimension,
                                                NULL);
     }
   }
@@ -992,6 +1037,26 @@ void writeDataInfo(simulation_result *self,
         dataInfo[cur].interpolation = INTERPOLATION_LINEAR;
         dataInfo[cur].extrapolation = EXTRAPOLATION_CONSTANT;
         cur++;
+      }
+    }
+  }
+
+  /* String variables (#15969): stored in the separate stringData matrix. The
+   * index is a 1-based string signal index (the column base in stringData). */
+  {
+    int stringSignalIndex = 0;
+    for (int arrayIdx = 0; arrayIdx < modelData->nVariablesStringArray; arrayIdx++)
+    {
+      if (!modelData->stringVarsData[arrayIdx].filterOutput)
+      {
+        for (int i = 0; i < modelData->stringVarsData[arrayIdx].dimension.scalar_length; i++)
+        {
+          dataInfo[cur].channel = CHANNEL_STRING;
+          dataInfo[cur].index = ++stringSignalIndex;
+          dataInfo[cur].interpolation = INTERPOLATION_LINEAR;
+          dataInfo[cur].extrapolation = EXTRAPOLATION_CONSTANT;
+          cur++;
+        }
       }
     }
   }
@@ -1492,6 +1557,24 @@ void mat4_emit4(simulation_result *self, DATA *data, threadData_t *threadData)
     }
   }
 
+  /* #15969: buffer the current string values (written as the stringData matrix
+   * when the file is closed). */
+  if (matData->stringValues != NULL)
+  {
+    std::vector<std::string> *sv = (std::vector<std::string> *)matData->stringValues;
+    for (int arrayIdx = 0; arrayIdx < mData->nVariablesStringArray; arrayIdx++)
+    {
+      if (!mData->stringVarsData[arrayIdx].filterOutput)
+      {
+        for (int i = 0; i < mData->stringVarsData[arrayIdx].dimension.scalar_length; i++)
+        {
+          modelica_string s = data->localData[0]->stringVars[data->simulationInfo->stringVarsIndex[arrayIdx] + i];
+          sv->push_back(s ? std::string(MMC_STRINGDATA(s)) : std::string());
+        }
+      }
+    }
+  }
+
   fwrite(matData->data_2, sizeofMatVer4Type(matData->type), matData->nData2, matData->pFile);
   matData->nEmits++;
 
@@ -1530,6 +1613,37 @@ void mat4_free4(simulation_result *self, DATA *data, threadData_t *threadData)
   {
     updateHeader_matVer4(matData->pFile, matData->data2HdrPos, "data_2", matData->nData2, matData->nEmits, matData->type);
     matData->nEmits = 0;
+  }
+
+  /* #15969: write the stringData matrix holding all time-varying string values.
+   * It is a character matrix with maxLen rows and (nStringSignals * nEmits)
+   * columns; column (emit * nStringSignals + signal) holds one string. */
+  if (matData->stringValues != NULL)
+  {
+    std::vector<std::string> *sv = (std::vector<std::string> *)matData->stringValues;
+    size_t total = sv->size();
+    if (total > 0)
+    {
+      size_t maxLen = 1;
+      for (size_t k = 0; k < total; k++)
+      {
+        if ((*sv)[k].size() + 1 > maxLen) maxLen = (*sv)[k].size() + 1;
+      }
+      char *sbuf = (char *)calloc(maxLen * total, sizeof(char));
+      if (sbuf)
+      {
+        for (size_t c = 0; c < total; c++)
+        {
+          const std::string &s = (*sv)[c];
+          memcpy(sbuf + c * maxLen, s.data(), s.size());
+        }
+        fseek(matData->pFile, 0, SEEK_END);
+        writeMatrix_matVer4(matData->pFile, "stringData", maxLen, total, sbuf, MatVer4Type_CHAR);
+        free(sbuf);
+      }
+    }
+    delete sv;
+    matData->stringValues = NULL;
   }
 
   if (matData->data_2)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/discrete_changes.c
@@ -159,14 +159,20 @@ modelica_boolean checkForDiscreteChanges(DATA *data, threadData_t *threadData)
         size_t scalarIdx = simulationInfo->stringVarsIndex[arrayIdx] + i;
         modelica_string v1 = simulationInfo->stringVarsPre[scalarIdx];
         modelica_string v2 = data->localData[0]->stringVars[scalarIdx];
-        if (0 != strcmp(MMC_STRINGDATA(v1), MMC_STRINGDATA(v2)))
+        /* A string variable may not have been assigned a value yet (e.g. an
+         * algebraic string evaluated only from its equation); treat an
+         * unassigned (NULL) string as the empty string instead of dereferencing
+         * it. */
+        const char *s1 = (0 != v1) ? MMC_STRINGDATA(v1) : "";
+        const char *s2 = (0 != v2) ? MMC_STRINGDATA(v2) : "";
+        if (0 != strcmp(s1, s2))
         {
           needToIterate = TRUE;
           if (OMC_ACTIVE_STREAM(OMC_LOG_EVENTS_V))
           {
             printMultiDimArrayIndex(&modelData->stringVarsData[arrayIdx].dimension, scalarIdx, index_buffer, buffer_size);
             infoStreamPrint(OMC_LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s",
-                            modelData->stringVarsData[arrayIdx].info.name, MMC_STRINGDATA(v1), MMC_STRINGDATA(v2));
+                            modelData->stringVarsData[arrayIdx].info.name, s1, s2);
           }
           else
           {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -638,7 +638,10 @@ void setAllVarsToStart(SIMULATION_DATA *simulationData, const SIMULATION_INFO *s
 #if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING > 0
   for (array_idx = 0; array_idx < modelData->nVariablesString; ++array_idx)
   {
-    simulationData->stringVars[array_idx] = mmc_mk_scon_persist(modelData->stringVarsData[array_idx].attribute.start);
+    /* A string variable without an explicit start attribute defaults to the
+     * empty string; guard against a NULL start to avoid dereferencing it. */
+    const char *stringStart = modelData->stringVarsData[array_idx].attribute.start;
+    simulationData->stringVars[array_idx] = mmc_mk_scon_persist(stringStart ? stringStart : "");
   }
 #endif
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -668,7 +668,10 @@ void setAllVarsToStart(SIMULATION_DATA *simulationData, const SIMULATION_INFO *s
 #if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING > 0
   for (array_idx = 0; array_idx < modelData->nVariablesString; ++array_idx)
   {
-    simulationData->stringVars[array_idx] = mmc_mk_scon_persist(modelData->stringVarsData[array_idx].attribute.start);
+    /* A string variable without an explicit start attribute defaults to the
+     * empty string; guard against a NULL start to avoid dereferencing it. */
+    const char *stringStart = modelData->stringVarsData[array_idx].attribute.start;
+    simulationData->stringVars[array_idx] = mmc_mk_scon_persist(stringStart ? stringStart : "");
   }
 #endif
 }

--- a/OMCompiler/SimulationRuntime/c/util/read_csv.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include "read_csv.h"
 #include "read_matlab4.h"
 #include "libcsv.h"
@@ -58,7 +59,37 @@ struct csv_body
   int cur_size;
   int row_length;
   int error;
+  /* String result support, only used when keepStrings is set. */
+  int keepStrings;
+  char **strres;     /* raw (un-escaped) text of every data cell */
+  char *isStringCol; /* per-column flag, set when a non-numeric cell is seen */
 };
+
+/* In-place transpose of a w*h matrix of pointers, same layout/semantics as
+   matrix_transpose (used to lay String cells out column-major like the data). */
+static void transpose_str(char **m, int w, int h)
+{
+  int start;
+  char *tmp;
+  if (!m) {
+    return;
+  }
+  for (start = 0; start <= w * h - 1; start++) {
+    int next = start;
+    int i = 0;
+    do {  i++;
+      next = (next % h) * w + next / h;
+    } while (next > start);
+    if (next < start || i == 1) continue;
+
+    tmp = m[next = start];
+    do {
+      i = (next % h) * w + next / h;
+      m[next] = (i == start) ? tmp : m[i];
+      next = i;
+    } while (next > start);
+  }
+}
 
 static void do_nothing(void *data, size_t len, void *t)
 {
@@ -160,6 +191,7 @@ static void add_cell(void *data, size_t len, void *t)
 {
   struct csv_body *body = (struct csv_body*) t;
   char *endptr = "";
+  int idx;
   if (body->error) {
     return;
   }
@@ -172,16 +204,36 @@ static void add_cell(void *data, size_t len, void *t)
     body->buffer_size = body->res ? 2*body->buffer_size : body->row_length*1024; /* Guess it's 1024 time points; we could also take the size of the file or something, but this is cool too */
     body->buffer_size = body->buffer_size > 0 ? body->buffer_size : 1024;
     body->res = body->res ? (double*)realloc(body->res, sizeof(double)*body->buffer_size) : (double*) malloc(sizeof(double)*body->buffer_size);
+    if (body->keepStrings) {
+      body->strres = body->strres ? (char**)realloc(body->strres, sizeof(char*)*body->buffer_size) : (char**) malloc(sizeof(char*)*body->buffer_size);
+    }
+  }
+  idx = body->size;
+  /* libcsv has already un-escaped the cell (doubled quotes collapsed, quotes and
+     embedded newlines removed), so store its content verbatim. */
+  if (body->keepStrings) {
+    body->strres[idx] = omc_strdup(data ? (char*) data : "");
   }
   if (data == NULL) {
-    body->res[body->size++] = 0.0;
+    body->res[idx] = 0.0;
+    body->size++;
     return;
   }
-  body->res[body->size++] = data ? om_strtod((const char*)data,&endptr) : 0;
+  body->res[idx] = om_strtod((const char*)data,&endptr);
   if (*endptr) {
-    fprintf(stderr,"Found non-double data in csv result-file: %s\n", (char*) data);
-    body->error = 1;
+    if (body->keepStrings) {
+      /* A non-numeric cell (e.g. a String value): remember that this column is a
+         String column and store NaN so numeric readers skip it. */
+      if (body->isStringCol && body->row_length > 0) {
+        body->isStringCol[idx % body->row_length] = 1;
+      }
+      body->res[idx] = NAN;
+    } else {
+      fprintf(stderr,"Found non-double data in csv result-file: %s\n", (char*) data);
+      body->error = 1;
+    }
   }
+  body->size++;
 }
 
 static void add_row(int c, void *t)
@@ -192,6 +244,11 @@ static void add_row(int c, void *t)
     fprintf(stderr,"Did not find time points for all variables for row: %d\n", body->found_first_row);
     body->error = 1;
     return;
+  }
+  /* The header row has just been counted, so row_length is now known: allocate
+     the per-column String flags before the first data row is parsed. */
+  if (body->keepStrings && body->found_first_row == 1 && !body->isStringCol && body->row_length > 0) {
+    body->isStringCol = (char*) calloc(body->row_length, sizeof(char));
   }
 }
 
@@ -239,7 +296,7 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   return body.res;
 }
 
-struct csv_data* read_csv(const char *filename)
+static struct csv_data* read_csv_internal(const char *filename, int keepStrings)
 {
   const int buf_size = 4096;
   char buf[4096];
@@ -251,6 +308,8 @@ struct csv_data* read_csv(const char *filename)
   size_t offset = 0;
   unsigned char delim = CSV_COMMA;
   size_t len;
+
+  body.keepStrings = keepStrings;
 
   FILE *fin = omc_fopen(filename, "r");
   if (!fin) {
@@ -300,10 +359,38 @@ struct csv_data* read_csv(const char *filename)
   res->variables = variables;
   res->data = body.res;
   res->numvars = body.row_length;
-  res->numsteps = body.size / body.row_length;
+  res->numsteps = body.row_length ? body.size / body.row_length : 0;
+  res->strdata = NULL;
+  res->isStringVar = NULL;
   matrix_transpose(res->data,res->numvars,res->numsteps);
+  if (keepStrings) {
+    /* Free the String storage of the numeric columns to keep memory low, then
+       lay out the String columns column-major like the data. */
+    if (body.strres && body.isStringCol && res->numvars > 0) {
+      int i;
+      for (i = 0; i < body.size; i++) {
+        if (!body.isStringCol[i % res->numvars]) {
+          free(body.strres[i]);
+          body.strres[i] = NULL;
+        }
+      }
+    }
+    transpose_str(body.strres, res->numvars, res->numsteps);
+    res->strdata = body.strres;
+    res->isStringVar = body.isStringCol;
+  }
   /* printf("num vars %d in %s num steps %d\n", body.row_length, filename, res->numsteps); */
   return res;
+}
+
+struct csv_data* read_csv(const char *filename)
+{
+  return read_csv_internal(filename, 0);
+}
+
+struct csv_data* read_csv_all(const char *filename)
+{
+  return read_csv_internal(filename, 1);
 }
 
 double* read_csv_dataset(struct csv_data *data, const char *var)
@@ -318,7 +405,25 @@ double* read_csv_dataset(struct csv_data *data, const char *var)
   if (found == -1) {
     return NULL;
   }
-  return data->data + i*data->numsteps;
+  return data->data + found*data->numsteps;
+}
+
+char** read_csv_dataset_str(struct csv_data *data, const char *var)
+{
+  int i,found=-1;
+  if (!data->strdata) {
+    return NULL;
+  }
+  for (i=0; i<data->numvars; i++) {
+    if (0==strcmp(data->variables[i],var)) {
+      found=i;
+      break;
+    }
+  }
+  if (found == -1 || (data->isStringVar && !data->isStringVar[found])) {
+    return NULL;
+  }
+  return data->strdata + found*data->numsteps;
 }
 
 void omc_free_csv_reader(struct csv_data *data)
@@ -329,7 +434,16 @@ void omc_free_csv_reader(struct csv_data *data)
   }
   free(data->variables);
   free(data->data);
+  if (data->strdata) {
+    for (i=0; i<data->numvars*data->numsteps; i++) {
+      free(data->strdata[i]);
+    }
+    free(data->strdata);
+  }
+  free(data->isStringVar);
   data->variables = 0;
   data->data = 0;
+  data->strdata = 0;
+  data->isStringVar = 0;
   free(data);
 }

--- a/OMCompiler/SimulationRuntime/c/util/read_csv.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.h
@@ -33,6 +33,13 @@ struct csv_data {
   double *data;
   int numvars;
   int numsteps;
+  /* String result support. strdata holds the (already un-escaped) raw text of
+     the cells of the String columns, laid out like data (numvars*numsteps,
+     column-major after read_csv_all); it is NULL for numeric-only columns and
+     for readers that did not request strings. isStringVar[i] is non-zero if
+     variable i is a String column. Both are only populated by read_csv_all. */
+  char **strdata;
+  char *isStringVar;
 };
 
 #ifdef __cplusplus
@@ -43,8 +50,17 @@ int read_csv_dataset_size(const char* filename);
 
 char** read_csv_variables(FILE *fin, int *length, unsigned char delim);
 
+/* Reads a CSV result file. Non-numeric cells are an error (used e.g. for
+   numeric external input files). */
 struct csv_data* read_csv(const char *filename);
+/* Like read_csv, but tolerates String columns: non-numeric cells are kept as
+   strings (see strdata / isStringVar) and stored as NaN in the numeric matrix,
+   so numeric variables stay readable even when the file has String columns. */
+struct csv_data* read_csv_all(const char *filename);
 double* read_csv_dataset(struct csv_data *data, const char *var);
+/* Returns the numsteps un-escaped String values of a String variable, or NULL
+   if the variable is not a String column. Only valid after read_csv_all. */
+char** read_csv_dataset_str(struct csv_data *data, const char *var);
 void omc_free_csv_reader(struct csv_data *data);
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -161,6 +161,10 @@ void omc_free_matlab4_reader(ModelicaMatReader *reader)
     free(reader->params);
     reader->params=NULL;
   }
+  if (reader->stringData) { /* #15969 */
+    free(reader->stringData);
+    reader->stringData=NULL;
+  }
   for(i=0; i<reader->nvar*2; i++) {
     if (reader->vars[i]) free(reader->vars[i]);
   }
@@ -419,6 +423,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
           }
           reader->allInfo[k].name[hdr.mrows] = '\0';
           reader->allInfo[k].isParam = -1;
+          reader->allInfo[k].isString = 0;
           reader->allInfo[k].index = -1;
           trimWhitespace(reader->allInfo[k].name);
           /* fprintf(stderr, "    Adding variable '%s'\n", reader->allInfo[k].name); */
@@ -437,6 +442,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
           }
           reader->allInfo[k].name[hdr.ncols] = '\0';
           reader->allInfo[k].isParam = -1;
+          reader->allInfo[k].isString = 0;
           reader->allInfo[k].index = -1;
           trimWhitespace(reader->allInfo[k].name);
           /* fprintf(stderr, "    Adding variable '%s'\n", reader->allInfo[k].name); */
@@ -484,14 +490,22 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
       if(binTrans==1) {
         for(k=0; k<hdr.ncols; k++) {
           reader->allInfo[k].isParam = tmp[k*hdr.mrows] == 1;
+          reader->allInfo[k].isString = tmp[k*hdr.mrows] == 3; /* #15969: CHANNEL_STRING */
           reader->allInfo[k].index = tmp[k*hdr.mrows+1];
+          if (reader->allInfo[k].isString && tmp[k*hdr.mrows+1] > (int32_t)reader->nStringSignals) {
+            reader->nStringSignals = tmp[k*hdr.mrows+1];
+          }
           /* fprintf(stderr, "    Variable %s isParam=%d index=%d\n", reader->allInfo[k].name, reader->allInfo[k].isParam, reader->allInfo[k].index); */
         }
       }
       if(binTrans==0) {
         for(k=0; k<hdr.mrows; k++) {
           reader->allInfo[k].isParam = tmp[k] == 1;
+          reader->allInfo[k].isString = tmp[k] == 3; /* #15969: CHANNEL_STRING */
           reader->allInfo[k].index =  tmp[k + hdr.mrows];
+          if (reader->allInfo[k].isString && tmp[k + hdr.mrows] > (int32_t)reader->nStringSignals) {
+            reader->nStringSignals = tmp[k + hdr.mrows];
+          }
           /* fprintf(stderr, "    Variable %s isParam=%d index=%d\n", reader->allInfo[k].name, reader->allInfo[k].isParam, reader->allInfo[k].index); */
         }
       }
@@ -590,6 +604,29 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
       return "Implementation error: Unknown case";
     }
   }
+
+  /* #15969: optionally read the stringData matrix, present when the model has
+   * time-varying String variables. The file is positioned right after data_2. */
+  if (reader->nStringSignals > 0) {
+    MHeader_t hdr;
+    if (1 == omc_fread(&hdr, sizeof(MHeader_t), 1, reader->file, 0)) {
+      char *name = (char*) malloc(hdr.namelen);
+      if (1 == omc_fread(name, hdr.namelen, 1, reader->file, 0)
+          && hdr.namelen > 0 && name[hdr.namelen-1] == '\0'
+          && 0 == strcmp(name, "stringData")) {
+        size_t total = (size_t)hdr.mrows * hdr.ncols;
+        reader->stringMaxLen = hdr.mrows;
+        reader->stringData = (char*) malloc(total ? total : 1);
+        if (total && read_chars(hdr.type, total, reader->file, reader->stringData)) {
+          free(name);
+          return "Corrupt header: stringData matrix";
+        }
+        reader->nStringRows = reader->nStringSignals ? (hdr.ncols / reader->nStringSignals) : 0;
+      }
+      free(name);
+    }
+  }
+
   return 0;
 }
 
@@ -1154,6 +1191,32 @@ int omc_matlab4_read_vars_val(double *res, ModelicaMatReader *reader, ModelicaMa
       }
     }
     return 0;
+}
+
+/* #15969: read the value of a time-varying String variable at a given time.
+   Strings are step-like display values, so we return the value at the row at or
+   just before the requested time. */
+const char* omc_matlab4_read_string_val(ModelicaMatReader *reader, ModelicaMatVariable_t *var, double time)
+{
+  int i1, i2;
+  double w1, w2;
+  size_t row, col;
+  if (!var || !var->isString || !reader->stringData || reader->nStringSignals == 0 || reader->nStringRows == 0) {
+    return NULL;
+  }
+  if (!omc_matlab4_read_vals(reader, 1)) {
+    return NULL;
+  }
+  find_closest_points(time, reader->vars[0], reader->nrows, &i1, &w1, &i2, &w2);
+  row = (i1 >= 0) ? (size_t)i1 : (i2 >= 0 ? (size_t)i2 : 0);
+  if (row >= reader->nStringRows) {
+    row = reader->nStringRows - 1;
+  }
+  if (var->index < 1 || (uint32_t)var->index > reader->nStringSignals) {
+    return NULL;
+  }
+  col = row * reader->nStringSignals + (var->index - 1);
+  return reader->stringData + (size_t)col * reader->stringMaxLen;
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -161,7 +161,7 @@ void omc_free_matlab4_reader(ModelicaMatReader *reader)
     free(reader->params);
     reader->params=NULL;
   }
-  if (reader->stringData) { /* #15969 */
+  if (reader->stringData) {
     free(reader->stringData);
     reader->stringData=NULL;
   }
@@ -490,7 +490,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
       if(binTrans==1) {
         for(k=0; k<hdr.ncols; k++) {
           reader->allInfo[k].isParam = tmp[k*hdr.mrows] == 1;
-          reader->allInfo[k].isString = tmp[k*hdr.mrows] == 3; /* #15969: CHANNEL_STRING */
+          reader->allInfo[k].isString = tmp[k*hdr.mrows] == 3; /* CHANNEL_STRING */
           reader->allInfo[k].index = tmp[k*hdr.mrows+1];
           if (reader->allInfo[k].isString && tmp[k*hdr.mrows+1] > (int32_t)reader->nStringSignals) {
             reader->nStringSignals = tmp[k*hdr.mrows+1];
@@ -501,7 +501,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
       if(binTrans==0) {
         for(k=0; k<hdr.mrows; k++) {
           reader->allInfo[k].isParam = tmp[k] == 1;
-          reader->allInfo[k].isString = tmp[k] == 3; /* #15969: CHANNEL_STRING */
+          reader->allInfo[k].isString = tmp[k] == 3; /* CHANNEL_STRING */
           reader->allInfo[k].index =  tmp[k + hdr.mrows];
           if (reader->allInfo[k].isString && tmp[k + hdr.mrows] > (int32_t)reader->nStringSignals) {
             reader->nStringSignals = tmp[k + hdr.mrows];
@@ -605,7 +605,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
     }
   }
 
-  /* #15969: optionally read the stringData matrix, present when the model has
+  /* optionally read the stringData matrix, present when the model has
    * time-varying String variables. The file is positioned right after data_2. */
   if (reader->nStringSignals > 0) {
     MHeader_t hdr;
@@ -1193,7 +1193,7 @@ int omc_matlab4_read_vars_val(double *res, ModelicaMatReader *reader, ModelicaMa
     return 0;
 }
 
-/* #15969: read the value of a time-varying String variable at a given time.
+/* read the value of a time-varying String variable at a given time.
    Strings are step-like display values, so we return the value at the row at or
    just before the requested time. */
 const char* omc_matlab4_read_string_val(ModelicaMatReader *reader, ModelicaMatVariable_t *var, double time)

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -766,7 +766,12 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex)
 {
   size_t absVarIndex = abs(varIndex);
   size_t ix = (varIndex < 0 ? absVarIndex + reader->nvar : absVarIndex) -1;
-  assert(absVarIndex > 0 && absVarIndex <= reader->nvar);
+  /* A String variable's index refers to the stringData matrix, not data_2, so it
+   * can be larger than nvar; guard against indexing the numeric data/vars arrays
+   * out of bounds (returning NULL rather than corrupting the heap). */
+  if (!(absVarIndex > 0 && absVarIndex <= reader->nvar)) {
+    return NULL;
+  }
   if (0 == reader->nrows) {
     return NULL;
   } else if(!reader->vars[ix]) {

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.h
@@ -48,6 +48,10 @@ typedef struct {
        *descr;
   /** Non-zero if this entry is a parameter (stored in data_1). */
   int isParam;
+  /** Non-zero if this entry is a time-varying String variable (#15969); its
+      value is stored in the stringData matrix, and `index` is the 1-based string
+      signal index. */
+  int isString;
   /** 1-based index into the appropriate data block; negative values indicate a
       negative alias (the file also contains negative alias columns). */
   int index;
@@ -87,6 +91,14 @@ typedef struct {
   double **vars;
   /** 1 if stored in double precision, 0 if stored as float */
   char doublePrecision;
+  /** #15969: string result support. stringData is a column-major char matrix of
+      stringMaxLen rows and (nStringSignals * nStringRows) columns; the string
+      for signal s (1-based) at time row r is stringData + (r*nStringSignals +
+      (s-1)) * stringMaxLen. */
+  char *stringData;
+  uint32_t stringMaxLen;
+  uint32_t nStringSignals;
+  uint32_t nStringRows;
 } ModelicaMatReader;
 
 
@@ -105,6 +117,11 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex);
 int omc_matlab4_val(double *res, ModelicaMatReader *reader, ModelicaMatVariable_t *var, double time);
 
 int omc_matlab4_read_vars_val(double *res, ModelicaMatReader *reader, ModelicaMatVariable_t **var, int N, double time);
+
+/* #15969: read the value of a time-varying String variable at a given time.
+   Returns a pointer into the reader's stringData (valid until the reader is
+   freed), or NULL if `var` is not a string variable / has no data. */
+const char* omc_matlab4_read_string_val(ModelicaMatReader *reader, ModelicaMatVariable_t *var, double time);
 
 void omc_matlab4_print_all_vars(FILE *stream, ModelicaMatReader *reader);
 

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.h
@@ -48,7 +48,7 @@ typedef struct {
        *descr;
   /** Non-zero if this entry is a parameter (stored in data_1). */
   int isParam;
-  /** Non-zero if this entry is a time-varying String variable (#15969); its
+  /** Non-zero if this entry is a time-varying String variable; its
       value is stored in the stringData matrix, and `index` is the 1-based string
       signal index. */
   int isString;
@@ -91,7 +91,7 @@ typedef struct {
   double **vars;
   /** 1 if stored in double precision, 0 if stored as float */
   char doublePrecision;
-  /** #15969: string result support. stringData is a column-major char matrix of
+  /** string result support. stringData is a column-major char matrix of
       stringMaxLen rows and (nStringSignals * nStringRows) columns; the string
       for signal s (1-based) at time row r is stringData + (r*nStringSignals +
       (s-1)) * stringMaxLen. */
@@ -118,7 +118,7 @@ int omc_matlab4_val(double *res, ModelicaMatReader *reader, ModelicaMatVariable_
 
 int omc_matlab4_read_vars_val(double *res, ModelicaMatReader *reader, ModelicaMatVariable_t **var, int N, double time);
 
-/* #15969: read the value of a time-varying String variable at a given time.
+/* read the value of a time-varying String variable at a given time.
    Returns a pointer into the reader's stringData (valid until the reader is
    freed), or NULL if `var` is not a string variable / has no data. */
 const char* omc_matlab4_read_string_val(ModelicaMatReader *reader, ModelicaMatVariable_t *var, double time);

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_mat_reader/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_mat_reader/src/lib.rs
@@ -29,6 +29,10 @@ pub struct MatVariable {
     pub name: String,
     pub descr: String,
     pub isParam: bool,
+    /// True for a time-varying String variable (`dataInfo` channel 3). Its value
+    /// is not numeric data: `index` is the 1-based string-signal number into the
+    /// `stringData` matrix, unrelated to data_1/data_2.
+    pub isString: bool,
     /// 1-based index into data_1 (params) or data_2 (vars); negative selects the
     /// sign-inverted alias of that column.
     pub index: i32,
@@ -54,6 +58,15 @@ pub struct MatReader {
     data2: Option<Vec<f64>>,
     startTime: Option<f64>,
     stopTime: Option<f64>,
+    /// `stringData`: a char matrix of `stringMaxLen` rows and
+    /// `nStringSignals * nStringRows` columns, column-major, so the text of
+    /// signal `s` (1-based) at row `r` starts at
+    /// `(r * nStringSignals + (s - 1)) * stringMaxLen`. Empty for a file
+    /// without String variables.
+    stringData: Vec<u8>,
+    stringMaxLen: usize,
+    nStringSignals: usize,
+    nStringRows: usize,
 }
 
 /// MATLAB v4 matrix header (5 little-endian u32 fields).
@@ -263,10 +276,16 @@ impl MatReader {
             data2: None,
             startTime: None,
             stopTime: None,
+            stringData: Vec::new(),
+            stringMaxLen: 0,
+            nStringSignals: 0,
+            nStringRows: 0,
         };
         // Parse sequentially using `file`; `reader.file` is the clone kept for
         // the lazy data_2 read.
         let mut binTrans = true;
+        // Where data_2 ends, i.e. where an optional `stringData` matrix starts.
+        let mut data2_end = 0u64;
 
         for i in 0..6 {
             let hdr = read_header(&mut file).map_err(|_| "Corrupt header (1)".to_string())?;
@@ -328,6 +347,7 @@ impl MatReader {
                             name: fixed_str(&bytes),
                             descr: String::new(),
                             isParam: false,
+                            isString: false,
                             index: -1,
                         });
                     }
@@ -361,7 +381,14 @@ impl MatReader {
                             (tmp[k], tmp[k + mrows])
                         };
                         reader.allInfo[k].isParam = isparam_cell == 1;
+                        // CHANNEL_STRING: the value lives in `stringData`, and the
+                        // index counts string signals, so the largest one is how
+                        // many there are.
+                        reader.allInfo[k].isString = isparam_cell == 3;
                         reader.allInfo[k].index = index_cell;
+                        if reader.allInfo[k].isString && index_cell > reader.nStringSignals as i32 {
+                            reader.nStringSignals = index_cell as usize;
+                        }
                     }
                     reader
                         .allInfo
@@ -412,12 +439,63 @@ impl MatReader {
                         reader.nvar = hdr.ncols as usize;
                     }
                     reader.var_offset = file.stream_position().map_err(|e| e.to_string())?;
-                    let _ = matrix_length; // data_2 is the final matrix; nothing follows.
+                    data2_end = reader.var_offset + matrix_length as u64;
                 }
                 _ => unreachable!(),
             }
         }
+        // stringData follows data_2 for a model with time-varying String
+        // variables (C appends it when the file is closed). Optional: a file
+        // whose dataInfo names no string signal has none.
+        if reader.nStringSignals > 0 {
+            reader.read_string_data(&mut file, data2_end)?;
+        }
         Ok(reader)
+    }
+
+    /// Read the `stringData` char matrix, positioned right after data_2. A file
+    /// that ends there (or carries a different matrix) simply has no string
+    /// values; only a truncated `stringData` is an error.
+    fn read_string_data(&mut self, file: &mut Src, at: u64) -> Result<(), String> {
+        if file.seek(SeekFrom::Start(at)).is_err() {
+            return Ok(());
+        }
+        let Ok(hdr) = read_header(file) else { return Ok(()) };
+        let namelen = hdr.namelen as usize;
+        let Ok(name_bytes) = read_exact_vec(file, namelen) else { return Ok(()) };
+        if namelen == 0 || name_bytes[namelen - 1] != 0 || &name_bytes[..namelen - 1] != b"stringData" {
+            return Ok(());
+        }
+        let total = hdr.mrows as usize * hdr.ncols as usize;
+        self.stringMaxLen = hdr.mrows as usize;
+        self.stringData = read_chars(hdr.ty as i32, total, file)
+            .map_err(|_| "Corrupt header: stringData matrix".to_string())?;
+        self.nStringRows = hdr.ncols as usize / self.nStringSignals;
+        Ok(())
+    }
+
+    /// The text of the String variable `varIdx` at `time`, or `None` if it is not
+    /// a String variable / the file carries no values for it. A String is a
+    /// step-like display value, so the row at or just before `time` is returned
+    /// rather than an interpolation.
+    pub fn read_string_val(&mut self, varIdx: usize, time: f64) -> Option<&str> {
+        let info = self.allInfo.get(varIdx)?;
+        let index = info.index;
+        if !info.isString || self.stringData.is_empty() || self.nStringRows == 0 {
+            return None;
+        }
+        if index < 1 || index as usize > self.nStringSignals {
+            return None;
+        }
+        let timevec = self.read_vals(1)?;
+        let (i1, _, i2, _) = find_closest_points(time, &timevec);
+        let row = if i1 >= 0 { i1 as usize } else if i2 >= 0 { i2 as usize } else { 0 };
+        let row = row.min(self.nStringRows - 1);
+        let col = row * self.nStringSignals + (index as usize - 1);
+        let at = col * self.stringMaxLen;
+        let cell = self.stringData.get(at..at + self.stringMaxLen)?;
+        let end = cell.iter().position(|&b| b == 0).unwrap_or(cell.len());
+        core::str::from_utf8(&cell[..end]).ok()
     }
 
     /// Bytes one element of data_2 occupies on disk.

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_mat_writer/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_mat_writer/src/lib.rs
@@ -44,6 +44,11 @@ pub enum MatKind {
     Param { negate: Neg },
     /// A compile-time constant written directly to `data_1`.
     Const { value: f64 },
+    /// A time-varying String signal. Its values are not numeric data: they go to
+    /// the `stringData` char matrix, and `dataInfo` points at them with channel 3
+    /// and the 1-based string-signal index. The values come from the `strings`
+    /// slice, in `String`-signal order, one group per output row.
+    String,
 }
 
 /// The precision of the real-valued result data (`data_1`/`data_2`). Mirrors C's
@@ -87,6 +92,7 @@ pub fn write_mat4(
     rows: &[f64],
     n_reals: u32,
     params: &[f64],
+    strings: &[&str],
     precision: Precision,
 ) -> Vec<u8> {
     let n_reals = n_reals as usize;
@@ -171,6 +177,7 @@ pub fn write_mat4(
     // dataInfo (4 x nSignals int32, column-major): [channel, index, interp, extrap].
     let mut data_info: Vec<i32> = Vec::with_capacity(signals.len() * 4);
     let mut next_scalar_row: i32 = 2;
+    let mut next_string_signal: i32 = 0;
     for v in signals {
         let info = match &v.kind {
             MatKind::Time => [0, 1, 0, -1],
@@ -198,6 +205,12 @@ pub fn write_mat4(
                 let r = next_scalar_row;
                 next_scalar_row += 1;
                 [1, r, 0, 0]
+            }
+            // Channel 3 is not a data_1/data_2 row: the index is the 1-based
+            // string-signal number, i.e. the column base in `stringData`.
+            MatKind::String => {
+                next_string_signal += 1;
+                [3, next_string_signal, 0, 0]
             }
         };
         data_info.extend_from_slice(&info);
@@ -247,6 +260,13 @@ pub fn write_mat4(
         }
     }
     write_real_matrix(&mut out, "data_2", n_reals2, n_rows, &data_2, precision);
+
+    // stringData (maxLen x (nStringSignals * n_rows) char, column-major): one
+    // column per (row, string signal), so the value of signal `s` (1-based) at
+    // output row `r` is column `r * nStringSignals + (s - 1)`.
+    if next_string_signal > 0 && !strings.is_empty() {
+        write_char_matrix_cols(&mut out, "stringData", strings);
+    }
 
     out
 }
@@ -354,6 +374,41 @@ mod tests {
         payload.chunks_exact(4).map(|c| i32::from_le_bytes(c.try_into().unwrap())).collect()
     }
 
+    /// A time-varying String signal: `dataInfo` channel 3 with the 1-based
+    /// string-signal number, and one `stringData` column per (row, signal).
+    #[test]
+    fn writes_string_signals() {
+        let vars = [
+            MatVar { name: "time", comment: "Time in s", kind: MatKind::Time },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+            MatVar { name: "s", comment: "", kind: MatKind::String },
+            MatVar { name: "t", comment: "", kind: MatKind::String },
+        ];
+        let rows = [0.0, 0.0, /*r1*/ 0.5, 1.0, /*r2*/ 1.0, 2.0];
+        // Row-major (row, signal): 3 rows x 2 string signals.
+        let strings = ["a", "bb", "c", "dd", "e", "ff"];
+        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &[], &strings, Precision::Double);
+
+        let (_r, _c, di) = find_matrix(&buf, "dataInfo");
+        let di = i32s(di);
+        assert_eq!(&di[8..12], &[3, 1, 0, 0]); // s: string signal 1
+        assert_eq!(&di[12..16], &[3, 2, 0, 0]); // t: string signal 2
+
+        // stringData: maxLen ("bb"/"dd"/"ff" -> 3) rows, 3*2 columns.
+        let (mrows, ncols, sd) = find_matrix(&buf, "stringData");
+        assert_eq!((mrows, ncols), (3, 6));
+        let cell = |c: usize| {
+            let col = &sd[c * mrows..(c + 1) * mrows];
+            let end = col.iter().position(|&b| b == 0).unwrap_or(col.len());
+            core::str::from_utf8(&col[..end]).unwrap().to_string()
+        };
+        // Column (row * nStringSignals + (signal - 1)).
+        assert_eq!(cell(0), "a");
+        assert_eq!(cell(1), "bb");
+        assert_eq!(cell(4), "e");
+        assert_eq!(cell(5), "ff");
+    }
+
     /// time + one varying real state + one parameter + one constant, 3 rows.
     /// Row layout `n_reals = 2`: column 0 = time, column 1 = the state `x`.
     #[test]
@@ -367,7 +422,7 @@ mod tests {
         // 3 communication points; x ramps 0,1,2.
         let rows = [0.0, 0.0, /*r1*/ 0.5, 1.0, /*r2*/ 1.0, 2.0];
         let params = [7.0]; // p = 7
-        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &params, Precision::Double);
+        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &params, &[], Precision::Double);
 
         // name matrix: 4 columns, one per signal, column-major null-padded.
         let (mrows, ncols, name_payload) = find_matrix(&buf, "name");
@@ -412,7 +467,7 @@ mod tests {
         ];
         // n_reals = 3: [time, x, b]; b toggles, so its column stays time-variant.
         let rows = [0.0, 1.0, 0.0, /*r1*/ 0.5, 2.0, 1.0];
-        let buf = write_mat4(&vars, 0.0, 0.5, &rows, 3, &[1.0], Precision::Double);
+        let buf = write_mat4(&vars, 0.0, 0.5, &rows, 3, &[1.0], &[], Precision::Double);
 
         let (_r, _c, di) = find_matrix(&buf, "dataInfo");
         let di = i32s(di);
@@ -461,7 +516,7 @@ mod tests {
         ];
         // 2 rows; x is 0.5 and 1.5 (exact in f32), p = 7 (exact in f32).
         let rows = [0.0, 0.5, 1.0, 1.5];
-        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &[7.0], Precision::Single);
+        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &[7.0], &[], Precision::Single);
 
         assert_eq!(matrix_type(&buf, "data_1"), 10);
         assert_eq!(matrix_type(&buf, "data_2"), 10);
@@ -483,7 +538,7 @@ mod tests {
         ];
         // 1/3 is not exact in f32; the stored value must equal the f32 rounding.
         let rows = [0.0, 1.0 / 3.0];
-        let buf = write_mat4(&vars, 0.0, 0.0, &rows, 2, &[], Precision::Single);
+        let buf = write_mat4(&vars, 0.0, 0.0, &rows, 2, &[], &[], Precision::Single);
         let (_r, _c, d2) = find_matrix(&buf, "data_2");
         let d2 = f32s(d2);
         assert_eq!(d2[1], (1.0 / 3.0) as f32);
@@ -498,8 +553,8 @@ mod tests {
             MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
         ];
         let rows = [0.0, 0.0, 1.0, 0.5, 2.0, 1.5];
-        let single = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], Precision::Single);
-        let double = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], Precision::Double);
+        let single = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], &[], Precision::Single);
+        let double = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], &[], Precision::Double);
         assert!(single.len() < double.len());
     }
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -1006,6 +1006,9 @@ pub struct RunResult {
     pub n_reals: u32,
     /// Parameter values (in result `Param` order), read from `SimData` after the run.
     pub params: Vec<f64>,
+    /// Captured String values, row-major `n_rows * SimLayout::n_str_alg()`, in
+    /// lockstep with `rows`. Empty for a model with no String result signal.
+    pub strings: Vec<String>,
     /// Solver statistics (steps, evaluations, events).
     pub stats: SolveStats,
     /// `-l`'s linearized model, for the caller to write out.
@@ -2781,6 +2784,99 @@ impl HomotopyPath {
     }
 }
 
+/// The String values captured beside the numeric rows. A String is an i32
+/// runtime-String handle in `SimData`, not a number, so it cannot ride in the
+/// f64 row buffer; C has the same split (`stringVars` are read straight out of
+/// `localData` by the result writer). Every driver funnels through
+/// [`capture_row`], so one buffer here stays in lockstep with `rows` without
+/// threading a second `Vec` through each of them.
+pub mod strings {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    #[cfg(feature = "std")]
+    mod state {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::RefCell;
+        std::thread_local! {
+            static BUF: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+            static WIDTH: RefCell<u32> = const { RefCell::new(0) };
+        }
+        pub fn with<R>(f: impl FnOnce(&mut Vec<String>, &mut u32) -> R) -> R {
+            BUF.with(|b| WIDTH.with(|w| f(&mut b.borrow_mut(), &mut w.borrow_mut())))
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    mod state {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::UnsafeCell;
+        // The in-wasm runtime is single-threaded, so a plain cell is sound.
+        struct Store(UnsafeCell<(Vec<String>, u32)>);
+        unsafe impl Sync for Store {}
+        static BUF: Store = Store(UnsafeCell::new((Vec::new(), 0)));
+        pub fn with<R>(f: impl FnOnce(&mut Vec<String>, &mut u32) -> R) -> R {
+            let s = unsafe { &mut *BUF.0.get() };
+            f(&mut s.0, &mut s.1)
+        }
+    }
+
+    /// Arm the capture for a run whose result file lists String signals; `width`
+    /// is `SimLayout::n_str_alg()`. `width == 0` disarms it.
+    pub fn begin(width: u32) {
+        state::with(|buf, w| {
+            buf.clear();
+            *w = width;
+        });
+    }
+
+    /// Whether a row capture should read the String slots.
+    pub fn armed() -> bool {
+        state::with(|_, w| *w != 0)
+    }
+
+    pub(crate) fn push(values: impl Iterator<Item = String>) {
+        state::with(|buf, _| buf.extend(values));
+    }
+
+    /// Drop the values captured past `rows_mark` numeric elements, so a retried
+    /// step that rewinds `rows` rewinds the String capture with it.
+    pub fn truncate(rows_mark: usize, n_reals: u32) {
+        state::with(|buf, w| {
+            if *w == 0 || n_reals == 0 {
+                return;
+            }
+            buf.truncate(rows_mark / n_reals as usize * *w as usize);
+        });
+    }
+
+    /// Take the captured values (row-major `n_rows * width`) and disarm.
+    pub fn take() -> Vec<String> {
+        state::with(|buf, w| {
+            *w = 0;
+            core::mem::take(buf)
+        })
+    }
+}
+
+/// Decode the blob a wasm-side run exports its captured String values as: per
+/// value a little-endian `u32` byte length followed by its UTF-8 bytes, in the
+/// driver's row-major order. A truncated tail is dropped rather than guessed at.
+pub fn decode_string_blob(blob: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut p = 0usize;
+    while p + 4 <= blob.len() {
+        let n = u32::from_le_bytes([blob[p], blob[p + 1], blob[p + 2], blob[p + 3]]) as usize;
+        p += 4;
+        let Some(bytes) = blob.get(p..p + n) else { break };
+        out.push(String::from_utf8_lossy(bytes).into_owned());
+        p += n;
+    }
+    out
+}
+
 /// Append one trajectory row to `rows`: the real part `[time | realVars]`
 /// followed by the integer and boolean algebraic slots (converted to f64),
 /// matching `SimLayout::n_row_total()` and the column layout `kind_from_slot`
@@ -2790,8 +2886,21 @@ pub fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout
     // C's `emit` — the result writer's share of the run (`SIM_TIMER_OUTPUT`).
     rtclock::tick(rtclock::OUTPUT);
     let out = capture_row_values(e, rows, sim_data, layout);
+    if out.is_ok() && strings::armed() {
+        capture_row_strings(e, sim_data, layout);
+    }
     rtclock::accumulate(rtclock::OUTPUT);
     out
+}
+
+/// The String text behind every string-algebraic slot, one group per output row.
+/// An unassigned handle reads as the empty string, as C's writer does for a NULL
+/// `stringVars` entry.
+fn capture_row_strings(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) {
+    strings::push(
+        (0..layout.n_str_alg())
+            .map(|i| e.string_at(sim_data + layout.str_off + i * 4).unwrap_or_default()),
+    );
 }
 
 fn capture_row_values(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout) -> Result<()> {
@@ -3128,6 +3237,9 @@ fn write_output_vars(
                     }
                 },
                 ResultKind::Const { value } => out.push_str(&format!(",{name}={}", format_g(*value, 20))),
+                // Printed by the `soti.strings` walk below, which reads the live
+                // handle rather than the captured row.
+                ResultKind::StringColumn { .. } => {}
             }
         }
         // Strings own no result column; C reads them from `stringVars`/`stringParameter`.
@@ -4556,6 +4668,10 @@ pub fn drive(
     // `+profiling` is C's other `measure_time_flag` source.
     rtclock::reset(omclog::active(omclog::STATS) || omclog::active(omclog::STATS_V) || model.prof.is_some());
     rtclock::tick(rtclock::TOTAL);
+    // Arm the String capture only for a model whose result file lists a String
+    // signal, so a run without one costs nothing.
+    let has_strings = model.vars.iter().any(|v| matches!(v.kind, crate::MetaKind::StringColumn { .. }));
+    strings::begin(if has_strings { layout.n_str_alg() } else { 0 });
     let lv_time = crate::simflags::with_flags(|f| f.lv_time);
     if let Some((t0, t1)) = lv_time {
         omclog::info(
@@ -4635,6 +4751,10 @@ pub fn drive(
             && !csv_input_given()
             && model.prof.is_none()
             && model.parmod.is_none()
+            // The in-wasm loop returns only the numeric buffer, so a model with a
+            // String result signal keeps the row-emitting host driver, which reads
+            // the String slots as it goes.
+            && !has_strings
         {
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
@@ -4751,7 +4871,7 @@ pub fn drive(
     crate::profiling::end_of_run(e);
     (stats.timers, stats.tcalls) = rtclock::snapshot();
     stats.systems = e.sys_stats();
-    Ok((RunResult { rows, n_reals, params, stats, lin }, label))
+    Ok((RunResult { rows, n_reals, params, stats, lin, strings: strings::take() }, label))
 }
 
 /// In-wasm driver: initialize here (so the run initializes like every other
@@ -4902,6 +5022,7 @@ impl Driver for EulerDriver {
             return Ok(false);
         };
         self.rows.truncate(self.retry.rows_mark);
+        strings::truncate(self.retry.rows_mark, model.layout.n_row_total());
         let n_steps = model.n_output_rows() - 1;
         let target = if self.row >= n_steps {
             model.stop_time
@@ -6358,6 +6479,7 @@ impl Driver for DasslDriver {
             return Ok(false);
         };
         self.rows.truncate(self.retry.rows_mark);
+        strings::truncate(self.retry.rows_mark, model.layout.n_row_total());
         // C halves `currentStepSize` without advancing `__currStepNo`: the same output
         // step is retaken over half the interval and the next one catches up.
         let n_steps = model.n_output_rows() - 1;
@@ -8913,6 +9035,7 @@ impl Driver for EventsDriver {
             return Ok(false);
         };
         self.rows.truncate(self.retry.rows_mark);
+        strings::truncate(self.retry.rows_mark, model.layout.n_row_total());
         let n_steps = model.n_output_rows() - 1;
         let target = self.pending_tout.unwrap_or(if self.row >= n_steps {
             model.stop_time
@@ -9301,6 +9424,7 @@ impl Driver for CvodeDriver {
             return Ok(false);
         };
         self.rows.truncate(self.retry.rows_mark);
+        strings::truncate(self.retry.rows_mark, model.layout.n_row_total());
         let n_steps = model.n_output_rows() - 1;
         let target = self.pending_tout.unwrap_or(if self.row >= n_steps {
             model.stop_time
@@ -10264,6 +10388,7 @@ impl Driver for IdaDriver {
             return Ok(false);
         };
         self.rows.truncate(self.retry.rows_mark);
+        strings::truncate(self.retry.rows_mark, model.layout.n_row_total());
         let n_steps = model.n_output_rows() - 1;
         let target = self.pending_tout.unwrap_or(if self.row >= n_steps {
             model.stop_time

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
@@ -489,6 +489,12 @@ impl Layout {
     pub fn n_bool_alg(&self) -> u32 {
         (self.bparam_off - self.bool_off) / 4
     }
+    /// String algebraic variables (between `str_off` and `sparam_off`). They are
+    /// i32 runtime-String handles, not part of the numeric row; the result
+    /// writers capture their text separately ([`MetaKind::StringColumn`]).
+    pub fn n_str_alg(&self) -> u32 {
+        (self.sparam_off - self.str_off) / 4
+    }
     /// Total f64 columns in a result row: the real part, the integer and boolean
     /// algebraics (captured per row as f64), then the sensitivities.
     pub fn n_row_total(&self) -> u32 {
@@ -566,6 +572,11 @@ pub enum MetaKind {
     Param { off: u32, wty: WTy, negate: Neg },
     /// A compile-time constant.
     Const { value: f64 },
+    /// A time-variant String signal, `idx` being its index among the model's
+    /// string algebraic slots (`Layout::str_off + idx * 4`). Its text is captured
+    /// per output row beside the numeric row; C stores the same values in the
+    /// `.mat` `stringData` matrix and as a quoted CSV column.
+    StringColumn { idx: u32 },
 }
 
 impl MetaKind {
@@ -582,6 +593,7 @@ impl MetaKind {
             MetaKind::Column { col, negate } => MatKind::Column { col: *col, negate: neg(negate) },
             MetaKind::Param { negate, .. } => MatKind::Param { negate: neg(negate) },
             MetaKind::Const { value } => MatKind::Const { value: *value },
+            MetaKind::StringColumn { .. } => MatKind::String,
         }
     }
 
@@ -598,6 +610,9 @@ impl MetaKind {
             MetaKind::Column { col, negate } => PltKind::Column { col: *col, negate: neg(negate) },
             MetaKind::Param { negate, .. } => PltKind::Param { negate: neg(negate) },
             MetaKind::Const { value } => PltKind::Const { value: *value },
+            // C's `simulation_result_plt` writes no String signals; `result::plt`
+            // drops them before it gets here.
+            MetaKind::StringColumn { .. } => PltKind::Const { value: 0.0 },
         }
     }
 }
@@ -1548,6 +1563,10 @@ fn put_kind(o: &mut Vec<u8>, k: &MetaKind) {
             o.push(3);
             put_f64(o, *value);
         }
+        MetaKind::StringColumn { idx } => {
+            o.push(4);
+            put_u32(o, *idx);
+        }
     }
 }
 
@@ -2027,6 +2046,7 @@ impl<'a> Reader<'a> {
                 negate: Neg::from_code(self.u8()?),
             },
             3 => MetaKind::Const { value: self.f64()? },
+            4 => MetaKind::StringColumn { idx: self.u32()? },
             _ => return Err("sim_meta: bad MetaKind tag"),
         })
     }
@@ -2407,6 +2427,7 @@ mod tests {
                 MetaVar { name: "p".to_string(), comment: "a param".to_string(), kind: MetaKind::Param { off: 88, wty: WTy::F64, negate: Neg::Arith }, filter: 0 },
                 MetaVar { name: "n".to_string(), comment: "".to_string(), kind: MetaKind::Param { off: 92, wty: WTy::I32, negate: Neg::None }, filter: var_filter::HIDE_RESULT },
                 MetaVar { name: "k".to_string(), comment: "".to_string(), kind: MetaKind::Const { value: 9.5 }, filter: var_filter::FILTERED },
+                MetaVar { name: "s".to_string(), comment: "a string".to_string(), kind: MetaKind::StringColumn { idx: 2 }, filter: 0 },
             ],
             jac_a: Some(JacAInfo {
                 n: 2,
@@ -2585,11 +2606,11 @@ mod tests {
             m.vars.iter().zip(keep).filter(|(_, k)| *k).map(|(v, _)| v.name.as_str()).collect()
         };
         simflags::set_flags(simflags::SimFlags::default());
-        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p"]);
+        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p", "s"]);
 
         let mut f = simflags::SimFlags { ignore_hide_result: true, ..Default::default() };
         simflags::set_flags(f.clone());
-        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p", "n"]);
+        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p", "n", "s"]);
 
         // A `-variableFilter` replaces the model's verdict, so `k` is reachable;
         // `time` is never filtered and the parameter `p` is exempt.

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/result.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/result.rs
@@ -19,7 +19,9 @@ pub fn known(format: &str) -> bool {
 
 /// The file for `format`, or `None` for `empty`. `rows` is row-major
 /// `n_rows * n_reals`, `params` positional over the unfiltered `Param` signals,
-/// `keep` one flag per signal ([`SimMeta::output_keep`]).
+/// `keep` one flag per signal ([`SimMeta::output_keep`]). `strings` is the
+/// captured String text, row-major `n_rows * Layout::n_str_alg()` — the writers
+/// pick out the kept [`MetaKind::StringColumn`] signals themselves.
 pub fn write(
     meta: &SimMeta,
     format: &str,
@@ -27,14 +29,49 @@ pub fn write(
     n_reals: u32,
     params: &[f64],
     keep: &[bool],
+    strings: &[String],
     precision: Precision,
 ) -> Option<Vec<u8>> {
     match format {
-        "mat" => Some(mat(meta, rows, n_reals, params, keep, precision)),
-        "csv" => Some(csv(meta, rows, n_reals, keep).into_bytes()),
+        "mat" => Some(mat(meta, rows, n_reals, params, keep, strings, precision)),
+        "csv" => Some(csv(meta, rows, n_reals, keep, strings).into_bytes()),
         "plt" => Some(plt(meta, rows, n_reals, params, keep)),
         _ => None,
     }
+}
+
+/// The string-algebraic slot indices of the kept `StringColumn` signals, in
+/// signal order — the order the `.mat`'s string-signal numbering and the CSV's
+/// String columns follow.
+fn string_signals(meta: &SimMeta, keep: &[bool]) -> Vec<u32> {
+    meta.vars
+        .iter()
+        .zip(keep)
+        .filter_map(|(v, &k)| match v.kind {
+            MetaKind::StringColumn { idx } if k => Some(idx),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The `.mat` `stringData` columns: one per (output row, kept String signal), in
+/// that order — C appends the same group after every emit. Empty for a run with
+/// no String signal.
+pub fn string_columns<'a>(
+    meta: &SimMeta,
+    keep: &[bool],
+    strings: &'a [String],
+    n_rows: usize,
+) -> Vec<&'a str> {
+    let signals = string_signals(meta, keep);
+    let n_str = meta.layout.n_str_alg() as usize;
+    let mut out = Vec::with_capacity(n_rows * signals.len());
+    for r in 0..n_rows {
+        for &idx in &signals {
+            out.push(cell(strings, r, n_str, idx));
+        }
+    }
+    out
 }
 
 /// The kept parameters' values, in signal order, for a writer that lists them.
@@ -58,6 +95,7 @@ pub fn mat(
     n_reals: u32,
     params: &[f64],
     keep: &[bool],
+    strings: &[String],
     precision: Precision,
 ) -> Vec<u8> {
     let kept = kept_params(meta, params, |i, _| keep[i]);
@@ -68,12 +106,37 @@ pub fn mat(
         .filter(|(_, k)| **k)
         .map(|(v, _)| MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() })
         .collect();
-    openmodelica_mat_writer::write_mat4(&vars, meta.start_time, meta.stop_time, rows, n_reals, &kept, precision)
+    let n_rows = if n_reals == 0 { 0 } else { rows.len() / n_reals as usize };
+    let str_cols = string_columns(meta, keep, strings, n_rows);
+    openmodelica_mat_writer::write_mat4(
+        &vars,
+        meta.start_time,
+        meta.stop_time,
+        rows,
+        n_reals,
+        &kept,
+        &str_cols,
+        precision,
+    )
+}
+
+/// The captured text of string slot `idx` at output row `r`, or `""` when the
+/// run recorded nothing for it (C emits an unassigned String as the empty one).
+fn cell(strings: &[String], r: usize, n_str: usize, idx: u32) -> &str {
+    if n_str == 0 {
+        return "";
+    }
+    strings.get(r * n_str + idx as usize).map(String::as_str).unwrap_or("")
 }
 
 /// C's `simulation_result_plt`, which omits integer and boolean parameters.
 pub fn plt(meta: &SimMeta, rows: &[f64], n_reals: u32, params: &[f64], keep: &[bool]) -> Vec<u8> {
-    let emit = |i: usize, k: &MetaKind| keep[i] && !matches!(k, MetaKind::Param { wty: WTy::I32, .. });
+    // C's plt writer has no String channel, so a String signal is not a column.
+    let emit = |i: usize, k: &MetaKind| {
+        keep[i]
+            && !matches!(k, MetaKind::Param { wty: WTy::I32, .. })
+            && !matches!(k, MetaKind::StringColumn { .. })
+    };
     let kept = kept_params(meta, params, emit);
     let signals: Vec<PltVar> = meta
         .vars
@@ -86,41 +149,76 @@ pub fn plt(meta: &SimMeta, rows: &[f64], n_reals: u32, params: &[f64], keep: &[b
 }
 
 /// C's `simulation_result_csv`: a quoted-name header, then one line per row with
-/// `%.16g` reals and `%i` integers/booleans. Time-invariant signals are not
-/// columns.
-pub fn csv(meta: &SimMeta, rows: &[f64], n_reals: u32, keep: &[bool]) -> String {
+/// `%.16g` reals, `%i` integers/booleans and quoted, escaped String values.
+/// Time-invariant signals are not columns.
+pub fn csv(meta: &SimMeta, rows: &[f64], n_reals: u32, keep: &[bool], strings: &[String]) -> String {
     let layout = &meta.layout;
     let int_col0 = layout.n_reals_row();
     let sens_col0 = layout.sens_col0();
-    let cols: Vec<(&str, u32, crate::Neg, bool)> = meta
+    let n_str = layout.n_str_alg() as usize;
+    /// A CSV column: a numeric one reading the row buffer, or a String one
+    /// reading the captured text of a string slot.
+    enum Col<'a> {
+        Num { name: &'a str, col: u32, negate: crate::Neg, is_int: bool },
+        Str { name: &'a str, idx: u32 },
+    }
+    let cols: Vec<Col> = meta
         .vars
         .iter()
         .zip(keep)
-        .filter_map(|(v, &k)| match v.kind {
-            MetaKind::Column { col, negate } if k => {
-                Some((v.name.as_str(), col, negate, col >= int_col0 && col < sens_col0))
+        .filter_map(|(v, &k)| {
+            if !k {
+                return None;
             }
-            _ => None,
+            match v.kind {
+                MetaKind::Column { col, negate } => Some(Col::Num {
+                    name: v.name.as_str(),
+                    col,
+                    negate,
+                    is_int: col >= int_col0 && col < sens_col0,
+                }),
+                MetaKind::StringColumn { idx } => Some(Col::Str { name: v.name.as_str(), idx }),
+                _ => None,
+            }
         })
         .collect();
     let mut out = String::from("\"time\"");
-    for (name, ..) in &cols {
-        out.push_str(&format!(",\"{}\"", name.replace('"', "\"\"")));
+    for c in &cols {
+        let name = match c {
+            Col::Num { name, .. } | Col::Str { name, .. } => name,
+        };
+        out.push_str(&format!(",\"{}\"", escape(name)));
     }
     out.push('\n');
     let n_reals = n_reals.max(1) as usize;
-    for row in rows.chunks_exact(n_reals) {
+    for (r, row) in rows.chunks_exact(n_reals).enumerate() {
         out.push_str(&crate::driver::format_g(row[0], 16));
-        for &(_, col, negate, is_int) in &cols {
-            let v = negate.apply_f64(row.get(col as usize).copied().unwrap_or(0.0));
+        for c in &cols {
             out.push(',');
-            if is_int {
-                out.push_str(&format!("{}", v as i64));
-            } else {
-                out.push_str(&crate::driver::format_g(v, 16));
+            match c {
+                Col::Num { col, negate, is_int, .. } => {
+                    let v = negate.apply_f64(row.get(*col as usize).copied().unwrap_or(0.0));
+                    if *is_int {
+                        out.push_str(&format!("{}", v as i64));
+                    } else {
+                        out.push_str(&crate::driver::format_g(v, 16));
+                    }
+                }
+                // A String value is arbitrary text (it can come from a user
+                // function), so it is always quoted and its quotes doubled.
+                Col::Str { idx, .. } => {
+                    out.push('"');
+                    out.push_str(&escape(cell(strings, r, n_str, *idx)));
+                    out.push('"');
+                }
             }
         }
         out.push('\n');
     }
     out
+}
+
+/// C's `csvEscapedString`: a `"` inside a quoted CSV field is written twice.
+fn escape(s: &str) -> String {
+    s.replace('"', "\"\"")
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/meta.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/meta.rs
@@ -186,6 +186,22 @@ pub fn build(data: *mut DATA, xml: &InitXml, layout: &Layout, prefix: &str) -> S
         }
     }
 
+    // String variables. Their text is not numeric data: the driver captures it
+    // per output row and the result writers put it in the `.mat`'s `stringData`
+    // matrix / its own quoted CSV column, as C's writers do.
+    for a in 0..md.nVariablesStringArray as usize {
+        let v = unsafe { &*md.stringVarsData.add(a) };
+        let base = unsafe { *si.stringVarsIndex.add(a) };
+        for (k, name) in scalar_names(&cstr(v.info.name), &v.dimension, false).into_iter().enumerate() {
+            vars.push(MetaVar {
+                name,
+                comment: cstr(v.info.comment),
+                kind: MetaKind::StringColumn { idx: (base + k) as u32 },
+                filter: filter_bits(v.filterOutput, false),
+            });
+        }
+    }
+
     // Parameters, read out of `SimData` once the run is over.
     for a in 0..md.nParametersRealArray as usize {
         let v = unsafe { &*md.realParameterData.add(a) };
@@ -307,6 +323,26 @@ pub fn build(data: *mut DATA, xml: &InitXml, layout: &Layout, prefix: &str) -> S
                     filter: filter_bits(al.filterOutput, true),
                 });
             }
+        }
+    }
+
+    // String aliases share the aliased variable's string slot; a String has no
+    // negation, and a String *parameter* alias is not in the result file (C's
+    // writers skip `ALIAS_TYPE_PARAMETER` there too).
+    for a in 0..md.nAliasStringArray as usize {
+        let al = unsafe { &*md.stringAlias.add(a) };
+        if al.aliasType == 1 {
+            continue;
+        }
+        let base = unsafe { *si.stringVarsIndex.add(al.nameID as usize) };
+        let dim = alias_dimension(md, al, 3);
+        for (k, name) in scalar_names(&cstr(al.info.name), dim, false).into_iter().enumerate() {
+            vars.push(MetaVar {
+                name,
+                comment: cstr(al.info.comment),
+                kind: MetaKind::StringColumn { idx: (base + k) as u32 },
+                filter: filter_bits(al.filterOutput, true),
+            });
         }
     }
 
@@ -452,6 +488,8 @@ fn alias_dimension(md: &MODEL_DATA, al: &DATA_ALIAS, kind: usize) -> &'static DI
             (1, 1) => &(*md.integerParameterData.add(ix)).dimension,
             (2, 0) => &(*md.booleanVarsData.add(ix)).dimension,
             (2, 1) => &(*md.booleanParameterData.add(ix)).dimension,
+            (3, 0) => &(*md.stringVarsData.add(ix)).dimension,
+            (3, 1) => &(*md.stringParameterData.add(ix)).dimension,
             _ => SCALAR,
         }
     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
@@ -867,6 +867,8 @@ fn write_state(path: &str) -> Result<(), String> {
         meta.layout.n_row_total(),
         &params,
         &meta.output_keep(None),
+        // One guessed point, no run: nothing captured a String value.
+        &[],
         openmodelica_mat_writer::Precision::Double,
     ) else {
         return Err(String::from("cannot write the initial guess file"));

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/run.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/run.rs
@@ -395,6 +395,7 @@ fn write_result(meta: &SimMeta, result: &driver::RunResult, data: *mut DATA) -> 
         result.n_reals,
         &result.params,
         &meta.output_keep(None),
+        &result.strings,
         precision,
     ) else {
         return Ok(());

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -257,6 +257,13 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
     auto var_eval = [&](std::string name) -> FlatModelica::Expression {
       auto vname = QString::fromStdString(name);
       if (readFromResultFileForDynamicSelect) {
+        // #15969: a DynamicSelect user-function result is stored as an auxiliary
+        // variable in the result file. If it is a String variable, read it as a
+        // string; otherwise read it as a number.
+        QPair<QString, bool> stringValue = MainWindow::instance()->getVariablesWidget()->readVariableStringValue(vname, time);
+        if (stringValue.second) {
+          return FlatModelica::Expression(stringValue.first.toStdString());
+        }
         QPair<double, bool> value = MainWindow::instance()->getVariablesWidget()->readVariableValue(vname, time, false);
         if (value.second) {
           return FlatModelica::Expression(value.first);

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -257,7 +257,7 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
     auto var_eval = [&](std::string name) -> FlatModelica::Expression {
       auto vname = QString::fromStdString(name);
       if (readFromResultFileForDynamicSelect) {
-        // #15969: a DynamicSelect user-function result is stored as an auxiliary
+        // A DynamicSelect user-function result is stored as an auxiliary
         // variable in the result file. If it is a String variable, read it as a
         // string; otherwise read it as a number.
         QPair<QString, bool> stringValue = MainWindow::instance()->getVariablesWidget()->readVariableStringValue(vname, time);

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2073,6 +2073,29 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
 }
 
 /*!
+ * \brief VariablesWidget::readVariableStringValue
+ * Reads the value of a time-varying String variable from the .mat result file
+ * at a specific time (issue #15969). Returns (value, true) only if the variable
+ * exists and is a string variable.
+ * \param variable
+ * \param time
+ * \return
+ */
+QPair<QString, bool> VariablesWidget::readVariableStringValue(QString variable, double time)
+{
+  if (mModelicaMatReader.file) {
+    ModelicaMatVariable_t* var = omc_matlab4_find_var(&mModelicaMatReader, variable.toUtf8().constData());
+    if (var && var->isString) {
+      const char *str = omc_matlab4_read_string_val(&mModelicaMatReader, var, time);
+      if (str) {
+        return qMakePair(QString::fromUtf8(str), true);
+      }
+    }
+  }
+  return qMakePair(QString(), false);
+}
+
+/*!
  * \brief VariablesWidget::plotVariables
  * Plot/unplot the checked/unchecked index.
  * \param index

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2074,6 +2074,20 @@ QPair<QString, bool> VariablesWidget::readVariableStringValue(QString variable, 
         return qMakePair(QString::fromUtf8(str), true);
       }
     }
+  } else if (mpCSVData) {
+    char **strDataSet = read_csv_dataset_str(mpCSVData, variable.toUtf8().constData());
+    double *timeDataSet = read_csv_dataset(mpCSVData, "time");
+    if (strDataSet && timeDataSet) {
+      const double tolerance = 1e-12;
+      for (int i = 0 ; i < mpCSVData->numsteps ; i++) {
+        // relative distance. See #14959
+        double diff  = qAbs(timeDataSet[i] - time);
+        double scale = qMax(qAbs(timeDataSet[i]), qAbs(time));
+        if (diff <= tolerance * qMax(1.0, scale)) {
+          return qMakePair(QString::fromUtf8(strDataSet[i] ? strDataSet[i] : ""), true);
+        }
+      }
+    }
   }
   return qMakePair(QString(), false);
 }
@@ -2766,7 +2780,7 @@ void VariablesWidget::openResultFile(VariablesTreeItem *pVariablesTreeItem, doub
         errorString = msg[0];
       }
     } else if (pVariablesTreeItem->getFileName().endsWith(".csv")) {
-      mpCSVData = read_csv(fileName.toUtf8().constData());
+      mpCSVData = read_csv_all(fileName.toUtf8().constData());
       if (mpCSVData) {
         //Read in timevector
         double *timeVals = read_csv_dataset(mpCSVData, "time");

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2075,7 +2075,7 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
 /*!
  * \brief VariablesWidget::readVariableStringValue
  * Reads the value of a time-varying String variable from the .mat result file
- * at a specific time (issue #15969). Returns (value, true) only if the variable
+ * at a specific time. Returns (value, true) only if the variable
  * exists and is a string variable.
  * \param variable
  * \param time

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2058,7 +2058,7 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
 /*!
  * \brief VariablesWidget::readVariableStringValue
  * Reads the value of a time-varying String variable from the .mat result file
- * at a specific time (issue #15969). Returns (value, true) only if the variable
+ * at a specific time. Returns (value, true) only if the variable
  * exists and is a string variable.
  * \param variable
  * \param time

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2056,6 +2056,29 @@ QPair<double, bool> VariablesWidget::readVariableValue(QString variable, double 
 }
 
 /*!
+ * \brief VariablesWidget::readVariableStringValue
+ * Reads the value of a time-varying String variable from the .mat result file
+ * at a specific time (issue #15969). Returns (value, true) only if the variable
+ * exists and is a string variable.
+ * \param variable
+ * \param time
+ * \return
+ */
+QPair<QString, bool> VariablesWidget::readVariableStringValue(QString variable, double time)
+{
+  if (mModelicaMatReader.file) {
+    ModelicaMatVariable_t* var = omc_matlab4_find_var(&mModelicaMatReader, variable.toUtf8().constData());
+    if (var && var->isString) {
+      const char *str = omc_matlab4_read_string_val(&mModelicaMatReader, var, time);
+      if (str) {
+        return qMakePair(QString::fromUtf8(str), true);
+      }
+    }
+  }
+  return qMakePair(QString(), false);
+}
+
+/*!
  * \brief VariablesWidget::plotVariables
  * Plot/unplot the checked/unchecked index.
  * \param index

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2091,6 +2091,20 @@ QPair<QString, bool> VariablesWidget::readVariableStringValue(QString variable, 
         return qMakePair(QString::fromUtf8(str), true);
       }
     }
+  } else if (mpCSVData) {
+    char **strDataSet = read_csv_dataset_str(mpCSVData, variable.toUtf8().constData());
+    double *timeDataSet = read_csv_dataset(mpCSVData, "time");
+    if (strDataSet && timeDataSet) {
+      const double tolerance = 1e-12;
+      for (int i = 0 ; i < mpCSVData->numsteps ; i++) {
+        // relative distance. See #14959
+        double diff  = qAbs(timeDataSet[i] - time);
+        double scale = qMax(qAbs(timeDataSet[i]), qAbs(time));
+        if (diff <= tolerance * qMax(1.0, scale)) {
+          return qMakePair(QString::fromUtf8(strDataSet[i] ? strDataSet[i] : ""), true);
+        }
+      }
+    }
   }
   return qMakePair(QString(), false);
 }
@@ -2783,7 +2797,7 @@ void VariablesWidget::openResultFile(VariablesTreeItem *pVariablesTreeItem, doub
         errorString = msg[0];
       }
     } else if (pVariablesTreeItem->getFileName().endsWith(".csv")) {
-      mpCSVData = read_csv(fileName.toUtf8().constData());
+      mpCSVData = read_csv_all(fileName.toUtf8().constData());
       if (mpCSVData) {
         //Read in timevector
         double *timeVals = read_csv_dataset(mpCSVData, "time");

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -265,6 +265,7 @@ public:
   void updatePlotWindows();
   void updateBrowserTime(double time);
   QPair<double, bool> readVariableValue(QString variable, double time, bool reportError = true);
+  QPair<QString, bool> readVariableStringValue(QString variable, double time);
   void closeResultFile();
 private:
   TreeSearchFilters *mpTreeSearchFilters;

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -153,6 +153,16 @@ void ExpressionTest::dynamicSelect_data()
   QTest::addRow("OpenIPSL Bus angle")
     << "DynamicSelect(\"Angle\", String(angleDisplay, significantDigits=3) + \"°\")"
     << "DynamicSelect(\"Angle\",\"1°\")";
+
+  // #15969: when the frontend rewrites a DynamicSelect user-function call, its
+  // dynamic argument becomes a reference to the synthesized auxiliary variable.
+  // OMEdit must evaluate that reference from the result file (here the test
+  // substitutes every variable with 1.0). The real auxiliary name contains '$'
+  // and is delivered as a JSON cref, so it is looked up by name and never parsed
+  // from a string.
+  QTest::addRow("DynamicSelectAuxVariable")
+    << "DynamicSelect(\"0.0\", dynamicSelectAux)"
+    << "DynamicSelect(\"0.0\",1)";
 }
 
 void ExpressionTest::operators()

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -165,6 +165,47 @@ void ExpressionTest::dynamicSelect_data()
     << "DynamicSelect(\"0.0\",1)";
 }
 
+// The DynamicSelect user-function fix synthesizes an auxiliary result variable.
+// For a sub-component the frontend delivers the reference by its full instance
+// path as a JSON cref, e.g. parts ["display", "$DynamicSelect$926893828"]. OMEdit
+// must join those parts into the dotted name "display.$DynamicSelect$926893828"
+// and look that name up in the enclosing model's result file; a bare
+// "$DynamicSelect$926893828" (without the component prefix) would not be found,
+// so a sub-component's icon would not animate in the enclosing model's diagram.
+void ExpressionTest::dynamicSelectAuxCref()
+{
+  const QString auxName = "display.$DynamicSelect$926893828";
+
+  QJsonValue auxCref = QJsonObject{
+    {"$kind", "cref"},
+    {"parts", QJsonArray{
+      QJsonObject{{"name", "display"}},
+      QJsonObject{{"name", "$DynamicSelect$926893828"}}
+    }}
+  };
+
+  try {
+    FlatModelica::Expression e;
+    e.deserialize(auxCref);
+
+    // The parts are joined into the dotted instance-path name.
+    QCOMPARE(e.toQString(), auxName);
+
+    // Evaluating the reference looks the variable up by that exact name, which is
+    // how OMEdit reads its value from the result file.
+    std::string requested;
+    FlatModelica::Expression value = e.evaluate([&] (const std::string &name) {
+      requested = name;
+      return FlatModelica::Expression(2.5);
+    });
+
+    QCOMPARE(QString::fromStdString(requested), auxName);
+    QCOMPARE(value.realValue(), 2.5);
+  } catch (const std::exception &e) {
+    QFAIL(e.what());
+  }
+}
+
 void ExpressionTest::operators()
 {
   QFETCH(QString, string);

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -154,7 +154,7 @@ void ExpressionTest::dynamicSelect_data()
     << "DynamicSelect(\"Angle\", String(angleDisplay, significantDigits=3) + \"°\")"
     << "DynamicSelect(\"Angle\",\"1°\")";
 
-  // #15969: when the frontend rewrites a DynamicSelect user-function call, its
+  // When the frontend rewrites a DynamicSelect user-function call, its
   // dynamic argument becomes a reference to the synthesized auxiliary variable.
   // OMEdit must evaluate that reference from the result file (here the test
   // substitutes every variable with 1.0). The real auxiliary name contains '$'

--- a/OMEdit/Testsuite/Expression/ExpressionTest.h
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.h
@@ -53,6 +53,7 @@ class ExpressionTest: public QObject
 private slots:
   void dynamicSelect();
   void dynamicSelect_data();
+  void dynamicSelectAuxCref();
   void operators();
   void operators_data();
   void functions();

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -646,6 +646,15 @@ void PlotWindow::plot(PlotCurve *pPlotCurve)
     for (uint32_t i = 0; i < reader.nall; i++) {
       if (mVariablesList.contains(reader.allInfo[i].name) || isPlotAll()) {
         variablesPlotted.append(reader.allInfo[i].name);
+        // String variables (e.g. the DynamicSelect string auxiliaries written by
+        // the instance API) are not numeric and cannot be plotted as curves. Skip
+        // them; they are counted as plotted above so an explicit request for one
+        // does not raise a spurious "variable does not exist" error. Their index
+        // refers to the separate string-signal table, so reading it as numeric
+        // data would otherwise plot an unrelated column.
+        if (reader.allInfo[i].isString) {
+          continue;
+        }
         // create the plot curve for variable
         if (!editCase) {
           QFileInfo fileInfo(mFile);

--- a/testsuite/openmodelica/instance-API/DynamicSelectAuxNameConsistency.mos
+++ b/testsuite/openmodelica/instance-API/DynamicSelectAuxNameConsistency.mos
@@ -1,0 +1,50 @@
+// name: DynamicSelectAuxNameConsistency
+// keywords: DynamicSelect annotation hash
+// status: correct
+//
+// The auxiliary variable name for a DynamicSelect user-function call is derived
+// independently on the instance-API side (getModelInstance) and on the
+// flattening side (simulation). They must agree even when the dynamic
+// expression is not already in simplified form (here f(u*1), which simplifies
+// to f(u)); otherwise OMEdit would read a variable that is not in the result
+// file. This checks the two names match by extracting the hash from both the
+// getModelInstance output and the result file. Regression test for a mismatch.
+//
+
+setCommandLineOptions("-d=nfAPIDynamicSelectAux"); getErrorString();
+loadString("
+  function f
+    input Real u;
+    output Real y = u;
+  end f;
+  model M
+    Real u(start = 0.0, fixed = true);
+  equation
+    der(u) = 1.0 - u;
+    annotation(Icon(graphics = {Rectangle(extent = {{-100, -100}, {100, 100}}, lineThickness = DynamicSelect(0.25, f(u*1)))}));
+  end M;
+"); getErrorString();
+(_,instMatch) := regex(getModelInstance(M, prettyPrint=false), "DynamicSelect.([0-9]+)", 2); getErrorString();
+simulate(M, stopTime=1.0, numberOfIntervals=1, outputFormat="csv"); getErrorString();
+(_,csvMatch) := regex(readFile("M_res.csv"), "DynamicSelect.([0-9]+)", 2); getErrorString();
+instMatch[2] <> "" and instMatch[2] == csvMatch[2];
+
+// Result:
+// true
+// ""
+// true
+// ""
+//
+// ""
+// record SimulationResult
+//     resultFile = "M_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+//
+// ""
+// true
+// endResult

--- a/testsuite/openmodelica/instance-API/DynamicSelectDiagram.mos
+++ b/testsuite/openmodelica/instance-API/DynamicSelectDiagram.mos
@@ -4,13 +4,18 @@
 //
 // A component whose icon uses a DynamicSelect user function must animate when it
 // is shown as a sub-component in an enclosing model's diagram. OMEdit draws the
-// icon from getModelInstance on the component's own class and reads the values
-// from the enclosing model's result file, so two things must hold:
+// diagram from getModelInstance on the enclosing model and reads the values from
+// that model's result file, so for the sub-component's icon three things must
+// hold:
 //   * the enclosing model must build/simulate (the synthesized auxiliary binding
-//     must reference the instance, e.g. display.u, not the class A.B.u), and
-//   * the auxiliary variable name from getModelInstance on the component must
-//     match the one in the result file (independent of the instantiation
-//     context; here f(u*1) also checks that simplification agrees).
+//     must reference the instance, e.g. display.u, not the class A.B.u),
+//   * getModelInstance on the enclosing model must reference the auxiliary
+//     variable by its instance path (display.$DynamicSelect$H), matching the
+//     name it is given in the result file, and
+//   * the auxiliary name must be independent of the instantiation context: the
+//     hash from getModelInstance on the component's own class (where it is typed
+//     as f(u)) must equal the one in the result file (here f(u*1) also checks
+//     that simplification agrees).
 //
 
 setCommandLineOptions("-d=nfAPIDynamicSelectAux"); getErrorString();
@@ -29,15 +34,21 @@ loadString("
     Display display;
   end DynSelDiagram;
 "); getErrorString();
+// The hash from the component's own class (context-independent, no prefix).
 (_,compMatch) := regex(getModelInstance(Display, prettyPrint=false), "DynamicSelect.([0-9]+)", 2); getErrorString();
+// The instance-path reference from the enclosing model: prefix and hash.
+(_,diagMatch) := regex(getModelInstance(DynSelDiagram, prettyPrint=false), "\"([A-Za-z0-9_]+)\"[]}, {[]+\"name\":\"[$]DynamicSelect[$]([0-9]+)", 3); getErrorString();
 simulate(DynSelDiagram, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
-(_,resMatch) := regex(readFile("DynSelDiagram_res.csv"), "DynamicSelect.([0-9]+)", 2); getErrorString();
-compMatch[2] <> "" and compMatch[2] == resMatch[2];
+// The instance-path name in the result file: prefix and hash.
+(_,resMatch) := regex(readFile("DynSelDiagram_res.csv"), "([A-Za-z0-9_]+)[.][$]DynamicSelect[$]([0-9]+)", 3); getErrorString();
+compMatch[2] <> "" and compMatch[2] == resMatch[3] and diagMatch[2] == "display" and diagMatch[3] == resMatch[3] and resMatch[2] == "display";
 
 // Result:
 // true
 // ""
 // true
+// ""
+//
 // ""
 //
 // ""

--- a/testsuite/openmodelica/instance-API/DynamicSelectDiagram.mos
+++ b/testsuite/openmodelica/instance-API/DynamicSelectDiagram.mos
@@ -1,0 +1,55 @@
+// name: DynamicSelectDiagram
+// keywords: DynamicSelect annotation diagram
+// status: correct
+//
+// A component whose icon uses a DynamicSelect user function must animate when it
+// is shown as a sub-component in an enclosing model's diagram. OMEdit draws the
+// icon from getModelInstance on the component's own class and reads the values
+// from the enclosing model's result file, so two things must hold:
+//   * the enclosing model must build/simulate (the synthesized auxiliary binding
+//     must reference the instance, e.g. display.u, not the class A.B.u), and
+//   * the auxiliary variable name from getModelInstance on the component must
+//     match the one in the result file (independent of the instantiation
+//     context; here f(u*1) also checks that simplification agrees).
+//
+
+setCommandLineOptions("-d=nfAPIDynamicSelectAux"); getErrorString();
+loadString("
+  function f
+    input Real u;
+    output Real y = 1.0 + 9.0*u;
+  end f;
+  model Display
+    Real u(start = 0.0, fixed = true);
+  equation
+    der(u) = 1.0 - u;
+    annotation(Icon(graphics = {Rectangle(extent = {{-100,-100},{100,100}}, lineThickness = DynamicSelect(0.25, f(u*1)))}));
+  end Display;
+  model DynSelDiagram
+    Display display;
+  end DynSelDiagram;
+"); getErrorString();
+(_,compMatch) := regex(getModelInstance(Display, prettyPrint=false), "DynamicSelect.([0-9]+)", 2); getErrorString();
+simulate(DynSelDiagram, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
+(_,resMatch) := regex(readFile("DynSelDiagram_res.csv"), "DynamicSelect.([0-9]+)", 2); getErrorString();
+compMatch[2] <> "" and compMatch[2] == resMatch[2];
+
+// Result:
+// true
+// ""
+// true
+// ""
+//
+// ""
+// record SimulationResult
+//     resultFile = "DynSelDiagram_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DynSelDiagram', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+//
+// ""
+// true
+// endResult

--- a/testsuite/openmodelica/instance-API/DynamicSelectUserFunctions.mos
+++ b/testsuite/openmodelica/instance-API/DynamicSelectUserFunctions.mos
@@ -1,0 +1,56 @@
+// name: DynamicSelectUserFunctions
+// keywords: DynamicSelect annotation
+// status: correct
+//
+// Tests #15969: a DynamicSelect whose dynamic expression calls a user function
+// gets an auxiliary result variable synthesized (numeric and String), so the
+// value is written to the (here CSV) result file and can be read back by OMEdit.
+//
+
+setCommandLineOptions("-d=nfAPIDynamicSelectAux"); getErrorString();
+loadString("
+  function scaleVal
+    input Real u;
+    output Real y;
+  algorithm
+    y := 100.0*u;
+  end scaleVal;
+  function dispVal
+    input Real u;
+    output String s;
+  algorithm
+    s := \"u=\" + String(u, format=\".2f\");
+  end dispVal;
+  model DynSelAux
+    Real u(start = 0.0, fixed = true);
+  equation
+    der(u) = 1.0 - u;
+    annotation(Icon(graphics = {
+      Rectangle(extent = {{-100,-100},{100,100}}, lineThickness = DynamicSelect(0.25, scaleVal(u))),
+      Text(extent = {{-100,-100},{100,100}}, textString = DynamicSelect(\"0\", dispVal(u)))
+    }));
+  end DynSelAux;
+"); getErrorString();
+simulate(DynSelAux, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
+readFile("DynSelAux_res.csv");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "DynSelAux_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DynSelAux', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "\"time\",\"u\",\"der(u)\",\"$DynamicSelect$320314351\",\"$DynamicSelect$85559355\"
+// 0,0,1,0,\"u=0.00\"
+// 0.5,0.3934686188569886,0.6065313811430114,39.34686188569886,\"u=0.39\"
+// 1,0.6321217723555973,0.3678782276444027,63.21217723555973,\"u=0.63\"
+// 1,0.6321217723555973,0.3678782276444027,63.21217723555973,\"u=0.63\"
+// "
+// endResult

--- a/testsuite/openmodelica/instance-API/DynamicSelectUserFunctions.mos
+++ b/testsuite/openmodelica/instance-API/DynamicSelectUserFunctions.mos
@@ -2,37 +2,39 @@
 // keywords: DynamicSelect annotation
 // status: correct
 //
-// Tests #15969: a DynamicSelect whose dynamic expression calls a user function
-// gets an auxiliary result variable synthesized (numeric and String), so the
-// value is written to the (here CSV) result file and can be read back by OMEdit.
+// A DynamicSelect whose dynamic expression calls a user function gets an
+// auxiliary result variable synthesized (numeric and String), so the value is
+// written to the (here CSV) result file and can be read back by OMEdit. The
+// model is self-contained (the functions are members of the class) so it is
+// representative of a class that can be loaded and animated in OMEdit.
 //
 
 setCommandLineOptions("-d=nfAPIDynamicSelectAux"); getErrorString();
 loadString("
-  function scaleVal
-    input Real u;
-    output Real y;
-  algorithm
-    y := 100.0*u;
-  end scaleVal;
-  function dispVal
-    input Real u;
-    output String s;
-  algorithm
-    s := \"u=\" + String(u, format=\".2f\");
-  end dispVal;
-  model DynSelAux
+  model DynamicSelectUserFunctions
     Real u(start = 0.0, fixed = true);
+    function scaleVal
+      input Real u;
+      output Real y;
+    algorithm
+      y := 100.0*u;
+    end scaleVal;
+    function dispVal
+      input Real u;
+      output String s;
+    algorithm
+      s := \"u=\" + String(u, format=\".2f\");
+    end dispVal;
   equation
     der(u) = 1.0 - u;
     annotation(Icon(graphics = {
       Rectangle(extent = {{-100,-100},{100,100}}, lineThickness = DynamicSelect(0.25, scaleVal(u))),
       Text(extent = {{-100,-100},{100,100}}, textString = DynamicSelect(\"0\", dispVal(u)))
     }));
-  end DynSelAux;
+  end DynamicSelectUserFunctions;
 "); getErrorString();
-simulate(DynSelAux, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
-readFile("DynSelAux_res.csv");
+simulate(DynamicSelectUserFunctions, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
+readFile("DynamicSelectUserFunctions_res.csv");
 
 // Result:
 // true
@@ -40,14 +42,14 @@ readFile("DynSelAux_res.csv");
 // true
 // ""
 // record SimulationResult
-//     resultFile = "DynSelAux_res.csv",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DynSelAux', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "DynamicSelectUserFunctions_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DynamicSelectUserFunctions', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""
-// "\"time\",\"u\",\"der(u)\",\"$DynamicSelect$320314351\",\"$DynamicSelect$85559355\"
+// "\"time\",\"u\",\"der(u)\",\"$DynamicSelect$312756872\",\"$DynamicSelect$345633756\"
 // 0,0,1,0,\"u=0.00\"
 // 0.5,0.3934686188569886,0.6065313811430114,39.34686188569886,\"u=0.39\"
 // 1,0.6321217723555973,0.3678782276444027,63.21217723555973,\"u=0.63\"

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -1,6 +1,9 @@
 TEST = ../../rtest -v
 
 TESTFILES = \
+DynamicSelectUserFunctions.mos \
+StringResultCSV.mos \
+StringResultMat.mos \
 GetModelInstanceAlgorithm1.mos \
 GetModelInstanceAnnotation1.mos \
 GetModelInstanceAnnotation2.mos \

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../rtest -v
 
 TESTFILES = \
+DynamicSelectAuxNameConsistency.mos \
 DynamicSelectUserFunctions.mos \
 StringResultCSV.mos \
 StringResultMat.mos \

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -2,6 +2,7 @@ TEST = ../../rtest -v
 
 TESTFILES = \
 DynamicSelectAuxNameConsistency.mos \
+DynamicSelectDiagram.mos \
 DynamicSelectUserFunctions.mos \
 StringResultCSV.mos \
 StringResultMat.mos \

--- a/testsuite/openmodelica/instance-API/StringResultCSV.mos
+++ b/testsuite/openmodelica/instance-API/StringResultCSV.mos
@@ -1,0 +1,37 @@
+// name: StringResultCSV
+// keywords: string result csv
+// status: correct
+//
+// Tests #15969: a model with a time-varying String variable is written to a CSV
+// result file, with the string values in their own column.
+//
+
+loadString("
+  model StringResultCSV
+    Real u(start = 0.0, fixed = true);
+    String s = \"u=\" + String(u, format=\".1f\");
+  equation
+    der(u) = 1.0;
+  end StringResultCSV;
+"); getErrorString();
+simulate(StringResultCSV, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
+readFile("StringResultCSV_res.csv");
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "StringResultCSV_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'StringResultCSV', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "\"time\",\"u\",\"der(u)\",\"s\"
+// 0,0,1,\"u=0.0\"
+// 0.5,0.5,1,\"u=0.5\"
+// 1,1,1,\"u=1.0\"
+// 1,1,1,\"u=1.0\"
+// "
+// endResult

--- a/testsuite/openmodelica/instance-API/StringResultCSV.mos
+++ b/testsuite/openmodelica/instance-API/StringResultCSV.mos
@@ -2,14 +2,18 @@
 // keywords: string result csv
 // status: correct
 //
-// Tests #15969: a model with a time-varying String variable is written to a CSV
-// result file, with the string values in their own column.
+// Tests that a model with time-varying String variables is written to a CSV
+// result file, with the string values in their own column. A second string is
+// crafted to contain characters that would otherwise break the CSV (a double
+// quote, a comma and a newline); it must be escaped (quotes doubled, the field
+// quoted) so the file stays well-formed.
 //
 
 loadString("
   model StringResultCSV
     Real u(start = 0.0, fixed = true);
     String s = \"u=\" + String(u, format=\".1f\");
+    String escape_me_if_you_can = \"a\\\"b,c\" + String(1.0) + \"\\nd\";
   equation
     der(u) = 1.0;
   end StringResultCSV;
@@ -28,10 +32,14 @@ readFile("StringResultCSV_res.csv");
 // "
 // end SimulationResult;
 // ""
-// "\"time\",\"u\",\"der(u)\",\"s\"
-// 0,0,1,\"u=0.0\"
-// 0.5,0.5,1,\"u=0.5\"
-// 1,1,1,\"u=1.0\"
-// 1,1,1,\"u=1.0\"
+// "\"time\",\"u\",\"der(u)\",\"escape_me_if_you_can\",\"s\"
+// 0,0,1,\"a\"\"b,c1
+// d\",\"u=0.0\"
+// 0.5,0.5,1,\"a\"\"b,c1
+// d\",\"u=0.5\"
+// 1,1,1,\"a\"\"b,c1
+// d\",\"u=1.0\"
+// 1,1,1,\"a\"\"b,c1
+// d\",\"u=1.0\"
 // "
 // endResult

--- a/testsuite/openmodelica/instance-API/StringResultCSV.mos
+++ b/testsuite/openmodelica/instance-API/StringResultCSV.mos
@@ -6,7 +6,9 @@
 // result file, with the string values in their own column. A second string is
 // crafted to contain characters that would otherwise break the CSV (a double
 // quote, a comma and a newline); it must be escaped (quotes doubled, the field
-// quoted) so the file stays well-formed.
+// quoted) so the file stays well-formed. Reading the file back (here listing its
+// variables) must succeed, i.e. the escaping round-trips: an incorrect escape
+// would misalign the columns or make the reader fail.
 //
 
 loadString("
@@ -19,7 +21,8 @@ loadString("
   end StringResultCSV;
 "); getErrorString();
 simulate(StringResultCSV, stopTime=1.0, numberOfIntervals=2, outputFormat="csv"); getErrorString();
-readFile("StringResultCSV_res.csv");
+readFile("StringResultCSV_res.csv"); getErrorString();
+readSimulationResultVars("StringResultCSV_res.csv");
 
 // Result:
 // true
@@ -42,4 +45,6 @@ readFile("StringResultCSV_res.csv");
 // 1,1,1,\"a\"\"b,c1
 // d\",\"u=1.0\"
 // "
+// ""
+// {"time", "u", "der(u)", "escape_me_if_you_can", "s"}
 // endResult

--- a/testsuite/openmodelica/instance-API/StringResultMat.mos
+++ b/testsuite/openmodelica/instance-API/StringResultMat.mos
@@ -1,0 +1,36 @@
+// name: StringResultMat
+// keywords: string result mat
+// status: correct
+//
+// Tests #15969: a model with a time-varying String variable can be simulated to
+// a .mat result file (the string is written to the stringData matrix) and the
+// file remains readable (the string variable is listed and numeric variables
+// read back correctly).
+//
+
+loadString("
+  model StringResultMat
+    Real u(start = 0.0, fixed = true);
+    String s = \"u=\" + String(u, format=\".1f\");
+  equation
+    der(u) = 1.0;
+  end StringResultMat;
+"); getErrorString();
+simulate(StringResultMat, stopTime=1.0, numberOfIntervals=2); getErrorString();
+readSimulationResultVars("StringResultMat_res.mat");
+readSimulationResult("StringResultMat_res.mat", {u});
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "StringResultMat_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'StringResultMat', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// {"der(u)", "s", "time", "u"}
+// {{0.0, 0.5, 1.0, 1.0}}
+// endResult

--- a/testsuite/openmodelica/instance-API/StringResultMat.mos
+++ b/testsuite/openmodelica/instance-API/StringResultMat.mos
@@ -2,8 +2,8 @@
 // keywords: string result mat
 // status: correct
 //
-// Tests #15969: a model with a time-varying String variable can be simulated to
-// a .mat result file (the string is written to the stringData matrix) and the
+// Tests that a model with a time-varying String variable can be simulated to a
+// .mat result file (the string is written to the stringData matrix) and the
 // file remains readable (the string variable is listed and numeric variables
 // read back correctly).
 //


### PR DESCRIPTION
Fixes #15969.

## What

OMEdit's annotation evaluator cannot call Modelica user functions, so a `DynamicSelect(static, dynamic)` whose *dynamic* expression calls a user function could not be animated, e.g.

```mo
DynamicSelect("0.0 MW", OpenIPSL.NonElectrical.Functions.displayPower(P, " MW"))
```

This PR adds, **behind the new debug flag `-d=nfAPIDynamicSelectAux`** (default off, so the normal simulation path is unchanged), a mechanism that synthesizes an auxiliary variable bound to each user function call. The result is written to the simulation result file, and OMEdit reads it instead of calling the function.

## How

For each user function call in the dynamic expression, the frontend:

1. **Instance API side** – rewrites the annotation's dynamic argument, replacing **only the user function calls** with references to auxiliary variables and keeping the rest of the expression, so OMEdit still evaluates the parts it can. For example:

   ```mo
   DynamicSelect(0.25, if userColor(u) > 50 then 2 else 0.5)
   ```

   is returned to OMEdit as

   ```mo
   DynamicSelect(0.25, if $DynamicSelect$<hash> > 50 then 2 else 0.5)
   ```

   OMEdit still evaluates the `if`/comparison/literals itself and only reads the opaque `$DynamicSelect$<hash>` from the result file. Likewise `displayPower(P, " MW")` inside `displayPower(P, " MW") + " total"` only replaces the call, and OMEdit does the string concatenation.

2. **Flattening side** – synthesizes one auxiliary variable per user function call, bound to that call (e.g. `$DynamicSelect$<hash> = userColor(u)`), so its value is written to the result file. The auxiliary variable's class node is taken from the function's output component, so any return type is handled – basic types, enumerations and records.

Both sides use the same deterministic content-hash name (derived from the call), so they agree without any shared state.

`DynamicSelect` is also made a **special builtin**: its two arguments can have different types (arrays, expressions, literals), so they are now typed and cast individually instead of being forced through a single polymorphic `<__Any>` function signature; both arguments are always kept so OMEdit can select the static or dynamic part.

String display values (like `displayPower`) required end-to-end support for time-varying `String` variables in result files, which is also added.

## Commits

- **`[NF]` frontend** – `DynamicSelect` special builtin; per-call auxiliary-variable rewrite shared by the instance API and the flattening synthesis; new flag `nfAPIDynamicSelectAux`.
- **`[SimRT]` runtime** – write/read time-varying `String` variables in CSV and MATLAB v4 (`.mat`) result files (new `stringData` matrix + `CHANNEL_STRING`; `omc_matlab4_read_string_val`); string init/robustness fixes. Gated on the model having `String` variables, so numeric-only models are unaffected.
- **`[OMEdit]`** – read `String` auxiliary variables from the result file (`readVariableStringValue`); `DynamicAnnotation` reads the dynamic value as a string when the auxiliary variable is a `String`.
- **`[test]`** – OMC testsuite (`DynamicSelectUserFunctions`, `DynamicSelectAuxNameConsistency`, `DynamicSelectDiagram`, `StringResultCSV`, `StringResultMat`) and an OMEdit `ExpressionTest` row.
- **`wasm-jit`** – the same two things in the Rust runtime and the `--simCodeTarget=wasm-jit` code generator, which are a second implementation of the result file (see below).

## The wasm-jit / Rust runtime

The Rust runtime and the `wasm-jit` target write the result file themselves, so they had to learn the same two things. Without that, the four new tests fail under `--simCodeTarget=wasm-jit` (they pass on every other target) for two reasons:

- `CodegenWasmJit`'s result-variable filter dropped every `$`-prefixed name except four optimization ones, so the `$DynamicSelect$<hash>` auxiliaries never reached the result file.
- The Rust runtime had no `String` result channel at all: a result signal was `Time | Column | Param | Const` over an `f64` row buffer, and the `String` slots were laid out but never emitted.

So a `StringColumn` result kind joins the others and is carried through every layer:

- The driver captures the text of each string slot in `capture_row`, the one funnel all drivers share, and rewinds it together with the numeric rows when a step is retried. A model with no `String` result signal does not pay for the capture.
- The `.mat` writer emits `dataInfo` channel 3 plus the `stringData` character matrix in C's layout, and the CSV writer a quoted, escaped `String` column. C's `.plt` writer has no `String` channel, so neither does this one.
- The readers follow: `stringData` and `omc_matlab4_read_string_val` on the `.mat` side, `read_csv_all` / `read_csv_dataset_str` on the CSV side, both also exported from the Rust omc's C ABI so OMEdit works against either compiler.
- The Rust simulation runtime over a C-generated model (`OM_ENABLE_RUST_SIM_RUNTIME`) builds the same `String` variables and aliases into its metadata, so the two runtimes write the same file.

Checked with a `-DOM_OMC_ENABLE_RUST=ON` build: all 104 `openmodelica/instance-API` tests pass under `--simCodeTarget=wasm-jit`, and the two implementations read each other's `.mat` — the C `omc` reads a file the Rust runtime wrote with a `String` variable, and the Rust `omc` reads one the C runtime wrote.

## Notes

- The feature is opt-in via the flag (per the issue: "this approach should NOT affect the usual simulation path so we should add this on a flag"); the flag must be set for both `getModelInstance` and `buildModel`.
- Making `DynamicSelect` a special builtin causes no regression in the `openmodelica/instance-API` testsuite.

---

generated by Claude Code

