### PR TITLE
Fix ColPack header path for MinGW omc build

### DIFF
--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -47,7 +47,7 @@ endif
 LDFLAGS=-L./ $(LOMPARSE) $(LCOMPILERRUNTIME) -L"$(OMHOME)/lib/omc" \
 -lOpenModelicaRuntimeC \
 -lomantlr3 -lregex -lwsock32 -luuid -lole32 -lws2_32 -limagehlp \
--lRpcrt4 -lopenblas -fopenmp -lomcgc -lryu -lpthread $(FMILIB_OR_BOOT) -lshlwapi -liconv -lintl -lmetis \
+-lRpcrt4 -lopenblas -fopenmp -lomcgc -lryu -lpthread $(FMILIB_OR_BOOT) -lshlwapi -liconv -lintl -lmetis -lcolpack \
 -Wl,--enable-stdcall-fixup -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -static-libgcc \
 -lgfortran -ltre \
 -lzmq \

--- a/OMCompiler/Compiler/runtime/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/runtime/Makefile.omdev.mingw
@@ -28,6 +28,11 @@ ZMQINCLUDE = ../../3rdParty/libzmq/include
 GCINCLUDE = -DGC_WIN32_PTHREADS -I../../3rdParty/gc/include
 OMC_CONFIG_INC = $(top_builddir)
 
+COLPACKDIR = $(top_builddir)/3rdParty/ColPack
+COLPACK_HEADERS = inc src/Utilities src/GeneralGraphColoring src/BipartiteGraphBicoloring src/BipartiteGraphPartialColoring src/Recovery src/SMPGC
+COLPACK_INCLUDES = $(addprefix -I$(COLPACKDIR)/,$(COLPACK_HEADERS))
+
+
 OMC=$(OMBUILDDIR)/bin/omc
 SHREXT=.a
 OMPCC = gcc -fopenmp
@@ -47,7 +52,7 @@ endif
 SHELL	= /bin/sh
 CC	= gcc
 CXX = g++
-override CFLAGS += $(CORBA_C_CLFAGS) $(USE_METIS) -Werror=implicit-function-declaration -Wall -Wno-unused-variable -I$(OMC_CONFIG_INC) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc $(CORBAINCL) $(GCINCLUDE) -I$(FMIINCLUDE) -I$(CJSONINCLUDE) -I$(GRAPHINCLUDE) -I$(SQLITE3INCLUDE) -I$(ZMQINCLUDE) -I"$(TOP_DIR)/3rdParty/zlib" -I"$(TOP_DIR)/3rdParty/libffi/install/include/" -DWIN32_LEAN_AND_MEAN
+override CFLAGS += $(CORBA_C_CLFAGS) $(USE_METIS) -Werror=implicit-function-declaration -Wall -Wno-unused-variable -I$(OMC_CONFIG_INC) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc $(CORBAINCL) $(GCINCLUDE) $(COLPACK_INCLUDES) -I$(FMIINCLUDE) -I$(CJSONINCLUDE) -I$(GRAPHINCLUDE) -I$(SQLITE3INCLUDE) -I$(ZMQINCLUDE) -I"$(TOP_DIR)/3rdParty/zlib" -I"$(TOP_DIR)/3rdParty/libffi/install/include/" -DWIN32_LEAN_AND_MEAN
 override CXXFLAGS += -std=c++17 $(CFLAGS)
 
 include Makefile.common


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/commit/6d125c97fd7bbb3a7d43d769199145bda3aae851

### Purpose

Include `colPack headers` to mingw builds

