### PR TITLE
OMEdit: Nuke webkit path

### DIFF
--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -11,11 +11,7 @@ omc_option(OM_OMEDIT_ANIMATION_QUICK3D "Use the Qt Quick 3D animation backend in
 
 find_package(Qt${OM_QT_MAJOR_VERSION} COMPONENTS Widgets PrintSupport Xml OpenGL Network Svg REQUIRED)
 
-if (OM_QT_MAJOR_VERSION VERSION_GREATER_EQUAL 6)
-  find_package(Qt${OM_QT_MAJOR_VERSION} COMPONENTS WebEngineWidgets REQUIRED)
-else ()
-  find_package(Qt${OM_QT_MAJOR_VERSION} COMPONENTS WebKitWidgets REQUIRED)
-endif ()
+find_package(Qt${OM_QT_MAJOR_VERSION} COMPONENTS WebEngineWidgets REQUIRED)
 
 if (OM_QT_MAJOR_VERSION VERSION_GREATER_EQUAL 6)
   find_package(Qt6 COMPONENTS OpenGLWidgets Core5Compat REQUIRED)

--- a/OMEdit/OMEdit.config.pre.pri
+++ b/OMEdit/OMEdit.config.pre.pri
@@ -30,14 +30,12 @@
 #
 # See the full OSMC Public License conditions for more details.
 
-QT += network core gui xml svg opengl printsupport widgets concurrent
+QT += network core gui xml svg opengl printsupport widgets concurrent webenginewidgets
 equals(QT_MAJOR_VERSION, 6) {
-  QT += core5compat openglwidgets webenginewidgets
+  QT += core5compat openglwidgets
   greaterThan(QT_MINOR_VERSION, 4) {
     QT += httpserver
   }
-} else {
-  QT += webkit webkitwidgets
 }
 
 # Set the C++ standard.

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -371,11 +371,7 @@ target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::OpenGL)
 target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::Network)
 target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::Svg)
 
-if (OM_QT_MAJOR_VERSION VERSION_GREATER_EQUAL 6)
-  target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::WebEngineWidgets)
-else ()
-  target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::WebKitWidgets)
-endif ()
+target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::WebEngineWidgets)
 
 target_link_libraries(OMEditLib PUBLIC Qt${OM_QT_MAJOR_VERSION}::OpenGL)
 if (OM_QT_MAJOR_VERSION VERSION_GREATER_EQUAL 6)

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -54,12 +54,10 @@
 #include <QApplication>
 #if defined(__EMSCRIPTEN__) || defined(OM_OMEDIT_NO_WEBENGINE)
 // QtWebEngine stubs come in via DocumentationWidget.h on wasm.
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#else
 #include <QWebEnginePage>
 #include <QWebEngineSettings>
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <QWebFrame>
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#endif
 #include <QWidgetAction>
 #include <QButtonGroup>
 #include <QInputDialog>
@@ -193,40 +191,24 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   mpBoldAction->setStatusTip(tr("Make your text bold"));
   mpBoldAction->setShortcut(QKeySequence("Ctrl+b"));
   mpBoldAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpBoldAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::ToggleBold), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpBoldAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleBold), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // italic action
   mpItalicAction = new QAction(QIcon(":/Resources/icons/italic-icon.svg"), Helper::italic, this);
   mpItalicAction->setStatusTip(tr("Italicize your text"));
   mpItalicAction->setShortcut(QKeySequence("Ctrl+i"));
   mpItalicAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpItalicAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::ToggleItalic), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpItalicAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleItalic), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // underline action
   mpUnderlineAction = new QAction(QIcon(":/Resources/icons/underline-icon.svg"), Helper::underline, this);
   mpUnderlineAction->setStatusTip(tr("Underline your text"));
   mpUnderlineAction->setShortcut(QKeySequence("Ctrl+u"));
   mpUnderlineAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpUnderlineAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::ToggleUnderline), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpUnderlineAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleUnderline), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // strikethrough action
   mpStrikethroughAction = new QAction(QIcon(":/Resources/icons/strikethrough-icon.svg"), tr("Strikethrough"), this);
   mpStrikethroughAction->setStatusTip(tr("Cross something out by drawing a line through it"));
   mpStrikethroughAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpStrikethroughAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::ToggleStrikethrough), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpStrikethroughAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleStrikethrough), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // subscript superscript action group
   QActionGroup *pSubscriptSuperscriptActionGroup = new QActionGroup(this);
   pSubscriptSuperscriptActionGroup->setExclusive(true);
@@ -234,20 +216,12 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   mpSubscriptAction = new QAction(QIcon(":/Resources/icons/subscript-icon.svg"), tr("Subscript"), pSubscriptSuperscriptActionGroup);
   mpSubscriptAction->setStatusTip(tr("Type very small letters just below the line of text"));
   mpSubscriptAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpSubscriptAction, SIGNAL(triggered()), SLOT(subscript()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpSubscriptAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleSubscript), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // superscript action
   mpSuperscriptAction = new QAction(QIcon(":/Resources/icons/superscript-icon.svg"), tr("Superscript"), pSubscriptSuperscriptActionGroup);
   mpSuperscriptAction->setStatusTip(tr("Type very small letters just above the line of text"));
   mpSuperscriptAction->setCheckable(true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpSuperscriptAction, SIGNAL(triggered()), SLOT(superscript()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpSuperscriptAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::ToggleSuperscript), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // text color toobutton
   mTextColor = Qt::black;
   mpTextColorDialog = new QColorDialog;
@@ -333,19 +307,11 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   // decrease indent action
   mpDecreaseIndentAction = new QAction(QIcon(":/Resources/icons/decrease-indent.svg"), tr("Decrease Indent"), this);
   mpDecreaseIndentAction->setStatusTip(tr("Decreases the indent by moving left"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpDecreaseIndentAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::Outdent), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpDecreaseIndentAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::Outdent), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // increase indent action
   mpIncreaseIndentAction = new QAction(QIcon(":/Resources/icons/increase-indent.svg"), tr("Increase Indent"), this);
   mpIncreaseIndentAction->setStatusTip(tr("Increases the indent by moving right"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   connect(mpIncreaseIndentAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebEnginePage::Indent), SLOT(trigger()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  connect(mpIncreaseIndentAction, SIGNAL(triggered()), mpHTMLEditor->pageAction(QWebPage::Indent), SLOT(trigger()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // bullet list action
   mpBulletListAction = new QAction(QIcon(":/Resources/icons/bullet-list.svg"), tr("Bullet List"), this);
   mpBulletListAction->setStatusTip(tr("Creates a bulleted list"));
@@ -395,11 +361,9 @@ DocumentationWidget::DocumentationWidget(QWidget *pParent)
   mpEditorToolBar->addAction(mpUnLinkAction);
   // update the actions whenever the selectionChanged signal is raised.
   connect(mpHTMLEditor->page(), SIGNAL(selectionChanged()), SLOT(updateActions()));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // Qt webengine editing works only when we have a selection.
   // Call updateActions() to disable all actions since there is not selection yet.
   updateActions();
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // add a layout to html editor widget
   QVBoxLayout *pHTMLWidgetLayout = new QVBoxLayout;
   pHTMLWidgetLayout->setAlignment(Qt::AlignTop);
@@ -527,13 +491,8 @@ void DocumentationWidget::showDocumentation(LibraryTreeItem *pLibraryTreeItem)
 void DocumentationWidget::execCommand(const QString &commandName)
 {
   QString javaScript = QString("document.execCommand(\"%1\", false, null)").arg(commandName);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QWebEnginePage *pWebPage = mpHTMLEditor->page();
   pWebPage->runJavaScript(javaScript);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  pWebFrame->evaluateJavaScript(javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 }
 
 /*!
@@ -546,16 +505,10 @@ void DocumentationWidget::execCommand(const QString &commandName)
 void DocumentationWidget::execCommand(const QString &command, const QString &valueArgument)
 {
   QString javaScript = QString("document.execCommand(\"%1\", false, \"%2\")").arg(command).arg(valueArgument);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QWebEnginePage *pWebPage = mpHTMLEditor->page();
   pWebPage->runJavaScript(javaScript);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  pWebFrame->evaluateJavaScript(javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 struct JavaScriptResult {
   QVariant result;
   bool finished;
@@ -587,7 +540,6 @@ QVariant DocumentationWidget::runJavaScript(const QString &javaScript)
   delete pJavaScriptResult;
   return result;
 }
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 
 /*!
  * \brief DocumentationWidget::queryCommandState
@@ -600,12 +552,7 @@ bool DocumentationWidget::queryCommandState(const QString &commandName)
 {
   QString javaScript = QString("document.queryCommandState(\"%1\")").arg(commandName);
   QVariant result;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   result = runJavaScript(javaScript);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  result = pWebFrame->evaluateJavaScript(javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   return result.toString().simplified().toLower() == "true";
 }
 
@@ -620,12 +567,7 @@ QString DocumentationWidget::queryCommandValue(const QString &commandName)
 {
   QString javaScript = QString("document.queryCommandValue(\"%1\")").arg(commandName);
   QVariant result;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   result = runJavaScript(javaScript);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  result = pWebFrame->evaluateJavaScript(javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   return result.toString();
 }
 
@@ -637,11 +579,7 @@ void DocumentationWidget::saveScrollPosition()
 {
   if (mDocumentationHistoryPos > -1 && mpDocumentationHistoryList->size() > 0) {
     DocumentationHistory documentationHistory = mpDocumentationHistoryList->at(mDocumentationHistoryPos);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     documentationHistory.mScrollPosition = mpDocumentationViewer->page()->scrollPosition().toPoint();
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    documentationHistory.mScrollPosition = mpDocumentationViewer->page()->mainFrame()->scrollPosition();
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     mpDocumentationHistoryList->replace(mDocumentationHistoryPos, documentationHistory);
   }
 }
@@ -760,12 +698,7 @@ bool DocumentationWidget::isLinkSelected()
                                "}"
                                "isLinkSelected()");
   QVariant result;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   result = runJavaScript(javaScript);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  result = pWebFrame->evaluateJavaScript(javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   return result.toString().simplified().toLower() == "true";
 }
 
@@ -805,7 +738,6 @@ bool DocumentationWidget::removeDocumentationHistory(LibraryTreeItem *pLibraryTr
  */
 void DocumentationWidget::updateHTMLSourceEditor()
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QEventLoop eventLoop;
   QTimer timer;
   connect(&timer, SIGNAL(timeout()), &eventLoop, SLOT(quit()));
@@ -823,9 +755,6 @@ void DocumentationWidget::updateHTMLSourceEditor()
   QString contents = textEdit->toPlainText();
   contents.remove(" contenteditable=\"true\"");
   textEdit->setPlainText(contents);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  mpHTMLSourceEditor->getPlainTextEdit()->setPlainText(mpHTMLEditor->page()->mainFrame()->toHtml());
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 }
 
 /*!
@@ -852,14 +781,6 @@ void DocumentationWidget::updateActionsHelper()
   // Remove single quote around the font name.
   fontName = StringHandler::removeFirstLastSingleQuotes(fontName);
 #endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  /* Issue #13038
-   * We get the current font name by calling `document.queryCommandValue("fontName")` via JavaScript on current cursor position.
-   * The webkit returns `-webkit-standard` for default font name instead of the actual font name.
-   * When we get `-webkit-standard` convert it to default system font name.
-   */
-  if (fontName.compare(QStringLiteral("-webkit-standard")) == 0) {
-    fontName = Helper::systemFontInfo.family();
-  }
   currentIndex = mpFontComboBox->findText(fontName, Qt::MatchExactly);
   if (currentIndex > -1) {
     mpFontComboBox->setCurrentIndex(currentIndex);
@@ -872,21 +793,12 @@ void DocumentationWidget::updateActionsHelper()
     mpFontSizeSpinBox->setValue(fontSize);
     mpFontSizeSpinBox->blockSignals(state);
   }
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   mpBoldAction->setChecked(queryCommandState("bold"));
   mpItalicAction->setChecked(queryCommandState("italic"));
   mpUnderlineAction->setChecked(queryCommandState("underline"));
   mpStrikethroughAction->setChecked(queryCommandState("strikeThrough"));
   mpSubscriptAction->setChecked(queryCommandState("subscript"));
   mpSuperscriptAction->setChecked(queryCommandState("superscript"));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  mpBoldAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleBold)->isChecked());
-  mpItalicAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleItalic)->isChecked());
-  mpUnderlineAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleUnderline)->isChecked());
-  mpStrikethroughAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleStrikethrough)->isChecked());
-  mpSubscriptAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleSubscript)->isChecked());
-  mpSuperscriptAction->setChecked(mpHTMLEditor->pageAction(QWebPage::ToggleSuperscript)->isChecked());
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   mpAlignLeftToolButton->setChecked(queryCommandState("justifyLeft"));
   mpAlignCenterToolButton->setChecked(queryCommandState("justifyCenter"));
   mpAlignRightToolButton->setChecked(queryCommandState("justifyRight"));
@@ -1401,12 +1313,7 @@ void DocumentationWidget::createLink()
                                "}"
                                "getLinkHref()");
   QString href;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   href = runJavaScript(javaScript).toString();
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebFrame *pWebFrame = mpHTMLEditor->page()->mainFrame();
-  href = pWebFrame->evaluateJavaScript(javaScript).toString();
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   href = QInputDialog::getText(this, tr("Create Link"), "Enter URL", QLineEdit::Normal, href);
   execCommand("createLink", href);
 }
@@ -1420,7 +1327,6 @@ void DocumentationWidget::removeLink()
   execCommand("unlink");
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 DocumentationPage::DocumentationPage(QObject *parent)
   : QWebEnginePage(parent)
 {
@@ -1470,7 +1376,6 @@ void DocumentationPage::emitLinkClicked()
 {
   emit linkClicked(mUrl);
 }
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 
 /*!
  * \class DocumentationViewer
@@ -1482,11 +1387,7 @@ void DocumentationPage::emitLinkClicked()
  * \param isContentEditable
  */
 DocumentationViewer::DocumentationViewer(DocumentationWidget *pDocumentationWidget, bool isContentEditable)
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   : QWebEngineView(pDocumentationWidget)
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  : QWebView(pDocumentationWidget)
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   , mIsContentEditable(isContentEditable)
 {
   mpDocumentationWidget = pDocumentationWidget;
@@ -1494,31 +1395,19 @@ DocumentationViewer::DocumentationViewer(DocumentationWidget *pDocumentationWidg
   connect(this, SIGNAL(customContextMenuRequested(QPoint)), SLOT(showContextMenu(QPoint)));
   resetZoom();
   // set DocumentationViewer settings
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // create a new QWebEnginePage so we can handle link clicks
   mpDocumentationPage = new DocumentationPage(this);
   setPage(mpDocumentationPage);
   settings()->setFontFamily(QWebEngineSettings::StandardFont, Helper::systemFontInfo.family());
   settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  settings()->setFontFamily(QWebSettings::StandardFont, Helper::systemFontInfo.family());
-  settings()->setAttribute(QWebSettings::LocalStorageEnabled, true);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   settings()->setDefaultTextEncoding(Helper::utf8.toUtf8().constData());
   // set DocumentationViewer web page policy
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   // Set the contenteditable="true" in pageLoaded()
   /* Qt WebEngine doesn't support DelegateAllLinks, linkClicked
    * We created an object of QWebEnginePage which overrides acceptNavigationRequest to handle link clicks
    */
   connect(page(), SIGNAL(linkClicked(QUrl)), SLOT(processLinkClick(QUrl)));
   connect(page(), SIGNAL(linkHovered(QString)), SLOT(processLinkHover(QString)));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  page()->setContentEditable(mIsContentEditable);
-  page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
-  connect(page(), SIGNAL(linkClicked(QUrl)), SLOT(processLinkClick(QUrl)));
-  connect(page(), SIGNAL(linkHovered(QString,QString,QString)), SLOT(processLinkHover(QString,QString,QString)));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   createActions();
   connect(this, SIGNAL(loadFinished(bool)), SLOT(pageLoaded(bool)));
 }
@@ -1545,13 +1434,10 @@ void DocumentationViewer::createActions()
 {
 #if defined(__EMSCRIPTEN__) || defined(OM_OMEDIT_NO_WEBENGINE)
   // QWebEnginePage shim has no page actions (action() returns nullptr).
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#else
   page()->action(QWebEnginePage::SelectAll)->setShortcut(QKeySequence("Ctrl+a"));
   page()->action(QWebEnginePage::Copy)->setShortcut(QKeySequence("Ctrl+c"));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  page()->action(QWebPage::SelectAll)->setShortcut(QKeySequence("Ctrl+a"));
-  page()->action(QWebPage::Copy)->setShortcut(QKeySequence("Ctrl+c"));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#endif
 }
 
 /*!
@@ -1593,14 +1479,7 @@ void DocumentationViewer::processLinkClick(QUrl url)
       }
     }
   } else { // if it is normal http request then check if its not redirected to https
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // TODO: QNetworkAccessManager
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QNetworkAccessManager* accessManager = page()->networkAccessManager();
-    QNetworkRequest request(url);
-    QNetworkReply* reply = accessManager->get(request);
-    connect(reply, SIGNAL(finished()), SLOT(requestFinished()));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   }
 }
 
@@ -1659,13 +1538,10 @@ void DocumentationViewer::showContextMenu(QPoint point)
   // add QWebPage default actions
 #if defined(__EMSCRIPTEN__) || defined(OM_OMEDIT_NO_WEBENGINE)
   // QWebEnginePage shim has no page actions.
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#else
   menu.addAction(page()->action(QWebEnginePage::SelectAll));
   menu.addAction(page()->action(QWebEnginePage::Copy));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  menu.addAction(page()->action(QWebPage::SelectAll));
-  menu.addAction(page()->action(QWebPage::Copy));
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#endif
   menu.exec(mapToGlobal(point));
 }
 
@@ -1679,15 +1555,9 @@ void DocumentationViewer::pageLoaded(bool ok)
   Q_UNUSED(ok);
   if (!mIsContentEditable) {
     const QPoint scrollPosition = mpDocumentationWidget->getScrollPosition();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     page()->runJavaScript(QString("window.scrollTo(%1, %2);").arg(scrollPosition.x()).arg(scrollPosition.y()));
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    page()->mainFrame()->scroll(scrollPosition.x(), scrollPosition.y());
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     page()->runJavaScript("document.documentElement.contentEditable = true");
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   }
 }
 
@@ -1696,20 +1566,11 @@ void DocumentationViewer::pageLoaded(bool ok)
  * \param type
  * \return
  */
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 QWebEngineView* DocumentationViewer::createWindow(QWebEnginePage::WebWindowType type)
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-QWebView* DocumentationViewer::createWindow(QWebPage::WebWindowType type)
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 {
   Q_UNUSED(type);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QWebEngineView *webView = new QWebEngineView;
   QWebEnginePage *newWeb = new QWebEnginePage(webView);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebView *webView = new QWebView;
-  QWebPage *newWeb = new QWebPage(webView);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   webView->setAttribute(Qt::WA_DeleteOnClose, true);
   webView->setPage(newWeb);
   webView->show();
@@ -1730,17 +1591,9 @@ void DocumentationViewer::keyPressEvent(QKeyEvent *event)
   if (mIsContentEditable) {
     if (!shiftModifier && (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)) {
 //      mpDocumentationWidget->execCommand("insertHTML", "<p><br></p>");
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
       QWebEngineView::keyPressEvent(event);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-      QWebView::keyPressEvent(event);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
       QWebEngineView::keyPressEvent(event);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-      QWebView::keyPressEvent(event);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     }
   } else { // if non-editable QWebView
     if (shiftModifier && !controlModifier && event->key() == Qt::Key_Backspace) {
@@ -1752,17 +1605,9 @@ void DocumentationViewer::keyPressEvent(QKeyEvent *event)
         mpDocumentationWidget->previousDocumentation();
       }
     } else if (controlModifier && event->key() == Qt::Key_A) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
       page()->triggerAction(QWebEnginePage::SelectAll);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-      page()->triggerAction(QWebPage::SelectAll);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
       QWebEngineView::keyPressEvent(event);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-      QWebView::keyPressEvent(event);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     }
   }
 }
@@ -1797,11 +1642,7 @@ void DocumentationViewer::wheelEvent(QWheelEvent *event)
     }
     setZoomFactor(zf);
   } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QWebEngineView::wheelEvent(event);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QWebView::wheelEvent(event);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   }
 }
 
@@ -1816,10 +1657,6 @@ void DocumentationViewer::mouseDoubleClickEvent(QMouseEvent *event)
   if (event->modifiers().testFlag(Qt::ControlModifier)) {
     resetZoom();
   } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QWebEngineView::mouseDoubleClickEvent(event);
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QWebView::mouseDoubleClickEvent(event);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -46,12 +46,10 @@
 #include <QFile>
 #if defined(__EMSCRIPTEN__) || defined(OM_OMEDIT_NO_WEBENGINE)
 #include "Modeling/qtwebengine_compat.h" // QtWebEngine unavailable on wasm / stubbed on MSVC
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#else
 #include <QWebEngineView>
 #include <QWebEnginePage>
-#else // #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QWebView>
-#endif // #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#endif
 #include <QToolBar>
 #include <QComboBox>
 #include <QFontComboBox>
@@ -95,9 +93,7 @@ public:
   void showDocumentation(LibraryTreeItem *pLibraryTreeItem);
   void execCommand(const QString &commandName);
   void execCommand(const QString &commandName, const QString &valueArgument);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QVariant runJavaScript(const QString &javaScript);
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   bool queryCommandState(const QString &commandName);
   QString queryCommandValue(const QString &commandName);
   void saveScrollPosition();
@@ -192,7 +188,6 @@ public slots:
   void removeLink();
 };
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 class DocumentationPage : public QWebEnginePage
 {
   Q_OBJECT
@@ -209,16 +204,11 @@ private slots:
 };
 
 class DocumentationViewer : public QWebEngineView
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-class DocumentationViewer : public QWebView
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 {
   Q_OBJECT
 private:
   DocumentationWidget *mpDocumentationWidget;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   DocumentationPage *mpDocumentationPage;
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 public:
   DocumentationViewer(DocumentationWidget *pDocumentationWidget, bool isContentEditable = false);
   void setFocusInternal();
@@ -233,11 +223,7 @@ public slots:
   void showContextMenu(QPoint point);
   void pageLoaded(bool ok);
 protected:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type) override;
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  virtual QWebView* createWindow(QWebPage::WebWindowType type) override;
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   virtual void keyPressEvent(QKeyEvent *event) override;
   virtual void wheelEvent(QWheelEvent *event) override;
   virtual void mouseDoubleClickEvent(QMouseEvent *event) override;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -60,9 +60,6 @@
 #include <QStatusBar>
 #include <QListWidget>
 #include <QMdiArea>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QtWebKit>
-#endif // #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QSplitter>
 #include <QUndoStack>
 #include <QUndoView>

--- a/OMEdit/OMEditLIB/Traceability/TraceabilityGraphViewWidget.cpp
+++ b/OMEdit/OMEditLIB/Traceability/TraceabilityGraphViewWidget.cpp
@@ -38,11 +38,7 @@
 TraceabilityGraphViewWidget::TraceabilityGraphViewWidget(QWidget *pParent)
   : QWidget(pParent)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   mpTraceabilityGraphWebView = new QWebEngineView;
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  mpTraceabilityGraphWebView = new QWebView;
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   mpTraceabilityGraphWebView->load(QUrl("http://localhost:7474/browser/"));
   mpTraceabilityGraphViewLabel = new QLabel(tr("Traceability Graph View"));
   QFont font;

--- a/OMEdit/OMEditLIB/Traceability/TraceabilityGraphViewWidget.h
+++ b/OMEdit/OMEditLIB/Traceability/TraceabilityGraphViewWidget.h
@@ -44,11 +44,9 @@
 #include "QUrl"
 #if defined(__EMSCRIPTEN__) || defined(OM_OMEDIT_NO_WEBENGINE)
 #include "Modeling/qtwebengine_compat.h" // QtWebEngine unavailable on wasm / stubbed on MSVC
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#else
 #include <QWebEngineView>
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <QWebView>
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#endif
 
 class TraceabilityGraphViewWidget: public QWidget
 {
@@ -56,11 +54,7 @@ class TraceabilityGraphViewWidget: public QWidget
 public:
   TraceabilityGraphViewWidget(QWidget *pParent = 0);
 private:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QWebEngineView *mpTraceabilityGraphWebView;
-#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  QWebView *mpTraceabilityGraphWebView;
-#endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   QLabel *mpTraceabilityGraphViewLabel;
 };
 


### PR DESCRIPTION
@adrpo #15593 removed OM_OMEDIT_ENABLE_QTWEBENGINE and assumes qt5 means webkit and qt6 means webengine so its no longer possible to choose qt5+webengine, lets drop the webkit path altogether instead of reintroducing the option to restore qt5+webengine support
