### PR TITLE
Fix negation in flow alias eliminiation

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFStreamFlowAlias.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStreamFlowAlias.mo
@@ -638,7 +638,7 @@ public
     end if;
 
     if negated then
-      b := Binding.mapExp(binding, Expression.negate);
+      b := Binding.mapExpShallow(binding, Expression.negate);
     else
       b := binding;
     end if;
@@ -682,7 +682,7 @@ public
               attr_binding := evalAliasAttribute(attr_binding);
 
               if negated then
-                attr_binding := Binding.mapExp(attr_binding, Expression.negate);
+                attr_binding := Binding.mapExpShallow(attr_binding, Expression.negate);
               end if;
 
               startValues := (var.name, attr_binding) :: startValues;
@@ -694,7 +694,7 @@ public
               attr_binding := evalAliasAttribute(attr_binding);
 
               if negated then
-                attr_binding := Binding.mapExp(attr_binding, Expression.negate);
+                attr_binding := Binding.mapExpShallow(attr_binding, Expression.negate);
               end if;
 
               nominalValues := (var.name, attr_binding) :: nominalValues;

--- a/testsuite/openmodelica/basemodelica/FlowAlias13.mos
+++ b/testsuite/openmodelica/basemodelica/FlowAlias13.mos
@@ -1,0 +1,58 @@
+// name: FlowAlias13
+// status: correct
+
+loadFile("TestAliasStream.mo"); getErrorString();
+
+loadString("
+  model Splitter
+    TestAliasStream.FluidPort C;
+    TestAliasStream.FluidPort H;
+  equation
+    connect(C, H);
+  end Splitter;
+
+  model Test13
+    Splitter splitter[2];
+  end Test13;
+");
+
+setCommandLineOptions("-f -d=flowAliasElimination"); getErrorString();
+instantiateModel(Test13); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// true
+// ""
+// "//! base 0.1.0
+// package 'Test13'
+//   model 'Test13'
+//     Real 'splitter[1].C.p';
+//     Real 'splitter[1].C.h';
+//     Real 'splitter[1].H.p';
+//     Real 'splitter[1].H.h';
+//     Real 'splitter[2].C.p';
+//     Real 'splitter[2].C.h';
+//     Real 'splitter[2].H.p';
+//     Real 'splitter[2].H.h';
+//     Real 'splitter[1].C.w';
+//     Real 'splitter[1].H.w' = -'splitter[1].C.w' \"Alias variable\";
+//     Real 'splitter[2].C.w';
+//     Real 'splitter[2].H.w' = -'splitter[2].C.w' \"Alias variable\";
+//   equation
+//     'splitter[1].C.h' = 'splitter[1].H.h';
+//     'splitter[1].H.h' = 'splitter[1].C.h';
+//     'splitter[2].C.h' = 'splitter[2].H.h';
+//     'splitter[2].H.h' = 'splitter[2].C.h';
+//     'splitter[1].C.p' = 'splitter[1].H.p';
+//     'splitter[2].C.p' = 'splitter[2].H.p';
+//     'splitter[1].C.w' = 0.0;
+//     -'splitter[1].C.w' = 0.0;
+//     'splitter[2].C.w' = 0.0;
+//     -'splitter[2].C.w' = 0.0;
+//   end 'Test13';
+// end 'Test13';
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -29,6 +29,7 @@ TESTFILES = \
 	FlowAlias10.mos \
 	FlowAlias11.mos \
 	FlowAlias12.mos \
+	FlowAlias13.mos \
 	Functional1.mo \
 	If1.mo \
 	If2.mo \


### PR DESCRIPTION
- Don't use the recursive version of Binding.mapExp, we only want to negate the binding expression itself.

Fixes #15984
