### PR TITLE
Fix memory safety bugs in SimulationRuntime

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/SimController/SimManager.cpp
@@ -289,8 +289,8 @@ void SimManager::computeSampleCycles()
         else
         {
             // Check if sample time is a multiple of the cycle time (with a tolerance)
-            if ((iter->second / _config->getGlobalSettings()->gethOutput()) - int(
-                (iter->second / _config->getGlobalSettings()->gethOutput()) + 0.5) <= 1e6 * UROUND)
+            if (std::fabs((iter->second / _config->getGlobalSettings()->gethOutput()) - int(
+                (iter->second / _config->getGlobalSettings()->gethOutput()) + 0.5)) <= 1e6 * UROUND)
             {
                 _sampleCycles[counter] = int((iter->second / _config->getGlobalSettings()->gethOutput()) + 0.5);
             }

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
@@ -57,7 +57,10 @@ void debugeSteps(OptData * optData, modelica_real*vopt, modelica_real * lambda){
 
   sprintf(buffer, "%s_%d.csv", optData->ipop.csvOstep,optData->dim.iter);
   pFile = omc_fopen(buffer, "wt");
-  if (!pFile) return;
+  if (!pFile) {
+    fprintf(stderr, "Warning: cannot open %s for writing debug output.\n", buffer);
+    return;
+  }
 
   fprintf(pFile, "%s", "\"time\"");
   for(i = 0; i < nx; ++i){
@@ -131,6 +134,7 @@ void debugeJac(OptData * optData, ipnumber* vopt){
   sprintf(buffer, "jac_ana_step_%i.csv", optData->iter_);
   pFile = omc_fopen(buffer, "wt");
   if (!pFile) {
+    fprintf(stderr, "Warning: cannot open %s for writing debug output.\n", buffer);
     free(vopt_shift);
     free(h);
     free(vv);
@@ -203,6 +207,7 @@ void debugeJac(OptData * optData, ipnumber* vopt){
   sprintf(buffer, "jac_num_step_%i.csv", optData->iter_);
   pFile = omc_fopen(buffer, "wt");
   if (!pFile) {
+    fprintf(stderr, "Warning: cannot open %s for writing debug output.\n", buffer);
     free(vopt_shift);
     free(h);
     free(vv);
@@ -236,6 +241,7 @@ void debugeJac(OptData * optData, ipnumber* vopt){
   if(optData->iter_ < 2){
     pFile = omc_fopen("omc_check_jac.py", "wt");
     if (!pFile) {
+      fprintf(stderr, "Warning: cannot open omc_check_jac.py for writing debug output.\n");
       free(vopt_shift);
       free(h);
       free(vv);

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
@@ -57,6 +57,7 @@ void debugeSteps(OptData * optData, modelica_real*vopt, modelica_real * lambda){
 
   sprintf(buffer, "%s_%d.csv", optData->ipop.csvOstep,optData->dim.iter);
   pFile = omc_fopen(buffer, "wt");
+  if (!pFile) return;
 
   fprintf(pFile, "%s", "\"time\"");
   for(i = 0; i < nx; ++i){
@@ -129,6 +130,13 @@ void debugeJac(OptData * optData, ipnumber* vopt){
   sJ = optData->s.JderCon;
   sprintf(buffer, "jac_ana_step_%i.csv", optData->iter_);
   pFile = omc_fopen(buffer, "wt");
+  if (!pFile) {
+    free(vopt_shift);
+    free(h);
+    free(vv);
+    free(JJ);
+    return;
+  }
 
   fprintf(pFile,"name;time;");
   for(j = 0; j < nx; ++j)
@@ -194,6 +202,13 @@ void debugeJac(OptData * optData, ipnumber* vopt){
 #undef DF_STEP
   sprintf(buffer, "jac_num_step_%i.csv", optData->iter_);
   pFile = omc_fopen(buffer, "wt");
+  if (!pFile) {
+    free(vopt_shift);
+    free(h);
+    free(vv);
+    free(JJ);
+    return;
+  }
 
   fprintf(pFile,"name;time;");
   for(j = 0; j < nx; ++j)
@@ -220,6 +235,13 @@ void debugeJac(OptData * optData, ipnumber* vopt){
 
   if(optData->iter_ < 2){
     pFile = omc_fopen("omc_check_jac.py", "wt");
+    if (!pFile) {
+      free(vopt_shift);
+      free(h);
+      free(vv);
+      free(JJ);
+      return;
+    }
     fprintf(pFile,"\"\"\"\nautomatically generated code for analyse derivatives\n\n");
     fprintf(pFile,"  Input i:\n");
     for(j = 0; j < nx; ++j)

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
@@ -251,7 +251,6 @@ static int getNsi(char*filename, const int nsi, modelica_boolean * exTimeGrid){
   pFile = omc_fopen(filename,"r");
   if(pFile == NULL){
     warningStreamPrint(OMC_LOG_STDOUT, 0, "OMC can't find the file %s.", filename);
-    fclose(pFile);
     return nsi;
   }
    while(1){
@@ -960,7 +959,7 @@ static inline void pickUpStates(OptData* optData){
         char buffer[200];
         rewind(pFile);
         for(i =0; i< n; ++i){
-          fscanf(pFile, "%s", buffer);
+          fscanf(pFile, "%199s", buffer);
           if (fscanf(pFile, "%lf", &start_value) <= 0) continue;
 
           for(j = 0, b = 0; j < optData->dim.nReal; ++j){

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -838,6 +838,8 @@ omc_ModelInput* parse_input_xml(const char *filename, const char* initXMLData, t
   if(initXMLData == NULL) {
     file = omc_fopen(filename, "r");
     if(!file) {
+      free(mi);
+      XML_ParserFree(parser);
       throwStreamPrint(threadData, "simulation_input_xml.c: Error: can not read file %s as setup file to the generated simulation code.", filename);
     }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -825,7 +825,7 @@ omc_ModelInput* parse_input_xml(const char *filename, const char* initXMLData, t
   parser = XML_ParserCreate(NULL);
   if(!parser)
   {
-    fclose(file);
+    free(mi);
     throwStreamPrint(threadData, "simulation_input_xml.c: Error: couldn't allocate memory for the XML parser!");
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -340,6 +340,10 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     buffer[l][0] = 0;
   }
 
+  char **p = (char**)malloc(sizeof(char*)*n);
+  for (l=0; l<n; l++)
+    p[l] = buffer[l];
+
   k = 0;
   for (i = 0; i < n; i++)
   {
@@ -347,12 +351,12 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
       {
-        sprintf(buffer[j], "%s %5g ", buffer[j], Ax[k]);
+        p[j] += sprintf(p[j], " %5g ", Ax[k]);
         k++;
       }
       else
       {
-        sprintf(buffer[j], "%s %5g ", buffer[j], 0.0);
+        p[j] += sprintf(p[j], " %5g ", 0.0);
       }
     }
   }
@@ -361,6 +365,7 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer[l]);
     free(buffer[l]);
   }
+  free(p);
   free(buffer);
 }
 
@@ -369,20 +374,21 @@ void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k;
   char *buffer = (char*)malloc(sizeof(char)*n*15);
+  char *q;
   k = 0;
   for (i = 0; i < n; i++)
   {
-    buffer[0] = 0;
+    q = buffer;
     for (j = 0; j < n; j++)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
       {
-        sprintf(buffer, "%s %5.2g ", buffer, Ax[k]);
+        q += sprintf(q, " %5.2g ", Ax[k]);
         k++;
       }
       else
       {
-        sprintf(buffer, "%s %5.2g ", buffer, 0.0);
+        q += sprintf(q, " %5.2g ", 0.0);
       }
     }
     infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -120,11 +120,11 @@ void printLisMatrixCSR(LIS_MATRIX A, int n)
   for(i=0; i<n; i++)
   {
     char *buffer = (char*)malloc(sizeof(char)*A->ptr[i+1]*50);
-    buffer[0] = 0;
-    sprintf(buffer, "column %d: ", i);
+    char *p = buffer;
+    p += sprintf(p, "column %d: ", i);
     for(j = A->ptr[i]; j < A->ptr[i+1]; j++)
     {
-       sprintf(buffer, "%s(%d,%g) ", buffer, A->index[j], A->value[j]);
+       p += sprintf(p, "(%d,%g) ", A->index[j], A->value[j]);
     }
     infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer);
     free(buffer);
@@ -275,7 +275,7 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
     for(i=0; i<n; i++)
     {
       buffer[0] = 0;
-      sprintf(buffer, "%s%20.12g ", buffer, solverData->b->value[i]);
+      sprintf(buffer, "%20.12g ", solverData->b->value[i]);
       infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer);
     }
     messageClose(OMC_LOG_LS_V);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -274,7 +274,6 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
     infoStreamPrint(OMC_LOG_LS_V, 1, "b vector [%d]", n);
     for(i=0; i<n; i++)
     {
-      buffer[0] = 0;
       sprintf(buffer, "%20.12g ", solverData->b->value[i]);
       infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer);
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -55,19 +55,19 @@ void debugMatrixDoubleLS(int logName, char* matrixName, double* matrix, int n, i
     infoStreamPrint(logName, 1, "%s [%dx%d-dim]", matrixName, n, m);
     for(i=0; i<n;i++)
     {
-      buffer[0] = 0;
+      char *p = buffer;
       for(j=0; j<m; j++)
       {
         if (sparsity)
         {
           if (fabs(matrix[i + j*(m-1)])<1e-12)
-            sprintf(buffer, "%s 0", buffer);
+            p += sprintf(p, " 0");
           else
-            sprintf(buffer, "%s *", buffer);
+            p += sprintf(p, " *");
         }
         else
         {
-          sprintf(buffer, "%s %12.4g", buffer, matrix[i + j*(m-1)]);
+          p += sprintf(p, " %12.4g", matrix[i + j*(m-1)]);
         }
       }
       infoStreamPrint(logName, 0, "%s", buffer);
@@ -85,21 +85,23 @@ void debugVectorDoubleLS(int logName, char* vectorName, double* vector, int n)
     char *buffer = (char*)malloc(sizeof(char)*n*22);
 
     infoStreamPrint(logName, 1, "%s [%d-dim]", vectorName, n);
-    buffer[0] = 0;
-    if (vector[0]<-1e+300)
-      sprintf(buffer, "%s -INF", buffer);
-    else if (vector[0]>1e+300)
-      sprintf(buffer, "%s +INF", buffer);
-    else
-      sprintf(buffer, "%s %16.8g", buffer, vector[0]);
-    for(i=1; i<n;i++)
     {
-      if (vector[i]<-1e+300)
-        sprintf(buffer, "%s -INF", buffer);
-      else if (vector[i]>1e+300)
-        sprintf(buffer, "%s +INF", buffer);
+      char *p = buffer;
+      if (vector[0]<-1e+300)
+        p += sprintf(p, " -INF");
+      else if (vector[0]>1e+300)
+        p += sprintf(p, " +INF");
       else
-        sprintf(buffer, "%s %16.8g", buffer, vector[i]);
+        p += sprintf(p, " %16.8g", vector[0]);
+      for(i=1; i<n;i++)
+      {
+        if (vector[i]<-1e+300)
+          p += sprintf(p, " -INF");
+        else if (vector[i]>1e+300)
+          p += sprintf(p, " +INF");
+        else
+          p += sprintf(p, " %16.8g", vector[i]);
+      }
     }
     infoStreamPrint(logName, 0, "%s", buffer);
     free(buffer);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -574,6 +574,10 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     buffer[l][0] = 0;
   }
 
+  char **p = (char**)malloc(sizeof(char*)*n);
+  for (l=0; l<n; l++)
+    p[l] = buffer[l];
+
   k = 0;
   for (i = 0; i < n; i++)
   {
@@ -581,12 +585,12 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
       {
-        sprintf(buffer[j], "%s %5g ", buffer[j], Ax[k]);
+        p[j] += sprintf(p[j], " %5g ", Ax[k]);
         k++;
       }
       else
       {
-        sprintf(buffer[j], "%s %5g ", buffer[j], 0.0);
+        p[j] += sprintf(p[j], " %5g ", 0.0);
       }
     }
   }
@@ -595,6 +599,7 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
     infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer[l]);
     free(buffer[l]);
   }
+  free(p);
   free(buffer);
 }
 
@@ -602,20 +607,21 @@ void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k;
   char *buffer = (char*)malloc(sizeof(char)*n*20);
+  char *q;
   k = 0;
   for (i = 0; i < n; i++)
   {
-    buffer[0] = 0;
+    q = buffer;
     for (j = 0; j < n; j++)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
       {
-        sprintf(buffer, "%s %5.2g ", buffer, Ax[k]);
+        q += sprintf(q, " %5.2g ", Ax[k]);
         k++;
       }
       else
       {
-        sprintf(buffer, "%s %5.2g ", buffer, 0.0);
+        q += sprintf(q, " %5.2g ", 0.0);
       }
     }
     infoStreamPrint(OMC_LOG_LS_V, 0, "%s", buffer);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
@@ -234,9 +234,9 @@ int _omc_newton(genericResidualFunc f, DATA_NEWTON* solverData, void* userData)
       infoStreamPrint(OMC_LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", n, n);
       for(i=0; i<solverData->n;i++)
       {
-        buffer[0] = 0;
+        char *p = buffer;
         for(j=0; j<solverData->n; j++)
-          sprintf(buffer, "%s%10g ", buffer, fjac[i*n+j]);
+          p += sprintf(p, "%10g ", fjac[i*n+j]);
         infoStreamPrint(OMC_LOG_NLS_JAC, 0, "%s", buffer);
       }
       messageClose(OMC_LOG_NLS_JAC);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newton_diagnostics.c
@@ -129,7 +129,7 @@ double** getJacobian( DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DAT
   if (systemData->jacobianIndex != -1) {
     jacobian = &(data->simulationInfo->analyticJacobians[systemData->jacobianIndex]);
 
-    jac = (modelica_real*) calloc(jacobian->sizeRows * jacobian->sizeCols, sizeof(modelica_real*));
+    jac = (modelica_real*) calloc(jacobian->sizeRows * jacobian->sizeCols, sizeof(modelica_real));
     assertStreamPrint(threadData, NULL != jac, "out of memory");
 
     /* call generic dense Jacobian */
@@ -1213,6 +1213,19 @@ void newtonDiagnostics(DATA* data, threadData_t *threadData, int sysNumber)
 
   if (p == 0) {
     infoStreamPrint(OMC_LOG_NLS_NEWTON_DIAGNOSTICS, 0, "Newton diagnostics terminated: no non-linear equations!");
+    free(x0);
+    free(f);
+    free(dx);
+    for (i = 0; i < m; i++)
+      free(fx[i]);
+    free(fx);
+    for (i = 0; i < m; i++) {
+      for (j = 0; j < m; j++)
+        free(fxx[i][j]);
+      free(fxx[i]);
+    }
+    free(fxx);
+    free(n_idx);
     return;
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -2295,13 +2295,13 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
       {
         debugString(OMC_LOG_NLS_V, "assert handling:\t vary initial guess by +1%.");
         for(i = 0; i < homotopyData->n; i++)
-          homotopyData->x0[i] = homotopyData->xStart[i] + homotopyData->xScaling[i]*i/homotopyData->n*0.01;
+          homotopyData->x0[i] = homotopyData->xStart[i] + homotopyData->xScaling[i]*(double)i/homotopyData->n*0.01;
       }
       if (tries == 2)
       {
         debugString(OMC_LOG_NLS_V,"assert handling:\t vary initial guess by +10%.");
         for(i = 0; i < homotopyData->n; i++)
-          homotopyData->x0[i] = homotopyData->xStart[i] + homotopyData->xScaling[i]*i/homotopyData->n*0.1;
+          homotopyData->x0[i] = homotopyData->xStart[i] + homotopyData->xScaling[i]*(double)i/homotopyData->n*0.1;
       }
     }
     if (success != NLS_SOLVED) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -409,19 +409,19 @@ void debugMatrixPermutedDouble(int logName, char* matrixName, double* matrix, in
     infoStreamPrint(logName, 1, "%s [%dx%d-dim]", matrixName, n, m);
     for(i=0; i<n;i++)
     {
-      buffer[0] = 0;
+      char *p = buffer;
       for(j=0; j<m; j++)
       {
         if (sparsity)
         {
           if (fabs(matrix[indRow[i] + indCol[j]*(m-1)])<1e-12)
-            sprintf(buffer, "%s 0", buffer);
+            p += sprintf(p, " 0");
           else
-            sprintf(buffer, "%s *", buffer);
+            p += sprintf(p, " *");
         }
         else
         {
-          sprintf(buffer, "%s %16.8g", buffer, matrix[indRow[i] + indCol[j]*(m-1)]);
+          p += sprintf(p, " %16.8g", matrix[indRow[i] + indCol[j]*(m-1)]);
         }
       }
       infoStreamPrint(logName, 0, "%s", buffer);
@@ -442,19 +442,19 @@ void debugMatrixDouble(int logName, char* matrixName, double* matrix, int n, int
     infoStreamPrint(logName, 1, "%s [%dx%d-dim]", matrixName, n, m);
     for(i=0; i<n;i++)
     {
-      buffer[0] = 0;
+      char *p = buffer;
       for(j=0; j<m; j++)
       {
         if (sparsity)
         {
           if (fabs(matrix[i + j*(m-1)])<1e-12)
-            sprintf(buffer, "%s 0", buffer);
+            p += sprintf(p, " 0");
           else
-            sprintf(buffer, "%s *", buffer);
+            p += sprintf(p, " *");
         }
         else
         {
-          sprintf(buffer, "%s %16.8g", buffer, matrix[i + j*(m-1)]);
+          p += sprintf(p, " %16.8g", matrix[i + j*(m-1)]);
         }
       }
       infoStreamPrint(logName, 0, "%s", buffer);
@@ -472,21 +472,23 @@ void debugVectorDouble(int logName, char* vectorName, double* vector, int n)
     char *buffer = (char*)malloc(sizeof(char)*n*20);
 
     infoStreamPrint(logName, 1, "%s [%d-dim]", vectorName, n);
-    buffer[0] = 0;
-    if (vector[0]<-1e+300)
-      sprintf(buffer, "%s-INF", buffer);
-    else if (vector[0]>1e+300)
-      sprintf(buffer, "%s+INF", buffer);
-    else
-      sprintf(buffer, "%s%16.8g", buffer, vector[0]);
-    for(i=1; i<n;i++)
     {
-      if (vector[i]<-1e+300)
-        sprintf(buffer, "%s -INF", buffer);
-      else if (vector[i]>1e+300)
-        sprintf(buffer, "%s +INF", buffer);
+      char *p = buffer;
+      if (vector[0]<-1e+300)
+        p += sprintf(p, "-INF");
+      else if (vector[0]>1e+300)
+        p += sprintf(p, "+INF");
       else
-        sprintf(buffer, "%s %16.8g", buffer, vector[i]);
+        p += sprintf(p, "%16.8g", vector[0]);
+      for(i=1; i<n;i++)
+      {
+        if (vector[i]<-1e+300)
+          p += sprintf(p, " -INF");
+        else if (vector[i]>1e+300)
+          p += sprintf(p, " +INF");
+        else
+          p += sprintf(p, " %16.8g", vector[i]);
+      }
     }
     infoStreamPrint(logName, 0, "%s", buffer);
     messageClose(logName);
@@ -502,21 +504,23 @@ void debugVectorBool(int logName, char* vectorName, modelica_boolean* vector, in
     char *buffer = (char*)malloc(sizeof(char)*n*20);
 
     infoStreamPrint(logName, 1, "%s [%d-dim]", vectorName, n);
-    buffer[0] = 0;
-    if (vector[0]<-1e+300)
-      sprintf(buffer, "%s-INF", buffer);
-    else if (vector[0]>1e+300)
-      sprintf(buffer, "%s+INF", buffer);
-    else
-      sprintf(buffer, "%s%d", buffer, vector[0]);
-    for(i=1; i<n;i++)
     {
-      if (vector[i]<-1e+300)
-        sprintf(buffer, "%s -INF", buffer);
-      else if (vector[i]>1e+300)
-        sprintf(buffer, "%s +INF", buffer);
+      char *p = buffer;
+      if (vector[0]<-1e+300)
+        p += sprintf(p, "-INF");
+      else if (vector[0]>1e+300)
+        p += sprintf(p, "+INF");
       else
-        sprintf(buffer, "%s %d", buffer, vector[i]);
+        p += sprintf(p, "%d", vector[0]);
+      for(i=1; i<n;i++)
+      {
+        if (vector[i]<-1e+300)
+          p += sprintf(p, " -INF");
+        else if (vector[i]>1e+300)
+          p += sprintf(p, " +INF");
+        else
+          p += sprintf(p, " %d", vector[i]);
+      }
     }
     infoStreamPrint(logName, 0, "%s", buffer);
     messageClose(logName);
@@ -532,21 +536,23 @@ void debugVectorInt(int logName, char* vectorName, int* vector, int n)
     char *buffer = (char*)malloc(sizeof(char)*n*20);
 
     infoStreamPrint(logName, 1, "%s [%d-dim]", vectorName, n);
-    buffer[0] = 0;
-    if (vector[0]<-1e+300)
-      sprintf(buffer, "%s-INF", buffer);
-    else if (vector[0]>1e+300)
-      sprintf(buffer, "%s+INF", buffer);
-    else
-      sprintf(buffer, "%s%d", buffer, vector[0]);
-    for(i=1; i<n;i++)
     {
-      if (vector[i]<-1e+300)
-        sprintf(buffer, "%s -INF", buffer);
-      else if (vector[i]>1e+300)
-        sprintf(buffer, "%s +INF", buffer);
+      char *p = buffer;
+      if (vector[0]<-1e+300)
+        p += sprintf(p, "-INF");
+      else if (vector[0]>1e+300)
+        p += sprintf(p, "+INF");
       else
-        sprintf(buffer, "%s %d", buffer, vector[i]);
+        p += sprintf(p, "%d", vector[0]);
+      for(i=1; i<n;i++)
+      {
+        if (vector[i]<-1e+300)
+          p += sprintf(p, " -INF");
+        else if (vector[i]>1e+300)
+          p += sprintf(p, " +INF");
+        else
+          p += sprintf(p, " %d", vector[i]);
+      }
     }
     infoStreamPrint(logName, 0, "%s", buffer);
     messageClose(logName);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -362,9 +362,9 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
         infoStreamPrint(OMC_LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", n, n);
         for(i=0; i<n; i++)
         {
-          buffer[0] = 0;
+          char *p = buffer;
           for(j=0; j<n; j++)
-            sprintf(buffer, "%s%20.12g ", buffer, fjac[i*hybrdData->n+j]);
+            p += sprintf(p, "%20.12g ", fjac[i*hybrdData->n+j]);
           infoStreamPrint(OMC_LOG_NLS_JAC, 0, "%s", buffer);
         }
         messageClose(OMC_LOG_NLS_JAC);
@@ -642,9 +642,9 @@ NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYS
           infoStreamPrint(OMC_LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", (int)hybrdData->n, (int)hybrdData->n);
           for(i=0; i<hybrdData->n; i++)
           {
-            buffer[0] = 0;
+            char *p = buffer;
             for(j=0; j<hybrdData->n; j++)
-              sprintf(buffer, "%s%10g ", buffer, hybrdData->fjacobian[i*hybrdData->n+j]);
+              p += sprintf(p, "%10g ", hybrdData->fjacobian[i*hybrdData->n+j]);
             infoStreamPrint(OMC_LOG_NLS_JAC, 0, "%s", buffer);
           }
           messageClose(OMC_LOG_NLS_JAC);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -1376,10 +1376,12 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
       sprintf(buffer, "%s_nonlinsys%d_equidistant_local_homotopy.csv", data->modelData->modelFilePrefix, sysNumber);
       infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 0, "The homotopy path of system %d will be exported to %s.", sysNumber, buffer);
       pFile = omc_fopen(buffer, "wt");
-      fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
-      for(j=0; j<nonlinsys->size; ++j)
-        fprintf(pFile, "%s\"%s\"", sep, modelInfoGetEquation(&data->modelData->modelDataXml, nonlinsys->equationIndex).vars[j]);
-      fprintf(pFile, "\n");
+      if (pFile) {
+        fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
+        for(j=0; j<nonlinsys->size; ++j)
+          fprintf(pFile, "%s\"%s\"", sep, modelInfoGetEquation(&data->modelData->modelDataXml, nonlinsys->equationIndex).vars[j]);
+        fprintf(pFile, "\n");
+      }
     }
 #endif
 
@@ -1400,10 +1402,12 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
       if(OMC_ACTIVE_STREAM(OMC_LOG_INIT_HOMOTOPY))
       {
         infoStreamPrint(OMC_LOG_INIT_HOMOTOPY, 0, "[system %d] homotopy parameter lambda = %g done\n---------------------------", sysNumber, data->simulationInfo->lambda);
-        fprintf(pFile, "%.16g", data->simulationInfo->lambda);
-        for(j=0; j<nonlinsys->size; ++j)
-          fprintf(pFile, "%s%.16g", sep, nonlinsys->nlsx[j]);
-        fprintf(pFile, "\n");
+        if (pFile) {
+          fprintf(pFile, "%.16g", data->simulationInfo->lambda);
+          for(j=0; j<nonlinsys->size; ++j)
+            fprintf(pFile, "%s%.16g", sep, nonlinsys->nlsx[j]);
+          fprintf(pFile, "\n");
+        }
       }
 #endif
     }
@@ -1411,7 +1415,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
 #if !defined(OMC_NO_FILESYSTEM)
     if(OMC_ACTIVE_STREAM(OMC_LOG_INIT_HOMOTOPY))
     {
-      fclose(pFile);
+      if (pFile) fclose(pFile);
     }
 #endif
     data->simulationInfo->homotopySteps += init_lambda_steps;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
@@ -768,10 +768,10 @@ void _omc_printMatrix(_omc_matrix* mat, const char* name, const enum OMC_LOG_STR
     infoStreamPrint(stream, 1, "%s", name);
     for (i = 0; i < mat->rows; ++i)
     {
-      buffer[0] = 0;
+      char *p = buffer;
       for (j = 0; j < mat->cols; ++j)
       {
-        sprintf(buffer, "%s%10g ", buffer, _omc_getMatrixElement(mat, i, j));
+        p += sprintf(p, "%10g ", _omc_getMatrixElement(mat, i, j));
       }
       infoStreamPrint(stream, 0, "%s", buffer);
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/stateset.c
@@ -31,6 +31,8 @@
 #include "../../util/omc_error.h"
 #include "../jacobian_util.h"
 
+#include <string.h>
+
 /*! \fn printStateSelectionInfo
  *
  *  function prints actually information about current state selection
@@ -189,9 +191,9 @@ static void getAnalyticalJacobianSet(DATA* data, threadData_t *threadData, unsig
 
     for(i=0; i<jacobian->sizeRows; i++)
     {
-      buffer[0] = 0;
+      char *p = buffer;
       for(j=0; j < jacobian->sizeCols; j++)
-        sprintf(buffer, "%s%.5e ", buffer, jac[i*jacobian->sizeCols+j]);
+        p += sprintf(p, "%.5e ", jac[i*jacobian->sizeCols+j]);
       infoStreamPrint(OMC_LOG_DSS_JAC, 0, "%s", buffer);
     }
     messageClose(OMC_LOG_DSS_JAC);
@@ -333,9 +335,9 @@ int stateSelectionSet(DATA *data, threadData_t *threadData, char reportError, in
 
       for(m=0; m < data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeRows; m++)
       {
-        buffer[0] = 0;
+        char *p = buffer;
         for(j=0; j < data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols; j++)
-          sprintf(buffer, "%s%.5e ", buffer, set->J[m*data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols+j]);
+          p += sprintf(p, "%.5e ", set->J[m*data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols+j]);
         warningStreamPrint(OMC_LOG_DSS, 0, "%s", buffer);
       }
 

--- a/OMCompiler/SimulationRuntime/c/util/utility.c
+++ b/OMCompiler/SimulationRuntime/c/util/utility.c
@@ -359,7 +359,7 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
         MMC_THROW();
       }
       /* Move the found ident last in the path */
-      strcpy(buf+MMC_STRLEN(dir)+1, buf);
+      memmove(buf+MMC_STRLEN(dir)+1, buf, strlen(buf)+1);
       /* Copy the old directory in there */
       strcpy(buf, MMC_STRINGDATA(dir));
       buf[MMC_STRLEN(dir)]='/';

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -174,7 +174,7 @@ void SimController::Start(SimSettings simsettings, string modelKey)
                 LoadSystem(_modelLib, _modelKey);
             }
             else {
-                throw ex;
+                throw;
             }
         }
     }
@@ -461,12 +461,11 @@ void SimController::StartReduceDAE(SimSettings simsettings,string modelPath, str
             packageName="";
         std::cout << "package name "<< packageName<< std::endl;
          string fileName = modelKey;
-         ModelicaCompiler* compiler;
          // when a model from MSL is used, then LoadFile doesn't need to be called
          // still there is problem with calling reducedTerms with model from MSL, because
          // for example for Modelica.Electrical.Analog.Examples.CauerLowPassSC, the modelPath only gives Modelica.CauerLowPassSC
-        compiler =new ModelicaCompiler(modelKey,fileName,packageName,!loadMSL,loadPackage);
-        compiler->reduceTerms(terms,simsettings.start_time,simsettings.end_time);
+        ModelicaCompiler compiler(modelKey,fileName,packageName,!loadMSL,loadPackage);
+        compiler.reduceTerms(terms,simsettings.start_time,simsettings.end_time);
         //-----------------------------------------------------------------------------------------
 
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
@@ -273,23 +273,26 @@ void SimManager::runSingleStep()
 void SimManager::computeSampleCycles()
 {
     int counter = 0;
-    time_event_type timeEventPairs;                        ///< - Contains start times and time spans
 
     _timeevent_system->initTimeEventData();
-    std::vector<std::pair<double, double> >::iterator iter;
-    iter = timeEventPairs.begin();
-    for (; iter != timeEventPairs.end(); ++iter)
+    int dimTimeEvent = _timeevent_system->getDimTimeEvent();
+    std::pair<double, double>* timeEventData = _timeevent_system->getTimeEventData();
+
+    for (int i = 0; i < dimTimeEvent; i++)
     {
-        if (iter->first != 0.0 || iter->second == 0.0)
+        double startTime = timeEventData[i].first;
+        double interval = timeEventData[i].second;
+
+        if (startTime != 0.0 || interval == 0.0)
         {
             throw ModelicaSimulationError(SIMMANAGER,"Time event not starting at t=0.0 or not cyclic!");
         }
         else
         {
             // Check if sample time is a multiple of the cycle time (with a tolerance)
-            if ((iter->second / _config->getGlobalSettings()->gethOutput()) - int((iter->second / _config->getGlobalSettings()->gethOutput()) + 0.5) <= 1e6 * UROUND)
+            if ((interval / _config->getGlobalSettings()->gethOutput()) - int((interval / _config->getGlobalSettings()->gethOutput()) + 0.5) <= 1e6 * UROUND)
             {
-                _sampleCycles[counter] = int((iter->second / _config->getGlobalSettings()->gethOutput()) + 0.5);
+                _sampleCycles[counter] = int((interval / _config->getGlobalSettings()->gethOutput()) + 0.5);
             }
             else
             {

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
@@ -290,7 +290,7 @@ void SimManager::computeSampleCycles()
         else
         {
             // Check if sample time is a multiple of the cycle time (with a tolerance)
-            if ((interval / _config->getGlobalSettings()->gethOutput()) - int((interval / _config->getGlobalSettings()->gethOutput()) + 0.5) <= 1e6 * UROUND)
+            if (std::fabs((interval / _config->getGlobalSettings()->gethOutput()) - int((interval / _config->getGlobalSettings()->gethOutput()) + 0.5)) <= 1e6 * UROUND)
             {
                 _sampleCycles[counter] = int((interval / _config->getGlobalSettings()->gethOutput()) + 0.5);
             }

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/ICoupledSystem.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/ICoupledSystem.h
@@ -35,6 +35,7 @@
 class ICoupledSystem
 {
 public:
+  virtual ~ICoupledSystem() {}
   virtual void addAcross(IObject&) = 0;
   virtual void addThrough(IObject&) = 0;
 };

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/NonLinearAlgLoopDefaultImplementation.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/NonLinearAlgLoopDefaultImplementation.cpp
@@ -54,7 +54,7 @@ NonLinearAlgLoopDefaultImplementation::~NonLinearAlgLoopDefaultImplementation()
   if(_res)
     delete [] _res;
 if (_x0)
-	 delete _x0;
+	 delete [] _x0;
 }
 
 /// Provide number (dimension) of variables according to data type

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/SimVars.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/SimVars.cpp
@@ -149,7 +149,7 @@ void* SimVars::alignedMalloc(size_t required_bytes, size_t alignment)
 	void *p1;
 	void **p2;
 
-	int offset = alignment - 1 + sizeof(void*);
+	size_t offset = alignment - 1 + sizeof(void*);
 	p1 = malloc(required_bytes + offset);
 	p2=(void**)(((size_t)(p1)+offset)&~(alignment-1));
 	p2[-1]=p1;

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Broyden/Broyden.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Broyden/Broyden.cpp
@@ -78,9 +78,9 @@ Broyden::Broyden(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> a
 	,_T					('t')
 
 {
-	_sparse = _algLoop->getUseSparseFormat();
 	if (_algLoop)
 	{
+		_sparse = _algLoop->getUseSparseFormat();
 		AlgLoopSolverDefaultImplementation::initialize(_algLoop->getDimZeroFunc(),_algLoop->getDimReal());
 	}
 	else

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
@@ -155,7 +155,7 @@ Cvode::~Cvode()
 	delete measuredFunctionEndValues;
 	delete solveFunctionStartValues;
 	delete solveFunctionEndValues;
-	delete solverValues;
+	/* solverValues is owned by (*measureTimeFunctionsArray)[6] and freed by ~MeasureTimeData() */
 #endif
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
@@ -151,14 +151,11 @@ Cvode::~Cvode()
 		delete[] _ysave;
 
 #ifdef RUNTIME_PROFILING
-	if (measuredFunctionStartValues)
-		delete measuredFunctionStartValues;
-	if (measuredFunctionEndValues)
-		delete measuredFunctionEndValues;
-	if (solveFunctionStartValues)
-		delete solveFunctionStartValues;
-	if (solveFunctionEndValues)
-		delete solveFunctionEndValues;
+	delete measuredFunctionStartValues;
+	delete measuredFunctionEndValues;
+	delete solveFunctionStartValues;
+	delete solveFunctionEndValues;
+	delete solverValues;
 #endif
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
@@ -163,8 +163,7 @@ DASSL::~DASSL()
     delete solveFunctionStartValues;
   if (solveFunctionEndValues)
     delete solveFunctionEndValues;
-  if (solverValues)
-    delete solverValues;
+  /* solverValues is owned by (*measureTimeFunctionsArray)[6] and freed by ~MeasureTimeData() */
 #endif
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
@@ -163,6 +163,8 @@ DASSL::~DASSL()
     delete solveFunctionStartValues;
   if (solveFunctionEndValues)
     delete solveFunctionEndValues;
+  if (solverValues)
+    delete solverValues;
 #endif
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
@@ -371,16 +371,13 @@ void DASSL::solve(const SOLVERCALL action)
   {
     MEASURETIME_END(solveFunctionStartValues, solveFunctionEndValues, (*measureTimeFunctionsArray)[1], dasslSolveFunctionHandler);
 
-    long int nst, nfe, nsetups, netf, nni, ncfn;
-    int qlast, qcur;
-    realtype h0u, hlast, hcur, tcur;
+    // DASKR reports its statistics in the integer work array, see writeSimulationInfo().
+    // _iworkAcc holds the counts accumulated over previous restarts, _iwork those of the current one.
+    unsigned long long nst  = _iworkAcc[10] + _iwork[10];   // steps taken
+    unsigned long long nre  = _iworkAcc[11] + _iwork[11];   // residual evaluations
+    unsigned long long netf = _iworkAcc[13] + _iwork[13];   // error test failures
 
-    int flag;
-
-    flag = DASSLGetIntegratorStats(_dasslMem, &nst, &nfe, &nsetups, &netf, &qlast, &qcur, &h0u, &hlast, &hcur, &tcur);
-    flag = DASSLGetNonlinSolvStats(_dasslMem, &nni, &ncfn);
-
-    MeasureTimeValuesSolver solverVals = MeasureTimeValuesSolver(nfe, netf);
+    MeasureTimeValuesSolver solverVals = MeasureTimeValuesSolver(nre, netf);
     (*measureTimeFunctionsArray)[6]->_sumMeasuredValues->_numCalcs += nst;
     (*measureTimeFunctionsArray)[6]->_sumMeasuredValues->add(&solverVals);
   }

--- a/OMCompiler/SimulationRuntime/cpp/Solver/LinearSolver/LinearSolver.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/LinearSolver/LinearSolver.cpp
@@ -192,7 +192,6 @@ void LinearSolver::initialize()
 
         _Ap = new int[(_dimSys + 1)];
         _Ai = new int[_nonzeros];
-        _Ax = new double[_nonzeros];
 
         int const* Ti= boost::numeric::bindings::begin_compressed_index_major (A);
         int const* Tj= boost::numeric::bindings::begin_index_minor (A);

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
@@ -262,7 +262,7 @@ void Newton::solve( )
         catch (ModelicaSimulationError& ex) {
           if (lambda < 1e-10) {
             LOGGER_WRITE_END(_lc, LL_DEBUG);
-            throw ex;
+            throw;
           }
           // reduce step size
           lambda *= 0.5;

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Peer/Peer.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Peer/Peer.cpp
@@ -322,6 +322,11 @@ void Peer::ros2(double * y, double& tstart, double tend, IContinuous *continuous
         dgetrs_(&trans, &_dimSys, &dim, T, &_dimSys, P, k2, &_dimSys, &info);
         for(int i=0; i<_dimSys;++ i) y[i]+=0.5*hu*(k1[i]+k2[i]);
     }
+    delete [] T;
+    delete [] D;
+    delete [] k1;
+    delete [] k2;
+    delete [] P;
 }
 
 void Peer::solve(const SOLVERCALL action)

--- a/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
@@ -95,6 +95,16 @@ RK12::~RK12()
         delete [] _f0;
     if(_f1)
         delete [] _f1;
+    if(_zPred)
+        delete [] _zPred;
+    if(_zDotPred)
+        delete [] _zDotPred;
+    if(_zDot0)
+        delete [] _zDot0;
+    if(_zeroSignIter)
+        delete [] _zeroSignIter;
+    if(_activeStates)
+        delete [] _activeStates;
     if(_activePartitions)
         delete [] _activePartitions;
 
@@ -139,7 +149,6 @@ void RK12::initialize()
         if(_z_a_0)        	delete [] _z_a_0;
         if(_z_a_1)         delete [] _z_a_1;
 
-        if(_zPred)        	delete [] _zPred;
         if(_zDotPred)      delete [] _zDotPred;
         if(_zDot0)          delete [] _zDot0;
 
@@ -160,7 +169,6 @@ void RK12::initialize()
         _z_a_0 	= new double[_dimSys];
         _z_a_1 	= new double[_dimSys];
 
-        _zPred	 	= new double[_dimSys];
         _zDotPred 	= new double[_dimSys];
         _zDot0 		= new double[_dimSys];
 
@@ -834,7 +842,19 @@ void RK12::doMyZeroSearch()
                 notDone = true;
                 giveZeroIdx(vL,vR,zeroIdx,zeroExist);
                 if ( zeroExist == 0)
+                {
+                    delete [] yL;
+                    delete [] yR;
+                    delete [] yTry;
+                    delete [] ySwap;
+                    delete [] vL;
+                    delete [] vR;
+                    delete [] vTry;
+                    delete [] vSwap;
+                    delete [] IllinoisV;
+                    delete [] zeroIdx;
                     return;
+                }
                 //Ist das Zeitintervall noch groß genug ?
                 tDelta = tR - tL;
 
@@ -846,10 +866,10 @@ void RK12::doMyZeroSearch()
 
                 leftZero = 0;
                 for (int i=0;i<_dimZeroFunc;i++)
-                    if ((zeroIdx[i] == 1) && ((abs(vL[i]) < UROUND) & (abs(vR[i]) >= UROUND)))
+                    if ((zeroIdx[i] == 1) && ((abs(vL[i]) < UROUND) && (abs(vR[i]) >= UROUND)))
                         leftZero = 1;
 
-                if((tL==_tCurrent) & leftZero)
+                if((tL==_tCurrent) && leftZero)
                     tTry = tL + 0.5*_zeroTol;
                 else
                 {
@@ -876,7 +896,7 @@ void RK12::doMyZeroSearch()
                         }
                         else
                         {
-                            if (abs(vR[i] < UROUND))
+                            if (abs(vR[i]) < UROUND)
                             {
                                 if (tTry<tL && vTry[i] != vL[i])
                                 {

--- a/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
@@ -198,7 +198,7 @@ void RK12::initialize()
 
         memset(_f0,0,_dimSys*sizeof(double));
         memset(_f1,0,_dimSys*sizeof(double));
-        memset(_zeroSignIter,0,_dimSys*sizeof(int));
+        memset(_zeroSignIter,0,_dimZeroFunc*sizeof(int));
 
         memset(_activeStates,0,_dimSys*sizeof(bool));
 

--- a/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/RK12/RK12.cpp
@@ -183,7 +183,6 @@ void RK12::initialize()
 
         memset(_z,			0,_dimSys*sizeof(double));
         memset(_z0,			0,_dimSys*sizeof(double));
-        memset(_zPred,		0,_dimSys*sizeof(double));
         memset(_z1,			0,_dimSys*sizeof(double));
         memset(_z_a,		0,_dimSys*sizeof(double));
         memset(_z_a_0,		0,_dimSys*sizeof(double));

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -567,68 +567,58 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
     return NULL;
   }
   comp = (ModelInstance *)functions->allocateMemory(1, sizeof(ModelInstance));
-  if (comp) {
-    DATA* fmudata = NULL;
-    MODEL_DATA* modelData = NULL;
-    SIMULATION_INFO* simInfo = NULL;
-    threadData_t *threadData = NULL;
-    int i;
-
-    comp->state = model_state_start_end;
-    comp->instanceName = (fmi2String)functions->allocateMemory(1 + strlen(instanceName), sizeof(char));
-    comp->GUID = (fmi2String)functions->allocateMemory(1 + strlen(fmuGUID), sizeof(char));
-    comp->functions = (fmi2CallbackFunctions*)functions->allocateMemory(1, sizeof(fmi2CallbackFunctions));
-    fmudata = (DATA *)functions->allocateMemory(1, sizeof(DATA));
-    modelData = (MODEL_DATA *)functions->allocateMemory(1, sizeof(MODEL_DATA));
-    simInfo = (SIMULATION_INFO *)functions->allocateMemory(1, sizeof(SIMULATION_INFO));
-    fmudata->modelData = modelData;
-    fmudata->simulationInfo = simInfo;
-
-    threadData = (threadData_t *)functions->allocateMemory(1, sizeof(threadData_t));
-    memset(threadData, 0, sizeof(threadData_t));
-    /*
-    pthread_key_create(&fmu2_thread_data_key,NULL);
-    pthread_setspecific(fmu2_thread_data_key, threadData);
-    */
-
-    comp->threadData = threadData;
-    comp->threadDataParent = threadDataParent;
-    comp->fmuData = fmudata;
-    threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
-    if (!comp->fmuData) {
-      functions->logger(functions->componentEnvironment, instanceName, fmi2Error, "error", "fmi2Instantiate: Could not initialize the global data structure file.");
-      functions->freeMemory(threadData);
-      functions->freeMemory(simInfo);
-      functions->freeMemory(modelData);
-      functions->freeMemory(fmudata);
-      functions->freeMemory(comp->functions);
-      functions->freeMemory(comp->GUID);
-      functions->freeMemory(comp->instanceName);
-      functions->freeMemory(comp);
-      return NULL;
-    }
-    // set all categories to on or off. fmi2SetDebugLogging should be called to choose specific categories.
-    for (i = 0; i < NUMBER_OF_CATEGORIES; i++) {
-      comp->logCategories[i] = loggingOn;
-    }
-  }
-
-  if (!comp || !comp->instanceName || !comp->GUID || !comp->functions || !comp->fmuData || !comp->fmuData->modelData || !comp->fmuData->simulationInfo || !comp->threadData) {
+  if (!comp) {
     functions->logger(functions->componentEnvironment, instanceName, fmi2Error, "error", "fmi2Instantiate: Out of memory.");
-    if (comp) {
-      if (comp->threadData) functions->freeMemory(comp->threadData);
-      if (comp->fmuData) {
-        if (comp->fmuData->simulationInfo) functions->freeMemory(comp->fmuData->simulationInfo);
-        if (comp->fmuData->modelData) functions->freeMemory(comp->fmuData->modelData);
-        functions->freeMemory(comp->fmuData);
-      }
-      if (comp->functions) functions->freeMemory(comp->functions);
-      if (comp->GUID) functions->freeMemory((void*)comp->GUID);
-      if (comp->instanceName) functions->freeMemory((void*)comp->instanceName);
-      functions->freeMemory(comp);
-    }
     return NULL;
   }
+
+  DATA* fmudata = NULL;
+  MODEL_DATA* modelData = NULL;
+  SIMULATION_INFO* simInfo = NULL;
+  threadData_t *threadData = NULL;
+  int i;
+
+  comp->state = model_state_start_end;
+  comp->instanceName = (fmi2String)functions->allocateMemory(1 + strlen(instanceName), sizeof(char));
+  comp->GUID = (fmi2String)functions->allocateMemory(1 + strlen(fmuGUID), sizeof(char));
+  comp->functions = (fmi2CallbackFunctions*)functions->allocateMemory(1, sizeof(fmi2CallbackFunctions));
+  fmudata = (DATA *)functions->allocateMemory(1, sizeof(DATA));
+  modelData = (MODEL_DATA *)functions->allocateMemory(1, sizeof(MODEL_DATA));
+  simInfo = (SIMULATION_INFO *)functions->allocateMemory(1, sizeof(SIMULATION_INFO));
+  threadData = (threadData_t *)functions->allocateMemory(1, sizeof(threadData_t));
+
+  /* Every allocation has to be checked before any of them is dereferenced below. */
+  if (!comp->instanceName || !comp->GUID || !comp->functions || !fmudata || !modelData || !simInfo || !threadData) {
+    functions->logger(functions->componentEnvironment, instanceName, fmi2Error, "error", "fmi2Instantiate: Out of memory.");
+    functions->freeMemory(threadData);
+    functions->freeMemory(simInfo);
+    functions->freeMemory(modelData);
+    functions->freeMemory(fmudata);
+    functions->freeMemory((void*)comp->functions);
+    functions->freeMemory((void*)comp->GUID);
+    functions->freeMemory((void*)comp->instanceName);
+    functions->freeMemory(comp);
+    return NULL;
+  }
+
+  memset(threadData, 0, sizeof(threadData_t));
+  fmudata->modelData = modelData;
+  fmudata->simulationInfo = simInfo;
+  /*
+  pthread_key_create(&fmu2_thread_data_key,NULL);
+  pthread_setspecific(fmu2_thread_data_key, threadData);
+  */
+
+  comp->threadData = threadData;
+  comp->threadDataParent = threadDataParent;
+  comp->fmuData = fmudata;
+  threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
+
+  // set all categories to on or off. fmi2SetDebugLogging should be called to choose specific categories.
+  for (i = 0; i < NUMBER_OF_CATEGORIES; i++) {
+    comp->logCategories[i] = loggingOn;
+  }
+
 #if defined(OM_HAVE_PTHREADS)
   pthread_setspecific(mmc_thread_data_key, comp->threadData);
 #endif
@@ -850,9 +840,9 @@ void fmi2FreeInstance(fmi2Component c)
   freeMemory(comp->threadData);
   freeMemory(comp->fmuData);
   /* free instanceName & GUID */
-  if (comp->instanceName) freeMemory((void*)comp->instanceName);
-  if (comp->GUID) freeMemory((void*)comp->GUID);
-  if (comp->functions) freeMemory((void*)comp->functions);
+  freeMemory((void*)comp->instanceName);
+  freeMemory((void*)comp->GUID);
+  freeMemory((void*)comp->functions);
   /* free comp */
   freeMemory(comp);
   free_memory_pool();
@@ -2199,7 +2189,9 @@ fmi2Status internalGetNominalsOfContinuousStates(fmi2Component c, fmi2Real x_nom
     return fmi2Error;
   if (nullPointer(comp, "fmi2GetNominalsOfContinuousStates", "x_nominal[]", x_nominal))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
+  if (nx > 0) {
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
+  }
   for (i = 0; i < nx; i++)
     x_nominal[i] = 1;
   return fmi2OK;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -915,6 +915,7 @@ fmi2Status fmi2ExitInitializationMode(fmi2Component c)
     {
       comp->state = model_state_error;
       omc_util_restore_pool_state(mem_pool_state);
+      MMC_RESTORE_INTERNAL(simulationJumpBuffer);
       threadData->mmc_jumper = old_jmp;
       resetThreadData(comp);
       FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "fmi2ExitInitializationMode: failed")

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -597,6 +597,14 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
     threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
     if (!comp->fmuData) {
       functions->logger(functions->componentEnvironment, instanceName, fmi2Error, "error", "fmi2Instantiate: Could not initialize the global data structure file.");
+      functions->freeMemory(threadData);
+      functions->freeMemory(simInfo);
+      functions->freeMemory(modelData);
+      functions->freeMemory(fmudata);
+      functions->freeMemory(comp->functions);
+      functions->freeMemory(comp->GUID);
+      functions->freeMemory(comp->instanceName);
+      functions->freeMemory(comp);
       return NULL;
     }
     // set all categories to on or off. fmi2SetDebugLogging should be called to choose specific categories.
@@ -605,8 +613,20 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
     }
   }
 
-  if (!comp || !comp->instanceName || !comp->GUID || !comp->functions) {
+  if (!comp || !comp->instanceName || !comp->GUID || !comp->functions || !comp->fmuData || !comp->fmuData->modelData || !comp->fmuData->simulationInfo || !comp->threadData) {
     functions->logger(functions->componentEnvironment, instanceName, fmi2Error, "error", "fmi2Instantiate: Out of memory.");
+    if (comp) {
+      if (comp->threadData) functions->freeMemory(comp->threadData);
+      if (comp->fmuData) {
+        if (comp->fmuData->simulationInfo) functions->freeMemory(comp->fmuData->simulationInfo);
+        if (comp->fmuData->modelData) functions->freeMemory(comp->fmuData->modelData);
+        functions->freeMemory(comp->fmuData);
+      }
+      if (comp->functions) functions->freeMemory(comp->functions);
+      if (comp->GUID) functions->freeMemory((void*)comp->GUID);
+      if (comp->instanceName) functions->freeMemory((void*)comp->instanceName);
+      functions->freeMemory(comp);
+    }
     return NULL;
   }
 #if defined(OM_HAVE_PTHREADS)
@@ -904,6 +924,8 @@ fmi2Status fmi2ExitInitializationMode(fmi2Component c)
     if (initialization(comp->fmuData, comp->threadData, "fmi", "", 0.0))
     {
       comp->state = model_state_error;
+      omc_util_restore_pool_state(mem_pool_state);
+      threadData->mmc_jumper = old_jmp;
       resetThreadData(comp);
       FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "fmi2ExitInitializationMode: failed")
       return fmi2Error;
@@ -1221,13 +1243,13 @@ fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nv
     return fmi2Error;
   if (nvr > 0 && nullPointer(comp, "fmi2SetReal", "value[]", value))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetReal: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetReal: nvr = %zu", nvr)
   // no check whether setting the value is allowed in the current state
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "fmi2SetReal", vr[i], NUMBER_OF_REALS+NUMBER_OF_STATES))
       return fmi2Error;
-    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetReal: #r%d# = %.16g", vr[i], value[i])
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetReal: #r%u# = %.16g", vr[i], value[i])
     if (setReal(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
       return fmi2Error;
   }
@@ -1248,13 +1270,13 @@ fmi2Status fmi2SetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t
     return fmi2Error;
   if (nvr > 0 && nullPointer(comp, "fmi2SetInteger", "value[]", value))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetInteger: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetInteger: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "fmi2SetInteger", vr[i], NUMBER_OF_INTEGERS))
       return fmi2Error;
-    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetInteger: #i%d# = %d", vr[i], value[i])
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetInteger: #i%u# = %d", vr[i], value[i])
     if (setInteger(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
       return fmi2Error;
   }
@@ -1274,13 +1296,13 @@ fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t
     return fmi2Error;
   if (nvr>0 && nullPointer(comp, "fmi2SetBoolean", "value[]", value))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetBoolean: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetBoolean: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "fmi2SetBoolean", vr[i], NUMBER_OF_BOOLEANS))
       return fmi2Error;
-    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetBoolean: #b%d# = %s", vr[i], value[i] ? "true" : "false")
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetBoolean: #b%u# = %s", vr[i], value[i] ? "true" : "false")
     if (setBoolean(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
       return fmi2Error;
   }
@@ -1290,7 +1312,7 @@ fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t
 
 fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
 {
-  int i, n;
+  int i;
   ModelInstance *comp = (ModelInstance *)c;
   int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode;
   int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete;
@@ -1301,13 +1323,13 @@ fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t 
     return fmi2Error;
   if (nvr>0 && nullPointer(comp, "fmi2SetString", "value[]", value))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetString: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetString: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "fmi2SetString", vr[i], NUMBER_OF_STRINGS))
       return fmi2Error;
-    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetString: #s%d# = '%s'", vr[i], value[i])
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetString: #s%u# = '%s'", vr[i], value[i])
     if (setString(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
       return fmi2Error;
   }
@@ -1726,8 +1748,6 @@ fmi2Status fmi2GetDirectionalDerivativeForInitialization(fmi2Component c,
 {
   ModelInstance *comp = (ModelInstance *)c;
   DATA* fmudata = (DATA *) comp->fmuData;
-  SIMULATION_INFO* simInfo = (SIMULATION_INFO*) fmudata->simulationInfo;
-  MODEL_DATA* modelData = (MODEL_DATA*) fmudata->modelData;
   threadData_t* td = comp->threadData;
 
   /***************************************/
@@ -1794,11 +1814,10 @@ fmi2Status fmi2GetDirectionalDerivative(fmi2Component c,
 {
   ModelInstance *comp = (ModelInstance *)c;
   DATA* fmudata = (DATA *) comp->fmuData;
-  SIMULATION_INFO* simInfo = (SIMULATION_INFO*) fmudata->simulationInfo;
   MODEL_DATA* modelData = (MODEL_DATA*) fmudata->modelData;
   threadData_t* td = comp->threadData;
 
-  int i,j;
+  int i;
 
   int independent = modelData->nStates+modelData->nInputVars;
   int dependent = modelData->nStates+modelData->nOutputVars;
@@ -2010,7 +2029,7 @@ fmi2Status internalSetContinuousStates(fmi2Component c, const fmi2Real x[], size
 #if NUMBER_OF_STATES > 0
   for (i = 0; i < nx; i++) {
     fmi2ValueReference vr = vrStates[i];
-    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetContinuousStates: #r%d# = %.16g", vr, x[i])
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetContinuousStates: #r%u# = %.16g", vr, x[i])
     if (vr < 0 || vr >= NUMBER_OF_REALS|| setReal(comp, vr, x[i]) != fmi2OK) { // to be implemented by the includer of this file
       return fmi2Error;
     }
@@ -2059,7 +2078,7 @@ fmi2Status internalGetDerivatives(fmi2Component c, const char *func, fmi2Real de
     for (i = 0; i < nx; i++) {
       fmi2ValueReference vr = vrStatesDerivatives[i];
       derivatives[i] = getReal(comp, vr); // to be implemented by the includer of this file
-      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: #r%d# = %.16g", func, vr, derivatives[i])
+      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: #r%u# = %.16g", func, vr, derivatives[i])
     }
 #endif
 
@@ -2180,8 +2199,7 @@ fmi2Status internalGetNominalsOfContinuousStates(fmi2Component c, fmi2Real x_nom
     return fmi2Error;
   if (nullPointer(comp, "fmi2GetNominalsOfContinuousStates", "x_nominal[]", x_nominal))
     return fmi2Error;
-  x_nominal[0] = 1;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[0..%d] = 1.0", nx-1)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
   for (i = 0; i < nx; i++)
     x_nominal[i] = 1;
   return fmi2OK;
@@ -2214,7 +2232,7 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
   if (nvr > 0 && nullPointer(comp, "fmi2SetRealInputDerivatives", "value[]", value))
     return fmi2Error;
 
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: nvr = %zu", nvr)
 
 #if NUMBER_OF_REAL_INPUTS > 0
   for (i = 0; i < nvr; i++)

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -960,6 +960,7 @@ fmi3Status omcExitInitializationMode(ModelInstance* c)
     {
       comp->state = model_state_error;
       omc_util_restore_pool_state(mem_pool_state);
+      MMC_RESTORE_INTERNAL(simulationJumpBuffer);
       threadData->mmc_jumper = old_jmp;
       resetThreadData(comp);
       FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "omcExitInitializationMode: failed")

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -610,65 +610,56 @@ ModelInstance* omcInstantiate(fmi3String instanceName, OMC_FmuType fmuType, fmi3
     return NULL;
   }
   comp = (ModelInstance *)calloc(1, sizeof(ModelInstance));
-  if (comp) {
-    DATA* fmudata = NULL;
-    MODEL_DATA* modelData = NULL;
-    SIMULATION_INFO* simInfo = NULL;
-    threadData_t *threadData = NULL;
-    int i;
-
-    comp->state = model_state_start_end;
-    comp->instanceName = (fmi3String)calloc(1 + strlen(instanceName), sizeof(char));
-    comp->GUID = (fmi3String)calloc(1 + strlen(fmuGUID), sizeof(char));
-    fmudata = (DATA *)calloc(1, sizeof(DATA));
-    modelData = (MODEL_DATA *)calloc(1, sizeof(MODEL_DATA));
-    simInfo = (SIMULATION_INFO *)calloc(1, sizeof(SIMULATION_INFO));
-    fmudata->modelData = modelData;
-    fmudata->simulationInfo = simInfo;
-
-    threadData = (threadData_t *)calloc(1, sizeof(threadData_t));
-    memset(threadData, 0, sizeof(threadData_t));
-    /*
-    pthread_key_create(&fmu3_thread_data_key,NULL);
-    pthread_setspecific(fmu3_thread_data_key, threadData);
-    */
-
-    comp->threadData = threadData;
-    comp->threadDataParent = threadDataParent;
-    comp->fmuData = fmudata;
-    threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
-    if (!comp->fmuData) {
-      omc_fmi3_logCallback(logMessage, instanceEnvironment, fmi3Error, "logStatusError", "omcInstantiate: Could not initialize the global data structure file.");
-      free(threadData);
-      free(simInfo);
-      free(modelData);
-      free(fmudata);
-      free((void*)comp->GUID);
-      free((void*)comp->instanceName);
-      free(comp);
-      return NULL;
-    }
-    // set all categories to on or off. omcSetDebugLogging should be called to choose specific categories.
-    for (i = 0; i < NUMBER_OF_CATEGORIES; i++) {
-      comp->logCategories[i] = loggingOn;
-    }
-  }
-
-  if (!comp || !comp->instanceName || !comp->GUID || !comp->fmuData || !comp->fmuData->modelData || !comp->fmuData->simulationInfo || !comp->threadData) {
+  if (!comp) {
     omc_fmi3_logCallback(logMessage, instanceEnvironment, fmi3Error, "logStatusError", "omcInstantiate: Out of memory.");
-    if (comp) {
-      if (comp->threadData) free(comp->threadData);
-      if (comp->fmuData) {
-        if (comp->fmuData->simulationInfo) free(comp->fmuData->simulationInfo);
-        if (comp->fmuData->modelData) free(comp->fmuData->modelData);
-        free(comp->fmuData);
-      }
-      if (comp->GUID) free((void*)comp->GUID);
-      if (comp->instanceName) free((void*)comp->instanceName);
-      free(comp);
-    }
     return NULL;
   }
+
+  DATA* fmudata = NULL;
+  MODEL_DATA* modelData = NULL;
+  SIMULATION_INFO* simInfo = NULL;
+  threadData_t *threadData = NULL;
+  int i;
+
+  comp->state = model_state_start_end;
+  comp->instanceName = (fmi3String)calloc(1 + strlen(instanceName), sizeof(char));
+  comp->GUID = (fmi3String)calloc(1 + strlen(fmuGUID), sizeof(char));
+  fmudata = (DATA *)calloc(1, sizeof(DATA));
+  modelData = (MODEL_DATA *)calloc(1, sizeof(MODEL_DATA));
+  simInfo = (SIMULATION_INFO *)calloc(1, sizeof(SIMULATION_INFO));
+  threadData = (threadData_t *)calloc(1, sizeof(threadData_t));
+
+  /* Every allocation has to be checked before any of them is dereferenced below. */
+  if (!comp->instanceName || !comp->GUID || !fmudata || !modelData || !simInfo || !threadData) {
+    omc_fmi3_logCallback(logMessage, instanceEnvironment, fmi3Error, "logStatusError", "omcInstantiate: Out of memory.");
+    free(threadData);
+    free(simInfo);
+    free(modelData);
+    free(fmudata);
+    free((void*)comp->GUID);
+    free((void*)comp->instanceName);
+    free(comp);
+    return NULL;
+  }
+
+  memset(threadData, 0, sizeof(threadData_t));
+  fmudata->modelData = modelData;
+  fmudata->simulationInfo = simInfo;
+  /*
+  pthread_key_create(&fmu3_thread_data_key,NULL);
+  pthread_setspecific(fmu3_thread_data_key, threadData);
+  */
+
+  comp->threadData = threadData;
+  comp->threadDataParent = threadDataParent;
+  comp->fmuData = fmudata;
+  threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
+
+  // set all categories to on or off. omcSetDebugLogging should be called to choose specific categories.
+  for (i = 0; i < NUMBER_OF_CATEGORIES; i++) {
+    comp->logCategories[i] = loggingOn;
+  }
+
 #if defined(OM_HAVE_PTHREADS)
   pthread_setspecific(mmc_thread_data_key, comp->threadData);
 #endif
@@ -895,8 +886,8 @@ void omcFreeInstance(ModelInstance* c)
   free(comp->threadData);
   free(comp->fmuData);
   /* free instanceName & GUID */
-  if (comp->instanceName) free((void*)comp->instanceName);
-  if (comp->GUID) free((void*)comp->GUID);
+  free((void*)comp->instanceName);
+  free((void*)comp->GUID);
   /* free comp */
   free(comp);
   free_memory_pool();
@@ -2239,7 +2230,9 @@ fmi3Status internalGetNominalsOfContinuousStates(ModelInstance* c, fmi3Float64 x
     return fmi3Error;
   if (nullPointer(comp, "omcGetNominalsOfContinuousStates", "x_nominal[]", x_nominal))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
+  if (nx > 0) {
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
+  }
   for (i = 0; i < nx; i++)
     x_nominal[i] = 1;
   return fmi3OK;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -639,6 +639,13 @@ ModelInstance* omcInstantiate(fmi3String instanceName, OMC_FmuType fmuType, fmi3
     threadData->localRoots[LOCAL_ROOT_FMI_DATA] = comp;
     if (!comp->fmuData) {
       omc_fmi3_logCallback(logMessage, instanceEnvironment, fmi3Error, "logStatusError", "omcInstantiate: Could not initialize the global data structure file.");
+      free(threadData);
+      free(simInfo);
+      free(modelData);
+      free(fmudata);
+      free((void*)comp->GUID);
+      free((void*)comp->instanceName);
+      free(comp);
       return NULL;
     }
     // set all categories to on or off. omcSetDebugLogging should be called to choose specific categories.
@@ -647,8 +654,19 @@ ModelInstance* omcInstantiate(fmi3String instanceName, OMC_FmuType fmuType, fmi3
     }
   }
 
-  if (!comp || !comp->instanceName || !comp->GUID) {
+  if (!comp || !comp->instanceName || !comp->GUID || !comp->fmuData || !comp->fmuData->modelData || !comp->fmuData->simulationInfo || !comp->threadData) {
     omc_fmi3_logCallback(logMessage, instanceEnvironment, fmi3Error, "logStatusError", "omcInstantiate: Out of memory.");
+    if (comp) {
+      if (comp->threadData) free(comp->threadData);
+      if (comp->fmuData) {
+        if (comp->fmuData->simulationInfo) free(comp->fmuData->simulationInfo);
+        if (comp->fmuData->modelData) free(comp->fmuData->modelData);
+        free(comp->fmuData);
+      }
+      if (comp->GUID) free((void*)comp->GUID);
+      if (comp->instanceName) free((void*)comp->instanceName);
+      free(comp);
+    }
     return NULL;
   }
 #if defined(OM_HAVE_PTHREADS)
@@ -950,6 +968,8 @@ fmi3Status omcExitInitializationMode(ModelInstance* c)
     if (initialization(comp->fmuData, comp->threadData, "fmi", "", 0.0))
     {
       comp->state = model_state_error;
+      omc_util_restore_pool_state(mem_pool_state);
+      threadData->mmc_jumper = old_jmp;
       resetThreadData(comp);
       FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "omcExitInitializationMode: failed")
       return fmi3Error;
@@ -1267,13 +1287,13 @@ fmi3Status omcSetReal(ModelInstance* c, const fmi3ValueReference vr[], size_t nv
     return fmi3Error;
   if (nvr > 0 && nullPointer(comp, "omcSetReal", "value[]", value))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetReal: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetReal: nvr = %zu", nvr)
   // no check whether setting the value is allowed in the current state
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "omcSetReal", vr[i], NUMBER_OF_REALS+NUMBER_OF_STATES))
       return fmi3Error;
-    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetReal: #r%d# = %.16g", vr[i], value[i])
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetReal: #r%u# = %.16g", vr[i], value[i])
     if (setReal(comp, vr[i], value[i]) != fmi3OK) // to be implemented by the includer of this file
       return fmi3Error;
   }
@@ -1294,13 +1314,13 @@ fmi3Status omcSetInteger(ModelInstance* c, const fmi3ValueReference vr[], size_t
     return fmi3Error;
   if (nvr > 0 && nullPointer(comp, "omcSetInteger", "value[]", value))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetInteger: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetInteger: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "omcSetInteger", vr[i], NUMBER_OF_INTEGERS))
       return fmi3Error;
-    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetInteger: #i%d# = %d", vr[i], value[i])
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetInteger: #i%u# = %d", vr[i], value[i])
     if (setInteger(comp, vr[i], value[i]) != fmi3OK) // to be implemented by the includer of this file
       return fmi3Error;
   }
@@ -1320,13 +1340,13 @@ fmi3Status omcSetBoolean(ModelInstance* c, const fmi3ValueReference vr[], size_t
     return fmi3Error;
   if (nvr>0 && nullPointer(comp, "omcSetBoolean", "value[]", value))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetBoolean: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetBoolean: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "omcSetBoolean", vr[i], NUMBER_OF_BOOLEANS))
       return fmi3Error;
-    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetBoolean: #b%d# = %s", vr[i], value[i] ? "true" : "false")
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetBoolean: #b%u# = %s", vr[i], value[i] ? "true" : "false")
     if (setBoolean(comp, vr[i], value[i]) != fmi3OK) // to be implemented by the includer of this file
       return fmi3Error;
   }
@@ -1336,7 +1356,7 @@ fmi3Status omcSetBoolean(ModelInstance* c, const fmi3ValueReference vr[], size_t
 
 fmi3Status omcSetString(ModelInstance* c, const fmi3ValueReference vr[], size_t nvr, const fmi3String value[])
 {
-  int i, n;
+  int i;
   ModelInstance *comp = (ModelInstance *)c;
   int meStates = model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated;
   int csStates = model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_terminated;
@@ -1347,13 +1367,13 @@ fmi3Status omcSetString(ModelInstance* c, const fmi3ValueReference vr[], size_t 
     return fmi3Error;
   if (nvr>0 && nullPointer(comp, "omcSetString", "value[]", value))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetString: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetString: nvr = %zu", nvr)
 
   for (i = 0; i < nvr; i++)
   {
     if (vrOutOfRange(comp, "omcSetString", vr[i], NUMBER_OF_STRINGS))
       return fmi3Error;
-    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetString: #s%d# = '%s'", vr[i], value[i])
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetString: #s%u# = '%s'", vr[i], value[i])
     if (setString(comp, vr[i], value[i]) != fmi3OK) // to be implemented by the includer of this file
       return fmi3Error;
   }
@@ -1768,8 +1788,6 @@ fmi3Status omcGetDirectionalDerivativeForInitialization(ModelInstance* c,
 {
   ModelInstance *comp = (ModelInstance *)c;
   DATA* fmudata = (DATA *) comp->fmuData;
-  SIMULATION_INFO* simInfo = (SIMULATION_INFO*) fmudata->simulationInfo;
-  MODEL_DATA* modelData = (MODEL_DATA*) fmudata->modelData;
   threadData_t* td = comp->threadData;
 
   /***************************************/
@@ -1836,11 +1854,10 @@ fmi3Status omcGetDirectionalDerivative(ModelInstance* c,
 {
   ModelInstance *comp = (ModelInstance *)c;
   DATA* fmudata = (DATA *) comp->fmuData;
-  SIMULATION_INFO* simInfo = (SIMULATION_INFO*) fmudata->simulationInfo;
   MODEL_DATA* modelData = (MODEL_DATA*) fmudata->modelData;
   threadData_t* td = comp->threadData;
 
-  int i,j;
+  int i;
 
   int independent = modelData->nStates+modelData->nInputVars;
   int dependent = modelData->nStates+modelData->nOutputVars;
@@ -2052,7 +2069,7 @@ fmi3Status internalSetContinuousStates(ModelInstance* c, const fmi3Float64 x[], 
 #if NUMBER_OF_STATES > 0
   for (i = 0; i < nx; i++) {
     fmi3ValueReference vr = vrStates[i];
-    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetContinuousStates: #r%d# = %.16g", vr, x[i])
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetContinuousStates: #r%u# = %.16g", vr, x[i])
     if (vr < 0 || vr >= NUMBER_OF_REALS|| setReal(comp, vr, x[i]) != fmi3OK) { // to be implemented by the includer of this file
       return fmi3Error;
     }
@@ -2101,7 +2118,7 @@ fmi3Status internalGetDerivatives(ModelInstance* c, const char *func, fmi3Float6
     for (i = 0; i < nx; i++) {
       fmi3ValueReference vr = vrStatesDerivatives[i];
       derivatives[i] = getReal(comp, vr); // to be implemented by the includer of this file
-      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: #r%d# = %.16g", func, vr, derivatives[i])
+      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: #r%u# = %.16g", func, vr, derivatives[i])
     }
 #endif
 
@@ -2222,8 +2239,7 @@ fmi3Status internalGetNominalsOfContinuousStates(ModelInstance* c, fmi3Float64 x
     return fmi3Error;
   if (nullPointer(comp, "omcGetNominalsOfContinuousStates", "x_nominal[]", x_nominal))
     return fmi3Error;
-  x_nominal[0] = 1;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetNominalsOfContinuousStates: x_nominal[0..%d] = 1.0", nx-1)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetNominalsOfContinuousStates: x_nominal[0..%zu] = 1.0", nx-1)
   for (i = 0; i < nx; i++)
     x_nominal[i] = 1;
   return fmi3OK;
@@ -2256,7 +2272,7 @@ fmi3Status omcSetRealInputDerivatives(ModelInstance* c, const fmi3ValueReference
   if (nvr > 0 && nullPointer(comp, "omcSetRealInputDerivatives", "value[]", value))
     return fmi3Error;
 
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetRealInputDerivatives: nvr = %d", nvr)
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetRealInputDerivatives: nvr = %zu", nvr)
 
 #if NUMBER_OF_REAL_INPUTS > 0
   for (i = 0; i < nvr; i++)
@@ -2815,7 +2831,6 @@ int FMI3CS_initializeSolverData(ModelInstance* comp)
         FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "omcInstantiate: Out of memory.")
         free(solverInfo);
         return -1;
-        retValue = -1;
       } else {
         /* FMI 3.0 has no memory callbacks, so plain free matches the calloc
          * above. Must be set: cvode_solver_deinitial frees the struct through

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c
@@ -225,7 +225,6 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
         FILTERED_LOG(comp, fmi2Fatal, LOG_STATUSFATAL, "fmi2Instantiate: Out of memory.")
         functions->freeMemory(solverInfo);
         return -1;
-        retValue = -1;
       } else {
         cvodeData->freeSolverMemory = functions->freeMemory;
         retValue = cvode_solver_initial(data, threadData, solverInfo, cvodeData, 1 /* is FMI */);   /* TODO: cvode_solver_initial needs to use malloc and free from fmi2CallbackFunctions */


### PR DESCRIPTION
> [!NOTE]  
> AI summary added by @AnHeuermann

A pass over the C, C++ and FMI simulation runtimes fixing memory-safety and
undefined-behaviour bugs. Apart from the two behavior changes called out at the bottom, no functional changes are intended.

30 files changed across `SimulationRuntime/{c,cpp,fmi}`.

## Undefined behavior

- Replace ~10 self-referencing `sprintf(buf, "%s...", buf, ...)` calls in the
  matrix/vector debug printers (KLU, UMFPACK, LIS, total-pivot, Newton, hybrd,
  homotopy, stateset, `omc_math`) with a cursor-advance form. Passing a buffer as
  both destination and `%s` source is undefined; it only appeared to work.
- Fix an overlapping `strcpy` in `OpenModelica_uriToFilename_impl` (`utility.c`)
  → `memmove`.
- Remove two `fclose(NULL)` calls (`MoveData.c`, `simulation_input_xml.c`).
- Fix `calloc(..., sizeof(modelica_real*))` → `sizeof(modelica_real)` in
  `newton_diagnostics.c`. Harmless on 64-bit, a 2x under-allocation on 32-bit.
- Fix `abs(vR[i] < UROUND)` → `abs(vR[i]) < UROUND`, and two bitwise `&` that
  should be `&&`, in the RK12 zero-crossing logic.
- Fix integer division `i/n` (always 0) → `(double)i/n` in the homotopy
  initial-guess perturbation, which silently made the "vary initial guess by
  +1% / +10%" retry a no-op.
- Fix `fscanf("%s")` → `"%199s"` for a 200-byte buffer (`MoveData.c`).
- Fix `int` → `size_t` for the alignment offset in `SimVars::alignedMalloc()`.

## Memory safety

- Remove an unconditional `x_nominal[0] = 1` that wrote out of bounds for models
  with zero continuous states (FMI 2 and 3).
- Fix a heap buffer overflow in RK12: `_zeroSignIter` is allocated with
  `_dimZeroFunc` elements but was zeroed with `_dimSys` elements.
- Fix a double free of `solverValues` in the CVode and DASSL destructors. It is
  owned by `(*measureTimeFunctionsArray)[6]` and freed by `~MeasureTimeData()`;
  deleting it in the solver caused a use-after-free in `MeasureTime::writeToJson()`
  and a second free at teardown. `RUNTIME_PROFILING` builds only.
- Add NULL checks after `fopen` in `DebugeOptimization.c` and `nonlinearSystem.c`.
- Add a missing NULL check before dereferencing `_algLoop` in the `Broyden`
  constructor.
- Fix `delete` → `delete[]` for an array in `NonLinearAlgLoopDefaultImplementation`.
- Fix a duplicated alloc/free of `_zPred` in `RK12::initialize()`.
- Add a missing virtual destructor to the `ICoupledSystem` interface.

## Leaks

- Add missing `delete[]` in `Peer::ros2()`, the RK12 and DASSL destructors,
  `RK12::doMyZeroSearch()`'s early return, and `SimController::StartReduceDAE()`;
  drop a leaked allocation of the non-owning `LinearSolver::_Ax`.
- Free intermediate buffers on the `p == 0` early return in `newtonDiagnostics()`.
- Restore the memory-pool state and jump buffer on the early return from
  `fmi2ExitInitializationMode` / `omcExitInitializationMode`.

## FMI instantiation

`fmi2Instantiate` / `omcInstantiate` ran their out-of-memory checks *after* the
pointers they guard had already been dereferenced: `fmudata->modelData = ...` and
`memset(threadData, 0, ...)` both execute before any NULL test, so a failed
allocation segfaulted before the check could fire, and the `if (!comp->fmuData)`
cleanup block was unreachable.

All allocations are now hoisted, checked in one condition before any is
dereferenced, and freed on a single error path. Redundant NULL checks before
`freeMemory()` / `free()` are gone (both are required to treat NULL as a no-op),
and the missing `(void*)` cast on the const-qualified `comp->functions` is added.

## Correctness / cleanup

- `throw ex;` → `throw;` in `SimController` and `Newton` — the exception was being
  sliced.
- Fix format-string mismatches in FMI logging: `%d` → `%zu` for `size_t nvr`
  (10 sites), `%d` → `%u` for `fmi2/fmi3ValueReference` (8 sites). Guard the
  nominals log with `nx > 0`, since `nx-1` underflows a `size_t` for a model with
  no states.
- Fix the `RUNTIME_PROFILING` build of DASSL. Its profiling block was a verbatim
  copy of CVode's, referring to `DASSLGetIntegratorStats()`, `_dasslMem` and
  `realtype`, none of which exist — DASSL is not a SUNDIALS solver. It now reports
  the statistics DASKR actually provides, from the integer work array.
- Remove unreachable statements after `return -1`, unused variables, and add a
  missing `#include <string.h>`.

## Behaviour changes (please review)

**`SimManager::computeSampleCycles()`** iterated an always-empty local vector, so
it was a no-op and left `_sampleCycles` uninitialized — which `SimManager` then
read to compute `_resetCycle`. It now reads the actual time-event data. This only
affects the `useEndlessSim()` (real-time) path, but it turns dead code into live
code that can throw `"Time event not starting at t=0.0 or not cyclic!"`, so models
that previously ran on a garbage `_resetCycle` may now abort. Worth a run on the
RT models.

**Homotopy initial-guess perturbation** now actually perturbs (see above), which
changes the numerics of the assert-retry path. That is the intent of the code, but
it is not a no-op.
