### PR TITLE
OMEdit: add optional built-in dark mode (--DarkMode)

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -185,6 +185,9 @@ void printOMEditUsage()
   fprintf(stderr, "  --NAPIProfiling=[true|false]  Enable profiling for the new JSON-based API.\n");
   fprintf(stderr, "                                Default: false.\n\n");
 
+  fprintf(stderr, "  --DarkMode=[true|false]       Use OMEdit's built-in dark stylesheet.\n");
+  fprintf(stderr, "                                Default: false.\n\n");
+
   fprintf(stderr, "  --StyleSheet=<file>           Load an additional Qt stylesheet after\n");
   fprintf(stderr, "                                OMEdit's default stylesheet.\n\n");
 

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <iostream>
+#include <QApplication>
 #include "TextAnnotation.h"
 #include "Modeling/Commands.h"
 #include "Options/OptionsDialog.h"
@@ -361,6 +362,9 @@ void TextAnnotation::drawAnnotation(QPainter *painter)
   QPointF p2 = mExtent.size() > 1 ? mExtent.at(1) : QPointF(100.0, 100.0);
   bool startInv = p1.x() > p2.x();
   applyLinePattern(painter);
+  if (qApp->property("omeditDarkMode").toBool() && painter->pen().color() == QColor(Qt::black)) {
+    painter->setPen(QColor(232, 234, 237));
+  }
   /* Don't apply the fill patterns on Text shapes. */
   /*applyFillPattern(painter);*/
   // store the existing transformations

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -3003,8 +3003,13 @@ InfoBar::InfoBar(QWidget *pParent)
   : QFrame(pParent)
 {
   QPalette pal = palette();
-  pal.setColor(QPalette::Window, QColor(255, 255, 225));
-  pal.setColor(QPalette::WindowText, Qt::black);
+  if (qApp->property("omeditDarkMode").toBool()) {
+    pal.setColor(QPalette::Window, QColor(31, 41, 55));
+    pal.setColor(QPalette::WindowText, QColor(232, 234, 237));
+  } else {
+    pal.setColor(QPalette::Window, QColor(255, 255, 225));
+    pal.setColor(QPalette::WindowText, Qt::black);
+  }
   setPalette(pal);
   setFrameStyle(QFrame::StyledPanel);
   setAutoFillBackground(true);
@@ -3046,8 +3051,13 @@ ReloadAsModelicaInfoBar::ReloadAsModelicaInfoBar(BaseEditor *pBaseEditor)
   : QFrame(pBaseEditor)
 {
   QPalette pal = palette();
-  pal.setColor(QPalette::Window, QColor(255, 255, 225));
-  pal.setColor(QPalette::WindowText, Qt::black);
+  if (qApp->property("omeditDarkMode").toBool()) {
+    pal.setColor(QPalette::Window, QColor(31, 41, 55));
+    pal.setColor(QPalette::WindowText, QColor(232, 234, 237));
+  } else {
+    pal.setColor(QPalette::Window, QColor(255, 255, 225));
+    pal.setColor(QPalette::WindowText, Qt::black);
+  }
   setPalette(pal);
   setFrameStyle(QFrame::StyledPanel);
   setAutoFillBackground(true);

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -46,6 +46,7 @@
 #include "Debugger/Breakpoints/BreakpointsWidget.h"
 #include "Util/ResourceCache.h"
 
+#include <QApplication>
 #include <QMenu>
 #include <QCompleter>
 #include <QMessageBox>
@@ -752,8 +753,13 @@ bool PlainTextEdit::eventFilter(QObject *pObject, QEvent *pEvent)
   QWidget *pCompleterToolTipWidget = qobject_cast<QWidget*>(pObject);
   if (pCompleterToolTipWidget && pEvent->type() == QEvent::Paint) {
     QPainter painter (pCompleterToolTipWidget);
-    painter.setPen(Qt::black);
-    painter.setBrush(Qt::white);
+    if (qApp->property("omeditDarkMode").toBool()) {
+      painter.setPen(QColor(107, 114, 128));
+      painter.setBrush(QColor(17, 24, 39));
+    } else {
+      painter.setPen(Qt::black);
+      painter.setBrush(Qt::white);
+    }
     QRect rectangle = pCompleterToolTipWidget->rect();
     rectangle.setWidth(pCompleterToolTipWidget->rect().width() - 1);
     rectangle.setHeight(pCompleterToolTipWidget->rect().height() - 1);
@@ -920,7 +926,8 @@ int PlainTextEdit::lineNumberAreaWidth()
 void PlainTextEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
 {
   QPainter painter(mpLineNumberArea);
-  painter.fillRect(event->rect(), QColor(240, 240, 240));
+  const bool darkMode = qApp->property("omeditDarkMode").toBool();
+  painter.fillRect(event->rect(), darkMode ? QColor(31, 41, 55) : QColor(240, 240, 240));
 
   QTextBlock block = firstVisibleBlock();
   int blockNumber = block.blockNumber();
@@ -978,9 +985,9 @@ void PlainTextEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
       }
       // make the current highlighted line number darker
       if (blockNumber == textCursor().blockNumber()) {
-        painter.setPen(QColor(64, 64, 64));
+        painter.setPen(darkMode ? QColor(229, 231, 235) : QColor(64, 64, 64));
       } else {
-        painter.setPen(Qt::gray);
+        painter.setPen(darkMode ? QColor(156, 163, 175) : QColor(Qt::gray));
       }
       painter.setFont(document()->defaultFont());
       painter.drawText(0, top, lineNumbersWidth, fm.height(), Qt::AlignRight, number);
@@ -990,7 +997,7 @@ void PlainTextEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
     if (pTextEditorPage->getSyntaxHighlightingGroupBox()->isChecked() && pTextEditorPage->getCodeFoldingCheckBox()->isChecked()) {
       painter.save();
       painter.setRenderHint(QPainter::Antialiasing, false);
-      painter.setPen(Qt::gray);
+      painter.setPen(darkMode ? QColor(156, 163, 175) : QColor(Qt::gray));
 
       TextBlockUserData *nextBlockUserData = BaseEditorDocumentLayout::testUserData(nextBlock);
       bool drawFoldingControl = nextBlockUserData && BaseEditorDocumentLayout::foldingIndent(block) < nextBlockUserData->foldingIndent();

--- a/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
@@ -47,10 +47,35 @@
 #include "Util/Helper.h"
 #include "Options/NotificationsDialog.h"
 
+#include <QApplication>
 #include <QCompleter>
 #include <QMenu>
 #include <QMessageBox>
 
+namespace {
+  QColor modelicaEditorSyntaxColor(ModelicaEditorPage *pModelicaEditorPage, const QString &item)
+  {
+    if (!qApp->property("omeditDarkMode").toBool()) {
+      return pModelicaEditorPage->getColor(item);
+    } else if (item.compare("Text") == 0) {
+      return QColor(232, 234, 237);
+    } else if (item.compare("Number") == 0) {
+      return QColor(251, 191, 36);
+    } else if (item.compare("Keyword") == 0) {
+      return QColor(248, 113, 113);
+    } else if (item.compare("Type") == 0) {
+      return QColor(147, 197, 253);
+    } else if (item.compare("Function") == 0) {
+      return QColor(192, 132, 252);
+    } else if (item.compare("Quotes") == 0) {
+      return QColor(134, 239, 172);
+    } else if (item.compare("Comment") == 0) {
+      return QColor(148, 163, 184);
+    } else {
+      return pModelicaEditorPage->getColor(item);
+    }
+  }
+}
 
 /*!
  * \class ModelicaEditor
@@ -723,15 +748,15 @@ void ModelicaHighlighter::initializeSettings()
   // set color highlighting
   mHighlightingRules.clear();
   HighlightingRule rule;
-  mTextFormat.setForeground(mpModelicaEditorPage->getColor("Text"));
-  mKeywordFormat.setForeground(mpModelicaEditorPage->getColor("Keyword"));
-  mTypeFormat.setForeground(mpModelicaEditorPage->getColor("Type"));
-  mSingleLineCommentFormat.setForeground(mpModelicaEditorPage->getColor("Comment"));
-  mMultiLineCommentFormat.setForeground(mpModelicaEditorPage->getColor("Comment"));
-  mFunctionFormat.setForeground(mpModelicaEditorPage->getColor("Function"));
-  mQuotationFormat.setForeground(mpModelicaEditorPage->getColor("Quotes"));
+  mTextFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Text"));
+  mKeywordFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Keyword"));
+  mTypeFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Type"));
+  mSingleLineCommentFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Comment"));
+  mMultiLineCommentFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Comment"));
+  mFunctionFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Function"));
+  mQuotationFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Quotes"));
   // Priority: keyword > func() > ident > number. Yes, the order matters :)
-  mNumberFormat.setForeground(mpModelicaEditorPage->getColor("Number"));
+  mNumberFormat.setForeground(modelicaEditorSyntaxColor(mpModelicaEditorPage, "Number"));
   rule.mPattern = QRegExp("[0-9][0-9]*([.][0-9]*)?([eE][+-]?[0-9]*)?");
   rule.mFormat = mNumberFormat;
   mHighlightingRules.append(rule);
@@ -994,7 +1019,7 @@ void ModelicaHighlighter::highlightBlock(const QString &text)
   if (pTextBlockUserData) {
     pTextBlockUserData->setFoldingState(false);
   }
-  setFormat(0, text.length(), mpModelicaEditorPage->getColor("Text"));
+  setFormat(0, text.length(), modelicaEditorSyntaxColor(mpModelicaEditorPage, "Text"));
   foreach (const HighlightingRule &rule, mHighlightingRules) {
     QRegExp expression(rule.mPattern);
     int index = expression.indexIn(text);

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -49,6 +49,7 @@
 #include "FMI/FMUExportOutputWidget.h"
 #include "CRML/CRMLTranslatorOutputWidget.h"
 
+#include <QApplication>
 #include <QMenu>
 #include <QMessageBox>
 
@@ -195,12 +196,30 @@ void MessageWidget::applyMessagesSettings()
   font.setPointSizeF(fontSize);
   mpMessagesTextBrowser->setFont(font);
   // set the messages color by setting the style sheet
-  QString messagesCSS = QString(".notification {color: %1}"
-                                ".warning {color: %2}"
-                                ".error {color: %3}")
-      .arg(OptionsDialog::instance()->getMessagesPage()->getNotificationColor().name())
-      .arg(OptionsDialog::instance()->getMessagesPage()->getWarningColor().name())
-      .arg(OptionsDialog::instance()->getMessagesPage()->getErrorColor().name());
+  QColor notificationColor = pMessagesPage->getNotificationColor();
+  QColor warningColor = pMessagesPage->getWarningColor();
+  QColor errorColor = pMessagesPage->getErrorColor();
+  QColor linkColor = QColor(Qt::blue);
+  if (qApp->property("omeditDarkMode").toBool()) {
+    if (notificationColor == QColor(Qt::black)) {
+      notificationColor = QColor(232, 234, 237);
+    }
+    if (warningColor == QColor(255, 170, 0)) {
+      warningColor = QColor(250, 204, 21);
+    }
+    if (errorColor == QColor(Qt::red)) {
+      errorColor = QColor(255, 107, 107);
+    }
+    linkColor = QColor(147, 197, 253);
+  }
+  QString messagesCSS = QString("a {color: %1}"
+                                ".notification {color: %2}"
+                                ".warning {color: %3}"
+                                ".error {color: %4}")
+      .arg(linkColor.name())
+      .arg(notificationColor.name())
+      .arg(warningColor.name())
+      .arg(errorColor.name());
   mpMessagesTextBrowser->document()->setDefaultStyleSheet(messagesCSS);
   // move the cursor to end.
   QTextCursor textCursor = mpMessagesTextBrowser->textCursor();

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -60,6 +60,7 @@
 #include "Util/NetworkAccessManager.h"
 #include "QuickInsertWidget.h"
 
+#include <QApplication>
 #include <QNetworkReply>
 #include <QMessageBox>
 #include <QMenu>
@@ -4518,19 +4519,25 @@ void GraphicsView::drawBackground(QPainter *painter, const QRectF &rect)
   if (mSkipBackground) {
     return;
   }
-  QPen grayPen(QBrush(QColor(192, 192, 192)), 0);
-  QPen lightGrayPen(QBrush(QColor(229, 229, 229)), 0);
+  const bool darkMode = qApp->property("omeditDarkMode").toBool();
+  const QColor gridLineColor = darkMode ? QColor(55, 65, 81) : QColor(229, 229, 229);
+  const QColor axisLineColor = darkMode ? QColor(107, 114, 128) : QColor(192, 192, 192);
+  const QColor extentBackgroundColor = darkMode ? QColor(31, 41, 55) : QColor(Qt::white);
+  QPen grayPen(QBrush(axisLineColor), 0);
+  QPen lightGrayPen(QBrush(gridLineColor), 0);
+  QColor backgroundColor;
   if (mpModelWidget->getLibraryTreeItem()->isSystemLibrary() || mpModelWidget->isElementMode() || isVisualizationView()) {
-    painter->setBrush(QBrush(Qt::white, Qt::SolidPattern));
+    backgroundColor = darkMode ? QColor(17, 24, 39) : QColor(Qt::white);
   } else if (isIconView()) {
-    painter->setBrush(QBrush(QColor(229, 244, 255), Qt::SolidPattern));
+    backgroundColor = darkMode ? QColor(19, 32, 56) : QColor(229, 244, 255);
   } else {
-    painter->setBrush(QBrush(QColor(242, 242, 242), Qt::SolidPattern));
+    backgroundColor = darkMode ? QColor(17, 24, 39) : QColor(242, 242, 242);
   }
-  // draw scene rectangle white background
+  painter->setBrush(QBrush(backgroundColor, Qt::SolidPattern));
+  // draw scene background
   painter->setPen(Qt::NoPen);
   painter->drawRect(rect);
-  painter->setBrush(QBrush(Qt::white, Qt::SolidPattern));
+  painter->setBrush(QBrush(extentBackgroundColor, Qt::SolidPattern));
   QRectF extentRectangle = mMergedCoordinateSystem.getExtentRectangle();
   painter->drawRect(extentRectangle);
   if (mpModelWidget->getModelWidgetContainer()->isShowGridLines()
@@ -4572,7 +4579,7 @@ void GraphicsView::drawBackground(QPainter *painter, const QRectF &rect)
     painter->drawLine(QPointF(rect.left(), 0), QPointF(rect.right(), 0));
     painter->drawLine(QPointF(0, rect.top()), QPointF(0, rect.bottom()));
   }
-  // draw scene rectangle
+  // draw coordinate system extent
   painter->setPen(grayPen);
   painter->drawRect(extentRectangle);
 }
@@ -5345,10 +5352,11 @@ void GraphicsView::leaveEvent(QEvent *event)
 WelcomePageWidget::WelcomePageWidget(QWidget *pParent)
   : QWidget(pParent)
 {
+  const bool darkMode = qApp->property("omeditDarkMode").toBool();
   // main frame
   QFrame *pMainFrame = new QFrame;
   pMainFrame->setContentsMargins(0, 0, 0, 0);
-  pMainFrame->setStyleSheet("QFrame{color:gray;}");
+  pMainFrame->setStyleSheet(darkMode ? "QFrame{background-color: #202124; color: #e8eaed;}" : "QFrame{color:gray;}");
   // top frame
   QFrame *pTopFrame = new QFrame;
   pTopFrame->setStyleSheet("QFrame{background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #828282, stop: 1 #5e5e5e);}");
@@ -5373,7 +5381,7 @@ WelcomePageWidget::WelcomePageWidget(QWidget *pParent)
   // RecentFiles Frame
   QFrame *pRecentFilesFrame = new QFrame;
   pRecentFilesFrame->setFrameShape(QFrame::StyledPanel);
-  pRecentFilesFrame->setStyleSheet("QFrame{background-color: white;}");
+  pRecentFilesFrame->setStyleSheet(darkMode ? "QFrame{background-color: #111827; color: #f3f4f6;}" : "QFrame{background-color: white;}");
   // recent items list
   Label *pRecentFilesLabel = Utilities::getHeadingLabel(tr("Recent Files"));
   mpNoRecentFileLabel = new Label(tr("No recent files found."));
@@ -5401,7 +5409,7 @@ WelcomePageWidget::WelcomePageWidget(QWidget *pParent)
   // LatestNews Frame
   mpLatestNewsFrame = new QFrame;
   mpLatestNewsFrame->setFrameShape(QFrame::StyledPanel);
-  mpLatestNewsFrame->setStyleSheet("QFrame{background-color: white;}");
+  mpLatestNewsFrame->setStyleSheet(darkMode ? "QFrame{background-color: #111827; color: #f3f4f6;}" : "QFrame{background-color: white;}");
   /* Read the show latest news settings */
   if (!OptionsDialog::instance()->getGeneralSettingsPage()->getShowLatestNewsCheckBox()->isChecked()) {
     mpLatestNewsFrame->setVisible(false);

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -122,6 +122,16 @@ namespace {
     return false;
   }
 
+  bool darkModeArgumentValue(const QString &argument, bool *pEnabled)
+  {
+    const QString optionPrefix = "--DarkMode=";
+    if (argument.startsWith(optionPrefix)) {
+      *pEnabled = argument.mid(optionPrefix.length()) == "true";
+      return true;
+    }
+    return false;
+  }
+
   bool readStyleSheetFile(const QString &fileName, QString *pStyleSheet, QString *pErrorString)
   {
     QFile styleSheetFile(fileName);
@@ -175,12 +185,23 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   qputenv("QTWEBENGINE_LOCALES_PATH", localesPath.toUtf8());
 #endif // #ifdef Q_OS_WIN
 
-/* We need a better handling of ligth and dark themes.
- * For now just force light theme for Qt 6.8
- * The default color scheme is based on the system theme, so Qt will automatically use light or dark theme based on the user's system settings.
+  bool darkMode = false;
+  if (arguments().size() > 1 && !testsuiteRunning) {
+    for (int i = 1; i < arguments().size(); i++) {
+      bool argumentDarkMode = false;
+      if (darkModeArgumentValue(arguments().at(i), &argumentDarkMode)) {
+        darkMode = argumentDarkMode;
+      }
+    }
+  }
+  setProperty("omeditDarkMode", darkMode);
+
+/* Qt 6.8 defaults to the system color scheme. Keep OMEdit in light mode unless
+ * dark mode is explicitly requested so the built-in stylesheets remain
+ * deterministic.
  */
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
-  styleHints()->setColorScheme(Qt::ColorScheme::Light);  // must be before setStyleSheet
+  styleHints()->setColorScheme(darkMode ? Qt::ColorScheme::Dark : Qt::ColorScheme::Light);  // must be before setStyleSheet
 #endif // #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   // set the stylesheet
   QString applicationStyleSheet;
@@ -189,6 +210,15 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   const bool defaultStyleSheetLoaded = readStyleSheetFile(":/Resources/css/stylesheet.qss", &applicationStyleSheet, &defaultStyleSheetLoadError);
   if (!defaultStyleSheetLoaded) {
     styleSheetLoadErrors.append(defaultStyleSheetLoadError);
+  }
+  if (defaultStyleSheetLoaded && darkMode) {
+    QString darkStyleSheet;
+    QString darkStyleSheetLoadError;
+    if (readStyleSheetFile(":/Resources/css/stylesheet-dark.qss", &darkStyleSheet, &darkStyleSheetLoadError)) {
+      appendStyleSheet(&applicationStyleSheet, darkStyleSheet);
+    } else {
+      styleSheetLoadErrors.append(darkStyleSheetLoadError);
+    }
   }
   if (defaultStyleSheetLoaded && arguments().size() > 1 && !testsuiteRunning) {
     for (int i = 1; i < arguments().size(); i++) {
@@ -263,6 +293,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   if (arguments().size() > 1 && !testsuiteRunning) {
     for (int i = 1; i < arguments().size(); i++) {
       QString styleSheetFileName;
+      bool darkModeEnabled = false;
       if (strncmp(arguments().at(i).toUtf8().constData(), "--Debug=",8) == 0) {
         QString debugArg = arguments().at(i);
         debugArg.remove("--Debug=");
@@ -285,6 +316,8 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         dumpQtPaths();
       } else if (styleSheetArgumentValue(arguments().at(i), &styleSheetFileName)) {
         // The stylesheet option is handled before MainWindow initialization.
+      } else if (darkModeArgumentValue(arguments().at(i), &darkModeEnabled)) {
+        // The dark mode option is handled before MainWindow initialization.
       } else {
         fileName = arguments().at(i);
         if (!fileName.isEmpty()) {

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -365,6 +365,7 @@ CONFIG(osg) {
 }
 
 OTHER_FILES += Resources/css/stylesheet.qss \
+  Resources/css/stylesheet-dark.qss \
   Debugger/Parser/GDBMIOutput.g \
   Debugger/Parser/GDBMIParser.h \
   Debugger/Parser/GDBMIParser.cpp \

--- a/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
+++ b/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
@@ -1,3 +1,39 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+
 QWidget {
   background-color: #202124;
   color: #e8eaed;

--- a/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
+++ b/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
@@ -24,7 +24,8 @@ QMenuBar::item:selected, QMenu::item:selected {
   background-color: #3a3f44;
 }
 
-QLineEdit, QTextEdit, QTextBrowser, QPlainTextEdit, QTreeView, QTreeWidget, QListView, QListWidget, QTableView, QTableWidget {
+QLineEdit, QTextEdit, QTextBrowser, QPlainTextEdit, QTreeView, QTreeWidget, QListView, QListWidget, QTableView, QTableWidget,
+QGraphicsView, QMdiArea, QScrollArea {
   background-color: #111827;
   color: #f3f4f6;
   border: 1px solid #4b5563;

--- a/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
+++ b/OMEdit/OMEditLIB/Resources/css/stylesheet-dark.qss
@@ -1,0 +1,129 @@
+QWidget {
+  background-color: #202124;
+  color: #e8eaed;
+  selection-background-color: #3b82f6;
+  selection-color: #ffffff;
+}
+
+QMainWindow, QMenuBar, QMenu, QToolBar, QDockWidget, QStatusBar, QTabWidget::pane {
+  background-color: #202124;
+  color: #e8eaed;
+}
+
+QDockWidget::title {
+  background-color: #2b2d31;
+  color: #e8eaed;
+  padding: 4px;
+}
+
+QMenu {
+  border: 1px solid #4b5563;
+}
+
+QMenuBar::item:selected, QMenu::item:selected {
+  background-color: #3a3f44;
+}
+
+QLineEdit, QTextEdit, QTextBrowser, QPlainTextEdit, QTreeView, QTreeWidget, QListView, QListWidget, QTableView, QTableWidget {
+  background-color: #111827;
+  color: #f3f4f6;
+  border: 1px solid #4b5563;
+}
+
+QTextEdit:disabled, QTextBrowser:disabled, QPlainTextEdit:disabled {
+  background-color: #1f2937;
+  color: #cbd5e1;
+}
+
+QTextEdit[readOnly="true"], QTextBrowser[readOnly="true"], QPlainTextEdit[readOnly="true"] {
+  background-color: #111827;
+  color: #f3f4f6;
+}
+
+QTextBrowser {
+  background-color: #111827;
+  color: #f3f4f6;
+}
+
+QAbstractItemView::item:selected {
+  background-color: #1d4ed8;
+  color: #ffffff;
+}
+
+QHeaderView::section {
+  background-color: #374151;
+  color: #f3f4f6;
+  border: 1px solid #4b5563;
+}
+
+QPushButton, QToolButton, QComboBox, QSpinBox, QDoubleSpinBox {
+  background-color: #374151;
+  color: #f3f4f6;
+  border: 1px solid #6b7280;
+  padding: 4px;
+}
+
+QPushButton:hover, QToolButton:hover, QComboBox:hover, QSpinBox:hover, QDoubleSpinBox:hover {
+  background-color: #4b5563;
+}
+
+QPushButton:disabled, QToolButton:disabled, QComboBox:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled {
+  background-color: #2b2d31;
+  color: #9ca3af;
+  border: 1px solid #4b5563;
+}
+
+QComboBox QAbstractItemView {
+  background-color: #111827;
+  color: #f3f4f6;
+  selection-background-color: #1d4ed8;
+  selection-color: #ffffff;
+}
+
+QTabBar::tab {
+  background-color: #374151;
+  color: #f3f4f6;
+  padding: 6px 10px;
+  border: 1px solid #4b5563;
+}
+
+QTabBar::tab:selected {
+  background-color: #111827;
+}
+
+QTabBar::tab:disabled {
+  color: #9ca3af;
+}
+
+QGroupBox {
+  border: 1px solid #4b5563;
+  margin-top: 8px;
+}
+
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 8px;
+  padding: 0 3px;
+}
+
+QScrollBar:vertical, QScrollBar:horizontal {
+  background: #111827;
+}
+
+QScrollBar::handle:vertical, QScrollBar::handle:horizontal {
+  background: #6b7280;
+}
+
+QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover {
+  background: #9ca3af;
+}
+
+QSplitter::handle {
+  background-color: #4b5563;
+}
+
+QToolTip {
+  background-color: #111827;
+  color: #f3f4f6;
+  border: 1px solid #6b7280;
+}

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -870,7 +870,7 @@ void Utilities::highlightCurrentLine(QPlainTextEdit *pPlainTextEdit)
 {
   QList<QTextEdit::ExtraSelection> selections = pPlainTextEdit->extraSelections();
   QTextEdit::ExtraSelection selection;
-  QColor lineColor = QColor(232, 242, 254);
+  QColor lineColor = qApp->property("omeditDarkMode").toBool() ? QColor(38, 47, 61) : QColor(232, 242, 254);
   selection.format.setBackground(lineColor);
   selection.format.setProperty(QTextFormat::FullWidthSelection, true);
   selection.cursor = pPlainTextEdit->textCursor();

--- a/OMEdit/OMEditLIB/resource_omedit.qrc
+++ b/OMEdit/OMEditLIB/resource_omedit.qrc
@@ -32,6 +32,7 @@
         <file>Resources/icons/translateAs.svg</file>
         <file>Resources/icons/runScript.svg</file>
         <file>Resources/css/stylesheet.qss</file>
+        <file>Resources/css/stylesheet-dark.qss</file>
         <file>Resources/icons/check.svg</file>
         <file>Resources/icons/check-all.svg</file>
         <file>Resources/icons/zoomReset.svg</file>


### PR DESCRIPTION
## Summary

Adds an opt-in dark mode to OMEdit, building on the stylesheet override support merged in #15766.

- New command-line option `--DarkMode=[true|false]` (default `false`), following the existing `--Debug=` / `--NAPIProfiling=` option style. When enabled:
  - a built-in dark stylesheet (`Resources/css/stylesheet-dark.qss`) is appended to the default stylesheet, using the single-`setStyleSheet` application pattern from #15766 (default → dark → user `--StyleSheet=` overrides → one `setStyleSheet` call);
  - on Qt ≥ 6.8 the color scheme hint is set to `Qt::ColorScheme::Dark` instead of the forced `Light`;
  - custom-drawn surfaces that ignore stylesheets (graphics view background/grid, editor line-number area, current-line highlight, info bars, completer tooltip, welcome page, text annotations drawn with a pure-black pen) switch to dark-appropriate colors, gated on a `qApp` property so light-mode rendering is untouched.
- `--StyleSheet=` continues to work on top of dark mode, so users can still override individual rules.

## Design notes

- Widget chrome is themed via the qss resource; hard-coded colors appear only at custom paint sites that stylesheets cannot reach.
- In dark mode the Modelica editor uses a fixed dark syntax palette (user-configured colors from Options are used in light mode, and for any item not covered by the palette). The default light syntax colors are unreadable on a dark background; a per-theme color option set would be a larger change and can be done as a follow-up if preferred.
- Messages browser colors are remapped only when they equal the light defaults, so user-customized message colors are preserved.
- With `--DarkMode=false` (or the option absent) rendering is unchanged: the color scheme stays forced to `Light` on Qt ≥ 6.8 and no dark branch executes.

## Testing

- The dark rendering has been in daily local use on macOS (OMEdit built from source) — editor, diagram/icon views, messages browser, and welcome page verified visually in both modes; an earlier revision of this branch was used, and this rebase onto current master keeps the rendering code identical while aligning the stylesheet application with the structure merged in #15766.
- This local environment cannot build the full tree (no Java for the Parser stage), so I am relying on the PR checks for build verification across platforms.