### PR TITLE
wasm-jit: refresh algebraics for the pre-event result row

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -112,6 +112,9 @@ struct SimLayout {
     /// `algVars ++ discreteAlgVars` (the real algebraic variables emitted as
     /// time-variant result signals after the states and derivatives).
     n_real_alg: u32,
+    /// When true, `functionAlgebraics` also runs the discrete update and saves the
+    /// `pre` regions, so drivers must call it only in the once-per-step order.
+    has_when: bool,
     rparam_off: u32,
     int_off: u32,
     iparam_off: u32,
@@ -200,6 +203,7 @@ impl SimLayout {
         n_rel: u32,
         n_stateset_f64: u32,
         n_math: u32,
+        has_when: bool,
     ) -> Self {
         let n_real = 2 * n_states + n_real_alg; // states | ders | algs
         let rparam_off = REAL_OFF + n_real * 8;
@@ -236,7 +240,7 @@ impl SimLayout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let total = mathevents_off + n_math_slots * 8;
         SimLayout {
-            n_states, n_real_alg, rparam_off, int_off, iparam_off, bool_off, bparam_off,
+            n_states, n_real_alg, has_when, rparam_off, int_off, iparam_off, bool_off, bparam_off,
             str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off,
             n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stateset_off, n_math, mathevents_off, total,
@@ -1325,6 +1329,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     let samples = collect_samples(&sim_code.timeEvents)?;
     let zero_crossings = collect_zero_crossings(&sim_code.zeroCrossings)?;
     let stateset_scratch_f64 = stateset_scratch_f64(&sim_code.stateSets)?;
+    let all_eqs = flatten_eqs(&sim_code.allEquations);
+    let has_when = all_eqs.iter().any(|e| matches!(&**e, SimCode::SimEqSystem::SES_WHEN { .. }));
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -1341,6 +1347,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         vi.numRelations.max(0) as u32,
         stateset_scratch_f64,
         vi.numMathEventFunctions.max(0) as u32,
+        has_when,
     );
 
     let (mut var_map, result_vars) = build_var_map(vars, &layout)?;
@@ -1436,8 +1443,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     // equations. `allEquations` is the full solved list in that order, so it is
     // used as the per-step function (in place of `algebraicEquations`), and
     // pre-values are saved after each step so the next step's edge test sees them.
-    let all_eqs = flatten_eqs(&sim_code.allEquations);
-    let has_when = all_eqs.iter().any(|e| matches!(&**e, SimCode::SimEqSystem::SES_WHEN { .. }));
     let algebraic_eqs = if has_when { all_eqs } else { flatten_eqs_ll(&sim_code.algebraicEquations) };
     // pre := live regions, appended to the per-step (algebraic) function when the
     // model has `when`-equations (see `sim_save_pre_values`).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -1058,11 +1058,16 @@ fn run_dassl_events(
     let _guard = ResCtxGuard;
     RES_CTX.with(|c| c.set(&mut ctx as *mut ResCtx));
 
-    // Snapshot the current state as a pre-event result row without running the
-    // discrete update (so the value just *before* the event is captured).
+    // Pre-event snapshot: the state just *before* the discrete update. Recorded
+    // real algebraics live in slots `functionAlgebraics` fills, so it must run or
+    // they keep the previous grid point's values. Skip it for `has_when` models —
+    // there it also saves `pre` early, breaking the post-event edge test.
     let capture_pre = |e: &mut dyn SimEngine, rows: &mut Vec<f64>, time: f64| -> Result<()> {
         write_f64(e, sim_data + TIME_OFF, time)?;
         e.call1("functionODE", sim_data)?;
+        if !layout.has_when {
+            e.call1("functionAlgebraics", sim_data)?;
+        }
         capture_row(e, rows, sim_data, layout)
     };
 


### PR DESCRIPTION
At a state event the DASSL-events driver emits a pre-event and a post-event row. The pre-event snapshot (capture_pre) ran functionODE only, so recorded real algebraics (aliases, der() outputs, contact torques) kept the previous grid point's values while the states were correctly interpolated to the event time. This made Backlash's inertia2.flange_a.tau, der(inertia2.w) and der(elastoBacklash.w_rel) diverge from the C target.

Run functionAlgebraics in capture_pre too, but only for models without when-equations: there functionAlgebraics also runs the discrete update and saves the pre regions, so calling it early breaks the post-event edge test (observed as BouncingBall's bounces no longer firing -> DASSL IDID=-33). For when-models functionODE alone is correct in that row. A new SimLayout.has_when flag carries the distinction to the driver.