### PR TITLE
wasm-jit: implement the homotopy() operator and continuation

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -115,6 +115,13 @@ struct SimLayout {
     /// When true, `functionAlgebraics` also runs the discrete update and saves the
     /// `pre` regions, so drivers must call it only in the once-per-step order.
     has_when: bool,
+    /// The model uses `homotopy()`, so a `functionInitialEquations_lambda0` is
+    /// emitted and the driver may fall back to the homotopy continuation on a
+    /// failed direct initialization.
+    has_homotopy: bool,
+    /// `SimData` byte offset of the homotopy parameter lambda (f64). 1.0 outside
+    /// the homotopy continuation; `homotopy(a, s)` reads it as `s + lambda*(a-s)`.
+    lambda_off: u32,
     rparam_off: u32,
     int_off: u32,
     iparam_off: u32,
@@ -204,6 +211,7 @@ impl SimLayout {
         n_stateset_f64: u32,
         n_math: u32,
         has_when: bool,
+        has_homotopy: bool,
     ) -> Self {
         let n_real = 2 * n_states + n_real_alg; // states | ders | algs
         let rparam_off = REAL_OFF + n_real * 8;
@@ -223,8 +231,10 @@ impl SimLayout {
         let terminate_off = pre_bool_off + n_bool_alg * 4;
         let n_out_off = terminate_off + 4;
         let nls_fail_off = n_out_off + 4;
+        // Homotopy parameter (f64), 8-aligned.
+        let lambda_off = (nls_fail_off + 4 + 7) & !7;
         // Sample region: 8-aligned start/interval f64 pairs, then i32 active flags.
-        let sample_off = (nls_fail_off + 4 + 7) & !7;
+        let sample_off = (lambda_off + 8 + 7) & !7;
         let sample_active_off = sample_off + n_samples * 16;
         // Zero-crossing values (f64 each), 8-aligned after the sample region.
         let zc_off = (sample_active_off + n_samples * 4 + 7) & !7;
@@ -240,7 +250,7 @@ impl SimLayout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let total = mathevents_off + n_math_slots * 8;
         SimLayout {
-            n_states, n_real_alg, has_when, rparam_off, int_off, iparam_off, bool_off, bparam_off,
+            n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off, bool_off, bparam_off,
             str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off,
             n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stateset_off, n_math, mathevents_off, total,
@@ -733,6 +743,8 @@ struct SimVarMap {
     mathevents_off: u32,
     /// Number of math-event slots (bounds the `mathEventsValuePre` region).
     n_mathevents: u32,
+    /// `SimData` byte offset of the homotopy parameter lambda (`SimLayout`).
+    lambda_off: u32,
 }
 
 /// Display name of a model variable's component reference (OMC `.`-separated
@@ -848,6 +860,7 @@ fn build_var_map(
         n_relations: layout.n_rel,
         mathevents_off: layout.mathevents_off,
         n_mathevents: layout.n_math,
+        lambda_off: layout.lambda_off,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
 
@@ -1331,6 +1344,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     let stateset_scratch_f64 = stateset_scratch_f64(&sim_code.stateSets)?;
     let all_eqs = flatten_eqs(&sim_code.allEquations);
     let has_when = all_eqs.iter().any(|e| matches!(&**e, SimCode::SimEqSystem::SES_WHEN { .. }));
+    // The backend only emits a lambda-0 initial system when the model uses
+    // `homotopy()`; its presence is the signal to wire up the continuation.
+    let has_homotopy = (&*sim_code.initialEquations_lambda0).into_iter().next().is_some();
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -1348,6 +1364,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         stateset_scratch_f64,
         vi.numMathEventFunctions.max(0) as u32,
         has_when,
+        has_homotopy,
     );
 
     let (mut var_map, result_vars) = build_var_map(vars, &layout)?;
@@ -1456,13 +1473,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         Vec::new()
     };
     let initial_eqs = flatten_eqs(&sim_code.initialEquations);
+    let lambda0_eqs = flatten_eqs(&sim_code.initialEquations_lambda0);
     let ode_eqs = flatten_eqs_ll(&sim_code.odeEquations);
     // Register every nonlinear system with the runtime solver `rt_solve_nls`
     // *before* lowering the equation functions (which call it): assign each a
     // shared-table job and thread the map through `var_map`. The systems' own
     // `residual`/`load` callbacks are emitted after the equation functions.
     let (nls_systems, nls_jobs, nls_hist_bytes) =
-        collect_nls_jobs(&[&param_eqs, &initial_eqs, &ode_eqs, &algebraic_eqs]);
+        collect_nls_jobs(&[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs]);
     var_map.nls_jobs = Arc::new(nls_jobs);
 
     // --- Type section: one type per import, per model function, per equation
@@ -1699,6 +1717,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         bodies.push(build_stateset_jac_fn(&sim_code.stateSets, &var_map, &eq_index, &by_name, &mut literals)?);
         Some(idx)
     };
+    // The lambda-0 (simplified) initial system, for the homotopy continuation's
+    // first step. Emitted only for models that use `homotopy()`.
+    let init_lambda0_idx = if lambda0_eqs.is_empty() {
+        None
+    } else {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(build_eq_fn("initialEquations_lambda0", lambda0_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
+        Some(idx)
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -1730,6 +1757,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     if stateset_jac_idx.is_some() {
         functions.function(eqfn_type); // functionStateSetJacobians: (i32) -> ()
     }
+    if init_lambda0_idx.is_some() {
+        functions.function(eqfn_type); // functionInitialEquations_lambda0: (i32) -> ()
+    }
 
     // --- Code section. ---
     let mut code = we::CodeSection::new();
@@ -1758,6 +1788,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     }
     if let Some(idx) = stateset_jac_idx {
         exports.export("functionStateSetJacobians", we::ExportKind::Func, idx);
+    }
+    if let Some(idx) = init_lambda0_idx {
+        exports.export("functionInitialEquations_lambda0", we::ExportKind::Func, idx);
     }
 
     let mut module = we::Module::new();
@@ -2023,6 +2056,7 @@ fn build_eq_fn_with_prelude(
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2069,6 +2103,7 @@ fn build_init_sample_fn(
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2108,6 +2143,7 @@ fn build_zero_crossings_fn(
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
         zc_context: true,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2506,6 +2542,7 @@ fn build_nls_fns(
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
         zc_context: false,
     };
     let finish = |ctx: FnCtx| -> we::Function {
@@ -2647,6 +2684,12 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     // locals: BUF(i32), H(f64), ROW(i32), DEST(i32)
     let mut f = we::Function::new([(1, we::ValType::I32), (1, we::ValType::F64), (2, we::ValType::I32)]);
     use we::Instruction as I;
+
+    // lambda = 1.0 so homotopy(a, s) evaluates to the actual expression (this
+    // in-wasm Euler path does no homotopy continuation).
+    f.instruction(&I::LocalGet(SIM_DATA));
+    f.instruction(&I::F64Const(1.0f64.into()));
+    f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg(layout.lambda_off, 3)));
 
     // functionParameters(sim_data); functionInitialEquations(sim_data)
     f.instruction(&I::LocalGet(SIM_DATA));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -278,6 +278,50 @@ fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()>
     Ok(())
 }
 
+/// Number of equidistant homotopy steps (C's `init_lambda_steps`).
+const HOMOTOPY_STEPS: i32 = 3;
+
+/// Solve the initial system: `functionParameters`, then `functionInitialEquations`
+/// with the relations fresh (init mode). Tries directly first (lambda = 1, so
+/// `homotopy(a, s)` = a); if that leaves a non-converged nonlinear system and the
+/// model uses `homotopy()`, fall back to the global equidistant homotopy
+/// continuation (C's `solveWithGlobalHomotopy`): lambda 0 -> 1 in `HOMOTOPY_STEPS`
+/// steps, step 0 solving the simplified `functionInitialEquations_lambda0`, each
+/// step seeded by the previous one's solution. Leaves lambda = 1.
+fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    e.call1("functionParameters", sim_data)?;
+    write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
+    if layout.n_samples > 0 {
+        e.call1("initSample", sim_data)?;
+    }
+    // Direct attempt (no continuation).
+    write_f64(e, sim_data + layout.lambda_off, 1.0)?;
+    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+    e.call1("functionInitialEquations", sim_data)?;
+    if check_nls(e, sim_data, layout).is_ok() {
+        return Ok(());
+    }
+    if !layout.has_homotopy {
+        check_nls(e, sim_data, layout)?; // re-surface the failure
+        return Ok(());
+    }
+    for step in 0..=HOMOTOPY_STEPS {
+        let lambda = step as f64 / HOMOTOPY_STEPS as f64;
+        write_f64(e, sim_data + layout.lambda_off, lambda)?;
+        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+        if step == 0 {
+            e.call1("functionInitialEquations_lambda0", sim_data)?;
+        } else {
+            e.call1("functionInitialEquations", sim_data)?;
+        }
+        if check_nls(e, sim_data, layout).is_err() {
+            bail!("CodegenWasmJit: homotopy initialization did not converge at lambda={lambda}");
+        }
+    }
+    write_f64(e, sim_data + layout.lambda_off, 1.0)?;
+    Ok(())
+}
+
 /// Append one trajectory row to `rows`: the real part `[time | realVars]`
 /// followed by the integer and boolean algebraic slots (converted to f64),
 /// matching `SimLayout::n_row_total()` and the column layout `kind_from_slot`
@@ -485,13 +529,10 @@ fn run_host(
 ) -> Result<Vec<f64>> {
     let layout = &model.layout;
     stats.steps = (n_rows - 1) as u64;
-    e.call1("functionParameters", sim_data)?;
-    // No state events on this path, so relations never need the held phase;
-    // evaluate them fresh throughout (mode 2). `rt_solve_nls` still holds them
-    // internally around its Newton solve.
-    write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
-    e.call1("functionInitialEquations", sim_data)?;
-    check_nls(e, sim_data, layout)?;
+    // Init (with homotopy fallback). No state events on this path, so relations
+    // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
+    // them internally around its Newton solve.
+    run_initialization(e, sim_data, layout)?;
 
     let n_states = layout.n_states;
     let n_steps = n_rows - 1;
@@ -694,13 +735,9 @@ fn run_dassl(
     daskr::aux::xsetf(0);
 
     let layout = &model.layout;
-    e.call1("functionParameters", sim_data)?;
-    // No state events on this path, so relations never need the held phase;
-    // evaluate them fresh throughout (mode 2). `rt_solve_nls` still holds them
-    // internally around its Newton solve.
-    write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
-    e.call1("functionInitialEquations", sim_data)?;
-    check_nls(e, sim_data, layout)?; // a non-converging init NLS is not recoverable
+    // Init (with homotopy fallback). No state events on this path, so relations
+    // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
+    run_initialization(e, sim_data, layout)?;
 
     let n_states = layout.n_states as usize;
     let states_base = sim_data + REAL_OFF;
@@ -932,15 +969,10 @@ fn run_dassl_events(
     daskr::aux::xsetf(0);
 
     let layout = &model.layout;
-    e.call1("functionParameters", sim_data)?;
-    // Relation mode 2 (init): all relations fresh, through the initial row, so
-    // `relations[]` is populated before the states loop starts holding it.
-    write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
-    if layout.n_samples > 0 {
-        e.call1("initSample", sim_data)?; // fill start/interval from parameters
-    }
-    e.call1("functionInitialEquations", sim_data)?;
-    check_nls(e, sim_data, layout)?;
+    // Init (with homotopy fallback). Relation mode 2 (all relations fresh through
+    // the initial row, so `relations[]` is populated before the states loop starts
+    // holding it) and `initSample` are handled inside run_initialization.
+    run_initialization(e, sim_data, layout)?;
 
     let n_states = layout.n_states as usize;
     let states_base = sim_data + REAL_OFF;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -976,6 +976,9 @@ pub(crate) struct SimCtx {
     pub(crate) mathevents_off: u32,
     /// Number of math-event slots (bounds the `mathEventsValuePre` region).
     pub(crate) n_mathevents: u32,
+    /// `SimData` byte offset of the homotopy parameter lambda (`homotopy(a, s)` =
+    /// `s + lambda*(a-s)`).
+    pub(crate) lambda_off: u32,
     /// True while lowering the `functionZeroCrossings` body: an indexed relation is
     /// then evaluated *fresh* (so a sign change is detectable) rather than held.
     pub(crate) zc_context: bool,
@@ -4452,6 +4455,32 @@ fn compile_math_builtin(
             need_args(&argv, 1, name)?;
             let w = compile_exp(ctx, argv[0])?;
             Ok(if w == WTy::F64 { SigTy::Real } else { SigTy::Int })
+        }
+        // `homotopy(actual, simplified)` = `simplified + lambda*(actual-simplified)`
+        // (C's `homotopy_` with `data->simulationInfo->lambda`). lambda is 1.0
+        // outside the continuation, so this is `actual` for the normal init and the
+        // non-initial partitions; the init driver sweeps lambda 0->1 on fallback.
+        "homotopy" => {
+            need_args(&argv, 2, name)?;
+            let (data, lambda_off) = { let s = ctx.sim()?; (s.data_local, s.lambda_off) };
+            let a = compile_exp(ctx, argv[0])?;
+            coerce(ctx, a, WTy::F64);
+            let at = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalSet(at));
+            let s = compile_exp(ctx, argv[1])?;
+            coerce(ctx, s, WTy::F64);
+            let st = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalSet(st));
+            // simplified + lambda*(actual - simplified)
+            ctx.emit(we::Instruction::LocalGet(st));
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::F64Load(mem_arg(lambda_off, 3)));
+            ctx.emit(we::Instruction::LocalGet(at));
+            ctx.emit(we::Instruction::LocalGet(st));
+            ctx.emit(we::Instruction::F64Sub);
+            ctx.emit(we::Instruction::F64Mul);
+            ctx.emit(we::Instruction::F64Add);
+            Ok(SigTy::Real)
         }
         // `pre(x)` reads x's pre-value slot (C's `*VarsPre`), populated by
         // savePreValues after each step. In simulation mode the argument is a


### PR DESCRIPTION
homotopy(actual, simplified) bailed at translate ("builtin function homotopy not yet supported"), so any model using it (e.g. Modelica.Blocks.Examples. PID_Controller via LimPID) failed to build.

Lower it as `simplified + lambda*(actual - simplified)` (C's homotopy_ with data->simulationInfo->lambda), reading a new lambda slot in SimData. Emit and export functionInitialEquations_lambda0 from the backend's lambda-0 system, and run the C initialization scheme in the drivers: try directly first (lambda = 1, so homotopy = actual); if a nonlinear system does not converge and the model uses homotopy(), fall back to the global equidistant continuation (lambda 0 -> 1 in 3 steps, step 0 solving the simplified lambda-0 system, each step seeded by the previous solution). lambda is left at 1 for the simulation phase.

New SimLayout.has_homotopy / lambda_off carry this to the drivers; the in-wasm Euler `simulate` sets lambda = 1 as well.

PID_Controller now builds, simulates and matches the C target (compareSimulationResults -> Files Equal!; rtest passes); forcing the continuation for PID reproduces the direct solution bit-for-bit. First, DoublePendulum and Backlash are unchanged (Files Equal! vs C).