### PR TITLE
wasm-jit: fix stale ModelicaExternalC error message

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -304,8 +304,8 @@ fn define_external_imports(
         bail!(
             "CodegenWasmJit: this model uses external \"C\" functions (e.g. table blocks, \
              string scanning), which need the ModelicaExternalC side module — unavailable in \
-             this web build (build with the Emscripten SDK on PATH so build.rs can produce \
-             modelicaexternalc.wasm)"
+             this web build (build.rs could not compile modelicaexternalc.wasm; install the \
+             apt packages `clang`, `lld`, `wasi-libc`, and `libclang-rt-dev-wasm32`)"
         );
     }
 


### PR DESCRIPTION
The web-build bail for models using external "C" functions still told users to put the Emscripten SDK on PATH, but modelicaexternalc.wasm is now compiled with clang --target=wasm32-wasi. Point at the actual apt packages instead.


Claude-Session: https://claude.ai/code/session_01JWYsTcgTkGcnrgbuNWgxHS

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
