### PR TITLE
OMEdit wasm: HTML splash screen with determinate library progress

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -195,6 +195,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   }
 #if !defined(__EMSCRIPTEN__)
   SplashScreen::instance()->showMessage(tr("Initializing"), Qt::AlignRight, Qt::white);
+#else
+  WasmSplash::setMessage(tr("Initializing"));
 #endif
   // Create an object of MessagesWidget.
   MessagesWidget::create();
@@ -213,6 +215,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   }
 #if !defined(__EMSCRIPTEN__)
   SplashScreen::instance()->showMessage(tr("Reading Settings"), Qt::AlignRight, Qt::white);
+#else
+  WasmSplash::setMessage(tr("Reading Settings"));
 #endif
   // Get the number of processors.
   mNumberOfProcessors = mpOMCProxy->numProcessors();
@@ -223,6 +227,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   OptionsDialog::create();
 #if !defined(__EMSCRIPTEN__)
   SplashScreen::instance()->showMessage(tr("Loading Widgets"), Qt::AlignRight, Qt::white);
+#else
+  WasmSplash::setMessage(tr("Loading Widgets"));
 #endif
   // apply MessagesWidget settings
   MessagesWidget::instance()->applyMessagesSettings();
@@ -379,6 +385,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   //Create Actions, Toolbar and Menus
 #if !defined(__EMSCRIPTEN__)
   SplashScreen::instance()->showMessage(tr("Creating Widgets"), Qt::AlignRight, Qt::white);
+#else
+  WasmSplash::stepMessage(tr("Creating widgets"));
 #endif
   setAcceptDrops(true);
   createActions();

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -1292,6 +1292,9 @@ void LibraryTreeModel::addModelicaLibraries(const QVector<QPair<QString, QString
   pLibraryTreeItem->setNameStructure(Helper::OMEditInternal);
   // load Modelica System Libraries.
   OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
+#if defined(__EMSCRIPTEN__)
+  WasmSplash::setMessage(tr("Loading system libraries"));
+#endif
   pOMCProxy->loadSystemLibraries(libraries);
   QStringList systemLibs = pOMCProxy->getClassNames();
   foreach (QString systemLib, systemLibs) {
@@ -1299,6 +1302,8 @@ void LibraryTreeModel::addModelicaLibraries(const QVector<QPair<QString, QString
     if (!pLibraryTreeItem) {
 #if !defined(__EMSCRIPTEN__)
       SplashScreen::instance()->showMessage(QString("%1 %2").arg(Helper::loading, systemLib), Qt::AlignRight, Qt::white);
+#else
+      WasmSplash::setMessage(QString("%1 %2").arg(Helper::loading, systemLib));
 #endif
       createLibraryTreeItem(systemLib, mpRootLibraryTreeItem, true, true, true);
     }
@@ -2279,7 +2284,15 @@ void LibraryTreeModel::createLibraryTreeItems(LibraryTreeItem *pLibraryTreeItem)
       libs.removeFirst();
     }
     LibraryTreeItem *pParentLibraryTreeItem = 0;
+#if defined(__EMSCRIPTEN__)
+    const int totalLibs = libs.size();
+    int doneLibs = 0;
+#endif
     foreach (QString lib, libs) {
+#if defined(__EMSCRIPTEN__)
+      // Drive the startup-splash progress bar; setProgress throttles the repaint.
+      WasmSplash::setProgress(++doneLibs, totalLibs);
+#endif
       /* $Code is a special OpenModelica keyword. No API command will work if we use it. */
       if (lib.contains("$Code")) {
         continue;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -132,6 +132,26 @@ EM_JS(void, omedit_worker_setup, (const char *ver), {
     return id;
   };
   Module.__omcSetStatus = (p) => {
+    const amt = p ? (p.total > 0 ? Math.round(100 * p.done / p.total) + "%"
+                                 : Math.round(p.done / 1024) + " KiB") : "";
+    // Drive the HTML startup splash bar with the real download progress, if it is
+    // up and the library-tree pass has not yet claimed it (once it has, this fires
+    // on every worker reply and would keep resetting the determinate bar).
+    const sfill = Module.__omeditSplashDeterminate ? null : document.querySelector("#omedit-splash .bar > div");
+    const smsg = Module.__omeditSplashDeterminate ? null : document.getElementById("omedit-splash-msg");
+    if (sfill) {
+      if (p && p.total > 0) {
+        sfill.style.animation = "none";
+        sfill.style.transform = "none";
+        sfill.style.width = (100 * p.done / p.total) + "%";
+      } else {
+        // finished or unknown size: restore the indeterminate slide
+        sfill.style.animation = "";
+        sfill.style.transform = "";
+        sfill.style.width = "40%";
+      }
+    }
+    if (smsg && p) smsg.textContent = "Downloading libraries… " + amt;
     let el = document.getElementById("omcStatus");
     if (!el) {
       el = document.createElement("div");
@@ -141,8 +161,6 @@ EM_JS(void, omedit_worker_setup, (const char *ver), {
       document.body.appendChild(el);
     }
     if (!p) { el.style.display = "none"; return; }
-    const amt = p.total > 0 ? Math.round(100 * p.done / p.total) + "%"
-                            : Math.round(p.done / 1024) + " KiB";
     el.textContent = "Downloading " + p.file + "  " + amt;
     el.style.display = "block";
   };

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -260,14 +260,19 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
       break;
     }
   }
-  // Splash Screen. Omitted on wasm: SplashScreen is compiled out (its repaint pumps
-  // the Qt-for-WebAssembly event dispatcher during early startup, which traps).
+  // Splash Screen. On wasm QSplashScreen is compiled out (its repaint pumps the
+  // Qt-for-WebAssembly event dispatcher during early startup, which traps); an HTML
+  // overlay drawn straight into the DOM stands in for it instead.
 #if !defined(__EMSCRIPTEN__)
   QPixmap pixmap(":/Resources/icons/omedit_splashscreen.png");
   SplashScreen *pSplashScreen = SplashScreen::instance();
   pSplashScreen->setPixmap(pixmap);
   if (!testsuiteRunning) {
     pSplashScreen->show();
+  }
+#else
+  if (!testsuiteRunning) {
+    WasmSplash::show();
   }
 #endif
   Helper::initHelperVariables();
@@ -389,6 +394,8 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
     // hide the splash screen
 #if !defined(__EMSCRIPTEN__)
     SplashScreen::instance()->finish(pMainwindow);
+#else
+    WasmSplash::finish();
 #endif
     //! @todo Remove this once new frontend is used as default and old frontend is removed.
     //! Fixes issue #7456

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -68,6 +68,148 @@ SplashScreen *SplashScreen::instance()
   }
   return mpInstance;
 }
+#else
+#include <emscripten.h>
+#include <QElapsedTimer>
+
+// Return to the browser event loop for one frame so it composites the DOM
+// mutations made just before. A nested QEventLoop cannot do this during startup:
+// the splash runs before qApp->exec(), so there is no Qt loop to suspend and only
+// a raw Asyncify suspend actually yields to the browser (this is exactly how omc's
+// pre-exec worker wait paints its download bar). Safe only pre-exec, which the
+// splash always is (finish() runs before exec()).
+EM_ASYNC_JS(void, wasm_splash_yield, (), {
+  await new Promise(function(resolve) {
+    requestAnimationFrame(function() { setTimeout(resolve, 0); });
+  });
+});
+
+namespace WasmSplash
+{
+  static bool sVisible = false;
+
+  void show()
+  {
+    if (sVisible) {
+      return;
+    }
+    // Pure HTML/DOM, no Qt at all: Qt drawing/resource access before the event
+    // loop stalls the async library install on wasm. The image is referenced by
+    // URL (served beside the page) rather than read through a Qt resource.
+    sVisible = true;
+    EM_ASM({
+      if (document.getElementById('omedit-splash')) return;
+      var style = document.createElement('style');
+      style.id = 'omedit-splash-style';
+      style.textContent =
+        '#omedit-splash{position:fixed;inset:0;z-index:100000;display:flex;flex-direction:column;'
+        + 'align-items:center;justify-content:center;background:#ffffff;font-family:sans-serif;'
+        + 'transition:opacity .4s ease;}'
+        + '#omedit-splash img{max-width:80%;max-height:60%;box-shadow:0 6px 28px rgba(0,0,0,.25);}'
+        + '#omedit-splash .msg{margin-top:20px;font-size:15px;color:#333;min-height:20px;text-align:center;}'
+        + '#omedit-splash .bar{margin-top:16px;width:280px;height:6px;background:#e2e2e2;border-radius:3px;overflow:hidden;}'
+        + '#omedit-splash .bar > div{height:100%;width:40%;background:#e87424;border-radius:3px;'
+        + 'animation:omedit-splash-slide 1.2s ease-in-out infinite;}'
+        // transform (not margin-left) so the compositor animates it smoothly even
+        // while the main thread is blocked building the library tree.
+        + '@keyframes omedit-splash-slide{0%{transform:translateX(-100%)}100%{transform:translateX(250%)}}';
+      document.head.appendChild(style);
+      var o = document.createElement('div');
+      o.id = 'omedit-splash';
+      var img = document.createElement('img');
+      img.src = new URL('omedit_splashscreen.png', document.baseURI).href;
+      img.onerror = function() { img.style.display = 'none'; };
+      o.appendChild(img);
+      var msg = document.createElement('div');
+      msg.className = 'msg';
+      msg.id = 'omedit-splash-msg';
+      msg.textContent = 'Starting OMEdit…';
+      o.appendChild(msg);
+      var bar = document.createElement('div');
+      bar.className = 'bar';
+      bar.appendChild(document.createElement('div'));
+      o.appendChild(bar);
+      document.body.appendChild(o);
+    });
+  }
+
+  void setMessage(const QString &message)
+  {
+    if (!sVisible) {
+      return;
+    }
+    EM_ASM({
+      var m = document.getElementById('omedit-splash-msg');
+      if (m) m.textContent = UTF8ToString($0);
+    }, message.toUtf8().constData());
+  }
+
+  void setProgress(int done, int total)
+  {
+    if (!sVisible || total <= 0) {
+      return;
+    }
+    // Callers drive this once per item; painting/yielding every time would dominate
+    // the actual work. Read a monotonic clock (no yield) and only touch the DOM
+    // ~every 300 ms. The first and last step always paint, so a determinate bar
+    // appears immediately (replacing the indeterminate slide) and lands on 100%.
+    int pct = done < 0 ? 0 : (done > total ? 100 : (100 * done) / total);
+    static QElapsedTimer sTimer;
+    static int sLastPct = -1;
+    const bool force = done <= 1 || done >= total;
+    if (!force) {
+      if (pct == sLastPct) {
+        return;
+      }
+      if (sTimer.isValid() && sTimer.elapsed() < 300) {
+        return;
+      }
+    }
+    sTimer.restart();
+    sLastPct = pct;
+    EM_ASM({
+      // Claim the bar: omc's __omcSetStatus fires on every worker reply and would
+      // otherwise keep restoring the indeterminate slide, fighting this update.
+      Module.__omeditSplashDeterminate = true;
+      var f = document.querySelector('#omedit-splash .bar > div');
+      if (f) { f.style.animation = 'none'; f.style.transform = 'none'; f.style.width = $0 + '%'; }
+    }, pct);
+    wasm_splash_yield();
+  }
+
+  void stepMessage(const QString &message)
+  {
+    if (!sVisible) {
+      return;
+    }
+    setMessage(message);
+    // The widget-creation steps are synchronous and never return to the event
+    // loop, so the message above would not paint until the whole phase ends.
+    wasm_splash_yield();
+  }
+
+  void finish()
+  {
+    if (!sVisible) {
+      return;
+    }
+    sVisible = false;
+    EM_ASM({
+      var o = document.getElementById('omedit-splash');
+      if (o) {
+        o.style.opacity = '0';
+        setTimeout(function() { if (o.parentNode) o.parentNode.removeChild(o); }, 450);
+      }
+      var s = document.getElementById('omedit-splash-style');
+      if (s && s.parentNode) s.parentNode.removeChild(s);
+    });
+  }
+
+  bool isVisible()
+  {
+    return sVisible;
+  }
+}
 #endif
 
 TreeSearchFilters::TreeSearchFilters(QWidget *pParent)

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -73,6 +73,21 @@
 
 class OMCProxy;
 
+#if defined(__EMSCRIPTEN__)
+// HTML splash overlay drawn straight into the DOM. Qt's QSplashScreen pumps the
+// Qt-for-WebAssembly event dispatcher during early startup, which traps, so on
+// wasm the splash and the startup passes are rendered outside Qt. See Utilities.cpp.
+namespace WasmSplash
+{
+  void show();
+  void setMessage(const QString &message);
+  void stepMessage(const QString &message);
+  void setProgress(int done, int total);
+  void finish();
+  bool isVisible();
+}
+#endif
+
 #if !defined(__EMSCRIPTEN__)
 // Omitted on wasm: showMessage()/repaint() pumps the Qt-for-WebAssembly event
 // dispatcher during early startup, which traps. Uses are guarded at the call sites.
@@ -104,6 +119,13 @@ public slots:
   void showMessage(const QString &message, int timeout = 0)
   {
     QStatusBar::showMessage(message, timeout);
+#if defined(__EMSCRIPTEN__)
+    // While the HTML splash is up (startup) the status bar is not yet on screen,
+    // so mirror its passes (loading libraries, …) onto the splash.
+    if (WasmSplash::isVisible()) {
+      WasmSplash::setMessage(message);
+    }
+#endif
     /* QStatusBar::showMessage calls update() which schedules a paint event for processing when Qt returns to the main event loop
      * so we call repaint() to get the immediate update. Calling repaint() is better than qApp->processEvents() which processes all pending events.
      */


### PR DESCRIPTION
QSplashScreen traps on Qt-for-WebAssembly (its repaint pumps the wasm event dispatcher during early startup), so on wasm the splash is drawn straight into the DOM via EM_ASM and the startup passes render outside Qt.

The library-tree pass drives a determinate progress bar over the classes it builds. Painting during that CPU-bound loop needs a real browser yield: the splash runs before qApp->exec(), so a nested QEventLoop cannot suspend — only a raw Asyncify suspend (EM_ASYNC_JS, as omc's pre-exec worker wait already uses) returns to the browser to composite. Updates are throttled to ~3/s via a monotonic clock so yielding does not dominate the work.

The bar is shared with omc's download-status callback, which fires on every worker reply and would keep restoring the indeterminate slide; the tree pass claims the bar (__omeditSplashDeterminate) so the download status leaves it alone once class-loading owns it.


Claude-Session: https://claude.ai/code/session_01JWYsTcgTkGcnrgbuNWgxHS

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
