### PR TITLE
wasm-jit: hysteretic zero-crossings + event iteration (fix Zeno fall-…

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -166,9 +166,9 @@ struct SimLayout {
     sample_active_off: u32,
     /// Number of state-event zero-crossing functions (`SimCode.zeroCrossings`).
     n_zc: u32,
-    /// Base of the zero-crossing value region (one f64 `g_i = lhs_i - rhs_i` per
-    /// crossing), written by the emitted `functionZeroCrossings` and read back by
-    /// the driver's DASKR root callback (`RtFn`). Empty when the model has none.
+    /// Base of the zero-crossing value region (one f64 `g_i` per crossing, ±1 as the
+    /// condition holds), written by the emitted `functionZeroCrossings` and read back
+    /// by the driver's DASKR root callback (`RtFn`). Empty when the model has none.
     zc_off: u32,
     /// Number of indexed relations (`SimCode.varInfo.numRelations`) — the C
     /// runtime's `relations[]`/hysteresis count.
@@ -190,6 +190,8 @@ struct SimLayout {
     n_math: u32,
     /// Base of the held math-event values (f64 each); C's `mathEventsValuePre`.
     mathevents_off: u32,
+    /// Zero-crossing hysteresis tolerance slot (f64); see [`SimCtx::zctol_off`].
+    zctol_off: u32,
     total: u32,
 }
 
@@ -248,12 +250,14 @@ impl SimLayout {
         // reserved slots.
         let mathevents_off = stateset_off + n_stateset_f64 * 8;
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
-        let total = mathevents_off + n_math_slots * 8;
+        // Zero-crossing tolerance (f64), 8-aligned after the math-event region.
+        let zctol_off = mathevents_off + n_math_slots * 8;
+        let total = zctol_off + 8;
         SimLayout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off, bool_off, bparam_off,
             str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off,
-            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stateset_off, n_math, mathevents_off, total,
+            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stateset_off, n_math, mathevents_off, zctol_off, total,
         }
     }
 
@@ -745,6 +749,8 @@ struct SimVarMap {
     n_mathevents: u32,
     /// `SimData` byte offset of the homotopy parameter lambda (`SimLayout`).
     lambda_off: u32,
+    /// `SimData` byte offset of the zero-crossing hysteresis tolerance (`SimCtx::zctol_off`).
+    zctol_off: u32,
 }
 
 /// Display name of a model variable's component reference (OMC `.`-separated
@@ -861,6 +867,7 @@ fn build_var_map(
         mathevents_off: layout.mathevents_off,
         n_mathevents: layout.n_math,
         lambda_off: layout.lambda_off,
+        zctol_off: layout.zctol_off,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
 
@@ -1196,12 +1203,10 @@ struct SampleInfo {
 /// and locates the sign change. `SimCode.zeroCrossings` maps 1:1 onto these (as
 /// in the C target's `function_ZeroCrossings`), one `g` per entry.
 pub(crate) enum ZcInfo {
-    /// A bare numeric inequality `lhs OP rhs`: `g = lhs - rhs`, a continuous
-    /// function whose zero DASKR interpolates exactly.
-    Diff { lhs: Arc<DAE::Exp>, rhs: Arc<DAE::Exp> },
-    /// Any other condition (boolean combination, `if`-guard, `==`/`<>`, integer
-    /// relation): `g = expr ? 1 : -1`, matching the C target's
-    /// `gout[i] = (relation_) ? 1 : -1`. DASKR brackets the ±1 step.
+    /// A relation or boolean condition: `g = expr ? 1 : -1`. DASKR brackets the ±1
+    /// step. A Real inequality is lowered with a hysteresis band and held-relation
+    /// direction (see `compile_relation`), consistent with how the same relation
+    /// reads in the equations, so an event fires exactly when the relation flips.
     Bool { expr: Arc<DAE::Exp> },
     /// A math-event builtin (`integer`/`floor`/`ceil`/`div`/`mod`): `g =
     /// (test(fresh arg) != test(pre[idx])) ? 1 : -1`, C's `zeroCrossingTpl`. `ops`
@@ -1243,18 +1248,6 @@ pub(crate) fn math_event_index(last: &DAE::Exp) -> Result<u32> {
     }
 }
 
-/// Whether a relational `operator`'s operands are numeric (real/integer), so
-/// `lhs - rhs` is a meaningful continuous crossing function. String/bool
-/// relations are not.
-fn is_numeric_relation(op: &DAE::Operator) -> bool {
-    use DAE::Operator as O;
-    let ty = match op {
-        O::LESS { ty } | O::LESSEQ { ty } | O::GREATER { ty } | O::GREATEREQ { ty } => ty,
-        _ => return false,
-    };
-    matches!(&**ty, DAE::Type::T_REAL { .. } | DAE::Type::T_INTEGER { .. })
-}
-
 /// Whether `path` is the unqualified builtin call `name`.
 fn path_ident_is(path: &openmodelica_ast::Absyn::Path, name: &str) -> bool {
     matches!(path, openmodelica_ast::Absyn::Path::IDENT { name: n } if &**n == name)
@@ -1286,9 +1279,6 @@ fn collect_zero_crossings(
             bail!("CodegenWasmJit: for-loop (iterator) zero-crossing not yet supported: {:?}", zc.relation_);
         }
         match &*zc.relation_ {
-            DAE::Exp::RELATION { exp1, operator, exp2, .. } if is_numeric_relation(operator) => {
-                out.push(ZcInfo::Diff { lhs: exp1.clone(), rhs: exp2.clone() });
-            }
             DAE::Exp::RELATION { .. } | DAE::Exp::LBINARY { .. } | DAE::Exp::LUNARY { .. } => {
                 out.push(ZcInfo::Bool { expr: zc.relation_.clone() });
             }
@@ -2057,6 +2047,7 @@ fn build_eq_fn_with_prelude(
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2104,6 +2095,7 @@ fn build_init_sample_fn(
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2144,6 +2136,7 @@ fn build_zero_crossings_fn(
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
         zc_context: true,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -2543,6 +2536,7 @@ fn build_nls_fns(
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
         zc_context: false,
     };
     let finish = |ctx: FnCtx| -> we::Function {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -361,6 +361,42 @@ fn save_pre_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
     e.write_bytes(sim_data + layout.pre_real_off, &buf)
 }
 
+/// Upper bound on discrete-update iterations at one event (C's `maxEventIterations`).
+const MAX_EVENT_ITER: usize = 20;
+
+/// Snapshot of the discrete state — boolean/integer algebraics and held relations
+/// — used to detect when an event's discrete update has reached a fixed point.
+fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<u8>> {
+    let mut buf = vec![0u8; ((layout.n_bool_alg() + layout.n_int_alg()) * 4 + layout.n_rel * 4) as usize];
+    let (bools, rest) = buf.split_at_mut((layout.n_bool_alg() * 4) as usize);
+    let (ints, rels) = rest.split_at_mut((layout.n_int_alg() * 4) as usize);
+    e.read_bytes(sim_data + layout.bool_off, bools)?;
+    e.read_bytes(sim_data + layout.int_off, ints)?;
+    e.read_bytes(sim_data + layout.relations_off, rels)?;
+    Ok(buf)
+}
+
+/// Run the discrete update to a fixed point: re-run `functionAlgebraics` (which
+/// fires edge-detected when-bodies and saves pre-values) until the discrete state
+/// stops changing. A single pass leaves conditions evaluated against the *pre*-event
+/// operands — after a `reinit` flips a state, the guarding relation must be
+/// recomputed and its pre refreshed, or the next crossing sees a stale edge (a
+/// bouncing ball then never settles). Assumes `functionODE` and the event time have
+/// already been written.
+fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    e.call1("functionAlgebraics", sim_data)?;
+    let mut prev = discrete_snapshot(e, sim_data, layout)?;
+    for _ in 1..MAX_EVENT_ITER {
+        e.call1("functionAlgebraics", sim_data)?;
+        let cur = discrete_snapshot(e, sim_data, layout)?;
+        if cur == prev {
+            break;
+        }
+        prev = cur;
+    }
+    Ok(())
+}
+
 /// Per-sample time-event state: each sample's next firing time and its interval,
 /// loaded from the sample region (populated by the model's `initSample`). The
 /// driver interleaves these events with the integration — at a firing time it
@@ -442,6 +478,10 @@ pub(super) fn drive(
     let n_rows = model.n_intervals + 1;
     let start = model.start_time;
     let stop = model.stop_time;
+
+    // Zero-crossing hysteresis band, from the same tolerance fed to DASSL below.
+    let rtol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+    write_f64(e, sim_data + layout.zctol_off, 1e-4 * rtol.max(1e-12))?;
 
     // Time events (`sample`) and state events (zero-crossings) both need the
     // host-side event loop, which drives DASSL between events (clamping to sample
@@ -1162,7 +1202,13 @@ fn run_dassl_events(
                     // real pre-region before the discrete update fires.
                     save_pre_real(e, sim_data, layout)?;
                     write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
-                    emit_row(e, &mut rows, troot)?;
+                    // Post-event row from the discrete update run to a fixed point.
+                    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+                    write_f64(e, sim_data + TIME_OFF, troot)?;
+                    e.call1("functionODE", sim_data)?;
+                    iterate_discrete(e, sim_data, layout)?;
+                    check_nls(e, sim_data, layout)?;
+                    capture_row(e, &mut rows, sim_data, layout)?;
                     if terminated(e, sim_data, layout)? {
                         return Ok(rows);
                     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -982,6 +982,12 @@ pub(crate) struct SimCtx {
     /// True while lowering the `functionZeroCrossings` body: an indexed relation is
     /// then evaluated *fresh* (so a sign change is detectable) rather than held.
     pub(crate) zc_context: bool,
+    /// `SimData` byte offset of the zero-crossing hysteresis tolerance, written by
+    /// the driver at run start from the run's tolerance. Continuous (Real) indexed
+    /// relations use a ±`tolZC*(max(|a|,|b|)+max(nom))` band at events and in
+    /// `functionZeroCrossings` so a relation stays put within the band — this keeps
+    /// a bouncing ball from chattering through the floor near rest.
+    pub(crate) zctol_off: u32,
 }
 
 /// One nonlinear system's `rt_solve_nls` wiring: `k` is the job ordinal (its
@@ -1200,13 +1206,6 @@ impl<'a> FnCtx<'a> {
         for (k, zc) in crossings.iter().enumerate() {
             self.emit(we::Instruction::LocalGet(data));
             match zc {
-                ZcInfo::Diff { lhs, rhs } => {
-                    let l = compile_exp(self, lhs)?;
-                    coerce(self, l, WTy::F64);
-                    let r = compile_exp(self, rhs)?;
-                    coerce(self, r, WTy::F64);
-                    self.emit(we::Instruction::F64Sub);
-                }
                 ZcInfo::Bool { expr } => {
                     // `select` picks `1.0` when the condition (top of stack) is
                     // nonzero, else `-1.0`; push both values first, condition last.
@@ -3889,38 +3888,149 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
         }
         return Ok(WTy::I32);
     }
-    // Relation hysteresis (C's `relationhysteresis`/`relation`): an indexed relation
-    // in an equation returns the *held* `relations[index]` during continuous
-    // integration (`rel_fresh == 0`) — so the value is fixed while a nonlinear
-    // solver varies the operands and the residual stays smooth — and only
-    // re-evaluates + stores when the driver requests it at an event/init
-    // (`rel_fresh != 0`). Inside `functionZeroCrossings` (`zc_context`) it is always
-    // evaluated fresh so a sign change is detectable.
-    let hyst = match ctx.sim() {
-        Ok(s) if !s.zc_context && index >= 0 && (index as u32) < s.n_relations => {
-            let off = s.relations_off + index as u32 * 4;
-            Some((s.data_local, off, s.rel_fresh_off))
+    // An indexed relation is held during continuous integration (`rel_fresh == 0`)
+    // and re-evaluated at events/init; the crossing function (`zc_context`) always
+    // re-evaluates. A Real inequality gets a hysteresis band (`compile_relation_hyst`)
+    // at events and in the crossing function, but stays exact at init (`rel_fresh == 2`)
+    // so a start value like `v <= 0` at `v == 0` resolves as written.
+    let indexed = matches!(ctx.sim(), Ok(s) if index >= 0 && (index as u32) < s.n_relations);
+    if !indexed {
+        return compile_relation_fresh(ctx, e1, op, e2);
+    }
+    let real_ineq = operand_type_of_relation(op)? == WTy::F64
+        && matches!(op, O::LESS { .. } | O::LESSEQ { .. } | O::GREATER { .. } | O::GREATEREQ { .. });
+    let data = ctx.sim()?.data_local;
+    let rel_off = ctx.sim()?.relations_off + index as u32 * 4;
+    let fresh_off = ctx.sim()?.rel_fresh_off;
+    if ctx.sim()?.zc_context {
+        if real_ineq {
+            compile_relation_hyst(ctx, e1, op, e2, rel_off)?;
+        } else {
+            compile_relation_fresh(ctx, e1, op, e2)?;
         }
-        _ => None,
-    };
-    if let Some((data, rel_off, fresh_off)) = hyst {
-        ctx.emit(we::Instruction::LocalGet(data));
-        ctx.emit(we::Instruction::I32Load(mem_arg(fresh_off, 2)));
-        ctx.emit(we::Instruction::If(we::BlockType::Result(we::ValType::I32)));
-        let v = ctx.alloc_temp(WTy::I32);
-        compile_relation_fresh(ctx, e1, op, e2)?;
-        ctx.emit(we::Instruction::LocalSet(v));
-        ctx.emit(we::Instruction::LocalGet(data)); // store relations[index] = v
-        ctx.emit(we::Instruction::LocalGet(v));
-        ctx.emit(we::Instruction::I32Store(mem_arg(rel_off, 2)));
-        ctx.emit(we::Instruction::LocalGet(v));
-        ctx.emit(we::Instruction::Else);
-        ctx.emit(we::Instruction::LocalGet(data)); // held: relations[index]
-        ctx.emit(we::Instruction::I32Load(mem_arg(rel_off, 2)));
-        ctx.emit(we::Instruction::End);
         return Ok(WTy::I32);
     }
-    compile_relation_fresh(ctx, e1, op, e2)
+    // Equation context: held / init-fresh / event-fresh selected on `rel_fresh`.
+    ctx.emit(we::Instruction::LocalGet(data));
+    ctx.emit(we::Instruction::I32Load(mem_arg(fresh_off, 2)));
+    ctx.emit(we::Instruction::If(we::BlockType::Result(we::ValType::I32)));
+    let v = ctx.alloc_temp(WTy::I32);
+    if real_ineq {
+        // rel_fresh == 2 (init): exact; else (event): hysteretic.
+        ctx.emit(we::Instruction::LocalGet(data));
+        ctx.emit(we::Instruction::I32Load(mem_arg(fresh_off, 2)));
+        ctx.emit(we::Instruction::I32Const(2));
+        ctx.emit(we::Instruction::I32Eq);
+        ctx.emit(we::Instruction::If(we::BlockType::Result(we::ValType::I32)));
+        compile_relation_fresh(ctx, e1, op, e2)?;
+        ctx.emit(we::Instruction::Else);
+        compile_relation_hyst(ctx, e1, op, e2, rel_off)?;
+        ctx.emit(we::Instruction::End);
+    } else {
+        compile_relation_fresh(ctx, e1, op, e2)?;
+    }
+    ctx.emit(we::Instruction::LocalSet(v));
+    ctx.emit(we::Instruction::LocalGet(data)); // store relations[index] = v
+    ctx.emit(we::Instruction::LocalGet(v));
+    ctx.emit(we::Instruction::I32Store(mem_arg(rel_off, 2)));
+    ctx.emit(we::Instruction::LocalGet(v));
+    ctx.emit(we::Instruction::Else);
+    ctx.emit(we::Instruction::LocalGet(data)); // held: relations[index]
+    ctx.emit(we::Instruction::I32Load(mem_arg(rel_off, 2)));
+    ctx.emit(we::Instruction::End);
+    Ok(WTy::I32)
+}
+
+/// Emit a Real inequality with C's zero-crossing hysteresis band, leaving an i32
+/// boolean on the stack. The comparison boundary is offset by
+/// ±`eps = tolZC * (max(|a|,|b|) + max(nominal(a), nominal(b)))` in the direction
+/// that resists a flip, using the held `relations[]` value at `rel_off` as the
+/// current side: once true the relation stays true until the operand clears the
+/// band, and vice versa. `tolZC` is read from `SimData` (`zctol_off`).
+fn compile_relation_hyst(
+    ctx: &mut FnCtx,
+    e1: &DAE::Exp,
+    op: &DAE::Operator,
+    e2: &DAE::Exp,
+    rel_off: u32,
+) -> Result<()> {
+    use we::Instruction as I;
+    let data = ctx.sim()?.data_local;
+    let zctol_off = ctx.sim()?.zctol_off;
+    let nom = nominal_const(e1).max(nominal_const(e2));
+
+    let a = ctx.alloc_temp(WTy::F64);
+    let wa = compile_exp(ctx, e1)?;
+    coerce(ctx, wa, WTy::F64);
+    ctx.emit(I::LocalSet(a));
+    let b = ctx.alloc_temp(WTy::F64);
+    let wb = compile_exp(ctx, e2)?;
+    coerce(ctx, wb, WTy::F64);
+    ctx.emit(I::LocalSet(b));
+
+    // eps = tolZC * (max(|a|,|b|) + nom)
+    let eps = ctx.alloc_temp(WTy::F64);
+    ctx.emit(I::LocalGet(a));
+    ctx.emit(I::F64Abs);
+    ctx.emit(I::LocalGet(b));
+    ctx.emit(I::F64Abs);
+    ctx.emit(I::F64Max);
+    ctx.emit(I::F64Const(nom.into()));
+    ctx.emit(I::F64Add);
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::F64Load(mem_arg(zctol_off, 3)));
+    ctx.emit(I::F64Mul);
+    ctx.emit(I::LocalSet(eps));
+
+    // diff = a - b
+    let diff = ctx.alloc_temp(WTy::F64);
+    ctx.emit(I::LocalGet(a));
+    ctx.emit(I::LocalGet(b));
+    ctx.emit(I::F64Sub);
+    ctx.emit(I::LocalSet(diff));
+
+    // relations[rel_off] chooses which band edge applies.
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Load(mem_arg(rel_off, 2)));
+    ctx.emit(I::If(we::BlockType::Result(we::ValType::I32)));
+    emit_hyst_cmp(ctx, op, diff, eps, true)?;
+    ctx.emit(I::Else);
+    emit_hyst_cmp(ctx, op, diff, eps, false)?;
+    ctx.emit(I::End);
+    Ok(())
+}
+
+/// Emit `diff <op> (±eps)`, leaving an i32 boolean. `dir` is the current relation
+/// value; it selects which side of the band the boundary sits on so the relation
+/// resists flipping.
+fn emit_hyst_cmp(ctx: &mut FnCtx, op: &DAE::Operator, diff: u32, eps: u32, dir: bool) -> Result<()> {
+    use DAE::Operator as O;
+    use we::Instruction as I;
+    // (comparison, whether the +eps edge applies for this direction).
+    let (cmp, plus) = match op {
+        O::LESSEQ { .. } => (I::F64Lt, dir),
+        O::LESS { .. } => (I::F64Le, dir),
+        O::GREATER { .. } => (I::F64Ge, !dir),
+        O::GREATEREQ { .. } => (I::F64Gt, !dir),
+        other => bail!("CodegenWasmJit: non-inequality in hysteresis path: {other:?}"),
+    };
+    ctx.emit(I::LocalGet(diff));
+    ctx.emit(I::LocalGet(eps));
+    if !plus {
+        ctx.emit(I::F64Neg);
+    }
+    ctx.emit(cmp);
+    Ok(())
+}
+
+/// A relation operand's nominal magnitude for the hysteresis band: the literal's
+/// magnitude for a constant, else the default nominal `1.0`.
+fn nominal_const(e: &DAE::Exp) -> f64 {
+    match e {
+        DAE::Exp::RCONST { real } => real.into_inner().abs(),
+        DAE::Exp::ICONST { integer } => (*integer as f64).abs(),
+        _ => 1.0,
+    }
 }
 
 /// Emit a plain (unheld) relational comparison, leaving an i32 boolean on the


### PR DESCRIPTION
…through)

The classic flying-flag BouncingBall (e=0.7) fell through the floor under the wasm-jit target instead of settling at rest: it chattered near h=0 with flying stuck true and free-fell to h~-0.96. Two gaps vs the reference behaviour:

- Zero-crossing relations flipped at exactly a==b, so a micro-bounce peak of a few 1e-11 kept toggling `impact = h<=0` and re-launching the ball. Numeric relations now lower as a hysteretic +/-1 crossing with a tolZC*(max(|a|,|b|)+max(nominal)) band keyed on the held relation value, at events and in functionZeroCrossings, matching how the same relation reads in the equations. tolZC lives in a SimData slot the driver writes from the run's tolerance, so a tolerance override still takes effect. Init evaluates exactly (no band) so start values like v<=0 at v==0 resolve as written. The old continuous ZcInfo::Diff crossing is removed.

- The driver ran functionAlgebraics once per state event, so `impact and v<=0` was evaluated against the pre-reinit velocity and its pre saved stale; the following v<=0 crossing then saw no rising edge and v_new=0 / flying=false never fired. iterate_discrete now re-runs functionAlgebraics until the boolean/integer/relation state reaches a fixed point (cap 20).

BouncingBall now rests (h~2e-11, v=0, flying=0). The simple reinit BouncingBall is unchanged and Rotational Backlash still compares equal to the C target.