### PR TITLE
SimulationRuntime: consistent output values in FMI ME GetReal calls

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1953,6 +1953,7 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFM
      *       in the whole ringbuffer
      */
     overwriteOldSimulationData(comp->fmuData);
+    comp->_need_update = 1;
     done=1;
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
@@ -2042,7 +2043,6 @@ fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_
     {
       comp->fmuData->callback->functionODE(comp->fmuData, comp->threadData);
       overwriteOldSimulationData(comp->fmuData);
-      comp->_need_update = 0;
     }
 
 #if NUMBER_OF_STATES > 0

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1995,6 +1995,7 @@ fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, fmi3Boolean noSetF
      *       in the whole ringbuffer
      */
     overwriteOldSimulationData(comp->fmuData);
+    comp->_need_update = 1;
     done=1;
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
@@ -2084,7 +2085,6 @@ fmi3Status internalGetDerivatives(ModelInstance* c, fmi3Float64 derivatives[], s
     {
       comp->fmuData->callback->functionODE(comp->fmuData, comp->threadData);
       overwriteOldSimulationData(comp->fmuData);
-      comp->_need_update = 0;
     }
 
 #if NUMBER_OF_STATES > 0


### PR DESCRIPTION
Two fixes in the FMI 2.0/3.0 model exchange runtime:

1. internalGetDerivatives: call functionAlgebraics and output_function after functionODE, so that localData[0] has consistent values when GetReal is called before CompletedIntegratorStep (PyFMI flow).

2. internal_CompletedIntegratorStep: set _need_update = 1 after overwriteOldSimulationData, so that GetReal called after CompletedIntegratorStep (FMPy flow) triggers updateIfNeeded and returns up-to-date values.

Fixes #15975
