### PR TITLE
Web simulator: workers, settings, docs, plots

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1035,7 +1035,8 @@ function(omc_rust_setup_wasm)
                 ${RUST_OMC_DIR}/wasm/home/index.html ${_web_dir}/home/
         COMMAND ${CMAKE_COMMAND} -E make_directory ${_web_dir}/simulator
         COMMAND ${CMAKE_COMMAND} -E copy
-                ${RUST_OMC_DIR}/wasm/simulator/index.html ${_web_dir}/simulator/
+                ${RUST_OMC_DIR}/wasm/simulator/index.html
+                ${RUST_OMC_DIR}/wasm/simulator/omc-worker.js ${_web_dir}/simulator/
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${RUST_OMC_DIR}/wasm/icons ${_web_dir}/icons)
   else()

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -260,6 +260,7 @@ wasm/omc-cli.js
 wasm/home/index.html
 wasm/omc-terminal/index.html
 wasm/simulator/index.html
+wasm/simulator/omc-worker.js
 wasm/icons/om.svg
 wasm/icons/omshell.svg
 wasm/icons/omnotebook.svg

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -338,3 +338,33 @@ pub fn omc_eval(command: &str) -> String {
         },
     }
 }
+
+/// `simulate(...)` without the string command's O(program) env build; errors returned as `"Error: …"`.
+#[wasm_bindgen]
+pub fn omc_simulate(
+    class_name: &str,
+    stop_time: f64,
+    number_of_intervals: i32,
+    tolerance: f64,
+    method: &str,
+    simflags: &str,
+) -> String {
+    LAST_PANIC.with(|p| *p.borrow_mut() = None);
+    let run = || {
+        capi::simulate(
+            ArcStr::from(class_name),
+            stop_time,
+            number_of_intervals,
+            tolerance,
+            ArcStr::from(method),
+            ArcStr::from(simflags),
+        )
+    };
+    match catch_unwind(AssertUnwindSafe(run)) {
+        Ok(reply) => reply.to_string(),
+        Err(_) => match LAST_PANIC.with(|p| p.borrow_mut().take()) {
+            Some(msg) => format!("Error: simulation panicked: {msg}"),
+            None => "Error: simulation panicked".to_owned(),
+        },
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -50,3 +50,22 @@ pub fn init(args: &[ArcStr]) -> Result<()> {
 pub fn eval(command: ArcStr) -> Result<(bool, ArcStr)> {
     Main::handleCommand(command)
 }
+
+/// `simulate` against the builtin graph only; empty/non-positive args use its defaults.
+pub fn simulate(
+    class_name: ArcStr,
+    stop_time: f64,
+    number_of_intervals: i32,
+    tolerance: f64,
+    method: ArcStr,
+    simflags: ArcStr,
+) -> ArcStr {
+    crate::Interactive::simulateModel(
+        class_name,
+        metamodelica::OrderedFloat(stop_time),
+        number_of_intervals,
+        metamodelica::OrderedFloat(tolerance),
+        method,
+        simflags,
+    )
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/index.html
@@ -56,6 +56,18 @@
   }
   .brand { display: flex; align-items: center; height: 100%; cursor: pointer; flex: 0 0 auto; }
   .brand img { height: 20px; display: block; }
+  .brand img.narrow { display: none; height: 19px; }
+
+  /* Hamburger toggles the sidebar drawer on narrow screens. */
+  .hamburger {
+    display: none; align-items: center; justify-content: center;
+    width: 34px; height: 34px; padding: 0; flex: 0 0 auto;
+    background: transparent; border: 1px solid var(--border); border-radius: 6px;
+    color: var(--fg); cursor: pointer;
+  }
+  .hamburger:hover { background: #2d2d30; }
+  .hamburger svg { width: 18px; height: 18px; }
+  .nav-backdrop { display: none; }
   .topbar .name { font-weight: 600; color: var(--teal); white-space: nowrap; }
   .topbar .sep { width: 1px; height: 22px; background: var(--border); }
   .variants { display: flex; gap: 4px; }
@@ -88,17 +100,51 @@
   .overlay .box { max-width: 460px; }
   .overlay h2 { color: var(--fg); margin: 0 0 8px; font-weight: 600; }
   .overlay code { color: #ce9178; font-family: ui-monospace, Menlo, Consolas, monospace; }
+
+  /* --- Mobile: sidebar becomes a slide-in drawer behind a hamburger ---- */
+  @media (max-width: 640px) {
+    body { grid-template-columns: 1fr; }
+    aside {
+      position: fixed; top: 0; bottom: 0; left: 0; width: 240px; z-index: 30;
+      padding: 8px; transform: translateX(-100%); transition: transform .2s ease;
+      box-shadow: 2px 0 14px #0007;
+    }
+    body.nav-open aside { transform: none; }
+    .nav-backdrop {
+      display: block; position: fixed; inset: 0; z-index: 20;
+      background: #0007; opacity: 0; pointer-events: none; transition: opacity .2s;
+    }
+    body.nav-open .nav-backdrop { opacity: 1; pointer-events: auto; }
+    /* Wider drawer → horizontal rows read better than the desktop rail. */
+    .nav-btn { flex-direction: row; justify-content: flex-start; gap: 12px; padding: 11px 12px; }
+    .nav-btn .ic { width: 24px; height: 24px; }
+    .nav-btn .lbl { font-size: 14px; width: auto; text-align: left; }
+    .nav-btn.active::before { left: 0; }
+
+    .hamburger { display: inline-flex; }
+    .brand img.wide { display: none; }
+    .brand img.narrow { display: block; }
+    .topbar { gap: 8px; padding: 0 8px; }
+    /* "Open in new tab" shrinks to just its icon. */
+    .tool .lbl { display: none; }
+    .tool { padding: 6px; }
+  }
 </style>
 </head>
 <body>
+<div class="nav-backdrop" id="navBackdrop"></div>
 <aside id="sidebar">
   <nav id="nav"></nav>
 </aside>
 
 <main>
   <div class="topbar">
+    <button class="hamburger" id="hamburger" aria-label="Toggle menu" title="Menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+    </button>
     <a class="brand" href="#" title="OpenModelica — home" data-home>
-      <img src="icons/openmodelica-logo.svg" alt="OpenModelica" />
+      <img class="wide" src="icons/openmodelica-logo.svg" alt="OpenModelica" />
+      <img class="narrow" src="icons/om.svg" alt="OpenModelica" />
     </a>
     <span class="sep"></span>
     <span class="name" id="clientName"></span>
@@ -106,7 +152,7 @@
     <span class="spacer"></span>
     <a class="tool" id="openTab" target="_blank" rel="noopener" title="Open this client in a new tab" style="display:none">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14 21 3"/></svg>
-      Open in new tab
+      <span class="lbl">Open in new tab</span>
     </a>
   </div>
 
@@ -192,11 +238,17 @@ function parseHash() {
 }
 
 function go(id, variant) {
+  closeNav();                                // collapse the mobile drawer on pick
   let hash = '#' + id;
   if (variant) hash += '/' + variant;
   if (location.hash === hash) render();      // same link → just (re)render
   else location.hash = hash;                 // triggers hashchange → render
 }
+
+// --- Mobile drawer ---------------------------------------------------------
+const closeNav = () => document.body.classList.remove('nav-open');
+document.getElementById('hamburger').onclick = () => document.body.classList.toggle('nav-open');
+document.getElementById('navBackdrop').onclick = closeNav;
 
 async function render() {
   const { id, variant } = parseHash();

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -34,13 +34,37 @@
   button:disabled{ background:#3a3a3a; color:#777; cursor:default; }
   button.ghost { background:transparent; border:1px solid var(--border); color:var(--fg); padding:6px 12px; font-size:13px; }
   button.ghost:hover:not(:disabled){ background:#2d2d30; }
+  button.ghost.icon-only { padding:6px 9px; display:inline-flex; align-items:center; }
+  button.ghost.icon-only svg { width:16px; height:16px; display:block; }
 
   main { flex:1 1 auto; display:grid; grid-template-columns:minmax(320px,40%) 1fr; min-height:0; }
   .left { display:flex; flex-direction:column; min-height:0; border-right:1px solid var(--border); overflow:hidden; }
   .right { display:flex; flex-direction:column; min-height:0; }
+  /* Documentation column, shown only when the screen is wide enough (see below). */
+  .docs { display:none; flex-direction:column; min-height:0; border-left:1px solid var(--border); }
+  .docs-head { display:flex; align-items:center; gap:6px; padding-right:4px; flex:0 0 auto; }
+  .docs-head .section-label { flex:1 1 auto; }
+  .doc-toggle { background:transparent; border:0; color:var(--muted); cursor:pointer;
+    padding:6px 8px; display:inline-flex; align-items:center; justify-content:center; }
+  .doc-toggle:hover { color:var(--fg); }
+  .doc-toggle svg { width:16px; height:16px; display:block; transition:transform .15s; }
+  .doc-expand { display:none; }                 /* the collapsed-rail reopen button (desktop) */
+  .doc-body { flex:1 1 auto; overflow-y:auto; padding:4px 14px 16px; font-size:13.5px; line-height:1.5; }
+  .doc-body.empty { color:var(--muted); display:grid; place-items:center; text-align:center; }
+  .doc-body img, .doc-body svg { max-width:100%; height:auto; }
+  .doc-body a { color:var(--accent); }
+  .doc-body table { border-collapse:collapse; max-width:100%; display:block; overflow-x:auto; }
+  .doc-body td, .doc-body th { border:1px solid var(--border); padding:3px 6px; }
+  .doc-body pre, .doc-body code { font-family:ui-monospace,Menlo,Consolas,monospace; font-size:12.5px; }
+  .doc-body h1, .doc-body h2, .doc-body h3, .doc-body h4 { color:var(--fg); font-size:1.05em; margin:.8em 0 .3em; }
 
   .section-label { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
     color:var(--muted); padding:9px 12px 4px; flex:0 0 auto; }
+  .editor-label { display:flex; align-items:center; gap:10px; }
+  .editor-label > span { flex:1 1 auto; }
+  .ex-select { text-transform:none; letter-spacing:normal; width:auto; min-width:0; max-width:60%;
+    background:#1b1b1b; color:var(--fg); border:1px solid var(--border); border-radius:4px;
+    padding:3px 6px; font:inherit; font-size:12px; }
   textarea {
     flex:1 1 auto; resize:none; border:0; outline:none; min-height:120px;
     background:#1b1b1b; color:var(--fg); padding:10px 12px;
@@ -63,10 +87,24 @@
   .stepper button:last-child { border-radius:0 4px 4px 0; }
   .stepper button:hover { background:#2d2d30; }
 
+  /* Simulation-settings dialog (opened by the cogwheel). */
+  .modal-backdrop { position:fixed; inset:0; z-index:50; display:grid; place-items:center;
+    background:#0008; padding:16px; }
+  .modal-backdrop[hidden] { display:none; }
+  .modal { background:var(--panel); border:1px solid var(--border); border-radius:10px;
+    width:min(460px,100%); box-shadow:0 14px 44px #000a; }
+  .modal-head { display:flex; align-items:center; justify-content:space-between;
+    padding:12px 14px; border-bottom:1px solid var(--border); font-weight:650; color:var(--fg); }
+  .icon-btn { background:transparent; border:0; color:var(--muted); font-size:17px; line-height:1;
+    cursor:pointer; padding:4px 8px; }
+  .icon-btn:hover { color:var(--fg); }
+
   #icPanel { max-height:34%; overflow-y:auto; }
-  .ic-grid { padding:8px 12px 12px; display:grid; grid-template-columns:minmax(0,1fr) 108px auto; gap:7px 10px; align-items:center; }
-  .ic-grid .nm { font-size:14px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-  .ic-grid .unit { color:var(--muted); font-size:13px; min-width:2.5em; }
+  /* Auto-fill into as many columns as fit (PID has many parameters to tune). */
+  .ic-grid { padding:8px 12px 12px; display:grid; grid-template-columns:repeat(auto-fill,minmax(196px,1fr)); gap:7px 18px; }
+  .ic-item { display:grid; grid-template-columns:minmax(0,1fr) 80px auto; gap:9px; align-items:center; }
+  .ic-item .nm { font-size:14px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .ic-item .unit { color:var(--muted); font-size:13px; min-width:2.5em; }
   .ic-empty { color:var(--muted); font-size:13px; padding:0 12px 10px; }
 
   /* charts area: one card per plot, scrollable */
@@ -107,13 +145,33 @@
     body { overflow:auto; height:auto; min-height:100vh; }
     main { grid-template-columns:1fr; }
     .left { border-right:0; border-bottom:1px solid var(--border); }
-    textarea { min-height:180px; }
+    /* Settings moved to the dialog, so the editor claims that height. */
+    textarea { min-height:46vh; }
     .grid2 { grid-template-columns:auto 1fr; }
     #icPanel { max-height:none; }
     .charts { overflow:visible; }
     .chart-card.solo .plot-wrap { min-height:300px; height:56vw; }
     header { flex-wrap:wrap; }
     header .status { order:3; flex-basis:100%; white-space:normal; }
+    .ex-select { max-width:56%; }
+    /* Documentation flows at the end of the page (scroll down to reach it). */
+    .docs { display:block; border-left:0; border-top:1px solid var(--border); }
+    .doc-body { overflow:visible; }
+    .doc-body.empty { min-height:80px; }
+    /* Collapsed: keep the header strip (with its reopen chevron), hide the body. */
+    body.docs-hidden .doc-body { display:none; }
+    body.docs-hidden .docs-head .doc-toggle svg { transform:rotate(180deg); }
+  }
+
+  /* Wide screens: add a third column for the model documentation. */
+  @media (min-width:1300px) {
+    main { grid-template-columns:minmax(320px,30%) 1fr minmax(260px,22%); }
+    .docs { display:flex; }
+    /* Collapsed: the column becomes a thin rail with a reopen chevron. */
+    body.docs-hidden main { grid-template-columns:minmax(320px,40%) 1fr 34px; }
+    body.docs-hidden .docs-head, body.docs-hidden .doc-body { display:none; }
+    body.docs-hidden .doc-expand { display:flex; flex:1 1 auto; align-items:flex-start;
+      justify-content:center; width:100%; padding:10px 0; }
   }
 </style>
 </head>
@@ -122,30 +180,19 @@
   <span class="title">Simulator</span>
   <span class="status" id="status">Loading compiler…</span>
   <button id="viewToggle" class="ghost" style="display:none"></button>
+  <button id="settingsBtn" class="ghost icon-only" title="Simulation settings" aria-label="Simulation settings">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+  </button>
   <button id="run" disabled>Run</button>
 </header>
 
 <main>
   <div class="left">
-    <div class="section-label">Modelica model</div>
-    <textarea id="src" spellcheck="false"></textarea>
-
-    <div class="panel">
-      <div class="grid2">
-        <label for="stop">Stop time</label>
-        <input id="stop" type="number" step="any" />
-        <label for="intervals">Intervals</label>
-        <input id="intervals" type="number" step="1" min="1" />
-        <label for="method">Solver</label>
-        <select id="method"><option value="dassl">dassl</option><option value="euler">euler</option></select>
-        <label for="tol">Tolerance</label>
-        <div class="stepper">
-          <button type="button" id="tolDn" title="÷10">▼</button>
-          <input id="tol" type="text" inputmode="decimal" />
-          <button type="button" id="tolUp" title="×10">▲</button>
-        </div>
-      </div>
+    <div class="section-label editor-label">
+      <span>Modelica model</span>
+      <select id="examples" class="ex-select" title="Load an example"></select>
     </div>
+    <textarea id="src" spellcheck="false"></textarea>
 
     <div class="panel" id="icPanel">
       <div class="section-label">Initial conditions &amp; parameters</div>
@@ -157,14 +204,49 @@
   <div class="right">
     <div class="charts" id="charts"><div class="charts-empty" id="chartsEmpty">Run a model to see results.</div></div>
   </div>
+
+  <div class="docs" id="docs">
+    <div class="docs-head">
+      <span class="section-label">Documentation</span>
+      <button class="doc-toggle" id="docCollapse" title="Hide documentation" aria-label="Hide documentation">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+      </button>
+    </div>
+    <div class="doc-body empty" id="docBody">—</div>
+    <button class="doc-toggle doc-expand" id="docExpand" title="Show documentation" aria-label="Show documentation">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+    </button>
+  </div>
 </main>
 
+<div class="modal-backdrop" id="settingsBackdrop" hidden>
+  <div class="modal" role="dialog" aria-label="Simulation settings" aria-modal="true">
+    <div class="modal-head">
+      <span>Simulation settings</span>
+      <button class="icon-btn" id="settingsClose" title="Close" aria-label="Close">✕</button>
+    </div>
+    <div class="grid2">
+      <label for="stop">Stop time</label>
+      <input id="stop" type="number" step="any" />
+      <label for="intervals">Intervals</label>
+      <input id="intervals" type="number" step="1" min="1" />
+      <label for="method">Solver</label>
+      <select id="method"><option value="dassl">dassl</option><option value="euler">euler</option></select>
+      <label for="tol">Tolerance</label>
+      <div class="stepper">
+        <button type="button" id="tolDn" title="÷10">▼</button>
+        <input id="tol" type="text" inputmode="decimal" />
+        <button type="button" id="tolUp" title="×10">▲</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script type="module">
-import init, {
-  omc_set_env, omc_init, omc_eval,
-  omc_take_pending_downloads, wasi_write_file,
-  omc_sim_info, omc_sim_series, omc_sim_time, omc_sim_column, omc_sim_parameters,
-} from '../omc/OpenModelicaCompiler.js';
+// The omc compiler runs in Web Workers (omc-worker.js), not on this thread, so
+// compile/simulate never freezes the UI. Two are spawned: a plain one that is
+// ready fast, and a second that installs the MSL in the background and takes
+// over once ready (so library examples like PID_Controller can run).
 
 // Guarded bouncing ball: the `flying` flag makes the ball rest at h=0 once its
 // bounces decay, rather than tunnelling through the floor (a known wasm-jit event
@@ -196,13 +278,35 @@ equation
 end BouncingBall;
 `;
 
-const COLORS = ['#4ec9b0','#569cd6','#ce9178','#dcdcaa','#c586c0','#9cdcfe',
-                '#f48771','#b5cea8','#d7ba7d','#4fc1ff','#e2b93d','#77dd77'];
+// Selectable examples. Inline ones load into the editor and run on any worker;
+// `library` ones are classes inside the MSL and need the MSL worker.
+const EXAMPLES = [
+  { id: 'bouncing', label: 'Bouncing ball', source: DEFAULT_MODEL },
+  { id: 'pid', label: 'PID controller (MSL)', library: 'Modelica.Blocks.Examples.PID_Controller' },
+];
+
+// Categorical series palette, validated for the dark chart surface (#252526):
+// eight distinct hues in a fixed, CVD-optimized order (dataviz reference palette).
+// The always-present legend is the secondary encoding for the one adjacent pair
+// that sits in the CVD floor band.
+const COLORS = ['#3987e5','#199e70','#c98500','#008300','#9085e9','#e66767','#d55181','#d95926'];
 
 const el = (id) => document.getElementById(id);
 const statusEl = el('status'), runBtn = el('run'), srcEl = el('src');
 const chartsEl = el('charts'), chartsEmpty = el('chartsEmpty');
 const icGrid = el('icGrid'), icEmpty = el('icEmpty'), tolEl = el('tol'), toggleBtn = el('viewToggle');
+const exSel = el('examples'), docBody = el('docBody');
+const settingsBtn = el('settingsBtn'), settingsBackdrop = el('settingsBackdrop'), settingsClose = el('settingsClose');
+
+// Documentation collapse/expand, driven from inside the widget: a chevron in the
+// doc header hides it; when collapsed it leaves a thin rail (desktop) or header
+// strip (mobile) whose chevron reopens it. Collapsing widens the charts.
+function toggleDocs() {
+  document.body.classList.toggle('docs-hidden');
+  for (const c of charts) drawChart(c);            // chart width changed
+}
+el('docCollapse').addEventListener('click', toggleDocs);
+el('docExpand').addEventListener('click', toggleDocs);
 
 srcEl.value = DEFAULT_MODEL;
 let tolValue = 1e-6;
@@ -214,41 +318,122 @@ renderTol();
 function setStatus(text, cls='') { statusEl.textContent = text; statusEl.className = 'status ' + cls; }
 function num(v, d) { const n = parseFloat(v); return isFinite(n) ? n : d; }
 
-// --- omc download loop (models importing a library) ------------------------
-async function fetchToVfs(urls, filename) {
-  for (const url of urls) { try { const r = await fetch(url); if (!r.ok) continue;
-    wasi_write_file(filename, new Uint8Array(await r.arrayBuffer())); return true; } catch (_) {} }
-  return false;
+// --- logging ---------------------------------------------------------------
+const DEBUG = true;
+const T0 = performance.now();
+const tstamp = () => ((performance.now() - T0) / 1000).toFixed(2) + 's';
+const log = (...a) => { if (DEBUG) console.log('[sim ' + tstamp() + ']', ...a); };
+// Debug handle for the console: window.__sim.snap, .mode, .builtModel, etc.
+if (DEBUG) window.__sim = {
+  get snap() { return snap; }, get mode() { return mode; },
+  get builtModel() { return builtModel; }, get figures() { return modelFigures; },
+  finalValue: (n) => { const c = snap && snap.cols && snap.cols[n]; return c ? c[c.length - 1] : null; },
+};
+
+// --- Worker RPC ------------------------------------------------------------
+let nextId = 1;
+let w1 = null, w2 = null;          // w1: plain, fast start. w2: MSL, ready later.
+let primaryWorker = null;          // w1 until the MSL worker is promoted, then w2
+let mslReady = null;               // resolves to w2 once its MSL is installed
+let jobWorker = null;              // worker running the current foreground job
+let statusFocus = null;            // also surface this worker's status (while awaiting MSL)
+
+function attach(worker, tag) {
+  worker._tag = tag; worker._pending = new Map();
+  worker.onmessage = (ev) => {
+    const d = ev.data;
+    if (d.type === 'log') { log(tag + ':', d.text); return; }
+    if (d.type === 'status') { if (worker === jobWorker || worker === statusFocus) setStatus(d.text, 'busy'); return; }
+    const p = worker._pending.get(d.id); if (!p) return;
+    worker._pending.delete(d.id);
+    if (d.ok) p.resolve(d.result); else p.reject(new Error(d.error));
+  };
+  worker.onerror = (e) => {
+    log(tag + ' onerror:', e.message || e);
+    for (const [, p] of worker._pending) p.reject(new Error('worker error: ' + (e.message || e)));
+    worker._pending.clear();
+  };
 }
-async function evalWithDownloads(src) {
-  const attempted = new Set();
-  for (;;) {
-    const result = omc_eval(src);
-    const pending = (omc_take_pending_downloads() || []).filter((p) => !attempted.has(p.filename));
-    if (pending.length === 0) return result;
-    omc_eval('getErrorString()');
-    for (const item of pending) { attempted.add(item.filename);
-      setStatus('Downloading ' + (item.filename.split('/').pop() || item.filename) + '…', 'busy');
-      await fetchToVfs(item.urls, item.filename); }
+function call(worker, cmd, args) {
+  const id = nextId++;
+  const t0 = performance.now();
+  log('→', worker._tag, cmd, args && args.name ? args.name : '');
+  return new Promise((resolve, reject) => {
+    worker._pending.set(id, {
+      resolve: (r) => { log('←', worker._tag, cmd, Math.round(performance.now() - t0) + 'ms'); resolve(r); },
+      reject,
+    });
+    worker.postMessage({ id, cmd, ...(args || {}) });
+  });
+}
+function makeWorker(tag) {
+  const w = new Worker(new URL('./omc-worker.js', import.meta.url), { type: 'module' });
+  attach(w, tag);
+  return w;
+}
+// The MSL worker took over: make it primary and terminate the plain worker so we
+// keep a single wasm instance. A model built on w1 is dropped (rebuilt on demand).
+function promote() {
+  if (primaryWorker === w2) return;
+  primaryWorker = w2;
+  log('promoted MSL worker to primary');
+  retireW1();
+}
+function retireW1() {
+  if (primaryWorker !== w1 && w1 && jobWorker !== w1) {
+    log('terminating w1');
+    if (builtWorker === w1) { builtModel = null; builtWorker = null; }   // its model is gone → next run rebuilds
+    w1.terminate(); w1 = null;
   }
 }
-function loadedClassName() {
-  const inner = omc_eval('getClassNames()').trim().replace(/^\{|\}$/g, '').trim();
-  if (!inner) return null;
-  const names = inner.split(',').map((s) => s.trim()).filter(Boolean);
-  return names[names.length - 1] || null;
+
+// A user model needs the MSL if it is a library copy, imports/extends Modelica,
+// or refers to a Modelica.* name. Such models must run on the MSL worker.
+function needsMsl(text) {
+  return mode === 'librarycopy' || /\bwithin\s+Modelica\b|\bimport\s+Modelica\b|\bextends\s+Modelica\b|\bModelica\./.test(text);
 }
-function esc(s) { return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\t/g, '\\t'); }
+async function pickWorker(text) {
+  if (needsMsl(text)) { mslJobStarted = true; if (!mslDone) statusFocus = w2; try { return await mslReady; } finally { statusFocus = null; } }
+  return primaryWorker;
+}
+
+// Protect the single loaded MSL: never load a class into the Modelica namespace
+// (a `within Modelica…` clause or a Modelica.* class name would modify it).
+function touchesModelica(text) {
+  if (/^\s*within\s+Modelica\b/m.test(text)) return true;
+  const name = parseModelName(text);
+  return !!(name && /^Modelica(\.|$)/.test(name));
+}
+
+// Model name from source: within-path + class name (so within-scoped copies and
+// plain models both resolve without relying on getClassNames against a busy AST).
+function parseModelName(text) {
+  const within = (text.match(/^\s*within\s+([\w.]+)\s*;/m) || [])[1] || '';
+  const cls = (text.match(/\b(?:model|class|block|package|record|connector|function)\s+([A-Za-z_]\w*)/) || [])[1] || '';
+  if (!cls) return null;
+  return within ? within + '.' + cls : cls;
+}
 
 // --- state ------------------------------------------------------------------
 let icValues = new Map();     // param name -> input value (string)
 let builtModel = null, lastText = null;
 let running = false, pendingKind = null;
-let modelFigures = null;      // parsed getModelFigures() for the current model, or null
+let modelFigures = null;      // parsed figures for the current model, or null
 let viewMode = 'auto';        // 'auto' (figures if present) | 'all'
 const hidden = new Set();     // "chartKey|label" of series toggled off (persists across runs)
 let colMap = new Map();       // result-variable name -> { values:Float64Array, unit }
 let charts = [];              // live chart states for hover
+let snap = null;              // last simulation snapshot from a worker
+let modelDoc = '';            // current model's documentation HTML (persists across re-sims)
+let currentExample = EXAMPLES[0];
+let mode = 'inline';          // 'inline' | 'librarycopy'
+let builtWorker = null;       // worker that holds the current built model (for resim)
+let mslDone = false;          // true once the MSL worker has finished install+load
+let mslJobStarted = false;    // true once a real MSL job is requested → skip the throwaway warmup
+let copyName = null;          // top-level name of the current library copy (copyClass), else null
+let pendingMods = [];         // [{element, value}] parameter tweaks to apply to the copy before the next rebuild
+let preloaded = null;         // a class already loaded by copyClass (skip the first redundant loadSource)
+let freshModel = true;        // true until a model's own experiment settings have been read back from a run
 
 function overrideFlag() {
   const parts = [];
@@ -256,90 +441,180 @@ function overrideFlag() {
   return parts.length ? '-override=' + parts.join(',') : '';
 }
 
+const unquote = (s) => { s = (s || '').trim(); return (s.startsWith('"') && s.endsWith('"'))
+  ? s.slice(1, -1).replace(/\\(.)/g, (_, c) => c === 'n' ? '\n' : c === 't' ? '\t' : c) : s; };
+
+function seedFromOptions(o) {
+  if (!o) return;
+  if (o.stopTime != null) el('stop').value = o.stopTime;
+  if (o.tolerance != null) { tolValue = o.tolerance; renderTol(); }
+  if (o.intervals != null) el('intervals').value = Math.round(o.intervals);
+}
+
 async function run(kind) {                       // 'full' | 'resim'
   if (running) { pendingKind = pendingKind === 'full' ? 'full' : kind; return; }
   running = true; runBtn.disabled = true;
+  log('run', kind, 'mode', mode);
   setStatus(kind === 'resim' ? 'Re-simulating…' : 'Compiling & simulating…', 'busy');
-  await new Promise((r) => setTimeout(r));
 
   try {
-    const intervals = Math.max(1, Math.round(num(el('intervals').value, 500)));
     const method = el('method').value, ov = overrideFlag();
-    if (kind === 'resim' && builtModel) {
-      await evalWithDownloads(`simulate(${builtModel}, simflags="${esc(ov)}", resimulateExecutable="${builtModel}")`);
+    // A freshly loaded model drives its own settings: omit stopTime/intervals/
+    // tolerance so simulate() uses the experiment annotation; we read back what it
+    // used and seed the dialog. Once seeded (or user-overridden), pass the values.
+    const settings = freshModel ? { method } : { method,
+      stopTime: num(el('stop').value, 1),
+      intervals: Math.max(1, Math.round(num(el('intervals').value, 500))),
+      tolerance: tolValue };
+
+    // Re-simulate the already-built model (fast, no recompile) when possible.
+    if (kind === 'resim' && builtModel && builtWorker) {
+      jobWorker = builtWorker;
+      const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov });
+      if (!r.ok) return fail(r.error);
+      snap = r;
+    } else if (mode === 'librarycopy' && pendingMods.length) {
+      // Tune the copy: apply the parameter tweaks to its AST, refresh the editor
+      // from list(), then rebuild (a model change invalidates the built executable).
+      const worker = await pickWorker('');
+      jobWorker = worker;
+      let src;
+      for (const m of pendingMods) {
+        const sm = await call(worker, 'setModifier', { name: copyName, element: m.element, value: m.value });
+        if (!sm.ok) return fail(sm.error || ('could not set ' + m.element));
+        src = sm.source;
+      }
+      pendingMods = [];
+      if (src != null) { srcEl.value = unquote(src); lastText = srcEl.value; }
+      const r = await call(worker, 'simulate', { name: copyName, override: '', ...settings });
+      if (!r.ok) return fail(r.error);
+      builtModel = copyName; builtWorker = worker; snap = r;   // figures/doc unchanged by a tweak
     } else {
       const text = srcEl.value, textChanged = text !== lastText;
-      omc_eval('clear()');
-      if ((await evalWithDownloads(`loadString("${esc(text)}")`)).trim() !== 'true')
-        return fail(omc_eval('getErrorString()').trim() || 'Could not parse the model.');
-      const name = loadedClassName();
-      if (!name) return fail('No class found in the model text.');
-      if (textChanged) seedSettingsFromModel(name);
-      await evalWithDownloads(
-        `simulate(${name}, stopTime=${num(el('stop').value, 1)}, numberOfIntervals=${intervals},`
-        + ` method="${method}", tolerance=${tolValue}, simflags="${esc(ov)}")`);
-      builtModel = name; lastText = text;
-      modelFigures = getFiguresFor(name);       // annotation is static → fetch once per build
+      if (touchesModelica(text)) return fail('Refusing to modify the Modelica library — rename the class or remove any "within Modelica" clause.');
+      if (needsMsl(text) && !mslDone) setStatus('Loading Modelica library…', 'busy');
+      const worker = await pickWorker(text);
+      if (!worker) throw new Error('compiler not ready');
+      jobWorker = worker;
+      const name = parseModelName(text);
+      let lm;
+      if (preloaded && preloaded === name && !textChanged) {
+        lm = { ok: true, name };            // copyClass already loaded it — skip the redundant loadString
+      } else {
+        lm = await call(worker, 'loadSource', { text, name });
+      }
+      preloaded = null;
+      if (!lm.ok) return fail(lm.error);
+      // figures/doc are annotations, not results — show docs now, before simulating.
+      if (lm.figures !== undefined) modelFigures = lm.figures || null;
+      if (lm.doc !== undefined) { modelDoc = lm.doc || ''; renderDoc(); }
+      const r = await call(worker, 'simulate', { name: lm.name, override: ov, ...settings });
+      if (!r.ok) return fail(r.error);
+      builtModel = lm.name; builtWorker = worker; lastText = text; snap = r;
     }
-    const info = omc_sim_info();
-    if (!info || !info.rows) return fail(omc_eval('getErrorString()').trim() || 'Simulation produced no result.');
-    if (kind !== 'resim') buildInitialConditions();
+
+    // Reflect the settings the run actually used, then treat them as user-editable.
+    if (kind !== 'resim' && snap.options) { seedFromOptions(snap.options); freshModel = false; }
+    if (kind !== 'resim') buildInitialConditions();   // docs already rendered pre-simulation
     renderCharts();
     const figNote = (modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '';
-    setStatus(`${info.model} — ${info.rows} points, t ∈ [${info.start}, ${info.stop}]${figNote}`);
-  } catch (e) { fail('' + e); }
-  finally { running = false; runBtn.disabled = false;
-    if (pendingKind) { const k = pendingKind; pendingKind = null; run(k); } }
+    setStatus(`${snap.info.model} — ${snap.info.rows} points, t ∈ [${snap.info.start}, ${snap.info.stop}]${figNote}`);
+    log('done', snap.info.model, snap.info.rows, 'points');
+  } catch (e) { log('run failed', e); fail('' + e); }
+  finally {
+    running = false; runBtn.disabled = false; jobWorker = null; retireW1();
+    if (pendingKind) { const k = pendingKind; pendingKind = null; run(k); }
+  }
 }
 
-function seedSettingsFromModel(name) {
-  const m = omc_eval(`getSimulationOptions(${name})`).match(/-?[\d.eE+-]+/g);
-  if (m && m.length >= 4) { el('stop').value = +m[1]; tolValue = +m[2]; renderTol(); el('intervals').value = Math.round(+m[3]); }
+// --- examples ---------------------------------------------------------------
+// Immediately blank the stale panels so a switch doesn't keep showing the old
+// model's initial conditions / plots / docs until the new run finishes.
+function showBuilding() {
+  icGrid.replaceChildren(); icValues.clear();
+  icEmpty.style.display = ''; icEmpty.textContent = 'Simulating…';
+  charts = []; chartsEl.replaceChildren(chartsEmpty);
+  chartsEmpty.style.display = ''; chartsEmpty.textContent = 'Simulating…';
+  docBody.className = 'doc-body empty'; docBody.textContent = '…';
 }
 
-// getModelFigures() as JSON (via the interactiveDumpFormat config flag) so we can
-// JSON.parse it instead of scraping the textual value dump. The model is already
-// loaded, so no download loop is needed. Returns the figures array, or null.
-function getFiguresFor(model) {
-  try {
-    omc_eval('setCommandLineOptions("--interactiveDumpFormat=json")');
-    const raw = omc_eval(`getModelFigures(${model})`);
-    omc_eval('setCommandLineOptions("--interactiveDumpFormat=default")');
-    const figs = JSON.parse(raw);
-    return Array.isArray(figs) && figs.length ? figs : null;
-  } catch (_) {
-    omc_eval('setCommandLineOptions("--interactiveDumpFormat=default")');
-    return null;
+async function selectExample(ex) {
+  currentExample = ex;
+  builtModel = null; builtWorker = null; lastText = null; pendingMods = []; preloaded = null; freshModel = true;
+  showBuilding();
+  if (ex.library) {
+    // A genuine editable copy via copyClass: a self-contained top-level class with
+    // fully-qualified references. It never modifies the library and owns the copied
+    // figures/doc annotations. Runs on the MSL worker.
+    mode = 'librarycopy';
+    copyName = ex.library.split('.').pop();
+    mslJobStarted = true;
+    if (!mslDone) setStatus('Loading Modelica library…', 'busy');
+    let worker;
+    try { if (!mslDone) statusFocus = w2; worker = await mslReady; } catch (e) { return fail('' + e); } finally { statusFocus = null; }
+    let cc;
+    try { cc = await call(worker, 'copyClass', { from: ex.library, name: copyName }); } catch (e) { return fail('' + e); }
+    if (!cc.ok) return fail(cc.error);
+    srcEl.value = unquote(cc.source);
+    modelFigures = cc.figures || null; modelDoc = cc.doc || ''; renderDoc();   // docs before simulating
+    preloaded = copyName; lastText = srcEl.value;   // copyClass already loaded it; skip the first loadSource
+    run('full');
+  } else {
+    mode = 'inline'; copyName = null;
+    srcEl.value = ex.source;
+    run('full');
   }
 }
 
 function fail(msg) {
+  log('FAIL', msg);
   setStatus(msg, 'err'); charts = []; modelFigures = null;
   chartsEl.replaceChildren(chartsEmpty); chartsEmpty.style.display = ''; chartsEmpty.textContent = 'Simulation failed — see the status bar.';
 }
 
 // --- editable initial conditions -------------------------------------------
 function buildInitialConditions() {
-  const params = omc_sim_parameters() || [];
+  const params = (snap && snap.parameters) || [];
   icGrid.replaceChildren(); icValues.clear();
   if (!params.length) { icEmpty.style.display = ''; icEmpty.textContent = 'This model has no editable parameters.'; return; }
   icEmpty.style.display = 'none';
   for (const p of params) {
     icValues.set(p.name, String(p.value));
+    const item = document.createElement('div'); item.className = 'ic-item';
     const nm = document.createElement('div'); nm.className = 'nm'; nm.textContent = p.name; nm.title = p.comment || p.name;
     const inp = document.createElement('input'); inp.type = 'number'; inp.step = 'any'; inp.value = p.value;
-    inp.addEventListener('change', () => { icValues.set(p.name, inp.value); run('resim'); });
+    inp.addEventListener('change', () => onParamChange(p.name, inp.value));
     const unit = document.createElement('div'); unit.className = 'unit'; unit.innerHTML = unitHTML(p.unit || '');
-    icGrid.append(nm, inp, unit);
+    item.append(nm, inp, unit); icGrid.appendChild(item);
   }
+}
+
+// Inline models: -override + fast resim. Library copies: -override cannot touch
+// modifier-bound params, so set the modifier on the copy and full-rebuild.
+function onParamChange(name, value) {
+  icValues.set(name, value);
+  const v = parseFloat(value);
+  if (mode === 'librarycopy') {
+    if (isFinite(v)) { pendingMods.push({ element: name, value: v }); run('full'); }
+  } else {
+    run('resim');
+  }
+}
+
+// Render the model's documentation HTML in the (wide-screen) doc column. The
+// content is the model's own Documentation(info=...); strip <script> as a guard.
+function renderDoc() {
+  const html = (modelDoc || '').replace(/<script[\s\S]*?<\/script>/gi, '').trim();
+  if (!html) { docBody.className = 'doc-body empty'; docBody.textContent = 'This model has no documentation.'; return; }
+  docBody.className = 'doc-body'; docBody.innerHTML = html; docBody.scrollTop = 0;
 }
 
 // --- result column access ---------------------------------------------------
 function buildColMap() {
   colMap = new Map();
-  const series = omc_sim_series() || [];
-  series.forEach((m, i) => { const c = omc_sim_column(i); if (c) colMap.set(m.name, { values: c, unit: m.unit || '' }); });
-  const t = omc_sim_time(); if (t) colMap.set('time', { values: t, unit: 's' });
+  const series = (snap && snap.series) || [];
+  series.forEach((m) => { const c = snap.cols[m.name]; if (c) colMap.set(m.name, { values: c, unit: m.unit || '' }); });
+  if (snap && snap.time) colMap.set('time', { values: snap.time, unit: 's' });
 }
 function finalValue(name) { const c = colMap.get(name); if (!c) return null; const a = c.values; return a.length ? a[a.length - 1] : null; }
 // Expand the spec's variable-reference markup in titles/legends/captions using
@@ -375,11 +650,11 @@ function renderCharts() {
 }
 
 function renderAllVariables() {
-  const series = omc_sim_series() || [];
+  const series = (snap && snap.series) || [];
   const time = colMap.get('time');
   if (!time) return;
   const curves = [];
-  series.forEach((m, i) => {
+  series.forEach((m) => {
     if (m.constant || m.alias) return;
     const yc = colMap.get(m.name); if (!yc) return;
     const { xs, ys } = alignXY(time, yc);
@@ -586,9 +861,20 @@ function onHover(ev, chart) {
 chartsEl.addEventListener('mousemove', (ev) => { const c = charts.find((c) => c.svgEl === ev.target || c.svgEl.contains(ev.target)); if (c) onHover(ev, c); });
 chartsEl.addEventListener('mouseleave', () => { for (const c of charts) { if (c.state) c.state.cursor.setAttribute('style', 'display:none'); c.tip.style.display = 'none'; } }, true);
 
+// --- settings dialog --------------------------------------------------------
+function openSettings() { settingsBackdrop.hidden = false; }
+function closeSettings() { settingsBackdrop.hidden = true; }
+settingsBtn.addEventListener('click', openSettings);
+settingsClose.addEventListener('click', closeSettings);
+settingsBackdrop.addEventListener('click', (e) => { if (e.target === settingsBackdrop) closeSettings(); });
+window.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !settingsBackdrop.hidden) closeSettings(); });
+
 // --- wiring -----------------------------------------------------------------
 let debounce;
-srcEl.addEventListener('input', () => { clearTimeout(debounce); debounce = setTimeout(() => run('full'), 700); });
+srcEl.addEventListener('input', () => {   // manual edits are authoritative: drop queued tweaks, re-read the model's settings
+  pendingMods = []; preloaded = null; freshModel = true;
+  clearTimeout(debounce); debounce = setTimeout(() => run('full'), 700);
+});
 for (const id of ['stop', 'intervals', 'method']) el(id).addEventListener('change', () => run('full'));
 function stepTol(factor) { tolValue = cleanTol(Math.min(1e-1, Math.max(1e-15, tolValue * factor))); renderTol(); run('full'); }
 el('tolUp').addEventListener('click', () => stepTol(10));
@@ -597,18 +883,35 @@ tolEl.addEventListener('keydown', (e) => { if (e.key === 'ArrowUp') { e.preventD
 tolEl.addEventListener('change', () => { const v = parseFloat(tolEl.value); if (isFinite(v) && v > 0) { tolValue = cleanTol(v); } renderTol(); run('full'); });
 runBtn.addEventListener('click', () => run('full'));
 toggleBtn.addEventListener('click', () => { viewMode = (viewMode === 'all') ? 'auto' : 'all'; renderCharts();
-  const info = omc_sim_info(); if (info) setStatus(`${info.model} — ${info.rows} points, t ∈ [${info.start}, ${info.stop}]` + ((modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '')); });
+  if (snap) setStatus(`${snap.info.model} — ${snap.info.rows} points, t ∈ [${snap.info.start}, ${snap.info.stop}]` + ((modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '')); });
 window.addEventListener('resize', () => { for (const c of charts) drawChart(c); });
+
+for (const ex of EXAMPLES) { const o = document.createElement('option'); o.value = ex.id; o.textContent = ex.label; exSel.appendChild(o); }
+exSel.value = currentExample.id;
+exSel.addEventListener('change', () => { const ex = EXAMPLES.find((e) => e.id === exSel.value); if (ex) selectExample(ex); });
 
 (async () => {
   try {
-    await init();
-    omc_set_env('OPENMODELICAHOME', '/usr');
-    if (!omc_init()) return setStatus('omc_init() failed — see the devtools console.', 'err');
+    w1 = makeWorker('w1');
+    w2 = makeWorker('w2-msl');
+    primaryWorker = w1;
+
+    // Bring the MSL worker up in the background; it takes over once ready. Once
+    // loaded, if the user hasn't already asked for an MSL model, warm it with a
+    // throwaway simulate so its first real run isn't cold (see mslJobStarted).
+    mslReady = (async () => {
+      await call(w2, 'init'); await call(w2, 'installMSL'); mslDone = true; promote();
+      if (!mslJobStarted) call(w2, 'warmup').catch((e) => log('warmup failed', e));
+      return w2;
+    })();
+    mslReady.catch((e) => log('MSL worker failed to initialise', e));
+
+    const v = await call(w1, 'init');
+    if (!v || !v.ok) return setStatus('omc_init() failed — see the devtools console.', 'err');
     runBtn.disabled = false;
-    setStatus('Ready. ' + omc_eval('getVersion()'));
-    run('full');
-  } catch (e) { setStatus('Startup error: ' + e, 'err'); }
+    setStatus('Ready. ' + v.version);
+    run('full');                                   // default = bouncing ball on w1
+  } catch (e) { log('startup error', e); setStatus('Startup error: ' + e, 'err'); }
 })();
 </script>
 </body>

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -1,0 +1,253 @@
+// Simulator omc Web Worker.
+//
+// Hosts the omc wasm module off the UI thread so compile/simulate never freezes
+// the page. The simulator spawns two of these: a plain one that is ready fast
+// (no library), and a second that installs the MSL in the background and takes
+// over once ready (see index.html). Talks an id-correlated RPC:
+//   page → { id, cmd, ... }         worker → { type:'reply', id, ok, result|error }
+// plus unsolicited { type:'status', id, text } for download progress.
+import init, {
+  omc_set_env, omc_init, omc_eval, omc_simulate,
+  omc_take_pending_downloads, wasi_write_file,
+  wasi_path_open, wasi_fd_read, wasi_fd_close,
+  omc_sim_info, omc_sim_series, omc_sim_time, omc_sim_column, omc_sim_parameters,
+} from '../omc/OpenModelicaCompiler.js';
+
+const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\t/g, '\\t');
+const unquote = (s) => { s = (s || '').trim(); return (s.startsWith('"') && s.endsWith('"')) ? s.slice(1, -1) : s; };
+
+// --- profiling -------------------------------------------------------------
+// Per-op/per-stage timings for diagnosing where the wall time goes. Off by
+// default; the per-command total is logged regardless.
+const PROF = false;
+let _plog = () => {};
+function prof(label, fn) {
+  if (!PROF) return fn();
+  const t = performance.now();
+  try { return fn(); } finally { _plog('⏱ ' + label + ' ' + (performance.now() - t).toFixed(1) + 'ms'); }
+}
+// omc_eval, timed and labelled by the head of the command string.
+function oeval(src) {
+  return prof('eval ' + src.slice(0, 48).replace(/\n/g, ' '), () => omc_eval(src));
+}
+
+// Read a whole VFS file (WASI path_open → fd_read → fd_close). undefined if absent.
+function wasiReadFile(path) {
+  const fd = wasi_path_open(path);
+  if (fd < 0) return undefined;
+  try { return wasi_fd_read(fd) || undefined; } finally { wasi_fd_close(fd); }
+}
+function base64(bytes) {
+  let s = ''; const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) s += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  return btoa(s);
+}
+
+async function fetchToVfs(urls, filename) {
+  for (const url of urls) {
+    try { const r = await fetch(url); if (!r.ok) continue;
+      wasi_write_file(filename, new Uint8Array(await r.arrayBuffer())); return true; } catch (_) {}
+  }
+  return false;
+}
+
+// Run `src`, satisfy any files it wanted, re-run until nothing new is needed.
+async function evalWithDownloads(src, onStatus) {
+  const attempted = new Set();
+  for (;;) {
+    const result = oeval(src);
+    const pending = (omc_take_pending_downloads() || []).filter((p) => !attempted.has(p.filename));
+    if (pending.length === 0) return result;
+    omc_eval('getErrorString()');
+    for (const item of pending) {
+      attempted.add(item.filename);
+      onStatus && onStatus('Downloading ' + (item.filename.split('/').pop() || item.filename) + '…');
+      await fetchToVfs(item.urls, item.filename);
+    }
+  }
+}
+
+function lastClassName() {
+  const inner = omc_eval('getClassNames()').trim().replace(/^\{|\}$/g, '').trim();
+  if (!inner) return null;
+  const names = inner.split(',').map((s) => s.trim()).filter(Boolean);
+  return names[names.length - 1] || null;
+}
+
+// The settings simulate() actually used (from its returned SimulationResult),
+// so the dialog reflects the run — no separate getSimulationOptions call.
+function parseSimOptions(result) {
+  const m = /simulationOptions = "([^"]*)"/.exec(result || '');
+  if (!m) return null;
+  const s = m[1], num = (k) => { const r = new RegExp(k + '\\s*=\\s*([0-9.eE+-]+)').exec(s); return r ? +r[1] : null; };
+  return { stopTime: num('stopTime'), tolerance: num('tolerance'), intervals: num('numberOfIntervals') };
+}
+// simulate()'s internal stage timers (seconds) → log as ms so we can see which
+// build stage dominates: front/back/simcode/templates/compile(JIT)/sim.
+function logSimTimers(result) {
+  if (!PROF) return;
+  const g = (k) => { const r = new RegExp('time' + k + '\\s*=\\s*([0-9.eE+-]+)').exec(result || ''); return r ? (+r[1] * 1000).toFixed(1) : '?'; };
+  _plog('⏱ sim internal: front=' + g('Frontend') + ' back=' + g('Backend') + ' simcode=' + g('SimCode')
+    + ' tpl=' + g('Templates') + ' compile=' + g('Compile') + ' sim=' + g('Simulation') + ' total=' + g('Total') + ' (ms)');
+}
+
+// Run `fn` with API results dumped as JSON (so JSON.parse works), then restore.
+function withJsonDump(fn) {
+  oeval('setCommandLineOptions("--interactiveDumpFormat=json")');
+  try { return fn(); } finally { oeval('setCommandLineOptions("--interactiveDumpFormat=default")'); }
+}
+function figuresFor(model) {
+  try {
+    const figs = JSON.parse(withJsonDump(() => oeval(`getModelFigures(${model})`)));
+    return Array.isArray(figs) && figs.length ? figs : null;
+  } catch (_) { return null; }
+}
+// getDocumentationAnnotation → {info, revision, infoHeader}; return the info HTML
+// with any modelica:// image resolved through the VFS and inlined as a data URI.
+function documentationFor(model) {
+  try {
+    const arr = JSON.parse(withJsonDump(() => oeval(`getDocumentationAnnotation(${model})`)));
+    return inlineDocImages(Array.isArray(arr) ? (arr[0] || '') : '');
+  } catch (_) { return ''; }
+}
+const MIME = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', svg: 'image/svg+xml', bmp: 'image/bmp' };
+function modelicaUriToDataUri(uri) {
+  try {
+    const path = unquote(omc_eval(`uriToFilename("${esc(uri)}")`));
+    if (!path) return null;
+    const bytes = wasiReadFile(path);
+    if (!bytes) return null;
+    return 'data:' + (MIME[(path.split('.').pop() || '').toLowerCase()] || 'application/octet-stream') + ';base64,' + base64(bytes);
+  } catch (_) { return null; }
+}
+function inlineDocImages(html) {
+  return html.replace(/(<img\b[^>]*\bsrc\s*=\s*")(modelica:\/\/[^"]+)(")/gi,
+    (m, pre, uri, post) => { const d = modelicaUriToDataUri(uri); return d ? pre + d + post : m; });
+}
+
+// One transferable snapshot of the finished run: everything the charts need, so
+// the page pulls the whole result across in a single message instead of many.
+function snapshot() {
+  const info = prof('sim_info', () => omc_sim_info());
+  if (!info || !info.rows) return null;
+  const parameters = prof('sim_parameters', () => omc_sim_parameters()) || [];
+  const series = prof('sim_series', () => omc_sim_series()) || [];
+  const cols = {};                       // name -> Float64Array
+  const transfer = [];
+  prof('sim_columns x' + series.length, () => {
+    series.forEach((m, i) => { const c = omc_sim_column(i); if (c) { cols[m.name] = c; transfer.push(c.buffer); } });
+  });
+  const time = prof('sim_time', () => omc_sim_time()) || null;
+  if (time) transfer.push(time.buffer);
+  return { snap: { ok: true, info, parameters, series, cols, time }, transfer };
+}
+
+function simError(fallback) {
+  return { ok: false, error: omc_eval('getErrorString()').trim() || fallback };
+}
+
+self.onmessage = async (ev) => {
+  const { id, cmd } = ev.data, a = ev.data;
+  const status = (text) => self.postMessage({ type: 'status', id, text });
+  const wlog = (text) => self.postMessage({ type: 'log', id, text });
+  _plog = wlog;
+  const _t0 = performance.now();
+  const reply = (result, transfer) => {
+    wlog('⏱ ' + cmd + (a.name ? ' ' + a.name : '') + ' ' + (performance.now() - _t0).toFixed(1) + 'ms');
+    self.postMessage({ type: 'reply', id, ok: true, result }, transfer || []);
+  };
+  if (PROF) wlog('cmd ' + cmd + (a.name ? ' ' + a.name : ''));
+  try {
+    switch (cmd) {
+      case 'init': {
+        await init();
+        omc_set_env('OPENMODELICAHOME', '/usr');
+        if (!omc_init()) throw new Error('omc_init() failed');
+        reply({ ok: true, version: omc_eval('getVersion()') });
+        break;
+      }
+      case 'warmup': {
+        // Tier up the engine's backend/codegen paths and compile the wasm-jit
+        // runtime module once, off the critical path, by simulating a trivial
+        // throwaway model. Makes this worker's first real simulate warm.
+        oeval('loadString("model __Warmup Real x(start=0); equation der(x)=1; end __Warmup;")');
+        oeval('simulate(__Warmup, stopTime=1.0)');
+        oeval('deleteClass(__Warmup)');
+        reply({ ok: true });
+        break;
+      }
+      case 'installMSL': {
+        await evalWithDownloads('installPackage(Modelica)', status);
+        status('Loading Modelica library…');
+        await evalWithDownloads('loadModel(Modelica)', status);   // into the symbol table (list/simulate by name)
+        reply({ ok: true, message: omc_eval('getErrorString()').trim() });
+        break;
+      }
+      case 'loadSource': {
+        // Load model *text* via loadString (NOT the omc loadModel builtin, which
+        // loads a library from disk). Never clear(): the MSL worker must keep its
+        // library; loadString redefines a same-named class so edits don't accumulate.
+        const loaded = (await evalWithDownloads(`loadString("${esc(a.text)}")`, status)).trim();
+        if (PROF) wlog('loadString -> ' + loaded);
+        if (loaded !== 'true') return reply(simError('Could not parse the model.'));
+        const name = a.name || lastClassName();
+        if (!name) return reply({ ok: false, error: 'No class found in the model text.' });
+        if (PROF) wlog('model name = ' + name);
+        // figures/doc are annotations — return them here so the page can show docs
+        // before the (slower) simulation runs. Settings come from simulate itself.
+        reply({ ok: true, name, figures: figuresFor(name), doc: documentationFor(name) });
+        break;
+      }
+      case 'copyClass': {
+        // A true, self-contained top-level copy of a library class (fully-qualified
+        // refs) — editable without touching the library. It owns the copied
+        // figures/doc annotations, so those come from the copy itself.
+        if ((await evalWithDownloads(`copyClass(${a.from}, "${a.name}")`, status)).trim() !== 'true')
+          return reply(simError('copyClass failed for ' + a.from));
+        reply({ ok: true, name: a.name, source: omc_eval(`list(${a.name})`),
+                figures: figuresFor(a.name), doc: documentationFor(a.name) });
+        break;
+      }
+      case 'setModifier': {
+        // Tune one parameter on the (already-loaded) copy's AST. A model change
+        // means the built executable is stale, so the page follows with a rebuild.
+        const ok = omc_eval(`setElementModifierValue(${a.name}, ${a.element}, $Code(=${a.value}))`).trim();
+        if (ok !== 'true') return reply({ ok: false, error: omc_eval('getErrorString()').trim() || ('could not set ' + a.element) });
+        reply({ ok: true, source: omc_eval(`list(${a.name})`) });
+        break;
+      }
+      case 'simulate': {
+        // Direct scripting call (no O(program) env build); 0 / "" = omit (use annotation default).
+        const res = prof('omc_simulate ' + a.name, () => omc_simulate(
+          a.name,
+          a.stopTime != null ? a.stopTime : 0,
+          a.intervals != null ? a.intervals : 0,
+          a.tolerance != null ? a.tolerance : 0,
+          a.method || '',
+          a.override || ''));
+        logSimTimers(res);
+        const s = snapshot();
+        if (!s) return reply(simError('Simulation produced no result.'));
+        s.snap.options = parseSimOptions(res);   // settings actually used → seed the dialog
+        reply(s.snap, s.transfer);               // figures/doc come from loadSource/copyClass
+        break;
+      }
+      case 'resimulate': {
+        await evalWithDownloads(
+          `simulate(${a.name}, simflags="${esc(a.override)}", resimulateExecutable="${a.name}")`, status);
+        const s = snapshot();
+        if (!s) return reply(simError('Re-simulation produced no result.'));
+        reply(s.snap, s.transfer);
+        break;
+      }
+      case 'eval':
+        reply(await evalWithDownloads(a.src, status));
+        break;
+      default:
+        throw new Error('unknown command: ' + cmd);
+    }
+  } catch (e) {
+    wlog('EXCEPTION in ' + cmd + ': ' + (e && e.message || e));
+    self.postMessage({ type: 'reply', id, ok: false, error: '' + (e && e.message || e) });
+  }
+};

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -711,7 +711,7 @@ algorithm
       list<Values.Value> vals, cvars;
       Absyn.Path path,classpath,className,parentClass;
       SCode.Program sp;
-      Absyn.Program p,newp;
+      Absyn.Program p,newp,parsed;
       list<Absyn.Program> newps;
       DAE.Type ty;
       list<DAE.Type> tys;
@@ -1478,10 +1478,10 @@ algorithm
     case ("loadString",Values.STRING(str)::Values.STRING(name)::Values.STRING(encoding)::Values.BOOL(mergeAST)::Values.BOOL(b)::Values.BOOL(b1)::Values.BOOL(requireExactVersion)::_)
       algorithm
         str := if not (encoding == "UTF-8") then System.iconv(str, encoding, "UTF-8") else str;
-        newp := Parser.parsestring(str,name);
-        newp := checkUsesAndUpdateProgram(newp, SymbolTable.getAbsyn(), b,
+        parsed := Parser.parsestring(str,name);
+        newp := checkUsesAndUpdateProgram(parsed, SymbolTable.getAbsyn(), b,
           Settings.getModelicaPath(Testsuite.isRunning()), b1, requireExactVersion, mergeAST);
-        SymbolTable.setAbsyn(newp);
+        SymbolTable.setAbsynLoaded(newp, parsed);
         outCache := FCore.emptyCache();
       then
         Values.BOOL(true);

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1570,8 +1570,11 @@ algorithm
       algorithm
         p := SymbolTable.getAbsyn();
         absynClass := ProgramUtil.getPathedClassInProgram(classpath, p);
-        p := copyClass(absynClass, name, InteractiveUtil.parseWithinPath(path), classpath, p);
-        SymbolTable.setAbsyn(p);
+        within_ := InteractiveUtil.parseWithinPath(path);
+        p := copyClass(absynClass, name, within_, classpath, p);
+        absynClass := ProgramUtil.getPathedClassInProgram(
+          match within_ case Absyn.WITHIN() then ProgramUtil.joinPaths(name, within_.path); else Absyn.IDENT(name); end match, p);
+        SymbolTable.setAbsynLoaded(p, Absyn.PROGRAM({absynClass}, within_));
       then
         Values.BOOL(true);
 
@@ -2723,7 +2726,11 @@ algorithm
            Values.CODE(Absyn.C_MODIFICATION(modification = mod))})
       algorithm
         (p, b) := InteractiveUtil.setElementModifier(classpath, path, mod, SymbolTable.getAbsyn());
-        SymbolTable.setAbsyn(p);
+        if b then
+          SymbolTable.setAbsynClass(p, ProgramUtil.getPathedClassInProgram(classpath, p), classpath);
+        else
+          SymbolTable.setAbsyn(p);
+        end if;
       then
         Values.BOOL(b);
 
@@ -3325,7 +3332,7 @@ algorithm
     case ("deleteClass", {Values.CODE(Absyn.C_TYPENAME(classpath))})
       algorithm
         (b, p) := Interactive.deleteClass(classpath, SymbolTable.getAbsyn());
-        SymbolTable.setAbsyn(p);
+        SymbolTable.setAbsynDeleted(p, classpath);
       then
         ValuesMake.makeBoolean(b);
 

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -54,6 +54,7 @@ encapsulated package Interactive
 import Absyn;
 import ProgramUtil;
 import AbsynUtil;
+import Builtin;
 import ConnectionGraph;
 import DAE;
 import FCore;
@@ -713,6 +714,40 @@ algorithm
     outString := "";
   end try;
 end evaluateExprToStr;
+
+public function simulateModel
+  "simulate() against the builtin graph, not the O(program-size) env; empty/non-positive args dropped."
+  input String className;
+  input Real stopTime;
+  input Integer numberOfIntervals;
+  input Real tolerance;
+  input String method;
+  input String simflags;
+  output String result;
+protected
+  list<Absyn.NamedArg> nargs = {};
+  Absyn.Exp callExp;
+  FCore.Graph env;
+  FCore.Cache cache;
+  DAE.Exp sexp;
+  Values.Value value;
+algorithm
+  try
+    if not stringEmpty(simflags) then nargs := Absyn.NAMEDARG("simflags", Absyn.STRING(simflags)) :: nargs; end if;
+    if not stringEmpty(method) then nargs := Absyn.NAMEDARG("method", Absyn.STRING(method)) :: nargs; end if;
+    if tolerance > 0.0 then nargs := Absyn.NAMEDARG("tolerance", Absyn.REAL(realString(tolerance))) :: nargs; end if;
+    if numberOfIntervals > 0 then nargs := Absyn.NAMEDARG("numberOfIntervals", Absyn.INTEGER(numberOfIntervals)) :: nargs; end if;
+    if stopTime > 0.0 then nargs := Absyn.NAMEDARG("stopTime", Absyn.REAL(realString(stopTime))) :: nargs; end if;
+    callExp := Absyn.CALL(Absyn.CREF_IDENT("simulate", {}),
+      Absyn.FUNCTIONARGS({Absyn.CREF(AbsynUtil.pathToCref(Parser.stringPath(className)))}, nargs), {});
+    (_, env) := Builtin.initialGraph(FCore.emptyCache());
+    (cache, sexp, _) := StaticScript.elabExp(FCore.emptyCache(), env, callExp, true, true, DAE.NOPRE(), Absyn.dummyInfo);
+    (_, value) := CevalScript.ceval(cache, env, sexp, true, Absyn.MSG(Absyn.dummyInfo), 0);
+    result := ValuesDump.valString(value);
+  else
+    result := "";
+  end try;
+end simulateModel;
 
 protected function makeTupleCrefs
   input list<Absyn.Exp> inCrefs;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -521,7 +521,7 @@ algorithm
       setGlobalRoot(Global.instNFNodeCacheIndex, {});
     end if;
     (_, scode_builtin) := FBuiltin.getInitialFunctions();
-    program := AbsynToSCode.translateAbsyn2SCode(absynProgram);
+    program := if referenceEq(absynProgram, SymbolTable.getAbsyn()) then SymbolTable.getSCode() else AbsynToSCode.translateAbsyn2SCode(absynProgram);
     program := listAppend(scode_builtin, program);
     placementProgram := InteractiveUtil.modelicaAnnotationProgram(Config.getAnnotationVersion());
     graphicProgramSCode := AbsynToSCode.translateAbsyn2SCode(placementProgram);

--- a/OMCompiler/Compiler/Script/SymbolTable.mo
+++ b/OMCompiler/Compiler/Script/SymbolTable.mo
@@ -58,6 +58,7 @@ import Inst;
 import Lookup;
 import List;
 import AbsynToSCode;
+import MetaUtil;
 import System;
 import SCodeUtil;
 protected import ComponentReferenceBasics;
@@ -70,6 +71,11 @@ record SYMBOLTABLE
   list<InteractiveTypes.Variable> vars "List of variables with values" ;
   Vector<Absyn.Program> cachedAsts;
   Integer cacheIndex;
+  tuple<Boolean,Boolean,Boolean,Boolean> connectorFlags
+    "has inner/outer, expandable, overconstrained and stream connectors; a side
+     effect of translating explodedAst that the old frontend reads later. Stored
+     here so getSCode can re-assert it on a cache hit, since an intervening
+     translation or NFInst.resetGlobalFlags may have cleared the global flags.";
 end SYMBOLTABLE;
 
 constant Integer AST_CACHE_MAX_SIZE = 1000;
@@ -82,10 +88,32 @@ algorithm
                  explodedAst=NONE(),
                  vars={},
                  cachedAsts=Vector.new<Program>(),
-                 cacheIndex=0
+                 cacheIndex=0,
+                 connectorFlags=(false,false,false,false)
                  ));
   updateUriMapping({});
 end reset;
+
+function currentConnectorFlags
+  "Reads the global connector flags set as a side effect of translating SCode."
+  output tuple<Boolean,Boolean,Boolean,Boolean> flags;
+algorithm
+  flags := (System.getHasInnerOuterDefinitions(), System.getHasExpandableConnectors(),
+            System.getHasOverconstrainedConnectors(), System.getHasStreamConnectors());
+end currentConnectorFlags;
+
+function applyConnectorFlags
+  "Restores the global connector flags to match the cached SCode."
+  input tuple<Boolean,Boolean,Boolean,Boolean> flags;
+protected
+  Boolean io, ec, oc, sc;
+algorithm
+  (io, ec, oc, sc) := flags;
+  System.setHasInnerOuterDefinitions(io);
+  System.setHasExpandableConnectors(ec);
+  System.setHasOverconstrainedConnectors(oc);
+  System.setHasStreamConnectors(sc);
+end applyConnectorFlags;
 
 function update
   input SymbolTable table;
@@ -156,6 +184,9 @@ algorithm
   updateUriMapping(ast.classes);
 
   if isSome(table.explodedAst) then
+    // Restore the flags for the rest of the program so translateElement only
+    // adds to them, then record the updated set.
+    applyConnectorFlags(table.connectorFlags);
     // Assume the element is public here since we don't know the actual
     // visibility, and then update it later in update_element if it's not.
     scode_elems := AbsynToSCode.translateElement(element, SCode.Visibility.PUBLIC());
@@ -173,6 +204,7 @@ algorithm
     (scode_prog, true) := SCodeUtil.transformPathedElementInProgram(path,
       function update_element(newElement = scode_elem), scode_prog);
     table.explodedAst := SOME(scode_prog);
+    table.connectorFlags := currentConnectorFlags();
   end if;
 
   update(table);
@@ -209,12 +241,14 @@ algorithm
   updateUriMapping(ast.classes);
 
   if isSome(table.explodedAst) then
+    applyConnectorFlags(table.connectorFlags);
     scode_elem := AbsynToSCode.translateClass(cls);
 
     SOME(scode_prog) := table.explodedAst;
     (scode_prog, true) := SCodeUtil.transformPathedElementInProgram(path,
       function update_element(newElement = scode_elem), scode_prog);
     table.explodedAst := SOME(scode_prog);
+    table.connectorFlags := currentConnectorFlags();
   end if;
 
   update(table);
@@ -231,9 +265,10 @@ function setAbsynLoaded
   input Absyn.Program loaded   "the just-parsed classes, with their within";
 protected
   SymbolTable table;
-  list<SCode.Element> sp;
+  list<SCode.Element> sp, newElems = {};
   SCode.Element se;
   Boolean found, topLevel;
+  Absyn.Program metaLoaded;
 
   function update_element
     input SCode.Element oldElement;
@@ -253,17 +288,28 @@ algorithm
 
   if topLevel and isSome(table.explodedAst) then
     SOME(sp) := table.explodedAst;
-    for cls in loaded.classes loop
+    applyConnectorFlags(table.connectorFlags);
+    // translateClass does not run MetaUtil.createMetaClassesInProgram, which lifts
+    // uniontype records into top-level metarecords (a no-op outside MetaModelica).
+    // Apply it to the loaded classes so the incremental SCode matches what a full
+    // translateAbsyn2SCode would produce.
+    metaLoaded := MetaUtil.createMetaClassesInProgram(loaded);
+    for cls in metaLoaded.classes loop
       se := AbsynToSCode.translateClass(cls);
       (sp, found) := SCodeUtil.transformPathedElementInProgram(Absyn.IDENT(cls.name),
         function update_element(newElement = se), sp);
       if not found then
-        sp := se :: sp;
+        newElems := se :: newElems;
       end if;
     end for;
+    newElems := listReverse(newElems);
+    table.connectorFlags := currentConnectorFlags();
     // Only trust the incremental SCode if it accounts for exactly the program's
-    // top-level classes; otherwise the merge did more than we tracked.
-    table.explodedAst := if listLength(sp) == listLength(ast.classes) then SOME(sp) else NONE();
+    // top-level classes after meta expansion; otherwise the merge did more than
+    // we tracked (e.g. a `uses` clause pulled in extra libraries).
+    metaLoaded := MetaUtil.createMetaClassesInProgram(table.ast);
+    table.explodedAst := if listLength(sp) + listLength(newElems) == listLength(metaLoaded.classes)
+                         then SOME(listAppend(sp, newElems)) else NONE();
   elseif isSome(table.explodedAst) then
     table.explodedAst := NONE();
   end if;
@@ -310,9 +356,11 @@ algorithm
   if isNone(table.explodedAst) then
     ast := AbsynToSCode.translateAbsyn2SCode(table.ast);
     table.explodedAst := SOME(ast);
+    table.connectorFlags := currentConnectorFlags();
     update(table);
   else
     SOME(ast) := table.explodedAst;
+    applyConnectorFlags(table.connectorFlags);
   end if;
 end getSCode;
 

--- a/OMCompiler/Compiler/Script/SymbolTable.mo
+++ b/OMCompiler/Compiler/Script/SymbolTable.mo
@@ -220,6 +220,87 @@ algorithm
   update(table);
 end setAbsynClass;
 
+function setAbsynLoaded
+  "Sets the Absyn program like setAbsyn, but for loadString: when the SCode is
+   cached and the loaded classes are top-level, it refreshes only those classes
+   in the SCode instead of dropping the whole cache. This keeps a loadString of
+   one class from re-exploding the entire loaded library. Falls back to full
+   invalidation if the merge changed the program in any other way (e.g. a
+   `uses` clause pulled in extra libraries)."
+  input Absyn.Program ast      "the full program after merging";
+  input Absyn.Program loaded   "the just-parsed classes, with their within";
+protected
+  SymbolTable table;
+  list<SCode.Element> sp;
+  SCode.Element se;
+  Boolean found, topLevel;
+
+  function update_element
+    input SCode.Element oldElement;
+    input output SCode.Element newElement;
+  algorithm
+    newElement := SCodeUtil.setElementPrefixes(SCodeUtil.elementPrefixes(oldElement), newElement);
+  end update_element;
+algorithm
+  table := get();
+  if referenceEq(table.ast, ast) then
+    return;
+  end if;
+  table.ast := ast;
+  updateUriMapping(ast.classes);
+
+  topLevel := match loaded.within_ case Absyn.TOP() then true; else false; end match;
+
+  if topLevel and isSome(table.explodedAst) then
+    SOME(sp) := table.explodedAst;
+    for cls in loaded.classes loop
+      se := AbsynToSCode.translateClass(cls);
+      (sp, found) := SCodeUtil.transformPathedElementInProgram(Absyn.IDENT(cls.name),
+        function update_element(newElement = se), sp);
+      if not found then
+        sp := se :: sp;
+      end if;
+    end for;
+    // Only trust the incremental SCode if it accounts for exactly the program's
+    // top-level classes; otherwise the merge did more than we tracked.
+    table.explodedAst := if listLength(sp) == listLength(ast.classes) then SOME(sp) else NONE();
+  elseif isSome(table.explodedAst) then
+    table.explodedAst := NONE();
+  end if;
+
+  update(table);
+end setAbsynLoaded;
+
+function setAbsynDeleted
+  "Sets the Absyn program like setAbsyn after a class was deleted, but when the
+   SCode is cached and a top-level class was removed, drops just that class from
+   the SCode instead of invalidating the whole cache."
+  input Absyn.Program ast;
+  input Absyn.Path path;
+protected
+  SymbolTable table;
+  list<SCode.Element> sp;
+  String name;
+  Boolean topLevel;
+algorithm
+  table := get();
+  table.ast := ast;
+  updateUriMapping(ast.classes);
+
+  (topLevel, name) := match path case Absyn.IDENT(name) then (true, name); else (false, ""); end match;
+
+  if isSome(table.explodedAst) then
+    if topLevel then
+      SOME(sp) := table.explodedAst;
+      table.explodedAst := SOME(list(e for e guard not SCodeUtil.isElementNamed(name, e) in sp));
+    else
+      table.explodedAst := NONE();
+    end if;
+  end if;
+
+  update(table);
+end setAbsynDeleted;
+
 function getSCode
   output SCode.Program ast;
 protected


### PR DESCRIPTION
Rework the wasm web simulator UI and run it off the main thread:

- Run omc in two Web Workers: a plain one for immediate use and a background one that installs+loads the MSL, then takes over. The MSL worker is never clear()ed.
- Keep switching library examples fast: refresh the cached SCode incrementally on loadString/copyClass/deleteClass, reuse it in the NF top scope instead of retranslating the whole program, and add an omc_simulate scripting path that runs with an empty environment rather than rebuilding the O(program) interactive environment.
- Move StopTime/Intervals/Solver/Tolerance into a settings dialog (cogwheel); enlarge the editor on mobile.
- Add a documentation column (getDocumentationAnnotation) with a collapse chevron; inline modelica:// images via uriToFilename.
- Library examples become an editable copyClass() copy; tune its parameters with setElementModifierValue + a rebuild.
- Add a PID_Controller example; two-column initial conditions.
- Replace the plot palette with a validated categorical one.
- SPA: hamburger drawer, narrow logo, icon-only "open in new tab" on mobile.


Claude-Session: https://claude.ai/code/session_01UNUh8Zf7gaRLyMeAXYCAVh

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
