### PR TITLE
wasm-jit: fix FullRobot friction event chatter

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -181,6 +181,15 @@ struct SimLayout {
     /// (evaluate fresh + store), 2 = initialization (fresh everywhere incl. NLS).
     /// `rt_solve_nls` forces held (0) around its residual evals unless mode 2.
     rel_fresh_off: u32,
+    /// Held relation snapshot (one i32 per relation): the hysteresis *direction* read
+    /// by `compile_relation_hyst` and the crossing function. The driver refreshes it
+    /// from `relations[]` at init and around each event, and holds it fixed for the
+    /// duration of one event's discrete update.
+    stored_rel_off: u32,
+    /// `relationsPre` (one i32 per relation): the value a held relation returns, so
+    /// it stays fixed while an NLS Newton solve varies the unknowns. The driver
+    /// refreshes it from `relations[]` at init and each event-iteration pass.
+    relations_pre_off: u32,
     /// Base of the state-set Jacobian scratch region (f64): the seed inputs and
     /// column result outputs of every `$STATESET` analytic Jacobian, so
     /// `functionStateSetJacobians` can evaluate a column into memory the driver
@@ -244,8 +253,12 @@ impl SimLayout {
         // the relation-mode flag.
         let relations_off = zc_off + n_zc * 8;
         let rel_fresh_off = relations_off + n_rel * 4;
+        // `storedRelations` snapshot (one i32 per relation), after the mode flag.
+        let stored_rel_off = rel_fresh_off + 4;
+        // `relationsPre` (one i32 per relation), the held-mode values.
+        let relations_pre_off = stored_rel_off + n_rel * 4;
         // State-set Jacobian scratch (f64), 8-aligned after the relation region.
-        let stateset_off = (rel_fresh_off + 4 + 7) & !7;
+        let stateset_off = (relations_pre_off + n_rel * 4 + 7) & !7;
         // 2-slot pad: C's `_event_mod_real` writes `pre[index+2]`, past its 2
         // reserved slots.
         let mathevents_off = stateset_off + n_stateset_f64 * 8;
@@ -257,7 +270,7 @@ impl SimLayout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off, bool_off, bparam_off,
             str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off,
-            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stateset_off, n_math, mathevents_off, zctol_off, total,
+            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, n_math, mathevents_off, zctol_off, total,
         }
     }
 
@@ -910,6 +923,10 @@ struct SimVarMap {
     relations_off: u32,
     /// `SimData` byte offset of the relation-evaluation-mode flag.
     rel_fresh_off: u32,
+    /// `SimData` byte offset of the held relation snapshot (`SimLayout::stored_rel_off`).
+    stored_rel_off: u32,
+    /// `SimData` byte offset of `relationsPre` (`SimLayout::relations_pre_off`).
+    relations_pre_off: u32,
     /// Number of indexed relations (bounds the `relations[]` region).
     n_relations: u32,
     /// `SimData` byte offset of the held math-event values (`mathEventsValuePre`).
@@ -1032,6 +1049,8 @@ fn build_var_map(
         sample_active_off: layout.sample_active_off,
         relations_off: layout.relations_off,
         rel_fresh_off: layout.rel_fresh_off,
+        stored_rel_off: layout.stored_rel_off,
+        relations_pre_off: layout.relations_pre_off,
         n_relations: layout.n_rel,
         mathevents_off: layout.mathevents_off,
         n_mathevents: layout.n_math,
@@ -1780,7 +1799,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     // Equation functions.
     let stateset_diag = stateset_diag_offsets(&sim_code.stateSets, &var_map)?;
     bodies.push(build_eq_fn_with_prelude("parameterEquations", &param_bindings, param_eqs, &var_map, &eq_index, &by_name, &mut literals, &[], &stateset_diag)?);
-    bodies.push(build_eq_fn("initialEquations", initial_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
+    // Seed `relationsPre := relations` at the end of init (the in-wasm `simulate`
+    // path skips the host `run_initialization`).
+    let init_save: Vec<(u32, u32, u32)> = if layout.n_rel > 0 {
+        vec![(layout.relations_pre_off, layout.relations_off, layout.n_rel * 4)]
+    } else {
+        Vec::new()
+    };
+    bodies.push(build_eq_fn_with_prelude("initialEquations", &[], initial_eqs, &var_map, &eq_index, &by_name, &mut literals, &init_save, &[])?);
     bodies.push(build_eq_fn("odeEquations", ode_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
     bodies.push(build_eq_fn_with_prelude("algebraicEquations", &[], algebraic_eqs, &var_map, &eq_index, &by_name, &mut literals, &save_pre, &[])?);
     // The integrator loop.
@@ -2273,6 +2299,8 @@ fn build_eq_fn_with_prelude(
         sample_active_off: var_map.sample_active_off,
         relations_off: var_map.relations_off,
         rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
@@ -2321,6 +2349,8 @@ fn build_init_sample_fn(
         sample_active_off: var_map.sample_active_off,
         relations_off: var_map.relations_off,
         rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
@@ -2362,6 +2392,8 @@ fn build_zero_crossings_fn(
         sample_active_off: var_map.sample_active_off,
         relations_off: var_map.relations_off,
         rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
@@ -2762,6 +2794,8 @@ fn build_nls_fns(
         sample_active_off: var_map.sample_active_off,
         relations_off: var_map.relations_off,
         rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
         n_relations: var_map.n_relations,
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -283,13 +283,6 @@ fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()>
 /// Number of equidistant homotopy steps (C's `init_lambda_steps`).
 const HOMOTOPY_STEPS: i32 = 3;
 
-/// Solve the initial system: `functionParameters`, then `functionInitialEquations`
-/// with the relations fresh (init mode). Tries directly first (lambda = 1, so
-/// `homotopy(a, s)` = a); if that leaves a non-converged nonlinear system and the
-/// model uses `homotopy()`, fall back to the global equidistant homotopy
-/// continuation (C's `solveWithGlobalHomotopy`): lambda 0 -> 1 in `HOMOTOPY_STEPS`
-/// steps, step 0 solving the simplified `functionInitialEquations_lambda0`, each
-/// step seeded by the previous one's solution. Leaves lambda = 1.
 thread_local! {
     /// Parameter `-override`s for the next run, resolved to `(SimData offset,
     /// type, value)`. Applied right after `functionParameters` so `-override=h0=2`
@@ -315,7 +308,20 @@ fn apply_param_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
     Ok(())
 }
 
+/// Solve the initial system: `functionParameters`, then `functionInitialEquations`
+/// with the relations fresh (init mode). Tries directly first (lambda = 1, so
+/// `homotopy(a, s)` = a); if that leaves a non-converged nonlinear system and the
+/// model uses `homotopy()`, fall back to the global equidistant homotopy
+/// continuation (C's `solveWithGlobalHomotopy`): lambda 0 -> 1 in `HOMOTOPY_STEPS`
+/// steps, step 0 solving the simplified `functionInitialEquations_lambda0`, each
+/// step seeded by the previous one's solution. Leaves lambda = 1, then seeds
+/// `relationsPre` for the continuous phase's held relations.
 fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    run_initialization_impl(e, sim_data, layout)?;
+    update_relations_pre(e, sim_data, layout)
+}
+
+fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     e.call1("functionParameters", sim_data)?;
     apply_param_overrides(e, sim_data)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
@@ -392,6 +398,31 @@ fn save_pre_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 /// Upper bound on discrete-update iterations at one event (C's `maxEventIterations`).
 const MAX_EVENT_ITER: usize = 20;
 
+/// Copy `relations[]` into the held relation snapshot at `stored_rel_off`. The
+/// hysteresis band and the zero-crossing function read the snapshot as their
+/// *direction*. It is refreshed at init and around each event, and left untouched
+/// during an event's discrete update so the band edge stays fixed while
+/// `iterate_discrete` rewrites `relations[]`.
+fn store_relations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.n_rel == 0 {
+        return Ok(());
+    }
+    let mut buf = vec![0u8; (layout.n_rel * 4) as usize];
+    e.read_bytes(sim_data + layout.relations_off, &mut buf)?;
+    e.write_bytes(sim_data + layout.stored_rel_off, &buf)
+}
+
+/// Copy `relations[]` into `relationsPre`. Freezing it before an event-iteration
+/// pass keeps held relations fixed while that pass's NLS solve runs.
+fn update_relations_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.n_rel == 0 {
+        return Ok(());
+    }
+    let mut buf = vec![0u8; (layout.n_rel * 4) as usize];
+    e.read_bytes(sim_data + layout.relations_off, &mut buf)?;
+    e.write_bytes(sim_data + layout.relations_pre_off, &buf)
+}
+
 /// Snapshot of the discrete state — boolean/integer algebraics and held relations
 /// — used to detect when an event's discrete update has reached a fixed point.
 fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<u8>> {
@@ -404,17 +435,25 @@ fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
     Ok(buf)
 }
 
-/// Run the discrete update to a fixed point: re-run `functionAlgebraics` (which
-/// fires edge-detected when-bodies and saves pre-values) until the discrete state
-/// stops changing. A single pass leaves conditions evaluated against the *pre*-event
-/// operands — after a `reinit` flips a state, the guarding relation must be
-/// recomputed and its pre refreshed, or the next crossing sees a stale edge (a
-/// bouncing ball then never settles). Assumes `functionODE` and the event time have
-/// already been written.
+/// Run the discrete update to a fixed point: re-evaluate the whole system —
+/// `functionODE` (relations in the continuous equations) then `functionAlgebraics`
+/// (algebraic relations, edge-detected when-bodies, pre-values) — until the discrete
+/// state stops changing. Re-running both each pass lets relations guarding the
+/// derivative equations re-settle after a when-body flips a discrete variable or
+/// `reinit`s a state; evaluating only the algebraic half leaves those relations at
+/// their pre-event value, so two mutually-triggering crossings never reach a
+/// consistent set and chatter on the integrator instead. Assumes the event time is
+/// already written.
 fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    // Each pass freezes `relationsPre = relations` so the NLS in `functionODE` holds
+    // this pass's relations; the discrete state settles across passes.
+    update_relations_pre(e, sim_data, layout)?;
+    e.call1("functionODE", sim_data)?;
     e.call1("functionAlgebraics", sim_data)?;
     let mut prev = discrete_snapshot(e, sim_data, layout)?;
     for _ in 1..MAX_EVENT_ITER {
+        update_relations_pre(e, sim_data, layout)?;
+        e.call1("functionODE", sim_data)?;
         e.call1("functionAlgebraics", sim_data)?;
         let cur = discrete_snapshot(e, sim_data, layout)?;
         if cur == prev {
@@ -1041,6 +1080,8 @@ fn run_dassl_events(
     // the initial row, so `relations[]` is populated before the states loop starts
     // holding it) and `initSample` are handled inside run_initialization.
     run_initialization(e, sim_data, layout)?;
+    // Seed the hysteresis direction from the initial relations.
+    store_relations(e, sim_data, layout)?;
 
     let n_states = layout.n_states as usize;
     let states_base = sim_data + REAL_OFF;
@@ -1066,6 +1107,7 @@ fn run_dassl_events(
     // A sample scheduled exactly at the start time fires before row 0.
     if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
         samp.fire(e, sim_data, start)?;
+        store_relations(e, sim_data, layout)?;
         stats.time_events += 1;
     }
     emit_row(e, &mut rows, start)?;
@@ -1090,6 +1132,7 @@ fn run_dassl_events(
                 // event landing on the grid point covers this row.
                 emit_row(e, &mut rows, te)?;
                 samp.fire(e, sim_data, te)?;
+                store_relations(e, sim_data, layout)?;
                 stats.time_events += 1;
                 emit_row(e, &mut rows, te)?;
                 if terminated(e, sim_data, layout)? {
@@ -1230,11 +1273,16 @@ fn run_dassl_events(
                     // real pre-region before the discrete update fires.
                     save_pre_real(e, sim_data, layout)?;
                     write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
+                    // Freeze the hysteresis direction at the pre-event relations for
+                    // the whole discrete update.
+                    store_relations(e, sim_data, layout)?;
                     // Post-event row from the discrete update run to a fixed point.
                     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
                     write_f64(e, sim_data + TIME_OFF, troot)?;
-                    e.call1("functionODE", sim_data)?;
                     iterate_discrete(e, sim_data, layout)?;
+                    // Advance the direction to the settled relations for the next
+                    // continuous phase.
+                    store_relations(e, sim_data, layout)?;
                     check_nls(e, sim_data, layout)?;
                     capture_row(e, &mut rows, sim_data, layout)?;
                     if terminated(e, sim_data, layout)? {
@@ -1262,6 +1310,7 @@ fn run_dassl_events(
                 emit_row(e, &mut rows, te)?; // pre-event row (held)
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
+                store_relations(e, sim_data, layout)?; // advance the hysteresis direction
                 stats.time_events += 1;
                 emit_row(e, &mut rows, te)?;
                 if terminated(e, sim_data, layout)? {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -456,7 +456,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),
 ];
 
 /// Model global holding the base index at which this module's per-system
@@ -970,6 +970,11 @@ pub(crate) struct SimCtx {
     pub(crate) relations_off: u32,
     /// `SimData` byte offset of the relation-evaluation-mode flag.
     pub(crate) rel_fresh_off: u32,
+    /// `SimData` byte offset of the held relation snapshot — the hysteresis
+    /// *direction* source, held fixed across an event's discrete update.
+    pub(crate) stored_rel_off: u32,
+    /// `SimData` byte offset of `relationsPre` (held-mode relation values).
+    pub(crate) relations_pre_off: u32,
     /// Number of indexed relations.
     pub(crate) n_relations: u32,
     /// `SimData` byte offset of the held math-event values (`mathEventsValuePre`).
@@ -3901,10 +3906,16 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
         && matches!(op, O::LESS { .. } | O::LESSEQ { .. } | O::GREATER { .. } | O::GREATEREQ { .. });
     let data = ctx.sim()?.data_local;
     let rel_off = ctx.sim()?.relations_off + index as u32 * 4;
+    // Held mode returns the frozen `relationsPre[index]`; the fresh branches store
+    // the live `relations[index]`.
+    let pre_off = ctx.sim()?.relations_pre_off + index as u32 * 4;
+    // The hysteresis band's direction is the held relation snapshot, not the live
+    // `relations[]` that an event's discrete update rewrites.
+    let dir_off = ctx.sim()?.stored_rel_off + index as u32 * 4;
     let fresh_off = ctx.sim()?.rel_fresh_off;
     if ctx.sim()?.zc_context {
         if real_ineq {
-            compile_relation_hyst(ctx, e1, op, e2, rel_off)?;
+            compile_relation_hyst(ctx, e1, op, e2, dir_off)?;
         } else {
             compile_relation_fresh(ctx, e1, op, e2)?;
         }
@@ -3924,7 +3935,7 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
         ctx.emit(we::Instruction::If(we::BlockType::Result(we::ValType::I32)));
         compile_relation_fresh(ctx, e1, op, e2)?;
         ctx.emit(we::Instruction::Else);
-        compile_relation_hyst(ctx, e1, op, e2, rel_off)?;
+        compile_relation_hyst(ctx, e1, op, e2, dir_off)?;
         ctx.emit(we::Instruction::End);
     } else {
         compile_relation_fresh(ctx, e1, op, e2)?;
@@ -3935,16 +3946,16 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
     ctx.emit(we::Instruction::I32Store(mem_arg(rel_off, 2)));
     ctx.emit(we::Instruction::LocalGet(v));
     ctx.emit(we::Instruction::Else);
-    ctx.emit(we::Instruction::LocalGet(data)); // held: relations[index]
-    ctx.emit(we::Instruction::I32Load(mem_arg(rel_off, 2)));
+    ctx.emit(we::Instruction::LocalGet(data)); // held: relationsPre[index]
+    ctx.emit(we::Instruction::I32Load(mem_arg(pre_off, 2)));
     ctx.emit(we::Instruction::End);
     Ok(WTy::I32)
 }
 
-/// Emit a Real inequality with C's zero-crossing hysteresis band, leaving an i32
+/// Emit a Real inequality with a zero-crossing hysteresis band, leaving an i32
 /// boolean on the stack. The comparison boundary is offset by
 /// ±`eps = tolZC * (max(|a|,|b|) + max(nominal(a), nominal(b)))` in the direction
-/// that resists a flip, using the held `relations[]` value at `rel_off` as the
+/// that resists a flip, using the held relation snapshot at `dir_off` as the
 /// current side: once true the relation stays true until the operand clears the
 /// band, and vice versa. `tolZC` is read from `SimData` (`zctol_off`).
 fn compile_relation_hyst(
@@ -3952,7 +3963,7 @@ fn compile_relation_hyst(
     e1: &DAE::Exp,
     op: &DAE::Operator,
     e2: &DAE::Exp,
-    rel_off: u32,
+    dir_off: u32,
 ) -> Result<()> {
     use we::Instruction as I;
     let data = ctx.sim()?.data_local;
@@ -3989,9 +4000,9 @@ fn compile_relation_hyst(
     ctx.emit(I::F64Sub);
     ctx.emit(I::LocalSet(diff));
 
-    // relations[rel_off] chooses which band edge applies.
+    // The held snapshot at `dir_off` chooses which band edge applies.
     ctx.emit(I::LocalGet(data));
-    ctx.emit(I::I32Load(mem_arg(rel_off, 2)));
+    ctx.emit(I::I32Load(mem_arg(dir_off, 2)));
     ctx.emit(I::If(we::BlockType::Result(we::ValType::I32)));
     emit_hyst_cmp(ctx, op, diff, eps, true)?;
     ctx.emit(I::Else);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -343,17 +343,11 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::I32Add);
     ctx.emit(I::LocalGet(data));
     ctx.emit(I::F64Load(mem_arg(0, 3))); // time at SimData offset 0
-    // relation-mode flag address: `rt_solve_nls` forces held relations around the
-    // solve (C's `solveContinuous`) so the residual stays smooth.
+    // relation-mode flag address: the solver holds relations around the Newton
+    // solve so the residual stays smooth.
     ctx.emit(I::LocalGet(data));
     ctx.emit(I::I32Const(rel_fresh_off as i32));
     ctx.emit(I::I32Add);
-    // relations base + count: the event iteration re-evaluates them fresh and
-    // detects when the discrete state has stabilized.
-    ctx.emit(I::LocalGet(data));
-    ctx.emit(I::I32Const(ctx.sim()?.relations_off as i32));
-    ctx.emit(I::I32Add);
-    ctx.emit(I::I32Const(ctx.sim()?.n_relations as i32));
     ctx.emit(I::Call(rt_index("rt_solve_nls")?));
     ctx.emit(I::Drop);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -364,8 +364,6 @@ pub extern "C" fn rt_solve_nls(
     hist_addr: u32,
     time: f64,
     rel_fresh_addr: u32,
-    relations_addr: u32,
-    n_relations: u32,
 ) -> i32 {
     let n = n as usize;
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
@@ -423,62 +421,36 @@ pub extern "C" fn rt_solve_nls(
         }
     }
 
-    // Held snapshot of the indexed relations, for the event-iteration fixpoint.
-    let n_rel = n_relations as usize;
-    let snapshot = || -> alloc::vec::Vec<u32> {
-        let mut v = vec![0u32; n_rel];
-        for (i, s) in v.iter_mut().enumerate() {
-            *s = unsafe { load_u32(relations_addr + (i * 4) as u32) };
-        }
-        v
-    };
-
     let mut scratch = vec![0.0f64; n];
     let mut x = guess.clone();
-    let mut converged;
-    let mut first = true;
-    const MAX_MIXED_ITER: i32 = 20;
-    let mut mixed_iter = 0;
-    loop {
-        if saved_rel_fresh != 2 {
-            unsafe { store_u32(rel_fresh_addr, 0) }; // hold relations across Newton
-        }
+    // At an event, refresh the inner relations at the guess before the held solve so
+    // a branch switch reaches `relations[]` for the driver's event loop.
+    if saved_rel_fresh == 1 {
+        unsafe { store_u32(rel_fresh_addr, 1) };
+        eval(&x, &mut scratch);
+    }
+    // Hold relations while Newton varies the unknowns (fresh at init, mode 2).
+    if saved_rel_fresh != 2 {
+        unsafe { store_u32(rel_fresh_addr, 0) };
+    }
+    let mut converged = newton_solve(n, &mut x, &mut eval);
+    if !converged {
+        // Second start value, then a trust-region globaliser from each start.
+        x.copy_from_slice(&warm);
         converged = newton_solve(n, &mut x, &mut eval);
-        if !converged && first {
-            // Second start value: the plain warm start.
-            x.copy_from_slice(&warm);
-            converged = newton_solve(n, &mut x, &mut eval);
-            // Trust-region globaliser (C's hybrd/homotopy analogue) when Newton
-            // stalls from both guesses.
-            if !converged {
-                x.copy_from_slice(&guess);
-                converged = lm_solve(n, &mut x, &mut eval);
-            }
-            if !converged {
-                x.copy_from_slice(&warm);
-                converged = lm_solve(n, &mut x, &mut eval);
-            }
-        }
-        first = false;
         if !converged {
-            break;
+            x.copy_from_slice(&guess);
+            converged = lm_solve(n, &mut x, &mut eval);
         }
-        if saved_rel_fresh == 1 {
-            // Event: re-evaluate the discrete relations fresh at the solution; a
-            // threshold crossing flips them, so re-solve the new branch until stable.
-            let before = snapshot();
-            unsafe { store_u32(rel_fresh_addr, 1) };
-            eval(&x, &mut scratch);
-            mixed_iter += 1;
-            if snapshot() == before || mixed_iter >= MAX_MIXED_ITER {
-                break;
-            }
-        } else {
-            // Continuous (held) / init (fresh): one final eval leaves slots + torn
-            // variables consistent at the solution.
-            eval(&x, &mut scratch);
-            break;
+        if !converged {
+            x.copy_from_slice(&warm);
+            converged = lm_solve(n, &mut x, &mut eval);
         }
+    }
+    if converged {
+        // Leave the slots + torn variables at the solution (held/init mode, so an
+        // event keeps the fresh-at-guess relations).
+        eval(&x, &mut scratch);
     }
 
     let ret = if converged {


### PR DESCRIPTION
FullRobot hung at its default stop time: the axis3 bearing friction's stuck<->slip mode never settled to Stuck as the motor speed w crossed 0, so two zero-crossings re-triggered each other with time frozen (Delta t ~ 1e-12).

Port the two missing pieces of the C runtime's event iteration (model_help.c / nonlinearSystem.c):

- relationsPre buffer (SimLayout.relations_pre_off): a held relation now returns a value frozen since the last updateRelationsPre, not the live relations[] that drifted while the NLS Newton solve varied sa. The driver freezes it each iterate_discrete pass and after init; functionInitialEquations seeds it for the in-wasm path.

- rt_solve_nls now mirrors updateInnerEquation + a held Newton solve: at an event it evaluates the inner discrete relations fresh at the guess, so a branch switch reaches relations[] and the single outer iterate_discrete loop (updateDiscreteSystem) discovers it. Evaluating fresh at the solution only confirmed the branch just solved for; the removed internal mixed iteration was a nested loop C does not have.

FullRobot now runs to completion (default stopTime) and resolves the friction to Stuck, matching /usr/bin/omc; positions track C to ~1e-6. Regression testmodels still pass bit-identically.


Claude-Session: https://claude.ai/code/session_01Q651G1L4HKnGGPNmPWVVXx

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
