### PR TITLE
SimulationRuntime: Fix segfault when FMU model calls terminate

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -232,6 +232,28 @@ static void omc_assert_fmi_warning(FILE_INFO info, const char *msg, ...)
   va_end(args);
 }
 
+static void omc_terminate_fmi(FILE_INFO info, const char *msg, ...)
+{
+  va_list ap;
+  va_start(ap, msg);
+  printInfo(stderr, info);
+  fputs("Modelica Terminate: ", stderr);
+  vfprintf(stderr, msg, ap);
+  fputs("!\n", stderr);
+  va_end(ap);
+  fflush(NULL);
+
+  threadData_t *threadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key);
+  if (threadData) {
+    ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
+    if (c) {
+      c->_terminate_simulation_requested = 1;
+    }
+  }
+
+  MMC_THROW();
+}
+
 // ---------------------------------------------------------------------------
 // Private helpers functions
 // ---------------------------------------------------------------------------
@@ -377,6 +399,15 @@ fmi2Status internalEventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
   if (done) {
     return fmi2OK;
   }
+
+  if (comp->_terminate_simulation_requested) {
+    comp->_terminate_simulation_requested = 0;
+    eventInfo->newDiscreteStatesNeeded = fmi2False;
+    eventInfo->terminateSimulation = fmi2True;
+    FILTERED_LOG(comp, fmi2OK, LOG_EVENTS, "internalEventUpdate: terminate simulation requested by the model.")
+    return fmi2OK;
+  }
+
   FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "internalEventUpdate: terminated by an assertion.")
   comp->_need_update = 1;
   return fmi2Error;
@@ -624,6 +655,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
 #endif
   omc_assert = omc_assert_fmi;
   omc_assert_warning = omc_assert_fmi_warning;
+  omc_terminate = omc_terminate_fmi;
 
   strcpy((char*)comp->instanceName, (const char*)instanceName);
   comp->type = fmuType;
@@ -1984,6 +2016,13 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, const char *func, f
   if (done) {
     return fmi2OK;
   }
+  if (comp->_terminate_simulation_requested) {
+    comp->_terminate_simulation_requested = 0;
+    *terminateSimulation = fmi2True;
+    FILTERED_LOG(comp, fmi2OK, LOG_EVENTS, "%s: terminate simulation requested by the model.", func)
+    return fmi2OK;
+  }
+
   FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "%s: terminated by an assertion.", func)
   return fmi2Error;
 }
@@ -2346,6 +2385,11 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
 #endif
 
   status = internalEventIteration(c, &eventInfo);
+  if (eventInfo.terminateSimulation) {
+    terminateSimulation = fmi2True;
+    done = 1;
+    goto doStep_cleanup;
+  }
   if (status != fmi2OK) goto doStep_cleanup;
 
   /* Integration loop */
@@ -2455,6 +2499,10 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
 
     /* signal completed integrator step */
     status = internal_CompletedIntegratorStep(c, "fmi2DoStep", fmi2True, &enterEventMode, &terminateSimulation);
+    if (terminateSimulation) {
+      done = 1;
+      goto doStep_cleanup;
+    }
     if (status != fmi2OK) goto doStep_cleanup;
 
     /* check for events */
@@ -2486,6 +2534,11 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
       eventInfo.nextEventTimeDefined              = fmi2False;
       eventInfo.nextEventTime                     = 0.0;
       status = internalEventIteration(c, &eventInfo);
+      if (eventInfo.terminateSimulation) {
+        terminateSimulation = fmi2True;
+        done = 1;
+        goto doStep_cleanup;
+      }
       if (status != fmi2OK) goto doStep_cleanup;
 
       if (eventInfo.valuesOfContinuousStatesChanged)
@@ -2525,11 +2578,19 @@ doStep_cleanup:
 
   if (!done)
   {
-    if (status == fmi2OK)
-    {
+    if (comp->_terminate_simulation_requested) {
+      comp->_terminate_simulation_requested = 0;
+      terminateSimulation = fmi2True;
+      FILTERED_LOG(comp, fmi2OK, LOG_EVENTS, "fmi2DoStep: terminate simulation requested by the model.")
+      status = fmi2OK;
+    } else if (status == fmi2OK) {
       FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "fmi2DoStep: terminated by an assertion.")
       status = fmi2Error;
     }
+  }
+
+  if (terminateSimulation) {
+    comp->state = model_state_cs_step_complete;
   }
 
   return status;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
@@ -94,6 +94,7 @@ typedef struct {
   fmi2Real stopTime;
 
   int _need_update;
+  int _terminate_simulation_requested;
   int _has_jacobian;
   int _has_jacobian_intialization;
   JACOBIAN* fmiDerJac;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -289,6 +289,28 @@ static void omc_assert_fmi_warning(FILE_INFO info, const char *msg, ...)
   va_end(args);
 }
 
+static void omc_terminate_fmi(FILE_INFO info, const char *msg, ...)
+{
+  va_list ap;
+  va_start(ap,msg);
+  printInfo(stderr, info);
+  fputs("Modelica Terminate: ", stderr);
+  vfprintf(stderr,msg,ap);
+  fputs("!\n", stderr);
+  va_end(ap);
+  fflush(NULL);
+
+  threadData_t *threadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key);
+  if (threadData) {
+    ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
+    if (c) {
+      c->_terminate_simulation_requested = 1;
+    }
+  }
+
+  MMC_THROW();
+}
+
 // ---------------------------------------------------------------------------
 // Private helpers functions
 // ---------------------------------------------------------------------------
@@ -434,6 +456,15 @@ fmi3Status internalEventUpdate(ModelInstance* c, EventInfo* eventInfo)
   if (done) {
     return fmi3OK;
   }
+
+  if (comp->_terminate_simulation_requested) {
+    comp->_terminate_simulation_requested = 0;
+    eventInfo->newDiscreteStatesNeeded = fmi3False;
+    eventInfo->terminateSimulation = fmi3True;
+    FILTERED_LOG(comp, fmi3OK, LOG_EVENTS, "internalEventUpdate: terminate simulation requested by the model.")
+    return fmi3OK;
+  }
+
   FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "internalEventUpdate: terminated by an assertion.")
   comp->_need_update = 1;
   return fmi3Error;
@@ -665,6 +696,7 @@ ModelInstance* omcInstantiate(fmi3String instanceName, OMC_FmuType fmuType, fmi3
 #endif
   omc_assert = omc_assert_fmi;
   omc_assert_warning = omc_assert_fmi_warning;
+  omc_terminate = omc_terminate_fmi;
 
   strcpy((char*)comp->instanceName, (const char*)instanceName);
   comp->type = fmuType;
@@ -2025,6 +2057,13 @@ fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, const char *func, 
   if (done) {
     return fmi3OK;
   }
+  if (comp->_terminate_simulation_requested) {
+    comp->_terminate_simulation_requested = 0;
+    *terminateSimulation = fmi3True;
+    FILTERED_LOG(comp, fmi3OK, LOG_EVENTS, "%s: terminate simulation requested by the model.", func)
+    return fmi3OK;
+  }
+
   FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "%s: terminated by an assertion.", func)
   return fmi3Error;
 }
@@ -2412,6 +2451,11 @@ static fmi3Status doStepInternal(ModelInstance* c, fmi3Float64 currentCommunicat
 #endif
 
   status = internalEventIteration(c, &eventInfo);
+  if (eventInfo.terminateSimulation) {
+    term = fmi3True;
+    done = 1;
+    goto doStep_cleanup;
+  }
   if (status != fmi3OK) goto doStep_cleanup;
 
   /* Integration loop */
@@ -2521,6 +2565,11 @@ static fmi3Status doStepInternal(ModelInstance* c, fmi3Float64 currentCommunicat
 
     /* signal completed integrator step */
     status = internal_CompletedIntegratorStep(c, "fmi3DoStep", fmi3True, &enterEventMode, &terminateSimulation);
+    if (terminateSimulation) {
+      term = fmi3True;
+      done = 1;
+      goto doStep_cleanup;
+    }
     if (status != fmi3OK) goto doStep_cleanup;
 
     /* check for events */
@@ -2569,6 +2618,11 @@ static fmi3Status doStepInternal(ModelInstance* c, fmi3Float64 currentCommunicat
       eventInfo.nextEventTimeDefined              = fmi3False;
       eventInfo.nextEventTime                     = 0.0;
       status = internalEventIteration(c, &eventInfo);
+      if (eventInfo.terminateSimulation) {
+        term = fmi3True;
+        done = 1;
+        goto doStep_cleanup;
+      }
       if (status != fmi3OK) goto doStep_cleanup;
 
       if (eventInfo.valuesOfContinuousStatesChanged)
@@ -2614,8 +2668,12 @@ doStep_cleanup:
 
   if (!done)
   {
-    if (status == fmi3OK)
-    {
+    if (comp->_terminate_simulation_requested) {
+      comp->_terminate_simulation_requested = 0;
+      term = fmi3True;
+      FILTERED_LOG(comp, fmi3OK, LOG_EVENTS, "fmi3DoStep: terminate simulation requested by the model.")
+      status = fmi3OK;
+    } else if (status == fmi3OK) {
       FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "fmi3DoStep: terminated by an assertion.")
       status = fmi3Error;
     }

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.h
@@ -125,6 +125,7 @@ typedef struct {
   fmi3Float64 stopTime;
 
   int _need_update;
+  int _terminate_simulation_requested;
   int _has_jacobian;
   int _has_jacobian_intialization;
   JACOBIAN* fmiDerJac;

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -25,6 +25,7 @@ reset_omc.mos \
 reset.mos \
 setStartTime.mos \
 sinus.mos \
+terminateTest.mos \
 testDirectionalDerivatives.mos \
 testLoopsOverFMUs.mos \
 testSynchronousFMU_01.mos \

--- a/testsuite/omsimulator/terminateTest.mos
+++ b/testsuite/omsimulator/terminateTest.mos
@@ -1,0 +1,45 @@
+// name: terminateTest
+// keywords: fmu export import terminate
+// status: correct
+// teardown_command: rm -rf terminateTest.fmu terminateTest.log terminateTest_systemCall.log terminateTest_info.json terminateTest_res.mat/
+
+loadString("
+  model terminateTest
+    Real x;
+  algorithm
+    when time > 1.2 then
+      terminate(\"Terminated.\");
+    end when;
+  equation
+    der(x) = -x;
+  end terminateTest;
+"); getErrorString();
+
+buildModelFMU(terminateTest, version="2.0", fmuType="me", platforms={"static"}); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator terminateTest.fmu --stopTime=1.5 --resultFile=terminateTest_res.mat --suppressPath=true", "terminateTest_systemCall.log");
+readFile("terminateTest_systemCall.log");
+
+
+// Result:
+// true
+// ""
+// "terminateTest.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0
+// "info:    *** FMU Simulation Info ***
+//           - model:     terminateTest (model exchange)
+//           - startTime: 0.000000
+//           - stopTime:  1.500000
+//           - tolerance: 0.000001
+//           - stepSize:  0.002000
+// info:    maximum step size for 'terminateTest.root': 0.002000
+// info:    Result file: terminateTest_res.mat (bufferSize=1)
+// [<interactive>:6:7-6:31:writable]Modelica Terminate: Terminated.!
+// info:    Simulation terminated by FMU terminateTest.root.terminateTest at time 1.200000
+// info:    Final Statistics for 'terminateTest.root':
+//          NumSteps = 0 NumRhsEvals  = 0 NumLinSolvSetups = 0
+//          NumNonlinSolvIters = 0 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult


### PR DESCRIPTION
When a Modelica model calls terminate() inside an FMU, the generated code longjmps via MMC_THROW(). The FMU runtime catch blocks in internalEventUpdate and internal_CompletedIntegratorStep treated this identically to assertion failures, returning fmi2Error without setting the terminateSimulation flag. Importers like PyFMI then crashed with a segfault upon receiving fmi2Error.

Fix by:
- Adding _terminate_simulation_requested flag to ModelInstance structs
- Providing an FMU-specific omc_terminate that sets this flag before throwing, letting catch blocks distinguish terminate from assertions
- Setting eventInfo.terminateSimulation = fmiTrue and returning OK instead of error when terminate is detected
- Checking terminateSimulation in fmi2DoStep/fmu3DoStepInternal to exit the integration loop cleanly

Closes #9474
