### PR TITLE
OMCompiler: Reinitialize solver after fmi2SetFMUstate

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1495,7 +1495,7 @@ fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
 
   // After restoring the FMU state, the internal solver (CVODE/Euler) has
   // outdated step history, Jacobians, and time.  Reinitialize it so that the
-  // next fmi2DoStep starts from a clean solver state (#12260).
+  // next fmi2DoStep starts from a clean solver state.
   if (status == fmi2OK && isCoSimulation(comp) && comp->solverInfo) {
     FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetFMUstate: reinitialising solver")
     FMI2CS_deInitializeSolverData(comp);

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1493,6 +1493,16 @@ fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
     }
   }
 
+  // After restoring the FMU state, the internal solver (CVODE/Euler) has
+  // outdated step history, Jacobians, and time.  Reinitialize it so that the
+  // next fmi2DoStep starts from a clean solver state (#12260).
+  if (status == fmi2OK && isCoSimulation(comp) && comp->solverInfo) {
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetFMUstate: reinitialising solver")
+    FMI2CS_deInitializeSolverData(comp);
+    FMI2CS_initializeSolverData(comp);
+    comp->solverInfo->currentTime = comp->fmuData->localData[0]->timeValue;
+  }
+
 cleanup:
   free(savedRealParam);
   free(savedIntParam);

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1544,6 +1544,16 @@ fmi3Status omcSetFMUstate(ModelInstance* c, fmi3FMUState FMUstate)
     }
   }
 
+  // After restoring the FMU state, the internal solver (CVODE/Euler) has
+  // outdated step history, Jacobians, and time.  Reinitialize it so that the
+  // next doStep starts from a clean solver state (#12260).
+  if (status == fmi3OK && isCoSimulation(comp) && comp->solverInfo) {
+    FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetFMUstate: reinitialising solver")
+    FMI3CS_deInitializeSolverData(comp);
+    FMI3CS_initializeSolverData(comp);
+    comp->solverInfo->currentTime = comp->fmuData->localData[0]->timeValue;
+  }
+
 cleanup:
   free(savedRealParam);
   free(savedIntParam);

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1546,7 +1546,7 @@ fmi3Status omcSetFMUstate(ModelInstance* c, fmi3FMUState FMUstate)
 
   // After restoring the FMU state, the internal solver (CVODE/Euler) has
   // outdated step history, Jacobians, and time.  Reinitialize it so that the
-  // next doStep starts from a clean solver state (#12260).
+  // next doStep starts from a clean solver state.
   if (status == fmi3OK && isCoSimulation(comp) && comp->solverInfo) {
     FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcSetFMUstate: reinitialising solver")
     FMI3CS_deInitializeSolverData(comp);


### PR DESCRIPTION
fmi2SetFMUstate restored FMU variable values (ring buffer + parameters) but did NOT reset the internal solver state (CVODE/Euler step history, Jacobians, internal time). When fmi2DoStep was called after a rollback, the solver tried to continue from its outdated internal state, which could cause hangs for complex models with stiff dynamics or events.

Call FMI[2/3]CS_deInitializeSolverData + FMI[2/3]CS_initializeSolverData at the end of fmi2SetFMUstate/omcSetFMUstate, so the solver starts fresh from the restored FMU state. Also set solverInfo->currentTime to the restored timeValue.

Closes #12260
