### PR TITLE
wasm-jit: cooperative simulation cancel

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -32,6 +32,7 @@ metamodelica/src/array/mod.rs
 metamodelica/src/array/static_array.rs
 metamodelica/src/assert.rs
 metamodelica/src/boolean.rs
+metamodelica/src/cancel.rs
 metamodelica/src/ext.rs
 metamodelica/src/gc.rs
 metamodelica/src/host_io.rs

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7642,6 +7642,7 @@ algorithm
 
   execStat("pre-optimization done (n="+String(daeSize(dae))+")");
   // transformation phase (matching and sorting using index reduction method)
+  Error.checkCancel();
   dae := causalizeDAE(dae, NONE(), matchingAlgorithm, daeHandler, true);
   execStat("matching and sorting (n="+String(daeSize(dae))+")");
 
@@ -7662,9 +7663,11 @@ algorithm
   end if;
 
   //generate Jacobian for StateSets for initial state selection
+  Error.checkCancel();
   dae := SymbolicJacobian.calculateStateSetsJacobians(dae);
 
   // generate system for initialization
+  Error.checkCancel();
   (outInitDAE, outInitDAE_lambda0_option, outRemovedInitialEquationLst, globalKnownVars, dae) := Initialization.solveInitialSystem(dae);
   if Flags.isSet(Flags.WARN_NO_NOMINAL) then
     warnAboutIterationVariablesWithNoNominal(outInitDAE);
@@ -7734,6 +7737,9 @@ algorithm
   else
   setGlobalRoot(Global.stackoverFlowIndex, NONE());
   ErrorExt.rollbackNumCheckpoints(ErrorExt.getNumCheckpoints()-numCheckpoints);
+  // A user cancel unwinds through this checkpoint like a failure; report it as
+  // such (after the rollback, so the message survives) rather than as overflow.
+  Error.checkCancel();
   Error.addInternalError("Stack overflow in "+getInstanceName()+"...\n"+stringDelimitList(StackOverflow.readableStacktraceMessages(), "\n"), sourceInfo());
   /* Do not fail or we can loop too much */
   StackOverflow.clearStacktraceMessages();
@@ -7766,6 +7772,7 @@ protected
 algorithm
   execStat("prepare preOptimizeDAE");
   for preOptModule in inPreOptModules loop
+    Error.checkCancel();
     (optModule, moduleStr) := preOptModule;
     moduleStr := moduleStr + " (" + BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType) + ")";
     try
@@ -8017,6 +8024,7 @@ protected
 algorithm
   execStat("prepare postOptimizeDAE");
   for postOptModule in inPostOptModules loop
+    Error.checkCancel();
     (optModule, moduleStr) := postOptModule;
     moduleStr := moduleStr + " (" + BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType) + ")";
     try

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -369,7 +369,7 @@ public
   algorithm
     System.reportProgress(-1, 4) "PHASE_BACKEND";
     for module in modules loop
-      System.checkCancel();
+      Error.checkCancel();
       (func, name) := module;
       if  Flags.isSet(Flags.FAILTRACE) then
         debugStr := "[failtrace] ........ [" + ClockIndexes.toString(clock_idx) + "] " + name;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -367,7 +367,9 @@ public
     Real clock_time;
     tuple<Integer, Integer> varSizes, eqnSizes;
   algorithm
+    System.reportProgress(-1, 4) "PHASE_BACKEND";
     for module in modules loop
+      System.checkCancel();
       (func, name) := module;
       if  Flags.isSet(Flags.FAILTRACE) then
         debugStr := "[failtrace] ........ [" + ClockIndexes.toString(clock_idx) + "] " + name;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -1111,7 +1111,7 @@ protected
   Class cls;
   Modifier outer_mod;
 algorithm
-  System.checkCancel();
+  Error.checkCancel();
   cls := InstNode.getClass(node);
   outer_mod := Class.getModifier(cls);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -191,6 +191,7 @@ algorithm
   // Instantiate expressions (i.e. anything that can contains crefs, like
   // bindings, dimensions, etc). This is done as a separate step after
   // instantiation to make sure that lookup is able to find the correct nodes.
+  Error.checkCancel();
   instExpressions(inst_cls, context = context, settings = settings);
   execStat("NFInst.instExpressions");
 
@@ -199,9 +200,11 @@ algorithm
   execStat("NFInst.updateImplicitVariability");
 
   // Type the class.
+  Error.checkCancel();
   Typing.typeClass(inst_cls, context);
 
   // Flatten the model and evaluate constants in it.
+  Error.checkCancel();
   flatModel := Flatten.flatten(inst_cls, classPath);
   flatModel := EvalConstants.evaluate(flatModel, context);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -435,6 +435,7 @@ function instantiate
   input InstContext.Type context;
   input Boolean instPartial = false "Whether to instantiate a partial class or not.";
 algorithm
+  System.reportProgress(-1, 3) "PHASE_INSTANTIATE";
   node := expand(node, context);
 
   if instPartial or not InstNode.isPartial(node) or
@@ -1110,6 +1111,7 @@ protected
   Class cls;
   Modifier outer_mod;
 algorithm
+  System.checkCancel();
   cls := InstNode.getClass(node);
   outer_mod := Class.getModifier(cls);
 

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -236,10 +236,28 @@ pub extern "C" fn omc_compiler_free_string(s: *mut c_char) {
     }
 }
 
-/// Request cancellation of a running in-process wasm-jit simulation (cross-thread —
-/// an OMEdit Cancel button, a Ctrl-C handler). `simulate` then returns a "cancelled"
-/// error, leaving omc consistent.
+/// Request cancellation of any running in-process op — a wasm-jit simulation, or
+/// a long frontend/loader/backend call (cross-thread — an OMEdit Cancel button, a
+/// Ctrl-C handler). The op then returns a "cancelled" error, leaving omc
+/// consistent.
 #[unsafe(no_mangle)]
 pub extern "C" fn omc_compiler_request_cancel() {
     capi::request_cancel();
+}
+
+/// Clear the cancel flag; call before starting a new cancellable op so a stale
+/// request from a previous op does not abort it immediately.
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_compiler_clear_cancel() {
+    capi::clear_cancel();
+}
+
+/// Register a host event-pump callback invoked at every cancel check (pass NULL
+/// to clear). An in-process GUI host (OMEdit) points this at a rate-limited
+/// `processEvents` so a long compile keeps the UI live and the Cancel button
+/// clickable; the host must disable all UI but Cancel while a call is in flight
+/// (the compiler is not reentrant).
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_compiler_set_pump_callback(cb: Option<extern "C" fn()>) {
+    capi::set_pump_callback(cb);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -235,3 +235,11 @@ pub extern "C" fn omc_compiler_free_string(s: *mut c_char) {
         }
     }
 }
+
+/// Request cancellation of a running in-process wasm-jit simulation (cross-thread —
+/// an OMEdit Cancel button, a Ctrl-C handler). `simulate` then returns a "cancelled"
+/// error, leaving omc consistent.
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_compiler_request_cancel() {
+    capi::request_cancel();
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -261,3 +261,18 @@ pub extern "C" fn omc_compiler_clear_cancel() {
 pub extern "C" fn omc_compiler_set_pump_callback(cb: Option<extern "C" fn()>) {
     capi::set_pump_callback(cb);
 }
+
+/// Last reported progress permille (0..=1000, or negative for an indeterminate
+/// spinner). An in-process host reads this from its pump callback to fill a
+/// progress bar during a long compile.
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_compiler_progress_permille() -> c_int {
+    capi::progress_permille()
+}
+
+/// Last reported progress phase (see the compiler's `PHASE_*` constants:
+/// 0 idle, 1 download, 2 parse, 3 instantiate, 4 backend, 5 simulate).
+#[unsafe(no_mangle)]
+pub extern "C" fn omc_compiler_progress_phase() -> c_int {
+    capi::progress_phase()
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -18,6 +18,29 @@ extern "C" {
     fn console_log(s: &str);
     #[wasm_bindgen(js_namespace = console, js_name = error)]
     fn console_error(s: &str);
+    // Wall-clock (ms) for the simulation chunk budget; wasm has no `Instant`.
+    #[wasm_bindgen(js_namespace = performance, js_name = now)]
+    fn perf_now() -> f64;
+    // Host cancel poll (a cross-thread `SharedArrayBuffer` flag, OMEdit-wasm). Only
+    // called after `omc_enable_cancel_poll`, so the global need not exist otherwise.
+    #[wasm_bindgen(js_namespace = globalThis, js_name = __omcPollCancel)]
+    fn omc_poll_cancel_js() -> i32;
+}
+
+fn wall_ms() -> f64 {
+    perf_now()
+}
+
+fn poll_cancel() -> bool {
+    omc_poll_cancel_js() != 0
+}
+
+/// Enable the cross-thread cancel poll for the blocking `simulate()` path. The
+/// worker must define `globalThis.__omcPollCancel` first (OMEdit-wasm); the
+/// simulator cancels via `omc_sim_free` instead and doesn't call this.
+#[wasm_bindgen]
+pub fn omc_enable_cancel_poll() {
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::set_cancel_poll(poll_cancel);
 }
 
 // The compiler emits stdout/stderr in fragments (a `print` call need not end on
@@ -83,6 +106,9 @@ pub fn omc_init() -> bool {
     // Route `plot(...)` through the in-page charton renderer instead of spawning
     // the external OMPlot process (which does not exist on wasm).
     crate::wasm_plot::register();
+
+    // wasm has no `Instant`; give the sim driver a wall-clock for the chunk budget.
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::set_clock(wall_ms);
 
     // `-d=-buildExternalLibs`: never try to *build* an external "C" library's
     // Resources/BuildProjects (autotools) — impossible in-browser, and it would
@@ -367,4 +393,54 @@ pub fn omc_simulate(
             None => "Error: simulation panicked".to_owned(),
         },
     }
+}
+
+// --- resumable / cancellable simulation --------------------------------------
+// The blocking `omc_simulate` can't be interrupted, and killing the worker loses the
+// loaded library + warmed JIT. Instead the worker builds the model then drives the
+// run in time-bounded chunks (`omc_sim_start`/`omc_sim_advance`/`omc_sim_free`),
+// draining a cancel between chunks; results reach the page via the `omc_sim_*`
+// getters. See HANDOFF-sim-cancel.md.
+
+/// Start a resumable run of a model already built by `buildModel` (keyed by its
+/// `prefix`; `result_file` is where the `.mat` goes). `false` on failure — read
+/// `getErrorString()`.
+#[wasm_bindgen]
+pub fn omc_sim_start(prefix: &str, result_file: &str, simflags: &str) -> bool {
+    LAST_PANIC.with(|p| *p.borrow_mut() = None);
+    let run = || openmodelica_codegen_wasm_jit::CodegenWasmJit::sim_start(prefix, result_file, simflags);
+    matches!(catch_unwind(AssertUnwindSafe(run)), Ok(Ok(())))
+}
+
+/// Integrate for about `budget_ms` of wall-clock, then return so the worker can
+/// yield. Codes: `0` running (call again), `1` done, `2` terminated (`terminate()`),
+/// `3` cancelled, `-1` error (read `getErrorString()`). On `1`/`2` the results are
+/// ready via the `omc_sim_*` getters and the `.mat` is written; on `3`/`-1`/`1`/`2`
+/// the session is freed.
+#[wasm_bindgen]
+pub fn omc_sim_advance(budget_ms: f64) -> i32 {
+    use openmodelica_codegen_wasm_jit::CodegenWasmJit::SimStatus;
+    LAST_PANIC.with(|p| *p.borrow_mut() = None);
+    let run = || openmodelica_codegen_wasm_jit::CodegenWasmJit::sim_advance(budget_ms);
+    match catch_unwind(AssertUnwindSafe(run)) {
+        Ok(Ok(SimStatus::Running)) => 0,
+        Ok(Ok(SimStatus::Done)) => 1,
+        Ok(Ok(SimStatus::Terminated)) => 2,
+        Ok(Ok(SimStatus::Cancelled)) => 3,
+        _ => -1,
+    }
+}
+
+/// Drop the active simulation session (freeing its external objects). Used by the
+/// worker's Cancel path; safe with no active session.
+#[wasm_bindgen]
+pub fn omc_sim_free() {
+    let _ = catch_unwind(AssertUnwindSafe(openmodelica_codegen_wasm_jit::CodegenWasmJit::sim_free));
+}
+
+/// Request cancellation of the running simulation (mirrors the native C ABI). The
+/// simulator cancels via `omc_sim_free` instead; this is used by the SAB cancel path.
+#[wasm_bindgen]
+pub fn omc_request_cancel() {
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::request_cancel();
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -21,10 +21,15 @@ extern "C" {
     // Wall-clock (ms) for the simulation chunk budget; wasm has no `Instant`.
     #[wasm_bindgen(js_namespace = performance, js_name = now)]
     fn perf_now() -> f64;
-    // Host cancel poll (a cross-thread `SharedArrayBuffer` flag, OMEdit-wasm). Only
-    // called after `omc_enable_cancel_poll`, so the global need not exist otherwise.
+    // Host cancel poll (control block index 0, a cross-thread `SharedArrayBuffer`
+    // flag, OMEdit-wasm). Only called after `omc_enable_cancel_poll`, so the
+    // global need not exist otherwise.
     #[wasm_bindgen(js_namespace = globalThis, js_name = __omcPollCancel)]
     fn omc_poll_cancel_js() -> i32;
+    // Host progress sink (control block indices 1/2). Only called after
+    // `omc_enable_progress_sink`, so the global need not exist otherwise.
+    #[wasm_bindgen(js_namespace = globalThis, js_name = __omcReportProgress)]
+    fn omc_report_progress_js(permille: i32, phase: i32);
 }
 
 fn wall_ms() -> f64 {
@@ -35,12 +40,25 @@ fn poll_cancel() -> bool {
     omc_poll_cancel_js() != 0
 }
 
-/// Enable the cross-thread cancel poll for the blocking `simulate()` path. The
-/// worker must define `globalThis.__omcPollCancel` first (OMEdit-wasm); the
-/// simulator cancels via `omc_sim_free` instead and doesn't call this.
+fn report_progress(permille: i32, phase: i32) {
+    omc_report_progress_js(permille, phase);
+}
+
+/// Enable the cross-thread cancel poll for any blocking omc call (simulate, and
+/// the frontend/loader/backend chokepoints). The worker must define
+/// `globalThis.__omcPollCancel` first (OMEdit-wasm); the standalone simulator
+/// cancels via `omc_sim_free` instead and doesn't call this.
 #[wasm_bindgen]
 pub fn omc_enable_cancel_poll() {
-    openmodelica_codegen_wasm_jit::CodegenWasmJit::set_cancel_poll(poll_cancel);
+    metamodelica::cancel::set_cancel_poll(poll_cancel);
+}
+
+/// Enable live progress reporting out of a blocking omc call: the runtime writes
+/// permille + phase into the shared control block via `globalThis.__omcReportProgress`
+/// (which the worker defines). The UI thread reads the block on its own timer.
+#[wasm_bindgen]
+pub fn omc_enable_progress_sink() {
+    metamodelica::cancel::set_progress_sink(report_progress);
 }
 
 // The compiler emits stdout/stderr in fragments (a `print` call need not end on

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
@@ -11,7 +11,7 @@
 //! [`cancelled_error`] so the op fails like any other error and leaves omc
 //! consistent (the caller must roll back partial state).
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 
 // ── Phases (control block index 2; see HANDOFF-coi-consolidation.md) ──────────
 pub const PHASE_IDLE: i32 = 0;
@@ -31,9 +31,12 @@ pub fn request_cancel() {
     CANCEL.store(true, Ordering::Relaxed);
 }
 
-/// Clear the cancel flag; call at the start of each new cancellable op.
+/// Clear the cancel flag; call at the start of each new cancellable op. Also
+/// resets progress to idle so a stale phase can't leak into the next op.
 pub fn clear_cancel() {
     CANCEL.store(false, Ordering::Relaxed);
+    PROGRESS_PERMILLE.store(PROGRESS_INDETERMINATE, Ordering::Relaxed);
+    PROGRESS_PHASE.store(PHASE_IDLE, Ordering::Relaxed);
 }
 
 // wasm: the blocked worker can't get a cancel message, so a cross-origin-isolated
@@ -117,19 +120,34 @@ pub fn set_progress_sink(f: fn(i32, i32)) {
     PROGRESS_SINK.with(|c| c.set(Some(f)));
 }
 
+// Last reported progress, readable by an in-process host (OMEdit) from its pump
+// callback to fill a status-bar progress bar. Kept on all targets so the cdylib
+// getters compile uniformly; on wasm the host reads the shared control block (fed
+// by the sink) instead, but storing here too is harmless.
+static PROGRESS_PERMILLE: AtomicI32 = AtomicI32::new(PROGRESS_INDETERMINATE);
+static PROGRESS_PHASE: AtomicI32 = AtomicI32::new(PHASE_IDLE);
+
 /// Report progress of the current op: `permille` in 0..=1000 (or
-/// [`PROGRESS_INDETERMINATE`]) and one of the `PHASE_*` constants. No-op unless a
-/// sink is installed (native, or a wasm host that didn't opt in).
+/// [`PROGRESS_INDETERMINATE`]) and one of the `PHASE_*` constants. wasm also
+/// forwards to the host sink; [`progress_permille`]/[`progress_phase`] read it back.
 #[inline]
 pub fn report_progress(permille: i32, phase: i32) {
+    PROGRESS_PERMILLE.store(permille, Ordering::Relaxed);
+    PROGRESS_PHASE.store(phase, Ordering::Relaxed);
     #[cfg(target_arch = "wasm32")]
     if let Some(f) = PROGRESS_SINK.with(|c| c.get()) {
         f(permille, phase);
     }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let _ = (permille, phase);
-    }
+}
+
+/// Last reported permille (0..=1000 or [`PROGRESS_INDETERMINATE`]).
+pub fn progress_permille() -> i32 {
+    PROGRESS_PERMILLE.load(Ordering::Relaxed)
+}
+
+/// Last reported phase (a `PHASE_*` constant).
+pub fn progress_phase() -> i32 {
+    PROGRESS_PHASE.load(Ordering::Relaxed)
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
@@ -1,0 +1,161 @@
+//! Cooperative cancellation and progress reporting shared across the whole
+//! compiler — frontend, loader, backend, and the wasm-jit sim driver.
+//!
+//! Native: a process-global `AtomicBool` flipped from another thread (an OMEdit
+//! Cancel button, a Ctrl-C handler). wasm: the omc worker is blocked inside one
+//! synchronous call and can't receive a message, so a cross-origin-isolated host
+//! injects a poll fn that reads a `SharedArrayBuffer` control block instead.
+//!
+//! Call sites `check_cancel()` at coarse chokepoints (per file / per class /
+//! per equation-system — NOT per AST node) and, on hitting it, unwind with
+//! [`cancelled_error`] so the op fails like any other error and leaves omc
+//! consistent (the caller must roll back partial state).
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+// ── Phases (control block index 2; see HANDOFF-coi-consolidation.md) ──────────
+pub const PHASE_IDLE: i32 = 0;
+pub const PHASE_DOWNLOAD: i32 = 1;
+pub const PHASE_PARSE: i32 = 2;
+pub const PHASE_INSTANTIATE: i32 = 3;
+pub const PHASE_BACKEND: i32 = 4;
+pub const PHASE_SIMULATE: i32 = 5;
+
+/// Permille value meaning "indeterminate" (spinner, not a bar).
+pub const PROGRESS_INDETERMINATE: i32 = -1;
+
+static CANCEL: AtomicBool = AtomicBool::new(false);
+
+/// Request cancellation of the running operation (native, cross-thread).
+pub fn request_cancel() {
+    CANCEL.store(true, Ordering::Relaxed);
+}
+
+/// Clear the cancel flag; call at the start of each new cancellable op.
+pub fn clear_cancel() {
+    CANCEL.store(false, Ordering::Relaxed);
+}
+
+// wasm: the blocked worker can't get a cancel message, so a cross-origin-isolated
+// host polls a `SharedArrayBuffer` flag through an injected fn ptr. Unset for
+// hosts that cancel another way (the standalone simulator frees its session).
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static CANCEL_POLL: std::cell::Cell<Option<fn() -> bool>> = const { std::cell::Cell::new(None) };
+}
+
+/// wasm: point the cancel check at a host poll (reads control block index 0).
+#[cfg(target_arch = "wasm32")]
+pub fn set_cancel_poll(f: fn() -> bool) {
+    CANCEL_POLL.with(|c| c.set(Some(f)));
+}
+
+// Native: a host embedding omc in-process (OMEdit) runs the compiler on its UI
+// thread, so a long call would freeze the GUI and the Cancel button could never
+// be clicked. The host registers a "pump" callback that we invoke at every
+// cancel check; its OMEdit implementation runs `QCoreApplication::processEvents`
+// (rate-limited on its side), which delivers the Cancel click that flips the
+// flag below and repaints progress — cooperative, on the same thread, so it is
+// safe with the compiler's non-reentrant global state as long as the host
+// disables everything but the Cancel affordance while a call is in flight.
+// Null (the default) for the CLI and any host that doesn't opt in. Defined on all
+// targets so the cdylib API is uniform; on wasm the worker frees the UI thread so
+// nothing registers a pump and it stays null (a harmless no-op).
+static PUMP: AtomicUsize = AtomicUsize::new(0);
+
+/// Register (or clear, with `None`) the host event-pump callback invoked at each
+/// [`check_cancel`]. See [`PUMP`]. No effect on wasm (no pump is registered).
+pub fn set_pump_callback(f: Option<extern "C" fn()>) {
+    PUMP.store(f.map_or(0, |f| f as usize), Ordering::Relaxed);
+}
+
+/// True if cancellation has been requested. Cheap (a relaxed atomic load, or one
+/// injected poll on wasm) — safe to call once per coarse work unit. Also drives
+/// the host event pump (see [`PUMP`]) so an in-process GUI stays live; null (and
+/// so a no-op) unless a host registered one.
+pub fn check_cancel() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    if CANCEL_POLL.with(|c| c.get()).map(|f| f()).unwrap_or(false) {
+        return true;
+    }
+    let p = PUMP.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: extern "C" fn() = unsafe { std::mem::transmute(p) };
+        f();
+    }
+    CANCEL.load(Ordering::Relaxed)
+}
+
+/// The canonical cancellation error. Distinct message so callers/UI can tell a
+/// user-cancel from a real failure.
+pub fn cancelled_error() -> anyhow::Error {
+    anyhow::anyhow!("Operation cancelled by user")
+}
+
+/// `Err(cancelled_error())` if cancellation was requested, else `Ok(())`.
+/// Use with `?` at a chokepoint: `metamodelica::bail_if_cancelled()?;`.
+#[inline]
+pub fn bail_if_cancelled() -> anyhow::Result<()> {
+    if check_cancel() {
+        return Err(cancelled_error());
+    }
+    Ok(())
+}
+
+// ── Progress (worker → main, control block indices 1/2) ───────────────────────
+//
+// Mirror of the cancel poll in the opposite direction. Native is a no-op; wasm
+// stores permille + phase into the shared control block through an injected sink.
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static PROGRESS_SINK: std::cell::Cell<Option<fn(i32, i32)>> = const { std::cell::Cell::new(None) };
+}
+
+/// wasm: point progress reports at a host sink (writes control block 1/2).
+#[cfg(target_arch = "wasm32")]
+pub fn set_progress_sink(f: fn(i32, i32)) {
+    PROGRESS_SINK.with(|c| c.set(Some(f)));
+}
+
+/// Report progress of the current op: `permille` in 0..=1000 (or
+/// [`PROGRESS_INDETERMINATE`]) and one of the `PHASE_*` constants. No-op unless a
+/// sink is installed (native, or a wasm host that didn't opt in).
+#[inline]
+pub fn report_progress(permille: i32, phase: i32) {
+    #[cfg(target_arch = "wasm32")]
+    if let Some(f) = PROGRESS_SINK.with(|c| c.get()) {
+        f(permille, phase);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = (permille, phase);
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    // The flag is process-global; this is the only test that touches it, so the
+    // set/clear ordering here is deterministic.
+    #[test]
+    fn request_then_clear() {
+        clear_cancel();
+        assert!(!check_cancel());
+        assert!(bail_if_cancelled().is_ok());
+
+        request_cancel();
+        assert!(check_cancel());
+        assert!(bail_if_cancelled().is_err());
+
+        clear_cancel();
+        assert!(!check_cancel());
+        assert!(bail_if_cancelled().is_ok());
+    }
+
+    #[test]
+    fn progress_is_noop_native() {
+        // Native has no sink; must not panic.
+        report_progress(500, PHASE_PARSE);
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
@@ -31,6 +31,7 @@ pub use num_traits::Float;
 use std::rc::Rc;
 use std::cell::RefCell;
 pub mod gc;
+pub mod cancel;
 
 /// MetaModelica `array<T>`. See module-level docs for rationale.
 pub type Array<A> = Rc<RefCell<Vec<A>>>;

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
@@ -481,6 +481,8 @@ fn registry() -> &'static BTreeMap<&'static str, Fallibility> {
         m.insert("System_getUsesCardinality", Infallible);
         m.insert("System_getVariableValue", Fallible);         // throws on lookup failure
         m.insert("System_getuid", Infallible);
+        m.insert("System_isCancelled", Infallible);           // pure read of the cancel flag
+        m.insert("System_reportProgress", Infallible);        // one-way progress store
         m.insert("System_initGarbageCollector", Infallible);
         m.insert("System_launchParallelTasks", Fallible);      // MMC_THROW_INTERNAL on pthread error
         m.insert("System_loadLibrary", Fallible);              // throws on dlopen failure

--- a/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
@@ -43,6 +43,13 @@ import * as OmcModule from "./omc/OpenModelicaCompiler.js";
 // Self-ID so a page console shows which omc_worker.js loaded (cache diagnosis).
 console.log("omc_worker.js loaded (WASI file surface)");
 
+// Cooperative simulation cancel (OMEdit-wasm): simulate() blocks here, so the main
+// thread writes a shared SharedArrayBuffer flag and the omc driver polls it per step
+// through this global (bound by omc_enable_cancel_poll). Null-safe until the main
+// thread hands over the buffer (`cancelBuf`).
+let cancelView = null;
+globalThis.__omcPollCancel = () => (cancelView ? Atomics.load(cancelView, 0) : 0);
+
 // Read a whole file from the worker store through the WASI preview1 flow
 // (path_open → fd_read → fd_close). Returns a Uint8Array or undefined if absent.
 function wasiReadFile(path) {
@@ -152,6 +159,10 @@ async function doInit(installMsl) {
   if (!omc_init()) {
     return { kind: "ready", ok: false, error: "omc_init() failed" };
   }
+  // Point the omc driver's cancel poll at __omcPollCancel (feature-detected).
+  if (typeof OmcModule.omc_enable_cancel_poll === "function") {
+    OmcModule.omc_enable_cancel_poll();
+  }
   // The browser omc has no pre-installed library, so install the MSL to make the
   // shell immediately usable. Best-effort: a failure (e.g. no network) only
   // surfaces its diagnostics, it does not stop the shell from starting. A client
@@ -199,6 +210,12 @@ async function doEval(src, keepErrors) {
 
 self.onmessage = async (e) => {
   const msg = e.data;
+  // One-way setup message (no reply): store the shared cancel view. Before
+  // `await ready` so it is in place before the first simulate.
+  if (msg.cmd === "cancelBuf") {
+    try { cancelView = msg.buf ? new Int32Array(msg.buf) : null; } catch (_) { cancelView = null; }
+    return;
+  }
   await ready;
   try {
     if (msg.cmd === "init") {

--- a/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
@@ -43,12 +43,34 @@ import * as OmcModule from "./omc/OpenModelicaCompiler.js";
 // Self-ID so a page console shows which omc_worker.js loaded (cache diagnosis).
 console.log("omc_worker.js loaded (WASI file surface)");
 
-// Cooperative simulation cancel (OMEdit-wasm): simulate() blocks here, so the main
-// thread writes a shared SharedArrayBuffer flag and the omc driver polls it per step
-// through this global (bound by omc_enable_cancel_poll). Null-safe until the main
-// thread hands over the buffer (`cancelBuf`).
-let cancelView = null;
-globalThis.__omcPollCancel = () => (cancelView ? Atomics.load(cancelView, 0) : 0);
+// Cooperative cancel + live progress (OMEdit-wasm): a long omc call (simulate,
+// installPackage, …) blocks here, so the main thread shares a SharedArrayBuffer
+// "control block" the worker reads/writes with Atomics. Layout (Int32Array):
+//   [0] cancel   main→worker  0 run / 1 cancel requested (omc polls per step)
+//   [1] progress worker→main  permille 0..1000, or -1 indeterminate
+//   [2] phase    worker→main  0 idle,1 download,2 parse,3 instantiate,4 backend,5 sim
+//   [3] generation main→both  bumped per op so a stale read is ignored
+// Null-safe until the main thread hands over the buffer (`controlBuf`/`cancelBuf`).
+let controlView = null;
+globalThis.__omcPollCancel = () => (controlView ? Atomics.load(controlView, 0) : 0);
+globalThis.__omcReportProgress = (permille, phase) => {
+  // Guard length so an older 4-byte (cancel-only) buffer doesn't throw.
+  if (controlView && controlView.length >= 3) {
+    Atomics.store(controlView, 1, permille);
+    Atomics.store(controlView, 2, phase);
+  }
+};
+// Clear cancel + progress once an op finishes, so a cancel flag set during (or
+// after) one op never leaks into the next and spuriously aborts it — the flag is
+// strictly per-op. Called after each eval/abi completes.
+function resetControl() {
+  if (!controlView) return;
+  Atomics.store(controlView, 0, 0);
+  if (controlView.length >= 3) {
+    Atomics.store(controlView, 1, -1);
+    Atomics.store(controlView, 2, 0);
+  }
+}
 
 // Read a whole file from the worker store through the WASI preview1 flow
 // (path_open → fd_read → fd_close). Returns a Uint8Array or undefined if absent.
@@ -163,6 +185,10 @@ async function doInit(installMsl) {
   if (typeof OmcModule.omc_enable_cancel_poll === "function") {
     OmcModule.omc_enable_cancel_poll();
   }
+  // Route omc progress reports into the control block (feature-detected).
+  if (typeof OmcModule.omc_enable_progress_sink === "function") {
+    OmcModule.omc_enable_progress_sink();
+  }
   // The browser omc has no pre-installed library, so install the MSL to make the
   // shell immediately usable. Best-effort: a failure (e.g. no network) only
   // surfaces its diagnostics, it does not stop the shell from starting. A client
@@ -210,10 +236,11 @@ async function doEval(src, keepErrors) {
 
 self.onmessage = async (e) => {
   const msg = e.data;
-  // One-way setup message (no reply): store the shared cancel view. Before
-  // `await ready` so it is in place before the first simulate.
-  if (msg.cmd === "cancelBuf") {
-    try { cancelView = msg.buf ? new Int32Array(msg.buf) : null; } catch (_) { cancelView = null; }
+  // One-way setup message (no reply): store the shared control block. Before
+  // `await ready` so it is in place before the first long call. `cancelBuf` is
+  // the old name for the same message (a 4-byte cancel-only buffer).
+  if (msg.cmd === "controlBuf" || msg.cmd === "cancelBuf") {
+    try { controlView = msg.buf ? new Int32Array(msg.buf) : null; } catch (_) { controlView = null; }
     return;
   }
   await ready;
@@ -222,6 +249,7 @@ self.onmessage = async (e) => {
       self.postMessage(await doInit(msg.installMsl !== false));
     } else if (msg.cmd === "eval") {
       const { msg: reply, transfer } = await doEval(msg.src, msg.keepErrors);
+      resetControl();
       // Transfer the result-file buffers (zero-copy) rather than clone them.
       self.postMessage(reply, transfer);
     } else if (msg.cmd === "abi") {
@@ -231,6 +259,7 @@ self.onmessage = async (e) => {
         typeof OmcModule.omc_abi === "function"
           ? await abiWithDownloads(msg.request)
           : JSON.stringify({ error: "omc_abi unavailable (omc built without the scripting_api feature)" });
+      resetControl();
       self.postMessage({ kind: "abiResult", id: msg.id, response });
     } else if (msg.cmd === "vfsGet") {
       // OMEdit reads some files (library index, install manifests, visual.xml)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
@@ -186,6 +186,13 @@ pub fn parse(
     _libraryPath: ArcStr,
     _lveInstance: Option<i32>,
 ) -> Result<Absyn::Program> {
+    // Loader cancel chokepoint: loadModel/loadFile/installPackage parse each file
+    // through here, so a per-file check makes the whole parse phase cancellable.
+    metamodelica::cancel::bail_if_cancelled()?;
+    metamodelica::cancel::report_progress(
+        metamodelica::cancel::PROGRESS_INDETERMINATE,
+        metamodelica::cancel::PHASE_PARSE,
+    );
     // The Rust parser operates on UTF-8 `&str` directly.  Anything else
     // would need transcoding via the `encoding_rs` crate; bail explicitly
     // rather than silently misinterpreting the bytes.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -71,6 +71,17 @@ pub fn set_pump_callback(f: Option<extern "C" fn()>) {
     metamodelica::cancel::set_pump_callback(f);
 }
 
+/// Last reported progress permille (0..=1000, or negative for indeterminate) for
+/// an in-process host to fill a progress bar from its pump callback.
+pub fn progress_permille() -> i32 {
+    metamodelica::cancel::progress_permille()
+}
+
+/// Last reported progress phase (a `metamodelica::cancel::PHASE_*` value).
+pub fn progress_phase() -> i32 {
+    metamodelica::cancel::progress_phase()
+}
+
 /// `simulate` against the builtin graph only; empty/non-positive args use its defaults.
 pub fn simulate(
     class_name: ArcStr,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -51,10 +51,24 @@ pub fn eval(command: ArcStr) -> Result<(bool, ArcStr)> {
     Main::handleCommand(command)
 }
 
-/// Request cancellation of a running in-process wasm-jit simulation (cross-thread;
-/// `simulate` then returns a "cancelled" error, leaving omc consistent).
+/// Request cancellation of any running in-process op — simulation, or a long
+/// frontend/loader/backend call (cross-thread; the op then returns a "cancelled"
+/// error, leaving omc consistent). Routes to the shared `metamodelica::cancel`
+/// flag every phase polls (the sim driver reads the same flag).
 pub fn request_cancel() {
-    openmodelica_codegen_wasm_jit::CodegenWasmJit::request_cancel();
+    metamodelica::cancel::request_cancel();
+}
+
+/// Clear the cancel flag; call at the start of each new cancellable op.
+pub fn clear_cancel() {
+    metamodelica::cancel::clear_cancel();
+}
+
+/// Register the host event-pump callback invoked at every cancel check (or clear
+/// with `None`). Lets an in-process GUI host keep its event loop alive during a
+/// long call so the Cancel button stays clickable. See `metamodelica::cancel`.
+pub fn set_pump_callback(f: Option<extern "C" fn()>) {
+    metamodelica::cancel::set_pump_callback(f);
 }
 
 /// `simulate` against the builtin graph only; empty/non-positive args use its defaults.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -51,6 +51,12 @@ pub fn eval(command: ArcStr) -> Result<(bool, ArcStr)> {
     Main::handleCommand(command)
 }
 
+/// Request cancellation of a running in-process wasm-jit simulation (cross-thread;
+/// `simulate` then returns a "cancelled" error, leaving omc consistent).
+pub fn request_cancel() {
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::request_cancel();
+}
+
 /// `simulate` against the builtin graph only; empty/non-positive args use its defaults.
 pub fn simulate(
     class_name: ArcStr,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -821,6 +821,190 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
 }
 
 // ===========================================================================
+// Resumable / cancellable simulation session
+// ===========================================================================
+//
+// `runSimulation` runs a prepared model in one blocking call. For cooperative
+// cancellation the run is split into a persistent session: `sim_start` builds the
+// engine + driver (init + row 0), `sim_advance(budget_ms)` integrates a time-bounded
+// chunk and returns, `sim_free` drops it. A run short enough to finish in one
+// `advance` never yields. See HANDOFF-sim-cancel.md.
+
+/// Status of a resumable simulation session.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SimStatus {
+    /// More rows remain; call `sim_advance` again.
+    Running,
+    /// Reached `stopTime`; results captured, `.mat` written, session freed.
+    Done,
+    /// `terminate()` ended it early; results captured, session freed.
+    Terminated,
+    /// Cancelled; externals freed, session dropped, no results captured.
+    Cancelled,
+}
+
+/// Request cancellation of the running simulation (native, cross-thread).
+#[cfg(feature = "jit")]
+pub fn request_cancel() {
+    sim_driver::request_cancel();
+}
+#[cfg(not(feature = "jit"))]
+pub fn request_cancel() {}
+
+/// Install the wasm wall-clock (`performance.now`) for the chunk budget; wasm-only.
+#[cfg(all(feature = "jit", target_arch = "wasm32"))]
+pub fn set_clock(f: fn() -> f64) {
+    sim_driver::set_clock(f);
+}
+
+/// Install a host cancel poll (a cross-thread `SharedArrayBuffer` flag read) so a
+/// blocking wasm `simulate()` can be cancelled from another thread — OMEdit-wasm.
+#[cfg(all(feature = "jit", target_arch = "wasm32"))]
+pub fn set_cancel_poll(f: fn() -> bool) {
+    sim_driver::set_cancel_poll(f);
+}
+
+#[cfg(feature = "jit")]
+mod session {
+    use super::*;
+
+    /// A resumable, cancellable simulation. Owns the JIT engine + driver across
+    /// `advance` calls. One per thread (omc is single-threaded per process).
+    pub(super) struct SimSession {
+        model: Arc<SimModel>,
+        engine: Box<dyn sim_driver::SimEngine + 'static>,
+        driver: Box<dyn sim_driver::Driver>,
+        sim_data: u32,
+        result_file: String,
+    }
+
+    thread_local! {
+        static SIM_SESSION: std::cell::RefCell<Option<SimSession>> = const { std::cell::RefCell::new(None) };
+    }
+
+    /// Start a resumable run of a model already prepared by `buildModel`
+    /// (`translateModel` + `finishCompile`). Mirrors `run_simulation_inner`'s setup
+    /// but stops before integrating. One session at a time — any prior one is freed.
+    pub fn sim_start(prefix: &str, result_file: &str, simflags: &str) -> Result<()> {
+        sim_free();
+        let model = sim_models()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(prefix)
+            .cloned()
+            .ok_or_else(|| anyhow!("no prepared wasm-jit model for `{prefix}` (translateModel not run?)"))?;
+        let fmt = model.output_format.as_str();
+        if fmt != "mat" && fmt != "empty" {
+            bail!("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
+        }
+        sim_driver::set_param_overrides(resolve_overrides(&model, simflags));
+        sim_driver::clear_cancel();
+        openmodelica_wasi::wasi::start_stdout_capture();
+        // Build engine + driver (instantiate, init, emit row 0). An init trap is
+        // usually a failed `assert()`; route it to the Error buffer.
+        let built = (|| -> Result<(Box<dyn sim_driver::SimEngine + 'static>, u32, Box<dyn sim_driver::Driver>)> {
+            let (mut engine, sim_data) = sim_runtime::build_engine(&model)?;
+            let (driver, _label) = sim_driver::make_driver(&mut *engine, &model, sim_data, model.method.as_str())
+                .map_err(|err| sim_driver::enrich_trap(&mut *engine, err))?;
+            Ok((engine, sim_data, driver))
+        })();
+        let (engine, sim_data, driver) = match built {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                record_error(format!("wasm-jit simulation failed: {e:#}"));
+                return Err(e);
+            }
+        };
+        SIM_SESSION.with(|s| {
+            *s.borrow_mut() = Some(SimSession { model, engine, driver, sim_data, result_file: result_file.to_string() })
+        });
+        Ok(())
+    }
+
+    /// Integrate for about `budget_ms` of wall-clock, then return. On completion
+    /// finalizes exactly as `run_simulation_inner` (capture results for the
+    /// `omc_sim_*` getters + write the `.mat`) and frees the session.
+    pub fn sim_advance(budget_ms: f64) -> Result<SimStatus> {
+        SIM_SESSION.with(|s| {
+            let mut guard = s.borrow_mut();
+            let Some(sess) = guard.as_mut() else {
+                bail!("no active simulation session");
+            };
+            let adv = sess
+                .driver
+                .advance(&mut *sess.engine, &sess.model, budget_ms)
+                .map_err(|err| sim_driver::enrich_trap(&mut *sess.engine, err));
+            let adv = match adv {
+                Ok(a) => a,
+                Err(e) => {
+                    let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                    record_error(format!("wasm-jit simulation failed: {e:#}"));
+                    *guard = None;
+                    return Err(e);
+                }
+            };
+            match adv {
+                sim_driver::Advance::Running => Ok(SimStatus::Running),
+                sim_driver::Advance::Cancelled => {
+                    // Free external objects so the cancelled run leaks nothing.
+                    let _ = sim_driver::finalize_run(&mut *sess.engine, &sess.model, sess.sim_data);
+                    let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                    *guard = None;
+                    Ok(SimStatus::Cancelled)
+                }
+                done => {
+                    let rows = sess.driver.take_rows();
+                    let params = sim_driver::finalize_run(&mut *sess.engine, &sess.model, sess.sim_data)?;
+                    let run = sim_driver::RunResult {
+                        rows,
+                        n_reals: sess.model.layout.n_row_total(),
+                        params,
+                        stats: SolveStats::default(),
+                    };
+                    capture_last_sim(&sess.model, &run);
+                    if sess.model.output_format == "mat" {
+                        write_mat4(&sess.model, &sess.result_file, &run.rows, run.n_reals, &run.params)?;
+                    }
+                    let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                    let st = if matches!(done, sim_driver::Advance::Terminated) {
+                        SimStatus::Terminated
+                    } else {
+                        SimStatus::Done
+                    };
+                    *guard = None;
+                    Ok(st)
+                }
+            }
+        })
+    }
+
+    /// Drop the active session, freeing its external objects. Safe to call with no
+    /// session (the cancel path and `sim_start`'s reset both use it).
+    pub fn sim_free() {
+        SIM_SESSION.with(|s| {
+            if let Some(mut sess) = s.borrow_mut().take() {
+                let _ = sim_driver::finalize_run(&mut *sess.engine, &sess.model, sess.sim_data);
+            }
+        });
+    }
+}
+
+#[cfg(feature = "jit")]
+pub use session::{sim_advance, sim_free, sim_start};
+
+#[cfg(not(feature = "jit"))]
+pub fn sim_start(_prefix: &str, _result_file: &str, _simflags: &str) -> Result<()> {
+    anyhow::bail!("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
+}
+#[cfg(not(feature = "jit"))]
+pub fn sim_advance(_budget_ms: f64) -> Result<SimStatus> {
+    anyhow::bail!("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
+}
+#[cfg(not(feature = "jit"))]
+pub fn sim_free() {}
+
+// ===========================================================================
 // Standalone WASI command-module export (native only)
 // ===========================================================================
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -211,7 +211,7 @@ fn read_rt_string(e: &dyn SimEngine, handle: i32) -> Result<String> {
 /// one is pending, route it to the error buffer (matching the C target's
 /// `[file:l:c] Error: <msg>`, and so OMEdit shows it) and return the enriched
 /// error; otherwise return the original trap error.
-fn enrich_trap(e: &mut dyn SimEngine, err: anyhow::Error) -> anyhow::Error {
+pub(super) fn enrich_trap(e: &mut dyn SimEngine, err: anyhow::Error) -> anyhow::Error {
     let Some(pa) = e.take_pending_assert() else { return err };
     let msg = read_rt_string(e, pa[0]).unwrap_or_default();
     let file = read_rt_string(e, pa[1]).unwrap_or_default();
@@ -244,6 +244,91 @@ pub(super) struct RunResult {
     pub(super) params: Vec<f64>,
     /// Solver statistics (steps, evaluations, events).
     pub(super) stats: SolveStats,
+}
+
+/// Outcome of one [`Driver::advance`] chunk.
+pub(super) enum Advance {
+    /// More rows remain; call again to continue where it left off.
+    Running,
+    Done,
+    /// `terminate()` fired; the rows so far are the result.
+    Terminated,
+    Cancelled,
+}
+
+/// A resumable simulation driver. All cross-row state (DASKR work arrays, `y`/`yp`,
+/// pivots, row index) lives in the driver, so an `advance` resumes the exact same
+/// continuation — `.mat` output is identical to running the whole loop at once.
+pub(super) trait Driver {
+    /// Advance until `budget_ms` of wall-clock elapses (checked before each DASKR
+    /// call and each output row, so a stuck/stiff interval yields too) or the run
+    /// finishes; `+inf` runs to completion. `e` is `'static` because the DASSL
+    /// residual callback stashes a raw pointer to it in a thread-local.
+    fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance>;
+    fn take_rows(&mut self) -> Vec<f64>;
+    fn fill_stats(&mut self, model: &SimModel, stats: &mut SolveStats);
+}
+
+// Wall-clock (ms) for the chunk budget. wasm has no `Instant`, so the host injects
+// a `performance.now` clock via `set_clock`; unset reads 0 (any finite deadline
+// then fires at once — safe, chatty).
+#[cfg(not(target_arch = "wasm32"))]
+fn now_ms() -> f64 {
+    use std::time::Instant;
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_secs_f64() * 1000.0
+}
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static CLOCK: std::cell::Cell<Option<fn() -> f64>> = const { std::cell::Cell::new(None) };
+}
+#[cfg(target_arch = "wasm32")]
+pub fn set_clock(f: fn() -> f64) {
+    CLOCK.with(|c| c.set(Some(f)));
+}
+#[cfg(target_arch = "wasm32")]
+fn now_ms() -> f64 {
+    CLOCK.with(|c| c.get()).map(|f| f()).unwrap_or(0.0)
+}
+
+/// `+inf` (one-shot) keeps `now_ms` off the hot path via `is_finite` short-circuit.
+fn deadline_from(budget_ms: f64) -> f64 {
+    if budget_ms.is_finite() { now_ms() + budget_ms } else { f64::INFINITY }
+}
+fn past_deadline(deadline: f64) -> bool {
+    deadline.is_finite() && now_ms() >= deadline
+}
+
+static CANCEL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Request cancellation of the running simulation (native, cross-thread).
+pub fn request_cancel() {
+    CANCEL.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+/// Clear the cancel flag; called at the start of each new run.
+pub fn clear_cancel() {
+    CANCEL.store(false, std::sync::atomic::Ordering::Relaxed);
+}
+
+// wasm: the blocked worker can't get a cancel message, so a cross-origin-isolated
+// host (OMEdit-wasm) polls a `SharedArrayBuffer` flag through an injected fn ptr.
+// Unset for hosts that cancel another way (the simulator frees its session).
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static CANCEL_POLL: std::cell::Cell<Option<fn() -> bool>> = const { std::cell::Cell::new(None) };
+}
+#[cfg(target_arch = "wasm32")]
+pub fn set_cancel_poll(f: fn() -> bool) {
+    CANCEL_POLL.with(|c| c.set(Some(f)));
+}
+
+fn cancel_requested() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    if CANCEL_POLL.with(|c| c.get()).map(|f| f()).unwrap_or(false) {
+        return true;
+    }
+    CANCEL.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Read one little-endian i32 from linear memory at byte address `addr`.
@@ -377,6 +462,31 @@ fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &S
 /// True if `terminate()` raised the `SimData` flag during the last step.
 fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bool> {
     Ok(read_i32(e, sim_data + layout.terminate_off)? != 0)
+}
+
+/// Emit one result row from SimData at `time`, recomputing `functionODE`/
+/// `functionAlgebraics` first so the reported derivatives/algebraics are consistent.
+/// The integrator has accepted the state, so a non-converging NLS here is a genuine
+/// failure; `nls_fail` is cleared first so `check_nls` sees only this point's solve.
+fn emit_row(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout, time: f64) -> Result<()> {
+    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+    write_f64(e, sim_data + TIME_OFF, time)?;
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)?;
+    check_nls(e, sim_data, layout)?;
+    capture_row(e, rows, sim_data, layout)
+}
+
+/// Pre-event snapshot row (state just before a discrete update). Skips
+/// `functionAlgebraics` for `has_when` models — there it saves `pre` early, which
+/// would break the post-event edge test.
+fn capture_pre(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout, time: f64) -> Result<()> {
+    write_f64(e, sim_data + TIME_OFF, time)?;
+    e.call1("functionODE", sim_data)?;
+    if !layout.has_when {
+        e.call1("functionAlgebraics", sim_data)?;
+    }
+    capture_row(e, rows, sim_data, layout)
 }
 
 /// Copy the live real-variable region (states | derivatives | real algebraics) to
@@ -528,64 +638,35 @@ impl Samples {
     }
 }
 
-/// Select the integrator and run it, then free external objects and read back the
-/// parameter values. `method` is the model's `experiment` integration method
-/// (empty = the DASSL default); `host_driven` forces the native Euler loop over
-/// the in-wasm one when `method="euler"` (for debugging / no-`simulate` builds).
-pub(super) fn drive(
+/// Build the resumable driver (init + row 0 + the zero-crossing band); shared by
+/// [`drive`] and the session. `method` empty = DASSL. Any events force the
+/// event-aware DASSL driver regardless of `method`.
+pub(super) fn make_driver(
     e: &mut (dyn SimEngine + 'static),
     model: &SimModel,
     sim_data: u32,
     method: &str,
-    host_driven: bool,
-    bench: bool,
-) -> Result<(RunResult, &'static str)> {
+) -> Result<(Box<dyn Driver>, &'static str)> {
     let layout = &model.layout;
-    let n_reals = layout.n_row_total();
-    let n_rows = model.n_intervals + 1;
-    let start = model.start_time;
-    let stop = model.stop_time;
-
-    // Zero-crossing hysteresis band, from the same tolerance fed to DASSL below.
+    // Zero-crossing hysteresis band, from the same tolerance fed to DASSL.
     let rtol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
     write_f64(e, sim_data + layout.zctol_off, 1e-4 * rtol.max(1e-12))?;
 
-    // Time events (`sample`) and state events (zero-crossings) both need the
-    // host-side event loop, which drives DASSL between events (clamping to sample
-    // times, root-finding for crossings); the in-wasm Euler `simulate` can do
-    // neither. So any model with events uses the event-aware DASSL driver
-    // regardless of the requested method (Euler-with-events falls back to DASSL).
-    let mut stats = SolveStats::default();
-    let (driver_result, label) = if layout.n_samples > 0 || layout.n_zc > 0 {
-        (run_dassl_events(e, model, sim_data, n_reals, n_rows, start, stop, bench, &mut stats), "dassl-events")
-    } else {
-        match method {
-            "dassl" | "dasslrt" | "ida" | "" => {
-                (run_dassl(e, model, sim_data, n_reals, n_rows, start, stop, bench, &mut stats), "dassl")
-            }
-            "euler" => {
-                if host_driven {
-                    (run_host(e, model, sim_data, n_reals, n_rows, start, stop, &mut stats), "euler-host")
-                } else {
-                    (run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats), "euler-wasm")
-                }
-            }
-            other => bail!(
-                "CodegenWasmJit: unsupported integration method `{other}` (supported: `dassl`, `euler`)"
-            ),
-        }
-    };
-    // A trap during integration is usually a failed model `assert()`; surface its
-    // message rather than a bare `unreachable` trap.
-    let rows = driver_result.map_err(|err| enrich_trap(e, err))?;
-    stats.method = label;
+    if layout.n_samples > 0 || layout.n_zc > 0 {
+        return Ok((Box::new(DasslEventsDriver::new(e, model, sim_data)?), "dassl-events"));
+    }
+    match method {
+        "dassl" | "dasslrt" | "ida" | "" => Ok((Box::new(DasslDriver::new(e, model, sim_data)?), "dassl")),
+        // Uniform host-driven Euler so it is resumable/cancellable like DASSL.
+        "euler" => Ok((Box::new(EulerDriver::new(e, model, sim_data)?), "euler-host")),
+        other => bail!("CodegenWasmJit: unsupported integration method `{other}` (supported: `dassl`, `euler`)"),
+    }
+}
 
-    // Free external objects (tables, etc.) constructed at init by calling each
-    // destructor in reverse order, so repeated simulations in one process (e.g.
-    // OMEdit) don't leak the native objects. Absent when the model has none.
+/// Free external objects (so repeated runs don't leak) and read back parameter
+/// values (result `Param` order) after a run.
+pub(super) fn finalize_run(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Result<Vec<f64>> {
     e.call1_if_present("callExternalObjectDestructors", sim_data)?;
-
-    // Read parameter values from SimData (result `Param` order).
     let mut params = Vec::new();
     for v in &model.result_vars {
         if let ResultKind::Param { off, wty, .. } = &v.kind {
@@ -596,7 +677,64 @@ pub(super) fn drive(
             params.push(val);
         }
     }
+    Ok(params)
+}
 
+/// Select the integrator and run it to completion, then finalize — the
+/// non-resumable one-shot path (native CLI and any caller that does not need
+/// cancellation). `host_driven` forces the resumable host Euler over the fast
+/// in-wasm one for `method="euler"`.
+pub(super) fn drive(
+    e: &mut (dyn SimEngine + 'static),
+    model: &SimModel,
+    sim_data: u32,
+    method: &str,
+    host_driven: bool,
+    bench: bool,
+) -> Result<(RunResult, &'static str)> {
+    clear_cancel(); // fresh run: discard any stale cancel request
+    let layout = &model.layout;
+    let n_reals = layout.n_row_total();
+    let n_rows = model.n_intervals + 1;
+    let start = model.start_time;
+    let stop = model.stop_time;
+
+    let mut stats = SolveStats::default();
+    let use_events = layout.n_samples > 0 || layout.n_zc > 0;
+
+    let (rows, label) = if !use_events && method == "euler" && !host_driven {
+        // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
+        let rtol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+        write_f64(e, sim_data + layout.zctol_off, 1e-4 * rtol.max(1e-12))?;
+        let rows = run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)
+            .map_err(|err| enrich_trap(e, err))?;
+        (rows, "euler-wasm")
+    } else {
+        // enrich_trap: a trap in init/integration is usually a failed model assert().
+        let (mut driver, label) = make_driver(e, model, sim_data, method).map_err(|err| enrich_trap(e, err))?;
+        // Infinite budget runs to completion; the per-step cancel poll still lets a
+        // native embedder interrupt. `OMC_WASM_SIM_YIELD_MS` forces a finite budget to
+        // self-test yield/resume (must be `.mat`-identical to the un-yielded run).
+        let budget_ms = std::env::var("OMC_WASM_SIM_YIELD_MS")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(f64::INFINITY);
+        loop {
+            match driver.advance(e, model, budget_ms).map_err(|err| enrich_trap(e, err))? {
+                Advance::Done | Advance::Terminated => break,
+                Advance::Cancelled => bail!("CodegenWasmJit: simulation cancelled"),
+                Advance::Running => continue,
+            }
+        }
+        driver.fill_stats(model, &mut stats);
+        (driver.take_rows(), label)
+    };
+    stats.method = label;
+    if bench {
+        eprintln!("wasm-jit sim [{label}]: {} steps, {} residual evals", stats.steps, stats.res_evals);
+    }
+
+    let params = finalize_run(e, model, sim_data)?;
     Ok((RunResult { rows, n_reals, params, stats }, label))
 }
 
@@ -623,59 +761,96 @@ fn run_wasm(
     Ok(bytes.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect())
 }
 
-/// Host-driven driver: the forward-Euler loop in native Rust.
-fn run_host(
-    e: &mut dyn SimEngine,
-    model: &SimModel,
+/// Host-driven forward-Euler driver (resumable). Emits output rows `0..=n_steps`
+/// on the equidistant grid, one Euler update between rows.
+struct EulerDriver {
     sim_data: u32,
-    n_reals: u32,
-    n_rows: u32,
-    start: f64,
-    stop: f64,
-    stats: &mut SolveStats,
-) -> Result<Vec<f64>> {
-    let layout = &model.layout;
-    stats.steps = (n_rows - 1) as u64;
-    // Init (with homotopy fallback). No state events on this path, so relations
-    // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
-    // them internally around its Newton solve.
-    run_initialization(e, sim_data, layout)?;
+    /// Next output row to produce (0-based).
+    row: u32,
+    pivots: Vec<StateSetPivot>,
+    rows: Vec<f64>,
+}
 
-    let n_states = layout.n_states;
-    let n_steps = n_rows - 1;
-    let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
-    let states_base = sim_data + REAL_OFF;
-    let ders_base = states_base + n_states * 8;
-    let mut pivots = init_state_pivots(&model.state_sets);
-
-    let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-    for row in 0..n_rows {
-        let time = start + row as f64 * h;
-        write_f64(e, sim_data + TIME_OFF, time)?;
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
-        check_nls(e, sim_data, layout)?; // Euler cannot back off — non-convergence is fatal
-        capture_row(e, &mut rows, sim_data, layout)?;
-        // terminate() fired in functionAlgebraics: keep this row, stop the run.
-        if terminated(e, sim_data, layout)? {
-            break;
-        }
-        if row == n_steps {
-            break;
-        }
-        // Re-select states before the Euler update; a switch reinits the states,
-        // so refresh the derivatives it uses (see `run_dassl`).
-        if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
-            e.call1("functionODE", sim_data)?;
-        }
-        // Forward-Euler update of the states.
-        for i in 0..n_states {
-            let s = read_f64(e, states_base + i * 8)?;
-            let d = read_f64(e, ders_base + i * 8)?;
-            write_f64(e, states_base + i * 8, s + h * d)?;
-        }
+impl EulerDriver {
+    fn new(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Result<Self> {
+        // Init (with homotopy fallback). No state events on this path, so relations
+        // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
+        // them internally around its Newton solve.
+        run_initialization(e, sim_data, &model.layout)?;
+        let n_rows = model.n_intervals + 1;
+        let n_reals = model.layout.n_row_total();
+        Ok(EulerDriver {
+            sim_data,
+            row: 0,
+            pivots: init_state_pivots(&model.state_sets),
+            rows: Vec::with_capacity((n_rows * n_reals) as usize),
+        })
     }
-    Ok(rows)
+}
+
+impl Driver for EulerDriver {
+    fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance> {
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        let n_states = layout.n_states;
+        let n_rows = model.n_intervals + 1;
+        let n_steps = n_rows - 1;
+        let start = model.start_time;
+        let stop = model.stop_time;
+        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let states_base = sim_data + REAL_OFF;
+        let ders_base = states_base + n_states * 8;
+
+        let deadline = deadline_from(budget_ms);
+        let mut did_step = false;
+        while self.row < n_rows {
+            if did_step && past_deadline(deadline) {
+                return Ok(Advance::Running);
+            }
+            if cancel_requested() {
+                return Ok(Advance::Cancelled);
+            }
+            did_step = true;
+            let time = start + self.row as f64 * h;
+            write_f64(e, sim_data + TIME_OFF, time)?;
+            e.call1("functionODE", sim_data)?;
+            e.call1("functionAlgebraics", sim_data)?;
+            check_nls(e, sim_data, layout)?; // Euler cannot back off — non-convergence is fatal
+            capture_row(e, &mut self.rows, sim_data, layout)?;
+            // terminate() fired in functionAlgebraics: keep this row, stop the run.
+            if terminated(e, sim_data, layout)? {
+                self.row = n_rows;
+                return Ok(Advance::Terminated);
+            }
+            if self.row == n_steps {
+                self.row = n_rows;
+                return Ok(Advance::Done);
+            }
+            // Re-select states before the Euler update; a switch reinits the states,
+            // so refresh the derivatives it uses (see `DasslDriver`).
+            if !model.state_sets.is_empty()
+                && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)?
+            {
+                e.call1("functionODE", sim_data)?;
+            }
+            // Forward-Euler update of the states.
+            for i in 0..n_states {
+                let s = read_f64(e, states_base + i * 8)?;
+                let d = read_f64(e, ders_base + i * 8)?;
+                write_f64(e, states_base + i * 8, s + h * d)?;
+            }
+            self.row += 1;
+        }
+        Ok(Advance::Done)
+    }
+
+    fn take_rows(&mut self) -> Vec<f64> {
+        std::mem::take(&mut self.rows)
+    }
+
+    fn fill_stats(&mut self, model: &SimModel, stats: &mut SolveStats) {
+        stats.steps = model.n_intervals as u64;
+    }
 }
 
 // ===========================================================================
@@ -823,228 +998,278 @@ unsafe fn dassl_res(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn run_dassl(
-    e: &mut (dyn SimEngine + 'static),
-    model: &SimModel,
+/// Resumable DASSL (daskr) driver, event-free path. Owns the DASKR work arrays
+/// and `y`/`yp` across chunks so an `advance` resumes the exact same
+/// continuation — the trajectory is identical to running the whole loop at once.
+struct DasslDriver {
     sim_data: u32,
-    n_reals: u32,
-    n_rows: u32,
-    start: f64,
-    stop: f64,
-    bench: bool,
-    stats: &mut SolveStats,
-) -> Result<Vec<f64>> {
-    use daskr::solver;
+    n_states: usize,
+    states_base: u32,
+    ders_base: u32,
+    /// Next output row to produce (row 0 was emitted in `new`).
+    row: u32,
+    y: Vec<f64>,
+    yp: Vec<f64>,
+    info: [i32; 24],
+    rtol: [f64; 1],
+    atol: [f64; 1],
+    rwork: Vec<f64>,
+    iwork: Vec<i32>,
+    rpar: [f64; 1],
+    ipar: [i32; 1],
+    jroot: [i32; 1],
+    idid: i32,
+    t: f64,
+    /// `RES` (functionODE) eval count, accumulated across chunks.
+    nfe: u64,
+    pivots: Vec<StateSetPivot>,
+    rows: Vec<f64>,
+    /// Target of an interval left in progress at a mid-solve yield; `None` at a
+    /// row boundary. Resumed on the next `advance`.
+    pending_tout: Option<f64>,
+    /// DASKR continuations spent on the in-progress interval (persisted so the
+    /// runaway cap bounds one interval across yields).
+    work_retries: i32,
+    /// `terminate()` fired at the initial point; the first `advance` reports it.
+    pending_terminate: bool,
+    finished: bool,
+}
 
-    // Silence DASKR's own diagnostic printing (it would go to stdout and corrupt
-    // the omc result record); failures are surfaced here via IDID instead.
-    daskr::auxiliary::xsetf(0);
+impl DasslDriver {
+    fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
+        // Silence DASKR's own diagnostic printing (it would go to stdout and corrupt
+        // the omc result record); failures are surfaced here via IDID instead.
+        daskr::auxiliary::xsetf(0);
+        let layout = &model.layout;
+        // Init (with homotopy fallback). No state events on this path, so relations
+        // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
+        run_initialization(e, sim_data, layout)?;
 
-    let layout = &model.layout;
-    // Init (with homotopy fallback). No state events on this path, so relations
-    // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
-    run_initialization(e, sim_data, layout)?;
+        let n_states = layout.n_states as usize;
+        let states_base = sim_data + REAL_OFF;
+        let ders_base = states_base + layout.n_states * 8;
+        let n_rows = model.n_intervals + 1;
+        let n_reals = layout.n_row_total();
+        let start = model.start_time;
 
-    let n_states = layout.n_states as usize;
-    let states_base = sim_data + REAL_OFF;
-    let ders_base = states_base + layout.n_states * 8;
-    let n_steps = n_rows - 1;
-    let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
+        // Row 0 at the start time.
+        emit_row(e, &mut rows, sim_data, layout, start)?;
+        let pending_terminate = terminated(e, sim_data, layout)?; // terminate() at the initial point
 
-    // Emit one result row (`[time, realVars…]`) from the current SimData, after
-    // setting `time` and recomputing `functionODE`/`functionAlgebraics` so the
-    // reported derivatives and algebraics are consistent with the states. At an
-    // output point DASSL has already accepted the state, so a non-converging NLS
-    // here is a genuine failure (not a step-size issue).
-    let emit_row = |e: &mut dyn SimEngine, rows: &mut Vec<f64>, time: f64| -> Result<()> {
-        // Clear the recoverable-NLS flag so `check_nls` reflects only this point's
-        // solve, not a transient failure leaked from an earlier `functionODE`
-        // (e.g. a DASKR root-finding probe at an awkward candidate state).
-        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
-        write_f64(e, sim_data + TIME_OFF, time)?;
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
-        check_nls(e, sim_data, layout)?;
-        capture_row(e, rows, sim_data, layout)
-    };
-
-    let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-    // Row 0 at the start time.
-    emit_row(e, &mut rows, start)?;
-    if terminated(e, sim_data, layout)? {
-        return Ok(rows); // terminate() at the initial point
-    }
-
-    // No states: nothing to integrate — just evaluate outputs on the grid.
-    if n_states == 0 {
-        for row in 1..n_rows {
-            let time = if row == n_steps { stop } else { start + row as f64 * h };
-            emit_row(e, &mut rows, time)?;
-            if terminated(e, sim_data, layout)? {
-                break;
+        // Dynamic state selection: seed the identity pivots (matching the wasm-side
+        // `A[n,n]=1`), then re-pivot once at the initial point on the resolved states
+        // — C re-selects immediately after initialisation. A switch reinits the state
+        // variables from their candidates, so refresh the derivatives before reading
+        // the initial `y`/`yp`. For an explicit ODE the consistent initial derivative
+        // is exactly f(t0, y0), which `functionODE` (already called by `emit_row`) has
+        // written into the derivative slots — so INFO(11)=0.
+        let mut pivots = init_state_pivots(&model.state_sets);
+        let (mut y, mut yp) = (Vec::new(), Vec::new());
+        if n_states > 0 && !pending_terminate {
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+                e.call1("functionODE", sim_data)?;
             }
+            y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;
+            yp = (0..n_states).map(|i| read_f64(e, ders_base + (i as u32) * 8)).collect::<Result<_>>()?;
         }
-        return Ok(rows);
+
+        // --- DASKR work arrays / options (dense, numerical Jacobian). ---
+        let neq = n_states as i32;
+        let nrt = 0i32;
+        let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+        let lrw = (60 + 9 * neq + neq * neq + 3 * nrt + 64) as usize;
+        let liw = (40 + neq + 64) as usize;
+        Ok(DasslDriver {
+            sim_data,
+            n_states,
+            states_base,
+            ders_base,
+            row: 1,
+            y,
+            yp,
+            // all defaults: dense direct method, numerical Jac, scalar tolerances,
+            // interpolating output, no IC calc.
+            info: [0i32; 24],
+            rtol: [tol],
+            atol: [tol],
+            rwork: vec![0.0f64; lrw],
+            iwork: vec![0i32; liw],
+            rpar: [0.0f64],
+            ipar: [0i32],
+            jroot: [0i32],
+            idid: 0,
+            t: start,
+            nfe: 0,
+            pivots,
+            rows,
+            pending_tout: None,
+            work_retries: 0,
+            pending_terminate,
+            finished: false,
+        })
     }
+}
 
-    // Dynamic state selection: seed the identity pivots (matching the wasm-side
-    // `A[n,n]=1`), then re-pivot once at the initial point on the resolved states
-    // — C re-selects immediately after initialisation. A switch reinits the state
-    // variables from their candidates, so refresh the derivatives before reading
-    // the initial `y`/`yp`.
-    let mut pivots = init_state_pivots(&model.state_sets);
-    if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
-        e.call1("functionODE", sim_data)?;
-    }
+impl Driver for DasslDriver {
+    fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance> {
+        use daskr::solver;
+        if self.finished {
+            return Ok(Advance::Done);
+        }
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        if self.pending_terminate {
+            self.pending_terminate = false;
+            self.finished = true;
+            return Ok(Advance::Terminated);
+        }
+        let n_rows = model.n_intervals + 1;
+        let n_steps = n_rows - 1;
+        let start = model.start_time;
+        let stop = model.stop_time;
+        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let deadline = deadline_from(budget_ms);
 
-    // Initial y, y' from SimData. For an explicit ODE the consistent initial
-    // derivative is exactly f(t0, y0), which `functionODE` (already called by
-    // `emit_row`) has written into the derivative slots — so INFO(11)=0.
-    let mut y: Vec<f64> = (0..n_states)
-        .map(|i| read_f64(e, states_base + (i as u32) * 8))
-        .collect::<Result<_>>()?;
-    let mut yp: Vec<f64> = (0..n_states)
-        .map(|i| read_f64(e, ders_base + (i as u32) * 8))
-        .collect::<Result<_>>()?;
+        // No states: nothing to integrate — just evaluate outputs on the grid.
+        if self.n_states == 0 {
+            let mut did_step = false;
+            while self.row < n_rows {
+                if did_step && past_deadline(deadline) {
+                    return Ok(Advance::Running);
+                }
+                if cancel_requested() {
+                    return Ok(Advance::Cancelled);
+                }
+                did_step = true;
+                let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                emit_row(e, &mut self.rows, sim_data, layout, time)?;
+                if terminated(e, sim_data, layout)? {
+                    self.finished = true;
+                    return Ok(Advance::Terminated);
+                }
+                self.row += 1;
+            }
+            self.finished = true;
+            return Ok(Advance::Done);
+        }
 
-    // --- DASKR work arrays / options (dense, numerical Jacobian). ---
-    let neq = n_states as i32;
-    let nrt = 0i32;
-    let mut info = [0i32; 24]; // all defaults: dense direct method, numerical Jac,
-                               // scalar tolerances, interpolating output, no IC calc.
-    let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
-    let mut rtol = [tol];
-    let mut atol = [tol];
-    let lrw = (60 + 9 * neq + neq * neq + 3 * nrt + 64) as usize;
-    let liw = (40 + neq + 64) as usize;
-    let mut rwork = vec![0.0f64; lrw];
-    let mut iwork = vec![0i32; liw];
-    let mut rpar = [0.0f64];
-    let mut ipar = [0i32];
-    let mut jroot = [0i32];
-    let mut idid = 0i32;
-    let mut t = start;
+        let n_states = self.n_states;
+        let states_base = self.states_base;
+        let ders_base = self.ders_base;
+        let neq = n_states as i32;
+        let nrt = 0i32;
+        let lrw = self.rwork.len();
+        let liw = self.iwork.len();
 
-    // Install the wasm context for the residual callback. `engine` is a raw
-    // pointer to `*e`, live only across the `ddaskr` calls below (`e` is not used
-    // directly meanwhile); the guard clears the thread-local on any exit.
-    let engine: *mut dyn SimEngine = &mut *e;
-    let mut ctx = ResCtx {
-        engine,
-        sim_data,
-        states_base,
-        ders_base,
-        n_states,
-        nls_fail_off: layout.nls_fail_off,
-        nfe: 0,
-        zc_off: 0,
-        n_zc: 0,
-        err: None,
-    };
-    let _guard = ResCtxGuard;
-    RES_CTX.with(|c| c.set(&mut ctx as *mut ResCtx));
+        // Install the residual context for the duration of this chunk. `engine` is a
+        // raw pointer to `*e`, live only across the `ddaskr` calls below (`e` is not
+        // used directly meanwhile); the guard clears the thread-local on any exit.
+        // `nfe` carries over between chunks.
+        let mut ctx = ResCtx {
+            engine: &mut *e as *mut dyn SimEngine,
+            sim_data,
+            states_base,
+            ders_base,
+            n_states,
+            nls_fail_off: layout.nls_fail_off,
+            nfe: self.nfe,
+            zc_off: 0,
+            n_zc: 0,
+            err: None,
+        };
+        let _guard = ResCtxGuard;
+        RES_CTX.with(|c| c.set(&mut ctx as *mut ResCtx));
 
-    for row in 1..n_rows {
-        let mut tout = if row == n_steps { stop } else { start + row as f64 * h };
-        // DASKR integrates past TOUT and interpolates back to T = TOUT
-        // (INFO(3)=0), updating t, y, yp in place. INFO(1) stays 0 across
-        // continuation calls (DASKR tracks state in rwork/iwork).
-        // IDID = -1 means DASKR expended its per-call work quota (~500 internal
-        // steps) before reaching TOUT — recoverable by calling again to resume
-        // (t/y/yp are updated in place). A stiff interval that needs many steps
-        // (fullRobot's controllers/mechanics) hits this repeatedly, so continue up
-        // to a generous cap before declaring a runaway.
-        let mut work_retries = 0;
-        loop {
+        // Yield when the budget is spent, checked before each `ddaskr` call (so a
+        // stuck interval spinning the work-quota loop yields too). `did_step` forces
+        // ≥1 solver call per advance, so any budget (even 0) makes progress.
+        let mut did_step = false;
+        let outcome = loop {
+            if self.row >= n_rows {
+                break Advance::Done;
+            }
+            if did_step && past_deadline(deadline) {
+                break Advance::Running;
+            }
+            if cancel_requested() {
+                break Advance::Cancelled;
+            }
+            did_step = true;
+            // IDID=-1: DASKR hit its per-call work quota before TOUT — resume with
+            // INFO(1)=1 (a stiff interval hits this repeatedly), up to a cap.
+            // `pending_tout`/`work_retries` persist an interval unfinished at a yield.
+            let mut tout =
+                self.pending_tout.unwrap_or(if self.row == n_steps { stop } else { start + self.row as f64 * h });
             unsafe {
                 solver::ddaskr(
-                    dassl_res,
-                    neq,
-                    &mut t,
-                    y.as_mut_ptr(),
-                    yp.as_mut_ptr(),
-                    &mut tout,
-                    info.as_mut_ptr(),
-                    rtol.as_mut_ptr(),
-                    atol.as_mut_ptr(),
-                    &mut idid,
-                    rwork.as_mut_ptr(),
-                    lrw as i32,
-                    iwork.as_mut_ptr(),
-                    liw as i32,
-                    rpar.as_mut_ptr(),
-                    ipar.as_mut_ptr(),
-                    solver::dummy_jacd,
-                    solver::dummy_jack,
-                    solver::dummy_psol,
-                    solver::dummy_rt,
-                    nrt,
-                    jroot.as_mut_ptr(),
+                    dassl_res, neq, &mut self.t, self.y.as_mut_ptr(), self.yp.as_mut_ptr(),
+                    &mut tout, self.info.as_mut_ptr(), self.rtol.as_mut_ptr(), self.atol.as_mut_ptr(),
+                    &mut self.idid, self.rwork.as_mut_ptr(), lrw as i32, self.iwork.as_mut_ptr(), liw as i32,
+                    self.rpar.as_mut_ptr(), self.ipar.as_mut_ptr(), solver::dummy_jacd, solver::dummy_jack,
+                    solver::dummy_psol, solver::dummy_rt, nrt, self.jroot.as_mut_ptr(),
                 );
             }
-            if ctx.err.is_some() {
-                break;
+            self.nfe = ctx.nfe;
+            // Surface a wasm error captured in the callback, then DASSL failures.
+            if let Some(err) = ctx.err.take() {
+                return Err(err.context(format!("in DASSL residual at t={}", self.t)));
             }
-            if idid == -1 && work_retries < 10_000 {
-                // Resume the interrupted step: INFO(1)=1 is DASKR's continuation
-                // flag. It returns IDID=-1 with INFO(1) left at -1 (an internal
-                // marker); calling again without setting it to 1 reads as illegal
-                // input and trips DASKR's "apparent infinite loop" abort (which
-                // calls process::exit). Setting it to 1 continues cleanly.
-                info[0] = 1;
-                work_retries += 1;
+            if self.idid == -1 && self.work_retries < 10_000 {
+                // Work quota expended before TOUT: stay on this interval, continue.
+                self.info[0] = 1;
+                self.work_retries += 1;
+                self.pending_tout = Some(tout);
                 continue;
             }
-            break;
-        }
-        // Surface a wasm error captured in the callback, then DASSL failures.
-        if let Some(err) = ctx.err.take() {
-            return Err(err.context(format!("in DASSL residual at t={t}")));
-        }
-        if idid < 0 {
-            bail!("CodegenWasmJit: DASSL (daskr) failed at t={t} (target {tout}), IDID={idid}");
-        }
-        // t == tout now; write the interpolated state back and emit the row.
-        for i in 0..n_states {
-            write_f64(e, states_base + (i as u32) * 8, y[i])?;
-        }
-        emit_row(e, &mut rows, tout)?;
-        if terminated(e, sim_data, layout)? {
-            break; // terminate() fired: keep this row, stop integrating
-        }
-        // Re-select states at the accepted point. A switch changes the meaning of
-        // the state vector (a discontinuity), so refresh the derivatives, re-read
-        // y/yp from the reinitialised states, and restart DASKR (INFO(1)=0).
-        if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
-            e.call1("functionODE", sim_data)?;
-            for i in 0..n_states {
-                y[i] = read_f64(e, states_base + (i as u32) * 8)?;
-                yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+            if self.idid < 0 {
+                bail!("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tout}), IDID={}", self.t, self.idid);
             }
-            info[0] = 0;
+            // Interval complete: reset the resume state, write the interpolated state
+            // back, and emit the row.
+            self.pending_tout = None;
+            self.work_retries = 0;
+            for i in 0..n_states {
+                write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
+            }
+            emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+            if terminated(e, sim_data, layout)? {
+                break Advance::Terminated; // terminate() fired: keep this row, stop
+            }
+            // Re-select states at the accepted point. A switch changes the meaning of
+            // the state vector (a discontinuity), so refresh the derivatives, re-read
+            // y/yp from the reinitialised states, and restart DASKR (INFO(1)=0).
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
+                e.call1("functionODE", sim_data)?;
+                for i in 0..n_states {
+                    self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                    self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                }
+                self.info[0] = 0;
+            }
+            self.row += 1;
+        };
+        self.nfe = ctx.nfe;
+        if matches!(outcome, Advance::Done | Advance::Terminated) {
+            self.finished = true;
         }
+        Ok(outcome)
     }
 
-    // DASKR IWORK counters (1-based in the docs): IWORK(11)=NST steps,
-    // IWORK(13)=NJE Jacobian evals, IWORK(14)=NETF error-test failures,
-    // IWORK(15)=NCFN nonlinear convergence failures. functionODE calls are the
-    // host's own `RES` counter (ctx.nfe).
-    let nst = iwork.get(10).copied().unwrap_or(0);
-    let nje = iwork.get(12).copied().unwrap_or(0);
-    if bench {
-        eprintln!(
-            "wasm-jit sim [dassl] DASKR stats: {nst} steps, {} residual evals (={:.1}/step), {nje} Jacobian evals",
-            ctx.nfe,
-            ctx.nfe as f64 / (nst.max(1) as f64),
-        );
+    fn take_rows(&mut self) -> Vec<f64> {
+        std::mem::take(&mut self.rows)
     }
-    stats.steps = nst.max(0) as u64;
-    stats.res_evals = ctx.nfe;
-    stats.jac_evals = nje.max(0) as u64;
-    stats.err_test_fails = iwork.get(13).copied().unwrap_or(0).max(0) as u64;
-    stats.conv_test_fails = iwork.get(14).copied().unwrap_or(0).max(0) as u64;
-    Ok(rows)
+
+    fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
+        // DASKR IWORK counters (1-based): IWORK(11)=NST steps, IWORK(13)=NJE Jacobian
+        // evals, IWORK(14)=NETF error-test failures, IWORK(15)=NCFN convergence fails.
+        let nst = self.iwork.get(10).copied().unwrap_or(0);
+        stats.steps = nst.max(0) as u64;
+        stats.res_evals = self.nfe;
+        stats.jac_evals = self.iwork.get(12).copied().unwrap_or(0).max(0) as u64;
+        stats.err_test_fails = self.iwork.get(13).copied().unwrap_or(0).max(0) as u64;
+        stats.conv_test_fails = self.iwork.get(14).copied().unwrap_or(0).max(0) as u64;
+    }
 }
 
 // ===========================================================================
@@ -1060,311 +1285,405 @@ fn run_dassl(
 // state re-reads y and recomputes yp before restarting; state events on algebraic
 // variables that need the full discrete solve are only approximately handled.
 
-#[allow(clippy::too_many_arguments)]
-fn run_dassl_events(
-    e: &mut (dyn SimEngine + 'static),
-    model: &SimModel,
+/// Resumable DASSL driver with event handling (time + state events). Like
+/// [`DasslDriver`] but clamps integration to each `sample` time and root-finds the
+/// zero-crossings. `mid_row`/`grid_covered` persist a partial output row so a yield
+/// mid-interval (or a stuck stiff/chattering one) resumes exactly.
+struct DasslEventsDriver {
     sim_data: u32,
-    n_reals: u32,
-    n_rows: u32,
-    start: f64,
-    stop: f64,
-    bench: bool,
-    stats: &mut SolveStats,
-) -> Result<Vec<f64>> {
-    use daskr::solver;
-    daskr::auxiliary::xsetf(0);
+    n_states: usize,
+    states_base: u32,
+    ders_base: u32,
+    row: u32,
+    y: Vec<f64>,
+    yp: Vec<f64>,
+    info: [i32; 24],
+    rtol: [f64; 1],
+    atol: [f64; 1],
+    rwork: Vec<f64>,
+    iwork: Vec<i32>,
+    rpar: [f64; 1],
+    ipar: [i32; 1],
+    jroot: Vec<i32>,
+    nrt: i32,
+    idid: i32,
+    t: f64,
+    nfe: u64,
+    pivots: Vec<StateSetPivot>,
+    samp: Samples,
+    rows: Vec<f64>,
+    /// Resume state for a yield mid output row: `mid_row` (so `grid_covered` isn't
+    /// reset) and `ev_retries` (the in-progress target's continuation count).
+    mid_row: bool,
+    grid_covered: bool,
+    ev_retries: i32,
+    state_events: u64,
+    time_events: u64,
+    pending_terminate: bool,
+    finished: bool,
+}
 
-    let layout = &model.layout;
-    // Init (with homotopy fallback). Relation mode 2 (all relations fresh through
-    // the initial row, so `relations[]` is populated before the states loop starts
-    // holding it) and `initSample` are handled inside run_initialization.
-    run_initialization(e, sim_data, layout)?;
-    // Seed the hysteresis direction from the initial relations.
-    store_relations(e, sim_data, layout)?;
-
-    let n_states = layout.n_states as usize;
-    let states_base = sim_data + REAL_OFF;
-    let ders_base = states_base + layout.n_states * 8;
-    let n_steps = n_rows - 1;
-    let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
-
-    let emit_row = |e: &mut dyn SimEngine, rows: &mut Vec<f64>, time: f64| -> Result<()> {
-        // Clear the recoverable-NLS flag so `check_nls` reflects only this point's
-        // solve, not a transient failure leaked from an earlier `functionODE`
-        // (e.g. a DASKR root-finding probe at an awkward candidate state).
-        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
-        write_f64(e, sim_data + TIME_OFF, time)?;
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
-        check_nls(e, sim_data, layout)?;
-        capture_row(e, rows, sim_data, layout)
-    };
-
-    let mut samp = Samples::load(e, sim_data, layout)?;
-    let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-
-    // A sample scheduled exactly at the start time fires before row 0.
-    if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
-        samp.fire(e, sim_data, start)?;
+impl DasslEventsDriver {
+    fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
+        daskr::auxiliary::xsetf(0);
+        let layout = &model.layout;
+        // Init (with homotopy fallback). Relation mode 2 and `initSample` are handled
+        // inside run_initialization; seed the hysteresis direction from the relations.
+        run_initialization(e, sim_data, layout)?;
         store_relations(e, sim_data, layout)?;
-        stats.time_events += 1;
-    }
-    emit_row(e, &mut rows, start)?;
-    if terminated(e, sim_data, layout)? {
-        return Ok(rows);
-    }
 
-    // No continuous states: evaluate outputs on the grid, firing events between.
-    if n_states == 0 {
-        for row in 1..n_rows {
-            let tout = if row == n_steps { stop } else { start + row as f64 * h };
-            let eps = tout.abs().max(1.0) * 1e-10;
-            let mut grid_covered = false;
-            while samp.next_time() <= tout + eps {
-                let te = samp.next_time();
-                // Snap an event onto the grid point it (near-)coincides with, so
-                // the output row lands at exactly `tout` (float accumulation of the
-                // sample times otherwise drifts the final row off `stop`).
-                let te = if (te - tout).abs() <= eps { tout } else { te };
-                // Emit a pre-event row (old values), fire, then a post-event row
-                // (new values) — a step in the result, as the C runtime does. An
-                // event landing on the grid point covers this row.
-                emit_row(e, &mut rows, te)?;
-                samp.fire(e, sim_data, te)?;
-                store_relations(e, sim_data, layout)?;
-                stats.time_events += 1;
-                emit_row(e, &mut rows, te)?;
-                if terminated(e, sim_data, layout)? {
-                    return Ok(rows);
-                }
-                if te >= tout - eps {
-                    grid_covered = true;
-                }
-            }
-            if !grid_covered {
-                emit_row(e, &mut rows, tout)?;
-                if terminated(e, sim_data, layout)? {
-                    break;
-                }
-            }
+        let n_states = layout.n_states as usize;
+        let states_base = sim_data + REAL_OFF;
+        let ders_base = states_base + layout.n_states * 8;
+        let n_rows = model.n_intervals + 1;
+        let n_reals = layout.n_row_total();
+        let start = model.start_time;
+
+        let mut samp = Samples::load(e, sim_data, layout)?;
+        let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
+        let mut time_events = 0u64;
+        // A sample scheduled exactly at the start time fires before row 0.
+        if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
+            samp.fire(e, sim_data, start)?;
+            store_relations(e, sim_data, layout)?;
+            time_events += 1;
         }
-        return Ok(rows);
-    }
+        emit_row(e, &mut rows, sim_data, layout, start)?;
+        let pending_terminate = terminated(e, sim_data, layout)?;
 
-    // Dynamic state selection: identity pivots, then re-pivot at the initial point
-    // (see `run_dassl`). A switch reinits states, so refresh the derivatives first.
-    let mut pivots = init_state_pivots(&model.state_sets);
-    if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
-        e.call1("functionODE", sim_data)?;
-    }
-
-    // Continuous states: DASSL between events, with DASKR root-finding on the
-    // zero-crossing functions for state events.
-    let mut y: Vec<f64> = (0..n_states)
-        .map(|i| read_f64(e, states_base + (i as u32) * 8))
-        .collect::<Result<_>>()?;
-    let mut yp: Vec<f64> = (0..n_states)
-        .map(|i| read_f64(e, ders_base + (i as u32) * 8))
-        .collect::<Result<_>>()?;
-
-    let neq = n_states as i32;
-    let nrt = layout.n_zc as i32;
-    let rt_fn: solver::RtFn = if layout.n_zc > 0 { dassl_rt } else { solver::dummy_rt };
-    let mut info = [0i32; 24];
-    let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
-    let mut rtol = [tol];
-    let mut atol = [tol];
-    let lrw = (60 + 9 * neq + neq * neq + 3 * nrt + 64) as usize;
-    let liw = (40 + neq + 64) as usize;
-    let mut rwork = vec![0.0f64; lrw];
-    let mut iwork = vec![0i32; liw];
-    let mut rpar = [0.0f64];
-    let mut ipar = [0i32];
-    let mut jroot = vec![0i32; (nrt as usize).max(1)];
-    let mut idid = 0i32;
-    let mut t = start;
-
-    let engine: *mut dyn SimEngine = &mut *e;
-    let mut ctx = ResCtx {
-        engine,
-        sim_data,
-        states_base,
-        ders_base,
-        n_states,
-        nls_fail_off: layout.nls_fail_off,
-        nfe: 0,
-        zc_off: layout.zc_off,
-        n_zc: layout.n_zc as usize,
-        err: None,
-    };
-    let _guard = ResCtxGuard;
-    RES_CTX.with(|c| c.set(&mut ctx as *mut ResCtx));
-
-    // Pre-event snapshot: the state just *before* the discrete update. Recorded
-    // real algebraics live in slots `functionAlgebraics` fills, so it must run or
-    // they keep the previous grid point's values. Skip it for `has_when` models —
-    // there it also saves `pre` early, breaking the post-event edge test.
-    let capture_pre = |e: &mut dyn SimEngine, rows: &mut Vec<f64>, time: f64| -> Result<()> {
-        write_f64(e, sim_data + TIME_OFF, time)?;
-        e.call1("functionODE", sim_data)?;
-        if !layout.has_when {
-            e.call1("functionAlgebraics", sim_data)?;
+        // Dynamic state selection: identity pivots, then re-pivot at the initial
+        // point (see `DasslDriver`). A switch reinits states, so refresh derivatives.
+        let mut pivots = init_state_pivots(&model.state_sets);
+        let (mut y, mut yp) = (Vec::new(), Vec::new());
+        if n_states > 0 && !pending_terminate {
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+                e.call1("functionODE", sim_data)?;
+            }
+            y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;
+            yp = (0..n_states).map(|i| read_f64(e, ders_base + (i as u32) * 8)).collect::<Result<_>>()?;
         }
-        capture_row(e, rows, sim_data, layout)
-    };
 
-    for row in 1..n_rows {
-        let tout = if row == n_steps { stop } else { start + row as f64 * h };
-        let eps = tout.abs().max(1.0) * 1e-10;
-        let mut grid_covered = false;
-        loop {
-            // Mode 0: hold relations across the DASKR solve so its residual/Jacobian
-            // probes are smooth (C's `solveContinuous`); events/outputs refresh them.
-            write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-            let te = samp.next_time();
-            let target = tout.min(te);
-            // Integrate from the current t toward `target` (a grid point or the
-            // next scheduled sample). DASKR may stop early at a zero-crossing root.
-            if target - t > eps {
-                let mut tt = target;
-                let mut work_retries = 0;
-                loop {
-                    unsafe {
-                        solver::ddaskr(
-                            dassl_res, neq, &mut t, y.as_mut_ptr(), yp.as_mut_ptr(), &mut tt,
-                            info.as_mut_ptr(), rtol.as_mut_ptr(), atol.as_mut_ptr(), &mut idid,
-                            rwork.as_mut_ptr(), lrw as i32, iwork.as_mut_ptr(), liw as i32,
-                            rpar.as_mut_ptr(), ipar.as_mut_ptr(), solver::dummy_jacd,
-                            solver::dummy_jack, solver::dummy_psol, rt_fn, nrt,
-                            jroot.as_mut_ptr(),
-                        );
+        let neq = n_states as i32;
+        let nrt = layout.n_zc as i32;
+        let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+        let lrw = (60 + 9 * neq + neq * neq + 3 * nrt + 64) as usize;
+        let liw = (40 + neq + 64) as usize;
+        Ok(DasslEventsDriver {
+            sim_data,
+            n_states,
+            states_base,
+            ders_base,
+            row: 1,
+            y,
+            yp,
+            info: [0i32; 24],
+            rtol: [tol],
+            atol: [tol],
+            rwork: vec![0.0f64; lrw],
+            iwork: vec![0i32; liw],
+            rpar: [0.0f64],
+            ipar: [0i32],
+            jroot: vec![0i32; (nrt as usize).max(1)],
+            nrt,
+            idid: 0,
+            t: start,
+            nfe: 0,
+            pivots,
+            samp,
+            rows,
+            mid_row: false,
+            grid_covered: false,
+            ev_retries: 0,
+            state_events: 0,
+            time_events,
+            pending_terminate,
+            finished: false,
+        })
+    }
+}
+
+impl Driver for DasslEventsDriver {
+    fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance> {
+        use daskr::solver;
+        if self.finished {
+            return Ok(Advance::Done);
+        }
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        if self.pending_terminate {
+            self.pending_terminate = false;
+            self.finished = true;
+            return Ok(Advance::Terminated);
+        }
+        let n_rows = model.n_intervals + 1;
+        let n_steps = n_rows - 1;
+        let start = model.start_time;
+        let stop = model.stop_time;
+        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let deadline = deadline_from(budget_ms);
+
+        // No continuous states: evaluate outputs on the grid, firing events between.
+        if self.n_states == 0 {
+            let mut did_step = false;
+            while self.row < n_rows {
+                if did_step && past_deadline(deadline) {
+                    return Ok(Advance::Running);
+                }
+                if cancel_requested() {
+                    return Ok(Advance::Cancelled);
+                }
+                did_step = true;
+                let tout = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                let eps = tout.abs().max(1.0) * 1e-10;
+                let mut grid_covered = false;
+                while self.samp.next_time() <= tout + eps {
+                    let te = self.samp.next_time();
+                    // Snap an event onto the grid point it (near-)coincides with.
+                    let te = if (te - tout).abs() <= eps { tout } else { te };
+                    // Pre-event row (old), fire, post-event row (new) — a step.
+                    emit_row(e, &mut self.rows, sim_data, layout, te)?;
+                    self.samp.fire(e, sim_data, te)?;
+                    store_relations(e, sim_data, layout)?;
+                    self.time_events += 1;
+                    emit_row(e, &mut self.rows, sim_data, layout, te)?;
+                    if terminated(e, sim_data, layout)? {
+                        self.finished = true;
+                        return Ok(Advance::Terminated);
                     }
-                    if ctx.err.is_some() {
+                    if te >= tout - eps {
+                        grid_covered = true;
+                    }
+                }
+                if !grid_covered {
+                    emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+                    if terminated(e, sim_data, layout)? {
+                        self.finished = true;
+                        return Ok(Advance::Terminated);
+                    }
+                }
+                self.row += 1;
+            }
+            self.finished = true;
+            return Ok(Advance::Done);
+        }
+
+        let n_states = self.n_states;
+        let states_base = self.states_base;
+        let ders_base = self.ders_base;
+        let neq = n_states as i32;
+        let nrt = self.nrt;
+        let rt_fn: solver::RtFn = if layout.n_zc > 0 { dassl_rt } else { solver::dummy_rt };
+        let lrw = self.rwork.len();
+        let liw = self.iwork.len();
+
+        let mut ctx = ResCtx {
+            engine: &mut *e as *mut dyn SimEngine,
+            sim_data,
+            states_base,
+            ders_base,
+            n_states,
+            nls_fail_off: layout.nls_fail_off,
+            nfe: self.nfe,
+            zc_off: layout.zc_off,
+            n_zc: layout.n_zc as usize,
+            err: None,
+        };
+        let _guard = ResCtxGuard;
+        RES_CTX.with(|c| c.set(&mut ctx as *mut ResCtx));
+
+        // Yields happen only at the inner-loop boundary or in the work-quota loop —
+        // safe resume points: re-entry recomputes the same `target` and DASKR
+        // continues via INFO(1)=1. `mid_row`/`grid_covered` carry the partial row over.
+        let mut did_step = false;
+        let outcome = 'outer: loop {
+            if self.row >= n_rows {
+                break Advance::Done;
+            }
+            if did_step && past_deadline(deadline) {
+                break Advance::Running;
+            }
+            if cancel_requested() {
+                break Advance::Cancelled;
+            }
+            let tout = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            let eps = tout.abs().max(1.0) * 1e-10;
+            if !self.mid_row {
+                self.grid_covered = false;
+            }
+            loop {
+                // Yield at the inner-loop boundary (before any state mutation).
+                if did_step && past_deadline(deadline) {
+                    self.mid_row = true;
+                    self.nfe = ctx.nfe;
+                    return Ok(Advance::Running);
+                }
+                if cancel_requested() {
+                    self.nfe = ctx.nfe;
+                    return Ok(Advance::Cancelled);
+                }
+                // Mode 0: hold relations across the DASKR solve so its residual/Jacobian
+                // probes are smooth (C's `solveContinuous`); events/outputs refresh them.
+                write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+                let te = self.samp.next_time();
+                let target = tout.min(te);
+                // Integrate from the current t toward `target` (a grid point or the
+                // next scheduled sample). DASKR may stop early at a zero-crossing root.
+                if target - self.t > eps {
+                    let mut tt = target;
+                    loop {
+                        // Yield inside the work-quota loop too, so a stuck stiff interval
+                        // is interruptible; resume re-enters the inner loop (same target).
+                        if did_step && past_deadline(deadline) {
+                            self.mid_row = true;
+                            self.nfe = ctx.nfe;
+                            return Ok(Advance::Running);
+                        }
+                        if cancel_requested() {
+                            self.nfe = ctx.nfe;
+                            return Ok(Advance::Cancelled);
+                        }
+                        unsafe {
+                            solver::ddaskr(
+                                dassl_res, neq, &mut self.t, self.y.as_mut_ptr(), self.yp.as_mut_ptr(), &mut tt,
+                                self.info.as_mut_ptr(), self.rtol.as_mut_ptr(), self.atol.as_mut_ptr(), &mut self.idid,
+                                self.rwork.as_mut_ptr(), lrw as i32, self.iwork.as_mut_ptr(), liw as i32,
+                                self.rpar.as_mut_ptr(), self.ipar.as_mut_ptr(), solver::dummy_jacd,
+                                solver::dummy_jack, solver::dummy_psol, rt_fn, nrt,
+                                self.jroot.as_mut_ptr(),
+                            );
+                        }
+                        self.nfe = ctx.nfe;
+                        did_step = true;
+                        if ctx.err.is_some() {
+                            break;
+                        }
+                        if self.idid == -1 && self.ev_retries < 10_000 {
+                            self.info[0] = 1;
+                            self.ev_retries += 1;
+                            continue;
+                        }
                         break;
                     }
-                    if idid == -1 && work_retries < 10_000 {
-                        info[0] = 1;
-                        work_retries += 1;
+                    self.ev_retries = 0; // this target's integration is done (or failing)
+                    if let Some(err) = ctx.err.take() {
+                        return Err(err.context(format!("in DASSL residual at t={}", self.t)));
+                    }
+                    if self.idid < 0 {
+                        bail!("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tt}), IDID={}", self.t, self.idid);
+                    }
+                    for i in 0..n_states {
+                        write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
+                    }
+                    // IDID=5: a zero-crossing root at `t` (< target). Handle the state
+                    // event here, then restart the integrator and keep going.
+                    if self.idid == 5 {
+                        self.state_events += 1;
+                        let troot = self.t;
+                        // pre-event row (before the discrete update), then event +
+                        // post-event row.
+                        capture_pre(e, &mut self.rows, sim_data, layout, troot)?;
+                        // pre(x) of continuous vars must be the value at the crossing.
+                        save_pre_real(e, sim_data, layout)?;
+                        write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
+                        store_relations(e, sim_data, layout)?;
+                        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+                        write_f64(e, sim_data + TIME_OFF, troot)?;
+                        iterate_discrete(e, sim_data, layout)?;
+                        store_relations(e, sim_data, layout)?;
+                        check_nls(e, sim_data, layout)?;
+                        capture_row(e, &mut self.rows, sim_data, layout)?;
+                        if terminated(e, sim_data, layout)? {
+                            break 'outer Advance::Terminated;
+                        }
+                        // Re-read states (a reinit may have jumped one), recompute the
+                        // consistent derivative, and restart DASKR at troot (INFO(1)=0).
+                        for i in 0..n_states {
+                            self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                        }
+                        e.call1("functionODE", sim_data)?;
+                        for i in 0..n_states {
+                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                        }
+                        self.info[0] = 0;
                         continue;
                     }
+                }
+                // Reached `target`. Fire a sample event at `te` if it lands at or
+                // before this output point (pre-event row, fire, post-event row).
+                if te <= tout + eps {
+                    // Snap an event near a grid point onto it (keeps the final row at
+                    // `stop` despite float drift).
+                    let te = if (te - tout).abs() <= eps { tout } else { te };
+                    did_step = true;
+                    emit_row(e, &mut self.rows, sim_data, layout, te)?; // pre-event row (held)
+                    write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
+                    self.samp.fire(e, sim_data, te)?;
+                    store_relations(e, sim_data, layout)?; // advance the hysteresis direction
+                    self.time_events += 1;
+                    emit_row(e, &mut self.rows, sim_data, layout, te)?;
+                    if terminated(e, sim_data, layout)? {
+                        break 'outer Advance::Terminated;
+                    }
+                    for i in 0..n_states {
+                        self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                    }
+                    // A sample may change discrete state the derivative depends on;
+                    // recompute yp and restart so DASKR continues consistently.
+                    if layout.n_zc > 0 {
+                        e.call1("functionODE", sim_data)?;
+                        for i in 0..n_states {
+                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                        }
+                        self.info[0] = 0;
+                    }
+                    if te >= tout - eps {
+                        self.grid_covered = true;
+                    }
+                }
+                if target >= tout - eps {
                     break;
                 }
-                if let Some(err) = ctx.err.take() {
-                    return Err(err.context(format!("in DASSL residual at t={t}")));
-                }
-                if idid < 0 {
-                    bail!("CodegenWasmJit: DASSL (daskr) failed at t={t} (target {tt}), IDID={idid}");
-                }
-                for i in 0..n_states {
-                    write_f64(e, states_base + (i as u32) * 8, y[i])?;
-                }
-                // IDID=5: a zero-crossing root at `t` (< target). Handle the state
-                // event here, then restart the integrator and keep going.
-                if idid == 5 {
-                    stats.state_events += 1;
-                    let troot = t;
-                    // pre-event row (before the discrete update), then the event +
-                    // post-event row (emit_row runs functionAlgebraics, whose
-                    // edge-detected when-bodies fire and may reinit a state).
-                    capture_pre(e, &mut rows, troot)?;
-                    // pre(x) of continuous vars must be the value at the crossing
-                    // (e.g. reinit's `pre(v)` = impact velocity), so refresh the
-                    // real pre-region before the discrete update fires.
-                    save_pre_real(e, sim_data, layout)?;
-                    write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
-                    // Freeze the hysteresis direction at the pre-event relations for
-                    // the whole discrete update.
-                    store_relations(e, sim_data, layout)?;
-                    // Post-event row from the discrete update run to a fixed point.
-                    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
-                    write_f64(e, sim_data + TIME_OFF, troot)?;
-                    iterate_discrete(e, sim_data, layout)?;
-                    // Advance the direction to the settled relations for the next
-                    // continuous phase.
-                    store_relations(e, sim_data, layout)?;
-                    check_nls(e, sim_data, layout)?;
-                    capture_row(e, &mut rows, sim_data, layout)?;
-                    if terminated(e, sim_data, layout)? {
-                        return Ok(rows);
-                    }
-                    // Re-read states (a reinit may have jumped one), recompute the
-                    // consistent derivative, and restart DASKR at troot (INFO(1)=0).
-                    for i in 0..n_states {
-                        y[i] = read_f64(e, states_base + (i as u32) * 8)?;
-                    }
-                    e.call1("functionODE", sim_data)?;
-                    for i in 0..n_states {
-                        yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-                    }
-                    info[0] = 0;
-                    continue;
-                }
             }
-            // Reached `target`. Fire a sample event at `te` if it lands at or
-            // before this output point (pre-event row, fire, post-event row).
-            if te <= tout + eps {
-                // Snap an event near a grid point onto it so the row lands exactly
-                // there (keeps the final row at `stop` despite float drift).
-                let te = if (te - tout).abs() <= eps { tout } else { te };
-                emit_row(e, &mut rows, te)?; // pre-event row (held)
-                write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
-                samp.fire(e, sim_data, te)?;
-                store_relations(e, sim_data, layout)?; // advance the hysteresis direction
-                stats.time_events += 1;
-                emit_row(e, &mut rows, te)?;
+            // Row's inner loop done; the rest is bounded — next yield is a clean boundary.
+            self.mid_row = false;
+            if !self.grid_covered {
+                write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+                did_step = true;
+                emit_row(e, &mut self.rows, sim_data, layout, tout)?;
                 if terminated(e, sim_data, layout)? {
-                    return Ok(rows);
+                    break 'outer Advance::Terminated;
                 }
+            }
+            // Re-select states at the accepted output point (see `DasslDriver`).
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
+                e.call1("functionODE", sim_data)?;
                 for i in 0..n_states {
-                    y[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                    self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                    self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
                 }
-                // A sample may change discrete state the derivative depends on;
-                // recompute yp and restart so DASKR continues consistently.
-                if layout.n_zc > 0 {
-                    e.call1("functionODE", sim_data)?;
-                    for i in 0..n_states {
-                        yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-                    }
-                    info[0] = 0;
-                }
-                if te >= tout - eps {
-                    grid_covered = true;
-                }
+                self.info[0] = 0;
             }
-            if target >= tout - eps {
-                break;
-            }
+            self.row += 1;
+        };
+        self.nfe = ctx.nfe;
+        if matches!(outcome, Advance::Done | Advance::Terminated) {
+            self.finished = true;
         }
-        if !grid_covered {
-            write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
-            emit_row(e, &mut rows, tout)?;
-            if terminated(e, sim_data, layout)? {
-                break;
-            }
-        }
-        // Re-select states at the accepted output point (see `run_dassl`).
-        if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
-            e.call1("functionODE", sim_data)?;
-            for i in 0..n_states {
-                y[i] = read_f64(e, states_base + (i as u32) * 8)?;
-                yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-            }
-            info[0] = 0;
-        }
+        Ok(outcome)
     }
 
-    let nst = iwork.get(10).copied().unwrap_or(0);
-    if bench {
-        eprintln!(
-            "wasm-jit sim [dassl-events] DASKR stats: {nst} steps, {} residual evals",
-            ctx.nfe,
-        );
+    fn take_rows(&mut self) -> Vec<f64> {
+        std::mem::take(&mut self.rows)
     }
-    stats.steps = nst.max(0) as u64;
-    stats.res_evals = ctx.nfe;
-    stats.jac_evals = iwork.get(12).copied().unwrap_or(0).max(0) as u64;
-    stats.err_test_fails = iwork.get(13).copied().unwrap_or(0).max(0) as u64;
-    stats.conv_test_fails = iwork.get(14).copied().unwrap_or(0).max(0) as u64;
-    Ok(rows)
+
+    fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
+        let nst = self.iwork.get(10).copied().unwrap_or(0);
+        stats.steps = nst.max(0) as u64;
+        stats.res_evals = self.nfe;
+        stats.jac_evals = self.iwork.get(12).copied().unwrap_or(0).max(0) as u64;
+        stats.err_test_fails = self.iwork.get(13).copied().unwrap_or(0).max(0) as u64;
+        stats.conv_test_fails = self.iwork.get(14).copied().unwrap_or(0).max(0) as u64;
+        stats.state_events = self.state_events;
+        stats.time_events = self.time_events;
+    }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -300,35 +300,16 @@ fn past_deadline(deadline: f64) -> bool {
     deadline.is_finite() && now_ms() >= deadline
 }
 
-static CANCEL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Request cancellation of the running simulation (native, cross-thread).
-pub fn request_cancel() {
-    CANCEL.store(true, std::sync::atomic::Ordering::Relaxed);
-}
-/// Clear the cancel flag; called at the start of each new run.
-pub fn clear_cancel() {
-    CANCEL.store(false, std::sync::atomic::Ordering::Relaxed);
-}
-
-// wasm: the blocked worker can't get a cancel message, so a cross-origin-isolated
-// host (OMEdit-wasm) polls a `SharedArrayBuffer` flag through an injected fn ptr.
-// Unset for hosts that cancel another way (the simulator frees its session).
+// The cancel primitive now lives in the shared `metamodelica::cancel` crate so
+// the frontend/loader/backend can use the same flag. These re-exports keep the
+// existing `CodegenWasmJit::{request_cancel,clear_cancel,set_cancel_poll}`
+// callers (wasm_api, capi) working unchanged.
+pub use metamodelica::cancel::{clear_cancel, request_cancel};
 #[cfg(target_arch = "wasm32")]
-thread_local! {
-    static CANCEL_POLL: std::cell::Cell<Option<fn() -> bool>> = const { std::cell::Cell::new(None) };
-}
-#[cfg(target_arch = "wasm32")]
-pub fn set_cancel_poll(f: fn() -> bool) {
-    CANCEL_POLL.with(|c| c.set(Some(f)));
-}
+pub use metamodelica::cancel::set_cancel_poll;
 
 fn cancel_requested() -> bool {
-    #[cfg(target_arch = "wasm32")]
-    if CANCEL_POLL.with(|c| c.get()).map(|f| f()).unwrap_or(false) {
-        return true;
-    }
-    CANCEL.load(std::sync::atomic::Ordering::Relaxed)
+    metamodelica::cancel::check_cancel()
 }
 
 /// Read one little-endian i32 from linear memory at byte address `addr`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -616,6 +616,29 @@ fn read_side_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, off: u3
 
 pub(super) fn run(model: &SimModel) -> Result<sim_driver::RunResult> {
     let bench = std::env::var("OMC_WASM_SIM_BENCH").is_ok();
+    let (mut engine, sim_data) = build_engine(model)?;
+    // `OMC_WASM_SIM_DRIVER=host` forces the native Euler loop over the in-wasm one.
+    let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
+    let n_steps = model.n_intervals;
+    let n_rows = n_steps + 1;
+    let t0 = Instant::now();
+    let (result, driver_label) =
+        sim_driver::drive(&mut *engine, model, sim_data, model.method.as_str(), host_driven, bench)?;
+    if bench {
+        let elapsed = t0.elapsed();
+        eprintln!(
+            "wasm-jit sim [{}]: integrate {:?} ({} intervals, {:.2} us/interval)",
+            driver_label, elapsed, n_steps, elapsed.as_secs_f64() * 1e6 / (n_rows.max(1) as f64),
+        );
+    }
+    Ok(result)
+}
+
+/// Build the engine (compile/join modules, instantiate, allocate `SimData`), boxed
+/// with the `SimData` pointer; owned by the session across `advance` calls, reused
+/// by [`run`] one-shot.
+pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimEngine + 'static>, u32)> {
+    let bench = std::env::var("OMC_WASM_SIM_BENCH").is_ok();
     let engine = sim_engine();
 
     // Phase 1: obtain the compiled modules. The runtime module is compiled once
@@ -675,29 +698,15 @@ pub(super) fn run(model: &SimModel) -> Result<sim_driver::RunResult> {
     let rt_alloc: wasmer::TypedFunction<u32, u32> = wt(rt_inst.exports.get_typed_function(&store, "rt_alloc"))?;
 
     let layout = &model.layout;
-    let n_steps = model.n_intervals;
-    let n_rows = n_steps + 1;
 
     // Allocate the shared SimData block.
     let sim_data = wt(rt_alloc.call(&mut store, layout.total))?;
 
-    // Hand the instance to the engine-independent drivers (select integrator,
-    // integrate, free external objects, read parameters). `OMC_WASM_SIM_DRIVER=host`
-    // forces the native Euler loop over the in-wasm one for `method="euler"`.
-    let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
-    let mut engine = WasmerEngine { store, memory, instance, funcs: HashMap::new() };
-    let t0 = Instant::now();
-    let (result, driver_label) =
-        sim_driver::drive(&mut engine, model, sim_data, model.method.as_str(), host_driven, bench)?;
-    let elapsed = t0.elapsed();
     if bench {
-        eprintln!(
-            "wasm-jit sim [{}]: compile {:?} | instantiate {:?} | integrate {:?} ({} intervals, {:.2} us/interval)",
-            driver_label, compile_time, inst_time, elapsed, n_steps,
-            elapsed.as_secs_f64() * 1e6 / (n_rows.max(1) as f64),
-        );
+        eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
     }
-    Ok(result)
+    let engine = WasmerEngine { store, memory, instance, funcs: HashMap::new() };
+    Ok((Box::new(engine), sim_data))
 }
 
 /// wasmer backend for the [`sim_driver::SimEngine`] drivers: owns the store, the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
@@ -418,6 +418,29 @@ unsafe fn call_external(
 
 pub(super) fn run(model: &SimModel) -> Result<sim_driver::RunResult> {
     let bench = std::env::var("OMC_WASM_SIM_BENCH").is_ok();
+    let (mut engine, sim_data) = build_engine(model)?;
+    // `OMC_WASM_SIM_DRIVER=host` forces the native Euler loop over the in-wasm one.
+    let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
+    let n_steps = model.n_intervals;
+    let n_rows = n_steps + 1;
+    let t0 = Instant::now();
+    let (result, driver_label) =
+        sim_driver::drive(&mut *engine, model, sim_data, model.method.as_str(), host_driven, bench)?;
+    if bench {
+        let elapsed = t0.elapsed();
+        eprintln!(
+            "wasm-jit sim [{}]: integrate {:?} ({} intervals, {:.2} us/interval)",
+            driver_label, elapsed, n_steps, elapsed.as_secs_f64() * 1e6 / (n_rows.max(1) as f64),
+        );
+    }
+    Ok(result)
+}
+
+/// Build the engine (compile/join modules, instantiate, allocate `SimData`), boxed
+/// with the `SimData` pointer; owned by the session across `advance` calls, reused
+/// by [`run`] one-shot.
+pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimEngine + 'static>, u32)> {
+    let bench = std::env::var("OMC_WASM_SIM_BENCH").is_ok();
     let engine = sim_engine();
     let mut linker = wasmtime::Linker::new(engine);
     add_host_builtins(&mut linker)?;
@@ -468,29 +491,15 @@ pub(super) fn run(model: &SimModel) -> Result<sim_driver::RunResult> {
     let rt_alloc = wt(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
 
     let layout = &model.layout;
-    let n_steps = model.n_intervals;
-    let n_rows = n_steps + 1;
 
     // Allocate the shared SimData block.
     let sim_data = wt(rt_alloc.call(&mut store, layout.total))?;
 
-    // Hand the instance to the engine-independent drivers (select integrator,
-    // integrate, free external objects, read parameters). `OMC_WASM_SIM_DRIVER=host`
-    // forces the native Euler loop over the in-wasm one for `method="euler"`.
-    let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
-    let mut engine = WasmtimeEngine { store, memory, instance, funcs: HashMap::new() };
-    let t0 = Instant::now();
-    let (result, driver_label) =
-        sim_driver::drive(&mut engine, model, sim_data, model.method.as_str(), host_driven, bench)?;
-    let elapsed = t0.elapsed();
     if bench {
-        eprintln!(
-            "wasm-jit sim [{}]: compile {:?} | instantiate {:?} | integrate {:?} ({} intervals, {:.2} us/interval)",
-            driver_label, compile_time, inst_time, elapsed, n_steps,
-            elapsed.as_secs_f64() * 1e6 / (n_rows.max(1) as f64),
-        );
+        eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
     }
-    Ok(result)
+    let engine = WasmtimeEngine { store, memory, instance, funcs: HashMap::new() };
+    Ok((Box::new(engine), sim_data))
 }
 
 /// wasmtime backend for the [`sim_driver::SimEngine`] drivers: owns the store,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -2385,6 +2385,21 @@ pub fn threadWorkFailed() {
     panic!("System.threadWorkFailed: worker thread aborted by user code");
 }
 
+pub fn isCancelled() -> bool {
+    metamodelica::cancel::check_cancel()
+}
+
+pub fn checkCancel() -> Result<()> {
+    if isCancelled() {
+        return Err(metamodelica::cancel::cancelled_error());
+    }
+    Ok(())
+}
+
+pub fn reportProgress(permille: i32, phase: i32) {
+    metamodelica::cancel::report_progress(permille, phase);
+}
+
 pub fn getMemorySize() -> metamodelica::Real {
     // Total system memory in bytes. The C runtime reads `_SC_PHYS_PAGES *
     // _SC_PAGE_SIZE` on POSIX; we don't have a portable shortcut in std.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -2389,13 +2389,6 @@ pub fn isCancelled() -> bool {
     metamodelica::cancel::check_cancel()
 }
 
-pub fn checkCancel() -> Result<()> {
-    if isCancelled() {
-        return Err(metamodelica::cancel::cancelled_error());
-    }
-    Ok(())
-}
-
 pub fn reportProgress(permille: i32, phase: i32) {
     metamodelica::cancel::report_progress(permille, phase);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -32,6 +32,8 @@
   }
   button:hover:not(:disabled){ background:#1177bb; }
   button:disabled{ background:#3a3a3a; color:#777; cursor:default; }
+  button.cancel{ background:#a1260d; }
+  button.cancel:hover:not(:disabled){ background:#c42b0e; }
   button.ghost { background:transparent; border:1px solid var(--border); color:var(--fg); padding:6px 12px; font-size:13px; }
   button.ghost:hover:not(:disabled){ background:#2d2d30; }
   button.ghost.icon-only { padding:6px 9px; display:inline-flex; align-items:center; }
@@ -453,7 +455,7 @@ function seedFromOptions(o) {
 
 async function run(kind) {                       // 'full' | 'resim'
   if (running) { pendingKind = pendingKind === 'full' ? 'full' : kind; return; }
-  running = true; runBtn.disabled = true;
+  running = true; setRunUI(true);
   log('run', kind, 'mode', mode);
   setStatus(kind === 'resim' ? 'Re-simulating…' : 'Compiling & simulating…', 'busy');
 
@@ -471,6 +473,7 @@ async function run(kind) {                       // 'full' | 'resim'
     if (kind === 'resim' && builtModel && builtWorker) {
       jobWorker = builtWorker;
       const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov });
+      if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
       snap = r;
     } else if (mode === 'librarycopy' && pendingMods.length) {
@@ -487,6 +490,7 @@ async function run(kind) {                       // 'full' | 'resim'
       pendingMods = [];
       if (src != null) { srcEl.value = unquote(src); lastText = srcEl.value; }
       const r = await call(worker, 'simulate', { name: copyName, override: '', ...settings });
+      if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
       builtModel = copyName; builtWorker = worker; snap = r;   // figures/doc unchanged by a tweak
     } else {
@@ -509,6 +513,7 @@ async function run(kind) {                       // 'full' | 'resim'
       if (lm.figures !== undefined) modelFigures = lm.figures || null;
       if (lm.doc !== undefined) { modelDoc = lm.doc || ''; renderDoc(); }
       const r = await call(worker, 'simulate', { name: lm.name, override: ov, ...settings });
+      if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
       builtModel = lm.name; builtWorker = worker; lastText = text; snap = r;
     }
@@ -520,11 +525,31 @@ async function run(kind) {                       // 'full' | 'resim'
     const figNote = (modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '';
     setStatus(`${snap.info.model} — ${snap.info.rows} points, t ∈ [${snap.info.start}, ${snap.info.stop}]${figNote}`);
     log('done', snap.info.model, snap.info.rows, 'points');
-  } catch (e) { log('run failed', e); fail('' + e); }
+  } catch (e) {
+    log('run failed', e); fail('' + e);
+  }
   finally {
-    running = false; runBtn.disabled = false; jobWorker = null; retireW1();
+    running = false; setRunUI(false); jobWorker = null; retireW1();
     if (pendingKind) { const k = pendingKind; pendingKind = null; run(k); }
   }
+}
+
+// Run ↔ Cancel: while a job is running the button turns into a red Cancel.
+function setRunUI(busy) {
+  runBtn.textContent = busy ? 'Cancel' : 'Run';
+  runBtn.classList.toggle('cancel', busy);
+  runBtn.disabled = false;
+}
+
+// Cooperative cancel: the worker yields to its message loop every ~150ms, so this
+// message lands and the in-flight simulate resolves {cancelled:true} — worker (MSL +
+// JIT) and the built model survive for a re-run.
+function cancelRun() {
+  if (!running || !jobWorker) return;
+  pendingKind = null;
+  log('cancel: requesting', jobWorker._tag);
+  setStatus('Cancelling…', 'busy');
+  jobWorker.postMessage({ cmd: 'cancelSim' });
 }
 
 // --- examples ---------------------------------------------------------------
@@ -881,7 +906,7 @@ el('tolUp').addEventListener('click', () => stepTol(10));
 el('tolDn').addEventListener('click', () => stepTol(0.1));
 tolEl.addEventListener('keydown', (e) => { if (e.key === 'ArrowUp') { e.preventDefault(); stepTol(10); } else if (e.key === 'ArrowDown') { e.preventDefault(); stepTol(0.1); } });
 tolEl.addEventListener('change', () => { const v = parseFloat(tolEl.value); if (isFinite(v) && v > 0) { tolValue = cleanTol(v); } renderTol(); run('full'); });
-runBtn.addEventListener('click', () => run('full'));
+runBtn.addEventListener('click', () => { if (running) cancelRun(); else run('full'); });
 toggleBtn.addEventListener('click', () => { viewMode = (viewMode === 'all') ? 'auto' : 'all'; renderCharts();
   if (snap) setStatus(`${snap.info.model} — ${snap.info.rows} points, t ∈ [${snap.info.start}, ${snap.info.stop}]` + ((modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '')); });
 window.addEventListener('resize', () => { for (const c of charts) drawChart(c); });

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -8,10 +8,15 @@
 // plus unsolicited { type:'status', id, text } for download progress.
 import init, {
   omc_set_env, omc_init, omc_eval, omc_simulate,
+  omc_sim_start, omc_sim_advance, omc_sim_free,
   omc_take_pending_downloads, wasi_write_file,
   wasi_path_open, wasi_fd_read, wasi_fd_close,
   omc_sim_info, omc_sim_series, omc_sim_time, omc_sim_column, omc_sim_parameters,
 } from '../omc/OpenModelicaCompiler.js';
+
+// Set by a {cmd:'cancelSim'} message; honored by `runResumable` between chunks, so a
+// long sim is cancelled without killing the worker (which would drop the MSL + JIT).
+let simCancel = false;
 
 const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\t/g, '\\t');
 const unquote = (s) => { s = (s || '').trim(); return (s.startsWith('"') && s.endsWith('"')) ? s.slice(1, -1) : s; };
@@ -146,8 +151,37 @@ function simError(fallback) {
   return { ok: false, error: omc_eval('getErrorString()').trim() || fallback };
 }
 
+// Chunked, cancellable integration of a prepared model. Each `omc_sim_advance`
+// runs ~BUDGET_MS of wall-clock (it times itself), then we yield to the message
+// loop so a queued {cmd:'cancelSim'} can set `simCancel`. A run that finishes in
+// one chunk never yields. Returns the status: 1 done, 2 terminated, 3 cancelled, <0 error.
+async function runResumable(prefix, simflags, onStatus) {
+  simCancel = false;   // discard a cancel that raced in after the previous run
+  if (!omc_sim_start(prefix, prefix + '_res.mat', simflags)) return -1;
+  onStatus && onStatus('Simulating…');
+  const BUDGET_MS = 150;
+  for (;;) {
+    if (simCancel) { simCancel = false; omc_sim_free(); return 3; }
+    const st = omc_sim_advance(BUDGET_MS);
+    if (st !== 0) return st;
+    await new Promise((r) => setTimeout(r, 0));   // let cancelSim land
+  }
+}
+
+// The settings a run used, to seed the dialog: the explicit ones the page sent, or
+// getSimulationOptions → (startTime, stopTime, tolerance, numberOfIntervals) for a
+// fresh model driven by its `experiment` annotation.
+function simOptions(name, a) {
+  if (a.stopTime) return { stopTime: a.stopTime, tolerance: a.tolerance || null, intervals: a.intervals || null };
+  const n = (omc_eval(`getSimulationOptions(${name})`).match(/-?[0-9][0-9.eE+-]*/g) || []).map(Number);
+  return { stopTime: n[1] ?? null, tolerance: n[2] ?? null, intervals: n[3] ?? null };
+}
+
 self.onmessage = async (ev) => {
   const { id, cmd } = ev.data, a = ev.data;
+  // Out-of-band: arrives while a simulate handler is parked at its inter-chunk
+  // `await`, so it just raises the flag (no reply; the sim replies {cancelled:true}).
+  if (cmd === 'cancelSim') { simCancel = true; return; }
   const status = (text) => self.postMessage({ type: 'status', id, text });
   const wlog = (text) => self.postMessage({ type: 'log', id, text });
   _plog = wlog;
@@ -217,24 +251,30 @@ self.onmessage = async (ev) => {
         break;
       }
       case 'simulate': {
-        // Direct scripting call (no O(program) env build); 0 / "" = omit (use annotation default).
-        const res = prof('omc_simulate ' + a.name, () => omc_simulate(
-          a.name,
-          a.stopTime != null ? a.stopTime : 0,
-          a.intervals != null ? a.intervals : 0,
-          a.tolerance != null ? a.tolerance : 0,
-          a.method || '',
-          a.override || ''));
-        logSimTimers(res);
+        // buildModel (translate + JIT, bakes the settings) then runResumable (a
+        // cancellable chunked run + `.mat`). Omitted args use the experiment annotation.
+        const opts = [];
+        if (a.stopTime) opts.push(`stopTime=${a.stopTime}`);
+        if (a.intervals) opts.push(`numberOfIntervals=${a.intervals}`);
+        if (a.tolerance) opts.push(`tolerance=${a.tolerance}`);
+        if (a.method) opts.push(`method="${a.method}"`);
+        const built = (await evalWithDownloads(`buildModel(${a.name}${opts.length ? ',' + opts.join(',') : ''})`, status)).trim();
+        // buildModel → {"<prefix>","<initfile>"}; an empty first element means it failed.
+        if (!/^\{\s*"[^"]/.test(built)) return reply(simError('Build failed.'));
+        const st = await runResumable(a.name, a.override ? `-override=${a.override}` : '', status);
+        if (st === 3) return reply({ ok: false, cancelled: true });
+        if (st < 0) return reply(simError('Simulation failed.'));
         const s = snapshot();
         if (!s) return reply(simError('Simulation produced no result.'));
-        s.snap.options = parseSimOptions(res);   // settings actually used → seed the dialog
+        s.snap.options = simOptions(a.name, a);  // settings actually used → seed the dialog
         reply(s.snap, s.transfer);               // figures/doc come from loadSource/copyClass
         break;
       }
       case 'resimulate': {
-        await evalWithDownloads(
-          `simulate(${a.name}, simflags="${esc(a.override)}", resimulateExecutable="${a.name}")`, status);
+        // Re-run the already-built model (no rebuild) — same cancellable chunked path.
+        const st = await runResumable(a.name, a.override ? `-override=${a.override}` : '', status);
+        if (st === 3) return reply({ ok: false, cancelled: true });
+        if (st < 0) return reply(simError('Re-simulation failed.'));
         const s = snapshot();
         if (!s) return reply(simError('Re-simulation produced no result.'));
         reply(s.snap, s.transfer);

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3748,6 +3748,10 @@ algorithm
     case (_, _)
       guard Error.getNumErrorMessages() == numError
       algorithm
+        // A user cancel unwinds with its message rolled back by the failed
+        // speculation above; re-emit it here (the accepted branch) so it is not
+        // masked by the generic "no error message" below.
+        Error.checkCancel();
         Error.addMessage(Error.INTERNAL_ERROR,
           {"Instantiation of " + AbsynUtil.pathString(className) + " failed with no error message."});
         FlagsUtil.set(Flags.SCODE_INST, nf_inst_actual);

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1339,6 +1339,8 @@ public constant ErrorTypes.Message ENCRYPTION_NOT_SUPPORTED = ErrorTypes.MESSAGE
   "File not Found: %s. Compile OpenModelica with Encryption support.");
 public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_NOT_SUPPORTED = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "DAE mode (--daeMode) is not supported for FMU export. Please remove the --daeMode flag.");
+public constant ErrorTypes.Message USER_CANCELLED = ErrorTypes.MESSAGE(7028, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  "Operation cancelled by user.");
 
 constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
 
@@ -1418,6 +1420,15 @@ algorithm
       then str;
   end match;
 end getCurrentComponent;
+
+public function checkCancel "Fails with a USER_CANCELLED message if the user requested cancellation.
+  A coarse chokepoint for the frontend/backend driver loops."
+algorithm
+  if System.isCancelled() then
+    addMessage(USER_CANCELLED, {});
+    fail();
+  end if;
+end checkCancel;
 
 public function addMessage "Implementation of Relations
   function: addMessage

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1265,13 +1265,6 @@ public function isCancelled "True if the user has requested cancellation of the 
   external "C" cancelled = System_isCancelled() annotation(Library = "omcruntime");
 end isCancelled;
 
-public function checkCancel "Fails if cancellation was requested. A coarse chokepoint for the frontend/backend driver loops."
-algorithm
-  if isCancelled() then
-    fail();
-  end if;
-end checkCancel;
-
 public function reportProgress "Report progress of the running operation to the host UI. permille is 0..1000 or -1 (indeterminate); phase is one of the metamodelica::cancel PHASE_* constants (2 parse, 3 instantiate, 4 backend, 5 simulate)."
   input Integer permille;
   input Integer phase;

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1260,6 +1260,24 @@ public function threadWorkFailed "Exits the current thread with a failure."
   external "C" System_threadFail(OpenModelica.threadData());
 end threadWorkFailed;
 
+public function isCancelled "True if the user has requested cancellation of the running operation."
+  output Boolean cancelled;
+  external "C" cancelled = System_isCancelled() annotation(Library = "omcruntime");
+end isCancelled;
+
+public function checkCancel "Fails if cancellation was requested. A coarse chokepoint for the frontend/backend driver loops."
+algorithm
+  if isCancelled() then
+    fail();
+  end if;
+end checkCancel;
+
+public function reportProgress "Report progress of the running operation to the host UI. permille is 0..1000 or -1 (indeterminate); phase is one of the metamodelica::cancel PHASE_* constants (2 parse, 3 instantiate, 4 backend, 5 simulate)."
+  input Integer permille;
+  input Integer phase;
+  external "C" System_reportProgress(permille, phase) annotation(Library = "omcruntime");
+end reportProgress;
+
 public function getMemorySize
   output Real memory(unit="MB");
 external "C" memory=System_getMemorySize() annotation(Library = {"omcruntime"});

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -312,6 +312,50 @@ extern void System_setUsesCardinality(int b)
   usesCardinality = b;
 }
 
+/* Cooperative cancellation. System_isCancelled is polled by the compiler
+ * (System.checkCancel); System_requestCancel/System_clearCancel are the host
+ * (OMEdit) side. Progress is one-way, compiler → host. */
+extern int System_isCancelled()
+{
+  if (pumpCallback) {
+    pumpCallback();
+  }
+  return cancelRequested;
+}
+
+extern void System_setPumpCallback(void (*cb)(void))
+{
+  pumpCallback = cb;
+}
+
+extern void System_requestCancel()
+{
+  cancelRequested = 1;
+}
+
+extern void System_clearCancel()
+{
+  cancelRequested = 0;
+  progressPermille = -1;
+  progressPhase = 0;
+}
+
+extern void System_reportProgress(int permille, int phase)
+{
+  progressPermille = permille;
+  progressPhase = phase;
+}
+
+extern int System_progressPermille()
+{
+  return progressPermille;
+}
+
+extern int System_progressPhase()
+{
+  return progressPhase;
+}
+
 extern void* System_strtok(const char *str0, const char *delimit)
 {
   char *s;

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -313,7 +313,7 @@ extern void System_setUsesCardinality(int b)
 }
 
 /* Cooperative cancellation. System_isCancelled is polled by the compiler
- * (System.checkCancel); System_requestCancel/System_clearCancel are the host
+ * (Error.checkCancel); System_requestCancel/System_clearCancel are the host
  * (OMEdit) side. Progress is one-way, compiler → host. */
 extern int System_isCancelled()
 {

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -178,6 +178,16 @@ static int usesCardinality = 1;
 static char* class_names_for_simulation = NULL;
 static const char *select_from_dir = NULL;
 
+/* Cooperative cancellation + progress, mirrors metamodelica::cancel in the Rust
+ * port. The flag is set from another context (an OMEdit Cancel button) and
+ * polled at the frontend/backend chokepoints via System_isCancelled. */
+static volatile int cancelRequested = 0;
+static volatile int progressPermille = -1;
+static volatile int progressPhase = 0;
+/* Host event-pump invoked at each cancel check; keeps an in-process GUI live
+ * during a long call. NULL for the CLI. */
+static void (*pumpCallback)(void) = NULL;
+
 
 /* TODO: Unused functions referenced by the bootstrapping sources.
  *       Remove when the sources have been updated. */

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -235,6 +235,13 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpProgressBar->setMaximumWidth(300);
   mpProgressBar->setTextVisible(false);
   mpProgressBar->setVisible(false);
+  // Cancel button for a running omc operation (parse/instantiate/backend/sim)
+  mpCancelOperationButton = new QToolButton;
+  mpCancelOperationButton->setIcon(QIcon(":/Resources/icons/delete.svg"));
+  mpCancelOperationButton->setToolTip(tr("Cancel the running operation"));
+  mpCancelOperationButton->setAutoRaise(true);
+  mpCancelOperationButton->setVisible(false);
+  connect(mpCancelOperationButton, SIGNAL(clicked()), SLOT(cancelOmcOperation()));
   // Position Label
   mpPositionLabel = new Label;
   mpPositionLabel->setMinimumWidth(75);
@@ -270,6 +277,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpStatusBar->setContentsMargins(0, 0, 0, 0);
   // add items to statusbar
   mpStatusBar->addPermanentWidget(mpProgressBar);
+  mpStatusBar->addPermanentWidget(mpCancelOperationButton);
   mpStatusBar->addPermanentWidget(mpPositionLabel);
   mpStatusBar->addPermanentWidget(mpPerspectiveTabbar);
   // set status bar for MainWindow
@@ -3637,6 +3645,80 @@ void MainWindow::toggleAutoSave()
   } else {
     mpAutoSaveTimer->stop();
   }
+}
+
+// Cancel setter, one per backend. The compiler polls this flag at its chokepoints
+// (System.checkCancel) and unwinds cooperatively; nothing is force-terminated.
+// extern "C": these are C-linkage symbols (EM_JS / the omc C ABI), so the
+// declarations must not be C++-mangled or the reference won't resolve.
+extern "C" {
+#if defined(__EMSCRIPTEN__)
+void omedit_cancel_sim();                        // omc Web Worker: SharedArrayBuffer store (OMCProxy.cpp)
+#elif defined(OMC_RUST_ABI)
+void omc_compiler_request_cancel();              // Rust omc in-process (libOpenModelicaCompiler)
+#else
+void System_requestCancel();                     // classic C omc runtime
+#endif
+}
+
+/*!
+ * \brief MainWindow::showCancelOperationButton
+ * Shows or hides the status-bar Cancel button for a running omc operation.
+ */
+void MainWindow::showCancelOperationButton(bool show)
+{
+  // May be called by an omc command issued before the status bar is built.
+  if (mpCancelOperationButton) {
+    mpCancelOperationButton->setVisible(show);
+  }
+}
+
+/*!
+ * \brief MainWindow::setOmcOperationRunning
+ * Disables everything but the status-bar Cancel button for the duration of an
+ * omc command, so the pumped event loop (omedit_pump_events) can deliver the
+ * Cancel click without re-entering the non-reentrant compiler. Also parks the
+ * auto-save timer, which would otherwise fire an omc command mid-operation.
+ */
+void MainWindow::setOmcOperationRunning(bool running)
+{
+  const bool enabled = !running;
+  if (centralWidget()) {
+    centralWidget()->setEnabled(enabled);
+  }
+  if (menuBar()) {
+    menuBar()->setEnabled(enabled);
+  }
+  for (QToolBar *pToolBar : findChildren<QToolBar*>()) {
+    pToolBar->setEnabled(enabled);
+  }
+  for (QDockWidget *pDockWidget : findChildren<QDockWidget*>()) {
+    pDockWidget->setEnabled(enabled);
+  }
+  if (mpAutoSaveTimer) {
+    if (running) {
+      mAutoSaveWasActive = mpAutoSaveTimer->isActive();
+      mpAutoSaveTimer->stop();
+    } else if (mAutoSaveWasActive) {
+      mpAutoSaveTimer->start();
+    }
+  }
+  showCancelOperationButton(running);
+}
+
+/*!
+ * \brief MainWindow::cancelOmcOperation
+ * Requests cancellation of the operation omc is currently running.
+ */
+void MainWindow::cancelOmcOperation()
+{
+#if defined(__EMSCRIPTEN__)
+  omedit_cancel_sim();
+#elif defined(OMC_RUST_ABI)
+  omc_compiler_request_cancel();
+#else
+  System_requestCancel();
+#endif
 }
 
 /*!

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -3703,7 +3703,11 @@ void MainWindow::setOmcOperationRunning(bool running)
       mpAutoSaveTimer->start();
     }
   }
-  showCancelOperationButton(running);
+  // The button is revealed by OmcBusyScope's delayed timer so quick commands
+  // don't flash it; here we only guarantee it is hidden once the op ends.
+  if (!running) {
+    showCancelOperationButton(false);
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -60,6 +60,7 @@ extern "C" {
 #include <QMainWindow>
 #include <QDialog>
 #include <QProgressBar>
+#include <QToolButton>
 #include <QMimeData>
 #include <QDomDocument>
 #include <QStackedWidget>
@@ -156,6 +157,8 @@ public:
   QProgressBar* getProgressBar() {return mpProgressBar;}
   void showProgressBar() {mpProgressBar->setVisible(true);}
   void hideProgressBar() {mpProgressBar->setVisible(false);}
+  void showCancelOperationButton(bool show);
+  void setOmcOperationRunning(bool running);
   Label* getPositionLabel() {return mpPositionLabel;}
   bool isModelingPerspectiveActive();
   bool isPlottingPerspectiveActive();
@@ -320,11 +323,13 @@ private:
   TraceabilityInformationURI *mpTraceabilityInformationURI;
   QStackedWidget *mpCentralStackedWidget;
   QTabWidget *mpMessagesTabWidget;
-  QProgressBar *mpProgressBar;
+  QProgressBar *mpProgressBar = nullptr;
+  QToolButton *mpCancelOperationButton = nullptr;
   Label *mpPositionLabel;
   QTabBar *mpPerspectiveTabbar;
-  StatusBar *mpStatusBar;
-  QTimer *mpAutoSaveTimer;
+  StatusBar *mpStatusBar = nullptr;
+  QTimer *mpAutoSaveTimer = nullptr;
+  bool mAutoSaveWasActive = false;
   QShortcut *mpSearchBrowserShortcut;
   // File Menu
   // Modelica File Actions
@@ -585,6 +590,7 @@ public slots:
   void updateDebuggerToolBarMenu();
   void toggleAutoSave();
 private slots:
+  void cancelOmcOperation();
   void perspectiveTabChanged(int tabIndex);
   void documentationDockWidgetVisibilityChanged(bool visible);
   void messagesTabBarClicked(int index);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -66,10 +66,18 @@ void omc_System_initGarbageCollector(void *threadData);
 #if defined(_WIN32)
 void omc_Main_setWindowsPaths(threadData_t *threadData, void* _inOMHome);
 #endif
+#if !defined(__EMSCRIPTEN__) && defined(OMC_RUST_ABI)
+void omc_compiler_clear_cancel();                       // Rust in-process: reset the cancel flag per op
+void omc_compiler_set_pump_callback(void (*cb)(void));  // register the event-pump callback
+#elif !defined(__EMSCRIPTEN__)
+void System_clearCancel();                              // classic C omc runtime
+void System_setPumpCallback(void (*cb)(void));
+#endif
 }
 
 #include <QMessageBox>
 #include <QStringBuilder>
+#include <QCoreApplication>
 
 #if defined(__EMSCRIPTEN__)
 #include <cstdlib>
@@ -94,17 +102,19 @@ EM_JS(void, omedit_worker_setup, (const char *ver), {
   url.search = "v=" + UTF8ToString(ver);
   const w = new Worker(url, { type: "module" });
   Module.__omcWorker = w;
-  // Cooperative simulation cancel: a shared flag the omc driver polls per step (needs
-  // cross-origin isolation for SharedArrayBuffer). simulate() blocks the worker, so
-  // cancel can't be a message — the main thread writes this flag, the worker reads it.
-  Module.__omcCancelView = null;
+  // Cooperative cancel + live progress: a shared "control block" the omc worker
+  // polls/writes (needs cross-origin isolation for SharedArrayBuffer). A long omc
+  // call blocks the worker, so cancel can't be a message — the main thread writes
+  // control[0], the worker reads it; the worker writes progress into control[1]/[2].
+  // Layout (Int32Array): [0] cancel, [1] progress permille, [2] phase, [3] generation.
+  Module.__omcControlView = null;
   try {
     if (typeof SharedArrayBuffer !== "undefined" && self.crossOriginIsolated) {
-      const cbuf = new SharedArrayBuffer(4);
-      Module.__omcCancelView = new Int32Array(cbuf);
-      w.postMessage({ cmd: "cancelBuf", buf: cbuf });
+      const cbuf = new SharedArrayBuffer(16);
+      Module.__omcControlView = new Int32Array(cbuf);
+      w.postMessage({ cmd: "controlBuf", buf: cbuf });
     }
-  } catch (e) { Module.__omcCancelView = null; }
+  } catch (e) { Module.__omcControlView = null; }
   Module.__omcPending = null;
   Module.__omcMsgId = 0;
   Module.__omcCallId = 0;
@@ -239,16 +249,33 @@ EM_ASYNC_JS(void, omedit_await_call, (int id), {
 
 EM_JS(void, omedit_wake_now, (), { if (Module.__omcWake) Module.__omcWake(); });
 
-// Cooperative simulation cancel flag (shared with the omc worker). Available only
-// when cross-origin isolated (SharedArrayBuffer); omedit_cancel_available reports it.
+// Cooperative cancel + progress control block (shared with the omc worker).
+// Available only when cross-origin isolated (SharedArrayBuffer);
+// omedit_cancel_available reports it. Indices: 0 cancel, 1 progress, 2 phase,
+// 3 generation.
 EM_JS(int, omedit_cancel_available, (), {
-  return Module.__omcCancelView ? 1 : 0;
+  return Module.__omcControlView ? 1 : 0;
 });
 EM_JS(void, omedit_cancel_sim, (), {
-  if (Module.__omcCancelView) Atomics.store(Module.__omcCancelView, 0, 1);
+  if (Module.__omcControlView) Atomics.store(Module.__omcControlView, 0, 1);
 });
+// Clear the cancel flag and reset progress at the start of a new op; bump the
+// generation so a late progress write from the previous op is ignored.
 EM_JS(void, omedit_clear_cancel, (), {
-  if (Module.__omcCancelView) Atomics.store(Module.__omcCancelView, 0, 0);
+  const v = Module.__omcControlView;
+  if (v) {
+    Atomics.store(v, 0, 0);
+    Atomics.store(v, 1, -1);
+    Atomics.store(v, 2, 0);
+    Atomics.add(v, 3, 1);
+  }
+});
+// Read current progress permille (-1 indeterminate) / phase for the UI timer.
+EM_JS(int, omedit_progress_permille, (), {
+  return Module.__omcControlView ? Atomics.load(Module.__omcControlView, 1) : -1;
+});
+EM_JS(int, omedit_progress_phase, (), {
+  return Module.__omcControlView ? Atomics.load(Module.__omcControlView, 2) : 0;
 });
 
 static QVarLengthArray<QEventLoop *> g_omcWaitStack;
@@ -263,6 +290,55 @@ static void ensureWakeInstalled() {
   });
   EM_ASM({ Module.__omcWakeIndex = $0; }, idx);
   g_omcWakeInstalled = true;
+}
+
+// Progress phase (metamodelica::cancel PHASE_*) → user-facing label.
+static QString omcPhaseLabel(int phase) {
+  switch (phase) {
+    case 1: return QObject::tr("Downloading…");
+    case 2: return QObject::tr("Parsing…");
+    case 3: return QObject::tr("Instantiating…");
+    case 4: return QObject::tr("Compiling model…");
+    case 5: return QObject::tr("Simulating…");
+    default: return QString();
+  }
+}
+
+// Read the worker's progress control block and reflect it on the main-window
+// status bar while a blocking call is in flight. Sets ownsBar when it is the
+// one that made the bar visible, so the wait can restore it on completion.
+static void omcDriveProgressUi(bool &ownsBar) {
+  int phase = omedit_progress_phase();
+  if (phase == 0) return; // PHASE_IDLE — nothing running to report
+  MainWindow *w = MainWindow::instance();
+  // The status bar / progress bar are built partway through MainWindow's
+  // constructor, but omc commands (getVersion, …) run before that from the
+  // OMCProxy constructor — and the wait's QTimer can fire during them. Bail
+  // until they exist so we never make a virtual call on an uninitialised member.
+  if (!w || !w->getProgressBar() || !w->getStatusBar()) return;
+  QProgressBar *bar = w->getProgressBar();
+  if (!bar->isVisible()) {
+    ownsBar = true;
+    w->showProgressBar();
+  }
+  int permille = omedit_progress_permille();
+  if (permille < 0) {
+    bar->setRange(0, 0); // indeterminate spinner
+  } else {
+    bar->setRange(0, 1000);
+    bar->setValue(permille);
+  }
+  w->showCancelOperationButton(true);
+  w->getStatusBar()->showMessage(omcPhaseLabel(phase));
+}
+
+static void omcClearProgressUi() {
+  MainWindow *w = MainWindow::instance();
+  if (!w || !w->getProgressBar() || !w->getStatusBar()) return;
+  w->showCancelOperationButton(false);
+  w->hideProgressBar();
+  w->getProgressBar()->setRange(0, 100);
+  w->getStatusBar()->clearMessage();
 }
 
 void omcWorkerWaitReply(int id) {
@@ -282,9 +358,24 @@ void omcWorkerWaitReply(int id) {
     loop.exec();
     return;
   }
+  // Only the outermost wait drives the progress UI (nested calls would fight
+  // over the same status bar) and only when the shared control block exists
+  // (cross-origin isolated); a quick call finishes before the 100 ms tick, so
+  // the bar never flashes for trivial requests.
+  bool outermost = g_omcWaitStack.isEmpty();
   g_omcWaitStack.append(&loop);
+  QTimer progressTimer;
+  bool ownsBar = false;
+  if (outermost && omedit_cancel_available()) {
+    QObject::connect(&progressTimer, &QTimer::timeout, &loop, [&ownsBar]() {
+      omcDriveProgressUi(ownsBar);
+    });
+    progressTimer.start(100);
+  }
   while (!omedit_call_ready(id)) loop.exec();
+  progressTimer.stop();
   g_omcWaitStack.removeLast();
+  if (ownsBar) omcClearProgressUi();
   if (!g_omcWaitStack.isEmpty()) omedit_wake_now();
 }
 
@@ -393,6 +484,59 @@ bool omcWorkerStageFile(const char *path) {
   return omedit_stage_into_memfs(id, path) != 0;
 }
 #endif // __EMSCRIPTEN__
+
+#if !defined(__EMSCRIPTEN__)
+// omc runs in-process on the UI thread, so a long compile would freeze the GUI.
+// omc invokes this at every cancel check (System.checkCancel); it hands the
+// thread back to Qt so the Cancel click is delivered (flipping the flag omc then
+// reads) and progress repaints. Rate-limited — checkCancel fires per class.
+// Reentering omc is prevented by OmcBusyScope disabling all UI but Cancel.
+extern "C" void omedit_pump_events()
+{
+  static QElapsedTimer sLastPump;
+  if (sLastPump.isValid() && sLastPump.elapsed() < 40) {
+    return;
+  }
+  sLastPump.restart();
+  QCoreApplication::processEvents();
+}
+
+// Registers omedit_pump_events with whichever omc backend is linked, once.
+static void omedit_install_pump()
+{
+#if defined(OMC_RUST_ABI)
+  omc_compiler_set_pump_callback(omedit_pump_events);
+#else
+  System_setPumpCallback(omedit_pump_events);
+#endif
+}
+
+// Marks omc busy for the duration of a command: at the outermost call it clears
+// any stale cancel and disables the UI (except Cancel) so the pumped event loop
+// can't reenter the non-reentrant compiler. Nested calls (e.g. loadModelCB) are
+// no-ops. RAII so early returns in sendCommand still restore the UI.
+namespace {
+int g_omcCommandDepth = 0;
+struct OmcBusyScope {
+  bool outer;
+  OmcBusyScope() : outer(g_omcCommandDepth == 0) {
+    g_omcCommandDepth++;
+    if (outer) {
+#if defined(OMC_RUST_ABI)
+      omc_compiler_clear_cancel();
+#else
+      System_clearCancel();
+#endif
+      if (MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(true);
+    }
+  }
+  ~OmcBusyScope() {
+    g_omcCommandDepth--;
+    if (outer && MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(false);
+  }
+};
+}
+#endif // !__EMSCRIPTEN__
 
 /*!
  * \class OMCProxy
@@ -612,6 +756,7 @@ bool OMCProxy::initializeOMC(threadData_t *threadData)
   threadData->loadModelCB = MainWindow::LoadModelCallbackFunction;
   MMC_CATCH_TOP(return false;)
   mpOMCInterface = new OMCInterface(threadData);
+  omedit_install_pump();
 #endif
   connect(mpOMCInterface, SIGNAL(logCommand(QString)), this, SLOT(logCommand(QString)));
   connect(mpOMCInterface, SIGNAL(logResponse(QString,QString,double)), this, SLOT(logResponse(QString,QString,double)));
@@ -716,6 +861,9 @@ void OMCProxy::sendCommand(const QString expression, bool saveToHistory)
     }
   }
 #else
+  // Busy scope (outermost call) clears any stale cancel and disables all UI but
+  // the Cancel button, so omedit_pump_events can run the event loop safely.
+  OmcBusyScope omcBusy;
   if (!omc_Main_handleCommand(threadData, mmc_mk_scon(expression.toUtf8().constData()), &reply_str)) {
     if (expression == "quit()") {
       return;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -69,15 +69,32 @@ void omc_Main_setWindowsPaths(threadData_t *threadData, void* _inOMHome);
 #if !defined(__EMSCRIPTEN__) && defined(OMC_RUST_ABI)
 void omc_compiler_clear_cancel();                       // Rust in-process: reset the cancel flag per op
 void omc_compiler_set_pump_callback(void (*cb)(void));  // register the event-pump callback
+int omc_compiler_progress_permille();                   // 0..1000, or <0 for indeterminate
+int omc_compiler_progress_phase();                      // PHASE_* (0 idle)
 #elif !defined(__EMSCRIPTEN__)
 void System_clearCancel();                              // classic C omc runtime
 void System_setPumpCallback(void (*cb)(void));
+int System_progressPermille();
+int System_progressPhase();
 #endif
 }
 
 #include <QMessageBox>
 #include <QStringBuilder>
 #include <QCoreApplication>
+
+// Progress phase (compiler PHASE_* / metamodelica::cancel) → user-facing label.
+// Shared by the wasm worker-wait UI and the native pump-driven progress bar.
+static QString omcPhaseLabel(int phase) {
+  switch (phase) {
+    case 1: return QObject::tr("Downloading…");
+    case 2: return QObject::tr("Parsing…");
+    case 3: return QObject::tr("Instantiating…");
+    case 4: return QObject::tr("Compiling model…");
+    case 5: return QObject::tr("Simulating…");
+    default: return QString();
+  }
+}
 
 #if defined(__EMSCRIPTEN__)
 #include <cstdlib>
@@ -292,22 +309,10 @@ static void ensureWakeInstalled() {
   g_omcWakeInstalled = true;
 }
 
-// Progress phase (metamodelica::cancel PHASE_*) → user-facing label.
-static QString omcPhaseLabel(int phase) {
-  switch (phase) {
-    case 1: return QObject::tr("Downloading…");
-    case 2: return QObject::tr("Parsing…");
-    case 3: return QObject::tr("Instantiating…");
-    case 4: return QObject::tr("Compiling model…");
-    case 5: return QObject::tr("Simulating…");
-    default: return QString();
-  }
-}
-
 // Read the worker's progress control block and reflect it on the main-window
 // status bar while a blocking call is in flight. Sets ownsBar when it is the
 // one that made the bar visible, so the wait can restore it on completion.
-static void omcDriveProgressUi(bool &ownsBar) {
+static void omcDriveProgressUi(bool &ownsBar, bool &ownsCancel) {
   int phase = omedit_progress_phase();
   if (phase == 0) return; // PHASE_IDLE — nothing running to report
   MainWindow *w = MainWindow::instance();
@@ -328,17 +333,23 @@ static void omcDriveProgressUi(bool &ownsBar) {
     bar->setRange(0, 1000);
     bar->setValue(permille);
   }
+  ownsCancel = true;
   w->showCancelOperationButton(true);
   w->getStatusBar()->showMessage(omcPhaseLabel(phase));
 }
 
-static void omcClearProgressUi() {
+// Restore whatever this wait made visible. The bar and cancel button are
+// tracked separately: a wait may show the Cancel button while another widget
+// already owns the progress bar, and must still hide the button on completion.
+static void omcClearProgressUi(bool ownsBar, bool ownsCancel) {
   MainWindow *w = MainWindow::instance();
   if (!w || !w->getProgressBar() || !w->getStatusBar()) return;
-  w->showCancelOperationButton(false);
-  w->hideProgressBar();
-  w->getProgressBar()->setRange(0, 100);
-  w->getStatusBar()->clearMessage();
+  if (ownsCancel) w->showCancelOperationButton(false);
+  if (ownsBar) {
+    w->hideProgressBar();
+    w->getProgressBar()->setRange(0, 100);
+    w->getStatusBar()->clearMessage();
+  }
 }
 
 void omcWorkerWaitReply(int id) {
@@ -366,16 +377,17 @@ void omcWorkerWaitReply(int id) {
   g_omcWaitStack.append(&loop);
   QTimer progressTimer;
   bool ownsBar = false;
+  bool ownsCancel = false;
   if (outermost && omedit_cancel_available()) {
-    QObject::connect(&progressTimer, &QTimer::timeout, &loop, [&ownsBar]() {
-      omcDriveProgressUi(ownsBar);
+    QObject::connect(&progressTimer, &QTimer::timeout, &loop, [&ownsBar, &ownsCancel]() {
+      omcDriveProgressUi(ownsBar, ownsCancel);
     });
     progressTimer.start(100);
   }
   while (!omedit_call_ready(id)) loop.exec();
   progressTimer.stop();
   g_omcWaitStack.removeLast();
-  if (ownsBar) omcClearProgressUi();
+  if (ownsBar || ownsCancel) omcClearProgressUi(ownsBar, ownsCancel);
   if (!g_omcWaitStack.isEmpty()) omedit_wake_now();
 }
 
@@ -491,6 +503,47 @@ bool omcWorkerStageFile(const char *path) {
 // thread back to Qt so the Cancel click is delivered (flipping the flag omc then
 // reads) and progress repaints. Rate-limited — checkCancel fires per class.
 // Reentering omc is prevented by OmcBusyScope disabling all UI but Cancel.
+// Reflect the compiler's last-reported progress (read via the backend getters)
+// on the status bar while an in-process op is in flight. Tracks whether it was
+// the one that made the bar visible so OmcBusyScope can restore it on completion.
+static bool g_omcNativeOwnsBar = false;
+static void omcDriveNativeProgress()
+{
+  MainWindow *w = MainWindow::instance();
+  if (!w || !w->getProgressBar() || !w->getStatusBar()) return;
+#if defined(OMC_RUST_ABI)
+  int phase = omc_compiler_progress_phase();
+  int permille = omc_compiler_progress_permille();
+#else
+  int phase = System_progressPhase();
+  int permille = System_progressPermille();
+#endif
+  if (phase == 0) return; // nothing reported yet
+  QProgressBar *bar = w->getProgressBar();
+  if (!bar->isVisible()) {
+    g_omcNativeOwnsBar = true;
+    w->showProgressBar();
+  }
+  if (permille < 0) {
+    bar->setRange(0, 0); // indeterminate spinner
+  } else {
+    bar->setRange(0, 1000);
+    bar->setValue(permille);
+  }
+  w->getStatusBar()->showMessage(omcPhaseLabel(phase));
+}
+
+static void omcClearNativeProgress()
+{
+  if (!g_omcNativeOwnsBar) return;
+  g_omcNativeOwnsBar = false;
+  MainWindow *w = MainWindow::instance();
+  if (!w || !w->getProgressBar() || !w->getStatusBar()) return;
+  w->hideProgressBar();
+  w->getProgressBar()->setRange(0, 100);
+  w->getStatusBar()->clearMessage();
+}
+
 extern "C" void omedit_pump_events()
 {
   static QElapsedTimer sLastPump;
@@ -498,6 +551,7 @@ extern "C" void omedit_pump_events()
     return;
   }
   sLastPump.restart();
+  omcDriveNativeProgress();
   QCoreApplication::processEvents();
 }
 
@@ -519,6 +573,10 @@ namespace {
 int g_omcCommandDepth = 0;
 struct OmcBusyScope {
   bool outer;
+  // Reveal Cancel only if the op runs past this; quick commands (the vast
+  // majority) finish first and never flash the button. The UI-disable itself
+  // is immediate — the pump can fire mid-op, so reentrancy must be blocked now.
+  QTimer showButtonTimer;
   OmcBusyScope() : outer(g_omcCommandDepth == 0) {
     g_omcCommandDepth++;
     if (outer) {
@@ -528,11 +586,20 @@ struct OmcBusyScope {
       System_clearCancel();
 #endif
       if (MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(true);
+      showButtonTimer.setSingleShot(true);
+      QObject::connect(&showButtonTimer, &QTimer::timeout, []() {
+        if (MainWindow::instance()) MainWindow::instance()->showCancelOperationButton(true);
+      });
+      showButtonTimer.start(100);
     }
   }
   ~OmcBusyScope() {
     g_omcCommandDepth--;
-    if (outer && MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(false);
+    if (outer) {
+      showButtonTimer.stop();
+      omcClearNativeProgress();
+      if (MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(false);
+    }
   }
 };
 }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -94,6 +94,17 @@ EM_JS(void, omedit_worker_setup, (const char *ver), {
   url.search = "v=" + UTF8ToString(ver);
   const w = new Worker(url, { type: "module" });
   Module.__omcWorker = w;
+  // Cooperative simulation cancel: a shared flag the omc driver polls per step (needs
+  // cross-origin isolation for SharedArrayBuffer). simulate() blocks the worker, so
+  // cancel can't be a message — the main thread writes this flag, the worker reads it.
+  Module.__omcCancelView = null;
+  try {
+    if (typeof SharedArrayBuffer !== "undefined" && self.crossOriginIsolated) {
+      const cbuf = new SharedArrayBuffer(4);
+      Module.__omcCancelView = new Int32Array(cbuf);
+      w.postMessage({ cmd: "cancelBuf", buf: cbuf });
+    }
+  } catch (e) { Module.__omcCancelView = null; }
   Module.__omcPending = null;
   Module.__omcMsgId = 0;
   Module.__omcCallId = 0;
@@ -227,6 +238,18 @@ EM_ASYNC_JS(void, omedit_await_call, (int id), {
 });
 
 EM_JS(void, omedit_wake_now, (), { if (Module.__omcWake) Module.__omcWake(); });
+
+// Cooperative simulation cancel flag (shared with the omc worker). Available only
+// when cross-origin isolated (SharedArrayBuffer); omedit_cancel_available reports it.
+EM_JS(int, omedit_cancel_available, (), {
+  return Module.__omcCancelView ? 1 : 0;
+});
+EM_JS(void, omedit_cancel_sim, (), {
+  if (Module.__omcCancelView) Atomics.store(Module.__omcCancelView, 0, 1);
+});
+EM_JS(void, omedit_clear_cancel, (), {
+  if (Module.__omcCancelView) Atomics.store(Module.__omcCancelView, 0, 0);
+});
 
 static QVarLengthArray<QEventLoop *> g_omcWaitStack;
 static bool g_omcWakeInstalled = false;

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -65,6 +65,12 @@
 
 extern "C" {
 extern const char* System_openModelicaPlatform();
+#if defined(__EMSCRIPTEN__)
+// Cooperative wasm-jit simulation cancel; defined as EM_JS in OMCProxy.cpp.
+int omedit_cancel_available();
+void omedit_cancel_sim();
+void omedit_clear_cancel();
+#endif
 }
 
 /*!
@@ -497,7 +503,23 @@ void SimulationOutputWidget::runWasmJitSimulation(const QString &simulationParam
   // Echo the flags in the compilation output (always visible) so the run is
   // debuggable even if the simulation-messages path has a problem.
   writeCompilationOutput(tr("Simulation flags: %1").arg(simflags.isEmpty() ? tr("(none)") : simflags), Qt::black);
+#if defined(__EMSCRIPTEN__)
+  // Cooperative cancel: enable the button (sendCommand spins a nested QEventLoop, so
+  // a click reaches cancelCompilationOrSimulation and sets the shared flag the omc
+  // driver polls). Only when the shared buffer exists (cross-origin isolated).
+  mWasmJitCancelled = false;
+  if (omedit_cancel_available()) {
+    omedit_clear_cancel();
+    mIsWasmJitSimulationRunning = true;
+    mpCancelButton->setText(tr("Cancel Simulation"));
+    mpCancelButton->setEnabled(true);
+  }
+#endif
   pOMCProxy->sendCommand(command);
+#if defined(__EMSCRIPTEN__)
+  mIsWasmJitSimulationRunning = false;
+  mpCancelButton->setEnabled(false);
+#endif
   const QString simulationResult = pOMCProxy->getResult();
   pOMCProxy->printMessagesStringInternal();
   // The SimulationResult record carries the run's messages; an empty resultFile
@@ -533,7 +555,8 @@ void SimulationOutputWidget::runWasmJitSimulation(const QString &simulationParam
 #endif
   mpProgressBar->setRange(0, 100);
   mpProgressBar->setValue(100);
-  const QString progressStr = ok ? tr("Simulation of %1 finished.").arg(mSimulationOptions.getClassName())
+  const QString progressStr = mWasmJitCancelled ? tr("Simulation of %1 cancelled.").arg(mSimulationOptions.getClassName())
+                            : ok ? tr("Simulation of %1 finished.").arg(mSimulationOptions.getClassName())
                                  : tr("Simulation of %1 failed.").arg(mSimulationOptions.getClassName());
   mpProgressLabel->setText(progressStr);
   updateMessageTab(progressStr);
@@ -1326,6 +1349,16 @@ void SimulationOutputWidget::cancelCompilationOrSimulation()
   mpProgressLabel->setText(progressStr);
   updateMessageTab(progressStr);
 #endif // QT_CONFIG(process)
+#if defined(__EMSCRIPTEN__)
+  // wasm-jit run: no QProcess to kill — set the shared flag; the blocking simulate()
+  // aborts and runWasmJitSimulation reports it.
+  if (mIsWasmJitSimulationRunning) {
+    omedit_cancel_sim();
+    mWasmJitCancelled = true;
+    mpCancelButton->setEnabled(false);
+    mpProgressLabel->setText(tr("Cancelling simulation of %1…").arg(mSimulationOptions.getClassName()));
+  }
+#endif
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -151,6 +151,10 @@ private:
   QProcess *mpSimulationProcess;
   bool mIsSimulationProcessKilled;
   bool mIsSimulationProcessRunning;
+  // wasm-jit in-process run (no QProcess): whether a cancellable simulate() is in
+  // flight, and whether the user asked to cancel it (shared-flag cooperative cancel).
+  bool mIsWasmJitSimulationRunning = false;
+  bool mWasmJitCancelled = false;
   QDateTime mResultFileLastModifiedDateTime;
 
   void compileModel();


### PR DESCRIPTION
Split the wasm-jit simulation into a resumable driver + session so a long run can be cancelled without killing the omc worker (web) or process (native) -- which would lose the loaded library and warmed JIT.

The three drivers (Euler, DASSL, DASSL-events) become resumable structs; advance(budget_ms) integrates a wall-clock-bounded chunk and returns, checking cancel before each solver call so a stuck NLS or event interval also yields. Resume is bit-exact (DASKR state persists in the driver). Native cancel is a per-step AtomicBool; web uses a shared flag polled through an injected host fn (OMEdit, cross-origin isolated) or the worker declining to advance (standalone simulator).

Wire it into the standalone web simulator (Run/Cancel button) and OMEdit-wasm (SimulationOutputWidget cancel button + OMCProxy shared SharedArrayBuffer flag). Native C ABI omc_compiler_request_cancel() for in-process embedders.

Verified: native one-shot .mat matches the C target, and the forced yield/resume path is bit-identical to the un-yielded run.


Claude-Session: https://claude.ai/code/session_01Q651G1L4HKnGGPNmPWVVXx

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
