### PR TITLE
Parallelize parsing in the Rust omc port

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Parser.mo
+++ b/OMCompiler/Compiler/FrontEnd/Parser.mo
@@ -240,7 +240,7 @@ algorithm
     partialResults := list(loadFileThread(t) for t in workList);
   else
     // GCExt.disable(); // Seems to sometimes break building nightly omc
-    partialResults := System.launchParallelTasks(min(8, numThreads) /* Boehm GC does not scale to infinity */, workList, loadFileThread);
+    partialResults := System.launchParallelTasksThreaded(min(8, numThreads) /* Boehm GC does not scale to infinity */, workList, loadFileThread);
     // GCExt.enable();
   end if;
 end parallelParseFilesWork;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
@@ -35,7 +35,8 @@
 #![allow(non_snake_case)]
 
 use std::cell::RefCell;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::thread::ThreadId;
 
 use arcstr::ArcStr;
 use metamodelica::{List, SourceInfo, nil, cons};
@@ -219,6 +220,31 @@ thread_local! {
 
 fn with_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
     STATE.with(|s| f(&mut s.borrow_mut()))
+}
+
+// Parallel-parse message merge: workers drain their thread-local queue into
+// PARALLEL_STAGING (via moveMessagesToParentThread), the parent splices it back
+// in end_parallel_merge once the fan-out is done.
+static PARALLEL_PARENT: Mutex<Option<ThreadId>> = Mutex::new(None);
+static PARALLEL_STAGING: Mutex<Vec<QueuedMessage>> = Mutex::new(Vec::new());
+
+pub fn begin_parallel_merge() {
+    *PARALLEL_PARENT.lock().unwrap() = Some(std::thread::current().id());
+    PARALLEL_STAGING.lock().unwrap().clear();
+}
+
+pub fn end_parallel_merge() {
+    *PARALLEL_PARENT.lock().unwrap() = None;
+    let staged = std::mem::take(&mut *PARALLEL_STAGING.lock().unwrap());
+    if staged.is_empty() {
+        return;
+    }
+    with_state(|s| {
+        for qm in staged {
+            bump_counters(s, &qm.msg.severity, 1);
+            s.queue.push(qm);
+        }
+    });
 }
 
 fn bump_counters(state: &mut State, severity: &Severity, delta: i32) {
@@ -606,11 +632,26 @@ pub fn isTopCheckpoint(id: ArcStr) -> bool {
     with_state(|s| s.check_points.last().map(|(_, cid)| cid == &id).unwrap_or(false))
 }
 
-/// Hand off pending messages to the parent thread's queue when a worker
-/// thread terminates. The bootstrap is single-threaded with respect to
-/// the error buffer, so there is no parent to merge into.
+/// Drain a worker's pending messages into the parallel staging buffer. A no-op
+/// outside a parallel run, or on the parent thread itself (rayon may run a task
+/// inline — those messages are already where they belong).
 pub fn moveMessagesToParentThread() {
-    // Intentional no-op — see doc comment.
+    let Some(parent) = *PARALLEL_PARENT.lock().unwrap() else {
+        return;
+    };
+    if parent == std::thread::current().id() {
+        return;
+    }
+    let drained = with_state(|s| {
+        let q = std::mem::take(&mut s.queue);
+        s.num_errors = 0;
+        s.num_warnings = 0;
+        s.check_points.clear();
+        q
+    });
+    if !drained.is_empty() {
+        PARALLEL_STAGING.lock().unwrap().extend(drained);
+    }
 }
 
 /// Roll back the messages added since the most recent checkpoint and

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
@@ -32,6 +32,8 @@ nalgebra = { version = "0.33", default-features = false, features = ["std"], opt
 # feature-off fallback that reports the interactive ZMQ mode unavailable).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 zmq = { workspace = true, optional = true }
+# System::launchParallelTasksThreaded; absent on wasm32 (no OS threads).
+rayon.workspace = true
 
 # Lapack_nalgebra.rs implements the LAPACK builtins over nalgebra's pure-Rust
 # decompositions (LU/SVD/QR/eigen). Used unconditionally where there is no

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -2372,6 +2372,78 @@ pub fn launchParallelTasks<AnyInput: Clone + 'static, AnyOutput: Clone + 'static
     Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()))
 }
 
+// A process-wide pool, sized on first use to the requested thread count and
+// reused across calls — rebuilding one per call would churn OS threads. The
+// count is stable in practice (min(8, numProcs)).
+#[cfg(not(target_arch = "wasm32"))]
+fn parallel_pool(n: usize) -> Option<&'static rayon::ThreadPool> {
+    use std::sync::OnceLock;
+    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
+    POOL.get_or_init(|| rayon::ThreadPoolBuilder::new().num_threads(n).build().ok())
+        .as_ref()
+}
+
+// Real-threaded map, opted into per call site. The `Send` bounds reject the
+// non-`Send` payloads the other `launchParallelTasks` sites carry.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn launchParallelTasksThreaded<AnyInput: Clone + Send + 'static, AnyOutput: Clone + Send + 'static>(
+    numThreads: i32,
+    inData: Arc<List<AnyInput>>,
+    func: Arc<dyn Fn(AnyInput) -> Result<AnyOutput> + 'static>,
+) -> Result<Arc<List<AnyOutput>>> {
+    use rayon::prelude::*;
+
+    let items: Vec<AnyInput> = (&*inData).into_iter().cloned().collect();
+    if numThreads <= 1 || items.len() < 2 {
+        let results: Result<Vec<AnyOutput>> = items.into_iter().map(|x| func(x)).collect();
+        return Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()));
+    }
+
+    struct SendSync<T>(T);
+    // SAFETY: the func is always a zero-capture top-level `fnptr!` (already
+    // `Send + Sync`); this re-attaches the marker the `Arc<dyn Fn>` cast drops.
+    unsafe impl<T> Send for SendSync<T> {}
+    unsafe impl<T> Sync for SendSync<T> {}
+
+    struct MergeGuard;
+    impl Drop for MergeGuard {
+        fn drop(&mut self) {
+            openmodelica_error::ErrorExt::end_parallel_merge();
+        }
+    }
+
+    let n = (numThreads as usize).min(items.len());
+    let func = SendSync(func);
+    openmodelica_error::ErrorExt::begin_parallel_merge();
+    let _guard = MergeGuard;
+    let results: Vec<Result<AnyOutput>> = match parallel_pool(n) {
+        // `let f = &func` captures the whole SendSync wrapper, not the bare
+        // `func.0` field (disjoint capture drops the Send + Sync markers).
+        Some(pool) => pool.install(|| {
+            items.into_par_iter().map(|x| { let f = &func; (f.0)(x) }).collect()
+        }),
+        None => items.into_iter().map(|x| (func.0)(x)).collect(),
+    };
+
+    let mut out = Vec::with_capacity(results.len());
+    for r in results {
+        out.push(r?);
+    }
+    Ok(Arc::new(out.into_iter().collect::<List<AnyOutput>>()))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn launchParallelTasksThreaded<AnyInput: Clone + Send + 'static, AnyOutput: Clone + Send + 'static>(
+    _numThreads: i32,
+    inData: Arc<List<AnyInput>>,
+    func: Arc<dyn Fn(AnyInput) -> Result<AnyOutput> + 'static>,
+) -> Result<Arc<List<AnyOutput>>> {
+    // wasm32-unknown-unknown has no OS threads; run serially.
+    let results: Result<Vec<AnyOutput>> =
+        (&*inData).into_iter().map(|x| func(x.clone())).collect();
+    Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()))
+}
+
 pub fn exit(status: i32) -> Result<()> {
     std::process::exit(status);
 }

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1251,6 +1251,20 @@ public function launchParallelTasks "Takes a list of inputs and produces a list 
 external "C" result = System_launchParallelTasks(OpenModelica.threadData(), numThreads, inData, func) annotation(Library = {"omcruntime"});
 end launchParallelTasks;
 
+public function launchParallelTasksThreaded "Like launchParallelTasks, but only for call sites whose task input/output are safe to move across OS threads. In the classic runtime this is an alias for launchParallelTasks; the Rust port uses it to opt a call site into real (rayon) threading."
+  input Integer numThreads;
+  input list<AnyInput> inData;
+  input ForkFunction func;
+  output list<AnyOutput> result;
+  partial function ForkFunction
+    input AnyInput inData;
+    output AnyOutput outData;
+  end ForkFunction;
+  replaceable type AnyInput subtypeof Any;
+  replaceable type AnyOutput subtypeof Any;
+external "C" result = System_launchParallelTasks(OpenModelica.threadData(), numThreads, inData, func) annotation(Library = {"omcruntime"});
+end launchParallelTasksThreaded;
+
 public function exit "Exits the compiler at this point with the given exit status."
   input Integer status;
 external "C" exit(status) annotation(Include = "#include <stdlib.h>");


### PR DESCRIPTION
Route Parser.parallelParseFilesWork through a new builtin System.launchParallelTasksThreaded, whose Rust body runs the parse worklist on a rayon thread pool. The generic launchParallelTasks stays serial: three of its four call sites carry non-Send payloads (Rc-bearing SymbolTable, Arc<dyn Fn> thunks), so the new function's AnyInput/ AnyOutput: Send bounds opt in only the parse site.

The func arrives as the Arc<dyn Fn + 'static> codegen emits; an internal SendSync newtype re-adds the marker the cast drops (sound: routed funcs are always zero-capture top-level fnptr!s). The pool is a process-wide OnceLock sized to the requested thread count, so it is neither oversubscribed nor rebuilt per call.

The external "C" binding reuses the existing System_launchParallelTasks symbol, so the classic runtime is a plain alias and no new C code or mmtorust codegen change is needed.

ErrorExt.moveMessagesToParentThread (previously a no-op) now drains a worker's thread-local message queue into a shared staging buffer that the parent splices back after the fan-out completes.

loadModel(Modelica) parse phase: ~1.5s -> ~0.47s (~3x). wasm32 has no OS threads and falls back to the serial map.