### PR TITLE
Add getClassInformationList scripting API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -5320,6 +5320,32 @@ annotation(
 </html>"), preferredView="text");
 end getClassInformation;
 
+function getClassInformationList
+  "Like getClassInformation, but for several classes in a single call."
+  input String classNames[:];
+  output ClassInformation classInformation[:];
+  record ClassInformation
+    String restriction, comment;
+    Boolean partialPrefix, finalPrefix, encapsulatedPrefix;
+    String fileName;
+    Boolean fileReadOnly;
+    Integer lineNumberStart, columnNumberStart, lineNumberEnd, columnNumberEnd;
+    String dimensions[:];
+    Boolean isProtectedClass;
+    Boolean isDocumentationClass;
+    String version;
+    String preferredView;
+    Boolean state;
+    String access;
+    String versionDate;
+    String versionBuild;
+    String dateModified;
+    String revisionId;
+  end ClassInformation;
+external "builtin";
+annotation(preferredView="text");
+end getClassInformationList;
+
 function getCrefInfo
   "Deprecated; use getClassInformation instead."
   input TypeName cl;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -5574,6 +5574,32 @@ annotation(
 </html>"), preferredView="text");
 end getClassInformation;
 
+function getClassInformationList
+  "Like getClassInformation, but for several classes in a single call."
+  input String classNames[:];
+  output ClassInformation classInformation[:];
+  record ClassInformation
+    String restriction, comment;
+    Boolean partialPrefix, finalPrefix, encapsulatedPrefix;
+    String fileName;
+    Boolean fileReadOnly;
+    Integer lineNumberStart, columnNumberStart, lineNumberEnd, columnNumberEnd;
+    String dimensions[:];
+    Boolean isProtectedClass;
+    Boolean isDocumentationClass;
+    String version;
+    String preferredView;
+    Boolean state;
+    String access;
+    String versionDate;
+    String versionBuild;
+    String dateModified;
+    String revisionId;
+  end ClassInformation;
+external "builtin";
+annotation(preferredView="text");
+end getClassInformationList;
+
 function getCrefInfo
   "Deprecated; use getClassInformation instead."
   input TypeName cl;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -826,6 +826,9 @@ algorithm
                                 Values.BOOL(false),Values.INTEGER(0),Values.INTEGER(0),Values.INTEGER(0),Values.INTEGER(0),Values.ARRAY({},{0}),
                                 Values.BOOL(false),Values.BOOL(false),Values.STRING(""),Values.STRING(""),Values.BOOL(false),Values.STRING("")});
 
+    case ("getClassInformationList",{Values.ARRAY(valueLst=vals)})
+      then ValuesMake.makeArray(list(getClassInformationRecord(v) for v in vals));
+
     case ("getTransitions",{Values.CODE(Absyn.C_TYPENAME(className))})
       algorithm
         false := Interactive.existClass(className, SymbolTable.getAbsyn());
@@ -8219,6 +8222,42 @@ algorithm
     Values.STRING(revisionId)
   });
 end getClassInformation;
+
+protected function getClassInformationRecord
+  input Values.Value className;
+  output Values.Value res;
+protected
+  Absyn.Path path;
+  String str;
+  list<Values.Value> fields;
+algorithm
+  Values.STRING(str) := className;
+  path := Parser.stringPath(str);
+  // Keep one record per input, so the result stays aligned with the query even
+  // when a name is not a class (getClassInformation fails on those).
+  fields := matchcontinue path
+    local
+      list<Values.Value> f;
+    case _
+      algorithm
+        Values.TUPLE(f) := getClassInformation(path, SymbolTable.getAbsyn());
+      then f;
+    else {Values.STRING(""),Values.STRING(""),Values.BOOL(false),Values.BOOL(false),Values.BOOL(false),
+          Values.STRING(""),Values.BOOL(false),Values.INTEGER(0),Values.INTEGER(0),Values.INTEGER(0),
+          Values.INTEGER(0),ValuesMake.makeArray({}),Values.BOOL(false),Values.BOOL(false),Values.STRING(""),
+          Values.STRING(""),Values.BOOL(false),Values.STRING(""),Values.STRING(""),Values.STRING(""),
+          Values.STRING(""),Values.STRING("")};
+  end matchcontinue;
+  res := Values.RECORD(
+    Absyn.QUALIFIED("OpenModelica", Absyn.QUALIFIED("Scripting", Absyn.QUALIFIED("getClassInformationList", Absyn.IDENT("ClassInformation")))),
+    fields,
+    {"restriction","comment","partialPrefix","finalPrefix","encapsulatedPrefix","fileName","fileReadOnly",
+     "lineNumberStart","columnNumberStart","lineNumberEnd","columnNumberEnd","dimensions","isProtectedClass",
+     "isDocumentationClass","version","preferredView","state","access","versionDate","versionBuild",
+     "dateModified","revisionId"},
+    -1
+  );
+end getClassInformationRecord;
 
 function getClassDimensions
 "return the dimensions of a class

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -2352,6 +2352,15 @@ void LibraryTreeModel::createLibraryTreeItems(LibraryTreeItem *pLibraryTreeItem)
     if (!libs.isEmpty()) {
       libs.removeFirst();
     }
+    // Bulk-fetch class information for the whole subtree in one call; each item
+    // created below then reads it from cache instead of a round-trip.
+    QStringList prefetchClasses;
+    foreach (QString lib, libs) {
+      if (!lib.contains("$Code")) {
+        prefetchClasses.append(lib);
+      }
+    }
+    pOMCProxy->prefetchClassInformationList(prefetchClasses);
     LibraryTreeItem *pParentLibraryTreeItem = 0;
 #if defined(__EMSCRIPTEN__)
     const int totalLibs = libs.size();

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -59,6 +59,10 @@
 #endif
 #include "FlatModelica/Expression.h"
 
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+
 extern "C" {
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 void* omc_Main_init(void *threadData, void *args);
@@ -1447,7 +1451,20 @@ QStringList OMCProxy::searchClassNames(QString searchText, bool findInText)
   */
 OMCInterface::getClassInformation_res OMCProxy::getClassInformation(QString className)
 {
+  if (mClassInformationCache.contains(className)) {
+    return mClassInformationCache.take(className);
+  }
   OMCInterface::getClassInformation_res classInformation = mpOMCInterface->getClassInformation(className);
+  fixClassInformationComment(classInformation);
+  return classInformation;
+}
+
+/*!
+  Rewrites the class comment so tooltips and the documentation view can render it:
+  unescapes quotes, resolves modelica:// URIs to files, and drops the file:// scheme.
+  */
+void OMCProxy::fixClassInformationComment(OMCInterface::getClassInformation_res &classInformation)
+{
   QString comment = classInformation.comment.replace("\\\"", "\"");
   comment = makeDocumentationUriToFileName(comment);
   // since tooltips can't handle file:// scheme so we have to remove it in order to display images and make links work.
@@ -1457,7 +1474,71 @@ OMCInterface::getClassInformation_res OMCProxy::getClassInformation(QString clas
   comment.replace("src=\"file://", "src=\"");
 #endif
   classInformation.comment = comment;
-  return classInformation;
+}
+
+/*!
+  Prefetches getClassInformation for many classes in one call and caches the
+  results, so later getClassInformation() lookups avoid a round-trip each. Goes
+  through the JSON interactive format since records are not in the typed ABI; the
+  result is positional. On any mismatch the cache is left empty and callers fall
+  back to per-class calls.
+  \param classNames - fully qualified class names.
+  */
+void OMCProxy::prefetchClassInformationList(const QStringList &classNames)
+{
+  if (classNames.isEmpty()) {
+    return;
+  }
+  QStringList quoted;
+  for (QString name : classNames) {
+    name.replace("\\", "\\\\").replace("\"", "\\\"");
+    quoted.append("\"" + name + "\"");
+  }
+  setCommandLineOptions("--interactiveDumpFormat=json");
+  sendCommand("getClassInformationList({" + quoted.join(",") + "})");
+  QString resultJson = getResult();
+  setCommandLineOptions("--interactiveDumpFormat=default");
+
+  QJsonParseError jsonParserError;
+  QJsonDocument doc = QJsonDocument::fromJson(resultJson.toUtf8(), &jsonParserError);
+  if (jsonParserError.error != QJsonParseError::NoError || !doc.isArray()) {
+    return;
+  }
+  QJsonArray classInformationArray = doc.array();
+  if (classInformationArray.size() != classNames.size()) {
+    return;
+  }
+  for (int i = 0; i < classInformationArray.size(); ++i) {
+    QJsonObject o = classInformationArray.at(i).toObject();
+    OMCInterface::getClassInformation_res r;
+    r.restriction = o.value("restriction").toString();
+    r.comment = o.value("comment").toString();
+    r.partialPrefix = o.value("partialPrefix").toBool();
+    r.finalPrefix = o.value("finalPrefix").toBool();
+    r.encapsulatedPrefix = o.value("encapsulatedPrefix").toBool();
+    r.fileName = o.value("fileName").toString();
+    r.fileReadOnly = o.value("fileReadOnly").toBool();
+    r.lineNumberStart = o.value("lineNumberStart").toInteger();
+    r.columnNumberStart = o.value("columnNumberStart").toInteger();
+    r.lineNumberEnd = o.value("lineNumberEnd").toInteger();
+    r.columnNumberEnd = o.value("columnNumberEnd").toInteger();
+    const QJsonArray dimensions = o.value("dimensions").toArray();
+    for (const QJsonValue &dimension : dimensions) {
+      r.dimensions.append(dimension.toString());
+    }
+    r.isProtectedClass = o.value("isProtectedClass").toBool();
+    r.isDocumentationClass = o.value("isDocumentationClass").toBool();
+    r.version = o.value("version").toString();
+    r.preferredView = o.value("preferredView").toString();
+    r.state = o.value("state").toBool();
+    r.access = o.value("access").toString();
+    r.versionDate = o.value("versionDate").toString();
+    r.versionBuild = o.value("versionBuild").toString();
+    r.dateModified = o.value("dateModified").toString();
+    r.revisionId = o.value("revisionId").toString();
+    fixClassInformationComment(r);
+    mClassInformationCache.insert(classNames.at(i), r);
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -89,6 +89,10 @@ private:
   QStringList mLibrariesBrowserAdditionCommandsList;
   QStringList mLibrariesBrowserDeletionCommandsList;
   bool mLoadModelError;
+  // One-shot cache filled by prefetchClassInformationList and drained by
+  // getClassInformation, so a whole subtree loads in one bulk call.
+  QHash<QString, OMCInterface::getClassInformation_res> mClassInformationCache;
+  void fixClassInformationComment(OMCInterface::getClassInformation_res &classInformation);
 public:
   OMCProxy(threadData_t *threadData, QWidget *pParent = 0);
   ~OMCProxy();
@@ -126,6 +130,7 @@ public:
                             bool sort = false, bool builtin = false, bool showProtected = true, bool includeConstants = false);
   QStringList searchClassNames(QString searchText, bool findInText = false);
   OMCInterface::getClassInformation_res getClassInformation(QString className);
+  void prefetchClassInformationList(const QStringList &classNames);
   bool isPackage(QString className);
   bool isBuiltinType(QString typeName);
   QString getBuiltinType(QString typeName);

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -58,6 +58,7 @@ GetAllSubtypeOf3.mos \
 GetAllSubtypeOf4.mos \
 GetAllSubtypeOf5.mos \
 getClassComment.mos \
+getClassInformationList.mos \
 getClassNames.mos \
 getCommandLineOptions.mos \
 GetComponents.mos \

--- a/testsuite/openmodelica/interactive-API/getClassInformationList.mos
+++ b/testsuite/openmodelica/interactive-API/getClassInformationList.mos
@@ -1,0 +1,93 @@
+// name: getClassInformationList.mos
+// keywords: getClassInformationList getClassInformation
+// status: correct
+//
+// Bulk form of getClassInformation. The middle name is a constant, not a class,
+// so it exercises the default-record fallback that keeps the result aligned with
+// the query.
+//
+
+loadString("package P
+  model M \"a model\"
+    Real x;
+  end M;
+  constant Real c = 1.0;
+end P;"); getErrorString();
+
+getClassInformationList({"P.M", "P.c", "P"}); getErrorString();
+
+// Result:
+// true
+// ""
+// {record OpenModelica.Scripting.getClassInformationList.ClassInformation
+//     restriction = "model",
+//     comment = "a model",
+//     partialPrefix = false,
+//     finalPrefix = false,
+//     encapsulatedPrefix = false,
+//     fileName = "<interactive>",
+//     fileReadOnly = false,
+//     lineNumberStart = 2,
+//     columnNumberStart = 3,
+//     lineNumberEnd = 4,
+//     columnNumberEnd = 8,
+//     dimensions = {},
+//     isProtectedClass = false,
+//     isDocumentationClass = false,
+//     version = "",
+//     preferredView = "",
+//     state = false,
+//     access = "",
+//     versionDate = "",
+//     versionBuild = "",
+//     dateModified = "",
+//     revisionId = ""
+// end OpenModelica.Scripting.getClassInformationList.ClassInformation;, record OpenModelica.Scripting.getClassInformationList.ClassInformation
+//     restriction = "",
+//     comment = "",
+//     partialPrefix = false,
+//     finalPrefix = false,
+//     encapsulatedPrefix = false,
+//     fileName = "",
+//     fileReadOnly = false,
+//     lineNumberStart = 0,
+//     columnNumberStart = 0,
+//     lineNumberEnd = 0,
+//     columnNumberEnd = 0,
+//     dimensions = {},
+//     isProtectedClass = false,
+//     isDocumentationClass = false,
+//     version = "",
+//     preferredView = "",
+//     state = false,
+//     access = "",
+//     versionDate = "",
+//     versionBuild = "",
+//     dateModified = "",
+//     revisionId = ""
+// end OpenModelica.Scripting.getClassInformationList.ClassInformation;, record OpenModelica.Scripting.getClassInformationList.ClassInformation
+//     restriction = "package",
+//     comment = "",
+//     partialPrefix = false,
+//     finalPrefix = false,
+//     encapsulatedPrefix = false,
+//     fileName = "<interactive>",
+//     fileReadOnly = false,
+//     lineNumberStart = 1,
+//     columnNumberStart = 1,
+//     lineNumberEnd = 6,
+//     columnNumberEnd = 6,
+//     dimensions = {},
+//     isProtectedClass = false,
+//     isDocumentationClass = false,
+//     version = "",
+//     preferredView = "",
+//     state = false,
+//     access = "",
+//     versionDate = "",
+//     versionBuild = "",
+//     dateModified = "",
+//     revisionId = ""
+// end OpenModelica.Scripting.getClassInformationList.ClassInformation;}
+// ""
+// endResult


### PR DESCRIPTION
Bulk form of getClassInformation for many classes in one call, so OMEdit's library tree loads with one call per package subtree instead of a getClassInformation round-trip per class. This is the main win for "Loading Modelica" on the web build, where every round-trip crosses the Asyncify/worker boundary.

The input is String[:] rather than TypeName[:]: an array of the TypeName $Code type does not elaborate (only C_VARIABLENAMES accepts an array literal), so names are passed as strings and parsed in the backend. A name that is not a class yields a default record, keeping the result aligned with the query.

OMEdit prefetches the whole subtree via getClassInformationList and caches the results; getClassInformation then reads the cache instead of a round-trip. It goes through the JSON interactive format because records are not expressible in the typed ABI.