### PR TITLE
Reduce Jenkinsfile CPS-compiled method size

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -36,57 +36,47 @@ pipeline {
           }
           steps {
             script {
-              echo "Running on: ${env.NODE_NAME}"
-              withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
-                sh "echo PATH: $PATH"
-                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
-                                          + " -DCMAKE_INSTALL_PREFIX=build"
-                                          // Look in /opt/local first to prefer the macports libraries
-                                          // over others in the system.
-                                          + " -DCMAKE_PREFIX_PATH=/opt/local"
-                                          // Always specify the compilers explicilty for macOS
-                                          + " -DCMAKE_C_COMPILER=gcc"
-                                          + " -DCMAKE_CXX_COMPILER=g++"
-                                          // Disable fortran (and ipopt) for this build because
-                                          // we build a pkg from it and we do not want to depend
-                                          // on Fortran for now.
-                                          + " -DOM_OMC_ENABLE_FORTRAN=OFF"
-                                          + " -DOM_OMC_ENABLE_OPTIMIZATION=OFF"
-                                          + " -DOM_OMC_ENABLE_MOO=OFF"
-                                      )
-                sh "build/bin/omc --version"
-                // Create a product build package
-                sh "cd build_cmake && cpack -G productbuild"
-                // Get the generated pkg filename.
-                pkg_filename = sh(script: 'basename build_cmake/_packages/*', returnStdout: true).trim()
-                echo "Package file name: ${pkg_filename}"
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=build",
+                "-DCMAKE_PREFIX_PATH=/opt/local",    // Look in /opt/local first to prefer the macports libraries over others in the system.
+                "-DCMAKE_C_COMPILER=gcc",            // Always specify the compilers explicitly for macOS
+                "-DCMAKE_CXX_COMPILER=g++",
+                "-DOM_OMC_ENABLE_FORTRAN=OFF",       // Disable fortran (and ipopt) for this build because we build a pkg from it and we do not want to depend on Fortran for now.
+                "-DOM_OMC_ENABLE_OPTIMIZATION=OFF",
+                "-DOM_OMC_ENABLE_MOO=OFF"
+                ])
+              // Create a product build package
+              sh "cd build_cmake && cpack -G productbuild"
+              // Get the generated pkg filename.
+              pkg_filename = sh(script: 'basename build_cmake/_packages/*', returnStdout: true).trim()
+              echo "Package file name: ${pkg_filename}"
 
-                // This is relative to the ssh config specified in Jenkins configuration.
-                relative_remote_dir = "pkg/arm64/nightly/"
-                echo "Relative destination path: ${relative_remote_dir}"
-                // The full dest path. Because relative paths do not seem to work for creating symlinks. Not sure why.
-                full_remote_dir = "/home/build/mac/${relative_remote_dir}"
-                echo "Full destination path: ${full_remote_dir}"
+              // This is relative to the ssh config specified in Jenkins configuration.
+              relative_remote_dir = "pkg/arm64/nightly/"
+              echo "Relative destination path: ${relative_remote_dir}"
+              // The full dest path. Because relative paths do not seem to work for creating symlinks. Not sure why.
+              full_remote_dir = "/home/build/mac/${relative_remote_dir}"
+              echo "Full destination path: ${full_remote_dir}"
 
-                // Publish to build.openmodelica.org:/home/build/mac (using the ssh config 'cmake-macos-packages')
-                sshPublisher (
-                  failOnError: true,
-                  publishers: [
-                    sshPublisherDesc(
-                      configName: 'cmake-macos-packages',
-                      transfers: [
-                        sshTransfer(
-                          remoteDirectory: "${relative_remote_dir}",
-                          sourceFiles: "build_cmake/_packages/${pkg_filename}",
-                          removePrefix: "build_cmake/_packages/",
-                          // Make a symbolic link to the latest package.
-                          // Unfortunatelly, relative paths do not seem to work. Use full path to the files.
-                          execCommand: "ln -sf ${full_remote_dir}/${pkg_filename} ${full_remote_dir}/OpenModelica-latest.pkg")
-                      ]
-                    )
-                  ]
-                )
-              }
+              // Publish to build.openmodelica.org:/home/build/mac (using the ssh config 'cmake-macos-packages')
+              sshPublisher (
+                failOnError: true,
+                publishers: [
+                  sshPublisherDesc(
+                    configName: 'cmake-macos-packages',
+                    transfers: [
+                      sshTransfer(
+                        remoteDirectory: "${relative_remote_dir}",
+                        sourceFiles: "build_cmake/_packages/${pkg_filename}",
+                        removePrefix: "build_cmake/_packages/",
+                        // Make a symbolic link to the latest package.
+                        // Unfortunatelly, relative paths do not seem to work. Use full path to the files.
+                        execCommand: "ln -sf ${full_remote_dir}/${pkg_filename} ${full_remote_dir}/OpenModelica-latest.pkg")
+                    ]
+                  )
+                ]
+              )
             }
           }
         }

--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -71,7 +71,7 @@ pipeline {
                         sourceFiles: "build_cmake/_packages/${pkg_filename}",
                         removePrefix: "build_cmake/_packages/",
                         // Make a symbolic link to the latest package.
-                        // Unfortunatelly, relative paths do not seem to work. Use full path to the files.
+                        // Unfortunately, relative paths do not seem to work. Use full path to the files.
                         execCommand: "ln -sf ${full_remote_dir}/${pkg_filename} ${full_remote_dir}/OpenModelica-latest.pkg")
                     ]
                   )

--- a/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
@@ -40,14 +40,11 @@ pipeline {
           }
           steps {
             script {
-              withEnv (["PATH=C:\\OMDev\\tools\\msys\\usr\\bin;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
-                bat "echo PATH: %PATH%"
-                common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release'
-                                        + ' -DOM_USE_CCACHE=OFF'
-                                        + ' -DCMAKE_INSTALL_PREFIX=build'
-                                        + ' -G "MSYS Makefiles"'
-                                      )
-              }
+              common.buildOMC_CMake([
+                '-DCMAKE_BUILD_TYPE=Release',
+                '-DOM_USE_CCACHE=OFF',
+                '-DCMAKE_INSTALL_PREFIX=build',
+                '-G "MSYS Makefiles"'])
             }
           }
         }

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -58,11 +58,11 @@ pipeline {
           }
           steps {
             script {
-              common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
-                                        + " -DOM_USE_CCACHE=OFF"
-                                        + " -DCMAKE_INSTALL_PREFIX=build"
-                                        + " -DSUNDIALS_BUILD_SHARED_LIBS=ON")
-              sh "build/bin/omc --version"
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOM_USE_CCACHE=OFF",
+                "-DCMAKE_INSTALL_PREFIX=build",
+                "-DSUNDIALS_BUILD_SHARED_LIBS=ON"])
             }
             stash name: 'omc-cmake-gcc', includes: 'build/**'
           }

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -3,6 +3,10 @@ def isWindows() {
   return !isUnix()
 }
 
+def isMac() {
+  return isUnix() && sh(script: 'uname', returnStdout: true).startsWith("Darwin")
+}
+
 void standardSetup() {
   echo "${env.NODE_NAME}"
 
@@ -324,14 +328,13 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
       sanityCheck('build', true)
     }
   }
-  else {
-    def uname = sh script: 'uname', returnStdout: true
-    def isMac = uname.startsWith("Darwin")
-    def envOverrides = isMac ? ["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"] : []
-    withEnv (envOverrides) {
-      if (isMac) {
-        sh "echo PATH: $PATH"
-      }
+  else if (isMac()) {
+    // /opt/local/bin (MacPorts) must come first so "gcc"/"g++"/"gfortran" resolve
+    // to the real GCC toolchain implied by -DCMAKE_PREFIX_PATH=/opt/local, rather
+    // than falling through to Apple Clang's /usr/bin/gcc wrapper (which lacks
+    // OpenMP support / omp.h).
+    withEnv (["PATH=/opt/local/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
+      sh "echo PATH: $PATH"
       sh "mkdir ./build_cmake"
       sh "${cmake_exe} --version"
       sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args_str}"
@@ -339,6 +342,15 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
       sh "build/bin/omc --version"
     }
+    sanityCheck('build', true)
+  }
+  else {
+    sh "mkdir ./build_cmake"
+    sh "${cmake_exe} --version"
+    sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args_str}"
+    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
+    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
+    sh "build/bin/omc --version"
     sanityCheck('build', true)
   }
 }

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -329,11 +329,7 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
     }
   }
   else if (isMac()) {
-    // /opt/local/bin (MacPorts) must come first so "gcc"/"g++"/"gfortran" resolve
-    // to the real GCC toolchain implied by -DCMAKE_PREFIX_PATH=/opt/local, rather
-    // than falling through to Apple Clang's /usr/bin/gcc wrapper (which lacks
-    // OpenMP support / omp.h).
-    withEnv (["PATH=/opt/local/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
+    withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
       sh "echo PATH: $PATH"
       sh "mkdir ./build_cmake"
       sh "${cmake_exe} --version"

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -321,6 +321,7 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
         set MSYS2_PATH_TYPE=inherit
         %OMDEV%\\tools\\msys\\usr\\bin\\sh --login -i -c "cd `cygpath '${WORKSPACE}'` && chmod +x buildOMCWindows.sh && ./buildOMCWindows.sh && rm -f ./buildOMCWindows.sh"
       """)
+      sanityCheck('build', true)
     }
   }
   else {
@@ -338,9 +339,8 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
       sh "build/bin/omc --version"
     }
+    sanityCheck('build', true)
   }
-
-  sanityCheck('build', true)
 }
 
 // sccache config for the cargo builds: a shared S3 (MinIO) compile cache at

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -276,36 +276,68 @@ void buildOMC(CC, CXX, extraFlags, Boolean buildCpp, Boolean clean) {
   sanityCheck('build', buildCpp)
 }
 
-void buildOMC_CMake(cmake_args, cmake_exe='cmake') {
+/**
+ * Configure and build OMC via CMake, and run the sanity check.
+ *
+ * Detects the current platform and applies the platform-specific setup
+ * itself, so callers never need to wrap this in their own withEnv/OMDev
+ * boilerplate:
+ *  - Windows: clones/updates OMDev and extends PATH with its MSYS2 toolchain.
+ *  - macOS: prefers Homebrew/MacPorts tools on PATH.
+ *  - Linux: no extra setup.
+ *
+ * @param cmake_args list of individual CMake "-DFOO=BAR"-style arguments
+ *                   (not a pre-joined string); they are joined with spaces
+ *                   before being passed to the cmake CLI.
+ * @param cmake_exe  the cmake executable to invoke.
+ */
+void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
+  echo "Running on: ${env.NODE_NAME}"
   standardSetup()
 
-  if (isWindows()) {
-    bat (label: 'build', script: """
-      If Defined LOCALAPPDATA (echo LOCALAPPDATA: %LOCALAPPDATA%) Else (Set "LOCALAPPDATA=C:\\Users\\OpenModelica\\AppData\\Local")
-      echo on
-      (
-      echo export MSYS_WORKSPACE="`cygpath '${WORKSPACE}'`"
-      echo echo MSYS_WORKSPACE: \${MSYS_WORKSPACE}
-      echo cd \${MSYS_WORKSPACE}
-      echo which cmake
-      echo set -ex
-      echo mkdir build_cmake
-      echo ${cmake_exe} --version
-      echo ${cmake_exe} -S ./ -B ./build_cmake ${cmake_args}
-      echo time ${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install
-      ) > buildOMCWindows.sh
+  def cmake_args_str = cmake_args.join(' ')
 
-      set MSYSTEM=UCRT64
-      set MSYS2_PATH_TYPE=inherit
-      %OMDEV%\\tools\\msys\\usr\\bin\\sh --login -i -c "cd `cygpath '${WORKSPACE}'` && chmod +x buildOMCWindows.sh && ./buildOMCWindows.sh && rm -f ./buildOMCWindows.sh"
-    """)
+  if (isWindows()) {
+    withEnv (["OMDEV=C:\\OMDevUCRT",
+              "PATH=${env.OMDEV}\\tools\\msys\\usr\\bin;${env.OMDEV}\\tools\\msys\\ucrt64;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
+      bat "echo PATH: %PATH%"
+      cloneOMDev()
+      bat (label: 'build', script: """
+        If Defined LOCALAPPDATA (echo LOCALAPPDATA: %LOCALAPPDATA%) Else (Set "LOCALAPPDATA=C:\\Users\\OpenModelica\\AppData\\Local")
+        echo on
+        (
+        echo export MSYS_WORKSPACE="`cygpath '${WORKSPACE}'`"
+        echo echo MSYS_WORKSPACE: \${MSYS_WORKSPACE}
+        echo cd \${MSYS_WORKSPACE}
+        echo which cmake
+        echo set -ex
+        echo mkdir build_cmake
+        echo ${cmake_exe} --version
+        echo ${cmake_exe} -S ./ -B ./build_cmake ${cmake_args_str}
+        echo time ${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install
+        ) > buildOMCWindows.sh
+
+        set MSYSTEM=UCRT64
+        set MSYS2_PATH_TYPE=inherit
+        %OMDEV%\\tools\\msys\\usr\\bin\\sh --login -i -c "cd `cygpath '${WORKSPACE}'` && chmod +x buildOMCWindows.sh && ./buildOMCWindows.sh && rm -f ./buildOMCWindows.sh"
+      """)
+    }
   }
   else {
-    sh "mkdir ./build_cmake"
-    sh "${cmake_exe} --version"
-    sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args}"
-    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
+    def uname = sh script: 'uname', returnStdout: true
+    def isMac = uname.startsWith("Darwin")
+    def envOverrides = isMac ? ["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"] : []
+    withEnv (envOverrides) {
+      if (isMac) {
+        sh "echo PATH: $PATH"
+      }
+      sh "mkdir ./build_cmake"
+      sh "${cmake_exe} --version"
+      sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args_str}"
+      sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
+      sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
+      sh "build/bin/omc --version"
+    }
   }
 
   sanityCheck('build', true)
@@ -778,6 +810,16 @@ def cacheBranch() {
   return "${env.CHANGE_TARGET ?: env.GIT_BRANCH}"
 }
 
+// Send the default failure-notification email, but only for master builds.
+void notifyOnFailure() {
+  if (cacheBranch() == "master") {
+    emailext subject: '$DEFAULT_SUBJECT',
+    body: '$DEFAULT_CONTENT',
+    replyTo: '$DEFAULT_REPLYTO',
+    to: '$DEFAULT_TO'
+  }
+}
+
 def cacheBranchEscape() {
   def name = (cacheBranch()).replace('maintenance/v','')
   name = name.replace('/','-')
@@ -794,7 +836,7 @@ def makeCommand() {
   return env.GMAKE ?: "make"
 }
 
-def shouldWeBuildUCRT() {
+private def shouldWeBuildUCRT() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Build MSYS2-UCRT64")) {
       return true
@@ -803,7 +845,7 @@ def shouldWeBuildUCRT() {
   return params.BUILD_MSYS2_UCRT64
 }
 
-def shouldWeBuildAlpine() {
+private def shouldWeBuildAlpine() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Build Alpine")) {
       return true
@@ -812,7 +854,7 @@ def shouldWeBuildAlpine() {
   return params.BUILD_ALPINE
 }
 
-def shouldWeDisableAllCMakeBuilds() {
+private def shouldWeDisableAllCMakeBuilds() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Disable/All")) {
       return true
@@ -821,7 +863,7 @@ def shouldWeDisableAllCMakeBuilds() {
   return params.DISABLE_ALL_CMAKE_BUILDS
 }
 
-def shouldWeEnableUCRTCMakeBuild() {
+private def shouldWeEnableUCRTCMakeBuild() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Enable/MSYS2-UCRT64")) {
       return true
@@ -830,7 +872,7 @@ def shouldWeEnableUCRTCMakeBuild() {
   return params.ENABLE_MSYS2_UCRT64_CMAKE_BUILD
 }
 
-def shouldWeEnableMacOSCMakeBuild() {
+private def shouldWeEnableMacOSCMakeBuild() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Enable/macOS")) {
       return true
@@ -839,7 +881,7 @@ def shouldWeEnableMacOSCMakeBuild() {
   return params.ENABLE_MACOS_CMAKE_BUILD
 }
 
-def shouldWeRunRustTests() {
+private def shouldWeRunRustTests() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Enable Rust Tests")) {
       return true
@@ -854,7 +896,7 @@ def rustWasmOptCMakeFlag() {
   return isPR() ? "-DRUST_OMC_WASM_OPT=OFF" : "-DRUST_OMC_WASM_OPT=ON"
 }
 
-def shouldWeRunTests() {
+private def shouldWeRunTests() {
   if (isPR()) {
     def skipTestsFilesList = [".*[.]md",
                               "OMEdit/.*",
@@ -876,8 +918,35 @@ def shouldWeRunTests() {
   return true
 }
 
-def isPR() {
+private def isPR() {
   return env.CHANGE_ID ? true : false
+}
+
+/**
+ * Evaluate all the shouldWe... / isPR build flags used to gate pipeline stages,
+ * printing each one, and return them as a map. Centralising this in one
+ * function (instead of the Jenkinsfile calling+printing each individually)
+ * keeps the CPS-compiled pipeline script itself small.
+ */
+Map evaluateBuildFlags() {
+  def flags = [:]
+  flags.isPR = isPR()
+  print "isPR: ${flags.isPR}"
+  flags.shouldWeBuildUCRT = shouldWeBuildUCRT()
+  print "shouldWeBuildUCRT: ${flags.shouldWeBuildUCRT}"
+  flags.shouldWeBuildAlpine = shouldWeBuildAlpine()
+  print "shouldWeBuildAlpine: ${flags.shouldWeBuildAlpine}"
+  flags.shouldWeDisableAllCMakeBuilds = shouldWeDisableAllCMakeBuilds()
+  print "shouldWeDisableAllCMakeBuilds: ${flags.shouldWeDisableAllCMakeBuilds}"
+  flags.shouldWeEnableMacOSCMakeBuild = shouldWeEnableMacOSCMakeBuild()
+  print "shouldWeEnableMacOSCMakeBuild: ${flags.shouldWeEnableMacOSCMakeBuild}"
+  flags.shouldWeEnableUCRTCMakeBuild = shouldWeEnableUCRTCMakeBuild()
+  print "shouldWeEnableUCRTCMakeBuild: ${flags.shouldWeEnableUCRTCMakeBuild}"
+  flags.shouldWeRunTests = shouldWeRunTests()
+  print "shouldWeRunTests: ${flags.shouldWeRunTests}"
+  flags.shouldWeRunRustTests = flags.shouldWeRunTests && shouldWeRunRustTests()
+  print "shouldWeRunRustTests: ${flags.shouldWeRunRustTests}"
+  return flags
 }
 
 def outputSync()

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -337,7 +337,7 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
       sh "build/bin/omc --version"
-    sanityCheck('build', true)
+      sanityCheck('build', true)
     }
   }
   else {

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -337,8 +337,8 @@ void buildOMC_CMake(List cmake_args, cmake_exe='cmake') {
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
       sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
       sh "build/bin/omc --version"
-    }
     sanityCheck('build', true)
+    }
   }
   else {
     sh "mkdir ./build_cmake"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,9 +179,7 @@ pipeline {
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DOM_USE_CCACHE=OFF",
                 "-DCMAKE_INSTALL_PREFIX=build",
-                // Look in /opt/local first to prefer the macports libraries over others in the system.
-                // Look in /opt/homebrew for boost
-                '-DCMAKE_PREFIX_PATH="/opt/local;/opt/homebrew"',
+                "-DCMAKE_PREFIX_PATH=/opt/local",   // Look in /opt/local first to prefer the macports libraries over others in the system.
                 "-DCMAKE_C_COMPILER=gcc",           // Always specify the compilers explicitly for macOS
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,12 @@
 def common
-def shouldWeBuildUCRT
-def shouldWeBuildAlpine_value
-def shouldWeDisableAllCMakeBuilds_value
-def shouldWeEnableMacOSCMakeBuild_value
-def shouldWeEnableUCRTCMakeBuild_value
-def shouldWeRunTests
 def isPR
+def shouldWeBuildAlpine
+def shouldWeBuildUCRT
+def shouldWeDisableAllCMakeBuilds
+def shouldWeEnableMacOSCMakeBuild
+def shouldWeEnableUCRTCMakeBuild
+def shouldWeRunTests
+
 pipeline {
   agent none
   options {
@@ -42,22 +43,15 @@ pipeline {
             milestone(buildNumber)
           }
           common = load("${env.workspace}/.CI/common.groovy")
-          isPR = common.isPR()
-          print "isPR: ${isPR}"
-          shouldWeBuildUCRT = common.shouldWeBuildUCRT()
-          print "shouldWeBuildUCRT: ${shouldWeBuildUCRT}"
-          shouldWeBuildAlpine_value = common.shouldWeBuildAlpine()
-          print "shouldWeBuildAlpine: ${shouldWeBuildAlpine_value}"
-          shouldWeDisableAllCMakeBuilds_value = common.shouldWeDisableAllCMakeBuilds()
-          print "shouldWeDisableAllCMakeBuilds: ${shouldWeDisableAllCMakeBuilds_value}"
-          shouldWeEnableMacOSCMakeBuild_value = common.shouldWeEnableMacOSCMakeBuild()
-          print "shouldWeEnableMacOSCMakeBuild: ${shouldWeEnableMacOSCMakeBuild_value}"
-          shouldWeEnableUCRTCMakeBuild_value = common.shouldWeEnableUCRTCMakeBuild()
-          print "shouldWeEnableUCRTCMakeBuild: ${shouldWeEnableUCRTCMakeBuild_value}"
-          shouldWeRunTests = common.shouldWeRunTests()
-          print "shouldWeRunTests: ${shouldWeRunTests}"
-          shouldWeRunRustTests = shouldWeRunTests && common.shouldWeRunRustTests()
-          print "shouldWeRunRustTests: ${shouldWeRunRustTests}"
+          def buildFlags = common.evaluateBuildFlags()
+          isPR = buildFlags.isPR
+          shouldWeBuildAlpine = buildFlags.shouldWeBuildAlpine
+          shouldWeBuildUCRT = buildFlags.shouldWeBuildUCRT
+          shouldWeDisableAllCMakeBuilds = buildFlags.shouldWeDisableAllCMakeBuilds
+          shouldWeEnableMacOSCMakeBuild = buildFlags.shouldWeEnableMacOSCMakeBuild
+          shouldWeEnableUCRTCMakeBuild = buildFlags.shouldWeEnableUCRTCMakeBuild
+          shouldWeRunRustTests = buildFlags.shouldWeRunRustTests
+          shouldWeRunTests = buildFlags.shouldWeRunTests
         }
       }
     }
@@ -79,7 +73,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds_value }
+            expression { !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -163,18 +157,17 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds_value }
+            expression { !shouldWeDisableAllCMakeBuilds }
           }
           options {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
             script {
-              echo "Running on: ${env.NODE_NAME}"
-              common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
-                                        + " -DOM_USE_CCACHE=OFF"
-                                        + " -DCMAKE_INSTALL_PREFIX=build")
-              sh "build/bin/omc --version"
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOM_USE_CCACHE=OFF",
+                "-DCMAKE_INSTALL_PREFIX=build"])
             }
             //stash name: 'omc-cmake-gcc', includes: 'build_cmake/**, build/**'
           }
@@ -187,29 +180,21 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds_value && shouldWeEnableMacOSCMakeBuild_value}
+            expression { !shouldWeDisableAllCMakeBuilds && shouldWeEnableMacOSCMakeBuild}
           }
           options {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
             script {
-              echo "Running on: ${env.NODE_NAME}"
-              withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
-                sh "echo PATH: $PATH"
-                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
-                                          + " -DOM_USE_CCACHE=OFF"
-                                          + " -DCMAKE_INSTALL_PREFIX=build"
-                                          // Look in /opt/local first to prefer the macports libraries
-                                          // over others in the system.
-                                          + " -DCMAKE_PREFIX_PATH=/opt/local"
-                                          // Always specify the compilers explicilty for macOS
-                                          + " -DCMAKE_C_COMPILER=gcc"
-                                          + " -DCMAKE_CXX_COMPILER=g++"
-                                          + " -DCMAKE_Fortran_COMPILER=gfortran"
-                                      )
-                sh "build/bin/omc --version"
-              }
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOM_USE_CCACHE=OFF",
+                "-DCMAKE_INSTALL_PREFIX=build",
+                "-DCMAKE_PREFIX_PATH=/opt/local", // Look in /opt/local first to prefer the macports libraries over others in the system.
+                "-DCMAKE_C_COMPILER=gcc",         // Always specify the compilers explicitly for macOS
+                "-DCMAKE_CXX_COMPILER=g++",
+                "-DCMAKE_Fortran_COMPILER=gfortran"])
             }
           }
         }
@@ -227,20 +212,19 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds_value && shouldWeBuildAlpine_value }
+            expression { !shouldWeDisableAllCMakeBuilds && shouldWeBuildAlpine }
           }
           options {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
             script {
-              echo "Running on: ${env.NODE_NAME}"
-              common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
-                                        + " -DOM_USE_CCACHE=OFF"
-                                        + " -DCMAKE_INSTALL_PREFIX=build"
-                                        + " -DCMAKE_C_COMPILER=clang"
-                                        + " -DCMAKE_CXX_COMPILER=clang++")
-              sh "build/bin/omc --version"
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOM_USE_CCACHE=OFF",
+                "-DCMAKE_INSTALL_PREFIX=build",
+                "-DCMAKE_C_COMPILER=clang",
+                "-DCMAKE_CXX_COMPILER=clang++"])
             }
           }
         }
@@ -252,22 +236,17 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds_value && shouldWeEnableUCRTCMakeBuild_value}
+            expression { !shouldWeDisableAllCMakeBuilds && shouldWeEnableUCRTCMakeBuild}
           }
           options {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
             script {
-              echo "Running on: ${env.NODE_NAME}"
-              withEnv (["OMDEV=C:\\OMDevUCRT","PATH=${env.OMDEV}}tools\\msys\\usr\\bin;${env.OMDEV}}tools\\msys\\ucrt64;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
-                bat "echo PATH: %PATH%"
-                common.cloneOMDev()
-                common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release'
-                                        + ' -DCMAKE_INSTALL_PREFIX=build'
-                                        + ' -G "MSYS Makefiles"'
-                                      )
-              }
+              common.buildOMC_CMake([
+                '-DCMAKE_BUILD_TYPE=Release',
+                '-DCMAKE_INSTALL_PREFIX=build',
+                '-G "MSYS Makefiles"'])
             }
           }
         }
@@ -315,7 +294,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -342,7 +321,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -369,7 +348,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -572,7 +551,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -598,7 +577,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -622,7 +601,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -646,7 +625,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script {
@@ -895,7 +874,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds_value }
+            expression { shouldWeRunTests && !shouldWeDisableAllCMakeBuilds }
           }
           steps {
             script { common.assembleWeb() }
@@ -1122,12 +1101,7 @@ pipeline {
   post {
     failure {
       script {
-        if (common.cacheBranch()=="master") {
-          emailext subject: '$DEFAULT_SUBJECT',
-          body: '$DEFAULT_CONTENT',
-          replyTo: '$DEFAULT_REPLYTO',
-          to: '$DEFAULT_TO'
-        }
+        common.notifyOnFailure()
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",
                 "-DOM_QT_MAJOR_VERSION=5",            // Use Qt5 on old macOS machines
-                "-DOM_OMC_ENABLE_COLPACK=OFF"])       // Disable ColPack missing OpenMP
+                "-DOM_OMC_ENABLE_COLPACK=OFF"])       // Disable ColPack (missing OpenMP)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,10 +191,11 @@ pipeline {
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DOM_USE_CCACHE=OFF",
                 "-DCMAKE_INSTALL_PREFIX=build",
-                "-DCMAKE_PREFIX_PATH=/opt/local", // Look in /opt/local first to prefer the macports libraries over others in the system.
-                "-DCMAKE_C_COMPILER=gcc",         // Always specify the compilers explicitly for macOS
+                "-DCMAKE_PREFIX_PATH=/opt/local",     // Look in /opt/local first to prefer the macports libraries over others in the system.
+                "-DCMAKE_C_COMPILER=gcc",             // Always specify the compilers explicitly for macOS
                 "-DCMAKE_CXX_COMPILER=g++",
-                "-DCMAKE_Fortran_COMPILER=gfortran"])
+                "-DCMAKE_Fortran_COMPILER=gfortran",
+                "-DOM_QT_MAJOR_VERSION=5"])           //Use Qt5 on old macOS machines
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,12 +179,14 @@ pipeline {
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DOM_USE_CCACHE=OFF",
                 "-DCMAKE_INSTALL_PREFIX=build",
-                "-DCMAKE_PREFIX_PATH=/opt/local",     // Look in /opt/local first to prefer the macports libraries over others in the system.
-                "-DCMAKE_C_COMPILER=gcc",             // Always specify the compilers explicitly for macOS
+                // Look in /opt/local first to prefer the macports libraries over others in the system.
+                // Look in /opt/homebrew for boost
+                "-DCMAKE_PREFIX_PATH=/opt/local;/opt/homebrew",
+                "-DCMAKE_C_COMPILER=gcc",           // Always specify the compilers explicitly for macOS
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",
-                "-DOM_QT_MAJOR_VERSION=5",            // Use Qt5 on old macOS machines
-                "-DOM_OMC_ENABLE_COLPACK=OFF"])       // Disable ColPack (missing OpenMP)
+                "-DOM_QT_MAJOR_VERSION=5",          // Use Qt5 on old macOS machines
+                "-DOM_OMC_ENABLE_COLPACK=OFF"])     // Disable ColPack (missing OpenMP)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,8 @@ pipeline {
                 "-DCMAKE_C_COMPILER=gcc",             // Always specify the compilers explicitly for macOS
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",
-                "-DOM_QT_MAJOR_VERSION=5"])           //Use Qt5 on old macOS machines
+                "-DOM_QT_MAJOR_VERSION=5",            // Use Qt5 on old macOS machines
+                "-DOM_OMC_ENABLE_COLPACK"])           // Disable ColPack missing OpenMP
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",
                 "-DOM_QT_MAJOR_VERSION=5",            // Use Qt5 on old macOS machines
-                "-DOM_OMC_ENABLE_COLPACK"])           // Disable ColPack missing OpenMP
+                "-DOM_OMC_ENABLE_COLPACK=OFF"])       // Disable ColPack missing OpenMP
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
                 "-DCMAKE_INSTALL_PREFIX=build",
                 // Look in /opt/local first to prefer the macports libraries over others in the system.
                 // Look in /opt/homebrew for boost
-                "-DCMAKE_PREFIX_PATH=/opt/local;/opt/homebrew",
+                '-DCMAKE_PREFIX_PATH="/opt/local;/opt/homebrew"',
                 "-DCMAKE_C_COMPILER=gcc",           // Always specify the compilers explicitly for macOS
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,30 +57,7 @@ pipeline {
     }
     stage('setup') {
       parallel {
-        // The Rust (mmtorust) omc port, GUI off; the GUI is built in parallel
-        // with the tests by the 'build-gui-rust' stage. See common.buildRustOMC().
-        stage('cmake-rust-clang') {
-          agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-26.04-rust'
-              label 'linux'
-              args "--mount type=volume,source=rust-cargo-registry,target=/opt/rust/cargo/registry " +
-                   "--mount type=volume,source=rust-sccache,target=/cache/sccache " +
-                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
-                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
-            }
-          }
-          when {
-            beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds }
-          }
-          steps {
-            script {
-              common.buildRustOMC()
-            }
-          }
-        }
+        // Linux build stages
         stage('gcc') {
           agent {
             docker {
@@ -122,27 +99,6 @@ pipeline {
             script { common.buildClangOMC() }
           }
         }
-        stage('Win/UCRT64') {
-          agent {
-            node {
-              label 'windows-no-release'
-            }
-          }
-          when {
-            beforeAgent true
-            expression { shouldWeBuildUCRT }
-          }
-          environment {
-            RUNTESTDB = '/c/dev/'
-            LIBRARIES = '/c/dev/jenkins-cache/omlibrary/'
-          }
-          options {
-            retry(count: 2, conditions: [nonresumable()])
-          }
-          steps {
-            script { common.buildWinUCRT() }
-          }
-        }
         stage('cmake-jammy-gcc') {
           agent {
             docker {
@@ -170,33 +126,6 @@ pipeline {
                 "-DCMAKE_INSTALL_PREFIX=build"])
             }
             //stash name: 'omc-cmake-gcc', includes: 'build_cmake/**, build/**'
-          }
-        }
-        stage('cmake-macos-arm64-gcc') {
-          agent {
-            node {
-              label 'M1'
-            }
-          }
-          when {
-            beforeAgent true
-            expression { !shouldWeDisableAllCMakeBuilds && shouldWeEnableMacOSCMakeBuild}
-          }
-          options {
-            retry(count: 2, conditions: [nonresumable()])
-          }
-          steps {
-            script {
-              common.buildOMC_CMake([
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DOM_USE_CCACHE=OFF",
-                "-DCMAKE_INSTALL_PREFIX=build",
-                "-DCMAKE_PREFIX_PATH=/opt/local",     // Look in /opt/local first to prefer the macports libraries over others in the system.
-                "-DCMAKE_C_COMPILER=gcc",             // Always specify the compilers explicitly for macOS
-                "-DCMAKE_CXX_COMPILER=g++",
-                "-DCMAKE_Fortran_COMPILER=gfortran",
-                "-DOM_QT_MAJOR_VERSION=5"])           //Use Qt5 on old macOS machines
-            }
           }
         }
         stage('cmake-alpine-clang') {
@@ -229,6 +158,58 @@ pipeline {
             }
           }
         }
+
+        // macOS build stages
+        stage('cmake-macos-arm64-gcc') {
+          agent {
+            node {
+              label 'M1'
+            }
+          }
+          when {
+            beforeAgent true
+            expression { !shouldWeDisableAllCMakeBuilds && shouldWeEnableMacOSCMakeBuild}
+          }
+          options {
+            retry(count: 2, conditions: [nonresumable()])
+          }
+          steps {
+            script {
+              common.buildOMC_CMake([
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOM_USE_CCACHE=OFF",
+                "-DCMAKE_INSTALL_PREFIX=build",
+                "-DCMAKE_PREFIX_PATH=/opt/local",     // Look in /opt/local first to prefer the macports libraries over others in the system.
+                "-DCMAKE_C_COMPILER=gcc",             // Always specify the compilers explicitly for macOS
+                "-DCMAKE_CXX_COMPILER=g++",
+                "-DCMAKE_Fortran_COMPILER=gfortran",
+                "-DOM_QT_MAJOR_VERSION=5"])           //Use Qt5 on old macOS machines
+            }
+          }
+        }
+
+        // Windows build stages
+        stage('Win/UCRT64') {
+          agent {
+            node {
+              label 'windows-no-release'
+            }
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeBuildUCRT }
+          }
+          environment {
+            RUNTESTDB = '/c/dev/'
+            LIBRARIES = '/c/dev/jenkins-cache/omlibrary/'
+          }
+          options {
+            retry(count: 2, conditions: [nonresumable()])
+          }
+          steps {
+            script { common.buildWinUCRT() }
+          }
+        }
         stage('cmake-OMDev-gcc') {
           agent {
             node {
@@ -251,6 +232,33 @@ pipeline {
             }
           }
         }
+
+        // The Rust (mmtorust) omc port, GUI off; the GUI is built in parallel
+        // with the tests by the 'build-gui-rust' stage. See common.buildRustOMC().
+        stage('cmake-rust-clang') {
+          agent {
+            docker {
+              alwaysPull true
+              image 'docker.openmodelica.org/build-deps:ubuntu-26.04-rust'
+              label 'linux'
+              args "--mount type=volume,source=rust-cargo-registry,target=/opt/rust/cargo/registry " +
+                   "--mount type=volume,source=rust-sccache,target=/cache/sccache " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          when {
+            beforeAgent true
+            expression { !shouldWeDisableAllCMakeBuilds }
+          }
+          steps {
+            script {
+              common.buildRustOMC()
+            }
+          }
+        }
+
+        // Checks
         stage('checks') {
           agent {
             docker {

--- a/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
@@ -131,12 +131,17 @@ ELSE(WIN32)
 	ELSE()
 		SET(Boost_LIBS_ ${Boost_Library_folder})
 	ENDIF()
-	IF("${Boost_INCLUDE_DIR}" STREQUAL "" OR
-	   "${Boost_INCLUDE_DIR}" STREQUAL "/usr/include")
+	IF(NOT "${Boost_INCLUDE_DIR}" STREQUAL "" AND NOT "${Boost_INCLUDE_DIR}" STREQUAL "/usr/include")
 		# standard /usr/include collides with cross compilation
-		SET(Boost_INCLUDE_ ".")
-	ELSE()
 		SET(Boost_INCLUDE_ ${Boost_INCLUDE_DIR})
+	ELSEIF(NOT "${Boost_INCLUDE_DIRS}" STREQUAL "")
+		# Boost_INCLUDE_DIR (singular) is only reliably set by CMake's legacy
+		# Module-mode FindBoost.cmake, which CMake >= 3.30 no longer ships.
+		# Config-mode discovery (Boost's own exported BoostConfig.cmake, e.g.
+		# from Homebrew) only sets Boost_INCLUDE_DIRS (plural); fall back to it.
+		list(GET Boost_INCLUDE_DIRS 0 Boost_INCLUDE_)
+	ELSE()
+		SET(Boost_INCLUDE_ ".")
 	ENDIF()
 	IF("${SUNDIALS_LIBS}" STREQUAL "")
 		SET(SUNDIALS_LIBS_ ".")

--- a/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
@@ -131,17 +131,12 @@ ELSE(WIN32)
 	ELSE()
 		SET(Boost_LIBS_ ${Boost_Library_folder})
 	ENDIF()
-	IF(NOT "${Boost_INCLUDE_DIR}" STREQUAL "" AND NOT "${Boost_INCLUDE_DIR}" STREQUAL "/usr/include")
+	IF("${Boost_INCLUDE_DIR}" STREQUAL "" OR
+	   "${Boost_INCLUDE_DIR}" STREQUAL "/usr/include")
 		# standard /usr/include collides with cross compilation
-		SET(Boost_INCLUDE_ ${Boost_INCLUDE_DIR})
-	ELSEIF(NOT "${Boost_INCLUDE_DIRS}" STREQUAL "")
-		# Boost_INCLUDE_DIR (singular) is only reliably set by CMake's legacy
-		# Module-mode FindBoost.cmake, which CMake >= 3.30 no longer ships.
-		# Config-mode discovery (Boost's own exported BoostConfig.cmake, e.g.
-		# from Homebrew) only sets Boost_INCLUDE_DIRS (plural); fall back to it.
-		list(GET Boost_INCLUDE_DIRS 0 Boost_INCLUDE_)
-	ELSE()
 		SET(Boost_INCLUDE_ ".")
+	ELSE()
+		SET(Boost_INCLUDE_ ${Boost_INCLUDE_DIR})
 	ENDIF()
 	IF("${SUNDIALS_LIBS}" STREQUAL "")
 		SET(SUNDIALS_LIBS_ ".")

--- a/testsuite/sanity-check/runSanity.sh
+++ b/testsuite/sanity-check/runSanity.sh
@@ -40,13 +40,13 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Normalize clean
-case "${CLEAN,,}" in
+case "$(printf '%s' "$CLEAN" | tr '[:upper:]' '[:lower:]')" in
   true|1|yes) CLEAN="true";;
   *) CLEAN="false";;
 esac
 
 # Normalize simCode target (accepts C or Cpp only)
-lc_sim="${SIM_CODE_TARGET,,}"
+lc_sim="$(printf '%s' "$SIM_CODE_TARGET" | tr '[:upper:]' '[:lower:]')"
 case "$lc_sim" in
   c) SIM_CODE_TARGET="C";;
   cpp) SIM_CODE_TARGET="Cpp";;


### PR DESCRIPTION
### Related Issues

Jenkins' CPS transformation compiles the pipeline script into a single method, which was hitting the JVM's 64KB per-method byte code limit in in https://github.com/OpenModelica/OpenModelica/pull/16016.

### Purpose

* Reduce the size by moving more functionality into common.groovy.
* Fixing OMDev build
* Fixing macOS build and C sanity check (C++ sanity check still failing because of missing boost)

### Approach

- `buildOMC_CMake()` now takes a List of args and detects the platform itself (Windows/OMDev, macOS, Linux), so callers no longer need their own withEnv/cloneOMDev/version-check boilerplate.
- `evaluateBuildFlags()` centralizes the shouldWe*/isPR flag evaluation and logging that was previously inlined per-line in the Environment stage.
- `notifyOnFailure()` replaces the inline post{failure} email logic.
- `shouldWe*/isPR` helpers are now private to common.groovy since nothing outside it calls them anymore.
- runSanity.sh removed lowercasing with non-POSIX Bash 4 functionality (https://stackoverflow.com/questions/2264428/how-to-convert-a-string-to-lower-case-in-bash) breaking macOS sanity check
- Reordering Jenkins build stages (Linux, macOS, Windows, Rust/WASM, checks)