### PR TITLE
Add optional mimalloc/jemalloc global allocators

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -4778,6 +4778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libopenmodelica_compiler"
 version = "0.1.0"
 dependencies = [
@@ -4787,6 +4796,7 @@ dependencies = [
  "js-sys",
  "libc",
  "metamodelica",
+ "mimalloc",
  "openmodelica_animation",
  "openmodelica_backend_main",
  "openmodelica_codegen_wasm_jit",
@@ -4796,6 +4806,7 @@ dependencies = [
  "openmodelica_scripting_qt",
  "openmodelica_util",
  "openmodelica_wasi",
+ "tikv-jemallocator",
  "wasm-bindgen",
  "web-sys",
  "zip",
@@ -5178,6 +5189,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -9535,6 +9555,26 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
@@ -29,6 +29,11 @@ arcstr.workspace = true
 # `mmc_mk_*` use malloc/strdup, so the shims free them with the same allocator).
 libc.workspace = true
 
+# Optional global allocators (native only; see the `mimalloc`/`jemalloc` features).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+mimalloc = { version = "0.1", optional = true }
+tikv-jemallocator = { version = "0.6", optional = true }
+
 # wasm build: the JS bindings (src/wasm_api.rs). Pinned to match the
 # wasm-bindgen the wasmer `js` backend targets (see the workspace Cargo.lock);
 # since wasmer 7.2 this is the same recent wasm-bindgen the OMShell GUIs use.
@@ -68,6 +73,14 @@ codegen_c = ["openmodelica_backend_main/codegen_c"]
 codegen_fmu = ["openmodelica_backend_main/codegen_fmu"]
 susan = ["openmodelica_backend_main/susan"]
 scripting_api = ["dep:openmodelica_scripting_qt"]
+
+# Select the process global allocator (native only). The whole compiler is
+# statically linked into this cdylib, so its `#[global_allocator]` governs every
+# Rust allocation the omc launcher drives. Both off by default; enable one to
+# A/B the backend allocation-bound phases (matching/sorting, loadModel).
+# `jemalloc` wins if both are set, so there is never a duplicate allocator.
+mimalloc = ["dep:mimalloc"]
+jemalloc = ["dep:tikv-jemallocator"]
 
 # Forward the wasm-jit engine choice (default wasmtime; see
 # openmodelica_codegen_wasm_jit).

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -26,6 +26,14 @@ use openmodelica_backend_main::capi;
 use std::ffi::{CStr, CString, c_char, c_int};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
+#[cfg(all(feature = "mimalloc", not(feature = "jemalloc"), not(target_arch = "wasm32")))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(feature = "jemalloc", not(target_arch = "wasm32")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // MetaModelica-ABI compatibility shims (`omc_Main_init` / `omc_Main_handleCommand`
 // / GC + Windows no-ops) OMEdit links against. Implemented over the embedding ABI
 // below; the `#[no_mangle]` entry points are exported from this cdylib directly.


### PR DESCRIPTION
Wire two optional, mutually-exclusive global allocators into the libopenmodelica_compiler cdylib (the whole compiler is statically linked into it, so its #[global_allocator] governs every allocation the omc launcher drives). Both are off by default, keeping the system allocator; enable one with

  --features libopenmodelica_compiler/mimalloc
  --features libopenmodelica_compiler/jemalloc

to A/B allocator-bound phases. jemalloc wins if both are set, so there is never a duplicate allocator. Native-only (cfg-gated off wasm).