### PR TITLE
Replace anyhow errors with static strings

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -5163,7 +5163,6 @@ dependencies = [
 name = "metamodelica"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "metamodelica_derive",
  "num-traits",
@@ -6553,7 +6552,6 @@ dependencies = [
 name = "openmodelica_error"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 metamodelica_derive = { path = "../metamodelica_derive" }
-anyhow.workspace=true
 arcstr.workspace=true
 ordered-float.workspace=true
 num-traits.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
@@ -1,7 +1,6 @@
 //! `MetaModelica.Dangerous` — bounds-check-skipping / destructive variants.
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
 use arcstr::ArcStr;
 pub use crate::*;
 
@@ -167,7 +166,7 @@ pub fn listSetRest<T: Clone>(list: Arc<List<T>>, new_tail: Arc<List<T>>) -> Resu
     unsafe {
         match &mut *ptr {
             List::Cons { tail, .. } => { *tail = new_tail; Ok(()) }
-            List::Nil => bail!("listSetRest: called on Nil"),
+            List::Nil => return Err("listSetRest: called on Nil"),
         }
     }
 }
@@ -178,7 +177,7 @@ pub fn listSetFirst<T: Clone>(list: Arc<List<T>>, new_head: T) -> Result<()> {
     unsafe {
         match &mut *ptr {
             List::Cons { head, .. } => { *head = new_head; Ok(()) }
-            List::Nil => bail!("listSetFirst: called on Nil"),
+            List::Nil => return Err("listSetFirst: called on Nil"),
         }
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::rc::Rc;
 use std::cell::RefCell;
-use anyhow::{Result, bail};
+use crate::Result;
 use crate::{Array, list::List};
 
 pub mod static_array;
@@ -37,7 +37,7 @@ pub fn arrayGet<A: Clone>(arr: Array<A>, index: i32) -> Result<A> {
     let v = arr.borrow();
     v.get(idx)
         .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Index {} out of bounds for array of length {}", index, v.len()))
+        .ok_or_else(|| "Index {} out of bounds for array of length {}")
 }
 
 /// Creates a new array of the given size, initialized with initialValue. O(size).
@@ -94,7 +94,7 @@ pub fn arrayUpdate<A: Clone>(arr: Array<A>, index: i32, new_value: A) -> Result<
         let mut v = arr.borrow_mut();
         let len = v.len();
         if idx >= len {
-            bail!("Index {} out of bounds for array of length {}", index, len);
+            return Err("Index {} out of bounds for array of length {}");
         }
         v[idx] = new_value;
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/assert.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/assert.rs
@@ -39,6 +39,6 @@ macro_rules! omc_assert {
     ($($arg:tt)*) => {{
         let __msg: ::std::string::String = ::std::format!($($arg)*);
         $crate::reportAssert(&__msg);
-        ::anyhow::bail!(__msg)
+        return ::std::result::Result::Err("assertion failed")
     }};
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/cancel.rs
@@ -91,14 +91,14 @@ pub fn check_cancel() -> bool {
 
 /// The canonical cancellation error. Distinct message so callers/UI can tell a
 /// user-cancel from a real failure.
-pub fn cancelled_error() -> anyhow::Error {
-    anyhow::anyhow!("Operation cancelled by user")
+pub fn cancelled_error() -> &'static str {
+    "Operation cancelled by user"
 }
 
 /// `Err(cancelled_error())` if cancellation was requested, else `Ok(())`.
 /// Use with `?` at a chokepoint: `metamodelica::bail_if_cancelled()?;`.
 #[inline]
-pub fn bail_if_cancelled() -> anyhow::Result<()> {
+pub fn bail_if_cancelled() -> crate::Result<()> {
     if check_cancel() {
         return Err(cancelled_error());
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
@@ -30,6 +30,13 @@ pub use num_traits::Float;
 
 use std::rc::Rc;
 use std::cell::RefCell;
+
+/// The MetaModelica failure type. MetaModelica exceptions carry no payload
+/// (all diagnostics go through the `Error` message buffer), so the failure
+/// channel is a zero-allocation `&'static str` — a debug breadcrumb, never
+/// surfaced to the user.
+pub type Result<T, E = &'static str> = ::core::result::Result<T, E>;
+
 pub mod gc;
 pub mod cancel;
 
@@ -101,7 +108,7 @@ pub use misc::*;
 macro_rules! fnptr {
     // Zero-argument form.
     ($f:path) => {
-        || -> ::anyhow::Result<_> { ::std::result::Result::Ok($f()) }
+        || -> $crate::Result<_> { ::std::result::Result::Ok($f()) }
     };
     // 1+ argument form. The argument *types* must be supplied at the call
     // site so the closure's signature is unambiguous to the type system
@@ -127,23 +134,23 @@ macro_rules! fnptr {
 #[doc(hidden)]
 macro_rules! __fnptr_dispatch {
     ($f:path, $t1:ty) =>
-        { |a1: $t1| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1)) } };
+        { |a1: $t1| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1)) } };
     ($f:path, $t1:ty, $t2:ty) =>
-        { |a1: $t1, a2: $t2| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2)) } };
+        { |a1: $t1, a2: $t2| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3)) } };
+        { |a1: $t1, a2: $t2, a3: $t3| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty, $t8:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty, $t8:ty, $t9:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8, a9: $t9| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8, a9)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8, a9: $t9| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8, a9)) } };
     ($f:path, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty, $t8:ty, $t9:ty, $t10:ty) =>
-        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8, a9: $t9, a10: $t10| -> ::anyhow::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)) } };
+        { |a1: $t1, a2: $t2, a3: $t3, a4: $t4, a5: $t5, a6: $t6, a7: $t7, a8: $t8, a9: $t9, a10: $t10| -> $crate::Result<_> { ::std::result::Result::Ok($f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)) } };
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
@@ -2,7 +2,7 @@
 //! Construction/field macros live in [`macros`].
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use crate::Result;
 
 #[macro_use]
 mod macros;
@@ -169,7 +169,7 @@ impl<T: Clone> List<T> {
     pub fn get(self: &Arc<List<T>>, index: i32) -> Result<T> {
         (&**self).into_iter().nth((index - 1) as usize)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("Index {} out of bounds for list of length {}", index, self.len()))
+            .ok_or_else(|| "Index {} out of bounds for list of length {}")
     }
     pub fn prepend_reverse(self: &Arc<List<T>>, prefix: &Arc<List<T>>) -> Arc<List<T>> {
         let mut result = self.clone();
@@ -181,7 +181,7 @@ impl<T: Clone> List<T> {
     /// Deletes the element at the given 1-based index. O(index).
     pub fn delete(self: &Arc<List<T>>, index: i32) -> Result<Arc<List<T>>> {
         if index < 1 {
-            bail!("Index must be positive, got {}", index);
+            return Err("Index must be positive, got {}");
         }
         if index == 1 {
             return self.rest();
@@ -192,7 +192,7 @@ impl<T: Clone> List<T> {
         loop {
             cur_index -= 1;
             let (head,tail) = match &**iter {
-                Nil => bail!("Index {} out of bounds for list", index),
+                Nil => return Err("Index {} out of bounds for list"),
                 Cons{head, tail} => (head, tail)
             };
             iter = tail;
@@ -215,7 +215,7 @@ impl<T: Clone> List<T> {
     /// Fails if the list is empty.
     pub fn head(self: &Arc<List<T>>) -> Result<&T> {
         match &**self {
-            Nil => bail!("Cannot get head of empty list"),
+            Nil => return Err("Cannot get head of empty list"),
             Cons{head, ..} => Ok(head),
         }
     }
@@ -223,7 +223,7 @@ impl<T: Clone> List<T> {
     /// Fails if the list is empty.
     pub fn rest(self: &Arc<List<T>>) -> Result<Arc<List<T>>> {
         match &**self {
-            Nil => bail!("Cannot get rest of empty list"),
+            Nil => return Err("Cannot get rest of empty list"),
             Cons{tail, ..} => Ok(tail.clone()),
         }
     }
@@ -267,7 +267,7 @@ pub fn listMember<T: Clone+PartialEq>(element: T, lst: Arc<List<T>>) -> bool {
 }
 
 pub fn listHead<T: Clone>(lst: Arc<List<T>>) -> Result<T> {
-    let Cons{head, ..} = &*lst else {bail!("Cannot get head of empty list")};
+    let Cons{head, ..} = &*lst else {return Err("Cannot get head of empty list")};
     Ok(head.clone())
 }
 
@@ -285,7 +285,7 @@ pub fn listDelete<T: Clone>(lst: Arc<List<T>>, index: i32) -> Result<Arc<List<T>
 
 pub fn listRest<T: Clone>(lst: Arc<List<T>>) -> Result<Arc<List<T>>> {
     match &*lst {
-        Nil => bail!("Cannot get rest of empty list"),
+        Nil => return Err("Cannot get rest of empty list"),
         Cons{tail, ..} => Ok(tail.clone()),
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/misc.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/misc.rs
@@ -1,6 +1,6 @@
 //! Option predicates and miscellaneous builtins.
 
-use anyhow::{Result, bail};
+use crate::Result;
 
 /// Returns true if the Option is NONE.
 pub fn isNone<A>(opt: Option<A>) -> bool {
@@ -33,7 +33,7 @@ pub fn isPresent<T>(_ident: &T) -> Result<bool> {
 
 /// Fail function - unconditionally raises an error.
 pub fn fail() -> Result<()> {
-    bail!("fail() was called - unrecoverable error")
+    return Err("fail() was called - unrecoverable error")
 }
 
 #[cfg(test)]

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/real/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/real/mod.rs
@@ -1,7 +1,7 @@
 //! Real arithmetic, comparison and conversion builtins.
 //! The shortest-round-trip string formatter lives in [`ryu`].
 
-use anyhow::{Result, bail};
+use crate::Result;
 use ordered_float::OrderedFloat;
 use crate::Real;
 
@@ -44,7 +44,7 @@ pub fn realDiv(r1: Real, r2: Real) -> Real {
 #[inline(always)]
 pub fn real_div_checked(r1: Real, r2: Real) -> Result<Real> {
     if r2.0 == 0.0 {
-        bail!("Real division by zero");
+        return Err("Real division by zero");
     }
     Ok(r1 / r2)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/mod.rs
@@ -2,7 +2,7 @@
 //! `substring`. Hashing lives in [`hash`], URI resolution in [`uri`].
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use crate::Result;
 use arcstr::{ArcStr, format};
 use ordered_float::OrderedFloat;
 use crate::{Real, list::List};
@@ -19,11 +19,11 @@ pub fn stringCharInt(ch: ArcStr) -> Result<i32> {
     // may span several bytes (e.g. "ö"). Count chars, not bytes, and return its
     // code point.
     if ch.chars().count() != 1 {
-        bail!("stringCharInt expects a single-character string, got '{}'", ch);
+        return Err("stringCharInt expects a single-character string, got '{}'");
     };
     ch.chars().next()
         .map(|c| c as i32)
-        .ok_or_else(|| anyhow::anyhow!("Failed to get character from string: {}", ch))
+        .ok_or_else(|| "Failed to get character from string: {}")
 }
 
 /// Returns a single-character string from an ASCII code point.
@@ -39,7 +39,7 @@ pub fn intStringChar(i: i32) -> ArcStr {
 pub fn stringInt(str: ArcStr) -> Result<i32> {
     str.trim_start_matches(c_isspace)
         .parse::<i32>()
-        .map_err(|_| anyhow::anyhow!("Failed to parse integer from string: {}", str))
+        .map_err(|_| "Failed to parse integer from string: {}")
 }
 
 /// The C-locale `isspace` set that `strtol`/`strtod` skip before a number.
@@ -59,7 +59,7 @@ pub fn stringReal(str: ArcStr) -> Result<Real> {
     str.trim_start_matches(c_isspace)
         .parse::<f64>()
         .map(OrderedFloat)
-        .map_err(|_| anyhow::anyhow!("Failed to parse real from string: {}", str))
+        .map_err(|_| "Failed to parse real from string: {}")
 }
 
 /// Converts a string to a list of single-character strings.
@@ -119,7 +119,7 @@ pub fn stringGet(str: ArcStr, index: i32) -> Result<i32> {
     let idx = (index - 1) as usize; // 1-based to 0-based
     str.bytes().nth(idx)
         .map(|b| b as i32)
-        .ok_or_else(|| anyhow::anyhow!("Index {} out of bounds for string of length {}", index, str.len()))
+        .ok_or_else(|| "Index {} out of bounds for string of length {}")
 }
 
 /// Returns the character at the given 1-based index as a string.
@@ -127,19 +127,19 @@ pub fn stringGetStringChar(str: ArcStr, index: i32) -> Result<ArcStr> {
     let idx = (index - 1) as usize; // 1-based to 0-based
     str.chars().nth(idx)
         .map(|c| format!("{}", c))
-        .ok_or_else(|| anyhow::anyhow!("Index {} out of bounds for string of length {}", index, str.chars().count()))
+        .ok_or_else(|| "Index {} out of bounds for string of length {}")
 }
 
 /// Updates the character at the given 1-based index with newch.
 /// newch should be a single character.
 pub fn stringUpdateStringChar(str: ArcStr, newch: ArcStr, index: i32) -> Result<ArcStr> {
     if newch.is_empty() {
-        bail!("newch must not be empty");
+        return Err("newch must not be empty");
     }
     let idx = (index - 1) as usize; // 1-based to 0-based
     let mut chars: Vec<char> = str.chars().collect();
     if idx >= chars.len() {
-        bail!("Index {} out of bounds for string with {} characters", index, chars.len());
+        return Err("Index {} out of bounds for string with {} characters");
     }
     let new_char = newch.chars().next().unwrap_or(' ');
     chars[idx] = new_char;
@@ -189,7 +189,7 @@ pub fn stringCompare(s1: ArcStr, s2: ArcStr) -> i32 {
 /// Fails for bogus start/stop values.
 pub fn substring(str: ArcStr, start: i32, stop: i32) -> Result<ArcStr> {
     if start < 1 || stop < start || start > stop {
-        bail!("Invalid substring range: start={}, stop={}", start, stop);
+        return Err("Invalid substring range: start={}, stop={}");
     }
     // `substring` is byte-indexed to match the rest of the MetaModelica
     // string surface (stringLength returns bytes via `.len()`, stringGet
@@ -201,7 +201,7 @@ pub fn substring(str: ArcStr, start: i32, stop: i32) -> Result<ArcStr> {
     let start_idx = (start - 1) as usize; // 1-based to 0-based
     let stop_idx = stop as usize;         // 1-based, inclusive -> exclusive
     if stop_idx > str.len() {
-        bail!("Stop index {} exceeds string length {}", stop, str.len());
+        return Err("Stop index {} exceeds string length {}");
     }
     match str.get(start_idx..stop_idx) {
         Some(slice) => Ok(ArcStr::from(slice)),
@@ -209,10 +209,7 @@ pub fn substring(str: ArcStr, start: i32, stop: i32) -> Result<ArcStr> {
         // no valid string to return. Surface this rather than silently
         // producing nonsense; the call site should be rewritten to use
         // codepoint indices if that's what it meant.
-        None => bail!(
-            "substring({}, {}) does not fall on UTF-8 character boundaries",
-            start, stop
-        ),
+        None => return Err("substring({}, {}) does not fall on UTF-8 character boundaries"),
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/uri.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/uri.rs
@@ -1,7 +1,7 @@
 //! `modelica://` / `file://` URI resolution (`uriToFilename`).
 
 use std::cell::RefCell;
-use anyhow::Result;
+use crate::Result;
 use arcstr::ArcStr;
 use crate::Array;
 use crate::omc_assert;

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/global_root.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/global_root.rs
@@ -7,7 +7,7 @@
 //! Values are erased through `Rc<dyn Any>`; `getGlobalRoot::<A>`
 //! downcasts on retrieval.
 
-use anyhow::Result;
+use crate::Result;
 
 thread_local! {
     static GLOBAL_ROOTS: std::cell::RefCell<Vec<Option<std::rc::Rc<dyn std::any::Any>>>> =
@@ -32,14 +32,10 @@ pub fn getGlobalRoot<A: std::any::Any + Clone + 'static>(index: i32) -> Result<A
         let entry = v
             .get(index as usize)
             .and_then(|o| o.clone())
-            .ok_or_else(|| anyhow::anyhow!("getGlobalRoot: index {} is uninitialized", index))?;
+            .ok_or_else(|| "getGlobalRoot: index {} is uninitialized")?;
         match entry.downcast::<A>() {
             Ok(rc) => Ok((*rc).clone()),
-            Err(_) => Err(anyhow::anyhow!(
-                "getGlobalRoot: index {} type mismatch (expected {})",
-                index,
-                std::any::type_name::<A>()
-            )),
+            Err(_) => Err("getGlobalRoot: index type mismatch"),
         }
     })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/mod.rs
@@ -4,7 +4,7 @@
 
 use arcstr::{ArcStr, format};
 use ordered_float::OrderedFloat;
-use anyhow::Result;
+use crate::Result;
 use crate::Real;
 
 pub mod reference_eq;

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/reference_eq.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/reference_eq.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 use std::rc::Rc;
-use anyhow::Result;
+use crate::Result;
 use arcstr::{ArcStr, format};
 use crate::Real;
 use crate::list::List;

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -1239,7 +1239,7 @@ impl GenCtx {
             "this OpenModelica build was compiled without the '{feature}' code generation target"
         );
         let off = if self.current_fn_fallible {
-            format!("bail!({what:?})")
+            format!("return Err({what:?})")
         } else {
             format!("panic!({what:?})")
         };
@@ -1262,7 +1262,7 @@ impl GenCtx {
             "this OpenModelica build was compiled without the '{feature}' code generation target"
         );
         let body = if self.current_fn_fallible {
-            format!("bail!({what:?})")
+            format!("return Err({what:?})")
         } else {
             format!("panic!({what:?})")
         };
@@ -2427,7 +2427,7 @@ fn generate_file<'a>(top_name: &str, node: &NameNode<'_>, crate_map: &BTreeMap<S
     writeln!(out, "#![allow(unreachable_patterns, unreachable_code, non_camel_case_types, non_snake_case, dead_code, unused_imports, unused_variables, non_upper_case_globals, unused_mut)]").unwrap();
     writeln!(out, "
 use std::sync::Arc;
-use anyhow::{{Result, bail}};
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;
@@ -10312,9 +10312,9 @@ fn emit_diverging_fail(msg: &str, is_const: bool, ctx: &GenCtx) -> String {
     }
     match &ctx.qmode {
         QMode::TryBlock(label) => {
-            format!("break {label} Err::<_, _>(anyhow::anyhow!(\"{msg}\"))")
+            format!("break {label} Err::<_, _>(\"{msg}\")")
         }
-        QMode::Function if ctx.current_fn_fallible => format!("bail!(\"{msg}\")"),
+        QMode::Function if ctx.current_fn_fallible => format!("return Err(\"{msg}\")"),
         _ => format!("panic!(\"{msg}\")"),
     }
 }
@@ -10515,7 +10515,7 @@ fn emit_reduction<'a>(
                 Some(id) => format!("__acc.unwrap_or({id})"),
                 // No identity for this element type: an empty reduction stays a
                 // runtime error, surfaced as Result via the caller's qmode.
-                None => ctx.q(&format!("__acc.ok_or_else(|| anyhow::anyhow!(\"empty {func} reduction\"))")),
+                None => ctx.q(&format!("__acc.ok_or_else(|| \"empty {func} reduction\")")),
             };
             (
                 format!("let mut __acc: Option<{elem_ty}> = None;"),
@@ -10606,7 +10606,7 @@ fn emit_reduction<'a>(
                         format!("let mut __acc: Option<{acc_ty}> = None;"),
                         update,
                         ctx.q(&format!(
-                            "__acc.ok_or_else(|| anyhow::anyhow!(\"empty {func} reduction\"))"
+                            "__acc.ok_or_else(|| \"empty {func} reduction\")"
                         )),
                     )
                 }
@@ -10956,9 +10956,9 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
             // an Err instead.
             match &ctx.qmode {
                 QMode::TryBlock(label) => {
-                    Ok(format!("break {label} Err::<_, _>(anyhow::anyhow!(\"fail\"))"))
+                    Ok(format!("break {label} Err::<_, _>(\"fail\")"))
                 }
-                _ => Ok("bail!(\"fail\")".to_owned()),
+                _ => Ok("return Err(\"fail\")".to_owned()),
             }
         },
         // setGlobalRoot(index, value)
@@ -11067,7 +11067,7 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
                     // resulting `Result` per the current `QMode` (`?`, `.unwrap()`,
                     // or `unwrap_break_err!` inside a `try` block).
                     let read = format!(
-                        "{var_path}.with(|__root| __root.borrow().clone()).ok_or_else(|| anyhow::anyhow!(\"getGlobalRoot: empty slot {}\"))",
+                        "{var_path}.with(|__root| __root.borrow().clone()).ok_or_else(|| \"getGlobalRoot: empty slot {}\")",
                         grc.const_name,
                     );
                     return Ok(ctx.q(&read));
@@ -15016,7 +15016,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                 // too: a value-typed `Err(…)` would not unify with the
                 // `!`-typed arms (and the `loop` body must stay `()`/`!`).
                 if active_tail.is_some() && ctx.current_fn_fallible {
-                    ",\n        _ => return Err(anyhow::anyhow!(\"match: no arm matched\"))".to_owned()
+                    ",\n        _ => return Err(\"match: no arm matched\")".to_owned()
                 } else {
                     ",\n        _ => unreachable!(\"tail-call lowered match: no arm matched\")".to_owned()
                 }
@@ -15027,7 +15027,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                 // semantics that wouldn't typecheck in every callsite.
                 ",\n        _ => unreachable!(\"match_deref! exhaustiveness placeholder\")".to_owned()
             } else if ctx.current_fn_fallible {
-                ",\n        _ => bail!(\"match: no arm matched\")".to_owned()
+                ",\n        _ => return Err(\"match: no arm matched\")".to_owned()
             } else {
                 // A non-fallible function can't `bail!`; a runtime miss of a
                 // non-exhaustive match panics instead (the typical source is an
@@ -15279,7 +15279,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                     if parts.is_empty() {
                         String::new()
                     } else {
-                        format!("            if !({}) {{ bail!(\"guard\") }}\n", parts.join(" && "))
+                        format!("            if !({}) {{ return Err(\"guard\") }}\n", parts.join(" && "))
                     }
                 };
 
@@ -15586,7 +15586,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                     s.push_str(&body.replace("            ", "                    "));
                     s.push_str(&format!("                    Ok({result})\n"));
                     s.push_str("                }\n");
-                    s.push_str("                _ => bail!(\"nomatch\"),\n");
+                    s.push_str("                _ => return Err(\"nomatch\"),\n");
                     s.push_str("            }}\n");
                 } else {
                     if bind_arc_directly {
@@ -15597,11 +15597,11 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                         let mut_prefix = if true { "mut " } else { "" };
                         s.push_str(&format!("            let {mut_prefix}{var_name} = __mc_input.clone();\n"));
                     } else if mc_uses_tuple_rewrite {
-                        s.push_str(&format!("            let {pat} = __mc_input.clone() else {{ bail!(\"nomatch\") }};\n"));
+                        s.push_str(&format!("            let {pat} = __mc_input.clone() else {{ return Err(\"nomatch\") }};\n"));
                     } else if input_is_arc {
-                        s.push_str(&format!("            let {pat} = __mc_input.as_ref() else {{ bail!(\"nomatch\") }};\n"));
+                        s.push_str(&format!("            let {pat} = __mc_input.as_ref() else {{ return Err(\"nomatch\") }};\n"));
                     } else {
-                        s.push_str(&format!("            let {pat} = __mc_input.clone() else {{ bail!(\"nomatch\") }};\n"));
+                        s.push_str(&format!("            let {pat} = __mc_input.clone() else {{ return Err(\"nomatch\") }};\n"));
                     }
                     s.push_str(&guard_check);
                     s.push_str(&body);
@@ -17812,10 +17812,10 @@ fn emit_pat_assign<'a>(
                     // rather than bailing out of a possibly-infallible function.
                     _ => match &ctx.qmode {
                         QMode::TryBlock(label) => {
-                            fail_owned = format!("break {label} Err::<_, _>(anyhow::anyhow!(\"pattern mismatch\"))");
+                            fail_owned = format!("break {label} Err::<_, _>(\"pattern mismatch\")");
                             &fail_owned
                         }
-                        _ => "bail!(\"pattern mismatch\")",
+                        _ => "return Err(\"pattern mismatch\")",
                     },
                 };
                 writeln!(out, "{indent}let {tmp} = ({scrut_expr});").unwrap();
@@ -17999,10 +17999,10 @@ fn emit_pat_assign<'a>(
                     // break can never escape across a closure.
                     FailureMode::Function | FailureMode::TryArm => match &ctx.qmode {
                         QMode::TryBlock(label) => {
-                            fail_owned = format!("break {label} Err::<_, _>(anyhow::anyhow!(\"pattern mismatch\"))");
+                            fail_owned = format!("break {label} Err::<_, _>(\"pattern mismatch\")");
                             &fail_owned
                         }
-                        _ => "bail!(\"pattern mismatch\")",
+                        _ => "return Err(\"pattern mismatch\")",
                     },
                     FailureMode::Failure => "()",
                     FailureMode::IfLetElse(else_code) => {
@@ -18150,10 +18150,10 @@ fn emit_pat_assign<'a>(
                     // possibly-infallible function.
                     FailureMode::Function | FailureMode::TryArm => match &ctx.qmode {
                         QMode::TryBlock(label) => {
-                            fail_owned = format!("break {label} Err::<_, _>(anyhow::anyhow!(\"pattern mismatch\"))");
+                            fail_owned = format!("break {label} Err::<_, _>(\"pattern mismatch\")");
                             &fail_owned
                         }
-                        _ => "bail!(\"pattern mismatch\")",
+                        _ => "return Err(\"pattern mismatch\")",
                     },
                     FailureMode::Failure => "()",
                     FailureMode::IfLetElse(_) => unreachable!(),
@@ -20804,7 +20804,7 @@ fn emit_stmt<'a>(
                 ctx.with_qmode(QMode::TryBlock(label.clone()), |ctx| {
                     emit_stmts(out, &format!("{indent}    "), body, FailureMode::TryArm, ctx, &mut benv, top_level, fresh);
                 });
-                writeln!(out, "{indent}    Ok::<(), anyhow::Error>(())").unwrap();
+                writeln!(out, "{indent}    Ok::<(), &'static str>(())").unwrap();
                 writeln!(out, "{indent}}}.is_err() {{").unwrap();
                 let mut eenv = env.clone();
                 emit_stmts(out, &format!("{indent}    "), else_body, fail_mode, ctx, &mut eenv, top_level, fresh);
@@ -20823,7 +20823,7 @@ fn emit_stmt<'a>(
                 ctx.with_qmode(QMode::TryBlock(label.clone()), |ctx| {
                     emit_stmts(out, &format!("{indent}    "), body, FailureMode::TryArm, ctx, &mut benv, top_level, fresh);
                 });
-                writeln!(out, "{indent}    Ok::<(), anyhow::Error>(())").unwrap();
+                writeln!(out, "{indent}    Ok::<(), &'static str>(())").unwrap();
                 writeln!(out, "{indent}}} {{").unwrap();
                 writeln!(out, "{indent}    Ok(()) => {{}}").unwrap();
                 writeln!(out, "{indent}    {err_pat} => {{").unwrap();
@@ -20863,7 +20863,7 @@ fn emit_stmt<'a>(
                 ctx.with_qmode(QMode::TryBlock(label.clone()), |ctx| {
                     emit_stmts(out, &format!("{indent}    "), body, FailureMode::TryArm, ctx, &mut benv, top_level, fresh);
                 });
-                writeln!(out, "{indent}    Ok::<_, anyhow::Error>({yield_tuple})").unwrap();
+                writeln!(out, "{indent}    Ok::<_, &'static str>({yield_tuple})").unwrap();
                 writeln!(out, "{indent}}} {{").unwrap();
                 writeln!(out, "{indent}    Ok({temp_pat}) => {{").unwrap();
                 for (v, t) in escaped_vars.iter().zip(temp_names.iter()) {
@@ -20898,8 +20898,8 @@ fn emit_stmt<'a>(
             ctx.with_qmode(QMode::TryBlock(label.clone()), |ctx| {
                 emit_stmts(out, &format!("{indent}    "), body, FailureMode::TryArm, ctx, &mut fenv, top_level, fresh);
             });
-            writeln!(out, "{indent}    Ok::<(), anyhow::Error>(())").unwrap();
-            writeln!(out, "{indent}}}.is_ok() {{ bail!(\"failure(): body succeeded\") }}").unwrap();
+            writeln!(out, "{indent}    Ok::<(), &'static str>(())").unwrap();
+            writeln!(out, "{indent}}}.is_ok() {{ return Err(\"failure(): body succeeded\") }}").unwrap();
         }
         S::Return => {
             // Expand `return;` into the same shape that emit_function produces

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 openmodelica_wasi.workspace = true
 metamodelica.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/Absyn.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/Absyn.rs
@@ -37,7 +37,7 @@
 #![allow(unreachable_patterns, unreachable_code, non_camel_case_types, non_snake_case, dead_code, unused_imports, unused_variables, non_upper_case_globals, unused_mut)]
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/GlobalScript.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/GlobalScript.rs
@@ -37,7 +37,7 @@
 #![allow(unreachable_patterns, unreachable_code, non_camel_case_types, non_snake_case, dead_code, unused_imports, unused_variables, non_upper_case_globals, unused_mut)]
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
@@ -31,7 +31,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use crate::Absyn;
@@ -99,14 +99,14 @@ fn report_syntax_messages(info_filename: &str) {
     }
 }
 
-/// Wrap [`parser::parse`]'s `Box<dyn Error>` into an `anyhow::Error` so
+/// Wrap [`parser::parse`]'s `Box<dyn Error>` into an `&'static str` so
 /// the MetaModelica-facing signatures (which return `anyhow::Result`)
 /// can use `?` directly. `filename` is the real path stored into SOURCEINFO;
 /// `info_filename` (the possibly testsuite-friendly name) is only used to
 /// display syntax errors — same split as the C parser's `filename_C` vs
 /// `filename_C_testsuiteFriendly` (Parser/parse.c).
 fn run_parse(src: &str, filename: &str, info_filename: &str, grammar: Grammar, readonly: bool, timestamp: f64) -> Result<Absyn::Program> {
-    let result = parser::parse(src, filename, info_filename, grammar, readonly, timestamp).map_err(|e| anyhow!(e.to_string()));
+    let result = parser::parse(src, filename, info_filename, grammar, readonly, timestamp).map_err(|_| "error");
     report_syntax_messages(info_filename);
     result
 }
@@ -197,13 +197,10 @@ pub fn parse(
     // would need transcoding via the `encoding_rs` crate; bail explicitly
     // rather than silently misinterpreting the bytes.
     if !encoding.is_empty() && !encoding.eq_ignore_ascii_case("UTF-8") && !encoding.eq_ignore_ascii_case("UTF8") {
-        return Err(anyhow!(
-            "ParserExt::parse: only UTF-8 input is supported, got encoding {:?}",
-            encoding.as_str()
-        ));
+        return Err("ParserExt::parse: only UTF-8 input is supported, got encoding {:?}");
     }
     let (src, orig_bytes) = read_source_file(filename.as_str())
-        .with_context(|| format!("ParserExt::parse: cannot read {filename}"))?;
+        .map_err(|_| "ParserExt::parse: cannot read {filename}")?;
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     parser::set_pure_impure_as_ident(languageStandardInt < 33 && strict);
     // Like parseFile in Parser/parse.c: classes parsed from a file the user
@@ -246,11 +243,11 @@ pub fn parseexp(
     _runningTestsuite: bool,
 ) -> Result<GlobalScript::Statements> {
     let (src, orig_bytes) = read_source_file(filename.as_str())
-        .with_context(|| format!("ParserExt::parseexp: cannot read {filename}"))?;
+        .map_err(|_| "ParserExt::parseexp: cannot read {filename}")?;
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     let readonly = !regular_file_writable(filename.as_str());
     parser::set_non_utf8_source_bytes(orig_bytes);
-    let result = parser::parse_statements(&src, filename.as_str(), infoFilename.as_str(), grammar, readonly, file_timestamp(filename.as_str())).map_err(|e| anyhow!(e.to_string()));
+    let result = parser::parse_statements(&src, filename.as_str(), infoFilename.as_str(), grammar, readonly, file_timestamp(filename.as_str())).map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     parser::set_non_utf8_source_bytes(None);
     result
@@ -264,7 +261,7 @@ pub fn parsestringexp(
     _runningTestsuite: bool,
 ) -> Result<GlobalScript::Statements> {
     let grammar = select_grammar(acceptedGram, languageStandardInt);
-    let result = parser::parse_statements(r#str.as_str(), infoFilename.as_str(), infoFilename.as_str(), grammar, /*readonly=*/false, now_timestamp()).map_err(|e| anyhow!(e.to_string()));
+    let result = parser::parse_statements(r#str.as_str(), infoFilename.as_str(), infoFilename.as_str(), grammar, /*readonly=*/false, now_timestamp()).map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     result
 }
@@ -279,7 +276,7 @@ pub fn stringPath(
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     let result = parser::parse_path(r#str.as_str(), infoFilename.as_str(), grammar)
         .map(Arc::new)
-        .map_err(|e| anyhow!(e.to_string()));
+        .map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     result
 }
@@ -294,7 +291,7 @@ pub fn stringCref(
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     let result = parser::parse_cref(r#str.as_str(), infoFilename.as_str(), grammar)
         .map(Arc::new)
-        .map_err(|e| anyhow!(e.to_string()));
+        .map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     result
 }
@@ -309,7 +306,7 @@ pub fn stringMod(
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     let result = parser::parse_modification(r#str.as_str(), infoFilename.as_str(), grammar)
         .map(Arc::new)
-        .map_err(|e| anyhow!(e.to_string()));
+        .map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     result
 }
@@ -324,7 +321,7 @@ pub fn stringEq(
     let grammar = select_grammar(acceptedGram, languageStandardInt);
     let result = parser::parse_equation(r#str.as_str(), infoFilename.as_str(), grammar)
         .map(Arc::new)
-        .map_err(|e| anyhow!(e.to_string()));
+        .map_err(|_| "error");
     report_syntax_messages(infoFilename.as_str());
     result
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast_collections/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast_collections/Cargo.toml
@@ -8,7 +8,6 @@ metamodelica.workspace = true
 openmodelica_ast.workspace = true
 openmodelica_frontend_dump.workspace = true
 openmodelica_util.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 openmodelica_codegen_graphml.workspace = true
 openmodelica_tpl.workspace = true
 openmodelica_error.workspace = true
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_ast.workspace=true
 openmodelica_backend_types.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/HpcOmBenchmarkExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/HpcOmBenchmarkExt.rs
@@ -45,7 +45,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use metamodelica::ext::{c_atof, c_atol};
@@ -108,7 +108,7 @@ pub fn readCalcTimesFromXml(fileName: ArcStr) -> Result<Arc<List<Real>>> {
     let Ok(content) = std::fs::read_to_string(fileName.as_str()) else {
         // Mirrors the printf in HpcOmBenchmarkExtImpl__readCalcTimesFromXml.
         println!("File '{}' does not exist", fileName);
-        bail!("File '{}' does not exist", fileName);
+        return Err("File '{}' does not exist");
     };
     let mut res: Arc<List<Real>> = metamodelica::nil();
     let doc = match roxmltree::Document::parse(&content) {
@@ -152,7 +152,7 @@ pub fn readCalcTimesFromJson(fileName: ArcStr) -> Result<Arc<List<Real>>> {
     let Ok(content) = std::fs::read(fileName.as_str()) else {
         // Mirrors the printf in HpcOmBenchmarkExtImpl__readCalcTimesFromJson.
         println!("File '{}' does not exist", fileName);
-        bail!("File '{}' does not exist", fileName);
+        return Err("File '{}' does not exist");
     };
     let mut res: Arc<List<Real>> = metamodelica::nil();
     let Ok(root) = serde_json::from_slice::<serde_json::Value>(&content) else {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/Cargo.toml
@@ -42,7 +42,6 @@ openmodelica_script_util.workspace=true
 openmodelica_susan = { workspace = true, optional = true }
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -22,7 +22,7 @@
 //! dedicated multi-MiB stack, because the port only lowers self-tail-calls and
 //! deep traversals can overflow the default 8 MiB).
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 use std::sync::Arc;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/Cargo.toml
@@ -18,7 +18,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_program_util.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/CevalScriptOMSimulator_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/CevalScriptOMSimulator_wasm.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use openmodelica_frontend_types::Values;
@@ -14,5 +14,5 @@ pub fn ceval(
     inFunctionName: ArcStr,
     _inVals: Arc<metamodelica::List<Arc<Values::Value>>>,
 ) -> Result<Arc<Values::Value>> {
-    bail!("CevalScriptOMSimulator: the OMSimulator scripting API (libOMSimulator) is unavailable on wasm (called `{inFunctionName}`)")
+    return Err("CevalScriptOMSimulator: the OMSimulator scripting API (libOMSimulator) is unavailable on wasm (called `{inFunctionName}`)")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/SerializeSparsityPattern.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/SerializeSparsityPattern.rs
@@ -47,7 +47,7 @@
 
 use std::io::Write;
 
-use anyhow::{bail, Context, Result};
+use metamodelica::Result;
 use arcstr::{literal, ArcStr};
 use metamodelica::{list, List};
 
@@ -66,7 +66,7 @@ pub fn serialize(code: SimCode::SimCode) -> Result<ArcStr> {
                         "SerializeSparsityPattern.serialize failed because no row coloring for the adjoint jacobian exists."
                     )],
                 )?;
-                bail!("fail");
+                return Err("fail");
             }
             (&jac.sparsityT, &jac.coloredRows)
         } else {
@@ -105,22 +105,22 @@ pub fn serialize(code: SimCode::SimCode) -> Result<ArcStr> {
 /// indices, each as a native-endian u32.
 fn serializeJacobian(name: &str, colPtrs: &[i32], rowInds: &[i32]) -> Result<()> {
     let file = std::fs::File::create(name)
-        .with_context(|| format!("Could not open sparsity pattern file {name}."))?;
+        .map_err(|_| "Could not open sparsity pattern file {name}.")?;
     let mut out = std::io::BufWriter::new(file);
     // Compute and write sparsePattern->leadindex.
     let mut j: u32 = 0;
     for &c in colPtrs {
         j = j.wrapping_add(c as u32);
         out.write_all(&j.to_ne_bytes())
-            .with_context(|| format!("Error while writing sparsePattern->leadindex to {name}."))?;
+            .map_err(|_| "Error while writing sparsePattern->leadindex to {name}.")?;
     }
     // Write sparsePattern->index.
     for &r in rowInds {
         out.write_all(&(r as u32).to_ne_bytes())
-            .with_context(|| format!("Error while writing sparsePattern->index to {name}."))?;
+            .map_err(|_| "Error while writing sparsePattern->index to {name}.")?;
     }
     out.flush()
-        .with_context(|| format!("Error while writing sparsity pattern file {name}."))?;
+        .map_err(|_| "Error while writing sparsity pattern file {name}.")?;
     Ok(())
 }
 
@@ -131,14 +131,14 @@ fn serializeColor(name: &str, columns: &[i32]) -> Result<()> {
         .create(true)
         .append(true)
         .open(name)
-        .with_context(|| format!("Could not open sparsity pattern file {name}."))?;
+        .map_err(|_| "Could not open sparsity pattern file {name}.")?;
     let mut out = std::io::BufWriter::new(file);
     // Write sparsePattern->colorCols.
     for &c in columns {
         out.write_all(&(c as u32).to_ne_bytes())
-            .with_context(|| format!("Error while writing sparsePattern->colorCols to {name}."))?;
+            .map_err(|_| "Error while writing sparsePattern->colorCols to {name}.")?;
     }
     out.flush()
-        .with_context(|| format!("Error while writing sparsity pattern file {name}."))?;
+        .map_err(|_| "Error while writing sparsity pattern file {name}.")?;
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_types/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_types/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_ast.workspace=true
 openmodelica_ast_collections.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/src/BackendDAEEXT.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/src/BackendDAEEXT.rs
@@ -48,7 +48,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use metamodelica::Array;
 
 // ── Per-task state ────────────────────────────────────────────────────────────
@@ -269,10 +269,10 @@ pub fn getAssignment(ass1: Array<i32>, ass2: Array<i32>) -> Result<()> {
         let len1 = ass1.borrow().len() as i32;
         let len2 = ass2.borrow().len() as i32;
         if s.n > len1 {
-            bail!("BackendDAEEXT.getAssignment failed because n={}>arrayLength(ass1)={}", s.n, len1);
+            return Err("BackendDAEEXT.getAssignment failed because n={}>arrayLength(ass1)={}");
         }
         if s.m > len2 {
-            bail!("BackendDAEEXT.getAssignment failed because m={}>arrayLength(ass2)={}", s.m, len2);
+            return Err("BackendDAEEXT.getAssignment failed because m={}>arrayLength(ass2)={}");
         }
         {
             let mut a1 = ass1.borrow_mut();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen/Cargo.toml
@@ -15,7 +15,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_c/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_c/Cargo.toml
@@ -16,7 +16,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cfunctions/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cfunctions/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp/Cargo.toml
@@ -18,7 +18,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_common/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_common/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_ext/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_ext/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_omsi/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_omsi/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_omsi_ext/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_cpp_omsi_ext/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
 openmodelica_codegen.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu_c/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu_c/Cargo.toml
@@ -18,7 +18,6 @@ openmodelica_codegen.workspace=true
 openmodelica_codegen_cfunctions.workspace=true
 openmodelica_codegen_c.workspace=true
 openmodelica_codegen_fmu.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu_omsi/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_fmu_omsi/Cargo.toml
@@ -18,7 +18,6 @@ openmodelica_codegen.workspace=true
 openmodelica_codegen_cfunctions.workspace=true
 openmodelica_codegen_c.workspace=true
 openmodelica_codegen_fmu_c.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_graphml/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_graphml/Cargo.toml
@@ -10,6 +10,5 @@ openmodelica_util.workspace = true
 openmodelica_util_datatypes_basic.workspace = true
 const-str.workspace = true
 arcstr.workspace = true
-anyhow.workspace = true
 loop_unwrap.workspace = true
 match_deref.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -15,7 +15,6 @@ openmodelica_error.workspace = true
 openmodelica_frontend_types.workspace = true
 openmodelica_frontend_dump.workspace = true
 openmodelica_util.workspace = true
-anyhow.workspace = true
 arcstr.workspace = true
 ordered-float.workspace = true
 wasm-encoder.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -42,7 +42,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 use wasm_encoder as we;
@@ -621,7 +621,7 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
     let _ = std::fs::remove_file(format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
     let outcome = build_sim_model(&simCode).and_then(|model| {
-        write_output(&format!("{prefix}.wasm"), &model.wasm)?;
+        write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), Arc::new(model));
         Ok(())
     });
@@ -696,7 +696,7 @@ pub fn emitStandalone(simCode: SimCode::SimCode) -> Result<()> {
     })?;
     write_output(&format!("{prefix}.wasm"), &bytes).map_err(|e| {
         record_error(format!("CodegenWasmJit: cannot write {prefix}.wasm: {e:#}"));
-        e
+        "CodegenWasmJit: cannot write standalone wasm"
     })?;
     Ok(())
 }
@@ -708,7 +708,7 @@ pub fn emitStandalone(simCode: SimCode::SimCode) -> Result<()> {
     let _ = simCode;
     let msg = "CodegenWasmJit: simCodeTarget=wasm (standalone export) is unavailable in the wasm omc build";
     record_error(msg.to_string());
-    bail!("{msg}")
+    return Err("{msg}")
 }
 
 /// `CodegenWasmJit.runSimulationWasmtime`: run the standalone module emitted by
@@ -738,7 +738,7 @@ fn run_wasmtime_inner(prefix: &str, result_file: &str, _simflags: &str) -> Resul
     use std::process::Command;
     let module = format!("{prefix}.wasm");
     if !std::path::Path::new(&module).exists() {
-        bail!("standalone module `{module}` not found (emitStandalone not run?)");
+        return Err("standalone module `{module}` not found (emitStandalone not run?)");
     }
     let wasmtime = std::env::var("OMC_WASMTIME").unwrap_or_else(|_| "wasmtime".to_owned());
     // `--dir .::.` preopens the cwd as the guest `.`; the module writes the result
@@ -749,22 +749,22 @@ fn run_wasmtime_inner(prefix: &str, result_file: &str, _simflags: &str) -> Resul
         .arg(".::.")
         .arg(&module)
         .status()
-        .map_err(|e| anyhow!("cannot run `{wasmtime}` (is it on PATH? override with OMC_WASMTIME): {e}"))?;
+        .map_err(|e| "cannot run `{wasmtime}` (is it on PATH? override with OMC_WASMTIME): {e}")?;
     if !status.success() {
-        bail!("`{wasmtime} run {module}` failed with {status}");
+        return Err("`{wasmtime} run {module}` failed with {status}");
     }
     // The module writes `<prefix>_res.mat`; rename if omc selected another name.
     let produced = format!("{prefix}_res.mat");
     if result_file != produced && std::path::Path::new(&produced).exists() {
         std::fs::rename(&produced, result_file)
-            .map_err(|e| anyhow!("cannot rename {produced} -> {result_file}: {e}"))?;
+            .map_err(|e| "cannot rename {produced} -> {result_file}: {e}")?;
     }
     Ok(())
 }
 
 #[cfg(target_arch = "wasm32")]
 fn run_wasmtime_inner(_prefix: &str, _result_file: &str, _simflags: &str) -> Result<()> {
-    bail!("CodegenWasmJit: simCodeTarget=wasm is unavailable in the wasm omc build")
+    return Err("CodegenWasmJit: simCodeTarget=wasm is unavailable in the wasm omc build")
 }
 
 // Runs the model and returns its captured stdout/stderr (the model's runtime
@@ -796,7 +796,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         .get(prefix)
         .cloned();
     let Some(model) = model else {
-        return (Err(anyhow!("no prepared wasm-jit model for `{prefix}` (translateModel not run?)")), String::new());
+        return (Err("no prepared wasm-jit model for `{prefix}` (translateModel not run?)"), String::new());
     };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
     let log_stats = simflags.contains("LOG_STATS") || simflags.contains("LOG_ALL");
@@ -810,7 +810,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         // benchmarking the solver in isolation from the `.mat` writer.
         let fmt = model.output_format.as_str();
         if fmt != "mat" && fmt != "empty" {
-            bail!("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
+            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
         }
         let run = sim_runtime::run(&model)?;
         if log_stats {
@@ -898,10 +898,10 @@ mod session {
             .unwrap_or_else(|e| e.into_inner())
             .get(prefix)
             .cloned()
-            .ok_or_else(|| anyhow!("no prepared wasm-jit model for `{prefix}` (translateModel not run?)"))?;
+            .ok_or_else(|| "no prepared wasm-jit model for `{prefix}` (translateModel not run?)")?;
         let fmt = model.output_format.as_str();
         if fmt != "mat" && fmt != "empty" {
-            bail!("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
+            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
         }
         sim_driver::set_param_overrides(resolve_overrides(&model, simflags));
         sim_driver::clear_cancel();
@@ -935,7 +935,7 @@ mod session {
         SIM_SESSION.with(|s| {
             let mut guard = s.borrow_mut();
             let Some(sess) = guard.as_mut() else {
-                bail!("no active simulation session");
+                return Err("no active simulation session");
             };
             let adv = sess
                 .driver
@@ -1001,11 +1001,11 @@ pub use session::{sim_advance, sim_free, sim_start};
 
 #[cfg(not(feature = "jit"))]
 pub fn sim_start(_prefix: &str, _result_file: &str, _simflags: &str) -> Result<()> {
-    anyhow::bail!("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
+    return Err("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
 }
 #[cfg(not(feature = "jit"))]
 pub fn sim_advance(_budget_ms: f64) -> Result<SimStatus> {
-    anyhow::bail!("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
+    return Err("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
 }
 #[cfg(not(feature = "jit"))]
 pub fn sim_free() {}
@@ -1042,11 +1042,7 @@ pub fn emit_standalone_module(sim_code: &SimCode::SimCode) -> Result<Vec<u8>> {
 fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
     use std::process::Command;
     if RUNTIME_WASIP1.is_empty() {
-        bail!(
-            "CodegenWasmJit: the wasip1 standalone runtime was not built \
-             (run `rustup target add wasm32-wasip1` and rebuild, or set \
-             OMC_WASM_RUNTIME_WASIP1=/path/to/runtime_wasip1.wasm)"
-        );
+        return Err("error");
     }
     let merge = std::env::var("OMC_WASM_MERGE").unwrap_or_else(|_| "wasm-merge".to_owned());
 
@@ -1055,12 +1051,12 @@ fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
         std::process::id(),
         model_wasm.as_ptr()
     ));
-    std::fs::create_dir_all(&dir)?;
+    std::fs::create_dir_all(&dir).map_err(|_| "CodegenWasmJit: cannot create temp merge dir")?;
     let rt_path = dir.join("runtime.wasm");
     let model_path = dir.join("model.wasm");
     let out_path = dir.join("standalone.wasm");
-    std::fs::write(&rt_path, RUNTIME_WASIP1)?;
-    std::fs::write(&model_path, model_wasm)?;
+    std::fs::write(&rt_path, RUNTIME_WASIP1).map_err(|_| "CodegenWasmJit: cannot write runtime.wasm")?;
+    std::fs::write(&model_path, model_wasm).map_err(|_| "CodegenWasmJit: cannot write model.wasm")?;
 
     // `-all` enables every wasm feature so the model's bulk-memory `memory.init`
     // (the metadata data segment) and the runtime's features pass through unmodified.
@@ -1073,11 +1069,11 @@ fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
         .arg(&out_path)
         .arg("-all")
         .status()
-        .map_err(|e| anyhow!("CodegenWasmJit: cannot run `{merge}`: {e}"))?;
+        .map_err(|e| "CodegenWasmJit: cannot run `{merge}`: {e}")?;
     if !status.success() {
-        bail!("CodegenWasmJit: `{merge}` failed with {status}");
+        return Err("CodegenWasmJit: `{merge}` failed with {status}");
     }
-    let bytes = std::fs::read(&out_path)?;
+    let bytes = std::fs::read(&out_path).map_err(|_| "CodegenWasmJit: cannot read merged wasm")?;
     let _ = std::fs::remove_dir_all(&dir);
     Ok(bytes)
 }
@@ -1530,14 +1526,14 @@ fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
         let Some(first) = elems.first() else { continue };
         let rank = first.0.len();
         if elems.iter().any(|(s, _, _)| s.len() != rank) {
-            bail!("CodegenWasmJit: inconsistent subscript rank for array variable `{base}`");
+            return Err("CodegenWasmJit: inconsistent subscript rank for array variable `{base}`");
         }
         // Shape: 1-based max index per axis.
         let mut dims = vec![0u32; rank];
         for (subs, _, _) in &elems {
             for (axis, &ix) in subs.iter().enumerate() {
                 if ix < 1 {
-                    bail!("CodegenWasmJit: non-positive subscript {ix} for array variable `{base}`");
+                    return Err("CodegenWasmJit: non-positive subscript {ix} for array variable `{base}`");
                 }
                 dims[axis] = dims[axis].max(ix as u32);
             }
@@ -1551,7 +1547,7 @@ fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
         }
         let wty = first.2;
         if elems.iter().any(|(_, _, w)| *w != wty) {
-            bail!("CodegenWasmJit: mixed element types for array variable `{base}`");
+            return Err("CodegenWasmJit: mixed element types for array variable `{base}`");
         }
         let stride = match wty { WTy::F64 => 8, WTy::I32 => 4 };
         let Some(base_off) = elems.iter().map(|(_, o, _)| *o).min() else { continue };
@@ -1563,11 +1559,7 @@ fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
             }
             let expected = base_off + lin * stride;
             if *off != expected {
-                bail!(
-                    "CodegenWasmJit: array variable `{base}` is not laid out contiguously in \
-                     row-major order (element {subs:?} at offset {off}, expected {expected}); \
-                     whole-array marshalling needs a contiguous slot range"
-                );
+                return Err("error");
             }
         }
         map.array_groups.insert(base, ArrayGroup { base_off, wty, dims, total });
@@ -1643,7 +1635,7 @@ pub(crate) fn math_event_kind(name: &str, nargs: usize) -> Option<MathEventKind>
 pub(crate) fn math_event_index(last: &DAE::Exp) -> Result<u32> {
     match last {
         DAE::Exp::ICONST { integer } if *integer >= 0 => Ok(*integer as u32),
-        other => bail!("CodegenWasmJit: math-event index is not a non-negative ICONST: {other:?}"),
+        other => return Err("CodegenWasmJit: math-event index is not a non-negative ICONST: {other:?}"),
     }
 }
 
@@ -1675,7 +1667,7 @@ fn collect_zero_crossings(
     let mut out = Vec::new();
     for zc in lst(zcs) {
         if zc.iter.is_some() {
-            bail!("CodegenWasmJit: for-loop (iterator) zero-crossing not yet supported: {:?}", zc.relation_);
+            return Err("CodegenWasmJit: for-loop (iterator) zero-crossing not yet supported: {:?}");
         }
         match &*zc.relation_ {
             DAE::Exp::RELATION { .. } | DAE::Exp::LBINARY { .. } | DAE::Exp::LUNARY { .. } => {
@@ -1695,7 +1687,7 @@ fn collect_zero_crossings(
                 let ops = argv[..argv.len() - 1].to_vec();
                 out.push(ZcInfo::Math { kind, ops, idx });
             }
-            other => bail!("CodegenWasmJit: unsupported zero-crossing form: {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported zero-crossing form: {other:?}"),
         }
     }
     Ok(out)
@@ -1712,7 +1704,7 @@ fn collect_samples(
     for te in lst(time_events) {
         if let TE::SAMPLE_TIME_EVENT { index, startExp, intervalExp, iter } = te {
             if iter.is_some() {
-                bail!("CodegenWasmJit: for-loop `sample` (iterator) not yet supported");
+                return Err("CodegenWasmJit: for-loop `sample` (iterator) not yet supported");
             }
             out.push(SampleInfo { index: *index, start: startExp.clone(), interval: intervalExp.clone() });
         }
@@ -2011,7 +2003,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     let settings = sim_code
         .simulationSettingsOpt
         .as_ref()
-        .ok_or_else(|| anyhow!("CodegenWasmJit: model has no simulation settings"))?;
+        .ok_or_else(|| "CodegenWasmJit: model has no simulation settings")?;
     let model_name = openmodelica_frontend_dump::AbsynUtil::pathString(mi.name.clone(), arcstr::literal!("."), true, false)?.to_string();
     let meta_bytes = openmodelica_sim_meta::encode(&build_sim_meta(&layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix));
     let meta_len = meta_bytes.len() as u32;
@@ -2054,7 +2046,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
             let key = extobj_destructor_key(sv)?;
             let didx = by_name
                 .get(&key)
-                .ok_or_else(|| anyhow!("CodegenWasmJit: external-object destructor `{key}` was not compiled"))?
+                .ok_or_else(|| "CodegenWasmJit: external-object destructor `{key}` was not compiled")?
                 .index;
             let slot = layout.eobj_off + (i as u32) * 4;
             f.instruction(&I::LocalGet(0)); // SimData*
@@ -2426,7 +2418,7 @@ fn count<T: Clone>(list: &Arc<List<T>>) -> usize {
 fn extobj_destructor_key(sv: &SimCodeVar::SimVar) -> Result<String> {
     let path = match &*sv.type_ {
         DAE::Type::T_COMPLEX { complexClassType: openmodelica_frontend_types::ClassInf::State::EXTERNAL_OBJ { path }, .. } => path.clone(),
-        _ => bail!("CodegenWasmJit: external object variable has a non-EXTERNAL_OBJ type"),
+        _ => return Err("CodegenWasmJit: external object variable has a non-EXTERNAL_OBJ type"),
     };
     let dpath = openmodelica_frontend_dump::AbsynUtil::joinPaths(
         path,
@@ -2552,11 +2544,11 @@ fn build_eq_fn_with_prelude(
     ctx.emit_stateset_diag_init(stateset_diag)?;
     for (cref, exp) in prelude {
         let lhs = DAE::Exp::CREF { componentRef: cref.clone(), ty: t_real() };
-        ctx.sim_assign(&lhs, exp).map_err(|e| anyhow!("in {which} binding: {e}"))?;
+        ctx.sim_assign(&lhs, exp).map_err(|e| "in {which} binding: {e}")?;
     }
     for eq in &eqs {
         lower_equation(&mut ctx, eq, eq_index)
-            .map_err(|e| anyhow!("in {which}: {e}"))?;
+            .map_err(|e| "in {which}: {e}")?;
     }
     ctx.sim_save_pre_values(save_pre)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -2677,15 +2669,11 @@ fn lower_equation(
         E::SES_ALIAS { aliasOf, .. } => {
             let target = eq_index
                 .get(aliasOf)
-                .ok_or_else(|| anyhow!("SES_ALIAS references unknown equation index {aliasOf}"))?
+                .ok_or_else(|| "SES_ALIAS references unknown equation index {aliasOf}")?
                 .clone();
             lower_equation(ctx, &target, eq_index)
         }
-        other => bail!(
-            "CodegenWasmJit: unsupported equation kind {} (index {})",
-            eq_kind_name(other),
-            eq_index_of(other),
-        ),
+        other => return Err("CodegenWasmJit: unsupported equation kind {} (index {})"),
     }
 }
 
@@ -2743,11 +2731,7 @@ fn lower_linear_system_symbolic(
         let (row, col, eq) = entry;
         match &**eq {
             E::SES_RESIDUAL { exp, .. } => a_entries.push((*row as usize, *col as usize, exp)),
-            other => bail!(
-                "CodegenWasmJit: SES_LINEAR (index {}) simJac entry is {} (only SES_RESIDUAL supported)",
-                lsystem.index,
-                eq_kind_name(other),
-            ),
+            other => return Err("CodegenWasmJit: SES_LINEAR (index {}) simJac entry is {} (only SES_RESIDUAL supported)"),
         }
     }
     let b_exps: Vec<&Arc<DAE::Exp>> = lst(&lsystem.beqs).collect();
@@ -2781,7 +2765,7 @@ fn stateset_scratch_f64(state_sets: &Arc<List<SimCode::StateSet>>) -> Result<u32
     for set in lst(state_sets) {
         let col = lst(&set.jacobianMatrix.columns)
             .next()
-            .ok_or_else(|| anyhow!("CodegenWasmJit: state set {} has no Jacobian column", set.index))?;
+            .ok_or_else(|| "CodegenWasmJit: state set {} has no Jacobian column")?;
         n += count(&set.jacobianMatrix.seedVars) as u32 + count(&col.columnVars) as u32;
     }
     Ok(n)
@@ -2803,9 +2787,9 @@ fn build_state_set_infos(
         let slot = var_map
             .vars
             .get(&key)
-            .ok_or_else(|| anyhow!("CodegenWasmJit: state-set variable `{key}` has no slot"))?;
+            .ok_or_else(|| "CodegenWasmJit: state-set variable `{key}` has no slot")?;
         if slot.wty != WTy::F64 {
-            bail!("CodegenWasmJit: state-set variable `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: state-set variable `{key}` is not a Real variable");
         }
         Ok(slot.off)
     };
@@ -2815,7 +2799,7 @@ fn build_state_set_infos(
         let n_dummy = n_candidates - n_states;
         let col = lst(&set.jacobianMatrix.columns)
             .next()
-            .ok_or_else(|| anyhow!("CodegenWasmJit: state set {} has no Jacobian column", set.index))?;
+            .ok_or_else(|| "CodegenWasmJit: state set {} has no Jacobian column")?;
 
         // Seed slots (candidate order) — register the seed var crefs.
         let mut seed_offs = Vec::new();
@@ -2851,7 +2835,7 @@ fn build_state_set_infos(
                 let slot = var_map
                     .vars
                     .get(&key)
-                    .ok_or_else(|| anyhow!("CodegenWasmJit: state-set matrix entry `{key}` has no slot"))?;
+                    .ok_or_else(|| "CodegenWasmJit: state-set matrix entry `{key}` has no slot")?;
                 a_offs.push(slot.off);
             }
         }
@@ -2913,9 +2897,9 @@ fn stateset_diag_offsets(
             let slot = var_map
                 .vars
                 .get(&key)
-                .ok_or_else(|| anyhow!("CodegenWasmJit: state-set matrix entry `{key}` has no slot"))?;
+                .ok_or_else(|| "CodegenWasmJit: state-set matrix entry `{key}` has no slot")?;
             if slot.wty != WTy::I32 {
-                bail!("CodegenWasmJit: state-set matrix entry `{key}` is not an Integer variable");
+                return Err("CodegenWasmJit: state-set matrix entry `{key}` is not an Integer variable");
             }
             offs.push(slot.off);
         }
@@ -2937,7 +2921,7 @@ fn lower_nonlinear_system(
         .sim()?
         .nls_jobs
         .get(&nlsystem.index)
-        .ok_or_else(|| anyhow!("CodegenWasmJit: SES_NONLINEAR (index {}) was not registered for rt_solve_nls", nlsystem.index))?;
+        .ok_or_else(|| "CodegenWasmJit: SES_NONLINEAR (index {}) was not registered for rt_solve_nls")?;
     emit_solve_nls_call(ctx, job)
 }
 
@@ -2958,14 +2942,11 @@ fn nls_parts(
         }
     }
     if res_exps.is_empty() {
-        bail!("CodegenWasmJit: SES_NONLINEAR (index {}) has no residual equations", nlsystem.index);
+        return Err("CodegenWasmJit: SES_NONLINEAR (index {}) has no residual equations");
     }
     let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
     if iter_vars.len() != res_exps.len() {
-        bail!(
-            "CodegenWasmJit: SES_NONLINEAR (index {}) has {} unknowns but {} residuals",
-            nlsystem.index, iter_vars.len(), res_exps.len()
-        );
+        return Err("CodegenWasmJit: SES_NONLINEAR (index {}) has {} unknowns but {} residuals");
     }
     Ok((inner, res_exps, iter_vars))
 }
@@ -3016,9 +2997,9 @@ fn build_nls_fns(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| anyhow!("CodegenWasmJit: nonlinear-system unknown `{key}` has no slot"))?;
+            .ok_or_else(|| "CodegenWasmJit: nonlinear-system unknown `{key}` has no slot")?;
         if slot.wty != WTy::F64 {
-            bail!("CodegenWasmJit: nonlinear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: nonlinear-system unknown `{key}` is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -3341,7 +3322,7 @@ fn write_mat4(model: &SimModel, path: &str, rows: &[f64], n_reals: u32, params: 
         .collect();
     let bytes = openmodelica_mat_writer::write_mat4(&vars, model.start_time, model.stop_time, rows, n_reals, params);
     let _ = &model.model_name; // (kept for diagnostics)
-    write_output(path, &bytes).map_err(|e| anyhow!("CodegenWasmJit: cannot write {path}: {e}"))
+    write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write {path}: {e}")
 }
 
 // The standalone-export merge uses `wasmtime::Module` to validate the result, so

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -11,7 +11,7 @@
 
 use std::cell::RefCell;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 use super::{JacAInfo, REAL_OFF, ResultKind, SimLayout, SimModel, SolveStats, StateSetInfo, TIME_OFF};
 use crate::CodegenWasmJitFunctions::WTy;
@@ -122,7 +122,7 @@ fn state_selection_set(
 
     let old_col = st.col_pivot.clone();
     if !pivot(&mut jac, nd, nc, &mut st.row_pivot, &mut st.col_pivot) {
-        bail!("CodegenWasmJit: singular Jacobian for dynamic state selection");
+        return Err("CodegenWasmJit: singular Jacobian for dynamic state selection");
     }
 
     // comparePivot: enable = 1 for the first nd pivot columns (dummy), 2 for the
@@ -211,7 +211,7 @@ fn read_rt_string(e: &dyn SimEngine, handle: i32) -> Result<String> {
 /// one is pending, route it to the error buffer (matching the C target's
 /// `[file:l:c] Error: <msg>`, and so OMEdit shows it) and return the enriched
 /// error; otherwise return the original trap error.
-pub(super) fn enrich_trap(e: &mut dyn SimEngine, err: anyhow::Error) -> anyhow::Error {
+pub(super) fn enrich_trap(e: &mut dyn SimEngine, err: &'static str) -> &'static str {
     let Some(pa) = e.take_pending_assert() else { return err };
     let msg = read_rt_string(e, pa[0]).unwrap_or_default();
     let file = read_rt_string(e, pa[1]).unwrap_or_default();
@@ -229,7 +229,7 @@ pub(super) fn enrich_trap(e: &mut dyn SimEngine, err: anyhow::Error) -> anyhow::
         metamodelica::cons(arcstr::ArcStr::from(msg.as_str()), metamodelica::nil()),
         info,
     );
-    anyhow::anyhow!("assertion failed: {msg}")
+    "assertion failed: {msg}"
 }
 
 /// Result of a simulation run.
@@ -341,7 +341,7 @@ fn write_i32(e: &mut dyn SimEngine, addr: u32, v: i32) -> Result<()> {
 /// point, the Euler loop). The DASSL residual handles this recoverably instead.
 fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if read_i32(e, sim_data + layout.nls_fail_off)? != 0 {
-        bail!("CodegenWasmJit: nonlinear system did not converge");
+        return Err("CodegenWasmJit: nonlinear system did not converge");
     }
     Ok(())
 }
@@ -415,7 +415,7 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
             e.call1("functionInitialEquations", sim_data)?;
         }
         if check_nls(e, sim_data, layout).is_err() {
-            bail!("CodegenWasmJit: homotopy initialization did not converge at lambda={lambda}");
+            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda={lambda}");
         }
     }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
@@ -640,7 +640,7 @@ pub(super) fn make_driver(
         "dassl" | "dasslrt" | "ida" | "" => Ok((Box::new(DasslDriver::new(e, model, sim_data)?), "dassl")),
         // Uniform host-driven Euler so it is resumable/cancellable like DASSL.
         "euler" => Ok((Box::new(EulerDriver::new(e, model, sim_data)?), "euler-host")),
-        other => bail!("CodegenWasmJit: unsupported integration method `{other}` (supported: `dassl`, `euler`)"),
+        other => return Err("CodegenWasmJit: unsupported integration method `{other}` (supported: `dassl`, `euler`)"),
     }
 }
 
@@ -703,7 +703,7 @@ pub(super) fn drive(
         loop {
             match driver.advance(e, model, budget_ms).map_err(|err| enrich_trap(e, err))? {
                 Advance::Done | Advance::Terminated => break,
-                Advance::Cancelled => bail!("CodegenWasmJit: simulation cancelled"),
+                Advance::Cancelled => return Err("CodegenWasmJit: simulation cancelled"),
                 Advance::Running => continue,
             }
         }
@@ -868,7 +868,7 @@ struct ResCtx {
     n_zc: usize,
     /// A wasm trap / memory error captured inside the callback, surfaced after
     /// `ddaskr` returns (the C-style callback cannot return a `Result`).
-    err: Option<anyhow::Error>,
+    err: Option<&'static str>,
     /// ODE Jacobian sparsity+coloring for the colored-FD `jacd`; null ⇒ the
     /// analytic path is off and daskr's own numerical Jacobian is used.
     jac: *const JacAInfo,
@@ -1335,7 +1335,7 @@ impl Driver for DasslDriver {
             self.nje = ctx.nje;
             // Surface a wasm error captured in the callback, then DASSL failures.
             if let Some(err) = ctx.err.take() {
-                return Err(err.context(format!("in DASSL residual at t={}", self.t)));
+                return Err(err);
             }
             if self.idid == -1 && self.work_retries < 10_000 {
                 // Work quota expended before TOUT: stay on this interval, continue.
@@ -1345,7 +1345,7 @@ impl Driver for DasslDriver {
                 continue;
             }
             if self.idid < 0 {
-                bail!("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tout}), IDID={}", self.t, self.idid);
+                return Err("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tout}), IDID={}");
             }
             // Interval complete: reset the resume state, write the interpolated state
             // back, and emit the row.
@@ -1714,10 +1714,10 @@ impl Driver for DasslEventsDriver {
                     }
                     self.ev_retries = 0; // this target's integration is done (or failing)
                     if let Some(err) = ctx.err.take() {
-                        return Err(err.context(format!("in DASSL residual at t={}", self.t)));
+                        return Err(err);
                     }
                     if self.idid < 0 {
-                        bail!("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tt}), IDID={}", self.t, self.idid);
+                        return Err("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tt}), IDID={}");
                     }
                     for i in 0..n_states {
                         write_f64(e, states_base + (i as u32) * 8, self.y[i])?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_stub.rs
@@ -2,7 +2,7 @@
 //! the crate is built without the `jit` feature. Mirrors the public surface the
 //! parent `CodegenWasmJit` module uses, reporting the engine as not built in.
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 use super::SimModel;
 
@@ -21,19 +21,19 @@ pub(super) struct RunResult {
 }
 
 pub(super) fn runtime_module() -> Result<&'static Module> {
-    bail!("{NO_ENGINE}")
+    return Err("{NO_ENGINE}")
 }
 
 pub(super) fn compile_model_module(_wasm: &[u8]) -> Result<Module> {
-    bail!("{NO_ENGINE}")
+    return Err("{NO_ENGINE}")
 }
 
 pub(super) fn start_runtime_compile() {}
 
 pub(super) fn take_compiled_model(_model: &SimModel) -> Result<Module> {
-    bail!("{NO_ENGINE}")
+    return Err("{NO_ENGINE}")
 }
 
 pub(super) fn run(_model: &SimModel) -> Result<RunResult> {
-    bail!("{NO_ENGINE}")
+    return Err("{NO_ENGINE}")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -18,7 +18,7 @@
 //
 // All drivers share the same generated model module and `SimData` layout.
 
-use anyhow::{Result, anyhow, bail};
+use metamodelica::Result;
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
@@ -107,7 +107,7 @@ pub(super) fn runtime_module() -> Result<&'static wasmer::Module> {
     MODULE
         .get_or_init(|| load_or_compile_runtime().map_err(|e| format!("{e:?}")))
         .as_ref()
-        .map_err(|e| anyhow!("CodegenWasmJit: obtaining runtime module: {e}"))
+        .map_err(|e| "CodegenWasmJit: obtaining runtime module: {e}")
 }
 
 /// Path of the on-disk AOT cache for the runtime module. Keyed by a hash of the
@@ -145,7 +145,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
     // the in-memory OnceLock already caches the compiled module for the session,
     // so compile straight from the embedded bytes.
     #[cfg(target_arch = "wasm32")]
-    return wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| anyhow!("{e:?}"));
+    return wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| "{e:?}");
     #[cfg(not(target_arch = "wasm32"))]
     {
     let path = runtime_cache_path();
@@ -160,7 +160,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
         // Incompatible/corrupt cache (e.g. wasmer upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| anyhow!("{e:?}"))?;
+    let module = wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| "{e:?}")?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -177,7 +177,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
 /// background thread from `translateModel` (overlapping the rest of the OMC
 /// pipeline) or inline from `run` as a fallback.
 pub(super) fn compile_model_module(wasm: &[u8]) -> Result<wasmer::Module> {
-    wasmer::Module::from_binary(sim_engine(), wasm).map_err(|e| anyhow!("{e:?}"))
+    wasmer::Module::from_binary(sim_engine(), wasm).map_err(|e| "{e:?}")
 }
 
 /// Begin compiling the fixed runtime module on a background thread, once per
@@ -212,13 +212,13 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmer::Module> {
         #[cfg(not(target_arch = "wasm32"))]
         Some(handle) => match handle.join() {
             Ok(Ok(m)) => Ok(m),
-            Ok(Err(e)) => bail!("CodegenWasmJit: background model-module compile failed: {e}"),
-            Err(_) => bail!("CodegenWasmJit: background model-module compile thread panicked"),
+            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed: {e}"),
+            Err(_) => return Err("CodegenWasmJit: background model-module compile thread panicked"),
         },
         #[cfg(target_arch = "wasm32")]
         Some(Ok(m)) => Ok(m),
         #[cfg(target_arch = "wasm32")]
-        Some(Err(e)) => bail!("CodegenWasmJit: model-module compile failed: {e}"),
+        Some(Err(e)) => return Err("CodegenWasmJit: model-module compile failed: {e}"),
         None => compile_model_module(&model.wasm),
     }
 }
@@ -229,7 +229,7 @@ type Store = wasmer::Store;
 /// — `RuntimeError`, `InstantiationError`, `MemoryAccessError`, … — do not share
 /// a single anyhow-convertible type, so we format via `Debug`).
 fn wt<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
-    r.map_err(|e| anyhow!("{e:?}"))
+    r.map_err(|e| "{e:?}")
 }
 
 /// Read a NUL-terminated C string from wasm memory at `ptr` (bounded).
@@ -247,7 +247,7 @@ fn read_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, ptr: u32) ->
 
 fn read_u32_mem(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, addr: u32) -> Result<u32> {
     let mut b = [0u8; 4];
-    mem.view(store).read(addr as u64, &mut b).map_err(|e| anyhow!("CodegenWasmJit: mem read: {e}"))?;
+    mem.view(store).read(addr as u64, &mut b).map_err(|e| "CodegenWasmJit: mem read: {e}")?;
     Ok(u32::from_le_bytes(b))
 }
 
@@ -301,17 +301,12 @@ fn define_external_imports(
     use wasmer::{AsStoreRef, Function, FunctionEnv, FunctionEnvMut, FunctionType, RuntimeError, Value};
 
     if EXTERNAL_C_WASM.is_empty() {
-        bail!(
-            "CodegenWasmJit: this model uses external \"C\" functions (e.g. table blocks, \
-             string scanning), which need the ModelicaExternalC side module — unavailable in \
-             this web build (build.rs could not compile modelicaexternalc.wasm; install the \
-             apt packages `clang`, `lld`, `wasi-libc`, and `libclang-rt-dev-wasm32`)"
-        );
+        return Err("error");
     }
 
     // Instantiate the side module with its `env.Modelica*Error`/`usertab`/
     // `ModelicaAllocateString` imports.
-    let side_module = wasmer::Module::from_binary(store.engine(), EXTERNAL_C_WASM).map_err(|e| anyhow!("{e:?}"))?;
+    let side_module = wasmer::Module::from_binary(store.engine(), EXTERNAL_C_WASM).map_err(|e| "{e:?}")?;
     let err_env = FunctionEnv::new(&mut *store, SideErrEnv { mem: None });
     let modelica_error = Function::new_typed_with_env(
         &mut *store, &err_env,
@@ -403,7 +398,7 @@ fn define_external_imports(
     let side_inst = wt(wasmer::Instance::new(&mut *store, &side_module, &side_imports))?;
 
     let side_mem = side_inst.exports.get_memory("memory")
-        .map_err(|e| anyhow!("CodegenWasmJit: modelicaexternalc.wasm has no `memory`: {e:?}"))?.clone();
+        .map_err(|e| "CodegenWasmJit: modelicaexternalc.wasm has no `memory`: {e:?}")?.clone();
     // Let the error hooks + WASI calls read/write the side module's memory.
     err_env.as_mut(&mut *store).mem = Some(side_mem.clone());
     wasi_env.as_mut(&mut *store).set_memory(side_mem.clone());
@@ -419,7 +414,7 @@ fn define_external_imports(
     for sig in &model.ext_imports {
         let name = &sig.name;
         let func = side_inst.exports.get_function(name)
-            .map_err(|e| anyhow!("CodegenWasmJit: ModelicaExternalC side module has no `{name}`: {e:?}"))?
+            .map_err(|e| "CodegenWasmJit: ModelicaExternalC side module has no `{name}`: {e:?}")?
             .clone();
         let functype = FunctionType::new(
             sig.wasm_params().iter().map(|s| valtype(s.wty())).collect::<Vec<_>>(),
@@ -492,8 +487,8 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         // array outputs are pre-allocated on the wasm side and marshalled by the
         // `Array` arm below (passed by pointer, copied back after the call).
         if *is_out && !matches!(ty, SigTy::Array { .. }) {
-            let cell = malloc.call(&mut store, 8).map_err(|e| anyhow!("{e:?}"))?;
-            side_mem.view(&store).write(cell as u64, &[0u8; 8]).map_err(|e| anyhow!("{e}"))?;
+            let cell = malloc.call(&mut store, 8).map_err(|e| "{e:?}")?;
+            side_mem.view(&store).write(cell as u64, &[0u8; 8]).map_err(|e| "{e}")?;
             temps.push(cell);
             out_cells.push((ty.clone(), cell));
             call_args.push(Value::I32(cell as i32));
@@ -502,31 +497,31 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         let v = &args[in_i];
         in_i += 1;
         match ty {
-            SigTy::Real => call_args.push(Value::F64(v.f64().ok_or_else(|| anyhow!("expected f64 arg {in_i}"))?)),
+            SigTy::Real => call_args.push(Value::F64(v.f64().ok_or_else(|| "expected f64 arg {in_i}")?)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => {
-                call_args.push(Value::I32(v.i32().ok_or_else(|| anyhow!("expected i32 arg {in_i}"))?))
+                call_args.push(Value::I32(v.i32().ok_or_else(|| "expected i32 arg {in_i}")?))
             }
             SigTy::Str => {
-                let off = v.i32().ok_or_else(|| anyhow!("expected i32 String handle arg {in_i}"))? as u32;
+                let off = v.i32().ok_or_else(|| "expected i32 String handle arg {in_i}")? as u32;
                 let len = read_u32_mem(&sim_mem, &store, off + 4)? as usize;
                 let mut buf = vec![0u8; len + 1]; // + NUL
-                sim_mem.view(&store).read((off + 8) as u64, &mut buf[..len]).map_err(|e| anyhow!("{e}"))?;
-                let dst = malloc.call(&mut store, (len + 1) as u32).map_err(|e| anyhow!("{e:?}"))?;
-                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| anyhow!("{e}"))?;
+                sim_mem.view(&store).read((off + 8) as u64, &mut buf[..len]).map_err(|e| "{e}")?;
+                let dst = malloc.call(&mut store, (len + 1) as u32).map_err(|e| "{e:?}")?;
+                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| "{e}")?;
                 temps.push(dst);
                 call_args.push(Value::I32(dst as i32));
             }
             SigTy::Array { elem, .. } => {
-                let off = v.i32().ok_or_else(|| anyhow!("expected i32 array handle arg {in_i}"))? as u32;
+                let off = v.i32().ok_or_else(|| "expected i32 array handle arg {in_i}")? as u32;
                 let ndims = read_u32_mem(&sim_mem, &store, off + 8)?;
                 let total = read_u32_mem(&sim_mem, &store, off + 12)? as usize;
                 let elem_size = if matches!(**elem, SigTy::Real) { 8 } else { 4 };
                 let data_off = (16 + ndims * 4 + 7) & !7;
                 let bytes = total * elem_size;
                 let mut buf = vec![0u8; bytes];
-                sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|e| anyhow!("{e}"))?;
-                let dst = malloc.call(&mut store, bytes as u32).map_err(|e| anyhow!("{e:?}"))?;
-                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| anyhow!("{e}"))?;
+                sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|e| "{e}")?;
+                let dst = malloc.call(&mut store, bytes as u32).map_err(|e| "{e:?}")?;
+                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| "{e}")?;
                 temps.push(dst);
                 call_args.push(Value::I32(dst as i32));
                 // An output array is filled by the callee in side memory; copy it
@@ -535,27 +530,27 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                     out_arrays.push((off, dst, bytes, data_off));
                 }
             }
-            other => bail!("input argument type {other:?} not marshalled for the web target"),
+            other => return Err("input argument type {other:?} not marshalled for the web target"),
         }
     }
 
-    let rets = func.call(&mut store, &call_args).map_err(|e| anyhow!("{e:?}"))?;
+    let rets = func.call(&mut store, &call_args).map_err(|e| "{e:?}")?;
 
     // Copy each output array back from the side module's memory into its
     // pre-allocated wasm array (the callee filled the side scratch in place).
     for (woff, dst, bytes, data_off) in &out_arrays {
         let mut buf = vec![0u8; *bytes];
-        side_mem.view(&store).read(*dst as u64, &mut buf).map_err(|e| anyhow!("{e}"))?;
-        sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|e| anyhow!("{e}"))?;
+        side_mem.view(&store).read(*dst as u64, &mut buf).map_err(|e| "{e}")?;
+        sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|e| "{e}")?;
     }
 
     // Build an in-wasm String (in the sim memory) from a NUL-terminated `char*` at
     // `coff` in the side module's memory; returns its sim-memory offset.
     let mut make_string = |store: &mut wasmer::StoreMut, coff: u32| -> Result<u32> {
         let bytes = read_side_cstr(&side_mem, &*store, coff)?;
-        let soff = rt_str_new.call(&mut *store, bytes.len() as u32).map_err(|e| anyhow!("{e:?}"))?;
-        let doff = rt_str_data.call(&mut *store, soff).map_err(|e| anyhow!("{e:?}"))?;
-        sim_mem.view(&*store).write(doff as u64, &bytes).map_err(|e| anyhow!("{e}"))?;
+        let soff = rt_str_new.call(&mut *store, bytes.len() as u32).map_err(|e| "{e:?}")?;
+        let doff = rt_str_data.call(&mut *store, soff).map_err(|e| "{e:?}")?;
+        sim_mem.view(&*store).write(doff as u64, &bytes).map_err(|e| "{e}")?;
         Ok(soff)
     };
     let result_val = |store: &mut wasmer::StoreMut, ty: &SigTy, raw: [u8; 8],
@@ -564,7 +559,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
             SigTy::Real => Value::F64(f64::from_le_bytes(raw)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => Value::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
             SigTy::Str => Value::I32(make(store, u32::from_le_bytes(raw[..4].try_into().unwrap()))? as i32),
-            other => bail!("output type {other:?} not marshalled for the web target"),
+            other => return Err("output type {other:?} not marshalled for the web target"),
         })
     };
 
@@ -572,9 +567,9 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     if let Some(ret_ty) = &sig.ret {
         // The C return value (from the wasm export's own result).
         let raw = match ret_ty {
-            SigTy::Real => rets.first().and_then(|v| v.f64()).ok_or_else(|| anyhow!("expected f64 return"))?.to_le_bytes(),
+            SigTy::Real => rets.first().and_then(|v| v.f64()).ok_or_else(|| "expected f64 return")?.to_le_bytes(),
             _ => {
-                let x = rets.first().and_then(|v| v.i32()).ok_or_else(|| anyhow!("expected i32 return"))?;
+                let x = rets.first().and_then(|v| v.i32()).ok_or_else(|| "expected i32 return")?;
                 let mut b = [0u8; 8];
                 b[..4].copy_from_slice(&x.to_le_bytes());
                 b
@@ -584,7 +579,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     }
     for (ty, cell) in &out_cells {
         let mut raw = [0u8; 8];
-        side_mem.view(&store).read(*cell as u64, &mut raw).map_err(|e| anyhow!("{e}"))?;
+        side_mem.view(&store).read(*cell as u64, &mut raw).map_err(|e| "{e}")?;
         results.push(result_val(&mut store, ty, raw, &mut make_string)?);
     }
 
@@ -606,7 +601,7 @@ fn read_side_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, off: u3
     let mut a = off as u64;
     loop {
         let mut b = [0u8; 1];
-        view.read(a, &mut b).map_err(|e| anyhow!("{e}"))?;
+        view.read(a, &mut b).map_err(|e| "{e}")?;
         if b[0] == 0 { break; }
         out.push(b[0]);
         a += 1;
@@ -680,7 +675,7 @@ pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimE
     let memory = rt_inst
         .exports
         .get_memory("memory")
-        .map_err(|e| anyhow!("CodegenWasmJit: runtime has no `memory` export: {e:?}"))?
+        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export: {e:?}")?
         .clone();
 
     // External "C" functions (`ext.*`): resolved by the ModelicaExternalC WASI side
@@ -732,10 +727,10 @@ impl WasmerEngine {
 
 impl sim_driver::SimEngine for WasmerEngine {
     fn read_bytes(&self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        self.memory.view(&self.store).read(addr as u64, buf).map_err(|e| anyhow!("CodegenWasmJit: mem read: {e}"))
+        self.memory.view(&self.store).read(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem read: {e}")
     }
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
-        self.memory.view(&self.store).write(addr as u64, buf).map_err(|e| anyhow!("CodegenWasmJit: mem write: {e}"))
+        self.memory.view(&self.store).write(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem write: {e}")
     }
     fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
@@ -18,7 +18,7 @@
 //
 // All drivers share the same generated model module and `SimData` layout.
 
-use anyhow::{Result, anyhow, bail};
+use metamodelica::Result;
 use std::collections::HashMap;
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -66,7 +66,7 @@ pub(super) fn runtime_module() -> Result<&'static wasmtime::Module> {
     MODULE
         .get_or_init(|| load_or_compile_runtime().map_err(|e| format!("{e:?}")))
         .as_ref()
-        .map_err(|e| anyhow!("CodegenWasmJit: obtaining runtime module: {e}"))
+        .map_err(|e| "CodegenWasmJit: obtaining runtime module: {e}")
 }
 
 /// Path of the on-disk AOT cache for the runtime module. Keyed by a hash of the
@@ -110,7 +110,7 @@ fn load_or_compile_runtime() -> Result<wasmtime::Module> {
         // Incompatible/corrupt cache (e.g. wasmtime upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wasmtime::Module::new(engine, RUNTIME_WASM).map_err(|e| anyhow!("{e:?}"))?;
+    let module = wasmtime::Module::new(engine, RUNTIME_WASM).map_err(|e| "{e:?}")?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -126,7 +126,7 @@ fn load_or_compile_runtime() -> Result<wasmtime::Module> {
 /// background thread from `translateModel` (overlapping the rest of the OMC
 /// pipeline) or inline from `run` as a fallback.
 pub(super) fn compile_model_module(wasm: &[u8]) -> Result<wasmtime::Module> {
-    wasmtime::Module::new(sim_engine(), wasm).map_err(|e| anyhow!("{e:?}"))
+    wasmtime::Module::new(sim_engine(), wasm).map_err(|e| "{e:?}")
 }
 
 /// Begin compiling the fixed runtime module on a background thread, once per
@@ -150,8 +150,8 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmtime::Module> 
     match job {
         Some(handle) => match handle.join() {
             Ok(Ok(m)) => Ok(m),
-            Ok(Err(e)) => bail!("CodegenWasmJit: background model-module compile failed: {e}"),
-            Err(_) => bail!("CodegenWasmJit: background model-module compile thread panicked"),
+            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed: {e}"),
+            Err(_) => return Err("CodegenWasmJit: background model-module compile thread panicked"),
         },
         None => compile_model_module(&model.wasm),
     }
@@ -160,7 +160,7 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmtime::Module> 
 type Store = wasmtime::Store<()>;
 
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
-    r.map_err(|e| anyhow!("{e:?}"))
+    r.map_err(|e| "{e:?}")
 }
 
 // External objects are native `void*` (e.g. a table `tableID`) that must survive
@@ -224,7 +224,7 @@ fn define_external_imports(
             sig.wasm_results().iter().map(|s| wty_valtype(s.wty())),
         );
         let addr = openmodelica_util::dynload::external_symbol(&sig.name)
-            .ok_or_else(|| anyhow!("external \"C\" function `{}` not found in any loaded library", sig.name))?;
+            .ok_or_else(|| "external \"C\" function `{}` not found in any loaded library")?;
         let name = sig.name.clone();
         let sig = sig.clone();
         let rt_str_new = rt_str_new.clone();
@@ -321,7 +321,7 @@ unsafe fn call_external(
                     let off = v.unwrap_i32() as usize;
                     let len = u32::from_le_bytes(mem[off + 4..off + 8].try_into().unwrap()) as usize;
                     let cs = std::ffi::CString::new(&mem[off + 8..off + 8 + len])
-                        .map_err(|_| anyhow!("external \"C\" `{}`: string argument has an interior NUL", sig.name))?;
+                        .map_err(|_| "external \"C\" `{}`: string argument has an interior NUL")?;
                     slots.push(Slot::P(cs.as_ptr() as *mut c_void));
                     cstrings.push(cs);
                     types.push(Type::pointer());
@@ -341,7 +341,7 @@ unsafe fn call_external(
                     slots.push(Slot::P(native as *mut c_void));
                     types.push(Type::pointer());
                 }
-                other => bail!("CodegenWasmJit: external \"C\" `{}`: input argument type {other:?} not yet marshalled", sig.name),
+                other => return Err("CodegenWasmJit: external \"C\" `{}`: input argument type {other:?} not yet marshalled"),
             }
         }
     }
@@ -359,7 +359,7 @@ unsafe fn call_external(
         Some(SigTy::Real) => Type::f64(),
         Some(SigTy::Int) | Some(SigTy::Bool) => Type::i32(),
         Some(SigTy::Str) | Some(SigTy::Ptr) => Type::pointer(),
-        Some(other) => bail!("CodegenWasmJit: external \"C\" `{}`: return type {other:?} not yet marshalled", sig.name),
+        Some(other) => return Err("CodegenWasmJit: external \"C\" `{}`: return type {other:?} not yet marshalled"),
     };
     let cif = Cif::new(types, ret_type);
     let mut rvalue = [0u8; 8];
@@ -379,7 +379,7 @@ unsafe fn call_external(
         openmodelica_modelica_utilities::sim_external_end();
         // A `ModelicaError` recorded its message in the Error buffer and unwound
         // here as a panic; surface a failure to the host.
-        bail!("CodegenWasmJit: external \"C\" `{}` raised a runtime error", sig.name);
+        return Err("CodegenWasmJit: external \"C\" `{}` raised a runtime error");
     }
 
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
@@ -398,7 +398,7 @@ unsafe fn call_external(
             SigTy::Int | SigTy::Bool => Val::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
             SigTy::Ptr => Val::I32(registry_put(usize::from_le_bytes(raw))),
             SigTy::Str => Val::I32(make(usize::from_le_bytes(raw) as *const std::os::raw::c_char)? as i32),
-            other => bail!("external \"C\": result type {other:?} not marshalled"),
+            other => return Err("external \"C\": result type {other:?} not marshalled"),
         })
     };
 
@@ -478,7 +478,7 @@ pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimE
     wt(linker.instance(&mut store, "rt", rt_inst))?;
     let memory = rt_inst
         .get_memory(&mut store, "memory")
-        .ok_or_else(|| anyhow!("CodegenWasmJit: runtime has no `memory` export"))?;
+        .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;
     // External "C" functions (module `ext`) resolved from the host; they share the
     // runtime's linear memory for string/array/pointer marshalling, and re-enter
     // the runtime's `rt_str_new`/`rt_str_data` to build in-wasm strings for `char*`
@@ -525,10 +525,10 @@ impl WasmtimeEngine {
 
 impl sim_driver::SimEngine for WasmtimeEngine {
     fn read_bytes(&self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        self.memory.read(&self.store, addr as usize, buf).map_err(|e| anyhow!("CodegenWasmJit: mem read: {e}"))
+        self.memory.read(&self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem read: {e}")
     }
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
-        self.memory.write(&mut self.store, addr as usize, buf).map_err(|e| anyhow!("CodegenWasmJit: mem write: {e}"))
+        self.memory.write(&mut self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem write: {e}")
     }
     fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/wasi_shim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/wasi_shim.rs
@@ -8,7 +8,7 @@
 // from `openmodelica_wasi::wasi`; each `mod` below re-imports them via
 // `use super::*`.
 
-use anyhow::{Result, anyhow};
+use metamodelica::Result;
 
 pub use openmodelica_wasi::wasi::*;
 
@@ -43,7 +43,7 @@ mod wasmtime_impl {
     /// Register the `wasi_snapshot_preview1` imports into `linker`.
     pub fn add_to_linker(linker: &mut Linker) -> Result<()> {
         let m = "wasi_snapshot_preview1";
-        let wt = |r: std::result::Result<&mut Linker, wasmtime::Error>| r.map(|_| ()).map_err(|e| anyhow!("{e:?}"));
+        let wt = |r: std::result::Result<&mut Linker, wasmtime::Error>| r.map(|_| ()).map_err(|e| "{e:?}");
 
         wt(linker.func_wrap(m, "fd_write", |mut c: Caller<'_, WasiCtx>, fd: i32, iovs: i32, n: i32, nw: i32| -> i32 {
             let (mut mem, ctx) = mem_ctx!(c);
@@ -175,21 +175,21 @@ mod wasmtime_impl {
     /// `openmodelica_wasi`, with relative paths keyed under `cwd`.
     pub fn run_command(wasm: &[u8], cwd: &str, args: Vec<String>) -> Result<u32> {
         let engine = wasmtime::Engine::default();
-        let module = wasmtime::Module::new(&engine, wasm).map_err(|e| anyhow!("{e:?}"))?;
+        let module = wasmtime::Module::new(&engine, wasm).map_err(|e| "{e:?}")?;
         let mut linker = Linker::new(&engine);
         add_to_linker(&mut linker)?;
         let mut store = wasmtime::Store::new(&engine, WasiCtx::new(cwd, args));
-        let instance = linker.instantiate(&mut store, &module).map_err(|e| anyhow!("{e:?}"))?;
+        let instance = linker.instantiate(&mut store, &module).map_err(|e| "{e:?}")?;
         let start = instance
             .get_typed_func::<(), ()>(&mut store, "_start")
-            .map_err(|e| anyhow!("module has no `_start`: {e:?}"))?;
+            .map_err(|e| "module has no `_start`: {e:?}")?;
         match start.call(&mut store, ()) {
             Ok(()) => Ok(0),
             // A `proc_exit` unwinds as an error after setting `exit_code`; that is
             // a normal termination, not a trap.
             Err(e) => match store.data().exit_code {
                 Some(code) => Ok(code),
-                None => Err(anyhow!("wasi command trapped: {e:?}")),
+                None => Err("wasi command trapped: {e:?}"),
             },
         }
     }
@@ -395,23 +395,23 @@ mod wasmer_impl {
         // (works on both the native `sys` and the worker `js` backends, where
         // `Store::default()` is not available).
         let engine = wasmer::Engine::default();
-        let module = Module::new(&engine, wasm).map_err(|e| anyhow!("{e:?}"))?;
+        let module = Module::new(&engine, wasm).map_err(|e| "{e:?}")?;
         let mut store = Store::new(engine);
         let env = FunctionEnv::new(&mut store, Env { ctx: WasiCtx::new(cwd, args), memory: None });
         let mut imports = Imports::new();
         add_to_imports(&mut store, &env, &mut imports);
-        let instance = Instance::new(&mut store, &module, &imports).map_err(|e| anyhow!("{e:?}"))?;
-        let memory = instance.exports.get_memory("memory").map_err(|e| anyhow!("no `memory` export: {e:?}"))?.clone();
+        let instance = Instance::new(&mut store, &module, &imports).map_err(|e| "{e:?}")?;
+        let memory = instance.exports.get_memory("memory").map_err(|e| "no `memory` export: {e:?}")?.clone();
         env.as_mut(&mut store).memory = Some(memory);
         let start = instance
             .exports
             .get_typed_function::<(), ()>(&store, "_start")
-            .map_err(|e| anyhow!("module has no `_start`: {e:?}"))?;
+            .map_err(|e| "module has no `_start`: {e:?}")?;
         match start.call(&mut store) {
             Ok(()) => Ok(0),
             Err(e) => match env.as_ref(&store).ctx.exit_code {
                 Some(code) => Ok(code),
-                None => Err(anyhow!("wasi command trapped: {e:?}")),
+                None => Err("wasi command trapped: {e:?}"),
             },
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -45,7 +45,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 
@@ -247,18 +247,18 @@ fn parse_sig_type(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<Si
                     match chars.next() {
                         Some(':') => break,
                         Some(c) => name.push(c),
-                        None => bail!("CodegenWasmJit: unterminated record field in signature"),
+                        None => return Err("CodegenWasmJit: unterminated record field in signature"),
                     }
                 }
                 fields.push((ArcStr::from(name.as_str()), parse_sig_type(chars)?));
             }
             match chars.next() {
                 Some('}') => {}
-                other => bail!("CodegenWasmJit: expected `}}` in record signature, got {other:?}"),
+                other => return Err("CodegenWasmJit: expected `}}` in record signature, got {other:?}"),
             }
             Ok(SigTy::Record { path: ArcStr::from(path.as_str()), fields: Arc::new(fields) })
         }
-        other => bail!("CodegenWasmJit: malformed signature type code {other:?}"),
+        other => return Err("CodegenWasmJit: malformed signature type code {other:?}"),
     }
 }
 
@@ -323,7 +323,7 @@ fn env_extra_index(name: &str) -> Result<u32> {
     let pos = ENV_EXTRA
         .iter()
         .position(|(n, _, _)| *n == name)
-        .ok_or_else(|| anyhow!("CodegenWasmJit: unknown env-extra import `{name}`"))?;
+        .ok_or_else(|| "CodegenWasmJit: unknown env-extra import `{name}`")?;
     Ok((BUILTINS.len() + RT_BUILTINS.len() + pos) as u32)
 }
 
@@ -469,7 +469,7 @@ pub(crate) fn rt_index(name: &str) -> Result<u32> {
     let pos = RT_BUILTINS
         .iter()
         .position(|(n, _, _)| *n == name)
-        .ok_or_else(|| anyhow!("CodegenWasmJit: unknown runtime function {name}"))?;
+        .ok_or_else(|| "CodegenWasmJit: unknown runtime function {name}")?;
     Ok((BUILTINS.len() + pos) as u32)
 }
 
@@ -546,7 +546,7 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
     // then the dependencies.
     let mut funcs: Vec<&SimCodeFunction::Function::Function> = Vec::new();
     let Some(main) = &fn_code.mainFunction else {
-        bail!("CodegenWasmJit: function code has no main function");
+        return Err("CodegenWasmJit: function code has no main function");
     };
     funcs.push(&**main);
     for f in &*fn_code.functions {
@@ -673,7 +673,7 @@ pub(crate) fn function_signature(f: &SimCodeFunction::Function::Function) -> Res
             let results = var_sigtys(outVars)?;
             Ok((mangle(name)?, FnSig { params, results }))
         }
-        _ => bail!("CodegenWasmJit: only plain Modelica/MetaModelica FUNCTIONs and known scalar-math external functions are supported"),
+        _ => return Err("CodegenWasmJit: only plain Modelica/MetaModelica FUNCTIONs and known scalar-math external functions are supported"),
     }
 }
 
@@ -790,7 +790,7 @@ pub(crate) fn external_general(f: &SimCodeFunction::Function::Function) -> bool 
 pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Result<ExtCallSig> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
     let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { extName, extArgs, extReturn, .. } = f else {
-        bail!("CodegenWasmJit: external_import_sig on a non-external function");
+        return Err("CodegenWasmJit: external_import_sig on a non-external function");
     };
     let mut args: Vec<(SigTy, bool)> = Vec::new();
     for a in &**extArgs {
@@ -799,14 +799,14 @@ pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Re
             A::SIMEXTARGSIZE { .. } => (SigTy::Int, false),
             A::SIMEXTARG { type_, isInput, .. } => (sig_ty(type_)?, !*isInput),
             A::SIMEXTARGEXP { type_, .. } => (sig_ty(type_)?, false),
-            other => bail!("CodegenWasmJit: unsupported external-call argument {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported external-call argument {other:?}"),
         };
         args.push((ty, is_out));
     }
     let ret = match &**extReturn {
         A::SIMNOEXTARG => None,
         A::SIMEXTARG { type_, .. } => Some(sig_ty(type_)?),
-        other => bail!("CodegenWasmJit: unsupported external return {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported external return {other:?}"),
     };
     Ok(ExtCallSig { name: extName.to_string(), args, ret })
 }
@@ -817,7 +817,7 @@ fn main_sig_types(f: &SimCodeFunction::Function::Function) -> Result<(Vec<SigTy>
     match f {
         F::FUNCTION { outVars, functionArguments, .. } => Ok((var_sigtys(functionArguments)?, var_sigtys(outVars)?)),
         F::EXTERNAL_FUNCTION { outVars, funArgs, .. } if external_known(f) || external_general(f) => Ok((var_sigtys(funArgs)?, var_sigtys(outVars)?)),
-        _ => bail!("CodegenWasmJit: only plain FUNCTIONs and known scalar-math external functions are supported"),
+        _ => return Err("CodegenWasmJit: only plain FUNCTIONs and known scalar-math external functions are supported"),
     }
 }
 
@@ -825,7 +825,7 @@ fn var_sigtys(vars: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>) -> Res
     let mut out = Vec::new();
     for v in &**vars {
         let SimCodeFunction::Variable::Variable::VARIABLE { ty, instDims, .. } = &**v else {
-            bail!("CodegenWasmJit: unsupported variable kind (function pointer)");
+            return Err("CodegenWasmJit: unsupported variable kind (function pointer)");
         };
         out.push(variable_sigty(ty, instDims)?);
     }
@@ -878,7 +878,7 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
         DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::EXTERNAL_OBJ { .. }, .. } => SigTy::Ptr,
         DAE::Type::T_COMPLEX { complexClassType, varLst, .. } => {
             let ClassInf::State::RECORD { path } = complexClassType else {
-                bail!("CodegenWasmJit: non-record complex type not supported: {complexClassType:?}");
+                return Err("CodegenWasmJit: non-record complex type not supported: {complexClassType:?}");
             };
             let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
             let mut fields = Vec::new();
@@ -887,8 +887,8 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
             }
             SigTy::Record { path: path_str, fields: Arc::new(fields) }
         }
-        DAE::Type::T_SUBTYPE_BASIC { .. } => bail!("CodegenWasmJit: subtype-basic types not yet supported"),
-        other => bail!("CodegenWasmJit: type not supported: {other:?}"),
+        DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
+        other => return Err("CodegenWasmJit: type not supported: {other:?}"),
     })
 }
 
@@ -1058,7 +1058,7 @@ impl<'a> FnCtx<'a> {
     pub(crate) fn sim(&self) -> Result<&SimCtx> {
         self.sim
             .as_ref()
-            .ok_or_else(|| anyhow!("CodegenWasmJit: sim context missing (internal error)"))
+            .ok_or_else(|| "CodegenWasmJit: sim context missing (internal error)")
     }
 
     /// Emit `A[n,n] = 1` for each state set's identity selection (C's
@@ -1254,7 +1254,7 @@ impl<'a> FnCtx<'a> {
         } else {
             for (i, c) in conds.iter().enumerate() {
                 if compile_sim_cref_read(self, c)?.is_none() {
-                    bail!("CodegenWasmJit: when-condition `{}` is not a model variable", sim_cref_key(c)?);
+                    return Err("CodegenWasmJit: when-condition `{}` is not a model variable");
                 }
                 let pre = pre_cref(c);
                 compile_sim_cref_read(self, &pre)?;
@@ -1275,7 +1275,7 @@ impl<'a> FnCtx<'a> {
                 openmodelica_simcode_types::SimCode::SimEqSystem::SES_WHEN {
                     conditions, whenStmtLst, elseWhen, ..
                 } => self.sim_when(conditions, whenStmtLst, elseWhen)?,
-                other => bail!("CodegenWasmJit: elseWhen is not a SES_WHEN: {}", crate::CodegenWasmJit::eq_kind_name(other)),
+                other => return Err("CodegenWasmJit: elseWhen is not a SES_WHEN: {}"),
             }
         }
         self.emit(I::End);
@@ -1327,7 +1327,7 @@ pub(crate) fn compile_function(
     }
     let SimCodeFunction::Function::Function::FUNCTION { outVars, functionArguments, variableDeclarations, body, .. } = f
     else {
-        bail!("CodegenWasmJit: only plain FUNCTIONs are supported");
+        return Err("CodegenWasmJit: only plain FUNCTIONs are supported");
     };
 
     let mut locals: HashMap<String, (u32, SigTy)> = HashMap::new();
@@ -1407,7 +1407,7 @@ fn compile_external_function(
 ) -> Result<we::Function> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
     let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { funArgs, outVars, extName, extArgs, .. } = f else {
-        bail!("CodegenWasmJit: compile_external_function on a non-external function");
+        return Err("CodegenWasmJit: compile_external_function on a non-external function");
     };
 
     let mut locals: HashMap<String, (u32, SigTy)> = HashMap::new();
@@ -1457,7 +1457,7 @@ fn compile_external_function(
                 let arr = Arc::new(DAE::Exp::CREF { componentRef: cref.clone(), ty: type_.clone() });
                 Some(Arc::new(DAE::Exp::SIZE { exp: arr, sz: Some(exp.clone()) }))
             }
-            other => bail!("CodegenWasmJit: unsupported external-call argument {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported external-call argument {other:?}"),
         })
     };
 
@@ -1487,12 +1487,12 @@ fn compile_external_function(
             .filter(|&i| !matches!(ctx.outputs[i].1, SigTy::Array { .. }))
             .collect();
         if results.len() != scalar_outs.len() {
-            bail!("CodegenWasmJit: external `{extName}` returns {} scalar value(s) but the function has {} non-array output(s)", results.len(), scalar_outs.len());
+            return Err("CodegenWasmJit: external `{extName}` returns {} scalar value(s) but the function has {} non-array output(s)");
         }
         for k in (0..scalar_outs.len()).rev() {
             let (out_idx, out_sty) = ctx.outputs[scalar_outs[k]].clone();
             if results[k].wty() != out_sty.wty() {
-                bail!("CodegenWasmJit: external `{extName}` output {k} type mismatch");
+                return Err("CodegenWasmJit: external `{extName}` output {k} type mismatch");
             }
             ctx.emit(we::Instruction::LocalSet(out_idx));
         }
@@ -1533,7 +1533,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
     if let Some(bi) = builtin_index(ext_name) {
         let (_, params, _) = BUILTINS[bi as usize];
         if args.len() != params.len() {
-            bail!("CodegenWasmJit: external `{ext_name}` expects {} args, got {}", params.len(), args.len());
+            return Err("CodegenWasmJit: external `{ext_name}` expects {} args, got {}");
         }
         for (a, p) in args.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -1543,7 +1543,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
         return Ok(SigTy::Real);
     }
     if args.len() != 1 {
-        bail!("CodegenWasmJit: external `{ext_name}` expects 1 arg, got {}", args.len());
+        return Err("CodegenWasmJit: external `{ext_name}` expects 1 arg, got {}");
     }
     let w = compile_exp(ctx, &args[0])?;
     coerce(ctx, w, WTy::F64);
@@ -1552,7 +1552,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
         "fabs" => ctx.emit(we::Instruction::F64Abs),
         "floor" => ctx.emit(we::Instruction::F64Floor),
         "ceil" => ctx.emit(we::Instruction::F64Ceil),
-        other => bail!("CodegenWasmJit: external math function `{other}` not supported"),
+        other => return Err("CodegenWasmJit: external math function `{other}` not supported"),
     }
     Ok(SigTy::Real)
 }
@@ -1566,10 +1566,10 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
     let key = format!("ext.{ext_name}");
     let (index, params, results) = match ctx.by_name.get(&key) {
         Some(info) => (info.index, info.sig.params.clone(), info.sig.results.clone()),
-        None => bail!("CodegenWasmJit: external `{ext_name}` import not declared"),
+        None => return Err("CodegenWasmJit: external `{ext_name}` import not declared"),
     };
     if args.len() != params.len() {
-        bail!("CodegenWasmJit: external `{ext_name}` expects {} input arg(s), got {}", params.len(), args.len());
+        return Err("CodegenWasmJit: external `{ext_name}` expects {} input arg(s), got {}");
     }
     for (a, p) in args.iter().zip(params.iter()) {
         let w = compile_exp(ctx, a)?;
@@ -1613,7 +1613,7 @@ fn intern_local(
 /// they live in `instDims`.
 fn var_array_dims(v: &SimCodeFunction::Variable::Variable) -> Result<Vec<Arc<DAE::Dimension>>> {
     let SimCodeFunction::Variable::Variable::VARIABLE { ty, instDims, .. } = v else {
-        bail!("CodegenWasmJit: function-pointer variables not supported");
+        return Err("CodegenWasmJit: function-pointer variables not supported");
     };
     let from_ty = type_array_dims(ty);
     Ok(if from_ty.is_empty() { (&**instDims).into_iter().cloned().collect() } else { from_ty })
@@ -1637,7 +1637,7 @@ fn type_array_dims(ty: &DAE::Type) -> Vec<Arc<DAE::Dimension>> {
 /// element kind, set the dimension sizes, and store the handle in `slot`.
 fn emit_array_alloc(ctx: &mut FnCtx, slot: u32, elem: &SigTy, dims: &[Arc<DAE::Dimension>]) -> Result<()> {
     if dims.is_empty() {
-        bail!("CodegenWasmJit: array local with no dimensions");
+        return Err("CodegenWasmJit: array local with no dimensions");
     }
     // Evaluate each dimension into a scratch local (reused for the total and the
     // per-axis size).
@@ -1721,7 +1721,7 @@ fn release_heap_locals(ctx: &mut FnCtx) -> Result<()> {
 /// [`variable_sigty`]). The name must be a plain `CREF_IDENT`.
 fn var_name_ty(v: &SimCodeFunction::Variable::Variable) -> Result<(String, SigTy)> {
     let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, instDims, .. } = v else {
-        bail!("CodegenWasmJit: function-pointer variables not supported");
+        return Err("CodegenWasmJit: function-pointer variables not supported");
     };
     Ok((cref_ident(name)?, variable_sigty(ty, instDims)?))
 }
@@ -1732,12 +1732,12 @@ fn cref_ident(cr: &DAE::ComponentRef) -> Result<String> {
     match cr {
         DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } => {
             if !subscriptLst.is_empty() {
-                bail!("CodegenWasmJit: subscripted component reference (arrays not supported)");
+                return Err("CodegenWasmJit: subscripted component reference (arrays not supported)");
             }
             Ok(ident.to_string())
         }
-        DAE::ComponentRef::CREF_QUAL { .. } => bail!("CodegenWasmJit: qualified component reference (records not supported)"),
-        other => bail!("CodegenWasmJit: unsupported component reference {other:?}"),
+        DAE::ComponentRef::CREF_QUAL { .. } => return Err("CodegenWasmJit: qualified component reference (records not supported)"),
+        other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
     }
 }
 
@@ -1752,7 +1752,7 @@ fn compile_stmts(ctx: &mut FnCtx, stmts: &Arc<List<Arc<DAE::Statement>>>) -> Res
 /// subscripted array element (`a[i,...] := x`, written in place).
 fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()> {
     let DAE::Exp::CREF { componentRef, .. } = lhs else {
-        bail!("CodegenWasmJit: assignment to non-cref lhs not supported");
+        return Err("CodegenWasmJit: assignment to non-cref lhs not supported");
     };
     // Simulation mode: assigning to a model variable writes into the shared
     // `SimData` block. Returns false for an ordinary wasm local handled below.
@@ -1765,13 +1765,13 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
         return compile_cref_assign_qual(ctx, componentRef, rhs);
     }
     let DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } = &**componentRef else {
-        bail!("CodegenWasmJit: assignment to qualified/record lhs not supported");
+        return Err("CodegenWasmJit: assignment to qualified/record lhs not supported");
     };
     let name = ident.to_string();
     let (idx, dst_sty) = ctx
         .locals
         .get(&name)
-        .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: assignment to unknown variable `{name}`"))?
+        .ok_or_else(|| "CodegenWasmJit: assignment to unknown variable `{name}`")?
         .clone();
 
     if !subscriptLst.is_empty() {
@@ -1779,7 +1779,7 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
         // own (private) array, so no copy-on-write is needed (Modelica arrays are
         // mutable value objects; aliasing is broken at whole-array assignment).
         let SigTy::Array { elem, rank } = dst_sty else {
-            bail!("CodegenWasmJit: subscripting non-array local `{name}`");
+            return Err("CodegenWasmJit: subscripting non-array local `{name}`");
         };
         let idx_exps = index_subscripts(subscriptLst, rank)?;
         return compile_elem_assign(ctx, idx, &elem, &idx_exps, rhs);
@@ -1842,12 +1842,12 @@ fn store_fresh_into_local(ctx: &mut FnCtx, idx: u32, dst_sty: &SigTy, vt: u32) -
 /// locals; subscripted / qualified tuple targets are not supported.
 fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &DAE::Exp) -> Result<()> {
     let DAE::Exp::CALL { path, expLst, attr } = call else {
-        bail!("CodegenWasmJit: tuple assignment rhs is not a function call: {call:?}");
+        return Err("CodegenWasmJit: tuple assignment rhs is not a function call: {call:?}");
     };
     let lhs_v: Vec<&Arc<DAE::Exp>> = (&**lhs).into_iter().collect();
     let results = compile_call(ctx, path, expLst, attr)?;
     if results.len() != lhs_v.len() {
-        bail!("CodegenWasmJit: tuple assignment arity mismatch ({} targets, {} results)", lhs_v.len(), results.len());
+        return Err("CodegenWasmJit: tuple assignment arity mismatch ({} targets, {} results)");
     }
     // Pop the results into temps (the last result is on top of the stack).
     let mut temps = vec![0u32; results.len()];
@@ -1860,7 +1860,7 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
         let sty = &results[i];
         let vt = temps[i];
         let DAE::Exp::CREF { componentRef, .. } = &***lhs_exp else {
-            bail!("CodegenWasmJit: tuple-assignment target is not a cref: {lhs_exp:?}");
+            return Err("CodegenWasmJit: tuple-assignment target is not a cref: {lhs_exp:?}");
         };
         match &**componentRef {
             // `_` output: discard (release a heap value).
@@ -1875,11 +1875,11 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
                 let (idx, dst_sty) = ctx
                     .locals
                     .get(&name)
-                    .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: tuple assignment to unknown variable `{name}`"))?
+                    .ok_or_else(|| "CodegenWasmJit: tuple assignment to unknown variable `{name}`")?
                     .clone();
                 store_fresh_into_local(ctx, idx, &dst_sty, vt)?;
             }
-            other => bail!("CodegenWasmJit: unsupported tuple-assignment target `{other:?}`"),
+            other => return Err("CodegenWasmJit: unsupported tuple-assignment target `{other:?}`"),
         }
     }
     Ok(())
@@ -1963,7 +1963,7 @@ fn record_field(fields: &[(ArcStr, SigTy)], name: &str) -> Result<(u32, SigTy)> 
             return Ok((layout.data_off + layout.field_off[i], fty.clone()));
         }
     }
-    bail!("CodegenWasmJit: record has no field `{name}`");
+    return Err("CodegenWasmJit: record has no field `{name}`");
 }
 
 pub(crate) fn mem_arg(offset: u32, align_log2: u32) -> we::MemArg {
@@ -2044,19 +2044,19 @@ fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_e
 /// to the type's declaration order by component name.
 fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &Arc<List<Arc<DAE::Exp>>>, comp: &Arc<List<ArcStr>>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: record constructor with non-record type {ty:?}");
+        return Err("CodegenWasmJit: record constructor with non-record type {ty:?}");
     };
     let expv: Vec<&Arc<DAE::Exp>> = (&**exps).into_iter().collect();
     let compv: Vec<&ArcStr> = (&**comp).into_iter().collect();
     if expv.len() != compv.len() || expv.len() != fields.len() {
-        bail!("CodegenWasmJit: record constructor arity mismatch ({} values, {} fields)", expv.len(), fields.len());
+        return Err("CodegenWasmJit: record constructor arity mismatch ({} values, {} fields)");
     }
     let mut field_exps = Vec::with_capacity(fields.len());
     for (fname, _) in fields.iter() {
         let pos = compv
             .iter()
             .position(|n| n.as_str() == fname.as_str())
-            .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: record constructor missing field `{fname}`"))?;
+            .ok_or_else(|| "CodegenWasmJit: record constructor missing field `{fname}`")?;
         field_exps.push(expv[pos]);
     }
     emit_record_construction(ctx, &fields, &field_exps)
@@ -2067,11 +2067,11 @@ fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &Arc<List<Arc<DAE::Exp>
 /// fields in declaration order.
 fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &Arc<List<Arc<DAE::Exp>>>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: record constructor call with non-record type {ty:?}");
+        return Err("CodegenWasmJit: record constructor call with non-record type {ty:?}");
     };
     let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
     if argv.len() != fields.len() {
-        bail!("CodegenWasmJit: record constructor call arity mismatch ({} args, {} fields)", argv.len(), fields.len());
+        return Err("CodegenWasmJit: record constructor call arity mismatch ({} args, {} fields)");
     }
     emit_record_construction(ctx, &fields, &argv)
 }
@@ -2081,7 +2081,7 @@ fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &Arc<List<Arc<DAE:
 /// field is read; a heap field is retained so the returned value is owned.
 fn compile_rsub(ctx: &mut FnCtx, exp: &DAE::Exp, name: &str) -> Result<WTy> {
     let SigTy::Record { fields, .. } = exp_sigty(exp)? else {
-        bail!("CodegenWasmJit: field access `.{name}` on a non-record expression");
+        return Err("CodegenWasmJit: field access `.{name}` on a non-record expression");
     };
     let (off, fty) = record_field(&fields, name)?;
     compile_exp(ctx, exp)?; // owned record handle
@@ -2154,11 +2154,11 @@ fn push_owned_record_base(
     let (idx, sty) = ctx
         .locals
         .get(ident)
-        .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: reference to unknown variable `{ident}`"))?
+        .ok_or_else(|| "CodegenWasmJit: reference to unknown variable `{ident}`")?
         .clone();
     if subs.is_empty() {
         let SigTy::Record { fields, .. } = sty else {
-            bail!("CodegenWasmJit: field access on non-record local `{ident}`");
+            return Err("CodegenWasmJit: field access on non-record local `{ident}`");
         };
         ctx.emit(we::Instruction::LocalGet(idx));
         ctx.emit(we::Instruction::LocalGet(idx));
@@ -2168,14 +2168,14 @@ fn push_owned_record_base(
         Ok((t, fields))
     } else {
         let SigTy::Array { elem, rank } = sty else {
-            bail!("CodegenWasmJit: subscripting non-array local `{ident}`");
+            return Err("CodegenWasmJit: subscripting non-array local `{ident}`");
         };
         let SigTy::Record { fields, .. } = &*elem else {
-            bail!("CodegenWasmJit: indexed base `{ident}[..]` is not an array of records");
+            return Err("CodegenWasmJit: indexed base `{ident}[..]` is not an array of records");
         };
         let fields = fields.clone();
         if !is_scalar_index(subs, rank) {
-            bail!("CodegenWasmJit: slicing an array of records before field access is not supported");
+            return Err("CodegenWasmJit: slicing an array of records before field access is not supported");
         }
         ctx.emit(we::Instruction::LocalGet(idx));
         ctx.emit(we::Instruction::LocalGet(idx));
@@ -2226,19 +2226,19 @@ fn step_into_record(
     let (vt, fty) = take_field(ctx, rec, fields, field)?;
     if fsubs.is_empty() {
         let SigTy::Record { fields: f2, .. } = fty else {
-            bail!("CodegenWasmJit: field access on non-record field `{field}`");
+            return Err("CodegenWasmJit: field access on non-record field `{field}`");
         };
         Ok((vt, f2))
     } else {
         let SigTy::Array { elem, rank } = fty else {
-            bail!("CodegenWasmJit: subscripting non-array field `{field}`");
+            return Err("CodegenWasmJit: subscripting non-array field `{field}`");
         };
         let SigTy::Record { fields: f2, .. } = &*elem else {
-            bail!("CodegenWasmJit: field access on non-record array element `{field}`");
+            return Err("CodegenWasmJit: field access on non-record array element `{field}`");
         };
         let f2 = f2.clone();
         if !is_scalar_index(fsubs, rank) {
-            bail!("CodegenWasmJit: slicing an array of records before field access is not supported");
+            return Err("CodegenWasmJit: slicing an array of records before field access is not supported");
         }
         ctx.emit(we::Instruction::LocalGet(vt)); // owned array handle
         let idx_exps = index_subscripts(fsubs, rank)?;
@@ -2255,7 +2255,7 @@ fn step_into_record(
 /// slice). Leaves the owned field value on the stack.
 fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<WTy> {
     let DAE::ComponentRef::CREF_QUAL { ident, subscriptLst, componentRef: rest, .. } = cref else {
-        bail!("CodegenWasmJit: compile_cref_read_qual on non-qualified cref");
+        return Err("CodegenWasmJit: compile_cref_read_qual on non-qualified cref");
     };
     let (mut rec, mut fields) = push_owned_record_base(ctx, ident, subscriptLst)?;
     let mut cur: &DAE::ComponentRef = rest;
@@ -2268,7 +2268,7 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
                     return Ok(fty.wty());
                 }
                 let SigTy::Array { elem, rank } = fty else {
-                    bail!("CodegenWasmJit: subscripting non-array field `{field}`");
+                    return Err("CodegenWasmJit: subscripting non-array field `{field}`");
                 };
                 ctx.emit(we::Instruction::LocalGet(vt)); // owned array handle
                 return if is_scalar_index(fsubs, rank) {
@@ -2284,7 +2284,7 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
                 fields = f2;
                 cur = inner;
             }
-            other => bail!("CodegenWasmJit: unsupported component reference {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
         }
     }
 }
@@ -2297,7 +2297,7 @@ fn navigate_qual<'c>(
     cref: &'c DAE::ComponentRef,
 ) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>, &'c str, &'c Arc<List<Arc<DAE::Subscript>>>)> {
     let DAE::ComponentRef::CREF_QUAL { ident, subscriptLst, componentRef: rest, .. } = cref else {
-        bail!("CodegenWasmJit: navigate_qual on non-qualified cref");
+        return Err("CodegenWasmJit: navigate_qual on non-qualified cref");
     };
     let (mut rec, mut fields) = push_owned_record_base(ctx, ident, subscriptLst)?;
     let mut cur: &DAE::ComponentRef = rest;
@@ -2312,7 +2312,7 @@ fn navigate_qual<'c>(
                 fields = f2;
                 cur = inner;
             }
-            other => bail!("CodegenWasmJit: unsupported component reference {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
         }
     }
 }
@@ -2329,7 +2329,7 @@ fn compile_cref_assign_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE
         // owned) array, in place.
         let (off, fty) = record_field(&fields, leaf)?;
         let SigTy::Array { elem, rank } = fty else {
-            bail!("CodegenWasmJit: subscripted field `{leaf}` is not an array");
+            return Err("CodegenWasmJit: subscripted field `{leaf}` is not an array");
         };
         let arr_t = ctx.alloc_temp(WTy::I32);
         ctx.emit(we::Instruction::LocalGet(rec));
@@ -2437,7 +2437,7 @@ fn emit_assert(
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
     let mw = compile_exp(ctx, msg)?; // owned String handle
     if mw != WTy::I32 {
-        bail!("CodegenWasmJit: assert message is not a String");
+        return Err("CodegenWasmJit: assert message is not a String");
     }
     let info = &source.info;
     emit_str_literal(ctx, info.fileName.as_bytes())?; // file String handle
@@ -2500,7 +2500,7 @@ fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
             let (brk, _) = *ctx
                 .loops
                 .last()
-                .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: `break` outside a loop"))?;
+                .ok_or_else(|| "CodegenWasmJit: `break` outside a loop")?;
             ctx.branch_to(brk);
             Ok(())
         }
@@ -2508,11 +2508,11 @@ fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
             let (_, cont) = *ctx
                 .loops
                 .last()
-                .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: `continue` outside a loop"))?;
+                .ok_or_else(|| "CodegenWasmJit: `continue` outside a loop")?;
             ctx.branch_to(cont);
             Ok(())
         }
-        other => bail!("CodegenWasmJit: statement not yet supported: {other:?}"),
+        other => return Err("CodegenWasmJit: statement not yet supported: {other:?}"),
     }
 }
 
@@ -2585,7 +2585,7 @@ fn compile_for_int_range(
     body: &Arc<List<Arc<DAE::Statement>>>,
 ) -> Result<()> {
     let DAE::Exp::RANGE { start, step, stop, .. } = range else {
-        bail!("CodegenWasmJit: for-loop over non-range expression not supported");
+        return Err("CodegenWasmJit: for-loop over non-range expression not supported");
     };
     // Allocate the iterator local and stop/step locals.
     let it = ctx.alloc_temp(WTy::I32);
@@ -2645,10 +2645,10 @@ fn compile_for_array(
     body: &Arc<List<Arc<DAE::Statement>>>,
 ) -> Result<()> {
     let SigTy::Array { elem, rank } = exp_sigty(range)? else {
-        bail!("CodegenWasmJit: for-loop over non-array, non-range expression not supported");
+        return Err("CodegenWasmJit: for-loop over non-array, non-range expression not supported");
     };
     if rank != 1 {
-        bail!("CodegenWasmJit: for-loop over a multi-dimensional array not yet supported");
+        return Err("CodegenWasmJit: for-loop over a multi-dimensional array not yet supported");
     }
     let elem = (*elem).clone();
     // Evaluate the iterable to an owned array handle.
@@ -2711,7 +2711,7 @@ fn emit_value_const(ctx: &mut FnCtx, v: &Values::Value, wty: WTy) -> Result<()> 
             ctx.emit(we::Instruction::F64Const(real.into_inner().into()));
             WTy::F64
         }
-        other => bail!("CodegenWasmJit: unsupported reduction default value {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported reduction default value {other:?}"),
     };
     coerce(ctx, from, wty);
     Ok(())
@@ -2798,7 +2798,7 @@ fn emit_red_nest(
         return body(ctx);
     };
     let DAE::Exp::RANGE { start, step, stop, .. } = &*iter.exp else {
-        bail!("CodegenWasmJit: reduction over a non-range iterator not supported");
+        return Err("CodegenWasmJit: reduction over a non-range iterator not supported");
     };
     let (it, step_l, stop_l) = emit_range_iter(ctx, &iter.id, start, step, stop)?;
     ctx.emit(we::Instruction::Block(we::BlockType::Empty));
@@ -2845,18 +2845,18 @@ fn compile_reduction(
 ) -> Result<WTy> {
     let iters: Vec<&Arc<DAE::ReductionIterator>> = (&**iterators).into_iter().collect();
     if iters.is_empty() {
-        bail!("CodegenWasmJit: reduction with no iterators");
+        return Err("CodegenWasmJit: reduction with no iterators");
     }
 
     if let Some(fold) = &info.foldExp {
         // Folding reduction. `info.exprType` is the (scalar) accumulator type.
         let elem_sty = sig_ty(&info.exprType)?;
         if elem_sty.is_heap() {
-            bail!("CodegenWasmJit: non-scalar reduction result not supported");
+            return Err("CodegenWasmJit: non-scalar reduction result not supported");
         }
         let elem_wty = elem_sty.wty();
         let Some(default) = &info.defaultValue else {
-            bail!("CodegenWasmJit: reduction without a default value not supported");
+            return Err("CodegenWasmJit: reduction without a default value not supported");
         };
         let acc = ctx.alloc_temp(elem_wty);
         let foldval = ctx.alloc_temp(elem_wty);
@@ -2880,11 +2880,11 @@ fn compile_reduction(
     // `array(...)` comprehension. The element type is the per-iteration
     // expression's type (`info.exprType` is the whole array type here).
     if iters.iter().any(|it| it.guardExp.is_some()) {
-        bail!("CodegenWasmJit: guarded array comprehension not supported");
+        return Err("CodegenWasmJit: guarded array comprehension not supported");
     }
     let elem_sty = exp_sigty(expr)?;
     if elem_sty.is_heap() {
-        bail!("CodegenWasmJit: array comprehension with non-scalar elements not supported");
+        return Err("CodegenWasmJit: array comprehension with non-scalar elements not supported");
     }
     let elem_wty = elem_sty.wty();
     let n = iters.len() as u32;
@@ -2893,7 +2893,7 @@ fn compile_reduction(
     let mut counts = Vec::with_capacity(iters.len());
     for it in &iters {
         let DAE::Exp::RANGE { start, step, stop, .. } = &*it.exp else {
-            bail!("CodegenWasmJit: array comprehension over a non-range iterator not supported");
+            return Err("CodegenWasmJit: array comprehension over a non-range iterator not supported");
         };
         counts.push(emit_range_count(ctx, start, step, stop)?);
     }
@@ -3011,7 +3011,7 @@ fn sim_cref_key_into(cr: &DAE::ComponentRef, s: &mut String) -> Result<()> {
             s.push('.');
             sim_cref_key_into(componentRef, s)?;
         }
-        other => bail!("CodegenWasmJit: unsupported component reference in simulation: {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported component reference in simulation: {other:?}"),
     }
     Ok(())
 }
@@ -3030,9 +3030,9 @@ fn sim_subs_into(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> Resul
                     s.push_str(&index.to_string());
                     s.push(']');
                 }
-                other => bail!("CodegenWasmJit: non-constant subscript in simulation cref: {other:?}"),
+                other => return Err("CodegenWasmJit: non-constant subscript in simulation cref: {other:?}"),
             },
-            other => bail!("CodegenWasmJit: unsupported subscript in simulation cref: {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported subscript in simulation cref: {other:?}"),
         }
     }
     Ok(())
@@ -3096,12 +3096,7 @@ fn emit_sim_array_elem_addr(
     sub_exps: &[Arc<DAE::Exp>],
 ) -> Result<WTy> {
     if sub_exps.len() != group.dims.len() {
-        bail!(
-            "CodegenWasmJit: {}-dim array indexed with {} non-constant subscript(s) \
-             (slicing with a variable subscript is not supported)",
-            group.dims.len(),
-            sub_exps.len()
-        );
+        return Err("error");
     }
     let (_, stride) = sim_array_elem_kind_stride(group.wty);
     let data = ctx.sim()?.data_local;
@@ -3165,7 +3160,7 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                         ctx.emit(we::Instruction::F64Const(0.0.into()));
                         Ok(Some(WTy::F64))
                     }
-                    None => bail!("CodegenWasmJit: $START for unknown variable `{key}`"),
+                    None => return Err("CodegenWasmJit: $START for unknown variable `{key}`"),
                 };
             }
             "$PRE" => {
@@ -3205,7 +3200,7 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 emit_sim_array_gather(ctx, &group)?;
                 return Ok(Some(WTy::I32));
             }
-            bail!("CodegenWasmJit: simulation reference to unknown variable `{key}`")
+            return Err("CodegenWasmJit: simulation reference to unknown variable `{key}`")
         }
     };
     let data = ctx.sim()?.data_local;
@@ -3296,11 +3291,11 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE:
                 emit_sim_array_scatter(ctx, &group, rhs)?;
                 return Ok(true);
             }
-            bail!("CodegenWasmJit: simulation assignment to unknown variable `{key}`")
+            return Err("CodegenWasmJit: simulation assignment to unknown variable `{key}`")
         }
     };
     if slot.negate {
-        bail!("CodegenWasmJit: assignment to negated alias `{key}`");
+        return Err("CodegenWasmJit: assignment to negated alias `{key}`");
     }
     let data = ctx.sim()?.data_local;
     if slot.heap {
@@ -3380,7 +3375,7 @@ fn emit_sim_array_scatter(ctx: &mut FnCtx, group: &ArrayGroup, rhs: &DAE::Exp) -
     let h = ctx.alloc_temp(WTy::I32);
     let rw = compile_exp(ctx, rhs)?;
     if rw != WTy::I32 {
-        bail!("CodegenWasmJit: whole-array assignment rhs is not an array handle");
+        return Err("CodegenWasmJit: whole-array assignment rhs is not an array handle");
     }
     ctx.emit(we::Instruction::LocalSet(h));
     // memory.copy(dst = SimData + base_off, src = rhs data, len = total * stride).
@@ -3450,13 +3445,13 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             }
             // A scalar/whole-value reference, or a subscripted array element.
             let DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } = &**componentRef else {
-                bail!("CodegenWasmJit: unsupported component reference {componentRef:?}");
+                return Err("CodegenWasmJit: unsupported component reference {componentRef:?}");
             };
             let name = ident.to_string();
             let (idx, sty) = ctx
                 .locals
                 .get(&name)
-                .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: reference to unknown variable `{name}`"))?
+                .ok_or_else(|| "CodegenWasmJit: reference to unknown variable `{name}`")?
                 .clone();
             if subscriptLst.is_empty() {
                 ctx.emit(we::Instruction::LocalGet(idx));
@@ -3474,7 +3469,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 // Indexed read `v[i, ...]`: push the (retained, owned) array
                 // handle, then load the element (which releases the handle).
                 let SigTy::Array { elem, rank } = sty else {
-                    bail!("CodegenWasmJit: subscripting non-array local `{name}`");
+                    return Err("CodegenWasmJit: subscripting non-array local `{name}`");
                 };
                 ctx.emit(we::Instruction::LocalGet(idx));
                 ctx.emit(we::Instruction::LocalGet(idx));
@@ -3518,7 +3513,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::LUNARY { operator, exp } => {
             // `not` — the only logical unary.
             let DAE::Operator::NOT { .. } = operator else {
-                bail!("CodegenWasmJit: unsupported logical unary operator {operator:?}");
+                return Err("CodegenWasmJit: unsupported logical unary operator {operator:?}");
             };
             // Element-wise `not` over a Boolean array.
             if matches!(exp_sigty(exp), Ok(SigTy::Array { .. })) {
@@ -3538,7 +3533,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 let (op_code, ty) = match operator {
                     DAE::Operator::AND { ty } => (OP_AND, ty),
                     DAE::Operator::OR { ty } => (OP_OR, ty),
-                    other => bail!("CodegenWasmJit: unsupported logical array operator {other:?}"),
+                    other => return Err("CodegenWasmJit: unsupported logical array operator {other:?}"),
                 };
                 return compile_array_ew(ctx, exp1, exp2, op_code, ty);
             }
@@ -3549,7 +3544,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             match operator {
                 DAE::Operator::AND { .. } => ctx.emit(we::Instruction::I32And),
                 DAE::Operator::OR { .. } => ctx.emit(we::Instruction::I32Or),
-                other => bail!("CodegenWasmJit: unsupported logical binary operator {other:?}"),
+                other => return Err("CodegenWasmJit: unsupported logical binary operator {other:?}"),
             }
             Ok(WTy::I32)
         }
@@ -3573,8 +3568,8 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             let results = compile_call(ctx, path, expLst, attr)?;
             match results.len() {
                 1 => Ok(results[0].wty()),
-                0 => bail!("CodegenWasmJit: call to {} used in expression position returns no value", mangle(path)?),
-                _ => bail!("CodegenWasmJit: call to {} returns multiple values; not usable in expression position", mangle(path)?),
+                0 => return Err("CodegenWasmJit: call to {} used in expression position returns no value"),
+                _ => return Err("CodegenWasmJit: call to {} returns multiple values; not usable in expression position"),
             }
         }
         // Array constructor `{e1, e2, ...}` or matrix `{{...}, {...}}`.
@@ -3604,7 +3599,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::REDUCTION { reductionInfo, expr, iterators } => {
             compile_reduction(ctx, reductionInfo, expr, iterators)
         }
-        other => bail!("CodegenWasmJit: expression not yet supported: {other:?}"),
+        other => return Err("CodegenWasmJit: expression not yet supported: {other:?}"),
     }
 }
 
@@ -3685,7 +3680,7 @@ fn operator_sigty(op: &DAE::Operator) -> Result<SigTy> {
         | O::POW_SCALAR_ARRAY { ty }
         | O::POW_ARR { ty }
         | O::POW_ARR2 { ty } => ty,
-        other => bail!("CodegenWasmJit: cannot determine type of operator {other:?}"),
+        other => return Err("CodegenWasmJit: cannot determine type of operator {other:?}"),
     };
     sig_ty(ty)
 }
@@ -3717,7 +3712,7 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         // (a full index yields the scalar element).
         E::ASUB { exp, sub } => {
             let SigTy::Array { elem, rank } = exp_sigty(exp)? else {
-                bail!("CodegenWasmJit: subscripting a non-array expression");
+                return Err("CodegenWasmJit: subscripting a non-array expression");
             };
             let n = (&**sub).into_iter().count() as u32;
             match rank.checked_sub(n) {
@@ -3730,7 +3725,7 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         E::SIZE { sz: None, .. } => SigTy::Array { elem: Arc::new(SigTy::Int), rank: 1 },
         // A record constructor / field access carry their type directly.
         E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty(ty)?,
-        other => bail!("CodegenWasmJit: cannot determine type of expression {other:?}"),
+        other => return Err("CodegenWasmJit: cannot determine type of expression {other:?}"),
     })
 }
 
@@ -3738,7 +3733,7 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
     // Array negation `-a`: negate every element into a fresh array.
     if let DAE::Operator::UMINUS_ARR { ty } = op {
         let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-            bail!("CodegenWasmJit: UMINUS_ARR with non-array type {ty:?}");
+            return Err("CodegenWasmJit: UMINUS_ARR with non-array type {ty:?}");
         };
         let rt = if elem.wty() == WTy::F64 { "rt_array_neg_f64" } else { "rt_array_neg_i32" };
         compile_exp(ctx, exp)?; // owned array
@@ -3750,7 +3745,7 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
         return Ok(WTy::I32);
     }
     let DAE::Operator::UMINUS { ty } = op else {
-        bail!("CodegenWasmJit: unsupported unary operator {op:?}");
+        return Err("CodegenWasmJit: unsupported unary operator {op:?}");
     };
     let wty = sig_ty(ty)?.wty();
     let w = compile_exp(ctx, exp)?;
@@ -3801,7 +3796,7 @@ fn compile_binary(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::
     // is a fresh String handle from the runtime.
     if operator_sigty(op)? == SigTy::Str {
         let O::ADD { .. } = op else {
-            bail!("CodegenWasmJit: unsupported String operator {op:?}");
+            return Err("CodegenWasmJit: unsupported String operator {op:?}");
         };
         str_binop(ctx, e1, e2, "rt_concat")?;
         return Ok(WTy::I32);
@@ -3863,7 +3858,7 @@ fn compile_binary(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::
         (O::MUL { .. }, WTy::I32) => ctx.emit(we::Instruction::I32Mul),
         (O::DIV { .. }, WTy::F64) => ctx.emit(we::Instruction::F64Div),
         (O::DIV { .. }, WTy::I32) => ctx.emit(we::Instruction::I32DivS),
-        (other, _) => bail!("CodegenWasmJit: unsupported binary operator {other:?}"),
+        (other, _) => return Err("CodegenWasmJit: unsupported binary operator {other:?}"),
     }
     Ok(wty)
 }
@@ -3889,7 +3884,7 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
                     _ => we::Instruction::I32GeS,
                 });
             }
-            other => bail!("CodegenWasmJit: unsupported String relation {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported String relation {other:?}"),
         }
         return Ok(WTy::I32);
     }
@@ -4023,7 +4018,7 @@ fn emit_hyst_cmp(ctx: &mut FnCtx, op: &DAE::Operator, diff: u32, eps: u32, dir: 
         O::LESS { .. } => (I::F64Le, dir),
         O::GREATER { .. } => (I::F64Ge, !dir),
         O::GREATEREQ { .. } => (I::F64Gt, !dir),
-        other => bail!("CodegenWasmJit: non-inequality in hysteresis path: {other:?}"),
+        other => return Err("CodegenWasmJit: non-inequality in hysteresis path: {other:?}"),
     };
     ctx.emit(I::LocalGet(diff));
     ctx.emit(I::LocalGet(eps));
@@ -4067,7 +4062,7 @@ fn compile_relation_fresh(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2
         (O::EQUAL { .. }, WTy::I32) => we::Instruction::I32Eq,
         (O::NEQUAL { .. }, WTy::F64) => we::Instruction::F64Ne,
         (O::NEQUAL { .. }, WTy::I32) => we::Instruction::I32Ne,
-        (other, _) => bail!("CodegenWasmJit: unsupported relational operator {other:?}"),
+        (other, _) => return Err("CodegenWasmJit: unsupported relational operator {other:?}"),
     };
     ctx.emit(instr);
     Ok(WTy::I32)
@@ -4083,7 +4078,7 @@ fn relation_operand_sigty(op: &DAE::Operator) -> Result<SigTy> {
     use DAE::Operator as O;
     let ty = match op {
         O::LESS { ty } | O::LESSEQ { ty } | O::GREATER { ty } | O::GREATEREQ { ty } | O::EQUAL { ty } | O::NEQUAL { ty } => ty,
-        other => bail!("CodegenWasmJit: not a relational operator: {other:?}"),
+        other => return Err("CodegenWasmJit: not a relational operator: {other:?}"),
     };
     sig_ty(ty)
 }
@@ -4108,7 +4103,7 @@ fn compile_call(
         let index = info.index;
         let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
         if argv.len() != params.len() {
-            bail!("CodegenWasmJit: call to {mangled} expects {} args, got {}", params.len(), argv.len());
+            return Err("CodegenWasmJit: call to {mangled} expects {} args, got {}");
         }
         for (a, p) in argv.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -4133,7 +4128,7 @@ fn compile_call(
 /// left on the stack (to be released if heap, otherwise dropped).
 fn compile_call_drop(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<Vec<SigTy>> {
     let DAE::Exp::CALL { path, expLst, attr } = exp else {
-        bail!("CodegenWasmJit: no-return statement is not a call: {exp:?}");
+        return Err("CodegenWasmJit: no-return statement is not a call: {exp:?}");
     };
     compile_call(ctx, path, expLst, attr)
 }
@@ -4200,7 +4195,7 @@ fn compile_math_event(
     let (data, base, fresh_off) = {
         let s = ctx.sim()?;
         if idx >= s.n_mathevents {
-            bail!("CodegenWasmJit: math-event index {idx} out of range (n={})", s.n_mathevents);
+            return Err("CodegenWasmJit: math-event index {idx} out of range (n={})");
         }
         (s.data_local, s.mathevents_off + idx * 8, s.rel_fresh_off)
     };
@@ -4303,7 +4298,7 @@ fn compile_math_event(
                 }
             }
         }
-        _ => bail!("CodegenWasmJit: not a math-event builtin: {name}"),
+        _ => return Err("CodegenWasmJit: not a math-event builtin: {name}"),
     }
 }
 
@@ -4338,7 +4333,7 @@ fn compile_math_builtin(
     if let Some(bi) = builtin_index(name) {
         let (_, params, _) = BUILTINS[bi as usize];
         if argv.len() != params.len() {
-            bail!("CodegenWasmJit: builtin {name} expects {} args", params.len());
+            return Err("CodegenWasmJit: builtin {name} expects {} args");
         }
         for (a, p) in argv.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -4609,13 +4604,13 @@ fn compile_math_builtin(
         "pre" => {
             need_args(&argv, 1, name)?;
             let DAE::Exp::CREF { componentRef, .. } = &**argv[0] else {
-                bail!("CodegenWasmJit: `pre` expects a variable reference");
+                return Err("CodegenWasmJit: `pre` expects a variable reference");
             };
             let pre = pre_cref(componentRef);
             match compile_sim_cref_read(ctx, &pre)? {
                 Some(WTy::F64) => Ok(SigTy::Real),
                 Some(WTy::I32) => Ok(SigTy::Int),
-                None => bail!("CodegenWasmJit: `pre` of a non-model variable"),
+                None => return Err("CodegenWasmJit: `pre` of a non-model variable"),
             }
         }
         // `sample(index, start, interval)` (the backend's 3-arg internal form,
@@ -4626,13 +4621,13 @@ fn compile_math_builtin(
         "sample" => {
             need_args(&argv, 3, name)?;
             let DAE::Exp::ICONST { integer } = &**argv[0] else {
-                bail!("CodegenWasmJit: `sample` index must be an integer literal");
+                return Err("CodegenWasmJit: `sample` index must be an integer literal");
             };
             let k = *ctx
                 .sim()?
                 .sample_map
                 .get(integer)
-                .ok_or_else(|| anyhow!("CodegenWasmJit: unknown sample index {integer}"))?;
+                .ok_or_else(|| "CodegenWasmJit: unknown sample index {integer}")?;
             let data = ctx.sim()?.data_local;
             let off = ctx.sim()?.sample_active_off + k * 4;
             ctx.emit(we::Instruction::LocalGet(data));
@@ -4644,15 +4639,15 @@ fn compile_math_builtin(
         "der" => {
             need_args(&argv, 1, name)?;
             let DAE::Exp::CREF { componentRef, .. } = &**argv[0] else {
-                bail!("CodegenWasmJit: der() of a non-reference expression not supported");
+                return Err("CodegenWasmJit: der() of a non-reference expression not supported");
             };
             let dcref = der_cref(componentRef);
             match compile_sim_cref_read(ctx, &dcref)? {
                 Some(_) => Ok(SigTy::Real),
-                None => bail!("CodegenWasmJit: der() is only supported in simulation mode"),
+                None => return Err("CodegenWasmJit: der() is only supported in simulation mode"),
             }
         }
-        other => bail!("CodegenWasmJit: builtin function `{other}` not yet supported"),
+        other => return Err("CodegenWasmJit: builtin function `{other}` not yet supported"),
     }
 }
 
@@ -4727,7 +4722,7 @@ fn emit_string_builtin(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>]) -> Result<SigTy
     // threaded through from the DAE type into the sidecar/runtime.
     if exp_is_enumeration(argv[0]) {
         let Some(names) = exp_enum_names(argv[0]) else {
-            bail!("CodegenWasmJit: String(Enumeration) on an enum literal whose names are not in scope");
+            return Err("CodegenWasmJit: String(Enumeration) on an enum literal whose names are not in scope");
         };
         emit_enum_string(ctx, argv[0], &names)?;
         // String(e, minimumLength, leftJustified): pad the name like any scalar.
@@ -4761,7 +4756,7 @@ fn emit_string_builtin(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>]) -> Result<SigTy
         }
         // String(Real, significantDigits, minimumLength, leftJustified).
         (SigTy::Real, 4) => emit_real_format(ctx, argv[0], argv[1], argv[2], argv[3]),
-        other => bail!("CodegenWasmJit: unsupported String() argument shape {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported String() argument shape {other:?}"),
     }
 }
 
@@ -4775,14 +4770,14 @@ fn emit_string_format(ctx: &mut FnCtx, val: &DAE::Exp, fmt: &DAE::Exp, vty: &Sig
         // Integer and Boolean share the integer formatter (Booleans coerce to
         // 0/1). The String format variant (`%s`) is not yet ported.
         SigTy::Int | SigTy::Bool => "rt_string_format_int",
-        other => bail!("CodegenWasmJit: String(value, format) not yet implemented for {other:?}"),
+        other => return Err("CodegenWasmJit: String(value, format) not yet implemented for {other:?}"),
     };
     let w = compile_exp(ctx, val)?;
     coerce(ctx, w, vty.wty());
     let fmt_t = ctx.alloc_temp(WTy::I32);
     let fw = compile_exp(ctx, fmt)?;
     if fw != WTy::I32 {
-        bail!("CodegenWasmJit: String() format argument is not a string");
+        return Err("CodegenWasmJit: String() format argument is not a string");
     }
     ctx.emit(we::Instruction::LocalTee(fmt_t)); // keep the handle, leave it on the stack
     ctx.emit(we::Instruction::Call(rt_index(rt_fn)?));
@@ -4966,7 +4961,7 @@ fn format_scalar_string(ctx: &mut FnCtx, arg: &DAE::Exp, ty: SigTy) -> Result<Si
         // `String(array)` / `String(record)` are not scalar conversions (the
         // frontend would not produce them here); reject rather than mis-format.
         SigTy::Array { .. } | SigTy::Record { .. } | SigTy::Ptr => {
-            bail!("CodegenWasmJit: String() of an array/record/external-object is not supported")
+            return Err("CodegenWasmJit: String() of an array/record/external-object is not supported")
         }
     }
 }
@@ -5013,7 +5008,7 @@ fn const_dims(ty: &DAE::Type) -> Result<Vec<u32>> {
     for d in &**dims {
         match &**d {
             DAE::Dimension::DIM_INTEGER { integer } if *integer >= 0 => out.push(*integer as u32),
-            other => bail!("CodegenWasmJit: array construction needs constant dimensions, got {other:?}"),
+            other => return Err("CodegenWasmJit: array construction needs constant dimensions, got {other:?}"),
         }
     }
     out.extend(const_dims(elem)?);
@@ -5049,11 +5044,11 @@ fn flatten_array_exp<'a>(exp: &'a DAE::Exp, out: &mut Vec<&'a DAE::Exp>) {
 /// element's reference transfers into the array (released by `rt_array_release`).
 fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> Result<()> {
     let SigTy::Array { elem, rank } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: array constructor with non-array type {ty:?}");
+        return Err("CodegenWasmJit: array constructor with non-array type {ty:?}");
     };
     let dims = const_dims(ty)?;
     if dims.len() as u32 != rank {
-        bail!("CodegenWasmJit: array constructor rank {rank} does not match {} dimensions", dims.len());
+        return Err("CodegenWasmJit: array constructor rank {rank} does not match {} dimensions");
     }
     let total: u32 = dims.iter().product();
     // The top-level structure (`ARRAY`/`MATRIX` nodes) is flattened to its
@@ -5108,7 +5103,7 @@ fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> R
         }
     }
     if k != total {
-        bail!("CodegenWasmJit: array constructor produced {k} elements but type implies {total}");
+        return Err("CodegenWasmJit: array constructor produced {k} elements but type implies {total}");
     }
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
@@ -5168,13 +5163,13 @@ fn operator_dae_type(op: &DAE::Operator) -> Option<Arc<DAE::Type>> {
 /// element-count rounding to stay byte-identical, so they fail loudly.
 fn compile_range_array(ctx: &mut FnCtx, ty: &DAE::Type, start: &DAE::Exp, step: Option<&DAE::Exp>, stop: &DAE::Exp) -> Result<()> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: range with non-array type {ty:?}");
+        return Err("CodegenWasmJit: range with non-array type {ty:?}");
     };
     match &*elem {
         // Integer and enumeration ranges (enum literals are their i32 index).
         SigTy::Int => compile_int_range_array(ctx, start, step, stop),
         SigTy::Real => compile_real_range_array(ctx, start, step, stop),
-        other => bail!("CodegenWasmJit: only Integer/Real ranges are supported as array values (element {other:?})"),
+        other => return Err("CodegenWasmJit: only Integer/Real ranges are supported as array values (element {other:?})"),
     }
 }
 
@@ -5372,7 +5367,7 @@ const OP_OR: i32 = 6;
 /// operand arrays are released after.
 fn compile_array_ew(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, ty: &DAE::Type) -> Result<WTy> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: element-wise array op with non-array type {ty:?}");
+        return Err("CodegenWasmJit: element-wise array op with non-array type {ty:?}");
     };
     let rt = if elem.wty() == WTy::F64 { "rt_array_ew_f64" } else { "rt_array_ew_i32" };
     compile_exp(ctx, e1)?;
@@ -5393,7 +5388,7 @@ fn compile_array_ew(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32,
 /// `v1 * v2` scalar (dot) product of two numeric vectors → a scalar. Both
 /// operand arrays are released; the scalar result is left on the stack.
 fn compile_dot(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> {
-    let elem = array_elem(e1)?.ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: scalar-product operand is not an array"))?;
+    let elem = array_elem(e1)?.ok_or_else(|| "CodegenWasmJit: scalar-product operand is not an array")?;
     let f64mode = elem.wty() == WTy::F64;
     let rt = if f64mode { "rt_array_dot_f64" } else { "rt_array_dot_i32" };
     compile_exp(ctx, e1)?;
@@ -5414,7 +5409,7 @@ fn compile_dot(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> {
 /// runtime computes the result shape from the operand ranks; both operands are
 /// released and the fresh result array handle is left on the stack.
 fn compile_matmul(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> {
-    let elem = array_elem(e1)?.ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: matrix-product operand is not an array"))?;
+    let elem = array_elem(e1)?.ok_or_else(|| "CodegenWasmJit: matrix-product operand is not an array")?;
     let rt = if elem.wty() == WTy::F64 { "rt_array_matmul_f64" } else { "rt_array_matmul_i32" };
     compile_exp(ctx, e1)?;
     let at = ctx.alloc_temp(WTy::I32);
@@ -5438,7 +5433,7 @@ fn compile_matmul(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> 
 /// order); the array operand is released after.
 fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, rev: bool, ty: &DAE::Type) -> Result<WTy> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        bail!("CodegenWasmJit: array-scalar op with non-array type {ty:?}");
+        return Err("CodegenWasmJit: array-scalar op with non-array type {ty:?}");
     };
     let elem_wty = elem.wty();
     let rt = if elem_wty == WTy::F64 { "rt_array_scalar_f64" } else { "rt_array_scalar_i32" };
@@ -5465,7 +5460,7 @@ fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: 
 /// element's wasm type.
 fn compile_index(ctx: &mut FnCtx, base: &DAE::Exp, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
     let SigTy::Array { elem, rank } = exp_sigty(base)? else {
-        bail!("CodegenWasmJit: subscripting a non-array expression");
+        return Err("CodegenWasmJit: subscripting a non-array expression");
     };
     compile_exp(ctx, base)?; // owned array handle
     if is_scalar_index(subs, rank) {
@@ -5497,13 +5492,13 @@ fn is_scalar_index(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> bool {
 fn index_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> Result<Vec<Arc<DAE::Exp>>> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
     if subs.len() as u32 != rank {
-        bail!("CodegenWasmJit: array slicing / partial indexing not supported ({} subscripts on rank {rank})", subs.len());
+        return Err("CodegenWasmJit: array slicing / partial indexing not supported ({} subscripts on rank {rank})");
     }
     let mut out = Vec::with_capacity(subs.len());
     for s in subs {
         match &**s {
             DAE::Subscript::INDEX { exp } => out.push(exp.clone()),
-            other => bail!("CodegenWasmJit: non-scalar subscript {other:?} (slicing not supported)"),
+            other => return Err("CodegenWasmJit: non-scalar subscript {other:?} (slicing not supported)"),
         }
     }
     Ok(out)
@@ -5620,7 +5615,7 @@ fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Resul
                 spec_elem_addr(ctx, spec_t, val_slot)?;
                 let w = compile_exp(ctx, exp)?; // owned Integer index array
                 if w != WTy::I32 {
-                    bail!("CodegenWasmJit: array slice subscript is not an integer index array");
+                    return Err("CodegenWasmJit: array slice subscript is not an integer index array");
                 }
                 let s_t = ctx.alloc_temp(WTy::I32);
                 ctx.emit(we::Instruction::LocalTee(s_t));
@@ -5661,7 +5656,7 @@ fn release_temp_array(ctx: &mut FnCtx, t: u32) -> Result<()> {
 /// released after.
 fn compile_size(ctx: &mut FnCtx, exp: &DAE::Exp, sz: Option<&DAE::Exp>) -> Result<()> {
     let SigTy::Array { rank, .. } = exp_sigty(exp)? else {
-        bail!("CodegenWasmJit: size() of a non-array expression");
+        return Err("CodegenWasmJit: size() of a non-array expression");
     };
     compile_exp(ctx, exp)?; // owned array handle
     let arr_t = ctx.alloc_temp(WTy::I32);
@@ -5727,11 +5722,11 @@ fn compile_array_builtin(
         // fill(s, d1, ..., dk): array of the given dims, every element = s.
         "fill" => {
             if argv.len() < 2 {
-                bail!("CodegenWasmJit: fill expects a value and at least one dimension");
+                return Err("CodegenWasmJit: fill expects a value and at least one dimension");
             }
             let arr_ty = sig_ty(&attr.ty)?;
             let SigTy::Array { elem, .. } = &arr_ty else {
-                bail!("CodegenWasmJit: fill result is not an array ({arr_ty:?})");
+                return Err("CodegenWasmJit: fill result is not an array ({arr_ty:?})");
             };
             let obj = emit_alloc_from_exprs(ctx, elem, &argv[1..])?;
             emit_fill_value(ctx, obj, elem, argv[0])?;
@@ -5741,11 +5736,11 @@ fn compile_array_builtin(
         // zeros(d...) / ones(d...): like fill with a constant 0 / 1.
         "zeros" | "ones" => {
             if argv.is_empty() {
-                bail!("CodegenWasmJit: {name} expects at least one dimension");
+                return Err("CodegenWasmJit: {name} expects at least one dimension");
             }
             let arr_ty = sig_ty(&attr.ty)?;
             let SigTy::Array { elem, .. } = &arr_ty else {
-                bail!("CodegenWasmJit: {name} result is not an array ({arr_ty:?})");
+                return Err("CodegenWasmJit: {name} result is not an array ({arr_ty:?})");
             };
             let obj = emit_alloc_from_exprs(ctx, elem, argv)?;
             emit_fill_const(ctx, obj, elem, if name == "ones" { 1 } else { 0 })?;
@@ -5786,7 +5781,7 @@ fn compile_array_builtin(
         // diagonal(v): n×n matrix with the vector v on the diagonal.
         "diagonal" if argv.len() == 1 => {
             if array_elem(argv[0])?.is_none() {
-                bail!("CodegenWasmJit: diagonal of a non-array expression");
+                return Err("CodegenWasmJit: diagonal of a non-array expression");
             }
             compile_exp(ctx, argv[0])?;
             let vt = ctx.alloc_temp(WTy::I32);
@@ -5810,7 +5805,7 @@ fn compile_array_builtin(
         // transpose(a): a fresh n×m array (the operand 2-D array is released).
         "transpose" if argv.len() == 1 => {
             if array_elem(argv[0])?.is_none() {
-                bail!("CodegenWasmJit: transpose of a non-array expression");
+                return Err("CodegenWasmJit: transpose of a non-array expression");
             }
             compile_exp(ctx, argv[0])?;
             let at = ctx.alloc_temp(WTy::I32);
@@ -5839,7 +5834,7 @@ fn compile_array_builtin(
             let mut in_temps = Vec::with_capacity(n as usize);
             for (i, a) in argv[1..].iter().enumerate() {
                 if array_elem(a)?.is_none() {
-                    bail!("CodegenWasmJit: cat argument is not an array");
+                    return Err("CodegenWasmJit: cat argument is not an array");
                 }
                 ctx.emit(we::Instruction::LocalGet(handles_t));
                 ctx.emit(we::Instruction::I32Const(i as i32 + 1));
@@ -5866,7 +5861,7 @@ fn compile_array_builtin(
         // ndims(a) -> Integer.
         "ndims" if argv.len() == 1 => {
             if array_elem(argv[0])?.is_none() {
-                bail!("CodegenWasmJit: ndims of a non-array expression");
+                return Err("CodegenWasmJit: ndims of a non-array expression");
             }
             emit_array_reduce(ctx, argv[0], "rt_array_ndims", None)?;
             Ok(Some(SigTy::Int))
@@ -5874,7 +5869,7 @@ fn compile_array_builtin(
         // scalar(a): the single element of an array whose dimensions are all 1.
         "scalar" if argv.len() == 1 => {
             let elem = array_elem(argv[0])?
-                .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: scalar() of a non-array expression"))?;
+                .ok_or_else(|| "CodegenWasmJit: scalar() of a non-array expression")?;
             compile_exp(ctx, argv[0])?; // owned array
             let arr_t = ctx.alloc_temp(WTy::I32);
             ctx.emit(we::Instruction::LocalSet(arr_t));
@@ -5927,7 +5922,7 @@ fn compile_array_builtin(
         // promote(a, n): add trailing size-1 dimensions to reach rank `n`.
         "promote" if argv.len() == 2 => {
             if array_elem(argv[0])?.is_none() {
-                bail!("CodegenWasmJit: promote of a non-array expression");
+                return Err("CodegenWasmJit: promote of a non-array expression");
             }
             compile_exp(ctx, argv[0])?;
             let at = ctx.alloc_temp(WTy::I32);
@@ -5951,7 +5946,7 @@ fn compile_array_builtin(
 /// result handle on the stack.
 fn emit_unary_array(ctx: &mut FnCtx, arg: &DAE::Exp, rt: &str) -> Result<()> {
     if array_elem(arg)?.is_none() {
-        bail!("CodegenWasmJit: {rt} of a non-array expression");
+        return Err("CodegenWasmJit: {rt} of a non-array expression");
     }
     compile_exp(ctx, arg)?;
     let at = ctx.alloc_temp(WTy::I32);
@@ -6068,7 +6063,7 @@ fn unary_f64(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>], instr: we::Instruction<'s
 
 fn need_args(argv: &[&Arc<DAE::Exp>], n: usize, name: &str) -> Result<()> {
     if argv.len() != n {
-        bail!("CodegenWasmJit: builtin {name} expects {n} args, got {}", argv.len());
+        return Err("CodegenWasmJit: builtin {name} expects {n} args, got {}");
     }
     Ok(())
 }
@@ -6120,8 +6115,8 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
     let sig = format!("{in_codes}\n{out_codes}\n");
     // Native writes the module + sidecar to disk; wasm has no OS filesystem, so
     // the facade stages them in the VFS where `load_and_execute` reads them back.
-    openmodelica_wasi::fs::write(&format!("{base}.wasm"), &bytes)?;
-    openmodelica_wasi::fs::write(&format!("{base}.wasm.sig"), sig.as_bytes())?;
+    openmodelica_wasi::fs::write(&format!("{base}.wasm"), &bytes).map_err(|_| "CodegenWasmJitFunctions: cannot write wasm")?;
+    openmodelica_wasi::fs::write(&format!("{base}.wasm.sig"), sig.as_bytes()).map_err(|_| "CodegenWasmJitFunctions: cannot write wasm.sig")?;
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 use metamodelica::List;
 use openmodelica_frontend_types::Values;
@@ -16,5 +16,5 @@ pub(super) fn load_and_execute(
     _name: &str,
     _args: &Arc<List<Arc<Values::Value>>>,
 ) -> Result<Arc<Values::Value>> {
-    bail!("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
+    return Err("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use anyhow::{Context, Result, anyhow, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 
@@ -21,7 +21,7 @@ use super::SigTy;
 /// — `RuntimeError`, `InstantiationError`, `ExportError`, … — do not share a
 /// single anyhow-convertible type, so we format via `Debug`).
 fn wt<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
-    r.map_err(|e| anyhow!("{e:?}"))
+    r.map_err(|e| "{e:?}")
 }
 
 /// The static linear-memory runtime, precompiled from
@@ -90,7 +90,7 @@ struct Sig {
 
 fn read_sig(path: &str) -> Result<Sig> {
     let text = openmodelica_wasi::fs::read_to_string(path)
-        .with_context(|| format!("CodegenWasmJit: cannot read sidecar {path}"))?;
+        .map_err(|_| "CodegenWasmJit: cannot read sidecar {path}")?;
     let mut lines = text.lines();
     let parse = |line: Option<&str>| -> Result<Vec<SigTy>> {
         super::parse_sig_types(line.unwrap_or(""))
@@ -171,7 +171,7 @@ fn value_as_f64(v: &Values::Value) -> Result<f64> {
         Values::Value::INTEGER { integer } => *integer as f64,
         Values::Value::BOOL { boolean } => *boolean as i64 as f64,
         Values::Value::ENUM_LITERAL { index, .. } => *index as f64,
-        other => bail!("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
     })
 }
 
@@ -182,7 +182,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
         Values::Value::BOOL { boolean } => *boolean as i32,
         Values::Value::ENUM_LITERAL { index, .. } => *index,
         Values::Value::REAL { real } => real.into_inner() as i32,
-        other => bail!("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
     })
 }
 
@@ -194,7 +194,7 @@ pub(super) fn load_and_execute(
     let wasm_path = format!("{file_name}.wasm");
     let sig = read_sig(&format!("{file_name}.wasm.sig"))?;
     let bytes = openmodelica_wasi::fs::read(&wasm_path)
-        .with_context(|| format!("CodegenWasmJit: cannot read module {wasm_path}"))?;
+        .map_err(|_| "CodegenWasmJit: cannot read module {wasm_path}")?;
 
     // Reuse the shared engine and the per-content compiled module. Each call
     // gets a fresh store + runtime instance (its own heap/linear memory); the
@@ -215,7 +215,7 @@ pub(super) fn load_and_execute(
     let memory = rt_inst
         .exports
         .get_memory("memory")
-        .map_err(|e| anyhow!("CodegenWasmJit: runtime has no `memory` export: {e:?}"))?
+        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export: {e:?}")?
         .clone();
     let rt = RtFns {
         mem: memory,
@@ -234,13 +234,13 @@ pub(super) fn load_and_execute(
     let func = instance
         .exports
         .get_function("main")
-        .map_err(|e| anyhow!("CodegenWasmJit: module has no `main` export: {e:?}"))?
+        .map_err(|e| "CodegenWasmJit: module has no `main` export: {e:?}")?
         .clone();
 
     // Marshal the arguments according to the input signature.
     let argv: Vec<&Arc<Values::Value>> = (&**args).into_iter().collect();
     if argv.len() != sig.inputs.len() {
-        bail!("CodegenWasmJit: function expects {} arguments, got {}", sig.inputs.len(), argv.len());
+        return Err("CodegenWasmJit: function expects {} arguments, got {}");
     }
     let mut params: Vec<wasmer::Value> = Vec::with_capacity(argv.len());
     for (a, ty) in argv.iter().zip(sig.inputs.iter()) {
@@ -264,12 +264,12 @@ pub(super) fn load_and_execute(
                 report_pending_assert(&mut store, &rt, &pa)?;
                 return Ok(Arc::new(Values::Value::META_FAIL));
             }
-            return Err(anyhow!("{e:?}"));
+            return Err("{e:?}");
         }
     };
 
     if results.len() != sig.outputs.len() {
-        bail!("CodegenWasmJit: wasm returned {} values but signature has {}", results.len(), sig.outputs.len());
+        return Err("CodegenWasmJit: wasm returned {} values but signature has {}");
     }
 
     let mut out: Vec<Arc<Values::Value>> = Vec::with_capacity(results.len());
@@ -291,7 +291,7 @@ fn read_rt_str(store: &mut Store, rt: &RtFns, handle: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, handle))? as usize;
     let data = wt(rt.str_data.call(&mut *store, handle))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.view(&*store).read(data as u64, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: {e}"))?;
+    rt.mem.view(&*store).read(data as u64, &mut buf).map_err(|e| "CodegenWasmJit: {e}")?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -347,7 +347,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
         SigTy::Str => wasmer::Value::I32(str_to_handle(store, rt, v)?),
         SigTy::Array { elem, rank } => wasmer::Value::I32(array_to_handle(store, rt, elem, *rank, v)?),
         SigTy::Record { fields, .. } => wasmer::Value::I32(record_to_handle(store, rt, fields, v)?),
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
@@ -357,7 +357,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
 /// is self-describing for release/copy.
 fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v: &Values::Value) -> Result<i32> {
     let Values::Value::RECORD { orderd, comp, .. } = v else {
-        bail!("CodegenWasmJit: expected a record argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a record argument, got {v:?}");
     };
     let layout = super::record_layout(fields);
     let obj = wt(rt.rec_new.call(&mut *store, layout.heap.len() as i32, layout.size as i32))?;
@@ -375,7 +375,7 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
     for (i, (fname, fty)) in fields.iter().enumerate() {
         let fv = by_name
             .get(fname.as_str())
-            .ok_or_else(|| anyhow!("CodegenWasmJit: record argument missing field `{fname}`"))?;
+            .ok_or_else(|| "CodegenWasmJit: record argument missing field `{fname}`")?;
         let addr = obj as usize + layout.data_off as usize + layout.field_off[i] as usize;
         write_elem(store, rt, fty, addr, fv)?;
     }
@@ -385,12 +385,12 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
 /// Materialize a `Values.STRING` into a fresh runtime string, returning its handle.
 fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32> {
     let Values::Value::STRING { string } = v else {
-        bail!("CodegenWasmJit: expected a String argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a String argument, got {v:?}");
     };
     let b = string.as_bytes();
     let h = wt(rt.str_new.call(&mut *store, b.len() as i32))?;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
-    rt.mem.view(&*store).write(d as u64, b).map_err(|e| anyhow!("CodegenWasmJit: memory write: {e}"))?;
+    rt.mem.view(&*store).write(d as u64, b).map_err(|e| "CodegenWasmJit: memory write: {e}")?;
     Ok(h)
 }
 
@@ -399,11 +399,11 @@ fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32
 /// dimension; the leaves are flattened row-major and written into the object.
 fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &Values::Value) -> Result<i32> {
     let Values::Value::ARRAY { dimLst, .. } = v else {
-        bail!("CodegenWasmJit: expected an array argument, got {v:?}");
+        return Err("CodegenWasmJit: expected an array argument, got {v:?}");
     };
     let dims: Vec<i32> = (&**dimLst).into_iter().copied().collect();
     if dims.len() as u32 != rank {
-        bail!("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}", dims.len());
+        return Err("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}");
     }
     let total: i32 = dims.iter().product();
     let obj = wt(rt.arr_new.call(&mut *store, elem.elem_kind() as i32, rank as i32, total))?;
@@ -414,7 +414,7 @@ fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &V
     let mut leaves = Vec::new();
     flatten_values(v, &mut leaves);
     if leaves.len() as i32 != total {
-        bail!("CodegenWasmJit: array argument has {} elements but dimensions imply {total}", leaves.len());
+        return Err("CodegenWasmJit: array argument has {} elements but dimensions imply {total}");
     }
     for (k, leaf) in leaves.iter().enumerate() {
         let addr = wt(rt.arr_elem_ptr.call(&mut *store, obj, k as i32 + 1))? as usize;
@@ -453,40 +453,40 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
             let h = record_to_handle(store, rt, fields, v)?;
             write_bytes(store, rt, addr, &h.to_le_bytes())?;
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     }
     Ok(())
 }
 
 fn write_bytes(store: &mut Store, rt: &RtFns, addr: usize, bytes: &[u8]) -> Result<()> {
-    rt.mem.view(&*store).write(addr as u64, bytes).map_err(|e| anyhow!("CodegenWasmJit: memory write: {e}"))
+    rt.mem.view(&*store).write(addr as u64, bytes).map_err(|e| "CodegenWasmJit: memory write: {e}")
 }
 
 /// Build a `Values.Value` from a wasm result of the given Modelica type.
 fn marshal_out(store: &mut Store, rt: &RtFns, ty: &SigTy, val: &wasmer::Value) -> Result<Values::Value> {
     Ok(match ty {
         SigTy::Int => Values::Value::INTEGER {
-            integer: val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 result"))?,
+            integer: val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 result")?,
         },
         SigTy::Bool => Values::Value::BOOL {
-            boolean: val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 result"))? != 0,
+            boolean: val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 result")? != 0,
         },
         SigTy::Real => Values::Value::REAL {
-            real: metamodelica::Real::from(val.f64().ok_or_else(|| anyhow!("CodegenWasmJit: expected f64 result"))?),
+            real: metamodelica::Real::from(val.f64().ok_or_else(|| "CodegenWasmJit: expected f64 result")?),
         },
         SigTy::Str => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 string handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 string handle result")?;
             Values::Value::STRING { string: ArcStr::from(read_string(store, rt, h)?.as_str()) }
         }
         SigTy::Array { elem, .. } => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 array handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 array handle result")?;
             read_array(store, rt, elem, h)?
         }
         SigTy::Record { path, fields } => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 record handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 record handle result")?;
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
@@ -526,8 +526,8 @@ fn read_string(store: &mut Store, rt: &RtFns, h: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, h))? as usize;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.view(&*store).read(d as u64, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: memory read: {e}"))?;
-    String::from_utf8(buf).map_err(|e| anyhow!("CodegenWasmJit: non-utf8 result string: {e}"))
+    rt.mem.view(&*store).read(d as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
+    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string: {e}")
 }
 
 /// Read a runtime array handle into a (nested) `Values.ARRAY` of element type
@@ -567,13 +567,13 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
             let h = i32::from_le_bytes(read_bytes::<4>(store, rt, addr)?);
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
 fn read_bytes<const N: usize>(store: &mut Store, rt: &RtFns, addr: usize) -> Result<[u8; N]> {
     let mut buf = [0u8; N];
-    rt.mem.view(&*store).read(addr as u64, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: memory read: {e}"))?;
+    rt.mem.view(&*store).read(addr as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
     Ok(buf)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use anyhow::{Result, anyhow, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 
@@ -20,7 +20,7 @@ use super::SigTy;
 /// wasmtime errors carry their own (re-exported) `anyhow`, which does not unify
 /// with ours under the feature set we build with; flatten via the message.
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
-    r.map_err(|e| anyhow!("{e:?}"))
+    r.map_err(|e| "{e:?}")
 }
 
 /// The static linear-memory runtime, precompiled from
@@ -95,7 +95,7 @@ struct Sig {
 }
 
 fn read_sig(path: &str) -> Result<Sig> {
-    let text = std::fs::read_to_string(path)?;
+    let text = std::fs::read_to_string(path).map_err(|_| "runtime_wasmtime: cannot read sig file")?;
     let mut lines = text.lines();
     let parse = |line: Option<&str>| -> Result<Vec<SigTy>> {
         super::parse_sig_types(line.unwrap_or(""))
@@ -169,7 +169,7 @@ fn value_as_f64(v: &Values::Value) -> Result<f64> {
         Values::Value::INTEGER { integer } => *integer as f64,
         Values::Value::BOOL { boolean } => *boolean as i64 as f64,
         Values::Value::ENUM_LITERAL { index, .. } => *index as f64,
-        other => bail!("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
     })
 }
 
@@ -180,7 +180,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
         Values::Value::BOOL { boolean } => *boolean as i32,
         Values::Value::ENUM_LITERAL { index, .. } => *index,
         Values::Value::REAL { real } => real.into_inner() as i32,
-        other => bail!("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
     })
 }
 
@@ -191,7 +191,7 @@ pub(super) fn load_and_execute(
 ) -> Result<Arc<Values::Value>> {
     let wasm_path = format!("{file_name}.wasm");
     let sig = read_sig(&format!("{file_name}.wasm.sig"))?;
-    let bytes = std::fs::read(&wasm_path)?;
+    let bytes = std::fs::read(&wasm_path).map_err(|_| "runtime_wasmtime: cannot read wasm file")?;
 
     // Reuse the shared engine/env-linker and the per-content compiled module.
     // Each call gets a fresh runtime instance (its own heap/linear memory); the
@@ -209,7 +209,7 @@ pub(super) fn load_and_execute(
     // and out of the shared heap.
     let memory = rt_inst
         .get_memory(&mut store, "memory")
-        .ok_or_else(|| anyhow!("CodegenWasmJit: runtime has no `memory` export"))?;
+        .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;
     let rt = RtFns {
         mem: memory,
         str_new: wt(rt_inst.get_typed_func(&mut store, "rt_str_new"))?,
@@ -226,12 +226,12 @@ pub(super) fn load_and_execute(
 
     let func = instance
         .get_func(&mut store, "main")
-        .ok_or_else(|| anyhow!("CodegenWasmJit: module has no `main` export"))?;
+        .ok_or_else(|| "CodegenWasmJit: module has no `main` export")?;
 
     // Marshal the arguments according to the input signature.
     let argv: Vec<&Arc<Values::Value>> = (&**args).into_iter().collect();
     if argv.len() != sig.inputs.len() {
-        bail!("CodegenWasmJit: function expects {} arguments, got {}", sig.inputs.len(), argv.len());
+        return Err("CodegenWasmJit: function expects {} arguments, got {}");
     }
     let mut params: Vec<wasmtime::Val> = Vec::with_capacity(argv.len());
     for (a, ty) in argv.iter().zip(sig.inputs.iter()) {
@@ -259,7 +259,7 @@ pub(super) fn load_and_execute(
     wt(call_res)?;
 
     if results.len() != sig.outputs.len() {
-        bail!("CodegenWasmJit: wasm returned {} values but signature has {}", results.len(), sig.outputs.len());
+        return Err("CodegenWasmJit: wasm returned {} values but signature has {}");
     }
 
     let mut out: Vec<Arc<Values::Value>> = Vec::with_capacity(results.len());
@@ -281,7 +281,7 @@ fn read_rt_str(store: &mut Store, rt: &RtFns, handle: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, handle))? as usize;
     let data = wt(rt.str_data.call(&mut *store, handle))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.read(&*store, data, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: {e}"))?;
+    rt.mem.read(&*store, data, &mut buf).map_err(|e| "CodegenWasmJit: {e}")?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -337,7 +337,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
         SigTy::Str => wasmtime::Val::I32(str_to_handle(store, rt, v)?),
         SigTy::Array { elem, rank } => wasmtime::Val::I32(array_to_handle(store, rt, elem, *rank, v)?),
         SigTy::Record { fields, .. } => wasmtime::Val::I32(record_to_handle(store, rt, fields, v)?),
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
@@ -347,7 +347,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
 /// is self-describing for release/copy.
 fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v: &Values::Value) -> Result<i32> {
     let Values::Value::RECORD { orderd, comp, .. } = v else {
-        bail!("CodegenWasmJit: expected a record argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a record argument, got {v:?}");
     };
     let layout = super::record_layout(fields);
     let obj = wt(rt.rec_new.call(&mut *store, (layout.heap.len() as i32, layout.size as i32)))?;
@@ -365,7 +365,7 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
     for (i, (fname, fty)) in fields.iter().enumerate() {
         let fv = by_name
             .get(fname.as_str())
-            .ok_or_else(|| anyhow!("CodegenWasmJit: record argument missing field `{fname}`"))?;
+            .ok_or_else(|| "CodegenWasmJit: record argument missing field `{fname}`")?;
         let addr = obj as usize + layout.data_off as usize + layout.field_off[i] as usize;
         write_elem(store, rt, fty, addr, fv)?;
     }
@@ -375,12 +375,12 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
 /// Materialize a `Values.STRING` into a fresh runtime string, returning its handle.
 fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32> {
     let Values::Value::STRING { string } = v else {
-        bail!("CodegenWasmJit: expected a String argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a String argument, got {v:?}");
     };
     let b = string.as_bytes();
     let h = wt(rt.str_new.call(&mut *store, b.len() as i32))?;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
-    rt.mem.write(&mut *store, d, b).map_err(|e| anyhow!("CodegenWasmJit: memory write: {e}"))?;
+    rt.mem.write(&mut *store, d, b).map_err(|e| "CodegenWasmJit: memory write: {e}")?;
     Ok(h)
 }
 
@@ -389,11 +389,11 @@ fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32
 /// dimension; the leaves are flattened row-major and written into the object.
 fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &Values::Value) -> Result<i32> {
     let Values::Value::ARRAY { dimLst, .. } = v else {
-        bail!("CodegenWasmJit: expected an array argument, got {v:?}");
+        return Err("CodegenWasmJit: expected an array argument, got {v:?}");
     };
     let dims: Vec<i32> = (&**dimLst).into_iter().copied().collect();
     if dims.len() as u32 != rank {
-        bail!("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}", dims.len());
+        return Err("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}");
     }
     let total: i32 = dims.iter().product();
     let obj = wt(rt.arr_new.call(&mut *store, (elem.elem_kind() as i32, rank as i32, total)))?;
@@ -404,7 +404,7 @@ fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &V
     let mut leaves = Vec::new();
     flatten_values(v, &mut leaves);
     if leaves.len() as i32 != total {
-        bail!("CodegenWasmJit: array argument has {} elements but dimensions imply {total}", leaves.len());
+        return Err("CodegenWasmJit: array argument has {} elements but dimensions imply {total}");
     }
     for (k, leaf) in leaves.iter().enumerate() {
         let addr = wt(rt.arr_elem_ptr.call(&mut *store, (obj, k as i32 + 1)))? as usize;
@@ -443,40 +443,40 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
             let h = record_to_handle(store, rt, fields, v)?;
             write_bytes(store, rt, addr, &h.to_le_bytes())?;
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     }
     Ok(())
 }
 
 fn write_bytes(store: &mut Store, rt: &RtFns, addr: usize, bytes: &[u8]) -> Result<()> {
-    rt.mem.write(&mut *store, addr, bytes).map_err(|e| anyhow!("CodegenWasmJit: memory write: {e}"))
+    rt.mem.write(&mut *store, addr, bytes).map_err(|e| "CodegenWasmJit: memory write: {e}")
 }
 
 /// Build a `Values.Value` from a wasm result of the given Modelica type.
 fn marshal_out(store: &mut Store, rt: &RtFns, ty: &SigTy, val: &wasmtime::Val) -> Result<Values::Value> {
     Ok(match ty {
         SigTy::Int => Values::Value::INTEGER {
-            integer: val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 result"))?,
+            integer: val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 result")?,
         },
         SigTy::Bool => Values::Value::BOOL {
-            boolean: val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 result"))? != 0,
+            boolean: val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 result")? != 0,
         },
         SigTy::Real => Values::Value::REAL {
-            real: metamodelica::Real::from(val.f64().ok_or_else(|| anyhow!("CodegenWasmJit: expected f64 result"))?),
+            real: metamodelica::Real::from(val.f64().ok_or_else(|| "CodegenWasmJit: expected f64 result")?),
         },
         SigTy::Str => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 string handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 string handle result")?;
             Values::Value::STRING { string: ArcStr::from(read_string(store, rt, h)?.as_str()) }
         }
         SigTy::Array { elem, .. } => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 array handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 array handle result")?;
             read_array(store, rt, elem, h)?
         }
         SigTy::Record { path, fields } => {
-            let h = val.i32().ok_or_else(|| anyhow!("CodegenWasmJit: expected i32 record handle result"))?;
+            let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 record handle result")?;
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
@@ -516,8 +516,8 @@ fn read_string(store: &mut Store, rt: &RtFns, h: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, h))? as usize;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.read(&*store, d, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: memory read: {e}"))?;
-    String::from_utf8(buf).map_err(|e| anyhow!("CodegenWasmJit: non-utf8 result string: {e}"))
+    rt.mem.read(&*store, d, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
+    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string: {e}")
 }
 
 /// Read a runtime array handle into a (nested) `Values.ARRAY` of element type
@@ -557,13 +557,13 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
             let h = i32::from_le_bytes(read_bytes::<4>(store, rt, addr)?);
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => bail!("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
     })
 }
 
 fn read_bytes<const N: usize>(store: &mut Store, rt: &RtFns, addr: usize) -> Result<[u8; N]> {
     let mut buf = [0u8; N];
-    rt.mem.read(&*store, addr, &mut buf).map_err(|e| anyhow!("CodegenWasmJit: memory read: {e}"))?;
+    rt.mem.read(&*store, addr, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
     Ok(buf)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 use openmodelica_frontend_types::DAE;
 use wasm_encoder as we;
@@ -108,10 +108,7 @@ pub(crate) fn compile_linear_system(
         return Ok(());
     }
     if res_exps.len() != n {
-        bail!(
-            "CodegenWasmJit: linear system has {n} unknowns but {} residuals",
-            res_exps.len()
-        );
+        return Err("CodegenWasmJit: linear system has {n} unknowns but {} residuals");
     }
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(n);
@@ -122,9 +119,9 @@ pub(crate) fn compile_linear_system(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: linear-system unknown `{key}` has no slot"))?;
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown `{key}` has no slot")?;
         if slot.wty != WTy::F64 {
-            bail!("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -230,10 +227,7 @@ pub(crate) fn compile_linear_system_symbolic(
         return Ok(());
     }
     if b_exps.len() != n {
-        bail!(
-            "CodegenWasmJit: SES_LINEAR (index {index}) has {n} unknowns but {} b entries",
-            b_exps.len()
-        );
+        return Err("CodegenWasmJit: SES_LINEAR (index {index}) has {n} unknowns but {} b entries");
     }
     let mut slots: Vec<u32> = Vec::with_capacity(n);
     for cr in vars {
@@ -243,9 +237,9 @@ pub(crate) fn compile_linear_system_symbolic(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| anyhow::anyhow!("CodegenWasmJit: linear-system unknown `{key}` has no slot"))?;
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown `{key}` has no slot")?;
         if slot.wty != WTy::F64 {
-            bail!("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -271,7 +265,7 @@ pub(crate) fn compile_linear_system_symbolic(
     // A[row + col*n] = element expression (column-major).
     for &(row, col, exp) in a_entries {
         if row >= n || col >= n {
-            bail!("CodegenWasmJit: SES_LINEAR (index {index}) simJac entry ({row},{col}) out of range for size {n}");
+            return Err("CodegenWasmJit: SES_LINEAR (index {index}) simJac entry ({row},{col}) out of range for size {n}");
         }
         let elem_off = a_off + ((col * n + row) as u32) * 8;
         ctx.emit(we::Instruction::LocalGet(base));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_xml/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_xml/Cargo.toml
@@ -15,7 +15,6 @@ openmodelica_frontend_dump.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_dump_extra/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_dump_extra/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 metamodelica.workspace = true
 openmodelica_ast.workspace = true
 openmodelica_frontend_dump.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 metamodelica.workspace = true
-anyhow.workspace = true
 const-str.workspace = true
 arcstr.workspace = true
 loop_unwrap.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorTypes.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorTypes.rs
@@ -37,7 +37,7 @@
 #![allow(unreachable_patterns, unreachable_code, non_camel_case_types, non_snake_case, dead_code, unused_imports, unused_variables, non_upper_case_globals, unused_mut)]
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/Cargo.toml
@@ -17,7 +17,6 @@ openmodelica_util_datatypes_basic.workspace=true
 openmodelica_ast_collections.workspace = true
 openmodelica_frontend_inst.workspace = true
 openmodelica_script_util.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
@@ -34,14 +34,14 @@ thread_local! {
         RefCell::new(openmodelica_util::BaseHashTable::emptyHashTableWork(
             openmodelica_util::Flags::getConfigInt(openmodelica_util::Flags::INST_CACHE_SIZE.clone()).unwrap_or(25343),
             (
-                (Arc::new(AbsynUtil::pathHash) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> anyhow::Result<i32> + 'static>),
-                (Arc::new(metamodelica::fnptr!(AbsynUtil::pathEqual, Arc<Absyn::Path>, Arc<Absyn::Path>)) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>, Arc<Absyn::Path>) -> anyhow::Result<bool> + 'static>),
-                (Arc::new(AbsynUtil::pathStringDefault) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> anyhow::Result<ArcStr> + 'static>),
+                (Arc::new(AbsynUtil::pathHash) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> metamodelica::Result<i32> + 'static>),
+                (Arc::new(metamodelica::fnptr!(AbsynUtil::pathEqual, Arc<Absyn::Path>, Arc<Absyn::Path>)) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>, Arc<Absyn::Path>) -> metamodelica::Result<bool> + 'static>),
+                (Arc::new(AbsynUtil::pathStringDefault) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> metamodelica::Result<ArcStr> + 'static>),
                 // `opaqVal` in InstHashTable is a private helper returning the
                 // constant "OPAQUE_VALUE" (used only for debug dumping of cache
                 // values); replicate it inline so this glue file stays
                 // self-contained.
-                (Arc::new(|_v: crate::InstHashTable::Value| -> anyhow::Result<ArcStr> { Ok(arcstr::literal!("OPAQUE_VALUE")) }) as Arc<dyn ::std::ops::Fn(crate::InstHashTable::Value) -> anyhow::Result<ArcStr> + 'static>),
+                (Arc::new(|_v: crate::InstHashTable::Value| -> metamodelica::Result<ArcStr> { Ok(arcstr::literal!("OPAQUE_VALUE")) }) as Arc<dyn ::std::ops::Fn(crate::InstHashTable::Value) -> metamodelica::Result<ArcStr> + 'static>),
             ),
         ));
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_base/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_base/Cargo.toml
@@ -14,7 +14,6 @@ openmodelica_frontend_inst.workspace = true
 openmodelica_ast_collections.workspace = true
 openmodelica_util.workspace = true
 openmodelica_util_datatypes_basic.workspace = true
-anyhow.workspace = true
 const-str.workspace = true
 arcstr.workspace = true
 loop_unwrap.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/Cargo.toml
@@ -10,7 +10,6 @@ openmodelica_ast.workspace = true
 openmodelica_frontend_types.workspace = true
 openmodelica_util_datatypes_basic.workspace=true
 openmodelica_util.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/component_reference_basics_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/component_reference_basics_tests.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::literal;
 use metamodelica::*;
 use openmodelica_frontend_types::DAE;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/dump_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/dump_tests.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use anyhow::Result;
+use metamodelica::Result;
 use metamodelica::*;
 use openmodelica_ast::Absyn;
 use crate::Dump;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/expression_basics_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/expression_basics_tests.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::literal;
 use metamodelica::*;
 use openmodelica_frontend_types::DAE;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/path_string_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/path_string_tests.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::literal;
 use openmodelica_ast::Absyn;
 use crate::AbsynUtil;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/unparse_str_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/unparse_str_tests.rs
@@ -10,7 +10,7 @@
 // Known bugs detected while writing these tests are documented inline with
 // "Bug:" prefixes.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use openmodelica_ast::parser::{parse, Grammar};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_inst/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_inst/Cargo.toml
@@ -9,7 +9,6 @@ openmodelica_ast.workspace = true
 openmodelica_frontend_types.workspace = true
 openmodelica_frontend_dump.workspace = true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_types/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_types/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 metamodelica.workspace = true
 openmodelica_ast.workspace = true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nbackend/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nbackend/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_ast.workspace=true
 openmodelica_backend_types.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 openmodelica_error.workspace = true
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_frontend_types.workspace=true
 openmodelica_frontend_dump.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI.rs
@@ -43,7 +43,7 @@
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use libffi::middle::{Cif, Type as MiddleType};
 
@@ -288,7 +288,7 @@ fn exp_alignment(exp: &Expression::NFExpression) -> Result<(CType, Alignment)> {
             let ctype = type_ctype(ty);
             (ctype, Alignment { size: size_of_type(ty), align: ctype.align(), ..Default::default() })
         }
-        _ => bail!("FFI.callFunction: unsupported argument expression"),
+        _ => return Err("FFI.callFunction: unsupported argument expression"),
     })
 }
 
@@ -333,7 +333,7 @@ unsafe fn write_exp_value(
             }
             Expression::NFExpression::STRING { value } => {
                 let c = CString::new(value.as_bytes())
-                    .map_err(|_| anyhow::anyhow!("FFI.callFunction: string argument contains NUL"))?;
+                    .map_err(|_| "FFI.callFunction: string argument contains NUL")?;
                 (ptr as *mut *const libc::c_char).write_unaligned(c.as_ptr());
                 strings.push(c);
                 ptr.add(8)
@@ -391,7 +391,7 @@ unsafe fn mk_string_exp(ptr: *const u8) -> Result<Arc<Expression::NFExpression>>
     let s = unsafe { (ptr as *const *const libc::c_char).read_unaligned() };
     if s.is_null() {
         // The C version would crash here; fail instead.
-        bail!("FFI.callFunction: external function returned a NULL string");
+        return Err("FFI.callFunction: external function returned a NULL string");
     }
     let value = ArcStr::from(unsafe { CStr::from_ptr(s) }.to_string_lossy().as_ref());
     Ok(Arc::new(Expression::NFExpression::STRING { value }))
@@ -405,10 +405,10 @@ unsafe fn mk_enum_exp(
 ) -> Result<Arc<Expression::NFExpression>> {
     let index = unsafe { (ptr as *const i32).read_unaligned() };
     let Type::NFType::ENUMERATION { literals, .. } = &**enum_ty else {
-        bail!("FFI.callFunction: expected an enumeration type");
+        return Err("FFI.callFunction: expected an enumeration type");
     };
     if index < 1 {
-        bail!("FFI.callFunction: enumeration index {index} out of range");
+        return Err("FFI.callFunction: enumeration index {index} out of range");
     }
     let mut cur = literals;
     let mut i = 1;
@@ -423,14 +423,14 @@ unsafe fn mk_enum_exp(
         i += 1;
         cur = tail;
     }
-    bail!("FFI.callFunction: enumeration index {index} out of range")
+    return Err("FFI.callFunction: enumeration index {index} out of range")
 }
 
 /// `mk_array_exp` / `mk_array_exp_2`: deserialise a contiguous C array into
 /// a (possibly nested) ARRAY expression of the given array type.
 unsafe fn mk_array_exp(ptr: *const u8, ty: &Arc<Type::NFType>) -> Result<Arc<Expression::NFExpression>> {
     let Type::NFType::ARRAY { elementType, dimensions } = &**ty else {
-        bail!("FFI.callFunction: expected an array type");
+        return Err("FFI.callFunction: expected an array type");
     };
     let dim_count = list_len(dimensions);
     let elem_count = array_scalar_count(ty);
@@ -446,7 +446,7 @@ unsafe fn mk_array_exp(ptr: *const u8, ty: &Arc<Type::NFType>) -> Result<Arc<Exp
                 Type::NFType::REAL => unsafe { mk_real_exp(p) },
                 Type::NFType::STRING => unsafe { mk_string_exp(p) }?,
                 Type::NFType::ENUMERATION { .. } => unsafe { mk_enum_exp(p, elementType) }?,
-                _ => bail!("FFI.callFunction: unsupported array element type"),
+                _ => return Err("FFI.callFunction: unsupported array element type"),
             });
         }
         v
@@ -479,7 +479,7 @@ unsafe fn mk_record_exp(
     align: &Alignment,
 ) -> Result<Arc<Expression::NFExpression>> {
     let Expression::NFExpression::RECORD { path, ty, elements } = arg else {
-        bail!("FFI.callFunction: expected a record expression");
+        return Err("FFI.callFunction: expected a record expression");
     };
     let mut out: Vec<Arc<Expression::NFExpression>> = Vec::with_capacity(align.fields.len());
     let mut cur = elements;
@@ -537,7 +537,7 @@ unsafe fn mk_exp_from_arg(
         Expression::NFExpression::ARRAY { ty, .. } => unsafe { mk_array_exp(ptr, ty) }?,
         Expression::NFExpression::RECORD { .. } => unsafe { mk_record_exp(ptr, arg, align) }?,
         Expression::NFExpression::EMPTY { ty } => unsafe { mk_exp_from_type(ty, ptr) }?,
-        _ => bail!("FFI.callFunction: unsupported argument expression"),
+        _ => return Err("FFI.callFunction: unsupported argument expression"),
     })
 }
 
@@ -574,7 +574,7 @@ pub fn callFunction(
     let args_vec: Vec<Arc<Expression::NFExpression>> = args.borrow().clone();
     let specs_vec: Vec<ArgSpec> = specs.borrow().clone();
     if args_vec.len() != specs_vec.len() {
-        bail!("FFI.callFunction: argument/spec count mismatch");
+        return Err("FFI.callFunction: argument/spec count mismatch");
     }
 
     // Marshal the arguments. String storage must outlive both the call and
@@ -617,7 +617,7 @@ pub fn callFunction(
     if caught != 0 {
         // Same as the C version's catch-all: the call failed, make the
         // surrounding evaluation fail (NFEvalFunction reports it).
-        bail!("FFI.callFunction: external function threw an exception");
+        return Err("FFI.callFunction: external function threw an exception");
     }
 
     // Read back the OUTPUT arguments, in declaration order.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI_wasm.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 use crate::NFExpression as Expression;
 use crate::NFType as Type;
@@ -38,5 +38,5 @@ pub fn callFunction(
     _specs: metamodelica::Array<ArgSpec>,
     _returnType: Arc<Type::NFType>,
 ) -> Result<(Arc<Expression::NFExpression>, Arc<metamodelica::List<Arc<Expression::NFExpression>>>)> {
-    bail!("FFI.callFunction: external \"C\" evaluation (dlopen+libffi) is unavailable on this target")
+    return Err("FFI.callFunction: external \"C\" evaluation (dlopen+libffi) is unavailable on this target")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_program_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_program_util/Cargo.toml
@@ -10,7 +10,6 @@ openmodelica_frontend.workspace=true
 openmodelica_frontend_dump.workspace=true
 openmodelica_util.workspace=true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace=true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/Cargo.toml
@@ -12,7 +12,6 @@ openmodelica_frontend_types.workspace = true
 openmodelica_frontend_dump.workspace = true
 openmodelica_util.workspace = true
 openmodelica_util_datatypes_basic.workspace=true
-anyhow.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl.rs
@@ -33,7 +33,7 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 use curl::easy::Easy;
 use metamodelica::List;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl_wasm.rs
@@ -21,7 +21,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use metamodelica::List;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/DynLoadExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/DynLoadExt.rs
@@ -29,7 +29,7 @@
 use std::ffi::{CStr, CString, c_char, c_void};
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 
@@ -124,9 +124,9 @@ struct MmcAlloc {
 impl MmcAlloc {
     fn resolve() -> Result<Self> {
         let mk_box_arr = dynload::runtime_symbol("mmc_mk_box_arr")
-            .ok_or_else(|| anyhow::anyhow!("runtime symbol `mmc_mk_box_arr` not found"))?;
+            .ok_or_else(|| "runtime symbol `mmc_mk_box_arr` not found")?;
         let mk_rcon = dynload::runtime_symbol("mmc_mk_rcon")
-            .ok_or_else(|| anyhow::anyhow!("runtime symbol `mmc_mk_rcon` not found"))?;
+            .ok_or_else(|| "runtime symbol `mmc_mk_rcon` not found")?;
         Ok(MmcAlloc {
             mk_box_arr: unsafe { std::mem::transmute::<usize, extern "C" fn(isize, usize, *const usize) -> usize>(mk_box_arr) },
             mk_rcon: unsafe { std::mem::transmute::<usize, extern "C" fn(f64) -> usize>(mk_rcon) },
@@ -189,7 +189,7 @@ fn value_to_desc(rt: &MmcAlloc, v: &Values::Value, store: &mut ArgStorage) -> Re
         Values::Value::RECORD { index, .. } if *index != -1 => Ok(TypeDesc::scalar(TD_MMC, value_to_mmc(rt, v)? as u64)),
         Values::Value::RECORD { record_, orderd, comp, .. } => record_to_desc(rt, record_, orderd, comp, store),
         Values::Value::ARRAY { valueLst, dimLst } => array_to_desc(rt, valueLst, dimLst, store),
-        other => bail!("DynLoad.executeFunction: marshalling argument {other:?} not yet supported"),
+        other => return Err("DynLoad.executeFunction: marshalling argument {other:?} not yet supported"),
     }
 }
 
@@ -233,7 +233,7 @@ fn value_to_mmc(rt: &MmcAlloc, v: &Values::Value) -> Result<usize> {
             }
             rt.mk_box((*index as i64 + 3) as usize, &slots)
         }
-        other => bail!("DynLoad.executeFunction: cannot marshal {other:?} into MetaModelica data"),
+        other => return Err("DynLoad.executeFunction: cannot marshal {other:?} into MetaModelica data"),
     })
 }
 
@@ -254,11 +254,11 @@ fn leak_record_description(path: &Arc<Absyn::Path>, field_names: &List<ArcStr>) 
 fn leak_record_description_raw(mangled_path: &str, dotted_name: &str, field_names: &[&str]) -> Result<usize> {
     let fields: Vec<*const c_char> = field_names
         .iter()
-        .map(|f| Ok(CString::new(*f)?.into_raw() as *const c_char))
+        .map(|f| Ok(CString::new(*f).map_err(|_| "DynLoad: NUL byte in field name")?.into_raw() as *const c_char))
         .collect::<Result<_>>()?;
     let desc = RecordDescription {
-        path: CString::new(mangled_path)?.into_raw(),
-        name: CString::new(dotted_name)?.into_raw(),
+        path: CString::new(mangled_path).map_err(|_| "DynLoad: NUL byte in path")?.into_raw(),
+        name: CString::new(dotted_name).map_err(|_| "DynLoad: NUL byte in name")?.into_raw(),
         field_names: Box::leak(fields.into_boxed_slice()).as_ptr(),
     };
     Ok(Box::into_raw(Box::new(desc)) as usize)
@@ -278,16 +278,16 @@ fn record_to_desc(
     let names: Vec<*const c_char> = field_names
         .into_iter()
         .map(|n| {
-            let c = CString::new(n.as_str())?;
+            let c = CString::new(n.as_str()).map_err(|_| "DynLoad: NUL byte in field name")?;
             let p = c.as_ptr();
             store.cstrings.push(c);
             Ok(p)
         })
         .collect::<Result<_>>()?;
     if elems.len() != names.len() {
-        bail!("DynLoad.executeFunction: record argument has {} fields but {} field names", elems.len(), names.len());
+        return Err("DynLoad.executeFunction: record argument has {} fields but {} field names");
     }
-    let record_name = CString::new(AbsynUtil::pathString(path.clone(), arcstr::literal!("."), false, false)?.as_str())?;
+    let record_name = CString::new(AbsynUtil::pathString(path.clone(), arcstr::literal!("."), false, false)?.as_str()).map_err(|_| "DynLoad: NUL byte in record name")?;
     let d0 = record_name.as_ptr() as u64;
     store.cstrings.push(record_name);
     let elems = elems.into_boxed_slice();
@@ -308,7 +308,7 @@ fn array_element_tag(values: &List<Arc<Values::Value>>) -> Result<i32> {
         Some(Values::Value::BOOL { .. }) => Ok(TD_BOOL_ARRAY),
         Some(Values::Value::STRING { .. }) => Ok(TD_STRING_ARRAY),
         Some(Values::Value::ARRAY { valueLst, .. }) => array_element_tag(valueLst),
-        Some(other) => bail!("DynLoad.executeFunction: array argument of {other:?} not supported"),
+        Some(other) => return Err("DynLoad.executeFunction: array argument of {other:?} not supported"),
     }
 }
 
@@ -320,7 +320,7 @@ fn flatten_array(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, depth: usize,
         match (&**v, depth) {
             (Values::Value::ARRAY { valueLst, .. }, 2..) => flatten_array(rt, valueLst, depth - 1, out)?,
             (scalar, 1) => out(scalar)?,
-            (other, _) => bail!("DynLoad.executeFunction: ragged or mixed array argument at {other:?}"),
+            (other, _) => return Err("DynLoad.executeFunction: ragged or mixed array argument at {other:?}"),
         }
     }
     Ok(())
@@ -333,7 +333,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
     let dims: Box<[i64]> = dim_lst.into_iter().map(|d| *d as i64).collect();
     let ndims = dims.len();
     if ndims == 0 {
-        bail!("DynLoad.executeFunction: array argument without dimensions");
+        return Err("DynLoad.executeFunction: array argument without dimensions");
     }
     let expected: i64 = dims.iter().product();
 
@@ -350,7 +350,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
                     buf.push(*index as i64);
                     Ok(())
                 },
-                other => bail!("DynLoad.executeFunction: expected Integer array element, got {other:?}"),
+                other => return Err("DynLoad.executeFunction: expected Integer array element, got {other:?}"),
             })?;
             let buf = buf.into_boxed_slice();
             let r = (buf.len(), buf.as_ptr() as u64);
@@ -364,7 +364,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
                     buf.push(real.into_inner());
                     Ok(())
                 },
-                other => bail!("DynLoad.executeFunction: expected Real array element, got {other:?}"),
+                other => return Err("DynLoad.executeFunction: expected Real array element, got {other:?}"),
             })?;
             let buf = buf.into_boxed_slice();
             let r = (buf.len(), buf.as_ptr() as u64);
@@ -378,7 +378,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
                     buf.push(*boolean as i32);
                     Ok(())
                 },
-                other => bail!("DynLoad.executeFunction: expected Boolean array element, got {other:?}"),
+                other => return Err("DynLoad.executeFunction: expected Boolean array element, got {other:?}"),
             })?;
             let buf = buf.into_boxed_slice();
             let r = (buf.len(), buf.as_ptr() as u64);
@@ -392,7 +392,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
                     buf.push(make_c_string(string)?);
                     Ok(())
                 },
-                other => bail!("DynLoad.executeFunction: expected String array element, got {other:?}"),
+                other => return Err("DynLoad.executeFunction: expected String array element, got {other:?}"),
             })?;
             let buf = buf.into_boxed_slice();
             let r = (buf.len(), buf.as_ptr() as u64);
@@ -402,7 +402,7 @@ fn array_to_desc(rt: &MmcAlloc, values: &List<Arc<Values::Value>>, dim_lst: &Lis
         _ => unreachable!("array_element_tag returns array tags only"),
     };
     if count as i64 != expected {
-        bail!("DynLoad.executeFunction: array argument has {count} elements but dimensions {dims:?}");
+        return Err("DynLoad.executeFunction: array argument has {count} elements but dimensions {dims:?}");
     }
     let d1 = dims.as_ptr() as u64;
     store.dims.push(dims);
@@ -450,12 +450,12 @@ fn underscore_name_to_path(name: &str) -> Arc<Absyn::Path> {
 /// region; the object header is 8 bytes before it and the tagged pointer adds 3.
 fn make_c_string(s: &str) -> Result<usize> {
     let mk = dynload::runtime_symbol("mmc_mk_scon_len_ret_ptr")
-        .ok_or_else(|| anyhow::anyhow!("runtime symbol `mmc_mk_scon_len_ret_ptr` not found"))?;
+        .ok_or_else(|| "runtime symbol `mmc_mk_scon_len_ret_ptr` not found")?;
     let mk: extern "C" fn(usize) -> *mut u8 = unsafe { std::mem::transmute(mk) };
     let bytes = s.as_bytes();
     let data = mk(bytes.len());
     if data.is_null() {
-        bail!("DynLoad.executeFunction: string allocation failed");
+        return Err("DynLoad.executeFunction: string allocation failed");
     }
     unsafe {
         std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
@@ -467,7 +467,7 @@ fn make_c_string(s: &str) -> Result<usize> {
 /// Read a NUL-terminated C string the generated code handed us.
 fn read_c_str(p: *const c_char) -> Result<String> {
     if p.is_null() {
-        bail!("DynLoad.executeFunction: NULL string in result description");
+        return Err("DynLoad.executeFunction: NULL string in result description");
     }
     Ok(unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned())
 }
@@ -485,7 +485,7 @@ fn desc_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
             let n = d.d0 as usize;
             let elems = d.d1 as *const TypeDesc;
             if n != 0 && elems.is_null() {
-                bail!("DynLoad.executeFunction: malformed result tuple");
+                return Err("DynLoad.executeFunction: malformed result tuple");
             }
             let mut vals: Vec<Arc<Values::Value>> = Vec::with_capacity(n);
             for i in 0..n {
@@ -502,7 +502,7 @@ fn desc_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
             let names = d.d2 as *const *const c_char;
             let elems = d.d3 as *const TypeDesc;
             if n != 0 && (names.is_null() || elems.is_null()) {
-                bail!("DynLoad.executeFunction: malformed result record");
+                return Err("DynLoad.executeFunction: malformed result record");
             }
             let mut vals: Vec<Arc<Values::Value>> = Vec::with_capacity(n);
             let mut comps: Vec<ArcStr> = Vec::with_capacity(n);
@@ -521,7 +521,7 @@ fn desc_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
         // `modelica_string` is itself a boxed MMC string metatype.
         TD_STRING => decode_metatype(d.d0 as usize),
         TD_MMC => decode_metatype(d.d0 as usize),
-        other => bail!("DynLoad.executeFunction: unsupported result type_description tag {other}"),
+        other => return Err("DynLoad.executeFunction: unsupported result type_description tag {other}"),
     }
 }
 
@@ -533,11 +533,11 @@ fn desc_array_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
     let dim_size = d.d1 as *const i64;
     let data = d.d2 as *const u8;
     if ndims < 1 || dim_size.is_null() {
-        bail!("DynLoad.executeFunction: malformed result array");
+        return Err("DynLoad.executeFunction: malformed result array");
     }
     let dims: Vec<i64> = (0..ndims as usize).map(|i| unsafe { *dim_size.add(i) }).collect();
     if data.is_null() && dims.iter().product::<i64>() != 0 {
-        bail!("DynLoad.executeFunction: result array without data");
+        return Err("DynLoad.executeFunction: result array without data");
     }
     let mut cursor = data;
     decode_array_level(d.tag, &dims, &mut cursor)
@@ -618,7 +618,7 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
                     break;
                 }
                 if h != MMC_CONSHDR {
-                    bail!("DynLoad.executeFunction: malformed list");
+                    return Err("DynLoad.executeFunction: malformed list");
                 }
                 items.push(decode_metatype(unsafe { slot(b, 1) })?);
                 cur = unsafe { slot(b, 2) };
@@ -665,7 +665,7 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
                 index: c as i32 - 3,
             }))
         }
-        _ => bail!("DynLoad.executeFunction: unsupported MMC header {hdr:#x}"),
+        _ => return Err("DynLoad.executeFunction: unsupported MMC header {hdr:#x}"),
     }
 }
 
@@ -766,7 +766,7 @@ fn sync_flags_global_root(rt: &MmcAlloc, thread_data: *mut c_void) -> Result<()>
         rt.mk_box(MMC_ARRAY_CTOR, &config),
     ]);
     let set_root = dynload::runtime_symbol("boxptr_setGlobalRoot")
-        .ok_or_else(|| anyhow::anyhow!("runtime symbol `boxptr_setGlobalRoot` not found"))?;
+        .ok_or_else(|| "runtime symbol `boxptr_setGlobalRoot` not found")?;
     let set_root: extern "C" fn(*mut c_void, usize, usize) = unsafe { std::mem::transmute(set_root) };
     set_root(thread_data, mmc_immediate(openmodelica_util::Global::flagsIndex as i64), flags_box);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
@@ -40,7 +40,7 @@
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::SystemTime;
 
-use anyhow::{bail, Result};
+use metamodelica::Result;
 use arcstr::{literal, ArcStr};
 
 use metamodelica::{List, OrderedFloat};
@@ -448,7 +448,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
     // `readDataset` wrapper performed.
     let mut guard = match lock_reader(&filename)? {
         Some(g) => g,
-        None => bail!("readDataset: could not open {filename}"),
+        None => return Err("readDataset: could not open {filename}"),
     };
     match &mut guard.as_mut().unwrap().reader {
         ResultReader::Mat(reader) => {
@@ -458,7 +458,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
             } else if reader.nrows as i32 != dim {
                 drop(guard);
                 err(&ERROR_DIMSIZE_MISMATCH, [])?;
-                bail!("readDataset: dimension size mismatch for {filename}");
+                return Err("readDataset: dimension size mismatch for {filename}");
             }
             let dim = dim as usize;
             let mut rows: Vec<Arc<Values::Value>> = Vec::new();
@@ -468,7 +468,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
                     None => {
                         drop(guard);
                         err(&ERROR_COULD_NOT_READ_VAR, [var.clone(), filename.clone()])?;
-                        bail!("readDataset: variable {var} not found in {filename}");
+                        return Err("readDataset: variable {var} not found in {filename}");
                     }
                 };
                 let info = &reader.allInfo[idx];
@@ -484,7 +484,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
                         None => {
                             drop(guard);
                             err(&ERROR_COULD_NOT_READ_VAR, [var.clone(), filename.clone()])?;
-                            bail!("readDataset: could not read variable {var} in {filename}");
+                            return Err("readDataset: could not read variable {var} in {filename}");
                         }
                     };
                     (0..dim).map(|i| mk_real(vals[i])).collect()
@@ -503,12 +503,12 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
                 let Some(interval) = interval else {
                     drop(guard);
                     err(&ERROR_PLT_INTERVAL_READ, [])?;
-                    bail!("readDataset: could not read interval size of {filename}");
+                    return Err("readDataset: could not read interval size of {filename}");
                 };
                 if interval as i32 != dimsize {
                     drop(guard);
                     err(&ERROR_PLT_INTERVAL_MISMATCH, [])?;
-                    bail!("readDataset: interval size not matching data size for {filename}");
+                    return Err("readDataset: interval size not matching data size for {filename}");
                 }
                 interval
             };
@@ -517,7 +517,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
                 let Some(vals) = reader.dataset(var.as_str(), dim) else {
                     drop(guard);
                     err(&ERROR_PLT_VAR_NOT_FOUND, [var.clone()])?;
-                    bail!("readDataset: variable {var} not found in {filename}");
+                    return Err("readDataset: variable {var} not found in {filename}");
                 };
                 rows.push(make_array(vals.into_iter().map(mk_real).collect()));
             }
@@ -536,7 +536,7 @@ pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr
                     _ => {
                         drop(guard);
                         err(&ERROR_COULD_NOT_READ_VAR, [var.clone(), filename.clone()])?;
-                        bail!("readDataset: could not read variable {var} in {filename}");
+                        return Err("readDataset: could not read variable {var} in {filename}");
                     }
                 };
                 rows.push(make_array(col.iter().copied().map(mk_real).collect()));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/UnitParserExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/UnitParserExt.rs
@@ -29,7 +29,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::{ArcStr, literal};
 use metamodelica::{List, OrderedFloat, Real, cons, nil};
 use openmodelica_util::Error;
@@ -1088,7 +1088,7 @@ pub fn str2unit(
             ERROR_PARSING_UNIT.clone(),
             Arc::new(List::from_iter([ArcStr::from(input), ArcStr::from(e.message())])),
         )?;
-        bail!("Error parsing unit {}: {}", input, e.message());
+        return Err("Error parsing unit {}: {}");
     }
 
     let scale_factor = unit.scale_factor.to_real() * 10f64.powf(unit.prefix_expo.to_real());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simcode_types/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simcode_types/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_ast.workspace=true
 openmodelica_backend_types.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simcode_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simcode_util/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_ast.workspace=true
 openmodelica_ast_collections.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_susan/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_susan/Cargo.toml
@@ -21,6 +21,5 @@ openmodelica_util_datatypes_basic.workspace=true
 openmodelica_tpl.workspace = true
 const-str.workspace=true
 arcstr.workspace=true
-anyhow.workspace=true
 loop_unwrap.workspace=true
 match_deref.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_tpl/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_tpl/Cargo.toml
@@ -9,6 +9,5 @@ openmodelica_util.workspace = true
 openmodelica_util_datatypes_basic.workspace = true
 const-str.workspace = true
 arcstr.workspace = true
-anyhow.workspace = true
 loop_unwrap.workspace = true
 match_deref.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 openmodelica_wasi.workspace = true
-anyhow.workspace=true
 metamodelica.workspace=true
 openmodelica_error.workspace=true
 const-str.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Corba.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Corba.rs
@@ -50,7 +50,7 @@
  *
  */
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 /// `Corba_haveCorba` — the stub build reports CORBA unavailable.
@@ -59,25 +59,25 @@ pub fn haveCorba() -> bool {
 }
 
 pub(crate) fn setObjectReferenceFilePath(_inObjectReferenceFilePath: ArcStr) -> Result<()> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }
 
 pub(crate) fn setSessionName(_inSessionName: ArcStr) -> Result<()> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }
 
 pub fn initialize() -> Result<()> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }
 
 pub fn waitForCommand() -> Result<ArcStr> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }
 
 pub fn sendreply(_inString: ArcStr) -> Result<()> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }
 
 pub fn close() -> Result<()> {
-    bail!("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
+    return Err("CORBA disabled. Configure with --with-omniORB (or --with-MICO) and recompile to enable.");
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
@@ -42,7 +42,7 @@
 use std::io::Read;
 use std::sync::Arc;
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
@@ -46,7 +46,7 @@ use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
 
-use anyhow::{bail, Result};
+use metamodelica::Result;
 use arcstr::{literal, ArcStr};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -96,14 +96,14 @@ impl FileInner {
             match self.file.as_mut() {
                 Some(f) => f
                     .write_all(bytes)
-                    .map_err(|e| anyhow::anyhow!("File.{what}: write to {}: {}", self.name, e)),
-                None => bail!("File.{what}: Failed to write to file: {} (not open)", self.name),
+                    .map_err(|e| "File.{what}: write to {}: {}"),
+                None => return Err("File.{what}: Failed to write to file: {} (not open)"),
             }
         }
         #[cfg(target_arch = "wasm32")]
         {
             if self.mode != Some(Mode::Write) {
-                bail!("File.{what}: Failed to write to file: {} (not open)", self.name);
+                return Err("File.{what}: Failed to write to file: {} (not open)");
             }
             let end = self.pos + bytes.len();
             if self.buf.len() < end {
@@ -191,10 +191,7 @@ impl File {
             }),
             Some(id) => FILE_REGISTRY.with(|r| {
                 r.borrow().get(&id).cloned().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "File.constructor: opaque file reference {id} is not registered \
-                         (already released, or created on another thread)"
-                    )
+                    "error"
                 })
             }),
         }
@@ -229,7 +226,7 @@ pub fn open(file: File, filename: ArcStr, mode: Mode) -> Result<()> {
                 .truncate(true)
                 .open(filename.as_str()),
         }
-        .map_err(|e| anyhow::anyhow!("File.open: Failed to open file {filename} with mode {mode:?}: {e}"))?;
+        .map_err(|e| "File.open: Failed to open file {filename} with mode {mode:?}: {e}")?;
         guard.file = Some(handle);
         guard.name = filename;
         Ok(())
@@ -241,7 +238,7 @@ pub fn open(file: File, filename: ArcStr, mode: Mode) -> Result<()> {
         match mode {
             Mode::Read => {
                 let bytes = openmodelica_wasi::read(filename.as_str()).ok_or_else(|| {
-                    anyhow::anyhow!("File.open: Failed to open file {filename} with mode {mode:?}: no such file")
+                    "File.open: Failed to open file {filename} with mode {mode:?}: no such file"
                 })?;
                 guard.buf = bytes;
             }
@@ -431,7 +428,7 @@ pub fn releaseReference(file: File) -> Result<()> {
         }
     });
     if !released {
-        bail!("File.releaseReference: file is not registered (double release?)");
+        return Err("File.releaseReference: file is not registered (double release?)");
     }
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
@@ -43,7 +43,7 @@
 
 use std::cell::RefCell;
 use std::sync::Arc;
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::SourceInfo;
 use openmodelica_util_datatypes_basic::DoubleEnded;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/IOStreamExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/IOStreamExt.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::List;
 
@@ -24,7 +24,7 @@ use metamodelica::List;
 macro_rules! nyi {
     ($name:literal) => {{
         eprintln!(concat!("NYI: IOStreamExt.", $name));
-        bail!(concat!("NYI: IOStreamExt.", $name));
+        return Err("NYI: IOStreamExt.");
     }};
 }
 
@@ -103,19 +103,19 @@ pub fn printReversedList(inStringLst: Arc<List<ArcStr>>, whereToPrint: i32) -> R
             let stdout = std::io::stdout();
             let mut f = stdout.lock();
             for s in chunks.into_iter().rev() {
-                f.write_all(s.as_bytes())?;
+                f.write_all(s.as_bytes()).map_err(|_| "IOStreamExt: write failed")?;
             }
-            f.flush()?;
+            f.flush().map_err(|_| "IOStreamExt: flush failed")?;
         }
         2 => {
             let stderr = std::io::stderr();
             let mut f = stderr.lock();
             for s in chunks.into_iter().rev() {
-                f.write_all(s.as_bytes())?;
+                f.write_all(s.as_bytes()).map_err(|_| "IOStreamExt: write failed")?;
             }
-            f.flush()?;
+            f.flush().map_err(|_| "IOStreamExt: flush failed")?;
         }
-        _ => bail!("IOStreamExt.printReversedList: invalid whereToPrint {whereToPrint}"),
+        _ => return Err("IOStreamExt.printReversedList: invalid whereToPrint {whereToPrint}"),
     }
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Print.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Print.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write as _;
 
-use anyhow::{Context, Result};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 #[derive(Default)]
@@ -120,7 +120,7 @@ pub fn saveAndClearBuf() -> Result<i32> {
 pub fn writeBuf(filename: ArcStr) -> Result<()> {
     let contents = with(|s| s.buf.clone());
     openmodelica_wasi::fs::write(filename.as_str(), contents.as_bytes())
-        .with_context(|| format!("Print.writeBuf: write failed for {filename}"))?;
+        .map_err(|_| "Print.writeBuf: write failed for {filename}")?;
     Ok(())
 }
 
@@ -207,7 +207,7 @@ pub fn writeBufConvertLines(filename: ArcStr) -> Result<()> {
         .create(true)
         .truncate(true)
         .open(filename.as_str())
-        .with_context(|| format!("Print.writeBufConvertLines: cannot open {filename}"))?;
+        .map_err(|_| "Print.writeBufConvertLines: cannot open {filename}")?;
     // The C version destructively clears the print buffer on the paths that
     // reach the line-by-line loop (and on the empty-buffer early exit the
     // buffer is empty anyway); it only stays intact when the file cannot be
@@ -215,7 +215,7 @@ pub fn writeBufConvertLines(filename: ArcStr) -> Result<()> {
     let contents = with(|s| std::mem::take(&mut s.buf));
     if contents.is_empty() {
         // C: "nothing to write to file, just close it and return 1"
-        anyhow::bail!("Print.writeBufConvertLines: nothing to write to {filename}");
+        return Err("Print.writeBufConvertLines: nothing to write to {filename}");
     }
 
     let mut out = String::with_capacity(contents.len() + contents.len() / 8);
@@ -270,6 +270,6 @@ pub fn writeBufConvertLines(filename: ArcStr) -> Result<()> {
     }
 
     f.write_all(out.as_bytes())
-        .with_context(|| format!("Print.writeBufConvertLines: write failed for {filename}"))?;
+        .map_err(|_| "Print.writeBufConvertLines: write failed for {filename}")?;
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Settings.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Settings.rs
@@ -24,7 +24,7 @@
 
 use std::sync::Mutex;
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use crate::Autoconf;
@@ -135,13 +135,13 @@ pub fn setInstallationDirectoryPath(inString: ArcStr) {
 /// and replaces it with a generic message that never mentions
 /// `OPENMODELICAHOME` — without the stderr line the actual cause is invisible.
 fn strip_bin_path(path: &str) -> Result<ArcStr> {
-    fn cannot_deduce(path: &str) -> anyhow::Error {
+    fn cannot_deduce(path: &str) -> &'static str {
         let msg = format!(
             "could not deduce the OpenModelica installation directory from \
              executable path: [{path}], please set OPENMODELICAHOME"
         );
         eprintln!("{msg}");
-        anyhow::anyhow!(msg)
+        "error"
     }
 
     if !path.contains("bin") && !path.contains("lib") {
@@ -197,7 +197,7 @@ pub fn getInstallationDirectoryPath() -> Result<ArcStr> {
     }
 
     let exe = std::env::current_exe()
-        .map_err(|e| anyhow::anyhow!("failed to determine executable path: {e}"))
+        .map_err(|e| "failed to determine executable path: {e}")
         .map(|p| convert_to_forward_slashes(&p.to_string_lossy()));
 
     if let Ok(exe) = &exe
@@ -262,7 +262,7 @@ pub fn getModelicaPath(runningTestsuite: bool) -> Result<ArcStr> {
         Ok(env) if !env.is_empty() => ArcStr::from(env),
         _ => {
             if runningTestsuite {
-                bail!("When using --running-testsuite, OPENMODELICALIBRARY must be set");
+                return Err("When using --running-testsuite, OPENMODELICALIBRARY must be set");
             }
             // `getHomeDir` locks `STATE` itself, so resolve it before re-locking.
             let home = getHomeDir(false);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/StackOverflow.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/StackOverflow.rs
@@ -37,7 +37,7 @@
 #![allow(unreachable_patterns, unreachable_code, non_camel_case_types, non_snake_case, dead_code, unused_imports, unused_variables, non_upper_case_globals, unused_mut)]
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;
@@ -69,7 +69,7 @@ fn stripAddresses(mut inSymbol: ArcStr) -> Result<ArcStr> {
     if n.clone() == 3 {
         let (__pa0, __pa1) = ::match_deref::match_deref! { match &(strs.clone()) {
             Deref @ metamodelica::List::Cons { head: _, tail: Deref @ metamodelica::List::Cons { head: __pa0, tail: Deref @ metamodelica::List::Cons { head: __pa1, tail: Deref @ metamodelica::List::Nil } } } => (__pa0.clone(), __pa1.clone()),
-            _ => bail!("pattern mismatch"),
+            _ => return Err("pattern mismatch"),
         } };
         so = __pa0.clone();
         fun = __pa1.clone();
@@ -79,7 +79,7 @@ fn stripAddresses(mut inSymbol: ArcStr) -> Result<ArcStr> {
         if n.clone() == 3 {
             let (__pa3, __pa4) = ::match_deref::match_deref! { match &(strs.clone()) {
                 Deref @ metamodelica::List::Cons { head: _, tail: Deref @ metamodelica::List::Cons { head: __pa3, tail: Deref @ metamodelica::List::Cons { head: __pa4, tail: Deref @ metamodelica::List::Nil } } } => (__pa3.clone(), __pa4.clone()),
-                _ => bail!("pattern mismatch"),
+                _ => return Err("pattern mismatch"),
             } };
             so = __pa3.clone();
             fun = __pa4.clone();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -25,7 +25,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result, bail};
+use metamodelica::Result;
 use arcstr::{ArcStr, literal};
 
 use metamodelica::List;
@@ -129,7 +129,7 @@ pub fn trimWhitespace(inString: ArcStr) -> ArcStr {
 
 pub fn trimChar(inString1: ArcStr, inString2: ArcStr) -> Result<ArcStr> {
     if inString2.chars().count() != 1 {
-        bail!("System.trimChar: second argument must be exactly one character");
+        return Err("System.trimChar: second argument must be exactly one character");
     }
     let c = inString2.chars().next().unwrap();
     Ok(ArcStr::from(inString1.trim_matches(c)))
@@ -442,7 +442,7 @@ pub fn strncmp(inString1: ArcStr, inString2: ArcStr, len: i32) -> i32 {
 
 pub fn stringReplace(r#str: ArcStr, source: ArcStr, target: ArcStr) -> Result<ArcStr> {
     if source.is_empty() {
-        bail!("System.stringReplace: source pattern must be non-empty");
+        return Err("System.stringReplace: source pattern must be non-empty");
     }
     Ok(ArcStr::from(r#str.replace(source.as_str(), target.as_str())))
 }
@@ -642,21 +642,21 @@ pub fn freeLibrary(inLibHandle: i32, inPrintDebug: bool) -> Result<()> {
 
 pub fn writeFile(fileNameToWrite: ArcStr, stringToBeWritten: ArcStr) -> Result<()> {
     openmodelica_wasi::fs::write(fileNameToWrite.as_str(), stringToBeWritten.as_bytes())
-        .with_context(|| format!("System.writeFile: cannot write {}", fileNameToWrite))?;
+        .map_err(|_| "System.writeFile: cannot write {}")?;
     Ok(())
 }
 
 pub fn appendFile(file: ArcStr, data: ArcStr) -> Result<()> {
     openmodelica_wasi::fs::append(file.as_str(), data.as_bytes())
-        .with_context(|| format!("System.appendFile: cannot append to {file}"))?;
+        .map_err(|_| "System.appendFile: cannot append to {file}")?;
     Ok(())
 }
 
 pub fn readFile(inString: ArcStr) -> Result<ArcStr> {
     let bytes = openmodelica_wasi::fs::read(inString.as_str())
-        .with_context(|| format!("System.readFile: cannot read {inString}"))?;
+        .map_err(|_| "System.readFile: cannot read {inString}")?;
     let s = String::from_utf8(bytes)
-        .with_context(|| format!("System.readFile: {inString} is not valid UTF-8"))?;
+        .map_err(|_| "System.readFile: {inString} is not valid UTF-8")?;
     Ok(ArcStr::from(s))
 }
 
@@ -883,7 +883,7 @@ pub fn createTemporaryDirectory(inPrefix: ArcStr) -> Result<ArcStr> {
             return Ok(ArcStr::from(candidate));
         }
     }
-    bail!("System.createTemporaryDirectory: failed to create unique directory under {inPrefix}")
+    return Err("System.createTemporaryDirectory: failed to create unique directory under {inPrefix}")
 }
 
 pub fn pwd() -> ArcStr {
@@ -916,7 +916,7 @@ pub fn readEnv(inString: ArcStr) -> Result<ArcStr> {
     }
     match std::env::var(inString.as_str()) {
         Ok(v) => Ok(ArcStr::from(v)),
-        Err(_) => bail!("System.readEnv: variable {inString} not set"),
+        Err(_) => return Err("System.readEnv: variable {inString} not set"),
     }
 }
 
@@ -1208,7 +1208,7 @@ pub fn getLoadModelPath(
             return Ok((e.dir.clone(), ArcStr::from(e.file.clone()), e.file_is_dir));
         }
     }
-    bail!("System.getLoadModelPath: no match for {className} on the MODELICAPATH")
+    return Err("System.getLoadModelPath: no match for {className} on the MODELICAPATH")
 }
 
 pub fn time() -> metamodelica::Real {
@@ -1836,7 +1836,7 @@ pub fn uriToClassAndPath(uri: ArcStr) -> Result<(ArcStr, ArcStr, ArcStr)> {
         let (name, path) = split_name_path(rest);
         if name.is_empty() {
             add_scripting_error("Modelica URI lacks classname: %s", &uri);
-            bail!("Modelica URI lacks classname: {uri}");
+            return Err("Modelica URI lacks classname: {uri}");
         }
         return Ok((literal!("modelica://"), ArcStr::from(name), ArcStr::from(path)));
     }
@@ -1844,16 +1844,16 @@ pub fn uriToClassAndPath(uri: ArcStr) -> Result<(ArcStr, ArcStr, ArcStr)> {
         let (name, path) = split_name_path(rest);
         if path.is_empty() {
             add_scripting_error("File URI has no path: %s", &uri);
-            bail!("File URI has no path: {uri}");
+            return Err("File URI has no path: {uri}");
         }
         if !name.is_empty() {
             add_scripting_error("File URI using hostnames is not supported: %s", &uri);
-            bail!("File URI using hostnames is not supported: {uri}");
+            return Err("File URI using hostnames is not supported: {uri}");
         }
         return Ok((literal!("file://"), literal!(""), ArcStr::from(path)));
     }
     add_scripting_error("Unknown uri: %s", &uri);
-    bail!("Unknown uri: {uri}")
+    return Err("Unknown uri: {uri}")
 }
 
 pub fn modelicaPlatform() -> ArcStr {
@@ -2091,7 +2091,7 @@ pub fn snprintff(format: ArcStr, maxlen: i32, val: metamodelica::Real) -> Result
     // and fall back to `{:?}` for anything else. The C runtime truncates
     // to maxlen-1 bytes; we mirror that.
     let formatted = c_format_double(format.as_str(), val.into_inner())
-        .with_context(|| format!("System.snprintff: unsupported format {format}"))?;
+        .ok_or("System.snprintff: unsupported format")?;
     let cap = (maxlen.max(0) as usize).saturating_sub(1);
     let truncated: String = formatted.chars().take(cap).collect();
     Ok(ArcStr::from(truncated))
@@ -2099,7 +2099,7 @@ pub fn snprintff(format: ArcStr, maxlen: i32, val: metamodelica::Real) -> Result
 
 pub fn sprintff(format: ArcStr, val: metamodelica::Real) -> Result<ArcStr> {
     let s = c_format_double(format.as_str(), val.into_inner())
-        .with_context(|| format!("System.sprintff: unsupported format {format}"))?;
+        .ok_or("System.sprintff: unsupported format")?;
     Ok(ArcStr::from(s))
 }
 
@@ -2265,7 +2265,7 @@ pub fn realpath(path: ArcStr) -> Result<ArcStr> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let canon = fs::canonicalize(path.as_str())
-            .with_context(|| format!("System.realpath: cannot resolve {path}"))?;
+            .map_err(|_| "System.realpath: cannot resolve {path}")?;
         Ok(ArcStr::from(canon.to_string_lossy().as_ref()))
     }
 }
@@ -2313,8 +2313,8 @@ pub fn fileIsNewerThan(file1: ArcStr, file2: ArcStr) -> Result<bool> {
         let _ = &file2;
         Ok(openmodelica_wasi::fs::is_file(file1.as_str()))
     } else {
-        let t1 = openmodelica_wasi::fs::modified(file1.as_str()).with_context(|| format!("stat {file1}"))?;
-        let t2 = openmodelica_wasi::fs::modified(file2.as_str()).with_context(|| format!("stat {file2}"))?;
+        let t1 = openmodelica_wasi::fs::modified(file1.as_str()).map_err(|_| "stat {file1}")?;
+        let t2 = openmodelica_wasi::fs::modified(file2.as_str()).map_err(|_| "stat {file2}")?;
         Ok(t1 > t2)
     }
 }
@@ -2614,7 +2614,7 @@ impl StringAllocator {
     pub fn new(sz: i32) -> Result<StringAllocator> {
         // `StringAllocator_constructor` throws (MMC_THROW) on a negative size.
         if sz < 0 {
-            bail!("StringAllocator: negative size {sz}");
+            return Err("StringAllocator: negative size {sz}");
         }
         Ok(StringAllocator {
             buf: Arc::new(std::sync::Mutex::new(vec![0u8; sz as usize])),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/TaskGraphResults.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/TaskGraphResults.rs
@@ -39,7 +39,7 @@
 use std::fmt::Write as _;
 use std::sync::Arc;
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::ArcStr;
 
 use metamodelica::ext::{c_atof, c_atol};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Vector.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Vector.rs
@@ -22,7 +22,7 @@
 #![allow(dead_code)]
 
 use std::sync::Arc;
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use arcstr::ArcStr;
 use metamodelica::{Array, List, stringDelimitList, cons, nil, listHead, listRest};
 
@@ -83,7 +83,7 @@ pub fn insert<T: Clone + 'static>(v: Arc<Vector<T>>, value: T, index: i32) -> Re
         return Ok(());
     }
     if index < 1 || index > sz {
-        bail!("Vector.insert: index {} out of bounds (size {})", index, sz);
+        return Err("Vector.insert: index {} out of bounds (size {})");
     }
     v.borrow_mut().insert(idx(index), value);
     Ok(())
@@ -153,7 +153,7 @@ pub fn remove<T: Clone + 'static>(v: Arc<Vector<T>>, index: i32) -> Result<()> {
     }
     // Match the MetaModelica check exactly (note: index < 0, not <= 0).
     if index < 0 || index > sz {
-        bail!("Vector.remove: index {} out of bounds (size {})", index, sz);
+        return Err("Vector.remove: index {} out of bounds (size {})");
     }
     data.remove(idx(index));
     Ok(())
@@ -163,7 +163,7 @@ pub fn update<T: Clone + 'static>(v: Arc<Vector<T>>, index: i32, value: T) -> Re
     let mut data = v.borrow_mut();
     let sz = data.len() as i32;
     if index <= 0 || index > sz {
-        bail!("Vector.update: index {} out of bounds (size {})", index, sz);
+        return Err("Vector.update: index {} out of bounds (size {})");
     }
     data[idx(index)] = value;
     Ok(())
@@ -177,7 +177,7 @@ pub fn get<T: Clone + 'static>(v: Arc<Vector<T>>, index: i32) -> Result<T> {
     let data = v.borrow();
     let sz = data.len() as i32;
     if index <= 0 || index > sz {
-        bail!("Vector.get: index {} out of bounds (size {})", index, sz);
+        return Err("Vector.get: index {} out of bounds (size {})");
     }
     Ok(data[idx(index)].clone())
 }
@@ -190,7 +190,7 @@ pub fn last<T: Clone + 'static>(v: Arc<Vector<T>>) -> Result<T> {
     let data = v.borrow();
     match data.last() {
         Some(e) => Ok(e.clone()),
-        None => bail!("Vector.last: empty vector"),
+        None => return Err("Vector.last: empty vector"),
     }
 }
 
@@ -224,7 +224,7 @@ pub fn fill<T: Clone + 'static>(v: Arc<Vector<T>>, value: T, from: i32, to: i32)
     let mut data = v.borrow_mut();
     let sz = data.len() as i32;
     if from < 1 || to < 1 || from > sz || to > sz {
-        bail!("Vector.fill: range [{}, {}] out of bounds (size {})", from, to, sz);
+        return Err("Vector.fill: range [{}, {}] out of bounds (size {})");
     }
     for i in from..=to {
         data[idx(i)] = value.clone();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use core::ffi::c_void;
 
 // `threadData_t` is 304 bytes in the current runtime; over-allocate generously
@@ -44,7 +44,7 @@ const THREADDATA_SIZE: usize = 4096;
 // ---------------------------------------------------------------------------
 #[cfg(unix)]
 pub(crate) mod dl {
-    use anyhow::{Result, bail};
+    use metamodelica::Result;
     use core::ffi::c_void;
     use libc::c_int;
     use std::ffi::{CStr, CString};
@@ -70,11 +70,11 @@ pub(crate) mod dl {
     }
 
     pub fn open(path: &str) -> Result<usize> {
-        let c = CString::new(path)?;
+        let c = CString::new(path).map_err(|_| "dynload: NUL byte in path")?;
         unsafe { libc::dlerror() }; // clear any stale error
         let h = unsafe { libc::dlopen(c.as_ptr(), FLAGS) };
         if h.is_null() {
-            bail!("dlopen `{path}`: {}", last_error());
+            return Err("dlopen `{path}`: {}");
         }
         Ok(h as usize)
     }
@@ -84,7 +84,7 @@ pub(crate) mod dl {
         unsafe { libc::dlerror() };
         let h = unsafe { libc::dlopen(std::ptr::null(), FLAGS) };
         if h.is_null() {
-            bail!("dlopen process: {}", last_error());
+            return Err("dlopen process: {}");
         }
         Ok(h as usize)
     }
@@ -121,7 +121,7 @@ pub(crate) mod dl {
 
 #[cfg(windows)]
 pub(crate) mod dl {
-    use anyhow::{Result, bail};
+    use metamodelica::Result;
     use core::ffi::{c_char, c_void};
     use std::ffi::CString;
 
@@ -149,10 +149,10 @@ pub(crate) mod dl {
     }
 
     pub fn open(path: &str) -> Result<usize> {
-        let c = CString::new(path)?;
+        let c = CString::new(path).map_err(|_| "dynload: NUL byte in path")?;
         let h = unsafe { LoadLibraryA(c.as_ptr()) };
         if h.is_null() {
-            bail!("LoadLibrary `{path}`: {}", last_error());
+            return Err("LoadLibrary `{path}`: {}");
         }
         Ok(h as usize)
     }
@@ -160,7 +160,7 @@ pub(crate) mod dl {
     pub fn open_self() -> Result<usize> {
         let h = unsafe { GetModuleHandleA(std::ptr::null()) };
         if h.is_null() {
-            bail!("GetModuleHandle(process): {}", last_error());
+            return Err("GetModuleHandle(process): {}");
         }
         Ok(h as usize)
     }
@@ -369,8 +369,8 @@ pub fn load_library(path: &str, relative: bool, debug: bool) -> Result<i32> {
 /// point) inside a loaded library and return a handle to it.
 pub fn lookup_function(lib: i32, name: &str) -> Result<i32> {
     let mut reg = REGISTRY.lock().unwrap();
-    let handle = *reg.libs.get(&lib).ok_or_else(|| anyhow::anyhow!("lookupFunction: invalid library handle {lib}"))?;
-    let addr = dlsym_addr(handle, name).ok_or_else(|| anyhow::anyhow!("lookupFunction: `{name}` not found: {}", dl::last_error()))?;
+    let handle = *reg.libs.get(&lib).ok_or_else(|| "lookupFunction: invalid library handle {lib}")?;
+    let addr = dlsym_addr(handle, name).ok_or_else(|| "lookupFunction: `{name}` not found: {}")?;
     let idx = reg.next_func;
     reg.next_func += 1;
     reg.funcs.insert(idx, addr);
@@ -397,7 +397,7 @@ pub fn free_library(lib: i32, _debug: bool) -> Result<()> {
 
 /// Address of the `in_*` entry point behind a function handle.
 pub fn function_addr(func: i32) -> Result<usize> {
-    REGISTRY.lock().unwrap().funcs.get(&func).copied().ok_or_else(|| anyhow::anyhow!("executeFunction: invalid function handle {func}"))
+    REGISTRY.lock().unwrap().funcs.get(&func).copied().ok_or_else(|| "executeFunction: invalid function handle {func}")
 }
 
 /// Resolve a symbol from the loaded C runtime (e.g. `mmc_mk_*`,
@@ -472,9 +472,9 @@ fn ensure_runtime(reg: &mut Registry) -> Result<()> {
     if reg.inited {
         return Ok(());
     }
-    let &lib = reg.libs.values().next().ok_or_else(|| anyhow::anyhow!("executeFunction: no library loaded"))?;
-    let mmc_init = dlsym_addr(lib, "mmc_init").ok_or_else(|| anyhow::anyhow!("runtime symbol `mmc_init` not found"))?;
-    let gc_alloc = dlsym_addr(lib, "GC_malloc_uncollectable").ok_or_else(|| anyhow::anyhow!("runtime symbol `GC_malloc_uncollectable` not found"))?;
+    let &lib = reg.libs.values().next().ok_or_else(|| "executeFunction: no library loaded")?;
+    let mmc_init = dlsym_addr(lib, "mmc_init").ok_or_else(|| "runtime symbol `mmc_init` not found")?;
+    let gc_alloc = dlsym_addr(lib, "GC_malloc_uncollectable").ok_or_else(|| "runtime symbol `GC_malloc_uncollectable` not found")?;
     // Pin the runtime shared object: locate it from `mmc_init`'s address and
     // re-open it so later closes of function libraries leave the GC heap and
     // `threadData` valid.
@@ -485,7 +485,7 @@ fn ensure_runtime(reg: &mut Registry) -> Result<()> {
         let alloc: extern "C" fn(usize) -> *mut c_void = std::mem::transmute(gc_alloc);
         let td = alloc(THREADDATA_SIZE);
         if td.is_null() {
-            bail!("executeFunction: threadData allocation failed");
+            return Err("executeFunction: threadData allocation failed");
         }
         std::ptr::write_bytes(td as *mut u8, 0, THREADDATA_SIZE);
         reg.thread_data = td as usize;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload_wasm.rs
@@ -4,14 +4,14 @@
 //! build evaluates functions through the in-process wasm JIT
 //! (`openmodelica_codegen_wasm_jit`) instead of this C/.so path.
 
-use anyhow::{Result, bail};
+use metamodelica::Result;
 
 pub fn load_library(_path: &str, _relative: bool, _debug: bool) -> Result<i32> {
-    bail!("System.loadLibrary: dynamic loading (dlopen) is unavailable on wasm")
+    return Err("System.loadLibrary: dynamic loading (dlopen) is unavailable on wasm")
 }
 
 pub fn lookup_function(_lib: i32, _name: &str) -> Result<i32> {
-    bail!("System.lookupFunction: dynamic loading is unavailable on wasm")
+    return Err("System.lookupFunction: dynamic loading is unavailable on wasm")
 }
 
 pub fn free_function(_func: i32, _debug: bool) -> Result<()> {
@@ -24,7 +24,7 @@ pub fn free_library(_lib: i32, _debug: bool) -> Result<()> {
 }
 
 pub fn function_addr(_func: i32) -> Result<usize> {
-    bail!("dynload::function_addr: dynamic loading is unavailable on wasm")
+    return Err("dynload::function_addr: dynamic loading is unavailable on wasm")
 }
 
 pub fn runtime_symbol(_name: &str) -> Option<usize> {
@@ -32,5 +32,5 @@ pub fn runtime_symbol(_name: &str) -> Option<usize> {
 }
 
 pub fn thread_data() -> Result<usize> {
-    bail!("dynload::thread_data: the dlopen'd MMC runtime is unavailable on wasm")
+    return Err("dynload::thread_data: the dlopen'd MMC runtime is unavailable on wasm")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_set_string_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_set_string_tests.rs
@@ -6,7 +6,7 @@
 // Key invariant: key comparison uses stringCompare; smaller keys go LEFT, larger
 // keys go RIGHT.  listKeys/listKeysReverse traverse in ascending/descending order.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_tree_string_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_tree_string_tests.rs
@@ -12,10 +12,10 @@
 //   return value into `Ok(...)`.  The tests below do the same.
 //
 // Known runtime bug:
-//   intersection() always fails (bail!("fail")), faithfully reproducing the
+//   intersection() always fails (return Err("fail")), faithfully reproducing the
 //   MetaModelica source which has `redeclare function intersection; algorithm fail();`.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/diff_algorithm_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/diff_algorithm_tests.rs
@@ -13,7 +13,7 @@
 // Known bugs / limitations found while writing these tests are documented
 // inline with "Bug:" prefixes.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::ArcStr;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/hash_set_string_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/hash_set_string_tests.rs
@@ -17,7 +17,7 @@
 //   hashSetList  → all stored keys as a list
 //   addUnique    → inserts only when key is absent; fails if already present
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/sb_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/sb_tests.rs
@@ -22,7 +22,7 @@
 //
 // Other known bugs documented inline with "Bug:" prefixes.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use crate::SBInterval;
@@ -793,7 +793,7 @@ fn partb_sbmi_cardinality_2d_sums_not_product() {
 /// dummy to the safe runtime variant `arrayCreateNoInitWithDummy` when the
 /// dummy expression is known-initialised (here, `arrayGet(mi1.intervals, 1)`).
 #[test]
-fn partb_sbmi_intersection_1d_overlapping() -> anyhow::Result<()> {
+fn partb_sbmi_intersection_1d_overlapping() -> metamodelica::Result<()> {
     let mi1 = raw_mi1d(1, 1, 5);
     let mi2 = raw_mi1d(3, 1, 7);
     let res = SBMultiInterval::intersection(mi1, mi2)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/string_util_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/string_util_tests.rs
@@ -6,7 +6,7 @@
 // Position indices are 1-based throughout (MetaModelica convention).
 // NO_POS (= 0) is returned when a character is not found.
 
-use anyhow::Result;
+use metamodelica::Result;
 use arcstr::{ArcStr, literal};
 use crate::StringUtil as S;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_map_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_map_tests.rs
@@ -8,7 +8,7 @@
 //
 // We use ArcStr keys and i32 values throughout.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_set_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_set_tests.rs
@@ -8,7 +8,7 @@
 //
 // We use ArcStr elements with stringHashDjb2 / stringEq throughout.
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/util_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/util_tests.rs
@@ -9,7 +9,7 @@
 //   - realRangeSize: missing parentheses → `inStart/inStep` subtracted from `inStop`
 //                    instead of `(inStop-inStart)/inStep`
 
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow.workspace=true
 metamodelica.workspace=true
 const-str.workspace=true
 loop_unwrap.workspace=true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/GCExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/GCExt.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 use arcstr::ArcStr;
-use anyhow::Result;
+use metamodelica::Result;
 use loop_unwrap::unwrap_break_err;
 use metamodelica::*; // Built-in types and functions
 use const_str;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/Pointer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/Pointer.rs
@@ -163,7 +163,7 @@ pub fn clone<T: Clone + PartialEq>(mutable: Pointer<T>) -> Pointer<T> {
 // the callback result: the MM analysis classified `Pointer.apply` infallible
 // based on its callees, which is only sound when the callback itself never
 // fails. Surface a misuse as a panic, consistent with the C runtime.
-pub fn apply<T: Clone + PartialEq + 'static>(mutable: Pointer<T>, func: std::sync::Arc<dyn ::std::ops::Fn(T) -> anyhow::Result<T> + 'static>) -> anyhow::Result<Pointer<T>> {
+pub fn apply<T: Clone + PartialEq + 'static>(mutable: Pointer<T>, func: std::sync::Arc<dyn ::std::ops::Fn(T) -> metamodelica::Result<T> + 'static>) -> metamodelica::Result<Pointer<T>> {
     let new = func(access(mutable.clone()))?;
     // The MM source skips the write when `func` returned its argument
     // unchanged (`if not referenceEq(newData, data)`). With `T` passed by

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::{ArcStr, literal};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/double_ended_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/double_ended_tests.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use crate::DoubleEnded;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use metamodelica::Result;
 use std::sync::Arc;
 use metamodelica::*;
 use arcstr::ArcStr;
@@ -348,7 +348,7 @@ fn test_fill() {
 #[test]
 fn test_filter() {
     let lst = list![1i32, 2, 3, 4, 5, 6];
-    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { bail!("skip") } }));
+    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -356,7 +356,7 @@ fn test_filter() {
 #[test]
 fn test_filter1() {
     let lst = list![1i32];
-    let result = L::filter1(Arc::clone(&lst), Arc::new(|x, _arg: i32| { if x > 0 { Ok(()) } else { bail!("skip") } }), 0i32);
+    let result = L::filter1(Arc::clone(&lst), Arc::new(|x, _arg: i32| { if x > 0 { Ok(()) } else { return Err("skip") } }), 0i32);
     assert_eq!(result, list![1i32]);
 }
 
@@ -414,7 +414,7 @@ fn test_filter_cons() {
 #[test]
 fn test_filter_map() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::filterMap(Arc::clone(&lst), Arc::new(|x| if x % 2 == 0 { Ok(x * 10) } else { bail!("skip") }));
+    let result = L::filterMap(Arc::clone(&lst), Arc::new(|x| if x % 2 == 0 { Ok(x * 10) } else { return Err("skip") }));
     assert_eq!(result, list![20i32, 40]);
 }
 
@@ -422,7 +422,7 @@ fn test_filter_map() {
 #[test]
 fn test_filter_map1() {
     let lst = list![2i32];
-    let result = L::filterMap1(Arc::clone(&lst), Arc::new(|x, _arg: i32| if x > 0 { Ok(x * 2) } else { bail!("skip") }), 0i32);
+    let result = L::filterMap1(Arc::clone(&lst), Arc::new(|x, _arg: i32| if x > 0 { Ok(x * 2) } else { return Err("skip") }), 0i32);
     assert_eq!(result, list![4i32]);
 }
 
@@ -2170,7 +2170,7 @@ fn test_fold_empty() {
 #[test]
 fn test_filter_empty_result() {
     let lst = list![1i32, 3, 5];
-    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { bail!("skip") } }));
+    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
     assert!(result.is_empty());
 }
 


### PR DESCRIPTION
The anyhow errors accounted for almost half of the allocations for some models.