### PR TITLE
FMI: pass func name through internal getters for logging

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1913,18 +1913,18 @@ fmi2Status fmi2EnterContinuousTimeMode(fmi2Component c)
   return fmi2OK;
 }
 
-fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFMUStatePriorToCurrentPoint, fmi2Boolean* enterEventMode, fmi2Boolean* terminateSimulation)
+fmi2Status internal_CompletedIntegratorStep(fmi2Component c, const char *func, fmi2Boolean noSetFMUStatePriorToCurrentPoint, fmi2Boolean* enterEventMode, fmi2Boolean* terminateSimulation)
 {
   int done=0;
   ModelInstance *comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp=threadData->mmc_jumper;
 
-  if (nullPointer(comp, "fmi2CompletedIntegratorStep", "enterEventMode", enterEventMode))
+  if (nullPointer(comp, func, "enterEventMode", enterEventMode))
     return fmi2Error;
-  if (nullPointer(comp, "fmi2CompletedIntegratorStep", "terminateSimulation", terminateSimulation))
+  if (nullPointer(comp, func, "terminateSimulation", terminateSimulation))
     return fmi2Error;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2CompletedIntegratorStep")
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, func)
 
   setThreadData(comp);
   MemPoolState mem_pool_state = omc_util_get_pool_state();
@@ -1945,7 +1945,7 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFM
     {
       /* if new set is calculated reinit the solver */
       *enterEventMode = fmi2True;
-      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2CompletedIntegratorStep: Need to iterate state values changed!")
+      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: Need to iterate state values changed!", func)
     }
 #endif
     /* TODO: fix the extrapolation in non-linear system
@@ -1964,7 +1964,7 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFM
   if (done) {
     return fmi2OK;
   }
-  FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "fmi2CompletedIntegratorStep: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "%s: terminated by an assertion.", func)
   return fmi2Error;
 }
 
@@ -1975,7 +1975,7 @@ fmi2Status fmi2CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFMUStat
   if (invalidState(comp, "fmi2CompletedIntegratorStep", model_state_me_continuous_time_mode, 0))
     return fmi2Error;
 
-  return internal_CompletedIntegratorStep(c, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
+  return internal_CompletedIntegratorStep(c, "fmi2CompletedIntegratorStep", noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
 }
 
 fmi2Status fmi2SetTime(fmi2Component c, fmi2Real t)
@@ -2022,15 +2022,15 @@ fmi2Status fmi2SetContinuousStates(fmi2Component c, const fmi2Real x[], size_t n
   return internalSetContinuousStates(c, x, nx);
 }
 
-fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_t nx)
+fmi2Status internalGetDerivatives(fmi2Component c, const char *func, fmi2Real derivatives[], size_t nx)
 {
   int i, done=0;
   ModelInstance* comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp = threadData->mmc_jumper;
-  if (invalidNumber(comp, "fmi2GetDerivatives", "nx", nx, NUMBER_OF_STATES))
+  if (invalidNumber(comp, func, "nx", nx, NUMBER_OF_STATES))
     return fmi2Error;
-  if (nullPointer(comp, "fmi2GetDerivatives", "derivatives[]", derivatives))
+  if (nullPointer(comp, func, "derivatives[]", derivatives))
     return fmi2Error;
 
   setThreadData(comp);
@@ -2049,7 +2049,7 @@ fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_
     for (i = 0; i < nx; i++) {
       fmi2ValueReference vr = vrStatesDerivatives[i];
       derivatives[i] = getReal(comp, vr); // to be implemented by the includer of this file
-      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetDerivatives: #r%d# = %.16g", vr, derivatives[i])
+      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: #r%d# = %.16g", func, vr, derivatives[i])
     }
 #endif
 
@@ -2064,7 +2064,7 @@ fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_
   if (done) {
     return fmi2OK;
   }
-  FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "fmi2GetDerivatives: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi2Error, LOG_FMI2_CALL, "%s: terminated by an assertion.", func)
   return fmi2Error;
 }
 
@@ -2074,16 +2074,16 @@ fmi2Status fmi2GetDerivatives(fmi2Component c, fmi2Real derivatives[], size_t nx
   if (invalidState(comp, "fmi2GetDerivatives", model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error, 0))
     return fmi2Error;
 
-  return internalGetDerivatives(c, derivatives, nx);
+  return internalGetDerivatives(c, "fmi2GetDerivatives", derivatives, nx);
 }
 
-fmi2Status internalGetEventIndicators(fmi2Component c, fmi2Real eventIndicators[], size_t nx)
+fmi2Status internalGetEventIndicators(fmi2Component c, const char *func, fmi2Real eventIndicators[], size_t nx)
 {
   int i, done=0;
   ModelInstance *comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp = threadData->mmc_jumper;
-  if (invalidNumber(comp, "fmi2GetEventIndicators", "nx", nx, NUMBER_OF_EVENT_INDICATORS))
+  if (invalidNumber(comp, func, "nx", nx, NUMBER_OF_EVENT_INDICATORS))
     return fmi2Error;
 
   setThreadData(comp);
@@ -2102,7 +2102,7 @@ fmi2Status internalGetEventIndicators(fmi2Component c, fmi2Real eventIndicators[
     comp->fmuData->callback->function_ZeroCrossings(comp->fmuData, comp->threadData, comp->fmuData->simulationInfo->zeroCrossings);
     for (i = 0; i < nx; i++) {
       eventIndicators[i] = comp->fmuData->simulationInfo->zeroCrossings[i];
-      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetEventIndicators: z%d = %.16g", i, eventIndicators[i])
+      FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: z%d = %.16g", func, i, eventIndicators[i])
     }
 #endif
     done=1;
@@ -2116,7 +2116,7 @@ fmi2Status internalGetEventIndicators(fmi2Component c, fmi2Real eventIndicators[
   if (done) {
     return fmi2OK;
   }
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetEventIndicators: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "%s: terminated by an assertion.", func)
   return fmi2Error;
 }
 
@@ -2130,7 +2130,7 @@ fmi2Status fmi2GetEventIndicators(fmi2Component c, fmi2Real eventIndicators[], s
   /*if (invalidState(comp, "fmi2GetEventIndicators", model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error))*/
     return fmi2Error;
 
-  return internalGetEventIndicators(c, eventIndicators, nx);
+  return internalGetEventIndicators(c, "fmi2GetEventIndicators", eventIndicators, nx);
 }
 
 fmi2Status internalGetContinuousStates(fmi2Component c, fmi2Real x[], size_t nx)
@@ -2351,7 +2351,7 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
 #endif
 
 #if NUMBER_OF_STATES > 0
-    status = internalGetDerivatives(c, states_der, NUMBER_OF_STATES);
+    status = internalGetDerivatives(c, "fmi2DoStep", states_der, NUMBER_OF_STATES);
   if (status != fmi2OK) goto doStep_cleanup;
 
     status = internalGetContinuousStates(c, states, NUMBER_OF_STATES);
@@ -2359,7 +2359,7 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
 #endif
 
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "fmi2DoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi2OK) goto doStep_cleanup;
 #endif
 
@@ -2433,12 +2433,12 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
 #endif
 
     /* signal completed integrator step */
-    status = internal_CompletedIntegratorStep(c, fmi2True, &enterEventMode, &terminateSimulation);
+    status = internal_CompletedIntegratorStep(c, "fmi2DoStep", fmi2True, &enterEventMode, &terminateSimulation);
     if (status != fmi2OK) goto doStep_cleanup;
 
     /* check for events */
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, event_indicators, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "fmi2DoStep", event_indicators, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi2OK) goto doStep_cleanup;
 
     for (i = 0; i < NUMBER_OF_EVENT_INDICATORS; i++)
@@ -2484,7 +2484,7 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
       }
 
       #if NUMBER_OF_EVENT_INDICATORS > 0
-        status = internalGetEventIndicators(c, event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+        status = internalGetEventIndicators(c, "fmi2DoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
         if (status != fmi2OK) goto doStep_cleanup;
       #endif
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_dummy_model_defines.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_dummy_model_defines.h
@@ -33,15 +33,27 @@
 /* Two reals: the state at index 0 and its derivative at index 1 (see
  * STATESDERIVATIVES below), so the dummy defines are internally consistent
  * when fmu3_model_interface.c is compiled against this placeholder. */
-#define NUMBER_OF_REALS 2
-#define NUMBER_OF_STATES 1
-#define NUMBER_OF_INTEGERS 1
-#define NUMBER_OF_BOOLEANS 1
-#define NUMBER_OF_STRINGS 1
-#define NUMBER_OF_EVENT_INDICATORS 1
+#define NUMBER_OF_REALS             2
+#define NUMBER_OF_STATES            1
+#define NUMBER_OF_REAL_INPUTS       1
+#define NUMBER_OF_INTEGERS          1
+#define NUMBER_OF_BOOLEANS          1
+#define NUMBER_OF_STRINGS           1
+#define NUMBER_OF_EVENT_INDICATORS  1
 #define NUMBER_OF_EXTERNALFUNCTIONS 1
+#define NUMBER_OF_EXTERNALOBJECTS   1
+#define NUMBER_OF_CLOCKS            1
 
-#define STATES { 0 }
+#define FMI3_REAL_VR_OFFSET           0
+#define FMI3_INTEGER_VR_OFFSET        (NUMBER_OF_REALS)
+#define FMI3_BOOLEAN_VR_OFFSET        (NUMBER_OF_REALS + NUMBER_OF_INTEGERS)
+#define FMI3_STRING_VR_OFFSET         (NUMBER_OF_REALS + NUMBER_OF_INTEGERS + NUMBER_OF_BOOLEANS)
+#define FMI3_BINARY_VR_OFFSET         (NUMBER_OF_REALS + NUMBER_OF_INTEGERS + NUMBER_OF_BOOLEANS + NUMBER_OF_STRINGS)
+#define FMI3_CLOCK_VR_OFFSET          (NUMBER_OF_REALS + NUMBER_OF_INTEGERS + NUMBER_OF_BOOLEANS + NUMBER_OF_STRINGS + NUMBER_OF_EXTERNALOBJECTS)
+#define FMI3_TIME_VR                  (NUMBER_OF_REALS + NUMBER_OF_INTEGERS + NUMBER_OF_BOOLEANS + NUMBER_OF_STRINGS + NUMBER_OF_EXTERNALOBJECTS + NUMBER_OF_CLOCKS)
+#define FMI3_EVENT_INDICATOR_VR_START (FMI3_TIME_VR + 1)
+
+#define STATES            { 0 }
 #define STATESDERIVATIVES { 1 }
 
 #endif /* FMU3_DUMMY_MODEL_DEFINES_H */

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1909,7 +1909,7 @@ fmi3Status omcGetDirectionalDerivative(ModelInstance* c,
 
 
 /***************************************************
-Functions for FMI2 for Model Exchange
+Functions for FMI3 for Model Exchange
 ****************************************************/
 fmi3Status omcEnterEventMode(ModelInstance* c)
 {
@@ -2300,19 +2300,9 @@ fmi3Status omcGetRealOutputDerivatives(ModelInstance* c, const fmi3ValueReferenc
 }
 
 /**
- * @brief FMI 2 doStep function.
+ * @brief Internal Co-Simulation step, called from fmi3DoStep.
  *
  * Compute time step to next communication point with explicit Euler or CVODE.
- *
- * @param c                                   FMU component.
- * @param currentCommunicationPoint           Current communication point of master algorithm.
- * @param communicationStepSize               Communication step size.
- * @param noSetFMUStatePriorToCurrentPoint    Unused.
- * @return fmi3Status                         Returns fmi3OK if communication point was reached successfully.
- *                                            Returns fmi3Error if something went wrong.
- */
-/**
- * @brief Internal Co-Simulation step shared by omcDoStep and fmi3DoStep.
  *
  * When @p eventModeUsed and @p earlyReturnAllowed are both true (FMI 3.0
  * Co-Simulation with Event Mode), the step stops at the first encountered event
@@ -2323,8 +2313,20 @@ fmi3Status omcGetRealOutputDerivatives(ModelInstance* c, const fmi3ValueReferenc
  * with a new step from @p lastSuccessfulTime. Otherwise events are handled
  * internally (FMI 2.0 behaviour) and the step always advances to the
  * communication point.
+ *
+ * @param c                                  FMU component instance.
+ * @param currentCommunicationPoint          Current communication point of the master algorithm.
+ * @param communicationStepSize              Communication step size.
+ * @param noSetFMUStatePriorToCurrentPoint   Unused.
+ * @param eventModeUsed                      True if the importer uses FMI 3.0 Co-Simulation Event Mode for this instance.
+ * @param earlyReturnAllowed                 True if the master allows the step to return early on a deferred event; only relevant when @p eventModeUsed is true.
+ * @param eventEncountered                   Output, may be NULL. Set to fmi3True if an event was encountered and deferred to the master.
+ * @param terminateSimulationOut             Output, may be NULL. Set to fmi3True if the simulation should terminate.
+ * @param earlyReturn                        Output, may be NULL. Set to fmi3True if the step returned before reaching the requested communication point due to a deferred event.
+ * @param lastSuccessfulTime                 Output, may be NULL. Simulation time actually reached by this step.
+ * @return fmi3Status                        Returns fmi3OK if the step (or partial step up to a deferred event) completed successfully, fmi3Error/fmi3Fatal otherwise.
  */
-static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommunicationPoint,
+static fmi3Status doStepInternal(ModelInstance* c, fmi3Float64 currentCommunicationPoint,
     fmi3Float64 communicationStepSize, fmi3Boolean noSetFMUStatePriorToCurrentPoint,
     fmi3Boolean eventModeUsed, fmi3Boolean earlyReturnAllowed,
     fmi3Boolean* eventEncountered, fmi3Boolean* terminateSimulationOut,
@@ -2355,7 +2357,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
   if (earlyReturn)            *earlyReturn = fmi3False;
   if (lastSuccessfulTime)     *lastSuccessfulTime = currentCommunicationPoint + communicationStepSize;
 
-  if (invalidState(comp, "omcDoStep", 0, model_state_cs_step_complete))
+  if (invalidState(comp, "fmi3DoStep", 0, model_state_cs_step_complete))
     return fmi3Error;
 
   MemPoolState doStep_pool_state = omc_util_get_pool_state();
@@ -2416,7 +2418,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
 #if NUMBER_OF_STATES > 0
-    status = internalGetDerivatives(c, "omcDoStep", states_der, NUMBER_OF_STATES);
+    status = internalGetDerivatives(c, "fmi3DoStep", states_der, NUMBER_OF_STATES);
   if (status != fmi3OK) goto doStep_cleanup;
 
     status = internalGetContinuousStates(c, states, NUMBER_OF_STATES);
@@ -2424,7 +2426,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, "omcDoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "fmi3DoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi3OK) goto doStep_cleanup;
 #endif
 
@@ -2453,18 +2455,18 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
         flag = cvode_solver_fmi_step(comp, tNext, states);
         if (flag < 0)
         {
-          FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "omcDoStep: CVODE integrator step failed.")
+          FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "fmi3DoStep: CVODE integrator step failed.")
           status = fmi3Fatal;
           goto doStep_cleanup;
         }
 #else
-        FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "omcDoStep: FMU not compiled with SUNDIALS but solver CVODE selected.")
+        FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "fmi3DoStep: FMU not compiled with SUNDIALS but solver CVODE selected.")
         status = fmi3Fatal;
         goto doStep_cleanup;
 #endif /* WITH_SUNDIALS */
         break;
       default:
-        FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "omcDoStep: Unknown solver method %d.", comp->solverInfo->solverMethod)
+        FILTERED_LOG(comp, fmi3Fatal, LOG_STATUSFATAL, "fmi3DoStep: Unknown solver method %d.", comp->solverInfo->solverMethod)
         status = fmi3Fatal;
         goto doStep_cleanup;
     }
@@ -2498,12 +2500,12 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
     /* signal completed integrator step */
-    status = internal_CompletedIntegratorStep(c, "omcDoStep", fmi3True, &enterEventMode, &terminateSimulation);
+    status = internal_CompletedIntegratorStep(c, "fmi3DoStep", fmi3True, &enterEventMode, &terminateSimulation);
     if (status != fmi3OK) goto doStep_cleanup;
 
     /* check for events */
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, "omcDoStep", event_indicators, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "fmi3DoStep", event_indicators, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi3OK) goto doStep_cleanup;
 
     for (i = 0; i < NUMBER_OF_EVENT_INDICATORS; i++)
@@ -2535,7 +2537,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
            deferred when the master allows early return, otherwise it is handled
            internally below. */
         ev = fmi3True;
-        FILTERED_LOG(comp, fmi3OK, LOG_EVENTS, "omcDoStep: event encountered at %g, deferring to the master", comp->fmuData->localData[0]->timeValue)
+        FILTERED_LOG(comp, fmi3OK, LOG_EVENTS, "fmi3DoStep: event encountered at %g, deferring to the master", comp->fmuData->localData[0]->timeValue)
         break;
       }
 
@@ -2566,7 +2568,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
       }
 
       #if NUMBER_OF_EVENT_INDICATORS > 0
-        status = internalGetEventIndicators(c, "omcDoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+        status = internalGetEventIndicators(c, "fmi3DoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
         if (status != fmi3OK) goto doStep_cleanup;
       #endif
 
@@ -2594,7 +2596,7 @@ doStep_cleanup:
   {
     if (status == fmi3OK)
     {
-      FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "omcDoStep: terminated by an assertion.")
+      FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "fmi3DoStep: terminated by an assertion.")
       status = fmi3Error;
     }
   }
@@ -2611,13 +2613,6 @@ doStep_cleanup:
   }
 
   return status;
-}
-
-/* FMI 2.0 Co-Simulation doStep: events are always handled internally. */
-fmi3Status omcDoStep(ModelInstance* c, fmi3Float64 currentCommunicationPoint, fmi3Float64 communicationStepSize, fmi3Boolean noSetFMUStatePriorToCurrentPoint)
-{
-  return fmu3DoStepInternal(c, currentCommunicationPoint, communicationStepSize,
-      noSetFMUStatePriorToCurrentPoint, fmi3False, fmi3False, NULL, NULL, NULL, NULL);
 }
 
 // ---------------------------------------------------------------------------
@@ -3789,7 +3784,7 @@ fmi3Status fmi3DoStep(fmi3Instance instance, fmi3Float64 currentCommunicationPoi
   fmi3Float64 lastTime = currentCommunicationPoint + communicationStepSize;
   fmi3Status status;
   if (!inst) return fmi3Error;
-  status = fmu3DoStepInternal(c, (fmi3Float64)currentCommunicationPoint,
+  status = doStepInternal(c, (fmi3Float64)currentCommunicationPoint,
       (fmi3Float64)communicationStepSize, noSetFMUStatePriorToCurrentPoint,
       inst->eventModeUsed ? fmi3True : fmi3False,
       inst->earlyReturnAllowed ? fmi3True : fmi3False,

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1955,18 +1955,18 @@ fmi3Status omcEnterContinuousTimeMode(ModelInstance* c)
   return fmi3OK;
 }
 
-fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean* enterEventMode, fmi3Boolean* terminateSimulation)
+fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, const char *func, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean* enterEventMode, fmi3Boolean* terminateSimulation)
 {
   int done=0;
   ModelInstance *comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp=threadData->mmc_jumper;
 
-  if (nullPointer(comp, "omcCompletedIntegratorStep", "enterEventMode", enterEventMode))
+  if (nullPointer(comp, func, "enterEventMode", enterEventMode))
     return fmi3Error;
-  if (nullPointer(comp, "omcCompletedIntegratorStep", "terminateSimulation", terminateSimulation))
+  if (nullPointer(comp, func, "terminateSimulation", terminateSimulation))
     return fmi3Error;
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcCompletedIntegratorStep")
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, func)
 
   setThreadData(comp);
   MemPoolState mem_pool_state = omc_util_get_pool_state();
@@ -1987,7 +1987,7 @@ fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, fmi3Boolean noSetF
     {
       /* if new set is calculated reinit the solver */
       *enterEventMode = fmi3True;
-      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcCompletedIntegratorStep: Need to iterate state values changed!")
+      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: Need to iterate state values changed!", func)
     }
 #endif
     /* TODO: fix the extrapolation in non-linear system
@@ -2006,7 +2006,7 @@ fmi3Status internal_CompletedIntegratorStep(ModelInstance* c, fmi3Boolean noSetF
   if (done) {
     return fmi3OK;
   }
-  FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "omcCompletedIntegratorStep: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "%s: terminated by an assertion.", func)
   return fmi3Error;
 }
 
@@ -2017,7 +2017,7 @@ fmi3Status omcCompletedIntegratorStep(ModelInstance* c, fmi3Boolean noSetFMUStat
   if (invalidState(comp, "omcCompletedIntegratorStep", model_state_me_continuous_time_mode, 0))
     return fmi3Error;
 
-  return internal_CompletedIntegratorStep(c, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
+  return internal_CompletedIntegratorStep(c, "omcCompletedIntegratorStep", noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
 }
 
 fmi3Status omcSetTime(ModelInstance* c, fmi3Float64 t)
@@ -2064,15 +2064,15 @@ fmi3Status omcSetContinuousStates(ModelInstance* c, const fmi3Float64 x[], size_
   return internalSetContinuousStates(c, x, nx);
 }
 
-fmi3Status internalGetDerivatives(ModelInstance* c, fmi3Float64 derivatives[], size_t nx)
+fmi3Status internalGetDerivatives(ModelInstance* c, const char *func, fmi3Float64 derivatives[], size_t nx)
 {
   int i, done=0;
   ModelInstance* comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp = threadData->mmc_jumper;
-  if (invalidNumber(comp, "omcGetDerivatives", "nx", nx, NUMBER_OF_STATES))
+  if (invalidNumber(comp, func, "nx", nx, NUMBER_OF_STATES))
     return fmi3Error;
-  if (nullPointer(comp, "omcGetDerivatives", "derivatives[]", derivatives))
+  if (nullPointer(comp, func, "derivatives[]", derivatives))
     return fmi3Error;
 
   setThreadData(comp);
@@ -2091,7 +2091,7 @@ fmi3Status internalGetDerivatives(ModelInstance* c, fmi3Float64 derivatives[], s
     for (i = 0; i < nx; i++) {
       fmi3ValueReference vr = vrStatesDerivatives[i];
       derivatives[i] = getReal(comp, vr); // to be implemented by the includer of this file
-      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetDerivatives: #r%d# = %.16g", vr, derivatives[i])
+      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: #r%d# = %.16g", func, vr, derivatives[i])
     }
 #endif
 
@@ -2106,26 +2106,26 @@ fmi3Status internalGetDerivatives(ModelInstance* c, fmi3Float64 derivatives[], s
   if (done) {
     return fmi3OK;
   }
-  FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "omcGetDerivatives: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi3Error, LOG_FMI3_CALL, "%s: terminated by an assertion.", func)
   return fmi3Error;
 }
 
 fmi3Status omcGetDerivatives(ModelInstance* c, fmi3Float64 derivatives[], size_t nx)
 {
   ModelInstance* comp = (ModelInstance *)c;
-  if (invalidState(comp, "omcGetDerivatives", model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error, 0))
+  if (invalidState(comp, "fmi3GetContinuousStateDerivatives", model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error, 0))
     return fmi3Error;
 
-  return internalGetDerivatives(c, derivatives, nx);
+  return internalGetDerivatives(c, "fmi3GetContinuousStateDerivatives", derivatives, nx);
 }
 
-fmi3Status internalGetEventIndicators(ModelInstance* c, fmi3Float64 eventIndicators[], size_t nx)
+fmi3Status internalGetEventIndicators(ModelInstance* c, const char *func, fmi3Float64 eventIndicators[], size_t nx)
 {
   int i, done=0;
   ModelInstance *comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp = threadData->mmc_jumper;
-  if (invalidNumber(comp, "omcGetEventIndicators", "nx", nx, NUMBER_OF_EVENT_INDICATORS))
+  if (invalidNumber(comp, func, "nx", nx, NUMBER_OF_EVENT_INDICATORS))
     return fmi3Error;
 
   setThreadData(comp);
@@ -2144,7 +2144,7 @@ fmi3Status internalGetEventIndicators(ModelInstance* c, fmi3Float64 eventIndicat
     comp->fmuData->callback->function_ZeroCrossings(comp->fmuData, comp->threadData, comp->fmuData->simulationInfo->zeroCrossings);
     for (i = 0; i < nx; i++) {
       eventIndicators[i] = comp->fmuData->simulationInfo->zeroCrossings[i];
-      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetEventIndicators: z%d = %.16g", i, eventIndicators[i])
+      FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: z%d = %.16g", func, i, eventIndicators[i])
     }
 #endif
     done=1;
@@ -2158,7 +2158,7 @@ fmi3Status internalGetEventIndicators(ModelInstance* c, fmi3Float64 eventIndicat
   if (done) {
     return fmi3OK;
   }
-  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcGetEventIndicators: terminated by an assertion.")
+  FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "%s: terminated by an assertion.", func)
   return fmi3Error;
 }
 
@@ -2172,7 +2172,7 @@ fmi3Status omcGetEventIndicators(ModelInstance* c, fmi3Float64 eventIndicators[]
   /*if (invalidState(comp, "omcGetEventIndicators", model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error))*/
     return fmi3Error;
 
-  return internalGetEventIndicators(c, eventIndicators, nx);
+  return internalGetEventIndicators(c, "omcGetEventIndicators", eventIndicators, nx);
 }
 
 fmi3Status internalGetContinuousStates(ModelInstance* c, fmi3Float64 x[], size_t nx)
@@ -2416,7 +2416,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
 #if NUMBER_OF_STATES > 0
-    status = internalGetDerivatives(c, states_der, NUMBER_OF_STATES);
+    status = internalGetDerivatives(c, "omcDoStep", states_der, NUMBER_OF_STATES);
   if (status != fmi3OK) goto doStep_cleanup;
 
     status = internalGetContinuousStates(c, states, NUMBER_OF_STATES);
@@ -2424,7 +2424,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "omcDoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi3OK) goto doStep_cleanup;
 #endif
 
@@ -2498,12 +2498,12 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
 #endif
 
     /* signal completed integrator step */
-    status = internal_CompletedIntegratorStep(c, fmi3True, &enterEventMode, &terminateSimulation);
+    status = internal_CompletedIntegratorStep(c, "omcDoStep", fmi3True, &enterEventMode, &terminateSimulation);
     if (status != fmi3OK) goto doStep_cleanup;
 
     /* check for events */
 #if NUMBER_OF_EVENT_INDICATORS > 0
-    status = internalGetEventIndicators(c, event_indicators, NUMBER_OF_EVENT_INDICATORS);
+    status = internalGetEventIndicators(c, "omcDoStep", event_indicators, NUMBER_OF_EVENT_INDICATORS);
   if (status != fmi3OK) goto doStep_cleanup;
 
     for (i = 0; i < NUMBER_OF_EVENT_INDICATORS; i++)
@@ -2566,7 +2566,7 @@ static fmi3Status fmu3DoStepInternal(ModelInstance* c, fmi3Float64 currentCommun
       }
 
       #if NUMBER_OF_EVENT_INDICATORS > 0
-        status = internalGetEventIndicators(c, event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
+        status = internalGetEventIndicators(c, "omcDoStep", event_indicators_prev, NUMBER_OF_EVENT_INDICATORS);
         if (status != fmi3OK) goto doStep_cleanup;
       #endif
 


### PR DESCRIPTION
### Related Issues

The logged function names in FMI 2/3 don't always match the called function.

### Purpose

* Print correct function names
* FMI3: Fix stale FMI2 doc comments, complete dummy defines

### Approach

* Additional argument with function name for internal functions used from multiple FMI functions.
