### PR TITLE
wasm-jit: fix param override + editable starts

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -201,6 +201,11 @@ struct SimLayout {
     mathevents_off: u32,
     /// Zero-crossing hysteresis tolerance slot (f64); see [`SimCtx::zctol_off`].
     zctol_off: u32,
+    /// Base of the overridable start-value region (one f64 per state, state `i` at
+    /// `start_off + i*8`): `functionInitStartValues` fills it from each start
+    /// expression and `$START.<state>` reads it back, so `-override=<state>=v` sets
+    /// the initial condition.
+    start_off: u32,
     total: u32,
 }
 
@@ -265,13 +270,20 @@ impl SimLayout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         // Zero-crossing tolerance (f64), 8-aligned after the math-event region.
         let zctol_off = mathevents_off + n_math_slots * 8;
-        let total = zctol_off + 8;
+        // Overridable start values (one f64 per state), 8-aligned after the tolerance.
+        let start_off = zctol_off + 8;
+        let total = start_off + n_states * 8;
         SimLayout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off, bool_off, bparam_off,
             str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off,
-            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, n_math, mathevents_off, zctol_off, total,
+            n_zc, zc_off, n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, n_math, mathevents_off, zctol_off, start_off, total,
         }
+    }
+
+    /// Byte offset of state `i`'s overridable start-value slot.
+    fn state_start_off(&self, i: u32) -> u32 {
+        self.start_off + i * 8
     }
 
     /// Offset of the `pre()` slot mirroring a live variable slot at byte offset
@@ -446,6 +458,9 @@ struct EditableParam {
     unit: String,
     off: u32,
     wty: WTy,
+    /// A state's start value (vs. a plain parameter): shown as the state's `t0`
+    /// value, and overridden after `functionInitStartValues` rather than before.
+    is_start: bool,
 }
 
 /// Process-wide table of prepared models, keyed by file-name prefix. Populated
@@ -560,6 +575,9 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
             }),
         }
     }
+    // A start value shows the state's t0 value; a plain parameter shows its slot.
+    let row0_by_name: HashMap<&str, f64> =
+        series.iter().map(|s| (s.name.as_str(), s.values.first().copied().unwrap_or(0.0))).collect();
     let params = model
         .editable_params
         .iter()
@@ -567,7 +585,11 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
             name: p.name.clone(),
             comment: p.comment.clone(),
             unit: p.unit.clone(),
-            value: param_value_by_off.get(&p.off).copied().unwrap_or(0.0),
+            value: if p.is_start {
+                row0_by_name.get(p.name.as_str()).copied().unwrap_or(0.0)
+            } else {
+                param_value_by_off.get(&p.off).copied().unwrap_or(0.0)
+            },
         })
         .collect();
     *last_sim().lock().unwrap_or_else(|e| e.into_inner()) = Some(CapturedSim {
@@ -774,19 +796,22 @@ fn run_wasmtime_inner(_prefix: &str, _result_file: &str, _simflags: &str) -> Res
 /// Parse `-override=name=value,...` tokens out of `simflags` and resolve each to
 /// its editable parameter's `SimData` slot. Unknown names / unparsable values are
 /// skipped (an unknown override is a no-op, as in the C runtime).
-fn resolve_overrides(model: &SimModel, simflags: &str) -> Vec<(u32, WTy, f64)> {
-    let mut out = Vec::new();
+/// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
+/// values, applied at different points of initialization (see `run_initialization`).
+fn resolve_overrides(model: &SimModel, simflags: &str) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
+    let mut params = Vec::new();
+    let mut starts = Vec::new();
     for tok in simflags.split_whitespace() {
         let Some(list) = tok.strip_prefix("-override=") else { continue };
         for item in list.split(',') {
             let Some((name, value)) = item.split_once('=') else { continue };
             let Ok(val) = value.trim().parse::<f64>() else { continue };
             if let Some(p) = model.editable_params.iter().find(|p| p.name == name.trim()) {
-                out.push((p.off, p.wty, val));
+                if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, val));
             }
         }
     }
-    out
+    (params, starts)
 }
 
 fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Result<()>, String) {
@@ -802,7 +827,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
     let log_stats = simflags.contains("LOG_STATS") || simflags.contains("LOG_ALL");
     // `-override=name=value,...`: resolve each editable parameter to its SimData
     // slot and hand the list to the driver (applied after `functionParameters`).
-    sim_driver::set_param_overrides(resolve_overrides(&model, simflags));
+    let (param_ov, start_ov) = resolve_overrides(&model, simflags);
+    sim_driver::set_param_overrides(param_ov, start_ov);
     openmodelica_wasi::wasi::start_stdout_capture();
     let mut extra = String::new();
     let res = (|| -> Result<()> {
@@ -903,7 +929,8 @@ mod session {
         if fmt != "mat" && fmt != "empty" {
             return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
         }
-        sim_driver::set_param_overrides(resolve_overrides(&model, simflags));
+        let (param_ov, start_ov) = resolve_overrides(&model, simflags);
+        sim_driver::set_param_overrides(param_ov, start_ov);
         sim_driver::clear_cancel();
         openmodelica_wasi::wasi::start_stdout_capture();
         // Build engine + driver (instantiate, init, emit row 0). An init trap is
@@ -1087,6 +1114,10 @@ fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
 struct SimVarMap {
     vars: HashMap<String, SimSlot>,
     starts: HashMap<String, Option<Arc<DAE::Exp>>>,
+    /// State cref key -> its start-value slot; when present, `$START.<key>` reads the
+    /// slot instead of the inline expression. Empty when building
+    /// `functionInitStartValues` (it fills the slots, so must not read them).
+    start_slots: HashMap<String, u32>,
     /// Finalized array-variable groups (base cref key -> contiguous slot range).
     array_groups: HashMap<String, ArrayGroup>,
     /// Transient accumulator: base cref key -> the scalarized elements seen
@@ -1226,6 +1257,7 @@ fn build_var_map(
     let mut map = SimVarMap {
         vars: HashMap::new(),
         starts: HashMap::new(),
+        start_slots: HashMap::new(),
         array_groups: HashMap::new(),
         array_acc: HashMap::new(),
         terminate_off: layout.terminate_off,
@@ -1246,6 +1278,8 @@ fn build_var_map(
     let mut result_vars: Vec<ResultVar> = Vec::new();
     // User-settable parameters (isValueChangeable), collected as they are laid out.
     let mut editable: Vec<EditableParam> = Vec::new();
+    // Collected separately: the `push_editable` closure borrows `editable`. Merged below.
+    let mut start_editable: Vec<EditableParam> = Vec::new();
     let mut push_editable = |sv: &SimCodeVar::SimVar, name: &str, off: u32, wty: WTy| {
         if sv.isValueChangeable && is_result_output(sv) {
             if let Some(disp) = result_name(name) {
@@ -1255,6 +1289,7 @@ fn build_var_map(
                     unit: sv.unit.to_string(),
                     off,
                     wty,
+                    is_start: false,
                 });
             }
         }
@@ -1298,6 +1333,21 @@ fn build_var_map(
     // States | derivatives | real algebraics -> the realVars region (data_2).
     for (i, sv) in states.iter().enumerate() {
         let name = cref_display(&sv.name)?;
+        // Every state gets a start slot; value-changeable ones are also editable.
+        let start_off = layout.state_start_off(i as u32);
+        map.start_slots.insert(sim_cref_key(&sv.name)?, start_off);
+        if sv.isValueChangeable && is_result_output(sv) {
+            if let Some(disp) = result_name(&name) {
+                start_editable.push(EditableParam {
+                    name: disp,
+                    comment: sv.comment.to_string(),
+                    unit: sv.unit.to_string(),
+                    off: start_off,
+                    wty: WTy::F64,
+                    is_start: true,
+                });
+            }
+        }
         push_primary(&mut map, &mut result_vars, &mut filtered, sv, REAL_OFF + (i as u32) * 8, WTy::F64, false, name)?;
     }
     for (i, sv) in ders.iter().enumerate() {
@@ -1450,6 +1500,7 @@ fn build_var_map(
     }
 
     finalize_array_groups(&mut map)?;
+    editable.extend(start_editable);
     Ok((map, result_vars, editable))
 }
 
@@ -1578,6 +1629,7 @@ struct EqFnIdx {
     initial: u32,
     ode: u32,
     algebraics: u32,
+    init_start_values: u32,
 }
 
 /// One `sample(index, start, interval)` time event, from `SimCode.timeEvents`.
@@ -1716,6 +1768,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     let mi = &sim_code.modelInfo;
     let vi = &mi.varInfo;
     let vars = &mi.vars;
+    let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
 
     let n_states = vi.numStateVars.max(0) as u32;
     let n_real_alg = (count(&vars.algVars) + count(&vars.discreteAlgVars)) as u32;
@@ -1825,12 +1878,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         initial: eq_base + 1,
         ode: eq_base + 2,
         algebraics: eq_base + 3,
+        // Always emitted (no-op with no states) so the fixed indices below hold.
+        init_start_values: eq_base + 4,
     };
-    let simulate_idx = eq_base + 4;
+    let simulate_idx = eq_base + 5;
     // The two metadata accessors the standalone wasip1 runtime imports
     // (`om_meta_ptr`/`om_meta_len`), appended after `simulate`.
-    let om_meta_ptr_idx = eq_base + 5;
-    let om_meta_len_idx = eq_base + 6;
+    let om_meta_ptr_idx = eq_base + 6;
+    let om_meta_len_idx = eq_base + 7;
 
     // --- Equation lists + nonlinear-system registration. Flattened here (before
     // the type/import sections, which need to know whether the model has any
@@ -1991,6 +2046,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     bodies.push(build_eq_fn_with_prelude("initialEquations", &[], initial_eqs, &var_map, &eq_index, &by_name, &mut literals, &init_save, &[])?);
     bodies.push(build_eq_fn("odeEquations", ode_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
     bodies.push(build_eq_fn_with_prelude("algebraicEquations", &[], algebraic_eqs, &var_map, &eq_index, &by_name, &mut literals, &save_pre, &[])?);
+    // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
+    bodies.push(build_init_start_values_fn(&states, &layout, &var_map, &by_name, &mut literals)?);
     // The integrator loop.
     bodies.push(build_simulate(&layout, &eqfn)?);
 
@@ -2055,7 +2112,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
         }
         f.instruction(&I::End);
         bodies.push(f);
-        Some(eq_base + 7)
+        Some(eq_base + 8)
     };
 
     // --- Nonlinear-system callbacks + `start`. For each system emit its
@@ -2121,7 +2178,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     for ti in &model_fn_type {
         functions.function(*ti);
     }
-    for _ in 0..4 {
+    // param / initial / ode / algebraics / initStartValues — all (i32) -> ().
+    for _ in 0..5 {
         functions.function(eqfn_type);
     }
     functions.function(simulate_type);
@@ -2161,6 +2219,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode) -> Result<SimModel> {
     let mut exports = we::ExportSection::new();
     exports.export("functionParameters", we::ExportKind::Func, eqfn.parameters);
     exports.export("functionInitialEquations", we::ExportKind::Func, eqfn.initial);
+    exports.export("functionInitStartValues", we::ExportKind::Func, eqfn.init_start_values);
     exports.export("functionODE", we::ExportKind::Func, eqfn.ode);
     exports.export("functionAlgebraics", we::ExportKind::Func, eqfn.algebraics);
     exports.export("simulate", we::ExportKind::Func, simulate_idx);
@@ -2523,6 +2582,7 @@ fn build_eq_fn_with_prelude(
         data_local: 0,
         vars: var_map.vars.clone(),
         starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         nls_fail_off: var_map.nls_fail_off,
@@ -2573,6 +2633,7 @@ fn build_init_sample_fn(
         data_local: 0,
         vars: var_map.vars.clone(),
         starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         nls_fail_off: var_map.nls_fail_off,
@@ -2602,6 +2663,53 @@ fn build_init_sample_fn(
     Ok(func)
 }
 
+/// Build `functionInitStartValues(SimData*)`: fill each state's start slot from its
+/// `start` expression. Called after `functionParameters` (so parameter-bound starts
+/// see final values) and before the initial equations. Empty `start_slots` here so
+/// the expressions compile inline (slots fill exactly as the old inline read).
+fn build_init_start_values_fn(
+    states: &[&SimCodeVar::SimVar],
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let sim = SimCtx {
+        data_local: 0,
+        vars: var_map.vars.clone(),
+        starts: var_map.starts.clone(),
+        start_slots: HashMap::new(),
+        array_groups: var_map.array_groups.clone(),
+        terminate_off: var_map.terminate_off,
+        nls_fail_off: var_map.nls_fail_off,
+        nls_jobs: var_map.nls_jobs.clone(),
+        sample_map: var_map.sample_map.clone(),
+        sample_active_off: var_map.sample_active_off,
+        relations_off: var_map.relations_off,
+        rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
+        n_relations: var_map.n_relations,
+        mathevents_off: var_map.mathevents_off,
+        n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
+        zc_context: false,
+    };
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = Vec::with_capacity(states.len());
+    for (i, sv) in states.iter().enumerate() {
+        pairs.push((sv.initialValue.clone(), layout.state_start_off(i as u32)));
+    }
+    ctx.emit_init_start_values(&pairs)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
 /// Build the `functionZeroCrossings(SimData*)` function: evaluate each crossing's
 /// `lhs - rhs` into the zero-crossing region (see [`FnCtx::emit_zero_crossings`]).
 /// Called by the driver's DASKR root callback.
@@ -2616,6 +2724,7 @@ fn build_zero_crossings_fn(
         data_local: 0,
         vars: var_map.vars.clone(),
         starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         nls_fail_off: var_map.nls_fail_off,
@@ -3007,6 +3116,7 @@ fn build_nls_fns(
         data_local: 0,
         vars: var_map.vars.clone(),
         starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         nls_fail_off: var_map.nls_fail_off,
@@ -3170,9 +3280,11 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     f.instruction(&I::F64Const(1.0f64.into()));
     f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg(layout.lambda_off, 3)));
 
-    // functionParameters(sim_data); functionInitialEquations(sim_data)
+    // functionParameters; functionInitStartValues; functionInitialEquations.
     f.instruction(&I::LocalGet(SIM_DATA));
     f.instruction(&I::Call(eqfn.parameters));
+    f.instruction(&I::LocalGet(SIM_DATA));
+    f.instruction(&I::Call(eqfn.init_start_values));
     f.instruction(&I::LocalGet(SIM_DATA));
     f.instruction(&I::Call(eqfn.initial));
 
@@ -3358,8 +3470,8 @@ mod standalone_tests {
         // Imported func index: rt_alloc = 0.
 
         let mut funcs = we::FunctionSection::new();
-        for _ in 0..4 {
-            funcs.function(1); // functionParameters/InitialEquations/ODE/Algebraics
+        for _ in 0..5 {
+            funcs.function(1); // param/initial/initStartValues/ODE/algebraics
         }
         funcs.function(2); // om_meta_ptr
         funcs.function(2); // om_meta_len
@@ -3367,15 +3479,16 @@ mod standalone_tests {
 
         let mut exports = we::ExportSection::new();
         exports.export("functionParameters", we::ExportKind::Func, 1);
-        exports.export("functionInitialEquations", we::ExportKind::Func, 2);
-        exports.export("functionODE", we::ExportKind::Func, 3);
-        exports.export("functionAlgebraics", we::ExportKind::Func, 4);
-        exports.export("om_meta_ptr", we::ExportKind::Func, 5);
-        exports.export("om_meta_len", we::ExportKind::Func, 6);
+        exports.export("functionInitStartValues", we::ExportKind::Func, 2);
+        exports.export("functionInitialEquations", we::ExportKind::Func, 3);
+        exports.export("functionODE", we::ExportKind::Func, 4);
+        exports.export("functionAlgebraics", we::ExportKind::Func, 5);
+        exports.export("om_meta_ptr", we::ExportKind::Func, 6);
+        exports.export("om_meta_len", we::ExportKind::Func, 7);
         m.section(&exports);
 
         let mut code = we::CodeSection::new();
-        for _ in 0..4 {
+        for _ in 0..5 {
             let mut f = we::Function::new([]);
             f.instruction(&I::End);
             code.function(&f);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_driver.rs
@@ -356,22 +356,35 @@ thread_local! {
     /// Set per run by `run_simulation_inner`; independent parameters only (a
     /// calculated parameter's binding still overwrites it in `functionParameters`).
     static PARAM_OVERRIDES: RefCell<Vec<(u32, WTy, f64)>> = const { RefCell::new(Vec::new()) };
+    /// Start-value `-override`s, applied *after* `functionInitStartValues` so they
+    /// replace the computed start instead of being overwritten by it.
+    static START_OVERRIDES: RefCell<Vec<(u32, WTy, f64)>> = const { RefCell::new(Vec::new()) };
 }
 
-/// Set the parameter overrides applied by the next [`run_initialization`].
-pub(super) fn set_param_overrides(overrides: Vec<(u32, WTy, f64)>) {
-    PARAM_OVERRIDES.with(|o| *o.borrow_mut() = overrides);
+/// Set the parameter/start overrides applied by the next [`run_initialization`].
+pub(super) fn set_param_overrides(params: Vec<(u32, WTy, f64)>, starts: Vec<(u32, WTy, f64)>) {
+    PARAM_OVERRIDES.with(|o| *o.borrow_mut() = params);
+    START_OVERRIDES.with(|o| *o.borrow_mut() = starts);
 }
 
-fn apply_param_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
-    let overrides = PARAM_OVERRIDES.with(|o| o.borrow().clone());
-    for (off, wty, val) in overrides {
+fn apply_overrides(e: &mut dyn SimEngine, sim_data: u32, overrides: &[(u32, WTy, f64)]) -> Result<()> {
+    for &(off, wty, val) in overrides {
         match wty {
             WTy::F64 => write_f64(e, sim_data + off, val)?,
             WTy::I32 => write_i32(e, sim_data + off, val as i32)?,
         }
     }
     Ok(())
+}
+
+fn apply_param_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
+    let overrides = PARAM_OVERRIDES.with(|o| o.borrow().clone());
+    apply_overrides(e, sim_data, &overrides)
+}
+
+fn apply_start_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
+    let overrides = START_OVERRIDES.with(|o| o.borrow().clone());
+    apply_overrides(e, sim_data, &overrides)
 }
 
 /// Solve the initial system: `functionParameters`, then `functionInitialEquations`
@@ -389,7 +402,11 @@ fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) 
 
 fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     e.call1("functionParameters", sim_data)?;
+    // Params first (a start expression may read one), then fill start slots, then
+    // start overrides (replacing the just-computed start).
     apply_param_overrides(e, sim_data)?;
+    e.call1("functionInitStartValues", sim_data)?;
+    apply_start_overrides(e, sim_data)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
     if layout.n_samples > 0 {
         e.call1("initSample", sim_data)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -946,6 +946,9 @@ pub(crate) struct SimCtx {
     /// zero). Stored separately from `vars` because `$START` reads the start
     /// attribute, not the live value.
     pub(crate) starts: HashMap<String, Option<Arc<DAE::Exp>>>,
+    /// State cref key -> its start-value slot; `$START.<key>` reads the slot when
+    /// present, else the inline expression. Empty while building the fill function.
+    pub(crate) start_slots: HashMap<String, u32>,
     /// Canonical cref key of an *array-valued* model variable (the base name with
     /// no final subscript, e.g. `body.R_start.T`) -> the contiguous slot range its
     /// scalarized elements occupy. A whole-array reference reads/writes the range
@@ -1192,6 +1195,27 @@ impl<'a> FnCtx<'a> {
                 coerce(self, w, WTy::F64);
                 self.emit(we::Instruction::F64Store(mem_arg(off, 3)));
             }
+        }
+        Ok(())
+    }
+
+    /// Store each state's `start` expression into its start slot (`0.0` when the
+    /// state has no explicit start, the Real default).
+    pub(crate) fn emit_init_start_values(
+        &mut self,
+        starts: &[(Option<Arc<DAE::Exp>>, u32)],
+    ) -> Result<()> {
+        let data = self.sim()?.data_local;
+        for (exp, off) in starts {
+            self.emit(we::Instruction::LocalGet(data));
+            match exp {
+                Some(e) => {
+                    let w = compile_exp(self, e)?;
+                    coerce(self, w, WTy::F64);
+                }
+                None => self.emit(we::Instruction::F64Const(0.0f64.into())),
+            }
+            self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
         }
         Ok(())
     }
@@ -3152,6 +3176,13 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
         match ident.as_str() {
             "$START" => {
                 let key = sim_cref_key(componentRef)?;
+                // Read the overridable start slot if this state has one.
+                if let Some(&off) = ctx.sim()?.start_slots.get(&key) {
+                    let data = ctx.sim()?.data_local;
+                    ctx.emit(we::Instruction::LocalGet(data));
+                    ctx.emit(we::Instruction::F64Load(mem_arg(off, 3)));
+                    return Ok(Some(WTy::F64));
+                }
                 let start = ctx.sim()?.starts.get(&key).cloned();
                 return match start {
                     Some(Some(exp)) => Ok(Some(compile_exp(ctx, &exp)?)),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -30,6 +30,7 @@ use openmodelica_sim_meta::{self as meta, Layout, MetaKind, SimMeta, WTy, REAL_O
 #[link(wasm_import_module = "model")]
 unsafe extern "C" {
     fn functionParameters(sim_data: u32);
+    fn functionInitStartValues(sim_data: u32);
     fn functionInitialEquations(sim_data: u32);
     fn functionODE(sim_data: u32);
     fn functionAlgebraics(sim_data: u32);
@@ -73,6 +74,7 @@ fn capture_row(rows: &mut Vec<f64>, sim_data: u32, layout: &Layout) {
 fn run_euler(m: &SimMeta, sim_data: u32, n_reals: u32, n_rows: u32) -> Vec<f64> {
     unsafe {
         functionParameters(sim_data);
+        functionInitStartValues(sim_data);
         functionInitialEquations(sim_data);
     }
     let n_states = m.layout.n_states;
@@ -149,6 +151,7 @@ fn run_dassl(m: &SimMeta, sim_data: u32, n_reals: u32, n_rows: u32) -> Vec<f64> 
     daskr::auxiliary::xsetf(0); // silence DASKR's own printing
     unsafe {
         functionParameters(sim_data);
+        functionInitStartValues(sim_data);
         functionInitialEquations(sim_data);
     }
     let n_states = m.layout.n_states as usize;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
@@ -261,16 +261,65 @@ pub fn write(file: File, data: ArcStr) -> Result<()> {
 }
 
 pub fn writeInt(file: File, data: i32, format: ArcStr) -> Result<()> {
-    // The C runtime uses `fprintf` with a user-supplied format string. We
-    // honor the common `%d` default with a fast path and fall through to a
-    // simple substitution otherwise. Full printf-compatibility would require
-    // a printf parser; callers in the OMC sources only use `%d` and `%ld`.
     let mut guard = file.inner.lock().unwrap();
-    let s = match format.as_str() {
-        "%d" | "%i" | "%ld" => data.to_string(),
-        other => other.replace("%d", &data.to_string()).replace("%ld", &data.to_string()),
-    };
+    let s = format_int(format.as_str(), data);
     guard.write_bytes(s.as_bytes(), "writeInt")
+}
+
+// Substitute the first printf integer conversion `%[0][width][l](d|i)` in `fmt`,
+// keeping surrounding literals. Callers use `%d`/`%i`/`%ld` and `%02d` (xsdateTime).
+fn format_int(fmt: &str, data: i32) -> String {
+    let bytes = fmt.as_bytes();
+    let mut out = String::with_capacity(fmt.len() + 8);
+    let mut i = 0;
+    let mut lit_start = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'%' {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 1;
+        let zero = j < bytes.len() && bytes[j] == b'0';
+        if zero {
+            j += 1;
+        }
+        let ws = j;
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        let width: usize = fmt.get(ws..j).and_then(|w| w.parse().ok()).unwrap_or(0);
+        while j < bytes.len() && bytes[j] == b'l' {
+            j += 1;
+        }
+        if j < bytes.len() && (bytes[j] == b'd' || bytes[j] == b'i') {
+            out.push_str(&fmt[lit_start..i]);
+            out.push_str(&fmt_int_field(data, zero, width));
+            j += 1;
+            i = j;
+            lit_start = j;
+        } else {
+            i += 1;
+        }
+    }
+    out.push_str(&fmt[lit_start..]);
+    out
+}
+
+// Zero- or space-pad `data` to `width` (sign kept outside the padding).
+fn fmt_int_field(data: i32, zero: bool, width: usize) -> String {
+    let num = data.to_string();
+    if num.len() >= width {
+        return num;
+    }
+    let pad = width - num.len();
+    if zero {
+        match num.strip_prefix('-') {
+            Some(rest) => format!("-{}{}", "0".repeat(pad), rest),
+            None => format!("{}{}", "0".repeat(pad), num),
+        }
+    } else {
+        format!("{}{}", " ".repeat(pad), num)
+    }
 }
 
 pub fn writeReal(file: File, data: metamodelica::Real, format: ArcStr) -> Result<()> {

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -283,7 +283,7 @@ self.onmessage = async (ev) => {
         const built = (await evalWithDownloads(`buildModel(${a.name}${opts.length ? ',' + opts.join(',') : ''})`, status)).trim();
         // buildModel → {"<prefix>","<initfile>"}; an empty first element means it failed.
         if (!/^\{\s*"[^"]/.test(built)) return reply(simError('Build failed.'));
-        const st = await runResumable(a.name, a.override ? `-override=${a.override}` : '', status);
+        const st = await runResumable(a.name, a.override || '', status);
         if (st === 3) return reply({ ok: false, cancelled: true });
         if (st < 0) return reply(simError('Simulation failed.'));
         const s = snapshot();
@@ -294,7 +294,7 @@ self.onmessage = async (ev) => {
       }
       case 'resimulate': {
         // Re-run the already-built model (no rebuild) — same cancellable chunked path.
-        const st = await runResumable(a.name, a.override ? `-override=${a.override}` : '', status);
+        const st = await runResumable(a.name, a.override || '', status);
         if (st === 3) return reply({ ok: false, cancelled: true });
         if (st < 0) return reply(simError('Re-simulation failed.'));
         const s = snapshot();

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1874,7 +1874,23 @@ void VariablesWidget::reSimulate(SimulationOptions simulationOptions, VariablesT
   simulationOptions.setReSimulate(true);
   if (pVariablesTreeItem) {
     MainWindow::instance()->getSimulationDialog()->removeInteractiveSimulation(simulationOptions.isInteractiveSimulation(), pVariablesTreeItem->getFileName(), false);
+#if defined(__EMSCRIPTEN__)
+    // wasm-jit takes changes only via -override (it never re-reads _init.xml, which
+    // also lives in the unreachable omc worker VFS): pass the changed values that way.
+    QHash<QString, QHash<QString, QString> > changed;
+    readVariablesAndUpdateXML(pVariablesTreeItem, simulationOptions.getFullResultFileName(), &changed);
+    QStringList overrides;
+    for (auto it = changed.constBegin(); it != changed.constEnd(); ++it) {
+      overrides << QString("%1=%2").arg(it.value().value("name"), it.value().value("value"));
+    }
+    if (!overrides.isEmpty()) {
+      QStringList flags = simulationOptions.getSimulationFlags();
+      flags << QString("-override=%1").arg(overrides.join(","));
+      simulationOptions.setSimulationFlags(flags);
+    }
+#else
     updateInitXmlFile(pVariablesTreeItem, simulationOptions);
+#endif
   }
 
   if (showSetup) {


### PR DESCRIPTION
The web simulator's resimulate double-wrapped the -override flag (regression from the cooperative-cancel refactor), so resolve_overrides parsed the first entry's name as "-override" and dropped it -- editing the first parameter did nothing. Pass the already-complete flag through unchanged.

Add editable, overridable state start values. A per-state start region is filled by a new functionInitStartValues (bit-identical to the old inline $START read) and $START.<state> reads that slot. Parameter overrides apply before the fill, start overrides after, so h(start=h0) still tracks an overridden h0. States now show up as initial conditions in the web simulator and can be re-simulated.

OMEdit (wasm): resimulate now passes the changed initial conditions as -override instead of the _init.xml round-trip, which wasm-jit never re-reads and QFile cannot reach in the omc worker VFS.

File::writeInt: handle %02d-style width/zero-pad specs, fixing the unfilled generationDateAndTime placeholder in _init.xml.


Claude-Session: https://claude.ai/code/session_01P5M9VjaGFf3Qpa8gJPvgXC

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
