### PR TITLE
wasm sim: fast param resim + enum dropdowns

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6065,7 +6065,6 @@ dependencies = [
 name = "openmodelica_ast"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6079,7 +6078,6 @@ dependencies = [
 name = "openmodelica_ast_collections"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6094,7 +6092,6 @@ dependencies = [
 name = "openmodelica_backend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6125,7 +6122,6 @@ dependencies = [
 name = "openmodelica_backend_main"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6168,7 +6164,6 @@ dependencies = [
 name = "openmodelica_backend_tools"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6193,7 +6188,6 @@ dependencies = [
 name = "openmodelica_backend_types"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6211,7 +6205,6 @@ dependencies = [
 name = "openmodelica_backend_util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6224,7 +6217,6 @@ dependencies = [
 name = "openmodelica_codegen"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6246,7 +6238,6 @@ dependencies = [
 name = "openmodelica_codegen_c"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6271,7 +6262,6 @@ dependencies = [
 name = "openmodelica_codegen_cfunctions"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6295,7 +6285,6 @@ dependencies = [
 name = "openmodelica_codegen_cpp"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6320,7 +6309,6 @@ dependencies = [
 name = "openmodelica_codegen_cpp_common"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6344,7 +6332,6 @@ dependencies = [
 name = "openmodelica_codegen_cpp_ext"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6370,7 +6357,6 @@ dependencies = [
 name = "openmodelica_codegen_cpp_omsi"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6395,7 +6381,6 @@ dependencies = [
 name = "openmodelica_codegen_cpp_omsi_ext"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6421,7 +6406,6 @@ dependencies = [
 name = "openmodelica_codegen_fmu"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6445,7 +6429,6 @@ dependencies = [
 name = "openmodelica_codegen_fmu_c"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6470,7 +6453,6 @@ dependencies = [
 name = "openmodelica_codegen_fmu_omsi"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6495,7 +6477,6 @@ dependencies = [
 name = "openmodelica_codegen_graphml"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6510,7 +6491,6 @@ dependencies = [
 name = "openmodelica_codegen_wasm_jit"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "daskr",
  "libffi",
@@ -6536,7 +6516,6 @@ dependencies = [
 name = "openmodelica_codegen_xml"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6558,7 +6537,6 @@ dependencies = [
 name = "openmodelica_dump_extra"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6582,7 +6560,6 @@ dependencies = [
 name = "openmodelica_frontend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6606,7 +6583,6 @@ dependencies = [
 name = "openmodelica_frontend_base"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6627,7 +6603,6 @@ dependencies = [
 name = "openmodelica_frontend_dump"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6644,7 +6619,6 @@ dependencies = [
 name = "openmodelica_frontend_inst"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6660,7 +6634,6 @@ dependencies = [
 name = "openmodelica_frontend_types"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6683,7 +6656,6 @@ dependencies = [
 name = "openmodelica_nbackend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6707,7 +6679,6 @@ dependencies = [
 name = "openmodelica_nf_frontend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "cc",
  "const-str 1.1.0",
@@ -6728,7 +6699,6 @@ dependencies = [
 name = "openmodelica_program_util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6745,7 +6715,6 @@ dependencies = [
 name = "openmodelica_script_util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "curl",
@@ -6789,7 +6758,6 @@ version = "0.1.0"
 name = "openmodelica_simcode_types"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6807,7 +6775,6 @@ dependencies = [
 name = "openmodelica_simcode_util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6829,7 +6796,6 @@ dependencies = [
 name = "openmodelica_susan"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6844,7 +6810,6 @@ dependencies = [
 name = "openmodelica_tpl"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",
@@ -6858,7 +6823,6 @@ dependencies = [
 name = "openmodelica_util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "cc",
  "const-str 1.1.0",
@@ -6882,7 +6846,6 @@ dependencies = [
 name = "openmodelica_util_datatypes_basic"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "const-str 1.1.0",
  "loop_unwrap",

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -316,9 +316,9 @@ pub fn omc_sim_series() -> JsValue {
     arr.into()
 }
 
-/// The last run's editable initial conditions (user-settable parameters): an
-/// array of `{ name, comment, unit, value }`. Feed edits back via a
-/// `-override=name=value` in `simflags` on the next `simulate`/resimulate.
+/// The last run's editable initial conditions: an array of `{ name, comment,
+/// unit, value }`, plus `enumNames` for an enumeration (its value is the 1-based
+/// index). Feed edits back via `-override=name=value` on the next simulate.
 #[wasm_bindgen]
 pub fn omc_sim_parameters() -> JsValue {
     let arr = js_sys::Array::new();
@@ -329,6 +329,13 @@ pub fn omc_sim_parameters() -> JsValue {
             let _ = js_sys::Reflect::set(&item, &JsValue::from_str("comment"), &JsValue::from_str(&p.comment));
             let _ = js_sys::Reflect::set(&item, &JsValue::from_str("unit"), &JsValue::from_str(&p.unit));
             let _ = js_sys::Reflect::set(&item, &JsValue::from_str("value"), &JsValue::from_f64(p.value));
+            if !p.enum_names.is_empty() {
+                let names = js_sys::Array::new();
+                for n in &p.enum_names {
+                    names.push(&JsValue::from_str(n));
+                }
+                let _ = js_sys::Reflect::set(&item, &JsValue::from_str("enumNames"), &names);
+            }
             arr.push(&item);
         }
     });

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -461,6 +461,8 @@ struct EditableParam {
     /// A state's start value (vs. a plain parameter): shown as the state's `t0`
     /// value, and overridden after `functionInitStartValues` rather than before.
     is_start: bool,
+    /// Enumeration literal names (1-based index → name), empty for non-enum.
+    enum_names: Vec<String>,
 }
 
 /// Process-wide table of prepared models, keyed by file-name prefix. Populated
@@ -493,6 +495,8 @@ pub struct CapturedParam {
     pub comment: String,
     pub unit: String,
     pub value: f64,
+    /// Enumeration literal names (1-based index → name), empty for non-enum.
+    pub enum_names: Vec<String>,
 }
 
 /// The last run's results, resolved from the model's [`RunResult`] into per-signal
@@ -590,6 +594,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
             } else {
                 param_value_by_off.get(&p.off).copied().unwrap_or(0.0)
             },
+            enum_names: p.enum_names.clone(),
         })
         .collect();
     *last_sim().lock().unwrap_or_else(|e| e.into_inner()) = Some(CapturedSim {
@@ -1168,6 +1173,17 @@ fn is_result_output(sv: &SimCodeVar::SimVar) -> bool {
     !sv.isProtected && sv.hideResult != Some(true)
 }
 
+/// Literal names of an enumeration type (through subtype/array wrappers), or
+/// `None` for a non-enumeration. The stored value is the 1-based index into these.
+fn enumeration_names(ty: &DAE::Type) -> Option<Vec<String>> {
+    match ty {
+        DAE::Type::T_ENUMERATION { names, .. } => Some(lst(names).map(|n| n.to_string()).collect()),
+        DAE::Type::T_SUBTYPE_BASIC { complexType, .. } => enumeration_names(complexType),
+        DAE::Type::T_ARRAY { ty, .. } => enumeration_names(ty),
+        _ => None,
+    }
+}
+
 /// Map a raw cref display name to the name it carries in the result file, or
 /// `None` to drop it. The new backend names a derivative of a non-state variable
 /// `$DER.x`; the C runtime shows it as `der(x)`. Other `$`-prefixed names are
@@ -1290,6 +1306,7 @@ fn build_var_map(
                     off,
                     wty,
                     is_start: false,
+                    enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }
         }
@@ -1345,6 +1362,7 @@ fn build_var_map(
                     off: start_off,
                     wty: WTy::F64,
                     is_start: true,
+                    enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -647,7 +647,9 @@ pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimE
     // Prefer the module already prepared by `finishCompile` (buildModel's
     // compile phase, counted as `timeCompile`); otherwise join/compile here.
     let t_model = Instant::now();
-    let prepared = model.prepared.lock().unwrap().take();
+    // Clone, not take: keep the module cached so a resimulate reuses it instead
+    // of recompiling the whole model.
+    let prepared = model.prepared.lock().unwrap().clone();
     let model_module = match prepared {
         Some(m) => m,
         None => take_compiled_model(model)?,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
@@ -456,7 +456,9 @@ pub(super) fn build_engine(model: &SimModel) -> Result<(Box<dyn sim_driver::SimE
     // Prefer the module already prepared by `finishCompile` (buildModel's
     // compile phase, counted as `timeCompile`); otherwise join/compile here.
     let t_model = Instant::now();
-    let prepared = model.prepared.lock().unwrap().take();
+    // Clone, not take: keep the module cached so a resimulate reuses it instead
+    // of recompiling the whole model.
+    let prepared = model.prepared.lock().unwrap().clone();
     let model_module = match prepared {
         Some(m) => m,
         None => take_compiled_model(model)?,

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -105,6 +105,8 @@
   /* Auto-fill into as many columns as fit (PID has many parameters to tune). */
   .ic-grid { padding:8px 12px 12px; display:grid; grid-template-columns:repeat(auto-fill,minmax(196px,1fr)); gap:7px 18px; }
   .ic-item { display:grid; grid-template-columns:minmax(0,1fr) 80px auto; gap:9px; align-items:center; }
+  /* Enum: name dropdown, no unit column. */
+  .ic-item.enum { grid-template-columns:minmax(0,1fr) minmax(0,1.4fr); }
   .ic-item .nm { font-size:14px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
   .ic-item .unit { color:var(--muted); font-size:13px; min-width:2.5em; }
   .ic-empty { color:var(--muted); font-size:13px; padding:0 12px 10px; }
@@ -478,7 +480,7 @@ function parseModelName(text) {
 // --- state ------------------------------------------------------------------
 let icValues = new Map();     // param name -> input value (string)
 let builtModel = null, lastText = null;
-let running = false, pendingKind = null;
+let running = false, pendingKind = null, runningKind = null;
 let modelFigures = null;      // parsed figures for the current model, or null
 let viewMode = 'auto';        // 'auto' (figures if present) | 'all'
 const hidden = new Set();     // "chartKey|label" of series toggled off (persists across runs)
@@ -492,7 +494,6 @@ let builtWorker = null;       // worker that holds the current built model (for 
 let mslDone = false;          // true once the MSL worker has finished install+load
 let mslJobStarted = false;    // true once a real MSL job is requested → skip the throwaway warmup
 let copyName = null;          // top-level name of the current library copy (copyClass), else null
-let pendingMods = [];         // [{element, value}] parameter tweaks to apply to the copy before the next rebuild
 let preloaded = null;         // a class already loaded by copyClass (skip the first redundant loadSource)
 let freshModel = true;        // true until a model's own experiment settings have been read back from a run
 let animator = null;          // the three.js Animator (lazily created on first use)
@@ -515,8 +516,14 @@ function seedFromOptions(o) {
 }
 
 async function run(kind) {                       // 'full' | 'resim'
-  if (running) { pendingKind = pendingKind === 'full' ? 'full' : kind; return; }
-  running = true; setRunUI(true);
+  if (running) {
+    pendingKind = pendingKind === 'full' ? 'full' : kind;
+    // Cancel an in-flight resim so the latest values run now; a full build is left
+    // alone (its compiled model is needed, and it can't yield mid-build).
+    if (runningKind === 'resim' && jobWorker) jobWorker.postMessage({ cmd: 'cancelSim' });
+    return;
+  }
+  running = true; runningKind = kind; setRunUI(true);
   log('run', kind, 'mode', mode);
   setStatus(kind === 'resim' ? 'Re-simulating…' : 'Compiling & simulating…', 'busy');
 
@@ -537,23 +544,6 @@ async function run(kind) {                       // 'full' | 'resim'
       if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
       snap = r;
-    } else if (mode === 'librarycopy' && pendingMods.length) {
-      // Tune the copy: apply the parameter tweaks to its AST, refresh the editor
-      // from list(), then rebuild (a model change invalidates the built executable).
-      const worker = await pickWorker('');
-      jobWorker = worker;
-      let src;
-      for (const m of pendingMods) {
-        const sm = await call(worker, 'setModifier', { name: copyName, element: m.element, value: m.value });
-        if (!sm.ok) return fail(sm.error || ('could not set ' + m.element));
-        src = sm.source;
-      }
-      pendingMods = [];
-      if (src != null) { srcEl.value = unquote(src); lastText = srcEl.value; }
-      const r = await call(worker, 'simulate', { name: copyName, override: '', ...settings });
-      if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
-      if (!r.ok) return fail(r.error);
-      builtModel = copyName; builtWorker = worker; snap = r;   // figures/doc unchanged by a tweak
     } else {
       const text = srcEl.value, textChanged = text !== lastText;
       if (touchesModelica(text)) return fail('Refusing to modify the Modelica library — rename the class or remove any "within Modelica" clause.');
@@ -591,7 +581,7 @@ async function run(kind) {                       // 'full' | 'resim'
     log('run failed', e); fail('' + e);
   }
   finally {
-    running = false; setRunUI(false); jobWorker = null; retireW1();
+    running = false; runningKind = null; setRunUI(false); jobWorker = null; retireW1();
     if (pendingKind) { const k = pendingKind; pendingKind = null; run(k); }
   }
 }
@@ -628,7 +618,7 @@ function showBuilding() {
 
 async function selectExample(ex) {
   currentExample = ex;
-  builtModel = null; builtWorker = null; lastText = null; pendingMods = []; preloaded = null; freshModel = true;
+  builtModel = null; builtWorker = null; lastText = null; preloaded = null; freshModel = true;
   showBuilding();
   if (ex.library) {
     // A genuine editable copy via copyClass: a self-contained top-level class with
@@ -698,26 +688,35 @@ function buildInitialConditions() {
   if (!params.length) { icEmpty.style.display = ''; icEmpty.textContent = 'This model has no editable parameters.'; return; }
   icEmpty.style.display = 'none';
   for (const p of params) {
-    icValues.set(p.name, String(p.value));
     const item = document.createElement('div'); item.className = 'ic-item';
     const nm = document.createElement('div'); nm.className = 'nm'; nm.textContent = p.name; nm.title = p.comment || p.name;
-    const inp = document.createElement('input'); inp.type = 'number'; inp.step = 'any'; inp.value = p.value;
-    inp.addEventListener('change', () => onParamChange(p.name, inp.value));
-    const unit = document.createElement('div'); unit.className = 'unit'; unit.innerHTML = unitHTML(p.unit || '');
-    item.append(nm, inp, unit); icGrid.appendChild(item);
+    item.appendChild(nm);
+    if (p.enumNames && p.enumNames.length) {
+      // Enum: the overridden value is the 1-based index.
+      item.classList.add('enum');
+      const idx = Math.round(p.value) || 1;
+      icValues.set(p.name, String(idx));
+      const sel = document.createElement('select');
+      p.enumNames.forEach((n, i) => { const o = document.createElement('option'); o.value = String(i + 1); o.textContent = n; sel.appendChild(o); });
+      sel.value = String(idx);
+      sel.addEventListener('change', () => onParamChange(p.name, sel.value));
+      item.appendChild(sel);
+    } else {
+      icValues.set(p.name, String(p.value));
+      const inp = document.createElement('input'); inp.type = 'number'; inp.step = 'any'; inp.value = p.value;
+      inp.addEventListener('change', () => onParamChange(p.name, inp.value));
+      const unit = document.createElement('div'); unit.className = 'unit'; unit.innerHTML = unitHTML(p.unit || '');
+      item.append(inp, unit);
+    }
+    icGrid.appendChild(item);
   }
 }
 
-// Inline models: -override + fast resim. Library copies: -override cannot touch
-// modifier-bound params, so set the modifier on the copy and full-rebuild.
+// -override=name=value re-simulates the built model without recompiling; no
+// write-back to the model text.
 function onParamChange(name, value) {
   icValues.set(name, value);
-  const v = parseFloat(value);
-  if (mode === 'librarycopy') {
-    if (isFinite(v)) { pendingMods.push({ element: name, value: v }); run('full'); }
-  } else {
-    run('resim');
-  }
+  run('resim');
 }
 
 // Render the model's documentation HTML in the (wide-screen) doc column. The
@@ -1091,8 +1090,8 @@ window.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !settingsB
 
 // --- wiring -----------------------------------------------------------------
 let debounce;
-srcEl.addEventListener('input', () => {   // manual edits are authoritative: drop queued tweaks, re-read the model's settings
-  pendingMods = []; preloaded = null; freshModel = true;
+srcEl.addEventListener('input', () => {   // manual edits are authoritative: re-read the model's settings
+  preloaded = null; freshModel = true;
   clearTimeout(debounce); debounce = setTimeout(() => run('full'), 700);
 });
 for (const id of ['stop', 'intervals', 'method']) el(id).addEventListener('change', () => run('full'));

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -264,14 +264,6 @@ self.onmessage = async (ev) => {
                 figures: figuresFor(a.name), doc: documentationFor(a.name) });
         break;
       }
-      case 'setModifier': {
-        // Tune one parameter on the (already-loaded) copy's AST. A model change
-        // means the built executable is stale, so the page follows with a rebuild.
-        const ok = omc_eval(`setElementModifierValue(${a.name}, ${a.element}, $Code(=${a.value}))`).trim();
-        if (ok !== 'true') return reply({ ok: false, error: omc_eval('getErrorString()').trim() || ('could not set ' + a.element) });
-        reply({ ok: true, source: omc_eval(`list(${a.name})`) });
-        break;
-      }
       case 'simulate': {
         // buildModel (translate + JIT, bakes the settings) then runResumable (a
         // cancellable chunked run + `.mat`). Omitted args use the experiment annotation.


### PR DESCRIPTION
Editing a parameter of a library-example copy (e.g. FullRobot) used to setModifier the copy and full-rebuild: slow, and it wrote the edit back into the model text. Route these edits through -override + resim like inline models -- no recompile, no write-back.

The larger cost was in the runtime: build_engine took the compiled model module out of SimModel.prepared, so the first run consumed it and every resimulate recompiled the whole model from scratch (~60 s for FullRobot). Clone instead of take so the module stays cached and resim reuses it (wasmer and wasmtime paths).

Enumeration parameters now show a dropdown of their literal names (omc_sim_parameters exposes enumNames; the value passed to -override is the 1-based index) instead of a numeric field that errored on edit.

A parameter change during an in-flight resimulate now cancels it, so the latest values run immediately rather than queuing behind a stale run.

Also sync Cargo.lock: drop anyhow, which the Cargo.toml files on this base no longer depend on (the checked-in lock was stale).
