### PR TITLE
SimulationRuntime/fmi: Handle NULL threadData in omc_assert_fmi

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -205,12 +205,19 @@ fmi2Boolean isCategoryLogged(ModelInstance *comp, int categoryIndex)
 static void omc_assert_fmi_common(threadData_t *threadData, fmi2Status status, int categoryIndex, FILE_INFO info, const char *msg, va_list args)
 {
   const char *str;
-  ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
   GC_vasprintf(&str, msg, args);
-  if (info.lineStart) {
-    FILTERED_LOG(c, status, categoryIndex, "%s:%d: %s", info.filename, info.lineStart, str)
+  if (threadData) {
+    ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
+    if (info.lineStart) {
+      FILTERED_LOG(c, status, categoryIndex, "%s:%d: %s", info.filename, info.lineStart, str)
+    } else {
+      FILTERED_LOG(c, status, categoryIndex, "%s", str)
+    }
   } else {
-    FILTERED_LOG(c, status, categoryIndex, "%s", str)
+    printInfo(stderr, info);
+    fputs("Modelica Assert: ", stderr);
+    fputs(str, stderr);
+    fputs("!\n", stderr);
   }
 }
 
@@ -221,7 +228,11 @@ static void omc_assert_fmi(threadData_t *threadData, FILE_INFO info, const char 
   va_start(args, msg);
   omc_assert_fmi_common(threadData, fmi2Error, LOG_STATUSERROR, info, msg, args);
   va_end(args);
-  MMC_THROW_INTERNAL();
+  if (threadData) {
+    MMC_THROW_INTERNAL();
+  } else {
+    MMC_THROW();
+  }
 }
 
 static void omc_assert_fmi_warning(FILE_INFO info, const char *msg, ...)

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -262,12 +262,19 @@ fmi3Boolean isCategoryLogged(ModelInstance *comp, int categoryIndex)
 static void omc_assert_fmi_common(threadData_t *threadData, fmi3Status status, int categoryIndex, FILE_INFO info, const char *msg, va_list args)
 {
   const char *str;
-  ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
   GC_vasprintf(&str, msg, args);
-  if (info.lineStart) {
-    FILTERED_LOG(c, status, categoryIndex, "%s:%d: %s", info.filename, info.lineStart, str)
+  if (threadData) {
+    ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
+    if (info.lineStart) {
+      FILTERED_LOG(c, status, categoryIndex, "%s:%d: %s", info.filename, info.lineStart, str)
+    } else {
+      FILTERED_LOG(c, status, categoryIndex, "%s", str)
+    }
   } else {
-    FILTERED_LOG(c, status, categoryIndex, "%s", str)
+    printInfo(stderr, info);
+    fputs("Modelica Assert: ", stderr);
+    fputs(str, stderr);
+    fputs("!\n", stderr);
   }
 }
 
@@ -278,7 +285,11 @@ static void omc_assert_fmi(threadData_t *threadData, FILE_INFO info, const char 
   va_start(args, msg);
   omc_assert_fmi_common(threadData, fmi3Error, LOG_STATUSERROR, info, msg, args);
   va_end(args);
-  MMC_THROW_INTERNAL();
+  if (threadData) {
+    MMC_THROW_INTERNAL();
+  } else {
+    MMC_THROW();
+  }
 }
 
 static void omc_assert_fmi_warning(FILE_INFO info, const char *msg, ...)

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -38,6 +38,7 @@ FMUResourceTest.mos \
 HelloFMIWorld.mos \
 HelloFMIWorldEvent.mos \
 IntegerNetwork1.mos \
+issue10978.mos \
 Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos \
 Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos \
 Modelica.Electrical.Analog.Examples.ChuaCircuit.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/issue10978.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/issue10978.mos
@@ -1,0 +1,45 @@
+// name:     issue10978
+// keywords: fmi assert null threadData
+// status: correct
+// teardown_command: rm -rf issue10978.fmu issue10978_me_FMU* output.log
+// cflags: -d=-newInst
+
+loadString("
+model issue10978
+  Real x(start=1, fixed=true);
+  String s;
+equation
+  der(x) = 0;
+  s = String(x, format=\"n\");
+end issue10978;
+"); getErrorString();
+
+buildModelFMU(issue10978, version="2.0"); getErrorString();
+importFMU("issue10978.fmu"); getErrorString();
+setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
+loadFile("issue10978_me_FMU.mo"); getErrorString();
+simulate(issue10978_me_FMU); getErrorString();
+
+// Result:
+// true
+// ""
+// "issue10978.fmu"
+// ""
+// "issue10978_me_FMU.mo"
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'issue10978_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "Simulation execution failed for model: issue10978_me_FMU
+// [:0:0-0:0:writable]Modelica Assert: Could not parse format string: invalid conversion specifier: n in n!
+// module = issue10978, log level = ERROR: [logFmi2Call][FMU status:Error] fmi2ExitInitializationMode: terminated by an assertion.
+// LOG_ASSERT        | debug   | fmi2ExitInitializationMode failed with status : Error
+// LOG_ASSERT        | info    | simulation terminated by an assertion at initialization
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
omc_assert_fmi_common dereferences threadData unconditionally, causing a segfault when omc_assert is called with NULL (e.g. from calc_base_index_va or modelica_string.c). Add a NULL check: fall back to stderr + MMC_THROW() when threadData is NULL, matching omc_assert_function in omc_error.c.

Closes #10978
