### PR TITLE
spatialDistribution with unused output

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -360,7 +360,8 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   double deltaX;
   double eventPreValue;
   double outValue;
-  double out0;    /* Output variable */
+  double out0;      /* First output variable */
+  double out1Val;   /* Second output variable, only written to *out1 if out1 != NULL */
 
   /* Access spatialDistribution */
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
@@ -401,8 +402,11 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     firstNodeData = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
     lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
     out0 = firstNodeData->value;
-    *out1 = lastNodeData->value;
-    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = (%f, %f)", out0, *out1);
+    out1Val = lastNodeData->value;
+    if (out1 != NULL) {
+      *out1 = out1Val;
+    }
+    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = (%f, %f)", out0, out1Val);
     messageClose(OMC_LOG_SPATIALDISTR);
     return out0;
   }
@@ -434,19 +438,23 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     } else {
       out0 = firstNodeData->value;
     }
-    *out1 = outValue;
+    out1Val = outValue;
   } else {
     out0 = outValue;
     if (jumped) {
-      *out1 = in1;
+      out1Val = in1;
     } else if (deltaX > SPATIAL_EPS && fabs(forelastNodeData->position-lastNodeData->position)>SPATIAL_EPS) {
-      *out1 = extrapolateTransportedQuantity(forelastNodeData, lastNodeData, -posX+1);
+      out1Val = extrapolateTransportedQuantity(forelastNodeData, lastNodeData, -posX+1);
     } else {
-      *out1 = lastNodeData->value;
+      out1Val = lastNodeData->value;
     }
   }
 
-  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = (%f, %f)", out0, *out1);
+  if (out1 != NULL) {
+    *out1 = out1Val;
+  }
+
+  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = (%f, %f)", out0, out1Val);
   messageClose(OMC_LOG_SPATIALDISTR);
   return out0;
 }

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../rtest -v
 TESTFILES = \
 	initSpatialDistribution.mos \
 	helloSpatialDistribution.mos \
+	singleOutputSpatialDistribution.mos \
 	negativeVelocity.mos \
 	pulseInput.mos \
 	mixedVelocity.mos \

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/singleOutputSpatialDistribution.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/singleOutputSpatialDistribution.mos
@@ -1,0 +1,90 @@
+// name:                singleOutputSpatialDistribution.mos
+// keywords:            spatialDistribution
+// status:              correct
+// teardown_command:    rm -f SingleOutput*
+//
+// Models that only use one of the two outputs of the spatialDistribution
+// operator. In that case the code generator passes NULL for the unused output
+// pointer and the runtime must not dereference it.
+// Regression test for #15431.
+
+loadModel(Modelica); getErrorString();
+
+// Only the first output is used, second output pointer is NULL.
+loadString("
+  model SingleOutputFirst
+    \"Only uses the first output of spatialDistribution (negative velocity).\"
+  extends Modelica.Icons.Example;
+  Real input_ = time*2;
+  Real leftOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {1.0, 1.0};
+  Real v;
+  Boolean posV;
+  Real x(start=0, fixed=true);
+equation
+  v = der(x);
+  v = -1;
+  posV = v >= 0;
+  leftOutput = spatialDistribution(input_, input_, x, posV, initialPoints, initialValues);
+end SingleOutputFirst;"); getErrorString();
+
+// Only the second output is used, first output pointer is unused (return value).
+loadString("
+  model SingleOutputSecond
+    \"Only uses the second output of spatialDistribution (positive velocity).\"
+  extends Modelica.Icons.Example;
+  Real input_ = time*2;
+  Real rightOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {1.0, 1.0};
+  Real v;
+  Boolean posV;
+  Real x(start=0, fixed=true);
+equation
+  v = der(x);
+  v = 1;
+  posV = v >= 0;
+  (, rightOutput) = spatialDistribution(input_, input_, x, posV, initialPoints, initialValues);
+end SingleOutputSecond;"); getErrorString();
+
+simulate(SingleOutputFirst, stopTime=2.0); getErrorString();
+val(leftOutput, 0.0);
+val(leftOutput, 1.0);
+val(leftOutput, 2.0);
+
+simulate(SingleOutputSecond, stopTime=2.0); getErrorString();
+val(rightOutput, 0.0);
+val(rightOutput, 1.0);
+val(rightOutput, 2.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "SingleOutputFirst_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SingleOutputFirst', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 0.0
+// 2.0
+// record SimulationResult
+//     resultFile = "SingleOutputSecond_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SingleOutputSecond', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 1.0
+// 2.0
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/15431

### Purpose

When a model only uses the first output of the spatialDistribution operator, the code generator passes NULL for the unused second-output pointer. The runtime spatialDistribution() unconditionally dereferenced *out1, causing a segmentation fault.

### Approach

* Compute the second output into a local and only write it through the pointer when out1 is non-NULL, so models using a single output simulate correctly.
* Add regression test covering both the "only first output used" (NULL out1) and "only second output used" cases.
