### PR TITLE
ParModelica: fix -ltbb link error on MSYS2 ucrt64 (use -ltbb12)

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -43,7 +43,9 @@ encapsulated package Autoconf
   constant String ldflags_runtime_fmu_static = " -lSimulationRuntimeFMI " + ldflags_runtime_fmu;
 
   // Libraries linked into generated simulation code when --parmodauto (ParModelica auto) is enabled.
-  constant String parModelicaAutoLibs = " -lParModelicaAuto -ltbb ";
+  // MSYS2 ucrt64's tbb package only ships the oneTBB-versioned import lib (libtbb12.dll.a),
+  // not an unversioned libtbb.dll.a/libtbb.a, so link against -ltbb12 here.
+  constant String parModelicaAutoLibs = " -lParModelicaAuto -ltbb12 ";
 
   constant String platform = if is64Bit then "WIN64" else "WIN32";
   constant String pathDelimiter = "/";


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/discussions/16064

### Purpose

MSYS2's ucrt64 tbb package has lib libtbb12.dll.a), not an unversioned libtbb.dll.a/libtbb.a, so --parmodauto builds failed at link time with "cannot find -ltbb".

