### PR TITLE
[NB] NBAlias: replace reinit stateVar when alias-eliminating a state

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
@@ -180,7 +180,7 @@ public
   algorithm
     // do nothing if replacements are empty
     if UnorderedMap.isEmpty(replacements) then return; end if;
-    eqData := EqData.mapExp(eqData, function applySimpleExp(replacements = replacements));
+    eqData := EqData.mapExp(eqData, function applySimpleExp(replacements = replacements), SOME(function applySimpleCref(replacements = replacements)));
 
     // apply on bindings (is this necessary?)
     varData := match varData
@@ -238,6 +238,23 @@ public
       else exp;
     end match;
   end applySimpleExp;
+
+  function applySimpleCref
+    "Needs to be used as funcCref in Equation.map() to replace crefs that appear
+    as direct ComponentRef arguments (e.g. the state variable of a reinit statement)."
+    input output ComponentRef cref;
+    input UnorderedMap<ComponentRef, Expression> replacements;
+  protected
+    Expression replacement;
+  algorithm
+    if UnorderedMap.contains(cref, replacements) then
+      replacement := UnorderedMap.getOrFail(cref, replacements);
+      cref := match replacement
+        case Expression.CREF() then replacement.cref;
+        else cref;
+      end match;
+    end if;
+  end applySimpleCref;
 
   function applySimpleVar
     "applys replacement on the variable binding expression"

--- a/testsuite/simulation/modelica/NBackend/Buildings/Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset.mos
+++ b/testsuite/simulation/modelica/NBackend/Buildings/Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset.mos
@@ -1,0 +1,23 @@
+// name: Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset
+// keywords: NewBackend Buildings CDL PID integrator reinit alias
+// status: correct
+// teardown_command: rm -rf Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset.libs Buildings*.libs
+
+loadModel(Buildings, {"12.1.1"}); getErrorString();
+setCommandLineOptions("--newBackend"); getErrorString();
+simulate(Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
When applySimple replaced alias variables in equations, it traversed expressions via applySimpleExp but passed no funcCref to EqData.mapExp. WhenStatement.REINIT stores its state variable as a bare ComponentRef, not an Expression, so the alias substitution was never applied to it. After alias elimination, the reinit stateVar still referenced the eliminated variable, causing lowerComponentReference to fail with "getVarSafe: variable not found" in the After Index Reduction Inline phase.

Fix: add applySimpleCref and pass it as funcCrefOpt to EqData.mapExp in applySimple, so that reinit stateVars (and any other bare ComponentRef arguments) are updated alongside expression substitutions.

Fixes Buildings.Controls.OBC.CDL.Reals.Validation.PIDWithReset and related models that use LimPID blocks with integrator reset.