### PR TITLE
Add rust-src to the pinned Rust toolchain

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/rust-toolchain.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/rust-toolchain.toml
@@ -7,8 +7,12 @@
 # wasm-jit builds; wasm32-wasip1 is for the standalone-export runtime that
 # openmodelica_codegen_wasm_jit/build.rs embeds (its unit tests need it, so it
 # must be present in the CI test container too, not just the cmake build).
+#
+# rust-src: the FMI3 wasm adapters build.rs compiles need `-Z build-std`, which
+# builds the std sources; without this component the adapter silently falls back
+# to an empty placeholder and FMI3 FMU export fails at runtime.
 [toolchain]
 channel = "nightly-2026-05-31"
 profile = "minimal"
-components = ["rustc-codegen-cranelift-preview", "clippy", "rustfmt"]
+components = ["rustc-codegen-cranelift-preview", "clippy", "rustfmt", "rust-src"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]


### PR DESCRIPTION
The FMI3 wasm adapters that openmodelica_codegen_wasm_jit/build.rs compiles are built with `-Z build-std`, which needs the rust-src component to build the std sources. Without it the adapter build silently fails, build.rs embeds an empty placeholder, and FMI3 FMU export fails at runtime with "FMI3 adapter unavailable".

Declaring it in components makes rustup auto-install it wherever the workspace is built.