### PR TITLE
wasm FMI CS: report events to the master

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -146,6 +146,10 @@ struct MeState {
     /// Built on exit-initialization-mode, once the model is initialized.
     #[cfg(feature = "cs")]
     cs: Option<CsDriver>,
+    /// `eventModeUsed` from instantiation: `do-step` stops at and reports each event
+    /// for the master, rather than handling it internally.
+    #[cfg(feature = "cs")]
+    event_mode: bool,
     vrs: Vrs,
     in_init: bool,
     /// Set during Initialization Mode, applied by `run_initialization`: states as
@@ -278,6 +282,8 @@ fn new_state() -> Option<MeState> {
         meta,
         #[cfg(feature = "cs")]
         cs: None,
+        #[cfg(feature = "cs")]
+        event_mode: false,
         in_init: false,
         init_overrides: Vec::new(),
         init_start_overrides: Vec::new(),
@@ -348,7 +354,18 @@ macro_rules! shared_instance_methods {
         }
         // The CS driver is built lazily on the first `do-step` (see there): a me_cs
         // component driven in Model Exchange must not pay for — or be perturbed by —
-        // a driver it never uses.
+        // a driver it never uses. Event Mode is the exception: the master's first
+        // action after init is an event iteration (`update-discrete-states`), which
+        // must run through the driver's sample schedule, so build it eagerly.
+        #[cfg(feature = "cs")]
+        if st.event_mode {
+            let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
+            let meta = st.meta.clone();
+            match CsDriver::new(&mut e, &meta, sim_data, t) {
+                Ok(d) => st.cs = Some(d),
+                Err(_) => return Status::Error,
+            }
+        }
         Status::Ok
     }
 
@@ -364,10 +381,31 @@ macro_rules! shared_instance_methods {
         let (sim_data, layout) = (st.sim_data, st.layout);
         let time = st.read_f64(TIME_OFF);
         let mut e = Engine;
+
+        #[cfg(feature = "cs")]
+        let up = if st.event_mode {
+            // Route through the driver so its sample schedule advances in step with
+            // the integrator (see `CsDriver::do_event_update`).
+            let meta = st.meta.clone();
+            let mut d = st.cs.take().ok_or(Status::Error)?;
+            let r = d.do_event_update(&mut e, &meta, time);
+            st.cs = Some(d);
+            match r {
+                Ok(up) => up,
+                Err(_) => return Err(Status::Error),
+            }
+        } else {
+            match event_update(&mut e, sim_data, &layout, st.samples.as_mut(), time) {
+                Ok(up) => up,
+                Err(_) => return Err(Status::Error),
+            }
+        };
+        #[cfg(not(feature = "cs"))]
         let up = match event_update(&mut e, sim_data, &layout, st.samples.as_mut(), time) {
             Ok(up) => up,
             Err(_) => return Err(Status::Error),
         };
+
         Ok(DiscreteStatesInfo {
             new_discrete_states_needed: false,
             terminate_simulation: up.terminate,
@@ -787,17 +825,18 @@ impl GuestCoSimulationInstance for Instance {
         _resource_path: String,
         _visible: bool,
         _logging_on: bool,
-        _event_mode_used: bool,
+        event_mode_used: bool,
         _early_return_allowed: bool,
         _required_intermediate_variables: Vec<u32>,
     ) -> Option<CoSimulationInstance> {
-        let st = new_state()?;
+        let mut st = new_state()?;
+        st.event_mode = event_mode_used;
         Some(CoSimulationInstance::new(Instance { st: RefCell::new(st) }))
     }
 
-    /// Integrate to the communication point, handling events on the way: the
-    /// modelDescription declares `hasEventMode="false"` for this target, so the
-    /// importer never drives Event Mode and `event-handling-needed` stays false.
+    /// Integrate to the communication point. Under `eventModeUsed` it stops at the
+    /// first event and returns `event-handling-needed`; otherwise events are handled
+    /// internally.
     fn do_step(
         &self,
         current_communication_point: f64,
@@ -806,10 +845,12 @@ impl GuestCoSimulationInstance for Instance {
     ) -> Result<DoStepResult, Status> {
         let mut st = self.st.borrow_mut();
         let target = current_communication_point + communication_step_size;
+        let event_mode = st.event_mode;
         let meta = st.meta.clone();
         let mut e = Engine;
         // Build the driver on first use, over the initialized state at the start
         // point (FMI ran Initialization Mode; the importer may also have set inputs).
+        // Event Mode already built it in exit-initialization-mode.
         if st.cs.is_none() {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
             match CsDriver::new(&mut e, &meta, sim_data, t) {
@@ -818,15 +859,26 @@ impl GuestCoSimulationInstance for Instance {
             }
         }
         let Some(mut driver) = st.cs.take() else { return Err(Status::Error) };
-        let outcome = driver.step_to(&mut e, &meta, target);
+        let outcome = if event_mode {
+            driver.step_to_event(&mut e, &meta, target)
+        } else {
+            driver.step_to(&mut e, &meta, target)
+        };
         let last = driver.time();
         st.cs = Some(driver);
+        let eps = target.abs().max(1.0) * 1e-10;
         match outcome {
             Ok(CsStep::Reached) => Ok(DoStepResult {
                 last_successful_time: last,
                 event_handling_needed: false,
                 terminate_simulation: false,
                 early_return: false,
+            }),
+            Ok(CsStep::Event { time }) => Ok(DoStepResult {
+                last_successful_time: time,
+                event_handling_needed: true,
+                terminate_simulation: false,
+                early_return: time + eps < target,
             }),
             Ok(CsStep::Terminated) => Ok(DoStepResult {
                 last_successful_time: last,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -1671,6 +1671,9 @@ enum Step {
     /// already emitted.
     Reached { grid_covered: bool },
     Terminated,
+    /// Located an event at `time`, discrete update left undone for the caller to
+    /// report (CS Event Mode). Only returned under `stop_at_event`.
+    Event { time: f64 },
     /// Out of budget mid-target; call again with the same `tout`.
     Yielded,
     Cancelled,
@@ -1778,6 +1781,8 @@ impl DasslCore {
     /// samples due on the way. `rows` collects the pre/post-event rows when the
     /// caller wants them; CS passes `None`. A `Yielded` return resumes on the same
     /// `tout` (DASKR continues via INFO(1)=1), so the yields are safe points.
+    /// `stop_at_event` (CS Event Mode) stops at the first event and returns
+    /// [`Step::Event`] instead of updating in place.
     #[allow(clippy::too_many_arguments)]
     fn integrate_to(
         &mut self,
@@ -1789,6 +1794,7 @@ impl DasslCore {
         deadline: f64,
         mut rows: Option<&mut Vec<f64>>,
         did_step: &mut bool,
+        stop_at_event: bool,
     ) -> Result<Step> {
         use daskr::solver;
         let layout = &model.layout;
@@ -1870,8 +1876,12 @@ impl DasslCore {
                 // IDID=5: a zero-crossing root at `t` (< target). Handle the state
                 // event here, then restart the integrator and keep going.
                 if self.idid == 5 {
-                    self.state_events += 1;
                     let troot = self.t;
+                    if stop_at_event {
+                        write_f64(e, sim_data + TIME_OFF, troot)?;
+                        return Ok(Step::Event { time: troot });
+                    }
+                    self.state_events += 1;
                     // pre-event row (before the discrete update), then event +
                     // post-event row.
                     if let Some(r) = rows.as_deref_mut() {
@@ -1904,6 +1914,11 @@ impl DasslCore {
                 // despite float drift).
                 let te = if (te - tout).abs() <= eps { tout } else { te };
                 *did_step = true;
+                if stop_at_event {
+                    self.t = te;
+                    write_f64(e, sim_data + TIME_OFF, te)?;
+                    return Ok(Step::Event { time: te });
+                }
                 if let Some(r) = rows.as_deref_mut() {
                     emit_row(e, r, sim_data, layout, te)?; // pre-event row (held)
                 }
@@ -1942,9 +1957,9 @@ impl DasslCore {
 
 /// Co-Simulation: the FMU owns the integration, the importer picks the
 /// communication points. Unlike [`DasslEventsDriver`] there is no output grid and
-/// no rows -- `step_to` just advances the shared [`DasslCore`] to the next
-/// communication point, handling events internally on the way (FMI's
-/// `eventModeUsed = false`).
+/// no rows. [`step_to`](CsDriver::step_to) handles events internally
+/// (`eventModeUsed = false`); [`step_to_event`](CsDriver::step_to_event) stops at
+/// each event and reports it for the master to drive (`eventModeUsed = true`).
 ///
 /// The caller initializes the model (`run_initialization`) before building this,
 /// since FMI does that in its own Initialization Mode.
@@ -1956,12 +1971,17 @@ pub struct CsDriver {
     /// Only ever set for event-free models (events force DASSL, as in `make_driver`).
     euler_h: Option<f64>,
     euler_steps: u64,
+    /// A `do_event_update` ran since the last step, so `step_to_event` must re-read
+    /// states and restart DASKR.
+    resume_reinit: bool,
 }
 
-/// What [`CsDriver::step_to`] did.
+/// What [`CsDriver::step_to`] / [`step_to_event`](CsDriver::step_to_event) did.
 pub enum CsStep {
     /// Reached the requested time.
     Reached,
+    /// Event Mode only: stopped at an event at `time` for the master to handle.
+    Event { time: f64 },
     /// `terminate()` fired; `last_time` is where it stopped.
     Terminated,
 }
@@ -1991,7 +2011,7 @@ impl CsDriver {
         } else {
             None
         };
-        Ok(CsDriver { core, samp, pivots, euler_h, euler_steps: 0 })
+        Ok(CsDriver { core, samp, pivots, euler_h, euler_steps: 0, resume_reinit: false })
     }
 
     /// The time reached so far (FMI's `last-successful-time`).
@@ -2037,13 +2057,16 @@ impl CsDriver {
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
         let mut did_step = false;
         let outcome = self.core.integrate_to(
-            e, model, &mut ctx, &mut self.samp, t_target, f64::INFINITY, None, &mut did_step,
+            e, model, &mut ctx, &mut self.samp, t_target, f64::INFINITY, None, &mut did_step, false,
         )?;
         self.core.nfe = ctx.nfe;
         match outcome {
             Step::Terminated => return Ok(CsStep::Terminated),
-            // `deadline` is +inf and CS does not cancel, so these cannot arise.
-            Step::Yielded | Step::Cancelled => return Err("CodegenWasmJit: CS step yielded unexpectedly"),
+            // `deadline` is +inf, CS does not cancel, and `stop_at_event` is off on
+            // this path, so none of these can arise.
+            Step::Yielded | Step::Cancelled | Step::Event { .. } => {
+                return Err("CodegenWasmJit: CS step yielded unexpectedly")
+            }
             Step::Reached { .. } => {}
         }
         // Refresh the outputs at the communication point, and re-select states there
@@ -2061,6 +2084,95 @@ impl CsDriver {
             return Ok(CsStep::Terminated);
         }
         Ok(CsStep::Reached)
+    }
+
+    /// Event Mode step (`eventModeUsed = true`): integrate toward `t_target`,
+    /// stopping at the first event and returning [`CsStep::Event`] without the
+    /// discrete update — the master runs that via [`do_event_update`] and resumes.
+    ///
+    /// [`do_event_update`]: CsDriver::do_event_update
+    pub fn step_to_event(
+        &mut self,
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        t_target: f64,
+    ) -> Result<CsStep> {
+        let layout = &model.layout;
+        let sim_data = self.core.sim_data;
+        // A reinit or discrete change in the master's update needs a DASKR restart.
+        if self.resume_reinit {
+            if self.core.n_states > 0 {
+                e.call1("functionODE", sim_data)?;
+                self.core.read_states(e)?;
+                self.core.info[0] = 0;
+            }
+            self.resume_reinit = false;
+        }
+        // No continuous states: stop at the next sample in the step for the master.
+        if self.core.n_states == 0 {
+            let eps = t_target.abs().max(1.0) * 1e-10;
+            let te = self.samp.next_time();
+            if te <= t_target + eps {
+                self.core.t = te;
+                write_f64(e, sim_data + TIME_OFF, te)?;
+                return Ok(CsStep::Event { time: te });
+            }
+            self.core.t = t_target;
+            write_f64(e, sim_data + TIME_OFF, t_target)?;
+            e.call1_if_present("functionAlgebraics", sim_data)?;
+            return Ok(CsStep::Reached);
+        }
+
+        let mut ctx = self.core.res_ctx(e, layout);
+        let _guard = ResCtxGuard;
+        RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
+        let mut did_step = false;
+        let outcome = self.core.integrate_to(
+            e, model, &mut ctx, &mut self.samp, t_target, f64::INFINITY, None, &mut did_step, true,
+        )?;
+        self.core.nfe = ctx.nfe;
+        match outcome {
+            Step::Terminated => return Ok(CsStep::Terminated),
+            Step::Event { time } => return Ok(CsStep::Event { time }),
+            // `deadline` is +inf and CS does not cancel.
+            Step::Yielded | Step::Cancelled => return Err("CodegenWasmJit: CS step yielded unexpectedly"),
+            Step::Reached { .. } => {}
+        }
+        // Communication point reached with no event: refresh outputs like `step_to`.
+        write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+        write_f64(e, sim_data + TIME_OFF, t_target)?;
+        e.call1("functionODE", sim_data)?;
+        e.call1_if_present("functionAlgebraics", sim_data)?;
+        if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
+            e.call1("functionODE", sim_data)?;
+            self.core.read_states(e)?;
+            self.core.info[0] = 0;
+        }
+        if terminated(e, sim_data, layout)? {
+            return Ok(CsStep::Terminated);
+        }
+        Ok(CsStep::Reached)
+    }
+
+    /// The master's `update-discrete-states` at the event `step_to_event` stopped on.
+    /// Fires any sample through the driver's own schedule so it stays in step with
+    /// the integrator, and flags a DASKR restart for the next step.
+    pub fn do_event_update(
+        &mut self,
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        time: f64,
+    ) -> Result<EventUpdate> {
+        let layout = &model.layout;
+        let eps = time.abs().max(1.0) * 1e-10;
+        if self.samp.next_time() <= time + eps {
+            self.core.time_events += 1;
+        } else {
+            self.core.state_events += 1;
+        }
+        let up = event_update(e, self.core.sim_data, layout, Some(&mut self.samp), time)?;
+        self.resume_reinit = true;
+        Ok(up)
     }
 
     /// Fixed-step forward Euler to `t_target`, sub-stepping by `h0` and landing
@@ -2263,7 +2375,7 @@ impl Driver for DasslEventsDriver {
                 self.grid_covered = false;
             }
             match self.core.integrate_to(
-                e, model, &mut ctx, &mut self.samp, tout, deadline, Some(&mut self.rows), &mut did_step,
+                e, model, &mut ctx, &mut self.samp, tout, deadline, Some(&mut self.rows), &mut did_step, false,
             )? {
                 Step::Yielded => {
                     // Resume on the same row; `mid_row` keeps `grid_covered`.
@@ -2272,6 +2384,8 @@ impl Driver for DasslEventsDriver {
                 }
                 Step::Cancelled => return Ok(Advance::Cancelled),
                 Step::Terminated => break Advance::Terminated,
+                // `stop_at_event` is false here, so `Event` never arises.
+                Step::Event { .. } => unreachable!("stop_at_event is off for the output-grid driver"),
                 Step::Reached { grid_covered } => self.grid_covered |= grid_covered,
             }
             // Row's inner loop done; the rest is bounded — next yield is a clean boundary.

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -26,6 +26,8 @@
     padding:0 5px; margin-right:4px; font-size:12px; color:var(--teal); }
   .tag.off { color:var(--muted); opacity:.55; }
   .grid2 .wide { grid-column:2 / -1; }
+  .grid2 label.chk:not([hidden]) { color:var(--fg); display:flex; align-items:center; gap:7px; white-space:normal; cursor:pointer; font-size:13px; }
+  .grid2 label.chk input { width:auto; margin:0; }
   input:disabled { color:var(--muted); }
 
   #icPanel { flex:1 1 auto; overflow-y:auto; min-height:80px; }
@@ -103,6 +105,8 @@
       <label for="stop">Stop</label><input id="stop" value="1" />
       <label for="step" id="stepLabel">Step size</label><input id="step" value="0.1" />
       <label for="tol">Tolerance</label><input id="tol" value="1e-6" />
+      <label for="eventMode" id="eventModeLabel" title="Report events to the master algorithm (Event Mode) instead of handling them inside the FMU" hidden>Event mode</label>
+      <label class="chk wide" id="eventModeCell" title="Report events to the master algorithm (Event Mode) instead of handling them inside the FMU" hidden><input type="checkbox" id="eventMode" checked /></label>
     </div>
   </div>
 
@@ -132,6 +136,7 @@ const chartsEl = el('charts'), chartsEmpty = el('chartsEmpty'), logEl = el('log'
 const charts = createCharts(chartsEl);
 const ifaceEl = el('interface'), startEl = el('start'), stopEl = el('stop'), stepEl = el('step'),
       tolEl = el('tol'), stepLabel = el('stepLabel');
+const eventModeEl = el('eventMode'), eventModeLabel = el('eventModeLabel'), eventModeCell = el('eventModeCell');
 
 let fmu = null;         // { md, exports, cs, me, resourcePath }
 let fields = [];        // { v, input, kind:'input'|'parameter' }
@@ -218,6 +223,9 @@ function renderInfo(fileName, probe) {
 ifaceEl.onchange = onIfaceChange;
 function onIfaceChange() {
   stepLabel.textContent = ifaceEl.value === 'me' ? 'Max step' : 'Step size';
+  // The Event Mode toggle only applies to a CS FMU that advertises the capability.
+  const showEventMode = ifaceEl.value === 'cs' && !!(fmu && fmu.md.cs && fmu.md.cs.hasEventMode);
+  eventModeLabel.hidden = eventModeCell.hidden = !showEventMode;
 }
 
 // Inputs are functions of t; parameters and start values are constants applied
@@ -312,6 +320,7 @@ async function run() {
       stepSize: num(stepEl.value, 0.1),
       tolerance: num(tolEl.value, 1e-6),
       inputs, parameters,
+      eventMode: eventModeEl.checked,
       shouldCancel: () => cancelled,
       onProgress: (t) => setStatus(`Simulating… t = ${(+t.toPrecision(4))}`, 'busy'),
     };

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/master.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/master.js
@@ -111,7 +111,8 @@ async function pump(o, t) {
 export async function runCS(inst, md, o) {
   const setInputs = makeInputs(o.inputs || []);
   const rec = makeRecorder(md);
-  const eventMode = !!(md.cs && md.cs.hasEventMode);
+  // Resolved by `simulate` (capability AND the user's choice); default on.
+  const eventMode = !!o.eventMode;
 
   initialize(inst, o, setInputs);
   if (eventMode) {
@@ -297,10 +298,13 @@ export async function simulate(fmu, kind, o) {
   const token = md.instantiationToken;
   let inst;
   if (kind === 'cs') {
+    // Needs the capability; within it the caller may opt out. Default on.
+    // eventModeUsed and earlyReturnAllowed move together.
+    const eventMode = !!md.cs.hasEventMode && (o.eventMode ?? true);
     inst = fmu.cs.CoSimulationInstance.instantiateCoSimulation(
-      name, token, fmu.resourcePath, false, true, !!md.cs.hasEventMode, false, []);
+      name, token, fmu.resourcePath, false, true, eventMode, eventMode, []);
     if (!inst) throw new Error('instantiate-co-simulation returned no instance');
-    return await runCS(inst, md, o);
+    return await runCS(inst, md, { ...o, eventMode });
   }
   inst = fmu.me.ModelExchangeInstance.instantiateModelExchange(
     name, token, fmu.resourcePath, false, true);

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -262,8 +262,8 @@ end ModelExchange3;
 template CoSimulation3(SimCode simCode, list<String> sourceFiles)
  "Generates the CoSimulation element for FMI 3.0. The capabilities are the
   runtime's, so they depend on the code-generation target: the wasm-jit adapter
-  integrates itself but has no output derivatives and handles events internally
-  (the importer never drives Event Mode)."
+  integrates itself and has no output derivatives, but supports Event Mode
+  (stops at events and reports them when the importer negotiates eventModeUsed)."
 ::=
 match simCode
 case SIMCODE(__) then
@@ -277,9 +277,9 @@ case SIMCODE(__) then
     canBeInstantiatedOnlyOncePerProcess="false"
     maxOutputDerivativeOrder="<%if stringEq(isWasm, "true") then "0" else "1"%>"
     providesIntermediateUpdate="false"
-    mightReturnEarlyFromDoStep="<%if stringEq(isWasm, "true") then "false" else "true"%>"
+    mightReturnEarlyFromDoStep="true"
     canReturnEarlyAfterIntermediateUpdate="false"
-    hasEventMode="<%if stringEq(isWasm, "true") then "false" else "true"%>"
+    hasEventMode="true"
     providesEvaluateDiscreteStates="false"
     recommendedIntermediateInputSmoothness="0"
     canGetAndSetFMUState="true"


### PR DESCRIPTION
The wasm Co-Simulation FMU declared hasEventMode="false" and handled every event inside do-step, so it never reported events to the master algorithm. Implement FMI 3.0 Event Mode for the CS target.

- driver.rs: integrate_to gains stop_at_event -> Step::Event, halting at a state zero-crossing or sample without doing the discrete update. CsDriver gains step_to_event, do_event_update (fires samples through its own schedule so it stays in step), and a restart-after-event path.
- fmi3_wasm: the instance stores eventModeUsed; in that mode the driver is built eagerly at exit-initialization-mode, update-discrete-states and do-step route through it, and do-step reports event-handling- needed / early-return.
- CodegenFMU3.tpl: wasm CS FMUs declare hasEventMode and mightReturnEarlyFromDoStep = "true".
- fmi-simulator: an "Event mode" checkbox (default on) appears for a CS FMU with the capability so the two paths can be compared; master.js negotiates earlyReturnAllowed and resolves the choice.

Verified natively, under node, and in a browser: BouncingBall and TestSample report their events through the enter-event-mode / update-discrete-states / enter-step-mode handshake, with results matching the internal-handling path and the analytic solutions.