### PR TITLE
[NB] Fix duplicate parameter equations for unbound known records in initialization

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
@@ -443,7 +443,10 @@ public
           if BVariable.isBound(c_var) then
             BVariable.setBindingAsStart(c_var, true);
           end if;
-          (parameter_eqs, initial_param_vars) := createParameterEquation(c_var, new_iters, idx, parameter_eqs, initial_param_vars);
+          // Only recurse for record children; scalar children are already handled by the parameters pass
+          if BVariable.isRecord(c_var) then
+            (parameter_eqs, initial_param_vars) := createParameterEquation(c_var, new_iters, idx, parameter_eqs, initial_param_vars);
+          end if;
         end for;
       end if;
 
@@ -453,7 +456,6 @@ public
       if not BVariable.hasEvaluableBinding(var) then
         // add variable to initial unknowns
         initial_param_vars := var :: initial_param_vars;
-        // generate equation only if variable is fixed
         if BVariable.isFixed(var) then
           parameter_eqs := Equation.generateBindingEquation(var, idx, true, new_iters) :: parameter_eqs;
         end if;

--- a/testsuite/simulation/modelica/NBackend/Buildings/Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump.mos
+++ b/testsuite/simulation/modelica/NBackend/Buildings/Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump.mos
@@ -1,0 +1,46 @@
+// name: Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump
+// keywords: NewBackend Buildings DHC pump record initialization parameter binding
+// status: correct
+// teardown_command: rm -rf Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump.libs Buildings*.libs
+
+loadModel(Buildings, {"12.0.0"}); getErrorString();
+setCommandLineOptions("--newBackend"); getErrorString();
+simulate(Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 172800.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 3 (699),
+// |                 | |       | because density of 0.09 remains under threshold of 0.10.
+// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 4 (1495),
+// |                 | |       | because density of 0.10 remains under threshold of 0.10.
+// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 6 (1847),
+// |                 | |       | because density of 0.08 remains under threshold of 0.10.
+// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
+// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: NBAlias.setStartFixed: Alias set with conflicting unfixed start values detected. Use -d=dumprepl for more information.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:799:5-799:70:writable] Warning: Variable t of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:800:5-800:57:writable] Warning: Variable h00 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:801:5-801:57:writable] Warning: Variable h10 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:802:5-802:57:writable] Warning: Variable h01 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:803:5-803:57:writable] Warning: Variable h11 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:804:5-804:23:writable] Warning: Variable aux3 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:805:5-805:25:writable] Warning: Variable aux2 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:799:5-799:70:writable] Warning: Variable $fDER_t of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:800:5-800:57:writable] Warning: Variable $fDER_h00 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:801:5-801:57:writable] Warning: Variable $fDER_h10 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:802:5-802:57:writable] Warning: Variable $fDER_h01 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:803:5-803:57:writable] Warning: Variable $fDER_h11 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:804:5-804:23:writable] Warning: Variable $fDER_aux3 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// [Modelica 4.0.0+maint.om/Fluid/Utilities.mo:805:5-805:25:writable] Warning: Variable $fDER_aux2 of the generated function $fDER0.Modelica.Fluid.Utilities.cubicHermite will be initialized to 0.0 because it could not be proven that it is always assigned before it is used.
+// "
+// endResult


### PR DESCRIPTION
In createParameterEquation, the ELSE branch (taken for known records with no record-level binding) unconditionally recursed into all children including scalar parameters. Those scalar children were already processed by the parameters pass (createParameterEquations for varData.parameters), producing duplicate binding equations. The overdetermination caused balanceInitialization to remove needed SIM equations instead of the duplicates, leaving pump performance parameters at 0 and triggering division by zero.

Fix: only recurse into record children in the ELSE branch; scalar children of unbound known records are fully handled by the parameters pass.

Fixes Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump with --newBackend.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
