### PR TITLE
wasm-jit: chattering detection + honest errors

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -504,6 +504,11 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
             "{output}LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.\n\
              LOG_SUCCESS       | info    | The simulation finished successfully.\n"
         ),
+        // Chattering abort (`-abortSlowSimulation`): init succeeded, then the driver's
+        // own `output` carries the chattering + aborting lines.
+        Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!(
+            "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.\n{output}"
+        ),
         Err(e) => format!("{output}LOG_ERROR         | error   | wasm-jit simulation failed: {e:#}\n"),
     };
     let _ = write_output(&format!("{fileNamePrefix}.log"), log.as_bytes());
@@ -564,7 +569,7 @@ pub fn emitStandalone(simCode: SimCode::SimCode) -> Result<()> {
     let _ = simCode;
     let msg = "CodegenWasmJit: simCodeTarget=wasm (standalone export) is unavailable in the wasm omc build";
     record_error(msg.to_string());
-    return Err("{msg}")
+    return Err(msg)
 }
 
 /// `CodegenWasmJit.runSimulationWasmtime`: run the standalone module emitted by
@@ -594,7 +599,7 @@ fn run_wasmtime_inner(prefix: &str, result_file: &str, _simflags: &str) -> Resul
     use std::process::Command;
     let module = format!("{prefix}.wasm");
     if !std::path::Path::new(&module).exists() {
-        return Err("standalone module `{module}` not found (emitStandalone not run?)");
+        return Err("standalone module not found (emitStandalone not run?)");
     }
     let wasmtime = std::env::var("OMC_WASMTIME").unwrap_or_else(|_| "wasmtime".to_owned());
     // `--dir .::.` preopens the cwd as the guest `.`; the module writes the result
@@ -611,15 +616,15 @@ fn run_wasmtime_inner(prefix: &str, result_file: &str, _simflags: &str) -> Resul
         .arg(".::.")
         .arg(&module)
         .status()
-        .map_err(|e| "cannot run `{wasmtime}` (is it on PATH? override with OMC_WASMTIME): {e}")?;
+        .map_err(|e| "cannot run (is it on PATH? override with OMC_WASMTIME)")?;
     if !status.success() {
-        return Err("`{wasmtime} run {module}` failed with {status}");
+        return Err("` run ` failed with");
     }
     // The module writes `<prefix>_res.mat`; rename if omc selected another name.
     let produced = format!("{prefix}_res.mat");
     if result_file != produced && std::path::Path::new(&produced).exists() {
         std::fs::rename(&produced, result_file)
-            .map_err(|e| "cannot rename {produced} -> {result_file}: {e}")?;
+            .map_err(|e| "cannot rename ->")?;
     }
     Ok(())
 }
@@ -661,7 +666,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         .get(prefix)
         .cloned();
     let Some(model) = model else {
-        return (Err("no prepared wasm-jit model for `{prefix}` (translateModel not run?)"), String::new());
+        return (Err("no prepared wasm-jit model for (translateModel not run?)"), String::new());
     };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
     let log_stats = simflags.contains("LOG_STATS") || simflags.contains("LOG_ALL");
@@ -669,6 +674,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
     // slot and hand the list to the driver (applied after `functionParameters`).
     let (param_ov, start_ov) = resolve_overrides(&model, simflags);
     sim_driver::set_param_overrides(param_ov, start_ov);
+    // `-abortSlowSimulation`: stop the run when chattering is detected.
+    sim_driver::set_abort_slow(simflags.split_whitespace().any(|t| t == "-abortSlowSimulation"));
     openmodelica_wasi::wasi::start_stdout_capture();
     let mut extra = String::new();
     let res = (|| -> Result<()> {
@@ -676,7 +683,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         // benchmarking the solver in isolation from the `.mat` writer.
         let fmt = model.output_format.as_str();
         if fmt != "mat" && fmt != "empty" {
-            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
+            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)");
         }
         let run = sim_runtime::run(&model)?;
         if log_stats {
@@ -688,6 +695,12 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         }
         Ok(())
     })();
+    // The driver reports chattering out-of-band (it can only return a `&'static str`);
+    // fold its log lines in whether the run finished or aborted.
+    for line in sim_driver::take_chatter_log() {
+        extra.push_str(&line);
+        extra.push('\n');
+    }
     let captured = openmodelica_wasi::wasi::take_stdout_capture();
     (res, format!("{captured}{extra}"))
 }
@@ -786,10 +799,10 @@ mod session {
             .unwrap_or_else(|e| e.into_inner())
             .get(prefix)
             .cloned()
-            .ok_or_else(|| "no prepared wasm-jit model for `{prefix}` (translateModel not run?)")?;
+            .ok_or_else(|| "no prepared wasm-jit model for (translateModel not run?)")?;
         let fmt = model.output_format.as_str();
         if fmt != "mat" && fmt != "empty" {
-            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got `{fmt}`)");
+            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)");
         }
         let (param_ov, start_ov) = resolve_overrides(&model, simflags);
         sim_driver::set_param_overrides(param_ov, start_ov);
@@ -1011,9 +1024,9 @@ fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
         .arg(&out_path)
         .arg("-all")
         .status()
-        .map_err(|e| "CodegenWasmJit: cannot run `{merge}`: {e}")?;
+        .map_err(|e| "CodegenWasmJit: cannot run")?;
     if !status.success() {
-        return Err("CodegenWasmJit: `{merge}` failed with {status}");
+        return Err("CodegenWasmJit: failed with");
     }
     let bytes = std::fs::read(&out_path).map_err(|_| "CodegenWasmJit: cannot read merged wasm")?;
     let _ = std::fs::remove_dir_all(&dir);
@@ -1979,7 +1992,7 @@ pub(crate) fn math_event_kind(name: &str, nargs: usize) -> Option<MathEventKind>
 pub(crate) fn math_event_index(last: &DAE::Exp) -> Result<u32> {
     match last {
         DAE::Exp::ICONST { integer } if *integer >= 0 => Ok(*integer as u32),
-        other => return Err("CodegenWasmJit: math-event index is not a non-negative ICONST: {other:?}"),
+        other => return Err("CodegenWasmJit: math-event index is not a non-negative ICONST"),
     }
 }
 
@@ -2011,7 +2024,7 @@ fn collect_zero_crossings(
     let mut out = Vec::new();
     for zc in lst(zcs) {
         if zc.iter.is_some() {
-            return Err("CodegenWasmJit: for-loop (iterator) zero-crossing not yet supported: {:?}");
+            return Err("CodegenWasmJit: for-loop (iterator) zero-crossing not yet supported");
         }
         match &*zc.relation_ {
             DAE::Exp::RELATION { .. } | DAE::Exp::LBINARY { .. } | DAE::Exp::LUNARY { .. } => {
@@ -2031,7 +2044,7 @@ fn collect_zero_crossings(
                 let ops = argv[..argv.len() - 1].to_vec();
                 out.push(ZcInfo::Math { kind, ops, idx });
             }
-            other => return Err("CodegenWasmJit: unsupported zero-crossing form: {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported zero-crossing form"),
         }
     }
     Ok(out)
@@ -2370,7 +2383,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let fmi_vrs = if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { Vec::new() };
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets, &state_nominals,
-        fmi_vrs,
+        fmi_vrs, zc_descriptions(&zero_crossings),
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -2414,7 +2427,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             let key = extobj_destructor_key(sv)?;
             let didx = by_name
                 .get(&key)
-                .ok_or_else(|| "CodegenWasmJit: external-object destructor `{key}` was not compiled")?
+                .ok_or_else(|| "CodegenWasmJit: external-object destructor was not compiled")?
                 .index;
             let slot = layout.eobj_off + (i as u32) * 4;
             f.instruction(&I::LocalGet(0)); // SimData*
@@ -2709,6 +2722,7 @@ fn build_sim_meta(
     state_sets: &[StateSetInfo],
     state_nominals: &[f64],
     fmi_vrs: Vec<FmiVr>,
+    zc_desc: Vec<String>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -2725,7 +2739,23 @@ fn build_sim_meta(
         state_sets: state_sets.to_vec(),
         state_nominals: state_nominals.to_vec(),
         fmi_vrs,
+        zc_desc,
     }
+}
+
+/// The Modelica source of each zero-crossing relation (via
+/// `ExpressionBasics::printExpStr`), so the driver can name the crossing that
+/// triggered chattering. A math-event crossing has no relation string.
+fn zc_descriptions(crossings: &[ZcInfo]) -> Vec<String> {
+    crossings
+        .iter()
+        .map(|zc| match zc {
+            ZcInfo::Bool { expr } => openmodelica_frontend_dump::ExpressionBasics::printExpStr(expr.clone())
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+            ZcInfo::Math { .. } => String::new(),
+        })
+        .collect()
 }
 
 /// A fresh `T_REAL` type for synthesizing the lhs `CREF` expression of a simple
@@ -2871,7 +2901,7 @@ fn build_eq_fn_with_prelude(
     ctx.emit_stateset_diag_init(stateset_diag)?;
     for (cref, exp) in prelude {
         let lhs = DAE::Exp::CREF { componentRef: cref.clone(), ty: t_real() };
-        ctx.sim_assign(&lhs, exp).map_err(|e| "in {which} binding: {e}")?;
+        ctx.sim_assign(&lhs, exp)?;
     }
     for (i, eq) in eqs.iter().enumerate() {
         // Cancellation poll, throttled: the equation functions are the bulk of the
@@ -2879,8 +2909,7 @@ fn build_eq_fn_with_prelude(
         if i & 63 == 0 {
             metamodelica::cancel::bail_if_cancelled()?;
         }
-        lower_equation(&mut ctx, eq, eq_index)
-            .map_err(|e| "in {which}: {e}")?;
+        lower_equation(&mut ctx, eq, eq_index)?;
     }
     ctx.sim_save_pre_values(save_pre)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -3050,11 +3079,11 @@ fn lower_equation(
         E::SES_ALIAS { aliasOf, .. } => {
             let target = eq_index
                 .get(aliasOf)
-                .ok_or_else(|| "SES_ALIAS references unknown equation index {aliasOf}")?
+                .ok_or_else(|| "SES_ALIAS references unknown equation index")?
                 .clone();
             lower_equation(ctx, &target, eq_index)
         }
-        other => return Err("CodegenWasmJit: unsupported equation kind {} (index {})"),
+        other => Err(eq_kind_name(other)),
     }
 }
 
@@ -3112,7 +3141,7 @@ fn lower_linear_system_symbolic(
         let (row, col, eq) = entry;
         match &**eq {
             E::SES_RESIDUAL { exp, .. } => a_entries.push((*row as usize, *col as usize, exp)),
-            other => return Err("CodegenWasmJit: SES_LINEAR (index {}) simJac entry is {} (only SES_RESIDUAL supported)"),
+            other => return Err("CodegenWasmJit: SES_LINEAR simJac entry is not SES_RESIDUAL"),
         }
     }
     let b_exps: Vec<&Arc<DAE::Exp>> = lst(&lsystem.beqs).collect();
@@ -3127,7 +3156,7 @@ fn stateset_scratch_f64(state_sets: &Arc<List<SimCode::StateSet>>) -> Result<u32
     for set in lst(state_sets) {
         let col = lst(&set.jacobianMatrix.columns)
             .next()
-            .ok_or_else(|| "CodegenWasmJit: state set {} has no Jacobian column")?;
+            .ok_or_else(|| "CodegenWasmJit: state set has no Jacobian column")?;
         n += count(&set.jacobianMatrix.seedVars) as u32 + count(&col.columnVars) as u32;
     }
     Ok(n)
@@ -3149,9 +3178,9 @@ fn build_state_set_infos(
         let slot = var_map
             .vars
             .get(&key)
-            .ok_or_else(|| "CodegenWasmJit: state-set variable `{key}` has no slot")?;
+            .ok_or_else(|| "CodegenWasmJit: state-set variable has no slot")?;
         if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: state-set variable `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: state-set variable is not a Real variable");
         }
         Ok(slot.off)
     };
@@ -3161,7 +3190,7 @@ fn build_state_set_infos(
         let n_dummy = n_candidates - n_states;
         let col = lst(&set.jacobianMatrix.columns)
             .next()
-            .ok_or_else(|| "CodegenWasmJit: state set {} has no Jacobian column")?;
+            .ok_or_else(|| "CodegenWasmJit: state set has no Jacobian column")?;
 
         // Seed slots (candidate order) — register the seed var crefs.
         let mut seed_offs = Vec::new();
@@ -3197,7 +3226,7 @@ fn build_state_set_infos(
                 let slot = var_map
                     .vars
                     .get(&key)
-                    .ok_or_else(|| "CodegenWasmJit: state-set matrix entry `{key}` has no slot")?;
+                    .ok_or_else(|| "CodegenWasmJit: state-set matrix entry has no slot")?;
                 a_offs.push(slot.off);
             }
         }
@@ -3259,9 +3288,9 @@ fn stateset_diag_offsets(
             let slot = var_map
                 .vars
                 .get(&key)
-                .ok_or_else(|| "CodegenWasmJit: state-set matrix entry `{key}` has no slot")?;
+                .ok_or_else(|| "CodegenWasmJit: state-set matrix entry has no slot")?;
             if slot.wty != WTy::I32 {
-                return Err("CodegenWasmJit: state-set matrix entry `{key}` is not an Integer variable");
+                return Err("CodegenWasmJit: state-set matrix entry is not an Integer variable");
             }
             offs.push(slot.off);
         }
@@ -3283,7 +3312,7 @@ fn lower_nonlinear_system(
         .sim()?
         .nls_jobs
         .get(&nlsystem.index)
-        .ok_or_else(|| "CodegenWasmJit: SES_NONLINEAR (index {}) was not registered for rt_solve_nls")?;
+        .ok_or_else(|| "CodegenWasmJit: SES_NONLINEAR was not registered for rt_solve_nls")?;
     emit_solve_nls_call(ctx, job)
 }
 
@@ -3304,11 +3333,11 @@ fn nls_parts(
         }
     }
     if res_exps.is_empty() {
-        return Err("CodegenWasmJit: SES_NONLINEAR (index {}) has no residual equations");
+        return Err("CodegenWasmJit: SES_NONLINEAR has no residual equations");
     }
     let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
     if iter_vars.len() != res_exps.len() {
-        return Err("CodegenWasmJit: SES_NONLINEAR (index {}) has {} unknowns but {} residuals");
+        return Err("CodegenWasmJit: SES_NONLINEAR unknown/residual count mismatch");
     }
     Ok((inner, res_exps, iter_vars))
 }
@@ -3359,9 +3388,9 @@ fn build_nls_fns(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| "CodegenWasmJit: nonlinear-system unknown `{key}` has no slot")?;
+            .ok_or_else(|| "CodegenWasmJit: nonlinear-system unknown has no slot")?;
         if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: nonlinear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: nonlinear-system unknown is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -3700,7 +3729,7 @@ fn write_mat4(model: &SimModel, path: &str, rows: &[f64], n_reals: u32, params: 
         .collect();
     let bytes = openmodelica_mat_writer::write_mat4(&vars, model.start_time, model.stop_time, rows, n_reals, params);
     let _ = &model.model_name; // (kept for diagnostics)
-    write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write {path}: {e}")
+    write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write")
 }
 
 // The standalone-export merge uses `wasmtime::Module` to validate the result, so

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_stub.rs
@@ -21,19 +21,19 @@ pub(super) struct RunResult {
 }
 
 pub(super) fn runtime_module() -> Result<&'static Module> {
-    return Err("{NO_ENGINE}")
+    return Err(NO_ENGINE)
 }
 
 pub(super) fn compile_model_module(_wasm: &[u8]) -> Result<Module> {
-    return Err("{NO_ENGINE}")
+    return Err(NO_ENGINE)
 }
 
 pub(super) fn start_runtime_compile() {}
 
 pub(super) fn take_compiled_model(_model: &SimModel) -> Result<Module> {
-    return Err("{NO_ENGINE}")
+    return Err(NO_ENGINE)
 }
 
 pub(super) fn run(_model: &SimModel) -> Result<RunResult> {
-    return Err("{NO_ENGINE}")
+    return Err(NO_ENGINE)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -107,7 +107,7 @@ pub(super) fn runtime_module() -> Result<&'static wasmer::Module> {
     MODULE
         .get_or_init(|| load_or_compile_runtime().map_err(|e| format!("{e:?}")))
         .as_ref()
-        .map_err(|e| "CodegenWasmJit: obtaining runtime module: {e}")
+        .map_err(|e| "CodegenWasmJit: obtaining runtime module")
 }
 
 /// Path of the on-disk AOT cache for the runtime module. Keyed by a hash of the
@@ -145,7 +145,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
     // the in-memory OnceLock already caches the compiled module for the session,
     // so compile straight from the embedded bytes.
     #[cfg(target_arch = "wasm32")]
-    return wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| "{e:?}");
+    return wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|_| "CodegenWasmJit: wasm engine error");
     #[cfg(not(target_arch = "wasm32"))]
     {
     let path = runtime_cache_path();
@@ -160,7 +160,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
         // Incompatible/corrupt cache (e.g. wasmer upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|e| "{e:?}")?;
+    let module = wasmer::Module::from_binary(engine, RUNTIME_WASM).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -177,7 +177,7 @@ fn load_or_compile_runtime() -> Result<wasmer::Module> {
 /// background thread from `translateModel` (overlapping the rest of the OMC
 /// pipeline) or inline from `run` as a fallback.
 pub(super) fn compile_model_module(wasm: &[u8]) -> Result<wasmer::Module> {
-    wasmer::Module::from_binary(sim_engine(), wasm).map_err(|e| "{e:?}")
+    wasmer::Module::from_binary(sim_engine(), wasm).map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 /// Begin compiling the fixed runtime module on a background thread, once per
@@ -212,13 +212,13 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmer::Module> {
         #[cfg(not(target_arch = "wasm32"))]
         Some(handle) => match handle.join() {
             Ok(Ok(m)) => Ok(m),
-            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed: {e}"),
+            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed"),
             Err(_) => return Err("CodegenWasmJit: background model-module compile thread panicked"),
         },
         #[cfg(target_arch = "wasm32")]
         Some(Ok(m)) => Ok(m),
         #[cfg(target_arch = "wasm32")]
-        Some(Err(e)) => return Err("CodegenWasmJit: model-module compile failed: {e}"),
+        Some(Err(e)) => return Err("CodegenWasmJit: model-module compile failed"),
         None => compile_model_module(&model.wasm),
     }
 }
@@ -229,7 +229,7 @@ type Store = wasmer::Store;
 /// — `RuntimeError`, `InstantiationError`, `MemoryAccessError`, … — do not share
 /// a single anyhow-convertible type, so we format via `Debug`).
 fn wt<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
-    r.map_err(|e| "{e:?}")
+    r.map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 /// Read a NUL-terminated C string from wasm memory at `ptr` (bounded).
@@ -247,7 +247,7 @@ fn read_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, ptr: u32) ->
 
 fn read_u32_mem(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, addr: u32) -> Result<u32> {
     let mut b = [0u8; 4];
-    mem.view(store).read(addr as u64, &mut b).map_err(|e| "CodegenWasmJit: mem read: {e}")?;
+    mem.view(store).read(addr as u64, &mut b).map_err(|e| "CodegenWasmJit: mem read")?;
     Ok(u32::from_le_bytes(b))
 }
 
@@ -306,7 +306,7 @@ fn define_external_imports(
 
     // Instantiate the side module with its `env.Modelica*Error`/`usertab`/
     // `ModelicaAllocateString` imports.
-    let side_module = wasmer::Module::from_binary(store.engine(), EXTERNAL_C_WASM).map_err(|e| "{e:?}")?;
+    let side_module = wasmer::Module::from_binary(store.engine(), EXTERNAL_C_WASM).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     let err_env = FunctionEnv::new(&mut *store, SideErrEnv { mem: None });
     let modelica_error = Function::new_typed_with_env(
         &mut *store, &err_env,
@@ -398,7 +398,7 @@ fn define_external_imports(
     let side_inst = wt(wasmer::Instance::new(&mut *store, &side_module, &side_imports))?;
 
     let side_mem = side_inst.exports.get_memory("memory")
-        .map_err(|e| "CodegenWasmJit: modelicaexternalc.wasm has no `memory`: {e:?}")?.clone();
+        .map_err(|e| "CodegenWasmJit: modelicaexternalc.wasm has no `memory")?.clone();
     // Let the error hooks + WASI calls read/write the side module's memory.
     err_env.as_mut(&mut *store).mem = Some(side_mem.clone());
     wasi_env.as_mut(&mut *store).set_memory(side_mem.clone());
@@ -414,7 +414,7 @@ fn define_external_imports(
     for sig in &model.ext_imports {
         let name = &sig.name;
         let func = side_inst.exports.get_function(name)
-            .map_err(|e| "CodegenWasmJit: ModelicaExternalC side module has no `{name}`: {e:?}")?
+            .map_err(|e| "CodegenWasmJit: ModelicaExternalC side module has no")?
             .clone();
         // Nothing to marshal: bind the export straight in, so the engine calls it
         // wasm->wasm instead of through a host trampoline.
@@ -506,8 +506,8 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         // array outputs are pre-allocated on the wasm side and marshalled by the
         // `Array` arm below (passed by pointer, copied back after the call).
         if *is_out && !matches!(ty, SigTy::Array { .. }) {
-            let cell = malloc.call(&mut store, 8).map_err(|e| "{e:?}")?;
-            side_mem.view(&store).write(cell as u64, &[0u8; 8]).map_err(|e| "{e}")?;
+            let cell = malloc.call(&mut store, 8).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            side_mem.view(&store).write(cell as u64, &[0u8; 8]).map_err(|_| "CodegenWasmJit: wasm engine error")?;
             temps.push(cell);
             out_cells.push((ty.clone(), cell));
             call_args.push(Value::I32(cell as i32));
@@ -516,31 +516,31 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         let v = &args[in_i];
         in_i += 1;
         match ty {
-            SigTy::Real => call_args.push(Value::F64(v.f64().ok_or_else(|| "expected f64 arg {in_i}")?)),
+            SigTy::Real => call_args.push(Value::F64(v.f64().ok_or_else(|| "expected f64 arg")?)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => {
-                call_args.push(Value::I32(v.i32().ok_or_else(|| "expected i32 arg {in_i}")?))
+                call_args.push(Value::I32(v.i32().ok_or_else(|| "expected i32 arg")?))
             }
             SigTy::Str => {
-                let off = v.i32().ok_or_else(|| "expected i32 String handle arg {in_i}")? as u32;
+                let off = v.i32().ok_or_else(|| "expected i32 String handle arg")? as u32;
                 let len = read_u32_mem(&sim_mem, &store, off + 4)? as usize;
                 let mut buf = vec![0u8; len + 1]; // + NUL
-                sim_mem.view(&store).read((off + 8) as u64, &mut buf[..len]).map_err(|e| "{e}")?;
-                let dst = malloc.call(&mut store, (len + 1) as u32).map_err(|e| "{e:?}")?;
-                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| "{e}")?;
+                sim_mem.view(&store).read((off + 8) as u64, &mut buf[..len]).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                let dst = malloc.call(&mut store, (len + 1) as u32).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                side_mem.view(&store).write(dst as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
                 temps.push(dst);
                 call_args.push(Value::I32(dst as i32));
             }
             SigTy::Array { elem, .. } => {
-                let off = v.i32().ok_or_else(|| "expected i32 array handle arg {in_i}")? as u32;
+                let off = v.i32().ok_or_else(|| "expected i32 array handle arg")? as u32;
                 let ndims = read_u32_mem(&sim_mem, &store, off + 8)?;
                 let total = read_u32_mem(&sim_mem, &store, off + 12)? as usize;
                 let elem_size = if matches!(**elem, SigTy::Real) { 8 } else { 4 };
                 let data_off = (16 + ndims * 4 + 7) & !7;
                 let bytes = total * elem_size;
                 let mut buf = vec![0u8; bytes];
-                sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|e| "{e}")?;
-                let dst = malloc.call(&mut store, bytes as u32).map_err(|e| "{e:?}")?;
-                side_mem.view(&store).write(dst as u64, &buf).map_err(|e| "{e}")?;
+                sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                let dst = malloc.call(&mut store, bytes as u32).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                side_mem.view(&store).write(dst as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
                 temps.push(dst);
                 call_args.push(Value::I32(dst as i32));
                 // An output array is filled by the callee in side memory; copy it
@@ -549,27 +549,27 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                     out_arrays.push((off, dst, bytes, data_off));
                 }
             }
-            other => return Err("input argument type {other:?} not marshalled for the web target"),
+            other => return Err("input argument type not marshalled for the web target"),
         }
     }
 
-    let rets = func.call(&mut store, &call_args).map_err(|e| "{e:?}")?;
+    let rets = func.call(&mut store, &call_args).map_err(|_| "CodegenWasmJit: wasm engine error")?;
 
     // Copy each output array back from the side module's memory into its
     // pre-allocated wasm array (the callee filled the side scratch in place).
     for (woff, dst, bytes, data_off) in &out_arrays {
         let mut buf = vec![0u8; *bytes];
-        side_mem.view(&store).read(*dst as u64, &mut buf).map_err(|e| "{e}")?;
-        sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|e| "{e}")?;
+        side_mem.view(&store).read(*dst as u64, &mut buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+        sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     }
 
     // Build an in-wasm String (in the sim memory) from a NUL-terminated `char*` at
     // `coff` in the side module's memory; returns its sim-memory offset.
     let mut make_string = |store: &mut wasmer::StoreMut, coff: u32| -> Result<u32> {
         let bytes = read_side_cstr(&side_mem, &*store, coff)?;
-        let soff = rt_str_new.call(&mut *store, bytes.len() as u32).map_err(|e| "{e:?}")?;
-        let doff = rt_str_data.call(&mut *store, soff).map_err(|e| "{e:?}")?;
-        sim_mem.view(&*store).write(doff as u64, &bytes).map_err(|e| "{e}")?;
+        let soff = rt_str_new.call(&mut *store, bytes.len() as u32).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+        let doff = rt_str_data.call(&mut *store, soff).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+        sim_mem.view(&*store).write(doff as u64, &bytes).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         Ok(soff)
     };
     let result_val = |store: &mut wasmer::StoreMut, ty: &SigTy, raw: [u8; 8],
@@ -578,7 +578,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
             SigTy::Real => Value::F64(f64::from_le_bytes(raw)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => Value::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
             SigTy::Str => Value::I32(make(store, u32::from_le_bytes(raw[..4].try_into().unwrap()))? as i32),
-            other => return Err("output type {other:?} not marshalled for the web target"),
+            other => return Err("output type not marshalled for the web target"),
         })
     };
 
@@ -598,7 +598,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     }
     for (ty, cell) in &out_cells {
         let mut raw = [0u8; 8];
-        side_mem.view(&store).read(*cell as u64, &mut raw).map_err(|e| "{e}")?;
+        side_mem.view(&store).read(*cell as u64, &mut raw).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         results.push(result_val(&mut store, ty, raw, &mut make_string)?);
     }
 
@@ -620,7 +620,7 @@ fn read_side_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, off: u3
     let mut a = off as u64;
     loop {
         let mut b = [0u8; 1];
-        view.read(a, &mut b).map_err(|e| "{e}")?;
+        view.read(a, &mut b).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         if b[0] == 0 { break; }
         out.push(b[0]);
         a += 1;
@@ -731,7 +731,7 @@ fn instantiate_modules(model: &SimModel) -> Result<Instantiated> {
     let memory = rt_inst
         .exports
         .get_memory("memory")
-        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export: {e:?}")?
+        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export")?
         .clone();
 
     // External "C" functions (`ext.*`): resolved by the ModelicaExternalC WASI side
@@ -789,10 +789,10 @@ impl WasmerEngine {
 
 impl sim_driver::SimEngine for WasmerEngine {
     fn read_bytes(&self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        self.memory.view(&self.store).read(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem read: {e}")
+        self.memory.view(&self.store).read(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem read")
     }
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
-        self.memory.view(&self.store).write(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem write: {e}")
+        self.memory.view(&self.store).write(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem write")
     }
     fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
@@ -66,7 +66,7 @@ pub(super) fn runtime_module() -> Result<&'static wasmtime::Module> {
     MODULE
         .get_or_init(|| load_or_compile_runtime().map_err(|e| format!("{e:?}")))
         .as_ref()
-        .map_err(|e| "CodegenWasmJit: obtaining runtime module: {e}")
+        .map_err(|e| "CodegenWasmJit: obtaining runtime module")
 }
 
 /// Path of the on-disk AOT cache for the runtime module. Keyed by a hash of the
@@ -110,7 +110,7 @@ fn load_or_compile_runtime() -> Result<wasmtime::Module> {
         // Incompatible/corrupt cache (e.g. wasmtime upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wasmtime::Module::new(engine, RUNTIME_WASM).map_err(|e| "{e:?}")?;
+    let module = wasmtime::Module::new(engine, RUNTIME_WASM).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -126,7 +126,7 @@ fn load_or_compile_runtime() -> Result<wasmtime::Module> {
 /// background thread from `translateModel` (overlapping the rest of the OMC
 /// pipeline) or inline from `run` as a fallback.
 pub(super) fn compile_model_module(wasm: &[u8]) -> Result<wasmtime::Module> {
-    wasmtime::Module::new(sim_engine(), wasm).map_err(|e| "{e:?}")
+    wasmtime::Module::new(sim_engine(), wasm).map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 /// Begin compiling the fixed runtime module on a background thread, once per
@@ -150,7 +150,7 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmtime::Module> 
     match job {
         Some(handle) => match handle.join() {
             Ok(Ok(m)) => Ok(m),
-            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed: {e}"),
+            Ok(Err(e)) => return Err("CodegenWasmJit: background model-module compile failed"),
             Err(_) => return Err("CodegenWasmJit: background model-module compile thread panicked"),
         },
         None => compile_model_module(&model.wasm),
@@ -160,7 +160,7 @@ pub(super) fn take_compiled_model(model: &SimModel) -> Result<wasmtime::Module> 
 type Store = wasmtime::Store<()>;
 
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
-    r.map_err(|e| "{e:?}")
+    r.map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 // External objects are native `void*` (e.g. a table `tableID`) that must survive
@@ -224,7 +224,7 @@ fn define_external_imports(
             sig.wasm_results().iter().map(|s| wty_valtype(s.wty())),
         );
         let addr = openmodelica_util::dynload::external_symbol(&sig.name)
-            .ok_or_else(|| "external \"C\" function `{}` not found in any loaded library")?;
+            .ok_or_else(|| "external \"C\" function not found in any loaded library")?;
         let name = sig.name.clone();
         let sig = sig.clone();
         let rt_str_new = rt_str_new.clone();
@@ -321,7 +321,7 @@ unsafe fn call_external(
                     let off = v.unwrap_i32() as usize;
                     let len = u32::from_le_bytes(mem[off + 4..off + 8].try_into().unwrap()) as usize;
                     let cs = std::ffi::CString::new(&mem[off + 8..off + 8 + len])
-                        .map_err(|_| "external \"C\" `{}`: string argument has an interior NUL")?;
+                        .map_err(|_| "external \"C\" : string argument has an interior NUL")?;
                     slots.push(Slot::P(cs.as_ptr() as *mut c_void));
                     cstrings.push(cs);
                     types.push(Type::pointer());
@@ -341,7 +341,7 @@ unsafe fn call_external(
                     slots.push(Slot::P(native as *mut c_void));
                     types.push(Type::pointer());
                 }
-                other => return Err("CodegenWasmJit: external \"C\" `{}`: input argument type {other:?} not yet marshalled"),
+                other => return Err("CodegenWasmJit: external \"C\" : input argument type not yet marshalled"),
             }
         }
     }
@@ -359,7 +359,7 @@ unsafe fn call_external(
         Some(SigTy::Real) => Type::f64(),
         Some(SigTy::Int) | Some(SigTy::Bool) => Type::i32(),
         Some(SigTy::Str) | Some(SigTy::Ptr) => Type::pointer(),
-        Some(other) => return Err("CodegenWasmJit: external \"C\" `{}`: return type {other:?} not yet marshalled"),
+        Some(other) => return Err("CodegenWasmJit: external \"C\" : return type not yet marshalled"),
     };
     let cif = Cif::new(types, ret_type);
     let mut rvalue = [0u8; 8];
@@ -379,7 +379,7 @@ unsafe fn call_external(
         openmodelica_modelica_utilities::sim_external_end();
         // A `ModelicaError` recorded its message in the Error buffer and unwound
         // here as a panic; surface a failure to the host.
-        return Err("CodegenWasmJit: external \"C\" `{}` raised a runtime error");
+        return Err("CodegenWasmJit: external \"C\" raised a runtime error");
     }
 
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
@@ -398,7 +398,7 @@ unsafe fn call_external(
             SigTy::Int | SigTy::Bool => Val::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
             SigTy::Ptr => Val::I32(registry_put(usize::from_le_bytes(raw))),
             SigTy::Str => Val::I32(make(usize::from_le_bytes(raw) as *const std::os::raw::c_char)? as i32),
-            other => return Err("external \"C\": result type {other:?} not marshalled"),
+            other => return Err("external \"C\": result type not marshalled"),
         })
     };
 
@@ -632,10 +632,10 @@ impl WasmtimeEngine {
 
 impl sim_driver::SimEngine for WasmtimeEngine {
     fn read_bytes(&self, addr: u32, buf: &mut [u8]) -> Result<()> {
-        self.memory.read(&self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem read: {e}")
+        self.memory.read(&self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem read")
     }
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
-        self.memory.write(&mut self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem write: {e}")
+        self.memory.write(&mut self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem write")
     }
     fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/wasi_shim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/wasi_shim.rs
@@ -43,7 +43,7 @@ mod wasmtime_impl {
     /// Register the `wasi_snapshot_preview1` imports into `linker`.
     pub fn add_to_linker(linker: &mut Linker) -> Result<()> {
         let m = "wasi_snapshot_preview1";
-        let wt = |r: std::result::Result<&mut Linker, wasmtime::Error>| r.map(|_| ()).map_err(|e| "{e:?}");
+        let wt = |r: std::result::Result<&mut Linker, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
 
         wt(linker.func_wrap(m, "fd_write", |mut c: Caller<'_, WasiCtx>, fd: i32, iovs: i32, n: i32, nw: i32| -> i32 {
             let (mut mem, ctx) = mem_ctx!(c);
@@ -175,21 +175,21 @@ mod wasmtime_impl {
     /// `openmodelica_wasi`, with relative paths keyed under `cwd`.
     pub fn run_command(wasm: &[u8], cwd: &str, args: Vec<String>) -> Result<u32> {
         let engine = wasmtime::Engine::default();
-        let module = wasmtime::Module::new(&engine, wasm).map_err(|e| "{e:?}")?;
+        let module = wasmtime::Module::new(&engine, wasm).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         let mut linker = Linker::new(&engine);
         add_to_linker(&mut linker)?;
         let mut store = wasmtime::Store::new(&engine, WasiCtx::new(cwd, args));
-        let instance = linker.instantiate(&mut store, &module).map_err(|e| "{e:?}")?;
+        let instance = linker.instantiate(&mut store, &module).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         let start = instance
             .get_typed_func::<(), ()>(&mut store, "_start")
-            .map_err(|e| "module has no `_start`: {e:?}")?;
+            .map_err(|e| "module has no `_start")?;
         match start.call(&mut store, ()) {
             Ok(()) => Ok(0),
             // A `proc_exit` unwinds as an error after setting `exit_code`; that is
             // a normal termination, not a trap.
             Err(e) => match store.data().exit_code {
                 Some(code) => Ok(code),
-                None => Err("wasi command trapped: {e:?}"),
+                None => Err("wasi command trapped"),
             },
         }
     }
@@ -395,23 +395,23 @@ mod wasmer_impl {
         // (works on both the native `sys` and the worker `js` backends, where
         // `Store::default()` is not available).
         let engine = wasmer::Engine::default();
-        let module = Module::new(&engine, wasm).map_err(|e| "{e:?}")?;
+        let module = Module::new(&engine, wasm).map_err(|_| "CodegenWasmJit: wasm engine error")?;
         let mut store = Store::new(engine);
         let env = FunctionEnv::new(&mut store, Env { ctx: WasiCtx::new(cwd, args), memory: None });
         let mut imports = Imports::new();
         add_to_imports(&mut store, &env, &mut imports);
-        let instance = Instance::new(&mut store, &module, &imports).map_err(|e| "{e:?}")?;
-        let memory = instance.exports.get_memory("memory").map_err(|e| "no `memory` export: {e:?}")?.clone();
+        let instance = Instance::new(&mut store, &module, &imports).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+        let memory = instance.exports.get_memory("memory").map_err(|e| "no `memory` export")?.clone();
         env.as_mut(&mut store).memory = Some(memory);
         let start = instance
             .exports
             .get_typed_function::<(), ()>(&store, "_start")
-            .map_err(|e| "module has no `_start`: {e:?}")?;
+            .map_err(|e| "module has no `_start")?;
         match start.call(&mut store) {
             Ok(()) => Ok(0),
             Err(e) => match env.as_ref(&store).ctx.exit_code {
                 Some(code) => Ok(code),
-                None => Err("wasi command trapped: {e:?}"),
+                None => Err("wasi command trapped"),
             },
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -257,11 +257,11 @@ fn parse_sig_type(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<Si
             }
             match chars.next() {
                 Some('}') => {}
-                other => return Err("CodegenWasmJit: expected `}}` in record signature, got {other:?}"),
+                other => return Err("CodegenWasmJit: expected a closing brace in record signature"),
             }
             Ok(SigTy::Record { path: ArcStr::from(path.as_str()), fields: Arc::new(fields) })
         }
-        other => return Err("CodegenWasmJit: malformed signature type code {other:?}"),
+        other => return Err("CodegenWasmJit: malformed signature type code"),
     }
 }
 
@@ -326,7 +326,7 @@ fn env_extra_index(name: &str) -> Result<u32> {
     let pos = ENV_EXTRA
         .iter()
         .position(|(n, _, _)| *n == name)
-        .ok_or_else(|| "CodegenWasmJit: unknown env-extra import `{name}`")?;
+        .ok_or_else(|| "CodegenWasmJit: unknown env-extra import")?;
     Ok((BUILTINS.len() + RT_BUILTINS.len() + pos) as u32)
 }
 
@@ -472,7 +472,7 @@ pub(crate) fn rt_index(name: &str) -> Result<u32> {
     let pos = RT_BUILTINS
         .iter()
         .position(|(n, _, _)| *n == name)
-        .ok_or_else(|| "CodegenWasmJit: unknown runtime function {name}")?;
+        .ok_or_else(|| "CodegenWasmJit: unknown runtime function")?;
     Ok((BUILTINS.len() + pos) as u32)
 }
 
@@ -802,14 +802,14 @@ pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Re
             A::SIMEXTARGSIZE { .. } => (SigTy::Int, false),
             A::SIMEXTARG { type_, isInput, .. } => (sig_ty(type_)?, !*isInput),
             A::SIMEXTARGEXP { type_, .. } => (sig_ty(type_)?, false),
-            other => return Err("CodegenWasmJit: unsupported external-call argument {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported external-call argument"),
         };
         args.push((ty, is_out));
     }
     let ret = match &**extReturn {
         A::SIMNOEXTARG => None,
         A::SIMEXTARG { type_, .. } => Some(sig_ty(type_)?),
-        other => return Err("CodegenWasmJit: unsupported external return {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported external return"),
     };
     Ok(ExtCallSig { name: extName.to_string(), args, ret })
 }
@@ -881,7 +881,7 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
         DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::EXTERNAL_OBJ { .. }, .. } => SigTy::Ptr,
         DAE::Type::T_COMPLEX { complexClassType, varLst, .. } => {
             let ClassInf::State::RECORD { path } = complexClassType else {
-                return Err("CodegenWasmJit: non-record complex type not supported: {complexClassType:?}");
+                return Err("CodegenWasmJit: non-record complex type not supported");
             };
             let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
             let mut fields = Vec::new();
@@ -891,7 +891,7 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
             SigTy::Record { path: path_str, fields: Arc::new(fields) }
         }
         DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
-        other => return Err("CodegenWasmJit: type not supported: {other:?}"),
+        other => return Err("CodegenWasmJit: type not supported"),
     })
 }
 
@@ -1281,7 +1281,7 @@ impl<'a> FnCtx<'a> {
         } else {
             for (i, c) in conds.iter().enumerate() {
                 if compile_sim_cref_read(self, c)?.is_none() {
-                    return Err("CodegenWasmJit: when-condition `{}` is not a model variable");
+                    return Err("CodegenWasmJit: when-condition is not a model variable");
                 }
                 let pre = pre_cref(c);
                 compile_sim_cref_read(self, &pre)?;
@@ -1302,7 +1302,7 @@ impl<'a> FnCtx<'a> {
                 openmodelica_simcode_types::SimCode::SimEqSystem::SES_WHEN {
                     conditions, whenStmtLst, elseWhen, ..
                 } => self.sim_when(conditions, whenStmtLst, elseWhen)?,
-                other => return Err("CodegenWasmJit: elseWhen is not a SES_WHEN: {}"),
+                other => return Err("CodegenWasmJit: elseWhen is not a SES_WHEN"),
             }
         }
         self.emit(I::End);
@@ -1484,7 +1484,7 @@ fn compile_external_function(
                 let arr = Arc::new(DAE::Exp::CREF { componentRef: cref.clone(), ty: type_.clone() });
                 Some(Arc::new(DAE::Exp::SIZE { exp: arr, sz: Some(exp.clone()) }))
             }
-            other => return Err("CodegenWasmJit: unsupported external-call argument {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported external-call argument"),
         })
     };
 
@@ -1514,12 +1514,12 @@ fn compile_external_function(
             .filter(|&i| !matches!(ctx.outputs[i].1, SigTy::Array { .. }))
             .collect();
         if results.len() != scalar_outs.len() {
-            return Err("CodegenWasmJit: external `{extName}` returns {} scalar value(s) but the function has {} non-array output(s)");
+            return Err("CodegenWasmJit: external scalar-return/output count mismatch");
         }
         for k in (0..scalar_outs.len()).rev() {
             let (out_idx, out_sty) = ctx.outputs[scalar_outs[k]].clone();
             if results[k].wty() != out_sty.wty() {
-                return Err("CodegenWasmJit: external `{extName}` output {k} type mismatch");
+                return Err("CodegenWasmJit: external output type mismatch");
             }
             ctx.emit(we::Instruction::LocalSet(out_idx));
         }
@@ -1560,7 +1560,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
     if let Some(bi) = builtin_index(ext_name) {
         let (_, params, _) = BUILTINS[bi as usize];
         if args.len() != params.len() {
-            return Err("CodegenWasmJit: external `{ext_name}` expects {} args, got {}");
+            return Err("CodegenWasmJit: external argument count mismatch");
         }
         for (a, p) in args.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -1570,7 +1570,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
         return Ok(SigTy::Real);
     }
     if args.len() != 1 {
-        return Err("CodegenWasmJit: external `{ext_name}` expects 1 arg, got {}");
+        return Err("CodegenWasmJit: external expects 1 argument");
     }
     let w = compile_exp(ctx, &args[0])?;
     coerce(ctx, w, WTy::F64);
@@ -1579,7 +1579,7 @@ fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Ex
         "fabs" => ctx.emit(we::Instruction::F64Abs),
         "floor" => ctx.emit(we::Instruction::F64Floor),
         "ceil" => ctx.emit(we::Instruction::F64Ceil),
-        other => return Err("CodegenWasmJit: external math function `{other}` not supported"),
+        other => return Err("CodegenWasmJit: external math function not supported"),
     }
     Ok(SigTy::Real)
 }
@@ -1593,10 +1593,10 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
     let key = format!("ext.{ext_name}");
     let (index, params, results) = match ctx.by_name.get(&key) {
         Some(info) => (info.index, info.sig.params.clone(), info.sig.results.clone()),
-        None => return Err("CodegenWasmJit: external `{ext_name}` import not declared"),
+        None => return Err("CodegenWasmJit: external import not declared"),
     };
     if args.len() != params.len() {
-        return Err("CodegenWasmJit: external `{ext_name}` expects {} input arg(s), got {}");
+        return Err("CodegenWasmJit: external input argument count mismatch");
     }
     for (a, p) in args.iter().zip(params.iter()) {
         let w = compile_exp(ctx, a)?;
@@ -1764,7 +1764,7 @@ fn cref_ident(cr: &DAE::ComponentRef) -> Result<String> {
             Ok(ident.to_string())
         }
         DAE::ComponentRef::CREF_QUAL { .. } => return Err("CodegenWasmJit: qualified component reference (records not supported)"),
-        other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported component reference"),
     }
 }
 
@@ -1798,7 +1798,7 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
     let (idx, dst_sty) = ctx
         .locals
         .get(&name)
-        .ok_or_else(|| "CodegenWasmJit: assignment to unknown variable `{name}`")?
+        .ok_or_else(|| "CodegenWasmJit: assignment to unknown variable")?
         .clone();
 
     if !subscriptLst.is_empty() {
@@ -1806,7 +1806,7 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
         // own (private) array, so no copy-on-write is needed (Modelica arrays are
         // mutable value objects; aliasing is broken at whole-array assignment).
         let SigTy::Array { elem, rank } = dst_sty else {
-            return Err("CodegenWasmJit: subscripting non-array local `{name}`");
+            return Err("CodegenWasmJit: subscripting non-array local");
         };
         let idx_exps = index_subscripts(subscriptLst, rank)?;
         return compile_elem_assign(ctx, idx, &elem, &idx_exps, rhs);
@@ -1869,12 +1869,12 @@ fn store_fresh_into_local(ctx: &mut FnCtx, idx: u32, dst_sty: &SigTy, vt: u32) -
 /// locals; subscripted / qualified tuple targets are not supported.
 fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &DAE::Exp) -> Result<()> {
     let DAE::Exp::CALL { path, expLst, attr } = call else {
-        return Err("CodegenWasmJit: tuple assignment rhs is not a function call: {call:?}");
+        return Err("CodegenWasmJit: tuple assignment rhs is not a function call");
     };
     let lhs_v: Vec<&Arc<DAE::Exp>> = (&**lhs).into_iter().collect();
     let results = compile_call(ctx, path, expLst, attr)?;
     if results.len() != lhs_v.len() {
-        return Err("CodegenWasmJit: tuple assignment arity mismatch ({} targets, {} results)");
+        return Err("CodegenWasmJit: tuple assignment arity mismatch");
     }
     // Pop the results into temps (the last result is on top of the stack).
     let mut temps = vec![0u32; results.len()];
@@ -1887,7 +1887,7 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
         let sty = &results[i];
         let vt = temps[i];
         let DAE::Exp::CREF { componentRef, .. } = &***lhs_exp else {
-            return Err("CodegenWasmJit: tuple-assignment target is not a cref: {lhs_exp:?}");
+            return Err("CodegenWasmJit: tuple-assignment target is not a cref");
         };
         match &**componentRef {
             // `_` output: discard (release a heap value).
@@ -1902,11 +1902,11 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
                 let (idx, dst_sty) = ctx
                     .locals
                     .get(&name)
-                    .ok_or_else(|| "CodegenWasmJit: tuple assignment to unknown variable `{name}`")?
+                    .ok_or_else(|| "CodegenWasmJit: tuple assignment to unknown variable")?
                     .clone();
                 store_fresh_into_local(ctx, idx, &dst_sty, vt)?;
             }
-            other => return Err("CodegenWasmJit: unsupported tuple-assignment target `{other:?}`"),
+            other => return Err("CodegenWasmJit: unsupported tuple-assignment target"),
         }
     }
     Ok(())
@@ -1990,7 +1990,7 @@ fn record_field(fields: &[(ArcStr, SigTy)], name: &str) -> Result<(u32, SigTy)> 
             return Ok((layout.data_off + layout.field_off[i], fty.clone()));
         }
     }
-    return Err("CodegenWasmJit: record has no field `{name}`");
+    return Err("CodegenWasmJit: record has no field");
 }
 
 pub(crate) fn mem_arg(offset: u32, align_log2: u32) -> we::MemArg {
@@ -2071,19 +2071,19 @@ fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_e
 /// to the type's declaration order by component name.
 fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &Arc<List<Arc<DAE::Exp>>>, comp: &Arc<List<ArcStr>>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: record constructor with non-record type {ty:?}");
+        return Err("CodegenWasmJit: record constructor with non-record type");
     };
     let expv: Vec<&Arc<DAE::Exp>> = (&**exps).into_iter().collect();
     let compv: Vec<&ArcStr> = (&**comp).into_iter().collect();
     if expv.len() != compv.len() || expv.len() != fields.len() {
-        return Err("CodegenWasmJit: record constructor arity mismatch ({} values, {} fields)");
+        return Err("CodegenWasmJit: record constructor arity mismatch");
     }
     let mut field_exps = Vec::with_capacity(fields.len());
     for (fname, _) in fields.iter() {
         let pos = compv
             .iter()
             .position(|n| n.as_str() == fname.as_str())
-            .ok_or_else(|| "CodegenWasmJit: record constructor missing field `{fname}`")?;
+            .ok_or_else(|| "CodegenWasmJit: record constructor missing field")?;
         field_exps.push(expv[pos]);
     }
     emit_record_construction(ctx, &fields, &field_exps)
@@ -2094,11 +2094,11 @@ fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &Arc<List<Arc<DAE::Exp>
 /// fields in declaration order.
 fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &Arc<List<Arc<DAE::Exp>>>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: record constructor call with non-record type {ty:?}");
+        return Err("CodegenWasmJit: record constructor call with non-record type");
     };
     let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
     if argv.len() != fields.len() {
-        return Err("CodegenWasmJit: record constructor call arity mismatch ({} args, {} fields)");
+        return Err("CodegenWasmJit: record constructor call arity mismatch");
     }
     emit_record_construction(ctx, &fields, &argv)
 }
@@ -2108,7 +2108,7 @@ fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &Arc<List<Arc<DAE:
 /// field is read; a heap field is retained so the returned value is owned.
 fn compile_rsub(ctx: &mut FnCtx, exp: &DAE::Exp, name: &str) -> Result<WTy> {
     let SigTy::Record { fields, .. } = exp_sigty(exp)? else {
-        return Err("CodegenWasmJit: field access `.{name}` on a non-record expression");
+        return Err("CodegenWasmJit: field access `.` on a non-record expression");
     };
     let (off, fty) = record_field(&fields, name)?;
     compile_exp(ctx, exp)?; // owned record handle
@@ -2181,11 +2181,11 @@ fn push_owned_record_base(
     let (idx, sty) = ctx
         .locals
         .get(ident)
-        .ok_or_else(|| "CodegenWasmJit: reference to unknown variable `{ident}`")?
+        .ok_or_else(|| "CodegenWasmJit: reference to unknown variable")?
         .clone();
     if subs.is_empty() {
         let SigTy::Record { fields, .. } = sty else {
-            return Err("CodegenWasmJit: field access on non-record local `{ident}`");
+            return Err("CodegenWasmJit: field access on non-record local");
         };
         ctx.emit(we::Instruction::LocalGet(idx));
         ctx.emit(we::Instruction::LocalGet(idx));
@@ -2195,10 +2195,10 @@ fn push_owned_record_base(
         Ok((t, fields))
     } else {
         let SigTy::Array { elem, rank } = sty else {
-            return Err("CodegenWasmJit: subscripting non-array local `{ident}`");
+            return Err("CodegenWasmJit: subscripting non-array local");
         };
         let SigTy::Record { fields, .. } = &*elem else {
-            return Err("CodegenWasmJit: indexed base `{ident}[..]` is not an array of records");
+            return Err("CodegenWasmJit: indexed base `[..]` is not an array of records");
         };
         let fields = fields.clone();
         if !is_scalar_index(subs, rank) {
@@ -2253,15 +2253,15 @@ fn step_into_record(
     let (vt, fty) = take_field(ctx, rec, fields, field)?;
     if fsubs.is_empty() {
         let SigTy::Record { fields: f2, .. } = fty else {
-            return Err("CodegenWasmJit: field access on non-record field `{field}`");
+            return Err("CodegenWasmJit: field access on non-record field");
         };
         Ok((vt, f2))
     } else {
         let SigTy::Array { elem, rank } = fty else {
-            return Err("CodegenWasmJit: subscripting non-array field `{field}`");
+            return Err("CodegenWasmJit: subscripting non-array field");
         };
         let SigTy::Record { fields: f2, .. } = &*elem else {
-            return Err("CodegenWasmJit: field access on non-record array element `{field}`");
+            return Err("CodegenWasmJit: field access on non-record array element");
         };
         let f2 = f2.clone();
         if !is_scalar_index(fsubs, rank) {
@@ -2295,7 +2295,7 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
                     return Ok(fty.wty());
                 }
                 let SigTy::Array { elem, rank } = fty else {
-                    return Err("CodegenWasmJit: subscripting non-array field `{field}`");
+                    return Err("CodegenWasmJit: subscripting non-array field");
                 };
                 ctx.emit(we::Instruction::LocalGet(vt)); // owned array handle
                 return if is_scalar_index(fsubs, rank) {
@@ -2311,7 +2311,7 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
                 fields = f2;
                 cur = inner;
             }
-            other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported component reference"),
         }
     }
 }
@@ -2339,7 +2339,7 @@ fn navigate_qual<'c>(
                 fields = f2;
                 cur = inner;
             }
-            other => return Err("CodegenWasmJit: unsupported component reference {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported component reference"),
         }
     }
 }
@@ -2356,7 +2356,7 @@ fn compile_cref_assign_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE
         // owned) array, in place.
         let (off, fty) = record_field(&fields, leaf)?;
         let SigTy::Array { elem, rank } = fty else {
-            return Err("CodegenWasmJit: subscripted field `{leaf}` is not an array");
+            return Err("CodegenWasmJit: subscripted field is not an array");
         };
         let arr_t = ctx.alloc_temp(WTy::I32);
         ctx.emit(we::Instruction::LocalGet(rec));
@@ -2539,7 +2539,7 @@ fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
             ctx.branch_to(cont);
             Ok(())
         }
-        other => return Err("CodegenWasmJit: statement not yet supported: {other:?}"),
+        other => return Err("CodegenWasmJit: statement not yet supported"),
     }
 }
 
@@ -2738,7 +2738,7 @@ fn emit_value_const(ctx: &mut FnCtx, v: &Values::Value, wty: WTy) -> Result<()> 
             ctx.emit(we::Instruction::F64Const(real.into_inner().into()));
             WTy::F64
         }
-        other => return Err("CodegenWasmJit: unsupported reduction default value {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported reduction default value"),
     };
     coerce(ctx, from, wty);
     Ok(())
@@ -3038,7 +3038,7 @@ fn sim_cref_key_into(cr: &DAE::ComponentRef, s: &mut String) -> Result<()> {
             s.push('.');
             sim_cref_key_into(componentRef, s)?;
         }
-        other => return Err("CodegenWasmJit: unsupported component reference in simulation: {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported component reference in simulation"),
     }
     Ok(())
 }
@@ -3057,9 +3057,9 @@ fn sim_subs_into(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> Resul
                     s.push_str(&index.to_string());
                     s.push(']');
                 }
-                other => return Err("CodegenWasmJit: non-constant subscript in simulation cref: {other:?}"),
+                other => return Err("CodegenWasmJit: non-constant subscript in simulation cref"),
             },
-            other => return Err("CodegenWasmJit: unsupported subscript in simulation cref: {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported subscript in simulation cref"),
         }
     }
     Ok(())
@@ -3194,7 +3194,7 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                         ctx.emit(we::Instruction::F64Const(0.0.into()));
                         Ok(Some(WTy::F64))
                     }
-                    None => return Err("CodegenWasmJit: $START for unknown variable `{key}`"),
+                    None => return Err("CodegenWasmJit: $START for unknown variable"),
                 };
             }
             "$PRE" => {
@@ -3234,7 +3234,7 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 emit_sim_array_gather(ctx, &group)?;
                 return Ok(Some(WTy::I32));
             }
-            return Err("CodegenWasmJit: simulation reference to unknown variable `{key}`")
+            return Err("CodegenWasmJit: simulation reference to unknown variable")
         }
     };
     let data = ctx.sim()?.data_local;
@@ -3325,11 +3325,11 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE:
                 emit_sim_array_scatter(ctx, &group, rhs)?;
                 return Ok(true);
             }
-            return Err("CodegenWasmJit: simulation assignment to unknown variable `{key}`")
+            return Err("CodegenWasmJit: simulation assignment to unknown variable")
         }
     };
     if slot.negate {
-        return Err("CodegenWasmJit: assignment to negated alias `{key}`");
+        return Err("CodegenWasmJit: assignment to negated alias");
     }
     let data = ctx.sim()?.data_local;
     if slot.heap {
@@ -3479,13 +3479,13 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             }
             // A scalar/whole-value reference, or a subscripted array element.
             let DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } = &**componentRef else {
-                return Err("CodegenWasmJit: unsupported component reference {componentRef:?}");
+                return Err("CodegenWasmJit: unsupported component reference");
             };
             let name = ident.to_string();
             let (idx, sty) = ctx
                 .locals
                 .get(&name)
-                .ok_or_else(|| "CodegenWasmJit: reference to unknown variable `{name}`")?
+                .ok_or_else(|| "CodegenWasmJit: reference to unknown variable")?
                 .clone();
             if subscriptLst.is_empty() {
                 ctx.emit(we::Instruction::LocalGet(idx));
@@ -3503,7 +3503,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 // Indexed read `v[i, ...]`: push the (retained, owned) array
                 // handle, then load the element (which releases the handle).
                 let SigTy::Array { elem, rank } = sty else {
-                    return Err("CodegenWasmJit: subscripting non-array local `{name}`");
+                    return Err("CodegenWasmJit: subscripting non-array local");
                 };
                 ctx.emit(we::Instruction::LocalGet(idx));
                 ctx.emit(we::Instruction::LocalGet(idx));
@@ -3547,7 +3547,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::LUNARY { operator, exp } => {
             // `not` — the only logical unary.
             let DAE::Operator::NOT { .. } = operator else {
-                return Err("CodegenWasmJit: unsupported logical unary operator {operator:?}");
+                return Err("CodegenWasmJit: unsupported logical unary operator");
             };
             // Element-wise `not` over a Boolean array.
             if matches!(exp_sigty(exp), Ok(SigTy::Array { .. })) {
@@ -3567,7 +3567,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 let (op_code, ty) = match operator {
                     DAE::Operator::AND { ty } => (OP_AND, ty),
                     DAE::Operator::OR { ty } => (OP_OR, ty),
-                    other => return Err("CodegenWasmJit: unsupported logical array operator {other:?}"),
+                    other => return Err("CodegenWasmJit: unsupported logical array operator"),
                 };
                 return compile_array_ew(ctx, exp1, exp2, op_code, ty);
             }
@@ -3578,7 +3578,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             match operator {
                 DAE::Operator::AND { .. } => ctx.emit(we::Instruction::I32And),
                 DAE::Operator::OR { .. } => ctx.emit(we::Instruction::I32Or),
-                other => return Err("CodegenWasmJit: unsupported logical binary operator {other:?}"),
+                other => return Err("CodegenWasmJit: unsupported logical binary operator"),
             }
             Ok(WTy::I32)
         }
@@ -3602,8 +3602,8 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             let results = compile_call(ctx, path, expLst, attr)?;
             match results.len() {
                 1 => Ok(results[0].wty()),
-                0 => return Err("CodegenWasmJit: call to {} used in expression position returns no value"),
-                _ => return Err("CodegenWasmJit: call to {} returns multiple values; not usable in expression position"),
+                0 => return Err("CodegenWasmJit: call to used in expression position returns no value"),
+                _ => return Err("CodegenWasmJit: call to returns multiple values; not usable in expression position"),
             }
         }
         // Array constructor `{e1, e2, ...}` or matrix `{{...}, {...}}`.
@@ -3633,7 +3633,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::REDUCTION { reductionInfo, expr, iterators } => {
             compile_reduction(ctx, reductionInfo, expr, iterators)
         }
-        other => return Err("CodegenWasmJit: expression not yet supported: {other:?}"),
+        other => return Err("CodegenWasmJit: expression not yet supported"),
     }
 }
 
@@ -3714,7 +3714,7 @@ fn operator_sigty(op: &DAE::Operator) -> Result<SigTy> {
         | O::POW_SCALAR_ARRAY { ty }
         | O::POW_ARR { ty }
         | O::POW_ARR2 { ty } => ty,
-        other => return Err("CodegenWasmJit: cannot determine type of operator {other:?}"),
+        other => return Err("CodegenWasmJit: cannot determine type of operator"),
     };
     sig_ty(ty)
 }
@@ -3759,7 +3759,7 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         E::SIZE { sz: None, .. } => SigTy::Array { elem: Arc::new(SigTy::Int), rank: 1 },
         // A record constructor / field access carry their type directly.
         E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty(ty)?,
-        other => return Err("CodegenWasmJit: cannot determine type of expression {other:?}"),
+        other => return Err("CodegenWasmJit: cannot determine type of expression"),
     })
 }
 
@@ -3767,7 +3767,7 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
     // Array negation `-a`: negate every element into a fresh array.
     if let DAE::Operator::UMINUS_ARR { ty } = op {
         let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-            return Err("CodegenWasmJit: UMINUS_ARR with non-array type {ty:?}");
+            return Err("CodegenWasmJit: UMINUS_ARR with non-array type");
         };
         let rt = if elem.wty() == WTy::F64 { "rt_array_neg_f64" } else { "rt_array_neg_i32" };
         compile_exp(ctx, exp)?; // owned array
@@ -3779,7 +3779,7 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
         return Ok(WTy::I32);
     }
     let DAE::Operator::UMINUS { ty } = op else {
-        return Err("CodegenWasmJit: unsupported unary operator {op:?}");
+        return Err("CodegenWasmJit: unsupported unary operator");
     };
     let wty = sig_ty(ty)?.wty();
     let w = compile_exp(ctx, exp)?;
@@ -3830,7 +3830,7 @@ fn compile_binary(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::
     // is a fresh String handle from the runtime.
     if operator_sigty(op)? == SigTy::Str {
         let O::ADD { .. } = op else {
-            return Err("CodegenWasmJit: unsupported String operator {op:?}");
+            return Err("CodegenWasmJit: unsupported String operator");
         };
         str_binop(ctx, e1, e2, "rt_concat")?;
         return Ok(WTy::I32);
@@ -3892,7 +3892,7 @@ fn compile_binary(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::
         (O::MUL { .. }, WTy::I32) => ctx.emit(we::Instruction::I32Mul),
         (O::DIV { .. }, WTy::F64) => ctx.emit(we::Instruction::F64Div),
         (O::DIV { .. }, WTy::I32) => ctx.emit(we::Instruction::I32DivS),
-        (other, _) => return Err("CodegenWasmJit: unsupported binary operator {other:?}"),
+        (other, _) => return Err("CodegenWasmJit: unsupported binary operator"),
     }
     Ok(wty)
 }
@@ -3918,7 +3918,7 @@ fn compile_relation(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE
                     _ => we::Instruction::I32GeS,
                 });
             }
-            other => return Err("CodegenWasmJit: unsupported String relation {other:?}"),
+            other => return Err("CodegenWasmJit: unsupported String relation"),
         }
         return Ok(WTy::I32);
     }
@@ -4052,7 +4052,7 @@ fn emit_hyst_cmp(ctx: &mut FnCtx, op: &DAE::Operator, diff: u32, eps: u32, dir: 
         O::LESS { .. } => (I::F64Le, dir),
         O::GREATER { .. } => (I::F64Ge, !dir),
         O::GREATEREQ { .. } => (I::F64Gt, !dir),
-        other => return Err("CodegenWasmJit: non-inequality in hysteresis path: {other:?}"),
+        other => return Err("CodegenWasmJit: non-inequality in hysteresis path"),
     };
     ctx.emit(I::LocalGet(diff));
     ctx.emit(I::LocalGet(eps));
@@ -4096,7 +4096,7 @@ fn compile_relation_fresh(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2
         (O::EQUAL { .. }, WTy::I32) => we::Instruction::I32Eq,
         (O::NEQUAL { .. }, WTy::F64) => we::Instruction::F64Ne,
         (O::NEQUAL { .. }, WTy::I32) => we::Instruction::I32Ne,
-        (other, _) => return Err("CodegenWasmJit: unsupported relational operator {other:?}"),
+        (other, _) => return Err("CodegenWasmJit: unsupported relational operator"),
     };
     ctx.emit(instr);
     Ok(WTy::I32)
@@ -4112,7 +4112,7 @@ fn relation_operand_sigty(op: &DAE::Operator) -> Result<SigTy> {
     use DAE::Operator as O;
     let ty = match op {
         O::LESS { ty } | O::LESSEQ { ty } | O::GREATER { ty } | O::GREATEREQ { ty } | O::EQUAL { ty } | O::NEQUAL { ty } => ty,
-        other => return Err("CodegenWasmJit: not a relational operator: {other:?}"),
+        other => return Err("CodegenWasmJit: not a relational operator"),
     };
     sig_ty(ty)
 }
@@ -4137,7 +4137,7 @@ fn compile_call(
         let index = info.index;
         let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
         if argv.len() != params.len() {
-            return Err("CodegenWasmJit: call to {mangled} expects {} args, got {}");
+            return Err("CodegenWasmJit: call argument count mismatch");
         }
         for (a, p) in argv.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -4162,7 +4162,7 @@ fn compile_call(
 /// left on the stack (to be released if heap, otherwise dropped).
 fn compile_call_drop(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<Vec<SigTy>> {
     let DAE::Exp::CALL { path, expLst, attr } = exp else {
-        return Err("CodegenWasmJit: no-return statement is not a call: {exp:?}");
+        return Err("CodegenWasmJit: no-return statement is not a call");
     };
     compile_call(ctx, path, expLst, attr)
 }
@@ -4229,7 +4229,7 @@ fn compile_math_event(
     let (data, base, fresh_off) = {
         let s = ctx.sim()?;
         if idx >= s.n_mathevents {
-            return Err("CodegenWasmJit: math-event index {idx} out of range (n={})");
+            return Err("CodegenWasmJit: math-event index out of range");
         }
         (s.data_local, s.mathevents_off + idx * 8, s.rel_fresh_off)
     };
@@ -4332,7 +4332,7 @@ fn compile_math_event(
                 }
             }
         }
-        _ => return Err("CodegenWasmJit: not a math-event builtin: {name}"),
+        _ => return Err("CodegenWasmJit: not a math-event builtin"),
     }
 }
 
@@ -4367,7 +4367,7 @@ fn compile_math_builtin(
     if let Some(bi) = builtin_index(name) {
         let (_, params, _) = BUILTINS[bi as usize];
         if argv.len() != params.len() {
-            return Err("CodegenWasmJit: builtin {name} expects {} args");
+            return Err("CodegenWasmJit: builtin expects args");
         }
         for (a, p) in argv.iter().zip(params.iter()) {
             let w = compile_exp(ctx, a)?;
@@ -4661,7 +4661,7 @@ fn compile_math_builtin(
                 .sim()?
                 .sample_map
                 .get(integer)
-                .ok_or_else(|| "CodegenWasmJit: unknown sample index {integer}")?;
+                .ok_or_else(|| "CodegenWasmJit: unknown sample index")?;
             let data = ctx.sim()?.data_local;
             let off = ctx.sim()?.sample_active_off + k * 4;
             ctx.emit(we::Instruction::LocalGet(data));
@@ -4681,7 +4681,7 @@ fn compile_math_builtin(
                 None => return Err("CodegenWasmJit: der() is only supported in simulation mode"),
             }
         }
-        other => return Err("CodegenWasmJit: builtin function `{other}` not yet supported"),
+        other => return Err("CodegenWasmJit: builtin function not yet supported"),
     }
 }
 
@@ -4790,7 +4790,7 @@ fn emit_string_builtin(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>]) -> Result<SigTy
         }
         // String(Real, significantDigits, minimumLength, leftJustified).
         (SigTy::Real, 4) => emit_real_format(ctx, argv[0], argv[1], argv[2], argv[3]),
-        other => return Err("CodegenWasmJit: unsupported String() argument shape {other:?}"),
+        other => return Err("CodegenWasmJit: unsupported String() argument shape"),
     }
 }
 
@@ -4804,7 +4804,7 @@ fn emit_string_format(ctx: &mut FnCtx, val: &DAE::Exp, fmt: &DAE::Exp, vty: &Sig
         // Integer and Boolean share the integer formatter (Booleans coerce to
         // 0/1). The String format variant (`%s`) is not yet ported.
         SigTy::Int | SigTy::Bool => "rt_string_format_int",
-        other => return Err("CodegenWasmJit: String(value, format) not yet implemented for {other:?}"),
+        other => return Err("CodegenWasmJit: String(value, format) not yet implemented for"),
     };
     let w = compile_exp(ctx, val)?;
     coerce(ctx, w, vty.wty());
@@ -5042,7 +5042,7 @@ fn const_dims(ty: &DAE::Type) -> Result<Vec<u32>> {
     for d in &**dims {
         match &**d {
             DAE::Dimension::DIM_INTEGER { integer } if *integer >= 0 => out.push(*integer as u32),
-            other => return Err("CodegenWasmJit: array construction needs constant dimensions, got {other:?}"),
+            other => return Err("CodegenWasmJit: array construction needs constant dimensions"),
         }
     }
     out.extend(const_dims(elem)?);
@@ -5078,11 +5078,11 @@ fn flatten_array_exp<'a>(exp: &'a DAE::Exp, out: &mut Vec<&'a DAE::Exp>) {
 /// element's reference transfers into the array (released by `rt_array_release`).
 fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> Result<()> {
     let SigTy::Array { elem, rank } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: array constructor with non-array type {ty:?}");
+        return Err("CodegenWasmJit: array constructor with non-array type");
     };
     let dims = const_dims(ty)?;
     if dims.len() as u32 != rank {
-        return Err("CodegenWasmJit: array constructor rank {rank} does not match {} dimensions");
+        return Err("CodegenWasmJit: array constructor rank does not match dimensions");
     }
     let total: u32 = dims.iter().product();
     // The top-level structure (`ARRAY`/`MATRIX` nodes) is flattened to its
@@ -5137,7 +5137,7 @@ fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> R
         }
     }
     if k != total {
-        return Err("CodegenWasmJit: array constructor produced {k} elements but type implies {total}");
+        return Err("CodegenWasmJit: array constructor element/type count mismatch");
     }
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
@@ -5197,13 +5197,13 @@ fn operator_dae_type(op: &DAE::Operator) -> Option<Arc<DAE::Type>> {
 /// element-count rounding to stay byte-identical, so they fail loudly.
 fn compile_range_array(ctx: &mut FnCtx, ty: &DAE::Type, start: &DAE::Exp, step: Option<&DAE::Exp>, stop: &DAE::Exp) -> Result<()> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: range with non-array type {ty:?}");
+        return Err("CodegenWasmJit: range with non-array type");
     };
     match &*elem {
         // Integer and enumeration ranges (enum literals are their i32 index).
         SigTy::Int => compile_int_range_array(ctx, start, step, stop),
         SigTy::Real => compile_real_range_array(ctx, start, step, stop),
-        other => return Err("CodegenWasmJit: only Integer/Real ranges are supported as array values (element {other:?})"),
+        other => return Err("CodegenWasmJit: only Integer/Real ranges are supported as array values"),
     }
 }
 
@@ -5401,7 +5401,7 @@ const OP_OR: i32 = 6;
 /// operand arrays are released after.
 fn compile_array_ew(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, ty: &DAE::Type) -> Result<WTy> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: element-wise array op with non-array type {ty:?}");
+        return Err("CodegenWasmJit: element-wise array op with non-array type");
     };
     let rt = if elem.wty() == WTy::F64 { "rt_array_ew_f64" } else { "rt_array_ew_i32" };
     compile_exp(ctx, e1)?;
@@ -5467,7 +5467,7 @@ fn compile_matmul(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> 
 /// order); the array operand is released after.
 fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, rev: bool, ty: &DAE::Type) -> Result<WTy> {
     let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: array-scalar op with non-array type {ty:?}");
+        return Err("CodegenWasmJit: array-scalar op with non-array type");
     };
     let elem_wty = elem.wty();
     let rt = if elem_wty == WTy::F64 { "rt_array_scalar_f64" } else { "rt_array_scalar_i32" };
@@ -5526,13 +5526,13 @@ fn is_scalar_index(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> bool {
 fn index_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> Result<Vec<Arc<DAE::Exp>>> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
     if subs.len() as u32 != rank {
-        return Err("CodegenWasmJit: array slicing / partial indexing not supported ({} subscripts on rank {rank})");
+        return Err("CodegenWasmJit: array slicing / partial indexing not supported");
     }
     let mut out = Vec::with_capacity(subs.len());
     for s in subs {
         match &**s {
             DAE::Subscript::INDEX { exp } => out.push(exp.clone()),
-            other => return Err("CodegenWasmJit: non-scalar subscript {other:?} (slicing not supported)"),
+            other => return Err("CodegenWasmJit: non-scalar subscript (slicing not supported)"),
         }
     }
     Ok(out)
@@ -5760,7 +5760,7 @@ fn compile_array_builtin(
             }
             let arr_ty = sig_ty(&attr.ty)?;
             let SigTy::Array { elem, .. } = &arr_ty else {
-                return Err("CodegenWasmJit: fill result is not an array ({arr_ty:?})");
+                return Err("CodegenWasmJit: fill result is not an array");
             };
             let obj = emit_alloc_from_exprs(ctx, elem, &argv[1..])?;
             emit_fill_value(ctx, obj, elem, argv[0])?;
@@ -5770,11 +5770,11 @@ fn compile_array_builtin(
         // zeros(d...) / ones(d...): like fill with a constant 0 / 1.
         "zeros" | "ones" => {
             if argv.is_empty() {
-                return Err("CodegenWasmJit: {name} expects at least one dimension");
+                return Err("CodegenWasmJit: expects at least one dimension");
             }
             let arr_ty = sig_ty(&attr.ty)?;
             let SigTy::Array { elem, .. } = &arr_ty else {
-                return Err("CodegenWasmJit: {name} result is not an array ({arr_ty:?})");
+                return Err("CodegenWasmJit: result is not an array");
             };
             let obj = emit_alloc_from_exprs(ctx, elem, argv)?;
             emit_fill_const(ctx, obj, elem, if name == "ones" { 1 } else { 0 })?;
@@ -5980,7 +5980,7 @@ fn compile_array_builtin(
 /// result handle on the stack.
 fn emit_unary_array(ctx: &mut FnCtx, arg: &DAE::Exp, rt: &str) -> Result<()> {
     if array_elem(arg)?.is_none() {
-        return Err("CodegenWasmJit: {rt} of a non-array expression");
+        return Err("CodegenWasmJit: of a non-array expression");
     }
     compile_exp(ctx, arg)?;
     let at = ctx.alloc_temp(WTy::I32);
@@ -6097,7 +6097,7 @@ fn unary_f64(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>], instr: we::Instruction<'s
 
 fn need_args(argv: &[&Arc<DAE::Exp>], n: usize, name: &str) -> Result<()> {
     if argv.len() != n {
-        return Err("CodegenWasmJit: builtin {name} expects {n} args, got {}");
+        return Err("CodegenWasmJit: builtin argument count mismatch");
     }
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -21,7 +21,7 @@ use super::SigTy;
 /// — `RuntimeError`, `InstantiationError`, `ExportError`, … — do not share a
 /// single anyhow-convertible type, so we format via `Debug`).
 fn wt<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
-    r.map_err(|e| "{e:?}")
+    r.map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 /// The static linear-memory runtime, precompiled from
@@ -90,7 +90,7 @@ struct Sig {
 
 fn read_sig(path: &str) -> Result<Sig> {
     let text = openmodelica_wasi::fs::read_to_string(path)
-        .map_err(|_| "CodegenWasmJit: cannot read sidecar {path}")?;
+        .map_err(|_| "CodegenWasmJit: cannot read sidecar")?;
     let mut lines = text.lines();
     let parse = |line: Option<&str>| -> Result<Vec<SigTy>> {
         super::parse_sig_types(line.unwrap_or(""))
@@ -185,7 +185,7 @@ fn value_as_f64(v: &Values::Value) -> Result<f64> {
         Values::Value::INTEGER { integer } => *integer as f64,
         Values::Value::BOOL { boolean } => *boolean as i64 as f64,
         Values::Value::ENUM_LITERAL { index, .. } => *index as f64,
-        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass to a wasm function"),
     })
 }
 
@@ -196,7 +196,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
         Values::Value::BOOL { boolean } => *boolean as i32,
         Values::Value::ENUM_LITERAL { index, .. } => *index,
         Values::Value::REAL { real } => real.into_inner() as i32,
-        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass to a wasm function"),
     })
 }
 
@@ -208,7 +208,7 @@ pub(super) fn load_and_execute(
     let wasm_path = format!("{file_name}.wasm");
     let sig = read_sig(&format!("{file_name}.wasm.sig"))?;
     let bytes = openmodelica_wasi::fs::read(&wasm_path)
-        .map_err(|_| "CodegenWasmJit: cannot read module {wasm_path}")?;
+        .map_err(|_| "CodegenWasmJit: cannot read module")?;
 
     // Reuse the shared engine and the per-content compiled module. Each call
     // gets a fresh store + runtime instance (its own heap/linear memory); the
@@ -229,7 +229,7 @@ pub(super) fn load_and_execute(
     let memory = rt_inst
         .exports
         .get_memory("memory")
-        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export: {e:?}")?
+        .map_err(|e| "CodegenWasmJit: runtime has no `memory` export")?
         .clone();
     let rt = RtFns {
         mem: memory,
@@ -248,13 +248,13 @@ pub(super) fn load_and_execute(
     let func = instance
         .exports
         .get_function("main")
-        .map_err(|e| "CodegenWasmJit: module has no `main` export: {e:?}")?
+        .map_err(|e| "CodegenWasmJit: module has no `main` export")?
         .clone();
 
     // Marshal the arguments according to the input signature.
     let argv: Vec<&Arc<Values::Value>> = (&**args).into_iter().collect();
     if argv.len() != sig.inputs.len() {
-        return Err("CodegenWasmJit: function expects {} arguments, got {}");
+        return Err("CodegenWasmJit: function argument count mismatch");
     }
     let mut params: Vec<wasmer::Value> = Vec::with_capacity(argv.len());
     for (a, ty) in argv.iter().zip(sig.inputs.iter()) {
@@ -278,12 +278,12 @@ pub(super) fn load_and_execute(
                 report_pending_assert(&mut store, &rt, &pa)?;
                 return Ok(Arc::new(Values::Value::META_FAIL));
             }
-            return Err("{e:?}");
+            return Err("CodegenWasmJit: wasm function call trapped");
         }
     };
 
     if results.len() != sig.outputs.len() {
-        return Err("CodegenWasmJit: wasm returned {} values but signature has {}");
+        return Err("CodegenWasmJit: wasm return-value/signature count mismatch");
     }
 
     let mut out: Vec<Arc<Values::Value>> = Vec::with_capacity(results.len());
@@ -305,7 +305,7 @@ fn read_rt_str(store: &mut Store, rt: &RtFns, handle: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, handle))? as usize;
     let data = wt(rt.str_data.call(&mut *store, handle))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.view(&*store).read(data as u64, &mut buf).map_err(|e| "CodegenWasmJit: {e}")?;
+    rt.mem.view(&*store).read(data as u64, &mut buf).map_err(|e| "CodegenWasmJit")?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -371,7 +371,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
 /// is self-describing for release/copy.
 fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v: &Values::Value) -> Result<i32> {
     let Values::Value::RECORD { orderd, comp, .. } = v else {
-        return Err("CodegenWasmJit: expected a record argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a record argument");
     };
     let layout = super::record_layout(fields);
     let obj = wt(rt.rec_new.call(&mut *store, layout.heap.len() as i32, layout.size as i32))?;
@@ -389,7 +389,7 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
     for (i, (fname, fty)) in fields.iter().enumerate() {
         let fv = by_name
             .get(fname.as_str())
-            .ok_or_else(|| "CodegenWasmJit: record argument missing field `{fname}`")?;
+            .ok_or_else(|| "CodegenWasmJit: record argument missing field")?;
         let addr = obj as usize + layout.data_off as usize + layout.field_off[i] as usize;
         write_elem(store, rt, fty, addr, fv)?;
     }
@@ -399,12 +399,12 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
 /// Materialize a `Values.STRING` into a fresh runtime string, returning its handle.
 fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32> {
     let Values::Value::STRING { string } = v else {
-        return Err("CodegenWasmJit: expected a String argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a String argument");
     };
     let b = string.as_bytes();
     let h = wt(rt.str_new.call(&mut *store, b.len() as i32))?;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
-    rt.mem.view(&*store).write(d as u64, b).map_err(|e| "CodegenWasmJit: memory write: {e}")?;
+    rt.mem.view(&*store).write(d as u64, b).map_err(|e| "CodegenWasmJit: memory write")?;
     Ok(h)
 }
 
@@ -413,11 +413,11 @@ fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32
 /// dimension; the leaves are flattened row-major and written into the object.
 fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &Values::Value) -> Result<i32> {
     let Values::Value::ARRAY { dimLst, .. } = v else {
-        return Err("CodegenWasmJit: expected an array argument, got {v:?}");
+        return Err("CodegenWasmJit: expected an array argument");
     };
     let dims: Vec<i32> = (&**dimLst).into_iter().copied().collect();
     if dims.len() as u32 != rank {
-        return Err("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}");
+        return Err("CodegenWasmJit: array argument has dimensions, expected rank");
     }
     let total: i32 = dims.iter().product();
     let obj = wt(rt.arr_new.call(&mut *store, elem.elem_kind() as i32, rank as i32, total))?;
@@ -428,7 +428,7 @@ fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &V
     let mut leaves = Vec::new();
     flatten_values(v, &mut leaves);
     if leaves.len() as i32 != total {
-        return Err("CodegenWasmJit: array argument has {} elements but dimensions imply {total}");
+        return Err("CodegenWasmJit: array argument element/dimension count mismatch");
     }
     for (k, leaf) in leaves.iter().enumerate() {
         let addr = wt(rt.arr_elem_ptr.call(&mut *store, obj, k as i32 + 1))? as usize;
@@ -473,7 +473,7 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
 }
 
 fn write_bytes(store: &mut Store, rt: &RtFns, addr: usize, bytes: &[u8]) -> Result<()> {
-    rt.mem.view(&*store).write(addr as u64, bytes).map_err(|e| "CodegenWasmJit: memory write: {e}")
+    rt.mem.view(&*store).write(addr as u64, bytes).map_err(|e| "CodegenWasmJit: memory write")
 }
 
 /// Build a `Values.Value` from a wasm result of the given Modelica type.
@@ -540,8 +540,8 @@ fn read_string(store: &mut Store, rt: &RtFns, h: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, h))? as usize;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.view(&*store).read(d as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
-    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string: {e}")
+    rt.mem.view(&*store).read(d as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read")?;
+    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string")
 }
 
 /// Read a runtime array handle into a (nested) `Values.ARRAY` of element type
@@ -587,7 +587,7 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
 
 fn read_bytes<const N: usize>(store: &mut Store, rt: &RtFns, addr: usize) -> Result<[u8; N]> {
     let mut buf = [0u8; N];
-    rt.mem.view(&*store).read(addr as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
+    rt.mem.view(&*store).read(addr as u64, &mut buf).map_err(|e| "CodegenWasmJit: memory read")?;
     Ok(buf)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -20,7 +20,7 @@ use super::SigTy;
 /// wasmtime errors carry their own (re-exported) `anyhow`, which does not unify
 /// with ours under the feature set we build with; flatten via the message.
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
-    r.map_err(|e| "{e:?}")
+    r.map_err(|_| "CodegenWasmJit: wasm engine error")
 }
 
 /// The static linear-memory runtime, precompiled from
@@ -179,7 +179,7 @@ fn value_as_f64(v: &Values::Value) -> Result<f64> {
         Values::Value::INTEGER { integer } => *integer as f64,
         Values::Value::BOOL { boolean } => *boolean as i64 as f64,
         Values::Value::ENUM_LITERAL { index, .. } => *index as f64,
-        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass to a wasm function"),
     })
 }
 
@@ -190,7 +190,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
         Values::Value::BOOL { boolean } => *boolean as i32,
         Values::Value::ENUM_LITERAL { index, .. } => *index,
         Values::Value::REAL { real } => real.into_inner() as i32,
-        other => return Err("CodegenWasmJit: cannot pass {other:?} to a wasm function"),
+        other => return Err("CodegenWasmJit: cannot pass to a wasm function"),
     })
 }
 
@@ -241,7 +241,7 @@ pub(super) fn load_and_execute(
     // Marshal the arguments according to the input signature.
     let argv: Vec<&Arc<Values::Value>> = (&**args).into_iter().collect();
     if argv.len() != sig.inputs.len() {
-        return Err("CodegenWasmJit: function expects {} arguments, got {}");
+        return Err("CodegenWasmJit: function argument count mismatch");
     }
     let mut params: Vec<wasmtime::Val> = Vec::with_capacity(argv.len());
     for (a, ty) in argv.iter().zip(sig.inputs.iter()) {
@@ -269,7 +269,7 @@ pub(super) fn load_and_execute(
     wt(call_res)?;
 
     if results.len() != sig.outputs.len() {
-        return Err("CodegenWasmJit: wasm returned {} values but signature has {}");
+        return Err("CodegenWasmJit: wasm return-value/signature count mismatch");
     }
 
     let mut out: Vec<Arc<Values::Value>> = Vec::with_capacity(results.len());
@@ -291,7 +291,7 @@ fn read_rt_str(store: &mut Store, rt: &RtFns, handle: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, handle))? as usize;
     let data = wt(rt.str_data.call(&mut *store, handle))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.read(&*store, data, &mut buf).map_err(|e| "CodegenWasmJit: {e}")?;
+    rt.mem.read(&*store, data, &mut buf).map_err(|e| "CodegenWasmJit")?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -357,7 +357,7 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
 /// is self-describing for release/copy.
 fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v: &Values::Value) -> Result<i32> {
     let Values::Value::RECORD { orderd, comp, .. } = v else {
-        return Err("CodegenWasmJit: expected a record argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a record argument");
     };
     let layout = super::record_layout(fields);
     let obj = wt(rt.rec_new.call(&mut *store, (layout.heap.len() as i32, layout.size as i32)))?;
@@ -375,7 +375,7 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
     for (i, (fname, fty)) in fields.iter().enumerate() {
         let fv = by_name
             .get(fname.as_str())
-            .ok_or_else(|| "CodegenWasmJit: record argument missing field `{fname}`")?;
+            .ok_or_else(|| "CodegenWasmJit: record argument missing field")?;
         let addr = obj as usize + layout.data_off as usize + layout.field_off[i] as usize;
         write_elem(store, rt, fty, addr, fv)?;
     }
@@ -385,12 +385,12 @@ fn record_to_handle(store: &mut Store, rt: &RtFns, fields: &[(ArcStr, SigTy)], v
 /// Materialize a `Values.STRING` into a fresh runtime string, returning its handle.
 fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32> {
     let Values::Value::STRING { string } = v else {
-        return Err("CodegenWasmJit: expected a String argument, got {v:?}");
+        return Err("CodegenWasmJit: expected a String argument");
     };
     let b = string.as_bytes();
     let h = wt(rt.str_new.call(&mut *store, b.len() as i32))?;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
-    rt.mem.write(&mut *store, d, b).map_err(|e| "CodegenWasmJit: memory write: {e}")?;
+    rt.mem.write(&mut *store, d, b).map_err(|e| "CodegenWasmJit: memory write")?;
     Ok(h)
 }
 
@@ -399,11 +399,11 @@ fn str_to_handle(store: &mut Store, rt: &RtFns, v: &Values::Value) -> Result<i32
 /// dimension; the leaves are flattened row-major and written into the object.
 fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &Values::Value) -> Result<i32> {
     let Values::Value::ARRAY { dimLst, .. } = v else {
-        return Err("CodegenWasmJit: expected an array argument, got {v:?}");
+        return Err("CodegenWasmJit: expected an array argument");
     };
     let dims: Vec<i32> = (&**dimLst).into_iter().copied().collect();
     if dims.len() as u32 != rank {
-        return Err("CodegenWasmJit: array argument has {} dimensions, expected rank {rank}");
+        return Err("CodegenWasmJit: array argument has dimensions, expected rank");
     }
     let total: i32 = dims.iter().product();
     let obj = wt(rt.arr_new.call(&mut *store, (elem.elem_kind() as i32, rank as i32, total)))?;
@@ -414,7 +414,7 @@ fn array_to_handle(store: &mut Store, rt: &RtFns, elem: &SigTy, rank: u32, v: &V
     let mut leaves = Vec::new();
     flatten_values(v, &mut leaves);
     if leaves.len() as i32 != total {
-        return Err("CodegenWasmJit: array argument has {} elements but dimensions imply {total}");
+        return Err("CodegenWasmJit: array argument element/dimension count mismatch");
     }
     for (k, leaf) in leaves.iter().enumerate() {
         let addr = wt(rt.arr_elem_ptr.call(&mut *store, (obj, k as i32 + 1)))? as usize;
@@ -459,7 +459,7 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
 }
 
 fn write_bytes(store: &mut Store, rt: &RtFns, addr: usize, bytes: &[u8]) -> Result<()> {
-    rt.mem.write(&mut *store, addr, bytes).map_err(|e| "CodegenWasmJit: memory write: {e}")
+    rt.mem.write(&mut *store, addr, bytes).map_err(|e| "CodegenWasmJit: memory write")
 }
 
 /// Build a `Values.Value` from a wasm result of the given Modelica type.
@@ -526,8 +526,8 @@ fn read_string(store: &mut Store, rt: &RtFns, h: i32) -> Result<String> {
     let len = wt(rt.str_len.call(&mut *store, h))? as usize;
     let d = wt(rt.str_data.call(&mut *store, h))? as usize;
     let mut buf = vec![0u8; len];
-    rt.mem.read(&*store, d, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
-    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string: {e}")
+    rt.mem.read(&*store, d, &mut buf).map_err(|e| "CodegenWasmJit: memory read")?;
+    String::from_utf8(buf).map_err(|e| "CodegenWasmJit: non-utf8 result string")
 }
 
 /// Read a runtime array handle into a (nested) `Values.ARRAY` of element type
@@ -573,7 +573,7 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
 
 fn read_bytes<const N: usize>(store: &mut Store, rt: &RtFns, addr: usize) -> Result<[u8; N]> {
     let mut buf = [0u8; N];
-    rt.mem.read(&*store, addr, &mut buf).map_err(|e| "CodegenWasmJit: memory read: {e}")?;
+    rt.mem.read(&*store, addr, &mut buf).map_err(|e| "CodegenWasmJit: memory read")?;
     Ok(buf)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -108,7 +108,7 @@ pub(crate) fn compile_linear_system(
         return Ok(());
     }
     if res_exps.len() != n {
-        return Err("CodegenWasmJit: linear system has {n} unknowns but {} residuals");
+        return Err("CodegenWasmJit: linear system unknown/residual count mismatch");
     }
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(n);
@@ -119,9 +119,9 @@ pub(crate) fn compile_linear_system(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| "CodegenWasmJit: linear-system unknown `{key}` has no slot")?;
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown has no slot")?;
         if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -227,7 +227,7 @@ pub(crate) fn compile_linear_system_symbolic(
         return Ok(());
     }
     if b_exps.len() != n {
-        return Err("CodegenWasmJit: SES_LINEAR (index {index}) has {n} unknowns but {} b entries");
+        return Err("CodegenWasmJit: SES_LINEAR unknown/b-entry count mismatch");
     }
     let mut slots: Vec<u32> = Vec::with_capacity(n);
     for cr in vars {
@@ -237,9 +237,9 @@ pub(crate) fn compile_linear_system_symbolic(
             .vars
             .get(&key)
             .copied()
-            .ok_or_else(|| "CodegenWasmJit: linear-system unknown `{key}` has no slot")?;
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown has no slot")?;
         if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: linear-system unknown `{key}` is not a Real variable");
+            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
         }
         slots.push(slot.off);
     }
@@ -265,7 +265,7 @@ pub(crate) fn compile_linear_system_symbolic(
     // A[row + col*n] = element expression (column-major).
     for &(row, col, exp) in a_entries {
         if row >= n || col >= n {
-            return Err("CodegenWasmJit: SES_LINEAR (index {index}) simJac entry ({row},{col}) out of range for size {n}");
+            return Err("CodegenWasmJit: SES_LINEAR simJac entry out of range for size");
         }
         let elem_off = a_off + ((col * n + row) as u32) * 8;
         ctx.emit(we::Instruction::LocalGet(base));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -509,6 +509,80 @@ fn apply_start_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
     apply_overrides(e, sim_data, &overrides_store::starts())
 }
 
+/// Returned to abort a run on detected chattering (`-abortSlowSimulation`).
+pub const CHATTER_ABORT_ERR: &str = "CodegenWasmJit: aborting simulation due to chattering";
+
+/// Log-line prefix `<stream>| <level>| ` at the runtime's column widths.
+fn log_prefix(stream: &str, level: &str) -> String {
+    format!("{stream:<18}| {level:<8}| ")
+}
+
+/// `-abortSlowSimulation` flag + the driver's chattering log lines, set on the host
+/// before a run (the driver can only return a `&'static str`).
+mod chatter_store {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    #[cfg(feature = "std")]
+    mod imp {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::{Cell, RefCell};
+        std::thread_local! {
+            static ABORT: Cell<bool> = const { Cell::new(false) };
+            static LOG: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+        }
+        pub fn set_abort(v: bool) {
+            ABORT.with(|a| a.set(v));
+        }
+        pub fn abort() -> bool {
+            ABORT.with(|a| a.get())
+        }
+        pub fn push(s: String) {
+            LOG.with(|l| l.borrow_mut().push(s));
+        }
+        pub fn take() -> Vec<String> {
+            LOG.with(|l| core::mem::take(&mut *l.borrow_mut()))
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::UnsafeCell;
+        // The in-wasm runtime is single-threaded, so a plain cell is sound.
+        struct Store(UnsafeCell<(bool, Vec<String>)>);
+        unsafe impl Sync for Store {}
+        static STORE: Store = Store(UnsafeCell::new((false, Vec::new())));
+        pub fn set_abort(v: bool) {
+            unsafe { (*STORE.0.get()).0 = v };
+        }
+        pub fn abort() -> bool {
+            unsafe { (*STORE.0.get()).0 }
+        }
+        pub fn push(s: String) {
+            unsafe { (*STORE.0.get()).1.push(s) };
+        }
+        pub fn take() -> Vec<String> {
+            unsafe { core::mem::take(&mut (*STORE.0.get()).1) }
+        }
+    }
+
+    pub use imp::{abort, push, set_abort, take};
+}
+
+/// Arm `-abortSlowSimulation` for the next run and clear any stale chattering log.
+pub fn set_abort_slow(v: bool) {
+    chatter_store::set_abort(v);
+    let _ = chatter_store::take();
+}
+
+/// Drain the chattering log lines the last run emitted.
+pub fn take_chatter_log() -> Vec<String> {
+    chatter_store::take()
+}
+
 /// Solve the initial system: `functionParameters`, then `functionInitialEquations`
 /// with the relations fresh (init mode). Tries directly first (lambda = 1, so
 /// `homotopy(a, s)` = a); if that leaves a non-converged nonlinear system and the
@@ -554,7 +628,7 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
             e.call1("functionInitialEquations", sim_data)?;
         }
         if check_nls(e, sim_data, layout).is_err() {
-            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda={lambda}");
+            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda=");
         }
     }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
@@ -856,7 +930,7 @@ pub fn make_driver(
         "dassl" | "dasslrt" | "ida" | "" => Ok((Box::new(DasslDriver::new(e, model, sim_data)?), "dassl")),
         // Uniform host-driven Euler so it is resumable/cancellable like DASSL.
         "euler" => Ok((Box::new(EulerDriver::new(e, model, sim_data)?), "euler-host")),
-        other => return Err("CodegenWasmJit: unsupported integration method `{other}` (supported: `dassl`, `euler`)"),
+        other => return Err("CodegenWasmJit: unsupported integration method (supported: `dassl`, `euler`)"),
     }
 }
 
@@ -1563,7 +1637,7 @@ impl Driver for DasslDriver {
                 continue;
             }
             if self.idid < 0 {
-                return Err("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tout}), IDID={}");
+                return Err("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
             }
             // Interval complete: reset the resume state, write the interpolated state
             // back, and emit the row.
@@ -1663,7 +1737,16 @@ struct DasslCore {
     jac_a: Option<JacAInfo>,
     state_events: u64,
     time_events: u64,
+    /// Chattering detector: a ring of the last [`CHATTER_LIMIT`] state-event times
+    /// + a consecutive-event counter. Fires once.
+    chatter_times: [f64; CHATTER_LIMIT],
+    chatter_idx: usize,
+    chatter_consec: u32,
+    chatter_emitted: bool,
 }
+
+/// Consecutive state events within one output step that count as chattering.
+const CHATTER_LIMIT: usize = 100;
 
 /// How far [`DasslCore::integrate_to`] got.
 enum Step {
@@ -1739,7 +1822,34 @@ impl DasslCore {
             jac_a,
             state_events: 0,
             time_events: 0,
+            chatter_times: [0.0; CHATTER_LIMIT],
+            chatter_idx: 0,
+            chatter_consec: 0,
+            chatter_emitted: false,
         }
+    }
+
+    /// Record a state event at `time`. `Some((t0, time))` once [`CHATTER_LIMIT`]
+    /// consecutive events span less than `step_size`.
+    fn note_chatter_event(&mut self, time: f64, step_size: f64) -> Option<(f64, f64)> {
+        self.chatter_times[self.chatter_idx] = time;
+        self.chatter_consec += 1;
+        let hit = if !self.chatter_emitted && self.chatter_consec >= CHATTER_LIMIT as u32 {
+            let t0 = self.chatter_times[(self.chatter_idx + 1) % CHATTER_LIMIT];
+            (time - t0 < step_size).then_some((t0, time))
+        } else {
+            None
+        };
+        if hit.is_some() {
+            self.chatter_emitted = true;
+        }
+        self.chatter_idx = (self.chatter_idx + 1) % CHATTER_LIMIT;
+        hit
+    }
+
+    /// A step with no state event breaks the run.
+    fn note_clean_step(&mut self) {
+        self.chatter_consec = 0;
     }
 
     /// Latch `(y, yp)` from `SimData` — after initialization, or after anything
@@ -1868,7 +1978,7 @@ impl DasslCore {
                     return Err(err);
                 }
                 if self.idid < 0 {
-                    return Err("CodegenWasmJit: DASSL (daskr) failed at t={} (target {tt}), IDID={}");
+                    return Err("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
                 }
                 for i in 0..n_states {
                     write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
@@ -1882,6 +1992,30 @@ impl DasslCore {
                         return Ok(Step::Event { time: troot });
                     }
                     self.state_events += 1;
+                    let step_size = if model.n_intervals > 0 {
+                        (model.stop_time - model.start_time) / model.n_intervals as f64
+                    } else {
+                        0.0
+                    };
+                    if let Some((t0, t1)) = self.note_chatter_event(troot, step_size) {
+                        let zc = self.jroot.iter().position(|&r| r != 0).unwrap_or(0);
+                        let desc = model.zc_desc.get(zc).map(String::as_str).unwrap_or("<zero-crossing>");
+                        chatter_store::push(format!(
+                            "{}Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state \
+                             events in a row with a total time delta less than the step size \
+                             {step_size}). This can be a performance bottleneck. Use -lv LOG_EVENTS \
+                             for more information. The zero-crossing was: {desc}",
+                            log_prefix("LOG_STDOUT", "info"),
+                        ));
+                        if chatter_store::abort() {
+                            chatter_store::push(format!(
+                                "{}Aborting simulation due to chattering being detected and the \
+                                 simulation flags requesting we do not continue further.",
+                                log_prefix("LOG_ASSERT", "debug"),
+                            ));
+                            return Err(CHATTER_ABORT_ERR);
+                        }
+                    }
                     // pre-event row (before the discrete update), then event +
                     // post-event row.
                     if let Some(r) = rows.as_deref_mut() {
@@ -1906,6 +2040,8 @@ impl DasslCore {
                     self.info[0] = 0;
                     continue;
                 }
+                // Reached the target with no state event: breaks a chattering run.
+                self.note_clean_step();
             }
             // Reached `target`. Fire a sample event at `te` if it lands at or
             // before `tout` (pre-event row, fire, post-event row).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -332,6 +332,10 @@ pub struct SimMeta {
     /// FMI value reference -> `SimData` slot, sorted by `vr`. Only filled for the
     /// FMU export; empty for a plain simulation.
     pub fmi_vrs: Vec<FmiVr>,
+    /// Per-zero-crossing description (Modelica source of the relation, e.g.
+    /// `x > 0.0`), 1:1 with the layout's zero-crossings — the driver names the
+    /// culprit crossing in the chattering message. Empty ⇒ descriptions absent.
+    pub zc_desc: Vec<String>,
 }
 
 // ─────────────────────────────── wire format ─────────────────────────────────
@@ -342,7 +346,7 @@ pub struct SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 3;
+const VERSION: u32 = 4;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -452,6 +456,10 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         o.push(v.negate as u8);
         put_u32(&mut o, v.start_off);
         o.push(v.is_string as u8);
+    }
+    put_u32(&mut o, m.zc_desc.len() as u32);
+    for d in &m.zc_desc {
+        put_str(&mut o, d);
     }
     o
 }
@@ -612,9 +620,14 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         let is_string = r.u8()? != 0;
         fmi_vrs.push(FmiVr { vr, off, wty, negate, start_off, is_string });
     }
+    let ndesc = r.u32()? as usize;
+    let mut zc_desc = Vec::with_capacity(ndesc);
+    for _ in 0..ndesc {
+        zc_desc.push(r.string()?);
+    }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
-        model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs,
+        model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs, zc_desc,
     })
 }
 
@@ -663,6 +676,7 @@ mod tests {
                 FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: false, start_off: 96, is_string: false },
                 FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true },
             ],
+            zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
         }
     }
 

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -138,6 +138,9 @@ for(@ARGV){
   }
   elsif(/^-simCodeTarget=(.*)$/) {
     $ENV{OPENMODELICA_TEST_SIMCODETARGET} = $1;
+    # Library sim tests read the env var (ModelTesting.mos); the standalone .mos
+    # tests only honour the omc flag, so pass it through RTEST_OMCFLAGS too.
+    $ENV{RTEST_OMCFLAGS} = (defined $ENV{RTEST_OMCFLAGS} ? $ENV{RTEST_OMCFLAGS} . " " : "") . "--simCodeTarget=$1";
   }
   elsif(/^-printtests$/) {
     $print_tests = 1;


### PR DESCRIPTION
Detect chattering in the DASSL simulation driver: a ring of the last 100 consecutive state-event times; when they span less than one output step, emit the "Chattering detected" message, and under -abortSlowSimulation abort the run. This mirrors the C runtime, whose chatteringInfo/FLAG_ABORT_SLOW the wasm-jit target did not implement, so those models used to loop until the testsuite killed them on timeout.

Carry a per-zero-crossing relation description through SimMeta (wire format VERSION 3->4, filled via ExpressionBasics::printExpStr) so the message can name the crossing that triggered chattering.

Fix the literal-placeholder error strings left by the anyhow->static string conversion (#16046): the error type is &'static str, so the `{...}` never interpolated and the template text leaked into the log (e.g. "cannot build simulation module ...: in {which}: {e}"), masking the real cause. Strip the placeholders to honest static text; a failed map_err now propagates the real error, and lower_equation returns the equation-kind name for an unsupported kind.

runtests.pl: -simCodeTarget=T now also appends --simCodeTarget=T to RTEST_OMCFLAGS, so the standalone .mos simulate-tests honour it and not only the ModelTesting library tests.