### PR TITLE
wasm-jit: print() and simulation output fixes

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6513,6 +6513,7 @@ dependencies = [
  "openmodelica_modelica_utilities",
  "openmodelica_sim_meta",
  "openmodelica_simcode_types",
+ "openmodelica_tpl",
  "openmodelica_util",
  "openmodelica_wasi",
  "openmodelica_wasi_libc",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -19,6 +19,7 @@ openmodelica_backend_types.workspace = true
 openmodelica_error.workspace = true
 openmodelica_frontend_types.workspace = true
 openmodelica_frontend_dump.workspace = true
+openmodelica_tpl.workspace = true
 openmodelica_util.workspace = true
 arcstr.workspace = true
 ordered-float.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -492,24 +492,37 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
 /// `CodegenWasmJit.runSimulation`: run the prepared model in-process and write
 /// the result file. Returns 0 on success, 1 on failure (matching the exit code
 /// the C target's executable would return, which `simulate` checks).
+/// The initialization success line, from the homotopy-step count the last
+/// `run_initialization` recorded (0 → "without homotopy method").
+fn init_success_line() -> String {
+    let steps = sim_driver::init_homotopy_steps();
+    if steps == 0 {
+        "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.".to_string()
+    } else {
+        format!("LOG_SUCCESS       | info    | The initialization finished successfully with {steps} homotopy steps.")
+    }
+}
+
 pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcStr) -> i32 {
-    let (res, output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
-    // The simulate scripting flow reads `<prefix>.log` after a run (the C target's
-    // executable writes one); match the C target's log exactly so rtest diffs are
-    // clean. `output` is the model's captured stdout (Streams.print, LOG_STATS, ...)
-    // folded in so it shows in the log instead of the process console. No start
-    // banner or flags line: OMEdit echoes those via its own compilation output.
+    let (res, init_output, sim_output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
+    // `simulate` reads `<prefix>.log` after a run; the model's captured stdout
+    // (`print`, LOG_STATS, ...) is folded in so it shows in the log rather than the
+    // process console.
+    let init_line = init_success_line();
+    // `LOG_ASSERT` warnings (min/max attribute violations, …) recorded during the run.
+    let warns: String = sim_driver::take_assert_warnings().concat();
+    let init_out = init_output.unwrap_or_default();
+    let combined = format!("{init_out}{sim_output}");
     let log = match &res {
+        // Init prints, the init line, then the sim prints and the final success.
         Ok(()) => format!(
-            "{output}LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.\n\
+            "{init_out}{init_line}\n{warns}{sim_output}\
              LOG_SUCCESS       | info    | The simulation finished successfully.\n"
         ),
-        // Chattering abort (`-abortSlowSimulation`): init succeeded, then the driver's
-        // own `output` carries the chattering + aborting lines.
-        Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!(
-            "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.\n{output}"
-        ),
-        Err(e) => format!("{output}LOG_ERROR         | error   | wasm-jit simulation failed: {e:#}\n"),
+        // Chattering abort (`-abortSlowSimulation`): the driver's output carries the
+        // chattering + aborting lines.
+        Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!("{init_line}\n{warns}{combined}"),
+        Err(e) => format!("{combined}{warns}LOG_ERROR         | error   | wasm-jit simulation failed: {e:#}\n"),
     };
     let _ = write_output(&format!("{fileNamePrefix}.log"), log.as_bytes());
     // Error is in `<prefix>.log` (hence the result `messages`); no stderr.
@@ -659,14 +672,37 @@ fn resolve_overrides(model: &SimModel, simflags: &str) -> (Vec<(u32, WTy, f64)>,
     (params, starts)
 }
 
-fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Result<()>, String) {
+thread_local! {
+    /// Model stdout captured during initialization, split from the simulation-phase
+    /// output so the log stays ordered. `None` until initialization completes.
+    static INIT_OUTPUT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+    /// Only [`run_simulation_inner`] wants the split; other `run_initialization`
+    /// callers (the interactive session) share the hook but must not split. Armed
+    /// for one firing.
+    static SPLIT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Init-done hook: take the init-phase stdout and restart the capture. A no-op
+/// unless [`run_simulation_inner`] armed it; disarms after firing.
+fn on_init_done() {
+    if !SPLIT_ARMED.with(|a| a.replace(false)) {
+        return;
+    }
+    let init = openmodelica_wasi::wasi::take_stdout_capture();
+    INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(init));
+    openmodelica_wasi::wasi::start_stdout_capture();
+}
+
+/// Run the model, returning the result and the model's stdout split into the
+/// initialization segment (`Some` once init completed) and the simulation segment.
+fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Result<()>, Option<String>, String) {
     let model = sim_models()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .get(prefix)
         .cloned();
     let Some(model) = model else {
-        return (Err("no prepared wasm-jit model for (translateModel not run?)"), String::new());
+        return (Err("no prepared wasm-jit model for (translateModel not run?)"), None, String::new());
     };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
     let log_stats = simflags.contains("LOG_STATS") || simflags.contains("LOG_ALL");
@@ -676,6 +712,9 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
     sim_driver::set_param_overrides(param_ov, start_ov);
     // `-abortSlowSimulation`: stop the run when chattering is detected.
     sim_driver::set_abort_slow(simflags.split_whitespace().any(|t| t == "-abortSlowSimulation"));
+    INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
+    sim_driver::set_init_done_hook(on_init_done);
+    SPLIT_ARMED.with(|a| a.set(true));
     openmodelica_wasi::wasi::start_stdout_capture();
     let mut extra = String::new();
     let res = (|| -> Result<()> {
@@ -701,8 +740,13 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (Res
         extra.push_str(&line);
         extra.push('\n');
     }
-    let captured = openmodelica_wasi::wasi::take_stdout_capture();
-    (res, format!("{captured}{extra}"))
+    // Disarm in case init failed before the hook fired.
+    SPLIT_ARMED.with(|a| a.set(false));
+    // Everything captured after the split is the simulation phase (plus `extra`:
+    // LOG_STATS / chattering lines). `INIT_OUTPUT` is `None` when init failed.
+    let sim_output = format!("{}{extra}", openmodelica_wasi::wasi::take_stdout_capture());
+    let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
+    (res, init_output, sim_output)
 }
 
 // ===========================================================================
@@ -2157,6 +2201,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     index_list(&sim_code.parameterEquations, &mut eq_index);
     index_list(&sim_code.removedEquations, &mut eq_index);
     index_list(&sim_code.startValueEquations, &mut eq_index);
+    index_list(&sim_code.algorithmAndEquationAsserts, &mut eq_index);
     for part in lst(&sim_code.odeEquations).chain(lst(&sim_code.algebraicEquations)) {
         index_list(part, &mut eq_index);
     }
@@ -2237,6 +2282,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     };
     let initial_eqs = flatten_eqs(&sim_code.initialEquations);
     let lambda0_eqs = flatten_eqs(&sim_code.initialEquations_lambda0);
+    let assert_eqs = flatten_eqs(&sim_code.algorithmAndEquationAsserts);
     let ode_eqs = flatten_eqs_ll(&sim_code.odeEquations);
     // Register every nonlinear system with the runtime solver `rt_solve_nls`
     // *before* lowering the equation functions (which call it): assign each a
@@ -2527,6 +2573,18 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         });
         idx
     };
+    // Min/max variable-attribute (and equation) assertion checks: C's
+    // `checkForAsserts`, evaluated at each accepted output point. Warning-level
+    // asserts record a `LOG_ASSERT` via `rt_assert_warning` and continue.
+    let check_asserts_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if assert_eqs.is_empty() {
+            empty_eqfn()
+        } else {
+            build_eq_fn("functionCheckAsserts", assert_eqs, &var_map, &eq_index, &by_name, &mut literals)?
+        });
+        idx
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -2554,6 +2612,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionZeroCrossings: (i32) -> ()
     functions.function(eqfn_type); // functionStateSetJacobians: (i32) -> ()
     functions.function(eqfn_type); // functionInitialEquations_lambda0: (i32) -> ()
+    functions.function(eqfn_type); // functionCheckAsserts: (i32) -> ()
 
     // --- Code section. ---
     let mut code = we::CodeSection::new();
@@ -2577,6 +2636,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionZeroCrossings", we::ExportKind::Func, zc_idx);
     exports.export("functionStateSetJacobians", we::ExportKind::Func, stateset_jac_idx);
     exports.export("functionInitialEquations_lambda0", we::ExportKind::Func, init_lambda0_idx);
+    exports.export("functionCheckAsserts", we::ExportKind::Func, check_asserts_idx);
 
     let mut module = we::Module::new();
     module.section(&types);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmer.rs
@@ -549,7 +549,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                     out_arrays.push((off, dst, bytes, data_off));
                 }
             }
-            other => return Err("input argument type not marshalled for the web target"),
+            _ => return Err("input argument type not marshalled for the web target"),
         }
     }
 
@@ -578,7 +578,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
             SigTy::Real => Value::F64(f64::from_le_bytes(raw)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => Value::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
             SigTy::Str => Value::I32(make(store, u32::from_le_bytes(raw[..4].try_into().unwrap()))? as i32),
-            other => return Err("output type not marshalled for the web target"),
+            _ => return Err("output type not marshalled for the web target"),
         })
     };
 
@@ -611,6 +611,38 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         }
     });
     Ok(results)
+}
+
+/// `rt.rt_print` for the web target: read the String handle's bytes from the
+/// shared memory and write them to the model's captured stdout. The wasmer
+/// counterpart of `sim_runtime_wasmtime::define_print_import`.
+fn define_print_import(store: &mut Store, imports: &mut wasmer::Imports, memory: &wasmer::Memory) {
+    use wasmer::{AsStoreRef, Function, FunctionEnv, FunctionEnvMut};
+    let env = FunctionEnv::new(&mut *store, memory.clone());
+    let f = Function::new_typed_with_env(
+        &mut *store,
+        &env,
+        |env: FunctionEnvMut<wasmer::Memory>, handle: i32| {
+            if handle == 0 {
+                return;
+            }
+            // String layout: [refcount:u32][len:u32][utf8]; bytes start at handle + 8.
+            let mem = env.data().clone();
+            let store_ref = env.as_store_ref();
+            let view = mem.view(&store_ref);
+            let h = handle as u64;
+            let mut lenb = [0u8; 4];
+            if view.read(h + 4, &mut lenb).is_err() {
+                return;
+            }
+            let mut bytes = vec![0u8; u32::from_le_bytes(lenb) as usize];
+            if view.read(h + 8, &mut bytes).is_err() {
+                return;
+            }
+            openmodelica_wasi::wasi::stdout_write(&bytes);
+        },
+    );
+    imports.define("rt", "rt_print", f);
 }
 
 /// Read a NUL-terminated C string from the side module's memory at `off`.
@@ -743,6 +775,7 @@ fn instantiate_modules(model: &SimModel) -> Result<Instantiated> {
         let rt_str_data: wasmer::TypedFunction<u32, u32> = wt(rt_inst.exports.get_typed_function(&store, "rt_str_data"))?;
         define_external_imports(&mut store, &mut imports, model, &memory, &rt_str_new, &rt_str_data)?;
     }
+    define_print_import(&mut store, &mut imports, &memory);
 
     let instance = wt(wasmer::Instance::new(&mut store, &model_module, &imports))?;
     let inst_time = t_inst.elapsed();
@@ -811,6 +844,9 @@ impl sim_driver::SimEngine for WasmerEngine {
     }
     fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
         crate::CodegenWasmJitFunctions::runtime::take_pending_assert()
+    }
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+        crate::CodegenWasmJitFunctions::runtime::take_pending_warnings()
     }
 }
 
@@ -914,6 +950,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
         crate::CodegenWasmJitFunctions::runtime::take_pending_assert()
+    }
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+        crate::CodegenWasmJitFunctions::runtime::take_pending_warnings()
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/sim_runtime_wasmtime.rs
@@ -238,6 +238,26 @@ fn define_external_imports(
     Ok(())
 }
 
+/// The `print` builtin's host import (`rt.rt_print`): read the String handle's
+/// bytes from the shared linear memory and write them to the model's captured
+/// stdout. The handle stays owned by the generated code, which releases it after.
+fn define_print_import(linker: &mut wasmtime::Linker<()>, memory: wasmtime::Memory) -> Result<()> {
+    wt(linker.func_wrap("rt", "rt_print", move |caller: wasmtime::Caller<'_, ()>, handle: i32| {
+        if handle == 0 {
+            return;
+        }
+        // String layout: [refcount:u32][len:u32][utf8]; bytes start at handle + 8.
+        let data = memory.data(&caller);
+        let h = handle as usize;
+        let Some(lenb) = data.get(h + 4..h + 8) else { return };
+        let len = u32::from_le_bytes(lenb.try_into().unwrap()) as usize;
+        if let Some(bytes) = data.get(h + 8..h + 8 + len) {
+            openmodelica_wasi::wasi::stdout_write(bytes);
+        }
+    }))?;
+    Ok(())
+}
+
 /// Call native external `addr` through libffi, marshalling by the C-call
 /// [`ExtCallSig`]. Input args (in `extArgs` order) come from the wasm parameters:
 /// scalars (Real→f64, Integer/Boolean→i64) by value; `Str` as a NUL-terminated
@@ -526,6 +546,7 @@ fn instantiate_modules(model: &SimModel) -> Result<Instantiated> {
     let rt_str_new = wt(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?;
     let rt_str_data = wt(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
     define_external_imports(&mut linker, model, memory, rt_str_new, rt_str_data)?;
+    define_print_import(&mut linker, memory)?;
     let instance = wt(linker.instantiate(&mut store, &model_module))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc = wt(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
@@ -654,6 +675,9 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
         crate::CodegenWasmJitFunctions::runtime::take_pending_assert()
     }
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+        crate::CodegenWasmJitFunctions::runtime::take_pending_warnings()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -754,6 +778,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
         crate::CodegenWasmJitFunctions::runtime::take_pending_assert()
+    }
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+        crate::CodegenWasmJitFunctions::runtime::take_pending_warnings()
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -51,6 +51,8 @@ use metamodelica::List;
 
 use openmodelica_ast::Absyn;
 use openmodelica_frontend_dump::AbsynUtil;
+use openmodelica_frontend_dump::ExpressionDumpTpl;
+use openmodelica_tpl::Tpl;
 use openmodelica_frontend_types::{ClassInf, DAE, Values};
 use openmodelica_simcode_types::SimCodeFunction;
 
@@ -314,11 +316,29 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly)` records a pending
 /// assertion failure (the message and source-info handles) for `load_and_execute`
 /// to route to the error buffer; the generated code then traps (`unreachable`).
-pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[(
-    "rt_assert",
-    &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
-    &[],
-)];
+///
+/// `rt_assert_warning(cond, msg, file, sline, scol, eline, ecol, isReadOnly)`
+/// records a *non-fatal* (AssertionLevel.warning) violation — the string handles
+/// (dumped condition, message, file) plus source position — for the driver to
+/// format as a `LOG_ASSERT` warning after the step. The generated code continues
+/// (no trap), matching C's `omc_assert_warning`.
+///
+/// `rt_print(str)` writes the String's bytes to the model's stdout (the `print`
+/// builtin). The host reads the handle's bytes from the shared memory during the
+/// call; the generated code releases the (owned) handle afterwards.
+pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
+    (
+        "rt_assert",
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[],
+    ),
+    (
+        "rt_assert_warning",
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[],
+    ),
+    ("rt_print", &[WTy::I32], &[]),
+];
 
 /// Absolute wasm function index of an `ENV_EXTRA` import (after the `BUILTINS`
 /// and `RT_BUILTINS`).
@@ -1329,7 +1349,7 @@ impl<'a> FnCtx<'a> {
                 self.emit(we::Instruction::I32Store(mem_arg(off, 2)));
                 Ok(())
             }
-            W::ASSERT { condition, message, source, .. } => emit_assert(self, condition, message, source),
+            W::ASSERT { condition, message, level, source } => emit_assert(self, condition, message, level, source),
             W::NORETCALL { exp, .. } => emit_noretcall(self, exp),
         }
     }
@@ -2550,23 +2570,54 @@ fn emit_noretcall(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<()> {
 /// distinguished here), so a failed assert routes its message + source info to
 /// the error buffer (host import `rt_assert`, read back by `load_and_execute`)
 /// and then traps, matching the `[file:l:c-l:c:writable] Error: <msg>` output.
+/// A warning-level assert (`AssertionLevel.warning`, `level` enum index 1 — e.g.
+/// the min/max variable-attribute checks) instead calls `rt_assert_warning` and
+/// continues: the driver formats the recorded violation as a `LOG_ASSERT` warning
+/// after the step, matching C's `omc_assert_warning` (warn once, do not throw).
 /// Shared by `STMT_ASSERT` and the `when`-body `ASSERT` operator.
 fn emit_assert(
     ctx: &mut FnCtx,
-    cond: &DAE::Exp,
+    cond: &Arc<DAE::Exp>,
     msg: &DAE::Exp,
+    level: &DAE::Exp,
     source: &DAE::ElementSource,
 ) -> Result<()> {
+    let is_warning = matches!(level, DAE::Exp::ENUM_LITERAL { index: 1, .. });
     let c = compile_exp(ctx, cond)?;
     coerce(ctx, c, WTy::I32);
     ctx.emit(we::Instruction::I32Eqz);
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    let info = &source.info;
+    let file = openmodelica_util::Testsuite::friendly(info.fileName.clone())?;
+    if is_warning {
+        // The dumped condition (C's `assert_cond`), then the message, then the
+        // source position — all consumed by `rt_assert_warning`; execution
+        // continues afterwards (no trap).
+        let cond_str = Tpl::textString(ExpressionDumpTpl::dumpExp(
+            Tpl::emptyTxt.clone(),
+            cond.clone(),
+            arcstr::literal!("\""),
+        )?)?;
+        emit_str_literal(ctx, cond_str.as_bytes())?; // dumped condition
+        let mw = compile_exp(ctx, msg)?; // owned message String handle
+        if mw != WTy::I32 {
+            return Err("CodegenWasmJit: assert message is not a String");
+        }
+        emit_str_literal(ctx, file.as_bytes())?; // file String handle
+        ctx.emit(we::Instruction::I32Const(info.lineNumberStart));
+        ctx.emit(we::Instruction::I32Const(info.columnNumberStart));
+        ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
+        ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
+        ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
+        ctx.emit(we::Instruction::Call(env_extra_index("rt_assert_warning")?));
+        ctx.emit(we::Instruction::End);
+        return Ok(());
+    }
     let mw = compile_exp(ctx, msg)?; // owned String handle
     if mw != WTy::I32 {
         return Err("CodegenWasmJit: assert message is not a String");
     }
-    let info = &source.info;
-    emit_str_literal(ctx, info.fileName.as_bytes())?; // file String handle
+    emit_str_literal(ctx, file.as_bytes())?; // file String handle
     ctx.emit(we::Instruction::I32Const(info.lineNumberStart));
     ctx.emit(we::Instruction::I32Const(info.columnNumberStart));
     ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
@@ -2620,7 +2671,7 @@ fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
             Ok(())
         }
         S::STMT_NORETCALL { exp, .. } => emit_noretcall(ctx, exp),
-        S::STMT_ASSERT { cond, msg, source, .. } => emit_assert(ctx, cond, msg, source),
+        S::STMT_ASSERT { cond, msg, level, source } => emit_assert(ctx, cond, msg, level, source),
         S::STMT_FOR { iter, range, statementLst, type_, .. } => compile_for(ctx, iter, range, statementLst, type_),
         S::STMT_BREAK { .. } => {
             let (brk, _) = *ctx
@@ -3211,6 +3262,61 @@ fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
+/// The value type of a component reference's leaf, after applying its final
+/// subscripts (so `states[2]` of `states : ThermodynamicState[2]` yields the
+/// record element type). Array dims are peeled one per index subscript.
+fn cref_leaf_value_type(cr: &DAE::ComponentRef) -> Result<Arc<DAE::Type>> {
+    use DAE::ComponentRef as C;
+    let (identType, nsubs) = match cr {
+        C::CREF_QUAL { componentRef, .. } => return cref_leaf_value_type(componentRef),
+        C::CREF_IDENT { identType, subscriptLst, .. } => {
+            (identType, (&**subscriptLst).into_iter().count())
+        }
+        _ => return Err("CodegenWasmJit: unsupported component reference"),
+    };
+    let mut ty = identType.clone();
+    let mut remaining = nsubs;
+    while remaining > 0 {
+        let DAE::Type::T_ARRAY { ty: inner, dims } = &*ty else { break };
+        let nd = (&**dims).into_iter().count();
+        if remaining < nd {
+            break;
+        }
+        remaining -= nd;
+        ty = inner.clone();
+    }
+    Ok(ty)
+}
+
+/// Append `field` (of DAE type `field_ty`) to the leaf of `cr`, turning e.g.
+/// `pipe.flowModel.states[2]` into `pipe.flowModel.states[2].field`.
+fn cref_append_field(
+    cr: &DAE::ComponentRef,
+    field: &DAE::Ident,
+    field_ty: Arc<DAE::Type>,
+) -> Arc<DAE::ComponentRef> {
+    use DAE::ComponentRef as C;
+    match cr {
+        C::CREF_IDENT { ident, identType, subscriptLst } => Arc::new(C::CREF_QUAL {
+            ident: ident.clone(),
+            identType: identType.clone(),
+            subscriptLst: subscriptLst.clone(),
+            componentRef: Arc::new(C::CREF_IDENT {
+                ident: field.clone(),
+                identType: field_ty,
+                subscriptLst: metamodelica::nil(),
+            }),
+        }),
+        C::CREF_QUAL { ident, identType, subscriptLst, componentRef } => Arc::new(C::CREF_QUAL {
+            ident: ident.clone(),
+            identType: identType.clone(),
+            subscriptLst: subscriptLst.clone(),
+            componentRef: cref_append_field(componentRef, field, field_ty),
+        }),
+        other => Arc::new(other.clone()),
+    }
+}
+
 /// Push the byte address of array element `base[e1,…,en]` within `SimData` onto
 /// the stack, for a `group` whose scalarized elements are contiguous row-major
 /// (verified in `finalize_array_groups`). The row-major linear index is built at
@@ -3331,6 +3437,11 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             // range into a fresh runtime array object.
             if let Some(group) = ctx.sim()?.array_groups.get(&key).cloned() {
                 emit_sim_array_gather(ctx, &group)?;
+                return Ok(Some(WTy::I32));
+            }
+            // A whole record model variable: gather its scalar field slots into a
+            // fresh runtime record object.
+            if try_emit_sim_record_gather(ctx, cref)? {
                 return Ok(Some(WTy::I32));
             }
             return Err("CodegenWasmJit: simulation reference to unknown variable")
@@ -3495,6 +3606,53 @@ fn emit_sim_array_gather(ctx: &mut FnCtx, group: &ArrayGroup) -> Result<()> {
     ctx.emit(we::Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
+}
+
+/// If `cref` names a whole record model variable (its leaf, after subscripts, is
+/// a record), build a fresh runtime record from the scalar `SimData` slots of
+/// its fields and leave the owned handle on the stack. Each field is read through
+/// its own extended cref, so nested records / arrays-of-records gather
+/// recursively. Returns `Ok(true)` when it handled the reference.
+fn try_emit_sim_record_gather(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<bool> {
+    let leaf_ty = cref_leaf_value_type(cref)?;
+    let DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::RECORD { .. }, varLst, .. } = &*leaf_ty
+    else {
+        return Ok(false);
+    };
+    let vars: Vec<&Arc<DAE::Var>> = (&**varLst).into_iter().collect();
+    let mut fields = Vec::with_capacity(vars.len());
+    for v in &vars {
+        fields.push((v.name.clone(), sig_ty(&v.ty)?));
+    }
+    let layout = record_layout(&fields);
+    ctx.emit(we::Instruction::I32Const(layout.heap.len() as i32));
+    ctx.emit(we::Instruction::I32Const(layout.size as i32));
+    ctx.emit(we::Instruction::Call(rt_index("rt_record_new")?));
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (k, (kind, foff)) in layout.heap.iter().enumerate() {
+        let base = 8 + k as u32 * 8;
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(*kind as i32));
+        ctx.emit(we::Instruction::I32Store(mem_arg(base, 2)));
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(*foff as i32));
+        ctx.emit(we::Instruction::I32Store(mem_arg(base + 4, 2)));
+    }
+    for (i, v) in vars.iter().enumerate() {
+        let fty = fields[i].1.clone();
+        let field_cref = cref_append_field(cref, &v.name, v.ty.clone());
+        let wty = compile_sim_cref_read(ctx, &field_cref)?
+            .ok_or("CodegenWasmJit: record field is not a simulation variable")?;
+        coerce(ctx, wty, fty.wty());
+        let vt = ctx.alloc_temp(fty.wty());
+        ctx.emit(we::Instruction::LocalSet(vt));
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::LocalGet(vt));
+        field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+    }
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(true)
 }
 
 /// Emit code that scatters a whole-array assignment into a model variable's
@@ -3732,6 +3890,35 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::REDUCTION { reductionInfo, expr, iterators } => {
             compile_reduction(ctx, reductionInfo, expr, iterators)
         }
+        // `f(...)[ix]` — pick one value out of a multi-output call's result
+        // tuple. Compile the call (leaving all results on the stack, first
+        // deepest), keep the `ix`-th (1-based) and release the rest.
+        E::TSUB { exp, ix, .. } => {
+            let DAE::Exp::CALL { path, expLst, attr } = &**exp else {
+                return Err("CodegenWasmJit: tuple subscript of a non-call expression");
+            };
+            let results = compile_call(ctx, path, expLst, attr)?;
+            let want = (*ix as usize).checked_sub(1)
+                .filter(|&i| i < results.len())
+                .ok_or("CodegenWasmJit: tuple subscript index out of range")?;
+            let mut temps = vec![0u32; results.len()];
+            for i in (0..results.len()).rev() {
+                let vt = ctx.alloc_temp(results[i].wty());
+                ctx.emit(we::Instruction::LocalSet(vt));
+                temps[i] = vt;
+            }
+            for (i, sty) in results.iter().enumerate() {
+                if i == want {
+                    continue;
+                }
+                if let Some(release_fn) = sty.release_fn() {
+                    ctx.emit(we::Instruction::LocalGet(temps[i]));
+                    ctx.emit(we::Instruction::Call(rt_index(release_fn)?));
+                }
+            }
+            ctx.emit(we::Instruction::LocalGet(temps[want]));
+            Ok(results[want].wty())
+        }
         other => return Err("CodegenWasmJit: expression not yet supported"),
     }
 }
@@ -3757,6 +3944,7 @@ fn exp_wty_hint(ctx: &FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::ARRAY { .. } | E::MATRIX { .. } | E::RANGE { .. } | E::SIZE { .. } | E::RECORD { .. } => WTy::I32,
         E::REDUCTION { reductionInfo, .. } => sig_ty(&reductionInfo.exprType)?.wty(),
         E::RSUB { ty, .. } => sig_ty(ty)?.wty(),
+        E::TSUB { ty, .. } => sig_ty(ty)?.wty(),
         E::ASUB { .. } => exp_sigty(exp).map(|s| s.wty()).unwrap_or(WTy::I32),
         _ => WTy::F64,
     })
@@ -3858,6 +4046,7 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         E::SIZE { sz: None, .. } => SigTy::Array { elem: Arc::new(SigTy::Int), rank: 1 },
         // A record constructor / field access carry their type directly.
         E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty(ty)?,
+        E::TSUB { ty, .. } => sig_ty(ty)?,
         other => return Err("CodegenWasmJit: cannot determine type of expression"),
     })
 }
@@ -4254,6 +4443,24 @@ fn compile_call(
     }
     // Otherwise it must be a (builtin) math/string function.
     let name = AbsynUtil::pathLastIdent(Arc::new(path.clone()))?.to_string();
+    // `print(s)`: write the String to the model's stdout via the host `rt_print`.
+    // A void procedure, so it yields no result; the owned handle is released after.
+    if name == "print" {
+        let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
+        if argv.len() != 1 {
+            return Err("CodegenWasmJit: print expects one argument");
+        }
+        let w = compile_exp(ctx, argv[0])?;
+        if w != WTy::I32 {
+            return Err("CodegenWasmJit: print expects a String");
+        }
+        let t = ctx.alloc_temp(WTy::I32);
+        ctx.emit(we::Instruction::LocalSet(t));
+        ctx.emit(we::Instruction::LocalGet(t));
+        ctx.emit(we::Instruction::Call(env_extra_index("rt_print")?));
+        release_temp(ctx, t)?;
+        return Ok(Vec::new());
+    }
     compile_math_builtin(ctx, &name, args, attr).map(|s| vec![s])
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -131,6 +131,20 @@ pub(crate) fn add_host_builtins(store: &mut Store, imports: &mut wasmer::Imports
             },
         ),
     );
+    // `rt_assert_warning` (see `super::ENV_EXTRA`): a non-fatal warning-level
+    // violation; record its handles for the driver to format post-step.
+    imports.define(
+        "rt",
+        "rt_assert_warning",
+        Function::new_typed(
+            store,
+            |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
+                PENDING_WARNINGS.with(|p| {
+                    p.borrow_mut().push([cond, msg, file, sline, scol, eline, ecol, read_only]);
+                });
+            },
+        ),
+    );
     // The in-wasm session driver (`rt_sim_*`) polls these for its chunk budget and
     // cooperative cancel, wasm-side, so it uses the *same* clock/cancel source as
     // the host driver. Present in every runtime instantiation (unused by the host
@@ -165,6 +179,15 @@ thread_local! {
     /// The most recent assertion recorded by `rt_assert` on this thread, consumed
     /// by [`load_and_execute`]. Single-threaded per call, so a plain cell suffices.
     static PENDING_ASSERT: std::cell::RefCell<Option<PendingAssert>> = const { std::cell::RefCell::new(None) };
+    /// Warning-level violations recorded by `rt_assert_warning`, drained by the
+    /// driver after `functionCheckAsserts`. See the wasmtime backend for the shape.
+    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 8]>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Take (and clear) the warning-level assertion violations recorded by
+/// `rt_assert_warning` since the last call.
+pub(crate) fn take_pending_warnings() -> Vec<[i32; 8]> {
+    PENDING_WARNINGS.with(|p| core::mem::take(&mut *p.borrow_mut()))
 }
 
 /// Take the pending assertion recorded by `rt_assert` (message + source-info

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -129,6 +129,20 @@ pub(crate) fn add_host_builtins(linker: &mut wasmtime::Linker<()>) -> Result<()>
             });
         },
     ))?;
+    // `rt_assert_warning` (see `super::ENV_EXTRA`): a non-fatal (AssertionLevel.
+    // warning) violation. Record the string handles + source position; the driver
+    // drains them after `functionCheckAsserts` and formats the `LOG_ASSERT` warning.
+    // The handles stay valid in the shared memory until the driver reads them
+    // (they were moved into this call, so the generated code does not free them).
+    wt(linker.func_wrap(
+        "rt",
+        "rt_assert_warning",
+        |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
+            PENDING_WARNINGS.with(|p| {
+                p.borrow_mut().push([cond, msg, file, sline, scol, eline, ecol, read_only]);
+            });
+        },
+    ))?;
     // The in-wasm session driver (`rt_sim_*`) polls these for its chunk budget and
     // cooperative cancel, wasm-side, so it uses the *same* clock/cancel source as
     // the host driver. Present in every runtime instantiation (unused by the host
@@ -159,6 +173,18 @@ thread_local! {
     /// The most recent assertion recorded by `rt_assert` on this thread, consumed
     /// by [`load_and_execute`]. Single-threaded per call, so a plain cell suffices.
     static PENDING_ASSERT: std::cell::RefCell<Option<PendingAssert>> = const { std::cell::RefCell::new(None) };
+    /// Warning-level assertion violations recorded by `rt_assert_warning`, drained
+    /// by the driver after each `functionCheckAsserts` call. Each entry is
+    /// `[cond, msg, file, sline, scol, eline, ecol, read_only]` (string handles +
+    /// source position into the shared memory).
+    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 8]>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Take (and clear) the warning-level assertion violations recorded by
+/// `rt_assert_warning` since the last call. Used by the `SimEngine` impls'
+/// `take_pending_warnings`.
+pub(crate) fn take_pending_warnings() -> Vec<[i32; 8]> {
+    PENDING_WARNINGS.with(|p| core::mem::take(&mut *p.borrow_mut()))
 }
 
 /// Take the pending assertion recorded by `rt_assert` (message + source-info

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -183,3 +183,42 @@ pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _elin
     }
     core::arch::wasm32::unreachable()
 }
+
+/// In-wasm `rt_print`: the `print` builtin. Write the String handle's bytes to
+/// stdout, flushed so the captured output stays ordered.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_print(handle: i32) {
+    if handle != 0 {
+        let h = handle as u32;
+        let len = unsafe { crate::load_u32(h + 4) } as usize;
+        let bytes = unsafe { core::slice::from_raw_parts((h + 8) as *const u8, len) };
+        use std::io::Write;
+        let mut out = std::io::stdout();
+        let _ = out.write_all(bytes);
+        let _ = out.flush();
+    }
+}
+
+/// In-wasm `rt_assert_warning`: a non-fatal (AssertionLevel.warning) violation.
+/// The standalone has no host driver to format a `LOG_ASSERT` block, so print the
+/// message (`msg` is an `rt` String handle) and continue — no trap.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_assert_warning(
+    _cond: i32,
+    msg: i32,
+    _file: i32,
+    _sline: i32,
+    _scol: i32,
+    _eline: i32,
+    _ecol: i32,
+    _read_only: i32,
+) {
+    if msg != 0 {
+        let h = msg as u32;
+        let len = unsafe { crate::load_u32(h + 4) } as usize;
+        let bytes = unsafe { core::slice::from_raw_parts((h + 8) as *const u8, len) };
+        if let Ok(s) = core::str::from_utf8(bytes) {
+            eprintln!("wasm-jit standalone: assertion warning: {s}");
+        }
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -204,6 +204,14 @@ pub trait SimEngine {
     /// into shared memory), else `None`. Backed by the engine's `rt_assert` host
     /// import; lets [`drive`] report a model assertion instead of a bare trap.
     fn take_pending_assert(&mut self) -> Option<[i32; 7]>;
+    /// Take the warning-level assertion violations (`AssertionLevel.warning`)
+    /// recorded by the `rt_assert_warning` host import since the last call, each as
+    /// `[cond, msg, file, sline, scol, eline, ecol, read_only]` (string handles +
+    /// source position). Drained by the drivers after `functionCheckAsserts` to
+    /// emit C's `LOG_ASSERT` warnings. Default: none (backends without the import).
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+        Vec::new()
+    }
 }
 
 /// Read a runtime String heap value (`[refcount:u32][len:u32][utf8]`, handle at
@@ -389,6 +397,22 @@ fn cancel_requested() -> bool {
     f()
 }
 
+// Fires once when `run_initialization` finishes — the boundary between the
+// initialization and simulation output. The host (which owns the stdout capture)
+// uses it to keep the model's `print` output ordered: init prints, the
+// "initialization finished" line, then the simulation prints.
+static INIT_DONE_HOOK: AtomicUsize = AtomicUsize::new(0);
+pub fn set_init_done_hook(f: fn()) {
+    INIT_DONE_HOOK.store(f as usize, Ordering::Relaxed);
+}
+fn signal_init_done() {
+    let p = INIT_DONE_HOOK.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn() = unsafe { core::mem::transmute(p) };
+        f();
+    }
+}
+
 /// Read one little-endian i32 from linear memory at byte address `addr`.
 pub fn read_i32(e: &dyn SimEngine, addr: u32) -> Result<i32> {
     let mut b = [0u8; 4];
@@ -572,6 +596,134 @@ mod chatter_store {
     pub use imp::{abort, push, set_abort, take};
 }
 
+/// Homotopy-step count of the last initialization, so the host can print C's
+/// "finished successfully with N homotopy steps" / "without homotopy method"
+/// (the driver only returns a `&'static str`). 0 = no homotopy was used.
+mod init_report {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    static HOMOTOPY_STEPS: AtomicU32 = AtomicU32::new(0);
+    pub fn set_homotopy_steps(n: u32) {
+        HOMOTOPY_STEPS.store(n, Ordering::Relaxed);
+    }
+    pub fn homotopy_steps() -> u32 {
+        HOMOTOPY_STEPS.load(Ordering::Relaxed)
+    }
+}
+
+/// Homotopy steps the last `run_initialization` used (0 = none); the host reads it
+/// to format the initialization success message like the C runtime.
+pub fn init_homotopy_steps() -> u32 {
+    init_report::homotopy_steps()
+}
+
+/// The formatted `LOG_ASSERT` warning lines (min/max variable-attribute checks and
+/// other `AssertionLevel.warning` asserts) collected during the last run, plus the
+/// per-site keys already reported so each warns only once (C's static
+/// `warningTriggered`). Cleared at run start; folded into the log by the host.
+mod assert_warn_store {
+    #[cfg(feature = "std")]
+    mod imp {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::RefCell;
+        std::thread_local! {
+            static LINES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+            static SEEN: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+        }
+        pub fn reset() {
+            LINES.with(|l| l.borrow_mut().clear());
+            SEEN.with(|s| s.borrow_mut().clear());
+        }
+        pub fn push_once(key: String, line: String) {
+            SEEN.with(|s| {
+                let mut s = s.borrow_mut();
+                if s.iter().any(|k| *k == key) {
+                    return;
+                }
+                s.push(key);
+                LINES.with(|l| l.borrow_mut().push(line));
+            });
+        }
+        pub fn take() -> Vec<String> {
+            LINES.with(|l| core::mem::take(&mut *l.borrow_mut()))
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use core::cell::UnsafeCell;
+        struct Store(UnsafeCell<(Vec<String>, Vec<String>)>);
+        unsafe impl Sync for Store {}
+        static STORE: Store = Store(UnsafeCell::new((Vec::new(), Vec::new())));
+        pub fn reset() {
+            unsafe {
+                (*STORE.0.get()).0.clear();
+                (*STORE.0.get()).1.clear();
+            }
+        }
+        pub fn push_once(key: String, line: String) {
+            unsafe {
+                let st = &mut *STORE.0.get();
+                if st.1.iter().any(|k| *k == key) {
+                    return;
+                }
+                st.1.push(key);
+                st.0.push(line);
+            }
+        }
+        pub fn take() -> Vec<String> {
+            unsafe { core::mem::take(&mut (*STORE.0.get()).0) }
+        }
+    }
+    pub use imp::{push_once, reset, take};
+}
+
+/// Drain the formatted `LOG_ASSERT` warning lines emitted during the last run.
+pub fn take_assert_warnings() -> Vec<String> {
+    assert_warn_store::take()
+}
+
+/// Format `%f`-style (C's `%f`: 6 fractional digits), for the assertion time value.
+fn format_f(v: f64) -> String {
+    alloc::format!("{v:.6}")
+}
+
+/// Evaluate `functionCheckAsserts` (C's `checkForAsserts`) at the current point and
+/// format any `AssertionLevel.warning` violation it recorded into a `LOG_ASSERT`
+/// block, once per site. Called by the drivers after each accepted output step.
+fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    e.call1_if_present("functionCheckAsserts", sim_data)?;
+    let pending = e.take_pending_warnings();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let time = read_f64(e, sim_data + TIME_OFF)?;
+    for w in pending {
+        let cond = read_rt_string(e, w[0])?;
+        let msg = read_rt_string(e, w[1])?;
+        let file = read_rt_string(e, w[2])?;
+        let (sl, sc, el, ec, ro) = (w[3], w[4], w[5], w[6], w[7] != 0);
+        let ro_str = if ro { "readonly" } else { "writable" };
+        // C (`omc_error.c` messageText + printInfo): a header line with the source
+        // position, then the message split on '\n' onto continuation lines whose
+        // stream/type columns are "|".
+        let head = log_prefix("LOG_ASSERT", "info");
+        let cont = log_prefix("|", "|");
+        // C wraps the already-parenthesised `assert_cond` = "(<dumped>)" once more
+        // in the `(%s)` format, so the displayed condition is double-parenthesised.
+        let line = alloc::format!(
+            "{head}[{file}:{sl}:{sc}-{el}:{ec}:{ro_str}]\n\
+             {cont}The following assertion has been violated at time {t}\n\
+             {cont}(({cond})) --> \"{msg}\"\n",
+            t = format_f(time),
+        );
+        let key = alloc::format!("{file}:{sl}:{sc}-{el}:{ec}|{cond}");
+        assert_warn_store::push_once(key, line);
+    }
+    Ok(())
+}
+
 /// Arm `-abortSlowSimulation` for the next run and clear any stale chattering log.
 pub fn set_abort_slow(v: bool) {
     chatter_store::set_abort(v);
@@ -593,10 +745,22 @@ pub fn take_chatter_log() -> Vec<String> {
 /// `relationsPre` for the continuous phase's held relations.
 pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     run_initialization_impl(e, sim_data, layout)?;
-    update_relations_pre(e, sim_data, layout)
+    // Seed the continuous phase's held relations from a full discrete fixed point.
+    // The initial system does not necessarily touch every relation guarding the
+    // continuous equations, so a straight snapshot of `relations[]` here would
+    // freeze those at their stale (zero) value and pick the wrong equation branch.
+    iterate_discrete(e, sim_data, layout)?;
+    store_relations(e, sim_data, layout)?;
+    update_relations_pre(e, sim_data, layout)?;
+    // Initialization output is complete; the next model output is the simulation
+    // phase. Let the host close the init segment of the capture.
+    signal_init_done();
+    Ok(())
 }
 
 fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    init_report::set_homotopy_steps(0);
+    assert_warn_store::reset();
     e.call1("functionParameters", sim_data)?;
     // Params first (a start expression may read one), then fill start slots, then
     // start overrides (replacing the just-computed start).
@@ -607,17 +771,29 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     if layout.n_samples > 0 {
         e.call1("initSample", sim_data)?;
     }
-    // Direct attempt (no continuation).
+
+    // A model whose initial system contains `homotopy()` (`has_homotopy`) is solved
+    // with the global equidistant homotopy continuation on the first try — C's
+    // default `-homotopyOnFirstTry` for homotopy-support models — not tried directly
+    // first. This matches C's initialization path and its "with N homotopy steps"
+    // report. A model without homotopy is solved directly.
+    if layout.has_homotopy {
+        run_homotopy_continuation(e, sim_data, layout)?;
+        init_report::set_homotopy_steps(HOMOTOPY_STEPS as u32);
+        return Ok(());
+    }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     e.call1("functionInitialEquations", sim_data)?;
-    if check_nls(e, sim_data, layout).is_ok() {
-        return Ok(());
-    }
-    if !layout.has_homotopy {
-        check_nls(e, sim_data, layout)?; // re-surface the failure
-        return Ok(());
-    }
+    check_nls(e, sim_data, layout)?;
+    Ok(())
+}
+
+/// Global equidistant homotopy continuation (C's `solveWithGlobalHomotopy`):
+/// lambda 0 → 1 in `HOMOTOPY_STEPS` steps, step 0 solving the simplified
+/// `functionInitialEquations_lambda0`, each step seeded by the previous solution.
+/// Leaves lambda = 1.
+fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     for step in 0..=HOMOTOPY_STEPS {
         let lambda = step as f64 / HOMOTOPY_STEPS as f64;
         write_f64(e, sim_data + layout.lambda_off, lambda)?;
@@ -668,7 +844,8 @@ fn emit_row(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &
     e.call1("functionODE", sim_data)?;
     e.call1("functionAlgebraics", sim_data)?;
     check_nls(e, sim_data, layout)?;
-    capture_row(e, rows, sim_data, layout)
+    capture_row(e, rows, sim_data, layout)?;
+    check_asserts(e, sim_data, layout)
 }
 
 /// Pre-event snapshot row (state just before a discrete update). Skips
@@ -806,20 +983,17 @@ fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 /// already written.
 fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     // Each pass freezes `relationsPre = relations` so the NLS in `functionODE` holds
-    // this pass's relations; the discrete state settles across passes.
-    update_relations_pre(e, sim_data, layout)?;
-    e.call1("functionODE", sim_data)?;
-    e.call1("functionAlgebraics", sim_data)?;
-    let mut prev = discrete_snapshot(e, sim_data, layout)?;
-    for _ in 1..MAX_EVENT_ITER {
+    // this pass's relations, then re-evaluates the continuous system; the discrete
+    // state settles across passes. Comparing the snapshot before and after the
+    // evaluation lets an already-settled system stop after a single evaluation.
+    for _ in 0..MAX_EVENT_ITER {
+        let prev = discrete_snapshot(e, sim_data, layout)?;
         update_relations_pre(e, sim_data, layout)?;
         e.call1("functionODE", sim_data)?;
         e.call1("functionAlgebraics", sim_data)?;
-        let cur = discrete_snapshot(e, sim_data, layout)?;
-        if cur == prev {
+        if discrete_snapshot(e, sim_data, layout)? == prev {
             break;
         }
-        prev = cur;
     }
     Ok(())
 }
@@ -1023,7 +1197,7 @@ pub fn drive(
     // the cancel flag; the driver only polls it via the installed hook).
     let layout = &model.layout;
     let n_reals = layout.n_row_total();
-    let n_rows = model.n_intervals + 1;
+    let n_rows = model.n_output_rows();
     let start = model.start_time;
     let stop = model.stop_time;
 
@@ -1108,7 +1282,7 @@ impl EulerDriver {
         // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
         // them internally around its Newton solve.
         run_initialization(e, sim_data, &model.layout)?;
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_reals = model.layout.n_row_total();
         Ok(EulerDriver {
             sim_data,
@@ -1124,7 +1298,7 @@ impl Driver for EulerDriver {
         let layout = &model.layout;
         let sim_data = self.sim_data;
         let n_states = layout.n_states;
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
@@ -1180,7 +1354,7 @@ impl Driver for EulerDriver {
     }
 
     fn fill_stats(&mut self, model: &SimModel, stats: &mut SolveStats) {
-        stats.steps = model.n_intervals as u64;
+        stats.steps = (model.n_output_rows() - 1) as u64;
     }
 }
 
@@ -1493,7 +1667,7 @@ impl DasslDriver {
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
         let ders_base = states_base + layout.n_states * 8;
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_reals = layout.n_row_total();
         let start = model.start_time;
 
@@ -1585,7 +1759,7 @@ impl Driver for DasslDriver {
             self.finished = true;
             return Ok(Advance::Terminated);
         }
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
@@ -1670,6 +1844,16 @@ impl Driver for DasslDriver {
             // `pending_tout`/`work_retries` persist an interval unfinished at a yield.
             let mut tout =
                 self.pending_tout.unwrap_or(if self.row == n_steps { stop } else { start + self.row as f64 * h });
+            // Zero-length final interval (stop == start): daskr rejects TOUT == T,
+            // so emit the held state directly instead of stepping.
+            if tout <= self.t {
+                for i in 0..n_states {
+                    write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
+                }
+                emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+                self.row += 1;
+                continue;
+            }
             unsafe {
                 solver::ddaskr(
                     dassl_res, neq, &mut self.t, self.y.as_mut_ptr(), self.yp.as_mut_ptr(),
@@ -2080,6 +2264,7 @@ impl DasslCore {
                     event_update(e, sim_data, layout, None, troot)?;
                     if let Some(r) = rows.as_deref_mut() {
                         capture_row(e, r, sim_data, layout)?;
+                        check_asserts(e, sim_data, layout)?;
                     }
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
@@ -2440,7 +2625,7 @@ impl DasslEventsDriver {
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_reals = layout.n_row_total();
         let start = model.start_time;
 
@@ -2466,7 +2651,6 @@ impl DasslEventsDriver {
             core.read_states(e)?;
         }
         let _ = states_base;
-
         Ok(DasslEventsDriver {
             core,
             row: 1,
@@ -2493,7 +2677,7 @@ impl Driver for DasslEventsDriver {
             self.finished = true;
             return Ok(Advance::Terminated);
         }
-        let n_rows = model.n_intervals + 1;
+        let n_rows = model.n_output_rows();
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
@@ -2544,6 +2728,7 @@ impl Driver for DasslEventsDriver {
                         event_update(e, sim_data, layout, None, tr)?;
                         self.core.state_events += 1;
                         capture_row(e, &mut self.rows, sim_data, layout)?; // post-event row
+                        check_asserts(e, sim_data, layout)?;
                         if terminated(e, sim_data, layout)? {
                             self.finished = true;
                             return Ok(Advance::Terminated);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -338,6 +338,19 @@ pub struct SimMeta {
     pub zc_desc: Vec<String>,
 }
 
+impl SimMeta {
+    /// Number of equidistant output rows the run writes. `n_intervals + 1` for a
+    /// real interval; a zero-length run (`stop <= start`) writes the start and stop
+    /// points only — 2 rows, regardless of `numberOfIntervals`.
+    pub fn n_output_rows(&self) -> u32 {
+        if self.stop_time > self.start_time {
+            self.n_intervals + 1
+        } else {
+            2
+        }
+    }
+}
+
 // ─────────────────────────────── wire format ─────────────────────────────────
 //
 // A flat little-endian encoding behind a 4-byte magic + version. Strings are

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
@@ -32,6 +32,13 @@ pub fn take_stdout_capture() -> String {
         .unwrap_or_default()
 }
 
+/// Write to stdout (fd 1) through the same capture/host routing as a guest
+/// `fd_write` — for a host that emits model output (`print`) directly rather than
+/// through the WASI ABI.
+pub fn stdout_write(bytes: &[u8]) {
+    write_std(bytes, false);
+}
+
 /// Route a stdout/stderr write to the capture buffer if active, else to the host.
 fn write_std(bytes: &[u8], is_err: bool) {
     let captured = STDOUT_CAPTURE.with(|c| match c.borrow_mut().as_mut() {

--- a/testsuite/rust-ignore-tests.txt
+++ b/testsuite/rust-ignore-tests.txt
@@ -52,6 +52,11 @@
 ./flattening/modelica/scodeinst/FuncBuiltinMin2.mo
 ./flattening/modelica/scodeinst/FuncBuiltinReduction.mo
 ./flattening/modelica/scodeinst/CevalReduction1.mo
+# IntegerTest passes with the Rust port on the C runtime (modelica_integer is
+# 64-bit there). It only differs under --simCodeTarget=wasm-jit, whose runtime
+# Integer is i32, so `2147483647 * 2` wraps to -2 instead of 4294967294. Not an
+# ignore entry — left commented so it is not filtered out on the C-runtime path.
+#./simulation/modelica/types/IntegerTest.mos
 # saveTotalModel(obfuscate=true) replaces assert/terminate messages with
 # "<fn> message <stringHashDjb2(msg)>"; C's stringHashDjb2 accumulates djb2 in a
 # 64-bit modelica_integer (then labs), the port's Integer is i32 so the embedded


### PR DESCRIPTION
Support the print() builtin in the simulation code generator: a host import rt_print writes the String to the model's captured stdout, provided for the wasmtime, wasmer, and wasip1 standalone backends. Models that print no longer fail to build.

Keep the captured output ordered around the initialization log line -- initialization prints, the "initialization finished" line, then the simulation prints -- by splitting the capture at the end of initialization through a new sim-driver init-done hook, armed only for the one-shot run so the interactive session is unaffected.

Write two output rows for a zero-length run (stopTime == startTime) instead of numberOfIntervals + 1, with a guard on the DASSL path for the zero-length final step.

Settle an already-stable discrete system in a single evaluation during initialization by comparing the discrete snapshot before and after each pass.

Seed the held relations from a full discrete fixed point so the continuous phase does not freeze states, run the global homotopy continuation on the first try for homotopy-support models, and compile the min/max attribute assertion checks, reporting warning-level violations without trapping.

Lower whole-record model-variable reads and tuple subscripts of multi-output calls.