### PR TITLE
Export Modelica figures as FMU vendor annotation

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
@@ -68,6 +68,50 @@ function iface(e) {
   };
 }
 
+// The OpenModelica <Figures> vendor annotation. Absent / unknown-version /
+// malformed degrades to []: such an FMU is plotted the ordinary way, never rejected.
+function parseFigures(root) {
+  const viz = root.querySelector(':scope > Annotations > Tool[name="OpenModelica"] > Figures');
+  if (!viz) return [];
+  const version = attr(viz, 'version');
+  if (version != null && version !== '1') return [];   // unknown schema: ignore, don't guess
+  const axis = (plot, role) => {
+    const a = plot.querySelector(`:scope > Axis[role="${role}"]`);
+    if (!a) return null;
+    return {
+      label: attr(a, 'label') || '', unit: attr(a, 'unit') || '',
+      min: numAttr(a, 'min'), max: numAttr(a, 'max'),
+      log: (attr(a, 'scale') || 'Linear') === 'Log',
+    };
+  };
+  const figures = [];
+  for (const f of viz.querySelectorAll(':scope > Figure')) {
+    const plots = [];
+    for (const p of f.querySelectorAll(':scope > Plot')) {
+      const curves = [];
+      for (const c of p.querySelectorAll(':scope > Curve')) {
+        const y = attr(c, 'y'); if (!y) continue;
+        curves.push({ x: attr(c, 'x') || '', y, legend: attr(c, 'legend') || '' });
+      }
+      const tr = p.querySelector(':scope > TerminalRef');
+      if (!curves.length) continue;   // TerminalRef-only plot: skip, we render explicit curves
+      plots.push({
+        title: attr(p, 'title') || '', preferred: boolAttr(p, 'preferred') === true,
+        terminal: tr ? attr(tr, 'terminal') : null, curves,
+        x: axis(p, 'x'), y: axis(p, 'y'), y2: axis(p, 'y2'),
+      });
+    }
+    if (!plots.length) continue;
+    const cap = f.querySelector(':scope > Caption');
+    figures.push({
+      title: attr(f, 'title') || '', group: attr(f, 'group') || '',
+      preferred: boolAttr(f, 'preferred') === true,
+      caption: cap ? cap.textContent : '', plots,
+    });
+  }
+  return figures;
+}
+
 export function parseModelDescription(xml) {
   const doc = new DOMParser().parseFromString(xml, 'application/xml');
   const perr = doc.querySelector('parsererror');
@@ -120,6 +164,7 @@ export function parseModelDescription(xml) {
     variables,
     nStates: ms ? ms.querySelectorAll(':scope > ContinuousStateDerivative').length : 0,
     nEventIndicators: ms ? ms.querySelectorAll(':scope > EventIndicator').length : 0,
+    figures: parseFigures(root),
   };
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -78,6 +78,7 @@
   <span class="status" id="status">Open an FMI 3.0 wasm FMU to begin.</span>
   <input type="file" id="file" accept=".fmu,application/zip" hidden />
   <button class="ghost" id="open">Open FMU…</button>
+  <button class="ghost" id="figToggle" title="Switch between the FMU's figures and all recorded variables" hidden>All variables</button>
   <button id="run" disabled>Simulate</button>
 </header>
 
@@ -137,10 +138,13 @@ const charts = createCharts(chartsEl);
 const ifaceEl = el('interface'), startEl = el('start'), stopEl = el('stop'), stepEl = el('step'),
       tolEl = el('tol'), stepLabel = el('stepLabel');
 const eventModeEl = el('eventMode'), eventModeLabel = el('eventModeLabel'), eventModeCell = el('eventModeCell');
+const figToggle = el('figToggle');
 
 let fmu = null;         // { md, exports, cs, me, resourcePath }
 let fields = [];        // { v, input, kind:'input'|'parameter' }
 let running = false, cancelled = false, logCount = 0;
+let lastRec = null;     // the most recent simulation record, for re-rendering
+let viewMode = 'auto';  // 'auto' -> figures when the FMU has them, else all vars
 
 const setStatus = (text, cls = '') => { statusEl.textContent = text; statusEl.className = 'status ' + cls; };
 const num = (v, d) => { const n = parseFloat(v); return isFinite(n) ? n : d; };
@@ -356,16 +360,33 @@ async function run() {
 }
 
 // --- charts -----------------------------------------------------------------
+const haveFigures = () => !!(fmu && fmu.md.figures && fmu.md.figures.length);
+
+// Reflect whether figures are available and which view is active on the toggle.
+function updateFigToggle() {
+  const have = haveFigures() && !!lastRec;
+  figToggle.hidden = !have;
+  figToggle.textContent = (viewMode === 'all') ? 'Figures' : 'All variables';
+}
+
 function renderCharts(rec) {
+  lastRec = rec;
   charts.clear();
-  const xs = Float64Array.from(rec.time);
   const finite = rec.columns.filter((c) => c.values.some((v) => isFinite(v)));
   if (!finite.length) {
     charts.clear(chartsEmpty);
     chartsEmpty.style.display = '';
     chartsEmpty.textContent = 'The FMU reported no output, local or input variables to plot.';
+    updateFigToggle();
     return;
   }
+  const useFigs = haveFigures() && viewMode !== 'all';
+  if (useFigs) renderFigures(rec, finite); else renderAllVariables(rec, finite);
+  updateFigToggle();
+}
+
+function renderAllVariables(rec, finite) {
+  const xs = Float64Array.from(rec.time);
   // `ys` references the recorded array, so all signals go into the legend cheaply;
   // big models default to one state visible with the rest toggled off (drawing all
   // would be unresponsive).
@@ -379,6 +400,52 @@ function renderCharts(rec) {
   }
   charts.add(spec, 'all');
 }
+
+// Render the FMU's <Figures> as the default plots (preferred first), like the
+// Modelica simulator; a curve whose variable is not in the result is skipped.
+function renderFigures(rec, finite) {
+  const xs = Float64Array.from(rec.time);
+  const byName = new Map(rec.columns.map((c) => [c.name, c]));
+  const figs = fmu.md.figures.slice().sort((a, b) => (b.preferred - a.preferred));
+  let plotted = 0;
+  figs.forEach((fig, fi) => {
+    if (fig.title) {
+      const h = document.createElement('div'); h.className = 'fig-head'; h.textContent = fig.title;
+      chartsEl.appendChild(h);
+    }
+    fig.plots.forEach((plot, pi) => {
+      const curves = [];
+      plot.curves.forEach((cv) => {
+        const yc = byName.get(cv.y); if (!yc) return;
+        const xc = cv.x ? byName.get(cv.x) : null;
+        curves.push({ label: cv.legend || cv.y, unit: yc.unit || '', color: COLORS[curves.length % COLORS.length],
+                      xs: xc ? Float64Array.from(xc.values) : xs, ys: yc.values, xName: cv.x || 'time' });
+      });
+      const yAxis = plot.y || {}, xAxis = plot.x || {};
+      const xIsTime = curves.every((c) => c.xName === 'time');
+      charts.add({
+        title: plot.title, curves, xIsTime,
+        xText: xAxis.label || (xIsTime ? 'time' : (curves[0] && curves[0].xName) || 'x'),
+        xUnit: xAxis.unit || (xIsTime ? 's' : ''),
+        yText: yAxis.label || '', yUnit: yAxis.unit || '',
+        yMin: yAxis.min != null ? yAxis.min : null, yMax: yAxis.max != null ? yAxis.max : null,
+        yLog: !!yAxis.log,
+        note: plot.curves.length && !curves.length ? 'Referenced variables are not in the result.' : '',
+      }, 'f' + fi + 'p' + pi);
+      if (curves.length) plotted++;
+    });
+    if (fig.caption) {
+      const c = document.createElement('div'); c.className = 'caption'; c.textContent = fig.caption;
+      chartsEl.appendChild(c);
+    }
+  });
+  if (!plotted) log('info', 'the figure annotation referenced no recorded variables; switch to All variables to plot.');
+}
+
+figToggle.onclick = () => {
+  viewMode = (viewMode === 'all') ? 'auto' : 'all';
+  if (lastRec) renderCharts(lastRec);
+};
 
 addEventListener('resize', () => charts.redraw());
 </script>

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -812,6 +812,47 @@ public uniontype FmiTerminalMember
   end FMI_TERMINAL_MEMBER;
 end FmiTerminalMember;
 
+/* The Documentation(figures=...) annotation resolved against the exported
+   variables; emitted by CodegenFMU3 as the OpenModelica <Figures> vendor
+   annotation. See SimCodeUtil.getFMI3Figures. */
+public uniontype FmiFigure
+  record FMI_FIGURE
+    String title;
+    String group            "plot-group name, \"\" if none";
+    Boolean preferred       "display automatically after simulation";
+    String caption          "\"\" if none";
+    list<FmiPlot> plots;
+  end FMI_FIGURE;
+end FmiFigure;
+
+public uniontype FmiPlot
+  record FMI_PLOT
+    String title;
+    list<FmiCurve> curves;
+    FmiFigureAxis xAxis;
+    FmiFigureAxis yAxis;
+    Option<String> terminal "set when every curve's y variable is a member of this one terminal";
+  end FMI_PLOT;
+end FmiPlot;
+
+public uniontype FmiCurve
+  record FMI_CURVE
+    Option<DAE.ComponentRef> xVariable "NONE() means simulation time; a cref is formatted like a modelDescription variable";
+    DAE.ComponentRef yVariable         "resolved exported variable; formatted like a modelDescription variable";
+    String legend                      "\"\" if none";
+  end FMI_CURVE;
+end FmiCurve;
+
+public uniontype FmiFigureAxis
+  record FMI_FIGURE_AXIS
+    String label            "\"\" if none";
+    String unit             "\"\" if none";
+    Option<Real> min        "only when explicitly set";
+    Option<Real> max        "only when explicitly set";
+    Boolean logScale        "true for a logarithmic axis";
+  end FMI_FIGURE_AXIS;
+end FmiFigureAxis;
+
 /* FMI 3.0 Clocks (output clocks from the model's clocked partitions) */
 public uniontype FmiClock
   record FMI_CLOCK

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15951,7 +15951,7 @@ protected
   list<Absyn.Exp> elems;
   Option<SimCode.FmiPlot> op;
 algorithm
-  elems := match oexp case SOME(e) then figureExpElements(e); else {}; end match;
+  elems := match oexp local Absyn.Exp e; case SOME(e) then figureExpElements(e); else {}; end match;
   for e in elems loop
     op := fmiPlotFromExp(e, nameMap, terminals);
     if isSome(op) then
@@ -15993,7 +15993,7 @@ protected
   list<Absyn.Exp> elems;
   Option<SimCode.FmiCurve> oc;
 algorithm
-  elems := match oexp case SOME(e) then figureExpElements(e); else {}; end match;
+  elems := match oexp local Absyn.Exp e; case SOME(e) then figureExpElements(e); else {}; end match;
   for e in elems loop
     oc := fmiCurveFromExp(e, nameMap);
     if isSome(oc) then
@@ -16016,21 +16016,22 @@ protected
   Boolean dropX;
 algorithm
   args := figureArgs(exp, {"x", "y", "legend"});
-  yref := match figureArgExp(args, "y") case SOME(e) then resolveFigureRef(e, nameMap); else NONE(); end match;
+  yref := match figureArgExp(args, "y") local Absyn.Exp e; case SOME(e) then resolveFigureRef(e, nameMap); else NONE(); end match;
   if isNone(yref) then
     return;
   end if;
   SOME(yc) := yref;
-  (xVar, dropX) := match figureArgExp(args, "x")
+  xVar := NONE();
+  dropX := false;
+  () := match figureArgExp(args, "x")
     local Absyn.Exp xe;
-    case NONE() then (NONE(), false);
-    case SOME(xe) guard isFigureTime(xe) then (NONE(), false);
+    case NONE() then ();
+    case SOME(xe) guard isFigureTime(xe) then ();
     case SOME(xe)
-      then match resolveFigureRef(xe, nameMap)
-        local DAE.ComponentRef xc;
-        case SOME(xc) then (SOME(xc), false);
-        else (NONE(), true);
-      end match;
+      algorithm
+        xVar := resolveFigureRef(xe, nameMap);
+        dropX := isNone(xVar);
+      then ();
   end match;
   if dropX then
     return;
@@ -16044,7 +16045,7 @@ protected function fmiAxisFromArg
 protected
   list<tuple<String, Absyn.Exp>> args;
 algorithm
-  args := match oexp case SOME(e) then figureArgs(e, {"min", "max", "unit", "label", "scale"}); else {}; end match;
+  args := match oexp local Absyn.Exp e; case SOME(e) then figureArgs(e, {"min", "max", "unit", "label", "scale"}); else {}; end match;
   axis := SimCode.FMI_FIGURE_AXIS(
     figureStrArg(args, "label"),
     figureStrArg(args, "unit"),

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -128,6 +128,7 @@ import SimCodeUtilShared;
 import Static;
 import StringUtil;
 import SymbolicJacobian;
+import SymbolTable;
 import System;
 import TypesDump;
 import Util;
@@ -15844,6 +15845,405 @@ algorithm
     else NONE();
   end matchcontinue;
 end connectorMemberOf;
+
+public function getFMI3Figures
+  "The model's Documentation(figures=...) annotation, resolved against the exported
+   SimVars, for CodegenFMU3 to emit as the OpenModelica <Figures> vendor annotation.
+   Curves that do not reference an exported variable (and plots/figures thereby left
+   empty) are dropped; an empty result writes no annotation. C and wasm FMU export."
+  input SimCode.SimCode simCode;
+  output list<SimCode.FmiFigure> figures = {};
+protected
+  Absyn.Program program;
+  Absyn.Class cls;
+  Option<list<Absyn.Exp>> ofigs;
+  list<Absyn.Exp> figExps;
+  list<tuple<String, DAE.ComponentRef>> nameMap;
+  list<SimCode.FmiTerminal> terminals;
+  SimCode.FmiFigure fig;
+algorithm
+  program := SymbolTable.getAbsyn();
+  try
+    cls := ProgramUtil.getPathedClassInProgram(simCode.modelInfo.name, program);
+  else
+    return;
+  end try;
+  ofigs := AbsynUtil.getNamedAnnotationInClass(cls,
+    Absyn.QUALIFIED("Documentation", Absyn.IDENT("figures")), figureExpsFromMod);
+  figExps := match ofigs case SOME(figExps) then figExps; else {}; end match;
+  if listEmpty(figExps) then
+    return;
+  end if;
+  nameMap := buildFmiFigureNameMap(simCode);
+  terminals := getFMI3Terminals(simCode);
+  for e in figExps loop
+    fig := fmiFigureFromExp(e, nameMap, terminals);
+    if not listEmpty(fig.plots) then
+      figures := fig :: figures;
+    end if;
+  end for;
+  figures := listReverse(figures);
+end getFMI3Figures;
+
+protected function figureExpsFromMod
+  input Option<Absyn.Modification> mod;
+  output list<Absyn.Exp> exps;
+algorithm
+  exps := match mod
+    local Absyn.Exp exp;
+    case SOME(Absyn.CLASSMOD(eqMod = Absyn.EQMOD(exp = exp))) then figureExpElements(exp);
+    else {};
+  end match;
+end figureExpsFromMod;
+
+protected function figureExpElements
+  input Absyn.Exp exp;
+  output list<Absyn.Exp> exps;
+algorithm
+  exps := match exp
+    case Absyn.ARRAY() then exp.arrayExp;
+    else {exp};
+  end match;
+end figureExpElements;
+
+protected function buildFmiFigureNameMap "name -> cref over every exported SimVar, to resolve curve references"
+  input SimCode.SimCode simCode;
+  output list<tuple<String, DAE.ComponentRef>> nameMap = {};
+protected
+  SimCodeVar.SimVars vars;
+  list<SimCodeVar.SimVar> allVars;
+algorithm
+  vars := simCode.modelInfo.vars;
+  allVars := List.flatten({vars.stateVars, vars.derivativeVars, vars.algVars,
+    vars.discreteAlgVars, vars.paramVars, vars.intAlgVars, vars.intParamVars,
+    vars.boolAlgVars, vars.boolParamVars, vars.stringAlgVars, vars.stringParamVars,
+    vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars});
+  for v in allVars loop
+    nameMap := (ComponentReference.crefStr(v.name), v.name) :: nameMap;
+  end for;
+end buildFmiFigureNameMap;
+
+protected function fmiFigureFromExp
+  input Absyn.Exp exp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  input list<SimCode.FmiTerminal> terminals;
+  output SimCode.FmiFigure figure;
+protected
+  list<tuple<String, Absyn.Exp>> args;
+  list<SimCode.FmiPlot> plots;
+algorithm
+  args := figureArgs(exp, {"title", "identifier", "group", "preferred", "plots", "caption"});
+  plots := fmiPlotsFromExp(figureArgExp(args, "plots"), nameMap, terminals);
+  figure := SimCode.FMI_FIGURE(
+    figureStrArg(args, "title"),
+    figureStrArg(args, "group"),
+    figureBoolFlag(args, "preferred"),
+    figureStrArg(args, "caption"),
+    plots);
+end fmiFigureFromExp;
+
+protected function fmiPlotsFromExp
+  input Option<Absyn.Exp> oexp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  input list<SimCode.FmiTerminal> terminals;
+  output list<SimCode.FmiPlot> plots = {};
+protected
+  list<Absyn.Exp> elems;
+  Option<SimCode.FmiPlot> op;
+algorithm
+  elems := match oexp case SOME(e) then figureExpElements(e); else {}; end match;
+  for e in elems loop
+    op := fmiPlotFromExp(e, nameMap, terminals);
+    if isSome(op) then
+      plots := Util.getOption(op) :: plots;
+    end if;
+  end for;
+  plots := listReverse(plots);
+end fmiPlotsFromExp;
+
+protected function fmiPlotFromExp
+  "A resolved plot, or NONE() when no curve resolved to an exported variable."
+  input Absyn.Exp exp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  input list<SimCode.FmiTerminal> terminals;
+  output Option<SimCode.FmiPlot> oplot;
+protected
+  list<tuple<String, Absyn.Exp>> args;
+  list<SimCode.FmiCurve> curves;
+algorithm
+  args := figureArgs(exp, {"title", "identifier", "curves", "x", "y"});
+  curves := fmiCurvesFromExp(figureArgExp(args, "curves"), nameMap);
+  if listEmpty(curves) then
+    oplot := NONE();
+  else
+    oplot := SOME(SimCode.FMI_PLOT(
+      figureStrArg(args, "title"),
+      curves,
+      fmiAxisFromArg(figureArgExp(args, "x")),
+      fmiAxisFromArg(figureArgExp(args, "y")),
+      curvesCommonTerminal(curves, terminals)));
+  end if;
+end fmiPlotFromExp;
+
+protected function fmiCurvesFromExp
+  input Option<Absyn.Exp> oexp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  output list<SimCode.FmiCurve> curves = {};
+protected
+  list<Absyn.Exp> elems;
+  Option<SimCode.FmiCurve> oc;
+algorithm
+  elems := match oexp case SOME(e) then figureExpElements(e); else {}; end match;
+  for e in elems loop
+    oc := fmiCurveFromExp(e, nameMap);
+    if isSome(oc) then
+      curves := Util.getOption(oc) :: curves;
+    end if;
+  end for;
+  curves := listReverse(curves);
+end fmiCurvesFromExp;
+
+protected function fmiCurveFromExp
+  "A resolved curve, or NONE() when y (or a given non-time x) is not an exported
+   variable. Only plain variable references resolve, not derived expressions."
+  input Absyn.Exp exp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  output Option<SimCode.FmiCurve> ocurve = NONE();
+protected
+  list<tuple<String, Absyn.Exp>> args;
+  Option<DAE.ComponentRef> yref, xVar;
+  DAE.ComponentRef yc;
+  Boolean dropX;
+algorithm
+  args := figureArgs(exp, {"x", "y", "legend"});
+  yref := match figureArgExp(args, "y") case SOME(e) then resolveFigureRef(e, nameMap); else NONE(); end match;
+  if isNone(yref) then
+    return;
+  end if;
+  SOME(yc) := yref;
+  (xVar, dropX) := match figureArgExp(args, "x")
+    local Absyn.Exp xe;
+    case NONE() then (NONE(), false);
+    case SOME(xe) guard isFigureTime(xe) then (NONE(), false);
+    case SOME(xe)
+      then match resolveFigureRef(xe, nameMap)
+        local DAE.ComponentRef xc;
+        case SOME(xc) then (SOME(xc), false);
+        else (NONE(), true);
+      end match;
+  end match;
+  if dropX then
+    return;
+  end if;
+  ocurve := SOME(SimCode.FMI_CURVE(xVar, yc, figureStrArg(args, "legend")));
+end fmiCurveFromExp;
+
+protected function fmiAxisFromArg
+  input Option<Absyn.Exp> oexp;
+  output SimCode.FmiFigureAxis axis;
+protected
+  list<tuple<String, Absyn.Exp>> args;
+algorithm
+  args := match oexp case SOME(e) then figureArgs(e, {"min", "max", "unit", "label", "scale"}); else {}; end match;
+  axis := SimCode.FMI_FIGURE_AXIS(
+    figureStrArg(args, "label"),
+    figureStrArg(args, "unit"),
+    figureBoundArg(args, "min"),
+    figureBoundArg(args, "max"),
+    figureScaleIsLog(figureArgExp(args, "scale")));
+end fmiAxisFromArg;
+
+protected function resolveFigureRef "the exported cref a curve x/y names, or NONE() if not a plain exported-var reference"
+  input Absyn.Exp exp;
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  output Option<DAE.ComponentRef> ocref;
+algorithm
+  ocref := match exp
+    local Absyn.ComponentRef acr;
+    case Absyn.CREF(componentRef = acr) then lookupFigureName(nameMap, AbsynUtil.crefString(acr));
+    else NONE();
+  end match;
+end resolveFigureRef;
+
+protected function isFigureTime
+  input Absyn.Exp exp;
+  output Boolean isTime;
+algorithm
+  isTime := match exp
+    local Absyn.ComponentRef acr;
+    case Absyn.CREF(componentRef = acr) then stringEq(AbsynUtil.crefString(acr), "time");
+    else false;
+  end match;
+end isFigureTime;
+
+protected function lookupFigureName
+  input list<tuple<String, DAE.ComponentRef>> nameMap;
+  input String key;
+  output Option<DAE.ComponentRef> ocref = NONE();
+protected
+  String k;
+  DAE.ComponentRef c;
+algorithm
+  for e in nameMap loop
+    (k, c) := e;
+    if stringEq(k, key) then
+      ocref := SOME(c);
+      return;
+    end if;
+  end for;
+end lookupFigureName;
+
+protected function curvesCommonTerminal "the terminal shared by all curves y-vars, else NONE()"
+  input list<SimCode.FmiCurve> curves;
+  input list<SimCode.FmiTerminal> terminals;
+  output Option<String> terminal = NONE();
+protected
+  Option<String> t;
+  Boolean first = true;
+algorithm
+  for c in curves loop
+    t := crefTerminalName(c.yVariable, terminals);
+    if isNone(t) then
+      terminal := NONE();
+      return;
+    end if;
+    if first then
+      terminal := t;
+      first := false;
+    elseif not stringEq(Util.getOption(t), Util.getOption(terminal)) then
+      terminal := NONE();
+      return;
+    end if;
+  end for;
+  if first then
+    terminal := NONE();
+  end if;
+end curvesCommonTerminal;
+
+protected function crefTerminalName
+  input DAE.ComponentRef cref;
+  input list<SimCode.FmiTerminal> terminals;
+  output Option<String> name = NONE();
+protected
+  String key;
+algorithm
+  key := ComponentReference.crefStr(cref);
+  for t in terminals loop
+    for m in t.members loop
+      if stringEq(ComponentReference.crefStr(m.variable), key) then
+        name := SOME(t.name);
+        return;
+      end if;
+    end for;
+  end for;
+end crefTerminalName;
+
+protected function figureArgs
+  "Maps a record-constructor call's arguments to (fieldName, exp) pairs; positional
+   args by declared field order, named args by name."
+  input Absyn.Exp exp;
+  input list<String> fieldNames;
+  output list<tuple<String, Absyn.Exp>> args = {};
+protected
+  list<Absyn.Exp> pos;
+  list<Absyn.NamedArg> named;
+  list<String> names = fieldNames;
+  String name;
+algorithm
+  () := match exp
+    case Absyn.CALL(functionArgs = Absyn.FUNCTIONARGS(args = pos, argNames = named))
+      algorithm
+        for e in pos loop
+          name :: names := names;
+          args := (name, e) :: args;
+        end for;
+        for na in named loop
+          args := (na.argName, na.argValue) :: args;
+        end for;
+      then ();
+    else ();
+  end match;
+end figureArgs;
+
+protected function figureArgExp
+  input list<tuple<String, Absyn.Exp>> args;
+  input String name;
+  output Option<Absyn.Exp> oexp = NONE();
+protected
+  String n;
+  Absyn.Exp e;
+algorithm
+  for a in args loop
+    (n, e) := a;
+    if n == name then
+      oexp := SOME(e);
+      return;
+    end if;
+  end for;
+end figureArgExp;
+
+protected function figureStrArg
+  input list<tuple<String, Absyn.Exp>> args;
+  input String name;
+  output String value;
+algorithm
+  value := match figureArgExp(args, name)
+    local String s;
+    case SOME(Absyn.STRING(value = s)) then s;
+    else "";
+  end match;
+end figureStrArg;
+
+protected function figureBoolFlag
+  input list<tuple<String, Absyn.Exp>> args;
+  input String name;
+  output Boolean value;
+algorithm
+  value := match figureArgExp(args, name)
+    local Boolean b;
+    case SOME(Absyn.BOOL(value = b)) then b;
+    else false;
+  end match;
+end figureBoolFlag;
+
+protected function figureBoundArg
+  "An axis bound: NONE() when absent (auto), SOME when explicitly set."
+  input list<tuple<String, Absyn.Exp>> args;
+  input String name;
+  output Option<Real> value;
+algorithm
+  value := match figureArgExp(args, name)
+    local Absyn.Exp e;
+    case SOME(e) then SOME(figureExpReal(e));
+    else NONE();
+  end match;
+end figureBoundArg;
+
+protected function figureExpReal
+  input Absyn.Exp exp;
+  output Real value;
+algorithm
+  value := match exp
+    local Integer i; String s;
+    case Absyn.INTEGER(value = i) then intReal(i);
+    case Absyn.REAL(value = s) then stringReal(s);
+    case Absyn.UNARY(op = Absyn.UMINUS()) then -figureExpReal(exp.exp);
+    else 0.0;
+  end match;
+end figureExpReal;
+
+protected function figureScaleIsLog
+  "Whether an axis scale argument denotes the logarithmic scale (Scale.Log)."
+  input Option<Absyn.Exp> oexp;
+  output Boolean isLog;
+algorithm
+  isLog := match oexp
+    local Absyn.ComponentRef cr;
+    case SOME(Absyn.CALL(function_ = cr)) then stringEq(AbsynUtil.crefIdent(cr), "Log");
+    case SOME(Absyn.CREF(componentRef = cr)) then stringEq(AbsynUtil.crefIdent(cr), "Log");
+    else false;
+  end match;
+end figureScaleIsLog;
 
 protected function crefConnectorSplit
   "Split a cref at its outermost connector-typed qualifier: returns the connector

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -109,9 +109,96 @@ case SIMCODE(__) then
     <%DefaultExperiment3(simulationSettingsOpt)%>
     <%fmiModelVariables3(simCode, FMUType)%>
     <%modelStructure3(simCode, modelStructure)%>
+    <%fmiFiguresAnnotation(simCode)%>
   </fmiModelDescription>
   >>
 end fmiModelDescription;
+
+template fmiFiguresAnnotation(SimCode simCode)
+ "The model's figures annotation as the OpenModelica <Figures> vendor annotation,
+  so an importer can offer default plots. Empty (schema-valid) when the model has
+  no resolvable figures. Common to the C and wasm FMU export."
+::=
+match SimCodeUtil.getFMI3Figures(simCode)
+case {} then ''
+case figures then
+  <<
+  <Annotations>
+    <Tool name="OpenModelica">
+      <Figures version="1">
+        <%figures |> f => Figure3(f) ;separator="\n"%>
+      </Figures>
+    </Tool>
+  </Annotations>
+  >>
+end fmiFiguresAnnotation;
+
+template Figure3(FmiFigure figure)
+::=
+match figure
+case FMI_FIGURE(__) then
+  let titleAttr = figureStrAttr("title", title)
+  let groupAttr = figureStrAttr("group", group)
+  let prefAttr = if preferred then ' preferred="true"'
+  let captionElt = if boolNot(stringEq(caption, "")) then '<%\n%>  <Caption><%Util.escapeModelicaStringToXmlString(caption)%></Caption>'
+  <<
+  <Figure<%titleAttr%><%groupAttr%><%prefAttr%>>
+    <%plots |> p => FigurePlot3(p) ;separator="\n"%><%captionElt%>
+  </Figure>
+  >>
+end Figure3;
+
+template FigurePlot3(FmiPlot plot)
+::=
+match plot
+case FMI_PLOT(__) then
+  let titleAttr = figureStrAttr("title", title)
+  let xAxisElt = FigureAxis3("x", xAxis)
+  let yAxisElt = FigureAxis3("y", yAxis)
+  let curveElts = (curves |> c => FigureCurve3(c) ;separator="\n")
+  let termRef = match terminal case SOME(t) then '<%\n%>  <TerminalRef terminal="<%Util.escapeModelicaStringToXmlString(t)%>"/>'
+  <<
+  <Plot<%titleAttr%>>
+    <%xAxisElt%><%yAxisElt%><%curveElts%><%termRef%>
+  </Plot>
+  >>
+end FigurePlot3;
+
+template FigureAxis3(String role, FmiFigureAxis axis)
+ "An <Axis> element, emitted only when it carries a non-default attribute."
+::=
+match axis
+case FMI_FIGURE_AXIS(__) then
+  let labelAttr = figureStrAttr("label", label)
+  let unitAttr = figureStrAttr("unit", unit)
+  let minAttr = match min case SOME(r) then ' min="<%r%>"'
+  let maxAttr = match max case SOME(r) then ' max="<%r%>"'
+  let scaleAttr = if logScale then ' scale="Log"'
+  let body = '<%labelAttr%><%unitAttr%><%minAttr%><%maxAttr%><%scaleAttr%>'
+  if stringEq(body, "") then '' else '<Axis role="<%role%>"<%body%>/><%\n%>  '
+end FigureAxis3;
+
+template FigureCurve3(FmiCurve curve)
+::=
+match curve
+case FMI_CURVE(__) then
+  let yAttr = ' y="<%figureCrefName(yVariable)%>"'
+  let xAttr = match xVariable case SOME(x) then ' x="<%figureCrefName(x)%>"'
+  let legendAttr = figureStrAttr("legend", legend)
+  '<Curve<%yAttr%><%xAttr%><%legendAttr%>/>'
+end FigureCurve3;
+
+template figureCrefName(DAE.ComponentRef cref)
+ "A cref formatted exactly like a variable name in modelDescription.xml."
+::=
+  Util.escapeModelicaStringToXmlString(System.stringReplace(crefStrNoUnderscore(cref),"$", "_D_"))
+end figureCrefName;
+
+template figureStrAttr(String name, String value)
+ "A non-empty XML attribute, or nothing."
+::=
+  if stringEq(value, "") then '' else ' <%name%>="<%Util.escapeModelicaStringToXmlString(value)%>"'
+end figureStrAttr;
 
 template fmiBuildDescriptionFile(SimCode simCode, list<String> sourceFiles, String fileNamePrefixHash)
  "Writes sources/buildDescription.xml (FMI 3.0). Returns the empty string (the

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1085,6 +1085,44 @@ end SparsityRow;
     end FMI_TERMINAL_MEMBER;
   end FmiTerminalMember;
 
+  uniontype FmiFigure
+    record FMI_FIGURE
+      String title;
+      String group;
+      Boolean preferred;
+      String caption;
+      list<FmiPlot> plots;
+    end FMI_FIGURE;
+  end FmiFigure;
+
+  uniontype FmiPlot
+    record FMI_PLOT
+      String title;
+      list<FmiCurve> curves;
+      FmiFigureAxis xAxis;
+      FmiFigureAxis yAxis;
+      Option<String> terminal;
+    end FMI_PLOT;
+  end FmiPlot;
+
+  uniontype FmiCurve
+    record FMI_CURVE
+      Option<DAE.ComponentRef> xVariable;
+      DAE.ComponentRef yVariable;
+      String legend;
+    end FMI_CURVE;
+  end FmiCurve;
+
+  uniontype FmiFigureAxis
+    record FMI_FIGURE_AXIS
+      String label;
+      String unit;
+      Option<Real> min;
+      Option<Real> max;
+      Boolean logScale;
+    end FMI_FIGURE_AXIS;
+  end FmiFigureAxis;
+
   uniontype FmiClock
     record FMI_CLOCK
       Integer valueReference;
@@ -1436,6 +1474,11 @@ package SimCodeUtil
     input SimCode.SimCode simCode;
     output list<SimCode.FmiTerminal> terminals;
   end getFMI3Terminals;
+
+  function getFMI3Figures
+    input SimCode.SimCode simCode;
+    output list<SimCode.FmiFigure> figures;
+  end getFMI3Figures;
 
   function isFMI3NestableAlias
     input SimCodeVar.SimVar simVar;


### PR DESCRIPTION
Preserve a model's Documentation(figures=...) annotation inside the exported FMU's modelDescription.xml as an OpenModelica <Figures> vendor annotation, so an importer can offer meaningful default plots.

Generated in the shared CodegenFMU3.fmiModelDescription template, so both the C and the wasm FMU export produce it:

- SimCodeUtil.getFMI3Figures resolves the annotation's curve references against the exported SimVars (mirroring getFMI3Terminals); unresolved curves and empty plots/figures are dropped.
- CodegenFMU3.tpl serializes the resolved FmiFigure IR (SimCode.mo, SimCodeTV.mo) into <Annotations><Tool name="OpenModelica"><Figures>.

The wasm FMI importer (fmi-simulator) parses it and uses the preferred figures as its default plots, with an all-variables toggle. A model with no figures writes no annotation and stays schema-valid.