### PR TITLE
OMCompiler: Fix memory leak from function-local arrays in co-simulation

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -1506,19 +1506,34 @@ case FUNCTION(__) then
   let boxedFn = if not funcHasParallelInOutArrays(fn) then functionBodyBoxed(fn, isSimulation) else ""
   let &afterBody = buffer ""
   let prototype = functionPrototype(fname, functionArguments, outVars, false, visibility, isSimulation, false, afterBody)
+  /* Issue #10790: save/restore the memory pool around function bodies so that
+     local array allocations (protected arrays) are freed on return, preventing
+     unbounded memory growth in FMU simulation.  Skip for functions that return
+     arrays or records, since the return value may point into pool memory. */
+  let doPoolSaveRestore = match outVars
+    case (v as VARIABLE(ty=T_ARRAY(__)))::_ then false
+    case (v as VARIABLE(ty=T_COMPLEX(__)))::_ then false
+    case _::_ then true
+    case _ then true
   <<
   <%auxFunction%>
   <% match visibility case PUBLIC(__) then "DLLDirection" %>
   <%prototype%>
   {
     <%varDecls%>
+    <% if doPoolSaveRestore then '#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    MemPoolState _omc_poolState = omc_util_get_pool_state();
+#endif
+' %>
     <% if boolNot(isSimulation) then 'MMC_SO();<%\n%>'%>_tailrecursive: OMC_LABEL_UNUSED
     <%varInits%>
     <%bodyPart%>
     _return: OMC_LABEL_UNUSED
     <%outVarAssign%><%restoreJmpbuf%>
-    <%if acceptParModelicaGrammar() then
-    '/* Free GPU/OpenCL CPU memory */<%\n%><%varFrees%>'%>
+    <% if doPoolSaveRestore then '#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    omc_util_restore_pool_state(_omc_poolState);
+#endif
+' %>
     <%freeConstructedExternalObjects%>
     <%match outVars
        case v::_ then 'return <%funArgName(v)%>;'

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -919,9 +919,15 @@ static int wrapper_fvec(DATA_HOMOTOPY* solverData, double* x, double* f)
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
   RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* TODO: change input to residualFunc from data to systemData */
   nlsData->residualFunc(&resUserData, x, f, &iflag);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
   solverData->numberOfFunctionEvaluations++;
 
   return 0;
@@ -941,9 +947,15 @@ int wrapper_fvec_constraints(DATA_HOMOTOPY* solverData, double* x, double* f)
   RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
   int retVal;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* TODO: change input to residualFunc from data to systemData */
   retVal = nlsData->residualFuncConstraints(&resUserData, x, f, &iflag);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
   solverData->numberOfFunctionEvaluations++;
 
   return retVal;
@@ -958,6 +970,9 @@ int wrapper_fvec_constraints(DATA_HOMOTOPY* solverData, double* x, double* f)
 static int wrapper_fvec_der(DATA_HOMOTOPY* solverData, double* x, double* fJac)
 {
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* performance measurement */
   rt_ext_tp_tick(&nlsData->jacobianTimeClock);
@@ -989,6 +1004,9 @@ static int wrapper_fvec_der(DATA_HOMOTOPY* solverData, double* x, double* fJac)
   /* performance measurement and statistics */
   nlsData->jacobianTime += rt_ext_tp_tock(&(nlsData->jacobianTimeClock));
   nlsData->numberOfJEval++;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   return 0;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -316,11 +316,17 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
     }
 
     /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
     if(hybrdData->useXScaling){
       (systemData->residualFunc)(&resUserData, (const double*) hybrdData->xScaled, f, (const int*)iflag);
     } else {
       (systemData->residualFunc)(&resUserData, x, f, (const int*)iflag);
     }
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    omc_util_restore_pool_state(mem_pool_state);
+#endif
 
     /* debug output */
     if(OMC_ACTIVE_STREAM(OMC_LOG_NLS_RES)) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -983,10 +983,16 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
 #endif
 
   /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
   if (nonlinsys->strictTearingFunctionCall != NULL)
     constraintViolated = nonlinsys->residualFuncConstraints(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
   else
     nonlinsys->residualFunc(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   /* replace extrapolated values by current x for discrete step */
   memcpy(nonlinsys->nlsxExtrapolation, nonlinsys->nlsx, nonlinsys->size*(sizeof(double)));

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -930,10 +930,16 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
 #endif
 
   /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
   if (nonlinsys->strictTearingFunctionCall != NULL)
     constraintViolated = nonlinsys->residualFuncConstraints(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
   else
     nonlinsys->residualFunc(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   /* replace extrapolated values by current x for discrete step */
   memcpy(nonlinsys->nlsxExtrapolation, nonlinsys->nlsx, nonlinsys->size*(sizeof(double)));

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/Makefile
@@ -6,6 +6,7 @@ ExportCvodeFmu_dynamic.mos \
 ExportCvodeFmu_static.mos \
 fmi_interpolation_01.mos \
 FmuExportFlags.mos \
+issue10790_memory_leak.mos \
 RecompileSourceCodeFMU.mos \
 simpleStiffFMU.mos \
 issue10523.mos \

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10790_memory_leak.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10790_memory_leak.mos
@@ -1,0 +1,57 @@
+// name:     issue10790_memory_leak
+// keywords: fmu export simulation memory leak co-simulation
+// status: correct
+// teardown_command: rm -rf issue10790.fmu issue10790* memoryLeakFmu* tmp-*
+// cflags: -d=-newInst
+//
+// Regression test for #10790: co-simulation FMU memory leak from un-freed
+// function-local array allocations.
+
+loadString("
+model memoryLeakFmu
+  function leakyFunc
+    input Real x;
+    output Real y;
+  protected
+    Real[100000] tmp;
+  algorithm
+    y := 0;
+    for i in 1:100000 loop
+      tmp[i] := x * i * 1e-12;
+      y := y + tmp[i];
+    end for;
+  end leakyFunc;
+
+  Real z;
+equation
+  der(z) = leakyFunc(time) - z;
+end memoryLeakFmu;
+"); getErrorString();
+
+buildModelFMU(memoryLeakFmu, version="2.0", fmuType="me_cs"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator memoryLeakFmu.fmu --mode=cs --stopTime=10.0 --stepSize=0.01 --resultFile=\"memoryLeakFmu_res.mat\" --suppressPath=true --tempDir=\"tmp-issue10790\"", "issue10790_sim.log"); getErrorString();
+readFile("issue10790_sim.log"); getErrorString();
+
+val(z, 10.0, "memoryLeakFmu_res.mat"); getErrorString();
+
+// Result:
+// true
+// ""
+// "memoryLeakFmu.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0
+// ""
+// "info:    *** FMU Simulation Info ***
+//           - model:     memoryLeakFmu (co-simulation)
+//           - startTime: 0.000000
+//           - stopTime:  10.000000
+//           - tolerance: 0.000001
+//           - stepSize:  0.010000
+// info:    Result file: memoryLeakFmu_res.mat (bufferSize=1)
+// "
+// ""
+// 0.0450006658583956
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10790_memory_leak.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10790_memory_leak.mos
@@ -1,7 +1,7 @@
 // name:     issue10790_memory_leak
 // keywords: fmu export simulation memory leak co-simulation
 // status: correct
-// teardown_command: rm -rf issue10790.fmu issue10790* memoryLeakFmu* tmp-*
+// teardown_command: rm -rf memoryLeakFmu* tmp-* issue10790_sim.log
 // cflags: -d=-newInst
 //
 // Regression test for #10790: co-simulation FMU memory leak from un-freed


### PR DESCRIPTION
Add pool save/restore (omc_util_get_pool_state/restore_pool_state) around each generated function body so that temporary arrays allocated in Modelica functions are freed on return.  Guard with OMC_MINIMAL_RUNTIME/OMC_FMI_RUNTIME so it only activates in the FMU pool allocator path.  Skip for functions returning arrays/records whose data pointers would dangle.

Closes #10790
