### PR TITLE
SimulationRuntime/c: Add pool save/restore in nonlinear solver wrappers

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -919,9 +919,15 @@ static int wrapper_fvec(DATA_HOMOTOPY* solverData, double* x, double* f)
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
   RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* TODO: change input to residualFunc from data to systemData */
   nlsData->residualFunc(&resUserData, x, f, &iflag);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
   solverData->numberOfFunctionEvaluations++;
 
   return 0;
@@ -941,9 +947,15 @@ int wrapper_fvec_constraints(DATA_HOMOTOPY* solverData, double* x, double* f)
   RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
   int retVal;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* TODO: change input to residualFunc from data to systemData */
   retVal = nlsData->residualFuncConstraints(&resUserData, x, f, &iflag);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
   solverData->numberOfFunctionEvaluations++;
 
   return retVal;
@@ -958,6 +970,9 @@ int wrapper_fvec_constraints(DATA_HOMOTOPY* solverData, double* x, double* f)
 static int wrapper_fvec_der(DATA_HOMOTOPY* solverData, double* x, double* fJac)
 {
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
 
   /* performance measurement */
   rt_ext_tp_tick(&nlsData->jacobianTimeClock);
@@ -989,6 +1004,9 @@ static int wrapper_fvec_der(DATA_HOMOTOPY* solverData, double* x, double* fJac)
   /* performance measurement and statistics */
   nlsData->jacobianTime += rt_ext_tp_tock(&(nlsData->jacobianTimeClock));
   nlsData->numberOfJEval++;
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   return 0;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -316,11 +316,17 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
     }
 
     /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
     if(hybrdData->useXScaling){
       (systemData->residualFunc)(&resUserData, (const double*) hybrdData->xScaled, f, (const int*)iflag);
     } else {
       (systemData->residualFunc)(&resUserData, x, f, (const int*)iflag);
     }
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    omc_util_restore_pool_state(mem_pool_state);
+#endif
 
     /* debug output */
     if(OMC_ACTIVE_STREAM(OMC_LOG_NLS_RES)) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -983,10 +983,16 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
 #endif
 
   /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
   if (nonlinsys->strictTearingFunctionCall != NULL)
     constraintViolated = nonlinsys->residualFuncConstraints(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
   else
     nonlinsys->residualFunc(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   /* replace extrapolated values by current x for discrete step */
   memcpy(nonlinsys->nlsxExtrapolation, nonlinsys->nlsx, nonlinsys->size*(sizeof(double)));

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -930,10 +930,16 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
 #endif
 
   /* call residual function */
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+#endif
   if (nonlinsys->strictTearingFunctionCall != NULL)
     constraintViolated = nonlinsys->residualFuncConstraints(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
   else
     nonlinsys->residualFunc(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
+#if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+  omc_util_restore_pool_state(mem_pool_state);
+#endif
 
   /* replace extrapolated values by current x for discrete step */
   memcpy(nonlinsys->nlsxExtrapolation, nonlinsys->nlsx, nonlinsys->size*(sizeof(double)));


### PR DESCRIPTION
Add omc_util_get_pool_state / omc_util_restore_pool_state around each residual function evaluation in the homotopy, hybrid, and direct nonlinear solvers.  Without this, every iteration of the nonlinear solver accumulates pool-allocated temporaries from the model functions, causing the pool to expand until it hits the assertion in pool_expand (memory_pool.c:100).

Closes #13905
