### PR TITLE
wasm-jit: non-scalarized arrays, nthRoot

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -2758,7 +2758,7 @@ algorithm
           fail();
         end if;
       then
-        Expression.REAL(v ^ (1/n));
+        Expression.REAL(if v < 0.0 and intMod(n, 2) <> 0 then -((-v) ^ (1/n)) else v ^ (1/n));
 
     else
       algorithm

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1608,6 +1608,161 @@ fn col_to_off(col: u32, layout: &SimLayout) -> u32 {
     }
 }
 
+/// Expand every whole-array `SimVar` (`--simCodeScalarize=false`) into its
+/// row-major scalar element `SimVar`s; already-scalar vars pass through.
+fn scalarize_sim_vars(vars: &SimCodeVar::SimVars) -> Result<SimCodeVar::SimVars> {
+    // Already scalarized by NBackend; the element vars still carry the parent's
+    // numArrayElement, so re-expanding would duplicate them.
+    if openmodelica_util::Flags::getConfigBool(openmodelica_util::Flags::SIM_CODE_SCALARIZE.clone())? {
+        return Ok(vars.clone());
+    }
+    let mut out = vars.clone();
+    out.stateVars = scalarize_var_list(&vars.stateVars)?;
+    out.derivativeVars = scalarize_var_list(&vars.derivativeVars)?;
+    out.algVars = scalarize_var_list(&vars.algVars)?;
+    out.discreteAlgVars = scalarize_var_list(&vars.discreteAlgVars)?;
+    out.intAlgVars = scalarize_var_list(&vars.intAlgVars)?;
+    out.boolAlgVars = scalarize_var_list(&vars.boolAlgVars)?;
+    out.inputVars = scalarize_var_list(&vars.inputVars)?;
+    out.outputVars = scalarize_var_list(&vars.outputVars)?;
+    out.aliasVars = scalarize_var_list(&vars.aliasVars)?;
+    out.intAliasVars = scalarize_var_list(&vars.intAliasVars)?;
+    out.boolAliasVars = scalarize_var_list(&vars.boolAliasVars)?;
+    out.paramVars = scalarize_var_list(&vars.paramVars)?;
+    out.intParamVars = scalarize_var_list(&vars.intParamVars)?;
+    out.boolParamVars = scalarize_var_list(&vars.boolParamVars)?;
+    out.stringAlgVars = scalarize_var_list(&vars.stringAlgVars)?;
+    out.stringParamVars = scalarize_var_list(&vars.stringParamVars)?;
+    out.stringAliasVars = scalarize_var_list(&vars.stringAliasVars)?;
+    out.extObjVars = scalarize_var_list(&vars.extObjVars)?;
+    out.constVars = scalarize_var_list(&vars.constVars)?;
+    out.intConstVars = scalarize_var_list(&vars.intConstVars)?;
+    out.boolConstVars = scalarize_var_list(&vars.boolConstVars)?;
+    out.stringConstVars = scalarize_var_list(&vars.stringConstVars)?;
+    Ok(out)
+}
+
+fn scalarize_var_list(list: &Arc<List<SimCodeVar::SimVar>>) -> Result<Arc<List<SimCodeVar::SimVar>>> {
+    let mut out: Vec<SimCodeVar::SimVar> = Vec::new();
+    for sv in &**list {
+        let dims = array_dims_of(&sv.numArrayElement)?;
+        if dims.is_empty() {
+            out.push(sv.clone());
+            continue;
+        }
+        for idx in row_major_indices(&dims) {
+            let mut e = sv.clone();
+            e.name = cref_with_indices(&sv.name, &idx);
+            e.numArrayElement = metamodelica::nil();
+            e.arrayCref = None;
+            e.aliasvar = reindex_aliasvar(&sv.aliasvar, &idx);
+            e.initialValue = index_attr(&sv.initialValue, &idx);
+            e.nominalValue = index_attr(&sv.nominalValue, &idx);
+            e.minValue = index_attr(&sv.minValue, &idx);
+            e.maxValue = index_attr(&sv.maxValue, &idx);
+            out.push(e);
+        }
+    }
+    Ok(Arc::new(out.into_iter().collect::<List<SimCodeVar::SimVar>>()))
+}
+
+/// Parse `numArrayElement` (dimension sizes) to integers; empty for a scalar.
+fn array_dims_of(nae: &Arc<List<ArcStr>>) -> Result<Vec<u32>> {
+    let mut dims = Vec::new();
+    for s in &**nae {
+        match s.trim().parse::<u32>() {
+            Ok(d) => dims.push(d),
+            Err(_) => {
+                record_error(format!("CodegenWasmJit: non-integer array dimension `{s}`"));
+                return Err("CodegenWasmJit: non-integer array dimension");
+            }
+        }
+    }
+    Ok(dims)
+}
+
+/// All 1-based index tuples of shape `dims`, row-major (last axis fastest).
+pub(crate) fn row_major_indices(dims: &[u32]) -> Vec<Vec<i32>> {
+    let mut out = vec![Vec::new()];
+    for &d in dims {
+        let mut next = Vec::with_capacity(out.len() * d as usize);
+        for prefix in &out {
+            for i in 1..=d as i32 {
+                let mut p = prefix.clone();
+                p.push(i);
+                next.push(p);
+            }
+        }
+        out = next;
+    }
+    out
+}
+
+/// A copy of `cr` with `idx` appended as `INDEX` subscripts on its deepest ident.
+fn cref_with_indices(cr: &Arc<DAE::ComponentRef>, idx: &[i32]) -> Arc<DAE::ComponentRef> {
+    use DAE::ComponentRef as C;
+    match &**cr {
+        C::CREF_IDENT { ident, identType, .. } => {
+            let subs: List<Arc<DAE::Subscript>> = idx
+                .iter()
+                .map(|&i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: i }) }))
+                .collect();
+            Arc::new(C::CREF_IDENT { ident: ident.clone(), identType: identType.clone(), subscriptLst: Arc::new(subs) })
+        }
+        C::CREF_QUAL { ident, identType, subscriptLst, componentRef } => Arc::new(C::CREF_QUAL {
+            ident: ident.clone(),
+            identType: identType.clone(),
+            subscriptLst: subscriptLst.clone(),
+            componentRef: cref_with_indices(componentRef, idx),
+        }),
+        _ => cr.clone(),
+    }
+}
+
+/// Index an optional array-valued attribute (start/nominal/min/max) to element `idx`.
+fn index_attr(attr: &Option<Arc<DAE::Exp>>, idx: &[i32]) -> Option<Arc<DAE::Exp>> {
+    attr.as_ref().map(|e| index_exp(e, idx))
+}
+
+/// Element `idx` of an array expression: literal `ARRAY`/`MATRIX` indexed
+/// statically, otherwise wrapped in an `ASUB` evaluated at run time.
+fn index_exp(exp: &Arc<DAE::Exp>, idx: &[i32]) -> Arc<DAE::Exp> {
+    use DAE::Exp as E;
+    if idx.is_empty() {
+        return exp.clone();
+    }
+    match &**exp {
+        E::ARRAY { array, .. } => {
+            if let Some(e) = (&**array).into_iter().nth((idx[0] - 1) as usize) {
+                return index_exp(e, &idx[1..]);
+            }
+        }
+        E::MATRIX { matrix, .. } if idx.len() >= 2 => {
+            if let Some(row) = (&**matrix).into_iter().nth((idx[0] - 1) as usize) {
+                if let Some(e) = (&**row).into_iter().nth((idx[1] - 1) as usize) {
+                    return index_exp(e, &idx[2..]);
+                }
+            }
+        }
+        _ => {}
+    }
+    let sub: List<Arc<DAE::Subscript>> = idx
+        .iter()
+        .map(|&i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: i }) }))
+        .collect();
+    Arc::new(E::ASUB { exp: exp.clone(), sub: Arc::new(sub) })
+}
+
+/// Subscript an alias target by the same `idx`; `NOALIAS` passes through.
+fn reindex_aliasvar(av: &SimCodeVar::AliasVariable, idx: &[i32]) -> SimCodeVar::AliasVariable {
+    use SimCodeVar::AliasVariable as A;
+    match av {
+        A::ALIAS { varName } => A::ALIAS { varName: cref_with_indices(varName, idx) },
+        A::NEGATEDALIAS { varName } => A::NEGATEDALIAS { varName: cref_with_indices(varName, idx) },
+        A::NOALIAS => A::NOALIAS,
+    }
+}
+
 /// Build the cref->slot map and the result-variable list from the model's
 /// `SimVars`. The slot offsets follow [`SimLayout`]; the result order matches
 /// the C runtime (time, states, state derivatives, real algebraics, then
@@ -2137,10 +2292,11 @@ fn collect_samples(
 fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimModel> {
     let mi = &sim_code.modelInfo;
     let vi = &mi.varInfo;
-    let vars = &mi.vars;
+    let scalarized_vars = scalarize_sim_vars(&mi.vars)?;
+    let vars = &scalarized_vars;
     let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
 
-    let n_states = vi.numStateVars.max(0) as u32;
+    let n_states = count(&vars.stateVars) as u32;
     let n_real_alg = (count(&vars.algVars) + count(&vars.discreteAlgVars)) as u32;
     let n_real_param = count(&vars.paramVars) as u32;
     let samples = collect_samples(&sim_code.timeEvents)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -2629,6 +2629,87 @@ fn emit_assert(
     Ok(())
 }
 
+/// Trap on a model error whose message String handle is already on the stack
+/// (dummy source position).
+fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
+    emit_str_literal(ctx, b"")?; // file
+    for _ in 0..5 {
+        ctx.emit(we::Instruction::I32Const(0)); // line/col start+end, isReadOnly
+    }
+    ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
+    ctx.emit(we::Instruction::Unreachable);
+    Ok(())
+}
+
+/// The dumped source form of `e`, for embedding in an assertion message.
+fn dumped_exp(e: &Arc<DAE::Exp>) -> Result<String> {
+    Ok(Tpl::textString(ExpressionDumpTpl::dumpExp(Tpl::emptyTxt.clone(), e.clone(), arcstr::literal!("\""))?)?.to_string())
+}
+
+/// `nthRoot(v, n) = copysign(pow(|v|, 1/n), v)` — the real n-th root,
+/// sign-preserving for odd n — guarded by two model-error assertions: n must be
+/// > 0, and even n requires v >= 0.
+fn emit_nth_root(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>], name: &str) -> Result<SigTy> {
+    need_args(argv, 2, name)?;
+    let vw = compile_exp(ctx, argv[0])?;
+    coerce(ctx, vw, WTy::F64);
+    let vt = ctx.alloc_temp(WTy::F64);
+    ctx.emit(we::Instruction::LocalSet(vt));
+    let nw = compile_exp(ctx, argv[1])?;
+    coerce(ctx, nw, WTy::I32);
+    let nt = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(nt));
+
+    let (vstr, nstr) = (dumped_exp(argv[0])?, dumped_exp(argv[1])?);
+
+    // assert(n > 0, "…must be > 0, got <n>")
+    ctx.emit(we::Instruction::LocalGet(nt));
+    ctx.emit(we::Instruction::I32Const(0));
+    ctx.emit(we::Instruction::I32GtS);
+    ctx.emit(we::Instruction::I32Eqz);
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    emit_str_literal(ctx, format!("Model error: Second argument of nthRoot({vstr}, {nstr}) must be > 0, got ").as_bytes())?;
+    ctx.emit(we::Instruction::LocalGet(nt));
+    ctx.emit(we::Instruction::Call(rt_index("rt_int_string")?));
+    ctx.emit(we::Instruction::Call(rt_index("rt_concat")?));
+    emit_model_error(ctx)?;
+    ctx.emit(we::Instruction::End);
+
+    // assert(mod(n, 2) != 0 or v >= 0, "…must be >= 0 if the second is even, got <v>")
+    ctx.emit(we::Instruction::LocalGet(nt));
+    ctx.emit(we::Instruction::I32Const(2));
+    ctx.emit(we::Instruction::I32RemS);
+    ctx.emit(we::Instruction::I32Const(0));
+    ctx.emit(we::Instruction::I32Ne);
+    ctx.emit(we::Instruction::LocalGet(vt));
+    ctx.emit(we::Instruction::F64Const(0.0f64.into()));
+    ctx.emit(we::Instruction::F64Ge);
+    ctx.emit(we::Instruction::I32Or);
+    ctx.emit(we::Instruction::I32Eqz);
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    emit_str_literal(ctx, format!("Model error: First argument of nthRoot({vstr}, {nstr}) must be >= 0 if the second is even, got ").as_bytes())?;
+    ctx.emit(we::Instruction::LocalGet(vt));
+    ctx.emit(we::Instruction::I32Const(6)); // significant digits
+    ctx.emit(we::Instruction::I32Const(0)); // minimum length
+    ctx.emit(we::Instruction::I32Const(0)); // left justified
+    ctx.emit(we::Instruction::Call(rt_index("rt_real_format")?));
+    ctx.emit(we::Instruction::Call(rt_index("rt_concat")?));
+    emit_model_error(ctx)?;
+    ctx.emit(we::Instruction::End);
+
+    // copysign(pow(|v|, 1/n), v)
+    ctx.emit(we::Instruction::LocalGet(vt));
+    ctx.emit(we::Instruction::F64Abs);
+    ctx.emit(we::Instruction::F64Const(1.0f64.into()));
+    ctx.emit(we::Instruction::LocalGet(nt));
+    coerce(ctx, WTy::I32, WTy::F64);
+    ctx.emit(we::Instruction::F64Div);
+    ctx.emit(we::Instruction::Call(builtin_index("pow").ok_or("CodegenWasmJit: pow builtin missing")?));
+    ctx.emit(we::Instruction::LocalGet(vt));
+    ctx.emit(we::Instruction::F64Copysign);
+    Ok(SigTy::Real)
+}
+
 fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
     use DAE::Statement as S;
     match stmt {
@@ -3384,23 +3465,15 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
         match ident.as_str() {
             "$START" => {
                 let key = sim_cref_key(componentRef)?;
-                // Read the overridable start slot if this state has one.
-                if let Some(&off) = ctx.sim()?.start_slots.get(&key) {
-                    let data = ctx.sim()?.data_local;
-                    ctx.emit(we::Instruction::LocalGet(data));
-                    ctx.emit(we::Instruction::F64Load(mem_arg(off, 3)));
-                    return Ok(Some(WTy::F64));
+                if let Some(wty) = emit_sim_start_scalar(ctx, &key)? {
+                    return Ok(Some(wty));
                 }
-                let start = ctx.sim()?.starts.get(&key).cloned();
-                return match start {
-                    Some(Some(exp)) => Ok(Some(compile_exp(ctx, &exp)?)),
-                    Some(None) => {
-                        // No explicit start: the type default (0.0 for Real).
-                        ctx.emit(we::Instruction::F64Const(0.0.into()));
-                        Ok(Some(WTy::F64))
-                    }
-                    None => return Err("CodegenWasmJit: $START for unknown variable"),
-                };
+                // Whole-array `$START.y` (e.g. `y := $START.y`).
+                if let Some(group) = ctx.sim()?.array_groups.get(&key).cloned() {
+                    emit_sim_start_array_gather(ctx, &group, &key)?;
+                    return Ok(Some(WTy::I32));
+                }
+                return Err("CodegenWasmJit: $START for unknown variable");
             }
             "$PRE" => {
                 // A registered `$PRE.<var>` slot resolves via the normal path
@@ -3681,6 +3754,68 @@ fn emit_sim_array_scatter(ctx: &mut FnCtx, group: &ArrayGroup, rhs: &DAE::Exp) -
     // Consume the rhs reference (we copied out the element data, not the handle).
     ctx.emit(we::Instruction::LocalGet(h));
     ctx.emit(we::Instruction::Call(rt_index("rt_array_release")?));
+    Ok(())
+}
+
+/// Push a scalar variable's `$START` value: its overridable start slot, else its
+/// start expression, else `0.0`. `None` (nothing emitted) if `key` has no start.
+fn emit_sim_start_scalar(ctx: &mut FnCtx, key: &str) -> Result<Option<WTy>> {
+    if let Some(&off) = ctx.sim()?.start_slots.get(key) {
+        let data = ctx.sim()?.data_local;
+        ctx.emit(we::Instruction::LocalGet(data));
+        ctx.emit(we::Instruction::F64Load(mem_arg(off, 3)));
+        return Ok(Some(WTy::F64));
+    }
+    match ctx.sim()?.starts.get(key).cloned() {
+        Some(Some(exp)) => Ok(Some(compile_exp(ctx, &exp)?)),
+        Some(None) => {
+            ctx.emit(we::Instruction::F64Const(0.0.into()));
+            Ok(Some(WTy::F64))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Gather a whole array's per-element `$START` values into a fresh (refcount-1)
+/// runtime array object, leaving the owned handle on the stack.
+fn emit_sim_start_array_gather(ctx: &mut FnCtx, group: &ArrayGroup, base_key: &str) -> Result<()> {
+    let (ek, stride) = sim_array_elem_kind_stride(group.wty);
+    let ndims = group.dims.len() as u32;
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(ek as i32));
+    ctx.emit(we::Instruction::I32Const(ndims as i32));
+    ctx.emit(we::Instruction::I32Const(group.total as i32));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_new")?));
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (axis, d) in group.dims.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(axis as i32));
+        ctx.emit(we::Instruction::I32Const(*d as i32));
+        ctx.emit(we::Instruction::Call(rt_index("rt_array_set_dim")?));
+    }
+    for (lin, idx) in crate::CodegenWasmJit::row_major_indices(&group.dims).into_iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(1));
+        ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+        if lin > 0 {
+            ctx.emit(we::Instruction::I32Const((lin as u32 * stride) as i32));
+            ctx.emit(we::Instruction::I32Add);
+        }
+        let mut elem_key = String::from(base_key);
+        for i in &idx {
+            elem_key.push('[');
+            elem_key.push_str(&i.to_string());
+            elem_key.push(']');
+        }
+        let wty = emit_sim_start_scalar(ctx, &elem_key)?
+            .ok_or("CodegenWasmJit: $START for unknown array element")?;
+        coerce(ctx, wty, group.wty);
+        match group.wty {
+            WTy::F64 => ctx.emit(we::Instruction::F64Store(mem_arg(0, 3))),
+            WTy::I32 => ctx.emit(we::Instruction::I32Store(mem_arg(0, 2))),
+        }
+    }
+    ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
 }
 
@@ -4688,6 +4823,7 @@ fn compile_math_builtin(
             unary_f64(ctx, &argv, we::Instruction::F64Sqrt)?;
             Ok(SigTy::Real)
         }
+        "nthRoot" => emit_nth_root(ctx, &argv, name),
         "floor" => {
             unary_f64(ctx, &argv, we::Instruction::F64Floor)?;
             Ok(SigTy::Real)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -1766,8 +1766,9 @@ impl Driver for DasslDriver {
         let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
         let deadline = deadline_from(budget_ms);
 
-        // No states: nothing to integrate — just evaluate outputs on the grid.
-        if self.n_states == 0 {
+        // No integration — just evaluate outputs on the grid — with no states or an
+        // empty time span (`stopTime <= startTime`; a zero-width `ddaskr` step errors).
+        if self.n_states == 0 || stop <= start {
             let mut did_step = false;
             while self.row < n_rows {
                 if did_step && past_deadline(deadline) {

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6537,7 +6537,7 @@ let &sub = buffer ""
       <%assertCommonVar('<%ntmp%> > 0.0', '"Model error: Second argument of nthRoot(<%Util.escapeModelicaStringToCString(vstr)%>, <%Util.escapeModelicaStringToCString(nstr)%>) must be > 0, got %d", <%ntmp%>', context, &varDecls, dummyInfo)%>
       <%assertCommonVar('modelica_integer_mod(<%ntmp%>, 2) != 0 || <%vtmp%> >= 0.0', '"Model error: First argument of nthRoot(<%Util.escapeModelicaStringToCString(vstr)%>, <%Util.escapeModelicaStringToCString(nstr)%>) must be >= 0 if the second is even, got %g", <%vtmp%>', context, &varDecls, dummyInfo)%>
       >>
-    'pow(<%vtmp%>, 1.0/<%ntmp%>)'
+    'copysign(pow(fabs(<%vtmp%>), 1.0/<%ntmp%>), <%vtmp%>)'
 
   case CALL(path=IDENT(name="log"), expLst={e1}, attr=attr as CALL_ATTR(__)) then
     let argStr = daeExp(e1, context, &preExp, &varDecls, &auxFunction)


### PR DESCRIPTION
Two independent wasm-jit simulation fixes.

Non-scalarized array variables:

With --simCodeScalarize=false a variable like Real x[3] reaches the codegen as one SimVar carrying numArrayElement, so element assignments failed with "assignment to unknown variable" and the layout reserved a single slot per array.

Scalarize whole-array SimVars into their row-major scalar elements (cref subscripted; start/nominal/min/max and alias targets indexed to match) before building the layout, so slots, result columns and array groups all follow. Whole-array $START.y (an array state's y := $START.y init equation) now gathers per-element start values into a runtime array. Also skip the DASSL driver when stopTime <= startTime: a zero-width ddaskr step errors out (this also fixed zero-length runs of scalar models).

nthRoot:

nthRoot(v, n) computed pow(v, 1/n), which is NaN for the odd root of a negative number (e.g. nthRoot(-4, 3)); the real root is -1.5874. Make it copysign(pow(|v|, 1/n), v), sign-preserving for odd n, in three places: NFCeval.evalBuiltinNthRoot (constant folding), CodegenCFunctions.tpl (C target), and the wasm-jit codegen (new emit_nth_root). The wasm-jit lowering also emits the two domain assertions the C target does (n > 0; even n requires v >= 0), with byte-identical "Model error:" messages so failure tests match across targets.