### PR TITLE
wasm-jit: add functionUpdateRelations

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2148,6 +2148,25 @@ fn collect_zero_crossings(
     Ok(out)
 }
 
+/// Collect `SimCode.relations`, one slot per entry as in C's `functionRelations`:
+/// `Some` for a bare relation, `None` for a form C's `relationTpl` also leaves
+/// untouched while still consuming its index.
+fn collect_relations(
+    rels: &Arc<List<openmodelica_backend_types::BackendDAE::ZeroCrossing>>,
+) -> Result<Vec<Option<Arc<DAE::Exp>>>> {
+    let mut out = Vec::new();
+    for zc in lst(rels) {
+        if zc.iter.is_some() {
+            return Err("CodegenWasmJit: for-loop (iterator) relation not yet supported");
+        }
+        out.push(match &*zc.relation_ {
+            DAE::Exp::RELATION { .. } => Some(zc.relation_.clone()),
+            _ => None,
+        });
+    }
+    Ok(out)
+}
+
 /// Collect the model's `SAMPLE_TIME_EVENT`s in order. For-loop samples (with an
 /// `iter`) expand to multiple runtime samples and are not handled yet, so bail
 /// loudly rather than mis-simulate.
@@ -2180,6 +2199,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let n_real_param = count(&vars.paramVars) as u32;
     let samples = collect_samples(&sim_code.timeEvents)?;
     let zero_crossings = collect_zero_crossings(&sim_code.zeroCrossings)?;
+    let relations = collect_relations(&sim_code.relations)?;
     let stateset_scratch_f64 = stateset_scratch_f64(&sim_code.stateSets)?;
     let all_eqs = flatten_eqs(&sim_code.allEquations);
     let has_when = all_eqs.iter().any(|e| matches!(&**e, SimCode::SimEqSystem::SES_WHEN { .. }));
@@ -2620,6 +2640,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         });
         idx
     };
+    let update_relations_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if relations.iter().all(Option::is_none) {
+            empty_eqfn()
+        } else {
+            build_update_relations_fn(&relations, &var_map, &by_name, &mut literals)?
+        });
+        idx
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -2648,6 +2677,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionStateSetJacobians: (i32) -> ()
     functions.function(eqfn_type); // functionInitialEquations_lambda0: (i32) -> ()
     functions.function(eqfn_type); // functionCheckAsserts: (i32) -> ()
+    functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
 
     // --- Code section. ---
     let mut code = we::CodeSection::new();
@@ -2672,6 +2702,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionStateSetJacobians", we::ExportKind::Func, stateset_jac_idx);
     exports.export("functionInitialEquations_lambda0", we::ExportKind::Func, init_lambda0_idx);
     exports.export("functionCheckAsserts", we::ExportKind::Func, check_asserts_idx);
+    exports.export("functionUpdateRelations", we::ExportKind::Func, update_relations_idx);
 
     let mut module = we::Module::new();
     module.section(&types);
@@ -3158,6 +3189,46 @@ fn build_zero_crossings_fn(
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_zero_crossings(crossings, layout.zc_off)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionUpdateRelations(SimData*)`: C's `function_updateRelations(data,
+/// 0)`, the exact recomputation of every `relations[]` entry.
+fn build_update_relations_fn(
+    relations: &[Option<Arc<DAE::Exp>>],
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let sim = SimCtx {
+        data_local: 0,
+        vars: var_map.vars.clone(),
+        starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
+        array_groups: var_map.array_groups.clone(),
+        terminate_off: var_map.terminate_off,
+        nls_fail_off: var_map.nls_fail_off,
+        nls_jobs: var_map.nls_jobs.clone(),
+        sample_map: var_map.sample_map.clone(),
+        sample_active_off: var_map.sample_active_off,
+        relations_off: var_map.relations_off,
+        rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
+        n_relations: var_map.n_relations,
+        mathevents_off: var_map.mathevents_off,
+        n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
+        zc_context: true,
+    };
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    ctx.emit_update_relations(relations, var_map.relations_off)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -3896,6 +3967,7 @@ mod standalone_tests {
             "functionZeroCrossings",
             "functionStateSetJacobians",
             "functionInitialEquations_lambda0",
+            "functionUpdateRelations",
         ];
 
         let mut funcs = we::FunctionSection::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1121,6 +1121,32 @@ impl<'a> FnCtx<'a> {
         Ok(())
     }
 
+    /// Emit `functionUpdateRelations`: store each relation's exact value into
+    /// `relations[i]`, C's `function_updateRelations(data, 0)`. No hysteresis band
+    /// and no held `relationsPre`, so the event handler can snapshot the result as
+    /// the band direction. `None` entries keep their index without a store.
+    pub(crate) fn emit_update_relations(
+        &mut self,
+        relations: &[Option<Arc<DAE::Exp>>],
+        relations_off: u32,
+    ) -> Result<()> {
+        let data = self.sim()?.data_local;
+        if relations.len() > self.sim()?.n_relations as usize {
+            return Err("CodegenWasmJit: relations list longer than the relations[] region");
+        }
+        for (i, rel) in relations.iter().enumerate() {
+            let Some(rel) = rel else { continue };
+            let DAE::Exp::RELATION { exp1, operator, exp2, .. } = &**rel else {
+                return Err("CodegenWasmJit: non-relation in the relations list");
+            };
+            self.emit(we::Instruction::LocalGet(data));
+            let w = compile_relation_fresh(self, exp1, operator, exp2)?;
+            coerce(self, w, WTy::I32);
+            self.emit(we::Instruction::I32Store(mem_arg(relations_off + i as u32 * 4, 2)));
+        }
+        Ok(())
+    }
+
     /// Lower a `when {conditions} then whenStmtLst; elseWhen` equation. The body
     /// runs on the rising edge of any condition — `cond && !pre(cond)`, matching
     /// the C target (`equationWhen`) — so it fires once per event and pre-values

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -51,10 +51,11 @@ const SLOT_INIT_SAMPLE: u32 = 7;
 const SLOT_SIMULATE: u32 = 8;
 const SLOT_EXT_DESTRUCT: u32 = 9;
 const SLOT_INIT_EQ_LAMBDA0: u32 = 10;
+const SLOT_UPDATE_RELATIONS: u32 = 11;
 /// Number of table slots the host must populate (in the order above). The host
 /// (a separate crate) mirrors this count and order in its table wiring.
 #[allow(dead_code)]
-pub const N_SLOTS: u32 = 11;
+pub const N_SLOTS: u32 = 12;
 
 fn slot_of(name: &str) -> Option<u32> {
     Some(match name {
@@ -68,6 +69,7 @@ fn slot_of(name: &str) -> Option<u32> {
         "functionZeroCrossings" => SLOT_ZERO_CROSSINGS,
         "initSample" => SLOT_INIT_SAMPLE,
         "callExternalObjectDestructors" => SLOT_EXT_DESTRUCT,
+        "functionUpdateRelations" => SLOT_UPDATE_RELATIONS,
         _ => return None,
     })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -42,6 +42,7 @@ unsafe extern "C" {
     fn functionAlgebraics(sim_data: u32);
     fn functionStateSetJacobians(sim_data: u32);
     fn functionZeroCrossings(sim_data: u32);
+    fn functionUpdateRelations(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
@@ -92,6 +93,7 @@ impl SimEngine for StandaloneEngine {
                 "functionAlgebraics" => functionAlgebraics(arg),
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
                 "functionZeroCrossings" => functionZeroCrossings(arg),
+                "functionUpdateRelations" => functionUpdateRelations(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("wasm-jit standalone: unknown model function"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -47,6 +47,7 @@ unsafe extern "C" {
     fn functionAlgebraics(sim_data: u32);
     fn functionStateSetJacobians(sim_data: u32);
     fn functionZeroCrossings(sim_data: u32);
+    fn functionUpdateRelations(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn om_meta_ptr() -> u32;
@@ -112,6 +113,7 @@ impl SimEngine for Engine {
                 "functionAlgebraics" => functionAlgebraics(arg),
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
                 "functionZeroCrossings" => functionZeroCrossings(arg),
+                "functionUpdateRelations" => functionUpdateRelations(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("fmi3-me: unknown model function"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -893,6 +893,16 @@ fn store_relations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> 
     e.write_bytes(sim_data + layout.stored_rel_off, &buf)
 }
 
+/// C's `updateDiscreteSystem` prologue: recompute every relation exactly, then
+/// seed both `relationsPre` and the held snapshot from it. Without it the snapshot
+/// comes from the banded evaluation the old snapshot itself steers, so a crossing
+/// is never consumed.
+fn refresh_relations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    e.call1("functionUpdateRelations", sim_data)?;
+    update_relations_pre(e, sim_data, layout)?;
+    store_relations(e, sim_data, layout)
+}
+
 /// Copy `relations[]` into `relationsPre`. Freezing it before an event-iteration
 /// pass keeps held relations fixed while that pass's NLS solve runs.
 fn update_relations_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
@@ -1100,7 +1110,7 @@ pub fn event_update(
         if let Some(s) = samples.as_deref_mut() {
             s.fire(e, sim_data, time)?;
         }
-        store_relations(e, sim_data, layout)?;
+        refresh_relations(e, sim_data, layout)?;
         // `fire` cleared the `active` flag; re-evaluate so the condition reads
         // false and `pre` records it, or the next firing sees no edge.
         e.call1("functionODE", sim_data)?;
@@ -1108,7 +1118,7 @@ pub fn event_update(
     } else {
         // `pre(x)` of a continuous variable must be its value at the crossing.
         save_pre_real(e, sim_data, layout)?;
-        store_relations(e, sim_data, layout)?;
+        refresh_relations(e, sim_data, layout)?;
         iterate_discrete(e, sim_data, layout)?;
         store_relations(e, sim_data, layout)?;
         check_nls(e, sim_data, layout)?;
@@ -2302,7 +2312,7 @@ impl DasslCore {
                 }
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
-                store_relations(e, sim_data, layout)?; // advance the hysteresis direction
+                refresh_relations(e, sim_data, layout)?;
                 self.time_events += 1;
                 if let Some(r) = rows.as_deref_mut() {
                     emit_row(e, r, sim_data, layout, te)?;
@@ -2449,7 +2459,7 @@ impl CsDriver {
         }
         // Refresh the outputs at the communication point, and re-select states there
         // (see `DasslDriver`).
-        write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
         write_f64(e, sim_data + TIME_OFF, t_target)?;
         e.call1("functionODE", sim_data)?;
         e.call1_if_present("functionAlgebraics", sim_data)?;
@@ -2517,7 +2527,7 @@ impl CsDriver {
             Step::Reached { .. } => {}
         }
         // Communication point reached with no event: refresh outputs like `step_to`.
-        write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
         write_f64(e, sim_data + TIME_OFF, t_target)?;
         e.call1("functionODE", sim_data)?;
         e.call1_if_present("functionAlgebraics", sim_data)?;
@@ -2636,7 +2646,7 @@ impl DasslEventsDriver {
         // A sample scheduled exactly at the start time fires before row 0.
         if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
             samp.fire(e, sim_data, start)?;
-            store_relations(e, sim_data, layout)?;
+            refresh_relations(e, sim_data, layout)?;
             core.time_events += 1;
         }
         emit_row(e, &mut rows, sim_data, layout, start)?;
@@ -2747,7 +2757,7 @@ impl Driver for DasslEventsDriver {
                         emit_row(e, &mut self.rows, sim_data, layout, te)?; // pre-event row
                         write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh
                         self.samp.fire(e, sim_data, te)?;
-                        store_relations(e, sim_data, layout)?;
+                        refresh_relations(e, sim_data, layout)?;
                         self.core.time_events += 1;
                         emit_row(e, &mut self.rows, sim_data, layout, te)?; // post-event row
                         if terminated(e, sim_data, layout)? {
@@ -2766,10 +2776,7 @@ impl Driver for DasslEventsDriver {
                     }
                 }
                 if !grid_covered {
-                    // Fresh (mode 1) output solve: every event up to `tout` is already
-                    // handled above, so no when-edge fires here, while an algebraic loop
-                    // (e.g. an ideal-diode network) needs its relations solved fresh.
-                    write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+                    write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
                     emit_row(e, &mut self.rows, sim_data, layout, tout)?;
                     if terminated(e, sim_data, layout)? {
                         self.finished = true;
@@ -2822,7 +2829,7 @@ impl Driver for DasslEventsDriver {
             // Row's inner loop done; the rest is bounded — next yield is a clean boundary.
             self.mid_row = false;
             if !self.grid_covered {
-                write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+                write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
                 did_step = true;
                 emit_row(e, &mut self.rows, sim_data, layout, tout)?;
                 if terminated(e, sim_data, layout)? {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -127,7 +127,7 @@ pub fn encode_overrides() -> Vec<u8> {
 /// Model export names in the fixed table-slot order the in-wasm session driver
 /// expects; must stay in sync with `openmodelica_codegen_wasm_jit_runtime::session`.
 #[cfg(feature = "jit")]
-pub const INWASM_SLOT_NAMES: [&str; 11] = [
+pub const INWASM_SLOT_NAMES: [&str; 12] = [
     "functionParameters",
     "functionInitStartValues",
     "functionInitialEquations",
@@ -139,4 +139,5 @@ pub const INWASM_SLOT_NAMES: [&str; 11] = [
     "simulate",
     "callExternalObjectDestructors",
     "functionInitialEquations_lambda0",
+    "functionUpdateRelations",
 ];


### PR DESCRIPTION
The C runtime opens every event in updateDiscreteSystem with function_updateRelations(data, 0), an exact recomputation of all relations[], then updateRelationsPre + storeRelations. wasm-jit had no such pass, so the hysteresis direction was snapshotted from a banded evaluation that the old direction itself steered, and a crossing the integrator had just located was never consumed.

Emit functionUpdateRelations from SimCode.relations, using C's functionRelations indexing, and run it as an event prologue in the driver. Register the new export in the standalone, in-wasm session, FMI3 and JIT engines.

Also stop setting rel_fresh = 1 at output points. C sets discreteCall only inside functionDAE; output rows go through updateContinuousSystem with relations held, so evaluating them fresh was rewriting relations[] between events. The three direct sample-fire paths now use the same refresh sequence as event_update.

This is not sufficient for simulation/modelica/tearing/minimalTearing: the NLS Newton solve still runs with relations live, so the event iteration can settle on a branch that undoes the exact update.