### PR TITLE
Fix spatialDistribution for nonzero start value of x

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -106,6 +106,9 @@ SPATIAL_DISTRIBUTION_DATA* allocSpatialDistribution(unsigned int nSpatialDistrib
   for(i=0; i<nSpatialDistributions; i++) {
     spatialDistributionData[i].index = i;
     spatialDistributionData[i].isInitialized = 0 /* false */;
+    spatialDistributionData[i].startPosXSet = 0 /* false */;
+    spatialDistributionData[i].startPosX = 0.0 /* false */;
+    spatialDistributionData[i].oldPosX = 0.0;
     spatialDistributionData[i].transportedQuantity = allocDoubleEndedList(sizeof(TRANSPORTED_QUANTITY_DATA)); /* empty double ended list */
     spatialDistributionData[i].storedEvents = allocDoubleEndedList(sizeof(TRANSPORTED_EVENT_DATA));           /* empty double ended list */
     spatialDistributionData[i].lastStoredEventValue = 0;
@@ -235,6 +238,30 @@ void initSpatialDistribution(DATA* data, threadData_t* threadData, unsigned int 
 
 
 /**
+ * @brief Shift posX so that the operator internally starts at x = 0.
+ *
+ * The spatialDistribution operator only depends on the change of the spatial
+ * coordinate x (the transport distance), not on its absolute value, and its
+ * initial profile (initialPoints/initialValues) is stored assuming x(t0) = 0.
+ * The value of x at the very first call is captured once and subtracted from
+ * every subsequent posX, so a model where x has a nonzero start value behaves
+ * exactly like one starting at x = 0 (and no longer triggers a spurious
+ * "x got reinitialized during an event" error at the initial event).
+ *
+ * @param spatialDistribution   Spatial distribution to shift for.
+ * @param posX                  Value of position x.
+ * @return double               posX relative to its value at the first call.
+ */
+static double shiftToStartPosX(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double posX) {
+  if (!spatialDistribution->startPosXSet) {
+    spatialDistribution->startPosX = posX;
+    spatialDistribution->startPosXSet = 1 /* true */;
+  }
+  return posX - spatialDistribution->startPosX;
+}
+
+
+/**
  * @brief Store spatial distribution data for an accepted step.
  *
  * @param data                Data
@@ -258,6 +285,9 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
   transportedQuantityList = spatialDistribution->transportedQuantity;
   storedEventsList = spatialDistribution->storedEvents;
+
+  /* Shift x so the operator starts at x = 0 (only the change of x matters) */
+  posX = shiftToStartPosX(spatialDistribution, posX);
 
   /* Debug log */
   infoStreamPrint(OMC_LOG_SPATIALDISTR, 1, "Calling storeSpatialDistribution (index=%i, time=%e)", index, data->localData[0]->timeValue);
@@ -367,10 +397,12 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
   transportedQuantityList = spatialDistribution->transportedQuantity;
 
+  /* Shift x so the operator starts at x = 0 (only the change of x matters) */
+  posX = shiftToStartPosX(spatialDistribution, posX);
+
   /* Debug log */
   infoStreamPrint(OMC_LOG_SPATIALDISTR, 1, "Calling spatialDistribution (index=%i, time=%e)", index, data->localData[0]->timeValue);
-  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = spatialDistribution(%f, %f, %f, %s)", in0, in1, posX, isPositiveVelocity?"true":"false");
-  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "                                     in0        in1        x     isPositiveVelocity");
+  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "(out0,out1) = spatialDistribution(in0=%f, in1=%f, x=%f, isPositiveVelocity=%s)", in0, in1, posX, isPositiveVelocity?"true":"false");
   doubleEndedListPrint(transportedQuantityList, OMC_LOG_SPATIALDISTR, &printTransportedQuantity);
 
   /* Get deltaX */
@@ -494,9 +526,12 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
   storedEventsList = spatialDistribution->storedEvents;
 
+  /* Shift x so the operator starts at x = 0 (only the change of x matters) */
+  posX = shiftToStartPosX(spatialDistribution, posX);
+
   if (doubleEndedListLen(storedEventsList) == 0) {
     zeroCrossingValue = data->simulationInfo->zeroCrossingsPre[relationIndex];
-    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "List of events for spatialDistributionZeroCrossing(%e) = %e\n", posX, zeroCrossingValue);
+    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "spatialDistributionZeroCrossing(%e) = %e (no stored events, returning previous value)", posX, zeroCrossingValue);
     return zeroCrossingValue;
   }
 
@@ -565,7 +600,7 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
   }
 
 
-  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "List of events for spatialDistributionZeroCrossing(%e) = %e\n", posX, zeroCrossingValue);
+  infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "List of events for spatialDistributionZeroCrossing(%e) = %e", posX, zeroCrossingValue);
   doubleEndedListPrint(storedEventsList, OMC_LOG_SPATIALDISTR, &printTransportedQuantity);
 
   return zeroCrossingValue;
@@ -783,7 +818,7 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
 
   currentDistance = fabs(currentNodeData->position - edgeNodePosition);
   if (currentDistance + SPATIAL_EPS < 1) {
-    errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\nThis case should not be possible. Please open a bug reoprt about it.");
+    errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\nThis case should not be possible. Please open a bug report about it.");
     omc_throw_function(NULL);
     return walkedOverEvents;
   }

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -782,6 +782,12 @@ typedef struct SPATIAL_DISTRIBUTION_DATA {
 
   modelica_real oldPosX;
 
+  modelica_boolean startPosXSet;  /* true once startPosX has been captured */
+  modelica_real startPosX;        /* value of x at the first call; x is shifted by
+                                     this so the operator always starts at x = 0.
+                                     Only the change of x (transport distance)
+                                     matters, so a nonzero start value of x is fine. */
+
   DOUBLE_ENDED_LIST* transportedQuantity;
   DOUBLE_ENDED_LIST* storedEvents;
   int lastStoredEventValue;

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -8,6 +8,7 @@ TESTFILES = \
 	pulseInput.mos \
 	mixedVelocity.mos \
 	bigSteps.mos \
+	nonZeroStartPosition.mos \
 	test1.mos \
 	test2.mos \
 	test3.mos \

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/nonZeroStartPosition.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/nonZeroStartPosition.mos
@@ -1,0 +1,72 @@
+// name:                nonZeroStartPosition.mos
+// keywords:            spatialDistribution, initialization
+// status:              correct
+// teardown_command:    rm -f SingleBeltNonZeroStartX*
+//
+// Regression test for issue #16100.
+// The spatial coordinate x of spatialDistribution does not start at 0. Only the
+// change of x (the transport distance) is physically relevant, so this must give
+// the same result as the same model with x(start=0). Previously the simulation
+// aborted at the initial event with
+//   "x got reinitialized during an event at time 0.000000. OpenModelica can't handle that."
+// because the operator's internal previous position was left at 0 instead of x(t0).
+
+loadModel(Modelica); getErrorString();
+loadString("
+  model SingleBeltNonZeroStartX
+    \"Single conveyor belt with constant positive velocity and input from the
+    left side, but with a spatial coordinate x that starts at 3.7 instead of 0.
+    rightOutput must match the analytical solution just like when x starts at 0.\"
+  extends Modelica.Icons.Example;
+  Real leftInput = sin(time);
+  Real rightInput = 0;
+  Real leftOutput;
+  Real rightOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {0.0, 1.0};
+  Real v = 1;
+  Boolean posV = v >= 0;
+  Real x(start = 3.7, fixed = true);
+  Real solution = if time < 1 then 1-time else sin(time-1);
+equation
+  v = der(x);
+  (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
+end SingleBeltNonZeroStartX;"); getErrorString();
+
+// Simulate
+simulate(SingleBeltNonZeroStartX, stopTime=2.0); getErrorString();
+
+// Initial value at the right output
+val(rightOutput, 0.0);  val(solution, 0.0);
+val(rightOutput, 0.5);  val(solution, 0.5);
+val(rightOutput, 1.0);  val(solution, 1.0);
+
+// Input from 1 second ago (belt fully traversed)
+val(rightOutput, 1.5);  val(solution, 1.5);
+val(rightOutput, 2.0);  val(solution, 2.0);
+
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "SingleBeltNonZeroStartX_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'SingleBeltNonZeroStartX', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 1.0
+// 0.5040000000000004
+// 0.5
+// 0.0040000000000004485
+// 0.0
+// 0.4759113823183197
+// 0.479425538604203
+// 0.8414709848078961
+// 0.8414709848078965
+// endResult


### PR DESCRIPTION
### Related Issues

Fixes #16100.

### Purpose

The operator aborted with "x got reinitialized during an event" whenever its spatial coordinate x did not start at 0: its previous position is zero-initialized, so at the initial event deltaX = 0 - x(t0) tripped the reinit guard.

### Approach

Per the Modelica spec (3.7.2.2) only the change of x matters, so capture x at the first call and subtract it everywhere. x(start=k) now gives the same result as x(start=0) for any k. Adds regression test nonZeroStartPosition.mos.
