### PR TITLE
[NB,C] Fix invalid C for non-Real iteration variables in static NLS data

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3497,12 +3497,22 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName, S
           sysData->min[i]     = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, <%kind%>, <%crefIndexWithComment(cr)%>);
           sysData->max[i++]   = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, <%kind%>, <%crefIndexWithComment(cr)%>);
           >>
+      case SIMVAR(type_=T_INTEGER(__))
+      case SIMVAR(type_=T_ENUMERATION(__)) then
+        <<
+        <%cComment%>
+        /* Integer iteration variable: nominal is a Real-only attribute, use neutral scaling. */
+        sysData->nominal[i] = 1.0;
+        sysData->min[i]     = <%crefAttributes(cr)%>.min;
+        sysData->max[i++]   = <%crefAttributes(cr)%>.max;
+        >>
       else
         <<
         <%cComment%>
-        sysData->nominal[i] = <%crefAttributes(cr)%>.nominal;
-        sysData->min[i]     = <%crefAttributes(cr)%>.min;
-        sysData->max[i++]   = <%crefAttributes(cr)%>.max;
+        /* iteration variable without nominal/min/max attributes: use defaults */
+        sysData->nominal[i] = 1.0;
+        sysData->min[i]     = -DBL_MAX;
+        sysData->max[i++]   = DBL_MAX;
         >>
 
   ;separator="\n")


### PR DESCRIPTION
### Problem

`generateStaticInitialData` (CodegenC.tpl) emits per-variable scaling/bounds
for the iteration variables of a nonlinear system. The fallthrough `else`
case unconditionally emitted `<attr>.nominal`:

```c
sysData->nominal[i] = <crefAttributes>.nominal;
```

Only `REAL_ATTRIBUTE` has a `nominal` field. `INTEGER_ATTRIBUTE`,
`BOOLEAN_ATTRIBUTE` and `STRING_ATTRIBUTE` do not. Any NLS with a non-Real
iteration variable therefore generates C that fails to compile:

```
error: no member named 'nominal' in 'struct INTEGER_ATTRIBUTE'
```

Reproducer (new backend): `Modelica.Fluid.Examples.InverseParameterization`,
whose nonlinear loop iterates on a medium `phase` Integer variable — its
`_02nls.c` fails to build.

### Fix

Split the fallthrough by type in `generateStaticInitialData`:

- **Integer / enumeration**: `nominal` is Real-only, so use neutral scaling
  `1.0` and read `min`/`max` from the integer attribute struct (which has them;
  enums are stored in `integerVarsData`).
- **everything else (Boolean / String)**: use neutral defaults
  (`1.0` / `-DBL_MAX` / `DBL_MAX`) rather than dereferencing nonexistent members.

### Testing

`omc --newBackend` on `Modelica.Fluid.Examples.InverseParameterization` now
generates C that compiles cleanly (previously failed with the error above).
