### PR TITLE
[OB/NB] restrict type safety to new backend

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1657,7 +1657,7 @@ algorithm
           // Also ensure the struct type itself is declared. Without this, sizeof(name) and
           // function return types using 'name' produce "unknown type name" C errors, because
           // RECORD_DECL_ADD_CONSTRCTOR does not emit a typedef or struct for the base record.
-          if isNone(UnorderedMap.get(name, recDeclsMap)) then
+          if Flags.getConfigBool(Flags.NEW_BACKEND) and isNone(UnorderedMap.get(name, recDeclsMap)) then
             vars := List.map(varlst, typesVar);
             recDecl := SimCodeFunction.RECORD_DECL_FULL(name, NONE(), path, vars, usedExternally);
             UnorderedMap.add(name, recDecl, recDeclsMap);


### PR DESCRIPTION
 - only create new record declaration for type safety for the new backend. the old backend seems to have some backup in the code generation for this that needs it the old way
 - fixes #16097
