### PR TITLE
wasm-jit: non-trapping float-to-int conversions

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -4558,7 +4558,7 @@ fn compile_math_event(
             ctx.emit(I::LocalGet(data));
             ctx.emit(I::F64Load(mem_arg(base, 3)));
             match name {
-                "integer" => { ctx.emit(I::I32TruncF64S); Ok(SigTy::Int) }
+                "integer" => { ctx.emit(I::I32TruncSatF64S); Ok(SigTy::Int) }
                 "ceil" => { ctx.emit(I::F64Ceil); Ok(SigTy::Real) }
                 _ => { ctx.emit(I::F64Floor); Ok(SigTy::Real) }
             }
@@ -4700,7 +4700,7 @@ fn compile_math_builtin(
         // integer(r): largest Integer <= r.
         "integer" => {
             unary_f64(ctx, &argv, we::Instruction::F64Floor)?;
-            ctx.emit(we::Instruction::I32TruncF64S);
+            ctx.emit(we::Instruction::I32TruncSatF64S);
             Ok(SigTy::Int)
         }
         // `Integer(e)` — the ordinal of an enumeration value. Enum values are
@@ -6414,7 +6414,9 @@ fn need_args(argv: &[&Arc<DAE::Exp>], n: usize, name: &str) -> Result<()> {
 fn coerce(ctx: &mut FnCtx, from: WTy, to: WTy) {
     match (from, to) {
         (WTy::I32, WTy::F64) => ctx.emit(we::Instruction::F64ConvertI32S),
-        (WTy::F64, WTy::I32) => ctx.emit(we::Instruction::I32TruncF64S),
+        // Saturating (non-trapping): a transient NaN/out-of-range value from an NLS
+        // probe must not trap the module.
+        (WTy::F64, WTy::I32) => ctx.emit(we::Instruction::I32TruncSatF64S),
         _ => {}
     }
 }


### PR DESCRIPTION
MixedTearing1/2-minimal failed with "wasm engine error": a wasm `i32.trunc_f64_s` traps on NaN / out-of-range, and a mixed Real/Integer/Boolean tearing system transiently produces such a value during an NLS probe, converted back to the Integer torn variable.

C's `(modelica_integer)` cast does not trap, so use the saturating `i32.trunc_sat_f64_s` for every Real->Integer conversion (the `coerce` choke point and the two `integer()` builtins). A valid value converts identically; a transient bad one saturates instead of trapping, so the solve proceeds and settles on the correct branch.

Both models now simulate and match a local C run exactly.