### PR TITLE
wasm-jit: C-faithful NLS relations at events

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -423,16 +423,14 @@ pub extern "C" fn rt_solve_nls(
 
     let mut scratch = vec![0.0f64; n];
     let mut x = guess.clone();
-    // At an event (mode 1) keep relations hysteretic during Newton, as C does (its
-    // residual recomputes them via `LessZC`/`GreaterZC` each eval). Freezing to
-    // `relationsPre` (mode 0) locks the discrete branch of a coupled system such as
-    // Rotational friction (sa ↔ mode/startForward) to the guess, converging to a
-    // different root than C. Integration (0) stays held/smooth; init (2) stays fresh.
+    // C's `solve_nonlinear_system`: Newton holds relations (`solveContinuous`); at an
+    // event, prime once live then hold, priming and solving from `nlsxOld` (=`warm`).
+    // Extrapolating past a just-switched branch re-flips the relation the event set.
     if saved_rel_fresh == 1 {
-        // Prime relations at the guess so a branch switch reaches the driver's event
-        // loop, then leave mode 1 for Newton.
         unsafe { store_u32(rel_fresh_addr, 1) };
-        eval(&x, &mut scratch);
+        eval(&warm, &mut scratch);
+        unsafe { store_u32(rel_fresh_addr, 0) };
+        x.copy_from_slice(&warm);
     } else if saved_rel_fresh == 0 {
         unsafe { store_u32(rel_fresh_addr, 0) };
     }


### PR DESCRIPTION
The NLS-at-event solve did not mirror C's solve_nonlinear_system, so minimalTearing (Rectifier) diverged from C early and gave the wrong result. Three things had to match C, all together:

- Hold the indexed relations (mode 0) for the whole Newton solve, as C does with solveContinuous=1. Solving with live relations let the NLS settle on a self-consistent wrong branch and consume a pending zero-crossing (e.g. IdealDiode2.s<0), so an event C fires was missed.
- Prime the relations at the last solution (nlsxOld = warm), not the extrapolated guess. C's getInitialGuess sets nlsx=nlsxOld and updateInnerEquation evaluates the residual there. At a crossing the last solution sits on the boundary, so the hysteresis keeps the relation the event just set; the extrapolation overshoots the switched branch and re-flips it (which made holding alone stall DASSL).
- Start Newton from nlsxOld too. The extrapolated start converged to a grazing s that tipped a knife-edge diode crossing into spurious events.

minimalTearing now matches both the msl32 reference and a local C run; TestNLS, BouncingBall, DoublePendulumInitTip and CharacteristicIdealDiodes are unaffected.