### PR TITLE
Freeze spatialDistribution in conditional branch when inactive

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -272,6 +272,7 @@ uniontype SpatialDistribution
     DAE.Exp initPnts      "initial grid points";
     DAE.Exp initVals      "initial grid values";
     Integer initSize      "number of initial points";
+    Option<DAE.Exp> condition "guard condition of the enclosing if-branch, if any";
   end SPATIAL_DISTRIBUTION;
 end SpatialDistribution;
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -5894,21 +5894,33 @@ protected
   list<SimCode.SpatialDistribution> spatial_lst;
   Mutable<Integer> maxIndex_ptr = Mutable.create(-1);
 algorithm
-  (_,spatial_lst) := BackendDAEUtil.traverseBackendDAEExps(dlow, Expression.traverseSubexpressionsHelper, (function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), {}));
+  // Traverse top-down so we can keep track of the guard condition of the
+  // enclosing if-branch a spatialDistribution() operator sits in. The
+  // storeSpatialDistribution() callback must be guarded by the same condition
+  (_, (_, spatial_lst)) := BackendDAEUtil.traverseBackendDAEExps(dlow, Expression.traverseSubexpressionsTopDownHelper, (function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), (NONE(), {})));
   spatialInfo := SimCode.SPATIAL_DISTRIBUTION_INFO(spatial_lst, Mutable.access(maxIndex_ptr));
 end extractSpatialDistributionInfo;
 
 function extractSpatialDistributionInfoExp
+  "Top-down expression traversal that collects every spatialDistribution() call
+   together with the guard condition of the enclosing if-branch it sits in.
+   The condition is carried in the traversal argument and conjoined per branch
+   (then = cond, else = not cond) so the generated storeSpatialDistribution
+   callback can be guarded by the same event as the operator's evaluation."
   input output DAE.Exp callExp;
-  input output list<SimCode.SpatialDistribution> spatialInfo;
+  output Boolean cont "Continue descending flag for Expression.traverseExpTopDown";
+  input output tuple<Option<DAE.Exp>, list<SimCode.SpatialDistribution>> tpl "current guard condition and collected operators";
   input Mutable<Integer> maxIndex_ptr;
 algorithm
-  spatialInfo := match callExp
+  (cont, tpl) := match callExp
     local
       Integer i, initSize;
-      DAE.Exp in0, in1, pos, dir, initPnts, initVals;
+      DAE.Exp in0, in1, pos, dir, initPnts, initVals, cond, tb, fb;
+      Option<DAE.Exp> curCond;
+      list<SimCode.SpatialDistribution> spatialInfo;
     case DAE.CALL(path = Absyn.IDENT("spatialDistribution"), expLst={DAE.ICONST(i), in0, in1, pos, dir, initPnts, initVals})
       algorithm
+        (curCond, spatialInfo) := tpl;
         if i > Mutable.access(maxIndex_ptr) then
           Mutable.update(maxIndex_ptr, i);
         end if;
@@ -5916,10 +5928,35 @@ algorithm
           Error.addInternalError("function extractDelayedExpressions failed: initialPoints and initialValues of spatialDistribution are not of the same size.", sourceInfo());
         end if;
         initSize := Expression.sizeOf(Expression.typeof(initPnts));
-    then SimCode.SPATIAL_DISTRIBUTION(i, in0, in1, pos, dir, initPnts, initVals, initSize) :: spatialInfo;
-    else spatialInfo;
+        spatialInfo := SimCode.SPATIAL_DISTRIBUTION(i, in0, in1, pos, dir, initPnts, initVals, initSize, curCond) :: spatialInfo;
+    then (true, (curCond, spatialInfo));
+
+    // Descend into the branches ourselves so the accumulated guard condition
+    // can differ between the then- and else-branch. Return cont=false to keep
+    // the generic traversal from visiting the children a second time.
+    case DAE.IFEXP(cond, tb, fb)
+      algorithm
+        (curCond, spatialInfo) := tpl;
+        (_, (_, spatialInfo)) := Expression.traverseExpTopDown(cond, function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), (curCond, spatialInfo));
+        (_, (_, spatialInfo)) := Expression.traverseExpTopDown(tb, function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), (SOME(combineGuardCondition(curCond, cond)), spatialInfo));
+        (_, (_, spatialInfo)) := Expression.traverseExpTopDown(fb, function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), (SOME(combineGuardCondition(curCond, Expression.negate(cond))), spatialInfo));
+    then (false, (curCond, spatialInfo));
+
+    else (true, tpl);
   end match;
 end extractSpatialDistributionInfoExp;
+
+function combineGuardCondition
+  "Conjoins an outer guard condition (if any) with a branch condition."
+  input Option<DAE.Exp> outerCond;
+  input DAE.Exp branchCond;
+  output DAE.Exp cond;
+algorithm
+  cond := match outerCond
+    case SOME(cond) then DAE.LBINARY(cond, DAE.AND(DAE.T_BOOL_DEFAULT), branchCond);
+    else branchCond;
+  end match;
+end combineGuardCondition;
 
 public function createExtObjInfo
   input BackendDAE.Shared shared;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3954,18 +3954,37 @@ template functionStoreSpatialDistribution(SpatialDistributionInfo spatialInfo, S
 ::=
   let &varDecls = buffer ""
   let &auxFunction = buffer ""
-  let storePart = (match spatialInfo case SPATIAL_DISTRIBUTION_INFO(__) then (spatialDistributions |> SPATIAL_DISTRIBUTION(index=index, in0=in0, in1=in1, pos=pos, dir=dir) =>
+  let storePart = (match spatialInfo case SPATIAL_DISTRIBUTION_INFO(__) then (spatialDistributions |> SPATIAL_DISTRIBUTION(index=index, in0=in0, in1=in1, pos=pos, dir=dir, condition=condition) =>
       let &preExp = buffer ""
       let in0T = daeExp(in0, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
       let in1T = daeExp(in1, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
       let posT = daeExp(pos, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
       let dirT = daeExp(dir, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
       // TODO @kabdelhak Use index of equation here, not the index of the spatial distribution
-      <<
-      equationIndexes[1] = <%index%>;
-      <%preExp%>
-      storeSpatialDistribution(data, threadData, <%index%>, <%in0T%>, <%in1T%>, <%posT%>, <%dirT%>);<%\n%>
-      >>
+      let storeStmts =
+        <<
+        equationIndexes[1] = <%index%>;
+        <%preExp%>
+        storeSpatialDistribution(data, threadData, <%index%>, <%in0T%>, <%in1T%>, <%posT%>, <%dirT%>);
+        >>
+      // When the spatialDistribution() operator sits inside an if-branch its
+      // evaluation is guarded by an event; the store must use the same guard,
+      // otherwise the operator's buffer is mutated while it is inactive (#16099).
+      match condition
+        case SOME(cond) then
+          let &condPreExp = buffer ""
+          let condT = daeExp(cond, contextSimulationNonDiscrete, &condPreExp, &varDecls, &auxFunction)
+          <<
+          <%condPreExp%>
+          if(<%condT%>)
+          {
+            <%storeStmts%>
+          }<%\n%>
+          >>
+        else
+          <<
+          <%storeStmts%><%\n%>
+          >>
     ))
   <<
   <%auxFunction%>

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -604,6 +604,7 @@ end SparsityRow;
       DAE.Exp initPnts      "initial grid points";
       DAE.Exp initVals      "initial grid values";
       Integer initSize      "number of initial points";
+      Option<DAE.Exp> condition "guard condition of the enclosing if-branch, if any";
     end SPATIAL_DISTRIBUTION;
   end SpatialDistribution;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -526,8 +526,17 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
   storedEventsList = spatialDistribution->storedEvents;
 
-  /* Shift x so the operator starts at x = 0 (only the change of x matters) */
-  posX = shiftToStartPosX(spatialDistribution, posX);
+  /* Shift x so the operator starts at x = 0 (only the change of x matters).
+   * Do NOT capture the start position here: the zero-crossing function is
+   * evaluated unconditionally by the solver, also while the operator is frozen
+   * inside an inactive if-branch. Capturing the start position here would mark
+   * the operator as started too early and make the guarded storeSpatialDistribution/
+   * spatialDistribution calls see a spurious jump in x (#16099). While the
+   * operator has not started yet its event list is empty and the returned value
+   * does not depend on posX anyway. */
+  if (spatialDistribution->startPosXSet) {
+    posX = posX - spatialDistribution->startPosX;
+  }
 
   if (doubleEndedListLen(storedEventsList) == 0) {
     zeroCrossingValue = data->simulationInfo->zeroCrossingsPre[relationIndex];

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -9,6 +9,7 @@ TESTFILES = \
 	mixedVelocity.mos \
 	bigSteps.mos \
 	nonZeroStartPosition.mos \
+	SpatialDistributionEvent.mos \
 	test1.mos \
 	test2.mos \
 	test3.mos \

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/SpatialDistributionEvent.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/SpatialDistributionEvent.mos
@@ -1,0 +1,64 @@
+// name:                SpatialDistributionEvent
+// keywords:            spatialDistribution, event
+// status:              correct
+// teardown_command:    rm -f SpatialDistributionBehindEvent*
+//
+// Model with spatialDistribution inside if-equation
+
+loadString("
+model SpatialDistributionBehindEvent
+  \"spatialDistribution() sitting inside the then-branch of a state-event
+   condition. While myCondition = false (time < 0.5) the operator is frozen:
+   it stores nothing and out1 comes from the else-branch. At time = 0.5 the
+   operator activates and starts transporting in0 = time with velocity der(x) = 1.
+   Because the transport domain has length 1 (initialPoints = {0, 1}) the first
+   activated value reaches the right boundary one time unit later, so out1 stays
+   at the initial value 0 until time = 1.5 and then follows out1(t) = in0(t - 1)\".
+
+  Real x(start = 1.0, fixed = true) \"Spatial coordinate fed to spatialDistribution\";
+  Real v = 1 \"Velocity der(x)\";
+  Boolean myCondition = time >= 0.5 \"Event that gates the spatialDistribution operator\";
+  Real in0 = time \"Value entering on the left\";
+  Real out1 \"Value leaving on the right\";
+equation
+  der(x) = v;
+
+  if myCondition then
+    (, out1) = spatialDistribution(in0, 0.0, x, true,
+                                   initialPoints = {0.0, 1.0},
+                                   initialValues = {0.0, 0.0});
+  else
+    out1 = -1.0;
+  end if;
+
+  annotation (experiment(StopTime = 2.0, Tolerance = 1e-6));
+end SpatialDistributionBehindEvent;"); getErrorString();
+
+// Simulate
+simulate(SpatialDistributionBehindEvent); getErrorString();
+
+val(out1, 0.48); // -1.0  operator inactive, out1 from else-branch
+val(out1, 0.52); //  0.0  operator just activated, still initial profile
+val(out1, 1.0);  //  0.0  within the transport delay, nothing transported yet
+val(out1, 1.6);  //  0.6  operator active: out1(t) = in0(t - 1)
+val(out1, 1.8);  //  0.8
+val(out1, 2.0);  //  1.0
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "SpatialDistributionBehindEvent_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SpatialDistributionBehindEvent', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// -1.0
+// 0.0
+// 0.0
+// 0.6
+// 0.8
+// 1.0
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test1.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test1.mos
@@ -3,7 +3,7 @@
 // status:              correct
 // teardown_command:    rm -f TestSpatialDiscretization.Test1*
 //
-// Modle with spatialDistribution with changing velocity.
+// Model with spatialDistribution with changing velocity.
 
 loadModel(Modelica); getErrorString();
 loadFile("TestSpatialDiscretization.mo"); getErrorString();

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test2.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test2.mos
@@ -3,7 +3,7 @@
 // status:              correct
 // teardown_command:    rm -f TestSpatialDiscretization.Test2*
 //
-// Mmoble with spatialDistribution with changing velocity.
+// Model with spatialDistribution with changing velocity.
 
 loadModel(Modelica); getErrorString();
 loadFile("TestSpatialDiscretization.mo"); getErrorString();

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test3.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/test3.mos
@@ -3,7 +3,7 @@
 // status:              correct
 // teardown_command:    rm -f TestSpatialDiscretization.Test3*
 //
-// Mmoble with spatialDistribution with changing velocity.
+// Model with spatialDistribution with changing velocity.
 
 loadModel(Modelica); getErrorString();
 loadFile("TestSpatialDiscretization.mo"); getErrorString();


### PR DESCRIPTION
### Related Issues

Mostly fixes https://github.com/OpenModelica/OpenModelica/issues/16099.

### Purpose

Guard the generated `storeSpatialDistribution` callback with the same condition as the operator's evaluation, so its buffer is no longer mutated while the enclosing if-branch is inactive.

### Approach

The store condition is tracked by a top-down traversal in extractSpatialDistributionInfo (then = cond, else = not cond, nested = conjunction).

Runtime: spatialDistributionZeroCrossing no longer captures startPosX,
which previously marked the operator as started during init and caused
a spurious "x got reinitialized" error at the activation event.

Add SpatialDistributionEvent.mos testing the frozen behavior.
