### PR TITLE
wasm-jit: delay operator + event/array support

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -154,6 +154,7 @@ openmodelica_codegen_wasm_jit_runtime/.gitignore
 openmodelica_codegen_wasm_jit_runtime/Cargo.lock
 openmodelica_codegen_wasm_jit_runtime/Cargo.toml
 openmodelica_codegen_wasm_jit_runtime/build-runtime.sh
+openmodelica_codegen_wasm_jit_runtime/src/delay.rs
 openmodelica_codegen_wasm_jit_runtime/src/lib.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls.rs
 openmodelica_codegen_wasm_jit_runtime/src/session.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1384,6 +1384,10 @@ struct SimVarMap {
     lambda_off: u32,
     /// `SimData` byte offset of the zero-crossing hysteresis tolerance (`SimCtx::zctol_off`).
     zctol_off: u32,
+    /// `SimData` byte offset of `zeroCrossingsPre` (`SimLayout::zc_pre_off`).
+    zc_pre_off: u32,
+    /// Number of `delay(...)` expression buffers (`delayedExps.maxDelayedIndex + 1`).
+    n_delays: u32,
 }
 
 /// Display name of a model variable's component reference (OMC `.`-separated
@@ -1670,6 +1674,8 @@ fn build_var_map(
         n_mathevents: layout.n_math,
         lambda_off: layout.lambda_off,
         zctol_off: layout.zctol_off,
+        zc_pre_off: layout.zc_pre_off,
+        n_delays: 0,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
     // User-settable parameters (isValueChangeable), collected as they are laid out.
@@ -2245,6 +2251,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         samples.iter().enumerate().map(|(k, s)| (s.index, k as u32)).collect();
     var_map.sample_map = Arc::new(sample_map);
     var_map.sample_active_off = layout.sample_active_off;
+    // Delay-expression buffer count (`maxDelayedIndex + 1`, 0 when the model has
+    // no `delay(...)`), baked into `functionInitDelay`'s `rt_delay_init` call.
+    var_map.n_delays = (sim_code.delayedExps.maxDelayedIndex + 1).max(0) as u32;
 
     // State sets: register the Jacobian seed/result crefs at the scratch region
     // and collect the driver-side selection metadata (candidate/state/A offsets).
@@ -2673,6 +2682,27 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         });
         idx
     };
+    // `functionStoreDelayed`: append each `delay(...)` expression's current value
+    // to its ring buffer (C's `function_storeDelayed`). `functionInitDelay`:
+    // `rt_delay_init(n_delays, startTime)` to reset the buffers for a fresh run.
+    let store_delayed_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if var_map.n_delays == 0 {
+            empty_eqfn()
+        } else {
+            build_store_delayed_fn(sim_code, &var_map, &by_name, &mut literals)?
+        });
+        idx
+    };
+    let init_delay_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if var_map.n_delays == 0 {
+            empty_eqfn()
+        } else {
+            build_init_delay_fn(var_map.n_delays)
+        });
+        idx
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -2708,6 +2738,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionInitialEquations_lambda0: (i32) -> ()
     functions.function(eqfn_type); // functionCheckAsserts: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
+    functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
+    functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
 
     // --- Code section. ---
     let mut code = we::CodeSection::new();
@@ -2733,6 +2765,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionInitialEquations_lambda0", we::ExportKind::Func, init_lambda0_idx);
     exports.export("functionCheckAsserts", we::ExportKind::Func, check_asserts_idx);
     exports.export("functionUpdateRelations", we::ExportKind::Func, update_relations_idx);
+    exports.export("functionStoreDelayed", we::ExportKind::Func, store_delayed_idx);
+    exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
 
     let mut module = we::Module::new();
     module.section(&types);
@@ -3069,6 +3103,7 @@ fn build_eq_fn_with_prelude(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -3124,6 +3159,7 @@ fn build_init_sample_fn(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -3169,6 +3205,7 @@ fn build_init_start_values_fn(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -3215,6 +3252,7 @@ fn build_zero_crossings_fn(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: true,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -3255,6 +3293,7 @@ fn build_update_relations_fn(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: true,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -3265,6 +3304,66 @@ fn build_update_relations_fn(
         func.instruction(i);
     }
     Ok(func)
+}
+
+/// Build `functionStoreDelayed(SimData*)`: append each `delay(...)` expression's
+/// current value to its ring buffer (C's `function_storeDelayed`). Evaluated in a
+/// normal (non-discrete) equation context.
+fn build_store_delayed_fn(
+    sim_code: &SimCode::SimCode,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let delayed: Vec<(i32, Arc<DAE::Exp>, Arc<DAE::Exp>, Arc<DAE::Exp>)> =
+        lst(&sim_code.delayedExps.delayedExps)
+            .map(|(i, (e, d, dmax))| (*i, e.clone(), d.clone(), dmax.clone()))
+            .collect();
+    let sim = SimCtx {
+        data_local: 0,
+        vars: var_map.vars.clone(),
+        starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
+        array_groups: var_map.array_groups.clone(),
+        terminate_off: var_map.terminate_off,
+        nls_fail_off: var_map.nls_fail_off,
+        nls_jobs: var_map.nls_jobs.clone(),
+        sample_map: var_map.sample_map.clone(),
+        sample_active_off: var_map.sample_active_off,
+        relations_off: var_map.relations_off,
+        rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
+        n_relations: var_map.n_relations,
+        mathevents_off: var_map.mathevents_off,
+        n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
+        zc_context: false,
+    };
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    ctx.emit_store_delayed(&delayed)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionInitDelay(SimData*)`: `rt_delay_init(n_delays, time)` to reset
+/// the ring buffers for a fresh run. Called at init when `time == startTime`, so
+/// `TIME_OFF` supplies the start time the runtime records.
+fn build_init_delay_fn(n_delays: u32) -> we::Function {
+    use we::Instruction as I;
+    let mut f = we::Function::new([]);
+    f.instruction(&I::I32Const(n_delays as i32));
+    f.instruction(&I::LocalGet(0)); // SimData*
+    f.instruction(&I::F64Load(crate::CodegenWasmJitFunctions::mem_arg(0, 3))); // time (TIME_OFF)
+    f.instruction(&I::Call(rt_index("rt_delay_init").expect("rt_delay_init is a runtime builtin")));
+    f.instruction(&I::End);
+    f
 }
 
 /// Lower a single `SimEqSystem` into the current equation function.
@@ -3780,6 +3879,7 @@ fn build_nls_fns(
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
         zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
     };
     let finish = |ctx: FnCtx| -> we::Function {
@@ -4202,6 +4302,8 @@ mod standalone_tests {
             "functionStateSetJacobians",
             "functionInitialEquations_lambda0",
             "functionUpdateRelations",
+            "functionStoreDelayed",
+            "functionInitDelay",
         ];
 
         let mut funcs = we::FunctionSection::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -371,6 +371,11 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
     ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
+    ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
+    ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
+    ("rt_delay_eval", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
+    ("rt_delay_zc", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
 ];
 
 /// Model global holding the base index at which this module's per-system
@@ -867,6 +872,9 @@ pub(crate) struct SimCtx {
     /// `functionZeroCrossings` so a relation stays put within the band — this keeps
     /// a bouncing ball from chattering through the floor near rest.
     pub(crate) zctol_off: u32,
+    /// `SimData` byte offset of `zeroCrossingsPre` — the previous accepted
+    /// g-values, read by the `delayZeroCrossing` builtin in `zc_context`.
+    pub(crate) zc_pre_off: u32,
 }
 
 /// One nonlinear system's `rt_solve_nls` wiring: `k` is the job ordinal (its
@@ -1162,6 +1170,26 @@ impl<'a> FnCtx<'a> {
             let w = compile_relation_fresh(self, exp1, operator, exp2)?;
             coerce(self, w, WTy::I32);
             self.emit(we::Instruction::I32Store(mem_arg(relations_off + i as u32 * 4, 2)));
+        }
+        Ok(())
+    }
+
+    /// Emit `functionStoreDelayed`: `rt_delay_store(idx, time, e, d, dmax)` per
+    /// `delay(...)` expression (C's `function_storeDelayed`).
+    pub(crate) fn emit_store_delayed(
+        &mut self,
+        delayed: &[(i32, Arc<DAE::Exp>, Arc<DAE::Exp>, Arc<DAE::Exp>)],
+    ) -> Result<()> {
+        let data = self.sim()?.data_local;
+        for (idx, e, d, dmax) in delayed {
+            self.emit(we::Instruction::I32Const(*idx));
+            self.emit(we::Instruction::LocalGet(data)); // time (TIME_OFF = 0)
+            self.emit(we::Instruction::F64Load(mem_arg(0, 3)));
+            for exp in [e, d, dmax] {
+                let w = compile_exp(self, exp)?;
+                coerce(self, w, WTy::F64);
+            }
+            self.emit(we::Instruction::Call(rt_index("rt_delay_store")?));
         }
         Ok(())
     }
@@ -3306,6 +3334,164 @@ fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
+/// If `cr` is `base[i1,…,ik, :, …, :]` — leading `INDEX` subscripts followed by
+/// only whole-dimension subscripts, subscripts on the final component and every
+/// ancestor unsubscripted — return `(base key, leading index expressions)`. The
+/// selected sub-array is a contiguous block in the row-major `SimData` layout
+/// (the trailing whole dimensions span the fastest-varying axes). Returns `None`
+/// for a plain scalar (no `:`), a `SLICE`, or an `INDEX` after a whole dim (that
+/// selection is not contiguous).
+fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::Exp>>)>> {
+    use DAE::ComponentRef as C;
+    let mut base = String::new();
+    let mut node = cr;
+    loop {
+        match node {
+            C::CREF_IDENT { ident, subscriptLst, .. } => {
+                base.push_str(ident);
+                let mut leading = Vec::new();
+                let mut seen_whole = false;
+                for sub in &**subscriptLst {
+                    match &**sub {
+                        DAE::Subscript::INDEX { exp } if !seen_whole => leading.push(exp.clone()),
+                        DAE::Subscript::WHOLEDIM | DAE::Subscript::WHOLE_NONEXP { .. } => seen_whole = true,
+                        _ => return Ok(None),
+                    }
+                }
+                if !seen_whole {
+                    return Ok(None);
+                }
+                return Ok(Some((base, leading)));
+            }
+            C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
+                if !subscriptLst.is_empty() {
+                    return Ok(None);
+                }
+                base.push_str(ident);
+                base.push('.');
+                node = componentRef;
+            }
+            _ => return Ok(None),
+        }
+    }
+}
+
+/// If `cr` is `base[subs]` — subscripts on the final component, every ancestor
+/// unsubscripted — return `(base key, final subscript list)`. Unlike
+/// [`sim_slice_of`] the subscripts are returned raw (any `INDEX`/`SLICE`/whole
+/// mix), for the general gather-then-slice read path.
+fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<List<Arc<DAE::Subscript>>>)>> {
+    use DAE::ComponentRef as C;
+    let mut base = String::new();
+    let mut node = cr;
+    loop {
+        match node {
+            C::CREF_IDENT { ident, subscriptLst, .. } => {
+                base.push_str(ident);
+                if subscriptLst.is_empty() {
+                    return Ok(None);
+                }
+                return Ok(Some((base, subscriptLst.clone())));
+            }
+            C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
+                if !subscriptLst.is_empty() {
+                    return Ok(None);
+                }
+                base.push_str(ident);
+                base.push('.');
+                node = componentRef;
+            }
+            _ => return Ok(None),
+        }
+    }
+}
+
+/// Push the byte address of the first element of the contiguous sub-array
+/// `group[leading, :, …]` (leading 1-based indices, remaining axes whole) and
+/// return `(trailing_element_count, element_stride)`. The trailing dimensions
+/// are the fastest-varying axes, so the block spans `trailing_total * stride`
+/// contiguous bytes from this address.
+fn emit_sim_slice_addr(ctx: &mut FnCtx, group: &ArrayGroup, leading: &[Arc<DAE::Exp>]) -> Result<(u32, u32)> {
+    let (_, stride) = sim_array_elem_kind_stride(group.wty);
+    let k = leading.len();
+    if k >= group.dims.len() {
+        return Err("CodegenWasmJit: array slice indexes all dimensions");
+    }
+    let trailing_total: u32 = group.dims[k..].iter().product();
+    let data = ctx.sim()?.data_local;
+    ctx.emit(we::Instruction::I32Const(0)); // acc = 0
+    for (axis, exp) in leading.iter().enumerate() {
+        ctx.emit(we::Instruction::I32Const(group.dims[axis] as i32));
+        ctx.emit(we::Instruction::I32Mul); // acc * dims[axis]
+        let wt = compile_exp(ctx, exp)?;
+        coerce(ctx, wt, WTy::I32);
+        ctx.emit(we::Instruction::I32Const(1));
+        ctx.emit(we::Instruction::I32Sub); // e - 1
+        ctx.emit(we::Instruction::I32Add); // acc = acc*dims[axis] + (e - 1)
+    }
+    // addr = data + base_off + acc * (trailing_total * stride)
+    ctx.emit(we::Instruction::I32Const((trailing_total * stride) as i32));
+    ctx.emit(we::Instruction::I32Mul);
+    ctx.emit(we::Instruction::LocalGet(data));
+    ctx.emit(we::Instruction::I32Add);
+    ctx.emit(we::Instruction::I32Const(group.base_off as i32));
+    ctx.emit(we::Instruction::I32Add);
+    Ok((trailing_total, stride))
+}
+
+/// Gather the contiguous sub-array `group[leading, :, …]` from `SimData` into a
+/// fresh (refcount-1) runtime array of the trailing dimensions, leaving the
+/// owned handle on the stack.
+fn emit_sim_slice_gather(ctx: &mut FnCtx, group: &ArrayGroup, leading: &[Arc<DAE::Exp>]) -> Result<()> {
+    let (ek, stride) = sim_array_elem_kind_stride(group.wty);
+    let trailing: Vec<u32> = group.dims[leading.len()..].to_vec();
+    let trailing_total: u32 = trailing.iter().product();
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(ek as i32));
+    ctx.emit(we::Instruction::I32Const(trailing.len() as i32));
+    ctx.emit(we::Instruction::I32Const(trailing_total as i32));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_new")?));
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (axis, d) in trailing.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(axis as i32));
+        ctx.emit(we::Instruction::I32Const(*d as i32));
+        ctx.emit(we::Instruction::Call(rt_index("rt_array_set_dim")?));
+    }
+    // memory.copy(dst = obj data, src = slice addr, len = trailing_total * stride).
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_sim_slice_addr(ctx, group, leading)?;
+    ctx.emit(we::Instruction::I32Const((trailing_total * stride) as i32));
+    ctx.emit(we::Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// Scatter a runtime array `rhs` into the contiguous sub-array
+/// `group[leading, :, …]` of `SimData` (the reverse of [`emit_sim_slice_gather`]).
+fn emit_sim_slice_scatter(ctx: &mut FnCtx, group: &ArrayGroup, leading: &[Arc<DAE::Exp>], rhs: RhsSource) -> Result<()> {
+    let (_, stride) = sim_array_elem_kind_stride(group.wty);
+    let trailing_total: u32 = group.dims[leading.len()..].iter().product();
+    let h = ctx.alloc_temp(WTy::I32);
+    let rw = rhs.push(ctx)?;
+    if rw != WTy::I32 {
+        return Err("CodegenWasmJit: array-slice assignment rhs is not an array handle");
+    }
+    ctx.emit(we::Instruction::LocalSet(h));
+    // memory.copy(dst = slice addr, src = rhs data, len = trailing_total * stride).
+    emit_sim_slice_addr(ctx, group, leading)?;
+    ctx.emit(we::Instruction::LocalGet(h));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    ctx.emit(we::Instruction::I32Const((trailing_total * stride) as i32));
+    ctx.emit(we::Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+    ctx.emit(we::Instruction::LocalGet(h));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_release")?));
+    Ok(())
+}
+
 /// The value type of a component reference's leaf, after applying its final
 /// subscripts (so `states[2]` of `states : ThermodynamicState[2]` yields the
 /// record element type). Array dims are peeled one per index subscript.
@@ -3464,6 +3650,26 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             }
         }
     }
+    // Contiguous sub-array slice `base[i,…,:]` (dynamic index + trailing whole
+    // dims): gather the row-major block into a runtime array.
+    if let Some((base, leading)) = sim_slice_of(cref)? {
+        if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
+            emit_sim_slice_gather(ctx, &group, &leading)?;
+            return Ok(Some(WTy::I32));
+        }
+    }
+    // Any other slice `base[subs]` (a column `[:,1]`, a strided range, …): gather
+    // the whole array and apply the runtime slice, which handles arbitrary
+    // `INDEX`/`SLICE`/whole subscript mixes.
+    if let Some((base, subs)) = sim_array_base_subs(cref)? {
+        if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
+            if !is_scalar_index(&subs, group.dims.len() as u32) {
+                emit_sim_array_gather(ctx, &group)?;
+                let wty = slice_loaded(ctx, &subs)?;
+                return Ok(Some(wty));
+            }
+        }
+    }
     let key = sim_cref_key(cref)?;
     let slot = match ctx.sim()?.vars.get(&key) {
         Some(s) => *s,
@@ -3581,6 +3787,14 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
                 }
                 return Ok(true);
             }
+        }
+    }
+    // Contiguous sub-array slice `base[i,…,:] := arr` (dynamic index + trailing
+    // whole dims): scatter the runtime array into the row-major block.
+    if let Some((base, leading)) = sim_slice_of(cref)? {
+        if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
+            emit_sim_slice_scatter(ctx, &group, &leading, rhs)?;
+            return Ok(true);
         }
     }
     let key = sim_cref_key(cref)?;
@@ -5111,6 +5325,47 @@ fn compile_math_builtin(
         // raises `active[k]` for the firing sample before the discrete update, so
         // this reads that i32 flag. `start`/`interval` are handled by `initSample`
         // and the driver, not evaluated here.
+        // delay(index, e, d, delayMax): `e` at `time - d` from buffer `index`.
+        "delay" => {
+            need_args(&argv, 4, name)?;
+            let DAE::Exp::ICONST { integer: index } = &**argv[0] else {
+                return Err("CodegenWasmJit: `delay` index must be an integer literal");
+            };
+            let data = ctx.sim()?.data_local;
+            ctx.emit(we::Instruction::I32Const(*index));
+            ctx.emit(we::Instruction::LocalGet(data)); // time (TIME_OFF = 0)
+            ctx.emit(we::Instruction::F64Load(mem_arg(0, 3)));
+            for a in &argv[1..4] {
+                let w = compile_exp(ctx, a)?;
+                coerce(ctx, w, WTy::F64);
+            }
+            ctx.emit(we::Instruction::Call(rt_index("rt_delay_eval")?));
+            Ok(SigTy::Real)
+        }
+        // delayZeroCrossing(index, rindex, d): zeroCrossingsPre[rindex], sign-
+        // flipped when a buffered event lies in the (time - d) window.
+        "delayZeroCrossing" => {
+            need_args(&argv, 3, name)?;
+            if !ctx.sim()?.zc_context {
+                return Err("CodegenWasmJit: delayZeroCrossing outside a zero-crossing context");
+            }
+            let DAE::Exp::ICONST { integer: index } = &**argv[0] else {
+                return Err("CodegenWasmJit: `delayZeroCrossing` index must be an integer literal");
+            };
+            let DAE::Exp::ICONST { integer: rindex } = &**argv[1] else {
+                return Err("CodegenWasmJit: `delayZeroCrossing` relation index must be an integer literal");
+            };
+            let (data, zc_pre_off) = { let s = ctx.sim()?; (s.data_local, s.zc_pre_off) };
+            ctx.emit(we::Instruction::I32Const(*index));
+            ctx.emit(we::Instruction::LocalGet(data)); // time (TIME_OFF = 0)
+            ctx.emit(we::Instruction::F64Load(mem_arg(0, 3)));
+            let w = compile_exp(ctx, argv[2])?; // delay time
+            coerce(ctx, w, WTy::F64);
+            ctx.emit(we::Instruction::LocalGet(data)); // zeroCrossingsPre[rindex]
+            ctx.emit(we::Instruction::F64Load(mem_arg(zc_pre_off + *rindex as u32 * 8, 3)));
+            ctx.emit(we::Instruction::Call(rt_index("rt_delay_zc")?));
+            Ok(SigTy::Real)
+        }
         "sample" => {
             need_args(&argv, 3, name)?;
             let DAE::Exp::ICONST { integer } = &**argv[0] else {
@@ -5219,6 +5474,13 @@ fn emit_string_builtin(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>]) -> Result<SigTy
     // stringify the index. Carrying enum names would need the literal table
     // threaded through from the DAE type into the sidecar/runtime.
     if exp_is_enumeration(argv[0]) {
+        // `String(enum, format)`: the printf-directive variant formats the 1-based
+        // Integer index (C's `String(x, "d")`), *not* the literal name — and unlike
+        // the name path it never traps on an out-of-range value (e.g. a min/max
+        // warning-assert message built while an enum is transiently 0).
+        if argv.len() == 2 && exp_sigty(argv[1])? == SigTy::Str {
+            return emit_string_format(ctx, argv[0], argv[1], &SigTy::Int);
+        }
         let Some(names) = exp_enum_names(argv[0]) else {
             return Err("CodegenWasmJit: String(Enumeration) on an enum literal whose names are not in scope");
         };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/delay.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/delay.rs
@@ -1,0 +1,277 @@
+//! Port of `SimulationRuntime/c/simulation/solver/delay.c`: one `(time, value)`
+//! ring buffer per `delay(...)` expression. State is a module global (single-
+//! threaded wasm), reset by `rt_delay_init` each run.
+
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+/// C `DBL_EPSILON`.
+const DBL_EPSILON: f64 = f64::EPSILON;
+
+/// One `(time, value)` ring-buffer row.
+type Row = (f64, f64);
+
+/// Per-run delay state: one buffer per delay expression, plus the run start time.
+pub struct DelayState {
+    buffers: Vec<VecDeque<Row>>,
+    start_time: f64,
+}
+
+/// Greatest row index whose time is `<= time` (C `findTime`). Caller guarantees a
+/// non-empty buffer.
+fn find_time(time: f64, buf: &VecDeque<Row>) -> usize {
+    let end = buf.len();
+    let mut pos = 0;
+    if time < buf[0].0 {
+        return 0;
+    }
+    while pos < end - 1 {
+        pos += 1;
+        if buf[pos].0 > time {
+            pos -= 1;
+            break;
+        }
+    }
+    pos
+}
+
+/// Whether the buffer holds an event (two adjacent rows with equal time) at or
+/// before `time` (C `searchEvent`).
+fn search_event(time: f64, buf: &VecDeque<Row>) -> bool {
+    let end = buf.len();
+    if end == 0 {
+        return false;
+    }
+    let mut cur = buf[0].0;
+    if time < cur {
+        return false;
+    }
+    let mut pos = 0;
+    let mut found = false;
+    while pos < end - 1 {
+        pos += 1;
+        let prev = cur;
+        cur = buf[pos].0;
+        if (prev - cur).abs() < 1e-12 {
+            found = true;
+            break;
+        }
+        if cur > time {
+            break;
+        }
+    }
+    found
+}
+
+impl DelayState {
+    fn new(n: usize, start_time: f64) -> Self {
+        let mut buffers = Vec::with_capacity(n);
+        for _ in 0..n {
+            buffers.push(VecDeque::new());
+        }
+        DelayState { buffers, start_time }
+    }
+
+    /// C `storeDelayedExpression`: append `(time, value)`, dropping stale tail rows
+    /// and dequeuing rows older than `time - delay_time` (unless an event sits on
+    /// that boundary).
+    fn store(&mut self, idx: usize, time: f64, value: f64, delay_time: f64) {
+        let buf = &mut self.buffers[idx];
+        let mut length = buf.len();
+        while length > 0 && time < buf[length - 1].0 {
+            buf.pop_back();
+            length = buf.len();
+        }
+        if length > 0 {
+            let last = buf[length - 1];
+            if (last.0 - time).abs() < 1e-10 && (last.1 - value).abs() < 1e-10 {
+                let row = find_time(time - delay_time + 1e-10, buf);
+                for _ in 0..row {
+                    buf.pop_front();
+                }
+                return;
+            }
+        }
+        buf.push_back((time, value));
+        let row = find_time(time - delay_time + DBL_EPSILON, buf);
+        if row > 0 && !search_event(time - delay_time + DBL_EPSILON, buf) {
+            for _ in 0..row {
+                buf.pop_front();
+            }
+        }
+    }
+
+    /// C `delayImpl`: `expr(time - delay_time)` by linear interpolation, with the
+    /// pre-start / empty / oldest-value special cases.
+    fn eval(&self, idx: usize, time: f64, value: f64, delay_time: f64) -> f64 {
+        let buf = &self.buffers[idx];
+        let length = buf.len();
+        if time <= self.start_time {
+            return value;
+        }
+        if length == 0 {
+            return value;
+        }
+        if time <= self.start_time + delay_time {
+            return buf[0].1;
+        }
+        let time_stamp = time - delay_time;
+        let last = buf[length - 1];
+        let (time0, value0, time1, value1);
+        if time_stamp > last.0 {
+            time0 = last.0;
+            value0 = last.1;
+            time1 = time;
+            value1 = value;
+        } else {
+            let i = find_time(time_stamp, buf);
+            time0 = buf[i].0;
+            value0 = buf[i].1;
+            if i + 1 == length {
+                return value0;
+            }
+            time1 = buf[i + 1].0;
+            value1 = buf[i + 1].1;
+        }
+        if time0 == time_stamp {
+            return value0;
+        }
+        if time1 == time_stamp {
+            return value1;
+        }
+        let timedif = time1 - time0;
+        let dt0 = time1 - time_stamp;
+        let dt1 = time_stamp - time0;
+        (value0 * dt0 + value1 * dt1) / timedif
+    }
+
+    /// C `delayZeroCrossing`: the wrapped relation's pre g-value, sign-flipped when
+    /// a buffered event lies in the `(time - delay_time)` window.
+    fn zc(&self, idx: usize, time: f64, delay_time: f64, zc_pre: f64) -> f64 {
+        let buf = &self.buffers[idx];
+        if buf.is_empty() {
+            return zc_pre;
+        }
+        if search_event(time - delay_time, buf) {
+            -zc_pre
+        } else {
+            zc_pre
+        }
+    }
+}
+
+struct DelayCell(UnsafeCell<Option<DelayState>>);
+// Single-threaded wasm: no concurrent access to the delay state.
+unsafe impl Sync for DelayCell {}
+static DELAY: DelayCell = DelayCell(UnsafeCell::new(None));
+
+#[inline]
+fn state() -> &'static mut DelayState {
+    unsafe { (*DELAY.0.get()).as_mut().expect("rt_delay_init not called") }
+}
+
+/// (Re)allocate `n_delays` empty buffers for a fresh run and record its start time.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_delay_init(n_delays: u32, start_time: f64) {
+    unsafe {
+        *DELAY.0.get() = Some(DelayState::new(n_delays as usize, start_time));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_delay_store(idx: u32, time: f64, value: f64, delay_time: f64, _delay_max: f64) {
+    state().store(idx as usize, time, value, delay_time);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_delay_eval(idx: u32, time: f64, value: f64, delay_time: f64, _delay_max: f64) -> f64 {
+    state().eval(idx as usize, time, value, delay_time)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_delay_zc(idx: u32, time: f64, delay_time: f64, zc_pre: f64) -> f64 {
+    state().zc(idx as usize, time, delay_time, zc_pre)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf(rows: &[Row]) -> VecDeque<Row> {
+        rows.iter().copied().collect()
+    }
+
+    #[test]
+    fn find_time_brackets() {
+        let b = buf(&[(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)]);
+        assert_eq!(find_time(-1.0, &b), 0);
+        assert_eq!(find_time(0.0, &b), 0);
+        assert_eq!(find_time(1.5, &b), 1);
+        assert_eq!(find_time(2.0, &b), 2);
+        assert_eq!(find_time(9.0, &b), 2);
+    }
+
+    #[test]
+    fn search_event_finds_duplicate_time() {
+        let b = buf(&[(0.0, 1.0), (1.0, 2.0), (1.0, 5.0), (2.0, 6.0)]);
+        assert!(!search_event(0.5, &b)); // before the event
+        assert!(search_event(1.0, &b)); // at the event
+        assert!(search_event(1.5, &b)); // after the event
+        let clean = buf(&[(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)]);
+        assert!(!search_event(2.0, &clean));
+    }
+
+    #[test]
+    fn eval_interpolates_linearly() {
+        let mut s = DelayState::new(1, 0.0);
+        s.store(0, 0.0, 0.0, 1.0);
+        s.store(0, 1.0, 10.0, 1.0);
+        s.store(0, 2.0, 20.0, 1.0);
+        // at time 2, delay 1 -> value at t=1 == 10
+        assert!((s.eval(0, 2.0, 20.0, 1.0) - 10.0).abs() < 1e-9);
+        // at time 1.5, delay 1 -> value at t=0.5 == 5 (interpolated 0..10)
+        assert!((s.eval(0, 1.5, 15.0, 1.0) - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn eval_pre_start_returns_arg() {
+        let s = DelayState::new(1, 0.0);
+        assert_eq!(s.eval(0, 0.0, 42.0, 1.0), 42.0); // time <= start
+        assert_eq!(s.eval(0, 0.5, 7.0, 1.0), 7.0); // empty buffer
+    }
+
+    #[test]
+    fn eval_before_delay_window_returns_oldest() {
+        let mut s = DelayState::new(1, 0.0);
+        s.store(0, 0.0, 3.0, 1.0);
+        s.store(0, 0.5, 4.0, 1.0);
+        // time 0.5 <= start(0) + delay(1) -> oldest value 3
+        assert_eq!(s.eval(0, 0.5, 4.0, 1.0), 3.0);
+    }
+
+    #[test]
+    fn zc_flips_on_event() {
+        let mut s = DelayState::new(1, 0.0);
+        s.store(0, 0.0, 3.0, 0.001);
+        // event at t=1: value jumps 3 -> 4 at the same time
+        s.store(0, 1.0, 3.0, 0.001);
+        s.store(0, 1.0, 4.0, 0.001);
+        // no event in window (time-delay = 0.5 < 1): unchanged pre value
+        assert_eq!(s.zc(0, 0.5, 0.001, 1.0), 1.0);
+        // event now inside the window (time-delay = 1.002 - 0.001 > 1.0): flip
+        assert_eq!(s.zc(0, 1.002, 0.001, 1.0), -1.0);
+    }
+
+    #[test]
+    fn store_drops_future_rows() {
+        let mut s = DelayState::new(1, 0.0);
+        s.store(0, 0.0, 1.0, 10.0);
+        s.store(0, 1.0, 2.0, 10.0);
+        s.store(0, 2.0, 3.0, 10.0);
+        // a step back in time (rejected step) pops the newer tail rows
+        s.store(0, 0.5, 9.0, 10.0);
+        let b = &s.buffers[0];
+        assert_eq!(b.back().copied(), Some((0.5, 9.0)));
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -40,6 +40,7 @@
 
 extern crate alloc;
 
+mod delay;
 mod nls;
 
 use alloc::format;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -743,8 +743,18 @@ pub fn take_chatter_log() -> Vec<String> {
 /// steps, step 0 solving the simplified `functionInitialEquations_lambda0`, each
 /// step seeded by the previous one's solution. Leaves lambda = 1, then seeds
 /// `relationsPre` for the continuous phase's held relations.
-pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
+    // Set the start time and reset the delay buffers before any equation function
+    // runs (`rt_delay_eval` traps on unallocated buffers; `functionInitDelay`
+    // reads `startTime` from `TIME_OFF`).
+    write_f64(e, sim_data + TIME_OFF, start_time)?;
+    e.call1_if_present("functionInitDelay", sim_data)?;
     run_initialization_impl(e, sim_data, layout)?;
+    // C's `storePreValues` after the initial solve (initialization.c:903): `pre(x)`
+    // for the discrete update is the value the initial system left in `x`, not the
+    // start value seeded before the solve. Without this, a discrete alg var assigned
+    // `x := pre(x)` by a non-firing `when` (a digital gate's `y_old`) reverts to 0.
+    seed_pre_from_live(e, sim_data, layout)?;
     // Seed the continuous phase's held relations from a full discrete fixed point.
     // The initial system does not necessarily touch every relation guarding the
     // continuous equations, so a straight snapshot of `relations[]` here would
@@ -752,6 +762,14 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
     iterate_discrete(e, sim_data, layout)?;
     store_relations(e, sim_data, layout)?;
     update_relations_pre(e, sim_data, layout)?;
+    // Seed the delay buffers at `startTime` and snapshot the crossings as
+    // `zeroCrossingsPre` so `delayZeroCrossing` has a held value on step 1.
+    e.call1_if_present("functionStoreDelayed", sim_data)?;
+    if layout.n_zc > 0 {
+        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+        e.call1("functionZeroCrossings", sim_data)?;
+        save_zc_pre(e, sim_data, layout)?;
+    }
     // Initialization output is complete; the next model output is the simulation
     // phase. Let the host close the init segment of the capture.
     signal_init_done();
@@ -767,6 +785,10 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     apply_param_overrides(e, sim_data)?;
     e.call1("functionInitStartValues", sim_data)?;
     apply_start_overrides(e, sim_data)?;
+    // C's `storePreValues` before the initial solve: `pre(x)` at initialization is
+    // the start value, so a `$PRE.<discrete>` read in an initial equation (e.g. a
+    // cross-coupled digital latch) sees `start`, not 0.
+    seed_pre_from_live(e, sim_data, layout)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
     if layout.n_samples > 0 {
         e.call1("initSample", sim_data)?;
@@ -876,8 +898,39 @@ fn save_pre_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
     e.write_bytes(sim_data + layout.pre_real_off, &buf)
 }
 
+/// Copy the live real/integer/boolean regions into their `pre()` mirrors (C's
+/// `storePreValues`), so `$PRE.<var>` reads the current value. Used at init to
+/// seed `pre` from the start values before the initial system solves.
+fn seed_pre_from_live(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    let regions = [
+        (REAL_OFF, layout.pre_real_off, (2 * layout.n_states + layout.n_real_alg) * 8),
+        (layout.int_off, layout.pre_int_off, layout.n_int_alg() * 4),
+        (layout.bool_off, layout.pre_bool_off, layout.n_bool_alg() * 4),
+    ];
+    for (live, pre, bytes) in regions {
+        if bytes == 0 {
+            continue;
+        }
+        let mut buf = vec![0u8; bytes as usize];
+        e.read_bytes(sim_data + live, &mut buf)?;
+        e.write_bytes(sim_data + pre, &buf)?;
+    }
+    Ok(())
+}
+
 /// Upper bound on discrete-update iterations at one event (C's `maxEventIterations`).
 const MAX_EVENT_ITER: usize = 20;
+
+/// Snapshot the zero-crossing g-values into `zeroCrossingsPre` (C's
+/// `saveZeroCrossings`); `delayZeroCrossing` reads it as the held g-value.
+fn save_zc_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.n_zc == 0 {
+        return Ok(());
+    }
+    let mut buf = vec![0u8; (layout.n_zc * 8) as usize];
+    e.read_bytes(sim_data + layout.zc_off, &mut buf)?;
+    e.write_bytes(sim_data + layout.zc_pre_off, &buf)
+}
 
 /// Copy `relations[]` into the held relation snapshot at `stored_rel_off`. The
 /// hysteresis band and the zero-crossing function read the snapshot as their
@@ -996,8 +1049,16 @@ fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
     // this pass's relations, then re-evaluates the continuous system; the discrete
     // state settles across passes. Comparing the snapshot before and after the
     // evaluation lets an already-settled system stop after a single evaluation.
-    for _ in 0..MAX_EVENT_ITER {
+    for iter in 0..MAX_EVENT_ITER {
         let prev = discrete_snapshot(e, sim_data, layout)?;
+        // C's `updateDiscreteSystem`: `storePreValues` at the head of each iteration
+        // after the first, so a discrete var this pass recomputes (a friction
+        // clutch's `mode`) is visible as `pre(mode)` to the next pass. Without it a
+        // `pre()`-dependent discrete equation (`locked = … not(pre(mode)==-1 …)`)
+        // never settles and the system fixes on the wrong branch.
+        if iter > 0 {
+            seed_pre_from_live(e, sim_data, layout)?;
+        }
         update_relations_pre(e, sim_data, layout)?;
         e.call1("functionODE", sim_data)?;
         e.call1("functionAlgebraics", sim_data)?;
@@ -1291,7 +1352,7 @@ impl EulerDriver {
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
         // them internally around its Newton solve.
-        run_initialization(e, sim_data, &model.layout)?;
+        run_initialization(e, sim_data, &model.layout, model.start_time)?;
         let n_rows = model.n_output_rows();
         let n_reals = model.layout.n_row_total();
         Ok(EulerDriver {
@@ -1672,7 +1733,7 @@ impl DasslDriver {
         let layout = &model.layout;
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
-        run_initialization(e, sim_data, layout)?;
+        run_initialization(e, sim_data, layout, model.start_time)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -2631,7 +2692,7 @@ impl DasslEventsDriver {
         let layout = &model.layout;
         // Init (with homotopy fallback). Relation mode 2 and `initSample` are handled
         // inside run_initialization; seed the hysteresis direction from the relations.
-        run_initialization(e, sim_data, layout)?;
+        run_initialization(e, sim_data, layout, model.start_time)?;
         store_relations(e, sim_data, layout)?;
 
         let n_states = layout.n_states as usize;
@@ -2745,7 +2806,9 @@ impl Driver for DasslEventsDriver {
                             return Ok(Advance::Terminated);
                         }
                         self.core.t = tr;
+                        e.call1_if_present("functionStoreDelayed", sim_data)?;
                         eval_zero_crossings(e, sim_data, layout, tr, &mut zc0)?;
+                        save_zc_pre(e, sim_data, layout)?;
                         continue;
                     }
                     // No state event before the next sample time. Fire the sample if
@@ -2765,8 +2828,10 @@ impl Driver for DasslEventsDriver {
                             return Ok(Advance::Terminated);
                         }
                         self.core.t = te;
+                        e.call1_if_present("functionStoreDelayed", sim_data)?;
                         if layout.n_zc > 0 {
                             eval_zero_crossings(e, sim_data, layout, te, &mut zc0)?;
+                            save_zc_pre(e, sim_data, layout)?;
                         }
                         if te >= tout - eps {
                             grid_covered = true;
@@ -2782,8 +2847,10 @@ impl Driver for DasslEventsDriver {
                         self.finished = true;
                         return Ok(Advance::Terminated);
                     }
+                    e.call1_if_present("functionStoreDelayed", sim_data)?;
                     if layout.n_zc > 0 {
                         eval_zero_crossings(e, sim_data, layout, tout, &mut zc0)?;
+                        save_zc_pre(e, sim_data, layout)?;
                     }
                 }
                 self.core.t = tout;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -90,6 +90,10 @@ pub struct Layout {
     pub n_zc: u32,
     /// Base of the zero-crossing value region (one f64 per crossing).
     pub zc_off: u32,
+    /// `zeroCrossingsPre`: the previous accepted g-value of each crossing (one f64
+    /// per crossing). `delayZeroCrossing` reads it; the driver snapshots it from
+    /// `zc_off` at init and after each accepted point/event.
+    pub zc_pre_off: u32,
     /// Number of indexed relations (hysteresis count).
     pub n_rel: u32,
     /// Base of the held relation values (one i32 per indexed relation).
@@ -161,7 +165,8 @@ impl Layout {
         let sample_off = (lambda_off + 8 + 7) & !7;
         let sample_active_off = sample_off + n_samples * 16;
         let zc_off = (sample_active_off + n_samples * 4 + 7) & !7;
-        let relations_off = zc_off + n_zc * 8;
+        let zc_pre_off = zc_off + n_zc * 8;
+        let relations_off = zc_pre_off + n_zc * 8;
         let rel_fresh_off = relations_off + n_rel * 4;
         let stored_rel_off = rel_fresh_off + 4;
         let relations_pre_off = stored_rel_off + n_rel * 4;
@@ -175,7 +180,7 @@ impl Layout {
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
-            terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off,
+            terminate_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
             mathevents_off, zctol_off, start_off, total,
         }
@@ -393,7 +398,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.n_states, l.n_real_alg, l.lambda_off, l.rparam_off, l.int_off, l.iparam_off, l.bool_off,
         l.bparam_off, l.str_off, l.sparam_off, l.eobj_off, l.pre_real_off, l.pre_int_off, l.pre_bool_off,
         l.terminate_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
-        l.n_zc, l.zc_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
+        l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off, l.total,
     ] {
         put_u32(o, v);
@@ -547,6 +552,7 @@ impl<'a> Reader<'a> {
             sample_active_off: self.u32()?,
             n_zc: self.u32()?,
             zc_off: self.u32()?,
+            zc_pre_off: self.u32()?,
             n_rel: self.u32()?,
             relations_off: self.u32()?,
             rel_fresh_off: self.u32()?,


### PR DESCRIPTION
Extend --simCodeTarget=wasm-jit so the Modelica.Electrical.Digital examples and CoupledClutches simulate correctly, adding the delay operator and the discrete-event and array-slice machinery they need.

delay / delayZeroCrossing: port the C delay ring buffers (simulation/solver/delay.c) into the runtime as
rt_delay_{init,store,eval,zc}, add a zeroCrossingsPre SimData region, generate the two builtins plus functionStoreDelayed / functionInitDelay, and wire the store and pre-snapshot hooks into the host driver (at init and each accepted point/event). delay() interpolates the buffered value; delayZeroCrossing returns the held g-value flipped when a buffered event lies in the delay window. Also route String(enum, format) through integer formatting so an out-of-range warning-assert no longer traps.

storePreValues, matching the three points the C runtime saves pre():
  - before the initial solve (after functionInitStartValues), so a $PRE.<discrete> read in an initial equation sees the start value instead of 0;
  - after the initial solve (initialization.c:903), so a discrete alg var assigned `x := pre(x)` by a non-firing when (a gate's y_old) keeps its solved value through the post-init discrete iteration instead of reverting to 0 -- which had tripped the Logic min/max assert and, where y_old indexes a table, trapped the wasm engine;
  - at the head of each discrete-update iteration after the first (updateDiscreteSystem), so a discrete var a pass recomputes is visible as pre() to the next pass. A friction clutch's `locked = not free and not (pre(mode)==1 or startForward or pre(mode)==-1 or startBackward)` is an algebraic inside its mixed nonlinear system while a when sets mode; without the reseed pass 1 set mode:=-1 but locked still saw pre(mode)=2, froze the clutch (a_relfric=0) and fixed the solve on the wrong branch.

Array-slice crefs in SimData: a simulation cref `a[i,...,:]` (leading scalar/dynamic indices, trailing whole dims) is a contiguous row-major block -- gather/scatter it with a single memory.copy (sim_slice_of in compile_sim_cref_read/assign). A non-contiguous slice such as a column `mue_pos[:,1]` instead gathers the whole array and reuses the runtime rt_array_slice. This unblocks dLATRAM's `mem[int_addr,:]` and the `table[:,1]` inside the inlined Modelica.Math.tempInterpol1.

Result: all 23 Modelica.Electrical.Digital.Examples pass, and CoupledClutches matches the C reference bit-for-bit (previously every mechanical state diverged after the first clutch engagement). No regression across the Digital suite or the mechanical/electrical hybrid models sampled.


Claude-Session: https://claude.ai/code/session_01N2Dt5jwzmumKPxtPoLaCKf

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
