### PR TITLE
IDA residualFunctionIDA: return recoverable error

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -1290,7 +1290,7 @@ static int residualFunctionIDA(double time, N_Vector yy, N_Vector yp, N_Vector r
 #endif
 
   if (!success) {
-    retVal = -1;  /* Non-recoverable error */
+    retVal = 1;  /* Recoverable error, reduce step size and retry */
   }
 
   threadData->currentErrorStage = saveJumpState;


### PR DESCRIPTION
### Related Issues

Fixes #16053.

### Purpose

* If some error was caught in `residualFunctionIDA` return a recoverable error like DASSL does.

### Approach

* Change error code from `-1` (non-recoverable error) to `1` (recoverable error).
