### PR TITLE
[NB] Fix sliced-equation solving for non-EW array operators in SLICED_COMPONENT

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -2947,6 +2947,26 @@ public
         case SCALAR_EQUATION()
         then {Statement.ASSIGNMENT(eqn.lhs, eqn.rhs, eqn.ty, eqn.source)};
 
+        // Array equations whose element type is a record are expanded per field so that each
+        // primitive field array assignment goes through the primitive indexed_assign path.
+        case ARRAY_EQUATION(lhs = Expression.CREF(cref = lhs_rec), rhs = Expression.CREF(cref = rhs_rec))
+          guard(Type.isComplex(Type.arrayElementType(eqn.ty))) algorithm
+          lhs_lst := BVariable.getRecordChildren(BVariable.getVarPointer(lhs_rec, sourceInfo()));
+          rhs_lst := BVariable.getRecordChildren(BVariable.getVarPointer(rhs_rec, sourceInfo()));
+          lhs_subs := ComponentRef.subscriptsAllFlat(lhs_rec);
+          rhs_subs := ComponentRef.subscriptsAllFlat(rhs_rec);
+          if List.compareLength(lhs_lst, rhs_lst) == 0 and not listEmpty(lhs_lst) then
+            for tpl in List.zip(lhs_lst, rhs_lst) loop
+              (lhs, rhs) := tpl;
+              lhs_exp := Expression.fromCref(ComponentRef.mergeSubscripts(lhs_subs, BVariable.getVarName(lhs), true));
+              rhs_exp := Expression.fromCref(ComponentRef.mergeSubscripts(rhs_subs, BVariable.getVarName(rhs), true));
+              stmts := Statement.ASSIGNMENT(lhs_exp, rhs_exp, Expression.typeOf(lhs_exp), eqn.source) :: stmts;
+            end for;
+          else
+            stmts := {Statement.ASSIGNMENT(eqn.lhs, eqn.rhs, eqn.ty, eqn.source)};
+          end if;
+        then stmts;
+
         case ARRAY_EQUATION()
         then {Statement.ASSIGNMENT(eqn.lhs, eqn.rhs, eqn.ty, eqn.source)};
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -2869,12 +2869,10 @@ function isJacobianResultVar
           varData.clocks      := VariablePointers.addList(var_lst, varData.clocks);
         then varData;
 
-        // IMPORTANT: requires the record elements to be added as children beforehand!
         case (VAR_DATA_SIM(), VarType.RECORD) algorithm
           varData.variables   := VariablePointers.addList(var_lst, varData.variables);
           varData.records     := VariablePointers.addList(var_lst, varData.records);
           varData.knowns      := VariablePointers.addList(var_lst, varData.knowns);
-          varData.records     := VariablePointers.mapPtr(varData.records, function BackendDAE.lowerRecordChildren(variables = varData.variables));
         then varData;
 
         // ToDo: other cases

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -265,6 +265,8 @@ protected
 
           // only remove trivial alias vars from the array of all variables
           varData.variables   := VariablePointers.removeList(alias_vars, varData.variables);
+          varData.records     := VariablePointers.removeList(alias_vars, varData.records);
+          varData.knowns      := VariablePointers.removeList(alias_vars, varData.knowns);
 
           // split off constant alias
           // update constant start values and add to parameters

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -1590,6 +1590,67 @@ protected
     end if;
   end tupleSolvable;
 
+  function expandArrayCrefExp
+    "Replaces a bare array cref with an explicit array of its elements:
+    e.g. Fs_fg (Real[2]) -> {Fs_fg[1], Fs_fg[2]}. Used to make sliced solving possible."
+    input output Expression exp;
+    input ComponentRef arrayCref;
+  protected
+    Type arrTy, elemTy;
+    list<Dimension> dims;
+    list<Integer> sizes;
+    list<Expression> elements;
+  algorithm
+    exp := match exp
+      case Expression.CREF() guard(ComponentRef.isEqual(exp.cref, arrayCref)) algorithm
+        arrTy    := ComponentRef.getSubscriptedType(arrayCref, true);
+        elemTy   := Type.arrayElementType(arrTy);
+        dims     := Type.arrayDims(arrTy);
+        sizes    := list(Dimension.size(dim) for dim in dims);
+        elements := expandArraySumExpDim(sizes, arrayCref, elemTy);
+      then Expression.makeArray(arrTy, listArray(elements), false);
+      else exp;
+    end match;
+  end expandArrayCrefExp;
+
+  function distributeSubscriptExp
+    "Distributes a flat list of subscripts over arithmetic operations.
+    Only descends into array-typed operands so scalar operands are left untouched.
+    For CREF and ARRAY applies subscripts directly.
+    Used to extract a scalar row from an ARRAY_EQUATION."
+    input output Expression exp;
+    input list<Subscript> subs;
+  protected
+    Operator scalar_op;
+  algorithm
+    exp := match exp
+      // For MULTARY, only distribute into array-typed operands (scalars stay unchanged)
+      case Expression.MULTARY() algorithm
+        scalar_op := Operator.toScalar(exp.operator);
+      then Expression.MULTARY(
+        list(if Type.isArray(Expression.typeOf(e)) then distributeSubscriptExp(e, subs) else e
+             for e in exp.arguments),
+        list(if Type.isArray(Expression.typeOf(e)) then distributeSubscriptExp(e, subs) else e
+             for e in exp.inv_arguments),
+        scalar_op);
+
+      // For BINARY, only distribute into the array-typed side
+      case Expression.BINARY() algorithm
+        scalar_op := Operator.toScalar(exp.operator);
+      then Expression.BINARY(
+        if Type.isArray(Expression.typeOf(exp.exp1)) then distributeSubscriptExp(exp.exp1, subs) else exp.exp1,
+        scalar_op,
+        if Type.isArray(Expression.typeOf(exp.exp2)) then distributeSubscriptExp(exp.exp2, subs) else exp.exp2);
+
+      // For UNARY negation the operand must be array (same type as result), distribute into it
+      case Expression.UNARY() algorithm
+        scalar_op := Operator.scalarize(exp.operator);
+      then Expression.UNARY(scalar_op, distributeSubscriptExp(exp.exp, subs));
+
+      else Expression.applySubscripts(subs, exp);
+    end match;
+  end distributeSubscriptExp;
+
   function expandArraySumExp
     "Replaces sum(arrayCref) with arrayCref[1] + ... + arrayCref[n] for 1D arrays.
     sum(A) without explicit iterator is represented as TYPED_CALL, not TYPED_REDUCTION."
@@ -1715,8 +1776,25 @@ protected
       (eqn, solve_status, implicit_index, _) := solveEquation(eqn, var_cref, funcMap, kind, implicit_index, slicing_map, varData, eqData);
       eqn_slice := Slice.SLICE(Pointer.create(eqn), {});
     elseif solve_status == Status.IMPLICIT then
-      // var_cref is a parent array containing cref as a slice; expand array sums to enable explicit solving
-      eqn := Equation.map(eqn, function expandArraySumExp(arrayCref = var_cref));
+      // var_cref is a parent array containing cref as a scalar slice.
+      // For ARRAY_EQUATION: extract the scalar row first, then solve the resulting
+      // SCALAR_EQUATION for cref (avoids wrong-type results from solveLinear on arrays).
+      // For other equation types: try expanding sum expressions.
+      eqn := match eqn
+        local
+          list<Subscript> subs;
+          Expression lhs_scalar, rhs_scalar;
+        case Equation.ARRAY_EQUATION() algorithm
+          // expand bare var_cref array cref to explicit element crefs
+          eqn.lhs  := Expression.map(eqn.lhs, function expandArrayCrefExp(arrayCref = var_cref));
+          eqn.rhs  := Expression.map(eqn.rhs, function expandArrayCrefExp(arrayCref = var_cref));
+          // extract the scalar row corresponding to cref by distributing its subscripts
+          subs       := ComponentRef.subscriptsAllFlat(cref);
+          lhs_scalar := distributeSubscriptExp(eqn.lhs, subs);
+          rhs_scalar := distributeSubscriptExp(eqn.rhs, subs);
+        then Equation.SCALAR_EQUATION(Expression.typeOf(lhs_scalar), lhs_scalar, rhs_scalar, eqn.source, eqn.attr);
+        else Equation.map(eqn, function expandArraySumExp(arrayCref = var_cref));
+      end match;
       (eqn, solve_status, implicit_index, _) := solveEquation(eqn, cref, funcMap, kind, implicit_index, slicing_map, varData, eqData);
       if solve_status < Status.UNSOLVABLE then
         eqn_slice := Slice.SLICE(Pointer.create(eqn), {});

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -2711,6 +2711,22 @@ public
         diff_stmt.rhs := SimplifyExp.simplifyDump(rhs, true, getInstanceName());
       then if isReverse then {diff_stmt} else {diff_stmt, stmt};
 
+      // I-c. differentiate tuple assignment — multiple Real outputs from a function call
+      // e.g. (m_flow_a, dm_flow_ddp_fric_a) := m_flow_of_dp_fric(...)
+      // Without this, derivative variables for the tuple outputs are never assigned,
+      // causing use-before-assign errors when later Real statements use them.
+      // Only apply when ALL tuple elements are Real; mixed tuples (e.g. (d, T, error)
+      // where error is Integer) must not be differentiated here, as the Integer
+      // derivative output would never be assigned.
+      case diff_stmt as Statement.ASSIGNMENT() guard(
+        Type.isTupleOfReals(Expression.typeOf(diff_stmt.lhs))
+      ) algorithm
+        (lhs, diffArguments) := differentiateExpression(diff_stmt.lhs, diffArguments);
+        (rhs, diffArguments) := differentiateExpression(diff_stmt.rhs, diffArguments);
+        diff_stmt.lhs := lhs;
+        diff_stmt.rhs := SimplifyExp.simplifyDump(rhs, true, getInstanceName());
+      then if isReverse then {diff_stmt} else {diff_stmt, stmt};
+
       // II. delegate differentiation to body and only return differentiated statement
       case diff_stmt as Statement.FOR() algorithm
         (branch_stmts, diffArguments) := List.mapFold(diff_stmt.body, function differentiateStatement(diffInfo = diffInfo), diffArguments);

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -1174,8 +1174,7 @@ public
           length              = length
         );
 
-        // kabdelhak: ToDo: need to discuss this case
-        case VAR_ATTR_RECORD() then {attributes};
+        case VAR_ATTR_RECORD() then list(attributes for i in 1:length);
 
         else algorithm
           Error.terminate(getInstanceName() + "failed. Not yet handled: " + toString(attributes), sourceInfo());

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -531,6 +531,7 @@ public
   algorithm
     ty := match cref
       case CREF()
+        algorithm
         then getSubscriptedType2(cref.restCref, Type.subscript(cref.ty, cref.subscripts), includeScope);
       else Type.UNKNOWN();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -7117,5 +7117,25 @@ public
       products := SimplifyExp.simplify(res[i]) :: products;
     end for;
   end productOfListExceptSelf;
+
+  function stripCrefSubscriptsAll
+    "Strips all subscripts from the cref inside a CREF expression and restores
+     the cref's node array type via ComponentRef.nodeType. Returns the expression
+     unchanged for any non-CREF expression."
+    input Expression exp;
+    output Expression outExp;
+  protected
+    ComponentRef cr;
+  algorithm
+    outExp := match exp
+      case CREF()
+        algorithm
+          cr := ComponentRef.stripSubscriptsAll(exp.cref);
+          outExp := CREF(ComponentRef.nodeType(cr), cr);
+        then outExp;
+      else exp;
+    end match;
+  end stripCrefSubscriptsAll;
+
 annotation(__OpenModelica_Interface="nf_frontend");
 end NFExpression;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -3044,7 +3044,10 @@ protected
             if isSome(stmt.range) then
               checkUseBeforeAssignExp(unassigned, Util.getOption(stmt.range), info, generatedName);
             end if;
-
+            // The for-loop iterator is assigned by the loop on each iteration
+            markAssignedOutput(unassigned,
+              Expression.fromCref(ComponentRef.fromNode(stmt.iterator, InstNode.getType(stmt.iterator))),
+              isSome(generatedName));
             checkUseBeforeAssign2(unassigned, stmt.body, generatedName);
           then
             ();

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
@@ -408,6 +408,35 @@ public
     op.ty := Type.arrayElementType(op.ty);
   end scalarize;
 
+  function toScalar
+    "Converts any array operator to its element-wise scalar equivalent:
+     strips EW suffixes and converts SCALAR_ARRAY / ARRAY_SCALAR variants to the
+     plain scalar op, and sets ty to the element type.
+     Operators that are already scalar (ADD, MUL, …) are left unchanged except
+     for the type adjustment."
+    input output Operator op;
+  algorithm
+    op.ty := Type.arrayElementType(op.ty);
+    () := match op.op
+      case Op.ADD_EW           algorithm op.op := Op.ADD; then ();
+      case Op.SUB_EW           algorithm op.op := Op.SUB; then ();
+      case Op.MUL_EW           algorithm op.op := Op.MUL; then ();
+      case Op.DIV_EW           algorithm op.op := Op.DIV; then ();
+      case Op.POW_EW           algorithm op.op := Op.POW; then ();
+      case Op.ADD_SCALAR_ARRAY algorithm op.op := Op.ADD; then ();
+      case Op.ADD_ARRAY_SCALAR algorithm op.op := Op.ADD; then ();
+      case Op.SUB_SCALAR_ARRAY algorithm op.op := Op.SUB; then ();
+      case Op.SUB_ARRAY_SCALAR algorithm op.op := Op.SUB; then ();
+      case Op.MUL_SCALAR_ARRAY algorithm op.op := Op.MUL; then ();
+      case Op.MUL_ARRAY_SCALAR algorithm op.op := Op.MUL; then ();
+      case Op.DIV_SCALAR_ARRAY algorithm op.op := Op.DIV; then ();
+      case Op.DIV_ARRAY_SCALAR algorithm op.op := Op.DIV; then ();
+      case Op.POW_SCALAR_ARRAY algorithm op.op := Op.POW; then ();
+      case Op.POW_ARRAY_SCALAR algorithm op.op := Op.POW; then ();
+      else ();
+    end match;
+  end toScalar;
+
   function unlift
     input output Operator op;
   algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -40,7 +40,7 @@ import NFFlatten.FunctionTree;
 
 protected
 import Attributes = NFAttributes;
-import NFBackendExtension.{BackendInfo, VariableAttributes};
+import NFBackendExtension.{BackendInfo, VariableAttributes, VariableKind};
 import ExecStat.execStat;
 import ComponentRef = NFComponentRef;
 import Type = NFType;
@@ -260,6 +260,9 @@ function scalarizeComplexVariable
   have already been resolved with scalarizeVariable()."
   input Variable var;
   input output list<Variable> vars = {};
+protected
+  Variable child_var;
+  BackendInfo elem_binfo;
 algorithm
   vars := match var.backendinfo.attributes
       local
@@ -267,16 +270,32 @@ algorithm
         String name;
         Integer index;
         Variable elem_var;
+        list<Pointer<Variable>> children;
+        VariableKind varKind;
 
     case attr as VariableAttributes.VAR_ATTR_RECORD() algorithm
+      children := match var.backendinfo.varKind
+        case varKind as VariableKind.RECORD() then varKind.children;
+        else {};
+      end match;
       for tpl in UnorderedMap.toList(attr.indexMap) loop
         (name, index) := tpl;
         elem_var := var;
-        elem_var.name := ComponentRef.prepend(elem_var.name, ComponentRef.rename(name, elem_var.name));
-        elem_var.backendinfo := BackendInfo.setAttributes(elem_var.backendinfo, attr.childrenAttr[index], var.backendinfo.annotations);
+        elem_var.name := ComponentRef.prepend(elem_var.name, ComponentRef.setSubscripts({}, ComponentRef.rename(name, elem_var.name)));
+        elem_binfo := BackendInfo.setAttributes(elem_var.backendinfo, attr.childrenAttr[index], var.backendinfo.annotations);
+        // propagate varKind from the matching child variable
+        for child_ptr in children loop
+          child_var := Pointer.access(child_ptr);
+          if ComponentRef.firstName(child_var.name) == name then
+            elem_binfo.varKind := child_var.backendinfo.varKind;
+          end if;
+        end for;
+        elem_var.backendinfo := elem_binfo;
         // update the types accordingly
         elem_var.ty := VariableAttributes.elemType(attr.childrenAttr[index]);
         elem_var.name := ComponentRef.setNodeType(elem_var.ty, elem_var.name);
+        // update the binding: append the field name to a CREF binding
+        elem_var.binding := appendFieldToBinding(elem_var.binding, name, elem_var.ty);
         vars := elem_var :: vars;
       end for;
     then listReverse(vars);
@@ -284,6 +303,27 @@ algorithm
     else {var};
   end match;
 end scalarizeComplexVariable;
+
+function appendFieldToBinding
+  "Transforms a record CREF binding to a scalar field binding by appending the
+  field name. E.g. binding 'rec[1]' becomes 'rec[1].field' for field 'field'."
+  input output Binding binding;
+  input String fieldName;
+  input Type fieldTy;
+protected
+  ComponentRef bindCref, newCref;
+algorithm
+  binding := match binding
+    local
+      Expression bindExp;
+    case Binding.FLAT_BINDING(bindingExp = bindExp as Expression.CREF(cref = bindCref)) algorithm
+      newCref := ComponentRef.prepend(bindCref, ComponentRef.setSubscripts({}, ComponentRef.rename(fieldName, bindCref)));
+      newCref := ComponentRef.setNodeType(fieldTy, newCref);
+      binding.bindingExp := Expression.CREF(fieldTy, newCref);
+    then binding;
+    else binding;
+  end match;
+end appendFieldToBinding;
 
 function expandComplexCref
   input output Expression exp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -693,6 +693,16 @@ public
     end match;
   end isTuple;
 
+  function isTupleOfReals
+    input Type ty;
+    output Boolean b;
+  algorithm
+    b := match ty
+      case TUPLE() then List.all(ty.types, isReal);
+      else false;
+    end match;
+  end isTupleOfReals;
+
   function isUnknown
     input Type ty;
     output Boolean isUnknown;

--- a/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
@@ -901,10 +901,18 @@ public
           simCodeIndices.equationIndex := simCodeIndices.equationIndex + 1;
         then tmp;
 
+        // Array equations with record element type need per-field expansion which happens in
+        // toStatement; route through createAlgorithm so that path is used.
+        case (BEquation.ARRAY_EQUATION(), NBSolve.Status.EXPLICIT)
+          guard(Type.isComplex(Type.arrayElementType(eqn.ty))) algorithm
+          (tmp, simCodeIndices) := createAlgorithm(eqn, simCodeIndices, equation_map);
+        then tmp;
+
         case (BEquation.ARRAY_EQUATION(), NBSolve.Status.EXPLICIT) algorithm
           // expand scalar rhs to array when lhs is array (implicit broadcast in Modelica)
           rhs := if Type.isArray(Expression.typeOf(eqn.rhs)) then eqn.rhs else Expression.fillType(eqn.ty, eqn.rhs);
-          tmp := ARRAY_ASSIGN(simCodeIndices.equationIndex, eqn.lhs, rhs, eqn.source, eqn.attr);
+          lhs := eqn.lhs;
+          tmp := ARRAY_ASSIGN(simCodeIndices.equationIndex, lhs, rhs, eqn.source, eqn.attr);
           simCodeIndices.equationIndex := simCodeIndices.equationIndex + 1;
         then tmp;
 

--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -619,6 +619,7 @@ public
         case VariableKind.DAE_AUX_VAR()             then OldBackendDAE.DAE_AUX_VAR();
         case VariableKind.LOOP_ITERATION()          then OldBackendDAE.LOOP_ITERATION();
         case VariableKind.LOOP_SOLVED()             then OldBackendDAE.LOOP_SOLVED();
+        case VariableKind.RECORD()                  then OldBackendDAE.VARIABLE();
         case VariableKind.FRONTEND_DUMMY()
           algorithm
             Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of wrong VariableKind FRONTEND_DUMMY(). This should not exist after frontend."});

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3332,6 +3332,7 @@ match sparsity
       unsigned int i, nnz;
       unsigned int col_counts[<%nCols%>];
       unsigned int col_fill[<%nCols%>];
+      threadData_t *threadData = NULL; /* for ASUB bounds error reporting (dead code for valid models) */
       <%varDecls%>
 
       <%preExp%>
@@ -4996,6 +4997,7 @@ match sparsityMatrix
       unsigned int i, nnz;
       unsigned int col_counts[<%nCols%>];
       unsigned int col_fill[<%nCols%>];
+      threadData_t *threadData = NULL; /* for ASUB bounds error reporting (dead code for valid models) */
       <%varDeclsC%><%varDeclsF%>
 
       <%preExpC%><%preExpF%>
@@ -5956,6 +5958,9 @@ match row
   case SPARSITY_ROW(dependencies=deps) then
     let forIter = (equation_iterators |> it => forIterator(it, context, &preExp, &varDecls, &auxFunction, &sub) ;separator="\n";empty)
     let forTail = (equation_iterators |> it => '}' ;separator="\n";empty)
+    // innerPreExp collects pre-expressions that may reference equation iterator variables.
+    // It is placed inside the for loop body so loop variables are in scope.
+    let &innerPreExp = buffer ""
     let bodyCode = (solved_crefs |> sc hasindex k =>
       // depsCode: dep-aware; for REGULAR 1D WHOLEDIM seeds uses resizableColCountRegular(_wr<%k%>).
       // Dep/rep condition checked inline; only valid where the outer _wr<%k%> loop variable is in scope.
@@ -5966,22 +5971,22 @@ match row
             if not listEmpty(kinds) then
               if not listHead(kinds) then
                 match crefSubs(seed)
-                case {WHOLEDIM()} then resizableColCountRegular(seed, k, context, &preExp, &varDecls, &auxFunction)
-                else resizableColCount(seed, context, &preExp, &varDecls, &auxFunction)
-              else resizableColCount(seed, context, &preExp, &varDecls, &auxFunction)
-            else resizableColCount(seed, context, &preExp, &varDecls, &auxFunction)
-          else resizableColCount(seed, context, &preExp, &varDecls, &auxFunction)
-        else resizableColCount(seed, context, &preExp, &varDecls, &auxFunction)
+                case {WHOLEDIM()} then resizableColCountRegular(seed, k, context, &innerPreExp, &varDecls, &auxFunction)
+                else resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction)
+              else resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction)
+            else resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction)
+          else resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction)
+        else resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction)
       ;separator="\n")
       // depsCodeReduced: always REDUCTION; used for SLICE sc (column alignment differs) and non-loop cases
-      let depsCodeReduced = (deps |> (seed, _, _) => resizableColCount(seed, context, &preExp, &varDecls, &auxFunction) ;separator="\n")
+      let depsCodeReduced = (deps |> (seed, _, _) => resizableColCount(seed, context, &innerPreExp, &varDecls, &auxFunction) ;separator="\n")
       match crefSubs(sc)
         case {WHOLEDIM()} then
           match context
           case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
             match simVarFromHT(crefStripSubs(sc), jacHT)
             case SIMVAR() then
-              let sz = dimension(listHead(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let sz = dimension(listHead(crefDims(sc)), context, &innerPreExp, &varDecls, &auxFunction)
               <<
               {
                 unsigned int _wr<%k%>;
@@ -5997,9 +6002,9 @@ match row
           case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
             match simVarFromHT(crefStripSubs(sc), jacHT)
             case SIMVAR() then
-              let sliceArr = daeExp(sliceExp, context, &preExp, &varDecls, &auxFunction)
+              let sliceArr = daeExp(sliceExp, context, &innerPreExp, &varDecls, &auxFunction)
               let nSlice = tempDecl("modelica_integer", &varDecls)
-              let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+              let &innerPreExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
               <<
               {
                 unsigned int _wr<%k%>;
@@ -6017,7 +6022,7 @@ match row
             case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
               match simVarFromHT(crefStripSubs(sc), jacHT)
               case SIMVAR() then
-                let sz = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+                let sz = dimension(List.last(crefDims(sc)), context, &innerPreExp, &varDecls, &auxFunction)
                 <<
                 {
                   unsigned int _wr<%k%>;
@@ -6035,6 +6040,7 @@ match row
       <<
       /* <%crefStrNoUnderscore(equation_name)%> [<%scNames%>] count */
       <%forIter%>
+        <%innerPreExp%>
         <%bodyCode%>
       <%forTail%>
       >>
@@ -6131,14 +6137,18 @@ match row
   case SPARSITY_ROW() then
     let forIter = (equation_iterators |> it => forIterator(it, context, &preExp, &varDecls, &auxFunction, &sub) ;separator="\n";empty)
     let forTail = (equation_iterators |> it => '}' ;separator="\n";empty)
+    // innerPreExp collects pre-expressions that may reference equation iterator variables.
+    // It is placed inside the for loop body so loop variables are in scope.
+    let &innerPreExp = buffer ""
     let bodyCode = (solved_crefs |> sc hasindex k =>
-      resizableFillDepsForRow(row, k, sc, context, &preExp, &varDecls, &auxFunction, spPattern)
+      resizableFillDepsForRow(row, k, sc, context, &innerPreExp, &varDecls, &auxFunction, spPattern)
     ;separator="\n")
     let scNames = (solved_crefs |> sc => System.stringReplace(System.stringReplace(crefStrNoUnderscore(sc), "/*", ""), "*/", "") ;separator=", ")
     if bodyCode then
       <<
       /* <%crefStrNoUnderscore(equation_name)%> [<%scNames%>] fill */
       <%forIter%>
+        <%innerPreExp%>
         <%bodyCode%>
       <%forTail%>
       >>

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -629,6 +629,8 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       #define <%rec_name%>_array_alloc_copy(src,dst)  generic_array_alloc_copy(src, &dst, <%cpy_func_name%>, sizeof(<%rec_name%>))
       #define <%rec_name%>_array_get(src,ndims,...)   (*(<%rec_name%>*)(generic_array_get(&src, sizeof(<%rec_name%>), __VA_ARGS__)))
       #define <%rec_name%>_set(dst,val,...)           generic_array_set(&dst, &val, <%cpy_func_name%>, sizeof(<%rec_name%>), __VA_ARGS__)
+      static inline void _<%rec_name%>_array_create(<%rec_name%>_array* dst, void* data, int ndims, ...) { va_list ap; va_start(ap, ndims); base_array_create((base_array_t*)dst, data, ndims, ap); va_end(ap); }
+      #define <%rec_name%>_array_create(dst, data, ndims, ...) _<%rec_name%>_array_create(dst, (void*)(data), ndims, __VA_ARGS__)
       >>
 end recordDeclarationFullHeader;
 
@@ -3250,12 +3252,13 @@ template indexedAssign(DAE.Exp lhs, String exp, Context context,
         'indexed_assign_<%arrayType%>(<%exp%>, &<%cref%>, &<%ispec%>);'
       else
         let type = expTypeShort(aty)
+        let typeCast = match aty case T_COMPLEX(__) then type else 'modelica_<%type%>'
         let wrapperArray = tempDecl(arrayType, &varDecls)
         let dimsLenStr = listLength(crefDims(cr))
         let dimsValuesStr = (crefDims(cr) |> dim => '(_index_t)<%dimension(dim, context, &preExp, &varDecls, &auxFunction)%>' ;separator=", ")
         let arrName = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
         <<
-        <%type%>_array_create(&<%wrapperArray%>, (modelica_<%type%>*)&<%arrName%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>
+        <%type%>_array_create(&<%wrapperArray%>, (<%typeCast%>*)&<%arrName%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>
         indexed_assign_<%arrayType%>(<%exp%>, &<%wrapperArray%>, &<%ispec%>);
         >>
   else
@@ -5494,6 +5497,7 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
 
   case ecr as CREF(componentRef=cr, ty=T_ARRAY(ty=aty, dims=dims)) then
     let type = expTypeShort(aty)
+    let typeCast = match aty case T_COMPLEX(__) then type else 'modelica_<%type%>'
     let arrayType = type + "_array"
     let wrapperArray = tempDecl(arrayType, &varDecls)
     if crefSubIsScalar(cr) then
@@ -5505,11 +5509,11 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
         else if Flags.getConfigBool(Flags.NEW_BACKEND) then
           let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
           let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-          '((modelica_<%type%>*)&(<%nosubname%>))'
+          '((<%typeCast%>*)&(<%nosubname%>))'
         else
           let &sub = buffer ""
           let nosubname = contextCref(crefArrayGetFirstCref(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-          '((modelica_<%type%>*)&(<%nosubname%>))'
+          '((<%typeCast%>*)&(<%nosubname%>))'
       let t = '<%type%>_array_create(&<%wrapperArray%>, <%arrayData%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let &preExp += t
     wrapperArray
@@ -5518,7 +5522,7 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
       let dimsLenStr = listLength(crefDims(cr))
       let dimsValuesStr = (crefDims(cr) |> dim => '(_index_t)<%dimension(dim, context, &preExp, &varDecls, &auxFunction)%>' ;separator=", ")
       let arrName = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-      let &preExp += '<%type%>_array_create(&<%wrapperArray%>, (modelica_<%type%>*)&<%arrName%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
+      let &preExp += '<%type%>_array_create(&<%wrapperArray%>, (<%typeCast%>*)&<%arrName%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let slicedArray = tempDecl(arrayType, &varDecls)
       let spec1 = daeExpCrefIndexSpec(crefSubs(cr), context, &preExp, &varDecls, &auxFunction)
       let &preExp += 'index_alloc_<%type%>_array(&<%wrapperArray%>, &<%spec1%>, &<%slicedArray%>);<%\n%>'
@@ -5679,6 +5683,7 @@ template daeExpCrefLhsSimContext(Exp ecr, Context context, Text &preExp,
 
   case ecr as CREF(componentRef=cr, ty=T_ARRAY(ty=aty, dims=dims)) then
     let type = expTypeShort(aty)
+    let typeCast = match aty case T_COMPLEX(__) then type else 'modelica_<%type%>'
     let arrayType = type + "_array"
     let wrapperArray = tempDecl(arrayType, &varDecls)
     if crefSubIsScalar(cr) then
@@ -5690,11 +5695,11 @@ template daeExpCrefLhsSimContext(Exp ecr, Context context, Text &preExp,
         else if Flags.getConfigBool(Flags.NEW_BACKEND) then
           let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
           let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-          '((modelica_<%type%>*)&(<%nosubname%>))'
+          '((<%typeCast%>*)&(<%nosubname%>))'
         else
           let &sub = buffer ""
           let nosubname = contextCref(crefArrayGetFirstCref(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-          '((modelica_<%type%>*)&(<%nosubname%>))'
+          '((<%typeCast%>*)&(<%nosubname%>))'
       let nosubname = contextCrefIsPre(crefStripSubs(cr),context, &auxFunction, isPre)
       let t = '<%type%>_array_create(&<%wrapperArray%>, <%arrayData%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let &preExp += t

--- a/testsuite/simulation/modelica/NBackend/ModelicaTest/Makefile
+++ b/testsuite/simulation/modelica/NBackend/ModelicaTest/Makefile
@@ -28,6 +28,7 @@ ModelicaTest.MultiBody.Joints.JointUPS.mos \
 # Run make failingtest
 FAILINGTESTFILES = \
 
+
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.
 DEPENDENCIES = \


### PR DESCRIPTION
SLICED_COMPONENT equations whose RHS contained MUL_ARRAY_SCALAR or similar non-element-wise array operators (e.g. `c * arr[i]`) were converted to SCALAR_EQUATION with the wrong operator still in the expression tree. The previously used `Operator.scalarize(Operator.stripEW(op))` only stripped _EW-suffixed operators and only fixed `op.ty`, leaving MUL_ARRAY_SCALAR with a scalar type — codegen still emitted `mul_alloc_real_array_scalar` causing C compilation errors.

Fix: add `Operator.toScalar` (NFOperator.mo) that changes both `op.op` (to its scalar counterpart ADD/MUL/DIV/…) and `op.ty` (to element type). Use it in `distributeSubscriptExp` (NBSolve.mo) for MULTARY and BINARY cases.

Additional fixes bundled in this branch:
- NBEquation: expand record array equations per primitive field for correct indexed_assign code generation
- NBVariable: fix lowering of record children
- NBAlias: remove alias variables from records/knowns VariablePointers
- NBDifferentiate: differentiate tuple assignments of all-Real outputs, fixing use-before-assign in generated derivative functions
- CodegenCFunctions: add record_array_create macro for complex-type arrays; fix indexed_assign type cast for record arrays
- CodegenC: fix threadData declaration in sparsity functions; fix innerPreExp scoping so sparsity row for-loop variables are in scope when building preExp