### PR TITLE
wasm-jit: make FMI3 adapter build mandatory

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -358,7 +358,8 @@ macro_rules! shared_instance_methods {
         let starts = core::mem::take(&mut st.init_start_overrides);
         set_param_overrides(params, starts);
         let mut e = Engine;
-        if run_initialization(&mut e, st.sim_data, &st.layout).is_err() {
+        let start_time = st.read_f64(TIME_OFF);
+        if run_initialization(&mut e, st.sim_data, &st.layout, start_time).is_err() {
             return Status::Error;
         }
         // Apply deferred String parameter sets now that init equations have run, so

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -61,6 +61,7 @@ fn main() {
 /// Build + embed the model-agnostic FMI3 ME adapter (`openmodelica_fmi3_wasm`) as
 /// a dylink side module, linked with the per-model module at FMU-export time.
 /// Built here regardless of omc's own target arch: build scripts run on the host.
+/// Mandatory: a failed build aborts rather than shipping an omc without it.
 fn build_fmi3_me_adapter(crate_dir: &Path, out_dir: &Path) {
     for v in ADAPTER_VARIANTS {
         build_fmi3_adapter(crate_dir, out_dir, v);
@@ -159,13 +160,13 @@ fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {
                 copy(&committed, &dest);
                 std::fs::write(&stamp, "prebuilt").ok();
             } else {
-                println!(
-                    "cargo:warning=could not build the FMI3 {} adapter ({e}); that FMI3 wasm \
-                     export will be unavailable. Install `rustup target add wasm32-unknown-unknown`.",
+                panic!(
+                    "failed to build the FMI3 {} adapter: {e}\n\
+                     FMI3 wasm FMU export requires it. Install the wasm target and std \
+                     sources (`rustup target add wasm32-unknown-unknown`, \
+                     `rustup component add rust-src`), or set {env_override} to a prebuilt .wasm.",
                     v.label
                 );
-                std::fs::write(&dest, []).ok();
-                std::fs::write(&stamp, "missing").ok();
             }
         }
     }


### PR DESCRIPTION
The FMI3 wasm adapter build fell back to a zero-byte placeholder plus a cargo:warning when the adapter failed to compile, so the build succeeded and shipped an omc whose FMI3 FMU export failed only at run time with "FMI3 adapter unavailable". On Jenkins the warning went unnoticed. Abort the build instead when no prebuilt fallback exists.

The adapter had in fact stopped compiling: run_initialization gained a start_time parameter that enter_initialization_mode already stores at TIME_OFF; read it back and pass it through.