### PR TITLE
wasm-jit: torn linear/nonlinear system codegen

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -56,7 +56,7 @@ use openmodelica_frontend_dump::ComponentReferenceBasics;
 use crate::CodegenWasmJitFunctions::{
     ArrayGroup, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_symbolic,
-    emit_nls_load_body, emit_nls_jac_body,
+    NlsResidual, emit_nls_load_body, emit_nls_jac_body,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
     external_general, function_signature, rt_index, sim_cref_key,
 };
@@ -2251,8 +2251,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         samples.iter().enumerate().map(|(k, s)| (s.index, k as u32)).collect();
     var_map.sample_map = Arc::new(sample_map);
     var_map.sample_active_off = layout.sample_active_off;
-    // Delay-expression buffer count (`maxDelayedIndex + 1`, 0 when the model has
-    // no `delay(...)`), baked into `functionInitDelay`'s `rt_delay_init` call.
+    // Delay-buffer count (0 when the model has no `delay(...)`).
     var_map.n_delays = (sim_code.delayedExps.maxDelayedIndex + 1).max(0) as u32;
 
     // State sets: register the Jacobian seed/result crefs at the scratch region
@@ -2262,12 +2261,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // Index -> equation map (for SES_ALIAS, which re-runs another equation by
     // index). An alias may point at an equation defined in a different system
     // list than the one being lowered (e.g. a parameter-equation alias to an
-    // initial equation), so index every list. `eqFunction_<n>` is emitted once in
-    // the C target and shared; here the target equation is inlined.
+    // initial equation), or at an equation nested inside a torn linear/nonlinear
+    // (or mixed / if-) system, so index every list recursively. `eqFunction_<n>`
+    // is emitted once in the C target and shared; here the target is inlined.
     let mut eq_index: HashMap<i32, Arc<SimCode::SimEqSystem>> = HashMap::new();
-    let mut index_list = |eqs: &Arc<List<Arc<SimCode::SimEqSystem>>>, idx: &mut HashMap<i32, Arc<SimCode::SimEqSystem>>| {
+    let index_list = |eqs: &Arc<List<Arc<SimCode::SimEqSystem>>>, idx: &mut HashMap<i32, Arc<SimCode::SimEqSystem>>| {
         for e in lst(eqs) {
-            idx.entry(eq_index_of(e)).or_insert_with(|| e.clone());
+            index_eq_recursive(e, idx);
         }
     };
     index_list(&sim_code.allEquations, &mut eq_index);
@@ -2500,7 +2500,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     bodies.push(build_eq_fn("odeEquations", ode_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
     bodies.push(build_eq_fn_with_prelude("algebraicEquations", &[], algebraic_eqs, &var_map, &eq_index, &by_name, &mut literals, &save_pre, &[])?);
     // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
-    bodies.push(build_init_start_values_fn(&states, &layout, &var_map, &by_name, &mut literals)?);
+    let real_algs: Vec<&SimCodeVar::SimVar> =
+        lst(&vars.algVars).chain(lst(&vars.discreteAlgVars)).collect();
+    bodies.push(build_init_start_values_fn(&states, &real_algs, &layout, &var_map, &by_name, &mut literals)?);
     // The integrator loop.
     bodies.push(build_simulate(&layout, &eqfn)?);
 
@@ -2682,9 +2684,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         });
         idx
     };
-    // `functionStoreDelayed`: append each `delay(...)` expression's current value
-    // to its ring buffer (C's `function_storeDelayed`). `functionInitDelay`:
-    // `rt_delay_init(n_delays, startTime)` to reset the buffers for a fresh run.
+    // `functionStoreDelayed` / `functionInitDelay` (C's `function_storeDelayed` +
+    // `rt_delay_init`); empty stubs when the model has no `delay(...)`.
     let store_delayed_idx = {
         let idx = import_base + bodies.len() as u32;
         bodies.push(if var_map.n_delays == 0 {
@@ -3174,12 +3175,14 @@ fn build_init_sample_fn(
     Ok(func)
 }
 
-/// Build `functionInitStartValues(SimData*)`: fill each state's start slot from its
-/// `start` expression. Called after `functionParameters` (so parameter-bound starts
-/// see final values) and before the initial equations. Empty `start_slots` here so
-/// the expressions compile inline (slots fill exactly as the old inline read).
+/// Build `functionInitStartValues(SimData*)`: seed each state's `$START` slot and
+/// each real algebraic's live slot from its `start` expression (C's
+/// `setAllVarsToStart`, initialization.c:809), so an NLS iteration variable's
+/// Newton guess is its start value. Called after `functionParameters` and before
+/// the initial equations. Empty `start_slots` so start expressions compile inline.
 fn build_init_start_values_fn(
     states: &[&SimCodeVar::SimVar],
+    real_algs: &[&SimCodeVar::SimVar],
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
@@ -3209,9 +3212,12 @@ fn build_init_start_values_fn(
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = Vec::with_capacity(states.len());
+    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = Vec::with_capacity(states.len() + real_algs.len());
     for (i, sv) in states.iter().enumerate() {
         pairs.push((sv.initialValue.clone(), layout.state_start_off(i as u32)));
+    }
+    for (j, sv) in real_algs.iter().enumerate() {
+        pairs.push((sv.initialValue.clone(), REAL_OFF + (2 * layout.n_states + j as u32) * 8));
     }
     ctx.emit_init_start_values(&pairs)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -3306,9 +3312,8 @@ fn build_update_relations_fn(
     Ok(func)
 }
 
-/// Build `functionStoreDelayed(SimData*)`: append each `delay(...)` expression's
-/// current value to its ring buffer (C's `function_storeDelayed`). Evaluated in a
-/// normal (non-discrete) equation context.
+/// Build `functionStoreDelayed(SimData*)` (C's `function_storeDelayed`): append
+/// each `delay(...)` expression's current value to its ring buffer.
 fn build_store_delayed_fn(
     sim_code: &SimCode::SimCode,
     var_map: &SimVarMap,
@@ -3352,9 +3357,8 @@ fn build_store_delayed_fn(
     Ok(func)
 }
 
-/// Build `functionInitDelay(SimData*)`: `rt_delay_init(n_delays, time)` to reset
-/// the ring buffers for a fresh run. Called at init when `time == startTime`, so
-/// `TIME_OFF` supplies the start time the runtime records.
+/// Build `functionInitDelay(SimData*)`: `rt_delay_init(n_delays, time)`, called at
+/// init with `time == startTime`.
 fn build_init_delay_fn(n_delays: u32) -> we::Function {
     use we::Instruction as I;
     let mut f = we::Function::new([]);
@@ -3529,13 +3533,14 @@ fn build_state_set_infos(
             .map(|cr| real_slot(var_map, cr))
             .collect::<Result<_>>()?;
 
-        // A[row][col] integer slots, row-major.
+        // A is a flat `nStates*nCandidates` integer array named `A[k]` (1-based,
+        // row-major: A[(row-1)*nCandidates + col]); a_offs stays in that order.
         let a_base_cref = openmodelica_frontend_dump::ComponentReferenceBasics::crefStripLastSubs(set.crA.clone())?;
         let a_base = sim_cref_key(&a_base_cref)?;
         let mut a_offs = Vec::new();
         for row in 1..=n_states {
             for c in 1..=n_candidates {
-                let key = format!("{a_base}[{row}][{c}]");
+                let key = format!("{a_base}[{}]", (row - 1) * n_candidates + c);
                 let slot = var_map
                     .vars
                     .get(&key)
@@ -3593,11 +3598,12 @@ fn stateset_diag_offsets(
 ) -> Result<Vec<u32>> {
     let mut offs = Vec::new();
     for set in lst(state_sets) {
-        // `crA` names the `A[1,1]` element; strip its subscripts to the base `A`.
+        // `crA` names the first `A` element; strip its subscripts to the base `A`.
+        // A is flat row-major, so the diagonal A[n,n] is `A[(n-1)*nCandidates + n]`.
         let base_cref = openmodelica_frontend_dump::ComponentReferenceBasics::crefStripLastSubs(set.crA.clone())?;
         let base = sim_cref_key(&base_cref)?;
         for n in 1..=set.nStates {
-            let key = format!("{base}[{n}][{n}]");
+            let key = format!("{base}[{}]", (n - 1) * set.nCandidates + n);
             let slot = var_map
                 .vars
                 .get(&key)
@@ -3635,24 +3641,36 @@ fn lower_nonlinear_system(
 /// [`build_nls_fns`] (which emits the callbacks).
 fn nls_parts(
     nlsystem: &SimCode::NonlinearSystem,
-) -> Result<(Vec<Arc<SimCode::SimEqSystem>>, Vec<Arc<DAE::Exp>>, Vec<Arc<DAE::ComponentRef>>)> {
+) -> Result<(Vec<Arc<SimCode::SimEqSystem>>, Vec<NlsResidual>, Vec<Arc<DAE::ComponentRef>>)> {
     use SimCode::SimEqSystem as E;
     let mut inner: Vec<Arc<SimCode::SimEqSystem>> = Vec::new();
-    let mut res_exps: Vec<Arc<DAE::Exp>> = Vec::new();
+    let mut residuals: Vec<NlsResidual> = Vec::new();
     for e in lst(&nlsystem.eqs) {
         match &**e {
-            E::SES_RESIDUAL { exp, .. } => res_exps.push(exp.clone()),
+            E::SES_RESIDUAL { exp, res_index, .. } => {
+                residuals.push(NlsResidual::Scalar { exp: exp.clone(), res_index: *res_index });
+            }
+            E::SES_FOR_RESIDUAL { iterators, exp, res_index, .. } => {
+                residuals.push(NlsResidual::For {
+                    iterators: lst(iterators).cloned().collect(),
+                    exp: exp.clone(),
+                    res_index: *res_index,
+                });
+            }
             _ => inner.push(e.clone()),
         }
     }
-    if res_exps.is_empty() {
+    if residuals.is_empty() {
         return Err("CodegenWasmJit: SES_NONLINEAR has no residual equations");
     }
     let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
-    if iter_vars.len() != res_exps.len() {
+    // A for-residual's count is only known at run time, so validate the unknown
+    // count only for scalar-only systems.
+    let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
+    if all_scalar && iter_vars.len() != residuals.len() {
         return Err("CodegenWasmJit: SES_NONLINEAR unknown/residual count mismatch");
     }
-    Ok((inner, res_exps, iter_vars))
+    Ok((inner, residuals, iter_vars))
 }
 
 /// Scan the compiled equation lists for `SES_NONLINEAR` systems (deduplicated by
@@ -3752,6 +3770,12 @@ fn nls_jac_result_rows(col: &SimCode::JacobianColumn, n: usize) -> Option<Vec<us
 /// seed per iteration variable and `JAC_VAR` results covering every residual row
 /// (a square dense Jacobian, as `hybrj` needs).
 fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
+    use SimCode::SimEqSystem as E;
+    // For/generic-residual Jacobian columns are array-valued, which the flat
+    // `emit_nls_jac_body` can't model; use the numerical Jacobian instead.
+    if lst(&nlsystem.eqs).any(|e| matches!(&**e, E::SES_FOR_RESIDUAL { .. } | E::SES_GENERIC_RESIDUAL { .. })) {
+        return false;
+    }
     let Some(jm) = &nlsystem.jacobianMatrix else { return false };
     let Some(col) = lst(&jm.columns).next() else { return false };
     let n = lst(&nlsystem.crefs).count();
@@ -3844,7 +3868,7 @@ fn build_nls_fns(
     literals: &mut Vec<Vec<u8>>,
     jac_info: Option<&NlsJacInfo>,
 ) -> Result<(we::Function, we::Function, Option<we::Function>)> {
-    let (inner, res_exps, iter_vars) = nls_parts(nlsystem)?;
+    let (inner, residuals, iter_vars) = nls_parts(nlsystem)?;
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(iter_vars.len());
     for cr in &iter_vars {
@@ -3900,7 +3924,7 @@ fn build_nls_fns(
             }
             Ok(())
         };
-        emit_nls_residual_body(&mut ctx, &slots, &res_exps, &mut lower_inner)?;
+        emit_nls_residual_body(&mut ctx, &slots, &residuals, &mut lower_inner)?;
         finish(ctx)
     };
     // load(sim_data, x): 2 params.
@@ -4031,6 +4055,60 @@ pub(crate) fn eq_kind_name(eq: &SimCode::SimEqSystem) -> &'static str {
 
 /// The `index` of a `SimEqSystem` (best-effort; systems without a top-level
 /// index report -1).
+/// Index `e` by its own index and recurse into nested equations (torn-system
+/// inner constraints, mixed cont/disc parts, if-branches), which an `SES_ALIAS`
+/// may target but which the top-level lists don't reach.
+fn index_eq_recursive(e: &Arc<SimCode::SimEqSystem>, idx: &mut HashMap<i32, Arc<SimCode::SimEqSystem>>) {
+    use SimCode::SimEqSystem as E;
+    let key = eq_index_of(e);
+    if key >= 0 {
+        idx.entry(key).or_insert_with(|| e.clone());
+    }
+    match &**e {
+        E::SES_LINEAR { lSystem, alternativeTearing, .. } => {
+            let mut index_lin = |s: &Arc<SimCode::LinearSystem>, idx: &mut _| {
+                for inner in lst(&s.residual) {
+                    index_eq_recursive(inner, idx);
+                }
+                for (_, _, inner) in lst(&s.simJac) {
+                    index_eq_recursive(inner, idx);
+                }
+            };
+            index_lin(lSystem, idx);
+            if let Some(alt) = alternativeTearing {
+                index_lin(alt, idx);
+            }
+        }
+        E::SES_NONLINEAR { nlSystem, alternativeTearing, .. } => {
+            for inner in lst(&nlSystem.eqs) {
+                index_eq_recursive(inner, idx);
+            }
+            if let Some(alt) = alternativeTearing {
+                for inner in lst(&alt.eqs) {
+                    index_eq_recursive(inner, idx);
+                }
+            }
+        }
+        E::SES_MIXED { cont, discEqs, .. } => {
+            index_eq_recursive(cont, idx);
+            for inner in lst(discEqs) {
+                index_eq_recursive(inner, idx);
+            }
+        }
+        E::SES_IFEQUATION { ifbranches, elsebranch, .. } => {
+            for (_, eqs) in lst(ifbranches) {
+                for inner in lst(eqs) {
+                    index_eq_recursive(inner, idx);
+                }
+            }
+            for inner in lst(elsebranch) {
+                index_eq_recursive(inner, idx);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn eq_index_of(eq: &SimCode::SimEqSystem) -> i32 {
     use SimCode::SimEqSystem as E;
     match eq {
@@ -4048,7 +4126,12 @@ fn eq_index_of(eq: &SimCode::SimEqSystem) -> i32 {
         | E::SES_INVERSE_ALGORITHM { index, .. }
         | E::SES_MIXED { index, .. }
         | E::SES_WHEN { index, .. }
+        | E::SES_ALGEBRAIC_SYSTEM { index, .. }
         | E::SES_FOR_LOOP { index, .. } => *index,
+        // Torn systems carry their index inside the system record, not as a
+        // top-level field; an `SES_ALIAS` can point at the whole system.
+        E::SES_LINEAR { lSystem, .. } => lSystem.index,
+        E::SES_NONLINEAR { nlSystem, .. } => nlSystem.index,
         _ => -1,
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -3334,13 +3334,10 @@ fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
-/// If `cr` is `base[i1,…,ik, :, …, :]` — leading `INDEX` subscripts followed by
-/// only whole-dimension subscripts, subscripts on the final component and every
-/// ancestor unsubscripted — return `(base key, leading index expressions)`. The
-/// selected sub-array is a contiguous block in the row-major `SimData` layout
-/// (the trailing whole dimensions span the fastest-varying axes). Returns `None`
-/// for a plain scalar (no `:`), a `SLICE`, or an `INDEX` after a whole dim (that
-/// selection is not contiguous).
+/// `base[i1,…,ik, :, …, :]` (leading `INDEX` subscripts, then whole dims; final
+/// component subscripted, ancestors bare) -> `(base key, leading index exprs)`.
+/// Such a selection is a contiguous row-major block. `None` for a scalar, a
+/// `SLICE`, or an `INDEX` after a whole dim.
 fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::Exp>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -3376,10 +3373,8 @@ fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
-/// If `cr` is `base[subs]` — subscripts on the final component, every ancestor
-/// unsubscripted — return `(base key, final subscript list)`. Unlike
-/// [`sim_slice_of`] the subscripts are returned raw (any `INDEX`/`SLICE`/whole
-/// mix), for the general gather-then-slice read path.
+/// `base[subs]` (final component subscripted, ancestors bare) -> `(base key, raw
+/// subscript list)`. Unlike [`sim_slice_of`], any `INDEX`/`SLICE`/whole mix.
 fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<List<Arc<DAE::Subscript>>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -3406,11 +3401,9 @@ fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<Lis
     }
 }
 
-/// Push the byte address of the first element of the contiguous sub-array
-/// `group[leading, :, …]` (leading 1-based indices, remaining axes whole) and
-/// return `(trailing_element_count, element_stride)`. The trailing dimensions
-/// are the fastest-varying axes, so the block spans `trailing_total * stride`
-/// contiguous bytes from this address.
+/// Push the byte address of element `group[leading, 1, …]` and return
+/// `(trailing_element_count, element_stride)`; the block spans
+/// `trailing_count * stride` contiguous bytes from there.
 fn emit_sim_slice_addr(ctx: &mut FnCtx, group: &ArrayGroup, leading: &[Arc<DAE::Exp>]) -> Result<(u32, u32)> {
     let (_, stride) = sim_array_elem_kind_stride(group.wty);
     let k = leading.len();
@@ -3650,17 +3643,15 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             }
         }
     }
-    // Contiguous sub-array slice `base[i,…,:]` (dynamic index + trailing whole
-    // dims): gather the row-major block into a runtime array.
+    // Contiguous slice `base[i,…,:]`: gather the row-major block.
     if let Some((base, leading)) = sim_slice_of(cref)? {
         if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
             emit_sim_slice_gather(ctx, &group, &leading)?;
             return Ok(Some(WTy::I32));
         }
     }
-    // Any other slice `base[subs]` (a column `[:,1]`, a strided range, …): gather
-    // the whole array and apply the runtime slice, which handles arbitrary
-    // `INDEX`/`SLICE`/whole subscript mixes.
+    // Any other slice (a column `[:,1]`, a strided range): gather the whole array
+    // and let the runtime slice handle it.
     if let Some((base, subs)) = sim_array_base_subs(cref)? {
         if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
             if !is_scalar_index(&subs, group.dims.len() as u32) {
@@ -3789,8 +3780,7 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
             }
         }
     }
-    // Contiguous sub-array slice `base[i,…,:] := arr` (dynamic index + trailing
-    // whole dims): scatter the runtime array into the row-major block.
+    // Contiguous slice `base[i,…,:] := arr`: scatter into the row-major block.
     if let Some((base, leading)) = sim_slice_of(cref)? {
         if let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() {
             emit_sim_slice_scatter(ctx, &group, &leading, rhs)?;
@@ -4024,8 +4014,8 @@ fn emit_sim_start_array_gather(ctx: &mut FnCtx, group: &ArrayGroup, base_key: &s
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
-    compile_linear_system, compile_linear_system_symbolic, emit_nls_jac_body, emit_nls_load_body,
-    emit_nls_residual_body, emit_solve_nls_call,
+    NlsResidual, compile_linear_system, compile_linear_system_symbolic, emit_nls_jac_body,
+    emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call,
 };
 
 fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
@@ -5229,6 +5219,19 @@ fn compile_math_builtin(
             ctx.emit(we::Instruction::I32Sub);
             Ok(SigTy::Int)
         }
+        // `$_signNoNull(x)` = (x >= 0.0 ? 1.0 : -1.0); a division-guard helper the
+        // backend's `ExpressionSolve` emits when solving torn equations.
+        "$_signNoNull" => {
+            need_args(&argv, 1, name)?;
+            ctx.emit(we::Instruction::F64Const(1.0f64.into()));
+            ctx.emit(we::Instruction::F64Const((-1.0f64).into()));
+            let w = compile_exp(ctx, argv[0])?;
+            coerce(ctx, w, WTy::F64);
+            ctx.emit(we::Instruction::F64Const(0.0f64.into()));
+            ctx.emit(we::Instruction::F64Ge);
+            ctx.emit(we::Instruction::Select);
+            Ok(SigTy::Real)
+        }
         // Number → String formatting via the runtime: a scalar becomes a freshly
         // allocated (refcount 1) String handle. The typed builtin names are
         // unambiguous; `String(x)` dispatches on the argument's Modelica type.
@@ -5474,10 +5477,8 @@ fn emit_string_builtin(ctx: &mut FnCtx, argv: &[&Arc<DAE::Exp>]) -> Result<SigTy
     // stringify the index. Carrying enum names would need the literal table
     // threaded through from the DAE type into the sidecar/runtime.
     if exp_is_enumeration(argv[0]) {
-        // `String(enum, format)`: the printf-directive variant formats the 1-based
-        // Integer index (C's `String(x, "d")`), *not* the literal name — and unlike
-        // the name path it never traps on an out-of-range value (e.g. a min/max
-        // warning-assert message built while an enum is transiently 0).
+        // `String(enum, format)` formats the 1-based index (C's `String(x, "d")`),
+        // not the name, and does not trap on an out-of-range value.
         if argv.len() == 2 && exp_sigty(argv[1])? == SigTy::Str {
             return emit_string_format(ctx, argv[0], argv[1], &SigTy::Int);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -36,15 +36,26 @@ fn emit_residual_eval(
     Ok(())
 }
 
+/// A nonlinear system residual: a scalar `SES_RESIDUAL`, or a `SES_FOR_RESIDUAL`
+/// (a run `r[res_index + shift]` from iterating `exp` over integer ranges).
+pub(crate) enum NlsResidual {
+    Scalar { exp: Arc<DAE::Exp>, res_index: i32 },
+    For {
+        iterators: Vec<(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)>,
+        exp: Arc<DAE::Exp>,
+        res_index: i32,
+    },
+}
+
 /// Emit the body of a nonlinear system's `residual(sim_data, x, r)` callback
 /// (wasm locals: 0 = `SimData`, 1 = `x` pointer, 2 = `r` pointer). Copies the
 /// `n` unknowns from `x` into their `slots`, runs the inner (torn) equations via
-/// `lower_inner`, then stores each residual as an f64 at `r[i]`. Reached from
-/// `rt_solve_nls` by `call_indirect`.
+/// `lower_inner`, then stores the residuals into `r`. Reached from `rt_solve_nls`
+/// by `call_indirect`.
 pub(crate) fn emit_nls_residual_body(
     ctx: &mut FnCtx,
     slots: &[u32],
-    res_exps: &[Arc<DAE::Exp>],
+    residuals: &[NlsResidual],
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
@@ -55,12 +66,95 @@ pub(crate) fn emit_nls_residual_body(
         ctx.emit(I::F64Store(mem_arg(off, 3)));
     }
     lower_inner(ctx)?;
-    for (i, exp) in res_exps.iter().enumerate() {
+    // All-scalar systems keep sequential `r[i]` addressing; a for-residual forces
+    // `res_index`-based addressing throughout (C's `res[res_index + shift]`).
+    let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
+    for (i, res) in residuals.iter().enumerate() {
+        match res {
+            NlsResidual::Scalar { exp, res_index } => {
+                let dest = if all_scalar { i as u32 } else { *res_index as u32 };
+                ctx.emit(I::LocalGet(2)); // r
+                let w = compile_exp(ctx, exp)?;
+                coerce(ctx, w, WTy::F64);
+                ctx.emit(I::F64Store(mem_arg(dest * 8, 3)));
+            }
+            NlsResidual::For { iterators, exp, res_index } => {
+                emit_for_residual(ctx, iterators, exp, *res_index, &[])?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Emit a `SES_FOR_RESIDUAL`: nested `for` loops (outermost first) storing
+/// `r[res_index + Σ(iter_k - start_k)] = exp` (C's `indexShift`). Each iterator
+/// registers as a wasm local so `compile_exp` resolves `x[$i]` and bare `$i`.
+fn emit_for_residual(
+    ctx: &mut FnCtx,
+    iterators: &[(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)],
+    exp: &Arc<DAE::Exp>,
+    res_index: i32,
+    outer: &[(u32, u32)],
+) -> Result<()> {
+    use we::Instruction as I;
+    let Some(((cref, range), rest)) = iterators.split_first() else {
+        // addr = r + (res_index + Σ(it - start)) * 8
         ctx.emit(I::LocalGet(2)); // r
+        ctx.emit(I::I32Const(res_index));
+        for &(it, start_l) in outer {
+            ctx.emit(I::LocalGet(it));
+            ctx.emit(I::LocalGet(start_l));
+            ctx.emit(I::I32Sub);
+            ctx.emit(I::I32Add);
+        }
+        ctx.emit(I::I32Const(8));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add); // element address
         let w = compile_exp(ctx, exp)?;
         coerce(ctx, w, WTy::F64);
-        ctx.emit(I::F64Store(mem_arg((i as u32) * 8, 3)));
+        ctx.emit(I::F64Store(mem_arg(0, 3)));
+        return Ok(());
+    };
+    let DAE::Exp::RANGE { start, step, stop, .. } = &**range else {
+        return Err("CodegenWasmJit: for-residual over a non-range iterator");
+    };
+    let id = cref_ident(cref)?;
+    let it = ctx.alloc_temp(WTy::I32);
+    ctx.locals.insert(id, (it, SigTy::Int));
+    let start_l = ctx.alloc_temp(WTy::I32);
+    let step_l = ctx.alloc_temp(WTy::I32);
+    let stop_l = ctx.alloc_temp(WTy::I32);
+    let sw = compile_exp(ctx, start)?;
+    coerce(ctx, sw, WTy::I32);
+    ctx.emit(I::LocalTee(start_l));
+    ctx.emit(I::LocalSet(it));
+    match step {
+        Some(e) => {
+            let w = compile_exp(ctx, e)?;
+            coerce(ctx, w, WTy::I32);
+        }
+        None => ctx.emit(I::I32Const(1)),
     }
+    ctx.emit(I::LocalSet(step_l));
+    let pw = compile_exp(ctx, stop)?;
+    coerce(ctx, pw, WTy::I32);
+    ctx.emit(I::LocalSet(stop_l));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(it));
+    ctx.emit(I::LocalGet(stop_l));
+    ctx.emit(I::I32GtS);
+    ctx.emit(I::BrIf(1));
+    let mut inner = outer.to_vec();
+    inner.push((it, start_l));
+    emit_for_residual(ctx, rest, exp, res_index, &inner)?;
+    ctx.emit(I::LocalGet(it));
+    ctx.emit(I::LocalGet(step_l));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(it));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End); // loop
+    ctx.emit(I::End); // block
     Ok(())
 }
 
@@ -144,9 +238,10 @@ pub(crate) fn emit_nls_jac_body(
 /// solution is scattered back into `iter_vars`, and the inner equations are run
 /// once more so the torn variables are consistent with the solution.
 ///
-/// `lower_inner` is invoked `n + 2` times (once per probe + once to recover); the
-/// inner equations read the unknowns from their `SimData` slots, which this code
-/// sets before each invocation.
+/// `lower_inner` is emitted twice — once for the `b` probe and once for the shared
+/// column-probe loop body (run `n` times) — plus once more to recover; the inner
+/// equations read the unknowns from their `SimData` slots, which this code sets
+/// before each invocation.
 pub(crate) fn compile_linear_system(
     ctx: &mut FnCtx,
     iter_vars: &[Arc<DAE::ComponentRef>],
@@ -177,23 +272,46 @@ pub(crate) fn compile_linear_system(
     }
     let data = ctx.sim()?.data_local;
 
-    // One scratch block: A (n*n, column-major) | b (n) | res0 (n) | rescol (n).
+    // One scratch block: A (n*n, column-major) | b (n) | res0 (n) | rescol (n) |
+    // offs (n i32 slot offsets, so the probe loop can index unknown `col` at run
+    // time). The `n` column probes share a single emitted residual body run inside
+    // a wasm loop — unrolling them (as `b`/recovery still are) is O(n) copies of
+    // the inner equations, which explodes the code for large systems.
     let a_off: u32 = 0;
     let b_off: u32 = (n * n * 8) as u32;
     let res0_off: u32 = ((n * n + n) * 8) as u32;
     let rescol_off: u32 = ((n * n + 2 * n) * 8) as u32;
-    let scratch_bytes: u32 = ((n * n + 3 * n) * 8) as u32;
+    let offs_off: u32 = ((n * n + 3 * n) * 8) as u32;
+    let scratch_bytes: u32 = offs_off + (n * 4) as u32;
 
     let base = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::I32Const(scratch_bytes as i32));
     ctx.emit(we::Instruction::Call(rt_index("rt_alloc")?));
     ctx.emit(we::Instruction::LocalSet(base));
 
+    // Record each unknown's slot offset in the `offs` array for run-time indexing.
+    for (j, &off) in slots.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(base));
+        ctx.emit(we::Instruction::I32Const(off as i32));
+        ctx.emit(we::Instruction::I32Store(mem_arg(offs_off + (j as u32) * 4, 2)));
+    }
+
     // Set unknown `j` to a literal 0.0 / 1.0 in its SimData slot.
     let set_unknown = |ctx: &mut FnCtx, slot_off: u32, val: f64| {
         ctx.emit(we::Instruction::LocalGet(data));
         ctx.emit(we::Instruction::F64Const(val.into()));
         ctx.emit(we::Instruction::F64Store(mem_arg(slot_off, 3)));
+    };
+    // Push the address of unknown `col` (SimData + offs[col]) onto the stack.
+    let push_unknown_addr = |ctx: &mut FnCtx, col: u32| {
+        ctx.emit(we::Instruction::LocalGet(data));
+        ctx.emit(we::Instruction::LocalGet(base));
+        ctx.emit(we::Instruction::LocalGet(col));
+        ctx.emit(we::Instruction::I32Const(4));
+        ctx.emit(we::Instruction::I32Mul);
+        ctx.emit(we::Instruction::I32Add);
+        ctx.emit(we::Instruction::I32Load(mem_arg(offs_off, 2)));
+        ctx.emit(we::Instruction::I32Add);
     };
 
     // --- b = -r(0): all unknowns 0, residual into res0, then negate into b. ---
@@ -210,24 +328,51 @@ pub(crate) fn compile_linear_system(
         ctx.emit(we::Instruction::F64Store(mem_arg(b_off + i * 8, 3)));
     }
 
-    // --- A columns: unknown `col` set to 1, the rest 0; A[:,col] = r(e_col) - r(0). ---
-    for col in 0..n {
-        for (j, &off) in slots.iter().enumerate() {
-            set_unknown(ctx, off, if j == col { 1.0 } else { 0.0 });
-        }
-        emit_residual_eval(ctx, base, res_exps, rescol_off, lower_inner)?;
-        for i in 0..n {
-            let i_u = i as u32;
-            let elem_off = a_off + ((col * n + i) as u32) * 8; // column-major
-            ctx.emit(we::Instruction::LocalGet(base));
-            ctx.emit(we::Instruction::LocalGet(base));
-            ctx.emit(we::Instruction::F64Load(mem_arg(rescol_off + i_u * 8, 3)));
-            ctx.emit(we::Instruction::LocalGet(base));
-            ctx.emit(we::Instruction::F64Load(mem_arg(res0_off + i_u * 8, 3)));
-            ctx.emit(we::Instruction::F64Sub);
-            ctx.emit(we::Instruction::F64Store(mem_arg(elem_off, 3)));
-        }
+    // --- A columns: probe unknown `col` = 1 (rest still 0), A[:,col] = r(e_col) -
+    // r(0), then reset it. All unknowns are 0 on entry (from the b probe) and left
+    // 0 after each reset, so only `col` is toggled per iteration. ---
+    let col = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(0));
+    ctx.emit(we::Instruction::LocalSet(col));
+    ctx.emit(we::Instruction::Block(we::BlockType::Empty));
+    ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
+    ctx.emit(we::Instruction::LocalGet(col));
+    ctx.emit(we::Instruction::I32Const(n as i32));
+    ctx.emit(we::Instruction::I32GeS);
+    ctx.emit(we::Instruction::BrIf(1));
+    push_unknown_addr(ctx, col);
+    ctx.emit(we::Instruction::F64Const(1.0f64.into()));
+    ctx.emit(we::Instruction::F64Store(mem_arg(0, 3)));
+    emit_residual_eval(ctx, base, res_exps, rescol_off, lower_inner)?;
+    // A[col*n + i] = rescol[i] - res0[i], the column address computed from `col`.
+    for i in 0..n {
+        let i_u = i as u32;
+        ctx.emit(we::Instruction::LocalGet(base));
+        ctx.emit(we::Instruction::LocalGet(col));
+        ctx.emit(we::Instruction::I32Const(n as i32));
+        ctx.emit(we::Instruction::I32Mul);
+        ctx.emit(we::Instruction::I32Const(i_u as i32));
+        ctx.emit(we::Instruction::I32Add);
+        ctx.emit(we::Instruction::I32Const(8));
+        ctx.emit(we::Instruction::I32Mul);
+        ctx.emit(we::Instruction::I32Add);
+        ctx.emit(we::Instruction::LocalGet(base));
+        ctx.emit(we::Instruction::F64Load(mem_arg(rescol_off + i_u * 8, 3)));
+        ctx.emit(we::Instruction::LocalGet(base));
+        ctx.emit(we::Instruction::F64Load(mem_arg(res0_off + i_u * 8, 3)));
+        ctx.emit(we::Instruction::F64Sub);
+        ctx.emit(we::Instruction::F64Store(mem_arg(0, 3)));
     }
+    push_unknown_addr(ctx, col);
+    ctx.emit(we::Instruction::F64Const(0.0f64.into()));
+    ctx.emit(we::Instruction::F64Store(mem_arg(0, 3)));
+    ctx.emit(we::Instruction::LocalGet(col));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::I32Add);
+    ctx.emit(we::Instruction::LocalSet(col));
+    ctx.emit(we::Instruction::Br(0));
+    ctx.emit(we::Instruction::End); // loop
+    ctx.emit(we::Instruction::End); // block
 
     // --- solve A x = b in place (b <- x); trap on a singular system. ---
     ctx.emit(we::Instruction::LocalGet(base)); // a_ptr (a_off == 0)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -744,16 +744,12 @@ pub fn take_chatter_log() -> Vec<String> {
 /// step seeded by the previous one's solution. Leaves lambda = 1, then seeds
 /// `relationsPre` for the continuous phase's held relations.
 pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
-    // Set the start time and reset the delay buffers before any equation function
-    // runs (`rt_delay_eval` traps on unallocated buffers; `functionInitDelay`
-    // reads `startTime` from `TIME_OFF`).
+    // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
+    // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
     run_initialization_impl(e, sim_data, layout)?;
-    // C's `storePreValues` after the initial solve (initialization.c:903): `pre(x)`
-    // for the discrete update is the value the initial system left in `x`, not the
-    // start value seeded before the solve. Without this, a discrete alg var assigned
-    // `x := pre(x)` by a non-firing `when` (a digital gate's `y_old`) reverts to 0.
+    // C's `storePreValues` after the initial solve (initialization.c:903).
     seed_pre_from_live(e, sim_data, layout)?;
     // Seed the continuous phase's held relations from a full discrete fixed point.
     // The initial system does not necessarily touch every relation guarding the
@@ -762,8 +758,7 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
     iterate_discrete(e, sim_data, layout)?;
     store_relations(e, sim_data, layout)?;
     update_relations_pre(e, sim_data, layout)?;
-    // Seed the delay buffers at `startTime` and snapshot the crossings as
-    // `zeroCrossingsPre` so `delayZeroCrossing` has a held value on step 1.
+    // Seed the delay buffers and snapshot `zeroCrossingsPre` for step 1.
     e.call1_if_present("functionStoreDelayed", sim_data)?;
     if layout.n_zc > 0 {
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
@@ -785,9 +780,8 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     apply_param_overrides(e, sim_data)?;
     e.call1("functionInitStartValues", sim_data)?;
     apply_start_overrides(e, sim_data)?;
-    // C's `storePreValues` before the initial solve: `pre(x)` at initialization is
-    // the start value, so a `$PRE.<discrete>` read in an initial equation (e.g. a
-    // cross-coupled digital latch) sees `start`, not 0.
+    // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
+    // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 2)?;
     if layout.n_samples > 0 {
@@ -1051,11 +1045,8 @@ fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
     // evaluation lets an already-settled system stop after a single evaluation.
     for iter in 0..MAX_EVENT_ITER {
         let prev = discrete_snapshot(e, sim_data, layout)?;
-        // C's `updateDiscreteSystem`: `storePreValues` at the head of each iteration
-        // after the first, so a discrete var this pass recomputes (a friction
-        // clutch's `mode`) is visible as `pre(mode)` to the next pass. Without it a
-        // `pre()`-dependent discrete equation (`locked = … not(pre(mode)==-1 …)`)
-        // never settles and the system fixes on the wrong branch.
+        // C's `updateDiscreteSystem` `storePreValues`: make this pass's discrete
+        // values visible as `pre()` to the next (e.g. a clutch's `pre(mode)`).
         if iter > 0 {
             seed_pre_from_live(e, sim_data, layout)?;
         }


### PR DESCRIPTION
Loop the torn linear-system probe. compile_linear_system recovered A by probing the residual and inlined the whole inner-equation block once per column (n+2 copies). A large torn linear system (e.g. Tearing12's 31-link MultiBody chain) blew this up to a 215 MB model module that wasmtime rejected as unparseable, so the model never ran. Emit the column probes as a wasm runtime loop over an in-memory table of the unknowns' slot offsets, so the inner/residual block is emitted twice (b probe + shared loop body) instead of n+2 times. Same probe-based A[:,j] = r(e_j) - r(0) assembly and rt_linsolve; O(n) code rather than O(n^2). Tearing12 drops to 2.47 MB and simulates.

Seed the nonlinear-solver initial guess from the `start` attributes, not just for states: functionInitStartValues now also fills each real algebraic's live slot (C's setAllVarsToStart), so an NLS iteration variable's Newton guess is its start value instead of 0 and it converges to the intended root.

Resolve an SES_ALIAS that targets a torn system: eq_index_of returns the LinearSystem/NonlinearSystem index (and SES_ALGEBRAIC_SYSTEM), and the index map is built recursively into torn-system inner equations, mixed cont/disc parts and if-branches.

Lower SES_FOR_RESIDUAL (the newBackend's compact array-equation residual) as a runtime loop writing r[res_index + shift], with the iterator as a wasm local so x[$i] resolves via the runtime array-element path; such systems use the numerical Jacobian. All-scalar systems keep the previous sequential r[i] addressing unchanged.

Also carries the state-set flat A[k] matrix indexing and delay/store comment tidying from earlier in this line of work.


Claude-Session: https://claude.ai/code/session_017wnjGgm1AZdCnfD8efKj3q

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
