### PR TITLE
wasm-jit: sparse solver for torn linear systems

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6520,6 +6520,7 @@ dependencies = [
  "openmodelica_backend",
  "openmodelica_backend_types",
  "openmodelica_error",
+ "openmodelica_frontend_base",
  "openmodelica_frontend_dump",
  "openmodelica_frontend_types",
  "openmodelica_mat_writer",
@@ -6909,6 +6910,7 @@ dependencies = [
  "openmodelica_sim_meta",
  "openmodelica_util",
  "openmodelica_wasi",
+ "rsparse",
  "wasm-encoder 0.252.0",
  "wasmer",
  "wasmtime",
@@ -8287,6 +8289,12 @@ checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "rsparse"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65dc8db760bdc8c94f4163c5d09be710f76fc92a4a1f698c441925db83c09e"
 
 [[package]]
 name = "rustc-demangle"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -21,6 +21,7 @@ openmodelica_backend_types.workspace = true
 openmodelica_error.workspace = true
 openmodelica_frontend_types.workspace = true
 openmodelica_frontend_dump.workspace = true
+openmodelica_frontend_base.workspace = true
 openmodelica_tpl.workspace = true
 openmodelica_util.workspace = true
 arcstr.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -55,7 +55,8 @@ use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
     ArrayGroup, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
-    SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_symbolic,
+    SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
+    compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     NlsResidual, emit_nls_load_body, emit_nls_jac_body,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
     external_general, function_signature, rt_index, sim_cref_key,
@@ -122,9 +123,10 @@ fn log_stats_block(s: &SolveStats) -> String {
          LOG_STATS         | info    | |   {:5} calls of functionODE\n\
          LOG_STATS         | info    | |   {:5} evaluations of jacobian\n\
          LOG_STATS         | info    | |   {:5} error test failures\n\
-         LOG_STATS         | info    | |   {:5} convergence test failures\n",
+         LOG_STATS         | info    | |   {:5} convergence test failures\n\
+         LOG_STATS         | info    | |   {:5} linear system solves\n",
         s.state_events, s.time_events, s.method, s.steps,
-        s.res_evals, s.jac_evals, s.err_test_fails, s.conv_test_fails,
+        s.res_evals, s.jac_evals, s.err_test_fails, s.conv_test_fails, s.lin_solves,
     )
 }
 
@@ -581,6 +583,13 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     // LOG_STATS / chattering lines). `INIT_OUTPUT` is `None` when init failed.
     let sim_output = format!("{}{extra}", openmodelica_wasi::wasi::take_stdout_capture());
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
+    // C prints the sparse-solver announcements (initializeLinearSystems) ahead of
+    // the init-success line; prepend our pre-rendered copy to the init output.
+    let init_output = if model.sparse_lss_log.is_empty() {
+        init_output
+    } else {
+        Some(format!("{}{}", model.sparse_lss_log, init_output.unwrap_or_default()))
+    };
     (res, init_output, sim_output)
 }
 
@@ -2207,7 +2216,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let zero_crossings = collect_zero_crossings(&sim_code.zeroCrossings)?;
     let relations = collect_relations(&sim_code.relations)?;
     let stateset_scratch_f64 = stateset_scratch_f64(&sim_code.stateSets)?;
-    let nls_jac_scratch_f64 = nls_jac_scratch_f64(sim_code);
+    // Jacobian scratch region: nonlinear-system slots + torn-linear slots (after).
+    let nls_jac_scratch_f64 = nls_jac_scratch_f64(sim_code) + lin_jac_scratch_f64(sim_code);
     let all_eqs = flatten_eqs(&sim_code.allEquations);
     // A model has discrete `when` behaviour through when-equations (SES_WHEN) or
     // when-statements inside an algorithm — both need the per-step pre-value save
@@ -2369,6 +2379,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // Register the analytic-Jacobian seed/result crefs before the equation
     // functions are lowered, so the column equations resolve their slots.
     let nls_jac_infos = build_nls_jac_infos(&nls_systems, &layout, &mut var_map)?;
+    // Same, for torn linear systems that assemble A analytically.
+    build_lin_jac_infos(sim_code, &layout, &mut var_map)?;
     var_map.nls_jobs = Arc::new(nls_jobs);
 
     // --- Type section: one type per import, per model function, per equation
@@ -2844,7 +2856,112 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         editable_params,
         var_units,
         meta,
+        sparse_lss_log: build_sparse_lss_log(sim_code),
     })
+}
+
+/// `LOG_STDOUT` prefix for the first line of a message, and the continuation
+/// prefix OMC's `streamPrint` uses for wrapped lines (see the C runtime output).
+const LOG_STDOUT_PREFIX: &str = "LOG_STDOUT        | info    | ";
+const LOG_CONT_PREFIX: &str = "|                 | |       | ";
+
+/// Wrap a `\n`-separated message in the `LOG_STDOUT`/continuation prefixes.
+fn format_log_stdout(msg: &str) -> String {
+    let mut out = String::new();
+    for (i, line) in msg.split('\n').enumerate() {
+        out.push_str(if i == 0 { LOG_STDOUT_PREFIX } else { LOG_CONT_PREFIX });
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Reproduce C's `initializeLinearSystems` sparse-solver announcements
+/// (`linearSystem.c`): for each torn linear system chosen as sparse (by
+/// [`lin_use_sparse`]), one message keyed on why (density and/or size), then one
+/// aggregate flag-hint. Systems are taken across the init + simulation equation
+/// lists, deduplicated and ordered by `indexLinearSystem` (C's array order).
+fn build_sparse_lss_log(sim_code: &SimCode::SimCode) -> String {
+    use crate::CodegenWasmJitFunctions::{lin_use_sparse, LSS_MAX_DENSITY, LSS_MIN_SIZE};
+    // (indexLinearSystem, size, nnz), deduped by index, in index order.
+    let mut seen: HashSet<i32> = HashSet::new();
+    let mut systems: Vec<(i32, usize, usize)> = Vec::new();
+    let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
+        for e in &eqs {
+            if let SimCode::SimEqSystem::SES_LINEAR { lSystem, .. } = &**e {
+                let size = count(&lSystem.vars) as usize;
+                let nnz = lin_system_nnz(lSystem);
+                if seen.insert(lSystem.indexLinearSystem) {
+                    systems.push((lSystem.indexLinearSystem, size, nnz));
+                }
+            }
+        }
+    };
+    scan(flatten_eqs(&sim_code.parameterEquations));
+    scan(flatten_eqs(&sim_code.initialEquations));
+    scan(flatten_eqs_ll(&sim_code.odeEquations));
+    scan(flatten_eqs_ll(&sim_code.algebraicEquations));
+    systems.sort_by_key(|&(idx, _, _)| idx);
+
+    let mut out = String::new();
+    let mut some_small_density = false;
+    let mut some_big_size = false;
+    for (idx, size, nnz) in &systems {
+        let (size, nnz) = (*size, *nnz);
+        if size == 0 || !lin_use_sparse(size, nnz) {
+            continue;
+        }
+        let density = nnz as f64 / (size * size) as f64;
+        let small_density = density < LSS_MAX_DENSITY;
+        let big_size = size > LSS_MIN_SIZE;
+        let body = if small_density {
+            some_small_density = true;
+            if big_size {
+                some_big_size = true;
+                format!(
+                    "Using sparse solver for linear system {idx},\nbecause density of {density:.3} remains under threshold of {LSS_MAX_DENSITY:.3}\nand size of {size} exceeds threshold of {LSS_MIN_SIZE}."
+                )
+            } else {
+                format!(
+                    "Using sparse solver for linear system {idx},\nbecause density of {density:.3} remains under threshold of {LSS_MAX_DENSITY:.3}."
+                )
+            }
+        } else {
+            some_big_size = true;
+            format!("Using sparse solver for linear system {idx},\nbecause size of {size} exceeds threshold of {LSS_MIN_SIZE}.")
+        };
+        out.push_str(&format_log_stdout(&body));
+    }
+    let hint = if some_small_density {
+        if some_big_size {
+            Some("The maximum density and the minimal system size for using sparse solvers can be\nspecified using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.")
+        } else {
+            Some("The maximum density for using sparse solvers can be specified\nusing the runtime flag '<-lssMaxDensity=value>'.")
+        }
+    } else if some_big_size {
+        Some("The minimal system size for using sparse solvers can be specified\nusing the runtime flag '<-lssMinSize=value>'.")
+    } else {
+        None
+    };
+    if let Some(h) = hint {
+        out.push_str(&format_log_stdout(h));
+    }
+    out
+}
+
+/// The nonzero count of a linear system's matrix `A`, matching C's
+/// `initializeLinearSystems`: `listLength(simJac)` for the non-torn (method-0)
+/// form, else the symbolic Jacobian's sparsity nnz (method 1, torn systems).
+fn lin_system_nnz(lsystem: &SimCode::LinearSystem) -> usize {
+    let sj = count(&lsystem.simJac) as usize;
+    if sj > 0 {
+        return sj;
+    }
+    lsystem
+        .jacobianMatrix
+        .as_ref()
+        .map(|jm| lst(&jm.sparsity).map(|(_, rows)| lst(rows).count()).sum())
+        .unwrap_or(0)
 }
 
 fn build_jac_a_info(sim_code: &SimCode::SimCode, n_states: u32) -> Option<JacAInfo> {
@@ -3404,13 +3521,16 @@ fn lower_equation(
     }
 }
 
-/// Lower a `SES_LINEAR` (torn) system. The `residual` list is partitioned into
-/// the inner constraint equations (which compute the torn variables from the
-/// iteration unknowns) and the `SES_RESIDUAL` residual expressions; the unknowns
-/// are `lSystem.vars`. The numerical-Jacobian assembly + solve + scatter is in
-/// [`compile_linear_system`]; here we just supply the unknowns, residual
-/// expressions, and a closure that lowers the inner equations (re-invoked for
-/// each residual probe).
+/// Lower a `SES_LINEAR` system. Matching the C runtime, `A` is assembled
+/// symbolically from `simJac` (`(row, col, SES_RESIDUAL(exp))`, 0-based,
+/// column-major) and `b` from `beqs` — `setLinearMatrixA`/`setLinearVectorb` —
+/// rather than by residual probing; [`compile_linear_system_symbolic`] then solves
+/// dense or sparse per the density/size threshold. For a torn system the
+/// `residual` list's non-`SES_RESIDUAL` entries are the inner equations that
+/// recover the non-iteration torn variables, run once at the solution.
+///
+/// The residual-probing path ([`compile_linear_system`]) is the fallback for the
+/// rare system without a usable `simJac`.
 fn lower_linear_system(
     ctx: &mut FnCtx,
     lsystem: &SimCode::LinearSystem,
@@ -3425,44 +3545,99 @@ fn lower_linear_system(
             _ => inner.push(e.clone()),
         }
     }
-    if res_exps.is_empty() {
-        // Non-torn symbolic form: A from `simJac`, b from `beqs` (the C runtime's
-        // setA/setb path). No inner equations — the entries are functions of the
-        // already-computed variables.
-        return lower_linear_system_symbolic(ctx, lsystem);
+    let torn = !res_exps.is_empty();
+    let vars: Vec<Arc<DAE::ComponentRef>> = lst(&lsystem.vars).map(|v| v.name.clone()).collect();
+    let n = vars.len();
+
+    // A from simJac, b from beqs. `usable` false if any entry is not an ordinary
+    // scalar residual (e.g. a for-residual we can't index statically).
+    let mut a_entries: Vec<(usize, usize, &Arc<DAE::Exp>)> = Vec::new();
+    let mut usable = true;
+    for entry in lst(&lsystem.simJac) {
+        let (row, col, eq) = entry;
+        match &**eq {
+            E::SES_RESIDUAL { exp, .. } => a_entries.push((*row as usize, *col as usize, exp)),
+            _ => {
+                usable = false;
+                break;
+            }
+        }
     }
-    let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&lsystem.vars).map(|v| v.name.clone()).collect();
+    let b_exps: Vec<&Arc<DAE::Exp>> = lst(&lsystem.beqs).collect();
+
+    if usable && !a_entries.is_empty() && b_exps.len() == n {
+        // Torn systems recover their inner variables at the solution; the non-torn
+        // form has none (its `inner` is empty regardless).
+        let mut lower_inner = |c: &mut FnCtx| -> Result<()> {
+            if torn {
+                for eq in &inner {
+                    lower_equation(c, eq, eq_index)?;
+                }
+            }
+            Ok(())
+        };
+        return compile_linear_system_symbolic(ctx, &vars, n, &a_entries, &b_exps, &mut lower_inner, lsystem.index);
+    }
+
+    // Only a torn system supplies the residuals both assembly paths need.
+    if !torn {
+        return Err("CodegenWasmJit: SES_LINEAR has neither a usable simJac nor residual equations");
+    }
+    let use_sparse = lin_torn_use_sparse(lsystem, n);
     let mut lower_inner = |c: &mut FnCtx| -> Result<()> {
         for eq in &inner {
             lower_equation(c, eq, eq_index)?;
         }
         Ok(())
     };
-    compile_linear_system(ctx, &iter_vars, &res_exps, &mut lower_inner)
+
+    // Prefer analytic-Jacobian assembly (C's method 1); probe only when there is no
+    // usable Jacobian (its slots were registered by `build_lin_jac_infos`).
+    if lin_jac_usable(lsystem, res_exps.len()) {
+        let (seed_offs, result_offs) = {
+            let vars = &ctx.sim()?.vars;
+            lin_jac_offsets(lsystem, vars, n)?
+        };
+        let jm = lsystem.jacobianMatrix.as_ref().unwrap();
+        let col = lst(&jm.columns).next().unwrap();
+        let constant_eqns: Vec<Arc<SimCode::SimEqSystem>> = lst(&col.constantEqns).cloned().collect();
+        let column_eqns: Vec<Arc<SimCode::SimEqSystem>> = lst(&col.columnEqns).cloned().collect();
+        let mut lower_constant = |c: &mut FnCtx| -> Result<()> {
+            for eq in &constant_eqns { lower_equation(c, eq, eq_index)?; }
+            Ok(())
+        };
+        let mut lower_column = |c: &mut FnCtx| -> Result<()> {
+            for eq in &column_eqns { lower_equation(c, eq, eq_index)?; }
+            Ok(())
+        };
+        // Sparse: assemble straight into CSC (no dense n² buffer) when the pattern
+        // remaps cleanly to res_index rows; otherwise dense A + runtime nonzero scan.
+        if use_sparse {
+            if let Some((colptr, rowidx)) = lin_jac_csc_pattern(lsystem, n) {
+                return compile_linear_system_analytic_csc(
+                    ctx, lsystem.index, &vars, &res_exps, &seed_offs, &result_offs, &colptr, &rowidx,
+                    &mut lower_inner, &mut lower_constant, &mut lower_column,
+                );
+            }
+        }
+        return compile_linear_system_analytic(
+            ctx, &vars, &res_exps, &seed_offs, &result_offs,
+            &mut lower_inner, &mut lower_constant, &mut lower_column, use_sparse,
+        );
+    }
+
+    compile_linear_system(ctx, &vars, &res_exps, &mut lower_inner, use_sparse)
 }
 
-/// Lower a non-torn `SES_LINEAR` system given symbolically as `A x = b`, where
-/// `A` comes from `simJac` (a sparse list of `(row, col, SES_RESIDUAL(exp))`,
-/// 0-based, column-major) and `b` from `beqs` (one expression per row). Mirrors
-/// the C `setLinearMatrixA`/`setLinearVectorb` + `dgesv` path: assemble A and b
-/// (both functions of already-solved variables), solve, and scatter into `vars`.
-fn lower_linear_system_symbolic(
-    ctx: &mut FnCtx,
-    lsystem: &SimCode::LinearSystem,
-) -> Result<()> {
-    use SimCode::SimEqSystem as E;
-    let vars: Vec<Arc<DAE::ComponentRef>> = lst(&lsystem.vars).map(|v| v.name.clone()).collect();
-    let n = vars.len();
-    let mut a_entries: Vec<(usize, usize, &Arc<DAE::Exp>)> = Vec::new();
-    for entry in lst(&lsystem.simJac) {
-        let (row, col, eq) = entry;
-        match &**eq {
-            E::SES_RESIDUAL { exp, .. } => a_entries.push((*row as usize, *col as usize, exp)),
-            other => return Err("CodegenWasmJit: SES_LINEAR simJac entry is not SES_RESIDUAL"),
-        }
+/// Whether a torn linear system uses the sparse solver (C's density/size
+/// threshold). `nnz` from `lin_system_nnz` so it agrees with the log message.
+fn lin_torn_use_sparse(lsystem: &SimCode::LinearSystem, n: usize) -> bool {
+    use crate::CodegenWasmJitFunctions::lin_use_sparse;
+    if n == 0 {
+        return false;
     }
-    let b_exps: Vec<&Arc<DAE::Exp>> = lst(&lsystem.beqs).collect();
-    compile_linear_system_symbolic(ctx, &vars, n, &a_entries, &b_exps, lsystem.index)
+    let nnz = lin_system_nnz(lsystem);
+    nnz > 0 && lin_use_sparse(n, nnz)
 }
 
 
@@ -3782,6 +3957,16 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
     n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(col, n).is_some()
 }
 
+/// Torn linear system usable for analytic assembly: square Jacobian with one seed
+/// per iteration variable and `JAC_VAR` results covering every residual row
+/// (`n_res` = number of `SES_RESIDUAL`). The `nls_jac_usable` analogue for linear.
+fn lin_jac_usable(lsystem: &SimCode::LinearSystem, n_res: usize) -> bool {
+    let Some(jm) = &lsystem.jacobianMatrix else { return false };
+    let Some(col) = lst(&jm.columns).next() else { return false };
+    let n = count(&lsystem.vars) as usize;
+    n > 0 && n == n_res && count(&jm.seedVars) as usize == n && nls_jac_result_rows(col, n).is_some()
+}
+
 /// Total f64 scratch slots the NLS analytic Jacobians need: seeds + column
 /// variables per usable system. Scans a superset of the systems
 /// [`collect_nls_jobs`] registers, so the region is always large enough.
@@ -3855,6 +4040,169 @@ fn build_nls_jac_infos(
         infos.insert(sys.index, NlsJacInfo { seed_offs, result_offs });
     }
     Ok(infos)
+}
+
+/// Number of scalar `SES_RESIDUAL` in a linear system (its `A x = b` row count).
+fn lin_n_res(lsystem: &SimCode::LinearSystem) -> usize {
+    use SimCode::SimEqSystem as E;
+    lst(&lsystem.residual).filter(|e| matches!(&***e, E::SES_RESIDUAL { .. })).count()
+}
+
+/// Usable torn linear systems, deduped by index. `lin_jac_scratch_f64` (reserve)
+/// and `build_lin_jac_infos` (register) both call this so they agree on the set.
+fn lin_jac_systems(sim_code: &SimCode::SimCode) -> Vec<Arc<SimCode::LinearSystem>> {
+    use SimCode::SimEqSystem as E;
+    let mut seen: HashSet<i32> = HashSet::new();
+    let mut out: Vec<Arc<SimCode::LinearSystem>> = Vec::new();
+    let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
+        for e in &eqs {
+            if let E::SES_LINEAR { lSystem, .. } = &**e {
+                if lSystem.tornSystem && seen.insert(lSystem.index) && lin_jac_usable(lSystem, lin_n_res(lSystem)) {
+                    out.push(lSystem.clone());
+                }
+            }
+        }
+    };
+    scan(flatten_eqs(&sim_code.parameterEquations));
+    scan(flatten_eqs(&sim_code.initialEquations));
+    scan(flatten_eqs(&sim_code.initialEquations_lambda0));
+    scan(flatten_eqs_ll(&sim_code.odeEquations));
+    scan(flatten_eqs_ll(&sim_code.algebraicEquations));
+    scan(flatten_eqs(&sim_code.allEquations));
+    out
+}
+
+/// f64 scratch slots the torn-linear analytic Jacobians need: seeds + all column
+/// variables per usable system. Reserved after the NLS portion of the Jacobian
+/// scratch region.
+fn lin_jac_scratch_f64(sim_code: &SimCode::SimCode) -> u32 {
+    let mut total = 0u32;
+    for sys in lin_jac_systems(sim_code) {
+        let jm = sys.jacobianMatrix.as_ref().unwrap();
+        let col = lst(&jm.columns).next().unwrap();
+        total += count(&jm.seedVars) as u32 + count(&col.columnVars) as u32;
+    }
+    total
+}
+
+/// Register each torn-linear system's Jacobian seed/column-result crefs in the
+/// Jacobian scratch region, starting after the NLS portion (`nls_jac_scratch_f64`).
+/// The column equations then resolve their `$SEED`/`$pDER` slots when lowered, and
+/// [`lin_jac_offsets`] reads the same slots back for assembly.
+fn build_lin_jac_infos(
+    sim_code: &SimCode::SimCode,
+    layout: &SimLayout,
+    var_map: &mut SimVarMap,
+) -> Result<()> {
+    let mut cursor = layout.nls_jac_off + nls_jac_scratch_f64(sim_code) * 8;
+    for sys in lin_jac_systems(sim_code) {
+        let jm = sys.jacobianMatrix.as_ref().unwrap();
+        let col = lst(&jm.columns).next().unwrap();
+        for sv in lst(&jm.seedVars).chain(lst(&col.columnVars)) {
+            var_map.vars.insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+            cursor += 8;
+        }
+    }
+    Ok(())
+}
+
+/// Seed slots (in `seedVars`/column order) and result slots (at residual row via
+/// `jac_result_row`) for a torn-linear Jacobian, read from the slots
+/// `build_lin_jac_infos` registered. Feeds `compile_linear_system_analytic`.
+fn lin_jac_offsets(lsystem: &SimCode::LinearSystem, vars: &HashMap<String, SimSlot>, n: usize) -> Result<(Vec<u32>, Vec<u32>)> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
+    let jm = lsystem.jacobianMatrix.as_ref().ok_or("CodegenWasmJit: torn-linear system has no Jacobian")?;
+    let col = lst(&jm.columns).next().ok_or("CodegenWasmJit: torn-linear Jacobian has no column")?;
+    let lookup = |cr: &Arc<DAE::ComponentRef>| -> Result<u32> {
+        let key = sim_cref_key(cr)?;
+        Ok(vars.get(&key).ok_or("CodegenWasmJit: torn-linear Jacobian slot not registered")?.off)
+    };
+    let seed_offs: Vec<u32> = lst(&jm.seedVars).map(|sv| lookup(&sv.name)).collect::<Result<_>>()?;
+    let mut result_offs = vec![u32::MAX; n];
+    for sv in lst(&col.columnVars) {
+        if matches!(sv.varKind, VarKind::JAC_VAR) {
+            let row = jac_result_row(&sv.name).filter(|&r| r < n)
+                .ok_or("CodegenWasmJit: torn-linear Jacobian result var has no row index")?;
+            result_offs[row] = lookup(&sv.name)?;
+        }
+    }
+    if seed_offs.len() != n || result_offs.iter().any(|&o| o == u32::MAX) {
+        return Err("CodegenWasmJit: torn-linear Jacobian seed/result mismatch");
+    }
+    Ok((seed_offs, result_offs))
+}
+
+/// Accumulate into `dep[lhs]` the seed columns that `eq`'s RHS depends on, for the
+/// [`lin_jac_csc_pattern`] dataflow: a seed cref contributes its own column, any
+/// other cref contributes its already-computed `dep` set (the column equations are
+/// in dependency order). Only `SES_SIMPLE_ASSIGN` is handled; anything else -> None.
+fn csc_accum_dep(
+    eq: &Arc<SimCode::SimEqSystem>,
+    seed_col: &HashMap<String, usize>,
+    dep: &mut HashMap<String, Vec<usize>>,
+) -> Option<()> {
+    use SimCode::SimEqSystem as E;
+    let E::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { return None };
+    let mut s: Vec<usize> = Vec::new();
+    let crefs = openmodelica_frontend_base::Expression::extractCrefsFromExp(exp.clone()).ok()?;
+    for cr in &*crefs {
+        let k = sim_cref_key(cr).ok()?;
+        if let Some(&c) = seed_col.get(&k) {
+            if !s.contains(&c) { s.push(c); }
+        } else if let Some(ds) = dep.get(&k) {
+            for &c in ds { if !s.contains(&c) { s.push(c); } }
+        }
+    }
+    dep.insert(sim_cref_key(cref).ok()?, s);
+    Some(())
+}
+
+/// CSC pattern (`colptr`, `rowidx`, in `res_index` rows / iteration-variable cols)
+/// of a torn-linear system's `A`, derived by propagating seed dependencies through
+/// the Jacobian column equations: `A[row][col] != 0` iff the residual `row`'s
+/// derivative depends on seed `col`. This is the true sparsity in the assembler's
+/// own row order — the Jacobian's stored `sparsity` is in a dependent-var order
+/// that does not map to `res_index`. Returns `None` for any unsupported equation
+/// (caller falls back to dense assembly).
+fn lin_jac_csc_pattern(lsystem: &SimCode::LinearSystem, n: usize) -> Option<(Vec<i32>, Vec<i32>)> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
+    let jm = lsystem.jacobianMatrix.as_ref()?;
+    let col = lst(&jm.columns).next()?;
+    let mut seed_col: HashMap<String, usize> = HashMap::new();
+    for (j, sv) in lst(&jm.seedVars).enumerate() {
+        seed_col.insert(sim_cref_key(&sv.name).ok()?, j);
+    }
+    let mut dep: HashMap<String, Vec<usize>> = HashMap::new();
+    for eq in lst(&col.constantEqns) {
+        csc_accum_dep(eq, &seed_col, &mut dep)?;
+    }
+    for eq in lst(&col.columnEqns) {
+        csc_accum_dep(eq, &seed_col, &mut dep)?;
+    }
+    // Column c (iteration var) gets residual row r whenever result r depends on seed c.
+    let mut cols: Vec<Vec<i32>> = vec![Vec::new(); n];
+    for sv in lst(&col.columnVars) {
+        if !matches!(sv.varKind, VarKind::JAC_VAR) {
+            continue;
+        }
+        let r = jac_result_row(&sv.name).filter(|&r| r < n)?;
+        if let Some(ds) = dep.get(&sim_cref_key(&sv.name).ok()?) {
+            for &c in ds {
+                cols[c].push(r as i32);
+            }
+        }
+    }
+    let mut colptr = vec![0i32; n + 1];
+    let mut rowidx = Vec::new();
+    for c in 0..n {
+        cols[c].sort_unstable();
+        rowidx.extend_from_slice(&cols[c]);
+        colptr[c + 1] = colptr[c] + cols[c].len() as i32;
+    }
+    if rowidx.is_empty() {
+        return None;
+    }
+    Some((colptr, rowidx))
 }
 
 /// Build the `residual(sim_data, x, r)` and `load(sim_data, x)` callback

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -363,6 +363,15 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // Dense linear solve `A x = b` in place (A column-major `n*n` f64 at a_ptr,
     // b `n` f64 at b_ptr; solution overwrites b). Returns 0 ok, 1 singular.
     ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // Sparse linear solve `A x = b` in place, A in CSC: (colptr n+1 i32, rowidx
+    // nnz i32, values nnz f64, b_ptr n f64, n, nnz) -> 0 ok / 1 singular. The C
+    // runtime's KLU path (AMD-ordered sparse LU); see `rt_solve_lin_sparse`.
+    ("rt_solve_lin_sparse", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // Solve `A x = b` from dense column-major A via the sparse solver; see
+    // `rt_solve_lin_dense_sparse`. (a_ptr, b_ptr, n) -> 0 ok / 1 singular.
+    ("rt_solve_lin_dense_sparse", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // (handle, colptr, rowidx, values, b, n, nnz) -> 0 ok / 1 singular; cached analysis.
+    ("rt_solve_lin_sparse_cached", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // Raw deallocation (frees a block from `rt_alloc`); used to release the
     // `SES_LINEAR` scratch (A/b/residual buffers) after each solve.
     ("rt_free", &[WTy::I32], &[]),
@@ -4014,8 +4023,10 @@ fn emit_sim_start_array_gather(ctx: &mut FnCtx, group: &ArrayGroup, base_key: &s
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
-    NlsResidual, compile_linear_system, compile_linear_system_symbolic, emit_nls_jac_body,
-    emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call,
+    LSS_MAX_DENSITY, LSS_MIN_SIZE, NlsResidual, compile_linear_system,
+    compile_linear_system_analytic, compile_linear_system_analytic_csc,
+    compile_linear_system_symbolic, emit_nls_jac_body, emit_nls_load_body,
+    emit_nls_residual_body, emit_solve_nls_call, lin_use_sparse,
 };
 
 fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -222,31 +222,19 @@ pub(crate) fn emit_nls_jac_body(
     Ok(())
 }
 
-/// Lower a torn linear system `A x = b` (the `SES_LINEAR` residual form) into the
-/// current simulation equation function.
-///
-/// The system solves `iter_vars` (the `n` tearing unknowns). `lower_inner` lowers
-/// the inner "local constraint" equations, which compute the torn variables (and
-/// any intermediates) from the current values of `iter_vars`; `res_exps` are the
-/// `n` residual expressions `r_i`, where the system is `r(x) = 0`. Because the
-/// system is linear, `r(x) = A x - b`, so we recover `A` and `b` exactly by
-/// probing the residual (the numerical-Jacobian approach the C runtime uses when
-/// `setA == NULL`):
-///   * `b_i = -r_i(0)` — residual with all unknowns set to 0;
-///   * `A[i][j] = r_i(e_j) - r_i(0)` — residual with unknown `j` set to 1.
-/// Then `rt_linsolve` (LU with partial pivoting) solves `A x = b` in place, the
-/// solution is scattered back into `iter_vars`, and the inner equations are run
-/// once more so the torn variables are consistent with the solution.
-///
-/// `lower_inner` is emitted twice — once for the `b` probe and once for the shared
-/// column-probe loop body (run `n` times) — plus once more to recover; the inner
-/// equations read the unknowns from their `SimData` slots, which this code sets
-/// before each invocation.
+/// Lower a torn linear system `A x = b` by residual probing (the fallback when the
+/// system has no usable symbolic Jacobian; see `compile_linear_system_analytic`).
+/// `r(x) = A x - b` for a linear system, so `b_i = -r_i(0)` and
+/// `A[i][j] = r_i(e_j) - r_i(0)` recover `A`/`b` (C's numerical-Jacobian path). The
+/// column probes share one emitted residual body run in a wasm loop (`n` unrolled
+/// copies would explode the code). `use_sparse` picks `rt_solve_lin_dense_sparse`
+/// over `rt_linsolve`, matching C's per-system choice.
 pub(crate) fn compile_linear_system(
     ctx: &mut FnCtx,
     iter_vars: &[Arc<DAE::ComponentRef>],
     res_exps: &[&Arc<DAE::Exp>],
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    use_sparse: bool,
 ) -> Result<()> {
     let n = iter_vars.len();
     if n == 0 {
@@ -374,55 +362,620 @@ pub(crate) fn compile_linear_system(
     ctx.emit(we::Instruction::End); // loop
     ctx.emit(we::Instruction::End); // block
 
-    // --- solve A x = b in place (b <- x); trap on a singular system. ---
-    ctx.emit(we::Instruction::LocalGet(base)); // a_ptr (a_off == 0)
-    ctx.emit(we::Instruction::LocalGet(base));
-    ctx.emit(we::Instruction::I32Const(b_off as i32));
-    ctx.emit(we::Instruction::I32Add); // b_ptr
-    ctx.emit(we::Instruction::I32Const(n as i32));
-    ctx.emit(we::Instruction::Call(rt_index("rt_linsolve")?));
-    ctx.emit(we::Instruction::If(we::BlockType::Empty)); // nonzero => singular
+    // --- solve, scatter the solution into the unknown slots, recover the torn
+    // variables (re-run inner at the solution), free the scratch. ---
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, lower_inner)
+}
+
+/// Trap (runtime error) when the solver returned nonzero (singular) — consumes the
+/// i32 result on the stack.
+fn emit_singular_check(ctx: &mut FnCtx) -> Result<()> {
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
     emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
     ctx.emit(we::Instruction::End);
-
-    // --- scatter the solution into the unknown slots. ---
-    for j in 0..n {
-        ctx.emit(we::Instruction::LocalGet(data));
-        ctx.emit(we::Instruction::LocalGet(base));
-        ctx.emit(we::Instruction::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
-        ctx.emit(we::Instruction::F64Store(mem_arg(slots[j], 3)));
-    }
-
-    // --- recover the torn variables: re-run the inner equations at the solution. ---
-    lower_inner(ctx)?;
-
-    // --- free the scratch block. ---
-    ctx.emit(we::Instruction::LocalGet(base));
-    ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
     Ok(())
 }
 
-/// Lower a non-torn `SES_LINEAR` system given symbolically as `A x = b`.
+/// Scatter the solution `x` (at `base+b_off`) into `slots`, recover the torn
+/// variables (`lower_inner` at the solution), and free `base`.
+fn emit_scatter_recover_free(
+    ctx: &mut FnCtx,
+    base: u32,
+    b_off: u32,
+    n: usize,
+    slots: &[u32],
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let data = ctx.sim()?.data_local;
+    for j in 0..n {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
+        ctx.emit(I::F64Store(mem_arg(slots[j], 3)));
+    }
+    lower_inner(ctx)?;
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    Ok(())
+}
+
+/// Solve the assembled dense `A x = b` (column-major `A` at `base+0`, `b` at
+/// `base+b_off`), then scatter/recover/free. `use_sparse` picks
+/// `rt_solve_lin_dense_sparse` vs `rt_linsolve`.
+fn emit_lin_solve_scatter(
+    ctx: &mut FnCtx,
+    base: u32,
+    b_off: u32,
+    n: usize,
+    slots: &[u32],
+    use_sparse: bool,
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    ctx.emit(I::LocalGet(base)); // a_ptr (a_off == 0)
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(b_off as i32));
+    ctx.emit(I::I32Add); // b_ptr
+    ctx.emit(I::I32Const(n as i32));
+    let solver = if use_sparse { "rt_solve_lin_dense_sparse" } else { "rt_linsolve" };
+    ctx.emit(I::Call(rt_index(solver)?));
+    emit_singular_check(ctx)?;
+    emit_scatter_recover_free(ctx, base, b_off, n, slots, lower_inner)
+}
+
+/// Lower a torn linear system `A x = b` by analytic-Jacobian assembly (C's method
+/// 1). `A = ∂r/∂x` is constant, evaluated once from the symbolic Jacobian columns
+/// (seed column `j`, run `lower_column`, read `result_offs[i]` = `∂r_i/∂x_j`);
+/// `b = -r(0)` from a single residual eval. Both land in `res_index` row order
+/// (`result_offs` placed by `jac_result_row`), so the solve is consistent. Replaces
+/// the O(n) residual probe with O(n) cheaper column-equation evals.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compile_linear_system_analytic(
+    ctx: &mut FnCtx,
+    iter_vars: &[Arc<DAE::ComponentRef>],
+    res_exps: &[&Arc<DAE::Exp>],
+    seed_offs: &[u32],
+    result_offs: &[u32],
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_constant: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    use_sparse: bool,
+) -> Result<()> {
+    use we::Instruction as I;
+    let n = iter_vars.len();
+    if n == 0 {
+        return Ok(());
+    }
+    if res_exps.len() != n || seed_offs.len() != n || result_offs.len() != n {
+        return Err("CodegenWasmJit: analytic linear system size/Jacobian mismatch");
+    }
+    let mut slots: Vec<u32> = Vec::with_capacity(n);
+    for cr in iter_vars {
+        let key = sim_cref_key(cr)?;
+        let slot = ctx.sim()?.vars.get(&key).copied()
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown has no slot")?;
+        if slot.wty != WTy::F64 {
+            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
+        }
+        slots.push(slot.off);
+    }
+    let data = ctx.sim()?.data_local;
+
+    // Scratch: A (n*n column-major f64) | b (n f64) | seed_tab (n i32) |
+    // res_tab (n i32). The two i32 tables hold the seed/result slot offsets so the
+    // column loop can index them at run time (the column-equation body is emitted
+    // once inside a wasm loop — unrolling it n times explodes the code for large
+    // systems, the same blow-up the residual probe avoids).
+    let b_off: u32 = (n * n * 8) as u32;
+    let seed_tab_off: u32 = b_off + (n * 8) as u32;
+    let res_tab_off: u32 = seed_tab_off + (n * 4) as u32;
+    let scratch_bytes: u32 = res_tab_off + (n * 4) as u32;
+    let base = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(scratch_bytes as i32));
+    ctx.emit(I::Call(rt_index("rt_alloc")?));
+    ctx.emit(I::LocalSet(base));
+
+    // Seed/result slot offsets in run-time index tables (the column loop is a wasm
+    // loop, so it indexes them rather than baking offsets in per column).
+    for (k, &soff) in seed_offs.iter().enumerate() {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(soff as i32));
+        ctx.emit(I::I32Store(mem_arg(seed_tab_off + (k as u32) * 4, 2)));
+    }
+    for (i, &roff) in result_offs.iter().enumerate() {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(roff as i32));
+        ctx.emit(I::I32Store(mem_arg(res_tab_off + (i as u32) * 4, 2)));
+    }
+
+    let store_slot = |ctx: &mut FnCtx, off: u32, val: f64| {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::F64Const(val.into()));
+        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    };
+    // Evaluate at x = 0 (A is constant, so any point works).
+    for &off in &slots {
+        store_slot(ctx, off, 0.0);
+    }
+    for &soff in seed_offs {
+        store_slot(ctx, soff, 0.0);
+    }
+    // b = -r(0): residual (inner at x=0 + res_exps) into b, then negate in place.
+    emit_residual_eval(ctx, base, res_exps, b_off, lower_inner)?;
+    for i in 0..n as u32 {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + i * 8, 3)));
+        ctx.emit(I::F64Neg);
+        ctx.emit(I::F64Store(mem_arg(b_off + i * 8, 3)));
+    }
+
+    // Constant Jacobian equations (evaluated once, at x=0 with the torn vars set).
+    lower_constant(ctx)?;
+
+    // `data + tab[idx*4 + tab_off]` — address of the slot named by index table
+    // `tab_off` at run-time index `idx` (an i32 local).
+    let push_tab_addr = |ctx: &mut FnCtx, tab_off: u32, idx: u32| {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(idx));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(tab_off, 2)));
+        ctx.emit(I::I32Add);
+    };
+
+    // for j in 0..n: seed[j]=1, zero results, run column eqns, A[j*n+i]=result[i],
+    // reset seed[j]=0. Column body emitted once; the two inner loops keep code O(1).
+    let jloc = ctx.alloc_temp(WTy::I32);
+    let iloc = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(jloc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(n as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // seed[j] = 1.
+    push_tab_addr(ctx, seed_tab_off, jloc);
+    ctx.emit(I::F64Const(1.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    // zero the result slots.
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(iloc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(iloc));
+    ctx.emit(I::I32Const(n as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    push_tab_addr(ctx, res_tab_off, iloc);
+    ctx.emit(I::F64Const(0.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(iloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(iloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    // evaluate column j.
+    lower_column(ctx)?;
+    // A[j*n + i] = result slot i (column-major).
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(iloc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(iloc));
+    ctx.emit(I::I32Const(n as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // A element address = base + (j*n + i)*8.
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(n as i32));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::LocalGet(iloc));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(8));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    push_tab_addr(ctx, res_tab_off, iloc);
+    ctx.emit(I::F64Load(mem_arg(0, 3)));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(iloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(iloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    // reset seed[j] = 0.
+    push_tab_addr(ctx, seed_tab_off, jloc);
+    ctx.emit(I::F64Const(0.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(jloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, lower_inner)
+}
+
+/// Greedy distance-1 column coloring (Curtis-Powell-Reid) of the CSC pattern:
+/// columns sharing a residual row get distinct colors, so every column of one color
+/// can be seeded at once and its nonzeros read from a single column-eqn pass. Returns
+/// `(color_ptr, color_cols)`: color `c` owns `color_cols[color_ptr[c]..color_ptr[c+1]]`.
+/// Cuts the analytic-assembly passes from `n` to `#colors` (≈ max row degree).
+fn lin_jac_coloring(colptr: &[i32], rowidx: &[i32], n: usize) -> (Vec<i32>, Vec<i32>) {
+    let nrows = rowidx.iter().copied().max().map_or(0, |m| m as usize + 1);
+    let mut row_cols: Vec<Vec<u32>> = vec![Vec::new(); nrows];
+    for j in 0..n {
+        for k in colptr[j] as usize..colptr[j + 1] as usize {
+            row_cols[rowidx[k] as usize].push(j as u32);
+        }
+    }
+    let mut color = vec![-1i32; n];
+    let mut forbidden = vec![u32::MAX; n]; // forbidden[c] == j: color c taken near col j
+    let mut ncolors = 0usize;
+    for j in 0..n {
+        for k in colptr[j] as usize..colptr[j + 1] as usize {
+            for &c2 in &row_cols[rowidx[k] as usize] {
+                let cc = color[c2 as usize];
+                if cc >= 0 {
+                    forbidden[cc as usize] = j as u32;
+                }
+            }
+        }
+        let mut chosen = 0usize;
+        while chosen < ncolors && forbidden[chosen] == j as u32 {
+            chosen += 1;
+        }
+        if chosen == ncolors {
+            ncolors += 1;
+        }
+        color[j] = chosen as i32;
+    }
+    let mut color_ptr = vec![0i32; ncolors + 1];
+    for &c in &color {
+        color_ptr[c as usize + 1] += 1;
+    }
+    for c in 0..ncolors {
+        color_ptr[c + 1] += color_ptr[c];
+    }
+    let mut color_cols = vec![0i32; n];
+    let mut cursor = color_ptr[..ncolors].to_vec();
+    for (j, &c) in color.iter().enumerate() {
+        color_cols[cursor[c as usize] as usize] = j as i32;
+        cursor[c as usize] += 1;
+    }
+    (color_ptr, color_cols)
+}
+
+/// Analytic assembly directly into CSC (no dense `n²` buffer) for a sparse torn
+/// linear system: `colptr`/`rowidx` are the compile-time pattern in `res_index` row
+/// order (from `lin_jac_csc_pattern`). Columns are colored, then each color is seeded
+/// as a group, the column equations run once, and `values[k] = result[rowidx[k]]` is
+/// read for every column of the color (orthogonal rows → one seed per row). This is
+/// `#colors` passes, not `n`. Row order matches `b = -r(0)` (both `res_index`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compile_linear_system_analytic_csc(
+    ctx: &mut FnCtx,
+    handle: i32,
+    iter_vars: &[Arc<DAE::ComponentRef>],
+    res_exps: &[&Arc<DAE::Exp>],
+    seed_offs: &[u32],
+    result_offs: &[u32],
+    colptr: &[i32],
+    rowidx: &[i32],
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_constant: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let n = iter_vars.len();
+    if n == 0 {
+        return Ok(());
+    }
+    if res_exps.len() != n || seed_offs.len() != n || result_offs.len() != n
+        || colptr.len() != n + 1
+    {
+        return Err("CodegenWasmJit: analytic-CSC linear system size mismatch");
+    }
+    let nnz = rowidx.len();
+    let (color_ptr, color_cols) = lin_jac_coloring(colptr, rowidx, n);
+    let ncolors = color_ptr.len() - 1;
+    let mut slots: Vec<u32> = Vec::with_capacity(n);
+    for cr in iter_vars {
+        let key = sim_cref_key(cr)?;
+        let slot = ctx.sim()?.vars.get(&key).copied()
+            .ok_or_else(|| "CodegenWasmJit: linear-system unknown has no slot")?;
+        if slot.wty != WTy::F64 {
+            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
+        }
+        slots.push(slot.off);
+    }
+    let data = ctx.sim()?.data_local;
+
+    // Scratch (f64 regions first for 8-alignment): values (nnz) | b (n) | colptr
+    // (n+1 i32) | rowidx (nnz i32) | seed_tab (n i32) | res_tab (n i32) |
+    // color_ptr (ncolors+1 i32) | color_cols (n i32).
+    let values_off: u32 = 0;
+    let b_off: u32 = (nnz * 8) as u32;
+    let colptr_off: u32 = b_off + (n * 8) as u32;
+    let rowidx_off: u32 = colptr_off + ((n + 1) * 4) as u32;
+    let seed_tab_off: u32 = rowidx_off + (nnz * 4) as u32;
+    let res_tab_off: u32 = seed_tab_off + (n * 4) as u32;
+    let colorptr_off: u32 = res_tab_off + (n * 4) as u32;
+    let colorcols_off: u32 = colorptr_off + ((ncolors + 1) * 4) as u32;
+    let scratch_bytes: u32 = colorcols_off + (n * 4) as u32;
+    let base = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(scratch_bytes as i32));
+    ctx.emit(I::Call(rt_index("rt_alloc")?));
+    ctx.emit(I::LocalSet(base));
+
+    let store_i32 = |ctx: &mut FnCtx, off: u32, v: i32| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(v));
+        ctx.emit(I::I32Store(mem_arg(off, 2)));
+    };
+    for (k, &p) in colptr.iter().enumerate() {
+        store_i32(ctx, colptr_off + (k as u32) * 4, p);
+    }
+    for (k, &r) in rowidx.iter().enumerate() {
+        store_i32(ctx, rowidx_off + (k as u32) * 4, r);
+    }
+    for (k, &soff) in seed_offs.iter().enumerate() {
+        store_i32(ctx, seed_tab_off + (k as u32) * 4, soff as i32);
+    }
+    for (i, &roff) in result_offs.iter().enumerate() {
+        store_i32(ctx, res_tab_off + (i as u32) * 4, roff as i32);
+    }
+    for (k, &p) in color_ptr.iter().enumerate() {
+        store_i32(ctx, colorptr_off + (k as u32) * 4, p);
+    }
+    for (k, &j) in color_cols.iter().enumerate() {
+        store_i32(ctx, colorcols_off + (k as u32) * 4, j);
+    }
+
+    let store_slot = |ctx: &mut FnCtx, off: u32, val: f64| {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::F64Const(val.into()));
+        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    };
+    for &off in &slots {
+        store_slot(ctx, off, 0.0);
+    }
+    for &soff in seed_offs {
+        store_slot(ctx, soff, 0.0);
+    }
+    // b = -r(0).
+    emit_residual_eval(ctx, base, res_exps, b_off, lower_inner)?;
+    for i in 0..n as u32 {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + i * 8, 3)));
+        ctx.emit(I::F64Neg);
+        ctx.emit(I::F64Store(mem_arg(b_off + i * 8, 3)));
+    }
+    lower_constant(ctx)?;
+
+    // Address `data + seed_tab[idx]` for run-time index `idx`.
+    let push_seed_addr = |ctx: &mut FnCtx, idx: u32| {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(idx));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(seed_tab_off, 2)));
+        ctx.emit(I::I32Add);
+    };
+
+    let cloc = ctx.alloc_temp(WTy::I32);
+    let mloc = ctx.alloc_temp(WTy::I32);
+    let mend = ctx.alloc_temp(WTy::I32);
+    let jloc = ctx.alloc_temp(WTy::I32);
+    let kloc = ctx.alloc_temp(WTy::I32);
+    let kend = ctx.alloc_temp(WTy::I32);
+    // mloc/mend = color_ptr[cloc + addc].
+    let load_colorptr = |ctx: &mut FnCtx, dst: u32, addc: i32| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(cloc));
+        if addc != 0 {
+            ctx.emit(I::I32Const(addc));
+            ctx.emit(I::I32Add);
+        }
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(colorptr_off, 2)));
+        ctx.emit(I::LocalSet(dst));
+    };
+    let load_j = |ctx: &mut FnCtx| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(mloc));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(colorcols_off, 2)));
+        ctx.emit(I::LocalSet(jloc));
+    };
+
+    // for c in 0..ncolors: seed every column of the color, run the column eqns once,
+    // then read each column's pattern nonzeros and clear its seed.
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(cloc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(cloc));
+    ctx.emit(I::I32Const(ncolors as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // seed pass: for m in color_ptr[c]..color_ptr[c+1]: seed[color_cols[m]] = 1.
+    load_colorptr(ctx, mloc, 0);
+    load_colorptr(ctx, mend, 1);
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::LocalGet(mend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    load_j(ctx);
+    push_seed_addr(ctx, jloc);
+    ctx.emit(I::F64Const(1.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(mloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    lower_column(ctx)?;
+    // read pass over the same color members.
+    load_colorptr(ctx, mloc, 0);
+    load_colorptr(ctx, mend, 1);
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::LocalGet(mend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    load_j(ctx);
+    // k = colptr[j]; kend = colptr[j+1].
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(colptr_off, 2)));
+    ctx.emit(I::LocalSet(kloc));
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(colptr_off, 2)));
+    ctx.emit(I::LocalSet(kend));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::LocalGet(kend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // values[k] address = base + values_off + k*8.
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::I32Const(8));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    // value = f64[data + res_tab[rowidx[k]]].
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(rowidx_off, 2))); // row
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(res_tab_off, 2))); // result slot offset
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::F64Load(mem_arg(0, 3)));
+    ctx.emit(I::F64Store(mem_arg(values_off, 3)));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(kloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    push_seed_addr(ctx, jloc);
+    ctx.emit(I::F64Const(0.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(mloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End); // read loop
+    ctx.emit(I::End); // read block
+    ctx.emit(I::LocalGet(cloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(cloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End); // color loop
+    ctx.emit(I::End); // color block
+
+    // rt_solve_lin_sparse_cached(handle, colptr, rowidx, values, b, n, nnz).
+    ctx.emit(I::I32Const(handle));
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(colptr_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(rowidx_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalGet(base)); // values_off == 0
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(b_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(n as i32));
+    ctx.emit(I::I32Const(nnz as i32));
+    ctx.emit(I::Call(rt_index("rt_solve_lin_sparse_cached")?));
+    emit_singular_check(ctx)?;
+    emit_scatter_recover_free(ctx, base, b_off, n, &slots, lower_inner)
+}
+
+/// C's linear sparse-solver selection: density below `lssMaxDensity` (default
+/// 0.2) OR size above `lssMinSize` (default 1000). See
+/// `SimulationRuntime/c/simulation/solver/linearSystem.c`.
+pub(crate) const LSS_MAX_DENSITY: f64 = 0.2;
+pub(crate) const LSS_MIN_SIZE: usize = 1000;
+pub(crate) fn lin_use_sparse(size: usize, nnz: usize) -> bool {
+    (nnz as f64) < LSS_MAX_DENSITY * (size * size) as f64 || size > LSS_MIN_SIZE
+}
+
+/// Lower a `SES_LINEAR` system given symbolically as `A x = b` from `simJac`/`beqs`
+/// (the C runtime's `setLinearMatrixA`/`setLinearVectorb`): `a_entries` are the
+/// nonzero elements `(row, col, exp)` (0-based, column-major); `b_exps` the dense
+/// right-hand side; both evaluate directly from already-solved variables — no
+/// residual probing. Solve `A x = b`, write each `x_j` back into its slot, then
+/// (torn systems) run `inner` to recover the non-iteration torn variables.
 ///
-/// `a_entries` are the sparse matrix elements `(row, col, exp)` (0-based,
-/// stored column-major); `b_exps` is the dense right-hand side (one expression
-/// per row). Both are functions of already-solved variables, so they evaluate
-/// directly — no residual probing. Faithful to the C runtime's `solveLapack`
-/// with `method == 0`: zero A, fill it from `setA`, fill b from `setb`, solve
-/// `A x = b` in place, then write each `x_j` back into its unknown's slot.
+/// Dense (`rt_linsolve`, LAPACK-like) or sparse (`rt_solve_lin_sparse`, KLU-like
+/// AMD-ordered CSC LU) per [`lin_use_sparse`], matching C's per-system choice.
 pub(crate) fn compile_linear_system_symbolic(
     ctx: &mut FnCtx,
     vars: &[Arc<DAE::ComponentRef>],
     n: usize,
     a_entries: &[(usize, usize, &Arc<DAE::Exp>)],
     b_exps: &[&Arc<DAE::Exp>],
-    index: i32,
+    inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    _index: i32,
 ) -> Result<()> {
+    use we::Instruction as I;
     if n == 0 {
         return Ok(());
     }
     if b_exps.len() != n {
         return Err("CodegenWasmJit: SES_LINEAR unknown/b-entry count mismatch");
+    }
+    for &(row, col, _) in a_entries {
+        if row >= n || col >= n {
+            return Err("CodegenWasmJit: SES_LINEAR simJac entry out of range for size");
+        }
     }
     let mut slots: Vec<u32> = Vec::with_capacity(n);
     for cr in vars {
@@ -439,65 +992,134 @@ pub(crate) fn compile_linear_system_symbolic(
         slots.push(slot.off);
     }
     let data = ctx.sim()?.data_local;
-
-    // Scratch: A (n*n, column-major) | b (n).
-    let a_off: u32 = 0;
-    let b_off: u32 = (n * n * 8) as u32;
-    let scratch_bytes: u32 = ((n * n + n) * 8) as u32;
+    let use_sparse = lin_use_sparse(n, a_entries.len());
 
     let base = ctx.alloc_temp(WTy::I32);
-    ctx.emit(we::Instruction::I32Const(scratch_bytes as i32));
-    ctx.emit(we::Instruction::Call(rt_index("rt_alloc")?));
-    ctx.emit(we::Instruction::LocalSet(base));
+    // `b` lives at the same offset in both layouts (after the matrix region), so
+    // the scatter/solve `b` handling is shared.
+    let b_off: u32;
 
-    // Zero A: simJac lists only the nonzero entries and rt_alloc does not zero.
-    for idx in 0..(n * n) {
-        ctx.emit(we::Instruction::LocalGet(base));
-        ctx.emit(we::Instruction::F64Const(0.0f64.into()));
-        ctx.emit(we::Instruction::F64Store(mem_arg(a_off + (idx as u32) * 8, 3)));
-    }
-
-    // A[row + col*n] = element expression (column-major).
-    for &(row, col, exp) in a_entries {
-        if row >= n || col >= n {
-            return Err("CodegenWasmJit: SES_LINEAR simJac entry out of range for size");
+    if use_sparse {
+        // CSC layout: colptr (n+1 i32) | rowidx (nnz i32) | values (nnz f64) | b (n f64).
+        let nnz = a_entries.len();
+        // Column-major, row-sorted within a column (CSC requires it; simJac is
+        // already column-major but re-sort defensively).
+        let mut entries: Vec<(usize, usize, &Arc<DAE::Exp>)> = a_entries.to_vec();
+        entries.sort_by_key(|&(row, col, _)| (col, row));
+        let mut colptr = vec![0i32; n + 1];
+        for &(_, col, _) in &entries {
+            colptr[col + 1] += 1;
         }
-        let elem_off = a_off + ((col * n + row) as u32) * 8;
-        ctx.emit(we::Instruction::LocalGet(base));
-        let w = compile_exp(ctx, exp)?;
-        coerce(ctx, w, WTy::F64);
-        ctx.emit(we::Instruction::F64Store(mem_arg(elem_off, 3)));
+        for c in 0..n {
+            colptr[c + 1] += colptr[c];
+        }
+        let colptr_off: u32 = 0;
+        let rowidx_off: u32 = ((n + 1) * 4) as u32;
+        let values_off: u32 = rowidx_off + (nnz * 4) as u32;
+        b_off = values_off + (nnz * 8) as u32;
+        let scratch_bytes: u32 = b_off + (n * 8) as u32;
+        ctx.emit(I::I32Const(scratch_bytes as i32));
+        ctx.emit(I::Call(rt_index("rt_alloc")?));
+        ctx.emit(I::LocalSet(base));
+        // colptr + rowidx: compile-time constants.
+        for (c, &p) in colptr.iter().enumerate() {
+            ctx.emit(I::LocalGet(base));
+            ctx.emit(I::I32Const(p));
+            ctx.emit(I::I32Store(mem_arg(colptr_off + (c as u32) * 4, 2)));
+        }
+        for (k, &(row, _, _)) in entries.iter().enumerate() {
+            ctx.emit(I::LocalGet(base));
+            ctx.emit(I::I32Const(row as i32));
+            ctx.emit(I::I32Store(mem_arg(rowidx_off + (k as u32) * 4, 2)));
+        }
+        // values: runtime-evaluated element expressions.
+        for (k, &(_, _, exp)) in entries.iter().enumerate() {
+            ctx.emit(I::LocalGet(base));
+            let w = compile_exp(ctx, exp)?;
+            coerce(ctx, w, WTy::F64);
+            ctx.emit(I::F64Store(mem_arg(values_off + (k as u32) * 8, 3)));
+        }
+        emit_b_exps(ctx, base, b_off, b_exps)?;
+        // rt_solve_lin_sparse(colptr, rowidx, values, b, n, nnz).
+        ctx.emit(I::LocalGet(base)); // colptr (off 0)
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(rowidx_off as i32));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(values_off as i32));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(b_off as i32));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Const(n as i32));
+        ctx.emit(I::I32Const(nnz as i32));
+        ctx.emit(I::Call(rt_index("rt_solve_lin_sparse")?));
+    } else {
+        // Dense layout: A (n*n column-major) | b (n).
+        let a_off: u32 = 0;
+        b_off = (n * n * 8) as u32;
+        let scratch_bytes: u32 = ((n * n + n) * 8) as u32;
+        ctx.emit(I::I32Const(scratch_bytes as i32));
+        ctx.emit(I::Call(rt_index("rt_alloc")?));
+        ctx.emit(I::LocalSet(base));
+        // Zero A (simJac lists only nonzeros; rt_alloc does not zero).
+        for idx in 0..(n * n) {
+            ctx.emit(I::LocalGet(base));
+            ctx.emit(I::F64Const(0.0f64.into()));
+            ctx.emit(I::F64Store(mem_arg(a_off + (idx as u32) * 8, 3)));
+        }
+        // A[row + col*n] = element expression (column-major).
+        for &(row, col, exp) in a_entries {
+            let elem_off = a_off + ((col * n + row) as u32) * 8;
+            ctx.emit(I::LocalGet(base));
+            let w = compile_exp(ctx, exp)?;
+            coerce(ctx, w, WTy::F64);
+            ctx.emit(I::F64Store(mem_arg(elem_off, 3)));
+        }
+        emit_b_exps(ctx, base, b_off, b_exps)?;
+        // rt_linsolve(a_ptr, b_ptr, n).
+        ctx.emit(I::LocalGet(base)); // a_ptr (a_off == 0)
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(b_off as i32));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Const(n as i32));
+        ctx.emit(I::Call(rt_index("rt_linsolve")?));
     }
 
-    // b[i] = right-hand-side expression.
+    ctx.emit(I::If(we::BlockType::Empty)); // nonzero => singular
+    emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
+    ctx.emit(I::End);
+
+    // Scatter the solution into the unknown slots.
+    for j in 0..n {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
+        ctx.emit(I::F64Store(mem_arg(slots[j], 3)));
+    }
+
+    // Recover the non-iteration torn variables at the solution (no-op for the
+    // non-torn form, whose `inner` is empty).
+    inner(ctx)?;
+
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    Ok(())
+}
+
+/// Emit `b[i] = exp` into the solve scratch at `base + b_off + i*8`.
+fn emit_b_exps(
+    ctx: &mut FnCtx,
+    base: u32,
+    b_off: u32,
+    b_exps: &[&Arc<DAE::Exp>],
+) -> Result<()> {
     for (i, exp) in b_exps.iter().enumerate() {
         ctx.emit(we::Instruction::LocalGet(base));
         let w = compile_exp(ctx, exp)?;
         coerce(ctx, w, WTy::F64);
         ctx.emit(we::Instruction::F64Store(mem_arg(b_off + (i as u32) * 8, 3)));
     }
-
-    // Solve A x = b in place (b <- x); trap on a singular system.
-    ctx.emit(we::Instruction::LocalGet(base)); // a_ptr (a_off == 0)
-    ctx.emit(we::Instruction::LocalGet(base));
-    ctx.emit(we::Instruction::I32Const(b_off as i32));
-    ctx.emit(we::Instruction::I32Add); // b_ptr
-    ctx.emit(we::Instruction::I32Const(n as i32));
-    ctx.emit(we::Instruction::Call(rt_index("rt_linsolve")?));
-    ctx.emit(we::Instruction::If(we::BlockType::Empty)); // nonzero => singular
-    emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
-    ctx.emit(we::Instruction::End);
-
-    // Scatter the solution into the unknown slots.
-    for j in 0..n {
-        ctx.emit(we::Instruction::LocalGet(data));
-        ctx.emit(we::Instruction::LocalGet(base));
-        ctx.emit(we::Instruction::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
-        ctx.emit(we::Instruction::F64Store(mem_arg(slots[j], 3)));
-    }
-
-    ctx.emit(we::Instruction::LocalGet(base));
-    ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "nalgebra",
  "openmodelica_mat_writer",
  "openmodelica_sim_meta",
+ "rsparse",
 ]
 
 [[package]]
@@ -193,6 +194,12 @@ dependencies = [
  "daskr",
  "libm",
 ]
+
+[[package]]
+name = "rsparse"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65dc8db760bdc8c94f4163c5d09be710f76fc92a4a1f698c441925db83c09e"
 
 [[package]]
 name = "shlex"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -18,10 +18,18 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-# The in-wasm `rt_sim_*` session driver (src/session.rs). Default on for the JIT
-# runtime build; the FMI3 adapter disables it (default-features = false).
+# In-wasm `rt_sim_*` session driver (src/session.rs) + its DAE solver (daskr). On
+# for the no_std JIT and web interactive runtimes; off for the native host-driven
+# runtime, so daskr/sim_meta are not linked there. The FMI3 adapter disables it.
 default = ["session"]
-session = []
+session = ["dep:daskr", "dep:openmodelica_sim_meta"]
+# Standalone-export driver (src/standalone.rs, `_start` + model-importing), wasip1 only.
+standalone = ["dep:daskr", "dep:openmodelica_sim_meta", "dep:openmodelica_mat_writer", "inwasm_solve"]
+# In-wasm sparse solve (rsparse). Off for the native interactive runtime, which
+# delegates to the host (`host_lin_solve`) instead of linking rsparse.
+inwasm_solve = ["dep:rsparse"]
+# Delegate the sparse solve to the host (`env.rt_host_lin_solve`); native interactive only.
+host_lin_solve = []
 
 [dependencies]
 dlmalloc = { version = "0.2.14", features = ["global"] }
@@ -42,16 +50,20 @@ nalgebra = { version = "0.35", default-features = false, features = ["alloc", "l
 # false`); math routes through libm. mat_writer is not needed here (rows go into
 # an rt_alloc buffer, not a `.mat`).
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-openmodelica_sim_meta = { path = "../openmodelica_sim_meta", default-features = false }
-daskr = { path = "../daskr", default-features = false }
+openmodelica_sim_meta = { path = "../openmodelica_sim_meta", default-features = false, optional = true }
+daskr = { path = "../daskr", default-features = false, optional = true }
 
 # Standalone-export (wasm32-wasip1) only: the in-wasm driver (`src/standalone.rs`)
 # decodes the model metadata, runs DASSL (daskr) / Euler, and serialises the
 # `.mat`. wasip1 has std, so these keep their default (`std`) features.
 [target.'cfg(target_os = "wasi")'.dependencies]
-openmodelica_sim_meta = { path = "../openmodelica_sim_meta" }
-openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
-daskr = { path = "../daskr" }
+openmodelica_sim_meta = { path = "../openmodelica_sim_meta", optional = true }
+openmodelica_mat_writer = { path = "../openmodelica_mat_writer", optional = true }
+daskr = { path = "../daskr", optional = true }
+# Sparse direct solver (CSparse port, AMD fill-reducing ordering) for torn linear
+# systems selected as sparse — the in-wasm-solve builds only (`inwasm_solve`); the
+# native interactive runtime delegates to the host instead. Pure Rust, zero deps.
+rsparse = { version = "1.2", optional = true }
 
 [profile.release]
 opt-level = "s"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -80,16 +80,14 @@ fn trap() -> ! {
 // wasm32-wasip1 target. It uses std (file I/O over WASI) + daskr + the shared
 // sim-meta / mat-writer crates, all wasi-gated, so the no_std JIT runtime
 // (wasm32-unknown-unknown) is unaffected.
-#[cfg(target_os = "wasi")]
+#[cfg(all(target_os = "wasi", feature = "standalone"))]
 mod standalone;
 
-// The in-wasm session driver (`rt_sim_*`), only on the no_std JIT runtime target
-// (wasm32-unknown-unknown): the shared driver + daskr compiled in-wasm so the
-// model's functionODE etc. are reached wasm->wasm via the shared table. Gated by
-// the default `session` feature so the FMI3 adapter (which links this crate for
-// its allocator + rt_* but drives the model via direct `model` imports, not the
-// `env` table) can drop it and avoid a dangling `env` table import.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "session"))]
+// The in-wasm session driver (`rt_sim_*`): the shared driver + daskr compiled
+// in-wasm so the model is reached wasm->wasm via the shared table. Both JIT
+// runtimes (unknown-unknown for web, wasip1 for native) enable it via the
+// `session` feature; the FMI3 adapter drops it to avoid a dangling table import.
+#[cfg(all(target_arch = "wasm32", feature = "session"))]
 mod session;
 
 // ---------------------------------------------------------------------------
@@ -2026,8 +2024,20 @@ pub extern "C" fn rt_sim_store_row(buf: u32, row: u32, sim_data: u32, n_reals: u
 ///
 /// LU with partial pivoting first (like C's `dgesv`); on a singular matrix a
 /// total-pivot search runs as fallback, mirroring C's `LS_DEFAULT`.
+/// Count of linear-system solves in the current run (every dense + sparse path).
+/// The session resets it per run via [`reset_lin_solves`]; surfaced in `LOG_STATS`.
+static LIN_SOLVES: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+pub fn lin_solves() -> u64 {
+    LIN_SOLVES.load(core::sync::atomic::Ordering::Relaxed)
+}
+pub fn reset_lin_solves() {
+    LIN_SOLVES.store(0, core::sync::atomic::Ordering::Relaxed);
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
+    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
     let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
@@ -2036,6 +2046,197 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     } else {
         1
     }
+}
+
+/// Solve a sparse `n`×`n` system `A x = b` in place, `A` given in CSC:
+/// `colptr` = `n+1` i32 column pointers, `rowidx`/`values` = `nnz` row indices /
+/// f64 values (column-major). `b ← x` on success (returns 0), 1 if singular.
+///
+/// Sparse LU with AMD fill-reducing ordering via `rsparse::lusol` (a CSparse port)
+/// on the in-wasm-solve build; the others densify and reuse the dense LU.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_solve_lin_sparse(colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: u32, nnz: u32) -> i32 {
+    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let n = n as usize;
+    let nnz = nnz as usize;
+    let colp = unsafe { core::slice::from_raw_parts(colptr as *const i32, n + 1) };
+    let rowi = unsafe { core::slice::from_raw_parts(rowidx as *const i32, nnz) };
+    let vals = unsafe { core::slice::from_raw_parts(values as *const f64, nnz) };
+    let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+
+    #[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
+    {
+        let a = rsparse::data::Sprs {
+            nzmax: nnz,
+            m: n,
+            n,
+            p: colp.iter().map(|&x| x as isize).collect(),
+            i: rowi.iter().map(|&x| x as usize).collect(),
+            x: vals.to_vec(),
+        };
+        // order 2 = AMD on A'A (CSparse's LU ordering); tol 1.0 = partial pivoting.
+        match rsparse::lusol(&a, b, 2, 1.0) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    }
+    #[cfg(not(all(target_os = "wasi", feature = "inwasm_solve")))]
+    {
+        // No in-wasm rsparse (native interactive / no_std): densify + dense LU.
+        let mut dense = alloc::vec![0.0f64; n * n];
+        for col in 0..n {
+            for k in colp[col] as usize..colp[col + 1] as usize {
+                dense[col * n + rowi[k] as usize] = vals[k];
+            }
+        }
+        if nls::lu_solve(&dense, b, n) || nls::total_pivot_solve(&dense, b, n) {
+            0
+        } else {
+            1
+        }
+    }
+}
+
+/// Solve `A x = b` from a dense column-major `A` (`a_ptr`, `n*n` f64): scan its
+/// structural nonzeros into CSC, then [`rt_solve_lin_sparse`]. 0 ok, 1 singular.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_solve_lin_dense_sparse(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
+    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let n = n as usize;
+    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+
+    #[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
+    {
+        let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+        let mut p = alloc::vec![0isize; n + 1];
+        let mut i = alloc::vec::Vec::new();
+        let mut x = alloc::vec::Vec::new();
+        for col in 0..n {
+            for row in 0..n {
+                let v = a[col * n + row];
+                if v != 0.0 {
+                    i.push(row);
+                    x.push(v);
+                }
+            }
+            p[col + 1] = i.len() as isize;
+        }
+        let sp = rsparse::data::Sprs { nzmax: i.len(), m: n, n, p, i, x };
+        match rsparse::lusol(&sp, b, 2, 1.0) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    }
+    #[cfg(not(all(target_os = "wasi", feature = "inwasm_solve")))]
+    {
+        // No in-wasm rsparse: A is already dense column-major, solve directly.
+        let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+        if nls::lu_solve(a, b, n) || nls::total_pivot_solve(a, b, n) {
+            0
+        } else {
+            1
+        }
+    }
+}
+
+// Native rsparse solve on the host (`openmodelica_wasm_jit::host::lin_solve`),
+// which caches the symbolic analysis host-side. Returns 0 (solved) or 1 (singular).
+#[cfg(all(target_os = "wasi", feature = "host_lin_solve"))]
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    fn rt_host_lin_solve(handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: u32, nnz: u32) -> i32;
+}
+
+// Per-system cached sparse-LU symbolic analysis (keyed by `handle`): the pattern is
+// constant over a run, so `sqr` runs once and each solve only refactors.
+#[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
+struct CachedLss {
+    a: rsparse::data::Sprs<f64>, // p/i fixed; x refreshed each solve
+    s: rsparse::data::Symb,
+    x: alloc::vec::Vec<f64>,
+}
+
+#[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
+thread_local! {
+    static LSS_CACHE: core::cell::RefCell<std::collections::HashMap<u32, CachedLss>> =
+        core::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Like [`rt_solve_lin_sparse`] but reuses the cached symbolic analysis for `handle`
+/// (pattern read only to seed the cache on the first call).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_solve_lin_sparse_cached(
+    handle: u32,
+    colptr: u32,
+    rowidx: u32,
+    values: u32,
+    b_ptr: u32,
+    n: u32,
+    nnz: u32,
+) -> i32 {
+    let n = n as usize;
+    let nnz = nnz as usize;
+
+    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    // Native interactive runtime: the host solves natively (cheap crossings).
+    #[cfg(all(target_os = "wasi", feature = "host_lin_solve"))]
+    {
+        return unsafe { rt_host_lin_solve(handle, colptr, rowidx, values, b_ptr, n as u32, nnz as u32) };
+    }
+    // In-wasm rsparse cache: web interactive (boundary too costly) + standalone.
+    #[cfg(all(target_os = "wasi", feature = "inwasm_solve", not(feature = "host_lin_solve")))]
+    {
+        return solve_lin_sparse_cached_inwasm(handle, colptr, rowidx, values, b_ptr, n, nnz);
+    }
+    // no_std (JIT fallback): densify + dense LU.
+    #[cfg(not(all(target_os = "wasi", any(feature = "host_lin_solve", feature = "inwasm_solve"))))]
+    {
+        let _ = handle;
+        rt_solve_lin_sparse(colptr, rowidx, values, b_ptr, n as u32, nnz as u32)
+    }
+}
+
+/// In-wasm cached sparse solve (rsparse) — the web interactive + standalone
+/// wasip1 runtimes (no host solver). Reuses the cached symbolic analysis for `handle`.
+#[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
+fn solve_lin_sparse_cached_inwasm(handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: usize, nnz: usize) -> i32 {
+    let vals = unsafe { core::slice::from_raw_parts(values as *const f64, nnz) };
+    let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+    LSS_CACHE.with(|cell| {
+        let mut cache = cell.borrow_mut();
+        let entry = cache.entry(handle).or_insert_with(|| {
+            let colp = unsafe { core::slice::from_raw_parts(colptr as *const i32, n + 1) };
+            let rowi = unsafe { core::slice::from_raw_parts(rowidx as *const i32, nnz) };
+            let a = rsparse::data::Sprs {
+                nzmax: nnz,
+                m: n,
+                n,
+                p: colp.iter().map(|&x| x as isize).collect(),
+                i: rowi.iter().map(|&x| x as usize).collect(),
+                x: vals.to_vec(),
+            };
+            let s = rsparse::sqr(&a, 2, false); // AMD ordering + symbolic, once
+            CachedLss { a, s, x: alloc::vec![0.0f64; n] }
+        });
+        entry.a.x.copy_from_slice(vals);
+        let CachedLss { a, s, x } = entry;
+        let nm = match rsparse::lu(a, s, 1.0) {
+            Ok(nm) => nm,
+            Err(_) => return 1,
+        };
+        // x = P*b, solve L/U, b = Q*x; rsparse's `ipvec` permute is private.
+        match &nm.pinv {
+            Some(p) => for k in 0..n { x[p[k] as usize] = b[k]; },
+            None => x[..n].copy_from_slice(&b[..n]),
+        }
+        rsparse::lsolve(&nm.l, &mut x[..]);
+        rsparse::usolve(&nm.u, &mut x[..]);
+        match &s.q {
+            Some(q) => for k in 0..n { b[q[k] as usize] = x[k]; },
+            None => b[..n].copy_from_slice(&x[..n]),
+        }
+        0
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -203,6 +203,7 @@ pub extern "C" fn rt_sim_set_overrides(ptr: u32, len: u32) -> i32 {
 pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, present_mask: u32) -> i32 {
     // Any prior session is dropped (frees its buffers) before starting a new one.
     *session() = None;
+    crate::reset_lin_solves();
 
     let bytes = unsafe { core::slice::from_raw_parts(meta_ptr as *const u8, meta_len as usize) };
     let model = match openmodelica_sim_meta::decode(bytes) {
@@ -318,6 +319,7 @@ pub extern "C" fn rt_sim_stat(which: u32) -> u64 {
         4 => s.stats.conv_test_fails,
         5 => s.stats.state_events,
         6 => s.stats.time_events,
+        7 => crate::lin_solves(),
         _ => 0,
     })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -260,13 +260,10 @@ dependencies = [
 name = "openmodelica_codegen_wasm_jit_runtime"
 version = "0.1.0"
 dependencies = [
- "daskr",
  "dlmalloc",
  "libm",
  "minpack",
  "nalgebra",
- "openmodelica_mat_writer",
- "openmodelica_sim_meta",
 ]
 
 [[package]]
@@ -277,10 +274,6 @@ dependencies = [
  "openmodelica_sim_meta",
  "wit-bindgen",
 ]
-
-[[package]]
-name = "openmodelica_mat_writer"
-version = "0.1.0"
 
 [[package]]
 name = "openmodelica_sim_meta"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -292,6 +292,7 @@ pub struct SolveStats {
     pub conv_test_fails: u64,
     pub state_events: u64,
     pub time_events: u64,
+    pub lin_solves: u64,
 }
 
 /// One FMI value reference and the `SimData` slot it names. The value references

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
@@ -23,6 +23,10 @@ default = ["jit"]
 jit = ["dep:wasmtime", "dep:daskr"]
 # Select wasmer instead of wasmtime (native benchmarking; mandatory on wasm32).
 engine-wasmer = ["jit", "dep:wasmer"]
+# Build the native interactive runtime with the in-wasm driver + solver (instead
+# of the lean host-delegating default), so OMC_WASM_INWASM_DRIVER=1 can run the
+# in-wasm session driver natively for benchmarking. Read by build.rs only.
+inwasm_driver = []
 
 # wasmtime is native-only; the wasm target uses wasmer-js.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -34,6 +38,10 @@ libc.workspace = true
 # our arena-backed ModelicaAllocateString.
 libffi.workspace = true
 openmodelica_modelica_utilities.workspace = true
+# Native sparse direct solver (CSparse port, AMD ordering) for the host-side
+# linear-system solve the interactive runtime delegates via `rt_host_lin_solve`.
+# Same crate/version as the in-wasm runtime, so the two paths match numerically.
+rsparse = "1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasmer = { workspace = true, features = ["js", "wasm-types-polyfill"], optional = true }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -54,6 +54,7 @@ fn main() {
     // invocation (the JIT build short-circuits on its own cache/override).
     build_jit_runtime(&crate_dir, &runtime_dir, &out_dir, &dest, &hash);
     build_wasip1_runtime(&crate_dir, &runtime_dir, &out_dir, &hash);
+    build_wasip1_interactive_runtime(&crate_dir, &runtime_dir, &out_dir, &hash);
     build_external_c_wasm(&crate_dir, &out_dir);
     build_fmi3_me_adapter(&crate_dir, &out_dir);
 }
@@ -413,7 +414,14 @@ fn build_wasip1_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, ha
         return;
     }
 
-    match build_runtime_wasm(runtime_dir, out_dir, "wasm32-wasip1") {
+    match build_runtime_wasm_named(
+        runtime_dir,
+        out_dir,
+        "wasm32-wasip1",
+        "openmodelica_codegen_wasm_jit_runtime",
+        "runtime-target",
+        &["--no-default-features", "--features", "standalone"],
+    ) {
         Ok(produced) => {
             copy(&produced, &dest);
             std::fs::write(&stamp, hash).expect("write runtime_wasip1.wasm.hash");
@@ -449,6 +457,69 @@ fn build_wasip1_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, ha
 /// build's lock, and scrubs host `RUSTFLAGS`/codegen-backend settings (the host
 /// workspace selects the cranelift backend, which cannot target wasm — the
 /// runtime must build with the default LLVM backend).
+/// Build + embed the `wasm32-wasip1` **interactive** runtime (`runtime_wasip1_
+/// interactive.wasm`): the crate with `--features session` (host-driven in-wasm
+/// driver) so it exports `rt_*`+`memory`+`__indirect_function_table` (the model
+/// imports them) and imports only `wasi_snapshot_preview1` — the std runtime the
+/// sparse solver (`rsparse`) needs, instantiated with the existing `wasi_shim`.
+/// Native omc adds `host_lin_solve` (delegate the solve to the host); web omc
+/// omits it and solves in-wasm.
+fn build_wasip1_interactive_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, hash: &str) {
+    let dest = out_dir.join("runtime_wasip1_interactive.wasm");
+    let stamp = out_dir.join("runtime_wasip1_interactive.wasm.hash");
+
+    // omc-on-wasm builds this too (Part A2 uses it via wasmer-js); no wasm-merge is
+    // needed, unlike the standalone variant, so it is not skipped for wasm32 omc.
+    if let Ok(path) = std::env::var("OMC_WASM_RUNTIME_WASIP1_INTERACTIVE") {
+        copy(Path::new(&path), &dest);
+        std::fs::write(&stamp, format!("override:{path}")).ok();
+        return;
+    }
+    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1_INTERACTIVE");
+
+    // Native wasmtime: lean host-delegating blob (`host_lin_solve`), no in-wasm
+    // driver/solver linked in. Web (wasm32) and native-wasmer solve in-wasm
+    // (`session,inwasm_solve`) — the wasmer host has no native solver. `inwasm_driver`
+    // opts the native build into the in-wasm variant for OMC_WASM_INWASM_DRIVER=1.
+    let native = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() != Ok("wasm32");
+    let wasmer = std::env::var("CARGO_FEATURE_ENGINE_WASMER").is_ok();
+    let inwasm_driver = std::env::var("CARGO_FEATURE_INWASM_DRIVER").is_ok();
+    let features = if native && !wasmer && !inwasm_driver {
+        "host_lin_solve"
+    } else {
+        "session,inwasm_solve"
+    };
+    // The feature set is part of the cache key: toggling the engine must rebuild.
+    let stamp_val = format!("{hash}:{features}");
+
+    if dest.exists() && std::fs::read_to_string(&stamp).ok().as_deref() == Some(stamp_val.as_str()) {
+        return;
+    }
+
+    match build_runtime_wasm_named(
+        runtime_dir,
+        out_dir,
+        "wasm32-wasip1",
+        "openmodelica_codegen_wasm_jit_runtime",
+        "runtime-interactive-target",
+        &["--no-default-features", "--features", features],
+    ) {
+        Ok(produced) => {
+            copy(&produced, &dest);
+            std::fs::write(&stamp, &stamp_val).expect("write runtime_wasip1_interactive.wasm.hash");
+        }
+        Err(e) => {
+            // Hard error, not a silent fallback: the no_std runtime would dense-solve.
+            let _ = crate_dir;
+            panic!(
+                "failed to build the wasip1 interactive runtime: {e}\n\
+                 Install the target with `rustup target add wasm32-wasip1`, or set \
+                 OMC_WASM_RUNTIME_WASIP1_INTERACTIVE=/path/to/runtime_wasip1_interactive.wasm."
+            );
+        }
+    }
+}
+
 fn build_runtime_wasm(runtime_dir: &Path, out_dir: &Path, target: &str) -> Result<PathBuf, String> {
     build_runtime_wasm_named(
         runtime_dir,
@@ -456,26 +527,30 @@ fn build_runtime_wasm(runtime_dir: &Path, out_dir: &Path, target: &str) -> Resul
         target,
         "openmodelica_codegen_wasm_jit_runtime",
         "runtime-target",
+        &[],
     )
 }
 
 /// Compile a wasm-only cdylib crate at `crate_dir` to `target` (release) and
 /// return the produced `<artifact>.wasm`. `target_dir_prefix` isolates its cargo
-/// target dir so parallel variants don't churn each other's cache. Scrubs the
-/// host build's RUSTFLAGS / codegen-backend so the wasm build uses the default
-/// LLVM backend.
+/// target dir so parallel variants don't churn each other's cache. `extra_args`
+/// passes cargo feature flags (e.g. `--no-default-features`). Scrubs the host
+/// build's RUSTFLAGS / codegen-backend so the wasm build uses the default LLVM
+/// backend.
 fn build_runtime_wasm_named(
     crate_dir: &Path,
     out_dir: &Path,
     target: &str,
     artifact: &str,
     target_dir_prefix: &str,
+    extra_args: &[&str],
 ) -> Result<PathBuf, String> {
     let target_dir = out_dir.join(format!("{target_dir_prefix}-{target}"));
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
     let status = Command::new(cargo)
         .current_dir(crate_dir)
         .args(["build", "--release", "--target", target])
+        .args(extra_args)
         .arg("--target-dir")
         .arg(&target_dir)
         // Don't inherit the host build's flags/backend selection.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -52,12 +52,92 @@ fn record_warning(rec: [i32; 8]) {
     PENDING_WARNINGS.with(|p| p.borrow_mut().push(rec));
 }
 
+// Native rsparse solve behind the `env.rt_host_lin_solve` import, which the native
+// interactive runtime calls from `rt_solve_lin_sparse_cached`. Symbolic analysis
+// cached per system `handle`; `count()` feeds `stats.lin_solves`.
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub mod lin_solve {
+    use std::cell::{Cell, RefCell};
+    use std::collections::HashMap;
+
+    struct Cached {
+        a: rsparse::data::Sprs<f64>, // p/i fixed after seeding; x refreshed per solve
+        s: rsparse::data::Symb,
+        x: Vec<f64>,
+    }
+    thread_local! {
+        static CACHE: RefCell<HashMap<u32, Cached>> = RefCell::new(HashMap::new());
+        static COUNT: Cell<u64> = const { Cell::new(0) };
+    }
+
+    /// Drop the per-system cache and zero the counter; called once per run setup.
+    pub fn reset() {
+        CACHE.with(|c| c.borrow_mut().clear());
+        COUNT.with(|c| c.set(0));
+    }
+    /// Linear solves performed host-side in the current run.
+    pub fn count() -> u64 {
+        COUNT.with(|c| c.get())
+    }
+
+    fn read_f64(mem: &[u8], off: usize, k: usize) -> Option<f64> {
+        let s = off + k * 8;
+        Some(f64::from_le_bytes(mem.get(s..s + 8)?.try_into().unwrap()))
+    }
+    fn read_i32(mem: &[u8], off: usize, k: usize) -> Option<i32> {
+        let s = off + k * 4;
+        Some(i32::from_le_bytes(mem.get(s..s + 4)?.try_into().unwrap()))
+    }
+
+    /// Solve `A x = b` (CSC in wasm `mem`) and return the solution to write back
+    /// into `b`, or `None` if singular. Mirrors the runtime's cached path.
+    pub fn solve(
+        handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32,
+        n: usize, nnz: usize, mem: &[u8],
+    ) -> Option<Vec<f64>> {
+        let (colptr, rowidx, values, b_ptr) = (colptr as usize, rowidx as usize, values as usize, b_ptr as usize);
+        let mut b: Vec<f64> = (0..n).map(|k| read_f64(mem, b_ptr, k)).collect::<Option<_>>()?;
+        let vals: Vec<f64> = (0..nnz).map(|k| read_f64(mem, values, k)).collect::<Option<_>>()?;
+        COUNT.with(|c| c.set(c.get() + 1));
+        CACHE.with(|cell| {
+            let mut cache = cell.borrow_mut();
+            let entry = match cache.entry(handle) {
+                std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    let p: Vec<isize> = (0..=n).map(|k| read_i32(mem, colptr, k).map(|x| x as isize)).collect::<Option<_>>()?;
+                    let i: Vec<usize> = (0..nnz).map(|k| read_i32(mem, rowidx, k).map(|x| x as usize)).collect::<Option<_>>()?;
+                    let a = rsparse::data::Sprs { nzmax: nnz, m: n, n, p, i, x: vals.clone() };
+                    let s = rsparse::sqr(&a, 2, false); // AMD ordering + symbolic, once
+                    slot.insert(Cached { a, s, x: vec![0.0f64; n] })
+                }
+            };
+            entry.a.x.copy_from_slice(&vals);
+            let Cached { a, s, x } = entry;
+            let nm = rsparse::lu(a, s, 1.0).ok()?;
+            // x = P*b, solve L/U, b = Q*x; rsparse's `ipvec` permute is private.
+            match &nm.pinv {
+                Some(p) => for k in 0..n { x[p[k] as usize] = b[k]; },
+                None => x[..n].copy_from_slice(&b[..n]),
+            }
+            rsparse::lsolve(&nm.l, &mut x[..]);
+            rsparse::usolve(&nm.u, &mut x[..]);
+            match &s.q {
+                Some(q) => for k in 0..n { b[q[k] as usize] = x[k]; },
+                None => b[..n].copy_from_slice(&x[..n]),
+            }
+            Some(b)
+        })
+    }
+}
+
 // `rt_assert`/`rt_assert_warning` register under `rt` (not `env`) so the merged
 // wasip1 export needs no `env` namespace; `rt_host_*` feed the in-wasm session
 // driver the host clock/cancel source.
+// Generic over the store data `T` (the closures never touch it), so both the sim
+// path (`Store<WasiCtx>`) and the `-d=gen` function-eval path (`Store<()>`) reuse it.
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
-pub fn add_host_builtins(linker: &mut wasmtime::Linker<()>) -> Result<()> {
-    let wt = |r: std::result::Result<&mut wasmtime::Linker<()>, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
+pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result<()> {
+    let wt = |r: std::result::Result<&mut wasmtime::Linker<T>, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
     wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
         record_assert(msg, file, sline, scol, eline, ecol, read_only);
     }))?;
@@ -66,6 +146,27 @@ pub fn add_host_builtins(linker: &mut wasmtime::Linker<()>) -> Result<()> {
     }))?;
     wt(linker.func_wrap("env", "rt_host_now_ms", || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }))?;
     wt(linker.func_wrap("env", "rt_host_cancel", || -> i32 { metamodelica::cancel::check_cancel() as i32 }))?;
+    // Solve the CSC system in the caller's (the runtime's) shared memory; the
+    // interactive runtime imports this. Returns 0 (solved, `b` overwritten) or 1.
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_lin_solve",
+        |mut caller: wasmtime::Caller<'_, T>, handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: u32, nnz: u32| -> i32 {
+            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 1 };
+            let x = lin_solve::solve(handle, colptr, rowidx, values, b_ptr, n as usize, nnz as usize, mem.data(&caller));
+            match x {
+                Some(x) => {
+                    let off = b_ptr as usize;
+                    let data = mem.data_mut(&mut caller);
+                    for (k, v) in x.iter().enumerate() {
+                        data[off + k * 8..off + k * 8 + 8].copy_from_slice(&v.to_le_bytes());
+                    }
+                    0
+                }
+                None => 1,
+            }
+        },
+    ))?;
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -4,6 +4,12 @@
 // the codegen crate (standalone/FMU emission).
 pub static RUNTIME_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/runtime.wasm"));
 pub static RUNTIME_WASIP1: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/runtime_wasip1.wasm"));
+/// The interactive `wasm32-wasip1` (std) runtime: exports `rt_*`+`memory`+table
+/// like `RUNTIME_WASM`, but built with std so the sparse solver (`rsparse`) links
+/// in; imports `wasi_snapshot_preview1` (satisfied by `wasi_shim`). Empty when the
+/// wasip1 target was unavailable at build time (host then uses `RUNTIME_WASM`).
+pub static RUNTIME_WASM_INTERACTIVE_WASIP1: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/runtime_wasip1_interactive.wasm"));
 pub static EXTERNAL_C_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/modelicaexternalc.wasm"));
 pub static FMI3_ME_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_me_adapter.wasm"));
 pub static FMI3_CS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_cs_adapter.wasm"));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -48,6 +48,10 @@ pub struct SimModel {
     pub var_units: HashMap<String, String>,
     /// Driver-facing metadata shared with the in-wasm driver (passed to `sim_driver::drive`).
     pub meta: SimMeta,
+    /// Pre-rendered `LOG_STDOUT` lines announcing which torn linear systems use the
+    /// sparse solver (C's `initializeLinearSystems` messages), prepended to the sim
+    /// log. Empty when no system is sparse.
+    pub sparse_lss_log: String,
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -44,7 +44,18 @@ use crate::sig::WTy;
 use crate::host::add_host_builtins;
 
 /// The runtime module, embedded the same way the function half embeds it.
-use crate::RUNTIME_WASM;
+use crate::{RUNTIME_WASM, RUNTIME_WASM_INTERACTIVE_WASIP1};
+
+/// The std wasip1 interactive runtime (in-wasm rsparse) when it was produced, else
+/// the no_std `RUNTIME_WASM` fallback (densifies). The interactive blob additionally
+/// imports `wasi_snapshot_preview1`, served by `wasi_shim`.
+fn runtime_blob() -> &'static [u8] {
+    if RUNTIME_WASM_INTERACTIVE_WASIP1.is_empty() {
+        RUNTIME_WASM
+    } else {
+        RUNTIME_WASM_INTERACTIVE_WASIP1
+    }
+}
 
 /// The ModelicaExternalC WASI side module (`build.rs`), providing the
 /// `ext.Modelica*_*` external functions (table blocks, string scanning, …) on the
@@ -123,8 +134,8 @@ pub fn runtime_module() -> std::result::Result<&'static wasmer::Module, String> 
 fn runtime_cache_path() -> std::path::PathBuf {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
-    RUNTIME_WASM.len().hash(&mut h);
-    RUNTIME_WASM.hash(&mut h);
+    runtime_blob().len().hash(&mut h);
+    runtime_blob().hash(&mut h);
     std::env::var("OMC_WASM_OPT_LEVEL").unwrap_or_default().hash(&mut h);
     let key = h.finish();
 
@@ -145,7 +156,7 @@ fn load_or_compile_runtime() -> std::result::Result<wasmer::Module, String> {
     // the in-memory OnceLock already caches the compiled module for the session,
     // so compile straight from the embedded bytes.
     #[cfg(target_arch = "wasm32")]
-    return wts(wasmer::Module::from_binary(engine, RUNTIME_WASM));
+    return wts(wasmer::Module::from_binary(engine, runtime_blob()));
     #[cfg(not(target_arch = "wasm32"))]
     {
     let path = runtime_cache_path();
@@ -160,7 +171,7 @@ fn load_or_compile_runtime() -> std::result::Result<wasmer::Module, String> {
         // Incompatible/corrupt cache (e.g. wasmer upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wts(wasmer::Module::from_binary(engine, RUNTIME_WASM))?;
+    let module = wts(wasmer::Module::from_binary(engine, runtime_blob()))?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -750,7 +761,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     if bench {
         eprintln!(
             "wasm-jit sim: module fetch — runtime.wasm ({} KB) {:?} (cached/compiled), model.wasm ({} KB) {:?} (join/compile)",
-            RUNTIME_WASM.len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
+            runtime_blob().len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
         );
     }
 
@@ -761,11 +772,17 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     let mut store = wasmer::Store::new(engine.clone());
     let mut imports = wasmer::Imports::new();
     add_host_builtins(&mut store, &mut imports)?;
+    // The interactive (std wasip1) runtime imports `wasi_snapshot_preview1`; serve it
+    // from the same shim the ext-C side module uses, bound to the runtime's memory
+    // (set after instantiation, once the export exists). No-op for the no_std fallback.
+    let rt_wasi_env = wasmer::FunctionEnv::new(&mut store, crate::wasi_shim::Env::new("/"));
+    crate::wasi_shim::add_to_imports(&mut store, &rt_wasi_env, &mut imports);
     let rt_inst = wts(wasmer::Instance::new(&mut store, runtime_module, &imports))?;
     // The generated module imports the runtime's exports under module name "rt".
     imports.register_namespace("rt", rt_inst.exports.iter().map(|(k, v)| (k.clone(), v.clone())));
 
     let memory = wts(rt_inst.exports.get_memory("memory"))?.clone();
+    rt_wasi_env.as_mut(&mut store).set_memory(memory.clone());
 
     // External "C" functions (`ext.*`): resolved by the ModelicaExternalC WASI side
     // module (table blocks / external objects / string scanning). Must be wired

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -28,7 +28,22 @@ use crate::model::SimModel;
 use crate::host::add_host_builtins;
 
 /// The runtime module, embedded the same way the function half embeds it.
-use crate::RUNTIME_WASM;
+use crate::{RUNTIME_WASM, RUNTIME_WASM_INTERACTIVE_WASIP1};
+use crate::wasi_shim;
+use openmodelica_wasi::wasi::WasiCtx;
+
+/// The runtime module the interactive host instantiates: the std wasip1 build
+/// (so the sparse solver links in) when it was produced, else the no_std
+/// `RUNTIME_WASM` fallback. Both export the same `rt_*`+`memory`+table interface;
+/// the wasip1 one additionally imports `wasi_snapshot_preview1` (served by the
+/// `wasi_shim`).
+fn runtime_blob() -> &'static [u8] {
+    if RUNTIME_WASM_INTERACTIVE_WASIP1.is_empty() {
+        RUNTIME_WASM
+    } else {
+        RUNTIME_WASM_INTERACTIVE_WASIP1
+    }
+}
 
 /// The compiled-module type for this backend; `CodegenWasmJit::SimModel` stores
 /// it backend-agnostically as `sim_runtime::Module`.
@@ -82,8 +97,8 @@ pub fn runtime_module() -> std::result::Result<&'static wasmtime::Module, String
 fn runtime_cache_path() -> std::path::PathBuf {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
-    RUNTIME_WASM.len().hash(&mut h);
-    RUNTIME_WASM.hash(&mut h);
+    runtime_blob().len().hash(&mut h);
+    runtime_blob().hash(&mut h);
     std::env::var("OMC_WASM_OPT_LEVEL").unwrap_or_default().hash(&mut h);
     let key = h.finish();
 
@@ -111,7 +126,7 @@ fn load_or_compile_runtime() -> std::result::Result<wasmtime::Module, String> {
         // Incompatible/corrupt cache (e.g. wasmtime upgrade): fall through to
         // recompile and overwrite it below.
     }
-    let module = wts(wasmtime::Module::new(engine, RUNTIME_WASM))?;
+    let module = wts(wasmtime::Module::new(engine, runtime_blob()))?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -158,7 +173,7 @@ pub fn take_compiled_model(model: &SimModel) -> std::result::Result<wasmtime::Mo
     }
 }
 
-type Store = wasmtime::Store<()>;
+type Store = wasmtime::Store<WasiCtx>;
 
 /// `SimEngine`-trait errors: collapse to the crate `&'static str` (a model
 /// `assert()` is decoded downstream by `enrich_trap`).
@@ -217,7 +232,7 @@ fn wty_valtype(w: crate::sig::WTy) -> wasmtime::ValType {
 /// natively and binds a marshalling trampoline sharing the runtime's linear
 /// memory (`memory`).
 fn define_external_imports(
-    linker: &mut wasmtime::Linker<()>,
+    linker: &mut wasmtime::Linker<WasiCtx>,
     model: &SimModel,
     memory: wasmtime::Memory,
     rt_str_new: wasmtime::TypedFunc<u32, u32>,
@@ -249,8 +264,8 @@ fn define_external_imports(
 /// The `print` builtin's host import (`rt.rt_print`): read the String handle's
 /// bytes from the shared linear memory and write them to the model's captured
 /// stdout. The handle stays owned by the generated code, which releases it after.
-fn define_print_import(linker: &mut wasmtime::Linker<()>, memory: wasmtime::Memory) -> Result<()> {
-    wt(linker.func_wrap("rt", "rt_print", move |caller: wasmtime::Caller<'_, ()>, handle: i32| {
+fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: wasmtime::Memory) -> Result<()> {
+    wt(linker.func_wrap("rt", "rt_print", move |caller: wasmtime::Caller<'_, WasiCtx>, handle: i32| {
         if handle == 0 {
             return;
         }
@@ -280,7 +295,7 @@ fn define_print_import(linker: &mut wasmtime::Linker<()>, memory: wasmtime::Memo
 unsafe fn call_external(
     addr: usize,
     sig: &crate::sig::ExtCallSig,
-    caller: &mut wasmtime::Caller<'_, ()>,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
     memory: wasmtime::Memory,
     rt_str_new: &wasmtime::TypedFunc<u32, u32>,
     rt_str_data: &wasmtime::TypedFunc<u32, u32>,
@@ -457,8 +472,11 @@ pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, Strin
     let n_steps = model.n_intervals;
     let n_rows = n_steps + 1;
     let t0 = Instant::now();
-    let (result, driver_label) =
+    let (mut result, driver_label) =
         sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench)?;
+    // The linear solves ran host-side (`rt_host_lin_solve`); the driver's stats
+    // don't see them, so surface the host counter for LOG_STATS.
+    result.stats.lin_solves = crate::host::lin_solve::count();
     if bench {
         let elapsed = t0.elapsed();
         eprintln!(
@@ -507,9 +525,14 @@ struct Instantiated {
 /// sharing the runtime's `memory`).
 fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, String> {
     let bench = crate::model::sim_bench_enabled();
+    crate::host::lin_solve::reset(); // drop the previous run's host-side LSS cache
     let engine = sim_engine();
     let mut linker = wasmtime::Linker::new(engine);
     add_host_builtins(&mut linker)?;
+    // The interactive runtime is the std wasip1 build; its `wasi_snapshot_preview1`
+    // imports (panic `fd_write`, `proc_exit`, `environ_*`) are served by the shared
+    // shim. Harmless for the no_std fallback, which imports none of them.
+    wasi_shim::add_to_linker(&mut linker)?;
 
     // Phase 1: obtain the compiled modules. The runtime module is compiled once
     // per process (cached); the model module was JIT-compiled on a background
@@ -534,13 +557,13 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     if bench {
         eprintln!(
             "wasm-jit sim: module fetch — runtime.wasm ({} KB) {:?} (cached/compiled), model.wasm ({} KB) {:?} (join/compile)",
-            RUNTIME_WASM.len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
+            runtime_blob().len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
         );
     }
 
     // Phase 2: instantiate (sharing the runtime's linear memory).
     let t_inst = Instant::now();
-    let mut store = wasmtime::Store::new(engine, ());
+    let mut store = wasmtime::Store::new(engine, WasiCtx::new(".", Vec::new()));
     let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
     // The generated module imports the runtime's exports under module name "rt".
     wts(linker.instance(&mut store, "rt", rt_inst))?;
@@ -829,6 +852,7 @@ impl InWasmSession {
         stats.conv_test_fails = stat(4)?;
         stats.state_events = stat(5)?;
         stats.time_events = stat(6)?;
+        stats.lin_solves = stat(7)?;
         Ok(sim_driver::RunResult { rows, n_reals, params, stats })
     }
 }


### PR DESCRIPTION
Give the `--simCodeTarget=wasm-jit` runtime a real sparse linear solver for torn linear systems, matching the C runtime: the same selection (density < 0.2 or size > 1000), its `Using sparse solver for linear system N …` log messages, and symbolic Jacobian assembly rather than residual probing.

- Assemble the torn linear `A` from the symbolic Jacobian columns (C's analytic method) directly into CSC — no dense n² buffer. The CSC pattern is derived by propagating seed dependencies through the Jacobian column equations, in `res_index` order, **not** from `jacobianMatrix.sparsity`: those rows are a dependent-var permutation that is not recoverable from SimCode.
- Color the column-equation sweep, so a 905-var system assembles in ~10 passes instead of 905.

- Sparse LU with AMD fill-reducing ordering (rsparse, a CSparse port).
- Cache the symbolic analysis per system: `sqr` runs once, each step only refactors + solves — KLU-style analyze-once / refactor-per-step.
- Emit the honest `Using sparse solver for linear system N …` messages and report the solve count in `LOG_STATS`.

The solve runs where boundary crossings are cheapest:

- **Native (wasmtime):** host-driven. The runtime delegates the solve to a host import (`env.rt_host_lin_solve` = native rsparse in libOpenModelicaCompiler.so) that caches the symbolic analysis host-side. Native crossings are cheap, and this keeps the whole host-driven path native.
- **Web (wasmer-js):** the solve stays in-wasm — the JS↔wasm boundary is too costly per solve — via the std wasip1 interactive runtime (rsparse linked in, WASI served by the shared shim). Allocations grow the wasm heap through `memory.grow`, never crossing to the host.

The interactive wasip1 runtime replaces the earlier no_std fallback, which densified the system and dense-LU-solved it.

rsparse / daskr / openmodelica_sim_meta / mat_writer are optional runtime deps, pulled only by the feature that needs them:

- `host_lin_solve` — delegate the solve to the host (native).
- `inwasm_solve` — link the in-wasm rsparse solve (web, standalone).
- `session` — link the in-wasm session driver (daskr).

So the native interactive runtime builds lean (`host_lin_solve` alone): none of rsparse/daskr/sim_meta/mat_writer are linked, and it imports only `env.rt_host_lin_solve`. Web and native-wasmer use `session,inwasm_solve`; the `inwasm_driver` build feature restores the native in-wasm driver for benchmarking.

Validated on Tearing12 (905-var dassl sparse) natively (~1.3s, within ~11% of C) and in-browser (738ms warm), plus the Tearing7/8 sparse targets and the Tearing4/9/15/16 dense guards.


Claude-Session: https://claude.ai/code/session_01N2Dt5jwzmumKPxtPoLaCKf

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
