### PR TITLE
wasm-jit: fix MultiBody init-NLS regressions

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/minpack/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/minpack/src/lib.rs
@@ -92,7 +92,9 @@ pub fn enorm(x: &[f64]) -> f64 {
 }
 
 /// Forward-difference Jacobian, dense (`ml+mu+1 >= n`) path. `fjac` is filled
-/// column-major; `eval(x, f)` computes the residual.
+/// column-major; `eval(x, f)` computes the residual. The perturbation matches the C
+/// runtime's `getNumericalJacobian` (floored at `sqrt(epsfcn)`, signed by `fvec[j]`),
+/// not stock MINPACK's `eps*|x|`, which stalls on systems with a huge start residual.
 fn fdjac1(
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
     n: usize,
@@ -102,13 +104,16 @@ fn fdjac1(
     epsfcn: f64,
     wa1: &mut [f64],
 ) {
-    let eps = sqrt(fmax(epsfcn, EPSMCH));
+    let delta_h = sqrt(fmax(epsfcn, EPSMCH));
     for j in 0..n {
         let temp = x[j];
-        let mut h = eps * abs(temp);
-        if h == 0.0 {
-            h = eps;
+        let delta_hhh = epsfcn * fvec[j];
+        let mut h = fmax(delta_h * fmax(abs(temp), abs(delta_hhh)), delta_h);
+        if fvec[j] < 0.0 {
+            h = -h;
         }
+        // Force h to the representable difference, as C does (`x+h-x`).
+        h = (temp + h) - temp;
         x[j] = temp + h;
         eval(x, wa1);
         x[j] = temp;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -704,9 +704,15 @@ mod session {
                 Ok(SessionBackend::InWasm(sim_runtime::build_inwasm_session(&model)?))
             } else {
                 let (mut engine, sim_data) = sim_runtime::build_engine(&model)?;
-                let (driver, _label) =
+                let made =
                     sim_driver::make_driver(&mut *engine, &model.meta, sim_data, model.method.as_str())
-                        .map_err(|err| sim_driver::enrich_trap(&mut *engine, err))?;
+                        .map_err(|err| sim_driver::enrich_trap(&mut *engine, err));
+                let (driver, _label) = match made {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(e.to_string());
+                    }
+                };
                 Ok(SessionBackend::Host { engine, driver, sim_data })
             }
         })();
@@ -3708,17 +3714,14 @@ fn build_state_set_infos(
             .map(|cr| real_slot(var_map, cr))
             .collect::<Result<_>>()?;
 
-        // A is a flat `nStates*nCandidates` integer array named `A[k]` (1-based,
-        // row-major: A[(row-1)*nCandidates + col]); a_offs stays in that order.
+        // `$STATESET.A` is an `nStates × nCandidates` integer selection matrix.
+        // a_offs is row-major (the driver reads `a_offs[row*nc+col]`).
         let a_base_cref = openmodelica_frontend_dump::ComponentReferenceBasics::crefStripLastSubs(set.crA.clone())?;
         let a_base = sim_cref_key(&a_base_cref)?;
         let mut a_offs = Vec::new();
         for row in 1..=n_states {
             for c in 1..=n_candidates {
-                let key = format!("{a_base}[{}]", (row - 1) * n_candidates + c);
-                let slot = var_map
-                    .vars
-                    .get(&key)
+                let slot = stateset_a_slot(var_map, &a_base, row, c, n_candidates)
                     .ok_or_else(|| "CodegenWasmJit: state-set matrix entry has no slot")?;
                 a_offs.push(slot.off);
             }
@@ -3758,6 +3761,22 @@ fn build_stateset_jac_fn(
     build_eq_fn("functionStateSetJacobians", eqs, var_map, eq_index, by_name, literals)
 }
 
+/// Slot of the state-set selection-matrix entry `A[row,col]` (1-based). The backend
+/// scalarizes `$STATESET{n}.A` either 2D (key `A[row][col]`) or flat row-major (key
+/// `A[k]`, `k = (row-1)*nCandidates + col`); try the 2D key first, then the flat one.
+fn stateset_a_slot<'a>(
+    var_map: &'a SimVarMap,
+    a_base: &str,
+    row: u32,
+    col: u32,
+    n_candidates: u32,
+) -> Option<&'a SimSlot> {
+    var_map.vars.get(&format!("{a_base}[{row}][{col}]")).or_else(|| {
+        let k = (row - 1) * n_candidates + col;
+        var_map.vars.get(&format!("{a_base}[{k}]"))
+    })
+}
+
 /// Byte offsets of the diagonal `$STATESET.A[n,n]` integer slots for every state
 /// set, so [`FnCtx::emit_stateset_diag_init`] can seed an identity state
 /// selection before initialisation (C's `initializeStateSetPivoting`). The A
@@ -3774,14 +3793,11 @@ fn stateset_diag_offsets(
     let mut offs = Vec::new();
     for set in lst(state_sets) {
         // `crA` names the first `A` element; strip its subscripts to the base `A`.
-        // A is flat row-major, so the diagonal A[n,n] is `A[(n-1)*nCandidates + n]`.
         let base_cref = openmodelica_frontend_dump::ComponentReferenceBasics::crefStripLastSubs(set.crA.clone())?;
         let base = sim_cref_key(&base_cref)?;
-        for n in 1..=set.nStates {
-            let key = format!("{base}[{}]", (n - 1) * set.nCandidates + n);
-            let slot = var_map
-                .vars
-                .get(&key)
+        let n_candidates = set.nCandidates.max(0) as u32;
+        for n in 1..=set.nStates.max(0) as u32 {
+            let slot = stateset_a_slot(var_map, &base, n, n, n_candidates)
                 .ok_or_else(|| "CodegenWasmJit: state-set matrix entry has no slot")?;
             if slot.wty != WTy::I32 {
                 return Err("CodegenWasmJit: state-set matrix entry is not an Integer variable");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -385,6 +385,9 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
     ("rt_delay_eval", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
     ("rt_delay_zc", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
+    // Recoverable-assert hooks for a nonlinear-solver residual (see `nls.rs`).
+    ("rt_nls_recovering", &[], &[WTy::I32]),
+    ("rt_nls_note_assert", &[], &[]),
 ];
 
 /// Model global holding the base index at which this module's per-system
@@ -2538,6 +2541,17 @@ fn emit_assert(
         ctx.emit(we::Instruction::Call(env_extra_index("rt_assert_warning")?));
         ctx.emit(we::Instruction::End);
         return Ok(());
+    }
+    // In a nonlinear-solver residual, note the failed assert and return so the solver
+    // backs off (C's ERROR_NONLINEARSOLVER) instead of trapping. Only in a void
+    // function (residuals are void) — a bare `return` in a value-returning function is
+    // invalid wasm, and such a function is not an NLS residual anyway.
+    if ctx.outputs.is_empty() {
+        ctx.emit(we::Instruction::Call(rt_index("rt_nls_recovering")?));
+        ctx.emit(we::Instruction::If(we::BlockType::Empty));
+        ctx.emit(we::Instruction::Call(rt_index("rt_nls_note_assert")?));
+        ctx.emit(we::Instruction::Return);
+        ctx.emit(we::Instruction::End);
     }
     let mw = compile_exp(ctx, msg)?; // owned String handle
     if mw != WTy::I32 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -4,13 +4,40 @@
 //! [`newton_solve`] and [`lm_solve`] as fallbacks.
 
 use alloc::vec;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::{load_f64, load_u32, rt_alloc, rt_free, store_f64, store_u32};
+
+/// Recoverable-assert state (C's `ERROR_NONLINEARSOLVER`). While `NLS_DEPTH` > 0 a
+/// failed model `assert()` records itself in `NLS_ASSERT_HIT` and returns instead of
+/// trapping; `eval` then turns that trial into a huge residual so the solver backs off.
+static NLS_DEPTH: AtomicU32 = AtomicU32::new(0);
+static NLS_ASSERT_HIT: AtomicU32 = AtomicU32::new(0);
+
+/// Model side (emitted by `emit_assert`): is a failed assert currently recoverable
+/// (i.e. inside a nonlinear-solver residual)? Non-zero → the model records the
+/// assert via [`rt_nls_note_assert`] and bails out instead of trapping.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_recovering() -> i32 {
+    (NLS_DEPTH.load(Ordering::Relaxed) > 0) as i32
+}
+
+/// Model side: flag that a recoverable assert fired at the current trial point.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_note_assert() {
+    NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
+}
 
 /// sqrt(DBL_EPSILON): the classic forward-difference relative step.
 const SQRT_EPS: f64 = 1.4901161193847656e-08;
 /// Newton/LM convergence tolerance: stop once a residual / step measure drops below.
 const NEWTON_EPS: f64 = 1.0e-6;
+/// C's `newtonFTol`/`newtonXTol` (nonlinearSolverHomotopy.c). `newton_solve`
+/// mirrors C's residual-gated convergence: a step-stall counts as success only
+/// when the residual is also small (`< NEWTON_FTOL*1e3`), else it fails so the
+/// homotopy globaliser engages instead of accepting a non-root.
+const NEWTON_FTOL: f64 = 1.0e-12;
+const NEWTON_XTOL: f64 = 1.0e-12;
 const MAX_ITER: i32 = 100;
 /// Line-search damping floor (2^-10): below this, keep the small step and let the
 /// outer iteration retry (or hit the iteration limit → recoverable failure).
@@ -106,6 +133,368 @@ pub(crate) fn total_pivot_solve(a: &[f64], b: &mut [f64], n: usize) -> bool {
     true
 }
 
+/// Over-determined total-pivot linear solver, C's `solveSystemWithTotalPivotSearch`
+/// (`nonlinearSolverHomotopy.c`). `a` is an `n×(n+1)` column-major matrix
+/// (`a[row + col*n]`); the last column is the right-hand side. With `pos < 0` it
+/// solves the homogeneous `n×(n+1)` system for the null vector (tangent), setting
+/// the freest coordinate to 1 and returning its index in `pos`. With `pos >= 0`
+/// that coordinate is fixed (its column treated as the RHS). Writes the length
+/// `n+1` solution into `x`. Returns `0` on success, `-1` if under-determined.
+fn total_pivot_augmented(n: usize, x: &mut [f64], a: &mut [f64], pos: &mut i32) -> i32 {
+    let m = n + 1;
+    let mut n_pivot = n;
+    let mut rank = n;
+    let mut ind_row: alloc::vec::Vec<usize> = (0..n).collect();
+    let mut ind_col: alloc::vec::Vec<usize> = (0..m).collect();
+    if *pos >= 0 {
+        let p = *pos as usize;
+        ind_col[n] = p;
+        ind_col[p] = n;
+    } else {
+        n_pivot = n + 1;
+    }
+    for i in 0..n {
+        // Total pivot over rows [i,n) and columns [i,n_pivot).
+        let mut abs_max = a[ind_row[i] + ind_col[i] * n].abs();
+        let (mut p_row, mut p_col) = (i, i);
+        for r in i..n {
+            for c in i..n_pivot {
+                let v = a[ind_row[r] + ind_col[c] * n].abs();
+                if v > abs_max {
+                    abs_max = v;
+                    p_row = r;
+                    p_col = c;
+                }
+            }
+        }
+        if abs_max < f64::EPSILON {
+            rank = i;
+            break;
+        }
+        ind_row.swap(i, p_row);
+        ind_col.swap(i, p_col);
+        let piv = a[ind_row[i] + ind_col[i] * n];
+        for k in (i + 1)..n {
+            let h = -a[ind_row[k] + ind_col[i] * n] / piv;
+            for j in (i + 1)..m {
+                a[ind_row[k] + ind_col[j] * n] += h * a[ind_row[i] + ind_col[j] * n];
+            }
+            a[ind_row[k] + ind_col[i] * n] = 0.0;
+        }
+    }
+    let mut det = 1.0;
+    for k in 0..n {
+        det *= a[ind_row[k] + ind_col[k] * n];
+    }
+    if det.is_nan() {
+        return -1;
+    }
+    for i in (0..n).rev() {
+        if i >= rank {
+            if a[ind_row[i] + ind_col[n] * n].abs() > 1e-6 {
+                return -1;
+            }
+            x[ind_col[i]] = 0.0;
+        } else {
+            let mut xi = -a[ind_row[i] + ind_col[n] * n];
+            for j in ((i + 1)..n).rev() {
+                xi -= a[ind_row[i] + ind_col[j] * n] * x[ind_col[j]];
+            }
+            x[ind_col[i]] = xi / a[ind_row[i] + ind_col[i] * n];
+        }
+    }
+    x[ind_col[n]] = 1.0;
+    if *pos < 0 {
+        *pos = ind_col[n] as i32;
+    }
+    0
+}
+
+/// Row-equilibrate an `n×(n+1)` matrix (C's `scaleMatrixRows`): divide each row by
+/// the max magnitude over its first `n` columns (the Jacobian part), 1 if all zero.
+fn scale_matrix_rows_aug(n: usize, a: &mut [f64]) {
+    let m = n + 1;
+    let mut rows_max = vec![0.0f64; n];
+    for j in 0..n {
+        for i in 0..n {
+            let v = a[i + j * n].abs();
+            if v > rows_max[i] {
+                rows_max[i] = v;
+            }
+        }
+    }
+    for r in rows_max.iter_mut() {
+        if *r <= 0.0 {
+            *r = 1.0;
+        }
+    }
+    for j in 0..m {
+        for i in 0..n {
+            a[i + j * n] /= rows_max[i];
+        }
+    }
+}
+
+/// Arc-length homotopy continuation, a port of C's `homotopyAlgorithm`
+/// (`nonlinearSolverHomotopy.c`): Newton homotopy `H(y) = F(x) − (1−λ)·F(x0)` tracked
+/// λ: 0→1 by a tangent predictor + fixed-coordinate Newton corrector with adaptive
+/// step `tau`. Follows folds a fixed-λ homotopy can't. `x` = guess in / λ=1 root out.
+fn homotopy_solve(
+    n: usize,
+    x: &mut [f64],
+    nominal: &[f64],
+    start_dir: f64,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    const TAU_START: f64 = 0.2;
+    const TAU_MAX: f64 = 10.0;
+    const TAU_MIN: f64 = 1.0e-4;
+    const H_EPS: f64 = 1.0e-5;
+    const ADAPT_BEND: f64 = 0.5;
+    const TAU_DEC: f64 = 10.0;
+    const TAU_DEC_PRED: f64 = 2.0;
+    const TAU_INC: f64 = 2.0;
+    const TAU_INC_THRESH: f64 = 10.0;
+    const MAX_NEWTON: usize = 20;
+    const MAX_TRIES: i32 = 10;
+    const MAX_LAMBDA_STEPS: usize = 1000;
+    let m = n + 1;
+
+    // xScaling[i] = max(nominal[i], |xStart[i]|) from the original start values.
+    let mut xscaling = vec![0.0f64; m];
+    for i in 0..n {
+        xscaling[i] = nominal[i].abs().max(x[i].abs());
+        if xscaling[i] <= 0.0 {
+            xscaling[i] = 1.0;
+        }
+    }
+    xscaling[m - 1] = 1.0;
+
+    // Regular-initial-point search (C solveHomotopy): the raw start may sit on a
+    // singularity (a spring loop seeds s_rel=0, where the residual and Jacobian
+    // blow up and the homotopy path becomes pathological). Perturb x0 by
+    // xScaling·(i/n)·{0, 1%, 10%} until f(x0) is finite and moderate.
+    let xstart = x[..n].to_vec();
+    let mut x0v = xstart.clone();
+    let mut fx0 = vec![0.0f64; n];
+    for tries in 0..=2 {
+        let pert = match tries {
+            1 => 0.01,
+            2 => 0.10,
+            _ => 0.0,
+        };
+        for i in 0..n {
+            x0v[i] = xstart[i] + xscaling[i] * (i as f64 / n as f64) * pert;
+        }
+        eval(&x0v, &mut fx0);
+        if fx0.iter().all(|v| v.is_finite() && v.abs() < 1e6) {
+            break;
+        }
+    }
+
+    // Homotopy function H and its FD Jacobian, both over the augmented y = [x, λ].
+    let fx0_ref = &fx0;
+    let h_function = |y: &[f64], hvec: &mut [f64], fx: &mut [f64], eval: &mut dyn FnMut(&[f64], &mut [f64])| {
+        eval(&y[..n], fx);
+        let lam = y[n];
+        for i in 0..n {
+            hvec[i] = fx[i] - (1.0 - lam) * fx0_ref[i];
+        }
+    };
+
+    let mut y0 = vec![0.0f64; m];
+    y0[..n].copy_from_slice(&x0v);
+    let mut prev_tangent = vec![0.0f64; m];
+    prev_tangent[m - 1] = start_dir;
+
+    let mut hvec = vec![0.0f64; n];
+    let mut fx = vec![0.0f64; n];
+    h_function(&y0, &mut hvec, &mut fx, eval);
+
+    let mut tau = TAU_START;
+    let mut iter: i32 = 0;
+    let mut num_steps = 0usize;
+    let mut initial_step = true;
+    let mut tangent = vec![0.0f64; m]; // dy0
+    let mut hjac = vec![0.0f64; n * m];
+    let mut y1 = vec![0.0f64; m];
+    let mut yt = vec![0.0f64; m];
+    let mut dy1 = vec![0.0f64; m];
+    let mut f2 = vec![0.0f64; n];
+    let mut res_scaling = vec![1.0f64; n];
+    let mut hvec_scaled = vec![0.0f64; n];
+
+    let mut tangent_pos: i32 = -1;
+
+    let delta_h = libm::sqrt(f64::EPSILON * 20.0);
+    // Build the scaled n×(n+1) homotopy Jacobian at `y` (FD, fx = F(x) base).
+    let build_jac = |y: &[f64],
+                     fbase: &[f64],
+                     hjac: &mut [f64],
+                     f2: &mut [f64],
+                     xscaling: &[f64],
+                     eval: &mut dyn FnMut(&[f64], &mut [f64])| {
+        let mut xp = y[..n].to_vec();
+        for j in 0..n {
+            let xsave = xp[j];
+            let hh = delta_h * (xsave.abs() + 1.0);
+            xp[j] = xsave + hh;
+            let inv = xscaling[j] / hh;
+            eval(&xp, f2);
+            for i in 0..n {
+                hjac[i + j * n] = (f2[i] - fbase[i]) * inv;
+            }
+            xp[j] = xsave;
+        }
+        // The λ column (∂H/∂λ = F(x0)) is filled in by the caller.
+    };
+
+    while y0[n] < 1.0 {
+        if iter >= MAX_TRIES || y0[n] < -1.0 || num_steps >= MAX_LAMBDA_STEPS {
+            return false;
+        }
+
+        // ---- Predictor: tangent vector (only after an accepted step) ----
+        if iter == 0 {
+            build_jac(&y0, &fx, &mut hjac, &mut f2, &xscaling, eval);
+            for i in 0..n {
+                hjac[i + n * n] = fx0[i]; // ∂H/∂λ = F(x0)
+            }
+            scale_matrix_rows_aug(n, &mut hjac);
+            tangent_pos = -1;
+            if total_pivot_augmented(n, &mut tangent, &mut hjac, &mut tangent_pos) == -1 {
+                return false;
+            }
+            for i in 0..m {
+                tangent[i] *= xscaling[i];
+            }
+            // Direction: keep an acute angle with the previous tangent.
+            let mut dot = 0.0;
+            for i in 0..m {
+                dot += tangent[i] * prev_tangent[i];
+            }
+            if dot < 0.0 || (dot.abs() < f64::EPSILON && start_dir == -1.0 && initial_step) {
+                for t in tangent.iter_mut() {
+                    *t = -*t;
+                }
+            }
+            // Cap tau so λ + tau·dλ ≤ 1.
+            if tangent[n].abs() > 1e-8 {
+                tau = tau.min((1.0 - y0[n]) / tangent[n].abs());
+            }
+        }
+
+        // Predictor point y1 = y0 + tau·tangent (shrink tau on a function assert).
+        let mut assert_ok = false;
+        loop {
+            for i in 0..m {
+                y1[i] = y0[i] + tau * tangent[i];
+            }
+            h_function(&y1, &mut hvec, &mut fx, eval);
+            if hvec.iter().all(|v| v.abs() < 1e30) {
+                assert_ok = true;
+                break;
+            }
+            tau /= TAU_DEC_PRED;
+            if tau <= TAU_MIN {
+                break;
+            }
+        }
+        if !assert_ok {
+            return false;
+        }
+        yt.copy_from_slice(&y1);
+
+        // ---- Corrector: Newton with coordinate `pos` fixed ----
+        let last_step = y1[n] >= 1.0;
+        let h_eps = if last_step { NEWTON_FTOL } else { H_EPS };
+        let mut pos = if last_step { n as i32 } else { tangent_pos };
+        let mut step_accept = false;
+        let mut corrector_ok = true;
+        hvec_scaled.copy_from_slice(&hvec); // C: hvecScaled starts as hvec (unscaled)
+        for _ in 0..MAX_NEWTON {
+            if enorm(&hvec) < h_eps || enorm(&hvec_scaled) < h_eps {
+                step_accept = true;
+                break;
+            }
+            build_jac(&y1, &fx, &mut hjac, &mut f2, &xscaling, eval);
+            for i in 0..n {
+                hjac[i + n * n] = fx0[i];
+            }
+            // resScaling[i] = row abs-sum of the homotopy Jacobian (before fixing pos).
+            for i in 0..n {
+                let mut s = 0.0;
+                for j in 0..m {
+                    s += hjac[i + j * n].abs();
+                }
+                res_scaling[i] = if s > 0.0 { s } else { 1.0 };
+            }
+            // Fix coordinate `pos`: put the residual into its column, then solve.
+            let pc = pos as usize;
+            for i in 0..n {
+                hjac[i + pc * n] = hvec[i];
+            }
+            scale_matrix_rows_aug(n, &mut hjac);
+            if total_pivot_augmented(n, &mut dy1, &mut hjac, &mut pos) == -1 {
+                corrector_ok = false;
+                break;
+            }
+            dy1[pc] = 0.0;
+            for i in 0..m {
+                dy1[i] *= xscaling[i];
+                y1[i] += dy1[i];
+            }
+            h_function(&y1, &mut hvec, &mut fx, eval);
+            if hvec.iter().any(|v| v.abs() >= 1e30) {
+                corrector_ok = false;
+                break;
+            }
+            for i in 0..n {
+                hvec_scaled[i] = hvec[i] / res_scaling[i];
+            }
+        }
+
+        // ---- Step acceptance and adaptive tau via path bending ----
+        let mut bend = 0.0;
+        if corrector_ok {
+            let mut corr = 0.0;
+            let mut pred = 0.0;
+            for i in 0..m {
+                let c = y1[i] - yt[i];
+                let p = yt[i] - y0[i];
+                corr += c * c;
+                pred += p * p;
+            }
+            let pred = libm::sqrt(pred);
+            bend = if pred > 0.0 { libm::sqrt(corr) / pred } else { f64::INFINITY };
+        }
+
+        if bend > ADAPT_BEND || !step_accept {
+            if corrector_ok && bend < f64::EPSILON {
+                return false;
+            }
+            let pre_tau = tau;
+            tau = TAU_MIN.max(tau / TAU_DEC);
+            if tau == pre_tau {
+                iter = MAX_TRIES;
+            } else {
+                iter += 1;
+            }
+        } else {
+            initial_step = false;
+            iter = 0;
+            num_steps += 1;
+            if bend < ADAPT_BEND / TAU_INC_THRESH {
+                tau = TAU_MAX.min(tau * TAU_INC);
+            }
+            y0.copy_from_slice(&y1);
+            prev_tangent.copy_from_slice(&tangent);
+        }
+    }
+    x[..n].copy_from_slice(&y1[..n]);
+    true
+}
+
 /// Newton's method with a forward-difference Jacobian and a damped (line-search)
 /// step, faithful to the C runtime's `_omc_newton` (`newtonIteration.c`). `x` is
 /// the entry guess in / solution out; `eval(x, r)` writes the residual `r = f(x)`.
@@ -132,12 +521,14 @@ pub(crate) fn newton_solve(
 
     eval(x, &mut fvec);
     let mut error_f = enorm(&fvec);
-    if error_f < NEWTON_EPS {
+    if error_f < NEWTON_FTOL {
         return true;
     }
     f_old.copy_from_slice(&fvec);
 
     let mut iter = 0;
+    let mut neg_steps = 0i32; // C's countNegativeSteps
+    let mut small_steps = 0i32; // C's numberOfSmallSteps
     loop {
         // Jacobian columns by forward differences: J[:,col] = (f(x+h e_col) - f(x)) / h.
         for col in 0..n {
@@ -181,12 +572,7 @@ pub(crate) fn newton_solve(
         let xn = enorm(x);
         let scale = if xn > 1.0 { xn } else { 1.0 };
         let delta_x_scaled = delta_x / scale;
-        let mut df2 = 0.0;
-        for i in 0..n {
-            let d = f_old[i] - fvec[i];
-            df2 += d * d;
-        }
-        let delta_f = libm::sqrt(df2);
+        let error_f_old = error_f;
         error_f = enorm(&fvec);
         // scaledError_f = ‖ fvec / resScaling ‖, resScaling[i] = max-norm of Jac row i.
         let mut se2 = 0.0;
@@ -213,13 +599,23 @@ pub(crate) fn newton_solve(
         x.copy_from_slice(&x_new);
         f_old.copy_from_slice(&fvec);
 
-        if error_f < NEWTON_EPS
-            || scaled_error_f < NEWTON_EPS
-            || delta_x < NEWTON_EPS
-            || delta_f < NEWTON_EPS
-            || delta_x_scaled < NEWTON_EPS
-        {
+        // C's newtonAlgorithm convergence (nonlinearSolverHomotopy.c): residual-gated.
+        // A vanishing step alone is NOT success — the residual must also be small,
+        // else the solver reports failure so the homotopy globaliser engages instead
+        // of accepting a non-root (the ThreeSprings spring-loop stall).
+        neg_steps += (error_f > 10.0 * error_f_old) as i32;
+        if neg_steps > 20 {
+            return false;
+        }
+        let f_small = error_f < NEWTON_FTOL || scaled_error_f < NEWTON_FTOL;
+        let x_small = delta_x < NEWTON_XTOL || delta_x_scaled < NEWTON_XTOL;
+        if f_small && x_small {
             return true;
+        }
+        small_steps += (delta_x < NEWTON_XTOL * 100.0 || delta_x_scaled < NEWTON_XTOL * 100.0) as i32;
+        if x_small || small_steps > 20 {
+            // Stalled step: accept only with a small residual (C's ftol*1e3), else fail.
+            return error_f < NEWTON_FTOL * 1.0e3 || scaled_error_f < NEWTON_FTOL * 1.0e3;
         }
         iter += 1;
         if iter > MAX_ITER {
@@ -371,6 +767,110 @@ fn nls_accept(status: minpack::Status, fvec: &[f64]) -> bool {
     status == minpack::Status::Converged || enorm(fvec) <= 1.0e-12
 }
 
+/// Residual-scaled norm (C's `xerror_scaled`): divide each residual by the row max
+/// of an FD Jacobian at `x`, then take the 2-norm. Lets a solver accept a stalled
+/// iterate whose residual is negligible relative to the system's own magnitudes.
+fn scaled_res_norm(
+    n: usize,
+    x: &[f64],
+    fvec: &[f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> f64 {
+    let mut xw = x.to_vec();
+    let mut rp = vec![0.0f64; n];
+    let mut scaled = vec![0.0f64; n];
+    for i in 0..n {
+        let mut row = 1e-16f64;
+        for j in 0..n {
+            let h = SQRT_EPS * (x[j].abs() + 1.0);
+            let saved = xw[j];
+            xw[j] = saved + h;
+            eval(&xw, &mut rp);
+            xw[j] = saved;
+            let d = ((rp[i] - fvec[i]) / h).abs();
+            if d > row {
+                row = d;
+            }
+        }
+        scaled[i] = fvec[i] / row;
+    }
+    enorm(&scaled)
+}
+
+/// C's `solveHybrd` (nonlinearSolverHybrd.c): numeric `hybrd` in a retry ladder. On a
+/// stall it restarts from the guess with the trust-region `factor` cut tenfold
+/// (100→10→1→0.1), then varies the start, rescales, then drops x-scaling. Accepts on
+/// convergence or a raw/residual-scaled norm at tolerance. The small-`factor` restart
+/// is what reaches the ThreeSprings physical root, where `factor=100` stalls near x0.
+fn hybrd_c(
+    n: usize,
+    x: &mut [f64],
+    nominal: &[f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    const LOCAL_TOL: f64 = 1e-12;
+    let maxfev = n * 10000;
+    let initial_factor = 100.0f64;
+    let mut factor = initial_factor;
+    let guess = x.to_vec(); // C's nlsxExtrapolation (=start values at init)
+    let mut xscale = vec![1.0f64; n];
+    for i in 0..n {
+        xscale[i] = x[i].abs().max(nominal[i]).max(1e-16);
+    }
+    let mut use_xscaling = true;
+    let mut fvec = vec![0.0f64; n];
+    let mut retries = 0i32;
+    loop {
+        let mut xw = vec![0.0f64; n];
+        for i in 0..n {
+            xw[i] = if use_xscaling { x[i] / xscale[i] } else { x[i] };
+        }
+        let mut real = vec![0.0f64; n];
+        let mut seval = |sx: &[f64], r: &mut [f64]| {
+            for i in 0..n {
+                real[i] = if use_xscaling { sx[i] * xscale[i] } else { sx[i] };
+            }
+            eval(&real, r);
+        };
+        let status = minpack::hybrd(&mut seval, n, &mut xw, &mut fvec, 1e-12, maxfev, 1e-12, factor);
+        drop(seval);
+        for i in 0..n {
+            x[i] = if use_xscaling { xw[i] * xscale[i] } else { xw[i] };
+        }
+        let xerror = enorm(&fvec);
+        let xerror_scaled = scaled_res_norm(n, x, &fvec, eval);
+        if status == minpack::Status::Converged || xerror <= LOCAL_TOL || xerror_scaled <= LOCAL_TOL {
+            return true;
+        }
+        // C retries on info 4/5 (stall); we also escalate on the trust-region /
+        // step-bound terminations, which are the same "no progress" condition here.
+        let no_progress = status != minpack::Status::Converged;
+        if no_progress && retries < 3 {
+            x.copy_from_slice(&guess);
+            factor /= 10.0;
+            retries += 1;
+        } else if no_progress && retries < 4 {
+            for i in 0..n {
+                x[i] += nominal[i] * 0.1;
+            }
+            factor = initial_factor;
+            retries += 1;
+        } else if no_progress && retries < 5 {
+            x.copy_from_slice(&guess);
+            for i in 0..n {
+                xscale[i] = guess[i].abs().max(nominal[i]).max(1e-16);
+            }
+            retries += 1;
+        } else if no_progress && retries < 6 {
+            x.copy_from_slice(&guess);
+            use_xscaling = false;
+            retries += 1;
+        } else {
+            return false;
+        }
+    }
+}
+
 /// [`minpack::hybrj`] with the same scaling as [`hybrd_scaled`], using the model's
 /// analytic Jacobian. `jac(x, fjac)` fills the column-major `n×n` Jacobian
 /// `∂f_i/∂x_j` at the unscaled `x`; column `j` is scaled by `scale[j]`.
@@ -420,11 +920,193 @@ fn hybrj_scaled(
     nls_accept(status, fvec)
 }
 
-/// wasm entry point: solve one `SES_NONLINEAR` system. `res_idx`/`load_idx` are
-/// shared-table indices of the model's `residual(sim_data, x, r)` and
-/// `load(sim_data, x)` functions; `n` is the unknown count; `nls_fail_addr` is
-/// the absolute address of the `SimData` recoverable-failure flag.
-///
+/// C's `newtonAlgorithm` (`nonlinearSolverHomotopy.c`): damped Newton with a
+/// Numerical-Recipes cubic line search and two-tier residual-gated convergence.
+/// Analytic Jacobian when `has_jac`, else FD; `x` = guess in / last iterate out.
+/// Returns `true` only on a small-residual root.
+fn newton_c(
+    n: usize,
+    x: &mut [f64],
+    nominal: &[f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    jaceval: &mut dyn FnMut(&[f64], &mut [f64]),
+    has_jac: bool,
+) -> bool {
+    const ALPHA: f64 = 1.0e-1;
+    const LAMBDA_MIN_C: f64 = 1.0e-4;
+    let ftol_sq = NEWTON_FTOL * NEWTON_FTOL;
+    let xtol_sq = NEWTON_XTOL * NEWTON_XTOL;
+    let nsq = |v: &[f64]| -> f64 {
+        let e = enorm(v);
+        e * e
+    };
+
+    let mut xscaling = vec![1.0f64; n];
+    for i in 0..n {
+        xscaling[i] = nominal[i].abs().max(x[i].abs());
+        if xscaling[i] <= 0.0 {
+            xscaling[i] = 1.0;
+        }
+    }
+
+    let mut fvec = vec![0.0f64; n];
+    let mut x1 = vec![0.0f64; n];
+    let mut rp = vec![0.0f64; n];
+    let mut step = vec![0.0f64; n]; // C's dy0 (the full Newton step −J⁻¹f)
+    let mut jac = vec![0.0f64; n * n];
+    let mut res_scaling = vec![1.0f64; n];
+
+    eval(x, &mut fvec);
+    let mut error_f_sqrd = nsq(&fvec);
+
+    let mut iter = 0i32;
+    let mut neg_steps = 0i32;
+    let mut small_steps = 0i32;
+    loop {
+        // Jacobian at x: analytic (as C's newtonAlgorithm uses) when available, else FD.
+        if has_jac {
+            jaceval(x, &mut jac);
+        } else {
+            for col in 0..n {
+                let h = SQRT_EPS * (x[col].abs() + 1.0);
+                let saved = x[col];
+                x[col] = saved + h;
+                eval(x, &mut rp);
+                for i in 0..n {
+                    jac[col * n + i] = (rp[i] - fvec[i]) / h;
+                }
+                x[col] = saved;
+            }
+        }
+        // resScaling[i] = row abs-sum of J (C's matVecMultAbsBB with ones).
+        for i in 0..n {
+            let mut s = 0.0;
+            for j in 0..n {
+                s += jac[j * n + i].abs();
+            }
+            res_scaling[i] = if s > 0.0 && s.is_finite() { s } else { 1.0 };
+        }
+        let scaled = |v: &[f64]| -> f64 {
+            let mut s = 0.0;
+            for i in 0..n {
+                let t = v[i] / res_scaling[i];
+                s += t * t;
+            }
+            s
+        };
+        let error_f_sqrd_scaled = scaled(&fvec);
+
+        // Newton step: solve J·d = f, then step = −d (so x1 = x + step).
+        step.copy_from_slice(&fvec);
+        if !lu_solve(&jac, &mut step, n) {
+            return false;
+        }
+        for s in step.iter_mut() {
+            *s = -*s;
+        }
+
+        let grad_f = -2.0 * error_f_sqrd;
+        let grad_f_scaled = -2.0 * error_f_sqrd_scaled;
+
+        // λ1: back off from the full step until the residual eval is finite.
+        let mut lambda1 = 1.0;
+        loop {
+            for i in 0..n {
+                x1[i] = x[i] + lambda1 * step[i];
+            }
+            eval(&x1, &mut fvec);
+            if fvec.iter().all(|v| v.abs() < 1e30) {
+                break;
+            }
+            lambda1 *= 0.655;
+            if lambda1 <= LAMBDA_MIN_C {
+                break;
+            }
+        }
+        if lambda1 < LAMBDA_MIN_C {
+            return false;
+        }
+        let error_f1_sqrd = nsq(&fvec);
+        let error_f1_sqrd_scaled = scaled(&fvec);
+
+        // Numerical-Recipes damping: quadratic then cubic model of ‖f‖².
+        if error_f1_sqrd > error_f_sqrd + ALPHA * lambda1 * grad_f
+            && error_f1_sqrd_scaled > error_f_sqrd_scaled + ALPHA * lambda1 * grad_f_scaled
+            && error_f_sqrd > 1e-12
+            && error_f_sqrd_scaled > 1e-12
+        {
+            let lambda2 = (-lambda1 * lambda1 * grad_f
+                / (2.0 * (error_f1_sqrd - error_f_sqrd - lambda1 * grad_f)))
+                .max(LAMBDA_MIN_C);
+            for i in 0..n {
+                x1[i] = x[i] + lambda2 * step[i];
+            }
+            eval(&x1, &mut fvec);
+            let error_f2_sqrd = nsq(&fvec);
+            if error_f1_sqrd > error_f_sqrd + ALPHA * lambda2 * grad_f
+                && error_f_sqrd > 1e-12
+                && error_f_sqrd_scaled > 1e-12
+            {
+                let rhs1 = error_f1_sqrd - grad_f * lambda1 - error_f_sqrd;
+                let rhs2 = error_f2_sqrd - grad_f * lambda2 - error_f_sqrd;
+                let a3 = (rhs1 / (lambda1 * lambda1) - rhs2 / (lambda2 * lambda2)) / (lambda1 - lambda2);
+                let a2 = (-lambda2 * rhs1 / (lambda1 * lambda1) + lambda1 * rhs2 / (lambda2 * lambda2))
+                    / (lambda1 - lambda2);
+                let mut lam;
+                if a3 == 0.0 {
+                    lam = -grad_f / (2.0 * a2);
+                } else {
+                    let d = a2 * a2 - 3.0 * a3 * grad_f;
+                    if d <= 0.0 {
+                        lam = 0.5 * lambda1;
+                    } else if a2 <= 0.0 {
+                        lam = (-a2 + libm::sqrt(d)) / (3.0 * a3);
+                    } else {
+                        lam = -grad_f / (a2 + libm::sqrt(d));
+                    }
+                }
+                lam = lam.max(LAMBDA_MIN_C);
+                for i in 0..n {
+                    x1[i] = x[i] + lam * step[i];
+                }
+                eval(&x1, &mut fvec);
+            }
+        }
+
+        // Error measures (C uses the FULL Newton step ‖dy0‖ for delta_x).
+        let delta_x_sqrd = nsq(&step);
+        let mut dxs = 0.0;
+        for i in 0..n {
+            let v = step[i] / xscaling[i];
+            dxs += v * v;
+        }
+        let delta_x_sqrd_scaled = dxs;
+        let error_f_old = error_f_sqrd;
+        error_f_sqrd = nsq(&fvec);
+        let error_f_sqrd_scaled2 = scaled(&fvec);
+        neg_steps += (error_f_sqrd > 10.0 * error_f_old) as i32;
+        if neg_steps > 20 {
+            return false;
+        }
+
+        x.copy_from_slice(&x1);
+
+        let f_ok = error_f_sqrd < ftol_sq || error_f_sqrd_scaled2 < ftol_sq;
+        let x_ok = delta_x_sqrd_scaled < xtol_sq || delta_x_sqrd < xtol_sq;
+        if f_ok && x_ok {
+            return true;
+        }
+        iter += 1;
+        if iter > MAX_ITER {
+            return false;
+        }
+        small_steps += (delta_x_sqrd < xtol_sq * 1e4 || delta_x_sqrd_scaled < xtol_sq * 1e4) as i32;
+        if delta_x_sqrd < xtol_sq || delta_x_sqrd_scaled < xtol_sq || small_steps > 20 {
+            return error_f_sqrd < ftol_sq * 1e6 || error_f_sqrd_scaled2 < ftol_sq * 1e6;
+        }
+    }
+}
+
 /// The `load` callback copies the current unknown slots into `x` (warm start);
 /// `residual` writes `x` back into the slots, runs the inner (torn) equations,
 /// and evaluates the residuals into `r`. On convergence the slots (and torn
@@ -484,9 +1166,21 @@ pub extern "C" fn rt_solve_nls(
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
+        // Asserts are recoverable while the residual runs (C's ERROR_NONLINEARSOLVER).
+        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
         residual(sim_data, x_ptr, r_ptr);
-        for i in 0..n {
-            r[i] = unsafe { load_f64(r_ptr + (i * 8) as u32) };
+        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        if NLS_ASSERT_HIT.load(Ordering::Relaxed) != 0 {
+            // A model assert failed at this trial (e.g. length < s_small): reject the
+            // step with a huge residual so the solver backtracks (C caught the longjmp).
+            for i in 0..n {
+                r[i] = 1e60;
+            }
+        } else {
+            for i in 0..n {
+                r[i] = unsafe { load_f64(r_ptr + (i * 8) as u32) };
+            }
         }
     };
 
@@ -499,7 +1193,12 @@ pub extern "C" fn rt_solve_nls(
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
+        // The Jacobian is evaluated at accepted iterates; keep asserts recoverable
+        // here too so a probe never traps, and drop any hit (the residual guards `r`).
+        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
         jacf(sim_data, x_ptr, jac_ptr);
+        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
         for k in 0..n * n {
             fj[k] = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
         }
@@ -563,6 +1262,34 @@ pub extern "C" fn rt_solve_nls(
         x.copy_from_slice(&warm);
         converged = newton_solve(n, &mut x, &mut eval);
     }
+    // C's init ladder: newtonAlgorithm, then solveHybrd (retry ladder) from x0.
+    if !converged && saved_rel_fresh == 2 {
+        x.copy_from_slice(&guess);
+        converged = newton_c(n, &mut x, &nominal, &mut eval, &mut jaceval, has_jac);
+    }
+    if !converged && saved_rel_fresh == 2 {
+        x.copy_from_slice(&guess);
+        converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+    }
+    // Seed collapsed zero unknowns (e.g. the spring-loop s_rel) to nominal, off the
+    // degenerate residual plateau, then re-solve — C's "zero start values to nominal".
+    if !converged && saved_rel_fresh == 2 {
+        x.copy_from_slice(&guess);
+        for i in 0..n {
+            if x[i] == 0.0 {
+                x[i] = nominal[i];
+            }
+        }
+        converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+    }
+    // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
+    if !converged {
+        converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+    }
+    if !converged {
+        x.copy_from_slice(&guess);
+        converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+    }
     if !converged {
         x.copy_from_slice(&guess);
         converged = lm_solve(n, &mut x, &mut eval);
@@ -570,6 +1297,18 @@ pub extern "C" fn rt_solve_nls(
     if !converged {
         x.copy_from_slice(&warm);
         converged = lm_solve(n, &mut x, &mut eval);
+    }
+    // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
+    if !converged && saved_rel_fresh == 2 {
+        // Forward then reversed start direction, as C's runHomotopy.
+        for &dir in &[1.0f64, -1.0f64] {
+            let mut hx = guess.clone();
+            if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
+                x.copy_from_slice(&hx);
+                converged = true;
+                break;
+            }
+        }
     }
     if converged {
         // Leave the slots + torn variables at the solution (held/init mode, so an

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -582,17 +582,30 @@ fn build_runtime_wasm_named(
 /// (`rt_sim_start failed`), not at build time.
 fn hash_inputs(runtime_dir: &Path) -> (String, Vec<PathBuf>) {
     let mut files = Vec::new();
-    let deps = runtime_dir.parent().expect("crate has a parent dir");
-    for d in [runtime_dir, &deps.join("openmodelica_sim_meta"), &deps.join("openmodelica_mat_writer")] {
-        collect_files(&d.join("src"), &mut files);
+    // Hash the runtime crate and every crate it reaches via `path = "..."` deps,
+    // discovered transitively from the Cargo.toml files: a hardcoded list silently
+    // misses edits to an unlisted path-dep and bakes a stale crate into the wasm.
+    let mut queue = vec![runtime_dir.to_path_buf()];
+    let mut seen: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+    while let Some(dir) = queue.pop() {
+        let key = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        collect_files(&dir.join("src"), &mut files);
+        let manifest = dir.join("Cargo.toml");
         for m in ["Cargo.toml", "Cargo.lock"] {
-            let p = d.join(m);
+            let p = dir.join(m);
             if p.exists() {
                 files.push(p);
             }
         }
+        for dep in path_deps(&manifest) {
+            queue.push(dir.join(dep));
+        }
     }
     files.sort();
+    files.dedup();
     // Map path -> content, hashed deterministically (FNV-1a over sorted entries).
     let mut entries: BTreeMap<String, Vec<u8>> = BTreeMap::new();
     for f in &files {
@@ -614,6 +627,28 @@ fn hash_inputs(runtime_dir: &Path) -> (String, Vec<PathBuf>) {
         feed(&[0]);
     }
     (format!("{h:016x}"), files)
+}
+
+/// Relative `path = "..."` values from a Cargo.toml (local path dependencies).
+fn path_deps(manifest: &Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(manifest) else { return Vec::new() };
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let Some(rest) = line.split_once("path").and_then(|(_, r)| {
+            let r = r.trim_start();
+            r.strip_prefix('=').map(|r| r.trim_start())
+        }) else {
+            continue;
+        };
+        let bytes = rest.as_bytes();
+        if bytes.first() != Some(&b'"') {
+            continue;
+        }
+        if let Some(end) = rest[1..].find('"') {
+            out.push(rest[1..=end].to_string());
+        }
+    }
+    out
 }
 
 fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -473,7 +473,12 @@ pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, Strin
     let n_rows = n_steps + 1;
     let t0 = Instant::now();
     let (mut result, driver_label) =
-        sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench)?;
+        match sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(e.to_string());
+            }
+        };
     // The linear solves ran host-side (`rt_host_lin_solve`); the driver's stats
     // don't see them, so surface the host counter for LOG_STATS.
     result.stats.lin_solves = crate::host::lin_solve::count();
@@ -607,7 +612,7 @@ pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver
         run_table_probe(&mut store, rt_inst, instance, memory, sim_data, layout.total)?;
     }
 
-    let engine = WasmtimeEngine { store, memory, instance, funcs: HashMap::new() };
+    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new() };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -668,6 +673,7 @@ struct WasmtimeEngine {
     store: Store,
     memory: wasmtime::Memory,
     instance: wasmtime::Instance,
+    rt_inst: wasmtime::Instance,
     funcs: HashMap<String, wasmtime::TypedFunc<u32, ()>>,
 }
 


### PR DESCRIPTION
The #16120 backend changes (flat $STATESET.A, sparse linear solver) regressed several MSL MultiBody models under --simCodeTarget=wasm-jit.

* $STATESET.A slot lookup: the backend scalarizes the selection matrix either 2D (key A[row][col]) or flat row-major (key A[k]); try both.

* Recoverable asserts during a nonlinear solve (C's ERROR_NONLINEAR- SOLVER): a model assert that fails inside a residual now records the hit and returns, and the solver rejects that trial, instead of trapping the whole simulation.

* ThreeSprings init NLS convergence. The size-6 spring-loop system is identical to C's but has a huge start residual; reaching the physical root needs the C runtime's numeric-Jacobian perturbation (getNumericalJacobian, not stock MINPACK's), C's solveHybrd trust-region retry ladder, and seeding collapsed zero unknowns to their nominal value.

* Runtime-wasm build hash: openmodelica_wasm_jit/build.rs listed the hashed dependency crates by hand and missed minpack and daskr, so edits to them baked a stale wasm. It now discovers path dependencies transitively from the Cargo.toml files.

All six MultiBody (incl. ThreeSprings) plus problem4/5, minimalTearing and Pendulum pass under wasm-jit.