### PR TITLE
wasm-jit: record layout, defaults, start seeding

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -295,11 +295,34 @@ fn write_output(path: &str, bytes: &[u8]) -> std::io::Result<()> {
 /// panic traps the wasm instance, after which the buffered error can't be read
 /// back (the web omc then reports a bare "Translation failed"). Callers return
 /// after this instead — an unsupported construct is a normal failure, not a crash.
+/// The position is the Rust call site, as `sourceInfo()` gives a MetaModelica
+/// `addInternalError`.
+#[track_caller]
 pub(crate) fn record_error(msg: String) {
+    let loc = std::panic::Location::caller();
     let _ = openmodelica_util::Error::addInternalError(
         ArcStr::from(msg.as_str()),
-        openmodelica_util::Error::dummyInfo.clone(),
+        metamodelica::SourceInfo {
+            fileName: ArcStr::from(loc.file()),
+            isReadOnly: false,
+            lineNumberStart: loc.line() as i32,
+            columnNumberStart: loc.column() as i32,
+            lineNumberEnd: loc.line() as i32,
+            columnNumberEnd: loc.column() as i32,
+            lastModification: metamodelica::OrderedFloat(0.0),
+        },
     );
+}
+
+/// `e` plus the engine's own message (trap kind + wasm backtrace) that the
+/// `&'static str` error dropped — but not for a model `assert()`, which already
+/// reported itself.
+fn with_engine_detail(e: &str) -> String {
+    let detail = openmodelica_wasm_jit::take_engine_error_detail();
+    match detail {
+        Some(d) if e != sim_driver::ASSERT_ERR => format!("{e}\n{d}"),
+        _ => e.to_string(),
+    }
 }
 
 /// `CodegenWasmJit.translateModel`: lower `simCode` to a model wasm module, write
@@ -359,7 +382,10 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
         // Chattering abort (`-abortSlowSimulation`): the driver's output carries the
         // chattering + aborting lines.
         Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!("{init_line}\n{warns}{combined}"),
-        Err(e) => format!("{combined}{warns}LOG_ERROR         | error   | wasm-jit simulation failed: {e:#}\n"),
+        Err(e) => format!(
+            "{combined}{warns}LOG_ERROR         | error   | wasm-jit simulation failed: {}\n",
+            with_engine_detail(e)
+        ),
     };
     let _ = write_output(&format!("{fileNamePrefix}.log"), log.as_bytes());
     // Error is in `<prefix>.log` (hence the result `messages`); no stderr.
@@ -720,7 +746,7 @@ mod session {
             Ok(v) => v,
             Err(e) => {
                 let _ = openmodelica_wasi::wasi::take_stdout_capture();
-                record_error(format!("wasm-jit simulation failed: {e:#}"));
+                record_error(format!("wasm-jit simulation failed: {}", with_engine_detail(&e)));
                 return Err("CodegenWasmJit: wasm-jit simulation failed");
             }
         };
@@ -822,7 +848,7 @@ mod session {
                 }
                 Err(e) => {
                     let _ = openmodelica_wasi::wasi::take_stdout_capture();
-                    record_error(format!("wasm-jit simulation failed: {e:#}"));
+                    record_error(format!("wasm-jit simulation failed: {}", with_engine_detail(e)));
                     *guard = None;
                     Err(e)
                 }
@@ -2212,6 +2238,7 @@ fn collect_samples(
 
 /// `fmi_vrs`: also record the FMI value-reference table (FMU export only).
 fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimModel> {
+    crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
     let mi = &sim_code.modelInfo;
     let vi = &mi.varInfo;
     let scalarized_vars = scalarize_sim_vars(&mi.vars)?;
@@ -2790,6 +2817,53 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionStoreDelayed", we::ExportKind::Func, store_delayed_idx);
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
 
+    // --- Name section: without it a trap backtrace is bare function indices. The
+    // unnamed remainder is the NLS callbacks. ---
+    let mut names: Vec<(u32, String)> = Vec::new();
+    for (i, name) in BUILTINS
+        .iter()
+        .map(|b| b.0)
+        .chain(RT_BUILTINS.iter().map(|b| b.0))
+        .chain(ENV_EXTRA.iter().map(|b| b.0))
+        .enumerate()
+    {
+        names.push((i as u32, name.to_string()));
+    }
+    for (i, sig) in ext_imports.iter().enumerate() {
+        names.push((ext_base + i as u32, format!("ext.{}", sig.name)));
+    }
+    for (id, f) in model_fns.iter().enumerate() {
+        names.push((import_base + id as u32, function_signature(f)?.0));
+    }
+    for (name, idx) in [
+        ("functionParameters", eqfn.parameters),
+        ("functionInitialEquations", eqfn.initial),
+        ("functionInitStartValues", eqfn.init_start_values),
+        ("functionODE", eqfn.ode),
+        ("functionAlgebraics", eqfn.algebraics),
+        ("simulate", simulate_idx),
+        ("om_meta_ptr", om_meta_ptr_idx),
+        ("om_meta_len", om_meta_len_idx),
+        ("callExternalObjectDestructors", destructors_idx),
+        ("initSample", init_sample_idx),
+        ("functionZeroCrossings", zc_idx),
+        ("functionStateSetJacobians", stateset_jac_idx),
+        ("functionInitialEquations_lambda0", init_lambda0_idx),
+        ("functionCheckAsserts", check_asserts_idx),
+        ("functionUpdateRelations", update_relations_idx),
+        ("functionStoreDelayed", store_delayed_idx),
+        ("functionInitDelay", init_delay_idx),
+    ] {
+        names.push((idx, name.to_string()));
+    }
+    names.sort_by_key(|(idx, _)| *idx);
+    let mut fn_names = we::NameMap::new();
+    for (idx, name) in &names {
+        fn_names.append(*idx, name);
+    }
+    let mut name_section = we::NameSection::new();
+    name_section.functions(&fn_names);
+
     let mut module = we::Module::new();
     module.section(&types);
     module.section(&imports);
@@ -2826,6 +2900,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         }
         module.section(&data);
     }
+    module.section(&name_section);
     let wasm = module.finish();
 
     // Kick off the (cranelift) JIT compile of this model module on a background
@@ -3341,12 +3416,12 @@ fn build_init_start_values_fn(
         zc_context: false,
     };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = Vec::with_capacity(states.len() + real_algs.len());
+    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32, Option<u32>)> = Vec::with_capacity(states.len() + real_algs.len());
     for (i, sv) in states.iter().enumerate() {
-        pairs.push((sv.initialValue.clone(), layout.state_start_off(i as u32)));
+        pairs.push((sv.initialValue.clone(), layout.state_start_off(i as u32), Some(REAL_OFF + (i as u32) * 8)));
     }
     for (j, sv) in real_algs.iter().enumerate() {
-        pairs.push((sv.initialValue.clone(), REAL_OFF + (2 * layout.n_states + j as u32) * 8));
+        pairs.push((sv.initialValue.clone(), REAL_OFF + (2 * layout.n_states + j as u32) * 8, None));
     }
     ctx.emit_init_start_values(&pairs)?;
     let (locals, instrs) = ctx.finish_sim();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -50,6 +50,7 @@ use arcstr::ArcStr;
 use metamodelica::List;
 
 use openmodelica_ast::Absyn;
+use openmodelica_frontend_base::Types;
 use openmodelica_frontend_dump::AbsynUtil;
 use openmodelica_frontend_dump::ExpressionDumpTpl;
 use openmodelica_tpl::Tpl;
@@ -430,6 +431,7 @@ pub(crate) struct FnInfo {
 /// Build the wasm module for `fnCode`. Returns the encoded module bytes and the
 /// input/output `SigTy`s of the main function (for the sidecar).
 fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec<SigTy>, Vec<SigTy>)> {
+    set_record_decls(&fn_code.extraRecordDecls)?;
     // Collect the functions: the main function first (wasm index BUILTINS.len()),
     // then the dependencies.
     let mut funcs: Vec<&SimCodeFunction::Function::Function> = Vec::new();
@@ -770,14 +772,58 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
             };
             let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
             let mut fields = Vec::new();
-            for v in &**varLst {
-                fields.push((v.name.clone(), sig_ty(&v.ty)?));
+            match record_decl_fields(&path_str) {
+                Some(decl) => {
+                    for (name, ty) in decl.iter() {
+                        fields.push((name.clone(), sig_ty(ty)?));
+                    }
+                }
+                None => {
+                    for v in &**varLst {
+                        fields.push((v.name.clone(), sig_ty(&v.ty)?));
+                    }
+                }
             }
             SigTy::Record { path: path_str, fields: Arc::new(fields) }
         }
         DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
         other => return Err("CodegenWasmJit: type not supported"),
     })
+}
+
+std::thread_local! {
+    /// One field list per record class (the C target's one `<Rec>` struct), keyed
+    /// by definition path. A record *expression*'s `T_COMPLEX` can disagree with
+    /// its consumer's about a field type, which would give the two ends different
+    /// field offsets; the declaration decides for both.
+    static RECORD_DECLS: std::cell::RefCell<HashMap<String, Arc<Vec<(ArcStr, Arc<DAE::Type>)>>>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Install the module's record declarations (see [`RECORD_DECLS`]).
+pub(crate) fn set_record_decls(
+    decls: &List<SimCodeFunction::RecordDeclaration>,
+) -> Result<()> {
+    let mut map = HashMap::new();
+    for d in decls {
+        // Only `RECORD_DECL_FULL` declares a layout.
+        let SimCodeFunction::RecordDeclaration::RECORD_DECL_FULL { defPath, variables, .. } = d else {
+            continue;
+        };
+        let path = AbsynUtil::pathString(defPath.clone(), arcstr::literal!("."), true, false)?;
+        let mut fields = Vec::new();
+        for v in &**variables {
+            let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, .. } = &**v else { continue };
+            fields.push((ArcStr::from(cref_ident(name)?), ty.clone()));
+        }
+        map.insert(path.to_string(), Arc::new(fields));
+    }
+    RECORD_DECLS.with(|r| *r.borrow_mut() = map);
+    Ok(())
+}
+
+fn record_decl_fields(path: &str) -> Option<Arc<Vec<(ArcStr, Arc<DAE::Type>)>>> {
+    RECORD_DECLS.with(|r| r.borrow().get(path).cloned())
 }
 
 // -------------------------------------------------------------------------
@@ -1105,14 +1151,17 @@ impl<'a> FnCtx<'a> {
         Ok(())
     }
 
-    /// Store each state's `start` expression into its start slot (`0.0` when the
-    /// state has no explicit start, the Real default).
+    /// Store each variable's `start` expression (`0.0` when it has none) at `off`,
+    /// and at `live_off` when the variable also has a live slot (a state, whose
+    /// `off` is its start attribute). The second store is C's `setAllVarsToStart`:
+    /// an initial equation reading a state before the initial system solves it
+    /// must see `start`, not zero.
     pub(crate) fn emit_init_start_values(
         &mut self,
-        starts: &[(Option<Arc<DAE::Exp>>, u32)],
+        starts: &[(Option<Arc<DAE::Exp>>, u32, Option<u32>)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
-        for (exp, off) in starts {
+        for (exp, off, live_off) in starts {
             self.emit(we::Instruction::LocalGet(data));
             match exp {
                 Some(e) => {
@@ -1121,7 +1170,16 @@ impl<'a> FnCtx<'a> {
                 }
                 None => self.emit(we::Instruction::F64Const(0.0f64.into())),
             }
-            self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+            if let Some(live) = live_off {
+                let v = self.alloc_temp(WTy::F64);
+                self.emit(we::Instruction::LocalTee(v));
+                self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::LocalGet(v));
+                self.emit(we::Instruction::F64Store(mem_arg(*live, 3)));
+            } else {
+                self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+            }
         }
         Ok(())
     }
@@ -1364,6 +1422,35 @@ pub(crate) fn compile_function(
     // resized by the first whole-array assignment.
     for (slot, elem, dims) in &array_allocs {
         emit_array_alloc(&mut ctx, *slot, elem, dims)?;
+    }
+    // Record locals/outputs are default-constructed at entry (C's
+    // `<Rec>_construct`), so a record without a binding still has its class
+    // defaults and its array fields' descriptors.
+    let mut constructed: Vec<u32> = Vec::new();
+    for v in (&**outVars).into_iter().chain(&**variableDeclarations) {
+        let SimCodeFunction::Variable::Variable::VARIABLE { ty, bind_from_outside, .. } = &**v else {
+            continue;
+        };
+        let (name, sty) = var_name_ty(v)?;
+        let elem_record = match &sty {
+            SigTy::Record { .. } => true,
+            SigTy::Array { elem, .. } => matches!(&**elem, SigTy::Record { .. }),
+            _ => false,
+        };
+        if *bind_from_outside || !elem_record {
+            continue;
+        }
+        let Some((slot, _)) = ctx.locals.get(&name).cloned() else { continue };
+        if constructed.contains(&slot) {
+            continue;
+        }
+        constructed.push(slot);
+        if matches!(sty, SigTy::Array { .. }) {
+            emit_array_record_defaults(&mut ctx, slot, &Types::arrayElementType(ty.clone()))?;
+        } else {
+            emit_record_default(&mut ctx, ty)?;
+            ctx.emit(we::Instruction::LocalSet(slot));
+        }
     }
     // Default-binding initializers for protected/output variables, in
     // declaration order, mirroring the C target's `varInit` (driven by the
@@ -2090,23 +2177,14 @@ fn field_store(ctx: &mut FnCtx, wty: WTy, offset: u32) {
     }
 }
 
-/// Construct a record (`E::RECORD`): allocate the object, fill the inline
-/// heap-field table, then store each field value (matched to the type's fields
-/// by name, so out-of-order constructor arguments are handled). Leaves the owned
-/// (+1) record handle on the stack.
-/// Emit a record construction: allocate the object, fill the inline heap-field
-/// table, then store each field value (`field_exps` in declaration order). The
-/// record owns heap field values. Leaves the owned (+1) record handle on the
-/// stack.
-fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_exps: &[&Arc<DAE::Exp>]) -> Result<()> {
-    let layout = record_layout(fields);
+/// Allocate a record object and fill its inline heap-field table, returning the
+/// temp holding the owned (+1) handle. The field data is left zeroed.
+fn emit_record_alloc(ctx: &mut FnCtx, layout: &RecordLayout) -> Result<u32> {
     ctx.emit(we::Instruction::I32Const(layout.heap.len() as i32));
     ctx.emit(we::Instruction::I32Const(layout.size as i32));
     ctx.emit(we::Instruction::Call(rt_index("rt_record_new")?));
     let obj = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::LocalSet(obj));
-
-    // Inline heap-field table: (elem_kind, field_off) for each heap field.
     for (k, (kind, foff)) in layout.heap.iter().enumerate() {
         let base = 8 + k as u32 * 8;
         ctx.emit(we::Instruction::LocalGet(obj));
@@ -2116,6 +2194,16 @@ fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_e
         ctx.emit(we::Instruction::I32Const(*foff as i32));
         ctx.emit(we::Instruction::I32Store(mem_arg(base + 4, 2)));
     }
+    Ok(obj)
+}
+
+/// Emit a record construction: allocate the object, fill the inline heap-field
+/// table, then store each field value (`field_exps` in declaration order). The
+/// record owns heap field values. Leaves the owned (+1) record handle on the
+/// stack.
+fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_exps: &[&Arc<DAE::Exp>]) -> Result<()> {
+    let layout = record_layout(fields);
+    let obj = emit_record_alloc(ctx, &layout)?;
     for (i, (_, fty)) in fields.iter().enumerate() {
         let w = compile_exp(ctx, field_exps[i])?;
         coerce(ctx, w, fty.wty());
@@ -2141,6 +2229,153 @@ fn emit_record_construction(ctx: &mut FnCtx, fields: &[(ArcStr, SigTy)], field_e
         field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
     }
     ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// The class default of record field `v` — the C target's `<Rec>_construct_p`
+/// field init plus `recordInitOutsideBindings`. A binding synthesized from a
+/// variable's own submods (`R r(i=2)`) is applied at its declaration, not here.
+fn record_field_default(v: &DAE::Var) -> Option<Arc<DAE::Exp>> {
+    match &*v.binding {
+        DAE::Binding::EQBOUND { source: DAE::BindingSource::BINDING_FROM_RECORD_SUBMODS, .. }
+            if !v.bind_from_outside => None,
+        DAE::Binding::EQBOUND { exp, .. } => Some(exp.clone()),
+        _ => None,
+    }
+}
+
+/// A record field: the list comes from the declaration (see [`RECORD_DECLS`]) so
+/// every site lays the record out alike, the default from the type's `varLst`.
+struct RecField {
+    name: ArcStr,
+    sig: SigTy,
+    ty: Arc<DAE::Type>,
+    default: Option<Arc<DAE::Exp>>,
+}
+
+/// The canonical fields of record type `ty`, or `None` if `ty` is not a record.
+fn record_fields(ty: &DAE::Type) -> Result<Option<Vec<RecField>>> {
+    let DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::RECORD { path }, varLst, .. } = ty
+    else {
+        return Ok(None);
+    };
+    let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
+    let vars: Vec<&Arc<DAE::Var>> = (&**varLst).into_iter().collect();
+    let declared: Vec<(ArcStr, Arc<DAE::Type>)> = match record_decl_fields(&path_str) {
+        Some(d) => d.iter().cloned().collect(),
+        None => vars.iter().map(|v| (v.name.clone(), v.ty.clone())).collect(),
+    };
+    let mut out = Vec::with_capacity(declared.len());
+    for (name, fty) in declared {
+        let var = vars.iter().find(|v| v.name == name);
+        out.push(RecField {
+            sig: sig_ty(&fty)?,
+            default: var.and_then(|v| record_field_default(v)),
+            ty: fty,
+            name,
+        });
+    }
+    Ok(Some(out))
+}
+
+fn rec_layout(fields: &[RecField]) -> RecordLayout {
+    record_layout(&fields.iter().map(|f| (f.name.clone(), f.sig.clone())).collect::<Vec<_>>())
+}
+
+/// Default-construct a record value of type `ty` (the C target's
+/// `<Rec>_construct`), leaving the owned handle on the stack.
+fn emit_record_default(ctx: &mut FnCtx, ty: &DAE::Type) -> Result<()> {
+    let Some(fields) = record_fields(ty)? else {
+        return Err("CodegenWasmJit: default construction of a non-record type");
+    };
+    let layout = rec_layout(&fields);
+    let obj = emit_record_alloc(ctx, &layout)?;
+    for (i, f) in fields.iter().enumerate() {
+        let fty = f.sig.clone();
+        match &f.default {
+            Some(exp) => {
+                let w = compile_exp(ctx, exp)?;
+                coerce(ctx, w, fty.wty());
+                if let Some((copy_fn, rel_fn)) = value_copy_fns(&fty) {
+                    if !value_rhs_is_fresh(exp) {
+                        let t = ctx.alloc_temp(WTy::I32);
+                        ctx.emit(we::Instruction::LocalSet(t));
+                        ctx.emit(we::Instruction::LocalGet(t));
+                        ctx.emit(we::Instruction::Call(rt_index(copy_fn)?));
+                        ctx.emit(we::Instruction::LocalGet(t));
+                        ctx.emit(we::Instruction::Call(rt_index(rel_fn)?));
+                    }
+                }
+            }
+            None => emit_type_default(ctx, &f.ty)?,
+        }
+        let vt = ctx.alloc_temp(fty.wty());
+        ctx.emit(we::Instruction::LocalSet(vt));
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::LocalGet(vt));
+        field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+    }
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// The value a variable of type `ty` has before anything is assigned to it: zero,
+/// an allocated (zeroed) array descriptor, or a default-built record.
+fn emit_type_default(ctx: &mut FnCtx, ty: &DAE::Type) -> Result<()> {
+    match ty {
+        DAE::Type::T_REAL { .. } => ctx.emit(we::Instruction::F64Const(0.0f64.into())),
+        DAE::Type::T_STRING { .. } => {
+            let exp = DAE::Exp::SCONST { string: arcstr::literal!("") };
+            compile_exp(ctx, &exp)?;
+        }
+        DAE::Type::T_ARRAY { ty: elem, .. } => {
+            let SigTy::Array { elem: esig, .. } = sig_ty(ty)? else {
+                return Err("CodegenWasmJit: array type did not lower to an array");
+            };
+            let dims = type_array_dims(ty);
+            let slot = ctx.alloc_temp(WTy::I32);
+            emit_array_alloc(ctx, slot, &esig, &dims)?;
+            if matches!(&*esig, SigTy::Record { .. }) {
+                emit_array_record_defaults(ctx, slot, elem)?;
+            }
+            ctx.emit(we::Instruction::LocalGet(slot));
+        }
+        DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::RECORD { .. }, .. } => {
+            emit_record_default(ctx, ty)?;
+        }
+        _ => ctx.emit(we::Instruction::I32Const(0)),
+    }
+    Ok(())
+}
+
+/// Fill the freshly allocated array in `slot` with default-constructed `elem`
+/// records (the C target's `generic_array_create` with the record constructor).
+fn emit_array_record_defaults(ctx: &mut FnCtx, slot: u32, elem: &DAE::Type) -> Result<()> {
+    let total = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalGet(slot));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_total")?));
+    ctx.emit(we::Instruction::LocalSet(total));
+    let i = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::LocalSet(i));
+    ctx.emit(we::Instruction::Block(we::BlockType::Empty));
+    ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
+    ctx.emit(we::Instruction::LocalGet(i));
+    ctx.emit(we::Instruction::LocalGet(total));
+    ctx.emit(we::Instruction::I32GtS);
+    ctx.emit(we::Instruction::BrIf(1));
+    ctx.emit(we::Instruction::LocalGet(slot));
+    ctx.emit(we::Instruction::LocalGet(i));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_record_default(ctx, elem)?;
+    ctx.emit(we::Instruction::I32Store(mem_arg(0, 2)));
+    ctx.emit(we::Instruction::LocalGet(i));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::I32Add);
+    ctx.emit(we::Instruction::LocalSet(i));
+    ctx.emit(we::Instruction::Br(0));
+    ctx.emit(we::Instruction::End);
+    ctx.emit(we::Instruction::End);
     Ok(())
 }
 
@@ -3849,6 +4084,11 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
                 emit_sim_array_scatter(ctx, &group, rhs)?;
                 return Ok(true);
             }
+            // A whole record model variable: evaluate the rhs to a runtime record
+            // and store each field into its own scalar slot.
+            if try_emit_sim_record_scatter(ctx, cref, rhs)? {
+                return Ok(true);
+            }
             crate::CodegenWasmJit::record_error(format!(
                 "CodegenWasmJit: simulation assignment to unknown variable `{key}`"
             ));
@@ -3932,33 +4172,14 @@ fn emit_sim_array_gather(ctx: &mut FnCtx, group: &ArrayGroup) -> Result<()> {
 /// recursively. Returns `Ok(true)` when it handled the reference.
 fn try_emit_sim_record_gather(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<bool> {
     let leaf_ty = cref_leaf_value_type(cref)?;
-    let DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::RECORD { .. }, varLst, .. } = &*leaf_ty
-    else {
+    let Some(fields) = record_fields(&leaf_ty)? else {
         return Ok(false);
     };
-    let vars: Vec<&Arc<DAE::Var>> = (&**varLst).into_iter().collect();
-    let mut fields = Vec::with_capacity(vars.len());
-    for v in &vars {
-        fields.push((v.name.clone(), sig_ty(&v.ty)?));
-    }
-    let layout = record_layout(&fields);
-    ctx.emit(we::Instruction::I32Const(layout.heap.len() as i32));
-    ctx.emit(we::Instruction::I32Const(layout.size as i32));
-    ctx.emit(we::Instruction::Call(rt_index("rt_record_new")?));
-    let obj = ctx.alloc_temp(WTy::I32);
-    ctx.emit(we::Instruction::LocalSet(obj));
-    for (k, (kind, foff)) in layout.heap.iter().enumerate() {
-        let base = 8 + k as u32 * 8;
-        ctx.emit(we::Instruction::LocalGet(obj));
-        ctx.emit(we::Instruction::I32Const(*kind as i32));
-        ctx.emit(we::Instruction::I32Store(mem_arg(base, 2)));
-        ctx.emit(we::Instruction::LocalGet(obj));
-        ctx.emit(we::Instruction::I32Const(*foff as i32));
-        ctx.emit(we::Instruction::I32Store(mem_arg(base + 4, 2)));
-    }
-    for (i, v) in vars.iter().enumerate() {
-        let fty = fields[i].1.clone();
-        let field_cref = cref_append_field(cref, &v.name, v.ty.clone());
+    let layout = rec_layout(&fields);
+    let obj = emit_record_alloc(ctx, &layout)?;
+    for (i, f) in fields.iter().enumerate() {
+        let fty = f.sig.clone();
+        let field_cref = cref_append_field(cref, &f.name, f.ty.clone());
         let wty = compile_sim_cref_read(ctx, &field_cref)?
             .ok_or("CodegenWasmJit: record field is not a simulation variable")?;
         coerce(ctx, wty, fty.wty());
@@ -3969,6 +4190,43 @@ fn try_emit_sim_record_gather(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Resu
         field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
     }
     ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(true)
+}
+
+/// The inverse of [`try_emit_sim_record_gather`]: evaluate `rhs` to an owned
+/// record and store each field into its own `SimData` slot, as the C target does
+/// for `$cse1 := f(...)`. Fields go through their own cref, so nested records and
+/// array fields scatter recursively.
+fn try_emit_sim_record_scatter(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSource) -> Result<bool> {
+    let leaf_ty = cref_leaf_value_type(cref)?;
+    let Some(fields) = record_fields(&leaf_ty)? else {
+        return Ok(false);
+    };
+    let layout = rec_layout(&fields);
+    let obj = ctx.alloc_temp(WTy::I32);
+    let rw = rhs.push(ctx)?;
+    if rw != WTy::I32 {
+        return Err("CodegenWasmJit: whole-record assignment rhs is not a record handle");
+    }
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (i, f) in fields.iter().enumerate() {
+        let fty = f.sig.clone();
+        let vt = ctx.alloc_temp(fty.wty());
+        ctx.emit(we::Instruction::LocalGet(obj));
+        field_load(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+        ctx.emit(we::Instruction::LocalSet(vt));
+        if fty.is_heap() {
+            // The record keeps its reference; the assignment consumes one.
+            ctx.emit(we::Instruction::LocalGet(vt));
+            ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
+        }
+        let field_cref = cref_append_field(cref, &f.name, f.ty.clone());
+        if !compile_sim_cref_assign(ctx, &field_cref, RhsSource::Temp { local: vt, wty: fty.wty() })? {
+            return Err("CodegenWasmJit: record field is not a simulation variable");
+        }
+    }
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::Call(rt_index("rt_record_release")?));
     Ok(true)
 }
 
@@ -5299,6 +5557,25 @@ fn compile_math_builtin(
             ctx.emit(we::Instruction::F64Const(0.0f64.into()));
             ctx.emit(we::Instruction::F64Ge);
             ctx.emit(we::Instruction::Select);
+            Ok(SigTy::Real)
+        }
+        // semiLinear(x, positiveSlope, negativeSlope) = x * (x >= 0 ? ps : ns).
+        "semiLinear" => {
+            need_args(&argv, 3, name)?;
+            let w = compile_exp(ctx, argv[0])?;
+            coerce(ctx, w, WTy::F64);
+            let t = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalSet(t));
+            ctx.emit(we::Instruction::LocalGet(t));
+            let p = compile_exp(ctx, argv[1])?;
+            coerce(ctx, p, WTy::F64);
+            let n = compile_exp(ctx, argv[2])?;
+            coerce(ctx, n, WTy::F64);
+            ctx.emit(we::Instruction::LocalGet(t));
+            ctx.emit(we::Instruction::F64Const(0.0f64.into()));
+            ctx.emit(we::Instruction::F64Ge);
+            ctx.emit(we::Instruction::Select);
+            ctx.emit(we::Instruction::F64Mul);
             Ok(SigTy::Real)
         }
         // Number → String formatting via the runtime: a scalar becomes a freshly

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -269,7 +269,7 @@ pub fn enrich_trap(e: &mut dyn SimEngine, err: &'static str) -> &'static str {
         let f: fn(&AssertInfo) = unsafe { core::mem::transmute(p) };
         f(&info);
     }
-    "assertion failed"
+    ASSERT_ERR
 }
 
 /// Result of a simulation run.
@@ -535,6 +535,8 @@ fn apply_start_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
 
 /// Returned to abort a run on detected chattering (`-abortSlowSimulation`).
 pub const CHATTER_ABORT_ERR: &str = "CodegenWasmJit: aborting simulation due to chattering";
+/// What [`enrich_trap`] returns for a trap that was a failed model `assert()`.
+pub const ASSERT_ERR: &str = "assertion failed";
 
 /// Log-line prefix `<stream>| <level>| ` at the runtime's column widths.
 fn log_prefix(stream: &str, level: &str) -> String {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -18,6 +18,22 @@ pub static FMI3_MECS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/
 pub mod sig;
 pub mod model;
 
+// A wasm trap collapses to the crate's `&'static str` error on the way out of the
+// engine, losing the trap kind and the backtrace. The engine parks its message
+// here for the caller that gives up on the run to add to the Error buffer.
+std::thread_local! {
+    static ENGINE_ERROR_DETAIL: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+pub fn set_engine_error_detail(msg: String) {
+    ENGINE_ERROR_DETAIL.with(|e| *e.borrow_mut() = Some(msg));
+}
+
+pub fn take_engine_error_detail() -> Option<String> {
+    ENGINE_ERROR_DETAIL.with(|e| e.borrow_mut().take())
+}
+
 #[cfg(feature = "jit")]
 pub mod host;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -240,7 +240,10 @@ type Store = wasmer::Store;
 /// (a model `assert()` is decoded downstream by `enrich_trap`). wasmer's error
 /// types don't share one convertible type, hence the generic `Debug` bound.
 fn wt<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
-    r.map_err(|_| "CodegenWasmJit: wasm engine error")
+    r.map_err(|e| {
+        crate::set_engine_error_detail(format!("{e:?}"));
+        "CodegenWasmJit: wasm engine error"
+    })
 }
 
 /// Setup path: keep the real wasmer message as a `String` for the run log.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -178,7 +178,10 @@ type Store = wasmtime::Store<WasiCtx>;
 /// `SimEngine`-trait errors: collapse to the crate `&'static str` (a model
 /// `assert()` is decoded downstream by `enrich_trap`).
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
-    r.map_err(|_| "CodegenWasmJit: wasm engine error")
+    r.map_err(|e| {
+        crate::set_engine_error_detail(format!("{e:?}"));
+        "CodegenWasmJit: wasm engine error"
+    })
 }
 
 /// Setup path: keep the real wasmtime message as a `String` for the run log.


### PR DESCRIPTION
Five fixes that take msl32 Modelica.Media from 0/35 to 30/35 with --simCodeTarget=wasm-jit:

* A record-valued equation (`$cse1 := derivsOf_ph(...)`) had no lowering: reads gathered a record from its scalar SimData slots, but writes had no counterpart. Add the scatter half.
* `semiLinear`, inlined as in openmodelica.h.
* Record locals/outputs are now default-constructed at function entry the way the C target emits `<Rec>_construct`, so a record without a binding has its class field defaults and its array fields' descriptors. `fid_R134a`'s `id.a[1]` read a null handle before.
* Take the field layout of a record from its declaration (SimCode.recordDecls) rather than from whichever T_COMPLEX the expression carries. `Hf=0` in SingleGasesData leaves that field typed Integer at the construction site and Real inside h_T, so the two ends disagreed on every following field offset and the array reads ran off the end of the record.
* functionInitStartValues wrote a state's start attribute slot but not its live slot, so an initial equation reading a state before the initial system solved it saw 0 -- IF97 rejected `region_ph(p, h=0)`. Seed both, as C's setAllVarsToStart does.

Generated model modules now carry a name section, so a trap backtrace names the Modelica function instead of `<wasm function 542>`, and the engine's own trap message reaches the Error buffer instead of being flattened to "wasm engine error" -- suppressed for a model assert(), which reports itself. record_error is #[track_caller], so an internal error carries the Rust source position sourceInfo() would give it.