### PR TITLE
wasm-jit: function references, terminal(), print

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -145,6 +145,7 @@ openmodelica_codegen_graphml/Cargo.toml
 openmodelica_codegen_wasm_jit/Cargo.toml
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6524,6 +6524,7 @@ dependencies = [
  "openmodelica_frontend_dump",
  "openmodelica_frontend_types",
  "openmodelica_mat_writer",
+ "openmodelica_modelica_utilities",
  "openmodelica_sim_meta",
  "openmodelica_simcode_types",
  "openmodelica_tpl",
@@ -6677,6 +6678,7 @@ name = "openmodelica_modelica_utilities"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "openmodelica_wasi",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 openmodelica_wasi.workspace = true
+# Shared `LOG_STDOUT` message formatting (also used by the ModelicaMessage shim).
+openmodelica_modelica_utilities.workspace = true
 # Host-side wasm execution engine (drivers, sim runtime, model, wasm artifacts).
 openmodelica_wasm_jit.workspace = true
 # External-"C" wasm-FMU artifacts, consumed by the FMU linker.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -545,14 +545,15 @@ thread_local! {
     static SPLIT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// Init-done hook: take the init-phase stdout and restart the capture. A no-op
-/// unless [`run_simulation_inner`] armed it; disarms after firing.
+/// Init-done hook: take the init-phase stdout and `LOG_ASSERT` warnings, then
+/// restart the capture. A no-op unless [`run_simulation_inner`] armed it.
 fn on_init_done() {
     if !SPLIT_ARMED.with(|a| a.replace(false)) {
         return;
     }
     let init = openmodelica_wasi::wasi::take_stdout_capture();
-    INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(init));
+    let warns: String = sim_driver::take_assert_warnings().concat();
+    INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(format!("{init}{warns}")));
     openmodelica_wasi::wasi::start_stdout_capture();
 }
 
@@ -1397,6 +1398,7 @@ struct SimVarMap {
     array_acc: HashMap<String, Vec<(Vec<i32>, u32, WTy)>>,
     /// `SimData` byte offset of the `terminate` flag (see [`SimLayout`]).
     terminate_off: u32,
+    terminal_off: u32,
     /// `SimData` byte offset of the fired `terminate`'s message + source position.
     term_info_off: u32,
     /// `SimData` byte offset of the nonlinear-solver failure flag (see [`SimLayout`]).
@@ -1704,6 +1706,7 @@ fn build_var_map(
         array_groups: HashMap::new(),
         array_acc: HashMap::new(),
         terminate_off: layout.terminate_off,
+        terminal_off: layout.terminal_off,
         term_info_off: layout.term_info_off,
         nls_fail_off: layout.nls_fail_off,
         nls_jobs: Arc::new(HashMap::new()),
@@ -2464,9 +2467,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // `om_meta_ptr`/`om_meta_len` type: () -> i32.
     let meta_fn_type = types.len();
     types.ty().function([], [we::ValType::I32]);
-    // Nonlinear-solver callback + `start` types (only when the model has
-    // nonlinear systems, so output stays byte-identical otherwise): `residual`
-    // (i32,i32,i32)->(), `load` (i32,i32)->(), `start` ()->().
+    // Nonlinear-solver callback types (only when the model has nonlinear systems,
+    // so output stays byte-identical otherwise): `residual` (i32,i32,i32)->(),
+    // `load` (i32,i32)->(). The `start` type is allocated at the end, with the
+    // closure thunks' types.
     let nls_types = if nls_systems.is_empty() {
         None
     } else {
@@ -2474,10 +2478,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         types.ty().function([we::ValType::I32, we::ValType::I32, we::ValType::I32], []);
         let load_type = types.len();
         types.ty().function([we::ValType::I32, we::ValType::I32], []);
-        let start_type = types.len();
-        types.ty().function([], []);
-        Some((residual_type, load_type, start_type))
+        Some((residual_type, load_type))
     };
+    // Function references met while lowering the bodies add thunks to the closure
+    // pool; this global holds their shared-table base.
+    let closure_global = crate::CodegenWasmJitFunctions::closure_base_global(nls_types.is_some());
+    crate::CodegenWasmJitFunctions::closures::begin(types.len(), closure_global);
 
     // --- Import section. ---
     let mut imports = we::ImportSection::new();
@@ -2505,18 +2511,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // the host (dlopen-self native; side module on wasm).
     for (i, sig) in ext_imports.iter().enumerate() {
         imports.import("ext", &sig.name, we::EntityType::Function(ext_type[i]));
-    }
-    // Share the runtime's `__indirect_function_table` (as with `rt.memory`) so
-    // the `start` function can append this model's `residual`/`load` callbacks and
-    // `rt_solve_nls` can reach them by `call_indirect`.
-    if !nls_systems.is_empty() {
-        imports.import("rt", "__indirect_function_table", we::EntityType::Table(we::TableType {
-            element_type: we::RefType::FUNCREF,
-            table64: false,
-            minimum: 1,
-            maximum: None,
-            shared: false,
-        }));
     }
 
     // --- Compile bodies (collecting String literals into the module pool). ---
@@ -2634,12 +2628,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         eq_base + 8
     };
 
-    // --- Nonlinear-system callbacks + `start`. For each system emit its
-    // `residual`/`load` functions, then one `start` function that appends them to
-    // the shared table (base recorded in the `nls_base` global). All `ref.func`d
-    // callbacks are also listed in a declared element segment (below) so the
-    // references validate. Emitted only when the model has nonlinear systems. ---
-    let nls_wiring = if let Some((_, _, _)) = nls_types {
+    // --- Nonlinear-system callbacks: per system a `residual`/`load` function.
+    // The module's `start` (built last, shared with the closure thunks) appends
+    // them to the shared table, base in the `nls_base` global; every `ref.func`d
+    // callback is also listed in the declared element segment below so the
+    // references validate. Only when the model has nonlinear systems. ---
+    let nls_wiring = if nls_types.is_some() {
         let mut callback_indices: Vec<u32> = Vec::new(); // for the declared segment
         // (residual, load, Option<jac>) per system; the shared table gets 3 slots
         // per system (`3k`, `3k+1`, `3k+2`), the jac slot left null when absent.
@@ -2661,9 +2655,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             });
             fn_indices.push((res_idx, load_idx, jac_idx));
         }
-        let start_idx = import_base + bodies.len() as u32;
-        bodies.push(build_nls_start_fn(&fn_indices, nls_hist_bytes, &nls_nominals));
-        Some((start_idx, callback_indices))
+        Some((fn_indices, callback_indices))
     } else {
         None
     };
@@ -2766,9 +2758,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(meta_fn_type); // om_meta_ptr
     functions.function(meta_fn_type); // om_meta_len
     // Optional eq functions — always emitted (order must match the `bodies` pushes:
-    // destructors, nls callbacks/start, initSample, zc, statesetJac, lambda0).
+    // destructors, nls callbacks, initSample, zc, statesetJac, lambda0, …, then
+    // the closure thunks and `start` below).
     functions.function(eqfn_type); // callExternalObjectDestructors
-    if let Some((residual_type, load_type, start_type)) = nls_types {
+    if let Some((residual_type, load_type)) = nls_types {
         for sys in &nls_systems {
             functions.function(residual_type);
             functions.function(load_type);
@@ -2779,7 +2772,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
                 functions.function(residual_type);
             }
         }
-        functions.function(start_type);
     }
     functions.function(eqfn_type); // initSample: (i32) -> ()
     functions.function(eqfn_type); // functionZeroCrossings: (i32) -> ()
@@ -2789,6 +2781,49 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
     functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
+
+    // --- Closure thunks and the module `start`. The thunks come after every
+    // other body — their `ref.func` indices are only known here. ---
+    let closure_wiring = crate::CodegenWasmJitFunctions::closures::take();
+    let mut thunk_indices: Vec<u32> = Vec::new();
+    for (type_index, body) in closure_wiring.thunks {
+        thunk_indices.push(import_base + bodies.len() as u32);
+        functions.function(type_index);
+        bodies.push(body);
+    }
+    for (params, results) in &closure_wiring.types {
+        types.ty().function(params.iter().copied(), results.iter().copied());
+    }
+    let start_wiring = if nls_wiring.is_some() || !thunk_indices.is_empty() {
+        let start_type = types.len();
+        types.ty().function([], []);
+        let start_idx = import_base + bodies.len() as u32;
+        let mut f = we::Function::new([]);
+        if let Some((fn_indices, _)) = &nls_wiring {
+            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals);
+        }
+        if !thunk_indices.is_empty() {
+            crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
+        }
+        f.instruction(&we::Instruction::End);
+        functions.function(start_type);
+        bodies.push(f);
+        let mut declared: Vec<u32> =
+            nls_wiring.as_ref().map(|(_, cbs)| cbs.clone()).unwrap_or_default();
+        declared.extend_from_slice(&thunk_indices);
+        Some((start_idx, declared))
+    } else {
+        None
+    };
+    if start_wiring.is_some() {
+        imports.import("rt", "__indirect_function_table", we::EntityType::Table(we::TableType {
+            element_type: we::RefType::FUNCREF,
+            table64: false,
+            minimum: 1,
+            maximum: None,
+            shared: false,
+        }));
+    }
 
     // --- Code section. ---
     let mut code = we::CodeSection::new();
@@ -2818,7 +2853,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
 
     // --- Name section: without it a trap backtrace is bare function indices. The
-    // unnamed remainder is the NLS callbacks. ---
+    // unnamed remainder is the NLS callbacks, the closure thunks and `start`. ---
     let mut names: Vec<(u32, String)> = Vec::new();
     for (i, name) in BUILTINS
         .iter()
@@ -2869,12 +2904,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     module.section(&imports);
     module.section(&functions);
     // Global + Start + Element sections (in the canonical order) carry the
-    // nonlinear-solver table wiring; present only when the model has NLS systems.
-    if nls_wiring.is_some() {
+    // shared-table wiring: NLS callbacks and/or closure thunks.
+    if start_wiring.is_some() {
         let mut globals = we::GlobalSection::new();
-        // NLS_BASE_GLOBAL (shared-table base), NLS_HIST_GLOBAL (history block base),
-        // and NLS_NOMINAL_GLOBAL (nominal block base); all set by the `start` function.
-        for _ in 0..3 {
+        // NLS_BASE_GLOBAL (shared-table base), NLS_HIST_GLOBAL (history block base)
+        // and NLS_NOMINAL_GLOBAL (nominal block base) when the model has nonlinear
+        // systems, then the closure-thunk table base; all set by `start`.
+        let n_globals = if thunk_indices.is_empty() { closure_global } else { closure_global + 1 };
+        for _ in 0..n_globals {
             globals.global(
                 we::GlobalType { val_type: we::ValType::I32, mutable: true, shared: false },
                 &we::ConstExpr::i32_const(0),
@@ -2883,10 +2920,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         module.section(&globals);
     }
     module.section(&exports);
-    if let Some((start_idx, callback_indices)) = &nls_wiring {
+    if let Some((start_idx, declared)) = &start_wiring {
         module.section(&we::StartSection { function_index: *start_idx });
         let mut elements = we::ElementSection::new();
-        elements.declared(we::Elements::Functions(callback_indices.as_slice().into()));
+        elements.declared(we::Elements::Functions(declared.as_slice().into()));
         module.section(&elements);
     }
     if !literals.is_empty() {
@@ -2944,20 +2981,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     })
 }
 
-/// `LOG_STDOUT` prefix for the first line of a message, and the continuation
-/// prefix OMC's `streamPrint` uses for wrapped lines (see the C runtime output).
-const LOG_STDOUT_PREFIX: &str = "LOG_STDOUT        | info    | ";
-const LOG_CONT_PREFIX: &str = "|                 | |       | ";
-
 /// Wrap a `\n`-separated message in the `LOG_STDOUT`/continuation prefixes.
 fn format_log_stdout(msg: &str) -> String {
-    let mut out = String::new();
-    for (i, line) in msg.split('\n').enumerate() {
-        out.push_str(if i == 0 { LOG_STDOUT_PREFIX } else { LOG_CONT_PREFIX });
-        out.push_str(line);
-        out.push('\n');
-    }
-    out
+    openmodelica_modelica_utilities::format_log_stdout(msg, openmodelica_modelica_utilities::LOG_STDOUT_INFO)
 }
 
 /// Reproduce C's `initializeLinearSystems` sparse-solver announcements
@@ -3292,6 +3318,7 @@ fn build_eq_fn_with_prelude(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -3349,6 +3376,7 @@ fn build_init_sample_fn(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -3398,6 +3426,7 @@ fn build_init_start_values_fn(
         start_slots: HashMap::new(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -3449,6 +3478,7 @@ fn build_zero_crossings_fn(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -3491,6 +3521,7 @@ fn build_update_relations_fn(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -3537,6 +3568,7 @@ fn build_store_delayed_fn(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -4339,6 +4371,7 @@ fn build_nls_fns(
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -4422,17 +4455,16 @@ fn build_nls_fns(
     Ok((residual, load, jac))
 }
 
-/// Build the module `start` function: grow the shared
-/// `rt.__indirect_function_table` by `2 * n` slots, record the base (the old
+/// The nonlinear-solver part of the module `start`: grow the shared
+/// `rt.__indirect_function_table` by `3 * n` slots, record the base (the old
 /// size) in the `nls_base` global, then write each system's `residual`/`load`
-/// function references into `base + 2k` / `base + 2k + 1`
-/// (`fn_indices[k] = (residual, load)`). `rt_solve_nls` reads these indices back
-/// via the global (see `emit_solve_nls_call`). Also `rt_alloc`s the
+/// function references into `base + 3k` / `base + 3k + 1`
+/// (`fn_indices[k] = (residual, load, jac)`). `rt_solve_nls` reads these indices
+/// back via the global (see `emit_solve_nls_call`). Also `rt_alloc`s the
 /// extrapolation-history block (`hist_bytes`) into `NLS_HIST_GLOBAL`.
-fn build_nls_start_fn(fn_indices: &[(u32, u32, Option<u32>)], hist_bytes: u32, nominals: &[f64]) -> we::Function {
+fn emit_nls_start(f: &mut we::Function, fn_indices: &[(u32, u32, Option<u32>)], hist_bytes: u32, nominals: &[f64]) {
     use we::Instruction as I;
     use crate::CodegenWasmJitFunctions::NLS_NOMINAL_GLOBAL;
-    let mut f = we::Function::new([]);
     // history block (zeroed by rt_alloc, so every system's count starts 0).
     if hist_bytes > 0 {
         f.instruction(&I::I32Const(hist_bytes as i32));
@@ -4458,23 +4490,22 @@ fn build_nls_start_fn(fn_indices: &[(u32, u32, Option<u32>)], hist_bytes: u32, n
     f.instruction(&I::I32Const((3 * fn_indices.len()) as i32));
     f.instruction(&I::TableGrow(0));
     f.instruction(&I::GlobalSet(NLS_BASE_GLOBAL));
-    let mut set_slot = |f: &mut we::Function, off: i32, idx: u32| {
+    fn set_slot(f: &mut we::Function, off: i32, idx: u32) {
+        use we::Instruction as I;
         f.instruction(&I::GlobalGet(NLS_BASE_GLOBAL));
         f.instruction(&I::I32Const(off));
         f.instruction(&I::I32Add);
         f.instruction(&I::RefFunc(idx));
         f.instruction(&I::TableSet(0));
-    };
+    }
     for (k, (res_idx, load_idx, jac_idx)) in fn_indices.iter().enumerate() {
         let base_off = (3 * k) as i32;
-        set_slot(&mut f, base_off, *res_idx);
-        set_slot(&mut f, base_off + 1, *load_idx);
+        set_slot(f, base_off, *res_idx);
+        set_slot(f, base_off + 1, *load_idx);
         if let Some(jac_idx) = jac_idx {
-            set_slot(&mut f, base_off + 2, *jac_idx);
+            set_slot(f, base_off + 2, *jac_idx);
         }
     }
-    f.instruction(&I::End);
-    f
 }
 
 pub(crate) fn eq_kind_name(eq: &SimCode::SimEqSystem) -> &'static str {
@@ -4669,6 +4700,15 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     f.instruction(&I::F64Mul);
     f.instruction(&I::F64Add);
     f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg(TIME_OFF, 3)));
+
+    // terminal = (row == n_steps): C's `finishSimulation` evaluates the last
+    // point with `terminal()` true. This path has no events, so raising the flag
+    // is the whole discrete update.
+    f.instruction(&I::LocalGet(SIM_DATA));
+    f.instruction(&I::LocalGet(ROW));
+    f.instruction(&I::LocalGet(N_STEPS));
+    f.instruction(&I::I32Eq);
+    f.instruction(&I::I32Store(crate::CodegenWasmJitFunctions::mem_arg(layout.terminal_off, 2)));
 
     // functionODE(sim_data); functionAlgebraics(sim_data)
     f.instruction(&I::LocalGet(SIM_DATA));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -155,6 +155,24 @@ fn parse_sig_type(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<Si
             }
             Ok(SigTy::Record { path: ArcStr::from(path.as_str()), fields: Arc::new(fields) })
         }
+        // `<params|results>` — a function reference (see [`SigTy::write_code`]).
+        Some('<') => {
+            let mut params = Vec::new();
+            while !matches!(chars.peek(), Some('|') | None) {
+                params.push(parse_sig_type(chars)?);
+            }
+            if chars.next() != Some('|') {
+                return Err("CodegenWasmJit: expected `|` in function-reference signature");
+            }
+            let mut results = Vec::new();
+            while !matches!(chars.peek(), Some('>') | None) {
+                results.push(parse_sig_type(chars)?);
+            }
+            if chars.next() != Some('>') {
+                return Err("CodegenWasmJit: expected a closing `>` in function-reference signature");
+            }
+            Ok(SigTy::Func { params: Arc::new(params), results: Arc::new(results) })
+        }
         other => return Err("CodegenWasmJit: malformed signature type code"),
     }
 }
@@ -396,6 +414,13 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
 /// `rt.__indirect_function_table` (set once by the module's `start` function).
 pub(crate) const NLS_BASE_GLOBAL: u32 = 0;
 
+/// Module global holding the base index this module's closure thunks were
+/// appended to the shared table at (set by `start`): after the three
+/// nonlinear-solver globals, or the only global when there are none.
+pub(crate) fn closure_base_global(has_nls: bool) -> u32 {
+    if has_nls { NLS_NOMINAL_GLOBAL + 1 } else { 0 }
+}
+
 /// Absolute wasm function index of a runtime import (after all [`BUILTINS`]).
 pub(crate) fn rt_index(name: &str) -> Result<u32> {
     let pos = RT_BUILTINS
@@ -501,13 +526,49 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
 
     // Compile the function bodies first (collecting any String literals into a
     // module-wide pool), so the data-segment count is known before the code
-    // section is emitted.
+    // section is emitted. Function references met on the way add thunks to the
+    // closure pool; the module's only global holds their table base.
+    closures::begin(types.len(), closure_base_global(false));
     let mut functions = we::FunctionSection::new();
     let mut bodies: Vec<we::Function> = Vec::with_capacity(funcs.len());
     let mut literals: Vec<Vec<u8>> = Vec::new();
     for (id, f) in funcs.iter().enumerate() {
         functions.function(base + id as u32); // type index = base + id
         bodies.push(compile_function(f, &by_name, &mut literals)?);
+    }
+    // Closure thunks, then the `start` that appends them to the shared table.
+    let closure_wiring = closures::take();
+    let mut thunk_indices: Vec<u32> = Vec::new();
+    for (type_index, body) in closure_wiring.thunks {
+        thunk_indices.push(base + bodies.len() as u32);
+        functions.function(type_index);
+        bodies.push(body);
+    }
+    for (params, results) in &closure_wiring.types {
+        types.ty().function(params.iter().copied(), results.iter().copied());
+    }
+    let start_idx = if thunk_indices.is_empty() {
+        None
+    } else {
+        let start_type = types.len();
+        types.ty().function([], []);
+        let idx = base + bodies.len() as u32;
+        let mut f = we::Function::new([]);
+        closures::emit_start(&mut f, &thunk_indices, closure_base_global(false));
+        f.instruction(&we::Instruction::End);
+        functions.function(start_type);
+        bodies.push(f);
+        Some(idx)
+    };
+    if start_idx.is_some() {
+        // The thunks are reached by `call_indirect` through the runtime's table.
+        imports.import("rt", "__indirect_function_table", we::EntityType::Table(we::TableType {
+            element_type: we::RefType::FUNCREF,
+            table64: false,
+            minimum: 1,
+            maximum: None,
+            shared: false,
+        }));
     }
     let mut code = we::CodeSection::new();
     for body in &bodies {
@@ -522,7 +583,21 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
     module.section(&types);
     module.section(&imports);
     module.section(&functions);
+    if start_idx.is_some() {
+        let mut globals = we::GlobalSection::new();
+        globals.global(
+            we::GlobalType { val_type: we::ValType::I32, mutable: true, shared: false },
+            &we::ConstExpr::i32_const(0),
+        );
+        module.section(&globals);
+    }
     module.section(&exports);
+    if let Some(start_idx) = start_idx {
+        module.section(&we::StartSection { function_index: start_idx });
+        let mut elements = we::ElementSection::new();
+        elements.declared(we::Elements::Functions(thunk_indices.as_slice().into()));
+        module.section(&elements);
+    }
     // String literals become passive data segments materialized at runtime with
     // `memory.init` (see SCONST in `compile_exp`). The DataCount section must
     // precede the code section; the Data section follows it.
@@ -714,10 +789,12 @@ fn main_sig_types(f: &SimCodeFunction::Function::Function) -> Result<(Vec<SigTy>
 fn var_sigtys(vars: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>) -> Result<Vec<SigTy>> {
     let mut out = Vec::new();
     for v in &**vars {
-        let SimCodeFunction::Variable::Variable::VARIABLE { ty, instDims, .. } = &**v else {
-            return Err("CodegenWasmJit: unsupported variable kind (function pointer)");
-        };
-        out.push(variable_sigty(ty, instDims)?);
+        out.push(match &**v {
+            SimCodeFunction::Variable::Variable::VARIABLE { ty, instDims, .. } => variable_sigty(ty, instDims)?,
+            SimCodeFunction::Variable::Variable::FUNCTION_PTR { tys, args, .. } => {
+                closures::function_ptr_sigty(tys, args)?
+            }
+        });
     }
     Ok(out)
 }
@@ -785,6 +862,15 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
                 }
             }
             SigTy::Record { path: path_str, fields: Arc::new(fields) }
+        }
+        // A function reference's argument/result types arrive MetaModelica-boxed
+        // (C calls one boxed `boxptr_` shape); our closures are typed and pass
+        // values unboxed, so the box is nothing.
+        DAE::Type::T_METABOXED { ty } => sig_ty(ty)?,
+        // A function reference: a closure handle, callable with the wrapped
+        // function type's signature.
+        DAE::Type::T_FUNCTION_REFERENCE_VAR { .. } | DAE::Type::T_FUNCTION_REFERENCE_FUNC { .. } => {
+            closures::reference_sigty(ty)?
         }
         DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
         other => return Err("CodegenWasmJit: type not supported"),
@@ -892,6 +978,9 @@ pub(crate) struct SimCtx {
     /// `SimData` byte offset of the `terminate` flag, written by a fired
     /// `terminate(...)` when-operator (see `lower_when_op`).
     pub(crate) terminate_off: u32,
+    /// `SimData` byte offset of the `terminal()` flag, raised by the driver for
+    /// the run's final discrete update.
+    pub(crate) terminal_off: u32,
     /// `SimData` byte offset of the fired `terminate(...)`'s message + source
     /// position (C's `TermMsg`/`TermInfo`).
     pub(crate) term_info_off: u32,
@@ -1839,10 +1928,14 @@ fn release_heap_locals(ctx: &mut FnCtx) -> Result<()> {
 /// Name and Modelica type of a `VARIABLE` (combining `ty` and `instDims`; see
 /// [`variable_sigty`]). The name must be a plain `CREF_IDENT`.
 fn var_name_ty(v: &SimCodeFunction::Variable::Variable) -> Result<(String, SigTy)> {
-    let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, instDims, .. } = v else {
-        return Err("CodegenWasmJit: function-pointer variables not supported");
-    };
-    Ok((cref_ident(name)?, variable_sigty(ty, instDims)?))
+    match v {
+        SimCodeFunction::Variable::Variable::VARIABLE { name, ty, instDims, .. } => {
+            Ok((cref_ident(name)?, variable_sigty(ty, instDims)?))
+        }
+        SimCodeFunction::Variable::Variable::FUNCTION_PTR { name, tys, args, .. } => {
+            Ok((name.to_string(), closures::function_ptr_sigty(tys, args)?))
+        }
+    }
 }
 
 /// The identifier of a scalar `CREF_IDENT` component reference (no subscripts /
@@ -4321,6 +4414,9 @@ fn emit_sim_start_array_gather(ctx: &mut FnCtx, group: &ArrayGroup, base_key: &s
     Ok(())
 }
 
+#[path = "CodegenWasmJitFunctions/closures.rs"]
+pub(crate) mod closures;
+
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
@@ -4560,6 +4656,14 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             ctx.emit(we::Instruction::LocalGet(temps[want]));
             Ok(results[want].wty())
         }
+        // MetaModelica boxing around a call through a function reference; our
+        // closures pass values unboxed, so both are the identity.
+        E::BOX { exp } | E::UNBOX { exp, .. } => compile_exp(ctx, exp),
+        // `function f(w=3)` — a closure over the applied arguments (`closures`).
+        E::PARTEVALFUNCTION { .. } => {
+            closures::compile_parteval(ctx, exp)?;
+            Ok(WTy::I32)
+        }
         other => return Err("CodegenWasmJit: expression not yet supported"),
     }
 }
@@ -4587,6 +4691,8 @@ fn exp_wty_hint(ctx: &FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::RSUB { ty, .. } => sig_ty(ty)?.wty(),
         E::TSUB { ty, .. } => sig_ty(ty)?.wty(),
         E::ASUB { .. } => exp_sigty(exp).map(|s| s.wty()).unwrap_or(WTy::I32),
+        E::BOX { exp } => exp_wty_hint(ctx, exp)?,
+        E::UNBOX { ty, .. } => sig_ty(ty)?.wty(),
         _ => WTy::F64,
     })
 }
@@ -4688,6 +4794,10 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         // A record constructor / field access carry their type directly.
         E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty(ty)?,
         E::TSUB { ty, .. } => sig_ty(ty)?,
+        // A function reference: what the value it produces may be called with.
+        E::PARTEVALFUNCTION { ty, .. } => closures::reference_sigty(ty)?,
+        E::BOX { exp } => exp_sigty(exp)?,
+        E::UNBOX { ty, .. } => sig_ty(ty)?,
         other => return Err("CodegenWasmJit: cannot determine type of expression"),
     })
 }
@@ -5097,6 +5207,14 @@ fn compile_call(
     args: &Arc<List<Arc<DAE::Exp>>>,
     attr: &DAE::CallAttributes,
 ) -> Result<Vec<SigTy>> {
+    // A call through a function-reference variable: `call_indirect` on the
+    // closure it holds. C likewise dispatches on the variable, not the path.
+    if attr.isFunctionPointerCall {
+        let Absyn::Path::IDENT { name } = path else {
+            return Err("CodegenWasmJit: function-pointer calls are only supported through a local variable");
+        };
+        return closures::compile_fnptr_call(ctx, name, args);
+    }
     let mangled = mangle(path)?;
     // A call to another generated function. Heap arguments are passed as owned
     // (+1) references — a generated function *consumes* its heap parameters
@@ -5715,6 +5833,15 @@ fn compile_math_builtin(
             ctx.emit(we::Instruction::Call(rt_index("rt_delay_zc")?));
             Ok(SigTy::Real)
         }
+        // `terminal()` — C's `simulationInfo->terminal`, true only during the
+        // run's final discrete update.
+        "terminal" => {
+            need_args(&argv, 0, name)?;
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, s.terminal_off) };
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::I32Load(mem_arg(off, 2)));
+            Ok(SigTy::Bool)
+        }
         "sample" => {
             need_args(&argv, 3, name)?;
             let DAE::Exp::ICONST { integer } = &**argv[0] else {
@@ -6067,7 +6194,7 @@ fn format_scalar_string(ctx: &mut FnCtx, arg: &DAE::Exp, ty: SigTy) -> Result<Si
         }
         // `String(array)` / `String(record)` are not scalar conversions (the
         // frontend would not produce them here); reject rather than mis-format.
-        SigTy::Array { .. } | SigTy::Record { .. } | SigTy::Ptr => {
+        SigTy::Array { .. } | SigTy::Record { .. } | SigTy::Ptr | SigTy::Func { .. } => {
             return Err("CodegenWasmJit: String() of an array/record/external-object is not supported")
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
@@ -1,0 +1,322 @@
+// Function references (`function f(w=3)` passed to a `partialScalarFunction`
+// formal, as `Modelica.Math.Nonlinear.solveOneNonlinearEquation` takes).
+//
+// `call_indirect` needs an exact type and the residual signature is static at
+// both ends, so each `PARTEVALFUNCTION` gets a *thunk* with that signature,
+// appended to the shared `rt.__indirect_function_table`. The value passed
+// around is a closure object: a two-field record `{fn: Integer, env}` over an
+// `env` record of the applied arguments, mirroring the C target's
+// `mmc_mk_box2(0, closure_fn, env)` over `mmc_mk_boxN(0, args…)`. Nesting the
+// environment keeps `fn` at a fixed offset — the call site knows nothing about
+// what the callee applied. Both are ordinary runtime records, so
+// `rt_record_release` frees the captured values.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arcstr::ArcStr;
+use metamodelica::{List, Result};
+use openmodelica_frontend_types::DAE;
+use openmodelica_simcode_types::SimCodeFunction;
+use wasm_encoder as we;
+
+use super::{
+    FnCtx, FnSig, SigTy, WTy, WTyVal, coerce, compile_exp, emit_record_alloc,
+    emit_record_construction, mangle, mem_arg, record_layout, rt_index, sig_ty, var_sigtys,
+};
+
+/// The closure object's own fields: the thunk's table index and the `env` handle.
+fn closure_fields() -> [(ArcStr, SigTy); 2] {
+    [
+        (arcstr::literal!("fn"), SigTy::Int),
+        (arcstr::literal!("env"), SigTy::Record { path: ArcStr::new(), fields: Arc::new(Vec::new()) }),
+    ]
+}
+
+/// Byte offsets of `fn` and `env` from the closure object's base.
+fn closure_offsets() -> (u32, u32) {
+    let l = record_layout(&closure_fields());
+    (l.data_off + l.field_off[0], l.data_off + l.field_off[1])
+}
+
+/// Synthetic field list for the environment record holding `tys` in order.
+fn env_fields(tys: &[SigTy]) -> Vec<(ArcStr, SigTy)> {
+    tys.iter().enumerate().map(|(i, t)| (ArcStr::from(format!("${i}")), t.clone())).collect()
+}
+
+/// Closure thunks and `call_indirect` types collected while lowering one
+/// module's function bodies; module assembly drains it with [`take`].
+struct ClosurePool {
+    /// `(type index, body)` in table order: entry `k` takes slot `base_global + k`.
+    thunks: Vec<(u32, we::Function)>,
+    /// Dedup key -> slot. Same function, same applied parameters, one thunk.
+    by_key: HashMap<String, u32>,
+    /// Distinct thunk / `call_indirect` types; entry `i` is `type_base + i`.
+    types: Vec<(Vec<we::ValType>, Vec<we::ValType>)>,
+    type_base: u32,
+    base_global: u32,
+}
+
+thread_local! {
+    static POOL: RefCell<ClosurePool> = RefCell::new(ClosurePool {
+        thunks: Vec::new(), by_key: HashMap::new(), types: Vec::new(), type_base: 0, base_global: 0,
+    });
+}
+
+/// What module assembly needs from the pool once every body is lowered.
+pub(crate) struct ClosureWiring {
+    pub(crate) thunks: Vec<(u32, we::Function)>,
+    /// Appended to the type section from the `type_base` given to [`begin`].
+    pub(crate) types: Vec<(Vec<we::ValType>, Vec<we::ValType>)>,
+}
+
+/// Start collecting for a new module: the next free type index, and the global
+/// the module's `start` stores the thunks' table base in.
+pub(crate) fn begin(type_base: u32, base_global: u32) {
+    POOL.with(|p| {
+        *p.borrow_mut() = ClosurePool {
+            thunks: Vec::new(),
+            by_key: HashMap::new(),
+            types: Vec::new(),
+            type_base,
+            base_global,
+        };
+    });
+}
+
+/// Take the collected wiring at the end of module assembly.
+pub(crate) fn take() -> ClosureWiring {
+    POOL.with(|p| {
+        let mut pool = p.borrow_mut();
+        ClosureWiring { thunks: std::mem::take(&mut pool.thunks), types: std::mem::take(&mut pool.types) }
+    })
+}
+
+/// The type index of `(i32 env, params…) -> results`, interning it on first use.
+fn intern_type(params: &[SigTy], results: &[SigTy]) -> u32 {
+    let p: Vec<we::ValType> =
+        std::iter::once(we::ValType::I32).chain(params.iter().map(|s| s.wty().val())).collect();
+    let r: Vec<we::ValType> = results.iter().map(|s| s.wty().val()).collect();
+    POOL.with(|pool| {
+        let mut pool = pool.borrow_mut();
+        match pool.types.iter().position(|(tp, tr)| *tp == p && *tr == r) {
+            Some(i) => pool.type_base + i as u32,
+            None => {
+                pool.types.push((p, r));
+                pool.type_base + pool.types.len() as u32 - 1
+            }
+        }
+    })
+}
+
+/// The `SigTy` of a `FUNCTION_PTR` function argument — what its holder may call.
+pub(crate) fn function_ptr_sigty(
+    tys: &Arc<List<Arc<DAE::Type>>>,
+    args: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>,
+) -> Result<SigTy> {
+    let results: Result<Vec<SigTy>> = (&**tys).into_iter().map(|t| sig_ty(t)).collect();
+    Ok(SigTy::Func { params: Arc::new(var_sigtys(args)?), results: Arc::new(results?) })
+}
+
+/// The `T_FUNCTION` inside a `T_FUNCTION_REFERENCE_VAR`/`_FUNC` wrapper.
+fn function_type(ty: &DAE::Type) -> Result<&DAE::Type> {
+    match ty {
+        DAE::Type::T_FUNCTION_REFERENCE_VAR { functionType }
+        | DAE::Type::T_FUNCTION_REFERENCE_FUNC { functionType, .. } => Ok(functionType),
+        DAE::Type::T_FUNCTION { .. } => Ok(ty),
+        other => Err("CodegenWasmJit: not a function-reference type"),
+    }
+}
+
+/// The formal-argument names of a function type, in declaration order.
+fn func_arg_names(ty: &DAE::Type) -> Result<Vec<ArcStr>> {
+    let DAE::Type::T_FUNCTION { funcArg, .. } = function_type(ty)? else {
+        return Err("CodegenWasmJit: function reference without a function type");
+    };
+    Ok((&**funcArg).into_iter().map(|a| a.name.clone()).collect())
+}
+
+/// The residual signature a function-reference expression's value is called with.
+pub(crate) fn reference_sigty(ty: &DAE::Type) -> Result<SigTy> {
+    let DAE::Type::T_FUNCTION { funcArg, funcResultType, .. } = function_type(ty)? else {
+        return Err("CodegenWasmJit: function reference without a function type");
+    };
+    let params: Result<Vec<SigTy>> = (&**funcArg).into_iter().map(|a| sig_ty(&a.ty)).collect();
+    let results = match &**funcResultType {
+        DAE::Type::T_NORETCALL { .. } => Vec::new(),
+        DAE::Type::T_TUPLE { types, .. } => {
+            (&**types).into_iter().map(|t| sig_ty(t)).collect::<Result<Vec<_>>>()?
+        }
+        other => vec![sig_ty(other)?],
+    };
+    Ok(SigTy::Func { params: Arc::new(params?), results: Arc::new(results) })
+}
+
+/// Lower a `PARTEVALFUNCTION`, leaving the owned closure handle on the stack.
+pub(crate) fn compile_parteval(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<()> {
+    let DAE::Exp::PARTEVALFUNCTION { path, expList, ty, origType } = exp else {
+        return Err("CodegenWasmJit: not a PARTEVALFUNCTION");
+    };
+    let target = mangle(path)?;
+    let Some(info) = ctx.by_name.get(&target) else {
+        return Err("CodegenWasmJit: function reference to a function that was not compiled");
+    };
+    let (target_index, target_sig) = (info.index, info.sig.clone());
+    // The applied parameters are the formals the residual type dropped, in
+    // declaration order — `expList`'s order (C's `setDifference`).
+    let all_names = func_arg_names(origType)?;
+    let residual_names = func_arg_names(ty)?;
+    if all_names.len() != target_sig.params.len() {
+        return Err("CodegenWasmJit: function reference disagrees with the function's argument count");
+    }
+    let applied: Vec<usize> =
+        (0..all_names.len()).filter(|i| !residual_names.contains(&all_names[*i])).collect();
+    let exps: Vec<&Arc<DAE::Exp>> = (&**expList).into_iter().collect();
+    if applied.len() != exps.len() {
+        return Err("CodegenWasmJit: function reference applies a different number of arguments than it drops");
+    }
+    let applied_tys: Vec<SigTy> = applied.iter().map(|i| target_sig.params[*i].clone()).collect();
+    let slot = intern_thunk(&target, target_index, &target_sig, &applied, &residual_names, &all_names)?;
+
+    let env = ctx.alloc_temp(WTy::I32);
+    let env_flds = env_fields(&applied_tys);
+    if env_flds.is_empty() {
+        ctx.emit(we::Instruction::I32Const(0));
+    } else {
+        emit_record_construction(ctx, &env_flds, &exps)?;
+    }
+    ctx.emit(we::Instruction::LocalSet(env));
+
+    let layout = record_layout(&closure_fields());
+    let (fn_off, env_off) = closure_offsets();
+    let obj = emit_record_alloc(ctx, &layout)?;
+    let base_global = POOL.with(|p| p.borrow().base_global);
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::GlobalGet(base_global));
+    ctx.emit(we::Instruction::I32Const(slot as i32));
+    ctx.emit(we::Instruction::I32Add);
+    ctx.emit(we::Instruction::I32Store(mem_arg(fn_off, 2)));
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::LocalGet(env));
+    ctx.emit(we::Instruction::I32Store(mem_arg(env_off, 2)));
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// Push the environment record's field at `off`; the closure is parameter 0.
+fn load_env_field(f: &mut we::Function, env_off: u32, off: u32, wty: WTy) {
+    use we::Instruction as I;
+    f.instruction(&I::LocalGet(0));
+    f.instruction(&I::I32Load(mem_arg(env_off, 2)));
+    match wty {
+        WTy::I32 => f.instruction(&I::I32Load(mem_arg(off, 2))),
+        WTy::F64 => f.instruction(&I::F64Load(mem_arg(off, 3))),
+    };
+}
+
+/// Emit (or reuse) the thunk for `target` applying the given parameter positions
+/// and return its table slot. It takes the closure, then the residual arguments,
+/// reads the applied ones out of `env` and calls `target` with the full list.
+fn intern_thunk(
+    target: &str,
+    target_index: u32,
+    target_sig: &FnSig,
+    applied: &[usize],
+    residual_names: &[ArcStr],
+    all_names: &[ArcStr],
+) -> Result<u32> {
+    let key = format!("{target}|{applied:?}");
+    if let Some(slot) = POOL.with(|p| p.borrow().by_key.get(&key).copied()) {
+        return Ok(slot);
+    }
+    // Residual arguments in the residual type's order, by name.
+    let residual: Vec<usize> = residual_names
+        .iter()
+        .map(|n| all_names.iter().position(|a| a == n))
+        .collect::<Option<Vec<usize>>>()
+        .ok_or_else(|| "CodegenWasmJit: function reference keeps an argument the function does not have")?;
+    let residual_tys: Vec<SigTy> = residual.iter().map(|i| target_sig.params[*i].clone()).collect();
+    let applied_tys: Vec<SigTy> = applied.iter().map(|i| target_sig.params[*i].clone()).collect();
+    let type_index = intern_type(&residual_tys, &target_sig.results);
+
+    let env_layout = record_layout(&env_fields(&applied_tys));
+    let (_, env_off) = closure_offsets();
+    use we::Instruction as I;
+    let mut f = we::Function::new([]);
+    for i in 0..all_names.len() {
+        match applied.iter().position(|a| *a == i) {
+            // An applied argument: read it out of the environment, retained —
+            // the target consumes its heap parameters, the closure keeps its own.
+            Some(k) => {
+                let off = env_layout.data_off + env_layout.field_off[k];
+                load_env_field(&mut f, env_off, off, applied_tys[k].wty());
+                if applied_tys[k].is_heap() {
+                    load_env_field(&mut f, env_off, off, WTy::I32);
+                    f.instruction(&I::Call(rt_index("rt_retain")?));
+                }
+            }
+            // A residual argument: pushed by the caller, already owned.
+            None => {
+                let k = residual.iter().position(|r| *r == i).ok_or_else(|| {
+                    "CodegenWasmJit: function-reference argument is neither applied nor residual"
+                })?;
+                f.instruction(&I::LocalGet(1 + k as u32));
+            }
+        }
+    }
+    f.instruction(&I::Call(target_index));
+    f.instruction(&I::End);
+
+    Ok(POOL.with(|p| {
+        let mut pool = p.borrow_mut();
+        let slot = pool.thunks.len() as u32;
+        pool.thunks.push((type_index, f));
+        pool.by_key.insert(key, slot);
+        slot
+    }))
+}
+
+/// Lower a call through a function-reference variable: push the closure (the
+/// thunk's environment), the arguments, the thunk's table index, `call_indirect`.
+pub(crate) fn compile_fnptr_call(
+    ctx: &mut FnCtx,
+    name: &str,
+    args: &Arc<List<Arc<DAE::Exp>>>,
+) -> Result<Vec<SigTy>> {
+    let Some((local, SigTy::Func { params, results })) = ctx.locals.get(name).cloned() else {
+        return Err("CodegenWasmJit: function-pointer calls are only supported through a local variable");
+    };
+    let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
+    if argv.len() != params.len() {
+        return Err("CodegenWasmJit: function-pointer call argument count mismatch");
+    }
+    let (fn_off, _) = closure_offsets();
+    ctx.emit(we::Instruction::LocalGet(local)); // the closure, borrowed as `env`
+    for (a, p) in argv.iter().zip(params.iter()) {
+        let w = compile_exp(ctx, a)?;
+        coerce(ctx, w, p.wty());
+    }
+    ctx.emit(we::Instruction::LocalGet(local));
+    ctx.emit(we::Instruction::I32Load(mem_arg(fn_off, 2)));
+    let type_index = intern_type(&params, &results);
+    ctx.emit(we::Instruction::CallIndirect { type_index, table_index: 0 });
+    Ok((*results).clone())
+}
+
+/// The `start` instructions appending the thunks (absolute wasm function
+/// indices, in table order) to the shared table, base recorded in `base_global`.
+pub(crate) fn emit_start(f: &mut we::Function, fn_indices: &[u32], base_global: u32) {
+    use we::Instruction as I;
+    f.instruction(&I::RefNull(we::HeapType::FUNC));
+    f.instruction(&I::I32Const(fn_indices.len() as i32));
+    f.instruction(&I::TableGrow(0));
+    f.instruction(&I::GlobalSet(base_global));
+    for (k, idx) in fn_indices.iter().enumerate() {
+        f.instruction(&I::GlobalGet(base_global));
+        f.instruction(&I::I32Const(k as i32));
+        f.instruction(&I::I32Add);
+        f.instruction(&I::RefFunc(*idx));
+        f.instruction(&I::TableSet(0));
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -284,7 +284,9 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
         SigTy::Str => wasmer::Value::I32(str_to_handle(store, rt, v)?),
         SigTy::Array { elem, rank } => wasmer::Value::I32(array_to_handle(store, rt, elem, *rank, v)?),
         SigTy::Record { fields, .. } => wasmer::Value::I32(record_to_handle(store, rt, fields, v)?),
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 
@@ -390,7 +392,9 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
             let h = record_to_handle(store, rt, fields, v)?;
             write_bytes(store, rt, addr, &h.to_le_bytes())?;
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     }
     Ok(())
 }
@@ -423,7 +427,9 @@ fn marshal_out(store: &mut Store, rt: &RtFns, ty: &SigTy, val: &wasmer::Value) -
             let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 record handle result")?;
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 
@@ -504,7 +510,9 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
             let h = i32::from_le_bytes(read_bytes::<4>(store, rt, addr)?);
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -283,7 +283,9 @@ fn marshal_in(store: &mut Store, rt: &RtFns, ty: &SigTy, v: &Values::Value) -> R
         SigTy::Str => wasmtime::Val::I32(str_to_handle(store, rt, v)?),
         SigTy::Array { elem, rank } => wasmtime::Val::I32(array_to_handle(store, rt, elem, *rank, v)?),
         SigTy::Record { fields, .. } => wasmtime::Val::I32(record_to_handle(store, rt, fields, v)?),
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 
@@ -389,7 +391,9 @@ fn write_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize, v: &Valu
             let h = record_to_handle(store, rt, fields, v)?;
             write_bytes(store, rt, addr, &h.to_le_bytes())?;
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     }
     Ok(())
 }
@@ -422,7 +426,9 @@ fn marshal_out(store: &mut Store, rt: &RtFns, ty: &SigTy, val: &wasmtime::Val) -
             let h = val.i32().ok_or_else(|| "CodegenWasmJit: expected i32 record handle result")?;
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 
@@ -503,7 +509,9 @@ fn read_elem(store: &mut Store, rt: &RtFns, elem: &SigTy, addr: usize) -> Result
             let h = i32::from_le_bytes(read_bytes::<4>(store, rt, addr)?);
             record_to_value(store, rt, path, fields, h)?
         }
-        SigTy::Ptr => return Err("CodegenWasmJit: external objects are not supported in function evaluation"),
+        SigTy::Ptr | SigTy::Func { .. } => {
+            return Err("CodegenWasmJit: external objects and function references are not supported in function evaluation");
+        }
     })
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# The simulation's captured stdout, where `ModelicaMessage` output lands.
+openmodelica_wasi.workspace = true
 
 # libc (dlsym RTLD_NEXT / malloc for the non-simulation forward) is native-only;
 # the wasm build always allocates from the arena.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
@@ -141,12 +141,13 @@ fn take_message(msg: *const c_char, prefix: &str) -> bool {
     true
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn omrs_modelica_message(msg: *const c_char) -> i32 {
+// The two hooks the simulation host hands to
+// `dynload::install_modelica_message_interception`.
+
+pub extern "C" fn modelica_message_hook(msg: *const c_char) -> i32 {
     take_message(msg, LOG_STDOUT_INFO) as i32
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn omrs_modelica_warning(msg: *const c_char) -> i32 {
+pub extern "C" fn modelica_warning_hook(msg: *const c_char) -> i32 {
     take_message(msg, LOG_STDOUT_WARNING) as i32
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
@@ -100,3 +100,53 @@ pub extern "C" fn omrs_sim_external_begin() {
 pub extern "C" fn omrs_sim_external_end() {
     sim_external_end();
 }
+
+// ---------------------------------------------------------------------------
+// ModelicaMessage / ModelicaWarning
+// ---------------------------------------------------------------------------
+//
+// The C runtime routes these to `OMC_LOG_STDOUT`, the stream `Streams.print`'s
+// output reaches the simulation log through — but the compiler process never
+// enables it. So the wasm-jit host rebinds the runtime's
+// `OpenModelica_ModelicaVFormat{Message,Warning}` slots (dynload +
+// runtime_error_shim.c) and the rendered message arrives here instead.
+
+/// C's `messageText` prefixes (util/omc_error.c: `%-17s | %-7s | `), for a
+/// message's first line and for its wrapped lines.
+pub const LOG_STDOUT_INFO: &str = "LOG_STDOUT        | info    | ";
+pub const LOG_STDOUT_WARNING: &str = "LOG_STDOUT        | warning | ";
+const LOG_CONT: &str = "|                 | |       | ";
+
+/// Prefix each line of a `\n`-separated message, the first with `prefix`.
+pub fn format_log_stdout(msg: &str, prefix: &str) -> String {
+    let mut out = String::new();
+    for (i, line) in msg.split('\n').enumerate() {
+        out.push_str(if i == 0 { prefix } else { LOG_CONT });
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Emit `msg` to the running simulation's captured stdout if an external call is
+/// in flight; returns whether it was taken. The caller's format string
+/// `\n`-terminates the line, which the prefixing re-adds.
+fn take_message(msg: *const c_char, prefix: &str) -> bool {
+    if !SIM_MODE.with(Cell::get) || msg.is_null() {
+        return false;
+    }
+    let text = unsafe { std::ffi::CStr::from_ptr(msg) }.to_string_lossy().into_owned();
+    let line = format_log_stdout(text.strip_suffix('\n').unwrap_or(&text), prefix);
+    openmodelica_wasi::wasi::stdout_write(line.as_bytes());
+    true
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omrs_modelica_message(msg: *const c_char) -> i32 {
+    take_message(msg, LOG_STDOUT_INFO) as i32
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn omrs_modelica_warning(msg: *const c_char) -> i32 {
+    take_message(msg, LOG_STDOUT_WARNING) as i32
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -725,7 +725,11 @@ fn format_f(v: f64) -> String {
 /// Evaluate `functionCheckAsserts` (C's `checkForAsserts`) at the current point and
 /// format any `AssertionLevel.warning` violation it recorded into a `LOG_ASSERT`
 /// block, once per site. Called by the drivers after each accepted output step.
-fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+///
+/// `level`: C reports a violation met while the integrator updates the system
+/// (`simulationUpdate`, which sets `noThrowAsserts`) as `info`, one met anywhere
+/// else — initialization, the terminal step — as `warning`.
+fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, level: &str) -> Result<()> {
     e.call1_if_present("functionCheckAsserts", sim_data)?;
     let pending = e.take_pending_warnings();
     if pending.is_empty() {
@@ -741,7 +745,7 @@ fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
         // C (`omc_error.c` messageText + printInfo): a header line with the source
         // position, then the message split on '\n' onto continuation lines whose
         // stream/type columns are "|".
-        let head = log_prefix("LOG_ASSERT", "info");
+        let head = log_prefix("LOG_ASSERT", level);
         let cont = log_prefix("|", "|");
         // C wraps the already-parenthesised `assert_cond` = "(<dumped>)" once more
         // in the `(%s)` format, so the displayed condition is double-parenthesised.
@@ -798,6 +802,9 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
         e.call1("functionZeroCrossings", sim_data)?;
         save_zc_pre(e, sim_data, layout)?;
     }
+    // C's `initializeModel` ends with `checkForAsserts` — before the
+    // initialization-success line.
+    check_asserts(e, sim_data, layout, "warning")?;
     // Initialization output is complete; the next model output is the simulation
     // phase. Let the host close the init segment of the capture.
     signal_init_done();
@@ -909,14 +916,46 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
 /// `functionAlgebraics` first so the reported derivatives/algebraics are consistent.
 /// The integrator has accepted the state, so a non-converging NLS here is a genuine
 /// failure; `nls_fail` is cleared first so `check_nls` sees only this point's solve.
-fn emit_row(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout, time: f64) -> Result<()> {
+fn emit_row(
+    e: &mut dyn SimEngine,
+    rows: &mut Vec<f64>,
+    sim_data: u32,
+    layout: &SimLayout,
+    time: f64,
+    stop: f64,
+) -> Result<()> {
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_f64(e, sim_data + TIME_OFF, time)?;
-    e.call1("functionODE", sim_data)?;
-    e.call1("functionAlgebraics", sim_data)?;
+    if time >= stop {
+        // C's `finishSimulation`: the row at the stop time is the terminal step,
+        // a *discrete* update with `terminal()` true, so a `when terminal()`
+        // body fires and reaches the result file. (C emits the stop time twice,
+        // before and after; we keep one row per output point, the updated one.)
+        write_i32(e, sim_data + layout.terminal_off, 1)?;
+        iterate_discrete(e, sim_data, layout)?;
+        write_i32(e, sim_data + layout.terminal_off, 0)?;
+    } else {
+        e.call1("functionODE", sim_data)?;
+        e.call1("functionAlgebraics", sim_data)?;
+    }
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
-    check_asserts(e, sim_data, layout)
+    check_asserts(e, sim_data, layout, if time >= stop { "warning" } else { "info" })
+}
+
+/// The initial result row. C emits it straight after `initializeModel` with no
+/// re-evaluation: `SimData` is already consistent, and re-running the equations
+/// would repeat any side effect they have (`Streams.print`).
+fn emit_initial_row(
+    e: &mut dyn SimEngine,
+    rows: &mut Vec<f64>,
+    sim_data: u32,
+    layout: &SimLayout,
+    time: f64,
+) -> Result<()> {
+    write_f64(e, sim_data + TIME_OFF, time)?;
+    capture_row(e, rows, sim_data, layout)?;
+    check_asserts(e, sim_data, layout, "warning")
 }
 
 /// Pre-event snapshot row (state just before a discrete update). Skips
@@ -1433,12 +1472,14 @@ impl Driver for EulerDriver {
                 return Ok(Advance::Cancelled);
             }
             did_step = true;
-            let time = start + self.row as f64 * h;
-            write_f64(e, sim_data + TIME_OFF, time)?;
-            e.call1("functionODE", sim_data)?;
-            e.call1("functionAlgebraics", sim_data)?;
+            // The last row lands exactly on `stop`: the terminal step.
+            let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            if self.row == 0 {
+                emit_initial_row(e, &mut self.rows, sim_data, layout, time)?;
+            } else {
+                emit_row(e, &mut self.rows, sim_data, layout, time, stop)?;
+            }
             check_nls(e, sim_data, layout)?; // Euler cannot back off — non-convergence is fatal
-            capture_row(e, &mut self.rows, sim_data, layout)?;
             // terminate() fired in functionAlgebraics: keep this row, stop the run.
             if terminated(e, sim_data, layout)? {
                 self.row = n_rows;
@@ -1790,7 +1831,7 @@ impl DasslDriver {
 
         let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
         // Row 0 at the start time.
-        emit_row(e, &mut rows, sim_data, layout, start)?;
+        emit_initial_row(e, &mut rows, sim_data, layout, start)?;
         let pending_terminate = terminated(e, sim_data, layout)?; // terminate() at the initial point
 
         // Dynamic state selection: seed the identity pivots (matching the wasm-side
@@ -1896,7 +1937,7 @@ impl Driver for DasslDriver {
                 }
                 did_step = true;
                 let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
-                emit_row(e, &mut self.rows, sim_data, layout, time)?;
+                emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time)?;
                 if terminated(e, sim_data, layout)? {
                     self.finished = true;
                     return Ok(Advance::Terminated);
@@ -1968,7 +2009,7 @@ impl Driver for DasslDriver {
                 for i in 0..n_states {
                     write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
                 }
-                emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+                emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
                 self.row += 1;
                 continue;
             }
@@ -2004,7 +2045,7 @@ impl Driver for DasslDriver {
             for i in 0..n_states {
                 write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
             }
-            emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+            emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated; // terminate() fired: keep this row, stop
             }
@@ -2382,7 +2423,7 @@ impl DasslCore {
                     event_update(e, sim_data, layout, None, troot)?;
                     if let Some(r) = rows.as_deref_mut() {
                         capture_row(e, r, sim_data, layout)?;
-                        check_asserts(e, sim_data, layout)?;
+                        check_asserts(e, sim_data, layout, "info")?;
                     }
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
@@ -2415,14 +2456,14 @@ impl DasslCore {
                     return Ok(Step::Event { time: te });
                 }
                 if let Some(r) = rows.as_deref_mut() {
-                    emit_row(e, r, sim_data, layout, te)?; // pre-event row (held)
+                    emit_row(e, r, sim_data, layout, te, model.stop_time)?; // pre-event row (held)
                 }
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
                 refresh_relations(e, sim_data, layout)?;
                 self.time_events += 1;
                 if let Some(r) = rows.as_deref_mut() {
-                    emit_row(e, r, sim_data, layout, te)?;
+                    emit_row(e, r, sim_data, layout, te, model.stop_time)?;
                 }
                 if terminated(e, sim_data, layout)? {
                     return Ok(Step::Terminated);
@@ -2756,7 +2797,7 @@ impl DasslEventsDriver {
             refresh_relations(e, sim_data, layout)?;
             core.time_events += 1;
         }
-        emit_row(e, &mut rows, sim_data, layout, start)?;
+        emit_initial_row(e, &mut rows, sim_data, layout, start)?;
         let pending_terminate = terminated(e, sim_data, layout)?;
 
         // Dynamic state selection: identity pivots, then re-pivot at the initial
@@ -2846,7 +2887,7 @@ impl Driver for DasslEventsDriver {
                         event_update(e, sim_data, layout, None, tr)?;
                         self.core.state_events += 1;
                         capture_row(e, &mut self.rows, sim_data, layout)?; // post-event row
-                        check_asserts(e, sim_data, layout)?;
+                        check_asserts(e, sim_data, layout, "info")?;
                         if terminated(e, sim_data, layout)? {
                             self.finished = true;
                             return Ok(Advance::Terminated);
@@ -2863,12 +2904,12 @@ impl Driver for DasslEventsDriver {
                     if te <= tout + eps {
                         let te = if (te - tout).abs() <= eps { tout } else { te };
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?; // held pre row
-                        emit_row(e, &mut self.rows, sim_data, layout, te)?; // pre-event row
+                        emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?; // pre-event row
                         write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh
                         self.samp.fire(e, sim_data, te)?;
                         refresh_relations(e, sim_data, layout)?;
                         self.core.time_events += 1;
-                        emit_row(e, &mut self.rows, sim_data, layout, te)?; // post-event row
+                        emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?; // post-event row
                         if terminated(e, sim_data, layout)? {
                             self.finished = true;
                             return Ok(Advance::Terminated);
@@ -2888,7 +2929,7 @@ impl Driver for DasslEventsDriver {
                 }
                 if !grid_covered {
                     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-                    emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+                    emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
                     if terminated(e, sim_data, layout)? {
                         self.finished = true;
                         return Ok(Advance::Terminated);
@@ -2944,7 +2985,7 @@ impl Driver for DasslEventsDriver {
             if !self.grid_covered {
                 write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
                 did_step = true;
-                emit_row(e, &mut self.rows, sim_data, layout, tout)?;
+                emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
                 if terminated(e, sim_data, layout)? {
                     break Advance::Terminated;
                 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -80,6 +80,9 @@ pub struct Layout {
     pub pre_bool_off: u32,
     /// `terminate(...)` flag (i32).
     pub terminate_off: u32,
+    /// `terminal()` flag (i32): C's `data->simulationInfo->terminal`, raised by
+    /// the driver for the run's final discrete update.
+    pub terminal_off: u32,
     /// C's `TermMsg`/`TermInfo`: the fired `terminate(...)`'s message and source
     /// position, as `[msg, file, lineStart, colStart, lineEnd, colEnd, readOnly]`
     /// (i32 each; the first two are String handles).
@@ -167,7 +170,8 @@ impl Layout {
         let pre_int_off = pre_real_off + n_real * 8;
         let pre_bool_off = pre_int_off + n_int_alg * 4;
         let terminate_off = pre_bool_off + n_bool_alg * 4;
-        let term_info_off = terminate_off + 4;
+        let terminal_off = terminate_off + 4;
+        let term_info_off = terminal_off + 4;
         let n_out_off = term_info_off + TERM_INFO_WORDS * 4;
         let nls_fail_off = n_out_off + 4;
         let lambda_off = (nls_fail_off + 4 + 7) & !7;
@@ -189,7 +193,7 @@ impl Layout {
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
-            terminate_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
+            terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
             mathevents_off, zctol_off, start_off, total,
         }
@@ -407,7 +411,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
     for v in [
         l.n_states, l.n_real_alg, l.lambda_off, l.rparam_off, l.int_off, l.iparam_off, l.bool_off,
         l.bparam_off, l.str_off, l.sparam_off, l.eobj_off, l.pre_real_off, l.pre_int_off, l.pre_bool_off,
-        l.terminate_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
+        l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off, l.total,
     ] {
@@ -555,6 +559,7 @@ impl<'a> Reader<'a> {
             pre_int_off: self.u32()?,
             pre_bool_off: self.u32()?,
             terminate_off: self.u32()?,
+            terminal_off: self.u32()?,
             term_info_off: self.u32()?,
             n_out_off: self.u32()?,
             nls_fail_off: self.u32()?,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -244,6 +244,11 @@ unsafe extern "C" {
     /// up here. See [`ensure_sim_error_interception`] and `runtime_error_shim.c`.
     fn omrs_install_modelica_error_panic(err_slot: *mut c_void, verr_slot: *mut c_void);
     fn omrs_install_omc_assert_panic(assert_slot: *mut c_void);
+
+    /// C shim: rebind the runtime's `OpenModelica_ModelicaVFormat{Message,Warning}`
+    /// slots so an external function's messages reach the running simulation's
+    /// log instead of the runtime's never-enabled `OMC_LOG_STDOUT` stream.
+    fn omrs_install_modelica_message(msg_slot: *mut c_void, warn_slot: *mut c_void);
 }
 
 /// Rebind the loaded runtime's `ModelicaError`/`ModelicaFormatError` hooks, the
@@ -422,12 +427,13 @@ pub fn external_symbol(name: &str) -> Option<usize> {
     dl::sym(me, name)
 }
 
-/// Install the panic-mode `ModelicaError`/`omc_assert` interception for the
-/// simulation host, once. A `ModelicaError` from an external library (e.g. a
-/// missing table file) then records its message in the compiler Error buffer and
-/// raises a Rust panic (`omrs_runtime_abort`), which the libffi call site catches
+/// Install the panic-mode `ModelicaError`/`omc_assert` interception, plus the
+/// `ModelicaMessage`/`ModelicaWarning` routing, for the simulation host, once. A
+/// `ModelicaError` from an external library (e.g. a missing table file) then
+/// records its message in the compiler Error buffer and raises a Rust panic
+/// (`omrs_runtime_abort`), which the libffi call site catches
 /// (`ErrorExt::catch_runtime_error`) — instead of longjmp-ing into an unset jump
-/// buffer and crashing. The runtime's `OpenModelica_Modelica*Error`/`omc_assert`
+/// buffer and crashing. The runtime's `OpenModelica_Modelica*`/`omc_assert`
 /// slots resolve through the global scope (`ensure_runtime_solibs` loaded the
 /// runtime `RTLD_GLOBAL`).
 fn ensure_sim_error_interception() {
@@ -443,6 +449,16 @@ fn ensure_sim_error_interception() {
         }
         if let Some(assert_slot) = dlsym_addr(me, "omc_assert") {
             unsafe { omrs_install_omc_assert_panic(assert_slot as *mut c_void) };
+        }
+        let msg_slot = dlsym_addr(me, "OpenModelica_ModelicaVFormatMessage");
+        let warn_slot = dlsym_addr(me, "OpenModelica_ModelicaVFormatWarning");
+        if msg_slot.is_some() || warn_slot.is_some() {
+            unsafe {
+                omrs_install_modelica_message(
+                    msg_slot.unwrap_or(0) as *mut c_void,
+                    warn_slot.unwrap_or(0) as *mut c_void,
+                )
+            };
         }
     });
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -248,8 +248,17 @@ unsafe extern "C" {
     /// C shim: rebind the runtime's `OpenModelica_ModelicaVFormat{Message,Warning}`
     /// slots so an external function's messages reach the running simulation's
     /// log instead of the runtime's never-enabled `OMC_LOG_STDOUT` stream.
-    fn omrs_install_modelica_message(msg_slot: *mut c_void, warn_slot: *mut c_void);
+    fn omrs_install_modelica_message(
+        msg_slot: *mut c_void,
+        warn_slot: *mut c_void,
+        msg_hook: ModelicaMessageHook,
+        warn_hook: ModelicaMessageHook,
+    );
 }
+
+/// Renders a `ModelicaMessage`/`ModelicaWarning` for the simulation host;
+/// returns whether it took it. See [`install_modelica_message_interception`].
+pub type ModelicaMessageHook = extern "C" fn(*const core::ffi::c_char) -> i32;
 
 /// Rebind the loaded runtime's `ModelicaError`/`ModelicaFormatError` hooks, the
 /// analogue of `Error_registerModelicaFormatError` (which the C compiler runs at
@@ -427,10 +436,9 @@ pub fn external_symbol(name: &str) -> Option<usize> {
     dl::sym(me, name)
 }
 
-/// Install the panic-mode `ModelicaError`/`omc_assert` interception, plus the
-/// `ModelicaMessage`/`ModelicaWarning` routing, for the simulation host, once. A
-/// `ModelicaError` from an external library (e.g. a missing table file) then
-/// records its message in the compiler Error buffer and raises a Rust panic
+/// Install the panic-mode `ModelicaError`/`omc_assert` interception for the
+/// simulation host, once. A `ModelicaError` from an external library (e.g. a
+/// missing table file) then records its message in the compiler Error buffer and raises a Rust panic
 /// (`omrs_runtime_abort`), which the libffi call site catches
 /// (`ErrorExt::catch_runtime_error`) — instead of longjmp-ing into an unset jump
 /// buffer and crashing. The runtime's `OpenModelica_Modelica*`/`omc_assert`
@@ -450,6 +458,19 @@ fn ensure_sim_error_interception() {
         if let Some(assert_slot) = dlsym_addr(me, "omc_assert") {
             unsafe { omrs_install_omc_assert_panic(assert_slot as *mut c_void) };
         }
+    });
+}
+
+/// Route an external function's `ModelicaMessage`/`ModelicaWarning` to `msg_hook`
+/// / `warn_hook` — the runtime sends them to `OMC_LOG_STDOUT`, a stream the
+/// compiler process never enables, so `Streams.print` output would vanish. A
+/// message the hook declines still reaches the original.
+pub fn install_modelica_message_interception(msg_hook: ModelicaMessageHook, warn_hook: ModelicaMessageHook) {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        ensure_runtime_solibs();
+        let Ok(me) = dl::open_self() else { return };
         let msg_slot = dlsym_addr(me, "OpenModelica_ModelicaVFormatMessage");
         let warn_slot = dlsym_addr(me, "OpenModelica_ModelicaVFormatWarning");
         if msg_slot.is_some() || warn_slot.is_some() {
@@ -457,6 +478,8 @@ fn ensure_sim_error_interception() {
                 omrs_install_modelica_message(
                     msg_slot.unwrap_or(0) as *mut c_void,
                     warn_slot.unwrap_or(0) as *mut c_void,
+                    msg_hook,
+                    warn_hook,
                 )
             };
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/runtime_error_shim.c
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/runtime_error_shim.c
@@ -224,16 +224,16 @@ void omrs_install_omc_assert_panic(omrs_assert_fn *assert_slot) {
  * simulation host. An external function's message would otherwise reach the
  * runtime's `va_infoStreamPrint(OMC_LOG_STDOUT, ...)`, a stream the compiler
  * process never enables, so `Streams.print` output vanished. The shims render
- * the message and offer it to Rust; anything not taken goes to the original,
- * leaving the compile-time `-d=gen` path unchanged.
+ * the message and offer it to the hook installed below; anything not taken goes
+ * to the original, leaving the compile-time `-d=gen` path unchanged.
  */
-extern int omrs_modelica_message(const char *msg);
-extern int omrs_modelica_warning(const char *msg);
-
 typedef void (*omrs_vmsg_fn)(const char *, va_list);
+typedef int (*omrs_msg_hook_fn)(const char *);
 
 static omrs_vmsg_fn omrs_orig_vformat_message = 0;
 static omrs_vmsg_fn omrs_orig_vformat_warning = 0;
+static omrs_msg_hook_fn omrs_message_hook = 0;
+static omrs_msg_hook_fn omrs_warning_hook = 0;
 
 static void omrs_modelica_vformat_message(const char *fmt, va_list ap) {
   char buf[8192];
@@ -241,7 +241,7 @@ static void omrs_modelica_vformat_message(const char *fmt, va_list ap) {
   va_copy(ap2, ap);
   vsnprintf(buf, sizeof(buf), fmt, ap2);
   va_end(ap2);
-  if (!omrs_modelica_message(buf) && omrs_orig_vformat_message) {
+  if (!(omrs_message_hook && omrs_message_hook(buf)) && omrs_orig_vformat_message) {
     omrs_orig_vformat_message(fmt, ap);
   }
 }
@@ -252,14 +252,20 @@ static void omrs_modelica_vformat_warning(const char *fmt, va_list ap) {
   va_copy(ap2, ap);
   vsnprintf(buf, sizeof(buf), fmt, ap2);
   va_end(ap2);
-  if (!omrs_modelica_warning(buf) && omrs_orig_vformat_warning) {
+  if (!(omrs_warning_hook && omrs_warning_hook(buf)) && omrs_orig_vformat_warning) {
     omrs_orig_vformat_warning(fmt, ap);
   }
 }
 
 /* The slots are the runtime's `OpenModelica_ModelicaVFormat{Message,Warning}`
-   function-pointer variables (dlsym'd in dynload::ensure_sim_error_interception). */
-void omrs_install_modelica_message(omrs_vmsg_fn *msg_slot, omrs_vmsg_fn *warn_slot) {
+   function-pointer variables (dlsym'd in
+   dynload::install_modelica_message_interception, which also supplies the
+   hooks — they live in the simulation host's crate, which this one does not
+   link against). */
+void omrs_install_modelica_message(omrs_vmsg_fn *msg_slot, omrs_vmsg_fn *warn_slot,
+                                   omrs_msg_hook_fn msg_hook, omrs_msg_hook_fn warn_hook) {
+  omrs_message_hook = msg_hook;
+  omrs_warning_hook = warn_hook;
   if (msg_slot) {
     omrs_orig_vformat_message = *msg_slot;
     *msg_slot = omrs_modelica_vformat_message;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/runtime_error_shim.c
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/runtime_error_shim.c
@@ -218,3 +218,54 @@ void omrs_install_omc_assert_panic(omrs_assert_fn *assert_slot) {
     *assert_slot = omrs_omc_assert_panic;
   }
 }
+
+/*
+ * `ModelicaMessage` / `ModelicaWarning` interception for the wasm-jit
+ * simulation host. An external function's message would otherwise reach the
+ * runtime's `va_infoStreamPrint(OMC_LOG_STDOUT, ...)`, a stream the compiler
+ * process never enables, so `Streams.print` output vanished. The shims render
+ * the message and offer it to Rust; anything not taken goes to the original,
+ * leaving the compile-time `-d=gen` path unchanged.
+ */
+extern int omrs_modelica_message(const char *msg);
+extern int omrs_modelica_warning(const char *msg);
+
+typedef void (*omrs_vmsg_fn)(const char *, va_list);
+
+static omrs_vmsg_fn omrs_orig_vformat_message = 0;
+static omrs_vmsg_fn omrs_orig_vformat_warning = 0;
+
+static void omrs_modelica_vformat_message(const char *fmt, va_list ap) {
+  char buf[8192];
+  va_list ap2;
+  va_copy(ap2, ap);
+  vsnprintf(buf, sizeof(buf), fmt, ap2);
+  va_end(ap2);
+  if (!omrs_modelica_message(buf) && omrs_orig_vformat_message) {
+    omrs_orig_vformat_message(fmt, ap);
+  }
+}
+
+static void omrs_modelica_vformat_warning(const char *fmt, va_list ap) {
+  char buf[8192];
+  va_list ap2;
+  va_copy(ap2, ap);
+  vsnprintf(buf, sizeof(buf), fmt, ap2);
+  va_end(ap2);
+  if (!omrs_modelica_warning(buf) && omrs_orig_vformat_warning) {
+    omrs_orig_vformat_warning(fmt, ap);
+  }
+}
+
+/* The slots are the runtime's `OpenModelica_ModelicaVFormat{Message,Warning}`
+   function-pointer variables (dlsym'd in dynload::ensure_sim_error_interception). */
+void omrs_install_modelica_message(omrs_vmsg_fn *msg_slot, omrs_vmsg_fn *warn_slot) {
+  if (msg_slot) {
+    omrs_orig_vformat_message = *msg_slot;
+    *msg_slot = omrs_modelica_vformat_message;
+  }
+  if (warn_slot) {
+    omrs_orig_vformat_warning = *warn_slot;
+    *warn_slot = omrs_modelica_vformat_warning;
+  }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
@@ -53,6 +53,10 @@ pub enum SigTy {
     /// wasm as an opaque `i32` handle into the host's pointer registry; not a
     /// wasm heap value (no ARC — freed by the object's `destructor`).
     Ptr,
+    /// A function reference (`function f(w=3)`): an `i32` handle to a runtime
+    /// closure (see the codegen's `closures` module). The signature is what the
+    /// holder may call, fixing the `call_indirect` type at every call site.
+    Func { params: Arc<Vec<SigTy>>, results: Arc<Vec<SigTy>> },
 }
 
 impl SigTy {
@@ -87,12 +91,25 @@ impl SigTy {
                 out.push('}');
             }
             SigTy::Ptr => out.push('P'),
+            // `<params|results>` — a function reference, angle-delimited so the
+            // reader can consume one whole (possibly nested) signature.
+            SigTy::Func { params, results } => {
+                out.push('<');
+                for p in params.iter() {
+                    p.write_code(out);
+                }
+                out.push('|');
+                for r in results.iter() {
+                    r.write_code(out);
+                }
+                out.push('>');
+            }
         }
     }
     pub fn wty(&self) -> WTy {
         match self {
-            SigTy::Int | SigTy::Bool | SigTy::Str | SigTy::Array { .. } | SigTy::Record { .. } | SigTy::Ptr => WTy::I32,
             SigTy::Real => WTy::F64,
+            _ => WTy::I32,
         }
     }
     /// The runtime element-kind tag stored in an array header when this type is
@@ -104,7 +121,8 @@ impl SigTy {
             SigTy::Bool => 2,
             SigTy::Str => 3,
             SigTy::Array { .. } => 4,
-            SigTy::Record { .. } => 5,
+            // A closure is a record object, so it releases/copies like one.
+            SigTy::Record { .. } | SigTy::Func { .. } => 5,
             // Not a real runtime element kind: arrays of external objects don't
             // occur (table data is Real/Integer). Stored 4-byte, non-heap.
             SigTy::Ptr => 0,
@@ -116,7 +134,7 @@ impl SigTy {
         match self {
             SigTy::Str => Some("rt_release"),
             SigTy::Array { .. } => Some("rt_array_release"),
-            SigTy::Record { .. } => Some("rt_record_release"),
+            SigTy::Record { .. } | SigTy::Func { .. } => Some("rt_record_release"),
             _ => None,
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -242,6 +242,10 @@ fn define_external_imports(
     rt_str_data: wasmtime::TypedFunc<u32, u32>,
 ) -> Result<()> {
     registry_reset();
+    openmodelica_util::dynload::install_modelica_message_interception(
+        openmodelica_modelica_utilities::modelica_message_hook,
+        openmodelica_modelica_utilities::modelica_warning_hook,
+    );
     let engine = linker.engine().clone();
     for sig in &model.ext_imports {
         let functype = wasmtime::FuncType::new(

--- a/OMCompiler/SimulationRuntime/c/util/ModelicaUtilities.c
+++ b/OMCompiler/SimulationRuntime/c/util/ModelicaUtilities.c
@@ -32,12 +32,26 @@
 #include <stdlib.h>
 #include "omc_error.h"
 
+void OpenModelica_Simulation_ModelicaVFormatMessage(const char*string, va_list args) {
+  va_infoStreamPrint(OMC_LOG_STDOUT, 0, string, args);
+}
+
+void OpenModelica_Simulation_ModelicaVFormatWarning(const char*string, va_list args) {
+  va_warningStreamPrint(OMC_LOG_STDOUT, 0, string, args);
+}
+
+/* Like OpenModelica_Modelica{,V}FormatError below: a host that runs the
+   simulation in its own process (the Rust omc's wasm-jit target) rebinds these
+   to route an external function's messages into its simulation log. */
+void (*OpenModelica_ModelicaVFormatMessage)(const char*,va_list) = OpenModelica_Simulation_ModelicaVFormatMessage;
+void (*OpenModelica_ModelicaVFormatWarning)(const char*,va_list) = OpenModelica_Simulation_ModelicaVFormatWarning;
+
 void ModelicaMessage(const char* string) {
   ModelicaFormatMessage("%s", string);
 }
 
 extern void ModelicaVFormatMessage(const char*string, va_list args) {
-  va_infoStreamPrint(OMC_LOG_STDOUT, 0, string, args);
+  OpenModelica_ModelicaVFormatMessage(string, args);
 }
 
 void ModelicaFormatMessage(const char* string,...) {
@@ -52,7 +66,7 @@ void ModelicaWarning(const char* string) {
 }
 
 extern void ModelicaVFormatWarning(const char*string, va_list args) {
-  va_warningStreamPrint(OMC_LOG_STDOUT, 0, string, args);
+  OpenModelica_ModelicaVFormatWarning(string, args);
 }
 
 void ModelicaFormatWarning(const char* string,...) {


### PR DESCRIPTION
Three gaps the MSL Media examples hit.

A function reference (`function f(w=3)` passed to a partial-function formal, as Modelica.Math.Nonlinear.solveOneNonlinearEquation takes) becomes a closure object plus a thunk appended to the shared rt.__indirect_function_table and reached by call_indirect. The C target boxes every argument and dispatches one generic pointer shape; wasm needs an exact type, and the residual signature is static at both ends, so each PARTEVALFUNCTION gets a thunk with that signature. The closure mirrors C's mmc_mk_box2(0, closure_fn, env) over mmc_mk_boxN(0, args): a two-field record {fn, env} whose env holds the applied arguments, so `fn` sits at a fixed offset the call site can read without knowing what the callee applied. Both are ordinary runtime records, so rt_record_release frees the captured values.

terminal() reads a new SimData flag the driver raises for the run's final row, which is now a discrete update (C's finishSimulation) rather than a plain continuous one. The initial row is emitted without re-evaluating the equations, as C does after initializeModel — running them again repeated any side effect they had, which is how the extra Streams.print line showed up in Inverse_sine.

Modelica.Utilities.Streams.print reached the C runtime's ModelicaFormatMessage, whose OMC_LOG_STDOUT stream the compiler process never enables, so the output vanished instead of reaching the simulation log. The runtime gets OpenModelica_ModelicaVFormat{Message, Warning} indirection slots, like the existing error ones, which the wasm-jit host rebinds to route an external function's messages into the running simulation's captured stdout. A violation met during initialization is a `warning` there, one met while the integrator updates the system an `info`, matching C's noThrowAsserts split.


Claude-Session: https://claude.ai/code/session_01VgEGUcLawkCeUCgTebicxn

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
