### PR TITLE
wasm-jit: sparse kinsol-style nonlinear solver

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -57,7 +57,7 @@ use crate::CodegenWasmJitFunctions::{
     ArrayGroup, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
-    NlsResidual, emit_nls_load_body, emit_nls_jac_body,
+    NlsResidual, emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
     external_general, function_signature, rt_index, sim_cref_key,
 };
@@ -610,12 +610,12 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     // LOG_STATS / chattering lines). `INIT_OUTPUT` is `None` when init failed.
     let sim_output = format!("{}{extra}", openmodelica_wasi::wasi::take_stdout_capture());
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
-    // C prints the sparse-solver announcements (initializeLinearSystems) ahead of
-    // the init-success line; prepend our pre-rendered copy to the init output.
-    let init_output = if model.sparse_lss_log.is_empty() {
+    // C prints the sparse-solver announcements (initializeLinear/NonlinearSystems)
+    // ahead of the init-success line; prepend our pre-rendered copy to the init output.
+    let init_output = if model.sparse_solver_log.is_empty() {
         init_output
     } else {
-        Some(format!("{}{}", model.sparse_lss_log, init_output.unwrap_or_default()))
+        Some(format!("{}{}", model.sparse_solver_log, init_output.unwrap_or_default()))
     };
     (res, init_output, sim_output)
 }
@@ -2413,7 +2413,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // shared-table job and thread the map through `var_map`. The systems' own
     // `residual`/`load` callbacks are emitted after the equation functions.
     let nls_nominal_map = build_nls_nominal_map(vars);
-    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals) =
+    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_patterns) =
         collect_nls_jobs(&[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs], &nls_nominal_map);
     // Register the analytic-Jacobian seed/result crefs before the equation
     // functions are lowered, so the column equations resolve their slots.
@@ -2800,7 +2800,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         let start_idx = import_base + bodies.len() as u32;
         let mut f = we::Function::new([]);
         if let Some((fn_indices, _)) = &nls_wiring {
-            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals);
+            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals, &nls_patterns);
         }
         if !thunk_indices.is_empty() {
             crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
@@ -2907,9 +2907,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // shared-table wiring: NLS callbacks and/or closure thunks.
     if start_wiring.is_some() {
         let mut globals = we::GlobalSection::new();
-        // NLS_BASE_GLOBAL (shared-table base), NLS_HIST_GLOBAL (history block base)
-        // and NLS_NOMINAL_GLOBAL (nominal block base) when the model has nonlinear
-        // systems, then the closure-thunk table base; all set by `start`.
+        // NLS_BASE_GLOBAL (shared-table base), NLS_HIST_GLOBAL (history block base),
+        // NLS_NOMINAL_GLOBAL (nominal block base) and NLS_PAT_GLOBAL (sparse-pattern
+        // block base) when the model has nonlinear systems, then the closure-thunk
+        // table base; all set by `start`.
         let n_globals = if thunk_indices.is_empty() { closure_global } else { closure_global + 1 };
         for _ in 0..n_globals {
             globals.global(
@@ -2977,7 +2978,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         editable_params,
         var_units,
         meta,
-        sparse_lss_log: build_sparse_lss_log(sim_code),
+        sparse_solver_log: format!("{}{}", build_sparse_lss_log(sim_code), build_sparse_nls_log(sim_code)),
     })
 }
 
@@ -3059,6 +3060,80 @@ fn build_sparse_lss_log(sim_code: &SimCode::SimCode) -> String {
     out
 }
 
+/// Reproduce C's `initializeNonlinearSystems` sparse-solver announcements
+/// (`nonlinearSystem.c`): one message per system handed to kinsol+KLU, keyed on
+/// why (density and/or size), then one aggregate flag-hint. Systems are in
+/// `indexNonLinearSystem` order (C's array order), matching the `sysNum` printed.
+fn build_sparse_nls_log(sim_code: &SimCode::SimCode) -> String {
+    use crate::CodegenWasmJitFunctions::{nls_use_sparse, NLSS_MAX_DENSITY, NLSS_MIN_SIZE};
+    let mut seen: HashSet<i32> = HashSet::new();
+    // (sysNum, equationIndex, size, nnz), deduped, in system-number order.
+    let mut systems: Vec<(i32, i32, usize, usize)> = Vec::new();
+    let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
+        for e in &eqs {
+            if let SimCode::SimEqSystem::SES_NONLINEAR { nlSystem, .. } = &**e {
+                if seen.insert(nlSystem.indexNonLinearSystem) {
+                    let size = lst(&nlSystem.crefs).count();
+                    systems.push((
+                        nlSystem.indexNonLinearSystem,
+                        nlSystem.index,
+                        size,
+                        nls_system_nnz(nlSystem),
+                    ));
+                }
+            }
+        }
+    };
+    scan(flatten_eqs(&sim_code.parameterEquations));
+    scan(flatten_eqs(&sim_code.initialEquations));
+    scan(flatten_eqs_ll(&sim_code.odeEquations));
+    scan(flatten_eqs_ll(&sim_code.algebraicEquations));
+    systems.sort_by_key(|&(idx, _, _, _)| idx);
+
+    let mut out = String::new();
+    let mut some_small_density = false;
+    let mut some_big_size = false;
+    for &(idx, eq_index, size, nnz) in &systems {
+        if size == 0 || nnz == 0 || !nls_use_sparse(size, nnz) {
+            continue;
+        }
+        let density = nnz as f64 / (size * size) as f64;
+        let big_size = size > NLSS_MIN_SIZE;
+        let body = if density < NLSS_MAX_DENSITY {
+            some_small_density = true;
+            if big_size {
+                some_big_size = true;
+                format!(
+                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {NLSS_MAX_DENSITY:.2}\nand size of {size} exceeds threshold of {NLSS_MIN_SIZE}."
+                )
+            } else {
+                format!(
+                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {NLSS_MAX_DENSITY:.2}."
+                )
+            }
+        } else {
+            some_big_size = true;
+            format!("Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause size of {size} exceeds threshold of {NLSS_MIN_SIZE}.")
+        };
+        out.push_str(&format_log_stdout(&body));
+    }
+    let hint = if some_small_density {
+        if some_big_size {
+            Some("The maximum density and the minimal system size for using sparse solvers can be\nspecified using the runtime flags '<-nlssMaxDensity=value>' and '<-nlssMinSize=value>'.")
+        } else {
+            Some("The maximum density for using sparse solvers can be specified\nusing the runtime flag '<-nlssMaxDensity=value>'.")
+        }
+    } else if some_big_size {
+        Some("The minimal system size for using sparse solvers can be specified\nusing the runtime flag '<-nlssMinSize=value>'.")
+    } else {
+        None
+    };
+    if let Some(h) = hint {
+        out.push_str(&format_log_stdout(h));
+    }
+    out
+}
+
 /// The nonzero count of a linear system's matrix `A`, matching C's
 /// `initializeLinearSystems`: `listLength(simJac)` for the non-torn (method-0)
 /// form, else the symbolic Jacobian's sparsity nnz (method 1, torn systems).
@@ -3072,6 +3147,80 @@ fn lin_system_nnz(lsystem: &SimCode::LinearSystem) -> usize {
         .as_ref()
         .map(|jm| lst(&jm.sparsity).map(|(_, rows)| lst(rows).count()).sum())
         .unwrap_or(0)
+}
+
+/// A nonlinear system's Jacobian sparsity in CSC — `colptr` (`n+1`), `rowidx`
+/// (`nnz`) and the column coloring — the same pattern C's
+/// `initialResizableAnalyticJacobian` builds: the column of a dependency is the
+/// seed variable's `SimVar.index`, the row of a solved `$pDER` cref is that
+/// variable's index. Only scalar rows are handled; an array-valued row (equation
+/// iterators or subscripted crefs) needs the run-time loops the C template emits,
+/// so those systems keep the numerical Jacobian.
+struct NlsJacPattern {
+    colptr: Vec<i32>,
+    rowidx: Vec<i32>,
+    colors: Vec<Vec<u32>>,
+}
+
+fn nls_jac_pattern(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
+    let SimCode::Sparsity::SPARSITY { rows } = &jm.sparsityMatrix else { return None };
+    let mut seed_col: HashMap<String, usize> = HashMap::new();
+    for sv in lst(&jm.seedVars) {
+        seed_col.insert(sim_cref_key(&sv.name).ok()?, usize::try_from(sv.index).ok()?);
+    }
+    let mut res_row: HashMap<String, usize> = HashMap::new();
+    for sv in &jac_column_vars(jm) {
+        if matches!(sv.varKind, VarKind::JAC_VAR) {
+            res_row.insert(sim_cref_key(&sv.name).ok()?, usize::try_from(sv.index).ok()?);
+        }
+    }
+    let mut cols: Vec<Vec<i32>> = vec![Vec::new(); n];
+    for row in lst(rows) {
+        if lst(&row.equation_iterators).next().is_some() {
+            return None;
+        }
+        for sc in lst(&row.solved_crefs) {
+            let r = *res_row.get(&sim_cref_key(sc).ok()?)?;
+            if r >= n {
+                return None;
+            }
+            for (seed, _, _) in lst(&row.dependencies) {
+                let c = *seed_col.get(&sim_cref_key(seed).ok()?)?;
+                if c >= n {
+                    return None;
+                }
+                cols[c].push(r as i32);
+            }
+        }
+    }
+    let mut colptr = vec![0i32; n + 1];
+    let mut rowidx: Vec<i32> = Vec::new();
+    for c in 0..n {
+        cols[c].sort_unstable();
+        cols[c].dedup();
+        rowidx.extend_from_slice(&cols[c]);
+        colptr[c + 1] = rowidx.len() as i32;
+    }
+    if rowidx.is_empty() {
+        return None;
+    }
+    let (color_ptr, color_cols) =
+        crate::CodegenWasmJitFunctions::lin_jac_coloring(&colptr, &rowidx, n);
+    let colors = (0..color_ptr.len() - 1)
+        .map(|c| {
+            color_cols[color_ptr[c] as usize..color_ptr[c + 1] as usize].iter().map(|&j| j as u32).collect()
+        })
+        .collect();
+    Some(NlsJacPattern { colptr, rowidx, colors })
+}
+
+/// The nonzero count of a nonlinear system's Jacobian, matching C's
+/// `initializeNonlinearSystemData` (`sparsePattern->nnz`).
+fn nls_system_nnz(nlsystem: &SimCode::NonlinearSystem) -> usize {
+    let Some(jm) = nlsystem.jacobianMatrix.as_ref() else { return 0 };
+    let n = lst(&nlsystem.crefs).count();
+    nls_jac_pattern(jm, n).map_or(0, |p| p.rowidx.len())
 }
 
 fn build_jac_a_info(sim_code: &SimCode::SimCode, n_states: u32) -> Option<JacAInfo> {
@@ -3987,12 +4136,16 @@ fn nls_parts(
 fn collect_nls_jobs(
     eq_lists: &[&[Arc<SimCode::SimEqSystem>]],
     nominal_of: &HashMap<String, f64>,
-) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>) {
+) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<i32>) {
     use SimCode::SimEqSystem as E;
     let mut systems: Vec<Arc<SimCode::NonlinearSystem>> = Vec::new();
     let mut jobs: HashMap<i32, NlsJob> = HashMap::new();
     let mut hist_off = 0u32;
     let mut nominal_off = 0u32;
+    let mut pat_off = 0u32;
+    // Concatenated `colptr[n+1] | rowidx[nnz]` of every sparsely-solved system, in
+    // system order; the module `start` writes them into the pattern block.
+    let mut patterns: Vec<i32> = Vec::new();
     // Concatenated nominal values, in system order; the module `start` writes them
     // into the nominal block, and each job's `nominal_off` indexes into it.
     let mut nominals: Vec<f64> = Vec::new();
@@ -4005,7 +4158,31 @@ fn collect_nls_jobs(
                 let n = lst(&nlSystem.crefs).count() as u32;
                 let has_jac = nls_jac_usable(nlSystem);
                 let mixed = nlSystem.mixedSystem;
-                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, hist_off, nominal_off, has_jac, mixed });
+                // Sparse (kinsol+KLU in C) when the symbolic pattern is available
+                // and passes C's density/size rule; the pattern is emitted into the
+                // pattern block so `rt_solve_nls` can factorize it.
+                let pat = has_jac
+                    .then(|| nls_jac_pattern(nlSystem.jacobianMatrix.as_ref().unwrap(), n as usize))
+                    .flatten()
+                    .filter(|p| nls_use_sparse(n as usize, p.rowidx.len()));
+                let nnz = pat.as_ref().map_or(0, |p| p.rowidx.len() as u32);
+                if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
+                    eprintln!(
+                        "wasm-jit nls {}: n={n} nnz={} jac={has_jac} mixed={mixed} sparse={} colors={}",
+                        nlSystem.index,
+                        nls_system_nnz(nlSystem),
+                        nnz != 0,
+                        pat.as_ref().map_or(0, |p| p.colors.len()),
+                    );
+                }
+                if let Some(p) = &pat {
+                    patterns.extend_from_slice(&p.colptr);
+                    patterns.extend_from_slice(&p.rowidx);
+                }
+                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, hist_off, nominal_off, has_jac, mixed, nnz, pat_off });
+                if nnz != 0 {
+                    pat_off += 4 * (n + 1 + nnz);
+                }
                 hist_off += crate::CodegenWasmJitFunctions::nls_hist_bytes(n);
                 nominal_off += 8 * n;
                 for cr in lst(&nlSystem.crefs) {
@@ -4016,7 +4193,7 @@ fn collect_nls_jobs(
             }
         }
     }
-    (systems, jobs, hist_off, nominals)
+    (systems, jobs, hist_off, nominals, patterns)
 }
 
 /// Map each scalar real variable's cref key to its nominal attribute, defaulting to
@@ -4046,24 +4223,72 @@ struct NlsJacInfo {
     result_offs: Vec<u32>,
 }
 
-/// The residual row a Jacobian result var maps to, from its name
-/// `$res_<matrixName>_<K>.…` → `K - 1`. `None` if the name has no positive
-/// trailing index.
-fn jac_result_row(cr: &Arc<DAE::ComponentRef>) -> Option<usize> {
-    let name = cref_display(cr).ok()?;
-    let first = name.split('.').next()?;
-    let k: usize = first.rsplit('_').next()?.parse().ok()?;
-    k.checked_sub(1)
+/// The residual row a Jacobian result var maps to: its `SimVar.index`, which is
+/// what the C template indexes `jacobian->resultVars[]` with.
+fn jac_result_row(sv: &SimCodeVar::SimVar) -> Option<usize> {
+    usize::try_from(sv.index).ok()
 }
 
-/// The residual rows of a column's `JAC_VAR` result variables, in `columnVars`
-/// order, iff they form a valid permutation of `0..n` (so the dense Jacobian rows
-/// can be placed unambiguously); otherwise `None`.
-fn nls_jac_result_rows(col: &SimCode::JacobianColumn, n: usize) -> Option<Vec<usize>> {
+/// Every variable a Jacobian's column equations can reference, other than the
+/// seeds: the `$pDER` results and the temporaries. The old backend lists them in
+/// `columnVars`; the new backend leaves that empty and registers them (together
+/// with the seeds, which are filtered out here) in `crefsHT` only.
+fn jac_column_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
     use openmodelica_backend_types::BackendDAE::VarKind;
-    let rows: Vec<usize> = lst(&col.columnVars)
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<SimCodeVar::SimVar> = Vec::new();
+    let mut push = |sv: &SimCodeVar::SimVar| {
+        if matches!(sv.varKind, VarKind::SEED_VAR) {
+            return;
+        }
+        if let Ok(key) = sim_cref_key(&sv.name) {
+            if seen.insert(key) {
+                out.push(sv.clone());
+            }
+        }
+    };
+    for sv in lst(&jm.columns).next().into_iter().flat_map(|c| lst(&c.columnVars)) {
+        push(sv);
+    }
+    if let Some((_, (_, _, entries), _, _)) = &jm.crefsHT {
+        for e in entries.borrow().iter().flatten() {
+            push(&e.1);
+        }
+    }
+    out
+}
+
+/// Whether a symbolic Jacobian can be lowered at all: every seed / column
+/// variable resolves to a scratch slot, and every column equation is a scalar
+/// assignment whose crefs do too. An array-valued Jacobian (whole-dimension seeds,
+/// sliced results) needs the run-time loops the C template emits, so such a system
+/// keeps the numerical Jacobian instead.
+fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
+    use SimCode::SimEqSystem as E;
+    let Some(col) = lst(&jm.columns).next() else { return false };
+    if lst(&jm.seedVars).any(|sv| sim_cref_key(&sv.name).is_err()) {
+        return false;
+    }
+    if lst(&col.columnVars).any(|sv| sim_cref_key(&sv.name).is_err()) {
+        return false;
+    }
+    lst(&col.constantEqns).chain(lst(&col.columnEqns)).all(|eq| {
+        let E::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { return false };
+        sim_cref_key(cref).is_ok()
+            && openmodelica_frontend_base::Expression::extractCrefsFromExp(exp.clone())
+                .is_ok_and(|crs| lst(&crs).all(|c| sim_cref_key(c).is_ok()))
+    })
+}
+
+/// The residual rows of the Jacobian's `JAC_VAR` result variables, in/// The residual rows of the Jacobian's `JAC_VAR` result variables, in
+/// [`jac_column_vars`] order, iff they form a valid permutation of `0..n` (so the
+/// Jacobian rows can be placed unambiguously); otherwise `None`.
+fn nls_jac_result_rows(jm: &SimCode::JacobianMatrix, n: usize) -> Option<Vec<usize>> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
+    let rows: Vec<usize> = jac_column_vars(jm)
+        .iter()
         .filter(|v| matches!(v.varKind, VarKind::JAC_VAR))
-        .map(|v| jac_result_row(&v.name))
+        .map(jac_result_row)
         .collect::<Option<Vec<_>>>()?;
     let mut sorted = rows.clone();
     sorted.sort_unstable();
@@ -4072,6 +4297,21 @@ fn nls_jac_result_rows(col: &SimCode::JacobianColumn, n: usize) -> Option<Vec<us
     } else {
         None
     }
+}
+
+/// The seed slot offsets in *column* order (`SimVar.index`, what the C template
+/// indexes `jacobian->seedVars[]` with), from the offsets registered for
+/// `jm.seedVars`. `None` unless the indices are a permutation of `0..n`.
+fn jac_seed_offs_by_column(jm: &SimCode::JacobianMatrix, offs: &[u32], n: usize) -> Option<Vec<u32>> {
+    let mut by_col = vec![u32::MAX; n];
+    for (sv, &off) in lst(&jm.seedVars).zip(offs) {
+        let c = usize::try_from(sv.index).ok()?;
+        if c >= n || by_col[c] != u32::MAX {
+            return None;
+        }
+        by_col[c] = off;
+    }
+    by_col.iter().all(|&o| o != u32::MAX).then_some(by_col)
 }
 
 /// A nonlinear system has a usable symbolic Jacobian: a `jacobianMatrix` with one
@@ -4084,10 +4324,25 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
     if lst(&nlsystem.eqs).any(|e| matches!(&**e, E::SES_FOR_RESIDUAL { .. } | E::SES_GENERIC_RESIDUAL { .. })) {
         return false;
     }
+    // `emit_nls_residual_body` writes `r[i]` for the i-th scalar residual while the
+    // Jacobian rows are in `res_index` space (C's `res[res_index]`), so the two only
+    // line up when the residuals are already in that order.
+    if lst(&nlsystem.eqs)
+        .filter_map(|e| match &**e {
+            E::SES_RESIDUAL { res_index, .. } => Some(*res_index),
+            _ => None,
+        })
+        .enumerate()
+        .any(|(i, r)| r != i as i32)
+    {
+        return false;
+    }
     let Some(jm) = &nlsystem.jacobianMatrix else { return false };
-    let Some(col) = lst(&jm.columns).next() else { return false };
+    if lst(&jm.columns).next().is_none_or(|c| lst(&c.columnEqns).next().is_none()) || !jac_lowerable(jm) {
+        return false;
+    }
     let n = lst(&nlsystem.crefs).count();
-    n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(col, n).is_some()
+    n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(jm, n).is_some()
 }
 
 /// Torn linear system usable for analytic assembly: square Jacobian with one seed
@@ -4095,9 +4350,11 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
 /// (`n_res` = number of `SES_RESIDUAL`). The `nls_jac_usable` analogue for linear.
 fn lin_jac_usable(lsystem: &SimCode::LinearSystem, n_res: usize) -> bool {
     let Some(jm) = &lsystem.jacobianMatrix else { return false };
-    let Some(col) = lst(&jm.columns).next() else { return false };
+    if lst(&jm.columns).next().is_none_or(|c| lst(&c.columnEqns).next().is_none()) || !jac_lowerable(jm) {
+        return false;
+    }
     let n = count(&lsystem.vars) as usize;
-    n > 0 && n == n_res && count(&jm.seedVars) as usize == n && nls_jac_result_rows(col, n).is_some()
+    n > 0 && n == n_res && count(&jm.seedVars) as usize == n && nls_jac_result_rows(jm, n).is_some()
 }
 
 /// Total f64 scratch slots the NLS analytic Jacobians need: seeds + column
@@ -4113,8 +4370,7 @@ fn nls_jac_scratch_f64(sim_code: &SimCode::SimCode) -> u32 {
                 if seen.insert(nlSystem.index) && nls_jac_usable(nlSystem) {
                     // seeds + all column variables (results + intermediates) get slots.
                     let jm = nlSystem.jacobianMatrix.as_ref().unwrap();
-                    let col = lst(&jm.columns).next().unwrap();
-                    total += count(&jm.seedVars) as u32 + count(&col.columnVars) as u32;
+                    total += count(&jm.seedVars) as u32 + jac_column_vars(jm).len() as u32;
                 }
             }
         }
@@ -4144,31 +4400,35 @@ fn build_nls_jac_infos(
             continue;
         }
         let jm = sys.jacobianMatrix.as_ref().unwrap();
-        let col = lst(&jm.columns).next().unwrap();
-        let mut seed_offs = Vec::new();
+        let mut listed_offs = Vec::new();
         for sv in lst(&jm.seedVars) {
             let off = cursor;
             cursor += 8;
             var_map.vars.insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
-            seed_offs.push(off);
+            listed_offs.push(off);
         }
         // Every column variable (results + intermediates) needs a slot so the
         // column equations resolve; the `JAC_VAR` results are placed at their
-        // residual row (`$res_..._K` → row `K-1`), since `columnVars` order need
-        // not be row order.
+        // residual row (`SimVar.index`), since the listing order need not be row
+        // order. Seeds are likewise placed at their column index.
         use openmodelica_backend_types::BackendDAE::VarKind;
-        let n = seed_offs.len();
-        let mut result_offs = vec![0u32; n];
-        for sv in lst(&col.columnVars) {
+        let n = listed_offs.len();
+        let seed_offs = jac_seed_offs_by_column(jm, &listed_offs, n)
+            .ok_or_else(|| "CodegenWasmJit: nonlinear-system Jacobian seed columns are not a permutation")?;
+        let mut result_offs = vec![u32::MAX; n];
+        for sv in &jac_column_vars(jm) {
             let off = cursor;
             cursor += 8;
             var_map.vars.insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
             if matches!(sv.varKind, VarKind::JAC_VAR) {
-                let row = jac_result_row(&sv.name)
+                let row = jac_result_row(sv)
                     .filter(|&r| r < n)
                     .ok_or_else(|| "CodegenWasmJit: nonlinear-system Jacobian result var has no row index")?;
                 result_offs[row] = off;
             }
+        }
+        if result_offs.contains(&u32::MAX) {
+            return Err("CodegenWasmJit: nonlinear-system Jacobian is missing a residual row");
         }
         infos.insert(sys.index, NlsJacInfo { seed_offs, result_offs });
     }
@@ -4212,8 +4472,7 @@ fn lin_jac_scratch_f64(sim_code: &SimCode::SimCode) -> u32 {
     let mut total = 0u32;
     for sys in lin_jac_systems(sim_code) {
         let jm = sys.jacobianMatrix.as_ref().unwrap();
-        let col = lst(&jm.columns).next().unwrap();
-        total += count(&jm.seedVars) as u32 + count(&col.columnVars) as u32;
+        total += count(&jm.seedVars) as u32 + jac_column_vars(jm).len() as u32;
     }
     total
 }
@@ -4230,8 +4489,7 @@ fn build_lin_jac_infos(
     let mut cursor = layout.nls_jac_off + nls_jac_scratch_f64(sim_code) * 8;
     for sys in lin_jac_systems(sim_code) {
         let jm = sys.jacobianMatrix.as_ref().unwrap();
-        let col = lst(&jm.columns).next().unwrap();
-        for sv in lst(&jm.seedVars).chain(lst(&col.columnVars)) {
+        for sv in lst(&jm.seedVars).chain(jac_column_vars(jm).iter()) {
             var_map.vars.insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
             cursor += 8;
         }
@@ -4245,16 +4503,17 @@ fn build_lin_jac_infos(
 fn lin_jac_offsets(lsystem: &SimCode::LinearSystem, vars: &HashMap<String, SimSlot>, n: usize) -> Result<(Vec<u32>, Vec<u32>)> {
     use openmodelica_backend_types::BackendDAE::VarKind;
     let jm = lsystem.jacobianMatrix.as_ref().ok_or("CodegenWasmJit: torn-linear system has no Jacobian")?;
-    let col = lst(&jm.columns).next().ok_or("CodegenWasmJit: torn-linear Jacobian has no column")?;
     let lookup = |cr: &Arc<DAE::ComponentRef>| -> Result<u32> {
         let key = sim_cref_key(cr)?;
         Ok(vars.get(&key).ok_or("CodegenWasmJit: torn-linear Jacobian slot not registered")?.off)
     };
-    let seed_offs: Vec<u32> = lst(&jm.seedVars).map(|sv| lookup(&sv.name)).collect::<Result<_>>()?;
+    let listed: Vec<u32> = lst(&jm.seedVars).map(|sv| lookup(&sv.name)).collect::<Result<_>>()?;
+    let seed_offs = jac_seed_offs_by_column(jm, &listed, n)
+        .ok_or("CodegenWasmJit: torn-linear Jacobian seed columns are not a permutation")?;
     let mut result_offs = vec![u32::MAX; n];
-    for sv in lst(&col.columnVars) {
+    for sv in &jac_column_vars(jm) {
         if matches!(sv.varKind, VarKind::JAC_VAR) {
-            let row = jac_result_row(&sv.name).filter(|&r| r < n)
+            let row = jac_result_row(sv).filter(|&r| r < n)
                 .ok_or("CodegenWasmJit: torn-linear Jacobian result var has no row index")?;
             result_offs[row] = lookup(&sv.name)?;
         }
@@ -4302,8 +4561,8 @@ fn lin_jac_csc_pattern(lsystem: &SimCode::LinearSystem, n: usize) -> Option<(Vec
     let jm = lsystem.jacobianMatrix.as_ref()?;
     let col = lst(&jm.columns).next()?;
     let mut seed_col: HashMap<String, usize> = HashMap::new();
-    for (j, sv) in lst(&jm.seedVars).enumerate() {
-        seed_col.insert(sim_cref_key(&sv.name).ok()?, j);
+    for sv in lst(&jm.seedVars) {
+        seed_col.insert(sim_cref_key(&sv.name).ok()?, usize::try_from(sv.index).ok()?);
     }
     let mut dep: HashMap<String, Vec<usize>> = HashMap::new();
     for eq in lst(&col.constantEqns) {
@@ -4314,13 +4573,16 @@ fn lin_jac_csc_pattern(lsystem: &SimCode::LinearSystem, n: usize) -> Option<(Vec
     }
     // Column c (iteration var) gets residual row r whenever result r depends on seed c.
     let mut cols: Vec<Vec<i32>> = vec![Vec::new(); n];
-    for sv in lst(&col.columnVars) {
+    for sv in &jac_column_vars(jm) {
         if !matches!(sv.varKind, VarKind::JAC_VAR) {
             continue;
         }
-        let r = jac_result_row(&sv.name).filter(|&r| r < n)?;
+        let r = jac_result_row(sv).filter(|&r| r < n)?;
         if let Some(ds) = dep.get(&sim_cref_key(&sv.name).ok()?) {
             for &c in ds {
+                if c >= n {
+                    return None;
+                }
                 cols[c].push(r as i32);
             }
         }
@@ -4444,10 +4706,21 @@ fn build_nls_fns(
                 }
                 Ok(())
             };
-            emit_nls_jac_body(
-                &mut ctx, &slots, &info.seed_offs, &info.result_offs,
-                &mut lower_inner, &mut lower_constant, &mut lower_column,
-            )?;
+            // Colored CSC assembly (C's `evalJacobian`) whenever the symbolic
+            // sparsity is available: `#colors` column-equation passes instead of
+            // `n`, into CSC values for a sparse system or a dense `n×n` otherwise.
+            match nls_jac_pattern(jm, slots.len()) {
+                Some(pat) => emit_nls_jac_csc_body(
+                    &mut ctx, &slots, &info.seed_offs, &info.result_offs,
+                    &pat.colptr, &pat.rowidx, &pat.colors,
+                    !nls_use_sparse(slots.len(), pat.rowidx.len()),
+                    &mut lower_inner, &mut lower_constant, &mut lower_column,
+                )?,
+                None => emit_nls_jac_body(
+                    &mut ctx, &slots, &info.seed_offs, &info.result_offs,
+                    &mut lower_inner, &mut lower_constant, &mut lower_column,
+                )?,
+            }
             Some(finish(ctx))
         }
         _ => None,
@@ -4462,9 +4735,15 @@ fn build_nls_fns(
 /// (`fn_indices[k] = (residual, load, jac)`). `rt_solve_nls` reads these indices
 /// back via the global (see `emit_solve_nls_call`). Also `rt_alloc`s the
 /// extrapolation-history block (`hist_bytes`) into `NLS_HIST_GLOBAL`.
-fn emit_nls_start(f: &mut we::Function, fn_indices: &[(u32, u32, Option<u32>)], hist_bytes: u32, nominals: &[f64]) {
+fn emit_nls_start(
+    f: &mut we::Function,
+    fn_indices: &[(u32, u32, Option<u32>)],
+    hist_bytes: u32,
+    nominals: &[f64],
+    patterns: &[i32],
+) {
     use we::Instruction as I;
-    use crate::CodegenWasmJitFunctions::NLS_NOMINAL_GLOBAL;
+    use crate::CodegenWasmJitFunctions::{NLS_NOMINAL_GLOBAL, NLS_PAT_GLOBAL};
     // history block (zeroed by rt_alloc, so every system's count starts 0).
     if hist_bytes > 0 {
         f.instruction(&I::I32Const(hist_bytes as i32));
@@ -4481,6 +4760,18 @@ fn emit_nls_start(f: &mut we::Function, fn_indices: &[(u32, u32, Option<u32>)], 
             f.instruction(&I::GlobalGet(NLS_NOMINAL_GLOBAL));
             f.instruction(&I::F64Const((*nom).into()));
             f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg((i * 8) as u32, 3)));
+        }
+    }
+    // sparse-pattern block: the concatenated `colptr`/`rowidx` of every system
+    // solved sparsely, indexed by each job's `pat_off`.
+    if !patterns.is_empty() {
+        f.instruction(&I::I32Const((patterns.len() * 4) as i32));
+        f.instruction(&I::Call(rt_index("rt_alloc").expect("rt_alloc is a runtime builtin")));
+        f.instruction(&I::GlobalSet(NLS_PAT_GLOBAL));
+        for (i, v) in patterns.iter().enumerate() {
+            f.instruction(&I::GlobalGet(NLS_PAT_GLOBAL));
+            f.instruction(&I::I32Const(*v));
+            f.instruction(&I::I32Store(crate::CodegenWasmJitFunctions::mem_arg((i * 4) as u32, 2)));
         }
     }
     // base = table.grow(null, 3n) — returns the old size (the growable table's max

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -398,7 +398,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
     ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
@@ -415,10 +415,10 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
 pub(crate) const NLS_BASE_GLOBAL: u32 = 0;
 
 /// Module global holding the base index this module's closure thunks were
-/// appended to the shared table at (set by `start`): after the three
+/// appended to the shared table at (set by `start`): after the four
 /// nonlinear-solver globals, or the only global when there are none.
 pub(crate) fn closure_base_global(has_nls: bool) -> u32 {
-    if has_nls { NLS_NOMINAL_GLOBAL + 1 } else { 0 }
+    if has_nls { NLS_PAT_GLOBAL + 1 } else { 0 }
 }
 
 /// Absolute wasm function index of a runtime import (after all [`BUILTINS`]).
@@ -1045,6 +1045,13 @@ pub(crate) struct NlsJob {
     pub(crate) has_jac: bool,
     /// C's `NONLINEAR_SYSTEM_DATA::mixedSystem`: the residual branches on discretes.
     pub(crate) mixed: bool,
+    /// Nonzero count of the Jacobian's CSC pattern when the system is solved
+    /// sparsely (C's kinsol+KLU choice), else 0: the `nls_jac` callback then fills
+    /// `nnz` CSC values instead of a dense `n×n` matrix.
+    pub(crate) nnz: u32,
+    /// Byte offset of this system's `colptr`/`rowidx` pattern into the pattern
+    /// block (`NLS_PAT_GLOBAL`); only meaningful when `nnz != 0`.
+    pub(crate) pat_off: u32,
 }
 
 /// Bytes of extrapolation history a system with `n` unknowns needs: a count
@@ -1061,6 +1068,10 @@ pub(crate) const NLS_HIST_GLOBAL: u32 = 1;
 /// Model global holding the base address of the NLS nominal block (`n` `f64`
 /// per system, filled with codegen-time constants by `start`).
 pub(crate) const NLS_NOMINAL_GLOBAL: u32 = 2;
+
+/// Model global holding the base address of the sparse-NLS pattern block
+/// (`colptr[n+1]` then `rowidx[nnz]`, `i32`, per sparsely-solved system).
+pub(crate) const NLS_PAT_GLOBAL: u32 = 3;
 
 /// The contiguous `SimData` slot range backing one scalarized array model
 /// variable. The backend lays an array's scalar elements out consecutively in
@@ -4420,10 +4431,10 @@ pub(crate) mod closures;
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
-    LSS_MAX_DENSITY, LSS_MIN_SIZE, NlsResidual, compile_linear_system,
-    compile_linear_system_analytic, compile_linear_system_analytic_csc,
-    compile_linear_system_symbolic, emit_nls_jac_body, emit_nls_load_body,
-    emit_nls_residual_body, emit_solve_nls_call, lin_use_sparse,
+    LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual,
+    compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
+    compile_linear_system_symbolic, emit_nls_jac_body, emit_nls_jac_csc_body, emit_nls_load_body,
+    emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring, lin_use_sparse, nls_use_sparse,
 };
 
 fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -222,6 +222,287 @@ pub(crate) fn emit_nls_jac_body(
     Ok(())
 }
 
+/// Emit the body of a nonlinear system's colored `jac(sim_data, x, out)` callback,
+/// mirroring C's `evalJacobian` (`simulation/jacobian_util.c`): the CSC pattern
+/// `colptr`/`rowidx` and the column `colors` come from the symbolic Jacobian, one
+/// color is seeded at a time, the column equations run once per color, and each
+/// column of the color reads its pattern nonzeros out of the result slots. `out`
+/// receives the `nnz` CSC values when `dense_out` is false, else a column-major
+/// `n×n` matrix. The column body is emitted once inside a wasm loop, so the code
+/// size is independent of `n` (unlike [`emit_nls_jac_body`]).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn emit_nls_jac_csc_body(
+    ctx: &mut FnCtx,
+    iter_slots: &[u32],
+    seed_offs: &[u32],
+    result_offs: &[u32],
+    colptr: &[i32],
+    rowidx: &[i32],
+    colors: &[Vec<u32>],
+    dense_out: bool,
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_constant: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let n = iter_slots.len();
+    let nnz = rowidx.len();
+    if seed_offs.len() != n || result_offs.len() != n || colptr.len() != n + 1 {
+        return Err("CodegenWasmJit: nonlinear-system CSC Jacobian size mismatch");
+    }
+    let ncolors = colors.len();
+    // color_ptr/color_cols: color `c` owns `color_cols[color_ptr[c]..color_ptr[c+1]]`.
+    let mut color_ptr = vec![0i32; ncolors + 1];
+    let mut color_cols: Vec<i32> = Vec::with_capacity(n);
+    for (c, cols) in colors.iter().enumerate() {
+        color_cols.extend(cols.iter().map(|&j| j as i32));
+        color_ptr[c + 1] = color_cols.len() as i32;
+    }
+
+    for (j, &off) in iter_slots.iter().enumerate() {
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::LocalGet(1));
+        ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
+        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    }
+    lower_inner(ctx)?;
+    lower_constant(ctx)?;
+
+    // Scratch index tables (i32): colptr | rowidx | seed_tab | res_tab |
+    // color_ptr | color_cols.
+    let colptr_off: u32 = 0;
+    let rowidx_off: u32 = ((n + 1) * 4) as u32;
+    let seed_tab_off: u32 = rowidx_off + (nnz * 4) as u32;
+    let res_tab_off: u32 = seed_tab_off + (n * 4) as u32;
+    let colorptr_off: u32 = res_tab_off + (n * 4) as u32;
+    let colorcols_off: u32 = colorptr_off + ((ncolors + 1) * 4) as u32;
+    let scratch_bytes: u32 = colorcols_off + (color_cols.len() * 4) as u32;
+    let base = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(scratch_bytes as i32));
+    ctx.emit(I::Call(rt_index("rt_alloc")?));
+    ctx.emit(I::LocalSet(base));
+    let store_i32 = |ctx: &mut FnCtx, off: u32, v: i32| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(v));
+        ctx.emit(I::I32Store(mem_arg(off, 2)));
+    };
+    for (k, &p) in colptr.iter().enumerate() {
+        store_i32(ctx, colptr_off + (k as u32) * 4, p);
+    }
+    for (k, &r) in rowidx.iter().enumerate() {
+        store_i32(ctx, rowidx_off + (k as u32) * 4, r);
+    }
+    for (k, &soff) in seed_offs.iter().enumerate() {
+        store_i32(ctx, seed_tab_off + (k as u32) * 4, soff as i32);
+    }
+    for (i, &roff) in result_offs.iter().enumerate() {
+        store_i32(ctx, res_tab_off + (i as u32) * 4, roff as i32);
+    }
+    for (k, &p) in color_ptr.iter().enumerate() {
+        store_i32(ctx, colorptr_off + (k as u32) * 4, p);
+    }
+    for (k, &j) in color_cols.iter().enumerate() {
+        store_i32(ctx, colorcols_off + (k as u32) * 4, j);
+    }
+
+    let cloc = ctx.alloc_temp(WTy::I32);
+    let mloc = ctx.alloc_temp(WTy::I32);
+    let mend = ctx.alloc_temp(WTy::I32);
+    let jloc = ctx.alloc_temp(WTy::I32);
+    let kloc = ctx.alloc_temp(WTy::I32);
+    let kend = ctx.alloc_temp(WTy::I32);
+
+    // Dense output keeps structural zeros at 0 (C memsets before the color loop).
+    if dense_out {
+        ctx.emit(I::I32Const(0));
+        ctx.emit(I::LocalSet(kloc));
+        ctx.emit(I::Block(we::BlockType::Empty));
+        ctx.emit(I::Loop(we::BlockType::Empty));
+        ctx.emit(I::LocalGet(kloc));
+        ctx.emit(I::I32Const((n * n) as i32));
+        ctx.emit(I::I32GeS);
+        ctx.emit(I::BrIf(1));
+        ctx.emit(I::LocalGet(2));
+        ctx.emit(I::LocalGet(kloc));
+        ctx.emit(I::I32Const(8));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::F64Const(0.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(0, 3)));
+        ctx.emit(I::LocalGet(kloc));
+        ctx.emit(I::I32Const(1));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::LocalSet(kloc));
+        ctx.emit(I::Br(0));
+        ctx.emit(I::End);
+        ctx.emit(I::End);
+    }
+    for &soff in seed_offs {
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::F64Const(0.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(soff, 3)));
+    }
+
+    // `data + seed_tab[idx]`, the seed slot at run-time column index `idx`.
+    let push_seed_addr = |ctx: &mut FnCtx, idx: u32| {
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(idx));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(seed_tab_off, 2)));
+        ctx.emit(I::I32Add);
+    };
+    let load_colorptr = |ctx: &mut FnCtx, dst: u32, addc: i32| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(cloc));
+        if addc != 0 {
+            ctx.emit(I::I32Const(addc));
+            ctx.emit(I::I32Add);
+        }
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(colorptr_off, 2)));
+        ctx.emit(I::LocalSet(dst));
+    };
+    let load_j = |ctx: &mut FnCtx| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(mloc));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(colorcols_off, 2)));
+        ctx.emit(I::LocalSet(jloc));
+    };
+
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(cloc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(cloc));
+    ctx.emit(I::I32Const(ncolors as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // seed every column of the color.
+    load_colorptr(ctx, mloc, 0);
+    load_colorptr(ctx, mend, 1);
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::LocalGet(mend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    load_j(ctx);
+    push_seed_addr(ctx, jloc);
+    ctx.emit(I::F64Const(1.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(mloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    lower_column(ctx)?;
+    // read each column's pattern nonzeros, then clear its seed.
+    load_colorptr(ctx, mloc, 0);
+    load_colorptr(ctx, mend, 1);
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::LocalGet(mend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    load_j(ctx);
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(colptr_off, 2)));
+    ctx.emit(I::LocalSet(kloc));
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(jloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(colptr_off, 2)));
+    ctx.emit(I::LocalSet(kend));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::LocalGet(kend));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    // destination address: out + nz*8 (CSC) or out + (j*n + row)*8 (dense).
+    ctx.emit(I::LocalGet(2));
+    if dense_out {
+        ctx.emit(I::LocalGet(jloc));
+        ctx.emit(I::I32Const(n as i32));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(kloc));
+        ctx.emit(I::I32Const(4));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Load(mem_arg(rowidx_off, 2)));
+        ctx.emit(I::I32Add);
+    } else {
+        ctx.emit(I::LocalGet(kloc));
+    }
+    ctx.emit(I::I32Const(8));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    // value = f64[data + res_tab[rowidx[k]]].
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(rowidx_off, 2)));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(res_tab_off, 2)));
+    ctx.emit(I::LocalGet(0));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::F64Load(mem_arg(0, 3)));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(kloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(kloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    push_seed_addr(ctx, jloc);
+    ctx.emit(I::F64Const(0.0f64.into()));
+    ctx.emit(I::F64Store(mem_arg(0, 3)));
+    ctx.emit(I::LocalGet(mloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(mloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+    ctx.emit(I::LocalGet(cloc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(cloc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
+
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    Ok(())
+}
+
 /// Lower a torn linear system `A x = b` by residual probing (the fallback when the
 /// system has no usable symbolic Jacobian; see `compile_linear_system_analytic`).
 /// `r(x) = A x - b` for a linear system, so `b_i = -r_i(0)` and
@@ -613,7 +894,7 @@ pub(crate) fn compile_linear_system_analytic(
 /// can be seeded at once and its nonzeros read from a single column-eqn pass. Returns
 /// `(color_ptr, color_cols)`: color `c` owns `color_cols[color_ptr[c]..color_ptr[c+1]]`.
 /// Cuts the analytic-assembly passes from `n` to `#colors` (≈ max row degree).
-fn lin_jac_coloring(colptr: &[i32], rowidx: &[i32], n: usize) -> (Vec<i32>, Vec<i32>) {
+pub(crate) fn lin_jac_coloring(colptr: &[i32], rowidx: &[i32], n: usize) -> (Vec<i32>, Vec<i32>) {
     let nrows = rowidx.iter().copied().max().map_or(0, |m| m as usize + 1);
     let mut row_cols: Vec<Vec<u32>> = vec![Vec::new(); nrows];
     for j in 0..n {
@@ -947,6 +1228,22 @@ pub(crate) fn lin_use_sparse(size: usize, nnz: usize) -> bool {
     (nnz as f64) < LSS_MAX_DENSITY * (size * size) as f64 || size > LSS_MIN_SIZE
 }
 
+/// C's nonlinear sparse-solver selection (`nonlinearSystem.c`
+/// `initializeNonlinearSystemData`): kinsol+KLU when the density is below
+/// `nlssMaxDensity` (default 0.1) or the size exceeds `nlssMinSize` (default 1000).
+pub(crate) const NLSS_MAX_DENSITY: f64 = 0.1;
+pub(crate) const NLSS_MIN_SIZE: usize = 1000;
+pub(crate) fn nls_use_sparse(size: usize, nnz: usize) -> bool {
+    (nnz as f64) / ((size * size) as f64) < NLSS_MAX_DENSITY || size > NLSS_MIN_SIZE
+}
+
+/// Cache key for a sparse nonlinear system's reused symbolic factorization. Torn
+/// linear systems key on their (non-negative) equation index, so the top bit keeps
+/// the two families apart in the runtime's one `rt_solve_lin_sparse_cached` cache.
+pub(crate) fn nls_lss_handle(k: u32) -> u32 {
+    0x8000_0000 | k
+}
+
 /// Lower a `SES_LINEAR` system given symbolically as `A x = b` from `simJac`/`beqs`
 /// (the C runtime's `setLinearMatrixA`/`setLinearVectorb`): `a_entries` are the
 /// nonzero elements `(row, col, exp)` (0-based, column-major); `b_exps` the dense
@@ -1178,6 +1475,18 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::I32Add);
     ctx.emit(I::I32Const(n_rel as i32));
     ctx.emit(I::I32Const(job.mixed as i32));
+    // Sparse systems: this system's `colptr`/`rowidx` in the pattern block, its
+    // nonzero count, and the cache key for the reused symbolic factorization.
+    // `nnz == 0` selects the dense solver ladder (`jac` fills an `n×n` matrix).
+    if job.nnz != 0 {
+        ctx.emit(I::GlobalGet(NLS_PAT_GLOBAL));
+        ctx.emit(I::I32Const(job.pat_off as i32));
+        ctx.emit(I::I32Add);
+    } else {
+        ctx.emit(I::I32Const(0));
+    }
+    ctx.emit(I::I32Const(job.nnz as i32));
+    ctx.emit(I::I32Const(nls_lss_handle(job.k) as i32));
     ctx.emit(I::Call(rt_index("rt_solve_nls")?));
     ctx.emit(I::Drop);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2174,10 +2174,25 @@ pub extern "C" fn rt_solve_lin_sparse_cached(
     n: u32,
     nnz: u32,
 ) -> i32 {
+    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    lin_sparse_cached(handle, colptr, rowidx, values, b_ptr, n, nnz)
+}
+
+/// [`rt_solve_lin_sparse_cached`] without the statistics counter — the sparse
+/// nonlinear solver's inner factorizations are kinsol/KLU solves in C, which the
+/// `### STATISTICS ###` "linear system solves" line does not count.
+pub(crate) fn lin_sparse_cached(
+    handle: u32,
+    colptr: u32,
+    rowidx: u32,
+    values: u32,
+    b_ptr: u32,
+    n: u32,
+    nnz: u32,
+) -> i32 {
     let n = n as usize;
     let nnz = nnz as usize;
 
-    LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     // Native interactive runtime: the host solves natively (cheap crossings).
     #[cfg(all(target_os = "wasi", feature = "host_lin_solve"))]
     {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1107,6 +1107,181 @@ fn newton_c(
     }
 }
 
+/// KINSOL function-norm / scaled-step stopping tolerances (C's `newtonFTol` /
+/// `newtonXTol`, `model_help.c`) and the norm below which C accepts a less
+/// accurate solution rather than failing (`FTOL_WITH_LESS_ACCURACY`).
+const KIN_FNORMTOL: f64 = 1.0e-12;
+const KIN_SCSTEPTOL: f64 = 1.0e-12;
+const KIN_FTOL_LESS_ACCURACY: f64 = 1.0e-6;
+
+/// `‖diag(scale)·v‖∞`, the norm KINSOL's stopping tests use.
+fn scaled_max_norm(v: &[f64], scale: &[f64]) -> f64 {
+    let mut m = 0.0f64;
+    for (a, s) in v.iter().zip(scale) {
+        let t = libm::fabs(a * s);
+        if !(t <= m) {
+            m = t;
+        }
+    }
+    m
+}
+
+/// The sparse (kinsol + KLU) nonlinear solver: a scaled Newton iteration with a
+/// line search over the symbolic Jacobian assembled straight into CSC, factorized
+/// by the runtime's sparse LU with its symbolic analysis cached per system.
+/// Mirrors C's `nlsKinsolSolve`: `xScale[i] = 1/max(nominal_i, |x_i|)`,
+/// `fScale[i] = 1/max_j |J_ij / xScale_j|`, convergence on `‖fScale·F‖∞ ≤ ftol`
+/// or a scaled step below `scsteptol`, and the same retry ladder
+/// (`nlsKinsolErrorHandler`) of start point / scaling / line-search variations.
+///
+/// `pat_addr` holds the compile-time pattern (`colptr[n+1]` then `rowidx[nnz]`),
+/// `val_ptr` the `nnz` values the model's `jac` callback fills, and `handle` keys
+/// the cached factorization.
+#[allow(clippy::too_many_arguments)]
+fn kinsol_sparse_solve(
+    n: usize,
+    x: &mut [f64],
+    guess: &[f64],
+    warm: &[f64],
+    nominal: &[f64],
+    sim_data: u32,
+    x_ptr: u32,
+    jac_idx: u32,
+    val_ptr: u32,
+    pat_addr: u32,
+    nnz: usize,
+    handle: u32,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    let colptr_addr = pat_addr;
+    let rowidx_addr = pat_addr + ((n + 1) * 4) as u32;
+    let colptr: alloc::vec::Vec<usize> =
+        (0..=n).map(|k| unsafe { load_u32(colptr_addr + (k * 4) as u32) } as usize).collect();
+    let rowidx: alloc::vec::Vec<usize> =
+        (0..nnz).map(|k| unsafe { load_u32(rowidx_addr + (k * 4) as u32) } as usize).collect();
+    let b_ptr = rt_alloc((n * 8) as u32);
+
+    let mut vals = vec![0.0f64; nnz];
+    let assemble = |xs: &[f64], vals: &mut [f64]| {
+        let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
+        for i in 0..n {
+            unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
+        }
+        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+        jacf(sim_data, x_ptr, val_ptr);
+        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        for (k, v) in vals.iter_mut().enumerate() {
+            *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
+        }
+    };
+
+    let mut f = vec![0.0f64; n];
+    let mut xscale = vec![1.0f64; n];
+    let mut fscale = vec![1.0f64; n];
+    let mut xnew = vec![0.0f64; n];
+    let mut dx = vec![0.0f64; n];
+
+    // `(start from the last accepted values, scaled, line search)` per attempt;
+    // attempt 0 is kinsol's configured default, the rest are C's retry ladder.
+    const ATTEMPTS: [(bool, bool, bool); 5] = [
+        (false, true, true),
+        (false, false, true),
+        (true, true, true),
+        (false, true, false),
+        (true, false, true),
+    ];
+    let mut solved = false;
+    for &(from_warm, scaled, linesearch) in ATTEMPTS.iter() {
+        x.copy_from_slice(if from_warm { warm } else { guess });
+        for i in 0..n {
+            xscale[i] = if scaled { 1.0 / libm::fmax(nominal[i], libm::fabs(x[i])) } else { 1.0 };
+        }
+        // f scaling from the column-scaled Jacobian at the entry point.
+        for s in fscale.iter_mut() {
+            *s = 1.0;
+        }
+        if scaled {
+            assemble(x, &mut vals);
+            let mut rowmax = vec![1.0e-12f64; n];
+            for c in 0..n {
+                for k in colptr[c]..colptr[c + 1] {
+                    let v = libm::fabs(vals[k] / xscale[c]);
+                    if v > rowmax[rowidx[k]] {
+                        rowmax[rowidx[k]] = v;
+                    }
+                }
+            }
+            for i in 0..n {
+                fscale[i] = 1.0 / rowmax[i];
+            }
+        }
+
+        eval(x, &mut f);
+        let mut fnorm = scaled_max_norm(&f, &fscale);
+        for _ in 0..100 * n {
+            if !fnorm.is_finite() {
+                break;
+            }
+            if fnorm <= KIN_FNORMTOL {
+                solved = true;
+                break;
+            }
+            assemble(x, &mut vals);
+            for i in 0..n {
+                unsafe { store_f64(b_ptr + (i * 8) as u32, -f[i]) };
+            }
+            if crate::lin_sparse_cached(
+                handle, colptr_addr, rowidx_addr, val_ptr, b_ptr, n as u32, nnz as u32,
+            ) != 0
+            {
+                break; // singular: next attempt
+            }
+            for i in 0..n {
+                dx[i] = unsafe { load_f64(b_ptr + (i * 8) as u32) };
+            }
+            // Damped step: halve until the scaled residual improves (kinsol's
+            // KIN_LINESEARCH; KIN_NONE takes the full step).
+            let mut lambda = 1.0f64;
+            let mut fnew;
+            loop {
+                for i in 0..n {
+                    xnew[i] = x[i] + lambda * dx[i];
+                }
+                eval(&xnew, &mut f);
+                fnew = scaled_max_norm(&f, &fscale);
+                if !linesearch || fnew < fnorm || lambda <= LAMBDA_MIN {
+                    break;
+                }
+                lambda *= 0.5;
+            }
+            // KIN_STEP_LT_STPTOL: a step this small cannot improve the iterate.
+            let mut step = 0.0f64;
+            for i in 0..n {
+                let d = libm::fabs(lambda * dx[i]) / libm::fmax(libm::fabs(x[i]), 1.0 / xscale[i]);
+                if !(d <= step) {
+                    step = d;
+                }
+            }
+            x.copy_from_slice(&xnew);
+            fnorm = fnew;
+            if step <= KIN_SCSTEPTOL {
+                solved = fnorm < KIN_FTOL_LESS_ACCURACY;
+                break;
+            }
+        }
+        if !solved && fnorm.is_finite() && fnorm < KIN_FTOL_LESS_ACCURACY {
+            // C's "move forward with a less accurate solution".
+            solved = true;
+        }
+        if solved {
+            break;
+        }
+    }
+    rt_free(b_ptr);
+    solved
+}
+
 /// The `load` callback copies the current unknown slots into `x` (warm start);
 /// `residual` writes `x` back into the slots, runs the inner (torn) equations,
 /// and evaluates the residuals into `r`. On convergence the slots (and torn
@@ -1136,6 +1311,9 @@ pub extern "C" fn rt_solve_nls(
     rel_addr: u32,
     n_rel: u32,
     mixed: u32,
+    pat_addr: u32,
+    nnz: u32,
+    lss_handle: u32,
 ) -> i32 {
     let n = n as usize;
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
@@ -1188,9 +1366,12 @@ pub extern "C" fn rt_solve_nls(
     };
 
     // Analytic Jacobian callback: `jac(sim_data, x, jptr)` fills a column-major
-    // `n×n` matrix. `u32::MAX` means none, so numeric `hybrd` is used.
+    // `n×n` matrix, or the `nnz` CSC values when the system is solved sparsely.
+    // `u32::MAX` means none, so numeric `hybrd` is used.
     let has_jac = jac_idx != u32::MAX;
-    let jac_ptr = if has_jac { rt_alloc((n * n * 8) as u32) } else { 0 };
+    let sparse = has_jac && nnz != 0;
+    let jac_len = if sparse { nnz as usize } else { n * n };
+    let jac_ptr = if has_jac { rt_alloc((jac_len * 8) as u32) } else { 0 };
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
         for i in 0..n {
@@ -1202,8 +1383,8 @@ pub extern "C" fn rt_solve_nls(
         jacf(sim_data, x_ptr, jac_ptr);
         NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
         NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
-        for k in 0..n * n {
-            fj[k] = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
+        for (k, v) in fj.iter_mut().enumerate() {
+            *v = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
         }
     };
 
@@ -1251,75 +1432,86 @@ pub extern "C" fn rt_solve_nls(
     } else if saved_rel_fresh == 0 {
         unsafe { store_u32(rel_fresh_addr, 0) };
     }
-    // hybrj (analytic Jacobian) when available, else numeric hybrd; on failure
-    // retry from the warm start, then Newton and LM.
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
-    let mut solve = |x: &mut [f64], fvec: &mut [f64]| {
-        if has_jac {
-            hybrj_scaled(n, x, fvec, &nominal, maxfev, &mut eval, &mut jaceval)
-        } else {
-            hybrd_scaled(n, x, fvec, &nominal, maxfev, &mut eval)
+    // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
+    // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
+    // O(n^3) per step, which is what the sparse choice exists to avoid.
+    let mut converged = if sparse {
+        kinsol_sparse_solve(
+            n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
+            pat_addr, nnz as usize, lss_handle, &mut eval,
+        )
+    } else {
+        // hybrj (analytic Jacobian) when available, else numeric hybrd; on failure
+        // retry from the warm start, then Newton and LM.
+        let mut solve = |x: &mut [f64], fvec: &mut [f64]| {
+            if has_jac {
+                hybrj_scaled(n, x, fvec, &nominal, maxfev, &mut eval, &mut jaceval)
+            } else {
+                hybrd_scaled(n, x, fvec, &nominal, maxfev, &mut eval)
+            }
+        };
+        let mut converged = solve(&mut x, &mut fvec);
+        if !converged {
+            x.copy_from_slice(&warm);
+            converged = solve(&mut x, &mut fvec);
         }
+        drop(solve);
+        if !converged {
+            x.copy_from_slice(&warm);
+            converged = newton_solve(n, &mut x, &mut eval);
+        }
+        // C's init ladder: newtonAlgorithm, then solveHybrd (retry ladder) from x0.
+        if !converged && saved_rel_fresh == 2 {
+            x.copy_from_slice(&guess);
+            converged = newton_c(n, &mut x, &nominal, &mut eval, &mut jaceval, has_jac);
+        }
+        if !converged && saved_rel_fresh == 2 {
+            x.copy_from_slice(&guess);
+            converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+        }
+        // Seed collapsed zero unknowns (e.g. the spring-loop s_rel) to nominal, off the
+        // degenerate residual plateau, then re-solve — C's "zero start values to nominal".
+        if !converged && saved_rel_fresh == 2 {
+            x.copy_from_slice(&guess);
+            for i in 0..n {
+                if x[i] == 0.0 {
+                    x[i] = nominal[i];
+                }
+            }
+            converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+        }
+        // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
+        if !converged {
+            converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+        }
+        if !converged {
+            x.copy_from_slice(&guess);
+            converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+        }
+        if !converged {
+            x.copy_from_slice(&guess);
+            converged = lm_solve(n, &mut x, &mut eval);
+        }
+        if !converged {
+            x.copy_from_slice(&warm);
+            converged = lm_solve(n, &mut x, &mut eval);
+        }
+        // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
+        if !converged && saved_rel_fresh == 2 {
+            // Forward then reversed start direction, as C's runHomotopy.
+            for &dir in &[1.0f64, -1.0f64] {
+                let mut hx = guess.clone();
+                if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
+                    x.copy_from_slice(&hx);
+                    converged = true;
+                    break;
+                }
+            }
+        }
+        converged
     };
-    let mut converged = solve(&mut x, &mut fvec);
-    if !converged {
-        x.copy_from_slice(&warm);
-        converged = solve(&mut x, &mut fvec);
-    }
-    drop(solve);
-    if !converged {
-        x.copy_from_slice(&warm);
-        converged = newton_solve(n, &mut x, &mut eval);
-    }
-    // C's init ladder: newtonAlgorithm, then solveHybrd (retry ladder) from x0.
-    if !converged && saved_rel_fresh == 2 {
-        x.copy_from_slice(&guess);
-        converged = newton_c(n, &mut x, &nominal, &mut eval, &mut jaceval, has_jac);
-    }
-    if !converged && saved_rel_fresh == 2 {
-        x.copy_from_slice(&guess);
-        converged = hybrd_c(n, &mut x, &nominal, &mut eval);
-    }
-    // Seed collapsed zero unknowns (e.g. the spring-loop s_rel) to nominal, off the
-    // degenerate residual plateau, then re-solve — C's "zero start values to nominal".
-    if !converged && saved_rel_fresh == 2 {
-        x.copy_from_slice(&guess);
-        for i in 0..n {
-            if x[i] == 0.0 {
-                x[i] = nominal[i];
-            }
-        }
-        converged = hybrd_c(n, &mut x, &nominal, &mut eval);
-    }
-    // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
-    if !converged {
-        converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-    }
-    if !converged {
-        x.copy_from_slice(&guess);
-        converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-    }
-    if !converged {
-        x.copy_from_slice(&guess);
-        converged = lm_solve(n, &mut x, &mut eval);
-    }
-    if !converged {
-        x.copy_from_slice(&warm);
-        converged = lm_solve(n, &mut x, &mut eval);
-    }
-    // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
-    if !converged && saved_rel_fresh == 2 {
-        // Forward then reversed start direction, as C's runHomotopy.
-        for &dir in &[1.0f64, -1.0f64] {
-            let mut hx = guess.clone();
-            if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
-                x.copy_from_slice(&hx);
-                converged = true;
-                break;
-            }
-        }
-    }
     if converged {
         // Leave the slots + torn variables at the solution. C's `solveHomotopy`: a
         // mixed system at an event re-checks the relations live at the solution and,
@@ -1329,7 +1521,12 @@ pub extern "C" fn rt_solve_nls(
             eval(&x, &mut scratch);
             if (0..n_rel).any(|i| unsafe { load_u32(rel_addr + i * 4) } != rel_backup[i as usize]) {
                 let held = core::mem::replace(&mut x, warm.clone());
-                let ok = if has_jac {
+                let ok = if sparse {
+                    kinsol_sparse_solve(
+                        n, &mut x, &warm, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
+                        pat_addr, nnz as usize, lss_handle, &mut eval,
+                    )
+                } else if has_jac {
                     hybrj_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval, &mut jaceval)
                 } else {
                     hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -48,10 +48,10 @@ pub struct SimModel {
     pub var_units: HashMap<String, String>,
     /// Driver-facing metadata shared with the in-wasm driver (passed to `sim_driver::drive`).
     pub meta: SimMeta,
-    /// Pre-rendered `LOG_STDOUT` lines announcing which torn linear systems use the
-    /// sparse solver (C's `initializeLinearSystems` messages), prepended to the sim
-    /// log. Empty when no system is sparse.
-    pub sparse_lss_log: String,
+    /// Pre-rendered `LOG_STDOUT` lines announcing which linear and nonlinear systems
+    /// use a sparse solver (C's `initializeLinearSystems` / `initializeNonlinearSystems`
+    /// messages), prepended to the sim log. Empty when no system is sparse.
+    pub sparse_solver_log: String,
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,


### PR DESCRIPTION
The new backend keeps a symbolic Jacobian's seed/result/temporary variables in the matrix' `crefsHT` and leaves `columnVars` holding only the temporaries, so `nls_jac_usable`/`lin_jac_usable` never found a `JAC_VAR` and every new-backend system fell back to a numerical Jacobian.  Reading the variables from `crefsHT` (and taking a result row from `SimVar.index`, which is what the C template indexes `resultVars[]` with) makes the analytic Jacobian reachable again.

On top of that, mirror C's per-system solver choice. `initialResizableAnalyticJacobian` builds the CSC pattern from the `sparsityMatrix` rows: column = the seed's index, row = the solved `$pDER` cref's index.  Deriving the same pattern at codegen time gives both the density rule of `initializeNonlinearSystemData` (`nlssMaxDensity` 0.1 / `nlssMinSize` 1000, with the matching `LOG_STDOUT` announcements) and a colored assembly: `evalJacobian`'s one seeded pass per color, into CSC values for a sparse system or a dense n*n otherwise, emitted once inside a wasm loop rather than unrolled per column.

`rt_solve_nls` gains the sparse branch: a scaled Newton iteration with a line search over that CSC Jacobian, factorized by the runtime's sparse LU with the symbolic analysis cached per system, and C's `nlsKinsolSolve` retry ladder of start point / scaling / line-search variations.  The dense hybrj/hybrd/LM ladder stays for everything else.

`jac_lowerable` keeps array-valued Jacobians (whole-dimension seeds, sliced results) on the numerical path, since only C's run-time loops can assemble those.

ScalableTestSuite DistributionSystemModelicaIndividual_N_10_M_10 (one 519x519 nonlinear system, 1246 nonzeros, 4 colors) goes from 866 s to 0.17 s of simulation time and now matches the reference log.