### PR TITLE
wasm-jit: KLU sparse solver and runtime flags

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -213,7 +213,12 @@ list(APPEND CARGO_ENV
      # ModelicaExternalC C-Sources dir, so openmodelica_codegen_wasm_jit's build.rs
      # can compile the ModelicaExternalC WASI side module (modelicaexternalc.wasm) —
      # the crate builds from a synced copy (rust-src) whose relative path can't reach it.
-     "OMC_EXTERNAL_C_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../SimulationRuntime/ModelicaExternalC/C-Sources")
+     "OMC_EXTERNAL_C_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../SimulationRuntime/ModelicaExternalC/C-Sources"
+     # Same reason for the vendored solver sources: build.rs cross-compiles SUNDIALS
+     # and SuiteSparse/KLU to wasm (their own CMake, a wasi toolchain file) for the
+     # wasip1 wasm-jit runtimes.
+     "OMC_SUNDIALS_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0"
+     "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1")
 
 # wasi-libc source (pinned wasi-sdk-32) for build.rs to build a -fPIC libc.so
 # (Debian's is non-PIC), passed as OMC_WASI_LIBC_SRC. Download failure is a WARNING,

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -155,11 +155,13 @@ openmodelica_codegen_wasm_jit_runtime/.gitignore
 openmodelica_codegen_wasm_jit_runtime/Cargo.lock
 openmodelica_codegen_wasm_jit_runtime/Cargo.toml
 openmodelica_codegen_wasm_jit_runtime/build-runtime.sh
+openmodelica_codegen_wasm_jit_runtime/build.rs
 openmodelica_codegen_wasm_jit_runtime/src/delay.rs
 openmodelica_codegen_wasm_jit_runtime/src/lib.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls.rs
 openmodelica_codegen_wasm_jit_runtime/src/session.rs
 openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
 openmodelica_fmi3_wasm/Cargo.lock
 openmodelica_fmi3_wasm/Cargo.toml
 openmodelica_fmi3_wasm/src/lib.rs
@@ -219,6 +221,7 @@ openmodelica_scripting_qt/src/lib.rs
 openmodelica_sim_meta/Cargo.toml
 openmodelica_sim_meta/src/driver.rs
 openmodelica_sim_meta/src/lib.rs
+openmodelica_sim_meta/src/simflags.rs
 openmodelica_simcode_types/Cargo.toml
 openmodelica_simcode_util/Cargo.toml
 openmodelica_susan/Cargo.toml

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -66,6 +66,7 @@ use crate::CodegenWasmJitFunctions::{
 // defined once in `openmodelica_sim_meta` and shared with the in-wasm driver, so
 // the emitted module and the driver's readback cannot drift. Aliased to their
 // historical host names.
+use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{
     FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind, MetaVar as ResultVar, SimMeta,
     StateSetInfo,
@@ -514,22 +515,39 @@ fn run_wasmtime_inner(_prefix: &str, _result_file: &str, _simflags: &str) -> Res
 // output — Modelica `Streams.print`, `ModelicaMessage`, …) alongside the result.
 // Capturing keeps that output out of the process stdout (the browser console on
 // the web target) so the caller can fold it into the simulation log.
-/// Parse `-override=name=value,...` tokens out of `simflags` and resolve each to
-/// its editable parameter's `SimData` slot. Unknown names / unparsable values are
-/// skipped (an unknown override is a no-op, as in the C runtime).
+/// What the wasm-jit runtimes can serve, for `simflags::check`. Checked at the host
+/// parse, where a rejection still has a message channel to report on.
+const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
+    klu: openmodelica_wasm_jit::SUNDIALS,
+    ida: false,
+    cvode: false,
+    gbode: false,
+};
+
+/// Parse `simflags` as an argv and install the result for this run. omc hands the
+/// flags over as one whitespace-separated string; `argv[0]` stands in for the
+/// program name a WASI command would see, so the same parser serves this path and a
+/// standalone `wasmtime model.wasm …` run.
+fn install_sim_flags(simflags: &str) -> std::result::Result<simflags::SimFlags, String> {
+    let argv: Vec<String> = core::iter::once("model".to_string())
+        .chain(simflags.split_whitespace().map(str::to_string))
+        .collect();
+    let f = simflags::parse(&argv)?;
+    simflags::check(&f, CAPABILITIES)?;
+    simflags::set_flags(f.clone());
+    Ok(f)
+}
+
+/// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
+/// Unknown names are skipped (an unknown override is a no-op, as in the C runtime).
 /// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
 /// values, applied at different points of initialization (see `run_initialization`).
-fn resolve_overrides(model: &SimModel, simflags: &str) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
+fn resolve_overrides(model: &SimModel, flags: &simflags::SimFlags) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
     let mut params = Vec::new();
     let mut starts = Vec::new();
-    for tok in simflags.split_whitespace() {
-        let Some(list) = tok.strip_prefix("-override=") else { continue };
-        for item in list.split(',') {
-            let Some((name, value)) = item.split_once('=') else { continue };
-            let Ok(val) = value.trim().parse::<f64>() else { continue };
-            if let Some(p) = model.editable_params.iter().find(|p| p.name == name.trim()) {
-                if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, val));
-            }
+    for (name, val) in &flags.overrides {
+        if let Some(p) = model.editable_params.iter().find(|p| &p.name == name) {
+            if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, *val));
         }
     }
     (params, starts)
@@ -568,14 +586,19 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     let Some(model) = model else {
         return (Err("no prepared wasm-jit model for (translateModel not run?)".to_string()), None, String::new());
     };
+    // The caller prefixes the failure, so this is the bare reason.
+    let flags = match install_sim_flags(simflags) {
+        Ok(f) => f,
+        Err(e) => return (Err(e), None, String::new()),
+    };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
-    let log_stats = simflags.contains("LOG_STATS") || simflags.contains("LOG_ALL");
+    let log_stats = flags.has_log("LOG_STATS");
     // `-override=name=value,...`: resolve each editable parameter to its SimData
     // slot and hand the list to the driver (applied after `functionParameters`).
-    let (param_ov, start_ov) = resolve_overrides(&model, simflags);
+    let (param_ov, start_ov) = resolve_overrides(&model, &flags);
     sim_driver::set_param_overrides(param_ov, start_ov);
     // `-abortSlowSimulation`: stop the run when chattering is detected.
-    sim_driver::set_abort_slow(simflags.split_whitespace().any(|t| t == "-abortSlowSimulation"));
+    sim_driver::set_abort_slow(flags.abort_slow);
     INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
     sim_driver::set_init_done_hook(on_init_done);
     SPLIT_ARMED.with(|a| a.set(true));
@@ -719,7 +742,11 @@ mod session {
         if fmt != "mat" && fmt != "empty" {
             return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)");
         }
-        let (param_ov, start_ov) = resolve_overrides(&model, simflags);
+        let flags = install_sim_flags(simflags).map_err(|e| {
+            record_error(format!("wasm-jit: {e}"));
+            "CodegenWasmJit: unusable simulation flags"
+        })?;
+        let (param_ov, start_ov) = resolve_overrides(&model, &flags);
         sim_driver::set_param_overrides(param_ov, start_ov);
         sim_driver::clear_cancel();
         openmodelica_wasi::wasi::start_stdout_capture();
@@ -5166,6 +5193,7 @@ mod standalone_tests {
             "functionStateSetJacobians",
             "functionInitialEquations_lambda0",
             "functionUpdateRelations",
+            "functionCheckAsserts",
             "functionStoreDelayed",
             "functionInitDelay",
         ];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1251,8 +1251,8 @@ pub(crate) fn nls_lss_handle(k: u32) -> u32 {
 /// residual probing. Solve `A x = b`, write each `x_j` back into its slot, then
 /// (torn systems) run `inner` to recover the non-iteration torn variables.
 ///
-/// Dense (`rt_linsolve`, LAPACK-like) or sparse (`rt_solve_lin_sparse`, KLU-like
-/// AMD-ordered CSC LU) per [`lin_use_sparse`], matching C's per-system choice.
+/// Dense (`rt_linsolve`) or sparse (`rt_solve_lin_sparse_cached`) per
+/// [`lin_use_sparse`], matching C's per-system choice.
 pub(crate) fn compile_linear_system_symbolic(
     ctx: &mut FnCtx,
     vars: &[Arc<DAE::ComponentRef>],
@@ -1260,7 +1260,7 @@ pub(crate) fn compile_linear_system_symbolic(
     a_entries: &[(usize, usize, &Arc<DAE::Exp>)],
     b_exps: &[&Arc<DAE::Exp>],
     inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
-    _index: i32,
+    index: i32,
 ) -> Result<()> {
     use we::Instruction as I;
     if n == 0 {
@@ -1337,7 +1337,10 @@ pub(crate) fn compile_linear_system_symbolic(
             ctx.emit(I::F64Store(mem_arg(values_off + (k as u32) * 8, 3)));
         }
         emit_b_exps(ctx, base, b_off, b_exps)?;
-        // rt_solve_lin_sparse(colptr, rowidx, values, b, n, nnz).
+        // rt_solve_lin_sparse_cached(handle, colptr, rowidx, values, b, n, nnz). The
+        // pattern is a compile-time constant, so the system index keys the runtime's
+        // cache and the symbolic factorization is computed once per run, as in C.
+        ctx.emit(I::I32Const(index));
         ctx.emit(I::LocalGet(base)); // colptr (off 0)
         ctx.emit(I::LocalGet(base));
         ctx.emit(I::I32Const(rowidx_off as i32));
@@ -1350,7 +1353,7 @@ pub(crate) fn compile_linear_system_symbolic(
         ctx.emit(I::I32Add);
         ctx.emit(I::I32Const(n as i32));
         ctx.emit(I::I32Const(nnz as i32));
-        ctx.emit(I::Call(rt_index("rt_solve_lin_sparse")?));
+        ctx.emit(I::Call(rt_index("rt_solve_lin_sparse_cached")?));
     } else {
         // Dense layout: A (n*n column-major) | b (n).
         let a_off: u32 = 0;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
@@ -1,0 +1,51 @@
+//! Links the wasm SUNDIALS/KLU archives into the wasip1 runtimes when
+//! `openmodelica_codegen_wasm_jit`'s build script has cross-compiled them
+//! (`OMC_SUNDIALS_WASM_DIR`), and sets `cfg(sundials)` so `src/sundials.rs` and its
+//! callers compile in. Absent archives are not an error: the runtime then keeps
+//! using its pure-Rust solvers, and a raw `cargo build` of this crate still works.
+
+use std::path::Path;
+
+/// Archives in link order: each entry may only depend on later ones. `wasm-ld`
+/// resolves archives in the order given, so a wrong order is an undefined symbol.
+const LIBS: &[&str] = &[
+    "sundials_kinsol",
+    "sundials_ida",
+    "sundials_cvode",
+    "sundials_sunlinsolklu",
+    "sundials_sunlinsoldense",
+    "sundials_sunmatrixsparse",
+    "sundials_sunmatrixdense",
+    "sundials_nvecserial",
+    "klu",
+    "amd",
+    "colamd",
+    "btf",
+    "suitesparseconfig",
+];
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(sundials)");
+    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
+
+    // wasip1 only: the no_std JIT runtime (wasm32-unknown-unknown) has no libc for
+    // SUNDIALS to call, and the host `cargo test` build links nothing.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("wasi") {
+        return;
+    }
+    let Ok(dir) = std::env::var("OMC_SUNDIALS_WASM_DIR") else { return };
+    let lib = Path::new(&dir).join("lib");
+    let missing: Vec<_> = LIBS.iter()
+        .filter(|l| !lib.join(format!("lib{l}.a")).exists())
+        .collect();
+    if !missing.is_empty() {
+        println!("cargo:warning=OMC_SUNDIALS_WASM_DIR={} is missing {missing:?}; building \
+                  without SUNDIALS", lib.display());
+        return;
+    }
+    println!("cargo:rustc-link-search=native={}", lib.display());
+    for l in LIBS {
+        println!("cargo:rustc-link-lib=static={l}");
+    }
+    println!("cargo:rustc-cfg=sundials");
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -42,6 +42,10 @@ extern crate alloc;
 
 mod delay;
 mod nls;
+// SUNDIALS/KLU. The archives are wasip1-only (they need a libc) and only linked
+// when the build script found them, so `cfg(sundials)` gates the calls; the module
+// itself compiles everywhere for its capability report.
+mod sundials;
 
 use alloc::format;
 use alloc::string::String;
@@ -2018,12 +2022,6 @@ pub extern "C" fn rt_sim_store_row(buf: u32, row: u32, sim_data: u32, n_reals: u
 // algorithm class as LAPACK's `dgesv`, so results track the C target closely.
 // ---------------------------------------------------------------------------
 
-/// Solve the dense `n`×`n` system `A x = b` in place: `A` is `a_ptr` as `n*n`
-/// f64 in **column-major** order, `b` is `b_ptr` as `n` f64. On success `b ← x`
-/// and 0 is returned; 1 only when the system is genuinely unsolvable.
-///
-/// LU with partial pivoting first (like C's `dgesv`); on a singular matrix a
-/// total-pivot search runs as fallback, mirroring C's `LS_DEFAULT`.
 /// Count of linear-system solves in the current run (every dense + sparse path).
 /// The session resets it per run via [`reset_lin_solves`]; surfaced in `LOG_STATS`.
 static LIN_SOLVES: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
@@ -2035,10 +2033,27 @@ pub fn reset_lin_solves() {
     LIN_SOLVES.store(0, core::sync::atomic::Ordering::Relaxed);
 }
 
+/// [`lin_solves`] for a host driving the model itself, which has no session and so
+/// no `rt_sim_stat` to read the counter from.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_lin_solves() -> u64 {
+    lin_solves()
+}
+
+/// Solve the dense `n`×`n` system `A x = b` in place: `A` is `a_ptr` as `n*n`
+/// f64 in **column-major** order, `b` is `b_ptr` as `n` f64. On success `b ← x`
+/// and 0 is returned; 1 only when the system is genuinely unsolvable.
+///
+/// LU with partial pivoting (like C's `dgesv`), then a total-pivot search on a
+/// singular matrix, mirroring C's `LS_DEFAULT`; `-ls=klu` uses KLU instead.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
+    #[cfg(sundials)]
+    if sundials::ls_is_klu() {
+        return sundials::klu_solve_dense(a_ptr, b_ptr, n);
+    }
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
     let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
     if nls::lu_solve(a, b, n) || nls::total_pivot_solve(a, b, n) {
@@ -2097,12 +2112,17 @@ pub extern "C" fn rt_solve_lin_sparse(colptr: u32, rowidx: u32, values: u32, b_p
     }
 }
 
-/// Solve `A x = b` from a dense column-major `A` (`a_ptr`, `n*n` f64): scan its
-/// structural nonzeros into CSC, then [`rt_solve_lin_sparse`]. 0 ok, 1 singular.
+/// Solve `A x = b` from a dense column-major `A` (`a_ptr`, `n*n` f64) with the
+/// `-lss` solver: its structural nonzeros are scanned into CSC first. There is no
+/// system handle, so nothing is cached. 0 ok, 1 singular.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_solve_lin_dense_sparse(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
+    #[cfg(sundials)]
+    if sundials::lss_backend() == sundials::Sparse::Klu {
+        return sundials::klu_solve_dense(a_ptr, b_ptr, n);
+    }
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
 
     #[cfg(all(target_os = "wasi", feature = "inwasm_solve"))]
@@ -2162,8 +2182,8 @@ thread_local! {
         core::cell::RefCell::new(std::collections::HashMap::new());
 }
 
-/// Like [`rt_solve_lin_sparse`] but reuses the cached symbolic analysis for `handle`
-/// (pattern read only to seed the cache on the first call).
+/// Solve the CSC system with the `-lss` solver, reusing `handle`'s cached symbolic
+/// analysis (the pattern is read only to seed the cache on the first call).
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_solve_lin_sparse_cached(
     handle: u32,
@@ -2175,12 +2195,13 @@ pub extern "C" fn rt_solve_lin_sparse_cached(
     nnz: u32,
 ) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-    lin_sparse_cached(handle, colptr, rowidx, values, b_ptr, n, nnz)
+    lin_sparse_cached(handle, colptr, rowidx, values, b_ptr, n, nnz, sundials::lss_backend())
 }
 
 /// [`rt_solve_lin_sparse_cached`] without the statistics counter — the sparse
 /// nonlinear solver's inner factorizations are kinsol/KLU solves in C, which the
-/// `### STATISTICS ###` "linear system solves" line does not count.
+/// `### STATISTICS ###` "linear system solves" line does not count. `backend` is
+/// the caller's selector: `-lss` here, `-nlsLS` inside the nonlinear solver.
 pub(crate) fn lin_sparse_cached(
     handle: u32,
     colptr: u32,
@@ -2189,9 +2210,17 @@ pub(crate) fn lin_sparse_cached(
     b_ptr: u32,
     n: u32,
     nnz: u32,
+    backend: sundials::Sparse,
 ) -> i32 {
     let n = n as usize;
     let nnz = nnz as usize;
+
+    #[cfg(sundials)]
+    if backend == sundials::Sparse::Klu {
+        return sundials::klu_solve_cached(handle, colptr, rowidx, values, b_ptr, n, nnz);
+    }
+    #[cfg(not(sundials))]
+    let _ = backend;
 
     // Native interactive runtime: the host solves natively (cheap crossings).
     #[cfg(all(target_os = "wasi", feature = "host_lin_solve"))]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -28,6 +28,35 @@ pub extern "C" fn rt_nls_note_assert() {
     NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
 }
 
+/// `Default` is the density-based choice plus the full retry ladder.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NlsPick {
+    Default,
+    Hybrid,
+    Kinsol,
+    Newton,
+    Mixed,
+    Homotopy,
+}
+
+/// Without `session`/`standalone` there is no flag store to read (the FMI3 adapter).
+#[cfg(any(feature = "session", feature = "standalone"))]
+fn nls_pick() -> NlsPick {
+    use openmodelica_sim_meta::simflags::Nls;
+    match openmodelica_sim_meta::simflags::flags().nls {
+        None => NlsPick::Default,
+        Some(Nls::Hybrid) => NlsPick::Hybrid,
+        Some(Nls::Kinsol) => NlsPick::Kinsol,
+        Some(Nls::Newton) => NlsPick::Newton,
+        Some(Nls::Mixed) => NlsPick::Mixed,
+        Some(Nls::Homotopy) => NlsPick::Homotopy,
+    }
+}
+#[cfg(not(any(feature = "session", feature = "standalone")))]
+fn nls_pick() -> NlsPick {
+    NlsPick::Default
+}
+
 /// sqrt(DBL_EPSILON): the classic forward-difference relative step.
 const SQRT_EPS: f64 = 1.4901161193847656e-08;
 /// Newton/LM convergence tolerance: stop once a residual / step measure drops below.
@@ -1233,6 +1262,7 @@ fn kinsol_sparse_solve(
             }
             if crate::lin_sparse_cached(
                 handle, colptr_addr, rowidx_addr, val_ptr, b_ptr, n as u32, nnz as u32,
+                crate::sundials::nls_ls_backend(),
             ) != 0
             {
                 break; // singular: next attempt
@@ -1434,6 +1464,14 @@ pub extern "C" fn rt_solve_nls(
     }
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
+    // `-nls=` overrides the codegen-time density choice; the dense solvers force
+    // the dense path.
+    let pick = nls_pick();
+    let sparse = match pick {
+        NlsPick::Default => sparse,
+        NlsPick::Kinsol => sparse,
+        _ => false,
+    };
     // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
     // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
     // O(n^3) per step, which is what the sparse choice exists to avoid.
@@ -1442,9 +1480,29 @@ pub extern "C" fn rt_solve_nls(
             n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
             pat_addr, nnz as usize, lss_handle, &mut eval,
         )
+    } else if pick == NlsPick::Newton {
+        let mut ok = newton_c(n, &mut x, &nominal, &mut eval, &mut jaceval, has_jac);
+        if !ok {
+            x.copy_from_slice(&warm);
+            ok = newton_solve(n, &mut x, &mut eval);
+        }
+        ok
+    } else if pick == NlsPick::Homotopy {
+        // Both start directions, as C's runHomotopy.
+        let mut ok = false;
+        for &dir in &[1.0f64, -1.0] {
+            let mut hx = guess.clone();
+            if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
+                x.copy_from_slice(&hx);
+                ok = true;
+                break;
+            }
+        }
+        ok
     } else {
         // hybrj (analytic Jacobian) when available, else numeric hybrd; on failure
-        // retry from the warm start, then Newton and LM.
+        // retry from the warm start, then Newton and LM. `-nls=hybrid` and `mixed`
+        // land here too: this ladder is minpack-first with the homotopy tail.
         let mut solve = |x: &mut [f64], fvec: &mut [f64]| {
             if has_jac {
                 hybrj_scaled(n, x, fvec, &nominal, maxfev, &mut eval, &mut jaceval)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -17,6 +17,7 @@ use core::cell::UnsafeCell;
 
 use openmodelica_sim_meta::WTy;
 use openmodelica_sim_meta::driver::{self, Advance, Driver, SimEngine};
+use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{SimMeta, SolveStats};
 
 // Host imports for the per-chunk budget clock and the cooperative cancel poll.
@@ -36,42 +37,16 @@ fn cancel_hook() -> bool {
     unsafe { rt_host_cancel() != 0 }
 }
 
-// Fixed table-slot order the host populates (relative to `fn_base`). The runtime
-// reaches slot `s` via `call_indirect(fn_base + s)`. Absent exports (optional
-// hooks, or functions a model without events/state-sets does not emit) get a
-// cleared `present_mask` bit.
-const SLOT_PARAMETERS: u32 = 0;
-const SLOT_INIT_START: u32 = 1;
-const SLOT_INIT_EQ: u32 = 2;
-const SLOT_ODE: u32 = 3;
-const SLOT_ALGEBRAICS: u32 = 4;
-const SLOT_STATE_SET_JAC: u32 = 5;
-const SLOT_ZERO_CROSSINGS: u32 = 6;
-const SLOT_INIT_SAMPLE: u32 = 7;
-const SLOT_SIMULATE: u32 = 8;
-const SLOT_EXT_DESTRUCT: u32 = 9;
-const SLOT_INIT_EQ_LAMBDA0: u32 = 10;
-const SLOT_UPDATE_RELATIONS: u32 = 11;
-/// Number of table slots the host must populate (in the order above). The host
-/// (a separate crate) mirrors this count and order in its table wiring.
+// Table-slot order the host populates (relative to `fn_base`): a function's slot is
+// its index in `driver::MODEL_FNS`, the one list both sides derive from. The runtime
+// reaches slot `s` via `call_indirect(fn_base + s)`; an export the model does not
+// have gets a cleared `present_mask` bit.
+/// Number of table slots the host must populate, in `MODEL_FNS` order.
 #[allow(dead_code)]
-pub const N_SLOTS: u32 = 12;
+pub const N_SLOTS: u32 = driver::MODEL_FNS.len() as u32;
 
 fn slot_of(name: &str) -> Option<u32> {
-    Some(match name {
-        "functionParameters" => SLOT_PARAMETERS,
-        "functionInitStartValues" => SLOT_INIT_START,
-        "functionInitialEquations" => SLOT_INIT_EQ,
-        "functionInitialEquations_lambda0" => SLOT_INIT_EQ_LAMBDA0,
-        "functionODE" => SLOT_ODE,
-        "functionAlgebraics" => SLOT_ALGEBRAICS,
-        "functionStateSetJacobians" => SLOT_STATE_SET_JAC,
-        "functionZeroCrossings" => SLOT_ZERO_CROSSINGS,
-        "initSample" => SLOT_INIT_SAMPLE,
-        "callExternalObjectDestructors" => SLOT_EXT_DESTRUCT,
-        "functionUpdateRelations" => SLOT_UPDATE_RELATIONS,
-        _ => return None,
-    })
+    driver::MODEL_FNS.iter().position(|&n| n == name).map(|i| i as u32)
 }
 
 /// In-wasm [`SimEngine`]: linear memory is directly addressable (the runtime *is*
@@ -122,10 +97,11 @@ impl SimEngine for InWasmEngine {
         Ok(())
     }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
-        if !self.present(SLOT_SIMULATE) {
+        let slot = slot_of("simulate").ok_or("in-wasm engine: `simulate` has no table slot")?;
+        if !self.present(slot) {
             return Err("in-wasm engine: no `simulate` export");
         }
-        let idx = self.fn_base + SLOT_SIMULATE;
+        let idx = self.fn_base + slot;
         let f: extern "C" fn(u32, f64, f64, u32) -> u32 = unsafe { core::mem::transmute(idx as usize) };
         Ok(f(sim_data, start, stop, n_steps))
     }
@@ -158,6 +134,27 @@ static SESSION: SessionCell = SessionCell(UnsafeCell::new(None));
 
 fn session() -> &'static mut Option<Session> {
     unsafe { &mut *SESSION.0.get() }
+}
+
+/// Set the runtime flags for the next [`rt_sim_start`] from an argv blob in the
+/// WASI `args_get` layout (NUL-terminated strings back to back, `argv[0]` the
+/// program name). Returns 0, or -1 if a flag is malformed or asks for something
+/// this runtime cannot do — the host parses the same argv with the same code, so
+/// it reports *which* flag without a second error channel.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_set_args(ptr: u32, len: u32) -> i32 {
+    let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    let argv = simflags::argv_from_bytes(bytes);
+    match simflags::parse(&argv).and_then(|f| {
+        simflags::check(&f, crate::sundials::capabilities()).map(|()| f)
+    }) {
+        Ok(f) => {
+            crate::sundials::apply_flags(&f);
+            simflags::set_flags(f);
+            0
+        }
+        Err(_) => -1,
+    }
 }
 
 /// Set the parameter/start overrides for the next [`rt_sim_start`]. The host's own
@@ -204,6 +201,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     // Any prior session is dropped (frees its buffers) before starting a new one.
     *session() = None;
     crate::reset_lin_solves();
+    crate::sundials::reset_caches();
 
     let bytes = unsafe { core::slice::from_raw_parts(meta_ptr as *const u8, meta_len as usize) };
     let model = match openmodelica_sim_meta::decode(bytes) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -26,6 +26,7 @@
 
 use openmodelica_mat_writer::{MatKind, MatVar};
 use openmodelica_sim_meta::driver::{self, SimEngine};
+use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{self as meta, MetaKind, SimMeta};
 
 // Model exports, resolved by wasm-merge (module "model"). Calls are unsafe; a
@@ -43,6 +44,9 @@ unsafe extern "C" {
     fn functionStateSetJacobians(sim_data: u32);
     fn functionZeroCrossings(sim_data: u32);
     fn functionUpdateRelations(sim_data: u32);
+    fn functionCheckAsserts(sim_data: u32);
+    fn functionStoreDelayed(sim_data: u32);
+    fn functionInitDelay(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
@@ -94,6 +98,9 @@ impl SimEngine for StandaloneEngine {
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
                 "functionZeroCrossings" => functionZeroCrossings(arg),
                 "functionUpdateRelations" => functionUpdateRelations(arg),
+                "functionCheckAsserts" => functionCheckAsserts(arg),
+                "functionStoreDelayed" => functionStoreDelayed(arg),
+                "functionInitDelay" => functionInitDelay(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("wasm-jit standalone: unknown model function"),
@@ -162,11 +169,25 @@ fn run() {
     std::fs::write(format!("{}_res.mat", m.prefix), bytes).expect("wasm-jit standalone: cannot write result file");
 }
 
-/// The command entry point. Runs wasi-libc ctors (preopen/stdio init) then the
-/// simulation. Exported by the cdylib; the merged module is a WASI command.
+/// The command entry point. Runs wasi-libc ctors (preopen/stdio init), takes the
+/// runtime flags off the command line, then simulates. The merged module is a WASI
+/// command, so `wasmtime model.wasm -nls=kinsol` arrives through `args_get`.
 #[unsafe(no_mangle)]
 pub extern "C" fn _start() {
     unsafe { __wasm_call_ctors() };
+    let argv: Vec<String> = std::env::args().collect();
+    match simflags::parse(&argv).and_then(|f| {
+        simflags::check(&f, crate::sundials::capabilities()).map(|()| f)
+    }) {
+        Ok(f) => {
+            crate::sundials::apply_flags(&f);
+            simflags::set_flags(f);
+        }
+        Err(e) => {
+            eprintln!("wasm-jit standalone: {e}");
+            core::arch::wasm32::unreachable()
+        }
+    }
     run();
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -1,0 +1,305 @@
+//! The real SUNDIALS/KLU, cross-compiled to wasm and linked in by `build.rs`
+//! (`cfg(sundials)`).
+//!
+//! Indices are `i32` (`SUNDIALS_INDEX_SIZE=32`, see the build script for why) and
+//! `sunrealtype` is `f64`.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Whether the real solvers are linked into this blob.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sundials_available() -> i32 {
+    cfg!(sundials) as i32
+}
+
+/// What this build can serve, for `simflags::check`.
+#[cfg(any(feature = "session", feature = "standalone"))]
+pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
+    openmodelica_sim_meta::simflags::Capabilities {
+        klu: cfg!(sundials),
+        ida: false,
+        cvode: false,
+        gbode: false,
+    }
+}
+
+// Solver selection, with C's defaults: dense systems go to LAPACK, sparse ones to
+// KLU (`-ls=lapack`, `-lss=klu`, `-nlsLS=klu`).
+
+static KLU_LS: AtomicBool = AtomicBool::new(false);
+static KLU_LSS: AtomicBool = AtomicBool::new(true);
+static KLU_NLS_LS: AtomicBool = AtomicBool::new(true);
+
+/// Which backend serves a sparse solve.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Sparse {
+    Klu,
+    Rsparse,
+}
+
+fn pick(klu: &AtomicBool) -> Sparse {
+    if cfg!(sundials) && klu.load(Ordering::Relaxed) {
+        Sparse::Klu
+    } else {
+        Sparse::Rsparse
+    }
+}
+
+/// `-lss`: torn linear systems solved sparsely.
+pub(crate) fn lss_backend() -> Sparse {
+    pick(&KLU_LSS)
+}
+
+/// `-nlsLS`: the linear solver inside the sparse nonlinear solver.
+pub(crate) fn nls_ls_backend() -> Sparse {
+    pick(&KLU_NLS_LS)
+}
+
+/// `-ls=klu`: dense-stored linear systems handed to KLU.
+pub(crate) fn ls_is_klu() -> bool {
+    cfg!(sundials) && KLU_LS.load(Ordering::Relaxed)
+}
+
+fn set_klu(ls: bool, lss: bool, nls_ls: bool) {
+    KLU_LS.store(ls, Ordering::Relaxed);
+    KLU_LSS.store(lss, Ordering::Relaxed);
+    KLU_NLS_LS.store(nls_ls, Ordering::Relaxed);
+}
+
+/// The three selectors for a host-driven run: that build links no flag store, so
+/// its host parses `-ls`/`-lss`/`-nlsLS` and sets the bits here.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_lin_set_klu(ls: i32, lss: i32, nls_ls: i32) {
+    set_klu(ls != 0, lss != 0, nls_ls != 0);
+}
+
+#[cfg(any(feature = "session", feature = "standalone"))]
+pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
+    let (ls, lss, nls_ls) = f.klu_selectors();
+    set_klu(ls, lss, nls_ls);
+}
+
+#[cfg(sundials)]
+unsafe extern "C" {
+    fn KINCreate() -> *mut core::ffi::c_void;
+    fn KINFree(kinmem: *mut *mut core::ffi::c_void);
+}
+
+/// Smoke test that the archives are linked and callable: `klu_defaults` reports
+/// success and its values land where [`klu::Common`] mirrors them, and KINSOL
+/// allocates.
+#[cfg(sundials)]
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sundials_selftest() -> i32 {
+    let common_ok = klu::Common::defaults().is_some();
+    let mut kin = unsafe { KINCreate() };
+    let kin_ok = !kin.is_null();
+    if kin_ok {
+        unsafe { KINFree(&mut kin) };
+    }
+    (common_ok && kin_ok) as i32
+}
+
+#[cfg(not(sundials))]
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sundials_selftest() -> i32 {
+    0
+}
+
+#[cfg(sundials)]
+pub(crate) mod klu {
+    use alloc::vec::Vec;
+    use core::ffi::c_void;
+
+    /// `klu_common` of the `SUNDIALS_INDEX_SIZE=32` build (`Int` = `int`), mirrored
+    /// rather than opaque because the factor/refactor decision reads `status` and
+    /// `rgrowth`. [`Common::defaults`] validates the layout against what
+    /// `klu_defaults` writes.
+    #[repr(C)]
+    pub struct Common {
+        pub tol: f64,
+        pub memgrow: f64,
+        pub initmem_amd: f64,
+        pub initmem: f64,
+        pub maxwork: f64,
+        pub btf: i32,
+        pub ordering: i32,
+        pub scale: i32,
+        pub user_order: *mut c_void,
+        pub user_data: *mut c_void,
+        pub halt_if_singular: i32,
+        pub status: i32,
+        pub nrealloc: i32,
+        pub structural_rank: i32,
+        pub numerical_rank: i32,
+        pub singular_col: i32,
+        pub noffdiag: i32,
+        pub flops: f64,
+        pub rcond: f64,
+        pub condest: f64,
+        pub rgrowth: f64,
+        pub work: f64,
+        pub memusage: usize,
+        pub mempeak: usize,
+    }
+
+    unsafe extern "C" {
+        pub fn klu_defaults(common: *mut Common) -> i32;
+        pub fn klu_analyze(n: i32, ap: *mut i32, ai: *mut i32, common: *mut Common) -> *mut c_void;
+        pub fn klu_factor(ap: *mut i32, ai: *mut i32, ax: *mut f64, symbolic: *mut c_void, common: *mut Common) -> *mut c_void;
+        pub fn klu_refactor(ap: *mut i32, ai: *mut i32, ax: *mut f64, symbolic: *mut c_void, numeric: *mut c_void, common: *mut Common) -> i32;
+        pub fn klu_rgrowth(ap: *mut i32, ai: *mut i32, ax: *mut f64, symbolic: *mut c_void, numeric: *mut c_void, common: *mut Common) -> i32;
+        pub fn klu_solve(symbolic: *mut c_void, numeric: *mut c_void, ldim: i32, nrhs: i32, b: *mut f64, common: *mut Common) -> i32;
+        pub fn klu_free_symbolic(symbolic: *mut *mut c_void, common: *mut Common) -> i32;
+        pub fn klu_free_numeric(numeric: *mut *mut c_void, common: *mut Common) -> i32;
+    }
+
+    impl Common {
+        /// `klu_defaults`, `None` if the values did not land where this mirror puts
+        /// them — a layout mismatch would otherwise show up as silent nonsense.
+        pub fn defaults() -> Option<Common> {
+            let mut c: Common = unsafe { core::mem::zeroed() };
+            if unsafe { klu_defaults(&mut c) } != 1 {
+                return None;
+            }
+            let laid_out = c.tol == 0.001
+                && c.initmem == 10.0
+                && c.btf == 1
+                && c.scale == 2
+                && c.halt_if_singular == 1
+                && c.status == 0
+                && c.structural_rank == -1
+                && c.rgrowth == -1.0
+                && c.memusage == 0;
+            laid_out.then_some(c)
+        }
+    }
+
+    /// C's `DATA_KLU` (`linearSolverKlu.c`): the symbolic analysis is done once per
+    /// system and reused, the numeric factorization refactored per solve. The
+    /// pattern is copied in because the caller's arrays live in a block that is
+    /// freed between solves; the values are only read, so they stay in place.
+    pub struct Solver {
+        common: Common,
+        symbolic: *mut c_void,
+        numeric: *mut c_void,
+        ap: Vec<i32>,
+        ai: Vec<i32>,
+    }
+
+    /// Below this reciprocal pivot growth the reused pivots are no longer good
+    /// enough and the factorization is redone (C's threshold).
+    const MIN_RGROWTH: f64 = 1e-3;
+
+    impl Solver {
+        pub fn new(n: usize, colptr: &[i32], rowidx: &[i32]) -> Option<Solver> {
+            let mut s = Solver {
+                common: Common::defaults()?,
+                symbolic: core::ptr::null_mut(),
+                numeric: core::ptr::null_mut(),
+                ap: colptr.to_vec(),
+                ai: rowidx.to_vec(),
+            };
+            s.symbolic = unsafe {
+                klu_analyze(n as i32, s.ap.as_mut_ptr(), s.ai.as_mut_ptr(), &mut s.common)
+            };
+            (!s.symbolic.is_null()).then_some(s)
+        }
+
+        /// Factorize with `values` (in the pattern's order) and solve `A x = b` in
+        /// place. `false` if the matrix is singular or a KLU call failed.
+        pub fn solve(&mut self, values: *const f64, b: *mut f64, n: usize) -> bool {
+            let ax = values as *mut f64;
+            let (ap, ai) = (self.ap.as_mut_ptr(), self.ai.as_mut_ptr());
+            if !self.numeric.is_null() {
+                let ok = unsafe {
+                    klu_refactor(ap, ai, ax, self.symbolic, self.numeric, &mut self.common) != 0
+                        && klu_rgrowth(ap, ai, ax, self.symbolic, self.numeric, &mut self.common) != 0
+                };
+                if !ok || self.common.rgrowth < MIN_RGROWTH {
+                    unsafe { klu_free_numeric(&mut self.numeric, &mut self.common) };
+                    self.numeric = core::ptr::null_mut();
+                }
+            }
+            if self.numeric.is_null() {
+                self.numeric = unsafe { klu_factor(ap, ai, ax, self.symbolic, &mut self.common) };
+            }
+            if self.numeric.is_null() || self.common.status != 0 {
+                return false;
+            }
+            unsafe { klu_solve(self.symbolic, self.numeric, n as i32, 1, b, &mut self.common) != 0 }
+        }
+    }
+
+    impl Drop for Solver {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.numeric.is_null() {
+                    klu_free_numeric(&mut self.numeric, &mut self.common);
+                }
+                klu_free_symbolic(&mut self.symbolic, &mut self.common);
+            }
+        }
+    }
+}
+
+#[cfg(sundials)]
+std::thread_local! {
+    /// One [`klu::Solver`] per system `handle`, so the symbolic analysis is done
+    /// once per run as it is in C.
+    static KLU_CACHE: core::cell::RefCell<std::collections::HashMap<u32, klu::Solver>> =
+        core::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Drop the per-system factorizations; their patterns belong to one run.
+pub(crate) fn reset_caches() {
+    #[cfg(sundials)]
+    KLU_CACHE.with(|c| c.borrow_mut().clear());
+}
+
+/// KLU solve of the CSC system `A x = b` (`b ← x`), reusing `handle`'s symbolic
+/// analysis. 0 solved, 1 singular.
+#[cfg(sundials)]
+pub(crate) fn klu_solve_cached(handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: usize, nnz: usize) -> i32 {
+    KLU_CACHE.with(|cell| {
+        let mut cache = cell.borrow_mut();
+        let entry = match cache.entry(handle) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                let colp = unsafe { core::slice::from_raw_parts(colptr as *const i32, n + 1) };
+                let rowi = unsafe { core::slice::from_raw_parts(rowidx as *const i32, nnz) };
+                match klu::Solver::new(n, colp, rowi) {
+                    Some(s) => slot.insert(s),
+                    None => return 1,
+                }
+            }
+        };
+        !entry.solve(values as *const f64, b_ptr as *mut f64, n) as i32
+    })
+}
+
+/// KLU solve of a dense column-major `A` (`n*n` f64 at `a_ptr`): scan the
+/// structural nonzeros into CSC and factorize from scratch, there being no system
+/// handle to cache under. 0 solved, 1 singular.
+#[cfg(sundials)]
+pub(crate) fn klu_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
+    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+    let mut colptr = alloc::vec::Vec::with_capacity(n + 1);
+    let mut rowidx = alloc::vec::Vec::new();
+    let mut values = alloc::vec::Vec::new();
+    colptr.push(0i32);
+    for col in 0..n {
+        for row in 0..n {
+            let v = a[col * n + row];
+            if v != 0.0 {
+                rowidx.push(row as i32);
+                values.push(v);
+            }
+        }
+        colptr.push(rowidx.len() as i32);
+    }
+    match klu::Solver::new(n, &colptr, &rowidx) {
+        Some(mut s) => !s.solve(values.as_ptr(), b_ptr as *mut f64, n) as i32,
+        None => 1,
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -182,6 +182,28 @@ fn run_state_selection(
     Ok(changed)
 }
 
+/// Every model entry point the drivers below may pass to [`SimEngine::call1`] /
+/// [`SimEngine::call1_if_present`], in the table-slot order the in-wasm session
+/// uses. The host's table wiring and the runtime's dispatch both derive from this,
+/// so they cannot disagree about which functions exist or where they sit.
+pub const MODEL_FNS: &[&str] = &[
+    "functionParameters",
+    "functionInitStartValues",
+    "functionInitialEquations",
+    "functionODE",
+    "functionAlgebraics",
+    "functionStateSetJacobians",
+    "functionZeroCrossings",
+    "initSample",
+    "simulate",
+    "callExternalObjectDestructors",
+    "functionInitialEquations_lambda0",
+    "functionUpdateRelations",
+    "functionCheckAsserts",
+    "functionStoreDelayed",
+    "functionInitDelay",
+];
+
 /// The per-run capabilities a backend must expose: read/write the instance's
 /// linear memory and call its exported functions. Object-safe so the drivers can
 /// take `&mut dyn SimEngine` (and the DASSL residual callback a `*mut dyn`).
@@ -211,6 +233,11 @@ pub trait SimEngine {
     /// emit C's `LOG_ASSERT` warnings. Default: none (backends without the import).
     fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
         Vec::new()
+    }
+    /// Linear-system solves the runtime performed in-wasm, which the host driver
+    /// never sees. Default: none (backends whose solver runs host-side).
+    fn lin_solves(&mut self) -> u64 {
+        0
     }
 }
 
@@ -1300,12 +1327,24 @@ pub fn set_zc_tolerance(
 /// Build the resumable driver (init + row 0 + the zero-crossing band); shared by
 /// [`drive`] and the session. `method` empty = DASSL. Any events force the
 /// event-aware DASSL driver regardless of `method`.
+/// `-s=` wins over the method compiled into the model's metadata. `ida`/`cvode`/
+/// `gbode` never reach here — `simflags::check` rejects them at startup rather than
+/// let them silently run as DASSL.
+pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
+    match crate::simflags::flags().solver {
+        Some(crate::simflags::Solver::Euler) => "euler",
+        Some(crate::simflags::Solver::Dassl) => "dassl",
+        _ => method,
+    }
+}
+
 pub fn make_driver(
     e: &mut (dyn SimEngine + 'static),
     model: &SimModel,
     sim_data: u32,
     method: &str,
 ) -> Result<(Box<dyn Driver>, &'static str)> {
+    let method = effective_method(method);
     let layout = &model.layout;
     set_zc_tolerance(e, sim_data, layout, model.tolerance)?;
 
@@ -1359,6 +1398,7 @@ pub fn drive(
 
     let mut stats = SolveStats::default();
     let use_events = layout.n_samples > 0 || layout.n_zc > 0;
+    let method = effective_method(method);
 
     let (rows, label) = if !use_events && method == "euler" && !host_driven {
         // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -25,6 +25,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub mod driver;
+pub mod simflags;
 
 /// Byte offset of `time` within `SimData`.
 pub const TIME_OFF: u32 = 0;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -1,0 +1,438 @@
+//! Runtime simulation flags, parsed from an **argv-shaped** list.
+//!
+//! One parser for every entry point. A wasip1 standalone module is a WASI command:
+//! its command line arrives through `args_sizes_get`/`args_get`, which
+//! `std::env::args()` reads. The interactive runtime is instantiated once and
+//! simulated many times, so its host hands the same argv over through
+//! `rt_sim_set_args`, in the byte layout `args_get` itself writes (the strings
+//! NUL-terminated back to back).
+//!
+//! Names and accepted values follow the C runtime's
+//! (`SimulationRuntime/c/util/simulation_options.c`). Every selector is an
+//! `Option`: `None` keeps the built-in default.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+/// `-s`
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Solver {
+    Dassl,
+    Ida,
+    Cvode,
+    Gbode,
+    Euler,
+}
+
+/// `-nls`
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Nls {
+    Hybrid,
+    Kinsol,
+    Newton,
+    Mixed,
+    Homotopy,
+}
+
+/// `-nlsLS`, the linear solver inside the nonlinear one. `Rsparse` is wasm-jit's
+/// own solver, not a C runtime value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NlsLs {
+    Default,
+    TotalPivot,
+    Lapack,
+    Klu,
+    Rsparse,
+}
+
+/// `-ls`
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Ls {
+    Default,
+    Lapack,
+    TotalPivot,
+    Klu,
+}
+
+/// `-lss`. `Rsparse` is wasm-jit's own solver, not a C runtime value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Lss {
+    Default,
+    Klu,
+    Rsparse,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SimFlags {
+    pub solver: Option<Solver>,
+    pub nls: Option<Nls>,
+    pub nls_ls: Option<NlsLs>,
+    pub ls: Option<Ls>,
+    pub lss: Option<Lss>,
+    /// `-lv` streams, uppercased.
+    pub log: Vec<String>,
+    pub abort_slow: bool,
+    /// `-override=name=value,…` unresolved: mapping a name to its `SimData` slot
+    /// needs the model, which only the caller has.
+    pub overrides: Vec<(String, f64)>,
+    /// Flags this runtime does not model, kept so a caller can report them.
+    pub unknown: Vec<String>,
+    /// The argv this was parsed from, so a host forwards the same bytes rather than
+    /// re-serializing a parsed form.
+    pub argv: Vec<String>,
+}
+
+impl SimFlags {
+    pub fn has_log(&self, stream: &str) -> bool {
+        self.log.iter().any(|s| s == stream || s == "LOG_ALL")
+    }
+
+    /// Which of `-ls`, `-lss` and `-nlsLS` ask for KLU, with C's defaults: dense
+    /// systems go to LAPACK, sparse ones to KLU. The unimplemented `-nlsLS` values
+    /// (`totalpivot`, `lapack`) land on `rsparse`.
+    pub fn klu_selectors(&self) -> (bool, bool, bool) {
+        (
+            self.ls == Some(Ls::Klu),
+            self.lss != Some(Lss::Rsparse),
+            !matches!(self.nls_ls, Some(NlsLs::Rsparse | NlsLs::TotalPivot | NlsLs::Lapack)),
+        )
+    }
+
+    /// [`argv`](Self::argv) in the WASI `args_get` layout, for `rt_sim_set_args`.
+    pub fn to_wasi_args(&self) -> Vec<u8> {
+        let mut b = Vec::new();
+        for a in &self.argv {
+            b.extend_from_slice(a.as_bytes());
+            b.push(0);
+        }
+        b
+    }
+}
+
+/// What the runtime can serve, so [`check`] fails an unsupported request at startup
+/// rather than running a different solver.
+#[derive(Clone, Copy, Debug)]
+pub struct Capabilities {
+    pub klu: bool,
+    pub ida: bool,
+    pub cvode: bool,
+    pub gbode: bool,
+}
+
+/// Reject flag values this runtime cannot honour.
+pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
+    if !cap.klu {
+        for (flag, requested) in [
+            ("lss", f.lss == Some(Lss::Klu)),
+            ("ls", f.ls == Some(Ls::Klu)),
+            ("nlsLS", f.nls_ls == Some(NlsLs::Klu)),
+        ] {
+            if requested {
+                return Err(format!("-{flag}=klu: this runtime has no KLU linear solver"));
+            }
+        }
+    }
+    let unsupported = match f.solver {
+        Some(Solver::Ida) if !cap.ida => "ida",
+        Some(Solver::Cvode) if !cap.cvode => "cvode",
+        Some(Solver::Gbode) if !cap.gbode => "gbode",
+        _ => return Ok(()),
+    };
+    Err(format!(
+        "-s={unsupported}: this runtime supports `dassl` and `euler` only"
+    ))
+}
+
+/// Parse an argv slice (`argv[0]` is the program name and is skipped).
+/// `-flag=value` and `-flag value` are both accepted, as in the C runtime.
+/// An unrecognized *value* for a recognized flag is an error listing what is
+/// accepted; an unrecognized *flag* is collected into [`SimFlags::unknown`].
+pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
+    let mut f = SimFlags {
+        argv: argv.iter().map(|a| a.as_ref().to_string()).collect(),
+        ..SimFlags::default()
+    };
+    let mut i = 1;
+    while i < argv.len() {
+        let arg = argv[i].as_ref();
+        i += 1;
+        let Some(body) = arg.strip_prefix('-') else { continue };
+        let (name, inline) = match body.split_once('=') {
+            Some((n, v)) => (n, Some(v)),
+            None => (body, None),
+        };
+        // A value-taking flag may carry it inline or as the next argument.
+        let mut value = |name: &str| -> Result<String, String> {
+            if let Some(v) = inline {
+                return Ok(v.to_string());
+            }
+            let v = argv.get(i).ok_or_else(|| format!("-{name} needs a value"))?;
+            i += 1;
+            Ok(v.as_ref().to_string())
+        };
+        match name {
+            "s" | "solver" => f.solver = Some(solver(&value(name)?)?),
+            "nls" => f.nls = Some(nls(&value(name)?)?),
+            "nlsLS" => f.nls_ls = Some(nls_ls(&value(name)?)?),
+            "ls" => f.ls = Some(ls(&value(name)?)?),
+            "lss" => f.lss = Some(lss(&value(name)?)?),
+            "lv" => {
+                for s in value(name)?.split(',') {
+                    let s = s.trim();
+                    if !s.is_empty() {
+                        f.log.push(s.to_uppercase());
+                    }
+                }
+            }
+            "override" => {
+                for item in value(name)?.split(',') {
+                    // An unparsable or unknown override is a no-op, as in C.
+                    if let Some((n, v)) = item.split_once('=') {
+                        if let Ok(val) = v.trim().parse::<f64>() {
+                            f.overrides.push((n.trim().to_string(), val));
+                        }
+                    }
+                }
+            }
+            "abortSlowSimulation" => f.abort_slow = true,
+            _ => f.unknown.push(arg.to_string()),
+        }
+    }
+    Ok(f)
+}
+
+fn bad(flag: &str, got: &str, accepted: &str) -> String {
+    format!("unrecognized value `{got}` for -{flag} (accepted: {accepted})")
+}
+
+fn solver(v: &str) -> Result<Solver, String> {
+    Ok(match v {
+        "dassl" | "dasslrt" => Solver::Dassl,
+        "ida" => Solver::Ida,
+        "cvode" => Solver::Cvode,
+        "gbode" => Solver::Gbode,
+        "euler" => Solver::Euler,
+        _ => return Err(bad("s", v, "dassl, ida, cvode, gbode, euler")),
+    })
+}
+
+fn nls(v: &str) -> Result<Nls, String> {
+    Ok(match v {
+        "hybrid" => Nls::Hybrid,
+        "kinsol" => Nls::Kinsol,
+        "newton" => Nls::Newton,
+        "mixed" => Nls::Mixed,
+        "homotopy" => Nls::Homotopy,
+        _ => return Err(bad("nls", v, "hybrid, kinsol, newton, mixed, homotopy")),
+    })
+}
+
+fn nls_ls(v: &str) -> Result<NlsLs, String> {
+    Ok(match v {
+        "default" => NlsLs::Default,
+        "totalpivot" => NlsLs::TotalPivot,
+        "lapack" => NlsLs::Lapack,
+        "klu" => NlsLs::Klu,
+        "rsparse" => NlsLs::Rsparse,
+        _ => return Err(bad("nlsLS", v, "default, totalpivot, lapack, klu, rsparse")),
+    })
+}
+
+fn ls(v: &str) -> Result<Ls, String> {
+    Ok(match v {
+        "default" => Ls::Default,
+        "lapack" => Ls::Lapack,
+        "totalpivot" => Ls::TotalPivot,
+        "klu" => Ls::Klu,
+        _ => return Err(bad("ls", v, "default, lapack, totalpivot, klu")),
+    })
+}
+
+fn lss(v: &str) -> Result<Lss, String> {
+    Ok(match v {
+        "default" => Lss::Default,
+        "klu" => Lss::Klu,
+        "rsparse" => Lss::Rsparse,
+        _ => return Err(bad("lss", v, "default, klu, rsparse")),
+    })
+}
+
+/// Set once per run before the driver starts; read from anywhere, since the NLS/LS
+/// entry points take no flag arguments.
+mod store {
+    use super::SimFlags;
+
+    #[cfg(feature = "std")]
+    mod imp {
+        use super::SimFlags;
+        use core::cell::RefCell;
+        std::thread_local! {
+            static FLAGS: RefCell<SimFlags> = RefCell::new(SimFlags::default());
+        }
+        pub fn set(f: SimFlags) {
+            FLAGS.with(|c| *c.borrow_mut() = f);
+        }
+        pub fn get() -> SimFlags {
+            FLAGS.with(|c| c.borrow().clone())
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use super::SimFlags;
+        use core::cell::UnsafeCell;
+        // Single-threaded in-wasm runtime, so a plain cell is sound (as in
+        // `driver::overrides_store`).
+        struct Store(UnsafeCell<Option<SimFlags>>);
+        unsafe impl Sync for Store {}
+        static STORE: Store = Store(UnsafeCell::new(None));
+        pub fn set(f: SimFlags) {
+            unsafe { *STORE.0.get() = Some(f) };
+        }
+        pub fn get() -> SimFlags {
+            unsafe { (*STORE.0.get()).clone().unwrap_or_default() }
+        }
+    }
+
+    pub use imp::{get, set};
+}
+
+pub fn set_flags(f: SimFlags) {
+    store::set(f);
+}
+
+pub fn flags() -> SimFlags {
+    store::get()
+}
+
+/// Split the WASI `args_get` byte layout — NUL-terminated strings back to back —
+/// into an argv vector. A trailing unterminated tail is taken as a final argument
+/// so a caller that forgot the last NUL loses nothing.
+pub fn argv_from_bytes(bytes: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    for part in bytes.split(|&b| b == 0) {
+        if !part.is_empty() {
+            out.push(String::from_utf8_lossy(part).into_owned());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(s: &[&str]) -> Vec<String> {
+        core::iter::once("model".to_string()).chain(s.iter().map(|x| x.to_string())).collect()
+    }
+
+    const NOTHING: Capabilities =
+        Capabilities { klu: false, ida: false, cvode: false, gbode: false };
+
+    #[test]
+    fn defaults_are_all_unset() {
+        let f = parse(&argv(&[])).expect("empty argv parses");
+        assert_eq!(f.solver, None);
+        assert_eq!((f.nls, f.nls_ls, f.ls, f.lss), (None, None, None, None));
+        assert!(f.log.is_empty() && f.overrides.is_empty() && !f.abort_slow);
+        assert!(check(&f, NOTHING).is_ok());
+    }
+
+    #[test]
+    fn argv_survives_a_round_trip_through_the_wasi_layout() {
+        let f = parse(&argv(&["-nls=newton", "-lv=LOG_STATS"])).expect("parses");
+        let back = parse(&argv_from_bytes(&f.to_wasi_args())).expect("re-parses");
+        assert_eq!(back, f);
+    }
+
+    #[test]
+    fn unavailable_solvers_are_rejected_with_the_flag_named() {
+        for (arg, needle) in [("-lss=klu", "KLU"), ("-ls=klu", "KLU"), ("-nlsLS=klu", "KLU"),
+                              ("-s=ida", "dassl"), ("-s=cvode", "dassl")] {
+            let f = parse(&argv(&[arg])).expect("parses");
+            let e = check(&f, NOTHING).expect_err("must reject");
+            assert!(e.contains(needle), "{arg}: {e}");
+        }
+        // With the capability present the same request is fine.
+        let f = parse(&argv(&["-lss=klu"])).expect("parses");
+        assert!(check(&f, Capabilities { klu: true, ..NOTHING }).is_ok());
+    }
+
+    #[test]
+    fn selectable_solvers_need_no_capability() {
+        for arg in ["-nls=kinsol", "-nls=hybrid", "-lss=rsparse", "-s=euler", "-s=dassl"] {
+            let f = parse(&argv(&[arg])).expect("parses");
+            assert!(check(&f, NOTHING).is_ok(), "{arg}");
+        }
+    }
+
+    #[test]
+    fn klu_serves_the_sparse_paths_by_default() {
+        let f = parse(&argv(&[])).expect("parses");
+        assert_eq!(f.klu_selectors(), (false, true, true));
+        let f = parse(&argv(&["-ls=klu", "-lss=rsparse", "-nlsLS=rsparse"])).expect("parses");
+        assert_eq!(f.klu_selectors(), (true, false, false));
+        // The unimplemented C values land on rsparse too, not on KLU.
+        let f = parse(&argv(&["-nlsLS=totalpivot"])).expect("parses");
+        assert_eq!(f.klu_selectors().2, false);
+    }
+
+    #[test]
+    fn inline_and_separate_values_agree() {
+        let a = parse(&argv(&["-nls=kinsol", "-lss=klu"])).expect("inline");
+        let b = parse(&argv(&["-nls", "kinsol", "-lss", "klu"])).expect("separate");
+        // `argv` differs by construction; the parsed selectors must not.
+        assert_eq!((a.nls, a.lss), (b.nls, b.lss));
+        assert_eq!(a.nls, Some(Nls::Kinsol));
+        assert_eq!(a.lss, Some(Lss::Klu));
+    }
+
+    #[test]
+    fn program_name_is_not_a_flag() {
+        // argv[0] is skipped even when it looks like one.
+        let f = parse(&["-nls=kinsol", "-lss=klu"]).expect("parses");
+        assert_eq!(f.nls, None);
+        assert_eq!(f.lss, Some(Lss::Klu));
+    }
+
+    #[test]
+    fn bad_value_is_an_error_listing_the_accepted_ones() {
+        let e = parse(&argv(&["-nls=nope"])).expect_err("must reject");
+        assert!(e.contains("nope") && e.contains("kinsol"), "{e}");
+    }
+
+    #[test]
+    fn unknown_flags_are_collected_not_rejected() {
+        let f = parse(&argv(&["-noEquidistantTimeGrid", "-lv=LOG_STATS"])).expect("parses");
+        assert_eq!(f.unknown, ["-noEquidistantTimeGrid"]);
+        assert!(f.has_log("LOG_STATS"));
+    }
+
+    #[test]
+    fn log_all_implies_every_stream() {
+        let f = parse(&argv(&["-lv=LOG_ALL"])).expect("parses");
+        assert!(f.has_log("LOG_NLS_V"));
+    }
+
+    #[test]
+    fn overrides_keep_order_and_skip_junk() {
+        let f = parse(&argv(&["-override=a=1,bad,b=2.5,c=x"])).expect("parses");
+        assert_eq!(f.overrides, [("a".to_string(), 1.0), ("b".to_string(), 2.5)]);
+    }
+
+    #[test]
+    fn missing_value_is_an_error() {
+        assert!(parse(&argv(&["-nls"])).is_err());
+    }
+
+    #[test]
+    fn wasi_args_layout_round_trips() {
+        let bytes = b"model\0-nls=kinsol\0-lv=LOG_STATS\0";
+        let a = argv_from_bytes(bytes);
+        assert_eq!(a, ["model", "-nls=kinsol", "-lv=LOG_STATS"]);
+        assert_eq!(parse(&a).expect("parses").nls, Some(Nls::Kinsol));
+        // A missing final NUL must not drop the last argument.
+        assert_eq!(argv_from_bytes(b"model\0-nls=newton"), ["model", "-nls=newton"]);
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -45,16 +45,27 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME");
 
     // Hash of every input that affects the produced wasm.
-    let (hash, tracked) = hash_inputs(&runtime_dir);
+    let (mut hash, tracked) = hash_inputs(&runtime_dir);
     for f in &tracked {
         println!("cargo:rerun-if-changed={}", f.display());
     }
+    // SUNDIALS/KLU for the wasip1 runtimes. Part of the stamp key: gaining or
+    // losing the archives changes the runtime's exports, so the blobs must rebuild.
+    let sundials = build_sundials_wasm(&crate_dir, &out_dir);
+    println!("cargo::rustc-check-cfg=cfg(sundials)");
+    if let Some((_, key)) = &sundials {
+        hash = format!("{hash}:{key}");
+        // Backs the crate's `SUNDIALS` const: with the archives, `-lss=klu` is
+        // servable.
+        println!("cargo:rustc-cfg=sundials");
+    }
+    let sundials_dir = sundials.as_ref().map(|(d, _)| d.as_path());
     // The JIT runtime (wasm32-unknown-unknown) and the standalone runtime
     // (wasm32-wasip1) are built from the same sources; both must run on every
     // invocation (the JIT build short-circuits on its own cache/override).
     build_jit_runtime(&crate_dir, &runtime_dir, &out_dir, &dest, &hash);
-    build_wasip1_runtime(&crate_dir, &runtime_dir, &out_dir, &hash);
-    build_wasip1_interactive_runtime(&crate_dir, &runtime_dir, &out_dir, &hash);
+    build_wasip1_runtime(&crate_dir, &runtime_dir, &out_dir, &hash, sundials_dir);
+    build_wasip1_interactive_runtime(&crate_dir, &runtime_dir, &out_dir, &hash, sundials_dir);
     build_external_c_wasm(&crate_dir, &out_dir);
     build_fmi3_me_adapter(&crate_dir, &out_dir);
 }
@@ -334,6 +345,240 @@ fn placeholder(dest: &Path) {
     }
 }
 
+/// The CMake targets cross-compiled to wasm: KLU and its SuiteSparse deps, then
+/// the SUNDIALS modules. Consumers pick from `lib/`; the link order lives in the
+/// runtime crate's build script.
+const SUITESPARSE_TARGETS: &[&str] = &["klu", "amd", "colamd", "btf", "suitesparseconfig"];
+const SUNDIALS_TARGETS: &[&str] = &[
+    "sundials_kinsol_static", "sundials_ida_static", "sundials_cvode_static",
+    "sundials_nvecserial_static", "sundials_sunmatrixdense_static",
+    "sundials_sunmatrixsparse_static", "sundials_sunlinsoldense_static",
+    "sundials_sunlinsolklu_static",
+];
+
+/// Bumped when the recipe below changes, to invalidate cached archives.
+const SUNDIALS_RECIPE: u32 = 2;
+
+/// Cross-compile the vendored SUNDIALS + SuiteSparse/KLU to `wasm32-wasip1` static
+/// archives, driving each project's own CMake with a generated wasi toolchain file
+/// (both configure and build unmodified; only shared libs must be off). Returns the
+/// directory holding `lib/*.a` plus a cache key, or `None` when the sources or the
+/// toolchain are missing — the runtime then builds without the real solvers and
+/// keeps using the pure-Rust ones.
+fn build_sundials_wasm(crate_dir: &Path, out_dir: &Path) -> Option<(PathBuf, String)> {
+    for var in ["OMC_SUNDIALS_WASM_DIR", "OMC_SUNDIALS_SOURCES", "OMC_SUITESPARSE_SOURCES",
+                "OMC_WASI_CLANG", "OMC_WASI_SYSROOT"] {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+    if let Ok(dir) = std::env::var("OMC_SUNDIALS_WASM_DIR") {
+        let dir = PathBuf::from(dir);
+        if dir.join("lib").is_dir() {
+            return Some((dir, "override".to_owned()));
+        }
+        println!("cargo:warning=OMC_SUNDIALS_WASM_DIR={} has no lib/", dir.display());
+        return None;
+    }
+
+    let third_party = |var: &str, name: &str| -> Option<PathBuf> {
+        std::env::var(var).ok().map(PathBuf::from).or_else(|| {
+            crate_dir.parent().and_then(Path::parent).and_then(Path::parent)
+                .map(|omc| omc.join("3rdParty").join(name))
+        }).filter(|p| p.join("CMakeLists.txt").exists())
+    };
+    let (Some(sundials_src), Some(suitesparse_src)) = (
+        third_party("OMC_SUNDIALS_SOURCES", "sundials-5.4.0"),
+        third_party("OMC_SUITESPARSE_SOURCES", "SuiteSparse-5.8.1"),
+    ) else {
+        println!("cargo:warning=no vendored SUNDIALS/SuiteSparse sources found; the wasm-jit \
+                  runtime will use its pure-Rust solvers. Set OMC_SUNDIALS_SOURCES / \
+                  OMC_SUITESPARSE_SOURCES.");
+        return None;
+    };
+
+    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
+    let sysroot = std::env::var("OMC_WASI_SYSROOT").unwrap_or_else(|_| "/usr".to_owned());
+    let root = out_dir.join("sundials-wasm");
+    let lib = root.join("lib");
+    let stamp = root.join("stamp");
+    let key = {
+        let mut h: u64 = 0xcbf29ce484222325;
+        let mut mix = |bytes: &[u8]| for &b in bytes { h ^= b as u64; h = h.wrapping_mul(0x100000001b3); };
+        // The pinned trees don't change in place; their paths carry the version, and
+        // the top-level CMakeLists catches an in-place patch.
+        for p in [&sundials_src, &suitesparse_src] {
+            mix(p.to_string_lossy().as_bytes());
+            if let Ok(b) = std::fs::read(p.join("CMakeLists.txt")) { mix(&b); }
+        }
+        mix(clang.as_bytes());
+        mix(sysroot.as_bytes());
+        mix(&SUNDIALS_RECIPE.to_le_bytes());
+        format!("{h:016x}")
+    };
+    if std::fs::read_to_string(&stamp).ok().as_deref() == Some(key.as_str()) {
+        return Some((root, key));
+    }
+
+    match build_sundials_archives(&sundials_src, &suitesparse_src, &root, &lib, &clang, &sysroot) {
+        Ok(()) => {
+            std::fs::write(&stamp, &key).ok();
+            Some((root, key))
+        }
+        Err(e) => {
+            println!("cargo:warning=could not cross-compile SUNDIALS/KLU to wasm ({e}); the \
+                      wasm-jit runtime will use its pure-Rust solvers. Needs cmake, clang with \
+                      a wasm32 target, llvm-ar and a wasi sysroot (OMC_WASI_SYSROOT).");
+            std::fs::remove_file(&stamp).ok();
+            None
+        }
+    }
+}
+
+/// Configure + build both trees for `wasm32-wasip1` and collect every `.a` into `lib`.
+fn build_sundials_archives(
+    sundials_src: &Path,
+    suitesparse_src: &Path,
+    root: &Path,
+    lib: &Path,
+    clang: &str,
+    sysroot: &str,
+) -> Result<(), String> {
+    let (ar, ranlib) = find_llvm_ar_ranlib(clang)
+        .ok_or("no llvm-ar/llvm-ranlib found (GNU ar cannot archive wasm objects)")?;
+    // `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` keeps CMake's compiler check
+    // from linking an executable, which needs a `libclang_rt.builtins` path clang
+    // does not find for this triple.
+    let toolchain = root.join("wasi-toolchain.cmake");
+    std::fs::create_dir_all(root).map_err(|e| format!("create {}: {e}", root.display()))?;
+    std::fs::write(&toolchain, format!(
+        "set(CMAKE_SYSTEM_NAME WASI)\n\
+         set(CMAKE_SYSTEM_PROCESSOR wasm32)\n\
+         set(CMAKE_C_COMPILER {clang})\n\
+         set(CMAKE_C_COMPILER_TARGET wasm32-wasip1)\n\
+         set(CMAKE_SYSROOT {sysroot})\n\
+         set(CMAKE_AR {})\n\
+         set(CMAKE_RANLIB {})\n\
+         set(CMAKE_C_FLAGS_INIT \"-O2\")\n\
+         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n\
+         set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)\n",
+        ar.display(), ranlib.display(),
+    )).map_err(|e| format!("write toolchain file: {e}"))?;
+
+    // Fresh build dirs: this only runs when the stamp is invalid, and a cache left
+    // by a previous recipe must not decide anything.
+    let ss_build = root.join("suitesparse-build");
+    let sd_build = root.join("sundials-build");
+    std::fs::remove_dir_all(&ss_build).ok();
+    std::fs::remove_dir_all(&sd_build).ok();
+    let toolchain_arg = format!("-DCMAKE_TOOLCHAIN_FILE={}", toolchain.display());
+
+    cmake(&[
+        "-S", &suitesparse_src.to_string_lossy(), "-B", &ss_build.to_string_lossy(),
+        &toolchain_arg, "-DBUILD_SHARED_LIBS=OFF",
+    ])?;
+    cmake_build(&ss_build, SUITESPARSE_TARGETS)?;
+
+    // `klu.h` includes `amd.h`/`btf.h`/`SuiteSparse_config.h`, which live in sibling
+    // dirs. They go in via CMAKE_C_FLAGS rather than KLU_INCLUDE_DIR, because
+    // `config/FindKLU.cmake` overwrites that variable with the single directory its
+    // `find_path(… klu.h …)` lands on, silently dropping any others.
+    let sibling_includes = ["AMD/Include", "COLAMD/Include", "BTF/Include", "SuiteSparse_config"]
+        .iter()
+        .map(|d| format!(" -I{}", suitesparse_src.join(d).display()))
+        .collect::<String>();
+    let mut args = vec![
+        "-S".to_owned(), sundials_src.to_string_lossy().into_owned(),
+        "-B".to_owned(), sd_build.to_string_lossy().into_owned(),
+        toolchain_arg,
+        "-DSUNDIALS_BUILD_STATIC_LIBS=ON".to_owned(),
+        // Shared libs must be off: their link step fails on the builtins path.
+        "-DSUNDIALS_BUILD_SHARED_LIBS=OFF".to_owned(),
+        // No LAPACK in the wasi sysroot; SUNDIALS' own dense solver is used instead.
+        "-DSUNDIALS_LAPACK_ENABLE=OFF".to_owned(),
+        "-DSUNDIALS_EXAMPLES_ENABLE_C=OFF".to_owned(),
+        "-DSUNDIALS_KLU_ENABLE=ON".to_owned(),
+        // 32-bit indices, unlike the native build's 64. Mandatory here:
+        // `sunlinsol_klu.c` *casts* `sunindextype*` to `KLU_INDEXTYPE*`, which it
+        // maps to `long int` for 64-bit indices — 4 bytes on wasm32, so an int64
+        // index array would be reinterpreted as int32 and the sparsity pattern
+        // silently garbled. With 32 both sides are `int`.
+        "-DSUNDIALS_INDEX_SIZE=32".to_owned(),
+        format!("-DKLU_INCLUDE_DIR={}", suitesparse_src.join("KLU/Include").display()),
+        format!("-DCMAKE_C_FLAGS=-O2{sibling_includes}"),
+    ];
+    for (var, name) in [("KLU_LIBRARY", "libklu.a"), ("AMD_LIBRARY", "libamd.a"),
+                        ("COLAMD_LIBRARY", "libcolamd.a"), ("BTF_LIBRARY", "libbtf.a"),
+                        ("SUITESPARSECONFIG_LIBRARY", "libsuitesparseconfig.a")] {
+        args.push(format!("-D{var}={}", ss_build.join(name).display()));
+    }
+    cmake(&args.iter().map(String::as_str).collect::<Vec<_>>())?;
+    cmake_build(&sd_build, SUNDIALS_TARGETS)?;
+
+    // Start from an empty lib/: a stale archive from an earlier recipe (e.g. the
+    // 64-bit-index build) must not survive into the link.
+    std::fs::remove_dir_all(lib).ok();
+    std::fs::create_dir_all(lib).map_err(|e| format!("create {}: {e}", lib.display()))?;
+    let mut found = Vec::new();
+    for dir in [&ss_build, &sd_build] {
+        collect_archives(dir, &mut found);
+    }
+    if found.is_empty() {
+        return Err("the CMake builds produced no .a".into());
+    }
+    for a in &found {
+        copy(a, &lib.join(a.file_name().expect("archive has a file name")));
+    }
+    Ok(())
+}
+
+fn cmake(args: &[&str]) -> Result<(), String> {
+    let status = Command::new("cmake").args(args).status()
+        .map_err(|e| format!("spawn cmake: {e}"))?;
+    status.success().then_some(()).ok_or_else(|| format!("cmake configure exited with {status}"))
+}
+
+fn cmake_build(build_dir: &Path, targets: &[&str]) -> Result<(), String> {
+    let jobs = std::env::var("NUM_JOBS").unwrap_or_else(|_| "1".to_owned());
+    let status = Command::new("cmake")
+        .args(["--build", &build_dir.to_string_lossy(), "-j", &jobs, "--target"])
+        .args(targets)
+        .status()
+        .map_err(|e| format!("spawn cmake --build: {e}"))?;
+    status.success().then_some(()).ok_or_else(|| format!("cmake --build exited with {status}"))
+}
+
+fn collect_archives(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = std::fs::read_dir(dir) else { return };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            collect_archives(&p, out);
+        } else if p.extension().map(|x| x == "a").unwrap_or(false) {
+            out.push(p);
+        }
+    }
+}
+
+/// `llvm-ar` + `llvm-ranlib`, unversioned or `-<N>` from clang's major (Ubuntu
+/// ships only the versioned names).
+fn find_llvm_ar_ranlib(clang: &str) -> Option<(PathBuf, PathBuf)> {
+    let mut stems = vec![String::new()];
+    if let Ok(out) = Command::new(clang).arg("-dumpversion").output() {
+        if let Some(major) = String::from_utf8_lossy(&out.stdout).trim().split('.').next() {
+            stems.push(format!("-{major}"));
+        }
+    }
+    stems.iter().find_map(|stem| {
+        let (ar, ranlib) = (which(&format!("llvm-ar{stem}")), which(&format!("llvm-ranlib{stem}")));
+        Some((ar?, ranlib?))
+    })
+}
+
+fn which(name: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).map(|d| d.join(name)).find(|p| p.is_file())
+    })
+}
+
 /// Build + embed the `wasm32-unknown-unknown` JIT runtime (`runtime.wasm`): the
 /// allocator / refcount / string + array primitives the generated model/function
 /// modules import at JIT time. Honours the `OMC_WASM_RUNTIME` override and an
@@ -388,7 +633,13 @@ fn build_jit_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, dest:
 /// the omc target is wasm32 or the wasip1 target/build is unavailable, so the
 /// native `include_bytes!` still compiles (`emit_standalone_module` reports the
 /// absence at call time).
-fn build_wasip1_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, hash: &str) {
+fn build_wasip1_runtime(
+    crate_dir: &Path,
+    runtime_dir: &Path,
+    out_dir: &Path,
+    hash: &str,
+    sundials_dir: Option<&Path>,
+) {
     let dest = out_dir.join("runtime_wasip1.wasm");
     let stamp = out_dir.join("runtime_wasip1.wasm.hash");
 
@@ -421,6 +672,7 @@ fn build_wasip1_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, ha
         "openmodelica_codegen_wasm_jit_runtime",
         "runtime-target",
         &["--no-default-features", "--features", "standalone"],
+        sundials_dir,
     ) {
         Ok(produced) => {
             copy(&produced, &dest);
@@ -464,7 +716,13 @@ fn build_wasip1_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, ha
 /// sparse solver (`rsparse`) needs, instantiated with the existing `wasi_shim`.
 /// Native omc adds `host_lin_solve` (delegate the solve to the host); web omc
 /// omits it and solves in-wasm.
-fn build_wasip1_interactive_runtime(crate_dir: &Path, runtime_dir: &Path, out_dir: &Path, hash: &str) {
+fn build_wasip1_interactive_runtime(
+    crate_dir: &Path,
+    runtime_dir: &Path,
+    out_dir: &Path,
+    hash: &str,
+    sundials_dir: Option<&Path>,
+) {
     let dest = out_dir.join("runtime_wasip1_interactive.wasm");
     let stamp = out_dir.join("runtime_wasip1_interactive.wasm.hash");
 
@@ -503,6 +761,7 @@ fn build_wasip1_interactive_runtime(crate_dir: &Path, runtime_dir: &Path, out_di
         "openmodelica_codegen_wasm_jit_runtime",
         "runtime-interactive-target",
         &["--no-default-features", "--features", features],
+        sundials_dir,
     ) {
         Ok(produced) => {
             copy(&produced, &dest);
@@ -528,6 +787,7 @@ fn build_runtime_wasm(runtime_dir: &Path, out_dir: &Path, target: &str) -> Resul
         "openmodelica_codegen_wasm_jit_runtime",
         "runtime-target",
         &[],
+        None,
     )
 }
 
@@ -544,11 +804,12 @@ fn build_runtime_wasm_named(
     artifact: &str,
     target_dir_prefix: &str,
     extra_args: &[&str],
+    sundials_dir: Option<&Path>,
 ) -> Result<PathBuf, String> {
     let target_dir = out_dir.join(format!("{target_dir_prefix}-{target}"));
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    let status = Command::new(cargo)
-        .current_dir(crate_dir)
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(crate_dir)
         .args(["build", "--release", "--target", target])
         .args(extra_args)
         .arg("--target-dir")
@@ -557,9 +818,14 @@ fn build_runtime_wasm_named(
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTFLAGS")
-        .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .status()
-        .map_err(|e| format!("could not spawn cargo: {e}"))?;
+        .env_remove("RUSTC_WORKSPACE_WRAPPER");
+    match sundials_dir {
+        Some(d) => { cmd.env("OMC_SUNDIALS_WASM_DIR", d); }
+        // Cargo's env is inherited; clear a stale outer setting so the nested build
+        // agrees with what this script actually produced.
+        None => { cmd.env_remove("OMC_SUNDIALS_WASM_DIR"); }
+    }
+    let status = cmd.status().map_err(|e| format!("could not spawn cargo: {e}"))?;
     if !status.success() {
         return Err(format!("cargo build for {target} exited with {status}"));
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -15,6 +15,10 @@ pub static FMI3_ME_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fm
 pub static FMI3_CS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_cs_adapter.wasm"));
 pub static FMI3_MECS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_adapter.wasm"));
 
+/// Whether the wasip1 runtimes above have the real SUNDIALS/KLU linked in (the
+/// build script cross-compiled the archives), so a `-lss=klu` run can be served.
+pub const SUNDIALS: bool = cfg!(sundials);
+
 pub mod sig;
 pub mod model;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -128,20 +128,7 @@ pub fn encode_overrides() -> Vec<u8> {
     b
 }
 
-/// Model export names in the fixed table-slot order the in-wasm session driver
-/// expects; must stay in sync with `openmodelica_codegen_wasm_jit_runtime::session`.
+/// Model export names in table-slot order. The runtime's `session::slot_of` derives
+/// from the same list, so the two sides cannot drift.
 #[cfg(feature = "jit")]
-pub const INWASM_SLOT_NAMES: [&str; 12] = [
-    "functionParameters",
-    "functionInitStartValues",
-    "functionInitialEquations",
-    "functionODE",
-    "functionAlgebraics",
-    "functionStateSetJacobians",
-    "functionZeroCrossings",
-    "initSample",
-    "simulate",
-    "callExternalObjectDestructors",
-    "functionInitialEquations_lambda0",
-    "functionUpdateRelations",
-];
+pub const INWASM_SLOT_NAMES: &[&str] = openmodelica_sim_meta::driver::MODEL_FNS;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -690,8 +690,10 @@ pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, Strin
     let n_steps = model.n_intervals;
     let n_rows = n_steps + 1;
     let t0 = Instant::now();
-    let (result, driver_label) =
+    let (mut result, driver_label) =
         sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench)?;
+    // The solves ran in-wasm, where the driver's stats cannot see them.
+    result.stats.lin_solves = engine.lin_solves();
     if bench {
         let elapsed = t0.elapsed();
         eprintln!(
@@ -801,6 +803,11 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     let instance = wts(wasmer::Instance::new(&mut store, &model_module, &imports))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_alloc"))?;
+    // Which of `-ls`/`-lss`/`-nlsLS` want KLU; see the wasmtime runtime.
+    if let Ok(set_klu) = rt_inst.exports.get_typed_function::<(i32, i32, i32), ()>(&store, "rt_lin_set_klu") {
+        let (ls, lss, nls_ls) = openmodelica_sim_meta::simflags::flags().klu_selectors();
+        wts(set_klu.call(&mut store, ls as i32, lss as i32, nls_ls as i32))?;
+    }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
     }
@@ -810,13 +817,13 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
 
 pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
     sim_driver::init_host_hooks(); // cancel poll + model-assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst: _, instance, memory, rt_alloc } = instantiate_modules(model)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model)?;
 
     let layout = &model.layout;
     // Allocate the shared SimData block.
     let sim_data = wts(rt_alloc.call(&mut store, layout.total))?;
 
-    let engine = WasmerEngine { store, memory, instance, funcs: HashMap::new() };
+    let engine = WasmerEngine { store, memory, instance, rt_inst, funcs: HashMap::new() };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -827,6 +834,7 @@ struct WasmerEngine {
     store: Store,
     memory: wasmer::Memory,
     instance: wasmer::Instance,
+    rt_inst: wasmer::Instance,
     funcs: HashMap<String, wasmer::TypedFunction<u32, ()>>,
 }
 
@@ -868,6 +876,12 @@ impl sim_driver::SimEngine for WasmerEngine {
     }
     fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
         crate::host::take_pending_warnings()
+    }
+    fn lin_solves(&mut self) -> u64 {
+        match self.rt_inst.exports.get_typed_function::<(), u64>(&self.store, "rt_lin_solves") {
+            Ok(f) => f.call(&mut self.store).unwrap_or(0),
+            Err(_) => 0,
+        }
     }
 }
 
@@ -924,6 +938,16 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         wts(rt_inst.exports.get_typed_function(&store, "rt_sim_set_overrides"))?;
     if wts(set_ov.call(&mut store, ov_ptr, ov.len() as u32))? < 0 {
         return Err("CodegenWasmJit: rt_sim_set_overrides failed".to_string());
+    }
+
+    // Same for the runtime flags, as the argv bytes a WASI command would receive.
+    let args = openmodelica_sim_meta::simflags::flags().to_wasi_args();
+    let args_ptr = wts(rt_alloc.call(&mut store, args.len().max(1) as u32))?;
+    wts(memory.view(&store).write(args_ptr as u64, &args))?;
+    let set_args: wasmer::TypedFunction<(u32, u32), i32> =
+        wts(rt_inst.exports.get_typed_function(&store, "rt_sim_set_args"))?;
+    if wts(set_args.call(&mut store, args_ptr, args.len() as u32))? < 0 {
+        return Err("CodegenWasmJit: the runtime rejected the simulation flags".to_string());
     }
 
     let start: wasmer::TypedFunction<(u32, u32, u32, u32), i32> =

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -486,9 +486,9 @@ pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, Strin
                 return Err(e.to_string());
             }
         };
-    // The linear solves ran host-side (`rt_host_lin_solve`); the driver's stats
-    // don't see them, so surface the host counter for LOG_STATS.
-    result.stats.lin_solves = crate::host::lin_solve::count();
+    // The solves ran host-side (`rt_host_lin_solve`) or in-wasm (KLU/rsparse);
+    // either way the driver's stats don't see them, so surface both counters.
+    result.stats.lin_solves = crate::host::lin_solve::count() + engine.lin_solves();
     if bench {
         let elapsed = t0.elapsed();
         eprintln!(
@@ -593,6 +593,12 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     let instance = wts(linker.instantiate(&mut store, &model_module))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
+    // Which of `-ls`/`-lss`/`-nlsLS` want KLU: the host-driven runtime links no flag
+    // store of its own. The session sets the same bits from the argv it receives.
+    if let Ok(set_klu) = rt_inst.get_typed_func::<(i32, i32, i32), ()>(&mut store, "rt_lin_set_klu") {
+        let (ls, lss, nls_ls) = openmodelica_sim_meta::simflags::flags().klu_selectors();
+        wts(set_klu.call(&mut store, (ls as i32, lss as i32, nls_ls as i32)))?;
+    }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
     }
@@ -722,6 +728,12 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
         crate::host::take_pending_warnings()
     }
+    fn lin_solves(&mut self) -> u64 {
+        match self.rt_inst.get_typed_func::<(), u64>(&mut self.store, "rt_lin_solves") {
+            Ok(f) => f.call(&mut self.store, ()).unwrap_or(0),
+            Err(_) => 0,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -778,6 +790,15 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
     let set_ov = wts(rt_inst.get_typed_func::<(u32, u32), i32>(&mut store, "rt_sim_set_overrides"))?;
     if wts(set_ov.call(&mut store, (ov_ptr, ov.len() as u32)))? < 0 {
         return Err("CodegenWasmJit: rt_sim_set_overrides failed".to_string());
+    }
+
+    // Same for the runtime flags, as the argv bytes a WASI command would receive.
+    let args = openmodelica_sim_meta::simflags::flags().to_wasi_args();
+    let args_ptr = wts(rt_alloc.call(&mut store, args.len().max(1) as u32))?;
+    wts(memory.write(&mut store, args_ptr as usize, &args))?;
+    let set_args = wts(rt_inst.get_typed_func::<(u32, u32), i32>(&mut store, "rt_sim_set_args"))?;
+    if wts(set_args.call(&mut store, (args_ptr, args.len() as u32)))? < 0 {
+        return Err("CodegenWasmJit: the runtime rejected the simulation flags".to_string());
     }
 
     let start = wts(rt_inst.get_typed_func::<(u32, u32, u32, u32), i32>(&mut store, "rt_sim_start"))?;


### PR DESCRIPTION
Cross-compile the vendored SUNDIALS/KLU to wasm, route every sparse solve through it, and give the simulation runtime the flags needed to pick a solver: wasm-jit now uses the linear solver the C runtime uses instead of approximating it.

### Building SUNDIALS/KLU for wasm

`sundials-5.4.0` and `SuiteSparse-5.8.1/KLU` cross-compile to `wasm32-wasip1` with their own CMake, unmodified, driven from `openmodelica_wasm_jit`'s build script with a generated wasi toolchain file — the pattern `openmodelica_wasi_libc` uses for wasi-libc. Only shared libraries have to be disabled: their link step looks for `libclang_rt.builtins` under a path clang does not resolve for this triple. The archives are stamp-cached and handed to the nested cargo as `OMC_SUNDIALS_WASM_DIR`; missing sources or toolchain is a warning that leaves the pure-Rust solvers in place.

The wasm build uses `SUNDIALS_INDEX_SIZE=32`, unlike the native build's
64. This is required, not a preference: `sunlinsol_klu.c` casts `sunindextype*` to `KLU_INDEXTYPE*`, which the 64-bit path maps to `long int`, and `long` is 4 bytes on wasm32 — an int64 index array would be reinterpreted as int32 and the sparsity pattern silently garbled.

### Runtime simulation flags, from one parser

`-s`, `-nls`, `-nlsLS`, `-ls`, `-lss`, `-lv`, `-override` and `-abortSlowSimulation` are parsed once, in
`openmodelica_sim_meta::simflags`, from an argv slice every entry point supplies the same way.

A wasip1 command has no `main(argc, argv)`: wasmtime calls `_start` and supplies the command line through `args_get`, so the standalone runtime parses `std::env::args()` directly and `Model.wasm -s=euler` works. The interactive runtime is instantiated once and simulated many times, so its host hands the same argv over through a new `rt_sim_set_args` export, in the byte layout `args_get` itself writes. The host turns omc's whitespace-separated `simflags` string into that same argv, so the native in-process driver and the in-wasm one cannot disagree.

Every selector is an `Option`, so an unflagged run behaves as before, and `simflags::check` rejects what the runtime cannot serve instead of quietly running something else — `-s=ida` used to run DASSL silently.

### KLU as the sparse linear solver

`klu::Solver` follows `linearSolverKlu.c`: analyze once per system, refactor per solve, re-pivot only when the reciprocal pivot growth drops below 1e-3 or the refactor fails. Solvers are cached per system handle and dropped at `rt_sim_start`. KLU serves `-lss` and `-nlsLS` by default, as in C, with the pure-Rust `rsparse` still reachable by name; `-ls=klu` routes dense-stored systems through it too.

`klu_common` is mirrored as `#[repr(C)]` rather than kept opaque, since the refactor decision reads `.status` and `.rgrowth`. The layout is checked at run time: `Common::defaults()` rejects a `Common` whose `klu_defaults` values did not land in the mirrored fields, so a mismatch fails the solve instead of garbling the pattern.

The symbolic linear lowering emitted the uncached `rt_solve_lin_sparse` even though its pattern is a compile-time constant; it now keys the runtime cache with the system index, so the symbolic analysis is computed once per run there too.

The native interactive blob has no in-wasm flag store (`host_lin_solve` links neither the session nor `sim_meta`), so `rt_lin_set_klu` carries the three selectors from the host, which derives them with the same `SimFlags::klu_selectors()` the in-wasm entry points use. KLU displaces the host-side rsparse there, which left `LOG_STATS` reporting zero linear system solves: the runtime counter is exported as `rt_lin_solves()` and read through `SimEngine::lin_solves()`.

### Every model entry point reachable in-wasm

The driver calls `functionCheckAsserts`, `functionStoreDelayed` and `functionInitDelay` through `call1_if_present`, but neither in-wasm engine knew them. The standalone engine hard-errors on an unmapped name, so every standalone run using DASSL died with "unknown model function" — euler survived, its in-wasm `simulate` loop never reaches them. The session engine treats an unmapped name as absent, so it skipped them silently: `delay()` models on the web target dropped their delay history without a word.

The emitter always exports all three, so both engines only had to reach them. They kept separate lists of which functions exist and which table slot each occupies, which is what let them drift apart; both now derive from `driver::MODEL_FNS`.



Claude-Session: https://claude.ai/code/session_016wq1GUrRVcsSxWXWrL8Usx
Claude-Session: https://claude.ai/code/session_01VgEGUcLawkCeUCgTebicxn

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
