### PR TITLE
Refactor the wasi libraries to compile in cmake

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -476,7 +476,10 @@ void buildRustOMC() {
   // The mmtorust/susan-generated .rs, so the unit-tests-rust stage runs cargo test
   // without re-running codegen.
   stash name: 'rust-generated-src',
-        includes: 'build_cmake/OMCompiler/Compiler/rust-src/**/src/*.rs'
+        includes: 'build_cmake/OMCompiler/Compiler/rust-src/**/src/*.rs,' +
+                  'build_cmake/rust-wasi-pic-sysroot/**,' +
+                  'build_cmake/rust-sundials-wasm/**,' +
+                  'build_cmake/downloads/wasi_snapshot_preview1.reactor.wasm'
   stash name: 'omc-cmake-rust-gui-inputs',
         includes: 'build_cmake/OMCompiler/Compiler/rust-target/release/libOpenModelicaCompiler.so,' +
                   'build_cmake/OMCompiler/Compiler/scripting-api-qt/**'
@@ -659,8 +662,16 @@ void ctestRust() {
   // overlay them onto the crate source tree so cargo sees a complete workspace
   // (without the generated lib.rs the manifest load fails, "no targets specified").
   sh "cp -a build_cmake/OMCompiler/Compiler/rust-src/. OMCompiler/Compiler/OpenModelica.rs/"
+  // Env vars required by the openmodelica_wasi_libc and openmodelica_wasm_jit
+  // build.rs (wasm cross-compile artifacts from CMake build).
+  def wasmEnv = [
+    "OMC_WASI_PIC_SYSROOT=${env.WORKSPACE}/build_cmake/rust-wasi-pic-sysroot",
+    "OMC_SUNDIALS_WASM_DIR=${env.WORKSPACE}/build_cmake/rust-sundials-wasm",
+    "OMC_WASI_P1_ADAPTER=${env.WORKSPACE}/build_cmake/downloads/wasi_snapshot_preview1.reactor.wasm",
+    "OMC_EXTERNAL_C_SOURCES=${env.WORKSPACE}/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources",
+  ]
   try {
-    withSccache {
+    withSccache(wasmEnv) {
       sh "cd OMCompiler/Compiler/OpenModelica.rs && cargo nextest run --workspace --exclude openmodelica --profile ci --no-fail-fast"
     }
   } finally {

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -236,6 +236,13 @@ endif()
 # Built by CMake using wasi-libc's own CMakeLists.txt with BUILD_SHARED=ON
 # so it produces a -fPIC libc.so (Debian's is non-PIC).
 # ---------------------------------------------------------------------------
+if(NOT LLVM_AR_EXECUTABLE OR NOT LLVM_RANLIB_EXECUTABLE)
+  message(FATAL_ERROR "llvm-ar/llvm-ranlib not found; required to build the wasi-libc PIC sysroot.")
+endif()
+if(NOT _wasi_builtins OR NOT EXISTS ${_wasi_builtins})
+  message(FATAL_ERROR "libclang_rt.builtins-wasm32.a not found (install libclang-rt-*-dev-wasm32).")
+endif()
+
 set(RUST_WASI_PIC_SYSROOT ${CMAKE_BINARY_DIR}/rust-wasi-pic-sysroot
     CACHE PATH "Output directory for the PIC wasi-libc sysroot.")
 
@@ -760,9 +767,10 @@ function(omc_rust_setup_codegen)
   if(RUST_OMC_LAPACK_NALGEBRA)
     list(APPEND _rust_omc_features openmodelica_util/lapack-nalgebra)
   endif()
-  # Disable the sundials feature when the wasm cross-compile is not enabled.
-  if(NOT RUST_OMC_ENABLE_SUNDIALS)
-    list(APPEND _rust_omc_features openmodelica_codegen_wasm_jit/no-sundials)
+  # --no-default-features makes sundials off by default; enable it only when
+  # the wasm cross-compile is enabled.
+  if(RUST_OMC_ENABLE_SUNDIALS)
+    list(APPEND _rust_omc_features openmodelica_codegen_wasm_jit/sundials)
   endif()
   list(JOIN _rust_omc_features "," _rust_omc_features_csv)
   set(RUST_OMC_CDYLIB_FEATURES --no-default-features --features ${_rust_omc_features_csv})

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -205,29 +205,57 @@ endif()
 # reads them via option_env! (with a cfg!-based fallback). Single source of truth
 # shared with the C runtime build (only platform booleans, so it's safe here).
 include(${CMAKE_CURRENT_SOURCE_DIR}/runtime/rt_ldflags_generated_code.cmake)
-list(APPEND CARGO_ENV
-     "OMC_RT_LDFLAGS_GENERATED_CODE=${RT_LDFLAGS_GENERATED_CODE}"
-     "OMC_RT_LDFLAGS_GENERATED_CODE_SIM=${RT_LDFLAGS_GENERATED_CODE_SIM}"
-     "OMC_RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU=${RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU}"
-     "OMC_RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=${RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC}"
-     # ModelicaExternalC C-Sources dir, so openmodelica_codegen_wasm_jit's build.rs
-     # can compile the ModelicaExternalC WASI side module (modelicaexternalc.wasm) —
-     # the crate builds from a synced copy (rust-src) whose relative path can't reach it.
-     "OMC_EXTERNAL_C_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../SimulationRuntime/ModelicaExternalC/C-Sources"
-     # Same reason for the vendored solver sources: build.rs cross-compiles SUNDIALS
-     # and SuiteSparse/KLU to wasm (their own CMake, a wasi toolchain file) for the
-     # wasip1 wasm-jit runtimes.
-     "OMC_SUNDIALS_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0"
-     "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1")
 
-# wasi-libc source (pinned wasi-sdk-32) for build.rs to build a -fPIC libc.so
-# (Debian's is non-PIC), passed as OMC_WASI_LIBC_SRC. Download failure is a WARNING,
-# not FATAL: it only disables external "C" in wasm FMUs. Override the whole build
-# with a prebuilt sysroot via OMC_WASI_PIC_SYSROOT.
+# ---------------------------------------------------------------------------
+# WASI toolchain discovery (shared by wasi-libc PIC sysroot and sundials wasm).
+# ---------------------------------------------------------------------------
+find_program(LLVM_AR_EXECUTABLE llvm-ar)
+find_program(LLVM_RANLIB_EXECUTABLE llvm-ranlib)
+if(NOT LLVM_AR_EXECUTABLE OR NOT LLVM_RANLIB_EXECUTABLE)
+  execute_process(COMMAND clang -dumpversion OUTPUT_VARIABLE _clang_ver
+                  OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(_clang_ver MATCHES "^([0-9]+)")
+    set(_clang_major "${CMAKE_MATCH_1}")
+    find_program(LLVM_AR_EXECUTABLE llvm-ar-${_clang_major})
+    find_program(LLVM_RANLIB_EXECUTABLE llvm-ranlib-${_clang_major})
+  endif()
+endif()
+
+find_program(_omc_wasi_clang clang)
+if(_omc_wasi_clang)
+  execute_process(
+    COMMAND ${_omc_wasi_clang} -print-resource-dir
+    OUTPUT_VARIABLE _clang_res_dir OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(_clang_res_dir)
+    set(_wasi_builtins ${_clang_res_dir}/lib/wasi/libclang_rt.builtins-wasm32.a)
+  endif()
+endif()
+
+# PIC wasi-libc sysroot (for external "C" in wasm FMUs).
+#
+# Built by CMake using wasi-libc's own CMakeLists.txt with BUILD_SHARED=ON
+# so it produces a -fPIC libc.so (Debian's is non-PIC).
+# ---------------------------------------------------------------------------
+set(RUST_WASI_PIC_SYSROOT ${CMAKE_BINARY_DIR}/rust-wasi-pic-sysroot
+    CACHE PATH "Output directory for the PIC wasi-libc sysroot.")
+
+# Write the wasm32-wasip1 toolchain file for CMake to use when cross-compiling.
+set(_wasi_toolchain ${CMAKE_CURRENT_BINARY_DIR}/wasi-toolchain.cmake)
+file(WRITE ${_wasi_toolchain}
+  "set(CMAKE_SYSTEM_NAME WASI)\n"
+  "set(CMAKE_SYSTEM_PROCESSOR wasm32)\n"
+  "set(CMAKE_C_COMPILER clang)\n"
+  "set(CMAKE_C_COMPILER_TARGET wasm32-wasip1)\n"
+  "set(CMAKE_SYSROOT ${RUST_WASI_PIC_SYSROOT})\n"
+  "set(CMAKE_AR ${LLVM_AR_EXECUTABLE})\n"
+  "set(CMAKE_RANLIB ${LLVM_RANLIB_EXECUTABLE})\n"
+  "set(CMAKE_C_FLAGS_INIT \"-O2\")\n"
+  "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n"
+  "set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)\n")
 set(_wasi_libc_src ${CMAKE_BINARY_DIR}/downloads/wasi-libc/wasi-libc-wasi-sdk-32)
 if(NOT EXISTS ${_wasi_libc_src}/CMakeLists.txt)
   set(_wasi_tgz ${CMAKE_BINARY_DIR}/downloads/wasi-libc-wasi-sdk-32.tar.gz)
-  message(STATUS "Downloading wasi-libc (wasi-sdk-32) source for the PIC libc…")
+  message(STATUS "Downloading wasi-libc (wasi-sdk-32) source…")
   file(DOWNLOAD
        https://github.com/WebAssembly/wasi-libc/archive/refs/tags/wasi-sdk-32.tar.gz
        ${_wasi_tgz}
@@ -236,24 +264,137 @@ if(NOT EXISTS ${_wasi_libc_src}/CMakeLists.txt)
   list(GET _wasi_dl 0 _wasi_dl_code)
   if(NOT _wasi_dl_code EQUAL 0)
     file(REMOVE ${_wasi_tgz})
-    message(WARNING "Failed to download wasi-libc source (${_wasi_dl}); external \"C\" in wasm FMUs will be unavailable")
+    message(FATAL_ERROR "Failed to download wasi-libc source (${_wasi_dl})")
   else()
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/downloads/wasi-libc)
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${_wasi_tgz}
                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/downloads/wasi-libc
                     RESULT_VARIABLE _wasi_untar)
     if(NOT _wasi_untar EQUAL 0)
-      message(WARNING "Failed to unpack wasi-libc source; external \"C\" in wasm FMUs will be unavailable")
+      message(FATAL_ERROR "Failed to unpack wasi-libc source")
     endif()
   endif()
 endif()
-if(EXISTS ${_wasi_libc_src}/CMakeLists.txt)
-  list(APPEND CARGO_ENV "OMC_WASI_LIBC_SRC=${_wasi_libc_src}")
+
+# Build wasi-libc PIC sysroot via ExternalProject (honours jobserver, proper progress).
+include(ExternalProject)
+set(_wasi_libc_ep_build ${CMAKE_BINARY_DIR}/rust-wasi-libc-wasm-ep-build)
+ExternalProject_Add(rust_wasi_pic_sysroot
+  SOURCE_DIR ${_wasi_libc_src}
+  BINARY_DIR ${_wasi_libc_ep_build}
+  CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${_wasi_toolchain}
+    -DBUILD_SHARED=ON -DBUILD_TESTS=OFF
+    -DCMAKE_LINK_DEPENDS_USE_LINKER=OFF
+    -DBUILTINS_LIB=${_wasi_builtins}
+  BUILD_ALWAYS ON
+  BUILD_COMMAND ${CMAKE_COMMAND} --build ${_wasi_libc_ep_build} --parallel
+  INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${_wasi_libc_ep_build}/sysroot ${RUST_WASI_PIC_SYSROOT}
+  EXCLUDE_FROM_ALL ON)
+
+# ---------------------------------------------------------------------------
+# SUNDIALS/KLU wasm cross-compile.
+#
+# Separate from the native C runtime build (3rdParty/CMakeLists.txt). Uses the
+# same sources but a wasm32-wasip1 toolchain and a distinct build directory.
+# Produces static archives linked into the wasm-jit runtimes (FMI/web).
+# ---------------------------------------------------------------------------
+option(RUST_OMC_ENABLE_SUNDIALS "Build SUNDIALS/KLU for wasm32-wasip1 (sparse solver in wasm-jit runtime)." ON)
+
+if(RUST_OMC_ENABLE_SUNDIALS)
+  set(_sundials_sources ${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0)
+  set(_suitesparse_sources ${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1)
+
+  # SuiteSparse toolchain: base wasi toolchain + include dirs for KLU headers.
+  # CMAKE_C_FLAGS_INIT is a STRING (not list) so no semicolon issues.
+  set(_sundials_cflags "-O2 -I${_suitesparse_sources}/AMD/Include -I${_suitesparse_sources}/COLAMD/Include -I${_suitesparse_sources}/BTF/Include -I${_suitesparse_sources}/SuiteSparse_config")
+  set(_sundials_toolchain ${CMAKE_CURRENT_BINARY_DIR}/sundials-wasi-toolchain.cmake)
+  file(WRITE ${_sundials_toolchain}
+    "set(CMAKE_SYSTEM_NAME WASI)\n"
+    "set(CMAKE_SYSTEM_PROCESSOR wasm32)\n"
+    "set(CMAKE_C_COMPILER clang)\n"
+    "set(CMAKE_C_COMPILER_TARGET wasm32-wasip1)\n"
+    "set(CMAKE_SYSROOT ${RUST_WASI_PIC_SYSROOT})\n"
+    "set(CMAKE_AR ${LLVM_AR_EXECUTABLE})\n"
+    "set(CMAKE_RANLIB ${LLVM_RANLIB_EXECUTABLE})\n"
+    "set(CMAKE_C_FLAGS_INIT \"${_sundials_cflags}\")\n"
+    "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n"
+    "set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)\n")
+
+  # SuiteSparse wasm via ExternalProject.
+  set(_suitesparse_ep_build ${CMAKE_BINARY_DIR}/rust-suitesparse-wasm-ep-build)
+  ExternalProject_Add(rust_suitesparse_wasm
+    SOURCE_DIR ${_suitesparse_sources}
+    BINARY_DIR ${_suitesparse_ep_build}
+    CMAKE_ARGS
+      -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DBUILD_SHARED_LIBS=OFF
+    BUILD_COMMAND ${CMAKE_COMMAND} --build ${_suitesparse_ep_build} --parallel
+      --target klu amd colamd btf suitesparseconfig
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS ON
+    EXCLUDE_FROM_ALL ON)
+  add_dependencies(rust_suitesparse_wasm rust_wasi_pic_sysroot)
+
+  # SUNDIALS wasm via ExternalProject.
+  set(_sundials_ep_build ${CMAKE_BINARY_DIR}/rust-sundials-wasm-ep-build)
+  set(RUST_SUNDIALS_WASM_DIR ${CMAKE_BINARY_DIR}/rust-sundials-wasm
+      CACHE PATH "Output directory for the SUNDIALS/KLU wasm32-wasip1 archives.")
+  ExternalProject_Add(rust_sundials_wasm
+    SOURCE_DIR ${_sundials_sources}
+    BINARY_DIR ${_sundials_ep_build}
+    CMAKE_ARGS
+      -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DSUNDIALS_BUILD_STATIC_LIBS=ON
+      -DSUNDIALS_BUILD_SHARED_LIBS=OFF
+      -DSUNDIALS_LAPACK_ENABLE=OFF
+      -DSUNDIALS_EXAMPLES_ENABLE_C=OFF
+      -DSUNDIALS_KLU_ENABLE=ON
+      -DSUNDIALS_INDEX_SIZE=32
+      -DKLU_INCLUDE_DIR=${_suitesparse_sources}/KLU/Include
+      -DKLU_LIBRARY=${_suitesparse_ep_build}/libklu.a
+      -DAMD_LIBRARY=${_suitesparse_ep_build}/libamd.a
+      -DCOLAMD_LIBRARY=${_suitesparse_ep_build}/libcolamd.a
+      -DBTF_LIBRARY=${_suitesparse_ep_build}/libbtf.a
+      -DSUITESPARSECONFIG_LIBRARY=${_suitesparse_ep_build}/libsuitesparseconfig.a
+    BUILD_COMMAND ${CMAKE_COMMAND} --build ${_sundials_ep_build} --parallel
+      --target
+      sundials_kinsol_static sundials_ida_static sundials_cvode_static
+      sundials_nvecserial_static sundials_sunmatrixdense_static
+      sundials_sunmatrixsparse_static sundials_sunlinsoldense_static
+      sundials_sunlinsolklu_static
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS ON
+    EXCLUDE_FROM_ALL ON)
+  add_dependencies(rust_sundials_wasm rust_suitesparse_wasm)
+
+  # Collect all .a into RUST_SUNDIALS_WASM_DIR/lib/.
+  add_custom_target(rust_sundials_collect
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_WASM_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${_suitesparse_ep_build}/libklu.a
+      ${_suitesparse_ep_build}/libamd.a
+      ${_suitesparse_ep_build}/libcolamd.a
+      ${_suitesparse_ep_build}/libbtf.a
+      ${_suitesparse_ep_build}/libsuitesparseconfig.a
+      ${_sundials_ep_build}/src/kinsol/libsundials_kinsol.a
+      ${_sundials_ep_build}/src/ida/libsundials_ida.a
+      ${_sundials_ep_build}/src/cvode/libsundials_cvode.a
+      ${_sundials_ep_build}/src/nvector/serial/libsundials_nvecserial.a
+      ${_sundials_ep_build}/src/sunmatrix/dense/libsundials_sunmatrixdense.a
+      ${_sundials_ep_build}/src/sunmatrix/sparse/libsundials_sunmatrixsparse.a
+      ${_sundials_ep_build}/src/sunlinsol/dense/libsundials_sunlinsoldense.a
+      ${_sundials_ep_build}/src/sunlinsol/klu/libsundials_sunlinsolklu.a
+      ${RUST_SUNDIALS_WASM_DIR}/lib/
+    COMMENT "Rust: collecting SUNDIALS/KLU wasm archives -> ${RUST_SUNDIALS_WASM_DIR}/lib/"
+    VERBATIM)
+  add_dependencies(rust_sundials_collect rust_sundials_wasm)
 endif()
 
-# The wasi_snapshot_preview1 reactor adapter (wasmtime release) build.rs bridges
-# into the FMU component. Downloaded + cached like the other wasm vendor artifacts,
-# passed as OMC_WASI_P1_ADAPTER; WARNING (not FATAL) on failure.
+# ---------------------------------------------------------------------------
+# Preview1→preview2 reactor adapter (mandatory for FMI wasm FMU export).
+# ---------------------------------------------------------------------------
 set(_wasi_p1_adapter ${CMAKE_BINARY_DIR}/downloads/wasi_snapshot_preview1.reactor.wasm)
 if(NOT EXISTS ${_wasi_p1_adapter})
   message(STATUS "Downloading wasi_snapshot_preview1 reactor adapter (wasmtime v27.0.0)…")
@@ -265,11 +406,40 @@ if(NOT EXISTS ${_wasi_p1_adapter})
   list(GET _wasi_p1_dl 0 _wasi_p1_code)
   if(NOT _wasi_p1_code EQUAL 0)
     file(REMOVE ${_wasi_p1_adapter})
-    message(WARNING "Failed to download the wasi preview1 adapter (${_wasi_p1_dl}); external \"C\" in wasm FMUs will be unavailable")
+    message(FATAL_ERROR "Failed to download the wasi preview1 adapter (${_wasi_p1_dl})")
   endif()
 endif()
-if(EXISTS ${_wasi_p1_adapter})
-  list(APPEND CARGO_ENV "OMC_WASI_P1_ADAPTER=${_wasi_p1_adapter}")
+
+# ---------------------------------------------------------------------------
+# CARGO_ENV: env vars forwarded to every cargo invocation.
+# Prebuilt artifacts (PIC sysroot, sundials wasm) are passed as output paths
+# so the cargo build.rs uses them rather than rebuilding.
+# ---------------------------------------------------------------------------
+list(APPEND CARGO_ENV
+     "OMC_RT_LDFLAGS_GENERATED_CODE=${RT_LDFLAGS_GENERATED_CODE}"
+     "OMC_RT_LDFLAGS_GENERATED_CODE_SIM=${RT_LDFLAGS_GENERATED_CODE_SIM}"
+     "OMC_RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU=${RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU}"
+     "OMC_RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=${RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC}"
+     # ModelicaExternalC C-Sources dir (the crate builds from a synced copy whose
+     # relative path can't reach the real location).
+     "OMC_EXTERNAL_C_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../SimulationRuntime/ModelicaExternalC/C-Sources"
+     # Prebuilt PIC wasi-libc sysroot (with -fPIC libc.so) built by rust_wasi_pic_sysroot.
+     "OMC_WASI_PIC_SYSROOT=${RUST_WASI_PIC_SYSROOT}"
+     # Preview1 adapter for FMI wasm FMU export.
+     "OMC_WASI_P1_ADAPTER=${_wasi_p1_adapter}")
+
+if(RUST_OMC_ENABLE_SUNDIALS)
+  list(APPEND CARGO_ENV "OMC_SUNDIALS_WASM_DIR=${RUST_SUNDIALS_WASM_DIR}")
+endif()
+
+# Source paths (fallback for raw cargo builds without CMake).
+if(EXISTS ${_wasi_libc_src}/CMakeLists.txt)
+  list(APPEND CARGO_ENV "OMC_WASI_LIBC_SRC=${_wasi_libc_src}")
+endif()
+if(RUST_OMC_ENABLE_SUNDIALS)
+  list(APPEND CARGO_ENV
+       "OMC_SUNDIALS_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials-5.4.0"
+       "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse-5.8.1")
 endif()
 
 # Always via ${CARGO_BUILD} so target/ is never the in-source default.
@@ -590,6 +760,10 @@ function(omc_rust_setup_codegen)
   if(RUST_OMC_LAPACK_NALGEBRA)
     list(APPEND _rust_omc_features openmodelica_util/lapack-nalgebra)
   endif()
+  # Disable the sundials feature when the wasm cross-compile is not enabled.
+  if(NOT RUST_OMC_ENABLE_SUNDIALS)
+    list(APPEND _rust_omc_features openmodelica_codegen_wasm_jit/no-sundials)
+  endif()
   list(JOIN _rust_omc_features "," _rust_omc_features_csv)
   set(RUST_OMC_CDYLIB_FEATURES --no-default-features --features ${_rust_omc_features_csv})
 
@@ -612,9 +786,12 @@ function(omc_rust_setup_codegen)
     # which tracks byproducts globally; the cross-directory build order for the
     # Unix Makefiles generator is the add_dependencies in omc_rust_setup_omedit.
     BYPRODUCTS ${RUST_TARGET_DIR}/${RUST_OMC_ARTIFACT_SUBDIR}/${RUST_OMC_CDYLIB_NAME}
-    DEPENDS rust_codegen
+    DEPENDS rust_codegen rust_wasi_pic_sysroot
     COMMENT "Rust: building ${RUST_OMC_CDYLIB_NAME} (${RUST_OMC_PROFILE})"
     VERBATIM)
+  if(RUST_OMC_ENABLE_SUNDIALS)
+    add_dependencies(rust_libopenmodelica rust_sundials_collect)
+  endif()
 
   add_custom_target(rust_omc ALL
     WORKING_DIRECTORY ${RUST_OMC_DIR}
@@ -1057,6 +1234,11 @@ function(omc_rust_setup_wasm)
   if(RUST_OMC_SCRIPTING_API)
     set(_wasm_scripting_feature ",libopenmodelica_compiler/scripting_api")
   endif()
+  # Forward the sundials feature for the wasm-jit runtime (KLU sparse solver).
+  set(_wasm_sundials_feature "")
+  if(RUST_OMC_ENABLE_SUNDIALS)
+    set(_wasm_sundials_feature ",openmodelica_codegen_wasm_jit/sundials")
+  endif()
   # Standalone animation wasm for the browser pages, built in the same cargo pass
   # (features package-qualified so the extra -p stays unambiguous).
   set(_anim_pkg "")
@@ -1067,11 +1249,11 @@ function(omc_rust_setup_wasm)
     set(_wasm_common --target ${_wasm_target}
                      -p libopenmodelica_compiler -p omshell_egui -p omshell_dioxus ${_anim_pkg}
                      --no-default-features
-                     --features libopenmodelica_compiler/engine-wasmer,libopenmodelica_compiler/codegen_fmu,omshell_dioxus/web${_wasm_scripting_feature})
+                     --features libopenmodelica_compiler/engine-wasmer,libopenmodelica_compiler/codegen_fmu,omshell_dioxus/web${_wasm_scripting_feature}${_wasm_sundials_feature})
   else()
     set(_wasm_common --target ${_wasm_target} -p libopenmodelica_compiler ${_anim_pkg}
                      --no-default-features
-                     --features libopenmodelica_compiler/engine-wasmer,libopenmodelica_compiler/codegen_fmu${_wasm_scripting_feature})
+                     --features libopenmodelica_compiler/engine-wasmer,libopenmodelica_compiler/codegen_fmu${_wasm_scripting_feature}${_wasm_sundials_feature})
   endif()
 
   if(_profile STREQUAL "release")
@@ -1256,10 +1438,13 @@ function(omc_rust_setup_wasm)
     JOB_SERVER_AWARE TRUE
     COMMAND ${_wasm_cargo} ${_cargo_profile_flag} ${RUST_OMC_TIMINGS_FLAG} ${_wasm_common} ${_cargo_backend}
     BYPRODUCTS ${_wasm_artifact}
-    DEPENDS rust_codegen
+    DEPENDS rust_codegen rust_wasi_pic_sysroot
     COMMENT "Rust: cargo build wasm/web (${RUST_OMC_WASM_MODE})"
     VERBATIM)
   add_dependencies(rust_wasm_cargo rust_src_sync)
+  if(RUST_OMC_ENABLE_SUNDIALS)
+    add_dependencies(rust_wasm_cargo rust_sundials_collect)
+  endif()
   add_custom_command(
     OUTPUT ${_wasm_pkgdir}/${_wasm_name}_bg.wasm
     COMMAND ${CMAKE_COMMAND} -E rm -rf ${_web_dir}

--- a/OMCompiler/Compiler/.cmake/rust_src_removed.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_removed.txt
@@ -1,0 +1,3 @@
+# Files removed from the source tree that should be cleaned from synced copies.
+# One relative path per line (relative to OpenModelica.rs/).
+openmodelica_codegen_wasm_jit/build.rs

--- a/OMCompiler/Compiler/.cmake/rust_src_sync.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_src_sync.cmake
@@ -22,6 +22,22 @@ foreach(_rel ${_lines})
   file(COPY ${SRC}/${_rel} DESTINATION ${DST}/${_dir})
 endforeach()
 
+# Clean up files removed from the source tree (so cargo doesn't pick up stale build.rs).
+get_filename_component(MANIFEST_DIR ${MANIFEST} DIRECTORY)
+set(_removed_file ${MANIFEST_DIR}/rust_src_removed.txt)
+if(EXISTS ${_removed_file})
+  file(STRINGS ${_removed_file} _removed_lines)
+  foreach(_rel ${_removed_lines})
+    string(STRIP "${_rel}" _rel)
+    if(_rel STREQUAL "" OR _rel MATCHES "^#")
+      continue()
+    endif()
+    if(EXISTS ${DST}/${_rel})
+      file(REMOVE ${DST}/${_rel})
+    endif()
+  endforeach()
+endif()
+
 # Builtin .mo that openmodelica_wasi include_str!s via ../../../{FrontEnd,NFFrontEnd}
 # (paths reaching past the crate tree into Compiler/); mirror them beside the copy
 # at the same relative depth. Keep in sync with openmodelica_wasi/src/lib.rs.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -43,7 +43,7 @@ wasmparser = "0.252"
 # simulation target). Default on. Built without it, the crate still *emits* wasm
 # modules but cannot execute them (the entry points report the engine absent),
 # and neither wasmtime nor wasmer is pulled in.
-default = ["jit"]
+default = ["jit", "sundials"]
 # `jit` pulls the native default engine (wasmtime); on wasm32 the wasmtime dep
 # is target-absent and wasmer-js is used instead (requires `engine-wasmer`).
 jit = ["dep:wasmtime", "openmodelica_wasm_jit/jit"]
@@ -51,6 +51,11 @@ jit = ["dep:wasmtime", "openmodelica_wasm_jit/jit"]
 # (wasmer then wins over wasmtime), and mandatorily on wasm32 (its `js` backend
 # is the only engine that builds for wasm).
 engine-wasmer = ["jit", "dep:wasmer", "openmodelica_wasm_jit/engine-wasmer"]
+# SUNDIALS/KLU sparse solver for the wasm-jit runtimes (FMI/web). Default on;
+# the build script cross-compiles SUNDIALS to wasm32-wasip1 when this feature
+# is enabled (or uses OMC_SUNDIALS_WASM_DIR if CMake prebuilt it). Off only
+# when the CMake build disables RUST_OMC_ENABLE_SUNDIALS.
+sundials = []
 
 # wasmtime is native-only (no wasm32 build); the wasm target ignores
 # engine-wasmtime and always uses wasmer-js.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -51,10 +51,9 @@ jit = ["dep:wasmtime", "openmodelica_wasm_jit/jit"]
 # (wasmer then wins over wasmtime), and mandatorily on wasm32 (its `js` backend
 # is the only engine that builds for wasm).
 engine-wasmer = ["jit", "dep:wasmer", "openmodelica_wasm_jit/engine-wasmer"]
-# SUNDIALS/KLU sparse solver for the wasm-jit runtimes (FMI/web). Default on;
-# the build script cross-compiles SUNDIALS to wasm32-wasip1 when this feature
-# is enabled (or uses OMC_SUNDIALS_WASM_DIR if CMake prebuilt it). Off only
-# when the CMake build disables RUST_OMC_ENABLE_SUNDIALS.
+# SUNDIALS/KLU sparse solver for the wasm-jit runtimes (FMI/web).
+# CMake sets this via --features when RUST_OMC_ENABLE_SUNDIALS is ON; the
+# runtime's build.rs then links the precompiled wasm32-wasip1 archives.
 sundials = []
 
 # wasmtime is native-only (no wasm32 build); the wasm target ignores

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
@@ -1,8 +1,12 @@
 //! Links the wasm SUNDIALS/KLU archives into the wasip1 runtimes when
-//! `openmodelica_codegen_wasm_jit`'s build script has cross-compiled them
-//! (`OMC_SUNDIALS_WASM_DIR`), and sets `cfg(sundials)` so `src/sundials.rs` and its
-//! callers compile in. Absent archives are not an error: the runtime then keeps
-//! using its pure-Rust solvers, and a raw `cargo build` of this crate still works.
+//! `OMC_SUNDIALS_WASM_DIR` is set by the parent build script
+//! (`openmodelica_codegen_wasm_jit`'s build.rs, forwarded from CMake's
+//! `rust_sundials_wasm` target). Sets `cfg(sundials)` so `src/sundials.rs`
+//! and its callers compile in.
+//!
+//! When `OMC_SUNDIALS_WASM_DIR` is not set, sundials is simply not linked
+//! (the pure-Rust fallback is used). When it is set, missing archives are a
+//! hard error — the parent build script only sets it when the archives exist.
 
 use std::path::Path;
 
@@ -39,9 +43,8 @@ fn main() {
         .filter(|l| !lib.join(format!("lib{l}.a")).exists())
         .collect();
     if !missing.is_empty() {
-        println!("cargo:warning=OMC_SUNDIALS_WASM_DIR={} is missing {missing:?}; building \
-                  without SUNDIALS", lib.display());
-        return;
+        panic!("OMC_SUNDIALS_WASM_DIR={} is missing {missing:?}; the sundials wasm \
+                cross-compile failed (check the rust_sundials_wasm CMake target)", lib.display());
     }
     println!("cargo:rustc-link-search=native={}", lib.display());
     for l in LIBS {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -14,6 +14,11 @@ use crate::{load_f64, load_u32, rt_alloc, rt_free, store_f64, store_u32};
 static NLS_DEPTH: AtomicU32 = AtomicU32::new(0);
 static NLS_ASSERT_HIT: AtomicU32 = AtomicU32::new(0);
 
+/// Whether the last residual evaluation hit a recoverable model assert.
+pub(crate) fn assert_hit() -> bool {
+    NLS_ASSERT_HIT.load(Ordering::Relaxed) != 0
+}
+
 /// Model side (emitted by `emit_assert`): is a failed assert currently recoverable
 /// (i.e. inside a nonlinear-solver residual)? Non-zero → the model records the
 /// assert via [`rt_nls_note_assert`] and bails out instead of trapping.
@@ -1155,19 +1160,65 @@ fn scaled_max_norm(v: &[f64], scale: &[f64]) -> f64 {
     m
 }
 
-/// The sparse (kinsol + KLU) nonlinear solver: a scaled Newton iteration with a
-/// line search over the symbolic Jacobian assembled straight into CSC, factorized
-/// by the runtime's sparse LU with its symbolic analysis cached per system.
-/// Mirrors C's `nlsKinsolSolve`: `xScale[i] = 1/max(nominal_i, |x_i|)`,
-/// `fScale[i] = 1/max_j |J_ij / xScale_j|`, convergence on `‖fScale·F‖∞ ≤ ftol`
-/// or a scaled step below `scsteptol`, and the same retry ladder
-/// (`nlsKinsolErrorHandler`) of start point / scaling / line-search variations.
+/// The sparse nonlinear solver a system with an analytic sparsity pattern gets, as
+/// in C: KINSOL over the Jacobian assembled straight into CSC, factorized by KLU.
+/// [`newton_sparse_solve`] stands in for it where SUNDIALS is not linked in, and
+/// serves `-nlsLS=rsparse`.
 ///
 /// `pat_addr` holds the compile-time pattern (`colptr[n+1]` then `rowidx[nnz]`),
 /// `val_ptr` the `nnz` values the model's `jac` callback fills, and `handle` keys
-/// the cached factorization.
+/// the solver kept for this system.
 #[allow(clippy::too_many_arguments)]
 fn kinsol_sparse_solve(
+    n: usize,
+    x: &mut [f64],
+    guess: &[f64],
+    warm: &[f64],
+    nominal: &[f64],
+    sim_data: u32,
+    x_ptr: u32,
+    jac_idx: u32,
+    val_ptr: u32,
+    pat_addr: u32,
+    nnz: usize,
+    handle: u32,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    #[cfg(sundials)]
+    if crate::sundials::nls_ls_backend() == crate::sundials::Sparse::Klu {
+        // C's retry ladder re-picks the start point, but only through settings its
+        // loop head overrides; `warm` is the caller's own second attempt.
+        let colptr = unsafe { core::slice::from_raw_parts(pat_addr as *const i32, n + 1) };
+        let rowidx =
+            unsafe { core::slice::from_raw_parts((pat_addr + ((n + 1) * 4) as u32) as *const i32, nnz) };
+        let mut assemble = |xs: &[f64], vals: &mut [f64]| {
+            let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
+            for i in 0..n {
+                unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
+            }
+            NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+            jacf(sim_data, x_ptr, val_ptr);
+            NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+            NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+            for (k, v) in vals.iter_mut().enumerate() {
+                *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
+            }
+        };
+        return crate::sundials::kinsol_solve(
+            handle, n, nnz, colptr, rowidx, nominal, guess, x, eval, &mut assemble,
+        );
+    }
+    newton_sparse_solve(
+        n, x, guess, warm, nominal, sim_data, x_ptr, jac_idx, val_ptr, pat_addr, nnz, handle, eval,
+    )
+}
+
+/// A scaled Newton iteration with a line search over the same CSC Jacobian, using
+/// the runtime's own sparse LU: KINSOL's scaling (`xScale[i] = 1/max(nominal_i,
+/// |x_i|)`, `fScale[i] = 1/max_j |J_ij / xScale_j|`) and stopping tests, with C's
+/// retry ladder approximated by five start-point / scaling / line-search variations.
+#[allow(clippy::too_many_arguments)]
+fn newton_sparse_solve(
     n: usize,
     x: &mut [f64],
     guess: &[f64],

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -33,6 +33,29 @@ pub extern "C" fn rt_nls_note_assert() {
     NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
 }
 
+/// Build the Jacobian-assemble closure used by both kinsol and newton sparse paths.
+fn make_assemble(
+    n: usize,
+    x_ptr: u32,
+    sim_data: u32,
+    jac_idx: u32,
+    val_ptr: u32,
+) -> impl FnMut(&[f64], &mut [f64]) {
+    move |xs: &[f64], vals: &mut [f64]| {
+        let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
+        for i in 0..n {
+            unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
+        }
+        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+        jacf(sim_data, x_ptr, val_ptr);
+        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        for (k, v) in vals.iter_mut().enumerate() {
+            *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
+        }
+    }
+}
+
 /// `Default` is the density-based choice plus the full retry ladder.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum NlsPick {
@@ -1191,19 +1214,7 @@ fn kinsol_sparse_solve(
         let colptr = unsafe { core::slice::from_raw_parts(pat_addr as *const i32, n + 1) };
         let rowidx =
             unsafe { core::slice::from_raw_parts((pat_addr + ((n + 1) * 4) as u32) as *const i32, nnz) };
-        let mut assemble = |xs: &[f64], vals: &mut [f64]| {
-            let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
-            for i in 0..n {
-                unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
-            }
-            NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
-            jacf(sim_data, x_ptr, val_ptr);
-            NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
-            NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
-            for (k, v) in vals.iter_mut().enumerate() {
-                *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
-            }
-        };
+        let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
         return crate::sundials::kinsol_solve(
             handle, n, nnz, colptr, rowidx, nominal, guess, x, eval, &mut assemble,
         );
@@ -1242,19 +1253,7 @@ fn newton_sparse_solve(
     let b_ptr = rt_alloc((n * 8) as u32);
 
     let mut vals = vec![0.0f64; nnz];
-    let assemble = |xs: &[f64], vals: &mut [f64]| {
-        let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
-        for i in 0..n {
-            unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
-        }
-        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
-        jacf(sim_data, x_ptr, val_ptr);
-        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
-        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
-        for (k, v) in vals.iter_mut().enumerate() {
-            *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
-        }
-    };
+    let assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
 
     let mut f = vec![0.0f64; n];
     let mut xscale = vec![1.0f64; n];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1253,7 +1253,7 @@ fn newton_sparse_solve(
     let b_ptr = rt_alloc((n * 8) as u32);
 
     let mut vals = vec![0.0f64; nnz];
-    let assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
+    let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
 
     let mut f = vec![0.0f64; n];
     let mut xscale = vec![1.0f64; n];
@@ -1525,7 +1525,7 @@ pub extern "C" fn rt_solve_nls(
     // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
     // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
     // O(n^3) per step, which is what the sparse choice exists to avoid.
-    let mut converged = if sparse {
+    let converged = if sparse {
         kinsol_sparse_solve(
             n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
             pat_addr, nnz as usize, lss_handle, &mut eval,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -165,12 +165,12 @@ pub extern "C" fn rt_sim_set_args(ptr: u32, len: u32) -> i32 {
 pub extern "C" fn rt_sim_set_overrides(ptr: u32, len: u32) -> i32 {
     let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
     let mut p = 0usize;
-    let mut u32_at = |p: &mut usize| -> Option<u32> {
+    let u32_at = |p: &mut usize| -> Option<u32> {
         let v = bytes.get(*p..*p + 4)?;
         *p += 4;
         Some(u32::from_le_bytes(v.try_into().ok()?))
     };
-    let mut group = |p: &mut usize| -> Option<Vec<(u32, WTy, f64)>> {
+    let group = |p: &mut usize| -> Option<Vec<(u32, WTy, f64)>> {
         let n = u32_at(p)? as usize;
         let mut out = Vec::with_capacity(n);
         for _ in 0..n {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -385,7 +385,12 @@ pub(crate) mod kinsol {
         assemble: &'a mut dyn FnMut(&[f64], &mut [f64]),
     }
 
-    fn data(v: NVector, n: usize) -> &'static mut [f64] {
+    /// Extract the backing array pointer from an N_Vector.
+    ///
+    /// Returns `&mut [f64]` with a lifetime bounded by the `'a` parameter of the
+    /// enclosing Ud struct. The slice is only valid while the N_Vector exists;
+    /// the caller must not let it escape the callback scope.
+    fn data<'a>(v: NVector, n: usize) -> &'a mut [f64] {
         unsafe { core::slice::from_raw_parts_mut(N_VGetArrayPointer(v), n) }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -446,7 +446,10 @@ pub(crate) mod kinsol {
                 strategy: KIN_LINESEARCH,
                 maxstepfactor: MAXSTEPFACTOR,
             };
-            if s.kin.is_null() || s.u.is_null() || s.j.is_null() {
+            if s.kin.is_null()
+                || s.j.is_null()
+                || [s.u, s.xscale, s.fscale, s.ftmp].iter().any(|v| v.is_null())
+            {
                 return None;
             }
             s.ls = unsafe { SUNLinSol_KLU(s.u, s.j) };
@@ -578,6 +581,7 @@ pub(crate) mod kinsol {
             let mut success = false;
             let mut reset_tol = false;
             let mut retries = 0;
+            let mut passes = 0;
             loop {
                 data(self.u, self.n).copy_from_slice(guess);
                 self.x_scaling(nominal);
@@ -587,7 +591,8 @@ pub(crate) mod kinsol {
                 success = matches!(flag, KIN_SUCCESS | KIN_INITIAL_GUESS_OK | KIN_STEP_LT_STPTOL);
                 let retry = flag < 0 && self.handle_error(flag, &mut retries, &mut reset_tol);
                 retries += 1;
-                if success || !retry || retries >= RETRY_MAX {
+                passes += 1;
+                if success || !retry || retries >= RETRY_MAX || passes >= 2 * RETRY_MAX {
                     break;
                 }
             }
@@ -652,14 +657,16 @@ pub(crate) fn kinsol_solve(
     assemble: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
     KIN_CACHE.with(|cell| {
-        let mut cache = cell.borrow_mut();
-        let solver = match cache.entry(handle) {
-            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-            std::collections::hash_map::Entry::Vacant(slot) => match kinsol::Solver::new(n, nnz) {
-                Some(s) => slot.insert(s),
+        // Detach solver so model callbacks can re-enter kinsol_solve for a nested system.
+        let mut solver = match cell.borrow_mut().remove(&handle) {
+            Some(s) => s,
+            None => match kinsol::Solver::new(n, nnz) {
+                Some(s) => s,
                 None => return false,
             },
         };
-        solver.solve(guess, nominal, colptr, rowidx, x, eval, assemble)
+        let ok = solver.solve(guess, nominal, colptr, rowidx, x, eval, assemble);
+        cell.borrow_mut().insert(handle, solver);
+        ok
     })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -79,12 +79,6 @@ pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     set_klu(ls, lss, nls_ls);
 }
 
-#[cfg(sundials)]
-unsafe extern "C" {
-    fn KINCreate() -> *mut core::ffi::c_void;
-    fn KINFree(kinmem: *mut *mut core::ffi::c_void);
-}
-
 /// Smoke test that the archives are linked and callable: `klu_defaults` reports
 /// success and its values land where [`klu::Common`] mirrors them, and KINSOL
 /// allocates.
@@ -92,10 +86,10 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_sundials_selftest() -> i32 {
     let common_ok = klu::Common::defaults().is_some();
-    let mut kin = unsafe { KINCreate() };
+    let mut kin = unsafe { kinsol::KINCreate() };
     let kin_ok = !kin.is_null();
     if kin_ok {
-        unsafe { KINFree(&mut kin) };
+        unsafe { kinsol::KINFree(&mut kin) };
     }
     (common_ok && kin_ok) as i32
 }
@@ -251,10 +245,13 @@ std::thread_local! {
         core::cell::RefCell::new(std::collections::HashMap::new());
 }
 
-/// Drop the per-system factorizations; their patterns belong to one run.
+/// Drop the per-system factorizations and KINSOL memory; they belong to one run.
 pub(crate) fn reset_caches() {
     #[cfg(sundials)]
-    KLU_CACHE.with(|c| c.borrow_mut().clear());
+    {
+        KLU_CACHE.with(|c| c.borrow_mut().clear());
+        KIN_CACHE.with(|c| c.borrow_mut().clear());
+    }
 }
 
 /// KLU solve of the CSC system `A x = b` (`b ← x`), reusing `handle`'s symbolic
@@ -302,4 +299,367 @@ pub(crate) fn klu_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
         Some(mut s) => !s.solve(values.as_ptr(), b_ptr as *mut f64, n) as i32,
         None => 1,
     }
+}
+
+/// KINSOL over the sparse Jacobian, with KLU as its linear solver — C's
+/// `kinsolSolver.c` for a system with an analytic sparsity pattern.
+#[cfg(sundials)]
+pub(crate) mod kinsol {
+    use alloc::vec;
+    use core::ffi::{c_int, c_long, c_void};
+
+    pub type NVector = *mut c_void;
+    pub type SunMatrix = *mut c_void;
+    pub type SunLinSol = *mut c_void;
+
+    type SysFn = extern "C" fn(u: NVector, fval: NVector, user: *mut c_void) -> c_int;
+    type JacFn = extern "C" fn(u: NVector, fu: NVector, j: SunMatrix, user: *mut c_void, t1: NVector, t2: NVector) -> c_int;
+    type ErrFn = extern "C" fn(code: c_int, module: *const u8, function: *const u8, msg: *mut u8, user: *mut c_void);
+
+    unsafe extern "C" {
+        pub fn KINCreate() -> *mut c_void;
+        pub fn KINFree(kinmem: *mut *mut c_void);
+        fn KINInit(kinmem: *mut c_void, func: SysFn, tmpl: NVector) -> c_int;
+        fn KINSol(kinmem: *mut c_void, uu: NVector, strategy: c_int, u_scale: NVector, f_scale: NVector) -> c_int;
+        fn KINSetUserData(kinmem: *mut c_void, user: *mut c_void) -> c_int;
+        fn KINSetErrHandlerFn(kinmem: *mut c_void, eh: ErrFn, user: *mut c_void) -> c_int;
+        fn KINSetFuncNormTol(kinmem: *mut c_void, tol: f64) -> c_int;
+        fn KINSetScaledStepTol(kinmem: *mut c_void, tol: f64) -> c_int;
+        fn KINSetNumMaxIters(kinmem: *mut c_void, iters: c_long) -> c_int;
+        fn KINSetNoInitSetup(kinmem: *mut c_void, no_init_setup: c_int) -> c_int;
+        fn KINSetMaxSetupCalls(kinmem: *mut c_void, msbset: c_long) -> c_int;
+        fn KINSetMaxNewtonStep(kinmem: *mut c_void, mxnewtstep: f64) -> c_int;
+        fn KINSetLinearSolver(kinmem: *mut c_void, ls: SunLinSol, a: SunMatrix) -> c_int;
+        fn KINSetJacFn(kinmem: *mut c_void, jac: JacFn) -> c_int;
+        fn KINGetFuncNorm(kinmem: *mut c_void, fnorm: *mut f64) -> c_int;
+        fn N_VNew_Serial(len: i32) -> NVector;
+        fn N_VDestroy(v: NVector);
+        fn N_VGetArrayPointer(v: NVector) -> *mut f64;
+        fn N_VConst(c: f64, z: NVector);
+        fn N_VWL2Norm(x: NVector, w: NVector) -> f64;
+        fn SUNSparseMatrix(m: i32, n: i32, nnz: i32, sparsetype: c_int) -> SunMatrix;
+        fn SUNMatDestroy(a: SunMatrix);
+        fn SUNSparseMatrix_Data(a: SunMatrix) -> *mut f64;
+        fn SUNSparseMatrix_IndexPointers(a: SunMatrix) -> *mut i32;
+        fn SUNSparseMatrix_IndexValues(a: SunMatrix) -> *mut i32;
+        fn SUNLinSol_KLU(y: NVector, a: SunMatrix) -> SunLinSol;
+        fn SUNLinSol_KLUReInit(s: SunLinSol, a: SunMatrix, nnz: i32, reinit_type: c_int) -> c_int;
+        fn SUNLinSolFree(s: SunLinSol) -> c_int;
+    }
+
+    const CSC_MAT: c_int = 0;
+    const SUNKLU_REINIT_PARTIAL: c_int = 2;
+    const KIN_NONE: c_int = 0;
+    const KIN_LINESEARCH: c_int = 1;
+    const KIN_SUCCESS: c_int = 0;
+    const KIN_INITIAL_GUESS_OK: c_int = 1;
+    const KIN_STEP_LT_STPTOL: c_int = 2;
+    const KIN_MEM_NULL: c_int = -1;
+    const KIN_ILL_INPUT: c_int = -2;
+    const KIN_NO_MALLOC: c_int = -3;
+    const KIN_LINESEARCH_NONCONV: c_int = -5;
+    const KIN_MAXITER_REACHED: c_int = -6;
+    const KIN_MXNEWT_5X_EXCEEDED: c_int = -7;
+    const KIN_LINESEARCH_BCFAIL: c_int = -8;
+    const KIN_LINIT_FAIL: c_int = -10;
+    const KIN_LSETUP_FAIL: c_int = -11;
+    const KIN_LSOLVE_FAIL: c_int = -12;
+    const KIN_REPTD_SYSFUNC_ERR: c_int = -15;
+
+    /// C's `newtonFTol`/`newtonXTol`, `maxStepFactor` and `FTOL_WITH_LESS_ACCURACY`
+    /// defaults, and `RETRY_MAX`.
+    const FNORMTOL: f64 = 1.0e-12;
+    const SCSTEPTOL: f64 = 1.0e-12;
+    const MAXSTEPFACTOR: f64 = 1.0e12;
+    const FTOL_LESS_ACCURACY: f64 = 1.0e-6;
+    const RETRY_MAX: i32 = 5;
+
+    /// The system KINSOL is solving, handed to the callbacks through
+    /// `KINSetUserData` for the duration of one [`Solver::solve`].
+    struct Ud<'a> {
+        n: usize,
+        nnz: usize,
+        colptr: &'a [i32],
+        rowidx: &'a [i32],
+        eval: &'a mut dyn FnMut(&[f64], &mut [f64]),
+        assemble: &'a mut dyn FnMut(&[f64], &mut [f64]),
+    }
+
+    fn data(v: NVector, n: usize) -> &'static mut [f64] {
+        unsafe { core::slice::from_raw_parts_mut(N_VGetArrayPointer(v), n) }
+    }
+
+    extern "C" fn residual(u: NVector, fval: NVector, user: *mut c_void) -> c_int {
+        let ud = unsafe { &mut *(user as *mut Ud) };
+        let x = data(u, ud.n);
+        let f = data(fval, ud.n);
+        (ud.eval)(x, f);
+        // A model assert at this point is recoverable: KINSOL shortens the step, as
+        // it does for the C runtime's longjmp-caught residual.
+        crate::nls::assert_hit() as c_int
+    }
+
+    extern "C" fn jacobian(u: NVector, _fu: NVector, j: SunMatrix, user: *mut c_void, _t1: NVector, _t2: NVector) -> c_int {
+        let ud = unsafe { &mut *(user as *mut Ud) };
+        let x = data(u, ud.n);
+        let vals = unsafe { core::slice::from_raw_parts_mut(SUNSparseMatrix_Data(j), ud.nnz) };
+        (ud.assemble)(x, vals);
+        unsafe {
+            core::ptr::copy_nonoverlapping(ud.colptr.as_ptr(), SUNSparseMatrix_IndexPointers(j), ud.n + 1);
+            core::ptr::copy_nonoverlapping(ud.rowidx.as_ptr(), SUNSparseMatrix_IndexValues(j), ud.nnz);
+        }
+        0
+    }
+
+    /// KINSOL writes its own diagnostics to `stderr`, which is captured and dropped
+    /// during a simulation; the return code carries everything the ladder needs.
+    extern "C" fn silent(_code: c_int, _module: *const u8, _function: *const u8, _msg: *mut u8, _user: *mut c_void) {}
+
+    /// One system's KINSOL memory, kept across solves as C keeps its `NLS_KINSOL_DATA`:
+    /// the KLU symbolic factorization, the strategy and the step factor all persist.
+    pub struct Solver {
+        kin: *mut c_void,
+        u: NVector,
+        xscale: NVector,
+        fscale: NVector,
+        ftmp: NVector,
+        j: SunMatrix,
+        ls: SunLinSol,
+        n: usize,
+        nnz: usize,
+        strategy: c_int,
+        maxstepfactor: f64,
+    }
+
+    impl Solver {
+        pub fn new(n: usize, nnz: usize) -> Option<Solver> {
+            let mut s = Solver {
+                kin: unsafe { KINCreate() },
+                u: unsafe { N_VNew_Serial(n as i32) },
+                xscale: unsafe { N_VNew_Serial(n as i32) },
+                fscale: unsafe { N_VNew_Serial(n as i32) },
+                ftmp: unsafe { N_VNew_Serial(n as i32) },
+                j: unsafe { SUNSparseMatrix(n as i32, n as i32, nnz as i32, CSC_MAT) },
+                ls: core::ptr::null_mut(),
+                n,
+                nnz,
+                strategy: KIN_LINESEARCH,
+                maxstepfactor: MAXSTEPFACTOR,
+            };
+            if s.kin.is_null() || s.u.is_null() || s.j.is_null() {
+                return None;
+            }
+            s.ls = unsafe { SUNLinSol_KLU(s.u, s.j) };
+            if s.ls.is_null() {
+                return None;
+            }
+            unsafe {
+                KINSetErrHandlerFn(s.kin, silent, core::ptr::null_mut());
+                if KINInit(s.kin, residual, s.u) != KIN_SUCCESS
+                    || KINSetLinearSolver(s.kin, s.ls, s.j) != KIN_SUCCESS
+                    || KINSetJacFn(s.kin, jacobian) != KIN_SUCCESS
+                {
+                    return None;
+                }
+                KINSetFuncNormTol(s.kin, FNORMTOL);
+                KINSetScaledStepTol(s.kin, SCSTEPTOL);
+                KINSetNumMaxIters(s.kin, 100 * n as c_long);
+                KINSetNoInitSetup(s.kin, 0);
+            }
+            Some(s)
+        }
+
+        /// `xScale[i] = 1/max(nominal_i, |x_i|)` at the start point (C's
+        /// `SCALING_NOMINALSTART`).
+        fn x_scaling(&mut self, nominal: &[f64]) {
+            let start = data(self.u, self.n);
+            for (s, (nom, x)) in data(self.xscale, self.n).iter_mut().zip(nominal.iter().zip(start.iter())) {
+                *s = 1.0 / libm::fmax(*nom, libm::fabs(*x));
+            }
+        }
+
+        /// `fScale[i] = 1/max_j |J_ij / xScale_j|` from the Jacobian at the start
+        /// point (C's `SCALING_JACOBIAN`), with C's `1e-12` floor on the row maximum.
+        fn f_scaling(&mut self, ud: &mut Ud, vals: &mut [f64]) {
+            (ud.assemble)(data(self.u, self.n), vals);
+            let xscale = data(self.xscale, self.n);
+            let fscale = data(self.fscale, self.n);
+            fscale.fill(1e-12);
+            for c in 0..self.n {
+                for k in ud.colptr[c] as usize..ud.colptr[c + 1] as usize {
+                    let v = libm::fabs(vals[k] / xscale[c]);
+                    let row = &mut fscale[ud.rowidx[k] as usize];
+                    if *row < v {
+                        *row = v;
+                    }
+                }
+            }
+            for s in fscale.iter_mut() {
+                *s = 1.0 / *s;
+            }
+        }
+
+        /// `mxnewtstep = maxstepfactor * ‖xScale‖₂` (C's `nlsKinsolSetMaxNewtonStep`).
+        fn max_newton_step(&mut self) {
+            unsafe {
+                N_VConst(self.maxstepfactor, self.ftmp);
+                let step = N_VWL2Norm(self.xscale, self.ftmp);
+                KINSetMaxNewtonStep(self.kin, step);
+            }
+        }
+
+        /// C's `nlsKinsolErrorHandler`: `true` to try again. C also re-picks the
+        /// scaling and the start point per retry, but [`solve`](Self::solve) applies
+        /// both again before the next `KINSol`, so only what is set here survives.
+        fn handle_error(&mut self, code: c_int, retries: &mut i32, reset_tol: &mut bool) -> bool {
+            unsafe { KINSetNoInitSetup(self.kin, 0) };
+            match code {
+                KIN_MEM_NULL | KIN_ILL_INPUT | KIN_NO_MALLOC | KIN_LINIT_FAIL => return false,
+                KIN_MXNEWT_5X_EXCEEDED => {
+                    self.maxstepfactor *= 1e5;
+                    self.max_newton_step();
+                    return true;
+                }
+                KIN_LINESEARCH_NONCONV => {
+                    self.strategy = KIN_NONE;
+                    *retries -= 1;
+                    return true;
+                }
+                KIN_LSOLVE_FAIL => {
+                    // An out-of-date factorization; redo it from the pattern.
+                    unsafe { SUNLinSol_KLUReInit(self.ls, self.j, self.nnz as i32, SUNKLU_REINIT_PARTIAL) };
+                    return true;
+                }
+                // C answers `LSETUP_FAIL` by switching to a numeric Jacobian; this
+                // path only exists for systems that have the analytic one.
+                KIN_MAXITER_REACHED | KIN_REPTD_SYSFUNC_ERR | KIN_LSETUP_FAIL | KIN_LINESEARCH_BCFAIL => {}
+                _ => return false,
+            }
+            let mut fnorm = 0.0;
+            unsafe { KINGetFuncNorm(self.kin, &mut fnorm) };
+            if fnorm < FTOL_LESS_ACCURACY {
+                // C's "move forward with a less accurate solution".
+                unsafe {
+                    KINSetFuncNormTol(self.kin, FTOL_LESS_ACCURACY);
+                    KINSetScaledStepTol(self.kin, FTOL_LESS_ACCURACY);
+                }
+                *reset_tol = true;
+                return true;
+            }
+            match *retries {
+                0 => {}
+                1 => self.strategy = KIN_LINESEARCH,
+                2 => self.strategy = KIN_NONE,
+                3 | 4 => {
+                    unsafe { KINSetMaxSetupCalls(self.kin, 1) };
+                    self.strategy = KIN_LINESEARCH;
+                }
+                _ => return false,
+            }
+            true
+        }
+
+        /// C's `nlsKinsolSolve`: solve from `guess`, retrying per
+        /// [`handle_error`](Self::handle_error) until it gives up or `RETRY_MAX`.
+        /// On success `x` is the solution.
+        pub fn solve(
+            &mut self,
+            guess: &[f64],
+            nominal: &[f64],
+            colptr: &[i32],
+            rowidx: &[i32],
+            x: &mut [f64],
+            eval: &mut dyn FnMut(&[f64], &mut [f64]),
+            assemble: &mut dyn FnMut(&[f64], &mut [f64]),
+        ) -> bool {
+            let mut ud = Ud { n: self.n, nnz: self.nnz, colptr, rowidx, eval, assemble };
+            unsafe { KINSetUserData(self.kin, &mut ud as *mut Ud as *mut c_void) };
+            let mut vals = vec![0.0f64; self.nnz];
+            let mut success = false;
+            let mut reset_tol = false;
+            let mut retries = 0;
+            loop {
+                data(self.u, self.n).copy_from_slice(guess);
+                self.x_scaling(nominal);
+                self.f_scaling(&mut ud, &mut vals);
+                self.max_newton_step();
+                let flag = unsafe { KINSol(self.kin, self.u, self.strategy, self.xscale, self.fscale) };
+                success = matches!(flag, KIN_SUCCESS | KIN_INITIAL_GUESS_OK | KIN_STEP_LT_STPTOL);
+                let retry = flag < 0 && self.handle_error(flag, &mut retries, &mut reset_tol);
+                retries += 1;
+                if success || !retry || retries >= RETRY_MAX {
+                    break;
+                }
+            }
+            if reset_tol {
+                unsafe {
+                    KINSetFuncNormTol(self.kin, FNORMTOL);
+                    KINSetScaledStepTol(self.kin, SCSTEPTOL);
+                }
+            }
+            if success {
+                x.copy_from_slice(data(self.u, self.n));
+            }
+            unsafe { KINSetUserData(self.kin, core::ptr::null_mut()) };
+            success
+        }
+    }
+
+    impl Drop for Solver {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.kin.is_null() {
+                    KINFree(&mut self.kin);
+                }
+                if !self.ls.is_null() {
+                    SUNLinSolFree(self.ls);
+                }
+                if !self.j.is_null() {
+                    SUNMatDestroy(self.j);
+                }
+                for v in [self.u, self.xscale, self.fscale, self.ftmp] {
+                    if !v.is_null() {
+                        N_VDestroy(v);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(sundials)]
+std::thread_local! {
+    /// One [`kinsol::Solver`] per system `handle`, kept for the run so KINSOL and
+    /// KLU reuse their setup.
+    static KIN_CACHE: core::cell::RefCell<std::collections::HashMap<u32, kinsol::Solver>> =
+        core::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Solve system `handle` with KINSOL + KLU from `guess`, writing the solution into
+/// `x`. `eval` evaluates the residual, `assemble` the `nnz` CSC Jacobian values.
+#[cfg(sundials)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn kinsol_solve(
+    handle: u32,
+    n: usize,
+    nnz: usize,
+    colptr: &[i32],
+    rowidx: &[i32],
+    nominal: &[f64],
+    guess: &[f64],
+    x: &mut [f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    assemble: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    KIN_CACHE.with(|cell| {
+        let mut cache = cell.borrow_mut();
+        let solver = match cache.entry(handle) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(slot) => match kinsol::Solver::new(n, nnz) {
+                Some(s) => slot.insert(s),
+                None => return false,
+            },
+        };
+        solver.solve(guess, nominal, colptr, rowidx, x, eval, assemble)
+    })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
@@ -1,10 +1,12 @@
 //! Builds the external-"C" artifacts a host-free wasm FMU links in, embedded by
 //! `src/lib.rs`: a `-fPIC` wasi-libc `libc.so`, ModelicaExternalC as a PIC dylink
-//! side module, and the vendored `wasi_snapshot_preview1` adapter. Debian's
-//! wasi-libc is non-PIC, so a `-fPIC` one (wasi-sdk-32, `BUILD_SHARED=ON`) is built
-//! here and ModelicaExternalC compiled against it. Best-effort: empty placeholders
-//! when the toolchain is unavailable, and the consumer then reports external "C"
-//! in wasm FMUs as unsupported.
+//! side module, and the vendored `wasi_snapshot_preview1` adapter.
+//!
+//! All inputs are provided by CMake via environment variables. This crate does
+//! not build wasi-libc or sundials itself — the CMake targets `rust_wasi_pic_sysroot`
+//! and `rust_sundials_wasm` handle that before cargo runs.
+//!
+//! Failure in any step (sysroot missing, external-C clang failure) is a hard error.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -18,143 +20,57 @@ fn main() {
     let mec_dest = out_dir.join("modelicaexternalc_dylink.wasm");
     let libc_dest = out_dir.join("libc_pic.wasm");
 
-    let Some(sysroot) = ensure_pic_wasi_sysroot(&out_dir) else {
-        placeholder(&mec_dest);
-        placeholder(&libc_dest);
-        return;
-    };
+    // PIC wasi sysroot: provided by CMake's rust_wasi_pic_sysroot target.
+    let sysroot = ensure_pic_wasi_sysroot();
     let triple = "wasm32-wasip1";
     let libc_so = sysroot.join("lib").join(triple).join("libc.so");
     if !libc_so.exists() {
-        println!("cargo:warning=PIC wasi sysroot has no {}; external \"C\" in wasm FMUs disabled", libc_so.display());
-        placeholder(&mec_dest);
-        placeholder(&libc_dest);
-        return;
+        panic!("PIC wasi sysroot {} has no {}; external \"C\" in wasm FMUs requires libc.so",
+               sysroot.display(), libc_so.display());
     }
     copy(&libc_so, &libc_dest);
 
-    match build_external_c_dylink(&crate_dir, &out_dir, &sysroot, triple) {
-        Ok(m) => copy(&m, &mec_dest),
-        Err(e) => {
-            println!("cargo:warning=could not build the PIC ModelicaExternalC dylink module ({e}); \
-                      external \"C\" in wasm FMUs disabled");
-            placeholder(&mec_dest);
-            placeholder(&libc_dest);
-        }
-    }
+    // ModelicaExternalC dylink: mandatory for FMI wasm FMU export.
+    let module = build_external_c_dylink(&crate_dir, &out_dir, &sysroot, triple)
+        .unwrap_or_else(|e| panic!("failed to build the PIC ModelicaExternalC dylink module: {e}"));
+    copy(&module, &mec_dest);
 }
 
-const WASI_P1_ADAPTER_URL: &str =
-    "https://github.com/bytecodealliance/wasmtime/releases/download/v27.0.0/wasi_snapshot_preview1.reactor.wasm";
-
-/// The preview1→preview2 reactor adapter: `OMC_WASI_P1_ADAPTER` (CMake downloads it),
-/// else a cached curl download for a raw cargo build, else a placeholder.
+/// The preview1→preview2 reactor adapter: `OMC_WASI_P1_ADAPTER` from CMake.
 fn provide_preview1_adapter(dest: &Path) {
     println!("cargo:rerun-if-env-changed=OMC_WASI_P1_ADAPTER");
     if let Ok(p) = std::env::var("OMC_WASI_P1_ADAPTER") {
-        if Path::new(&p).exists() {
-            copy(Path::new(&p), dest);
+        let path = Path::new(&p);
+        if path.exists() {
+            copy(path, dest);
             return;
         }
     }
-    let cached = dest.with_extension("dl");
-    if !cached.exists() {
-        let ok = Command::new("curl")
-            .args(["-sSfL", "-o"]).arg(&cached).arg(WASI_P1_ADAPTER_URL)
-            .status().map(|s| s.success()).unwrap_or(false);
-        if !ok {
-            std::fs::remove_file(&cached).ok();
-        }
-    }
-    if cached.exists() { copy(&cached, dest); } else { placeholder(dest); }
+    panic!("wasi_snapshot_preview1 adapter not found. Set OMC_WASI_P1_ADAPTER (CMake provides it).");
 }
 
-/// A `-fPIC` wasi-libc sysroot: `OMC_WASI_PIC_SYSROOT` if set, else built + cached.
-fn ensure_pic_wasi_sysroot(out_dir: &Path) -> Option<PathBuf> {
+/// PIC wasi sysroot: `OMC_WASI_PIC_SYSROOT` from CMake's rust_wasi_pic_sysroot target.
+fn ensure_pic_wasi_sysroot() -> PathBuf {
     println!("cargo:rerun-if-env-changed=OMC_WASI_PIC_SYSROOT");
-    if let Ok(p) = std::env::var("OMC_WASI_PIC_SYSROOT") {
-        let p = PathBuf::from(p);
-        if p.join("lib/wasm32-wasip1/libc.so").exists() {
-            return Some(p);
-        }
-        println!("cargo:warning=OMC_WASI_PIC_SYSROOT={} has no lib/wasm32-wasip1/libc.so", p.display());
+    let p = std::env::var("OMC_WASI_PIC_SYSROOT")
+        .expect("OMC_WASI_PIC_SYSROOT not set — build via CMake which sets it");
+    let p = PathBuf::from(p);
+    if p.join("lib/wasm32-wasip1/libc.so").exists() {
+        return p;
     }
-    let sysroot = out_dir.join("wasi-pic-sysroot");
-    if sysroot.join("lib/wasm32-wasip1/libc.so").exists() {
-        return Some(sysroot);
-    }
-    match build_pic_wasi_libc(out_dir, &sysroot) {
-        Ok(()) => Some(sysroot),
-        Err(e) => {
-            println!("cargo:warning=could not build a PIC wasi-libc ({e}); set OMC_WASI_PIC_SYSROOT \
-                      to a prebuilt sysroot to enable external \"C\" in wasm FMUs");
-            None
-        }
-    }
+    panic!("OMC_WASI_PIC_SYSROOT={} has no lib/wasm32-wasip1/libc.so", p.display());
 }
 
-/// Build a PIC wasi-libc sysroot from `OMC_WASI_LIBC_SRC` (CMake provides it; a raw
-/// `cargo build` falls back to a git clone). The non-obvious flags: `BUILD_SHARED=ON`
-/// for the PIC `libc.so`; `CMAKE_LINK_DEPENDS_USE_LINKER=OFF` (wasm-ld rejects the
-/// `--dependency-file` CMake would pass); `CMAKE_AR=llvm-ar` (GNU `ar` can't archive
-/// wasm).
-fn build_pic_wasi_libc(out_dir: &Path, sysroot_out: &Path) -> Result<(), String> {
-    println!("cargo:rerun-if-env-changed=OMC_WASI_LIBC_SRC");
-    let src = match std::env::var("OMC_WASI_LIBC_SRC") {
-        Ok(p) => PathBuf::from(p),
-        Err(_) => {
-            let src = out_dir.join("wasi-libc-src");
-            if !src.join("CMakeLists.txt").exists() {
-                std::fs::remove_dir_all(&src).ok();
-                run("git", &[
-                    "clone", "--depth", "1", "--branch", "wasi-sdk-32",
-                    "https://github.com/WebAssembly/wasi-libc.git",
-                    &src.to_string_lossy(),
-                ])?;
-            }
-            src
-        }
-    };
-    if !src.join("CMakeLists.txt").exists() {
-        return Err(format!("wasi-libc source at {} has no CMakeLists.txt", src.display()));
-    }
-    let build = out_dir.join("wasi-libc-build");
-    // Start from a clean build dir so a stale CMakeCache (e.g. a prior configure that
-    // picked GNU `ar`) can't defeat the flags below.
-    std::fs::remove_dir_all(&build).ok();
-    let builtins = find_wasm_builtins().ok_or("no libclang_rt.builtins-wasm32.a found")?;
-    let (llvm_ar, llvm_ranlib) = find_llvm_ar_ranlib().ok_or("no llvm-ar found (need LLVM binutils)")?;
-    run("cmake", &[
-        "-S", &src.to_string_lossy(), "-B", &build.to_string_lossy(),
-        "-DCMAKE_C_COMPILER=clang", "-DTARGET_TRIPLE=wasm32-wasip1",
-        "-DBUILD_SHARED=ON", "-DBUILD_TESTS=OFF",
-        "-DCMAKE_LINK_DEPENDS_USE_LINKER=OFF",
-        &format!("-DCMAKE_AR={}", llvm_ar.display()),
-        &format!("-DCMAKE_RANLIB={}", llvm_ranlib.display()),
-        &format!("-DBUILTINS_LIB={}", builtins.display()),
-    ])?;
-    run("cmake", &["--build", &build.to_string_lossy(), "-j", &num_jobs()])?;
-    let built = build.join("sysroot");
-    if !built.join("lib/wasm32-wasip1/libc.so").exists() {
-        return Err("wasi-libc build produced no libc.so".into());
-    }
-    std::fs::remove_dir_all(sysroot_out).ok();
-    copy_dir(&built, sysroot_out).map_err(|e| format!("copy sysroot: {e}"))?;
-    Ok(())
-}
-
-/// Compile ModelicaExternalC (+ `DummyUsertab`, `external_c_callbacks.c` for the
-/// `env.Modelica*` callbacks, `external_c_stubs.c` for libc gaps) to a PIC dylink
-/// side module, then strip its `_initialize` export: reactor mode emits both
-/// `_initialize` and `__wasm_call_ctors`, and `wit_component::Linker` rejects a
-/// library exporting both — keep the dylink-standard `__wasm_call_ctors`.
+/// Compile ModelicaExternalC (+ `DummyUsertab`, `external_c_callbacks.c`,
+/// `external_c_stubs.c`) to a PIC dylink side module, then strip its
+/// `_initialize` export: reactor mode emits both `_initialize` and
+/// `__wasm_call_ctors`, and `wit_component::Linker` rejects a library
+/// exporting both — keep the dylink-standard `__wasm_call_ctors`.
 fn build_external_c_dylink(crate_dir: &Path, out_dir: &Path, sysroot: &Path, triple: &str) -> Result<PathBuf, String> {
     println!("cargo:rerun-if-env-changed=OMC_EXTERNAL_C_SOURCES");
-    let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES").ok().map(PathBuf::from).or_else(|| {
-        // From OpenModelica.rs/openmodelica_wasi_libc up to OMCompiler, then down.
-        crate_dir.parent().and_then(Path::parent).and_then(Path::parent)
-            .map(|omc| omc.join("SimulationRuntime/ModelicaExternalC/C-Sources"))
-    }).ok_or("no ModelicaExternalC C-Sources dir")?;
+    let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES").ok().map(PathBuf::from).ok_or_else(|| {
+        "OMC_EXTERNAL_C_SOURCES not set".to_owned()
+    })?;
     let names = [
         "ModelicaStandardTables.c", "ModelicaStrings.c", "ModelicaRandom.c",
         "ModelicaIO.c", "ModelicaMatIO.c", "snprintf.c",
@@ -267,35 +183,6 @@ fn strip_wasm_export(module: &[u8], name: &str) -> Vec<u8> {
     out
 }
 
-/// Locate `llvm-ar` + `llvm-ranlib` — unversioned, else `-<N>` from clang's major
-/// (Ubuntu ships only `llvm-ar-<N>`).
-fn find_llvm_ar_ranlib() -> Option<(PathBuf, PathBuf)> {
-    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
-    let mut stems = vec![String::new()];
-    if let Ok(out) = Command::new(&clang).arg("-dumpversion").output() {
-        if let Ok(v) = String::from_utf8(out.stdout) {
-            if let Some(major) = v.trim().split('.').next() {
-                stems.push(format!("-{major}"));
-            }
-        }
-    }
-    for stem in &stems {
-        if let (Some(ar), Some(ranlib)) =
-            (which(&format!("llvm-ar{stem}")), which(&format!("llvm-ranlib{stem}")))
-        {
-            return Some((ar, ranlib));
-        }
-    }
-    None
-}
-
-/// First match for `name` on `PATH` (a minimal `which`, to avoid a dep).
-fn which(name: &str) -> Option<PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).map(|d| d.join(name)).find(|p| p.is_file())
-    })
-}
-
 fn find_wasm_builtins() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("OMC_WASM_BUILTINS") {
         let p = PathBuf::from(p);
@@ -313,38 +200,6 @@ fn collect_c_files(dir: &Path) -> Vec<PathBuf> {
     rd.flatten().map(|e| e.path())
         .filter(|p| p.extension().map(|x| x == "c").unwrap_or(false))
         .collect()
-}
-
-fn run(cmd: &str, args: &[&str]) -> Result<(), String> {
-    let status = Command::new(cmd).args(args).status()
-        .map_err(|e| format!("spawn {cmd}: {e}"))?;
-    if status.success() { Ok(()) } else { Err(format!("{cmd} exited with {status}")) }
-}
-
-fn num_jobs() -> String {
-    std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4).to_string()
-}
-
-fn copy_dir(from: &Path, to: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(to)?;
-    for e in std::fs::read_dir(from)? {
-        let e = e?;
-        let (src, dst) = (e.path(), to.join(e.file_name()));
-        if e.file_type()?.is_dir() {
-            copy_dir(&src, &dst)?;
-        } else {
-            std::fs::copy(&src, &dst)?;
-        }
-    }
-    Ok(())
-}
-
-/// Write an empty artifact so `include_bytes!` still compiles; the consumer treats
-/// a zero-length module as "external \"C\" in wasm FMUs unavailable".
-fn placeholder(dest: &Path) {
-    if !dest.exists() || std::fs::metadata(dest).map(|m| m.len() > 0).unwrap_or(true) {
-        std::fs::write(dest, []).ok();
-    }
 }
 
 fn copy(from: &Path, to: &Path) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
@@ -55,7 +55,9 @@ fn ensure_pic_wasi_sysroot() -> PathBuf {
     let p = std::env::var("OMC_WASI_PIC_SYSROOT")
         .expect("OMC_WASI_PIC_SYSROOT not set — build via CMake which sets it");
     let p = PathBuf::from(p);
-    if p.join("lib/wasm32-wasip1/libc.so").exists() {
+    let libc_so = p.join("lib/wasm32-wasip1/libc.so");
+    println!("cargo:rerun-if-changed={}", libc_so.display());
+    if libc_so.exists() {
         return p;
     }
     panic!("OMC_WASI_PIC_SYSROOT={} has no lib/wasm32-wasip1/libc.so", p.display());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -51,8 +51,16 @@ fn main() {
     }
     // SUNDIALS/KLU for the wasip1 runtimes. Part of the stamp key: gaining or
     // losing the archives changes the runtime's exports, so the blobs must rebuild.
-    let sundials = build_sundials_wasm(&crate_dir, &out_dir);
+    // CMake sets OMC_SUNDIALS_WASM_DIR when the sundials feature is enabled.
     println!("cargo::rustc-check-cfg=cfg(sundials)");
+    let sundials = if std::env::var("OMC_SUNDIALS_WASM_DIR").is_ok() {
+        match build_sundials_wasm(&crate_dir, &out_dir) {
+            Some(s) => Some(s),
+            None => panic!("failed to build SUNDIALS/KLU for wasm32-wasip1"),
+        }
+    } else {
+        None
+    };
     if let Some((_, key)) = &sundials {
         hash = format!("{hash}:{key}");
         // Backs the crate's `SUNDIALS` const: with the archives, `-lss=klu` is
@@ -221,44 +229,35 @@ fn build_dylink_adapter(adapter_dir: &Path, out_dir: &Path, v: &AdapterVariant) 
 }
 
 /// Build + embed the ModelicaExternalC WASI side module (`modelicaexternalc.wasm`)
-/// that the web (wasmer) simulation host loads to provide the `ext.Modelica*_*`
-/// external functions (native uses libffi + the `.so` instead). Compiled from the
-/// ModelicaExternalC C sources with `clang --target=wasm32-wasi -mexec-model=reactor`
-/// over wasi-libc (Debian `wasi-libc` + `lld` + `libclang-rt-*-dev-wasm32`). Unlike
-/// Emscripten's `-sPURE_WASI` (which can't emit `path_open`), this produces a real
-/// WASI reactor whose `fopen`/`opendir` lower to `path_open`/`fd_readdir`, so the
-/// host's VFS-backed `wasi_shim` gives file-based tables + ModelicaIO readers real
-/// file access. `ModelicaIO`/`ModelicaMatIO`/zlib are compiled in (`-DHAVE_ZLIB`).
-/// Undefined `env.Modelica*` symbols become imports the host provides;
-/// `external_c_stubs.c` supplies the one libc gap (`mkdtemp`, MatIO write-path only).
-/// Best-effort: if `clang` is unavailable an empty placeholder is written (the wasmer
-/// host then reports these externals as unavailable; native builds don't use it).
+/// for the web (wasmer) simulation host. Provides `ext.Modelica*_*` external functions
+/// (native uses libffi + `.so` instead). Compiled with `clang --target=wasm32-wasip1
+/// --sysroot=OMC_WASI_PIC_SYSROOT`. Uses the same PIC wasi-libc sysroot as the dylink
+/// module built by openmodelica_wasi_libc.
+///
+/// Mandatory: a failed build is a hard error (no placeholder).
 fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     let dest = out_dir.join("modelicaexternalc.wasm");
     let stamp = out_dir.join("modelicaexternalc.wasm.hash");
     let stubs = crate_dir.join("external_c_stubs.c");
-    // The C-Sources dir: preferably the exact path the CMake build passes (the
-    // crate builds from a synced copy whose relative path can't reach it), else
-    // computed relative to the crate (in-tree cargo build).
+
     println!("cargo:rerun-if-env-changed=OMC_EXTERNAL_C_SOURCES");
-    let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES").ok().map(PathBuf::from).or_else(|| {
-        crate_dir.parent().and_then(Path::parent).and_then(Path::parent)
-            .map(|omc| omc.join("SimulationRuntime/ModelicaExternalC/C-Sources"))
-    });
-    // The C source files compiled into the module (each contributes its exports).
-    // ModelicaIO+MatIO+snprintf give the file-based readers; zlib backs v7 .mat.
+    let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES")
+        .map(PathBuf::from)
+        .expect("OMC_EXTERNAL_C_SOURCES not set (CMake provides it)");
+
     let sources = [
         "ModelicaStandardTables.c", "ModelicaStrings.c", "ModelicaRandom.c",
         "ModelicaIO.c", "ModelicaMatIO.c", "snprintf.c",
         "ModelicaInternal.c", "ModelicaFFT.c",
     ];
-    let src_paths: Vec<Option<PathBuf>> =
-        sources.iter().map(|s| c_sources.as_ref().map(|d| d.join(s))).collect();
+    let src_paths: Vec<PathBuf> = sources.iter().map(|s| c_sources.join(s)).collect();
 
     println!("cargo:rerun-if-changed={}", stubs.display());
-    for src in src_paths.iter().flatten() {
+    for src in &src_paths {
         println!("cargo:rerun-if-changed={}", src.display());
     }
+
+    // Check for prebuilt override (CI hand-off).
     println!("cargo:rerun-if-env-changed=OMC_WASM_EXTERNAL_C");
     if let Ok(path) = std::env::var("OMC_WASM_EXTERNAL_C") {
         copy(Path::new(&path), &dest);
@@ -266,28 +265,31 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
         return;
     }
 
-    let (c_sources, mut src_paths) = match c_sources {
-        Some(d) if src_paths.iter().all(|s| s.as_ref().map(|p| p.exists()).unwrap_or(false)) => {
-            (d, src_paths.into_iter().flatten().collect::<Vec<_>>())
+    // Verify all sources exist.
+    for src in &src_paths {
+        if !src.exists() {
+            panic!("missing C source: {}", src.display());
         }
-        _ => { placeholder(&dest); return; }
-    };
+    }
+
     let zlib_dir = c_sources.join("zlib");
     let mut zlib_srcs = collect_c_files(&zlib_dir);
     zlib_srcs.sort();
     for z in &zlib_srcs {
         println!("cargo:rerun-if-changed={}", z.display());
     }
-    src_paths.extend(zlib_srcs);
-    // Cache on all C inputs plus the compiler/sysroot selection.
+
     println!("cargo:rerun-if-env-changed=OMC_WASI_CLANG");
-    println!("cargo:rerun-if-env-changed=OMC_WASI_SYSROOT");
+    println!("cargo:rerun-if-env-changed=OMC_WASI_PIC_SYSROOT");
     let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
-    let sysroot = std::env::var("OMC_WASI_SYSROOT").unwrap_or_else(|_| "/usr".to_owned());
+    let sysroot = std::env::var("OMC_WASI_PIC_SYSROOT")
+        .expect("OMC_WASI_PIC_SYSROOT not set (CMake provides it)");
+
+    let all_srcs: Vec<_> = src_paths.iter().chain(zlib_srcs.iter()).collect();
     let hash = {
         let mut h: u64 = 0xcbf29ce484222325;
         let mut mix = |bytes: &[u8]| for &byte in bytes { h ^= byte as u64; h = h.wrapping_mul(0x100000001b3); };
-        for f in src_paths.iter().chain(std::iter::once(&stubs)) {
+        for f in all_srcs.iter().copied().chain(std::iter::once(&stubs)) {
             if let Ok(b) = std::fs::read(f) { mix(&b); }
         }
         mix(clang.as_bytes());
@@ -299,34 +301,36 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
         return;
     }
 
-    // `--export-all`: export every symbol / never dead-code-eliminate, so a
-    // compatibility entry point an older MSL calls (e.g. CombiTable1D_init2 vs
-    // init3) is always present — mirrors a native `.so`'s dynamic symbol table.
-    // `--allow-undefined`: unresolved `Modelica*` calls become `env` imports the
-    // host supplies. `-mexec-model=reactor`: exports `_initialize` (runs ctors) and
-    // no `_start`. `HAVE_ZLIB` enables v7 .mat; `NO_MUTEX` drops pthread deps.
+    // `--export-all`: export every symbol so older MSL compatibility entry points
+    // are always present. `--allow-undefined`: unresolved `Modelica*` calls become
+    // `env` imports the host supplies. `-mexec-model=reactor`: exports `_initialize`
+    // (runs ctors), no `_start`.
+    let builtins = find_wasm_builtins().ok_or_else(|| {
+        "no libclang_rt.builtins-wasm32.a found (need libclang-rt-*-dev-wasm32)"
+    }).unwrap_or_else(|e| panic!("{e}"));
     let status = Command::new(&clang)
-        .args(["--target=wasm32-wasi", "-O2", "-mexec-model=reactor",
-               "-DNO_MUTEX", "-DHAVE_ZLIB", "-Wno-error=implicit-function-declaration"])
+        .args(["--target=wasm32-wasip1", "-O2", "-mexec-model=reactor",
+               "-nodefaultlibs", "-DNO_MUTEX", "-DHAVE_ZLIB",
+               "-Wno-error=implicit-function-declaration"])
         .arg(format!("--sysroot={sysroot}"))
         .arg("-I").arg(&c_sources)
         .arg("-I").arg(&zlib_dir)
-        .args(&src_paths).arg(&stubs)
+        .args(&all_srcs).arg(&stubs)
+        .arg(&builtins)
         .args(["-Wl,--export-all", "-Wl,--allow-undefined"])
         .arg("-o").arg(&dest)
-        .status();
-    match status {
-        Ok(s) if s.success() && std::fs::metadata(&dest).map(|m| m.len() > 0).unwrap_or(false) => {
-            std::fs::write(&stamp, &hash).ok();
-        }
-        _ => {
-            println!("cargo:warning=could not build modelicaexternalc.wasm with `{clang}` \
-                      (--target=wasm32-wasi, sysroot {sysroot}); ModelicaExternalC functions \
-                      will be unavailable on the web target. Install `wasi-libc`, `lld`, and \
-                      `libclang-rt-<ver>-dev-wasm32`.");
-            placeholder(&dest);
-        }
+        .status()
+        .map_err(|e| format!("spawn {clang}: {e}")).unwrap_or_else(|e| {
+            panic!("modelicaexternalc.wasm: {e}")
+        });
+    if !status.success() {
+        panic!("clang exited with {status} (building modelicaexternalc.wasm, \
+                --target=wasm32-wasip1, sysroot {sysroot})");
     }
+    if !std::fs::metadata(&dest).map(|m| m.len() > 0).unwrap_or(false) {
+        panic!("modelicaexternalc.wasm is empty");
+    }
+    std::fs::write(&stamp, &hash).ok();
 }
 
 /// The `.c` files directly under `dir` (non-recursive), for the bundled zlib.
@@ -337,246 +341,34 @@ fn collect_c_files(dir: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Write an empty `modelicaexternalc.wasm` so `include_bytes!` still compiles; the wasmer
-/// host treats a zero-length module as "no table externals available".
-fn placeholder(dest: &Path) {
-    if !dest.exists() || std::fs::metadata(dest).map(|m| m.len() > 0).unwrap_or(true) {
-        std::fs::write(dest, []).ok();
+/// Locate the clang wasm builtins archive (`libclang_rt.builtins-wasm32.a`).
+/// Checked in env override first, then auto-detected via `clang -print-resource-dir`.
+fn find_wasm_builtins() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("OMC_WASM_BUILTINS") {
+        let p = PathBuf::from(p);
+        if p.exists() { return Some(p); }
     }
-}
-
-/// The CMake targets cross-compiled to wasm: KLU and its SuiteSparse deps, then
-/// the SUNDIALS modules. Consumers pick from `lib/`; the link order lives in the
-/// runtime crate's build script.
-const SUITESPARSE_TARGETS: &[&str] = &["klu", "amd", "colamd", "btf", "suitesparseconfig"];
-const SUNDIALS_TARGETS: &[&str] = &[
-    "sundials_kinsol_static", "sundials_ida_static", "sundials_cvode_static",
-    "sundials_nvecserial_static", "sundials_sunmatrixdense_static",
-    "sundials_sunmatrixsparse_static", "sundials_sunlinsoldense_static",
-    "sundials_sunlinsolklu_static",
-];
-
-/// Bumped when the recipe below changes, to invalidate cached archives.
-const SUNDIALS_RECIPE: u32 = 2;
-
-/// Cross-compile the vendored SUNDIALS + SuiteSparse/KLU to `wasm32-wasip1` static
-/// archives, driving each project's own CMake with a generated wasi toolchain file
-/// (both configure and build unmodified; only shared libs must be off). Returns the
-/// directory holding `lib/*.a` plus a cache key, or `None` when the sources or the
-/// toolchain are missing — the runtime then builds without the real solvers and
-/// keeps using the pure-Rust ones.
-fn build_sundials_wasm(crate_dir: &Path, out_dir: &Path) -> Option<(PathBuf, String)> {
-    for var in ["OMC_SUNDIALS_WASM_DIR", "OMC_SUNDIALS_SOURCES", "OMC_SUITESPARSE_SOURCES",
-                "OMC_WASI_CLANG", "OMC_WASI_SYSROOT"] {
-        println!("cargo:rerun-if-env-changed={var}");
-    }
-    if let Ok(dir) = std::env::var("OMC_SUNDIALS_WASM_DIR") {
-        let dir = PathBuf::from(dir);
-        if dir.join("lib").is_dir() {
-            return Some((dir, "override".to_owned()));
-        }
-        println!("cargo:warning=OMC_SUNDIALS_WASM_DIR={} has no lib/", dir.display());
-        return None;
-    }
-
-    let third_party = |var: &str, name: &str| -> Option<PathBuf> {
-        std::env::var(var).ok().map(PathBuf::from).or_else(|| {
-            crate_dir.parent().and_then(Path::parent).and_then(Path::parent)
-                .map(|omc| omc.join("3rdParty").join(name))
-        }).filter(|p| p.join("CMakeLists.txt").exists())
-    };
-    let (Some(sundials_src), Some(suitesparse_src)) = (
-        third_party("OMC_SUNDIALS_SOURCES", "sundials-5.4.0"),
-        third_party("OMC_SUITESPARSE_SOURCES", "SuiteSparse-5.8.1"),
-    ) else {
-        println!("cargo:warning=no vendored SUNDIALS/SuiteSparse sources found; the wasm-jit \
-                  runtime will use its pure-Rust solvers. Set OMC_SUNDIALS_SOURCES / \
-                  OMC_SUITESPARSE_SOURCES.");
-        return None;
-    };
-
     let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
-    let sysroot = std::env::var("OMC_WASI_SYSROOT").unwrap_or_else(|_| "/usr".to_owned());
-    let root = out_dir.join("sundials-wasm");
-    let lib = root.join("lib");
-    let stamp = root.join("stamp");
-    let key = {
-        let mut h: u64 = 0xcbf29ce484222325;
-        let mut mix = |bytes: &[u8]| for &b in bytes { h ^= b as u64; h = h.wrapping_mul(0x100000001b3); };
-        // The pinned trees don't change in place; their paths carry the version, and
-        // the top-level CMakeLists catches an in-place patch.
-        for p in [&sundials_src, &suitesparse_src] {
-            mix(p.to_string_lossy().as_bytes());
-            if let Ok(b) = std::fs::read(p.join("CMakeLists.txt")) { mix(&b); }
-        }
-        mix(clang.as_bytes());
-        mix(sysroot.as_bytes());
-        mix(&SUNDIALS_RECIPE.to_le_bytes());
-        format!("{h:016x}")
-    };
-    if std::fs::read_to_string(&stamp).ok().as_deref() == Some(key.as_str()) {
-        return Some((root, key));
-    }
-
-    match build_sundials_archives(&sundials_src, &suitesparse_src, &root, &lib, &clang, &sysroot) {
-        Ok(()) => {
-            std::fs::write(&stamp, &key).ok();
-            Some((root, key))
-        }
-        Err(e) => {
-            println!("cargo:warning=could not cross-compile SUNDIALS/KLU to wasm ({e}); the \
-                      wasm-jit runtime will use its pure-Rust solvers. Needs cmake, clang with \
-                      a wasm32 target, llvm-ar and a wasi sysroot (OMC_WASI_SYSROOT).");
-            std::fs::remove_file(&stamp).ok();
-            None
-        }
-    }
+    let out = Command::new(&clang).arg("-print-resource-dir").output().ok()?;
+    let dir = PathBuf::from(String::from_utf8(out.stdout).ok()?.trim());
+    let cand = dir.join("lib/wasi/libclang_rt.builtins-wasm32.a");
+    cand.exists().then_some(cand)
 }
 
-/// Configure + build both trees for `wasm32-wasip1` and collect every `.a` into `lib`.
-fn build_sundials_archives(
-    sundials_src: &Path,
-    suitesparse_src: &Path,
-    root: &Path,
-    lib: &Path,
-    clang: &str,
-    sysroot: &str,
-) -> Result<(), String> {
-    let (ar, ranlib) = find_llvm_ar_ranlib(clang)
-        .ok_or("no llvm-ar/llvm-ranlib found (GNU ar cannot archive wasm objects)")?;
-    // `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` keeps CMake's compiler check
-    // from linking an executable, which needs a `libclang_rt.builtins` path clang
-    // does not find for this triple.
-    let toolchain = root.join("wasi-toolchain.cmake");
-    std::fs::create_dir_all(root).map_err(|e| format!("create {}: {e}", root.display()))?;
-    std::fs::write(&toolchain, format!(
-        "set(CMAKE_SYSTEM_NAME WASI)\n\
-         set(CMAKE_SYSTEM_PROCESSOR wasm32)\n\
-         set(CMAKE_C_COMPILER {clang})\n\
-         set(CMAKE_C_COMPILER_TARGET wasm32-wasip1)\n\
-         set(CMAKE_SYSROOT {sysroot})\n\
-         set(CMAKE_AR {})\n\
-         set(CMAKE_RANLIB {})\n\
-         set(CMAKE_C_FLAGS_INIT \"-O2\")\n\
-         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n\
-         set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)\n",
-        ar.display(), ranlib.display(),
-    )).map_err(|e| format!("write toolchain file: {e}"))?;
-
-    // Fresh build dirs: this only runs when the stamp is invalid, and a cache left
-    // by a previous recipe must not decide anything.
-    let ss_build = root.join("suitesparse-build");
-    let sd_build = root.join("sundials-build");
-    std::fs::remove_dir_all(&ss_build).ok();
-    std::fs::remove_dir_all(&sd_build).ok();
-    let toolchain_arg = format!("-DCMAKE_TOOLCHAIN_FILE={}", toolchain.display());
-
-    cmake(&[
-        "-S", &suitesparse_src.to_string_lossy(), "-B", &ss_build.to_string_lossy(),
-        &toolchain_arg, "-DBUILD_SHARED_LIBS=OFF",
-    ])?;
-    cmake_build(&ss_build, SUITESPARSE_TARGETS)?;
-
-    // `klu.h` includes `amd.h`/`btf.h`/`SuiteSparse_config.h`, which live in sibling
-    // dirs. They go in via CMAKE_C_FLAGS rather than KLU_INCLUDE_DIR, because
-    // `config/FindKLU.cmake` overwrites that variable with the single directory its
-    // `find_path(… klu.h …)` lands on, silently dropping any others.
-    let sibling_includes = ["AMD/Include", "COLAMD/Include", "BTF/Include", "SuiteSparse_config"]
-        .iter()
-        .map(|d| format!(" -I{}", suitesparse_src.join(d).display()))
-        .collect::<String>();
-    let mut args = vec![
-        "-S".to_owned(), sundials_src.to_string_lossy().into_owned(),
-        "-B".to_owned(), sd_build.to_string_lossy().into_owned(),
-        toolchain_arg,
-        "-DSUNDIALS_BUILD_STATIC_LIBS=ON".to_owned(),
-        // Shared libs must be off: their link step fails on the builtins path.
-        "-DSUNDIALS_BUILD_SHARED_LIBS=OFF".to_owned(),
-        // No LAPACK in the wasi sysroot; SUNDIALS' own dense solver is used instead.
-        "-DSUNDIALS_LAPACK_ENABLE=OFF".to_owned(),
-        "-DSUNDIALS_EXAMPLES_ENABLE_C=OFF".to_owned(),
-        "-DSUNDIALS_KLU_ENABLE=ON".to_owned(),
-        // 32-bit indices, unlike the native build's 64. Mandatory here:
-        // `sunlinsol_klu.c` *casts* `sunindextype*` to `KLU_INDEXTYPE*`, which it
-        // maps to `long int` for 64-bit indices — 4 bytes on wasm32, so an int64
-        // index array would be reinterpreted as int32 and the sparsity pattern
-        // silently garbled. With 32 both sides are `int`.
-        "-DSUNDIALS_INDEX_SIZE=32".to_owned(),
-        format!("-DKLU_INCLUDE_DIR={}", suitesparse_src.join("KLU/Include").display()),
-        format!("-DCMAKE_C_FLAGS=-O2{sibling_includes}"),
-    ];
-    for (var, name) in [("KLU_LIBRARY", "libklu.a"), ("AMD_LIBRARY", "libamd.a"),
-                        ("COLAMD_LIBRARY", "libcolamd.a"), ("BTF_LIBRARY", "libbtf.a"),
-                        ("SUITESPARSECONFIG_LIBRARY", "libsuitesparseconfig.a")] {
-        args.push(format!("-D{var}={}", ss_build.join(name).display()));
+/// Use the SUNDIALS/KLU wasm archives prebuilt by CMake (`rust_sundials_wasm` target).
+///
+/// Called only when the `sundials` cargo feature is enabled. Returns `Some(dir, key)`
+/// on success; the caller (main) panics on `None`.
+fn build_sundials_wasm(_crate_dir: &Path, _out_dir: &Path) -> Option<(PathBuf, String)> {
+    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
+    let dir = std::env::var("OMC_SUNDIALS_WASM_DIR")
+        .expect("OMC_SUNDIALS_WASM_DIR not set (CMake sets it when sundials feature is enabled)");
+    let dir = PathBuf::from(dir);
+    if dir.join("lib").is_dir() {
+        Some((dir, "cmake".to_owned()))
+    } else {
+        None
     }
-    cmake(&args.iter().map(String::as_str).collect::<Vec<_>>())?;
-    cmake_build(&sd_build, SUNDIALS_TARGETS)?;
-
-    // Start from an empty lib/: a stale archive from an earlier recipe (e.g. the
-    // 64-bit-index build) must not survive into the link.
-    std::fs::remove_dir_all(lib).ok();
-    std::fs::create_dir_all(lib).map_err(|e| format!("create {}: {e}", lib.display()))?;
-    let mut found = Vec::new();
-    for dir in [&ss_build, &sd_build] {
-        collect_archives(dir, &mut found);
-    }
-    if found.is_empty() {
-        return Err("the CMake builds produced no .a".into());
-    }
-    for a in &found {
-        copy(a, &lib.join(a.file_name().expect("archive has a file name")));
-    }
-    Ok(())
-}
-
-fn cmake(args: &[&str]) -> Result<(), String> {
-    let status = Command::new("cmake").args(args).status()
-        .map_err(|e| format!("spawn cmake: {e}"))?;
-    status.success().then_some(()).ok_or_else(|| format!("cmake configure exited with {status}"))
-}
-
-fn cmake_build(build_dir: &Path, targets: &[&str]) -> Result<(), String> {
-    let jobs = std::env::var("NUM_JOBS").unwrap_or_else(|_| "1".to_owned());
-    let status = Command::new("cmake")
-        .args(["--build", &build_dir.to_string_lossy(), "-j", &jobs, "--target"])
-        .args(targets)
-        .status()
-        .map_err(|e| format!("spawn cmake --build: {e}"))?;
-    status.success().then_some(()).ok_or_else(|| format!("cmake --build exited with {status}"))
-}
-
-fn collect_archives(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(rd) = std::fs::read_dir(dir) else { return };
-    for e in rd.flatten() {
-        let p = e.path();
-        if p.is_dir() {
-            collect_archives(&p, out);
-        } else if p.extension().map(|x| x == "a").unwrap_or(false) {
-            out.push(p);
-        }
-    }
-}
-
-/// `llvm-ar` + `llvm-ranlib`, unversioned or `-<N>` from clang's major (Ubuntu
-/// ships only the versioned names).
-fn find_llvm_ar_ranlib(clang: &str) -> Option<(PathBuf, PathBuf)> {
-    let mut stems = vec![String::new()];
-    if let Ok(out) = Command::new(clang).arg("-dumpversion").output() {
-        if let Some(major) = String::from_utf8_lossy(&out.stdout).trim().split('.').next() {
-            stems.push(format!("-{major}"));
-        }
-    }
-    stems.iter().find_map(|stem| {
-        let (ar, ranlib) = (which(&format!("llvm-ar{stem}")), which(&format!("llvm-ranlib{stem}")));
-        Some((ar?, ranlib?))
-    })
-}
-
-fn which(name: &str) -> Option<PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).map(|d| d.join(name)).find(|p| p.is_file())
-    })
 }
 
 /// Build + embed the `wasm32-unknown-unknown` JIT runtime (`runtime.wasm`): the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -238,13 +238,21 @@ fn build_dylink_adapter(adapter_dir: &Path, out_dir: &Path, v: &AdapterVariant) 
 fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     let dest = out_dir.join("modelicaexternalc.wasm");
     let stamp = out_dir.join("modelicaexternalc.wasm.hash");
-    let stubs = crate_dir.join("external_c_stubs.c");
+
+    // Check for prebuilt override (CI hand-off) before requiring OMC_EXTERNAL_C_SOURCES.
+    println!("cargo:rerun-if-env-changed=OMC_WASM_EXTERNAL_C");
+    if let Ok(path) = std::env::var("OMC_WASM_EXTERNAL_C") {
+        copy(Path::new(&path), &dest);
+        std::fs::write(&stamp, format!("override:{path}")).ok();
+        return;
+    }
 
     println!("cargo:rerun-if-env-changed=OMC_EXTERNAL_C_SOURCES");
     let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES")
         .map(PathBuf::from)
         .expect("OMC_EXTERNAL_C_SOURCES not set (CMake provides it)");
 
+    let stubs = crate_dir.join("external_c_stubs.c");
     let sources = [
         "ModelicaStandardTables.c", "ModelicaStrings.c", "ModelicaRandom.c",
         "ModelicaIO.c", "ModelicaMatIO.c", "snprintf.c",
@@ -255,14 +263,6 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-changed={}", stubs.display());
     for src in &src_paths {
         println!("cargo:rerun-if-changed={}", src.display());
-    }
-
-    // Check for prebuilt override (CI hand-off).
-    println!("cargo:rerun-if-env-changed=OMC_WASM_EXTERNAL_C");
-    if let Ok(path) = std::env::var("OMC_WASM_EXTERNAL_C") {
-        copy(Path::new(&path), &dest);
-        std::fs::write(&stamp, format!("override:{path}")).ok();
-        return;
     }
 
     // Verify all sources exist.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -53,14 +53,7 @@ fn main() {
     // losing the archives changes the runtime's exports, so the blobs must rebuild.
     // CMake sets OMC_SUNDIALS_WASM_DIR when the sundials feature is enabled.
     println!("cargo::rustc-check-cfg=cfg(sundials)");
-    let sundials = if std::env::var("OMC_SUNDIALS_WASM_DIR").is_ok() {
-        match build_sundials_wasm(&crate_dir, &out_dir) {
-            Some(s) => Some(s),
-            None => panic!("failed to build SUNDIALS/KLU for wasm32-wasip1"),
-        }
-    } else {
-        None
-    };
+    let sundials = sundials_wasm_dir();
     if let Some((_, key)) = &sundials {
         hash = format!("{hash}:{key}");
         // Backs the crate's `SUNDIALS` const: with the archives, `-lss=klu` is
@@ -355,20 +348,16 @@ fn find_wasm_builtins() -> Option<PathBuf> {
     cand.exists().then_some(cand)
 }
 
-/// Use the SUNDIALS/KLU wasm archives prebuilt by CMake (`rust_sundials_wasm` target).
+/// Return the SUNDIALS/KLU wasm archives dir prebuilt by CMake.
 ///
-/// Called only when the `sundials` cargo feature is enabled. Returns `Some(dir, key)`
-/// on success; the caller (main) panics on `None`.
-fn build_sundials_wasm(_crate_dir: &Path, _out_dir: &Path) -> Option<(PathBuf, String)> {
+/// Returns `Some((dir, key))` when `OMC_SUNDIALS_WASM_DIR` is set (the key is
+/// appended to the runtime stamp so sundials on/off toggles rebuild the blobs).
+/// Returns `None` when the env var is absent (sundials feature disabled).
+fn sundials_wasm_dir() -> Option<(PathBuf, String)> {
     println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
-    let dir = std::env::var("OMC_SUNDIALS_WASM_DIR")
-        .expect("OMC_SUNDIALS_WASM_DIR not set (CMake sets it when sundials feature is enabled)");
-    let dir = PathBuf::from(dir);
-    if dir.join("lib").is_dir() {
-        Some((dir, "cmake".to_owned()))
-    } else {
-        None
-    }
+    let dir = std::env::var("OMC_SUNDIALS_WASM_DIR").ok()?
+        .into();
+    Some((dir, "cmake".to_owned()))
 }
 
 /// Build + embed the `wasm32-unknown-unknown` JIT runtime (`runtime.wasm`): the


### PR DESCRIPTION
This makes the build.rs scripts easier and makes compilation easier since it is hard to depend on a custom wasi-libc from one crate in the others.
