### PR TITLE
wasm-jit: make KINSOL reachable, fix string alloc

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -3177,19 +3177,49 @@ fn lin_system_nnz(lsystem: &SimCode::LinearSystem) -> usize {
 }
 
 /// A nonlinear system's Jacobian sparsity in CSC — `colptr` (`n+1`), `rowidx`
-/// (`nnz`) and the column coloring — the same pattern C's
-/// `initialResizableAnalyticJacobian` builds: the column of a dependency is the
-/// seed variable's `SimVar.index`, the row of a solved `$pDER` cref is that
-/// variable's index. Only scalar rows are handled; an array-valued row (equation
-/// iterators or subscripted crefs) needs the run-time loops the C template emits,
-/// so those systems keep the numerical Jacobian.
+/// (`nnz`) and the column coloring. Columns and rows are positional, as C's
+/// `evalJacobian` indexes `seedVars[column]` / `resultVars[row]`.
 struct NlsJacPattern {
     colptr: Vec<i32>,
     rowidx: Vec<i32>,
     colors: Vec<Vec<u32>>,
 }
 
+/// The two patterns C can carry, in the order `functionNonLinearResiduals` picks
+/// them.
 fn nls_jac_pattern(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
+    match &jm.sparsityMatrix {
+        SimCode::Sparsity::SPARSITY { .. } => nls_jac_pattern_resizable(jm, n),
+        _ => nls_jac_pattern_static(jm, n),
+    }
+}
+
+/// C's `generateStaticSparseData`: one `sparsity` entry per column holding its
+/// nonzero rows, coloring precomputed in `coloredCols`.
+fn nls_jac_pattern_static(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
+    let mut cols: Vec<Vec<i32>> =
+        lst(&jm.sparsity).map(|(_, rows)| lst(rows).copied().collect()).collect();
+    if cols.len() != n || cols.iter().flatten().any(|&r| r < 0 || r as usize >= n) {
+        return None;
+    }
+    let (colptr, rowidx) = csc_from_columns(&mut cols)?;
+    // A coloring that is not a partition of the columns would drop or double-count
+    // entries, so recompute instead of trusting it.
+    let colors: Vec<Vec<u32>> =
+        lst(&jm.coloredCols).map(|grp| lst(grp).map(|&c| c as u32).collect()).collect();
+    let mut seen = vec![false; n];
+    let partition = colors.iter().flatten().all(|&c| {
+        (c as usize) < n && !core::mem::replace(&mut seen[c as usize], true)
+    }) && seen.iter().all(|&s| s);
+    let colors = if partition { colors } else { computed_coloring(&colptr, &rowidx, n) };
+    Some(NlsJacPattern { colptr, rowidx, colors })
+}
+
+/// C's `initialResizableAnalyticJacobian`: the column of a dependency is the seed
+/// variable's `SimVar.index`, the row of a solved `$pDER` cref is that variable's
+/// index. An array-valued row (equation iterators) needs the run-time loops the C
+/// template emits, so those systems keep the numerical Jacobian.
+fn nls_jac_pattern_resizable(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
     use openmodelica_backend_types::BackendDAE::VarKind;
     let SimCode::Sparsity::SPARSITY { rows } = &jm.sparsityMatrix else { return None };
     let mut seed_col: HashMap<String, usize> = HashMap::new();
@@ -3221,25 +3251,35 @@ fn nls_jac_pattern(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPatte
             }
         }
     }
-    let mut colptr = vec![0i32; n + 1];
+    let (colptr, rowidx) = csc_from_columns(&mut cols)?;
+    let colors = computed_coloring(&colptr, &rowidx, n);
+    Some(NlsJacPattern { colptr, rowidx, colors })
+}
+
+/// Per-column row lists → CSC, sorted and deduplicated. `None` for an all-zero
+/// Jacobian.
+fn csc_from_columns(cols: &mut [Vec<i32>]) -> Option<(Vec<i32>, Vec<i32>)> {
+    let mut colptr = vec![0i32; cols.len() + 1];
     let mut rowidx: Vec<i32> = Vec::new();
-    for c in 0..n {
-        cols[c].sort_unstable();
-        cols[c].dedup();
-        rowidx.extend_from_slice(&cols[c]);
+    for (c, rows) in cols.iter_mut().enumerate() {
+        rows.sort_unstable();
+        rows.dedup();
+        rowidx.extend_from_slice(rows);
         colptr[c + 1] = rowidx.len() as i32;
     }
-    if rowidx.is_empty() {
-        return None;
-    }
+    (!rowidx.is_empty()).then_some((colptr, rowidx))
+}
+
+/// C's `computeColumnColoring`: one column-equation pass per group of columns
+/// sharing no row.
+fn computed_coloring(colptr: &[i32], rowidx: &[i32], n: usize) -> Vec<Vec<u32>> {
     let (color_ptr, color_cols) =
-        crate::CodegenWasmJitFunctions::lin_jac_coloring(&colptr, &rowidx, n);
-    let colors = (0..color_ptr.len() - 1)
+        crate::CodegenWasmJitFunctions::lin_jac_coloring(colptr, rowidx, n);
+    (0..color_ptr.len() - 1)
         .map(|c| {
             color_cols[color_ptr[c] as usize..color_ptr[c + 1] as usize].iter().map(|&j| j as u32).collect()
         })
-        .collect();
-    Some(NlsJacPattern { colptr, rowidx, colors })
+        .collect()
 }
 
 /// The nonzero count of a nonlinear system's Jacobian, matching C's

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1452,6 +1452,20 @@ pub extern "C" fn rt_solve_nls(
     let sparse = has_jac && nnz != 0;
     let jac_len = if sparse { nnz as usize } else { n * n };
     let jac_ptr = if has_jac { rt_alloc((jac_len * 8) as u32) } else { 0 };
+    // `-nls=` overrides the codegen-time density choice; the dense solvers force
+    // the dense path.
+    let pick = nls_pick();
+    let sparse = match pick {
+        NlsPick::Default | NlsPick::Kinsol => sparse,
+        _ => false,
+    };
+    // A dense solver over a CSC-emitting `jac`: C's `evalJacobian` with `isDense`.
+    let scatter = !sparse && nnz != 0 && jac_len == nnz as usize;
+    let pat: alloc::vec::Vec<u32> = if scatter {
+        (0..n + 1 + nnz as usize).map(|k| unsafe { load_u32(pat_addr + (k * 4) as u32) }).collect()
+    } else {
+        alloc::vec::Vec::new()
+    };
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
         for i in 0..n {
@@ -1463,6 +1477,16 @@ pub extern "C" fn rt_solve_nls(
         jacf(sim_data, x_ptr, jac_ptr);
         NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
         NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        if scatter {
+            fj.fill(0.0);
+            for c in 0..n {
+                for k in pat[c] as usize..pat[c + 1] as usize {
+                    let row = pat[n + 1 + k] as usize;
+                    fj[c * n + row] = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
+                }
+            }
+            return;
+        }
         for (k, v) in fj.iter_mut().enumerate() {
             *v = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
         }
@@ -1514,14 +1538,6 @@ pub extern "C" fn rt_solve_nls(
     }
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
-    // `-nls=` overrides the codegen-time density choice; the dense solvers force
-    // the dense path.
-    let pick = nls_pick();
-    let sparse = match pick {
-        NlsPick::Default => sparse,
-        NlsPick::Kinsol => sparse,
-        _ => false,
-    };
     // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
     // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
     // O(n^3) per step, which is what the sparse choice exists to avoid.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
@@ -36,19 +36,32 @@ fn arena_alloc(len: usize) -> *mut c_char {
     })
 }
 
-/// Allocation used outside simulation mode. Native: the C runtime's real
-/// `ModelicaAllocateString`, one hop up the symbol chain (past ours) — present when
-/// a runtime library is loaded (`-d=gen`); a leaking `malloc` otherwise (the caller
-/// contract is that the buffer is not freed by the caller). Wasm: no C runtime, so
-/// the arena is the only allocator.
+/// Allocation used outside simulation mode. Native: the C runtime's own
+/// allocator, one hop up the symbol chain (past ours) — present when a runtime
+/// library is loaded (`-d=gen`, or the FFI evaluation of an external "C"
+/// function); a leaking `malloc` otherwise (the caller contract is that the buffer
+/// is not freed by the caller). Wasm: no C runtime, so the arena is the only
+/// allocator.
+///
+/// The hop must target the leaf `ModelicaAllocateStringWithErrorReturn`: the C
+/// runtime's `ModelicaAllocateString` only wraps it, and that inner call resolves
+/// back to this crate's interposing definition — an unbounded cycle.
 #[cfg(not(target_arch = "wasm32"))]
 fn non_sim_alloc(len: usize) -> *mut c_char {
-    let next = unsafe { libc::dlsym(libc::RTLD_NEXT, c"ModelicaAllocateString".as_ptr()) };
+    let next =
+        unsafe { libc::dlsym(libc::RTLD_NEXT, c"ModelicaAllocateStringWithErrorReturn".as_ptr()) };
     if !next.is_null() {
         let f: extern "C" fn(usize) -> *mut c_char = unsafe { std::mem::transmute(next) };
-        return f(len);
+        let res = f(len);
+        if !res.is_null() {
+            return res;
+        }
     }
-    unsafe { libc::malloc(len + 1) as *mut c_char }
+    let res = unsafe { libc::malloc(len + 1) as *mut c_char };
+    if !res.is_null() {
+        unsafe { *res.add(len) = 0 };
+    }
+    res
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/testsuite/simulation/modelica/external_functions/CevalModelicaStrings.mos
+++ b/testsuite/simulation/modelica/external_functions/CevalModelicaStrings.mos
@@ -1,0 +1,44 @@
+// name:     CevalModelicaStrings
+// keywords: ModelicaUtilities ceval
+// status: correct
+//
+// An external "C" function that allocates its result with
+// ModelicaAllocateString, evaluated at compile time. Guards against the
+// allocator resolving back into itself (a stack overflow in the Rust port,
+// where libOpenModelicaCompiler interposes on the runtime's
+// ModelicaAllocateString).
+//
+
+loadString("
+package P
+  function substring
+    input String string;
+    input Integer startIndex;
+    input Integer endIndex;
+    output String result;
+    external \"C\" result = ModelicaStrings_substring(string, startIndex, endIndex)
+      annotation(Library=\"ModelicaExternalC\");
+  end substring;
+  model M
+    constant String s = substring(\"Yd01\", 1, 2);
+    Real x(start = 1.0, fixed = true);
+  equation
+    der(x) = -x;
+  end M;
+end P;
+"); getErrorString();
+
+instantiateModel(P.M); getErrorString();
+
+// Result:
+// true
+// ""
+// "class P.M
+//   constant String s = \"Yd\";
+//   Real x(start = 1.0, fixed = true);
+// equation
+//   der(x) = -x;
+// end P.M;
+// "
+// ""
+// endResult

--- a/testsuite/simulation/modelica/external_functions/Makefile
+++ b/testsuite/simulation/modelica/external_functions/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
+CevalModelicaStrings.mos \
 ExternalCFuncInputOnly.mos \
 ExternalLibraries.mos \
 ExternalRHSFlag.mos \


### PR DESCRIPTION
Two fixes that between them let a nonlinear system reach the real KINSOL+KLU solver on a real model for the first time.

nls_jac_pattern read only JAC_MATRIX.sparsityMatrix, the new backend's resizable pattern. The default backend fills JAC_MATRIX.sparsity plus coloredCols instead (what C's generateStaticSparseData emits), so nls_system_nnz was 0 for those models: every nonlinear system looked dense, and neither the CSC Jacobian codegen nor KINSOL was reachable. Split the function in two, picked in the order C's functionNonLinearResiduals picks them. The static pattern is positional: column k is sparsity's k-th entry and the seed var with SimVar.index == k, which C requires anyway since the generated column code reads seedVars[<%index%>] while evalJacobian writes seedVars[column]. coloredCols is used when it is a partition of the columns, recomputed otherwise.

A dense solver over a CSC-emitting jac read n*n values out of an nnz-sized buffer; rt_solve_nls now scatters CSC into the column-major matrix when -nls=hybrid|newton|homotopy|mixed overrides a system the codegen made sparse, as C's evalJacobian does with isDense.

The model that motivated this could not be compiled at all: omc died with a stack overflow. libOpenModelicaCompiler exports both ModelicaAllocateString and ModelicaAllocateStringWithErrorReturn and so interposes on libOpenModelicaRuntimeC's, which exports both too. Outside simulation mode non_sim_alloc hopped to the C runtime with dlsym(RTLD_NEXT, "ModelicaAllocateString") -- but that function only wraps ModelicaAllocateStringWithErrorReturn, whose call resolves back to ours, which calls our ModelicaAllocateString, which hops RTLD_NEXT again. Both Rust hops are tail calls, so each turn of the cycle leaves one C frame: 41000 of them under ModelicaStrings_substring("Yd01",1,1) before the stack ran out. Any compile-time evaluation of an external "C" function allocating its result this way hit it, so it was not depth-related -- 256 MB of stack overflowed as readily as 4 MB. Hop to the leaf allocator instead, and NUL-terminate the malloc fallback as the C runtime does.

Verified under RTEST_OMCFLAGS=--simCodeTarget=wasm-jit: nonlinear_system 14 -> 13 of 50 failing, the flip being problem6 [symjac], which now solves its two 98x98 sparse systems with real KINSOL and agrees with the C reference to ~1e-14. tearing, initialization, others, arrays, commonSubExp, equations, msl22 and events (530 tests) are unchanged but for arrays/gc.mos, which improves from a dead compiler to a wasm-jit unreachable trap. checkModel over all 34 Modelica.Electrical.{Machines,QuasiStationary} MSL 3.2.1 examples completes, where before it got through 5 and then aborted the process; TransformerTestbench simulates under wasm-jit and compareSimulationResults reports Files Equal. 1238 unit tests pass.


Claude-Session: https://claude.ai/code/session_016wq1GUrRVcsSxWXWrL8Usx

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
