### PR TITLE
wasm-jit: remove per-evaluation call overhead

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -944,6 +944,9 @@ pub(crate) struct FnCtx<'a> {
     /// skipped by `release_heap_locals` — currently the `for x in array` iterator,
     /// which aliases an element of the array that outlives the loop.
     borrowed_locals: Vec<u32>,
+    /// Scratch pair shared by every [`emit_elem_ptr`] in the body: its sequence is
+    /// straight-line, so one pair is enough.
+    elem_ptr_tmp: Option<(u32, u32)>,
     /// Set when lowering *simulation* equations (the `CodegenWasmJit` target): a
     /// resolver that maps model component references not bound as wasm locals to
     /// slots in the shared `SimData` block. `None` for ordinary function bodies.
@@ -1158,6 +1161,16 @@ impl<'a> FnCtx<'a> {
         self.extra_locals.push(wty.val());
         idx
     }
+    fn elem_ptr_temps(&mut self) -> (u32, u32) {
+        match self.elem_ptr_tmp {
+            Some(p) => p,
+            None => {
+                let p = (self.alloc_temp(WTy::I32), self.alloc_temp(WTy::I32));
+                self.elem_ptr_tmp = Some(p);
+                p
+            }
+        }
+    }
 
     /// Build a context for lowering one *simulation* equation function (see
     /// `CodegenWasmJit`). The function takes the `SimData` base pointer as its
@@ -1193,6 +1206,7 @@ impl<'a> FnCtx<'a> {
             ctrl_depth: 0,
             loops: Vec::new(),
             borrowed_locals: Vec::new(),
+            elem_ptr_tmp: None,
             sim: Some(sim),
         }
     }
@@ -1515,7 +1529,7 @@ pub(crate) fn compile_function(
         intern_local(v, &mut idx, &mut extra_locals, &mut locals, &mut array_allocs)?;
     }
 
-    let mut ctx = FnCtx { locals, extra_locals, n_params, outputs, by_name, literals, instrs: Vec::new(), ctrl_depth: 0, loops: Vec::new(), borrowed_locals: Vec::new(), sim: None };
+    let mut ctx = FnCtx { locals, extra_locals, n_params, outputs, by_name, literals, instrs: Vec::new(), ctrl_depth: 0, loops: Vec::new(), borrowed_locals: Vec::new(), elem_ptr_tmp: None, sim: None };
     // Allocate every array local/output up front so it is a real (possibly empty)
     // array object, never a null handle — matching the C runtime, where the array
     // descriptor always exists. Unknown (`:`) dimensions start at size 0 and are
@@ -1615,7 +1629,7 @@ fn compile_external_function(
         outputs.push(slot);
     }
 
-    let mut ctx = FnCtx { locals, extra_locals, n_params, outputs, by_name, literals, instrs: Vec::new(), ctrl_depth: 0, loops: Vec::new(), borrowed_locals: Vec::new(), sim: None };
+    let mut ctx = FnCtx { locals, extra_locals, n_params, outputs, by_name, literals, instrs: Vec::new(), ctrl_depth: 0, loops: Vec::new(), borrowed_locals: Vec::new(), elem_ptr_tmp: None, sim: None };
     for (slot, elem, dims) in &array_allocs {
         emit_array_alloc(&mut ctx, *slot, elem, dims)?;
     }
@@ -2078,7 +2092,7 @@ fn store_fresh_into_field(ctx: &mut FnCtx, rec_idx: u32, fields: &[(ArcStr, SigT
 /// `arr[idx_exps...]` (the array local privately owns its buffer), releasing the
 /// previous element first. The value is already owned, so no copy is made.
 fn store_fresh_into_elem(ctx: &mut FnCtx, arr_idx: u32, elem: &SigTy, idx_exps: &[Arc<DAE::Exp>], vt: u32) -> Result<()> {
-    emit_elem_addr(ctx, arr_idx, idx_exps)?;
+    emit_elem_addr(ctx, arr_idx, elem, idx_exps)?;
     let addr_t = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::LocalSet(addr_t));
     if let Some(release_fn) = elem.release_fn() {
@@ -2117,8 +2131,6 @@ fn store_fresh_into_cref(ctx: &mut FnCtx, cref: &DAE::ComponentRef, wty: WTy, vt
             let idx_exps = index_subscripts(lsubs, rank)?;
             store_fresh_into_elem(ctx, arr_t, &elem, &idx_exps, vt)?;
         }
-        ctx.emit(we::Instruction::LocalGet(rec));
-        ctx.emit(we::Instruction::Call(rt_index("rt_record_release")?));
         return Ok(());
     }
     let DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } = cref else {
@@ -2203,6 +2215,11 @@ fn value_rhs_is_fresh(e: &DAE::Exp) -> bool {
         _ => false,
     }
 }
+
+/// Array-object header offsets, matching the runtime's `ARR_*`.
+const ARR_NDIMS_OFF: u32 = 8;
+const ARR_TOTAL_OFF: u32 = 12;
+const ARR_DIMS_OFF: u32 = 16;
 
 // -------------------------------------------------------------------------
 // Record object layout (mirrors the runtime's record object)
@@ -2470,7 +2487,7 @@ fn emit_array_record_defaults(ctx: &mut FnCtx, slot: u32, elem: &DAE::Type) -> R
     ctx.emit(we::Instruction::BrIf(1));
     ctx.emit(we::Instruction::LocalGet(slot));
     ctx.emit(we::Instruction::LocalGet(i));
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_elem_ptr(ctx, &sig_ty(elem)?)?;
     emit_record_default(ctx, elem)?;
     ctx.emit(we::Instruction::I32Store(mem_arg(0, 2)));
     ctx.emit(we::Instruction::LocalGet(i));
@@ -2584,12 +2601,11 @@ fn compile_record_field_assign(ctx: &mut FnCtx, rec_idx: u32, fields: &[(ArcStr,
     Ok(())
 }
 
-/// Push an owned record handle for the head of a qualified cref onto a fresh
-/// temp: either a record local (retained, so the local keeps its reference) or
-/// an array-of-records local subscripted down to a single record element.
-/// Returns the temp holding the owned handle and the record's fields; the caller
-/// is responsible for releasing the temp.
-fn push_owned_record_base(
+/// Push a *borrowed* record handle for the head of a qualified cref into a temp:
+/// either a record local, or an array-of-records local subscripted to one element.
+/// The head is always a function local, which holds the reference for the whole
+/// expression, so no retain/release pair is needed.
+fn push_record_base(
     ctx: &mut FnCtx,
     ident: &str,
     subs: &Arc<List<Arc<DAE::Subscript>>>,
@@ -2603,12 +2619,7 @@ fn push_owned_record_base(
         let SigTy::Record { fields, .. } = sty else {
             return Err("CodegenWasmJit: field access on non-record local");
         };
-        ctx.emit(we::Instruction::LocalGet(idx));
-        ctx.emit(we::Instruction::LocalGet(idx));
-        ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
-        let t = ctx.alloc_temp(WTy::I32);
-        ctx.emit(we::Instruction::LocalSet(t));
-        Ok((t, fields))
+        Ok((idx, fields))
     } else {
         let SigTy::Array { elem, rank } = sty else {
             return Err("CodegenWasmJit: subscripting non-array local");
@@ -2620,21 +2631,31 @@ fn push_owned_record_base(
         if !is_scalar_index(subs, rank) {
             return Err("CodegenWasmJit: slicing an array of records before field access is not supported");
         }
-        ctx.emit(we::Instruction::LocalGet(idx));
-        ctx.emit(we::Instruction::LocalGet(idx));
-        ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
         let idx_exps = index_subscripts(subs, rank)?;
-        index_loaded(ctx, &elem, &idx_exps)?; // owned record element on the stack
+        emit_elem_addr(ctx, idx, &elem, &idx_exps)?;
+        elem_load(ctx, &elem);
         let t = ctx.alloc_temp(WTy::I32);
         ctx.emit(we::Instruction::LocalSet(t));
         Ok((t, fields))
     }
 }
 
-/// Read field `name` from the owned record handle in temp `rec`, consuming it
-/// (the record is released). Leaves the field value in a fresh temp and returns
-/// `(value_temp, field_type)`; a heap field value is retained so it is owned.
-fn take_field(
+/// Retain the borrowed heap value on top of the stack, leaving it there: the
+/// expression protocol hands its consumer an owned value. No-op for a scalar.
+fn retain_on_stack(ctx: &mut FnCtx, ty: &SigTy) -> Result<()> {
+    if !ty.is_heap() {
+        return Ok(());
+    }
+    let v = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalTee(v));
+    ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
+    ctx.emit(we::Instruction::LocalGet(v));
+    Ok(())
+}
+
+/// Read field `name` out of the borrowed record in `rec` into a fresh temp. The
+/// value is borrowed too.
+fn load_field(
     ctx: &mut FnCtx,
     rec: u32,
     fields: &[(ArcStr, SigTy)],
@@ -2645,13 +2666,6 @@ fn take_field(
     ctx.emit(we::Instruction::LocalGet(rec));
     field_load(ctx, fty.wty(), off);
     ctx.emit(we::Instruction::LocalSet(vt));
-    if fty.is_heap() {
-        // Own the field value before releasing the record that holds it.
-        ctx.emit(we::Instruction::LocalGet(vt));
-        ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
-    }
-    ctx.emit(we::Instruction::LocalGet(rec));
-    ctx.emit(we::Instruction::Call(rt_index("rt_record_release")?));
     Ok((vt, fty))
 }
 
@@ -2666,7 +2680,7 @@ fn step_into_record(
     field: &str,
     fsubs: &Arc<List<Arc<DAE::Subscript>>>,
 ) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>)> {
-    let (vt, fty) = take_field(ctx, rec, fields, field)?;
+    let (vt, fty) = load_field(ctx, rec, fields, field)?;
     if fsubs.is_empty() {
         let SigTy::Record { fields: f2, .. } = fty else {
             return Err("CodegenWasmJit: field access on non-record field");
@@ -2683,9 +2697,9 @@ fn step_into_record(
         if !is_scalar_index(fsubs, rank) {
             return Err("CodegenWasmJit: slicing an array of records before field access is not supported");
         }
-        ctx.emit(we::Instruction::LocalGet(vt)); // owned array handle
         let idx_exps = index_subscripts(fsubs, rank)?;
-        index_loaded(ctx, &elem, &idx_exps)?; // owned record element
+        emit_elem_addr(ctx, vt, &elem, &idx_exps)?;
+        elem_load(ctx, &elem);
         let t = ctx.alloc_temp(WTy::I32);
         ctx.emit(we::Instruction::LocalSet(t));
         Ok((t, f2))
@@ -2700,24 +2714,31 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
     let DAE::ComponentRef::CREF_QUAL { ident, subscriptLst, componentRef: rest, .. } = cref else {
         return Err("CodegenWasmJit: compile_cref_read_qual on non-qualified cref");
     };
-    let (mut rec, mut fields) = push_owned_record_base(ctx, ident, subscriptLst)?;
+    let (mut rec, mut fields) = push_record_base(ctx, ident, subscriptLst)?;
     let mut cur: &DAE::ComponentRef = rest;
     loop {
         match cur {
             DAE::ComponentRef::CREF_IDENT { ident: field, subscriptLst: fsubs, .. } => {
-                let (vt, fty) = take_field(ctx, rec, &fields, field)?;
+                let (vt, fty) = load_field(ctx, rec, &fields, field)?;
                 if fsubs.is_empty() {
                     ctx.emit(we::Instruction::LocalGet(vt));
+                    retain_on_stack(ctx, &fty)?;
                     return Ok(fty.wty());
                 }
                 let SigTy::Array { elem, rank } = fty else {
                     return Err("CodegenWasmJit: subscripting non-array field");
                 };
-                ctx.emit(we::Instruction::LocalGet(vt)); // owned array handle
                 return if is_scalar_index(fsubs, rank) {
                     let idx_exps = index_subscripts(fsubs, rank)?;
-                    index_loaded(ctx, &elem, &idx_exps)
+                    emit_elem_addr(ctx, vt, &elem, &idx_exps)?;
+                    elem_load(ctx, &elem);
+                    retain_on_stack(ctx, &elem)?;
+                    Ok(elem.wty())
                 } else {
+                    // `slice_loaded` consumes an owned handle.
+                    ctx.emit(we::Instruction::LocalGet(vt));
+                    ctx.emit(we::Instruction::LocalGet(vt));
+                    ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
                     slice_loaded(ctx, fsubs)
                 };
             }
@@ -2742,7 +2763,7 @@ fn navigate_qual<'c>(
     let DAE::ComponentRef::CREF_QUAL { ident, subscriptLst, componentRef: rest, .. } = cref else {
         return Err("CodegenWasmJit: navigate_qual on non-qualified cref");
     };
-    let (mut rec, mut fields) = push_owned_record_base(ctx, ident, subscriptLst)?;
+    let (mut rec, mut fields) = push_record_base(ctx, ident, subscriptLst)?;
     let mut cur: &DAE::ComponentRef = rest;
     loop {
         match cur {
@@ -2781,9 +2802,6 @@ fn compile_cref_assign_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE
         let idx_exps = index_subscripts(lsubs, rank)?;
         compile_elem_assign(ctx, arr_t, &elem, &idx_exps, rhs)?;
     }
-    // Release the navigated record handle (owned by us).
-    ctx.emit(we::Instruction::LocalGet(rec));
-    ctx.emit(we::Instruction::Call(rt_index("rt_record_release")?));
     Ok(())
 }
 
@@ -2792,7 +2810,7 @@ fn compile_cref_assign_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE
 /// the slot is released and the new owned value moved in; the old value is
 /// released only *after* the rhs is computed, in case the rhs reads it.
 fn compile_elem_assign(ctx: &mut FnCtx, arr_idx: u32, elem: &SigTy, idx_exps: &[Arc<DAE::Exp>], rhs: &DAE::Exp) -> Result<()> {
-    emit_elem_addr(ctx, arr_idx, idx_exps)?;
+    emit_elem_addr(ctx, arr_idx, elem, idx_exps)?;
     let addr_t = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::LocalSet(addr_t));
     if let Some(release_fn) = elem.release_fn() {
@@ -2820,7 +2838,7 @@ fn compile_elem_assign(ctx: &mut FnCtx, arr_idx: u32, elem: &SigTy, idx_exps: &[
 /// Emit the byte address of array element `a[idx_exps...]`, reading the array
 /// handle from local `arr_idx` (the local owns it — no retain/release). Leaves
 /// the address on the stack. Same row-major linear index as [`index_loaded`].
-fn emit_elem_addr(ctx: &mut FnCtx, arr_idx: u32, idx_exps: &[Arc<DAE::Exp>]) -> Result<()> {
+fn emit_elem_addr(ctx: &mut FnCtx, arr_idx: u32, elem: &SigTy, idx_exps: &[Arc<DAE::Exp>]) -> Result<()> {
     let acc = ctx.alloc_temp(WTy::I32);
     let w = compile_exp(ctx, &idx_exps[0])?;
     coerce(ctx, w, WTy::I32);
@@ -2830,8 +2848,7 @@ fn emit_elem_addr(ctx: &mut FnCtx, arr_idx: u32, idx_exps: &[Arc<DAE::Exp>]) -> 
     for (axis0, ie) in idx_exps.iter().enumerate().skip(1) {
         ctx.emit(we::Instruction::LocalGet(acc));
         ctx.emit(we::Instruction::LocalGet(arr_idx));
-        ctx.emit(we::Instruction::I32Const(axis0 as i32 + 1));
-        ctx.emit(we::Instruction::Call(rt_index("rt_array_dim")?));
+        emit_array_dim(ctx, axis0 as u32 + 1)?;
         ctx.emit(we::Instruction::I32Mul);
         let w = compile_exp(ctx, ie)?;
         coerce(ctx, w, WTy::I32);
@@ -2844,8 +2861,7 @@ fn emit_elem_addr(ctx: &mut FnCtx, arr_idx: u32, idx_exps: &[Arc<DAE::Exp>]) -> 
     ctx.emit(we::Instruction::LocalGet(acc));
     ctx.emit(we::Instruction::I32Const(1));
     ctx.emit(we::Instruction::I32Add);
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
-    Ok(())
+    emit_elem_ptr(ctx, elem)
 }
 
 /// Evaluate a call for its side effects and discard any results. A discarded
@@ -3320,7 +3336,7 @@ fn compile_for_array(
     // it = arr[k] (borrowed; the array outlives the loop).
     ctx.emit(we::Instruction::LocalGet(arr_t));
     ctx.emit(we::Instruction::LocalGet(k));
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_elem_ptr(ctx, &elem)?;
     elem_load(ctx, &elem);
     ctx.emit(we::Instruction::LocalSet(it));
     compile_loop_body(ctx, break_level, body)?;
@@ -3574,7 +3590,7 @@ fn compile_reduction(
         ctx.emit(we::Instruction::LocalGet(idx));
         ctx.emit(we::Instruction::I32Const(1));
         ctx.emit(we::Instruction::I32Add);
-        ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+        emit_elem_ptr(ctx, &store_sty)?;
         let w = compile_exp(ctx, expr)?;
         coerce(ctx, w, elem_wty);
         elem_store(ctx, &store_sty);
@@ -4503,18 +4519,22 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 }
                 Ok(sty.wty())
             } else {
-                // Indexed read `v[i, ...]`: push the (retained, owned) array
-                // handle, then load the element (which releases the handle).
                 let SigTy::Array { elem, rank } = sty else {
                     return Err("CodegenWasmJit: subscripting non-array local");
                 };
-                ctx.emit(we::Instruction::LocalGet(idx));
-                ctx.emit(we::Instruction::LocalGet(idx));
-                ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
+                // The local keeps the array alive for the whole expression, so read
+                // the element straight out of it; only a heap element is retained.
                 if is_scalar_index(subscriptLst, rank) {
                     let idx_exps = index_subscripts(subscriptLst, rank)?;
-                    index_loaded(ctx, &elem, &idx_exps)
+                    emit_elem_addr(ctx, idx, &elem, &idx_exps)?;
+                    elem_load(ctx, &elem);
+                    retain_on_stack(ctx, &elem)?;
+                    Ok(elem.wty())
                 } else {
+                    // The slice path consumes an owned handle.
+                    ctx.emit(we::Instruction::LocalGet(idx));
+                    ctx.emit(we::Instruction::LocalGet(idx));
+                    ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
                     slice_loaded(ctx, subscriptLst)
                 }
             }
@@ -6223,6 +6243,64 @@ fn emit_real_string(ctx: &mut FnCtx, arg: &DAE::Exp) -> Result<SigTy> {
 // Arrays (N-dimensional, flat row-major; see the runtime's Arrays section)
 // -------------------------------------------------------------------------
 
+/// Inline what `rt_array_elem_ptr` computes: the byte address of the element at
+/// row-major linear position `index` (1-based), with the same out-of-range trap.
+/// Stack is `[obj, index] -> [addr]`.
+///
+/// Inlined rather than called because element access is the hottest operation in
+/// generated model code (an IF97 property evaluation does hundreds) and the
+/// cross-module call dominated the per-evaluation cost. The stride follows the
+/// element's wasm type, which the load/store that follows already assumes.
+fn emit_elem_ptr(ctx: &mut FnCtx, elem: &SigTy) -> Result<()> {
+    use we::Instruction as I;
+    let (ot, it) = ctx.elem_ptr_temps();
+    let shift = match elem.wty() {
+        WTy::F64 => 3,
+        WTy::I32 => 2,
+    };
+    ctx.emit(I::LocalSet(it));
+    ctx.emit(I::LocalSet(ot));
+    // index < 1 || index > total -> trap.
+    ctx.emit(I::LocalGet(it));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32LtS);
+    ctx.emit(I::LocalGet(it));
+    ctx.emit(I::LocalGet(ot));
+    ctx.emit(I::I32Load(mem_arg(ARR_TOTAL_OFF, 2)));
+    ctx.emit(I::I32GtS);
+    ctx.emit(I::I32Or);
+    ctx.emit(I::If(we::BlockType::Empty));
+    ctx.emit(I::Unreachable);
+    ctx.emit(I::End);
+    // obj + align8(ARR_DIMS_OFF + ndims*4) + (index - 1) * stride
+    ctx.emit(I::LocalGet(ot));
+    ctx.emit(I::LocalGet(ot));
+    ctx.emit(I::I32Load(mem_arg(ARR_NDIMS_OFF, 2)));
+    ctx.emit(I::I32Const(2));
+    ctx.emit(I::I32Shl);
+    ctx.emit(I::I32Const(ARR_DIMS_OFF as i32 + 7));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(-8));
+    ctx.emit(I::I32And);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalGet(it));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Sub);
+    ctx.emit(I::I32Const(shift));
+    ctx.emit(I::I32Shl);
+    ctx.emit(I::I32Add);
+    Ok(())
+}
+
+/// Inline `rt_array_dim` for a constant 1-based `axis`. Stack `[obj] -> [size]`.
+fn emit_array_dim(ctx: &mut FnCtx, axis: u32) -> Result<()> {
+    if axis == 0 {
+        return Err("CodegenWasmJit: array dimension axis is 1-based");
+    }
+    ctx.emit(we::Instruction::I32Load(mem_arg(ARR_DIMS_OFF + (axis - 1) * 4, 2)));
+    Ok(())
+}
+
 /// Load one array element from the byte address on top of the stack, leaving its
 /// value. The wasm load instruction (and natural alignment) follow the element
 /// type.
@@ -6325,7 +6403,7 @@ fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> R
                 // Scalar element.
                 ctx.emit(we::Instruction::LocalGet(obj));
                 ctx.emit(we::Instruction::I32Const(k as i32 + 1));
-                ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+                emit_elem_ptr(ctx, &elem)?;
                 let w = compile_exp(ctx, leaf)?;
                 coerce(ctx, w, elem.wty());
                 elem_store(ctx, &elem);
@@ -6484,7 +6562,7 @@ fn compile_int_range_array(ctx: &mut FnCtx, start: &DAE::Exp, step: Option<&DAE:
     ctx.emit(we::Instruction::LocalGet(k_t));
     ctx.emit(we::Instruction::I32Const(1));
     ctx.emit(we::Instruction::I32Add);
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_elem_ptr(ctx, &SigTy::Int)?;
     ctx.emit(we::Instruction::LocalGet(start_t));
     ctx.emit(we::Instruction::LocalGet(k_t));
     ctx.emit(we::Instruction::LocalGet(step_t));
@@ -6581,7 +6659,7 @@ fn compile_real_range_array(ctx: &mut FnCtx, start: &DAE::Exp, step: Option<&DAE
     ctx.emit(we::Instruction::LocalGet(k_t));
     ctx.emit(we::Instruction::I32Const(1));
     ctx.emit(we::Instruction::I32Add);
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_elem_ptr(ctx, &SigTy::Real)?;
     ctx.emit(we::Instruction::LocalGet(val_t));
     elem_store(ctx, &SigTy::Real);
     ctx.emit(we::Instruction::LocalGet(val_t));
@@ -6767,8 +6845,7 @@ fn index_loaded(ctx: &mut FnCtx, elem: &SigTy, idx_exps: &[Arc<DAE::Exp>]) -> Re
     for (axis0, ie) in idx_exps.iter().enumerate().skip(1) {
         ctx.emit(we::Instruction::LocalGet(acc));
         ctx.emit(we::Instruction::LocalGet(arr_t));
-        ctx.emit(we::Instruction::I32Const(axis0 as i32 + 1)); // 1-based axis
-        ctx.emit(we::Instruction::Call(rt_index("rt_array_dim")?));
+        emit_array_dim(ctx, axis0 as u32 + 1)?; // 1-based axis
         ctx.emit(we::Instruction::I32Mul);
         let w = compile_exp(ctx, ie)?;
         coerce(ctx, w, WTy::I32);
@@ -6777,12 +6854,11 @@ fn index_loaded(ctx: &mut FnCtx, elem: &SigTy, idx_exps: &[Arc<DAE::Exp>]) -> Re
         ctx.emit(we::Instruction::I32Add);
         ctx.emit(we::Instruction::LocalSet(acc));
     }
-    // addr = rt_array_elem_ptr(arr, acc + 1); load the element.
     ctx.emit(we::Instruction::LocalGet(arr_t));
     ctx.emit(we::Instruction::LocalGet(acc));
     ctx.emit(we::Instruction::I32Const(1));
     ctx.emit(we::Instruction::I32Add);
-    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_elem_ptr(ctx, elem)?;
     elem_load(ctx, elem);
 
     if elem.is_heap() {
@@ -7120,7 +7196,7 @@ fn compile_array_builtin(
             ctx.emit(we::Instruction::LocalSet(arr_t));
             ctx.emit(we::Instruction::LocalGet(arr_t));
             ctx.emit(we::Instruction::I32Const(1));
-            ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+            emit_elem_ptr(ctx, &elem)?;
             elem_load(ctx, &elem);
             if elem.is_heap() {
                 // Retain the borrowed handle so it outlives the array release.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -66,7 +66,11 @@ daskr = { path = "../daskr", optional = true }
 rsparse = { version = "1.2", optional = true }
 
 [profile.release]
-opt-level = "s"
+# Speed, not size: `rt_solve_nls` + minpack and the array/record/allocator helpers
+# all run here, millions of times per simulated second (FullRobot 14% faster than
+# at `opt-level = "s"`). The ~50 KB it adds to `runtime.wasm` is 0.06% of the web
+# bundle's 84 MB compiler wasm.
+opt-level = 3
 lto = true
 panic = "abort"
 strip = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -125,6 +125,47 @@ unsafe fn store_f64(addr: u32, v: f64) {
 }
 
 // ---------------------------------------------------------------------------
+// Diagnostic counters
+// ---------------------------------------------------------------------------
+
+/// `rt_stat` slots, read by the host bench line (`OMC_WASM_SIM_BENCH`) — the
+/// wasm-jit analogue of C's `-lv=LOG_STATS`.
+pub const STAT_ALLOC: u32 = 0;
+pub const STAT_ARRAY_NEW: u32 = 1;
+pub const STAT_RECORD_NEW: u32 = 2;
+pub const STAT_STR_NEW: u32 = 3;
+pub const STAT_NLS_SOLVE: u32 = 4;
+pub const STAT_NLS_RES: u32 = 5;
+pub const STAT_NLS_JAC: u32 = 6;
+pub const STAT_NLS_FAIL: u32 = 7;
+pub const STAT_NLS_RETRY: u32 = 8;
+pub const STAT_ELEM_PTR: u32 = 9;
+pub const N_STATS: usize = 10;
+
+static STATS: [core::sync::atomic::AtomicU64; N_STATS] =
+    [const { core::sync::atomic::AtomicU64::new(0) }; N_STATS];
+
+#[inline]
+pub(crate) fn stat_inc(kind: u32) {
+    STATS[kind as usize].fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_stat(kind: u32) -> u64 {
+    match STATS.get(kind as usize) {
+        Some(c) => c.load(core::sync::atomic::Ordering::Relaxed),
+        None => 0,
+    }
+}
+
+/// Called per run (`rt_sim_start`), so the counters are per-run.
+pub fn reset_stats() {
+    for c in STATS.iter() {
+        c.store(0, core::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Allocator + reference counting
 // ---------------------------------------------------------------------------
 
@@ -134,12 +175,45 @@ unsafe fn store_f64(addr: u32, v: f64) {
 const HEADER: usize = 8;
 const ALIGN: usize = 8;
 
+/// Recycling free lists in front of `dlmalloc`. Generated code allocates and frees
+/// one array/record per array/record-typed function local on every call (an IF97
+/// property evaluation does hundreds), so a same-size block is nearly always
+/// available and bucketing by 8-byte size class turns both into a push/pop.
+/// `rt_alloc` writes the *rounded* total into the size word, so `rt_free` finds the
+/// same class and `dlmalloc` gets the layout it was handed.
+const CACHE_MAX: usize = 1024;
+const CACHE_CLASSES: usize = CACHE_MAX / ALIGN + 1;
+
+struct FreeLists(core::cell::UnsafeCell<[u32; CACHE_CLASSES]>);
+// The runtime is single-threaded (as is the in-wasm session driver).
+unsafe impl Sync for FreeLists {}
+static FREE: FreeLists = FreeLists(core::cell::UnsafeCell::new([0; CACHE_CLASSES]));
+
+/// `None` when `total` is not cached: too big, or no room for the link word.
+#[inline]
+fn cache_class(total: usize) -> Option<usize> {
+    (total <= CACHE_MAX && total >= HEADER + 4).then(|| total / ALIGN)
+}
+
 /// Allocate an object of `size` payload bytes (including its 4-byte refcount),
 /// returning its pointer. The reference count is left zero — the typed
 /// constructors below set it to 1.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_alloc(size: u32) -> u32 {
-    let total = HEADER + size as usize;
+    stat_inc(STAT_ALLOC);
+    let mut total = HEADER + size as usize;
+    if total <= CACHE_MAX {
+        total = (total + ALIGN - 1) & !(ALIGN - 1);
+    }
+    if let Some(class) = cache_class(total) {
+        let lists = unsafe { &mut *FREE.0.get() };
+        let head = lists[class];
+        if head != 0 {
+            lists[class] = unsafe { load_u32(head + HEADER as u32) };
+            unsafe { store_u32(head, total as u32) };
+            return head + HEADER as u32;
+        }
+    }
     let layout = Layout::from_size_align(total, ALIGN).expect("bad layout");
     let raw = unsafe { GLOBAL.alloc(layout) } as u32;
     if raw == 0 {
@@ -158,6 +232,12 @@ pub extern "C" fn rt_free(obj: u32) {
     }
     let raw = obj - HEADER as u32;
     let total = unsafe { load_u32(raw) } as usize;
+    if let Some(class) = cache_class(total) {
+        let lists = unsafe { &mut *FREE.0.get() };
+        unsafe { store_u32(raw + HEADER as u32, lists[class]) };
+        lists[class] = raw;
+        return;
+    }
     let layout = Layout::from_size_align(total, ALIGN).expect("bad layout");
     unsafe { GLOBAL.dealloc(raw as *mut u8, layout) };
 }
@@ -277,17 +357,17 @@ fn arr_data(obj: u32) -> u32 {
 /// partially filled array is safe.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_array_new(elem_kind: u32, ndims: u32, total: u32) -> u32 {
+    stat_inc(STAT_ARRAY_NEW);
     let data_off = arr_data_off(ndims);
-    let obj = rt_alloc(data_off + total * elem_stride(elem_kind));
+    let size = data_off + total * elem_stride(elem_kind);
+    let obj = rt_alloc(size);
     unsafe {
         store_u32(obj, 1); // refcount
         store_u32(obj + ARR_KIND_OFF, elem_kind);
         store_u32(obj + ARR_NDIMS_OFF, ndims);
         store_u32(obj + ARR_TOTAL_OFF, total);
         // Zero the dim words and the element area (rt_alloc does not zero).
-        for off in (ARR_DIMS_OFF..data_off + total * elem_stride(elem_kind)).step_by(4) {
-            store_u32(obj + off, 0);
-        }
+        core::ptr::write_bytes((obj + ARR_DIMS_OFF) as *mut u8, 0, (size - ARR_DIMS_OFF) as usize);
     }
     obj
 }
@@ -328,6 +408,7 @@ pub extern "C" fn rt_array_dim(obj: u32, axis: i32) -> u32 {
 /// the element's natural wasm type.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_array_elem_ptr(obj: u32, index: i32) -> u32 {
+    stat_inc(STAT_ELEM_PTR);
     let total = rt_array_total(obj) as i32;
     if index < 1 || index > total {
         trap();
@@ -1055,13 +1136,12 @@ fn rec_data_off(nheap: u32) -> u32 {
 /// start as the null handle, so releasing a partially built record is safe.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_record_new(nheap: u32, size: u32) -> u32 {
+    stat_inc(STAT_RECORD_NEW);
     let obj = rt_alloc(size);
     unsafe {
         store_u32(obj, 1); // refcount
         store_u32(obj + REC_NHEAP_OFF, nheap);
-        for off in (8..size).step_by(4) {
-            store_u32(obj + off, 0);
-        }
+        core::ptr::write_bytes((obj + 8) as *mut u8, 0, size.saturating_sub(8) as usize);
     }
     obj
 }
@@ -1462,6 +1542,7 @@ const STR_DATA_OFF: u32 = 8;
 /// set). The caller fills `rt_str_data(obj)..+len` with the bytes.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_str_new(len: u32) -> u32 {
+    stat_inc(STAT_STR_NEW);
     let obj = rt_alloc(STR_DATA_OFF + len);
     unsafe {
         store_u32(obj, 1); // refcount

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -6,7 +6,10 @@
 use alloc::vec;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use crate::{load_f64, load_u32, rt_alloc, rt_free, store_f64, store_u32};
+use crate::{
+    load_f64, load_u32, rt_alloc, rt_free, stat_inc, store_f64, store_u32, STAT_NLS_FAIL,
+    STAT_NLS_JAC, STAT_NLS_RES, STAT_NLS_RETRY, STAT_NLS_SOLVE,
+};
 
 /// Recoverable-assert state (C's `ERROR_NONLINEARSOLVER`). While `NLS_DEPTH` > 0 a
 /// failed model `assert()` records itself in `NLS_ASSERT_HIT` and returns instead of
@@ -1423,7 +1426,9 @@ pub extern "C" fn rt_solve_nls(
         nominal[i] = unsafe { load_f64(nominal_addr + (i * 8) as u32) };
     }
 
+    stat_inc(STAT_NLS_SOLVE);
     let mut eval = |xs: &[f64], r: &mut [f64]| {
+        stat_inc(STAT_NLS_RES);
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
@@ -1467,6 +1472,7 @@ pub extern "C" fn rt_solve_nls(
         alloc::vec::Vec::new()
     };
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
+        stat_inc(STAT_NLS_JAC);
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
@@ -1578,11 +1584,13 @@ pub extern "C" fn rt_solve_nls(
         };
         let mut converged = solve(&mut x, &mut fvec);
         if !converged {
+            stat_inc(STAT_NLS_RETRY);
             x.copy_from_slice(&warm);
             converged = solve(&mut x, &mut fvec);
         }
         drop(solve);
         if !converged {
+            stat_inc(STAT_NLS_RETRY);
             x.copy_from_slice(&warm);
             converged = newton_solve(n, &mut x, &mut eval);
         }
@@ -1608,6 +1616,7 @@ pub extern "C" fn rt_solve_nls(
         }
         // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
         if !converged {
+            stat_inc(STAT_NLS_RETRY);
             converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
         }
         if !converged {
@@ -1690,6 +1699,7 @@ pub extern "C" fn rt_solve_nls(
         }
         eval(&warm, &mut scratch);
         unsafe { store_u32(nls_fail_addr, 1) };
+        stat_inc(STAT_NLS_FAIL);
         1
     };
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -111,6 +111,13 @@ impl SimEngine for InWasmEngine {
         // to take in-wasm.
         None
     }
+    fn rt_stats(&mut self) -> [u64; driver::RT_STATS] {
+        let mut out = [0u64; driver::RT_STATS];
+        for (k, slot) in out.iter_mut().enumerate() {
+            *slot = crate::rt_stat(k as u32);
+        }
+        out
+    }
 }
 
 /// One resumable in-wasm run: engine, driver, decoded model view, and the result
@@ -201,6 +208,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     // Any prior session is dropped (frees its buffers) before starting a new one.
     *session() = None;
     crate::reset_lin_solves();
+    crate::reset_stats();
     crate::sundials::reset_caches();
 
     let bytes = unsafe { core::slice::from_raw_parts(meta_ptr as *const u8, meta_len as usize) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -239,7 +239,19 @@ pub trait SimEngine {
     fn lin_solves(&mut self) -> u64 {
         0
     }
+    /// The runtime's `rt_stat` counters, in slot order. Default: none.
+    fn rt_stats(&mut self) -> [u64; RT_STATS] {
+        [0; RT_STATS]
+    }
 }
+
+/// Must match the runtime's `N_STATS`.
+pub const RT_STATS: usize = 10;
+
+pub const RT_STAT_NAMES: [&str; RT_STATS] = [
+    "alloc", "array_new", "record_new", "str_new", "nls_solve", "nls_res", "nls_jac", "nls_fail", "nls_retry",
+    "elem_ptr",
+];
 
 /// Read a runtime String heap value (`[refcount:u32][len:u32][utf8]`, handle at
 /// its base; `0` is null) into a Rust `String`.
@@ -1433,6 +1445,12 @@ pub fn drive(
             "wasm-jit sim [{label}]: {} steps, {} residual evals, {} jacobian evals",
             stats.steps, stats.res_evals, stats.jac_evals
         );
+        let counters = e.rt_stats();
+        if counters.iter().any(|&c| c != 0) {
+            let line: Vec<String> =
+                RT_STAT_NAMES.iter().zip(counters.iter()).map(|(n, c)| format!("{n}={c}")).collect();
+            eprintln!("wasm-jit sim [{label}]: {}", line.join(" "));
+        }
     }
 
     let params = finalize_run(e, model, sim_data)?;
@@ -1850,6 +1868,24 @@ struct DasslDriver {
     jac_a: Option<JacAInfo>,
     /// Jacobian evaluation count, accumulated across chunks (for the bench line).
     nje: u64,
+    past: DaskrCounters,
+}
+
+/// DASKR zeroes its IWORK counters on a fresh start, so the run totals are folded
+/// in here before each restart.
+#[derive(Default)]
+struct DaskrCounters {
+    steps: u64,
+    err_test_fails: u64,
+    conv_test_fails: u64,
+}
+
+impl DaskrCounters {
+    fn fold(&mut self, iwork: &[i32]) {
+        self.steps += iwork.get(10).copied().unwrap_or(0).max(0) as u64;
+        self.err_test_fails += iwork.get(13).copied().unwrap_or(0).max(0) as u64;
+        self.conv_test_fails += iwork.get(14).copied().unwrap_or(0).max(0) as u64;
+    }
 }
 
 impl DasslDriver {
@@ -1940,7 +1976,14 @@ impl DasslDriver {
             finished: false,
             jac_a,
             nje: 0,
+            past: DaskrCounters::default(),
         })
+    }
+
+    /// Restart DASKR (INFO(1)=0), banking the IWORK run totals first.
+    fn restart(&mut self) {
+        self.past.fold(&self.iwork);
+        self.info[0] = 0;
     }
 }
 
@@ -2098,7 +2141,7 @@ impl Driver for DasslDriver {
                     self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
                     self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
                 }
-                self.info[0] = 0;
+                self.restart();
             }
             self.row += 1;
         };
@@ -2116,12 +2159,17 @@ impl Driver for DasslDriver {
     fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
         // DASKR IWORK counters (1-based): IWORK(11)=NST steps, IWORK(13)=NJE Jacobian
         // evals, IWORK(14)=NETF error-test failures, IWORK(15)=NCFN convergence fails.
-        let nst = self.iwork.get(10).copied().unwrap_or(0);
-        stats.steps = nst.max(0) as u64;
+        let mut total = DaskrCounters {
+            steps: self.past.steps,
+            err_test_fails: self.past.err_test_fails,
+            conv_test_fails: self.past.conv_test_fails,
+        };
+        total.fold(&self.iwork);
+        stats.steps = total.steps;
         stats.res_evals = self.nfe;
         stats.jac_evals = if self.jac_a.is_some() { self.nje } else { self.iwork.get(12).copied().unwrap_or(0).max(0) as u64 };
-        stats.err_test_fails = self.iwork.get(13).copied().unwrap_or(0).max(0) as u64;
-        stats.conv_test_fails = self.iwork.get(14).copied().unwrap_or(0).max(0) as u64;
+        stats.err_test_fails = total.err_test_fails;
+        stats.conv_test_fails = total.conv_test_fails;
     }
 }
 
@@ -2169,6 +2217,7 @@ struct DasslCore {
     nfe: u64,
     /// Jacobian evaluation count, accumulated across chunks (for the bench line).
     nje: u64,
+    past: DaskrCounters,
     /// The in-progress target's DASKR continuation count (IDID=-1 work quota).
     ev_retries: i32,
     /// Analytic-Jacobian sparsity+coloring (colored numerical FD); `None` ⇒
@@ -2257,6 +2306,7 @@ impl DasslCore {
             t,
             nfe: 0,
             nje: 0,
+            past: DaskrCounters::default(),
             ev_retries: 0,
             jac_a,
             state_events: 0,
@@ -2289,6 +2339,13 @@ impl DasslCore {
     /// A step with no state event breaks the run.
     fn note_clean_step(&mut self) {
         self.chatter_consec = 0;
+    }
+
+    /// Restart DASKR (INFO(1)=0), banking the IWORK run totals first. Every event
+    /// restarts, so without this the step count is only the last segment's.
+    fn restart(&mut self) {
+        self.past.fold(&self.iwork);
+        self.info[0] = 0;
     }
 
     /// Latch `(y, yp)` from `SimData` — after initialization, or after anything
@@ -2477,7 +2534,7 @@ impl DasslCore {
                     for i in 0..n_states {
                         self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
                     }
-                    self.info[0] = 0;
+                    self.restart();
                     continue;
                 }
                 // Reached the target with no state event: breaks a chattering run.
@@ -2518,7 +2575,7 @@ impl DasslCore {
                     for i in 0..n_states {
                         self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
                     }
-                    self.info[0] = 0;
+                    self.restart();
                 }
                 if te >= tout - eps {
                     grid_covered = true;
@@ -2654,7 +2711,7 @@ impl CsDriver {
         if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
             e.call1("functionODE", sim_data)?;
             self.core.read_states(e)?;
-            self.core.info[0] = 0;
+            self.core.restart();
         }
         if terminated(e, sim_data, layout)? {
             return Ok(CsStep::Terminated);
@@ -2680,7 +2737,7 @@ impl CsDriver {
             if self.core.n_states > 0 {
                 e.call1("functionODE", sim_data)?;
                 self.core.read_states(e)?;
-                self.core.info[0] = 0;
+                self.core.restart();
             }
             self.resume_reinit = false;
         }
@@ -2722,7 +2779,7 @@ impl CsDriver {
         if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
             e.call1("functionODE", sim_data)?;
             self.core.read_states(e)?;
-            self.core.info[0] = 0;
+            self.core.restart();
         }
         if terminated(e, sim_data, layout)? {
             return Ok(CsStep::Terminated);
@@ -2805,7 +2862,7 @@ impl CsDriver {
         stats.steps = if self.euler_h.is_some() {
             self.euler_steps
         } else {
-            c.iwork.get(10).copied().unwrap_or(0).max(0) as u64
+            c.past.steps + c.iwork.get(10).copied().unwrap_or(0).max(0) as u64
         };
         stats.res_evals = c.nfe;
         stats.state_events = c.state_events;
@@ -3037,7 +3094,7 @@ impl Driver for DasslEventsDriver {
                     self.core.y[i] = read_f64(e, self.core.states_base + (i as u32) * 8)?;
                     self.core.yp[i] = read_f64(e, self.core.ders_base + (i as u32) * 8)?;
                 }
-                self.core.info[0] = 0;
+                self.core.restart();
             }
             self.row += 1;
         };
@@ -3054,12 +3111,17 @@ impl Driver for DasslEventsDriver {
 
     fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
         let c = &self.core;
-        let nst = c.iwork.get(10).copied().unwrap_or(0);
-        stats.steps = nst.max(0) as u64;
+        let mut total = DaskrCounters {
+            steps: c.past.steps,
+            err_test_fails: c.past.err_test_fails,
+            conv_test_fails: c.past.conv_test_fails,
+        };
+        total.fold(&c.iwork);
+        stats.steps = total.steps;
         stats.res_evals = c.nfe;
         stats.jac_evals = if c.jac_a.is_some() { c.nje } else { c.iwork.get(12).copied().unwrap_or(0).max(0) as u64 };
-        stats.err_test_fails = c.iwork.get(13).copied().unwrap_or(0).max(0) as u64;
-        stats.conv_test_fails = c.iwork.get(14).copied().unwrap_or(0).max(0) as u64;
+        stats.err_test_fails = total.err_test_fails;
+        stats.conv_test_fails = total.conv_test_fails;
         stats.state_events = c.state_events;
         stats.time_events = c.time_events;
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -433,12 +433,12 @@ fn build_wasip1_runtime(
         return;
     }
 
+    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1");
     if let Ok(path) = std::env::var("OMC_WASM_RUNTIME_WASIP1") {
         copy(Path::new(&path), &dest);
         std::fs::write(&stamp, format!("override:{path}")).ok();
         return;
     }
-    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1");
 
     // The wasip1 variant is built from the same sources, so the same input hash
     // gates the cache.
@@ -509,12 +509,12 @@ fn build_wasip1_interactive_runtime(
 
     // omc-on-wasm builds this too (Part A2 uses it via wasmer-js); no wasm-merge is
     // needed, unlike the standalone variant, so it is not skipped for wasm32 omc.
+    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1_INTERACTIVE");
     if let Ok(path) = std::env::var("OMC_WASM_RUNTIME_WASIP1_INTERACTIVE") {
         copy(Path::new(&path), &dest);
         std::fs::write(&stamp, format!("override:{path}")).ok();
         return;
     }
-    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1_INTERACTIVE");
 
     // Native wasmtime: lean host-delegating blob (`host_lin_solve`), no in-wasm
     // driver/solver linked in. Web (wasm32) and native-wasmer solve in-wasm

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -66,6 +66,14 @@ pub fn sim_engine() -> &'static wasmtime::Engine {
             Ok("speed_and_size") => { cfg.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize); }
             _ => {}
         }
+        // Inline across the model/runtime boundary. Generated code reaches the
+        // `rt_*` helpers as *imported* functions, and wasmtime's default is no
+        // inlining at all, so a handful of instructions cost a call; `Yes` also
+        // covers inter-module. Costs module compilation time, which the on-disk
+        // AOT cache pays once for the runtime.
+        if std::env::var("OMC_WASM_NO_INLINE").is_err() {
+            cfg.compiler_inlining(wasmtime::Inlining::Yes);
+        }
         wasmtime::Engine::new(&cfg).expect("wasm-jit: failed to build wasmtime engine")
     })
 }
@@ -100,6 +108,7 @@ fn runtime_cache_path() -> std::path::PathBuf {
     runtime_blob().len().hash(&mut h);
     runtime_blob().hash(&mut h);
     std::env::var("OMC_WASM_OPT_LEVEL").unwrap_or_default().hash(&mut h);
+    std::env::var("OMC_WASM_NO_INLINE").is_ok().hash(&mut h);
     let key = h.finish();
 
     let home = openmodelica_util::Settings::getHomeDir(false);
@@ -733,6 +742,15 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             Ok(f) => f.call(&mut self.store, ()).unwrap_or(0),
             Err(_) => 0,
         }
+    }
+    fn rt_stats(&mut self) -> [u64; sim_driver::RT_STATS] {
+        let mut out = [0u64; sim_driver::RT_STATS];
+        if let Ok(f) = self.rt_inst.get_typed_func::<u32, u64>(&mut self.store, "rt_stat") {
+            for (k, slot) in out.iter_mut().enumerate() {
+                *slot = f.call(&mut self.store, k as u32).unwrap_or(0);
+            }
+        }
+        out
     }
 }
 


### PR DESCRIPTION
ThermoPower.Test.DistributedParameterComponents.TestFlow1D2phChen was by far the slowest wasm-jit testsuite case (911 s in partest, against a shard that does 1700 tests in two minutes), while its evaluation counts already matched the C runtime's almost exactly: 32354 residual and 267472 jacobian (colour) evals against C's 27050 functionODE and 13288 assemblies x 16 colours. So the solver was doing the right thing and the cost was per evaluation, not per step.

New rt_stat counters, printed on a second OMC_WASM_SIM_BENCH line, said where: ~45000 rt_array_elem_ptr calls per functionODE. Every array element access in generated code was a call into runtime.wasm, an indexed read of a local array was three (retain, elem_ptr, release) and a record field read was two. One IF97 g1() call touches Real[45] o a few hundred times.

  - emit_elem_ptr / emit_array_dim inline the address arithmetic and the out-of-range trap at the hot sites; the runtime exports stay for the remaining per-array ones.
  - Indexed reads of a local array and all qualified-cref record navigation now borrow: the head of a cref is always a function local, which holds the reference for the whole expression, so only a heap element/field value is retained.
  - rt_array_new / rt_record_new zero with memory.fill, and rt_alloc / rt_free keep 8-byte size-class free lists in front of dlmalloc.
  - The runtime crate builds opt-level = 3 rather than "s": rt_solve_nls and minpack live there, and so do the helpers generated code calls millions of times per simulated second.
  - Wasmtime inlines across the model/runtime boundary (Inlining::Yes; its default is No). The JIT path runs runtime.wasm and model.wasm as two instances sharing the runtime's memory and never merges them, so every rt_* is an imported call — which is why hand-inlining the element address was worth so much, and why the rest of the helpers now inline without touching the codegen. OMC_WASM_NO_INLINE turns it off for A/B; the runtime module's on-disk AOT cache key includes the setting.

DasslDriver/DasslCore also accumulate the DASKR IWORK run totals across restarts. Every event restarts DASKR, which zeroes them, so the step count reported only the last segment (276 instead of 13751), which made it useless to compare against C's LOG_STATS.

build.rs printed rerun-if-env-changed for OMC_WASM_RUNTIME_WASIP1 and OMC_WASM_RUNTIME_WASIP1_INTERACTIVE *after* the early return that honours them, so a build using an override never registered the dep: removing the variable left the script un-rerun and the overridden blob linked in silently. Hit while using that override to build a session-enabled wasip1 runtime, since OMC_WASM_INWASM_DRIVER cannot work on a native build otherwise (no rt_sim_* exports in the lean blob).

  TestFlow1D2phChen  575.6 s -> 35.4 s     (C runtime: 84.6 s)
  FullRobot            2.8 s ->  2.2 s     (C runtime:  1.4 s)

FullRobot gains only from the opt-level change: its hot path is rt_solve_nls reaching the model residual through call_indirect, which is not inlinable, plus minpack's own work. The element-access work does not apply there (it allocates 372k times, against TestFlow1D2phChen's 186M).

Evaluation counts are unchanged throughout, and diffSimulationResults reports no differing variables against the C runtime on TestFlow1D2phChen, CoupledClutches, ChuaCircuit, FullAdder, BusUsage, DoublePendulum, FreeBody, Tearing12-minimal and
DistributionSystemModelicaIndividual — nor against the pre-change wasm-jit result. 1238 workspace unit tests and the runtime crate's 15 pass. model.wasm grows about 15% from the inlined sequences, and runtime.wasm about 50 KB from opt-level 3, which is 0.06% of the 84 MB compiler wasm the web bundle already ships.