### PR TITLE
wasm-jit: C-identical assert/warning messages

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -435,6 +435,28 @@ pub fn omc_simulate(
 // draining a cancel between chunks; results reach the page via the `omc_sim_*`
 // getters. See HANDOFF-sim-cancel.md.
 
+/// The last resumable run's model output (prints, `LOG_ASSERT` blocks, chattering,
+/// `-lv=LOG_STATS`). Valid until the next `omc_sim_start`; set even on failure.
+#[wasm_bindgen]
+pub fn omc_sim_log() -> String {
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::last_sim_log()
+}
+
+/// `{ s, nls, nlsLS, ls, lss }`: the values each solver flag accepts in this
+/// build. KLU only appears where SUNDIALS is linked.
+#[wasm_bindgen]
+pub fn omc_sim_solver_options() -> JsValue {
+    let o = js_sys::Object::new();
+    for (flag, values) in openmodelica_codegen_wasm_jit::CodegenWasmJit::solver_options() {
+        let arr = js_sys::Array::new();
+        for v in values {
+            arr.push(&JsValue::from_str(v));
+        }
+        let _ = js_sys::Reflect::set(&o, &JsValue::from_str(flag), &arr);
+    }
+    o.into()
+}
+
 /// Start a resumable run of a model already built by `buildModel` (keyed by its
 /// `prefix`; `result_file` is where the `.mat` goes). `false` on failure — read
 /// `getErrorString()`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -15,8 +15,9 @@
 //     approach.
 //   * The forward-Euler integrator loop runs *in wasm* (the precompiled runtime
 //     primitives `rt_euler_step` / `rt_sim_store_row` plus an emitted `simulate`
-//     loop), so a whole run is a single host->wasm call with no per-step
-//     boundary crossing. A second, host-driven driver (the Euler loop in native
+//     loop), so the whole integration is a single host->wasm call with no
+//     per-step boundary crossing (initialization stays with the shared driver).
+//     A second, host-driven driver (the Euler loop in native
 //     Rust, one wasm call per step) is provided for benchmarking — selected with
 //     `OMC_WASM_SIM_DRIVER=host`.
 //
@@ -374,21 +375,24 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
     // (`print`, LOG_STATS, ...) is folded in so it shows in the log rather than the
     // process console.
     let init_line = init_success_line();
-    // `LOG_ASSERT` warnings (min/max attribute violations, …) recorded during the run.
-    let warns: String = sim_driver::take_assert_warnings().concat();
+    // A failed run keeps the init line too, as C does.
+    let init_done = init_output.is_some();
     let init_out = init_output.unwrap_or_default();
-    let combined = format!("{init_out}{sim_output}");
+    let init_seg = if init_done { format!("{init_out}{init_line}\n") } else { init_out };
     let log = match &res {
         // Init prints, the init line, then the sim prints and the final success.
         Ok(()) => format!(
-            "{init_out}{init_line}\n{warns}{sim_output}\
+            "{init_seg}{sim_output}\
              LOG_SUCCESS       | info    | The simulation finished successfully.\n"
         ),
         // Chattering abort (`-abortSlowSimulation`): the driver's output carries the
         // chattering + aborting lines.
-        Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!("{init_line}\n{warns}{combined}"),
+        Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!("{init_seg}{sim_output}"),
+        // A failed assertion has already logged C's `LOG_ASSERT` block; any other
+        // failure needs its reason spelled out.
+        Err(e) if *e == sim_driver::ASSERT_ERR => format!("{init_seg}{sim_output}"),
         Err(e) => format!(
-            "{combined}{warns}LOG_ERROR         | error   | wasm-jit simulation failed: {}\n",
+            "{init_seg}{sim_output}LOG_ERROR         | error   | wasm-jit simulation failed: {}\n",
             with_engine_detail(e)
         ),
     };
@@ -528,6 +532,12 @@ const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     gbode: false,
 };
 
+/// The solver values a caller may offer for this build, so a menu built from it
+/// cannot disagree with [`install_sim_flags`]'s check.
+pub fn solver_options() -> Vec<(&'static str, Vec<&'static str>)> {
+    simflags::supported(CAPABILITIES)
+}
+
 /// Parse `simflags` as an argv and install the result for this run. omc hands the
 /// flags over as one whitespace-separated string; `argv[0]` stands in for the
 /// program name a WASI command would see, so the same parser serves this path and a
@@ -567,15 +577,13 @@ thread_local! {
     static SPLIT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// Init-done hook: take the init-phase stdout and `LOG_ASSERT` warnings, then
-/// restart the capture. A no-op unless [`run_simulation_inner`] armed it.
+/// Init-done hook: take the initialization phase's output, then restart the
+/// capture. A no-op unless [`run_simulation_inner`] armed it.
 fn on_init_done() {
     if !SPLIT_ARMED.with(|a| a.replace(false)) {
         return;
     }
-    let init = openmodelica_wasi::wasi::take_stdout_capture();
-    let warns: String = sim_driver::take_assert_warnings().concat();
-    INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(format!("{init}{warns}")));
+    INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(openmodelica_wasi::wasi::take_stdout_capture()));
     openmodelica_wasi::wasi::start_stdout_capture();
 }
 
@@ -625,12 +633,6 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         }
         Ok(())
     })();
-    // The driver reports chattering out-of-band (it can only return a `&'static str`);
-    // fold its log lines in whether the run finished or aborted.
-    for line in sim_driver::take_chatter_log() {
-        extra.push_str(&line);
-        extra.push('\n');
-    }
     // Disarm in case init failed before the hook fired.
     SPLIT_ARMED.with(|a| a.set(false));
     // Everything captured after the split is the simulation phase (plus `extra`:
@@ -704,6 +706,34 @@ mod session {
         /// Wall-clock inside `advance`, summed over chunks: excludes the yields
         /// between them, so it stays comparable to the one-shot `run()` timing.
         integrate_ms: f64,
+        /// The model's output so far. `take_stdout_capture` ends the capture, so
+        /// each chunk drains it here and re-arms.
+        log: String,
+        /// `-lv=LOG_STATS` was requested.
+        log_stats: bool,
+    }
+
+    thread_local! {
+        /// The last run's model output, for [`last_sim_log`]: `sim_advance` returns
+        /// a status code and has no other channel for it.
+        static LAST_SIM_LOG: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+    }
+
+    /// The last session run's model output, including a failed run's.
+    pub fn last_sim_log() -> String {
+        LAST_SIM_LOG.with(|c| c.borrow().clone())
+    }
+
+    /// Drain the capture into `dst` and re-arm it for the next chunk.
+    fn drain_capture(dst: &mut String) {
+        dst.push_str(&openmodelica_wasi::wasi::take_stdout_capture());
+        openmodelica_wasi::wasi::start_stdout_capture();
+    }
+
+    /// End the capture, fold everything the run produced into `log`, and publish it.
+    fn publish_log(mut log: String) {
+        log.push_str(&openmodelica_wasi::wasi::take_stdout_capture());
+        LAST_SIM_LOG.with(|c| *c.borrow_mut() = log);
     }
 
     /// Either the host driver (Rust driver calling the model through the wasm
@@ -753,6 +783,12 @@ mod session {
         let (param_ov, start_ov) = resolve_overrides(&model, &flags);
         sim_driver::set_param_overrides(param_ov, start_ov);
         sim_driver::clear_cancel();
+        // Split init from simulation output as `run_simulation_inner` does; the
+        // hook fires while the backend below is built, which is what initializes.
+        LAST_SIM_LOG.with(|c| c.borrow_mut().clear());
+        INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
+        sim_driver::set_init_done_hook(on_init_done);
+        SPLIT_ARMED.with(|a| a.set(true));
         openmodelica_wasi::wasi::start_stdout_capture();
         // Build the backend (instantiate, init, emit row 0). An init trap is usually
         // a failed `assert()`; the host driver routes it via `enrich_trap`.
@@ -764,7 +800,7 @@ mod session {
                 let (mut engine, sim_data) = sim_runtime::build_engine(&model)?;
                 let made =
                     sim_driver::make_driver(&mut *engine, &model.meta, sim_data, model.method.as_str())
-                        .map_err(|err| sim_driver::enrich_trap(&mut *engine, err));
+                        .map_err(|err| sim_driver::enrich_trap_init(&mut *engine, err, model.start_time));
                 let (driver, _label) = match made {
                     Ok(v) => v,
                     Err(e) => {
@@ -774,10 +810,17 @@ mod session {
                 Ok(SessionBackend::Host { engine, driver, sim_data })
             }
         })();
+        // Disarm in case init failed before the hook fired.
+        SPLIT_ARMED.with(|a| a.set(false));
+        let init_log = format!(
+            "{}{}",
+            model.sparse_solver_log,
+            INIT_OUTPUT.with(|c| c.borrow_mut().take()).unwrap_or_default()
+        );
         let backend = match built {
             Ok(v) => v,
             Err(e) => {
-                let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                publish_log(init_log);
                 record_error(format!("wasm-jit simulation failed: {}", with_engine_detail(&e)));
                 return Err("CodegenWasmJit: wasm-jit simulation failed");
             }
@@ -788,6 +831,8 @@ mod session {
                 result_file: result_file.to_string(),
                 backend,
                 integrate_ms: 0.0,
+                log: init_log,
+                log_stats: flags.has_log("LOG_STATS"),
             })
         });
         Ok(())
@@ -806,8 +851,11 @@ mod session {
             // touch `guard` again (to clear it on completion/error).
             let model = sess.model.clone();
             let result_file = sess.result_file.clone();
+            let log_stats = sess.log_stats;
             // Stopped before the finalize/`.mat` work in each arm below.
             let mut adv_ms = 0.0f64;
+            // Filled by whichever arm finishes the run, appended to the log below.
+            let mut stats_block = String::new();
 
             // Advance one chunk. All `sess` borrows end when this block returns its
             // status value.
@@ -836,6 +884,9 @@ mod session {
                                 params,
                                 stats,
                             };
+                            if log_stats {
+                                stats_block = log_stats_block(&run.stats);
+                            }
                             finalize_and_capture(&model, &result_file, &run)?;
                             Ok(if matches!(done, sim_driver::Advance::Terminated) {
                                 SimStatus::Terminated
@@ -856,6 +907,9 @@ mod session {
                         Ok(rc) => {
                             // 1 done, 2 terminated
                             let run = inwasm.take_result()?;
+                            if log_stats {
+                                stats_block = log_stats_block(&run.stats);
+                            }
                             finalize_and_capture(&model, &result_file, &run)?;
                             Ok(if rc == 2 { SimStatus::Terminated } else { SimStatus::Done })
                         }
@@ -865,6 +919,13 @@ mod session {
             };
             sess.integrate_ms += adv_ms;
             let integrate_ms = sess.integrate_ms;
+            drain_capture(&mut sess.log);
+            sess.log.push_str(&stats_block);
+            // The run is over unless it asked for another chunk, so hand the log on.
+            let run_log = match outcome {
+                Ok(SimStatus::Running) => None,
+                _ => Some(core::mem::take(&mut sess.log)),
+            };
 
             match outcome {
                 Ok(SimStatus::Running) => Ok(SimStatus::Running),
@@ -876,12 +937,12 @@ mod session {
                             model.n_intervals,
                         );
                     }
-                    let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                    publish_log(run_log.unwrap_or_default());
                     *guard = None;
                     Ok(st)
                 }
                 Err(e) => {
-                    let _ = openmodelica_wasi::wasi::take_stdout_capture();
+                    publish_log(run_log.unwrap_or_default());
                     record_error(format!("wasm-jit simulation failed: {}", with_engine_detail(e)));
                     *guard = None;
                     Err(e)
@@ -895,6 +956,8 @@ mod session {
     pub fn sim_free() {
         SIM_SESSION.with(|s| {
             if let Some(mut sess) = s.borrow_mut().take() {
+                // Cancel path: end the capture, keeping what was printed.
+                publish_log(core::mem::take(&mut sess.log));
                 // The in-wasm session frees itself on `Drop` (`rt_sim_free`).
                 let SimSession { model, backend, .. } = &mut sess;
                 if let SessionBackend::Host { engine, sim_data, .. } = backend {
@@ -906,7 +969,7 @@ mod session {
 }
 
 #[cfg(feature = "jit")]
-pub use session::{sim_advance, sim_free, sim_start};
+pub use session::{last_sim_log, sim_advance, sim_free, sim_start};
 
 #[cfg(not(feature = "jit"))]
 pub fn sim_start(_prefix: &str, _result_file: &str, _simflags: &str) -> Result<()> {
@@ -918,6 +981,10 @@ pub fn sim_advance(_budget_ms: f64) -> Result<SimStatus> {
 }
 #[cfg(not(feature = "jit"))]
 pub fn sim_free() {}
+#[cfg(not(feature = "jit"))]
+pub fn last_sim_log() -> String {
+    String::new()
+}
 
 // ===========================================================================
 // Standalone WASI command-module export (native only)
@@ -2578,8 +2645,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let real_algs: Vec<&SimCodeVar::SimVar> =
         lst(&vars.algVars).chain(lst(&vars.discreteAlgVars)).collect();
     bodies.push(build_init_start_values_fn(&states, &real_algs, &layout, &var_map, &by_name, &mut literals)?);
-    // The integrator loop.
-    bodies.push(build_simulate(&layout, &eqfn)?);
+    // The integrator loop calls `functionCheckAsserts`, whose index is only known
+    // once the nonlinear systems below have taken theirs; keep its fixed slot
+    // (`simulate_idx`) and fill it in there.
+    let simulate_slot = bodies.len();
+    bodies.push(empty_eqfn());
 
     // --- Standalone-export metadata: encode the SimData layout, the run settings
     // and the result variables into a blob the standalone wasip1 runtime decodes
@@ -2739,15 +2809,17 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // Min/max variable-attribute (and equation) assertion checks: C's
     // `checkForAsserts`, evaluated at each accepted output point. Warning-level
     // asserts record a `LOG_ASSERT` via `rt_assert_warning` and continue.
+    let has_asserts = !assert_eqs.is_empty();
     let check_asserts_idx = {
         let idx = import_base + bodies.len() as u32;
-        bodies.push(if assert_eqs.is_empty() {
-            empty_eqfn()
-        } else {
+        bodies.push(if has_asserts {
             build_eq_fn("functionCheckAsserts", assert_eqs, &var_map, &eq_index, &by_name, &mut literals)?
+        } else {
+            empty_eqfn()
         });
         idx
     };
+    bodies[simulate_slot] = build_simulate(&layout, &eqfn, has_asserts.then_some(check_asserts_idx))?;
     let update_relations_idx = {
         let idx = import_base + bodies.len() as u32;
         bodies.push(if relations.iter().all(Option::is_none) {
@@ -4995,8 +5067,10 @@ fn empty_eqfn() -> we::Function {
 }
 
 /// Emit the in-wasm forward-Euler integrator loop:
-/// `simulate(sim_data, start, stop, n_steps) -> result_buffer`.
-fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
+/// `simulate(sim_data, start, stop, n_steps) -> result_buffer`. The caller
+/// (`driver::run_wasm`) has initialized the model, so this starts at row 0.
+/// `check_asserts` is `functionCheckAsserts` when the model has any min/max check.
+fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>) -> Result<we::Function> {
     // Params: 0 sim_data(i32), 1 start(f64), 2 stop(f64), 3 n_steps(i32).
     // Locals: 4 buf(i32), 5 h(f64), 6 row(i32).
     const SIM_DATA: u32 = 0;
@@ -5014,20 +5088,6 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     // locals: BUF(i32), H(f64), ROW(i32), DEST(i32)
     let mut f = we::Function::new([(1, we::ValType::I32), (1, we::ValType::F64), (2, we::ValType::I32)]);
     use we::Instruction as I;
-
-    // lambda = 1.0 so homotopy(a, s) evaluates to the actual expression (this
-    // in-wasm Euler path does no homotopy continuation).
-    f.instruction(&I::LocalGet(SIM_DATA));
-    f.instruction(&I::F64Const(1.0f64.into()));
-    f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg(layout.lambda_off, 3)));
-
-    // functionParameters; functionInitStartValues; functionInitialEquations.
-    f.instruction(&I::LocalGet(SIM_DATA));
-    f.instruction(&I::Call(eqfn.parameters));
-    f.instruction(&I::LocalGet(SIM_DATA));
-    f.instruction(&I::Call(eqfn.init_start_values));
-    f.instruction(&I::LocalGet(SIM_DATA));
-    f.instruction(&I::Call(eqfn.initial));
 
     // buf = rt_alloc((n_steps + 1) * n_total * 8)
     f.instruction(&I::LocalGet(N_STEPS));
@@ -5065,6 +5125,12 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     f.instruction(&I::F64Add);
     f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg(TIME_OFF, 3)));
 
+    // Row 0 is the initialized point: capture it without re-evaluating, as C does
+    // after `initializeModel` (a second pass would repeat the equations' side
+    // effects). Every later row is evaluated at its time.
+    f.instruction(&I::LocalGet(ROW));
+    f.instruction(&I::If(we::BlockType::Empty));
+
     // terminal = (row == n_steps): C's `finishSimulation` evaluates the last
     // point with `terminal()` true. This path has no events, so raising the flag
     // is the whole discrete update.
@@ -5079,6 +5145,8 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     f.instruction(&I::Call(eqfn.ode));
     f.instruction(&I::LocalGet(SIM_DATA));
     f.instruction(&I::Call(eqfn.algebraics));
+
+    f.instruction(&I::End); // if row != 0
 
     // Store the row at dest = buf + row * n_total * 8:
     //   - copy the real part [time | realVars] (contiguous from sim_data[0])
@@ -5107,6 +5175,23 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx) -> Result<we::Function> {
     for j in 0..layout.n_bool_alg() {
         store_islot(&mut f, layout.bool_off + j * 4, n_reals + layout.n_int_alg() + j);
     }
+
+    // The driver's per-row `check_asserts`: evaluate the min/max checks, then let
+    // the host format what they recorded while `time` still holds this row's.
+    // Level `warning` for the first and the terminal row, `info` in between.
+    if let Some(idx) = check_asserts {
+        f.instruction(&I::LocalGet(SIM_DATA));
+        f.instruction(&I::Call(idx));
+    }
+    f.instruction(&I::LocalGet(SIM_DATA));
+    f.instruction(&I::LocalGet(ROW));
+    f.instruction(&I::I32Eqz);
+    f.instruction(&I::LocalGet(ROW));
+    f.instruction(&I::LocalGet(N_STEPS));
+    f.instruction(&I::I32Eq);
+    f.instruction(&I::I32Or);
+    f.instruction(&I::Call(crate::CodegenWasmJitFunctions::env_extra_index("rt_row_asserts")?));
+    f.instruction(&I::BrIf(1)); // a suppressed assert ends the run; `run_wasm` throws
 
     // if terminate() fired this step (functionAlgebraics raised the flag): break,
     // keeping the row just stored as the last one.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -223,9 +223,11 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_*` indices are unaffected), just before the generated functions. The host
 /// closures live in `runtime::add_host_builtins`.
 ///
-/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly)` records a pending
-/// assertion failure (the message and source-info handles) for `load_and_execute`
-/// to route to the error buffer; the generated code then traps (`unreachable`).
+/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly, cond) -> shouldTrap`
+/// records the failed assertion and answers whether the generated code must trap:
+/// it need not while the driver has asserts suppressed (C's `noThrowAsserts`).
+/// `cond` is the dumped condition, or 0 for a model/runtime error, which is never
+/// suppressed; it comes last so callers that already pushed the message append.
 ///
 /// `rt_assert_warning(cond, msg, file, sline, scol, eline, ecol, isReadOnly)`
 /// records a *non-fatal* (AssertionLevel.warning) violation — the string handles
@@ -236,11 +238,16 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_print(str)` writes the String's bytes to the model's stdout (the `print`
 /// builtin). The host reads the handle's bytes from the shared memory during the
 /// call; the generated code releases the (owned) handle afterwards.
+///
+/// `rt_row_asserts(sim_data, warn) -> stop` formats the violations recorded at the
+/// output row the emitted `simulate` loop just stored — the driver's per-row
+/// `LOG_ASSERT` step, which that loop cannot reach from wasm. `warn` selects the
+/// level; a nonzero result means a suppressed `assert()` ends the run.
 pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     (
         "rt_assert",
-        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
-        &[],
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[WTy::I32],
     ),
     (
         "rt_assert_warning",
@@ -248,11 +255,12 @@ pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
         &[],
     ),
     ("rt_print", &[WTy::I32], &[]),
+    ("rt_row_asserts", &[WTy::I32, WTy::I32], &[WTy::I32]),
 ];
 
 /// Absolute wasm function index of an `ENV_EXTRA` import (after the `BUILTINS`
 /// and `RT_BUILTINS`).
-fn env_extra_index(name: &str) -> Result<u32> {
+pub(crate) fn env_extra_index(name: &str) -> Result<u32> {
     let pos = ENV_EXTRA
         .iter()
         .position(|(n, _, _)| *n == name)
@@ -2948,8 +2956,13 @@ fn emit_assert(
     ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
+    let cond_str = dumped_exp(cond)?;
+    emit_str_literal(ctx, cond_str.as_bytes())?; // dumped condition, for the report
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
+    // Trap unless the driver took it (suppressed during the event search).
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
     ctx.emit(we::Instruction::Unreachable);
+    ctx.emit(we::Instruction::End);
     ctx.emit(we::Instruction::End);
     Ok(())
 }
@@ -2961,7 +2974,9 @@ fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
     for _ in 0..5 {
         ctx.emit(we::Instruction::I32Const(0)); // line/col start+end, isReadOnly
     }
+    ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
+    ctx.emit(we::Instruction::Drop);
     ctx.emit(we::Instruction::Unreachable);
     Ok(())
 }
@@ -6085,7 +6100,9 @@ fn emit_runtime_error(ctx: &mut FnCtx, msg: &str) -> Result<()> {
     for _ in 0..6 {
         ctx.emit(we::Instruction::I32Const(0)); // file handle (null) + zeroed line/col
     }
+    ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
+    ctx.emit(we::Instruction::Drop);
     ctx.emit(we::Instruction::Unreachable);
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -28,6 +28,32 @@ use openmodelica_sim_meta::{SimMeta, SolveStats};
 unsafe extern "C" {
     fn rt_host_now_ms() -> f64;
     fn rt_host_cancel() -> i32;
+    /// Copy up to `max` of the violations the model left with the host's
+    /// `rt_assert`/`rt_assert_warning` (which it imports either way) to `ptr`.
+    fn rt_host_take_warnings(ptr: u32, max: u32) -> u32;
+    /// Open/close C's `noThrowAsserts` phase, on the host: that is where
+    /// `rt_assert` lives, whichever driver runs.
+    fn rt_host_set_no_throw(v: i32);
+    /// Initialization is over; the host splits its output capture there.
+    fn rt_host_init_done();
+}
+
+/// The driver's log lines go to stdout, the channel the model's own `print`
+/// output travels and the host captures.
+#[cfg(target_os = "wasi")]
+fn log_line(s: &str) {
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    let _ = out.write_all(s.as_bytes());
+    let _ = out.flush();
+}
+
+/// The no_std fallback runtime has no stdout to write them to.
+#[cfg(not(target_os = "wasi"))]
+fn log_line(_s: &str) {}
+
+fn init_done_hook() {
+    unsafe { rt_host_init_done() };
 }
 
 fn now_ms_hook() -> f64 {
@@ -105,7 +131,18 @@ impl SimEngine for InWasmEngine {
         let f: extern "C" fn(u32, f64, f64, u32) -> u32 = unsafe { core::mem::transmute(idx as usize) };
         Ok(f(sim_data, start, stop, n_steps))
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+        let mut out = Vec::new();
+        loop {
+            let mut buf = [[0i32; 9]; 8];
+            let n = unsafe { rt_host_take_warnings(buf.as_mut_ptr() as u32, buf.len() as u32) } as usize;
+            out.extend_from_slice(&buf[..n.min(buf.len())]);
+            if n < buf.len() {
+                return out;
+            }
+        }
+    }
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         // The model imports `rt_assert` from the host; a failed assert traps and
         // unwinds out of `rt_sim_advance` to the host, which reports it. Nothing
         // to take in-wasm.
@@ -222,6 +259,9 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
 
     driver::set_clock(now_ms_hook);
     driver::set_cancel_hook(cancel_hook);
+    driver::set_init_done_hook(init_done_hook);
+    driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
+    driver::set_log_sink(log_line);
 
     let mut engine = InWasmEngine { fn_base, present_mask };
     let sim_data = crate::rt_alloc(model.layout.total);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -116,7 +116,7 @@ impl SimEngine for StandaloneEngine {
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
         Ok(unsafe { simulate(sim_data, start, stop, n_steps) })
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         // No host to record it; a failed model assert traps (see `rt_assert`).
         None
     }
@@ -198,7 +198,7 @@ pub extern "C" fn _start() {
 /// assertion, so print the message (`msg` is an `rt` String handle:
 /// `[refcount:u32][len:u32][utf8…]`) and trap, which aborts the command.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32) {
+pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32, _cond: i32) -> i32 {
     if msg != 0 {
         let h = msg as u32;
         let len = unsafe { crate::load_u32(h + 4) } as usize;
@@ -223,6 +223,13 @@ pub extern "C" fn rt_print(handle: i32) {
         let _ = out.write_all(bytes);
         let _ = out.flush();
     }
+}
+
+/// In-wasm `rt_row_asserts`: nothing to format — `rt_assert_warning` below has
+/// already printed the message.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_row_asserts(_sim_data: i32, _warn: i32) -> i32 {
+    0
 }
 
 /// In-wasm `rt_assert_warning`: a non-fatal (AssertionLevel.warning) violation.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -65,7 +65,8 @@ pub extern "C" fn rt_assert(
     _eline: i32,
     _ecol: i32,
     _read_only: i32,
-) {
+    _cond: i32,
+) -> i32 {
     core::arch::wasm32::unreachable()
 }
 
@@ -87,6 +88,13 @@ pub extern "C" fn rt_assert_warning(
 /// The `print` builtin. No host stdout here, so the output is discarded.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_print(_str: i32) {}
+
+/// Per-row assert formatting: no logger, and the FMI master steps the model
+/// instead of the emitted `simulate` loop that calls this.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_row_asserts(_sim_data: i32, _warn: i32) -> i32 {
+    0
+}
 
 // ── SimEngine over the merged module's shared linear memory ──────────────────
 struct Engine;
@@ -127,7 +135,7 @@ impl SimEngine for Engine {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> driver::Result<u32> {
         Err("fmi3-me: simulate not used")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         None
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -222,16 +222,14 @@ pub trait SimEngine {
     /// in-wasm Euler driver; returns the result-buffer pointer.
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32>;
     /// If the last wasm call trapped on a failed `assert()`, take the recorded
-    /// assertion as `[msg, file, sline, scol, eline, ecol, read_only]` (handles
+    /// assertion as `[msg, file, sline, scol, eline, ecol, read_only, cond]` (handles
     /// into shared memory), else `None`. Backed by the engine's `rt_assert` host
     /// import; lets [`drive`] report a model assertion instead of a bare trap.
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]>;
-    /// Take the warning-level assertion violations (`AssertionLevel.warning`)
-    /// recorded by the `rt_assert_warning` host import since the last call, each as
-    /// `[cond, msg, file, sline, scol, eline, ecol, read_only]` (string handles +
-    /// source position). Drained by the drivers after `functionCheckAsserts` to
-    /// emit C's `LOG_ASSERT` warnings. Default: none (backends without the import).
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]>;
+    /// Take the violations that did not throw, each as `[kind, cond, msg, file,
+    /// sline, scol, eline, ecol, read_only]` (`kind` per `ASSERT_*`). Drained by
+    /// the drivers to emit C's `LOG_ASSERT` blocks. Default: none.
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         Vec::new()
     }
     /// Linear-system solves the runtime performed in-wasm, which the host driver
@@ -312,7 +310,18 @@ pub fn set_assert_reporter(f: fn(&AssertInfo)) {
 /// Decode it, hand it to the reporter hook if any, and return the enriched error;
 /// otherwise return the original trap error.
 pub fn enrich_trap(e: &mut dyn SimEngine, err: &'static str) -> &'static str {
+    enrich_trap_impl(e, err, None)
+}
+
+/// The same for a trap out of initialization, where C logs the violation itself
+/// (`errorStreamPrint` before the longjmp). `start_time` is the time it reports.
+pub fn enrich_trap_init(e: &mut dyn SimEngine, err: &'static str, start_time: f64) -> &'static str {
+    enrich_trap_impl(e, err, Some(start_time))
+}
+
+fn enrich_trap_impl(e: &mut dyn SimEngine, err: &'static str, init_time: Option<f64>) -> &'static str {
     let Some(pa) = e.take_pending_assert() else { return err };
+    let cond = read_rt_string(e, pa[7]).unwrap_or_default();
     let info = AssertInfo {
         msg: read_rt_string(e, pa[0]).unwrap_or_default(),
         file: read_rt_string(e, pa[1]).unwrap_or_default(),
@@ -322,6 +331,13 @@ pub fn enrich_trap(e: &mut dyn SimEngine, err: &'static str) -> &'static str {
         line_end: pa[4],
         col_end: pa[5],
     };
+    if let Some(t) = init_time {
+        log_assert_block(&info, &cond, t, true);
+        log_line(&alloc::format!(
+            "{}simulation terminated by an assertion at initialization\n",
+            log_prefix("LOG_ASSERT", "info")
+        ));
+    }
     let p = ASSERT_REPORTER.load(Ordering::Relaxed);
     if p != 0 {
         let f: fn(&AssertInfo) = unsafe { core::mem::transmute(p) };
@@ -463,13 +479,47 @@ static INIT_DONE_HOOK: AtomicUsize = AtomicUsize::new(0);
 pub fn set_init_done_hook(f: fn()) {
     INIT_DONE_HOOK.store(f as usize, Ordering::Relaxed);
 }
-fn signal_init_done() {
+/// Public because the in-wasm driver's hook cannot reach the host's capture: it
+/// relays the boundary over `env.rt_host_init_done`, which calls this.
+pub fn signal_init_done() {
     let p = INIT_DONE_HOOK.load(Ordering::Relaxed);
     if p != 0 {
         let f: fn() = unsafe { core::mem::transmute(p) };
         f();
     }
 }
+
+// C's `noThrowAsserts`. The flag lives with the `rt_assert` import — on the host —
+// so the in-wasm driver relays it over `env.rt_host_set_no_throw`.
+static NO_THROW_HOOK: AtomicUsize = AtomicUsize::new(0);
+pub fn set_no_throw_hook(f: fn(bool)) {
+    NO_THROW_HOOK.store(f as usize, Ordering::Relaxed);
+}
+fn set_no_throw(v: bool) {
+    let p = NO_THROW_HOOK.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(bool) = unsafe { core::mem::transmute(p) };
+        f(v);
+    }
+}
+
+// Where the driver's own log lines go. The model's `print` output shares the
+// channel, so the two interleave in the order C prints them.
+static LOG_SINK: AtomicUsize = AtomicUsize::new(0);
+pub fn set_log_sink(f: fn(&str)) {
+    LOG_SINK.store(f as usize, Ordering::Relaxed);
+}
+fn log_line(s: &str) {
+    let p = LOG_SINK.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(&str) = unsafe { core::mem::transmute(p) };
+        f(s);
+    }
+}
+
+/// [`SimEngine::take_pending_warnings`] kinds.
+pub const ASSERT_WARNING: i32 = 0;
+pub const ASSERT_SUPPRESSED: i32 = 1;
 
 /// Read one little-endian i32 from linear memory at byte address `addr`.
 pub fn read_i32(e: &dyn SimEngine, addr: u32) -> Result<i32> {
@@ -604,17 +654,11 @@ fn log_prefix(stream: &str, level: &str) -> String {
 /// `-abortSlowSimulation` flag + the driver's chattering log lines, set on the host
 /// before a run (the driver can only return a `&'static str`).
 mod chatter_store {
-    use alloc::string::String;
-    use alloc::vec::Vec;
-
     #[cfg(feature = "std")]
     mod imp {
-        use alloc::string::String;
-        use alloc::vec::Vec;
-        use core::cell::{Cell, RefCell};
+        use core::cell::Cell;
         std::thread_local! {
             static ABORT: Cell<bool> = const { Cell::new(false) };
-            static LOG: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
         }
         pub fn set_abort(v: bool) {
             ABORT.with(|a| a.set(v));
@@ -622,38 +666,24 @@ mod chatter_store {
         pub fn abort() -> bool {
             ABORT.with(|a| a.get())
         }
-        pub fn push(s: String) {
-            LOG.with(|l| l.borrow_mut().push(s));
-        }
-        pub fn take() -> Vec<String> {
-            LOG.with(|l| core::mem::take(&mut *l.borrow_mut()))
-        }
     }
 
     #[cfg(not(feature = "std"))]
     mod imp {
-        use alloc::string::String;
-        use alloc::vec::Vec;
         use core::cell::UnsafeCell;
         // The in-wasm runtime is single-threaded, so a plain cell is sound.
-        struct Store(UnsafeCell<(bool, Vec<String>)>);
+        struct Store(UnsafeCell<bool>);
         unsafe impl Sync for Store {}
-        static STORE: Store = Store(UnsafeCell::new((false, Vec::new())));
+        static ABORT: Store = Store(UnsafeCell::new(false));
         pub fn set_abort(v: bool) {
-            unsafe { (*STORE.0.get()).0 = v };
+            unsafe { *ABORT.0.get() = v };
         }
         pub fn abort() -> bool {
-            unsafe { (*STORE.0.get()).0 }
-        }
-        pub fn push(s: String) {
-            unsafe { (*STORE.0.get()).1.push(s) };
-        }
-        pub fn take() -> Vec<String> {
-            unsafe { core::mem::take(&mut (*STORE.0.get()).1) }
+            unsafe { *ABORT.0.get() }
         }
     }
 
-    pub use imp::{abort, push, set_abort, take};
+    pub use imp::{abort, set_abort};
 }
 
 /// Homotopy-step count of the last initialization, so the host can print C's
@@ -676,10 +706,8 @@ pub fn init_homotopy_steps() -> u32 {
     init_report::homotopy_steps()
 }
 
-/// The formatted `LOG_ASSERT` warning lines (min/max variable-attribute checks and
-/// other `AssertionLevel.warning` asserts) collected during the last run, plus the
-/// per-site keys already reported so each warns only once (C's static
-/// `warningTriggered`). Cleared at run start; folded into the log by the host.
+/// The per-site keys already reported, so a warning-level violation warns only
+/// once (C's static `warningTriggered`). Cleared at run start.
 mod assert_warn_store {
     #[cfg(feature = "std")]
     mod imp {
@@ -687,25 +715,20 @@ mod assert_warn_store {
         use alloc::vec::Vec;
         use core::cell::RefCell;
         std::thread_local! {
-            static LINES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
             static SEEN: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
         }
         pub fn reset() {
-            LINES.with(|l| l.borrow_mut().clear());
             SEEN.with(|s| s.borrow_mut().clear());
         }
-        pub fn push_once(key: String, line: String) {
+        pub fn first_time(key: String) -> bool {
             SEEN.with(|s| {
                 let mut s = s.borrow_mut();
                 if s.iter().any(|k| *k == key) {
-                    return;
+                    return false;
                 }
                 s.push(key);
-                LINES.with(|l| l.borrow_mut().push(line));
-            });
-        }
-        pub fn take() -> Vec<String> {
-            LINES.with(|l| core::mem::take(&mut *l.borrow_mut()))
+                true
+            })
         }
     }
     #[cfg(not(feature = "std"))]
@@ -713,35 +736,24 @@ mod assert_warn_store {
         use alloc::string::String;
         use alloc::vec::Vec;
         use core::cell::UnsafeCell;
-        struct Store(UnsafeCell<(Vec<String>, Vec<String>)>);
+        struct Store(UnsafeCell<Vec<String>>);
         unsafe impl Sync for Store {}
-        static STORE: Store = Store(UnsafeCell::new((Vec::new(), Vec::new())));
+        static SEEN: Store = Store(UnsafeCell::new(Vec::new()));
         pub fn reset() {
-            unsafe {
-                (*STORE.0.get()).0.clear();
-                (*STORE.0.get()).1.clear();
-            }
+            unsafe { (*SEEN.0.get()).clear() };
         }
-        pub fn push_once(key: String, line: String) {
+        pub fn first_time(key: String) -> bool {
             unsafe {
-                let st = &mut *STORE.0.get();
-                if st.1.iter().any(|k| *k == key) {
-                    return;
+                let seen = &mut *SEEN.0.get();
+                if seen.iter().any(|k| *k == key) {
+                    return false;
                 }
-                st.1.push(key);
-                st.0.push(line);
+                seen.push(key);
+                true
             }
-        }
-        pub fn take() -> Vec<String> {
-            unsafe { core::mem::take(&mut (*STORE.0.get()).0) }
         }
     }
-    pub use imp::{push_once, reset, take};
-}
-
-/// Drain the formatted `LOG_ASSERT` warning lines emitted during the last run.
-pub fn take_assert_warnings() -> Vec<String> {
-    assert_warn_store::take()
+    pub use imp::{first_time, reset};
 }
 
 /// Reported-once latch for the fired `terminate(...)`.
@@ -787,47 +799,177 @@ fn format_f(v: f64) -> String {
 /// `level`: C reports a violation met while the integrator updates the system
 /// (`simulationUpdate`, which sets `noThrowAsserts`) as `info`, one met anywhere
 /// else — initialization, the terminal step — as `warning`.
-fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, level: &str) -> Result<()> {
+fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, _layout: &SimLayout, level: &str) -> Result<()> {
     e.call1_if_present("functionCheckAsserts", sim_data)?;
-    let pending = e.take_pending_warnings();
-    if pending.is_empty() {
-        return Ok(());
-    }
-    let time = read_f64(e, sim_data + TIME_OFF)?;
-    for w in pending {
-        let cond = read_rt_string(e, w[0])?;
-        let msg = read_rt_string(e, w[1])?;
-        let file = read_rt_string(e, w[2])?;
-        let (sl, sc, el, ec, ro) = (w[3], w[4], w[5], w[6], w[7] != 0);
-        let ro_str = if ro { "readonly" } else { "writable" };
-        // C (`omc_error.c` messageText + printInfo): a header line with the source
-        // position, then the message split on '\n' onto continuation lines whose
-        // stream/type columns are "|".
-        let head = log_prefix("LOG_ASSERT", level);
-        let cont = log_prefix("|", "|");
-        // C wraps the already-parenthesised `assert_cond` = "(<dumped>)" once more
-        // in the `(%s)` format, so the displayed condition is double-parenthesised.
-        let line = alloc::format!(
-            "{head}[{file}:{sl}:{sc}-{el}:{ec}:{ro_str}]\n\
-             {cont}The following assertion has been violated at time {t}\n\
-             {cont}(({cond})) --> \"{msg}\"\n",
-            t = format_f(time),
-        );
-        let key = alloc::format!("{file}:{sl}:{sc}-{el}:{ec}|{cond}");
-        assert_warn_store::push_once(key, line);
-    }
+    drain_asserts(e, sim_data, level)?;
     Ok(())
 }
 
-/// Arm `-abortSlowSimulation` for the next run and clear any stale chattering log.
-pub fn set_abort_slow(v: bool) {
-    chatter_store::set_abort(v);
-    let _ = chatter_store::take();
+/// Log the violations recorded since the last call. A warning goes once per site;
+/// a suppressed error goes every time (as in C) and arms the re-throw, which the
+/// `true` return reports.
+fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: &str) -> Result<bool> {
+    let pending = e.take_pending_warnings();
+    if pending.is_empty() {
+        return Ok(false);
+    }
+    let mut armed = false;
+    let time = read_f64(e, sim_data + TIME_OFF)?;
+    for w in pending {
+        let suppressed = w[0] == ASSERT_SUPPRESSED;
+        let cond = read_rt_string(e, w[1])?;
+        let msg = read_rt_string(e, w[2])?;
+        let file = read_rt_string(e, w[3])?;
+        let (sl, sc, el, ec, ro) = (w[4], w[5], w[6], w[7], w[8] != 0);
+        let info = AssertInfo {
+            msg,
+            file,
+            read_only: ro,
+            line_start: sl,
+            col_start: sc,
+            line_end: el,
+            col_end: ec,
+        };
+        let line = assert_block(&info, &cond, time, false, if suppressed { "info" } else { level });
+        if suppressed {
+            log_line(&line);
+            rethrow_store::arm(info);
+            armed = true;
+        } else {
+            let key = alloc::format!("{}:{sl}:{sc}-{el}:{ec}|{cond}", info.file);
+            if assert_warn_store::first_time(key) {
+                log_line(&line);
+            }
+        }
+    }
+    Ok(armed)
 }
 
-/// Drain the chattering log lines the last run emitted.
-pub fn take_chatter_log() -> Vec<String> {
-    chatter_store::take()
+/// [`check_asserts`] for the in-wasm Euler loop (`rt_row_asserts`), which calls
+/// `functionCheckAsserts` itself and needs only the formatting. `warn` picks the
+/// level as [`emit_row`] does. Nonzero means a suppressed `assert()` ends the run,
+/// which [`run_wasm`] settles once the loop is out.
+pub fn row_asserts(e: &mut dyn SimEngine, sim_data: u32, warn: i32) -> i32 {
+    let level = if warn != 0 { "warning" } else { "info" };
+    drain_asserts(e, sim_data, level).unwrap_or(true) as i32
+}
+
+/// C's `LOG_ASSERT` block (`omc_error.c` messageText + printInfo). C wraps the
+/// already-parenthesised `assert_cond` in its own `(%s)`, hence the doubled
+/// parentheses; without a source position only the message is printed.
+fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool, level: &str) -> String {
+    let head = log_prefix("LOG_ASSERT", level);
+    let cont = log_prefix("|", "|");
+    let during = if initial { "during initialization " } else { "" };
+    let t = format_f(time);
+    if info.file.is_empty() {
+        return alloc::format!("{head}The following assertion has been violated {during}at time {t}\n");
+    }
+    let ro_str = if info.read_only { "readonly" } else { "writable" };
+    alloc::format!(
+        "{head}[{}:{}:{}-{}:{}:{ro_str}]\n\
+         {cont}The following assertion has been violated {during}at time {t}\n\
+         {cont}(({cond})) --> \"{}\"\n",
+        info.file, info.line_start, info.col_start, info.line_end, info.col_end, info.msg,
+    )
+}
+
+fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
+    log_line(&assert_block(info, cond, time, initial, "error"));
+}
+
+/// What the open window has seen: the first assertion suppressed in it, and
+/// whether an event was handled — which is what decides its fate.
+mod rethrow_store {
+    use super::AssertInfo;
+    #[cfg(feature = "std")]
+    mod imp {
+        use super::AssertInfo;
+        use core::cell::{Cell, RefCell};
+        std::thread_local! {
+            static PENDING: RefCell<Option<AssertInfo>> = const { RefCell::new(None) };
+            static EVENT: Cell<bool> = const { Cell::new(false) };
+        }
+        pub fn arm(info: AssertInfo) {
+            PENDING.with(|p| {
+                let mut p = p.borrow_mut();
+                if p.is_none() {
+                    *p = Some(info);
+                }
+            });
+        }
+        pub fn note_event() {
+            EVENT.with(|ev| ev.set(true));
+        }
+        pub fn take() -> (Option<AssertInfo>, bool) {
+            (PENDING.with(|p| p.borrow_mut().take()), EVENT.with(|ev| ev.replace(false)))
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use super::AssertInfo;
+        use core::cell::UnsafeCell;
+        struct Store(UnsafeCell<(Option<AssertInfo>, bool)>);
+        unsafe impl Sync for Store {}
+        static PENDING: Store = Store(UnsafeCell::new((None, false)));
+        pub fn arm(info: AssertInfo) {
+            unsafe {
+                let st = &mut *PENDING.0.get();
+                if st.0.is_none() {
+                    st.0 = Some(info);
+                }
+            }
+        }
+        pub fn note_event() {
+            unsafe { (*PENDING.0.get()).1 = true };
+        }
+        pub fn take() -> (Option<AssertInfo>, bool) {
+            unsafe {
+                let st = &mut *PENDING.0.get();
+                (st.0.take(), core::mem::replace(&mut st.1, false))
+            }
+        }
+    }
+    pub use imp::{arm, note_event, take};
+}
+
+/// Enter C's `noThrowAsserts` phase: a failed `assert()` is recorded, not thrown.
+/// Idempotent, so a chunk that yields mid-step just re-enters it.
+fn open_assert_window() {
+    set_no_throw(true);
+}
+
+/// Leave it and settle what was recorded (C's `simulationUpdate` tail): an event
+/// makes the point they were raised at obsolete, otherwise the run fails now.
+fn close_assert_window(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
+    set_no_throw(false);
+    drain_asserts(e, sim_data, "info")?;
+    let (info, found_event) = rethrow_store::take();
+    let Some(info) = info else {
+        return Ok(());
+    };
+    if found_event {
+        log_line(&alloc::format!(
+            "{}Found event, previous asserts are ignored.\n",
+            log_prefix("LOG_ASSERT", "info")
+        ));
+        return Ok(());
+    }
+    log_line(&alloc::format!(
+        "{}No event found, but assert was triggered. Throwing now!\n",
+        log_prefix("LOG_ASSERT", "error")
+    ));
+    let p = ASSERT_REPORTER.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(&AssertInfo) = unsafe { core::mem::transmute(p) };
+        f(&info);
+    }
+    Err(ASSERT_ERR)
+}
+
+/// Arm `-abortSlowSimulation` for the next run.
+pub fn set_abort_slow(v: bool) {
+    chatter_store::set_abort(v);
 }
 
 /// Solve the initial system: `functionParameters`, then `functionInitialEquations`
@@ -872,6 +1014,9 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
 fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     init_report::set_homotopy_steps(0);
     assert_warn_store::reset();
+    // Initialization throws on a failed assert (C clears `noThrowAsserts` here).
+    let _ = rethrow_store::take();
+    set_no_throw(false);
     term_report::reset();
     e.call1("functionParameters", sim_data)?;
     // Params first (a start expression may read one), then fill start slots, then
@@ -965,7 +1110,8 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
             format_f(read_f64(e, sim_data + TIME_OFF)?),
             log_prefix("|", "|"),
         ));
-        chatter_store::push(line);
+        line.push('\n');
+        log_line(&line);
     }
     Ok(true)
 }
@@ -1250,6 +1396,7 @@ impl Samples {
     /// flags and advance the fired samples by their interval. `t` is written as
     /// the current simulation time first.
     pub fn fire(&mut self, e: &mut dyn SimEngine, sim_data: u32, t: f64) -> Result<()> {
+        rethrow_store::note_event();
         let eps = t.abs().max(1.0) * 1e-10;
         let mut fired = vec![false; self.next.len()];
         for k in 0..self.next.len() {
@@ -1296,6 +1443,7 @@ pub fn event_update(
     samples: Option<&mut Samples>,
     time: f64,
 ) -> Result<EventUpdate> {
+    rethrow_store::note_event();
     let n_states = layout.n_states as usize;
     let states_base = sim_data + REAL_OFF;
     let mut before = vec![0.0f64; n_states];
@@ -1434,12 +1582,11 @@ pub fn drive(
     let (rows, label) = if !use_events && method == "euler" && !host_driven {
         // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
         set_zc_tolerance(e, sim_data, layout, model.tolerance)?;
-        let rows = run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)
-            .map_err(|err| enrich_trap(e, err))?;
-        (rows, "euler-wasm")
+        (run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)?, "euler-wasm")
     } else {
         // enrich_trap: a trap in init/integration is usually a failed model assert().
-        let (mut driver, label) = make_driver(e, model, sim_data, method).map_err(|err| enrich_trap(e, err))?;
+        let (mut driver, label) =
+            make_driver(e, model, sim_data, method).map_err(|err| enrich_trap_init(e, err, model.start_time))?;
         // Infinite budget runs to completion; the per-step cancel poll still lets a
         // native embedder interrupt. `OMC_WASM_SIM_YIELD_MS` forces a finite budget to
         // self-test yield/resume (must be `.mat`-identical to the un-yielded run).
@@ -1476,7 +1623,11 @@ pub fn drive(
     Ok((RunResult { rows, n_reals, params, stats }, label))
 }
 
-/// In-wasm driver: one call to `simulate`, then read the result buffer.
+/// In-wasm driver: initialize here (so the run initializes like every other
+/// driver, and the host sees the init/simulation boundary), then one call to
+/// `simulate` for the integration loop, then read the result buffer. C's
+/// `noThrowAsserts` phase stays open across the loop — Euler locates no event that
+/// could excuse a violation before the settle below.
 fn run_wasm(
     e: &mut dyn SimEngine,
     sim_data: u32,
@@ -1488,7 +1639,14 @@ fn run_wasm(
     stats: &mut SolveStats,
 ) -> Result<Vec<f64>> {
     stats.steps = (n_rows - 1) as u64;
-    let buf = e.call_simulate(sim_data, start, stop, n_rows - 1)?;
+    run_initialization(e, sim_data, layout, start).map_err(|err| enrich_trap_init(e, err, start))?;
+    open_assert_window();
+    let called = e.call_simulate(sim_data, start, stop, n_rows - 1);
+    let settled = close_assert_window(e, sim_data);
+    // A trap says what went wrong; the settle only fails on a suppressed assert.
+    let buf = called.map_err(|err| enrich_trap(e, err))?;
+    settled?;
+    terminated(e, sim_data, layout)?; // C's `checkSimulationTerminated` notice
     // The Euler loop cannot back off, so a non-converging NLS is fatal here.
     check_nls(e, sim_data, layout)?;
     // The loop records how many rows it wrote (< n_rows if terminate() fired).
@@ -1551,11 +1709,15 @@ impl Driver for EulerDriver {
             did_step = true;
             // The last row lands exactly on `stop`: the terminal step.
             let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
-            if self.row == 0 {
-                emit_initial_row(e, &mut self.rows, sim_data, layout, time)?;
+            // Euler locates no events, so a suppressed assert always throws; the
+            // window is what gets it reported like C's.
+            open_assert_window();
+            let emitted = if self.row == 0 {
+                emit_initial_row(e, &mut self.rows, sim_data, layout, time)
             } else {
-                emit_row(e, &mut self.rows, sim_data, layout, time, stop)?;
-            }
+                emit_row(e, &mut self.rows, sim_data, layout, time, stop)
+            };
+            close_assert_window(e, sim_data).and(emitted)?;
             check_nls(e, sim_data, layout)?; // Euler cannot back off — non-convergence is fatal
             // terminate() fired in functionAlgebraics: keep this row, stop the run.
             if terminated(e, sim_data, layout)? {
@@ -2048,7 +2210,9 @@ impl Driver for DasslDriver {
                 }
                 did_step = true;
                 let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
-                emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time)?;
+                open_assert_window();
+                let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
+                close_assert_window(e, sim_data).and(emitted)?;
                 if terminated(e, sim_data, layout)? {
                     self.finished = true;
                     return Ok(Advance::Terminated);
@@ -2157,7 +2321,9 @@ impl Driver for DasslDriver {
             for i in 0..n_states {
                 write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
             }
-            emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
+            open_assert_window();
+            let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
+            close_assert_window(e, sim_data).and(emitted)?;
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated; // terminate() fired: keep this row, stop
             }
@@ -2526,17 +2692,17 @@ impl DasslCore {
                     if let Some((t0, t1)) = self.note_chatter_event(troot, step_size) {
                         let zc = self.jroot.iter().position(|&r| r != 0).unwrap_or(0);
                         let desc = model.zc_desc.get(zc).map(String::as_str).unwrap_or("<zero-crossing>");
-                        chatter_store::push(format!(
+                        log_line(&format!(
                             "{}Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state \
                              events in a row with a total time delta less than the step size \
                              {step_size}). This can be a performance bottleneck. Use -lv LOG_EVENTS \
-                             for more information. The zero-crossing was: {desc}",
+                             for more information. The zero-crossing was: {desc}\n",
                             log_prefix("LOG_STDOUT", "info"),
                         ));
                         if chatter_store::abort() {
-                            chatter_store::push(format!(
+                            log_line(&format!(
                                 "{}Aborting simulation due to chattering being detected and the \
-                                 simulation flags requesting we do not continue further.",
+                                 simulation flags requesting we do not continue further.\n",
                                 log_prefix("LOG_ASSERT", "debug"),
                             ));
                             return Err(CHATTER_ABORT_ERR);
@@ -2995,6 +3161,7 @@ impl Driver for DasslEventsDriver {
                 let tout = tout_of(self.row);
                 let eps = tout.abs().max(1.0) * 1e-10;
                 let mut grid_covered = false;
+                open_assert_window();
                 // Handle every event (state or sample) up to `tout`, earliest first.
                 loop {
                     let te = self.samp.next_time();
@@ -3056,7 +3223,8 @@ impl Driver for DasslEventsDriver {
                 }
                 if !grid_covered {
                     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-                    emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
+                    let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
+                    close_assert_window(e, sim_data).and(emitted)?;
                     if terminated(e, sim_data, layout)? {
                         self.finished = true;
                         return Ok(Advance::Terminated);
@@ -3066,6 +3234,8 @@ impl Driver for DasslEventsDriver {
                         eval_zero_crossings(e, sim_data, layout, tout, &mut zc0)?;
                         save_zc_pre(e, sim_data, layout)?;
                     }
+                } else {
+                    close_assert_window(e, sim_data)?;
                 }
                 self.core.t = tout;
                 self.row += 1;
@@ -3093,6 +3263,9 @@ impl Driver for DasslEventsDriver {
             if !self.mid_row {
                 self.grid_covered = false;
             }
+            // C's `simulationUpdate` window: until this row's events are handled,
+            // the state the model is evaluated at may still be discarded.
+            open_assert_window();
             match self.core.integrate_to(
                 e, model, &mut ctx, &mut self.samp, tout, deadline, Some(&mut self.rows), &mut did_step, false,
             )? {
@@ -3112,10 +3285,13 @@ impl Driver for DasslEventsDriver {
             if !self.grid_covered {
                 write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
                 did_step = true;
-                emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
+                let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
+                close_assert_window(e, sim_data).and(emitted)?;
                 if terminated(e, sim_data, layout)? {
                     break Advance::Terminated;
                 }
+            } else {
+                close_assert_window(e, sim_data)?;
             }
             // Re-select states at the accepted output point (see `DasslDriver`).
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -152,6 +152,33 @@ pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
     ))
 }
 
+/// The values each solver flag accepts on this build, in menu order. A UI offering
+/// only these never builds a command line [`check`] rejects. `default` is left out:
+/// omitting a flag selects it.
+pub fn supported(cap: Capabilities) -> Vec<(&'static str, Vec<&'static str>)> {
+    let mut solver = alloc::vec!["dassl", "euler"];
+    for (name, have) in [("ida", cap.ida), ("cvode", cap.cvode), ("gbode", cap.gbode)] {
+        if have {
+            solver.push(name);
+        }
+    }
+    let mut nls_ls = alloc::vec!["totalpivot", "lapack", "rsparse"];
+    let mut ls = alloc::vec!["lapack", "totalpivot"];
+    let mut lss = alloc::vec!["rsparse"];
+    if cap.klu {
+        nls_ls.push("klu");
+        ls.push("klu");
+        lss.push("klu");
+    }
+    alloc::vec![
+        ("s", solver),
+        ("nls", alloc::vec!["hybrid", "kinsol", "newton", "mixed", "homotopy"]),
+        ("nlsLS", nls_ls),
+        ("ls", ls),
+        ("lss", lss),
+    ]
+}
+
 /// Parse an argv slice (`argv[0]` is the program name and is skipped).
 /// `-flag=value` and `-flag value` are both accepted, as in the C runtime.
 /// An unrecognized *value* for a recognized flag is an error listing what is
@@ -389,6 +416,22 @@ mod tests {
             let f = parse(&argv(&[arg])).expect("parses");
             assert!(check(&f, NOTHING).is_ok(), "{arg}");
         }
+    }
+
+    // `supported` feeds the web UI's solver menus, so an offered value must survive
+    // both the parser and the capability check of the build that offered it.
+    #[test]
+    fn everything_supported_parses_and_checks() {
+        for cap in [NOTHING, Capabilities { klu: true, ida: true, cvode: true, gbode: true }] {
+            for (flag, values) in supported(cap) {
+                for v in values {
+                    let f = parse(&argv(&[&format!("-{flag}={v}")])).expect(&format!("-{flag}={v}"));
+                    assert!(check(&f, cap).is_ok(), "-{flag}={v}");
+                }
+            }
+        }
+        // KLU is offered only where it is linked, so it never shows up above.
+        assert!(!supported(NOTHING).iter().any(|(_, v)| v.contains(&"klu")));
     }
 
     // The wire codes the wasm-jit runtime decodes: unset is 0, and the values are

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -6,6 +6,8 @@ use metamodelica::Result;
 /// A failing assertion recorded by `rt_assert`. `msg`/`file` are handles into the
 /// shared linear memory, decoded by the caller after the trap.
 pub struct PendingAssert {
+    /// The dumped condition, or 0 for a model/runtime error, which has none.
+    pub cond: i32,
     pub msg: i32,
     pub file: i32,
     pub sline: i32,
@@ -17,8 +19,21 @@ pub struct PendingAssert {
 
 thread_local! {
     static PENDING_ASSERT: std::cell::RefCell<Option<PendingAssert>> = const { std::cell::RefCell::new(None) };
-    /// `rt_assert_warning` records `[cond, msg, file, sline, scol, eline, ecol, read_only]`.
-    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 8]>> = const { std::cell::RefCell::new(Vec::new()) };
+    /// Violations that did not throw: `[kind, cond, msg, file, sline, scol, eline,
+    /// ecol, read_only]`, `kind` per `driver::ASSERT_*`.
+    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 9]>> = const { std::cell::RefCell::new(Vec::new()) };
+    /// C's `noThrowAsserts`: the driver has the model on a provisional state, so
+    /// `rt_assert` records instead of telling the caller to trap.
+    static NO_THROW: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Driver hook (`driver::set_no_throw_hook`). Opening drops the assertion a
+/// previous phase suppressed, so `enrich_trap` reports the one that failed.
+pub fn set_no_throw_asserts(v: bool) {
+    if v {
+        clear_pending_assert();
+    }
+    NO_THROW.with(|n| n.set(v));
 }
 
 /// Clear any stale pending assertion before a call.
@@ -31,25 +46,128 @@ pub fn take_pending_assert_raw() -> Option<PendingAssert> {
     PENDING_ASSERT.with(|p| p.borrow_mut().take())
 }
 
-/// Take the pending assertion as `[msg, file, sline, scol, eline, ecol, read_only]`
-/// (for the simulation drivers surfacing a failed `assert()` after a trap).
-pub fn take_pending_assert() -> Option<[i32; 7]> {
-    take_pending_assert_raw().map(|pa| [pa.msg, pa.file, pa.sline, pa.scol, pa.eline, pa.ecol, pa.read_only as i32])
+/// Take the pending assertion as `[msg, file, sline, scol, eline, ecol, read_only,
+/// cond]` (for the simulation drivers surfacing a failed `assert()` after a trap).
+pub fn take_pending_assert() -> Option<[i32; 8]> {
+    take_pending_assert_raw()
+        .map(|pa| [pa.msg, pa.file, pa.sline, pa.scol, pa.eline, pa.ecol, pa.read_only as i32, pa.cond])
 }
 
 /// Take (and clear) the warning-level assertion violations recorded since the last call.
-pub fn take_pending_warnings() -> Vec<[i32; 8]> {
+pub fn take_pending_warnings() -> Vec<[i32; 9]> {
     PENDING_WARNINGS.with(|p| core::mem::take(&mut *p.borrow_mut()))
 }
 
-fn record_assert(msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) {
+/// Take at most `max` of them, oldest first: `rt_host_take_warnings` hands them
+/// to the in-wasm driver a bufferful at a time.
+fn take_pending_warnings_upto(max: usize) -> Vec<[i32; 9]> {
+    PENDING_WARNINGS.with(|p| {
+        let mut p = p.borrow_mut();
+        let n = max.min(p.len());
+        p.drain(..n).collect()
+    })
+}
+
+/// Serialise the records into `dst` (little-endian `[i32; 9]` each).
+fn write_warnings(recs: &[[i32; 9]], dst: &mut [u8]) -> u32 {
+    let n = recs.len().min(dst.len() / REC_BYTES);
+    for (i, rec) in recs[..n].iter().enumerate() {
+        for (k, v) in rec.iter().enumerate() {
+            let off = i * REC_BYTES + k * 4;
+            dst[off..off + 4].copy_from_slice(&v.to_le_bytes());
+        }
+    }
+    n as u32
+}
+
+/// Wire size of one record, shared with the in-wasm reader.
+const REC_BYTES: usize = 9 * 4;
+
+/// A [`SimEngine`] over nothing but a read window into the shared linear memory:
+/// formatting a `LOG_ASSERT` block reads the time and the String handles and never
+/// calls back into the model. The reader is a closure so each engine can serve it
+/// from what it has in the import — a `&[u8]` or a `MemoryView`.
+#[cfg(feature = "jit")]
+struct MemEngine<'a>(&'a dyn Fn(u32, &mut [u8]) -> bool);
+
+#[cfg(feature = "jit")]
+impl openmodelica_sim_meta::driver::SimEngine for MemEngine<'_> {
+    fn read_bytes(&self, addr: u32, buf: &mut [u8]) -> metamodelica::Result<()> {
+        if (self.0)(addr, buf) { Ok(()) } else { Err("wasm-jit: read outside linear memory") }
+    }
+    fn write_bytes(&mut self, _addr: u32, _buf: &[u8]) -> metamodelica::Result<()> {
+        Err("wasm-jit: MemEngine is read-only")
+    }
+    fn call1(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
+        Err("wasm-jit: MemEngine cannot call the model")
+    }
+    fn call1_if_present(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
+        Err("wasm-jit: MemEngine cannot call the model")
+    }
+    fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> metamodelica::Result<u32> {
+        Err("wasm-jit: MemEngine cannot call the model")
+    }
+    /// Left to the engine that owns the run: taking it here would consume what
+    /// `enrich_trap` reports if the loop goes on to trap.
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+        None
+    }
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+        take_pending_warnings()
+    }
+}
+
+#[cfg(feature = "jit")]
+fn row_asserts(read: &dyn Fn(u32, &mut [u8]) -> bool, sim_data: u32, warn: i32) -> i32 {
+    openmodelica_sim_meta::driver::row_asserts(&mut MemEngine(read), sim_data, warn)
+}
+
+/// The run's shared linear memory. `rt_row_asserts` is called by the *model*
+/// module, which imports `memory` rather than exporting it, so `Caller::get_export`
+/// cannot find it; the engine sets it here instead (wasmer has [`HostMem`]).
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+mod sim_memory {
+    use std::cell::Cell;
+    thread_local! {
+        static MEMORY: Cell<Option<wasmtime::Memory>> = const { Cell::new(None) };
+    }
+    pub fn set(m: wasmtime::Memory) {
+        MEMORY.with(|c| c.set(Some(m)));
+    }
+    pub fn get() -> Option<wasmtime::Memory> {
+        MEMORY.with(|c| c.get())
+    }
+}
+
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub use sim_memory::set as set_sim_memory;
+
+fn record_assert(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) {
     PENDING_ASSERT.with(|p| {
-        *p.borrow_mut() = Some(PendingAssert { msg, file, sline, scol, eline, ecol, read_only: read_only != 0 });
+        *p.borrow_mut() = Some(PendingAssert { cond, msg, file, sline, scol, eline, ecol, read_only: read_only != 0 });
     });
 }
 
-fn record_warning(rec: [i32; 8]) {
+fn record_warning(rec: [i32; 9]) {
     PENDING_WARNINGS.with(|p| p.borrow_mut().push(rec));
+}
+
+/// `rt_assert`: a failed `assert()`. Returns 1 when the caller must trap — a model
+/// or runtime error (`cond == 0`) always does, a user assertion is recorded
+/// instead while the driver has asserts suppressed.
+fn assert_failed(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) -> i32 {
+    if cond != 0 && NO_THROW.with(|n| n.get()) {
+        record_warning([
+            openmodelica_sim_meta::driver::ASSERT_SUPPRESSED,
+            cond, msg, file, sline, scol, eline, ecol, read_only,
+        ]);
+        // Also as a pending assertion: if the phase throws, this reports it — the
+        // in-wasm driver's own reporter cannot reach the host's error buffer.
+        record_assert(cond, msg, file, sline, scol, eline, ecol, read_only);
+        return 0;
+    }
+    record_assert(cond, msg, file, sline, scol, eline, ecol, read_only);
+    1
 }
 
 // Native rsparse solve behind the `env.rt_host_lin_solve` import, which the native
@@ -138,14 +256,54 @@ pub mod lin_solve {
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result<()> {
     let wt = |r: std::result::Result<&mut wasmtime::Linker<T>, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
-    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-        record_assert(msg, file, sline, scol, eline, ecol, read_only);
+    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32| -> i32 {
+        assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only)
     }))?;
     wt(linker.func_wrap("rt", "rt_assert_warning", |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-        record_warning([cond, msg, file, sline, scol, eline, ecol, read_only]);
+        record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
     }))?;
+    wt(linker.func_wrap(
+        "rt",
+        "rt_row_asserts",
+        |caller: wasmtime::Caller<'_, T>, sim_data: u32, warn: i32| -> i32 {
+            let Some(mem) = sim_memory::get() else { return 1 };
+            let data = mem.data(&caller);
+            row_asserts(
+                &|addr: u32, buf: &mut [u8]| {
+                    let off = addr as usize;
+                    match data.get(off..off + buf.len()) {
+                        Some(src) => {
+                            buf.copy_from_slice(src);
+                            true
+                        }
+                        None => false,
+                    }
+                },
+                sim_data,
+                warn,
+            )
+        },
+    ))?;
     wt(linker.func_wrap("env", "rt_host_now_ms", || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }))?;
     wt(linker.func_wrap("env", "rt_host_cancel", || -> i32 { metamodelica::cancel::check_cancel() as i32 }))?;
+    wt(linker.func_wrap("env", "rt_host_init_done", || openmodelica_sim_meta::driver::signal_init_done()))?;
+    wt(linker.func_wrap("env", "rt_host_set_no_throw", |v: i32| set_no_throw_asserts(v != 0)))?;
+    // The model's violations land here even when the driver runs in-wasm; hand
+    // them over so that driver can format the `LOG_ASSERT` block.
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_take_warnings",
+        |mut caller: wasmtime::Caller<'_, T>, ptr: u32, max: u32| -> u32 {
+            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 0 };
+            let recs = take_pending_warnings_upto(max as usize);
+            let off = ptr as usize;
+            let data = mem.data_mut(&mut caller);
+            match data.get_mut(off..off + recs.len() * REC_BYTES) {
+                Some(dst) => write_warnings(&recs, dst),
+                None => 0,
+            }
+        },
+    ))?;
     // Solve the CSC system in the caller's (the runtime's) shared memory; the
     // interactive runtime imports this. Returns 0 (solved, `b` overwritten) or 1.
     wt(linker.func_wrap(
@@ -170,18 +328,67 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     Ok(())
 }
 
+/// The runtime's memory, handed to the wasmer host builtins by [`HostMem::set`]
+/// once the instance exists; the imports have to be defined before it.
 #[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
-pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Imports) -> Result<()> {
+pub struct HostMem(wasmer::FunctionEnv<Option<wasmer::Memory>>);
+
+#[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
+impl HostMem {
+    pub fn set(&self, store: &mut wasmer::Store, memory: &wasmer::Memory) {
+        *self.0.as_mut(store) = Some(memory.clone());
+    }
+}
+
+#[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
+pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Imports) -> Result<HostMem> {
     use wasmer::Function;
     imports.define("rt", "rt_assert", Function::new_typed(store,
-        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-            record_assert(msg, file, sline, scol, eline, ecol, read_only);
+        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32| -> i32 {
+            assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only)
         }));
     imports.define("rt", "rt_assert_warning", Function::new_typed(store,
         |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-            record_warning([cond, msg, file, sline, scol, eline, ecol, read_only]);
+            record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
         }));
+    // Both memory-reading imports share one env, filled in by `HostMem::set`.
+    let mem_env = wasmer::FunctionEnv::new(store, None);
+    imports.define(
+        "rt",
+        "rt_row_asserts",
+        Function::new_typed_with_env(
+            store,
+            &mem_env,
+            |env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, sim_data: u32, warn: i32| -> i32 {
+                let Some(memory) = env.data().clone() else { return 1 };
+                let view = memory.view(&env);
+                row_asserts(&|addr: u32, buf: &mut [u8]| view.read(addr as u64, buf).is_ok(), sim_data, warn)
+            },
+        ),
+    );
     imports.define("env", "rt_host_now_ms", Function::new_typed(store, || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }));
     imports.define("env", "rt_host_cancel", Function::new_typed(store, || -> i32 { metamodelica::cancel::check_cancel() as i32 }));
-    Ok(())
+    imports.define("env", "rt_host_init_done", Function::new_typed(store, || openmodelica_sim_meta::driver::signal_init_done()));
+    imports.define("env", "rt_host_set_no_throw", Function::new_typed(store, |v: i32| set_no_throw_asserts(v != 0)));
+    // See the wasmtime counterpart.
+    imports.define(
+        "env",
+        "rt_host_take_warnings",
+        Function::new_typed_with_env(
+            store,
+            &mem_env,
+            |mut env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, max: u32| -> u32 {
+                let (data, store) = env.data_and_store_mut();
+                let Some(memory) = data.clone() else { return 0 };
+                let recs = take_pending_warnings_upto(max as usize);
+                let mut buf = vec![0u8; recs.len() * REC_BYTES];
+                let n = write_warnings(&recs, &mut buf);
+                match memory.view(&store).write(ptr as u64, &buf) {
+                    Ok(()) => n,
+                    Err(_) => 0,
+                }
+            },
+        ),
+    );
+    Ok(HostMem(mem_env))
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
@@ -39,7 +39,17 @@ fn report_assert(info: &AssertInfo) {
 
 /// Install the host hooks (cancel poll + assertion reporter) into the shared
 /// driver. Idempotent; call before entering the driver.
+/// The driver's log lines join the model's captured stdout, so the run's log has
+/// them in the order they happened.
+fn log_to_stdout(s: &str) {
+    openmodelica_wasi::wasi::stdout_write(s.as_bytes());
+}
+
 pub fn init_host_hooks() {
     set_cancel_hook(metamodelica::cancel::check_cancel);
+    openmodelica_sim_meta::driver::set_log_sink(log_to_stdout);
     set_assert_reporter(report_assert);
+    // The host driver shares this process with `rt_assert`, so it sets the flag
+    // directly; the in-wasm driver relays it over a host import.
+    openmodelica_sim_meta::driver::set_no_throw_hook(crate::host::set_no_throw_asserts);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -776,7 +776,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     let t_inst = Instant::now();
     let mut store = wasmer::Store::new(engine.clone());
     let mut imports = wasmer::Imports::new();
-    add_host_builtins(&mut store, &mut imports)?;
+    let host_mem = add_host_builtins(&mut store, &mut imports)?;
     // The interactive (std wasip1) runtime imports `wasi_snapshot_preview1`; serve it
     // from the same shim the ext-C side module uses, bound to the runtime's memory
     // (set after instantiation, once the export exists). No-op for the no_std fallback.
@@ -788,6 +788,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
 
     let memory = wts(rt_inst.exports.get_memory("memory"))?.clone();
     rt_wasi_env.as_mut(&mut store).set_memory(memory.clone());
+    host_mem.set(&mut store, &memory);
 
     // External "C" functions (`ext.*`): resolved by the ModelicaExternalC WASI side
     // module (table blocks / external objects / string scanning). Must be wired
@@ -871,10 +872,10 @@ impl sim_driver::SimEngine for WasmerEngine {
             wt(self.instance.exports.get_typed_function(&self.store, "simulate"))?;
         wt(f.call(&mut self.store, sim_data, start, stop, n_steps))
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
     fn lin_solves(&mut self) -> u64 {
@@ -958,15 +959,13 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
 
     let start: wasmer::TypedFunction<(u32, u32, u32, u32), i32> =
         wts(rt_inst.exports.get_typed_function(&store, "rt_sim_start"))?;
-    let rc = wts(start.call(&mut store, meta_ptr, blob.len() as u32, fn_base, present_mask))?;
-    if rc < 0 {
-        return Err("CodegenWasmJit: rt_sim_start failed".to_string());
-    }
-
     let gf = |store: &Store, name: &'static str| -> std::result::Result<wasmer::TypedFunction<(), u32>, String> {
         wts(rt_inst.exports.get_typed_function(store, name))
     };
-    Ok(InWasmSession {
+    // Assembled before the run starts so that an initialization `assert()`, which
+    // traps out of `rt_sim_start`, is decoded through the same `SimEngine` as one
+    // that trips later instead of surfacing as a bare wasm trap.
+    let mut sess = InWasmSession {
         advance: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_advance"))?,
         rows_ptr: gf(&store, "rt_sim_rows_ptr")?,
         rows_len: gf(&store, "rt_sim_rows_len")?,
@@ -977,7 +976,18 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         free_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_free"))?,
         store,
         memory,
-    })
+    };
+    let started = start.call(&mut sess.store, meta_ptr, blob.len() as u32, fn_base, present_mask);
+    match started {
+        Ok(rc) if rc >= 0 => Ok(sess),
+        Ok(_) => Err("CodegenWasmJit: rt_sim_start failed".to_string()),
+        Err(_) => Err(sim_driver::enrich_trap_init(
+            &mut sess,
+            "CodegenWasmJit: in-wasm initialization failed",
+            model.start_time,
+        )
+        .to_string()),
+    }
 }
 
 // Memory access + pending-assert only; the model-call methods are never reached
@@ -999,10 +1009,10 @@ impl sim_driver::SimEngine for InWasmSession {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -599,6 +599,8 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     let rt_str_data = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
     define_external_imports(&mut linker, model, memory, rt_str_new, rt_str_data)?;
     define_print_import(&mut linker, memory)?;
+    // `rt_row_asserts` is called by the model, which only imports `memory`.
+    crate::host::set_sim_memory(memory);
     let instance = wts(linker.instantiate(&mut store, &model_module))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
@@ -732,10 +734,10 @@ impl sim_driver::SimEngine for WasmtimeEngine {
         let f = wt(self.instance.get_typed_func::<(u32, f64, f64, u32), u32>(&mut self.store, "simulate"))?;
         wt(f.call(&mut self.store, (sim_data, start, stop, n_steps)))
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
     fn lin_solves(&mut self) -> u64 {
@@ -828,13 +830,11 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
     }
 
     let start = wts(rt_inst.get_typed_func::<(u32, u32, u32, u32), i32>(&mut store, "rt_sim_start"))?;
-    let rc = wts(start.call(&mut store, (meta_ptr, blob.len() as u32, fn_base as u32, present_mask)))?;
-    if rc < 0 {
-        return Err("CodegenWasmJit: rt_sim_start failed".to_string());
-    }
-
     let gf = |store: &mut Store, name: &'static str| wts(rt_inst.get_typed_func::<(), u32>(store, name));
-    Ok(InWasmSession {
+    // Assembled before the run starts so that an initialization `assert()`, which
+    // traps out of `rt_sim_start`, is decoded through the same `SimEngine` as one
+    // that trips later instead of surfacing as a bare wasm trap.
+    let mut sess = InWasmSession {
         advance: wts(rt_inst.get_typed_func::<f64, i32>(&mut store, "rt_sim_advance"))?,
         rows_ptr: gf(&mut store, "rt_sim_rows_ptr")?,
         rows_len: gf(&mut store, "rt_sim_rows_len")?,
@@ -845,7 +845,18 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         free_f: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_sim_free"))?,
         store,
         memory,
-    })
+    };
+    let started = start.call(&mut sess.store, (meta_ptr, blob.len() as u32, fn_base as u32, present_mask));
+    match started {
+        Ok(rc) if rc >= 0 => Ok(sess),
+        Ok(_) => Err("CodegenWasmJit: rt_sim_start failed".to_string()),
+        Err(_) => Err(sim_driver::enrich_trap_init(
+            &mut sess,
+            "CodegenWasmJit: in-wasm initialization failed",
+            model.start_time,
+        )
+        .to_string()),
+    }
 }
 
 // Memory access + pending-assert only; the model-call methods are never reached
@@ -867,10 +878,10 @@ impl sim_driver::SimEngine for InWasmSession {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 7]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 8]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -59,6 +59,15 @@
   .modal-body select { background:#1b1b1b; color:var(--fg); border:1px solid var(--border);
     border-radius:4px; padding:3px 6px; font:inherit; }
   .modal-body select:disabled { opacity:.5; }
+  /* Settings dialog: label above control, two fields per row, so the solver names
+     and the tolerance stepper each get half the dialog instead of competing for it. */
+  #settingsBackdrop .modal { width:min(520px,100%); }
+  .settings { grid-template-columns:repeat(2,minmax(0,1fr)); align-items:end; }
+  .settings .fld { display:flex; flex-direction:column; gap:5px; min-width:0; }
+  .settings .fld.wide { grid-column:1 / -1; }
+  .settings label { color:var(--muted); font-size:13px; }
+  .settings label .flag { font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11.5px; opacity:.65; white-space:nowrap; }
+  .settings select { padding:6px 8px; font-size:15px; }
   .chk-group { display:flex; flex-direction:column; gap:6px; }
   .chk { display:flex; align-items:center; gap:7px; color:var(--fg); }
   .chk input { width:auto; }
@@ -82,7 +91,6 @@
     .left { border-right:0; border-bottom:1px solid var(--border); }
     /* Settings moved to the dialog, so the editor claims that height. */
     textarea { min-height:46vh; }
-    .grid2 { grid-template-columns:auto 1fr; }
     #icPanel { max-height:none; }
     .charts { overflow:visible; }
     header { flex-wrap:wrap; }
@@ -165,19 +173,30 @@
       <span>Simulation settings</span>
       <button class="icon-btn" id="settingsClose" title="Close" aria-label="Close">✕</button>
     </div>
-    <div class="grid2">
-      <label for="stop">Stop time</label>
-      <input id="stop" type="number" step="any" />
-      <label for="intervals">Intervals</label>
-      <input id="intervals" type="number" step="1" min="1" />
-      <label for="method">Solver</label>
-      <select id="method"><option value="dassl">dassl</option><option value="euler">euler</option></select>
-      <label for="tol">Tolerance</label>
-      <div class="stepper">
-        <button type="button" id="tolDn" title="÷10">▼</button>
-        <input id="tol" type="text" inputmode="decimal" />
-        <button type="button" id="tolUp" title="×10">▲</button>
-      </div>
+    <div class="modal-body settings">
+      <div class="fld"><label for="stop">Stop time</label>
+        <input id="stop" type="number" step="any" /></div>
+      <div class="fld"><label for="intervals">Intervals</label>
+        <input id="intervals" type="number" step="1" min="1" /></div>
+      <div class="fld"><label for="method">Integration method <span class="flag">-s</span></label>
+        <select id="method"><option value="dassl">dassl</option><option value="euler">euler</option></select></div>
+      <div class="fld"><label for="tol">Tolerance</label>
+        <div class="stepper">
+          <button type="button" id="tolDn" title="÷10">▼</button>
+          <input id="tol" type="text" inputmode="decimal" />
+          <button type="button" id="tolUp" title="×10">▲</button>
+        </div></div>
+      <div class="fld"><label for="nls">Nonlinear solver <span class="flag">-nls</span></label>
+        <select id="nls"></select></div>
+      <div class="fld"><label for="nlsLS" title="Linear solver used by the nonlinear solver">NLS linear solver <span class="flag">-nlsLS</span></label>
+        <select id="nlsLS"></select></div>
+      <div class="fld"><label for="ls">Linear solver <span class="flag">-ls</span></label>
+        <select id="ls"></select></div>
+      <div class="fld"><label for="lss">Sparse linear solver <span class="flag">-lss</span></label>
+        <select id="lss"></select></div>
+      <div class="fld wide"><label for="lv">Log streams <span class="flag">-lv</span></label>
+        <input id="lv" type="text" placeholder="LOG_STATS, LOG_SOLVER, …" title="Comma separated" /></div>
+      <p class="modal-hint">Solver selectors and log streams are read at each run, so changing one re-simulates without recompiling. The model's output goes to the browser console.</p>
     </div>
   </div>
 </div>
@@ -424,6 +443,33 @@ function overrideFlag() {
   return parts.length ? '-override=' + parts.join(',') : '';
 }
 
+// -nls/-nlsLS/-ls/-lss. The values come from the compiler (omc_sim_solver_options),
+// so the menus only offer what this build can actually run — KLU, for one, is there
+// only when SUNDIALS was linked. Empty means "don't pass the flag", i.e. the
+// runtime's own choice, which is the default and not always one of the named values.
+const SOLVER_FLAGS = ['nls', 'nlsLS', 'ls', 'lss'];
+function fillSolverMenus(options) {
+  if (!options) return;
+  for (const flag of SOLVER_FLAGS) {
+    const sel = el(flag), keep = sel.value;
+    sel.replaceChildren(new Option('default', ''));
+    for (const v of options[flag] || []) sel.add(new Option(v, v));
+    sel.value = keep;                     // survives a second worker reporting the same set
+  }
+  // The integration method has no "unset": it is a buildModel argument, not a flag.
+  const m = el('method'), keep = m.value;
+  if (options.s && options.s.length) {
+    m.replaceChildren(...options.s.map((v) => new Option(v, v)));
+    m.value = options.s.includes(keep) ? keep : options.s[0];
+  }
+}
+// The selectors plus `-lv` (log streams). Of these the runtime acts on LOG_STATS;
+// the rest are accepted and ignored, as unknown streams are for the C executable.
+const solverFlags = () => ({
+  ...Object.fromEntries(SOLVER_FLAGS.map((f) => [f, el(f).value])),
+  lv: el('lv').value.split(',').map((s) => s.trim()).filter(Boolean).join(','),
+});
+
 const unquote = (s) => { s = (s || '').trim(); return (s.startsWith('"') && s.endsWith('"'))
   ? s.slice(1, -1).replace(/\\(.)/g, (_, c) => c === 'n' ? '\n' : c === 't' ? '\t' : c) : s; };
 
@@ -449,7 +495,7 @@ async function run(kind) {                       // 'full' | 'resim'
   setStatus(kind === 'resim' ? 'Re-simulating…' : 'Compiling & simulating…', 'busy');
 
   try {
-    const method = el('method').value, ov = overrideFlag();
+    const method = el('method').value, ov = overrideFlag(), solvers = solverFlags();
     // A freshly loaded model drives its own settings: omit stopTime/intervals/
     // tolerance so simulate() uses the experiment annotation; we read back what it
     // used and seed the dialog. Once seeded (or user-overridden), pass the values.
@@ -461,7 +507,7 @@ async function run(kind) {                       // 'full' | 'resim'
     // Re-simulate the already-built model (fast, no recompile) when possible.
     if (kind === 'resim' && builtModel && builtWorker) {
       jobWorker = builtWorker;
-      const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov });
+      const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov, solvers });
       runMs = performance.now() - tRun;
       if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
@@ -485,7 +531,7 @@ async function run(kind) {                       // 'full' | 'resim'
       // figures/doc are annotations, not results — show docs now, before simulating.
       if (lm.figures !== undefined) modelFigures = lm.figures || null;
       if (lm.doc !== undefined) { modelDoc = lm.doc || ''; renderDoc(); }
-      const r = await call(worker, 'simulate', { name: lm.name, override: ov, ...settings });
+      const r = await call(worker, 'simulate', { name: lm.name, override: ov, solvers, ...settings });
       runMs = performance.now() - tRun;
       if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
@@ -831,6 +877,8 @@ srcEl.addEventListener('input', () => {   // manual edits are authoritative: re-
   clearTimeout(debounce); debounce = setTimeout(() => run('full'), 700);
 });
 for (const id of ['stop', 'intervals', 'method']) el(id).addEventListener('change', () => run('full'));
+// Solver selectors are runtime flags, not build settings: re-simulate, don't rebuild.
+for (const id of [...SOLVER_FLAGS, 'lv']) el(id).addEventListener('change', () => run('resim'));
 function stepTol(factor) { tolValue = cleanTol(Math.min(1e-1, Math.max(1e-15, tolValue * factor))); renderTol(); run('full'); }
 el('tolUp').addEventListener('click', () => stepTol(10));
 el('tolDn').addEventListener('click', () => stepTol(0.1));
@@ -920,6 +968,7 @@ exSel.addEventListener('change', () => { const ex = EXAMPLES.find((e) => e.id ==
 
     const v = await call(w1, 'init');
     if (!v || !v.ok) return setStatus('omc_init() failed — see the devtools console.', 'err');
+    fillSolverMenus(v.solverOptions);
     runBtn.disabled = false;
     el('exportFmu').disabled = false;
     setStatus('Ready. ' + v.version);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -9,7 +9,7 @@
 import init, {
   omc_set_env, omc_init, omc_eval, omc_simulate, omc_set_inwasm_driver,
   omc_enable_cancel_poll,
-  omc_sim_start, omc_sim_advance, omc_sim_free,
+  omc_sim_start, omc_sim_advance, omc_sim_free, omc_sim_solver_options, omc_sim_log,
   omc_take_pending_downloads, wasi_write_file,
   wasi_path_open, wasi_fd_read, wasi_fd_close,
   omc_sim_info, omc_sim_series, omc_sim_time, omc_sim_column, omc_sim_parameters,
@@ -33,7 +33,13 @@ let driverMode = null;
 let inited = false;
 
 const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\t/g, '\\t');
-const unquote = (s) => { s = (s || '').trim(); return (s.startsWith('"') && s.endsWith('"')) ? s.slice(1, -1) : s; };
+// omc prints a String result as a Modelica literal, so undo that: an empty result
+// is `""`, and a multi-line one (`getErrorString`) carries `\n` as two characters.
+const unquote = (s) => {
+  s = (s || '').trim();
+  return (s.startsWith('"') && s.endsWith('"'))
+    ? s.slice(1, -1).replace(/\\(.)/g, (_, c) => (c === 'n' ? '\n' : c === 't' ? '\t' : c)) : s;
+};
 
 // --- profiling -------------------------------------------------------------
 // Per-op/per-stage timings for diagnosing where the wall time goes. Off by
@@ -162,7 +168,15 @@ function snapshot() {
 }
 
 function simError(fallback) {
-  return { ok: false, error: omc_eval('getErrorString()').trim() || fallback };
+  return { ok: false, error: unquote(omc_eval('getErrorString()')) || fallback };
+}
+
+// What omc had to say about a step that nonetheless succeeded. Only a failure
+// reports the buffer to the page, so otherwise these are dropped by the next
+// `getErrorString` — or shown as part of an unrelated later error.
+function logCompilerMessages(what) {
+  const msg = unquote(omc_eval('getErrorString()'));
+  if (msg) console.warn('[omc ' + what + ']\n' + msg);
 }
 
 // Chunked, cancellable integration of a prepared model. Each `omc_sim_advance`
@@ -172,7 +186,7 @@ function simError(fallback) {
 async function runResumable(prefix, simflags, onStatus) {
   simCancel = false;   // discard a cancel that raced in after the previous run
   const _t0 = performance.now();
-  if (!omc_sim_start(prefix, prefix + '_res.mat', simflags)) return -1;
+  if (!omc_sim_start(prefix, prefix + '_res.mat', simflags)) { logModelOutput(prefix); return -1; }
   // Split off `omc_sim_start` (compile lookup, instantiate, init, row 0) and count
   // the chunks: a run that suddenly costs more is either paying instantiation again
   // or being yielded far more often than its budget should need.
@@ -190,11 +204,45 @@ async function runResumable(prefix, simflags, onStatus) {
     }
   } finally {
     lastPhases.advanceMs = performance.now() - _t1;
+    logModelOutput(prefix);
+  }
+}
+
+// The model's own output, which the run captures instead of the console.
+// Runtime log lines are `<stream><pad>| <level><pad>| text`, continued on lines
+// whose two columns are `|`; split on that so each record logs as one entry.
+const LOG_HEAD = /^(\S[^|\n]*?)\s*\|\s*(\S+)\s*\| ?/;
+const LOG_CONT = /^\|\s*\|\s*\| ?/;
+function logModelOutput(prefix) {
+  const out = omc_sim_log();
+  if (!out.trim()) return;
+  const records = [];
+  for (const line of out.replace(/\n$/, '').split('\n')) {
+    const head = LOG_HEAD.exec(line);
+    if (head && !LOG_CONT.test(line)) records.push({ stream: head[1], level: head[2], lines: [line] });
+    else if (records.length && (LOG_CONT.test(line) || head)) records[records.length - 1].lines.push(line);
+    else records.push({ stream: '', level: 'info', lines: [line] });
+  }
+  for (const r of records) {
+    // A violated assertion belongs in the console's warning list whatever the
+    // runtime's own severity — C prints one as `info` under `noThrowAsserts`.
+    const warn = r.level === 'warning' || r.level === 'error' || r.stream === 'LOG_ASSERT';
+    (warn ? console.warn : console.log)('[model ' + prefix + ']\n' + r.lines.join('\n'));
   }
 }
 
 // Phase breakdown of the last `runResumable`, reported back with the snapshot.
 let lastPhases = null;
+
+// The run's simflags: `-override=` plus the solver selectors the page picked.
+// They are read at `omc_sim_start`, not baked into the build, so a re-simulate
+// honours a change without recompiling; an empty selection is left out.
+function simflagsFor(a) {
+  const sel = a.solvers || {};
+  const flags = Object.keys(sel).filter((k) => sel[k]).map((k) => `-${k}=${sel[k]}`);
+  if (a.override) flags.push(a.override);
+  return flags.join(' ');
+}
 
 // The settings a run used, to seed the dialog: the explicit ones the page sent, or
 // getSimulationOptions → (startTime, stopTime, tolerance, numberOfIntervals) for a
@@ -241,7 +289,7 @@ self.onmessage = async (ev) => {
         // so this API call is how the option gets set (models may still opt in via
         // annotation(__OpenModelica_commandLineOptions="-d=visxml")).
         omc_eval('setCommandLineOptions("-d=visxml")');
-        reply({ ok: true, version: omc_eval('getVersion()') });
+        reply({ ok: true, version: omc_eval('getVersion()'), solverOptions: omc_sim_solver_options() });
         break;
       }
       case 'warmup': {
@@ -268,6 +316,7 @@ self.onmessage = async (ev) => {
         const loaded = (await evalWithDownloads(`loadString("${esc(a.text)}")`, status)).trim();
         if (PROF) wlog('loadString -> ' + loaded);
         if (loaded !== 'true') return reply(simError('Could not parse the model.'));
+        logCompilerMessages('loadString');
         const name = a.name || lastClassName();
         if (!name) return reply({ ok: false, error: 'No class found in the model text.' });
         if (PROF) wlog('model name = ' + name);
@@ -314,8 +363,9 @@ self.onmessage = async (ev) => {
         const buildMs = performance.now() - _tb;
         // buildModel → {"<prefix>","<initfile>"}; an empty first element means it failed.
         if (!/^\{\s*"[^"]/.test(built)) return reply(simError('Build failed.'));
+        logCompilerMessages('buildModel ' + a.name);
         const _ts = performance.now();
-        const st = await runResumable(a.name, a.override || '', status);
+        const st = await runResumable(a.name, simflagsFor(a), status);
         const simMs = performance.now() - _ts;
         if (st === 3) return reply({ ok: false, cancelled: true });
         if (st < 0) return reply(simError('Simulation failed.'));
@@ -329,7 +379,7 @@ self.onmessage = async (ev) => {
       case 'resimulate': {
         // Re-run the already-built model (no rebuild) — same cancellable chunked path.
         const _ts = performance.now();
-        const st = await runResumable(a.name, a.override || '', status);
+        const st = await runResumable(a.name, simflagsFor(a), status);
         const simMs = performance.now() - _ts;
         if (st === 3) return reply({ ok: false, cancelled: true });
         if (st < 0) return reply(simError('Re-simulation failed.'));


### PR DESCRIPTION
The model imports rt_assert/rt_assert_warning from the host whichever driver runs, so the in-wasm driver saw no violations at all: its check_asserts found an empty list and formatted nothing, and the web target (which always drives in-wasm) printed no warnings. Three host imports close the loop -- rt_host_take_warnings hands the records over, rt_host_init_done relays the init/simulation boundary, and rt_host_set_no_throw carries the flag below.

With the records in hand, port C's noThrowAsserts: rt_assert now takes the dumped condition (0 for a model/runtime error, never suppressed) and returns whether the caller must trap, and the driver opens a suppression phase per output row, settling it as simulationUpdate does -- an event found in the phase discards what it recorded, otherwise the run fails with C's "No event found, but assert was triggered". Models with an error assert in a when-clause used to fail where C completes them.

The driver's log lines (LOG_ASSERT blocks, chattering, the terminate notice) now go to the run's captured stdout where they happen instead of being collected and spliced in afterwards, which had put every warning ahead of the model's own print output.

Verified byte-identical to build-cmake-claude-c's omc, on both drivers, for warning-level asserts, min/max violations, print/warning interleaving, error asserts in a when-clause, continuous ones and initialization ones, terminate() and plain runs. getErrorString still gains the "[file:l:c] Error: msg" line C does not have; that is what OMEdit and the web page show.

The simulator page grows -nls/-nlsLS/-ls/-lss and -lv selectors, filled from the compiler so a build without SUNDIALS cannot offer KLU. The settings dialog puts the label above each field, two per row, so the solver names and the tolerance stepper stop competing for the width.