### PR TITLE
wasm-jit: math domain guards, -nls=newton, kinsol

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2488,7 +2488,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // the type/import sections, which need to know whether the model has any
     // nonlinear systems) and consumed by the equation-function builders below. ---
     let param_eqs = flatten_eqs(&sim_code.parameterEquations);
-    let param_bindings = collect_param_bindings(vars, &assigned_cref_keys(&param_eqs));
+    let initial_eqs = flatten_eqs(&sim_code.initialEquations);
+    let mut computed_params = assigned_cref_keys(&param_eqs);
+    computed_params.extend(assigned_cref_keys(&initial_eqs));
+    let param_bindings = collect_param_bindings(vars, &computed_params);
     // When the model has `when`-equations, the discrete update (when-bodies with
     // edge detection) must run each step between the condition and output
     // equations. `allEquations` is the full solved list in that order, so it is
@@ -2506,7 +2509,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     } else {
         Vec::new()
     };
-    let initial_eqs = flatten_eqs(&sim_code.initialEquations);
     let lambda0_eqs = flatten_eqs(&sim_code.initialEquations_lambda0);
     let assert_eqs = flatten_eqs(&sim_code.algorithmAndEquationAsserts);
     let ode_eqs = flatten_eqs_ll(&sim_code.odeEquations);
@@ -3548,11 +3550,10 @@ fn collect_param_bindings(
         .chain(lst(&vars.boolParamVars))
         .chain(lst(&vars.stringParamVars))
     {
-        // A parameter computed by a parameterEquation (e.g. `u_max =
-        // getTable1DAbscissaUmax(tableID)`, scheduled after the table
-        // constructor) must not also be assigned from its binding here: the
-        // prelude runs before parameterEquations, so it would evaluate the
-        // binding against not-yet-initialized dependencies (a null handle).
+        // A parameter an equation computes must not also be assigned from its binding
+        // here: the prelude runs before both equation lists, so the binding would see
+        // dependencies that are still 0 (or a null handle). C leaves such a parameter
+        // at the 0 of a `_init.xml` entry with no `start`.
         if let Some(v) = &p.initialValue {
             if sim_cref_key(&p.name).map(|k| computed.contains(&k)).unwrap_or(false) {
                 continue;
@@ -4305,20 +4306,20 @@ fn collect_nls_jobs(
                 let n = lst(&nlSystem.crefs).count() as u32;
                 let has_jac = nls_jac_usable(nlSystem);
                 let mixed = nlSystem.mixedSystem;
-                // Sparse (kinsol+KLU in C) when the symbolic pattern is available
-                // and passes C's density/size rule; the pattern is emitted into the
-                // pattern block so `rt_solve_nls` can factorize it.
+                // The pattern goes in whenever it exists: C's density/size rule only
+                // picks the *default* solver (kinsol+KLU vs the dense ladder), while
+                // `-nls=kinsol` hands every patterned system to KINSOL.
                 let pat = has_jac
                     .then(|| nls_jac_pattern(nlSystem.jacobianMatrix.as_ref().unwrap(), n as usize))
-                    .flatten()
-                    .filter(|p| nls_use_sparse(n as usize, p.rowidx.len()));
+                    .flatten();
                 let nnz = pat.as_ref().map_or(0, |p| p.rowidx.len() as u32);
+                let sparse_default = nnz != 0 && nls_use_sparse(n as usize, nnz as usize);
                 if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
                     eprintln!(
                         "wasm-jit nls {}: n={n} nnz={} jac={has_jac} mixed={mixed} sparse={} colors={}",
                         nlSystem.index,
                         nls_system_nnz(nlSystem),
-                        nnz != 0,
+                        sparse_default,
                         pat.as_ref().map_or(0, |p| p.colors.len()),
                     );
                 }
@@ -4326,7 +4327,7 @@ fn collect_nls_jobs(
                     patterns.extend_from_slice(&p.colptr);
                     patterns.extend_from_slice(&p.rowidx);
                 }
-                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, hist_off, nominal_off, has_jac, mixed, nnz, pat_off });
+                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default });
                 if nnz != 0 {
                     pat_off += 4 * (n + 1 + nnz);
                 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -50,6 +50,7 @@ use arcstr::ArcStr;
 use metamodelica::List;
 
 use openmodelica_ast::Absyn;
+use openmodelica_frontend_base::Expression;
 use openmodelica_frontend_base::Types;
 use openmodelica_frontend_dump::AbsynUtil;
 use openmodelica_frontend_dump::ExpressionDumpTpl;
@@ -406,7 +407,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
     ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
@@ -1056,13 +1057,15 @@ pub(crate) struct NlsJob {
     pub(crate) has_jac: bool,
     /// C's `NONLINEAR_SYSTEM_DATA::mixedSystem`: the residual branches on discretes.
     pub(crate) mixed: bool,
-    /// Nonzero count of the Jacobian's CSC pattern when the system is solved
-    /// sparsely (C's kinsol+KLU choice), else 0: the `nls_jac` callback then fills
-    /// `nnz` CSC values instead of a dense `n×n` matrix.
+    /// Nonzero count of the Jacobian's CSC pattern, 0 where there is none.
     pub(crate) nnz: u32,
     /// Byte offset of this system's `colptr`/`rowidx` pattern into the pattern
     /// block (`NLS_PAT_GLOBAL`); only meaningful when `nnz != 0`.
     pub(crate) pat_off: u32,
+    /// C's per-system default `nlsMethod` by the density/size rule: `NLS_KINSOL`
+    /// (sparse) rather than the dense `NLS_MIXED` ladder. `-nls=` overrides it, and
+    /// it also picks the format `nls_jac` writes (CSC vs dense `n×n`).
+    pub(crate) sparse_default: bool,
 }
 
 /// Per-system solver state for `n` unknowns: a count (padded to 8), the residual
@@ -2887,16 +2890,11 @@ fn emit_noretcall(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<()> {
     Ok(())
 }
 
-/// `if (!cond) { rt_assert(msg, file, line/col…); unreachable }`. The C target
-/// always emits `omc_assert` (an error that throws — the assertion level is not
-/// distinguished here), so a failed assert routes its message + source info to
-/// the error buffer (host import `rt_assert`, read back by `load_and_execute`)
-/// and then traps, matching the `[file:l:c-l:c:writable] Error: <msg>` output.
-/// A warning-level assert (`AssertionLevel.warning`, `level` enum index 1 — e.g.
-/// the min/max variable-attribute checks) instead calls `rt_assert_warning` and
-/// continues: the driver formats the recorded violation as a `LOG_ASSERT` warning
-/// after the step, matching C's `omc_assert_warning` (warn once, do not throw).
-/// Shared by `STMT_ASSERT` and the `when`-body `ASSERT` operator.
+/// C's `assertCommon`: `if (!cond) { rt_assert(msg, assert_cond, file, line/col…);
+/// unreachable }`, the host formatting the three as `omc_assert` does. A warning-level
+/// assert (`AssertionLevel.warning`, `level` enum index 1 — the min/max attribute
+/// checks) calls `rt_assert_warning` and continues instead, as C's
+/// `omc_assert_warning`. Shared by `STMT_ASSERT` and the `when`-body `ASSERT`.
 fn emit_assert(
     ctx: &mut FnCtx,
     cond: &Arc<DAE::Exp>,
@@ -2915,12 +2913,7 @@ fn emit_assert(
         // The dumped condition (C's `assert_cond`), then the message, then the
         // source position — all consumed by `rt_assert_warning`; execution
         // continues afterwards (no trap).
-        let cond_str = Tpl::textString(ExpressionDumpTpl::dumpExp(
-            Tpl::emptyTxt.clone(),
-            cond.clone(),
-            arcstr::literal!("\""),
-        )?)?;
-        emit_str_literal(ctx, cond_str.as_bytes())?; // dumped condition
+        emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition
         let mw = compile_exp(ctx, msg)?; // owned message String handle
         if mw != WTy::I32 {
             return Err("CodegenWasmJit: assert message is not a String");
@@ -2935,18 +2928,8 @@ fn emit_assert(
         ctx.emit(we::Instruction::End);
         return Ok(());
     }
-    // In a nonlinear-solver residual, note the failed assert and return so the solver
-    // backs off (C's ERROR_NONLINEARSOLVER) instead of trapping. Only in a void
-    // function (residuals are void) — a bare `return` in a value-returning function is
-    // invalid wasm, and such a function is not an NLS residual anyway.
-    if ctx.outputs.is_empty() {
-        ctx.emit(we::Instruction::Call(rt_index("rt_nls_recovering")?));
-        ctx.emit(we::Instruction::If(we::BlockType::Empty));
-        ctx.emit(we::Instruction::Call(rt_index("rt_nls_note_assert")?));
-        ctx.emit(we::Instruction::Return);
-        ctx.emit(we::Instruction::End);
-    }
-    let mw = compile_exp(ctx, msg)?; // owned String handle
+    emit_nls_recoverable_return(ctx)?;
+    let mw = compile_exp(ctx, msg)?; // owned message String handle
     if mw != WTy::I32 {
         return Err("CodegenWasmJit: assert message is not a String");
     }
@@ -2956,8 +2939,7 @@ fn emit_assert(
     ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
-    let cond_str = dumped_exp(cond)?;
-    emit_str_literal(ctx, cond_str.as_bytes())?; // dumped condition, for the report
+    emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     // Trap unless the driver took it (suppressed during the event search).
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
@@ -2967,8 +2949,22 @@ fn emit_assert(
     Ok(())
 }
 
-/// Trap on a model error whose message String handle is already on the stack
-/// (dummy source position).
+/// A model error inside a nonlinear-solver residual is recoverable in C
+/// (`ERROR_NONLINEARSOLVER` longjmps out and the solver shortens the step): note it
+/// and return, leaving the outputs at their entry values.
+fn emit_nls_recoverable_return(ctx: &mut FnCtx) -> Result<()> {
+    ctx.emit(we::Instruction::Call(rt_index("rt_nls_recovering")?));
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    ctx.emit(we::Instruction::Call(rt_index("rt_nls_note_assert")?));
+    release_heap_locals(ctx)?;
+    push_outputs(ctx);
+    ctx.emit(we::Instruction::Return);
+    ctx.emit(we::Instruction::End);
+    Ok(())
+}
+
+/// Trap on a model error whose message String handle is already on the stack — C's
+/// `assertCommonVar`: no dumped condition, `omc_dummyFileInfo`.
 fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
     emit_str_literal(ctx, b"")?; // file
     for _ in 0..5 {
@@ -2984,6 +2980,79 @@ fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
 /// The dumped source form of `e`, for embedding in an assertion message.
 fn dumped_exp(e: &Arc<DAE::Exp>) -> Result<String> {
     Ok(Tpl::textString(ExpressionDumpTpl::dumpExp(Tpl::emptyTxt.clone(), e.clone(), arcstr::literal!("\""))?)?.to_string())
+}
+
+/// A math builtin's accepted interval and the message text around the `%g`.
+struct Domain {
+    low: f64,
+    low_strict: bool,
+    high: Option<f64>,
+    head: &'static str,
+    tail: &'static str,
+}
+
+/// The guard C's `daeExpCall` emits for `name`, `None` where the whole range is valid.
+fn math_domain(name: &str) -> Option<Domain> {
+    match name {
+        "asin" | "acos" => Some(Domain {
+            low: -1.0,
+            low_strict: false,
+            high: Some(1.0),
+            head: "outside the domain -1.0 <= ",
+            tail: " <= 1.0",
+        }),
+        "log" | "log10" => Some(Domain {
+            low: 0.0,
+            low_strict: true,
+            high: None,
+            head: "was ",
+            tail: " should be > 0",
+        }),
+        "sqrt" => Some(Domain {
+            low: 0.0,
+            low_strict: false,
+            high: None,
+            head: "was ",
+            tail: " should be >= 0",
+        }),
+        _ => None,
+    }
+}
+
+/// C's `daeExpCall` guard (`CodegenCFunctions.tpl`): evaluate `arg` into a temp,
+/// assert its domain, leave it on the stack for the caller's call.
+fn emit_math_domain_guard(ctx: &mut FnCtx, name: &str, arg: &Arc<DAE::Exp>, d: &Domain) -> Result<()> {
+    use we::Instruction as I;
+    let w = compile_exp(ctx, arg)?;
+    coerce(ctx, w, WTy::F64);
+    let t = ctx.alloc_temp(WTy::F64);
+    ctx.emit(I::LocalTee(t));
+    ctx.emit(I::F64Const(d.low.into()));
+    ctx.emit(if d.low_strict { I::F64Gt } else { I::F64Ge });
+    if let Some(high) = d.high {
+        ctx.emit(I::LocalGet(t));
+        ctx.emit(I::F64Const(high.into()));
+        ctx.emit(I::F64Le);
+        ctx.emit(I::I32And);
+    }
+    ctx.emit(I::I32Eqz);
+    ctx.emit(I::If(we::BlockType::Empty));
+    emit_nls_recoverable_return(ctx)?;
+    let call = format!("{name}({})", dumped_exp(arg)?);
+    emit_str_literal(ctx, format!("Model error: Argument of {call} {}", d.head).as_bytes())?;
+    ctx.emit(I::LocalGet(t));
+    ctx.emit(I::I32Const(6)); // significant digits (C's `%g`)
+    ctx.emit(I::I32Const(0)); // minimum length
+    ctx.emit(I::I32Const(0)); // left justified
+    ctx.emit(I::Call(rt_index("rt_real_format")?));
+    ctx.emit(I::Call(rt_index("rt_concat")?));
+    emit_str_literal(ctx, d.tail.as_bytes())?;
+    ctx.emit(I::Call(rt_index("rt_concat")?));
+    emit_model_error(ctx)?;
+    ctx.emit(I::End);
+
+    ctx.emit(I::LocalGet(t));
+    Ok(())
 }
 
 /// `nthRoot(v, n) = copysign(pow(|v|, 1/n), v)` — the real n-th root,
@@ -5523,9 +5592,14 @@ fn compile_math_builtin(
         if argv.len() != params.len() {
             return Err("CodegenWasmJit: builtin expects args");
         }
-        for (a, p) in argv.iter().zip(params.iter()) {
-            let w = compile_exp(ctx, a)?;
-            coerce(ctx, w, *p);
+        match math_domain(name) {
+            Some(d) => emit_math_domain_guard(ctx, name, argv[0], &d)?,
+            None => {
+                for (a, p) in argv.iter().zip(params.iter()) {
+                    let w = compile_exp(ctx, a)?;
+                    coerce(ctx, w, *p);
+                }
+            }
         }
         ctx.emit(we::Instruction::Call(bi));
         return Ok(SigTy::Real);
@@ -5533,10 +5607,47 @@ fn compile_math_builtin(
 
     match name {
         "sqrt" => {
-            unary_f64(ctx, &argv, we::Instruction::F64Sqrt)?;
+            need_args(&argv, 1, name)?;
+            // C skips the guard where the argument is provably non-negative.
+            let guarded = !Expression::isPositiveOrZero(argv[0].clone())?;
+            match math_domain(name).filter(|_| guarded) {
+                Some(d) => emit_math_domain_guard(ctx, name, argv[0], &d)?,
+                None => {
+                    let w = compile_exp(ctx, argv[0])?;
+                    coerce(ctx, w, WTy::F64);
+                }
+            }
+            ctx.emit(we::Instruction::F64Sqrt);
             Ok(SigTy::Real)
         }
         "nthRoot" => emit_nth_root(ctx, &argv, name),
+        // C's `(modelica_integer)round(r)`: half-*away*-from-zero, which wasm's
+        // `nearest` (half-to-even) is not. Left as a Real — C's cast only narrows an
+        // already integral value, and the surrounding expression wants the Real.
+        "$_round" => {
+            need_args(&argv, 1, name)?;
+            let w = compile_exp(ctx, argv[0])?;
+            coerce(ctx, w, WTy::F64);
+            let v = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalTee(v));
+            ctx.emit(we::Instruction::F64Trunc);
+            let t = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalTee(t));
+            // + copysign(1, v) * (|v - trunc(v)| >= 0.5)
+            ctx.emit(we::Instruction::F64Const(1.0f64.into()));
+            ctx.emit(we::Instruction::LocalGet(v));
+            ctx.emit(we::Instruction::F64Copysign);
+            ctx.emit(we::Instruction::LocalGet(v));
+            ctx.emit(we::Instruction::LocalGet(t));
+            ctx.emit(we::Instruction::F64Sub);
+            ctx.emit(we::Instruction::F64Abs);
+            ctx.emit(we::Instruction::F64Const(0.5f64.into()));
+            ctx.emit(we::Instruction::F64Ge);
+            ctx.emit(we::Instruction::F64ConvertI32S);
+            ctx.emit(we::Instruction::F64Mul);
+            ctx.emit(we::Instruction::F64Add);
+            Ok(SigTy::Real)
+        }
         "floor" => {
             unary_f64(ctx, &argv, we::Instruction::F64Floor)?;
             Ok(SigTy::Real)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1478,9 +1478,10 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::I32Add);
     ctx.emit(I::I32Const(n_rel as i32));
     ctx.emit(I::I32Const(job.mixed as i32));
-    // Sparse systems: this system's `colptr`/`rowidx` in the pattern block, its
-    // nonzero count, and the cache key for the reused symbolic factorization.
-    // `nnz == 0` selects the dense solver ladder (`jac` fills an `n×n` matrix).
+    // A system with a symbolic pattern: its `colptr`/`rowidx` in the pattern block,
+    // the nonzero count, whether the pattern is also the default solver choice (else
+    // only `-nls=kinsol` uses it), and the symbolic-factorization cache key. With
+    // `nnz == 0` the dense ladder runs over an `n×n` `jac`.
     if job.nnz != 0 {
         ctx.emit(I::GlobalGet(NLS_PAT_GLOBAL));
         ctx.emit(I::I32Const(job.pat_off as i32));
@@ -1489,6 +1490,7 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
         ctx.emit(I::I32Const(0));
     }
     ctx.emit(I::I32Const(job.nnz as i32));
+    ctx.emit(I::I32Const(job.sparse_default as i32));
     ctx.emit(I::I32Const(nls_lss_handle(job.k) as i32));
     ctx.emit(I::Call(rt_index("rt_solve_nls")?));
     ctx.emit(I::Drop);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -65,12 +65,15 @@ pub extern "C" fn rt_nls_note_assert() {
 }
 
 /// Build the Jacobian-assemble closure used by both kinsol and newton sparse paths.
+/// `gather` is the pattern block where `jac` fills a dense `n×n` rather than the CSC
+/// values — a system `-nls=kinsol` solves sparsely though the codegen chose dense.
 fn make_assemble(
     n: usize,
     x_ptr: u32,
     sim_data: u32,
     jac_idx: u32,
     val_ptr: u32,
+    gather: Option<alloc::vec::Vec<u32>>,
 ) -> impl FnMut(&[f64], &mut [f64]) {
     move |xs: &[f64], vals: &mut [f64]| {
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
@@ -81,10 +84,27 @@ fn make_assemble(
         jacf(sim_data, x_ptr, val_ptr);
         NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
         NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
-        for (k, v) in vals.iter_mut().enumerate() {
-            *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
+        match &gather {
+            Some(pat) => {
+                for c in 0..n {
+                    for k in pat[c] as usize..pat[c + 1] as usize {
+                        let row = pat[n + 1 + k] as usize;
+                        vals[k] = unsafe { load_f64(val_ptr + ((c * n + row) * 8) as u32) };
+                    }
+                }
+            }
+            None => {
+                for (k, v) in vals.iter_mut().enumerate() {
+                    *v = unsafe { load_f64(val_ptr + (k * 8) as u32) };
+                }
+            }
         }
     }
+}
+
+/// The `colptr[n+1] ++ rowidx[nnz]` pattern block, out of linear memory.
+fn read_pattern(pat_addr: u32, n: usize, nnz: usize) -> alloc::vec::Vec<u32> {
+    (0..n + 1 + nnz).map(|k| unsafe { load_u32(pat_addr + (k * 4) as u32) }).collect()
 }
 
 
@@ -1339,6 +1359,313 @@ fn newton_c(
     }
 }
 
+// `-nls=newton`: C's `solveNewton` (nonlinearSolverNewton.c) over `_omc_newton`
+// (newtonIteration.c). Not the `newton_c` above, which is `solveHomotopy`'s inner
+// damped Newton — the two converge to different roots.
+
+/// LAPACK's `dgetf2`: in-place partial-pivot LU of the column-major `n×n` `a`, the
+/// factors left packed in `a` for C's Newton to reuse. Singularity goes unreported, as
+/// in C: `solveLinearSystem` overwrites `dgetrf`'s `info` with `dgetrs`'s.
+fn dgetf2(n: usize, a: &mut [f64], piv: &mut [usize]) {
+    /// `DLAMCH('S')`: below it, divide rather than scale by the reciprocal.
+    const SFMIN: f64 = 2.2250738585072014e-308;
+    for j in 0..n {
+        let mut p = j;
+        for i in j + 1..n {
+            if libm::fabs(a[j * n + i]) > libm::fabs(a[j * n + p]) {
+                p = i;
+            }
+        }
+        piv[j] = p;
+        if a[j * n + p] != 0.0 {
+            if p != j {
+                for c in 0..n {
+                    let t = a[c * n + j];
+                    a[c * n + j] = a[c * n + p];
+                    a[c * n + p] = t;
+                }
+            }
+            let d = a[j * n + j];
+            if libm::fabs(d) >= SFMIN {
+                let r = 1.0 / d;
+                for i in j + 1..n {
+                    a[j * n + i] *= r;
+                }
+            } else {
+                for i in j + 1..n {
+                    a[j * n + i] /= d;
+                }
+            }
+        }
+        // `dger`: rank-1 update of the trailing submatrix.
+        for c in j + 1..n {
+            let t = a[c * n + j];
+            if t != 0.0 {
+                for i in j + 1..n {
+                    a[c * n + i] += a[j * n + i] * -t;
+                }
+            }
+        }
+    }
+}
+
+/// LAPACK's `dgetrs('N')`, one right-hand side: `b ← A⁻¹b`.
+fn dgetrs(n: usize, a: &[f64], piv: &[usize], b: &mut [f64]) {
+    for j in 0..n {
+        b.swap(j, piv[j]);
+    }
+    for k in 0..n {
+        if b[k] != 0.0 {
+            for i in k + 1..n {
+                b[i] -= b[k] * a[k * n + i];
+            }
+        }
+    }
+    for k in (0..n).rev() {
+        if b[k] != 0.0 {
+            b[k] /= a[k * n + k];
+            for i in 0..k {
+                b[i] -= b[k] * a[k * n + i];
+            }
+        }
+    }
+}
+
+/// C's `compute_scaling_vector`, over a buffer that holds LU factors by then.
+fn newton_res_scaling(n: usize, jac: &[f64], scaling: &mut [f64]) {
+    for i in 0..n {
+        let mut m = libm::fabs(jac[i * n]);
+        for k in 1..n {
+            m = libm::fmax(libm::fabs(jac[i * n + k]), m);
+        }
+        scaling[i] = if m <= 0.0 {
+            1.0e-16
+        } else if !m.is_finite() {
+            1.0
+        } else {
+            m
+        };
+    }
+}
+
+/// C's `wrapper_fvec_newton(fj = 0)`: the analytic Jacobian, else forward differences
+/// stepped by `sqrt(DBL_EPSILON)·max(|x_i|, |f_i|)`, signed by `f_i`.
+#[allow(clippy::too_many_arguments)]
+fn newton_jacobian(
+    n: usize,
+    x: &mut [f64],
+    fvec: &[f64],
+    jac: &mut [f64],
+    rwork: &mut [f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    jaceval: &mut dyn FnMut(&[f64], &mut [f64]),
+    has_jac: bool,
+) {
+    if has_jac {
+        jaceval(x, jac);
+        return;
+    }
+    for i in 0..n {
+        let mut dhh = libm::fmax(
+            SQRT_EPS * libm::fmax(libm::fabs(x[i]), libm::fabs(fvec[i])),
+            SQRT_EPS,
+        );
+        if fvec[i] < 0.0 {
+            dhh = -dhh;
+        }
+        let saved = x[i];
+        dhh = saved + dhh - saved;
+        x[i] = saved + dhh;
+        let inv = 1.0 / dhh;
+        eval(x, rwork);
+        for j in 0..n {
+            jac[i * n + j] = (rwork[j] - fvec[j]) * inv;
+        }
+        x[i] = saved;
+    }
+}
+
+/// C's `damping_heuristic2` (the default `NEWTON_DAMPED2`): shrink by 3/4 until the
+/// residual improves; below `1e-4` take the full step, or the tiny one after five tries.
+#[allow(clippy::too_many_arguments)]
+fn damping_heuristic2(
+    n: usize,
+    x: &[f64],
+    x_incr: &[f64],
+    x_new: &mut [f64],
+    current: f64,
+    fvec: &mut [f64],
+    k: &mut i32,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) {
+    const TRESHOLD: f64 = 1.0e-4;
+    let mut lambda = 1.0f64;
+    eval(x_new, fvec);
+    while minpack::enorm(fvec) >= current {
+        lambda *= 0.75;
+        for i in 0..n {
+            x_new[i] = x[i] - lambda * x_incr[i];
+        }
+        eval(x_new, fvec);
+        if lambda <= TRESHOLD {
+            if *k < 5 {
+                for i in 0..n {
+                    x_new[i] = x[i] - x_incr[i];
+                }
+            }
+            eval(x_new, fvec);
+            *k += 1;
+            return;
+        }
+    }
+}
+
+/// C's `_omc_newton` tolerance; `solveNewton` relaxes only its acceptance bound.
+const NEWTON_ITER_TOL: f64 = 1.0e-6;
+
+/// C's `_omc_newton`: damped Newton over a factorization reused while `every_jac` is
+/// false (C's `calculate_jacobian = 0`). Returns `(info > 0, ‖fvec‖, ‖fvec/resScaling‖)`.
+#[allow(clippy::too_many_arguments)]
+fn omc_newton(
+    n: usize,
+    x: &mut [f64],
+    fvec: &mut [f64],
+    res_scaling: &mut [f64],
+    every_jac: bool,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    jaceval: &mut dyn FnMut(&[f64], &mut [f64]),
+    has_jac: bool,
+) -> (bool, f64, f64) {
+    let eps = NEWTON_ITER_TOL;
+    let maxfev = n * 100;
+    let mut jac = vec![0.0f64; n * n];
+    let mut piv = vec![0usize; n];
+    let mut f_old = vec![0.0f64; n];
+    let mut x_new = vec![0.0f64; n];
+    let mut x_incr = vec![0.0f64; n];
+    let mut rwork = vec![0.0f64; n];
+    let mut fvec_scaled = vec![0.0f64; n];
+
+    let mut info = 1i32;
+    let mut calc_jac = true;
+    let mut factorized = false;
+    let mut k = 0i32;
+    let mut l = 0usize;
+
+    eval(x, fvec);
+    f_old.copy_from_slice(fvec);
+    let mut error_f = minpack::enorm(fvec);
+    let mut current = error_f;
+    fvec_scaled.copy_from_slice(fvec);
+    // Unknown before the first iteration, so start above `eps`.
+    let mut scaled_error_f = 1.0 + eps;
+    let mut delta_x = 1.0 + eps;
+    let mut delta_f = 1.0 + eps;
+    let mut delta_x_scaled = 1.0 + eps;
+
+    while error_f > eps && scaled_error_f > eps && delta_x > eps && delta_f > eps && delta_x_scaled > eps {
+        stat_inc(STAT_NLS_ITER);
+        if calc_jac {
+            newton_jacobian(n, x, fvec, &mut jac, &mut rwork, eval, jaceval, has_jac);
+            factorized = false;
+            calc_jac = every_jac;
+        }
+        if !factorized {
+            dgetf2(n, &mut jac, &mut piv);
+            factorized = true;
+        }
+        x_incr.copy_from_slice(fvec);
+        dgetrs(n, &jac, &piv, &mut x_incr);
+        for i in 0..n {
+            x_new[i] = x[i] - x_incr[i];
+        }
+        damping_heuristic2(n, x, &x_incr, &mut x_new, current, fvec, &mut k, eval);
+
+        // C's `calculatingErrors`.
+        for i in 0..n {
+            rwork[i] = x[i] - x_new[i];
+        }
+        delta_x = minpack::enorm(&rwork);
+        let scale = minpack::enorm(x);
+        delta_x_scaled = if scale > 1.0 { delta_x * (1.0 / scale) } else { delta_x };
+        for i in 0..n {
+            rwork[i] = f_old[i] - fvec[i];
+        }
+        delta_f = minpack::enorm(&rwork);
+        error_f = minpack::enorm(fvec);
+        newton_res_scaling(n, &jac, res_scaling);
+        for i in 0..n {
+            fvec_scaled[i] = fvec[i] / res_scaling[i];
+        }
+        scaled_error_f = minpack::enorm(&fvec_scaled);
+
+        x.copy_from_slice(&x_new);
+        f_old.copy_from_slice(fvec);
+        current = error_f;
+        l += 1;
+        if l > maxfev || k > 5 {
+            info = -1;
+            break;
+        }
+    }
+    (info > 0, error_f, scaled_error_f)
+}
+
+/// C's `solveNewton`: [`omc_newton`] under a retry ladder that varies the start point,
+/// refreshes the Jacobian every iteration, then relaxes the acceptance bound. `warm` is
+/// C's `nlsxOld`.
+#[allow(clippy::too_many_arguments)]
+fn solve_newton_c(
+    n: usize,
+    x: &mut [f64],
+    warm: &[f64],
+    nominal: &[f64],
+    res_scaling: &mut [f64],
+    discrete_call: bool,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    jaceval: &mut dyn FnMut(&[f64], &mut [f64]),
+    has_jac: bool,
+) -> bool {
+    let mut fvec = vec![0.0f64; n];
+    let mut local_tol = NEWTON_ITER_TOL;
+    let mut every_jac = false;
+    let mut retries = 0i32;
+    let mut retries2 = 0i32;
+    loop {
+        let (ok, xerror, xerror_scaled) =
+            omc_newton(n, x, &mut fvec, res_scaling, every_jac, eval, jaceval, has_jac);
+        if ok && (xerror <= local_tol || xerror_scaled <= local_tol) {
+            return true;
+        }
+        stat_inc(STAT_NLS_RETRY);
+        if retries < 1 {
+            x.copy_from_slice(warm);
+            every_jac = true;
+            retries += 1;
+        } else if retries < 2 {
+            for i in 0..n {
+                x[i] += nominal[i] * 0.01;
+            }
+            retries += 1;
+        } else if retries < 3 {
+            x.copy_from_slice(nominal);
+            retries += 1;
+        } else if retries < 4 && discrete_call {
+            // C also holds the relations at their `pre` values here — as
+            // `rt_solve_nls` does throughout.
+            x.copy_from_slice(warm);
+            retries += 1;
+        } else if retries2 < 4 {
+            x.copy_from_slice(warm);
+            local_tol *= 10.0;
+            retries = 0;
+            retries2 += 1;
+        } else {
+            return false;
+        }
+    }
+}
+
 /// KINSOL function-norm / scaled-step stopping tolerances (C's `newtonFTol` /
 /// `newtonXTol`, `model_help.c`) and the norm below which C accepts a less
 /// accurate solution rather than failing (`FTOL_WITH_LESS_ACCURACY`).
@@ -1379,6 +1706,7 @@ fn kinsol_sparse_solve(
     val_ptr: u32,
     pat_addr: u32,
     nnz: usize,
+    jac_csc: bool,
     handle: u32,
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
@@ -1389,13 +1717,14 @@ fn kinsol_sparse_solve(
         let colptr = unsafe { core::slice::from_raw_parts(pat_addr as *const i32, n + 1) };
         let rowidx =
             unsafe { core::slice::from_raw_parts((pat_addr + ((n + 1) * 4) as u32) as *const i32, nnz) };
-        let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
+        let gather = (!jac_csc).then(|| read_pattern(pat_addr, n, nnz));
+        let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr, gather);
         return crate::sundials::kinsol_solve(
             handle, n, nnz, colptr, rowidx, nominal, guess, x, eval, &mut assemble,
         );
     }
     newton_sparse_solve(
-        n, x, guess, warm, nominal, sim_data, x_ptr, jac_idx, val_ptr, pat_addr, nnz, handle, eval,
+        n, x, guess, warm, nominal, sim_data, x_ptr, jac_idx, val_ptr, pat_addr, nnz, jac_csc, handle, eval,
     )
 }
 
@@ -1416,6 +1745,7 @@ fn newton_sparse_solve(
     val_ptr: u32,
     pat_addr: u32,
     nnz: usize,
+    jac_csc: bool,
     handle: u32,
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
@@ -1428,7 +1758,8 @@ fn newton_sparse_solve(
     let b_ptr = rt_alloc((n * 8) as u32);
 
     let mut vals = vec![0.0f64; nnz];
-    let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr);
+    let gather = (!jac_csc).then(|| read_pattern(pat_addr, n, nnz));
+    let mut assemble = make_assemble(n, x_ptr, sim_data, jac_idx, val_ptr, gather);
 
     let mut f = vec![0.0f64; n];
     let mut xscale = vec![1.0f64; n];
@@ -1568,6 +1899,7 @@ pub extern "C" fn rt_solve_nls(
     mixed: u32,
     pat_addr: u32,
     nnz: u32,
+    sparse_default: u32,
     lss_handle: u32,
 ) -> i32 {
     let n = n as usize;
@@ -1626,23 +1958,25 @@ pub extern "C" fn rt_solve_nls(
     // `n×n` matrix, or the `nnz` CSC values when the system is solved sparsely.
     // `u32::MAX` means none, so numeric `hybrd` is used.
     let has_jac = jac_idx != u32::MAX;
-    let sparse = has_jac && nnz != 0;
-    let jac_len = if sparse { nnz as usize } else { n * n };
+    // `sparse_default` also says which buffer `jac` fills: CSC values where the codegen
+    // chose to solve sparsely, a dense column-major `n×n` for the rest.
+    let jac_csc = has_jac && sparse_default != 0;
+    let jac_len = if jac_csc { nnz as usize } else { n * n };
     let jac_ptr = if has_jac { rt_alloc((jac_len * 8) as u32) } else { 0 };
-    // `-nls=` overrides the codegen-time density choice; the dense solvers force
-    // the dense path.
+    // `-nls=` overrides the codegen-time choice (C's per-system `nlsMethod`): `kinsol`
+    // takes every patterned system, the dense solvers force dense, unset keeps it.
     let pick = crate::solvers::nls();
-    let sparse = match pick {
-        Nls::Default | Nls::Kinsol => sparse,
-        _ => false,
-    };
+    let sparse = has_jac
+        && nnz != 0
+        && match pick {
+            Nls::Default => sparse_default != 0,
+            Nls::Kinsol => true,
+            _ => false,
+        };
     // A dense solver over a CSC-emitting `jac`: C's `evalJacobian` with `isDense`.
-    let scatter = !sparse && nnz != 0 && jac_len == nnz as usize;
-    let pat: alloc::vec::Vec<u32> = if scatter {
-        (0..n + 1 + nnz as usize).map(|k| unsafe { load_u32(pat_addr + (k * 4) as u32) }).collect()
-    } else {
-        alloc::vec::Vec::new()
-    };
+    let scatter = !sparse && jac_csc;
+    let pat: alloc::vec::Vec<u32> =
+        if scatter { read_pattern(pat_addr, n, nnz as usize) } else { alloc::vec::Vec::new() };
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
         stat_inc(STAT_NLS_JAC);
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
@@ -1719,18 +2053,13 @@ pub extern "C" fn rt_solve_nls(
     let converged = if sparse {
         kinsol_sparse_solve(
             n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
-            pat_addr, nnz as usize, lss_handle, &mut eval,
+            pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
         )
     } else if pick == Nls::Newton {
-        let (mut ok, s) =
-            newton_c(n, &mut x, &nominal, None, &mut res_scaling, &mut eval, &mut jaceval, has_jac);
-        settled = s;
-        if !ok {
-            settled = false;
-            x.copy_from_slice(&warm);
-            ok = newton_solve(n, &mut x, &mut eval);
-        }
-        ok
+        solve_newton_c(
+            n, &mut x, &warm, &nominal, &mut res_scaling, discrete_call, &mut eval, &mut jaceval,
+            has_jac,
+        )
     } else if pick == Nls::Homotopy {
         // Both start directions, as C's runHomotopy.
         let mut ok = false;
@@ -1860,7 +2189,7 @@ pub extern "C" fn rt_solve_nls(
                 let ok = if sparse {
                     kinsol_sparse_solve(
                         n, &mut x, &warm, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
-                        pat_addr, nnz as usize, lss_handle, &mut eval,
+                        pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
                     )
                 } else if has_jac {
                     hybrj_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval, &mut jaceval)
@@ -2099,6 +2428,32 @@ mod tests {
     }
 
     // Singular Jacobian → reported as failure, not a panic.
+    // Brown's almost-linear function (`nlsTestPackage.problem7`): reaching a root at
+    // all exercises the frozen-Jacobian first attempt, the damping and the retry.
+    // *Which* root is `problem7_newton`'s job to pin — it follows from the torn system.
+    #[test]
+    fn solve_newton_solves_browns_almost_linear() {
+        let n = 10;
+        let mut eval = |x: &[f64], r: &mut [f64]| {
+            let sum: f64 = x.iter().sum();
+            for i in 0..n - 1 {
+                r[i] = x[i] + sum - (n as f64 + 1.0);
+            }
+            r[n - 1] = x.iter().product::<f64>() - 1.0;
+        };
+        let mut jaceval = |_: &[f64], _: &mut [f64]| unreachable!();
+        let mut x = vec![1.5f64; n];
+        let warm = x.clone();
+        let nominal = vec![1.0f64; n];
+        let mut res_scaling = vec![0.0f64; n];
+        assert!(solve_newton_c(
+            n, &mut x, &warm, &nominal, &mut res_scaling, false, &mut eval, &mut jaceval, false,
+        ));
+        let mut r = vec![0.0f64; n];
+        eval(&x, &mut r);
+        assert!(minpack::enorm(&r) < 1e-6, "{:?}", r);
+    }
+
     #[test]
     fn newton_reports_singular() {
         let mut x = [0.0, 0.0];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -325,6 +325,8 @@ pub(crate) mod kinsol {
         rowidx: &'a [i32],
         eval: &'a mut dyn FnMut(&[f64], &mut [f64]),
         assemble: &'a mut dyn FnMut(&[f64], &mut [f64]),
+        /// Difference the Jacobian rather than assemble it analytically.
+        numeric: bool,
     }
 
     /// Extract the backing array pointer from an N_Vector.
@@ -346,11 +348,38 @@ pub(crate) mod kinsol {
         crate::nls::assert_hit() as c_int
     }
 
-    extern "C" fn jacobian(u: NVector, _fu: NVector, j: SunMatrix, user: *mut c_void, _t1: NVector, _t2: NVector) -> c_int {
+    /// C's `nlsSparseJac`: forward differences into the pattern's CSC values. C
+    /// perturbs a whole colour group per evaluation; column at a time gives the same
+    /// entries (no row sees two columns of a group) for more evaluations, and only on
+    /// the systems whose analytic Jacobian KINSOL has already rejected.
+    fn numeric_csc(ud: &mut Ud, x: &mut [f64], fx: &[f64], vals: &mut [f64]) {
+        /// `sqrt(DBL_EPSILON * 2e1)`, C's difference step.
+        const DELTA_H: f64 = 6.664001874625056e-08;
+        let mut fres = vec![0.0f64; ud.n];
+        for c in 0..ud.n {
+            let saved = x[c];
+            let dh = DELTA_H * (libm::fabs(saved) + 1.0);
+            x[c] = saved + dh;
+            (ud.eval)(x, &mut fres);
+            x[c] = saved;
+            let inv = 1.0 / dh;
+            for k in ud.colptr[c] as usize..ud.colptr[c + 1] as usize {
+                let row = ud.rowidx[k] as usize;
+                vals[k] = (fres[row] - fx[row]) * inv;
+            }
+        }
+    }
+
+    extern "C" fn jacobian(u: NVector, fu: NVector, j: SunMatrix, user: *mut c_void, _t1: NVector, _t2: NVector) -> c_int {
         let ud = unsafe { &mut *(user as *mut Ud) };
         let x = data(u, ud.n);
         let vals = unsafe { core::slice::from_raw_parts_mut(SUNSparseMatrix_Data(j), ud.nnz) };
-        (ud.assemble)(x, vals);
+        if ud.numeric {
+            let fx = data(fu, ud.n);
+            numeric_csc(ud, x, fx, vals);
+        } else {
+            (ud.assemble)(x, vals);
+        }
         unsafe {
             core::ptr::copy_nonoverlapping(ud.colptr.as_ptr(), SUNSparseMatrix_IndexPointers(j), ud.n + 1);
             core::ptr::copy_nonoverlapping(ud.rowidx.as_ptr(), SUNSparseMatrix_IndexValues(j), ud.nnz);
@@ -376,6 +405,8 @@ pub(crate) mod kinsol {
         nnz: usize,
         strategy: c_int,
         maxstepfactor: f64,
+        /// Set for good once `KIN_LSETUP_FAIL` rejects the analytic Jacobian.
+        numeric_jac: bool,
     }
 
     impl Solver {
@@ -392,6 +423,7 @@ pub(crate) mod kinsol {
                 nnz,
                 strategy: KIN_LINESEARCH,
                 maxstepfactor: MAXSTEPFACTOR,
+                numeric_jac: false,
             };
             if s.kin.is_null()
                 || s.j.is_null()
@@ -480,9 +512,10 @@ pub(crate) mod kinsol {
                     unsafe { SUNLinSol_KLUReInit(self.ls, self.j, self.nnz as i32, SUNKLU_REINIT_PARTIAL) };
                     return true;
                 }
-                // C answers `LSETUP_FAIL` by switching to a numeric Jacobian; this
-                // path only exists for systems that have the analytic one.
-                KIN_MAXITER_REACHED | KIN_REPTD_SYSFUNC_ERR | KIN_LSETUP_FAIL | KIN_LINESEARCH_BCFAIL => {}
+                // A Jacobian KLU cannot factorize (all-zero at the start point, say):
+                // difference it from here on, as C re-points `KINSetJacFn`.
+                KIN_LSETUP_FAIL => self.numeric_jac = true,
+                KIN_MAXITER_REACHED | KIN_REPTD_SYSFUNC_ERR | KIN_LINESEARCH_BCFAIL => {}
                 _ => return false,
             }
             let mut fnorm = 0.0;
@@ -522,7 +555,8 @@ pub(crate) mod kinsol {
             eval: &mut dyn FnMut(&[f64], &mut [f64]),
             assemble: &mut dyn FnMut(&[f64], &mut [f64]),
         ) -> bool {
-            let mut ud = Ud { n: self.n, nnz: self.nnz, colptr, rowidx, eval, assemble };
+            let mut ud =
+                Ud { n: self.n, nnz: self.nnz, colptr, rowidx, eval, assemble, numeric: self.numeric_jac };
             unsafe { KINSetUserData(self.kin, &mut ud as *mut Ud as *mut c_void) };
             let mut vals = vec![0.0f64; self.nnz];
             let mut success = false;
@@ -537,6 +571,7 @@ pub(crate) mod kinsol {
                 let flag = unsafe { KINSol(self.kin, self.u, self.strategy, self.xscale, self.fscale) };
                 success = matches!(flag, KIN_SUCCESS | KIN_INITIAL_GUESS_OK | KIN_STEP_LT_STPTOL);
                 let retry = flag < 0 && self.handle_error(flag, &mut retries, &mut reset_tol);
+                ud.numeric = self.numeric_jac;
                 retries += 1;
                 passes += 1;
                 if success || !retry || retries >= RETRY_MAX || passes >= 2 * RETRY_MAX {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -875,6 +875,13 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool, level: 
 }
 
 fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
+    // C's `assertCommonVar` (the math-domain guards, no source position): the warning
+    // names the time, a debug line carries the message.
+    if info.file.is_empty() {
+        log_line(&assert_block(info, cond, time, initial, "warning"));
+        log_line(&alloc::format!("{}{}\n", log_prefix("LOG_ASSERT", "debug"), info.msg));
+        return;
+    }
     log_line(&assert_block(info, cond, time, initial, "error"));
 }
 


### PR DESCRIPTION
Five nonlinear_system tests failed under wasm-jit for five unrelated reasons.

nonlinearFailed is entirely about C's daeExpCall domain assertion: 1.1 = sin(x) is solved as x = asin(1.1) + 2*pi*k, and C traps on the asin argument. Port the guards for asin/acos/log/log10/sqrt, skipping sqrt where Expression.isPositiveOrZero, as C does.

$_round was unsupported, so any model whose equation the backend inverted through a trigonometric function failed to build. Lower it inline; round is half-away-from-zero, which wasm's nearest is not.

A failed assert() went to the compiler Error buffer plus a LOG_ERROR line, where C prints a LOG_ASSERT block into the simulation log and ends with "simulation terminated by an assertion at initialization". enrich_trap now formats that block and runSimulation folds it into the log; the reporter hook is gone. C has two shapes, so rt_assert gained the dumped condition (0 = none) that rt_assert_warning already had: assertCommon is one LOG_ASSERT error carrying the source position and ((cond)) --> "msg", assertCommonVar (the math domains, which pass omc_dummyFileInfo) a warning naming the time plus a debug with the message.

-nls=newton ran newton_c, the damped Newton inside solveHomotopy, not C's solveNewton over _omc_newton, whose first attempt holds one factorization for the whole iteration and whose ladder varies the start point before refreshing the Jacobian. The two reach different roots of Brown's almost-linear function, which is what problem7_newton pins. Ported with C's dgetf2/dgetrs, damping_heuristic2, and residual scaling off the LU factors.

-nls=kinsol only reached KINSOL where the density rule had also chosen the system as sparse, because that rule filtered the sparsity pattern away entirely. Emit the pattern whenever there is one and let NlsJob.sparse_default carry the density rule, gathering the CSC values out of the dense Jacobian buffer where the callback fills one. Plus C's KIN_LSETUP_FAIL answer, switching that system to a differenced Jacobian for good: nonlinearMixed cannot start without it, its analytic Jacobian being all-zero at x=y=z=0.

Running TESTFILES of nonlinear_system, asserts, built_in_functions and equations against an omc built from the parent commit flips 9 tests to ok - the five above plus AssertTest, AssertTest1, AssertTest2 and testAssertSolve - and none the other way. fullRobot and TestFlow1D2phChen still pass with timeSimulation inside the run-to-run spread (1.88-2.19s vs 1.83-1.96s, 30.4-30.7s vs 31.3-35.2s).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
