### PR TITLE
[NB] fix partial-slice NLS/LS Jacobian for for-equation iteration variables

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -2014,6 +2014,7 @@ algorithm
 
       list<DAE.ComponentRef> conditions;
       Boolean initialCall;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 
     case ({},_) then ({});
 
@@ -2049,11 +2050,11 @@ algorithm
         xs := removeDiscreteAssignments(rest,vars);
       then DAE.STMT_IF(e,stmts,algElse,source)::xs;
 
-    case (((DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source))::rest),vars)
+    case (((DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source, sub_iters=sub_iters))::rest),vars)
       algorithm
         stmts := removeDiscreteAssignments(stmts,vars);
         xs := removeDiscreteAssignments(rest,vars);
-      then DAE.STMT_FOR(tp,b1,id1,e,stmts,source)::xs;
+      then DAE.STMT_FOR(tp,b1,id1,e,stmts,source,sub_iters)::xs;
 
     case (((DAE.STMT_WHILE(exp=e,statementLst=stmts, source = source))::rest),vars)
       algorithm

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -1765,6 +1765,7 @@ protected
   Boolean initialCall;
   Boolean b1,b2,b3;
   list<tuple<DAE.ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
+  list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 algorithm
   for stmt in inStatementLst loop
     (outStatementLst, replacementPerformed) := matchcontinue stmt
@@ -1815,7 +1816,7 @@ algorithm
         then
           replaceSTMT_IF(e1_2,statementLst,else_,source,repl,inFuncTypeExpExpToBooleanOption,outStatementLst,replacementPerformed or b1);
 
-      case DAE.STMT_FOR(type_=type_,iterIsArray=iterIsArray,iter=ident,range=e1,statementLst=statementLst,source=source)
+      case DAE.STMT_FOR(type_=type_,iterIsArray=iterIsArray,iter=ident,range=e1,statementLst=statementLst,source=source,sub_iters=sub_iters)
         algorithm
           repl := addIterationVar(repl,ident);
           (statementLst_1,b1) := replaceStatementLst(statementLst, repl,inFuncTypeExpExpToBooleanOption,{},false);
@@ -1826,7 +1827,7 @@ algorithm
           source := ElementSource.addSymbolicTransformationSimplify(b1,source,DAE.PARTIAL_EQUATION(e1_1),DAE.PARTIAL_EQUATION(e1_2));
           repl := removeIterationVar(repl,ident);
         then
-          (DAE.STMT_FOR(type_,iterIsArray,ident,e1_2,statementLst_1,source) :: outStatementLst, true);
+          (DAE.STMT_FOR(type_,iterIsArray,ident,e1_2,statementLst_1,source,sub_iters) :: outStatementLst, true);
 
       case DAE.STMT_PARFOR(type_=type_,iterIsArray=iterIsArray,iter=ident,range=e1,statementLst=statementLst,loopPrlVars=loopPrlVars,source=source)
         algorithm

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -802,6 +802,7 @@ algorithm
       list<DAE.Statement> statementLst, restStatements, derivedStatements1, derivedStatements2, else_statementLst, elseif_statementLst;
       String s1,s2;
       list<Option<DAE.Statement>> optDerivedStatements1;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 
     case {} then (listReverse(inStmtsAccum), inFunctionTree);
 
@@ -854,14 +855,14 @@ algorithm
         (derivedStatements2, functions) := differentiateStatements(restStatements, inDiffwrtCref, inInputData, inDiffType, derivedStatements2, functions, maxIter);
       then (derivedStatements2, functions);
 
-    case DAE.STMT_FOR(type_=type_, iterIsArray=iterIsArray, iter=ident, range=exp, statementLst=statementLst, source=source)::restStatements
+    case DAE.STMT_FOR(type_=type_, iterIsArray=iterIsArray, iter=ident, range=exp, statementLst=statementLst, source=source, sub_iters=sub_iters)::restStatements
       algorithm
         cref := ComponentReferenceBasics.makeCrefIdent(ident, DAE.T_INTEGER_DEFAULT, {});
         controlVar := BackendDAE.VAR(cref, BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false, false, false);
         inputData := addGlobalVars({controlVar}, inInputData);
         (derivedStatements1, functions) := differentiateStatements(statementLst, inDiffwrtCref, inputData, inDiffType, {}, inFunctionTree, maxIter);
 
-        derivedStatements1 := {DAE.STMT_FOR(type_, iterIsArray, ident, exp, derivedStatements1, source)};
+        derivedStatements1 := {DAE.STMT_FOR(type_, iterIsArray, ident, exp, derivedStatements1, source, sub_iters)};
 
         derivedStatements2 := listAppend(derivedStatements1, inStmtsAccum);
         (derivedStatements2, functions) := differentiateStatements(restStatements, inDiffwrtCref, inInputData, inDiffType, derivedStatements2, functions, maxIter);

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -1752,6 +1752,7 @@ protected
   list<tuple<DAE.ComponentRef, SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
   list<DAE.ComponentRef> conditions;
   Boolean initialCall;
+  list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 algorithm
   for stmt in inStmts loop
     (stmt, extraArg) := match stmt
@@ -1784,12 +1785,12 @@ algorithm
         (e_1, extraArg) := Expression.traverseExpTopDown(e, collectZCAlgsFor, extraArg);
       then (DAE.STMT_IF(e_1, stmts2, algElse, source), extraArg);
 
-      case DAE.STMT_FOR(type_=tp, iterIsArray=b1, iter=id1, range=e, statementLst=stmts, source=source) algorithm
+      case DAE.STMT_FOR(type_=tp, iterIsArray=b1, iter=id1, range=e, statementLst=stmts, source=source, sub_iters=sub_iters) algorithm
         cr := ComponentReferenceBasics.makeCrefIdent(id1, tp, {});
         iteratorExp := Expression.crefExp(cr);
         iteratorexps := BackendDAEUtil.extendRange(e, inKnvars);
         (stmts2, extraArg) := traverseStmtsForExps(iteratorExp, iteratorexps, e, stmts, inKnvars, extraArg);
-      then (DAE.STMT_FOR(tp, b1, id1, e, stmts2, source), extraArg);
+      then (DAE.STMT_FOR(tp, b1, id1, e, stmts2, source, sub_iters), extraArg);
 
       case DAE.STMT_PARFOR(type_=tp, iterIsArray=b1, iter=id1, range=e, statementLst=stmts, loopPrlVars= loopPrlVars, source=source) algorithm
         cr := ComponentReferenceBasics.makeCrefIdent(id1, tp, {});

--- a/OMCompiler/Compiler/FrontEnd/Algorithm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Algorithm.mo
@@ -683,17 +683,17 @@ algorithm
     case (i, e, DAE.PROP(type_ = DAE.T_ARRAY(ty = t, dims = dims)), stmts)
       algorithm
         isArray := Types.isNonscalarArray(t, dims);
-      then DAE.STMT_FOR(t, isArray, i, e, stmts, source);
+      then DAE.STMT_FOR(t, isArray, i, e, stmts, source, {});
 
     case (i, e, DAE.PROP(type_ = DAE.T_METALIST(ty = t)), stmts)
       algorithm
         t := Types.simplifyType(t);
-      then DAE.STMT_FOR(t, false, i, e, stmts, source);
+      then DAE.STMT_FOR(t, false, i, e, stmts, source, {});
 
     case (i, e, DAE.PROP(type_ = DAE.T_METAARRAY(ty = t)), stmts)
       algorithm
         t := Types.simplifyType(t);
-      then DAE.STMT_FOR(t, false, i, e, stmts, source);
+      then DAE.STMT_FOR(t, false, i, e, stmts, source, {});
 
     case (_, e, DAE.PROP(type_ = t), _)
       algorithm

--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -702,6 +702,7 @@ uniontype Statement "There are four kinds of statements:
     Exp range "range for the loop";
     list<Statement> statementLst;
     ElementSource source "the origin of the component/equation/algorithm" ;
+    list<tuple<ComponentRef, array<Exp>>> sub_iters "sub-iterators for ARRAY iterator case (NBackEnd only)";
   end STMT_FOR;
 
   record STMT_PARFOR

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -4130,6 +4130,7 @@ algorithm
       list<tuple<DAE.ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
       list<DAE.ComponentRef> conditions;
       Boolean initialCall,b;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 
     case (DAE.STMT_ASSIGN(type_ = tp,exp1 = e,exp = e2, source = source), extraArg)
       algorithm
@@ -4164,11 +4165,11 @@ algorithm
         stmts1 := if not b and referenceEq(e,e_1) and referenceEq(stmts,stmts2) and referenceEq(algElse,algElse1) then (inStmt::{}) else stmts1;
       then (stmts1,extraArg);
 
-    case (DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source), extraArg)
+    case (DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source, sub_iters=sub_iters), extraArg)
       algorithm
         (stmts2, extraArg) := traverseDAEEquationsStmtsList(stmts,func,opt,extraArg);
         (e_1, extraArg) := func(e, extraArg);
-        x := if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source);
+        x := if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source,sub_iters);
       then (x::{},extraArg);
 
     case (DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source), extraArg)
@@ -4323,6 +4324,7 @@ protected
   list<tuple<DAE.ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
   list<DAE.ComponentRef> conditions;
   Boolean initialCall;
+  list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 algorithm
   for stmt in inStmts loop
     outStmts := matchcontinue stmt
@@ -4361,12 +4363,12 @@ algorithm
         then
           List.append_reverse(stmts1, outStmts);
 
-      case DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source)
+      case DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source, sub_iters=sub_iters)
         algorithm
           (stmts2, extraArg) := traverseDAEStmts(stmts,func,extraArg);
           (e_1, extraArg) := func(e, stmt, extraArg);
         then
-          if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then stmt :: outStmts else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source)::outStmts;
+          if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then stmt :: outStmts else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source,sub_iters)::outStmts;
 
       case DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source)
         algorithm

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -491,6 +491,7 @@ algorithm
       DAE.ElementSource source;
       list<DAE.ComponentRef> conditions;
       Boolean initialCall;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
     case (DAE.STMT_ASSIGN(t,e1,e2,source),fns)
       algorithm
         (e1_1,source,b1,_) := inlineExp(e1,fns,source);
@@ -520,13 +521,13 @@ algorithm
         true := b1 or b2 or b3;
       then
         (DAE.STMT_IF(e_1,stmts_1,a_else_1,source),true);
-    case(DAE.STMT_FOR(t,b,i,e,stmts,source),fns)
+    case(DAE.STMT_FOR(t,b,i,e,stmts,source,sub_iters),fns)
       algorithm
         (e_1,source,b1,_) := inlineExp(e,fns,source);
         (stmts_1,b2) := inlineStatements(stmts,fns,{},false);
         true := b1 or b2;
       then
-        (DAE.STMT_FOR(t,b,i,e_1,stmts_1,source),true);
+        (DAE.STMT_FOR(t,b,i,e_1,stmts_1,source,sub_iters),true);
     case(DAE.STMT_WHILE(e,stmts,source),fns)
       algorithm
         (e_1,source,b1,_) := inlineExp(e,fns,source);

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -2945,6 +2945,7 @@ algorithm
       Boolean b;
       String id;
       DAE.ElementSource source;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 
     case DAE.STMT_ASSIGN(type_=ty,exp1=lhs,exp=exp,source=source as DAE.SOURCE(info=info))
       algorithm
@@ -2975,7 +2976,7 @@ algorithm
         useTree := AvlSetString.join(useTree,elseTree);
       then (DAE.STMT_IF(exp,body,else_,source),useTree);
 
-    case DAE.STMT_FOR(ty,b,id,exp,body,source)
+    case DAE.STMT_FOR(ty,b,id,exp,body,source,sub_iters)
       algorithm
         // Loops repeat, so check for usage in the whole loop before removing any dead stores.
         ErrorExt.setCheckpoint(getInstanceName());
@@ -2985,7 +2986,7 @@ algorithm
         (_,useTree) := Expression.traverseExpBottomUp(exp, useLocalCref, useTree);
         // TODO: We should remove ident from the use-tree in case of shadowing... But our avlTree cannot delete
         useTree := AvlSetString.join(useTree,inUseTree);
-      then (DAE.STMT_FOR(ty,b,id,exp,body,source),useTree);
+      then (DAE.STMT_FOR(ty,b,id,exp,body,source,sub_iters),useTree);
 
     case DAE.STMT_WHILE(exp=exp,statementLst=body,source=source)
       algorithm

--- a/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
@@ -1104,6 +1104,7 @@ algorithm
       list<DAE.Exp> eLst;
       Boolean bool;
       DAE.Else elseBranch;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
       case DAE.STMT_ASSIGN(t,e1,e,source)
         algorithm
           (outCache,e1) := prefixExpWork(outCache,env,inIH,e1,p);
@@ -1128,11 +1129,11 @@ algorithm
           outStmts := elem::outStmts;
         then ();
 
-      case DAE.STMT_FOR(t,bool,id,e,sList,source)
+      case DAE.STMT_FOR(t,bool,id,e,sList,source,sub_iters)
         algorithm
           (outCache,e) := prefixExpWork(outCache,env,inIH,e,p);
           (outCache,sList) := prefixStatements(outCache,env,inIH,sList,p);
-          elem := DAE.STMT_FOR(t,bool,id,e,sList,source);
+          elem := DAE.STMT_FOR(t,bool,id,e,sList,source,sub_iters);
           outStmts := elem::outStmts;
         then ();
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -699,6 +699,7 @@ public
           Call call;
           list<Frame> frames = {};
           Iterator tmp;
+          Iterator tmp_inner;
           list<Dimension> full_dims;
 
         case Expression.CALL(call = call as Call.TYPED_ARRAY_CONSTRUCTOR()) algorithm
@@ -714,6 +715,17 @@ public
           else
             iter := tmp;
           end if;
+
+          // createFrame creates a new "$i" iterator but leaves the body referencing the old "i"
+          // cref. add replacement rules here so applySimpleExp in extract() can update the body.
+          for frame in frames loop
+            _ := match Util.tuple33(frame)
+              case SOME(tmp_inner as SINGLE()) algorithm
+                UnorderedMap.add(tmp_inner.name, Expression.applySubscripts({Subscript.INDEX(Expression.fromCref(Util.tuple31(frame)))}, tmp_inner.range), replacements);
+              then ();
+              else ();
+            end match;
+          end for;
 
           // add the dimension -> iterator names to the dims map to apply the iterators correctly to the lhs
           full_dims := Type.arrayDims(Expression.typeOf(exp));
@@ -2971,8 +2983,12 @@ public
         local
           list<ComponentRef> iter_lst;
           list<Expression> range_lst;
-          ComponentRef iter, lhs_rec, rhs_rec;
+          list<Option<Iterator>> maps_lst;
+          Option<Iterator> map_opt;
+          list<tuple<ComponentRef, array<Expression>>> sub_iters_stmt;
+          ComponentRef iter, lhs_rec, rhs_rec, iter_name;
           Expression range, lhs_exp, rhs_exp;
+          array<Expression> iter_elems;
           list<Statement> body;
           Pointer<Variable> lhs, rhs;
           list<Pointer<Variable>> lhs_lst, rhs_lst;
@@ -3005,16 +3021,23 @@ public
         then {Statement.ASSIGNMENT(eqn.lhs, eqn.rhs, eqn.ty, eqn.source)};
 
         case FOR_EQUATION() algorithm
-          (iter_lst, range_lst) := Equation.Iterator.getFrames(eqn.iter);
+          (iter_lst, range_lst, maps_lst) := Equation.Iterator.getFrames(eqn.iter);
           body := List.flatten(list(toStatement(body_eqn) for body_eqn in eqn.body));
-          for tpl in listReverse(List.zip(iter_lst, range_lst)) loop
-            (iter, range) := tpl;
+          for tpl in listReverse(List.zip3(iter_lst, range_lst, maps_lst)) loop
+            (iter, range, map_opt) := tpl;
+            sub_iters_stmt := match map_opt
+              case SOME(Iterator.SINGLE(name = iter_name, range = Expression.ARRAY(elements = iter_elems), map = NONE()))
+                then {(iter_name, iter_elems)};
+              case SOME(_) then {};
+              else {};
+            end match;
             body := {Statement.FOR(
               iterator  = ComponentRef.node(iter),
               range     = SOME(range),
               body      = body,
               forType   = Statement.ForType.NORMAL(),
-              source    = eqn.source)};
+              source    = eqn.source,
+              sub_iters = sub_iters_stmt)};
           end for;
         then body;
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -699,7 +699,6 @@ public
           Call call;
           list<Frame> frames = {};
           Iterator tmp;
-          Iterator tmp_inner;
           list<Dimension> full_dims;
 
         case Expression.CALL(call = call as Call.TYPED_ARRAY_CONSTRUCTOR()) algorithm
@@ -715,17 +714,6 @@ public
           else
             iter := tmp;
           end if;
-
-          // createFrame creates a new "$i" iterator but leaves the body referencing the old "i"
-          // cref. add replacement rules here so applySimpleExp in extract() can update the body.
-          for frame in frames loop
-            _ := match Util.tuple33(frame)
-              case SOME(tmp_inner as SINGLE()) algorithm
-                UnorderedMap.add(tmp_inner.name, Expression.applySubscripts({Subscript.INDEX(Expression.fromCref(Util.tuple31(frame)))}, tmp_inner.range), replacements);
-              then ();
-              else ();
-            end match;
-          end for;
 
           // add the dimension -> iterator names to the dims map to apply the iterators correctly to the lhs
           full_dims := Type.arrayDims(Expression.typeOf(exp));

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1487,8 +1487,13 @@ function isJacobianResultVar
         // base-ptr cache so each outer element gets its own scalar seed var instead
         // of all elements sharing the first element's seed via the array ptr cache.
         // For non-subscripted crefs, use the cache normally (check first, create if absent).
-        ovar := getVarSeed(old_var_ptr);
-        () := match if ComponentRef.hasSubscripts(original_cref) then NONE() else ovar
+        if ComponentRef.hasSubscripts(original_cref) then
+          ovar := NONE();
+        else
+          ovar := getVarSeed(old_var_ptr);
+        end if;
+
+        () := match ovar
           case SOME(var_ptr) algorithm
             // Cache hit (non-subscripted case only): reuse existing seed
             cref := getVarName(var_ptr);

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1482,37 +1482,40 @@ function isJacobianResultVar
         original_cref := cref;
         // get the variable pointer from the old cref to later on link back to it
         old_var_ptr := getVarPointer(cref, sourceInfo());
-        // Skip base-ptr cache for subscripted element crefs (partial-slice NLS iter vars)
-        // so that each outer element gets its own scalar seed var instead of all elements
-        // sharing the first element's seed via the array ptr cache.
-        if not ComponentRef.hasSubscripts(original_cref) then
-          var_ptr := Util.getOption(getVarSeed(old_var_ptr));
-          cref := getVarName(var_ptr);
-        else
-          // prepend the seed str and the matrix name and create the new cref
-          qual.name := SEED_STR + "_" + name;
-          cref := ComponentRef.append(cref, ComponentRef.fromNode(qual, ComponentRef.scalarType(cref)));
-          var := fromCref(cref, NFAttributes.IMPL_DISCRETE_ATTR);
+        // For subscripted element crefs (partial-slice NLS iter vars), skip the
+        // base-ptr cache so each outer element gets its own scalar seed var instead
+        // of all elements sharing the first element's seed via the array ptr cache.
+        // For non-subscripted crefs, use the cache normally (check first, create if absent).
+        () := match if ComponentRef.hasSubscripts(original_cref) then NONE() else getVarSeed(old_var_ptr)
+          case SOME(var_ptr) algorithm
+            // Cache hit (non-subscripted case only): reuse existing seed
+            cref := getVarName(var_ptr);
+          then ();
+          else algorithm
+            // Cache miss OR subscripted element: create a new seed variable
+            qual.name := SEED_STR + "_" + name;
+            cref := ComponentRef.append(cref, ComponentRef.fromNode(qual, ComponentRef.scalarType(cref)));
+            var := fromCref(cref, NFAttributes.IMPL_DISCRETE_ATTR);
 
-          // update the variable to be a seed and pass the pointer to the original variable
-          // if it is a record, clear the children instead
-          varKind := match getVarKind(old_var_ptr)
-            case varKind as VariableKind.RECORD() algorithm
-              varKind.children := {};
-            then varKind;
-            else VariableKind.SEED_VAR();
-          end match;
-          var.backendinfo := BackendInfo.setVarKind(var.backendinfo, varKind);
+            // update the variable to be a seed and pass the pointer to the original variable
+            // if it is a record, clear the children instead
+            varKind := match getVarKind(old_var_ptr)
+              case varKind as VariableKind.RECORD() algorithm
+                varKind.children := {};
+              then varKind;
+              else VariableKind.SEED_VAR();
+            end match;
+            var.backendinfo := BackendInfo.setVarKind(var.backendinfo, varKind);
 
-          // create the new variable pointer and safe it to the component reference
-          (var_ptr, cref) := makeVarPtrCyclic(var, cref);
-          // For subscripted element crefs (partial-slice NLS iter vars), skip linking back to
-          // the base array ptr so the shared cache is not populated, allowing each element to
-          // create its own independent seed on subsequent calls.
-          if not ComponentRef.hasSubscripts(original_cref) then
-            connectPartners(old_var_ptr, var_ptr, BackendInfo.setVarSeed);
-          end if;
-        end if;
+            // create the new variable pointer and save it to the component reference
+            (var_ptr, cref) := makeVarPtrCyclic(var, cref);
+            // For non-subscripted crefs, connect partners to populate the cache.
+            // For subscripted element crefs, skip so the cache stays clean for other elements.
+            if not ComponentRef.hasSubscripts(original_cref) then
+              connectPartners(old_var_ptr, var_ptr, BackendInfo.setVarSeed);
+            end if;
+          then ();
+        end match;
       then ();
 
       else algorithm

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1474,6 +1474,7 @@ function isJacobianResultVar
       local
         InstNode qual;
         Pointer<Variable> old_var_ptr;
+        Option<Pointer<Variable>> ovar;
         Variable var;
         VariableKind varKind;
         ComponentRef original_cref;
@@ -1486,7 +1487,8 @@ function isJacobianResultVar
         // base-ptr cache so each outer element gets its own scalar seed var instead
         // of all elements sharing the first element's seed via the array ptr cache.
         // For non-subscripted crefs, use the cache normally (check first, create if absent).
-        () := match if ComponentRef.hasSubscripts(original_cref) then NONE() else getVarSeed(old_var_ptr)
+        ovar := getVarSeed(old_var_ptr);
+        () := match if ComponentRef.hasSubscripts(original_cref) then NONE() else ovar
           case SOME(var_ptr) algorithm
             // Cache hit (non-subscripted case only): reuse existing seed
             cref := getVarName(var_ptr);

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1477,11 +1477,16 @@ function isJacobianResultVar
         Option<Pointer<Variable>> ovar;
         Variable var;
         VariableKind varKind;
+        ComponentRef original_cref;
 
       case qual as InstNode.VAR_NODE() algorithm
+        original_cref := cref;
         // get the variable pointer from the old cref to later on link back to it
         old_var_ptr := getVarPointer(cref, sourceInfo());
-        ovar := getVarSeed(old_var_ptr);
+        // Skip base-ptr cache for subscripted element crefs (partial-slice NLS iter vars)
+        // so that each outer element gets its own scalar seed var instead of all elements
+        // sharing the first element's seed via the array ptr cache.
+        ovar := if ComponentRef.hasSubscripts(original_cref) then NONE() else getVarSeed(old_var_ptr);
         if isSome(ovar) then
           var_ptr := Util.getOption(ovar);
           cref := getVarName(var_ptr);
@@ -1503,7 +1508,12 @@ function isJacobianResultVar
 
           // create the new variable pointer and safe it to the component reference
           (var_ptr, cref) := makeVarPtrCyclic(var, cref);
-          connectPartners(old_var_ptr, var_ptr, BackendInfo.setVarSeed);
+          // For subscripted element crefs (partial-slice NLS iter vars), skip linking back to
+          // the base array ptr so the shared cache is not populated, allowing each element to
+          // create its own independent seed on subsequent calls.
+          if not ComponentRef.hasSubscripts(original_cref) then
+            connectPartners(old_var_ptr, var_ptr, BackendInfo.setVarSeed);
+          end if;
         end if;
       then ();
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1474,7 +1474,6 @@ function isJacobianResultVar
       local
         InstNode qual;
         Pointer<Variable> old_var_ptr;
-        Option<Pointer<Variable>> ovar;
         Variable var;
         VariableKind varKind;
         ComponentRef original_cref;
@@ -1486,9 +1485,8 @@ function isJacobianResultVar
         // Skip base-ptr cache for subscripted element crefs (partial-slice NLS iter vars)
         // so that each outer element gets its own scalar seed var instead of all elements
         // sharing the first element's seed via the array ptr cache.
-        ovar := if ComponentRef.hasSubscripts(original_cref) then NONE() else getVarSeed(old_var_ptr);
-        if isSome(ovar) then
-          var_ptr := Util.getOption(ovar);
+        if not ComponentRef.hasSubscripts(original_cref) then
+          var_ptr := Util.getOption(getVarSeed(old_var_ptr));
           cref := getVarName(var_ptr);
         else
           // prepend the seed str and the matrix name and create the new cref

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -87,6 +87,9 @@ protected
   // Sparsity-pattern graph coloring, shared with the old backend.
   import Coloring;
 
+  // NF scalarize (for partial-slice seed expansion)
+  import Scalarize = NFScalarize;
+
   // Util imports
   import StringUtil;
   import UnorderedMap;
@@ -513,7 +516,20 @@ protected
         residual_comps        := list(StrongComponent.fromSolvedEquationSlice(eqn) for eqn in strict.residual_eqns);
 
         // create seed and partial candidates
-        seed_candidates := list(Slice.getT(var) for var in strict.iteration_vars);
+        // Expand partial slices to scalar outer-element ptrs so that only the outer
+        // iteration variable elements become seed vars (not the inner LS elements
+        // that share the same base array but appear at different slice indices).
+        seed_candidates := {};
+        for slc in strict.iteration_vars loop
+          if Slice.isFull(slc) then
+            seed_candidates := Slice.getT(slc) :: seed_candidates;
+          else
+            for sv in Scalarize.scalarizeBackendVariable(Pointer.access(Slice.getT(slc)), slc.indices) loop
+              seed_candidates := Pointer.create(sv) :: seed_candidates;
+            end for;
+          end if;
+        end for;
+        seed_candidates := listReverse(seed_candidates);
         residual_vars   := list(Equation.getResidualVar(Slice.getT(eqn)) for eqn in strict.residual_eqns);
         inner_vars      := listAppend(list(var for var guard(BVariable.isContinuous(var, staticAsContinuous)) in StrongComponent.getVariables(comp)) for comp in strict.innerEquations);
 
@@ -543,6 +559,7 @@ protected
     Pointer<list<Pointer<Variable>>> seed_vars_ptr = Pointer.create({});
     Pointer<list<Pointer<Variable>>> pDer_vars_ptr = Pointer.create({});
     UnorderedMap<ComponentRef,ComponentRef> diff_map = UnorderedMap.new<ComponentRef>(ComponentRef.hash, ComponentRef.isEqual);
+    UnorderedMap<ComponentRef,ComponentRef> seed_diff_map;
     Differentiate.DifferentiationArguments diffArguments;
     Pointer<Integer> idx = Pointer.create(0);
 
@@ -552,6 +569,9 @@ protected
     Adjacency.Matrix fullLocal, sparsity;
     UnorderedSet<ComponentRef> seed_set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
     UnorderedSet<ComponentRef> pder_set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
+    UnorderedSet<ComponentRef> adj_base_seen;
+    list<Pointer<Variable>> adj_seed_list;
+    ComponentRef adj_base_cref;
 
     BVariable.checkVar func = getTmpFilterFunction(jacType);
   algorithm
@@ -570,6 +590,10 @@ protected
     for v in VariablePointers.toList(seedCandidates) loop
       if BVariable.isContinuous(v, staticAsContinuous) then
         UnorderedSet.add(BVariable.getVarName(v), seed_set);
+        // Also add base cref so iterator-subscripted deps from for-loop equations
+        // (where subscript is an iterator variable, not a literal integer) can
+        // match via base fallback in filterSet.
+        UnorderedSet.add(ComponentRef.stripSubscriptsAll(BVariable.getVarName(v)), seed_set);
       end if;
     end for;
 
@@ -587,6 +611,13 @@ protected
     res_vars_d := listReverse(Pointer.access(pDer_vars_ptr));
 
     pDer_vars_ptr := Pointer.create({});
+    // Snapshot diff_map before adding inner LS tmp pder entries.
+    // When an outer iter var and an inner LS var share the same base ComponentRef
+    // (slices of the same array variable), the tmp pder pass below would overwrite
+    // the outer seed entry. fullToSparsity must see the pre-overwrite version so
+    // that outer iter var dependencies resolve to outer seed columns (0..N-1), not
+    // to inner LS tmp pder columns (N..N+M-1).
+    seed_diff_map := UnorderedMap.copy(diff_map);
     for v in tmp_vars loop makeVarTraverse(v, name, pDer_vars_ptr, diff_map, function BVariable.makePDerVar(isTmp = true), staticAsContinuous = staticAsContinuous); end for;
     tmp_vars_d := Pointer.access(pDer_vars_ptr);
 
@@ -631,7 +662,21 @@ protected
     // Using part.adjacencyMatrix (the `full` param) would fail because residual
     // equations created by finalize() during tearing get new names and don't
     // appear in the partition's pre-tearing adjacency matrix.
-    adjacencyVars := VariablePointers.clone(seedCandidates);
+    // Build adjacencyVars from unique base variable ptrs derived from seedCandidates.
+    // When seedCandidates contains scalar element ptrs for partial-slice NLS iter vars,
+    // all elements of the same array share the same base ptr. Using base ptrs here
+    // preserves pseudo=true subscript-stripped lookup in getDependentCref, which matches
+    // any element expression (e.g. module[i].T for iterator i) to the base column.
+    adj_base_seen := UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
+    adj_seed_list := {};
+    for v in VariablePointers.toList(seedCandidates) loop
+      adj_base_cref := ComponentRef.stripSubscriptsAll(BVariable.getVarName(v));
+      if not UnorderedSet.contains(adj_base_cref, adj_base_seen) then
+        UnorderedSet.add(adj_base_cref, adj_base_seen);
+        adj_seed_list := BVariable.getVarPointer(BVariable.getVarName(v), sourceInfo()) :: adj_seed_list;
+      end if;
+    end for;
+    adjacencyVars := VariablePointers.fromList(listReverse(adj_seed_list));
     adjacencyVars := VariablePointers.addList(tmp_vars, adjacencyVars);
     // For ODE Jacobians, also include state derivatives as adjacency variables.
     // Some equations use der(x_j) as an RHS input (e.g. der(x_i) = f(der(x_j), x_k)).
@@ -641,7 +686,7 @@ protected
     end if;
     fullLocal := Adjacency.Matrix.createFull(adjacencyVars,
       EquationPointers.fromList(List.flatten(list(StrongComponent.getEquations(comp) for comp in comps))));
-    sparsity := Adjacency.Matrix.fullToSparsity(fullLocal, comps, seed_set, pder_set, diff_map);
+    sparsity := Adjacency.Matrix.fullToSparsity(fullLocal, comps, seed_set, pder_set, seed_diff_map);
 
     jacobian := SOME(Jacobian.JACOBIAN(
       name      = name,
@@ -1456,6 +1501,9 @@ protected
     for v in VariablePointers.toList(seedCandidates) loop
       if BVariable.isContinuous(v, staticAsContinuous) then
         UnorderedSet.add(BVariable.getVarName(v), seed_set);
+        // Also add base cref so iterator-subscripted deps from for-loop equations
+        // can match via base fallback in filterSet.
+        UnorderedSet.add(ComponentRef.stripSubscriptsAll(BVariable.getVarName(v)), seed_set);
       end if;
     end for;
 
@@ -1553,6 +1601,13 @@ protected
       Pointer.update(vars_ptr, diff_ptr :: Pointer.access(vars_ptr));
       // add x -> $<new>.x to the map for later lookup
       UnorderedMap.add(var.name, diff, map);
+      // For subscripted element crefs (partial-slice NLS iter vars), also add the
+      // base cref mapped to the first element seed (added only once so that
+      // later elements do not overwrite it). This allows iterator-subscripted
+      // deps from for-loop equations to find their seed via base fallback in Part D.
+      if ComponentRef.hasSubscripts(var.name) and not UnorderedMap.contains(ComponentRef.stripSubscriptsAll(var.name), map) then
+        UnorderedMap.add(ComponentRef.stripSubscriptsAll(var.name), diff, map);
+      end if;
 
       // differentiate parent and add to map
       () := match BVariable.getParent(var_ptr)

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -87,9 +87,6 @@ protected
   // Sparsity-pattern graph coloring, shared with the old backend.
   import Coloring;
 
-  // NF scalarize (for partial-slice seed expansion)
-  import Scalarize = NFScalarize;
-
   // Util imports
   import StringUtil;
   import UnorderedMap;
@@ -516,20 +513,9 @@ protected
         residual_comps        := list(StrongComponent.fromSolvedEquationSlice(eqn) for eqn in strict.residual_eqns);
 
         // create seed and partial candidates
-        // Expand partial slices to scalar outer-element ptrs so that only the outer
-        // iteration variable elements become seed vars (not the inner LS elements
-        // that share the same base array but appear at different slice indices).
-        seed_candidates := {};
-        for slc in strict.iteration_vars loop
-          if Slice.isFull(slc) then
-            seed_candidates := Slice.getT(slc) :: seed_candidates;
-          else
-            for sv in Scalarize.scalarizeBackendVariable(Pointer.access(Slice.getT(slc)), slc.indices) loop
-              seed_candidates := Pointer.create(sv) :: seed_candidates;
-            end for;
-          end if;
-        end for;
-        seed_candidates := listReverse(seed_candidates);
+        // Use the whole-array base pointer for every iteration var slice so that
+        // for-loop column equations can access the seed as an array (e.g. $SEED.x[$i1]).
+        seed_candidates := list(Slice.getT(var) for var in strict.iteration_vars);
         residual_vars   := list(Equation.getResidualVar(Slice.getT(eqn)) for eqn in strict.residual_eqns);
         inner_vars      := listAppend(list(var for var guard(BVariable.isContinuous(var, staticAsContinuous)) in StrongComponent.getVariables(comp)) for comp in strict.innerEquations);
 
@@ -569,10 +555,6 @@ protected
     Adjacency.Matrix fullLocal, sparsity;
     UnorderedSet<ComponentRef> seed_set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
     UnorderedSet<ComponentRef> pder_set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
-    UnorderedSet<ComponentRef> adj_base_seen;
-    list<Pointer<Variable>> adj_seed_list;
-    ComponentRef adj_base_cref;
-
     BVariable.checkVar func = getTmpFilterFunction(jacType);
   algorithm
     if isSome(strongComponents) then
@@ -662,21 +644,7 @@ protected
     // Using part.adjacencyMatrix (the `full` param) would fail because residual
     // equations created by finalize() during tearing get new names and don't
     // appear in the partition's pre-tearing adjacency matrix.
-    // Build adjacencyVars from unique base variable ptrs derived from seedCandidates.
-    // When seedCandidates contains scalar element ptrs for partial-slice NLS iter vars,
-    // all elements of the same array share the same base ptr. Using base ptrs here
-    // preserves pseudo=true subscript-stripped lookup in getDependentCref, which matches
-    // any element expression (e.g. module[i].T for iterator i) to the base column.
-    adj_base_seen := UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
-    adj_seed_list := {};
-    for v in VariablePointers.toList(seedCandidates) loop
-      adj_base_cref := ComponentRef.stripSubscriptsAll(BVariable.getVarName(v));
-      if not UnorderedSet.contains(adj_base_cref, adj_base_seen) then
-        UnorderedSet.add(adj_base_cref, adj_base_seen);
-        adj_seed_list := BVariable.getVarPointer(BVariable.getVarName(v), sourceInfo()) :: adj_seed_list;
-      end if;
-    end for;
-    adjacencyVars := VariablePointers.fromList(listReverse(adj_seed_list));
+    adjacencyVars := VariablePointers.clone(seedCandidates);
     adjacencyVars := VariablePointers.addList(tmp_vars, adjacencyVars);
     // For ODE Jacobians, also include state derivatives as adjacency variables.
     // Some equations use der(x_j) as an RHS input (e.g. der(x_i) = f(der(x_j), x_k)).

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -489,7 +489,8 @@ public
       function filterSet
         input ComponentRef cref;
         input UnorderedSet<ComponentRef> set;
-        output Boolean b = UnorderedSet.contains(ComponentRef.stripSubscriptsAll(cref), set);
+        output Boolean b = UnorderedSet.contains(cref, set) or
+                           UnorderedSet.contains(ComponentRef.stripSubscriptsAll(cref), set);
       end filterSet;
     algorithm
       sparsity := match full
@@ -506,6 +507,7 @@ public
           Boolean repeated;
           list<ComponentRef> inner_deps;
           Boolean changed;
+          Option<list<ComponentRef>> inner_opt;
           UnorderedMap<ComponentRef, Dependency> dep_map;
           UnorderedSet<ComponentRef> rep_set;
 
@@ -542,7 +544,19 @@ public
                 repeated := UnorderedSet.contains(dep_cref, full.repetitions[eqn_index]);
                 (inner_deps, changed) := match UnorderedMap.get(dep_cref, inner_map)
                   case SOME(inner_deps) then (inner_deps, true);
-                                        else ({dep_cref}, changed);
+                  else algorithm
+                    // Base-key fallback for subscripted inner LS vars (partial-slice NLS).
+                    // Guard prevents outer seed elements (which strip to the same base key
+                    // that may be in inner_map) from being misclassified as inner deps.
+                    inner_deps := {dep_cref};
+                    if not filterSet(dep_cref, seed_set) then
+                      inner_opt := UnorderedMap.get(ComponentRef.stripSubscriptsAll(dep_cref), inner_map);
+                      if isSome(inner_opt) then
+                        inner_deps := Util.getOption(inner_opt);
+                        changed := true;
+                      end if;
+                    end if;
+                  then (inner_deps, changed);
                 end match;
                 local_deps := (inner_deps, dep, repeated) :: local_deps;
               end for;
@@ -561,11 +575,19 @@ public
                   (inner_deps, dep, repeated) := tpl;
                   for dep_cref in inner_deps loop
                     if filterSet(dep_cref, seed_set) then
-                      seed_cref := match UnorderedMap.get(ComponentRef.stripSubscriptsAll(dep_cref), diff_map)
-                        case SOME(seed_cref) then ComponentRef.copySubscripts(dep_cref, seed_cref);
-                        else algorithm
-                          Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed because no seed was found for " + ComponentRef.toString(dep_cref) + " in diff_map."});
-                        then fail();
+                      // Try subscripted key first (NLS with per-element scalar seeds), then
+                      // base key with subscript copy (ODE/DAE with full-array base seeds).
+                      seed_cref := match UnorderedMap.get(dep_cref, diff_map)
+                        case SOME(seed_cref) then seed_cref;
+                        else match UnorderedMap.get(ComponentRef.stripSubscriptsAll(dep_cref), diff_map)
+                          // Strip subscripts from the base seed before copying so that
+                          // origin subscripts (iterator or literal) merge onto an empty
+                          // template rather than clashing with existing literal subscripts.
+                          case SOME(seed_cref) then ComponentRef.copySubscripts(dep_cref, ComponentRef.stripSubscriptsAll(seed_cref));
+                          else algorithm
+                            Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed because no seed was found for " + ComponentRef.toString(dep_cref) + " in diff_map."});
+                          then fail();
+                        end match;
                       end match;
                       UnorderedMap.add(seed_cref, dep, dep_map);
                       if repeated then

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -460,7 +460,11 @@ public
         list<Option<NBEquation.Iterator>> iterMaps;
         ComponentRef iterName;
         Expression iterRange;
+        Option<NBEquation.Iterator> iterMap;
+        list<tuple<ComponentRef, array<Expression>>> sub_iters_stmt;
         NBEquation.Iterator revIter;
+        ComponentRef iter_name;
+        array<Expression> iter_elems;
 
       // ===================== SCALAR_EQUATION (Assignment) =====================
       case Equation.SCALAR_EQUATION() algorithm
@@ -471,7 +475,10 @@ public
         if (not ComponentRef.isEmpty(lhsCref)) and UnorderedMap.contains(ComponentRef.stripSubscriptsAll(lhsCref), dm) then
           seedCref := UnorderedMap.getOrFail(ComponentRef.stripSubscriptsAll(lhsCref), dm);
           if not diffArguments.scalarized then
-            seedCref := ComponentRef.copySubscripts(lhsCref, seedCref);
+            // Strip subscripts from base seed before copying: diff_map[base] may store a
+            // subscripted element seed (partial-slice NLS). Stripping lets copySubscripts
+            // place the origin subscripts onto an unsubscripted template without conflict.
+            seedCref := ComponentRef.copySubscripts(lhsCref, ComponentRef.stripSubscriptsAll(seedCref));
           end if;
 
           // Set seed in diffArguments and differentiate RHS
@@ -494,9 +501,12 @@ public
 
         if (not ComponentRef.isEmpty(lhs_base)) and UnorderedMap.contains(ComponentRef.stripSubscriptsAll(lhs_base), dm) then
           seed_base := UnorderedMap.getOrFail(ComponentRef.stripSubscriptsAll(lhs_base), dm);
+          // Strip subscripts from base seed before applying: diff_map[base] may store
+          // a subscripted element seed (partial-slice NLS). applySubscripts then
+          // merges the lhs subscripts onto an unsubscripted template correctly.
           seed_subscripted := Expression.applySubscripts(
                 ComponentRef.subscriptsAllFlat(lhs_base),
-                Expression.fromCref(seed_base),
+                Expression.fromCref(ComponentRef.stripSubscriptsAll(seed_base)),
                 true);
           diffArguments.current_grad := seed_subscripted;
           diffArguments.collectAdjoints := true;
@@ -515,7 +525,8 @@ public
         if (not ComponentRef.isEmpty(lhsCref)) and UnorderedMap.contains(ComponentRef.stripSubscriptsAll(lhsCref), dm) then
           seedCref := UnorderedMap.getOrFail(ComponentRef.stripSubscriptsAll(lhsCref), dm);
           if not diffArguments.scalarized then
-            seedCref := ComponentRef.copySubscripts(lhsCref, seedCref);
+            // Strip subscripts from base seed before copying (same reason as SCALAR_EQUATION).
+            seedCref := ComponentRef.copySubscripts(lhsCref, ComponentRef.stripSubscriptsAll(seedCref));
           end if;
 
           diffArguments.current_grad := Expression.fromCref(seedCref);
@@ -548,14 +559,20 @@ public
         // Wrap in nested FOR statement with reversed iterator range
         revIter := reverseEquationIterator(eq.iter);
         (iterNames, iterRanges, iterMaps) := NBEquation.Iterator.getFrames(revIter);
-        for tpl in listReverse(List.zip(iterNames, iterRanges)) loop
-          (iterName, iterRange) := tpl;
+        for tpl in listReverse(List.zip3(iterNames, iterRanges, iterMaps)) loop
+          (iterName, iterRange, iterMap) := tpl;
+          sub_iters_stmt := match iterMap
+            case SOME(NBEquation.Iterator.SINGLE(name = iter_name, range = Expression.ARRAY(elements = iter_elems), map = NONE()))
+              then {(iter_name, iter_elems)};
+            else {};
+          end match;
           stmts := {Statement.FOR(
             ComponentRef.node(iterName),
             SOME(iterRange),
             stmts,
             Statement.ForType.NORMAL(),
-            DAE.emptyElementSource
+            DAE.emptyElementSource,
+            sub_iters_stmt
           )};
         end for;
       then (diffArguments, stmts);
@@ -632,7 +649,8 @@ public
           reverseForRange(stmt.range),
           allStmts,
           stmt.forType,
-          stmt.source
+          stmt.source,
+          stmt.sub_iters
         )};
       then (diffArguments, stmts);
 
@@ -1209,10 +1227,13 @@ public
           // get the derivative and reapply subscripts
           derCref := UnorderedMap.getOrFail(strippedCref, diff_map);
           dbg("[dCREF:JAC] mapped -> " + ComponentRef.toString(derCref));
-          res     := Expression.fromCref(ComponentRef.copySubscripts(exp.cref, derCref));
+          // Strip subscripts from derCref before copying: diff_map[base] may store a
+          // subscripted element seed (partial-slice NLS iter vars). Stripping ensures
+          // exp.cref subscripts (including iterators) merge onto an unsubscripted template.
+          res     := Expression.fromCref(ComponentRef.copySubscripts(exp.cref, ComponentRef.stripSubscriptsAll(derCref)));
           dbg("[dCREF:JAC] get variable for derivative cref: " + NBVariable.pointerToString(NBVariable.getVarPointer(derCref, sourceInfo())));
           if diffArguments.collectAdjoints then // if derCref is on the rhs then collect adjoint (collectAdjoints is false when differentiating lhs)
-            adjointKey := ComponentRef.copySubscripts(exp.cref, derCref);
+            adjointKey := ComponentRef.copySubscripts(exp.cref, ComponentRef.stripSubscriptsAll(derCref));
             if not UnorderedMap.contains(adjointKey, Util.getOption(diffArguments.adjoint_map)) then
               UnorderedMap.tryAdd(adjointKey, {}, Util.getOption(diffArguments.adjoint_map));
             end if;
@@ -3030,8 +3051,9 @@ public
           end if;
           // create subtraction and multiplication operator from the size classification of original division operator
           (_, sizeClass) := Operator.classify(operator);
-          // the frontend treats multiplication equally for element and nen elementwise, but pow needs to have the correct operator
-          addOp := Operator.fromClassification((NFOperator.MathClassification.ADDITION, sizeClass), operator.ty);
+          // the frontend treats multiplication equally for element and non-elementwise, but pow needs to have the correct operator
+          // the addition in the numerator f'g +/- fg' must be element-wise when the result is an array (same as multiplication case)
+          addOp := Operator.fromClassification((NFOperator.MathClassification.ADDITION, Operator.classifyAddition(operator)), operator.ty);
           mulOp := Operator.fromClassification((NFOperator.MathClassification.MULTIPLICATION, sizeClass), operator.ty);
       then (Expression.MULTARY(
               {Expression.MULTARY(

--- a/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBResizable.mo
@@ -692,7 +692,9 @@ protected
       end for;
       const := Expression.map(const, function Replacements.applySimpleExp(replacements = zero_replacements));
       const := SimplifyExp.simplify(const);
-      if not func(const) then fail(); end if;
+      // Only fail for literals: symbolic CREFs remaining after replacement are inner iterators
+      // (e.g. sum/product) whose bounds are guaranteed by their own range expression.
+      if not func(const) and Expression.isLiteral(const) then fail(); end if;
     end if;
 
     if debug then

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -2407,7 +2407,7 @@ public
         arr := NONE();
       end if;
     else
-      arr := if Type.isArray(getSubscriptedType(scal)) then SOME(scal) else NONE();
+      arr := if Type.isArray(getSubscriptedType(scal)) then SOME(stripSubscriptsAll(scal)) else NONE();
     end if;
   end getArrayCrefOpt;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1001,15 +1001,21 @@ protected
   DAE.ElementSource source;
   Statement.ForType for_type;
   list<tuple<DAE.ComponentRef, SourceInfo>> loop_vars;
+  list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters_dae;
+  list<tuple<ComponentRef, array<Expression>>> sub_iters;
 algorithm
-  Statement.FOR(iterator = iterator, range = SOME(range), body = body, forType = for_type, source = source) := forStmt;
+  Statement.FOR(iterator = iterator, range = SOME(range), body = body, forType = for_type, source = source, sub_iters = sub_iters) := forStmt;
   dbody := convertStatements(body);
   ty := InstNode.getType(iterator);
+  sub_iters_dae := list(
+    (ComponentRef.toDAE(Util.tuple21(si)),
+     listArray(list(Expression.toDAE(e) for e in arrayList(Util.tuple22(si)))))
+    for si in sub_iters);
 
   forDAE := match for_type
     case Statement.ForType.NORMAL()
       then DAE.Statement.STMT_FOR(Type.toDAE(ty), Type.isArray(ty),
-        InstNode.name(iterator), Expression.toDAE(range), dbody, source);
+        InstNode.name(iterator), Expression.toDAE(range), dbody, source, sub_iters_dae);
 
     case Statement.ForType.PARALLEL()
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4839,6 +4839,7 @@ public
       case UNARY() then isNonNegative(exp.exp);
       case CREF() then Util.applyOptionOrDefault(ComponentRef.lookupVarAttr(exp.cref, "max"), isNonPositive, false);
       case CALL() then Call.isNonPositive(exp.call);
+      case ARRAY() then Array.all(exp.elements, isNonPositive);
       else false;
     end match;
   end isNonPositive;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1420,7 +1420,7 @@ algorithm
         while not listEmpty(iters) loop
           iter :: iters := iters;
           range :: ranges := ranges;
-          body := {Statement.FOR(iter, SOME(range), body, Statement.ForType.NORMAL(), alg.source)};
+          body := {Statement.FOR(iter, SOME(range), body, Statement.ForType.NORMAL(), alg.source, {})};
         end while;
       then
         Algorithm.ALGORITHM(body, alg.inputs, alg.outputs, NONE(), alg.scope, alg.source); // ToDo: update inputs, outputs?

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3559,7 +3559,7 @@ algorithm
         next_context := InstContext.set(context, NFInstContext.FOR);
         stmtl := instStatements(scodeStmt.forBody, for_scope, next_context);
       then
-        Statement.FOR(iter, oexp, stmtl, Statement.ForType.NORMAL(), makeSource(scodeStmt.comment, info));
+        Statement.FOR(iter, oexp, stmtl, Statement.ForType.NORMAL(), makeSource(scodeStmt.comment, info), {});
 
     case SCode.Statement.ALG_PARFOR(info = info)
       algorithm
@@ -3568,7 +3568,7 @@ algorithm
         next_context := InstContext.set(context, NFInstContext.FOR);
         stmtl := instStatements(scodeStmt.parforBody, for_scope, next_context);
       then
-        Statement.FOR(iter, oexp, stmtl, Statement.ForType.PARALLEL({}), makeSource(scodeStmt.comment, info));
+        Statement.FOR(iter, oexp, stmtl, Statement.ForType.PARALLEL({}), makeSource(scodeStmt.comment, info), {});
 
     case SCode.Statement.ALG_IF(info = info)
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -458,7 +458,7 @@ function scalarizeStatement
 algorithm
   statements := match stmt
     case Statement.FOR()
-      then Statement.FOR(stmt.iterator, stmt.range, scalarizeStatements(stmt.body), stmt.forType, stmt.source) :: statements;
+      then Statement.FOR(stmt.iterator, stmt.range, scalarizeStatements(stmt.body), stmt.forType, stmt.source, stmt.sub_iters) :: statements;
 
     case Statement.IF()
       then scalarizeIfStatement(stmt.branches, stmt.source, statements);

--- a/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
@@ -77,6 +77,7 @@ public
     list<Statement> body "The body of the for loop.";
     ForType forType;
     DAE.ElementSource source;
+    list<tuple<ComponentRef, array<Expression>>> sub_iters "sub-iterators for ARRAY iterator case (NBackEnd only)";
   end FOR;
 
   record IF

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -3320,7 +3320,7 @@ algorithm
         next_context := InstContext.set(context, NFInstContext.FOR);
         body := typeStatements(st.body, next_context);
       then
-        Statement.FOR(st.iterator, SOME(e1), body, st.forType, st.source);
+        Statement.FOR(st.iterator, SOME(e1), body, st.forType, st.source, st.sub_iters);
 
     case Statement.IF()
       algorithm

--- a/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
@@ -123,7 +123,7 @@ public
       end for;"
       Integer index;
       Integer res_index;
-      list<tuple<ComponentRef, Expression>> iterators;
+      list<SimIterator> iterators;
       Expression exp;
       DAE.ElementSource source;
       EquationAttributes attr;
@@ -134,7 +134,7 @@ public
       Integer index;
       Integer res_index;
       list<Integer> scal_indices;
-      list<tuple<ComponentRef, Expression>> iterators;
+      list<SimIterator> iterators;
       Expression exp;
       DAE.ElementSource source;
       EquationAttributes attr;
@@ -284,14 +284,8 @@ public
     end toString;
 
     function forTplStr
-      input tuple<ComponentRef, Expression> tpl;
-      output String str;
-    protected
-      ComponentRef name;
-      Expression range;
-    algorithm
-      (name, range) := tpl;
-      str := ComponentRef.toString(name) + " in " + Expression.toString(range);
+      input SimIterator iter;
+      output String str = SimIterator.toString(iter);
     end forTplStr;
 
     function ifTplStr
@@ -807,8 +801,6 @@ public
           Block tmp;
           Integer i;
           list<Subscript> subs;
-          list<ComponentRef> names;
-          list<Expression> ranges;
 
         case (BEquation.SCALAR_EQUATION(), {}) algorithm
           tmp := RESIDUAL(simCodeIndices.equationIndex, res_idx, eqn.rhs, eqn.source, eqn.attr);
@@ -847,16 +839,14 @@ public
         // for equations have to be split up before. Since they are not causalized
         // they can be executed in any order
         case (BEquation.FOR_EQUATION(body = {_}), {}) algorithm
-          (names, ranges) := Iterator.getFrames(eqn.iter);
-          tmp := FOR_RESIDUAL(simCodeIndices.equationIndex, res_idx, List.zip(names, ranges), Util.getOption(Equation.getRHS(eqn)), eqn.source, eqn.attr);
+          tmp := FOR_RESIDUAL(simCodeIndices.equationIndex, res_idx, SimIterator.fromIterator(eqn.iter), Util.getOption(Equation.getRHS(eqn)), eqn.source, eqn.attr);
           simCodeIndices.equationIndex := simCodeIndices.equationIndex + 1;
           res_idx := res_idx + Equation.size(Slice.getT(slice));
         then tmp;
 
         // generic residual, for loop could not be fully recovered
         case (BEquation.FOR_EQUATION(body = {_}), _) algorithm
-          (names, ranges) := Iterator.getFrames(eqn.iter);
-          tmp := GENERIC_RESIDUAL(simCodeIndices.equationIndex, res_idx, slice.indices, List.zip(names, ranges), Util.getOption(Equation.getRHS(eqn)), eqn.source, eqn.attr);
+          tmp := GENERIC_RESIDUAL(simCodeIndices.equationIndex, res_idx, slice.indices, SimIterator.fromIterator(eqn.iter), Util.getOption(Equation.getRHS(eqn)), eqn.source, eqn.attr);
           simCodeIndices.equationIndex := simCodeIndices.equationIndex + 1;
           res_idx := res_idx + listLength(slice.indices);
         then tmp;
@@ -1115,27 +1105,15 @@ public
     algorithm
       oldBlck := match blck
         local
-          ComponentRef iter;
-          Expression range, exp;
-          list<tuple<DAE.ComponentRef, DAE.Exp>> old_iterators = {};
+          Expression exp;
           list<Block> blcks;
           list<tuple<DAE.Exp, list<OldSimCode.SimEqSystem>>> oldBranches = {};
           list<OldSimCode.SimEqSystem> else_branch = {};
 
         case RESIDUAL()         then OldSimCode.SES_RESIDUAL(blck.index, blck.res_index, Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
         case ARRAY_RESIDUAL()   then OldSimCode.SES_RESIDUAL(blck.index, blck.res_index, Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
-        case FOR_RESIDUAL() algorithm
-          for iterator in listReverse(blck.iterators) loop
-            (iter, range) := iterator;
-            old_iterators := (ComponentRef.toDAE(iter), Expression.toDAE(range)) :: old_iterators;
-          end for;
-        then OldSimCode.SES_FOR_RESIDUAL(blck.index, blck.res_index, old_iterators, Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
-        case GENERIC_RESIDUAL() algorithm
-          for iterator in listReverse(blck.iterators) loop
-            (iter, range) := iterator;
-            old_iterators := (ComponentRef.toDAE(iter), Expression.toDAE(range)) :: old_iterators;
-          end for;
-        then OldSimCode.SES_GENERIC_RESIDUAL(blck.index, blck.res_index, blck.scal_indices, old_iterators, Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
+        case FOR_RESIDUAL() then OldSimCode.SES_FOR_RESIDUAL(blck.index, blck.res_index, list(SimIterator.convert(it) for it in blck.iterators), Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
+        case GENERIC_RESIDUAL() then OldSimCode.SES_GENERIC_RESIDUAL(blck.index, blck.res_index, blck.scal_indices, list(SimIterator.convert(it) for it in blck.iterators), Expression.toDAE(blck.exp), blck.source, EquationAttributes.convert(blck.attr));
         case SIMPLE_ASSIGN()    then OldSimCode.SES_SIMPLE_ASSIGN(blck.index, ComponentRef.toDAE(blck.lhs), Expression.toDAE(blck.rhs), blck.source, EquationAttributes.convert(blck.attr));
         case ARRAY_ASSIGN()     then OldSimCode.SES_ARRAY_CALL_ASSIGN(blck.index, Expression.toDAE(blck.lhs), Expression.toDAE(blck.rhs), blck.source, EquationAttributes.convert(blck.attr));
         case RESIZABLE_ASSIGN() then OldSimCode.SES_RESIZABLE_ASSIGN(blck.index, blck.call_index, list(SimIterator.convert(it) for it in blck.iters), blck.source, EquationAttributes.convert(blck.attr));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use metamodelica::Result;
 
+use openmodelica_backend_types::BackendDAE;
 use openmodelica_frontend_types::DAE;
 use wasm_encoder as we;
 
@@ -41,7 +42,7 @@ fn emit_residual_eval(
 pub(crate) enum NlsResidual {
     Scalar { exp: Arc<DAE::Exp>, res_index: i32 },
     For {
-        iterators: Vec<(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)>,
+        iterators: Vec<Arc<BackendDAE::SimIterator>>,
         exp: Arc<DAE::Exp>,
         res_index: i32,
     },
@@ -91,13 +92,13 @@ pub(crate) fn emit_nls_residual_body(
 /// registers as a wasm local so `compile_exp` resolves `x[$i]` and bare `$i`.
 fn emit_for_residual(
     ctx: &mut FnCtx,
-    iterators: &[(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)],
+    iterators: &[Arc<BackendDAE::SimIterator>],
     exp: &Arc<DAE::Exp>,
     res_index: i32,
     outer: &[(u32, u32)],
 ) -> Result<()> {
     use we::Instruction as I;
-    let Some(((cref, range), rest)) = iterators.split_first() else {
+    let Some((sim_it, rest)) = iterators.split_first() else {
         // addr = r + (res_index + Σ(it - start)) * 8
         ctx.emit(I::LocalGet(2)); // r
         ctx.emit(I::I32Const(res_index));
@@ -115,7 +116,7 @@ fn emit_for_residual(
         ctx.emit(I::F64Store(mem_arg(0, 3)));
         return Ok(());
     };
-    let DAE::Exp::RANGE { start, step, stop, .. } = &**range else {
+    let BackendDAE::SimIterator::SIM_ITERATOR_RANGE { name: cref, start, step, stop, .. } = &**sim_it else {
         return Err("CodegenWasmJit: for-residual over a non-range iterator");
     };
     let id = cref_ident(cref)?;
@@ -128,12 +129,9 @@ fn emit_for_residual(
     coerce(ctx, sw, WTy::I32);
     ctx.emit(I::LocalTee(start_l));
     ctx.emit(I::LocalSet(it));
-    match step {
-        Some(e) => {
-            let w = compile_exp(ctx, e)?;
-            coerce(ctx, w, WTy::I32);
-        }
-        None => ctx.emit(I::I32Const(1)),
+    {
+        let w = compile_exp(ctx, step)?;
+        coerce(ctx, w, WTy::I32);
     }
     ctx.emit(I::LocalSet(step_l));
     let pw = compile_exp(ctx, stop)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -42,7 +42,7 @@ fn emit_residual_eval(
 pub(crate) enum NlsResidual {
     Scalar { exp: Arc<DAE::Exp>, res_index: i32 },
     For {
-        iterators: Vec<Arc<BackendDAE::SimIterator>>,
+        iterators: Vec<BackendDAE::SimIterator>,
         exp: Arc<DAE::Exp>,
         res_index: i32,
     },
@@ -92,7 +92,7 @@ pub(crate) fn emit_nls_residual_body(
 /// registers as a wasm local so `compile_exp` resolves `x[$i]` and bare `$i`.
 fn emit_for_residual(
     ctx: &mut FnCtx,
-    iterators: &[Arc<BackendDAE::SimIterator>],
+    iterators: &[BackendDAE::SimIterator],
     exp: &Arc<DAE::Exp>,
     res_index: i32,
     outer: &[(u32, u32)],
@@ -116,7 +116,7 @@ fn emit_for_residual(
         ctx.emit(I::F64Store(mem_arg(0, 3)));
         return Ok(());
     };
-    let BackendDAE::SimIterator::SIM_ITERATOR_RANGE { name: cref, start, step, stop, .. } = &**sim_it else {
+    let BackendDAE::SimIterator::SIM_ITERATOR_RANGE { name: cref, start, step, stop, .. } = sim_it else {
         return Err("CodegenWasmJit: for-residual over a non-range iterator");
     };
     let id = cref_ident(cref)?;

--- a/OMCompiler/Compiler/SimCode/ReduceDAE.mo
+++ b/OMCompiler/Compiler/SimCode/ReduceDAE.mo
@@ -500,6 +500,7 @@ protected function addLabelToAlgorithms
       DAE.Ident iter;
     list<DAE.ComponentRef> conditions;
     Boolean initialCall;
+    list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
     case({}, vars, idx)
       algorithm
 
@@ -535,7 +536,7 @@ protected function addLabelToAlgorithms
       then
         (DAE.STMT_IF(e,stmtLst2,else_,source)::rest2,vars_2,idx3,labels3);
 
-    case(DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst,source)::rest, vars, idx)
+    case(DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst,source,sub_iters)::rest, vars, idx)
       algorithm
 
         if(Flags.isSet(Flags.REDUCE_DAE)) then
@@ -545,7 +546,7 @@ protected function addLabelToAlgorithms
         (rest2,vars_2,idx3,labels2) := addLabelToAlgorithms(rest,vars_1,idx2,reduceList,inVarRepl);
         labels3:=listAppend(labels,labels2);
       then
-        (DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst2,source)::rest2,vars_2,idx3,labels3);
+        (DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst2,source,sub_iters)::rest2,vars_2,idx3,labels3);
 
     case(DAE.STMT_WHILE(e,stmtLst,source)::rest, vars, idx)
       algorithm

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -443,7 +443,7 @@ uniontype SimEqSystem
   record SES_FOR_RESIDUAL
     Integer index;
     Integer res_index;
-    list<tuple<DAE.ComponentRef, DAE.Exp>> iterators;
+    list<BackendDAE.SimIterator> iterators;
     DAE.Exp exp;
     DAE.ElementSource source;
     BackendDAE.EquationAttributes eqAttr;
@@ -454,7 +454,7 @@ uniontype SimEqSystem
     Integer index;
     Integer res_index;
     list<Integer> scal_indices;
-    list<tuple<DAE.ComponentRef, DAE.Exp>> iterators;
+    list<BackendDAE.SimIterator> iterators;
     DAE.Exp exp;
     DAE.ElementSource source;
     BackendDAE.EquationAttributes eqAttr;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3175,18 +3175,23 @@ match system
           case SES_RESIDUAL(__) then equationResidual(exp, varDecls, innerEqns, index, res_index)
           case SES_FOR_RESIDUAL(__) then
             let &preExp = buffer ""
+            let &auxFunction = buffer ""
             let expPart = daeExp(exp, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-            let forPart = (iterators |> iterator as (cref, range as DAE.RANGE()) =>
-                  let iter = daeExp(crefExp(cref), contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                  let start = daeExp(range.start, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                  let stop = daeExp(range.stop, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                  let step = match range.step case SOME(step) then daeExp(step, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns) else "1"
-                  <<for(int <%iter%>=<%start%>; <%iter%><=<%stop%>; <%iter%>+=<%step%>){>>
+            let forPart = (iterators |> iterator as SIM_ITERATOR_RANGE() =>
+                  let iter_ = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
+                  let start_ = daeExp(start, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                  let stop_ = daeExp(stop, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                  let step_ = daeExp(step, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                  let sub_iter_ = (sub_iter |> sub_i => subIterator(sub_i, iter_, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction, &sub); separator="\n")
+                  <<for(int <%iter_%>=<%start_%>; <%iter_%><=<%stop_%>; <%iter_%>+=<%step_%>){
+                  <%sub_iter_%>
+                  >>
                 ;separator="\n")
             let endForPart = (iterators |> iterator => "}")
-            let indexShift = (iterators |> iterator as (cref, range as DAE.RANGE()) =>
-                  let start = daeExp(range.start, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                  '<%daeExp(crefExp(cref), contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)%>-<%start%>'
+            let indexShift = (iterators |> iterator as SIM_ITERATOR_RANGE() =>
+                  let iter_ = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
+                  let start_ = daeExp(start, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                  '<%iter_%>-<%start_%>'
                 ;separator="+")
             let assignment = (if isArrayType(typeof(exp))
               then '<%preExp%>copy_real_array_data_mem(<%expPart%>, res+<%res_index%>+<%indexShift%>);'
@@ -3200,18 +3205,21 @@ match system
             >>
           case SES_GENERIC_RESIDUAL(__) then
             let &preExp = buffer ""
+            let &auxFunction = buffer ""
             let idx_len = listLength(scal_indices)
             let expPart = daeExp(exp, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-            let iter_ = (iterators |> iterator as (cref, range as DAE.RANGE()) =>
-                let iter = daeExp(crefExp(cref), contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                let start = daeExp(range.start, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                let stop = daeExp(range.stop, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns)
-                let step = match range.step case SOME(step) then daeExp(step, contextSimulationDiscrete, &preExp, &varDecls, &innerEqns) else "1"
+            let iter_ = (iterators |> iterator as SIM_ITERATOR_RANGE() =>
+                let iter = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
+                let start_ = daeExp(start, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                let stop_ = daeExp(stop, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                let step_ = daeExp(step, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction)
+                let sub_iter_ = (sub_iter |> sub_i => subIterator(sub_i, iter, contextSimulationDiscrete, &preExp, &varDecls, &auxFunction, &sub); separator="\n")
                 <<
-                const int <%iter%>_size = <%stop%> - <%start%> / <%step%> + 1;
+                const int <%iter%>_size = <%stop_%> - <%start_%> / <%step_%> + 1;
                 int <%iter%>_loc = tmp % <%iter%>_size;
-                int <%iter%> = <%step%> * <%iter%>_loc + <%start%>;
+                int <%iter%> = <%step_%> * <%iter%>_loc + <%start_%>;
                 tmp /= <%iter%>_size;
+                <%sub_iter_%>
                 >>;separator="\n")
             let assignment = (if isArrayType(typeof(exp))
               then '<%preExp%>copy_real_array_data_mem(<%expPart%>, res+<%res_index%>+i_);'
@@ -3296,7 +3304,7 @@ template generateResizableEmptySparseData(String indexName, String systemType)
   This template generates source code for functions that initialize the sparse-pattern."
 ::=
   <<
-  void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData)
+  void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData, threadData_t *threadData)
   {
     /* no sparsity pattern available */
     inSysData->sparsePattern = NULL;
@@ -3312,7 +3320,7 @@ match sparsity
   case EMPTY() then
     <<
 
-    void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData)
+    void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData, threadData_t *threadData)
     {
       inSysData->sparsePattern = NULL;
     }
@@ -3327,7 +3335,7 @@ match sparsity
     <<
 
     OMC_DISABLE_OPT
-    void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData)
+    void initializeResizableSparsityPattern<%indexName%>(<%systemType%>* inSysData, threadData_t *threadData)
     {
       unsigned int i, nnz;
       unsigned int col_counts[<%nCols%>];
@@ -3507,7 +3515,7 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName, S
 
   ;separator="\n")
   let sparsityInitCall = if useResizableSparsity
-    then 'initializeResizableSparsityPattern<%indexName%>(sysData);'
+    then 'initializeResizableSparsityPattern<%indexName%>(sysData, threadData);'
     else 'initializeSparsePattern<%indexName%>(sysData);'
   <<
 
@@ -6012,6 +6020,27 @@ match row
           else depsCodeReduced
         else
           match listReverse(crefSubs(sc))
+          case WHOLEDIM() :: {WHOLEDIM()} then
+            // 2D array sc, both dims whole: must match the fill template which generates two nested loops.
+            match context
+            case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
+              match simVarFromHT(crefStripSubs(sc), jacHT)
+              case SIMVAR() then
+                let szInner = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+                let szOuter = dimension(listHead(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+                <<
+                {
+                  unsigned int _wo<%k%>;
+                  for (_wo<%k%> = 0; _wo<%k%> < (unsigned int)(<%szOuter%>); _wo<%k%>++) {
+                    unsigned int _wr<%k%>;
+                    for (_wr<%k%> = 0; _wr<%k%> < (unsigned int)(<%szInner%>); _wr<%k%>++) {
+                      <%depsCodeReduced%>
+                    }
+                  }
+                }
+                >>
+              else depsCodeReduced
+            else depsCodeReduced
           case WHOLEDIM() :: _ then
             match context
             case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
@@ -6097,26 +6126,118 @@ template resizableColCount(ComponentRef seed, Context context, Text &preExp, Tex
             }
           }
           >>
+        case SLICE(exp=outerSliceExp) :: {WHOLEDIM()} then
+          // outer SLICE (e.g. module[1:9]) + inner WHOLEDIM (fillSubscripts added [:] for array field)
+          let sliceArr = daeExp(outerSliceExp, context, &preExp, &varDecls, &auxFunction)
+          let nSlice = tempDecl("modelica_integer", &varDecls)
+          let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+          let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          <<
+          <%seedComment%>
+          {
+            unsigned int _so<%v.index%>;
+            for (_so<%v.index%> = 0; _so<%v.index%> < (unsigned int)(<%nSlice%>); _so<%v.index%>++) {
+              unsigned int _wo<%v.index%>;
+              for (_wo<%v.index%> = 0; _wo<%v.index%> < (unsigned int)(<%sz%>); _wo<%v.index%>++) {
+                col_counts[<%v.index%> + (((modelica_integer*)<%sliceArr%>.data)[_so<%v.index%>] - 1) * (unsigned int)(<%sz%>) + _wo<%v.index%>]++;
+              }
+            }
+          }
+          >>
+        case WHOLEDIM() :: {WHOLEDIM()} then
+          // 2D array, both dims whole (e.g. module[:].T[:])
+          let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          let szOuter = dimension(listHead(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          <<
+          <%seedComment%>
+          {
+            unsigned int _wo2<%v.index%>;
+            for (_wo2<%v.index%> = 0; _wo2<%v.index%> < (unsigned int)(<%szOuter%>); _wo2<%v.index%>++) {
+              unsigned int _wc<%v.index%>;
+              for (_wc<%v.index%> = 0; _wc<%v.index%> < (unsigned int)(<%szInner%>); _wc<%v.index%>++) {
+                col_counts[<%v.index%> + _wo2<%v.index%> * (unsigned int)(<%szInner%>) + _wc<%v.index%>]++;
+              }
+            }
+          }
+          >>
         else
           match listReverse(crefSubs(seed))
           case WHOLEDIM() :: outer_rev_subs then
             let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &outerPreExp = buffer ""
             let outer_off = match outer_rev_subs
               case {} then '0'
-              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &preExp, &varDecls, &auxFunction)
+              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &outerPreExp, &varDecls, &auxFunction)
             <<
             <%seedComment%>
             {
               unsigned int _wc<%v.index%>;
               for (_wc<%v.index%> = 0; _wc<%v.index%> < (unsigned int)(<%sz%>); _wc<%v.index%>++) {
+                <%outerPreExp%>
                 col_counts[<%v.index%> + (<%outer_off%>) * (unsigned int)(<%sz%>) + _wc<%v.index%>]++;
               }
             }
             >>
-          else
-            let offset = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(seed))), listReverse(crefSubs(seed)), context, &preExp, &varDecls, &auxFunction)
+          case SLICE(exp=sliceExp) :: outer_rev_subs then
+            // inner SLICE (e.g. module[i].T[1:9]) - outer dims are INDEX subs
+            let sliceArr = daeExp(sliceExp, context, &preExp, &varDecls, &auxFunction)
+            let nSlice = tempDecl("modelica_integer", &varDecls)
+            let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+            let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &outerPreExp = buffer ""
+            let outer_off = match outer_rev_subs
+              case {} then '0'
+              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &outerPreExp, &varDecls, &auxFunction)
             <<
             <%seedComment%>
+            {
+              unsigned int _sc<%v.index%>;
+              for (_sc<%v.index%> = 0; _sc<%v.index%> < (unsigned int)(<%nSlice%>); _sc<%v.index%>++) {
+                <%outerPreExp%>
+                col_counts[<%v.index%> + (<%outer_off%>) * (unsigned int)(<%sz%>) + (((modelica_integer*)<%sliceArr%>.data)[_sc<%v.index%>] - 1)]++;
+              }
+            }
+            >>
+          case INDEX(exp=innerIndexExp) :: {WHOLEDIM()} then
+            // reversed [INDEX, WHOLEDIM] = original [WHOLEDIM, INDEX]: outer WHOLE, inner fixed INDEX
+            let szOuter = dimension(listHead(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &innerPreExp = buffer ""
+            let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            {
+              unsigned int _wo<%v.index%>;
+              for (_wo<%v.index%> = 0; _wo<%v.index%> < (unsigned int)(<%szOuter%>); _wo<%v.index%>++) {
+                <%innerPreExp%>
+                col_counts[<%v.index%> + _wo<%v.index%> * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1)]++;
+              }
+            }
+            >>
+          case INDEX(exp=innerIndexExp) :: {SLICE(exp=outerSliceExp)} then
+            // reversed [INDEX, SLICE] = original [SLICE, INDEX]: outer SLICE range, inner fixed INDEX
+            let sliceArr = daeExp(outerSliceExp, context, &preExp, &varDecls, &auxFunction)
+            let nSlice = tempDecl("modelica_integer", &varDecls)
+            let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+            let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &innerPreExp = buffer ""
+            let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            {
+              unsigned int _so<%v.index%>;
+              for (_so<%v.index%> = 0; _so<%v.index%> < (unsigned int)(<%nSlice%>); _so<%v.index%>++) {
+                <%innerPreExp%>
+                col_counts[<%v.index%> + (((modelica_integer*)<%sliceArr%>.data)[_so<%v.index%>] - 1) * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1)]++;
+              }
+            }
+            >>
+          else
+            let &offsetPreExp = buffer ""
+            let offset = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(seed))), listReverse(crefSubs(seed)), context, &offsetPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            <%offsetPreExp%>
             col_counts[<%v.index%> + (<%offset%>)]++;
             >>
     else '/* resizableColCount: seed not found in jacHT */'
@@ -6217,21 +6338,91 @@ match row
         else ''
       else
         match listReverse(crefSubs(sc))
+        case WHOLEDIM() :: {WHOLEDIM()} then
+          // 2D array sc, both dims whole (e.g. module[:].T[:])
+          match context
+          case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
+            match simVarFromHT(crefStripSubs(sc), jacHT)
+            case v as SIMVAR() then
+              let szInner = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let szOuter = dimension(listHead(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              <<
+              {
+                unsigned int _wo<%k%>;
+                for (_wo<%k%> = 0; _wo<%k%> < (unsigned int)(<%szOuter%>); _wo<%k%>++) {
+                  unsigned int _wr<%k%>;
+                  for (_wr<%k%> = 0; _wr<%k%> < (unsigned int)(<%szInner%>); _wr<%k%>++) {
+                    unsigned int row_<%k%> = <%v.index%> + _wo<%k%> * (unsigned int)(<%szInner%>) + _wr<%k%>;
+                    <%depsWholeReduced%>
+                  }
+                }
+              }
+              >>
+            else ''
+          else ''
         case WHOLEDIM() :: outer_rev_subs then
           match context
           case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
             match simVarFromHT(crefStripSubs(sc), jacHT)
             case v as SIMVAR() then
               let sz = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let &outerPreExp = buffer ""
               let outer_off = match outer_rev_subs
                 case {} then '0'
-                else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(sc)))), outer_rev_subs, context, &preExp, &varDecls, &auxFunction)
+                else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(sc)))), outer_rev_subs, context, &outerPreExp, &varDecls, &auxFunction)
               <<
               {
                 unsigned int _wr<%k%>;
                 for (_wr<%k%> = 0; _wr<%k%> < (unsigned int)(<%sz%>); _wr<%k%>++) {
+                  <%outerPreExp%>
                   unsigned int row_<%k%> = <%v.index%> + (<%outer_off%>) * (unsigned int)(<%sz%>) + _wr<%k%>;
                   <%depsWholeDep%>
+                }
+              }
+              >>
+            else ''
+          else ''
+        case INDEX(exp=innerIndexExp) :: {WHOLEDIM()} then
+          // reversed [INDEX, WHOLEDIM] = original [WHOLEDIM, INDEX]: outer WHOLE, inner fixed INDEX
+          match context
+          case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
+            match simVarFromHT(crefStripSubs(sc), jacHT)
+            case v as SIMVAR() then
+              let szOuter = dimension(listHead(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let szInner = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let &innerPreExp = buffer ""
+              let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+              <<
+              {
+                unsigned int _wo<%k%>;
+                for (_wo<%k%> = 0; _wo<%k%> < (unsigned int)(<%szOuter%>); _wo<%k%>++) {
+                  <%innerPreExp%>
+                  unsigned int row_<%k%> = <%v.index%> + _wo<%k%> * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1);
+                  <%depsWholeReduced%>
+                }
+              }
+              >>
+            else ''
+          else ''
+        case INDEX(exp=innerIndexExp) :: {SLICE(exp=outerSliceExp)} then
+          // reversed [INDEX, SLICE] = original [SLICE, INDEX]: outer SLICE range, inner fixed INDEX
+          match context
+          case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
+            match simVarFromHT(crefStripSubs(sc), jacHT)
+            case v as SIMVAR() then
+              let sliceArr = daeExp(outerSliceExp, context, &preExp, &varDecls, &auxFunction)
+              let nSlice = tempDecl("modelica_integer", &varDecls)
+              let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+              let szInner = dimension(List.last(crefDims(sc)), context, &preExp, &varDecls, &auxFunction)
+              let &innerPreExp = buffer ""
+              let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+              <<
+              {
+                unsigned int _so<%k%>;
+                for (_so<%k%> = 0; _so<%k%> < (unsigned int)(<%nSlice%>); _so<%k%>++) {
+                  <%innerPreExp%>
+                  unsigned int row_<%k%> = <%v.index%> + (((modelica_integer*)<%sliceArr%>.data)[_so<%k%>] - 1) * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1);
+                  <%depsWholeReduced%>
                 }
               }
               >>
@@ -6242,8 +6433,13 @@ match row
           case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
             match simVarFromHT(crefStripSubs(sc), jacHT)
             case v as SIMVAR() then
-              let off_sc = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(sc))), listReverse(crefSubs(sc)), context, &preExp, &varDecls, &auxFunction)
-              (deps |> (seed, _, _) => resizableColFill(seed, '<%v.index%> + (<%off_sc%>)', context, &preExp, &varDecls, &auxFunction, spPattern) ;separator="\n")
+              let &offPreExp = buffer ""
+              let off_sc = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(sc))), listReverse(crefSubs(sc)), context, &offPreExp, &varDecls, &auxFunction)
+              let fillCode = (deps |> (seed, _, _) => resizableColFill(seed, '<%v.index%> + (<%off_sc%>)', context, &preExp, &varDecls, &auxFunction, spPattern) ;separator="\n")
+              <<
+              <%offPreExp%>
+              <%fillCode%>
+              >>
             else ''
           else ''
 end resizableFillDepsForRow;
@@ -6305,26 +6501,118 @@ template resizableColFill(ComponentRef seed, String rowExpr, Context context, Te
             }
           }
           >>
+        case SLICE(exp=outerSliceExp) :: {WHOLEDIM()} then
+          // outer SLICE (e.g. module[1:9]) + inner WHOLEDIM (fillSubscripts added [:] for array field)
+          let sliceArr = daeExp(outerSliceExp, context, &preExp, &varDecls, &auxFunction)
+          let nSlice = tempDecl("modelica_integer", &varDecls)
+          let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+          let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          <<
+          <%seedComment%>
+          {
+            unsigned int _so<%v.index%>;
+            for (_so<%v.index%> = 0; _so<%v.index%> < (unsigned int)(<%nSlice%>); _so<%v.index%>++) {
+              unsigned int _wo<%v.index%>;
+              for (_wo<%v.index%> = 0; _wo<%v.index%> < (unsigned int)(<%sz%>); _wo<%v.index%>++) {
+                <%spPattern%>->index[col_fill[<%v.index%> + (((modelica_integer*)<%sliceArr%>.data)[_so<%v.index%>] - 1) * (unsigned int)(<%sz%>) + _wo<%v.index%>]++] = <%rowExpr%>;
+              }
+            }
+          }
+          >>
+        case WHOLEDIM() :: {WHOLEDIM()} then
+          // 2D array, both dims whole (e.g. module[:].T[:])
+          let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          let szOuter = dimension(listHead(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+          <<
+          <%seedComment%>
+          {
+            unsigned int _wo2<%v.index%>;
+            for (_wo2<%v.index%> = 0; _wo2<%v.index%> < (unsigned int)(<%szOuter%>); _wo2<%v.index%>++) {
+              unsigned int _wc<%v.index%>;
+              for (_wc<%v.index%> = 0; _wc<%v.index%> < (unsigned int)(<%szInner%>); _wc<%v.index%>++) {
+                <%spPattern%>->index[col_fill[<%v.index%> + _wo2<%v.index%> * (unsigned int)(<%szInner%>) + _wc<%v.index%>]++] = <%rowExpr%>;
+              }
+            }
+          }
+          >>
         else
           match listReverse(crefSubs(seed))
           case WHOLEDIM() :: outer_rev_subs then
             let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &outerPreExp = buffer ""
             let outer_off = match outer_rev_subs
               case {} then '0'
-              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &preExp, &varDecls, &auxFunction)
+              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &outerPreExp, &varDecls, &auxFunction)
             <<
             <%seedComment%>
             {
               unsigned int _wc<%v.index%>;
               for (_wc<%v.index%> = 0; _wc<%v.index%> < (unsigned int)(<%sz%>); _wc<%v.index%>++) {
+                <%outerPreExp%>
                 <%spPattern%>->index[col_fill[<%v.index%> + (<%outer_off%>) * (unsigned int)(<%sz%>) + _wc<%v.index%>]++] = <%rowExpr%>;
               }
             }
             >>
-          else
-            let offset = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(seed))), listReverse(crefSubs(seed)), context, &preExp, &varDecls, &auxFunction)
+          case SLICE(exp=sliceExp) :: outer_rev_subs then
+            // inner SLICE (e.g. module[i].T[1:9]) - outer dims are INDEX subs
+            let sliceArr = daeExp(sliceExp, context, &preExp, &varDecls, &auxFunction)
+            let nSlice = tempDecl("modelica_integer", &varDecls)
+            let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+            let sz = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &outerPreExp = buffer ""
+            let outer_off = match outer_rev_subs
+              case {} then '0'
+              else indexSubRecursive(List.restOrEmpty(listReverse(List.restOrEmpty(crefDims(seed)))), outer_rev_subs, context, &outerPreExp, &varDecls, &auxFunction)
             <<
             <%seedComment%>
+            {
+              unsigned int _sc<%v.index%>;
+              for (_sc<%v.index%> = 0; _sc<%v.index%> < (unsigned int)(<%nSlice%>); _sc<%v.index%>++) {
+                <%outerPreExp%>
+                <%spPattern%>->index[col_fill[<%v.index%> + (<%outer_off%>) * (unsigned int)(<%sz%>) + (((modelica_integer*)<%sliceArr%>.data)[_sc<%v.index%>] - 1)]++] = <%rowExpr%>;
+              }
+            }
+            >>
+          case INDEX(exp=innerIndexExp) :: {WHOLEDIM()} then
+            // reversed [INDEX, WHOLEDIM] = original [WHOLEDIM, INDEX]: outer WHOLE, inner fixed INDEX
+            let szOuter = dimension(listHead(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &innerPreExp = buffer ""
+            let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            {
+              unsigned int _wo<%v.index%>;
+              for (_wo<%v.index%> = 0; _wo<%v.index%> < (unsigned int)(<%szOuter%>); _wo<%v.index%>++) {
+                <%innerPreExp%>
+                <%spPattern%>->index[col_fill[<%v.index%> + _wo<%v.index%> * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1)]++] = <%rowExpr%>;
+              }
+            }
+            >>
+          case INDEX(exp=innerIndexExp) :: {SLICE(exp=outerSliceExp)} then
+            // reversed [INDEX, SLICE] = original [SLICE, INDEX]: outer SLICE range, inner fixed INDEX
+            let sliceArr = daeExp(outerSliceExp, context, &preExp, &varDecls, &auxFunction)
+            let nSlice = tempDecl("modelica_integer", &varDecls)
+            let &preExp += '<%nSlice%> = size_of_dimension_base_array(<%sliceArr%>, 1);<%\n%>'
+            let szInner = dimension(List.last(crefDims(seed)), context, &preExp, &varDecls, &auxFunction)
+            let &innerPreExp = buffer ""
+            let innerIdx = daeSubscriptExp(innerIndexExp, context, &innerPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            {
+              unsigned int _so<%v.index%>;
+              for (_so<%v.index%> = 0; _so<%v.index%> < (unsigned int)(<%nSlice%>); _so<%v.index%>++) {
+                <%innerPreExp%>
+                <%spPattern%>->index[col_fill[<%v.index%> + (((modelica_integer*)<%sliceArr%>.data)[_so<%v.index%>] - 1) * (unsigned int)(<%szInner%>) + ((<%innerIdx%>) - 1)]++] = <%rowExpr%>;
+              }
+            }
+            >>
+          else
+            let &offsetPreExp = buffer ""
+            let offset = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(seed))), listReverse(crefSubs(seed)), context, &offsetPreExp, &varDecls, &auxFunction)
+            <<
+            <%seedComment%>
+            <%offsetPreExp%>
             <%spPattern%>->index[col_fill[<%v.index%> + (<%offset%>)]++] = <%rowExpr%>;
             >>
     else '/* resizableColFill: seed not found in jacHT */'
@@ -8385,16 +8673,24 @@ template forIterator(SimIterator iter, Context context, Text &preExp, Text &varD
     let start_ = daeExp(start, context, &preExp, &varDecls, &auxFunction)
     let step_ = daeExp(step, context, &preExp, &varDecls, &auxFunction)
     let stop_ = daeExp(stop, context, &preExp, &varDecls, &auxFunction)
+    // sub_iter: dependent iterators whose values are selected by the outer range iterator.
+    // Emit them inside the loop body so expressions referencing them compile correctly.
+    let subIterDecls = (sub_iter |> si => subIterator(si, iter_, context, &preExp, &varDecls, &auxFunction, &sub); separator="\n")
     <<
     for(modelica_integer <%iter_%>=<%start_%>; in_range_integer(<%iter_%>, <%start_%>, <%stop_%>); <%iter_%>+=<%step_%>){
+    <%if subIterDecls then subIterDecls%>
     >>
   case SIM_ITERATOR_LIST() then
     let iter_ = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
     let arr = (lst |> elem => '<%elem%>'; separator=", ")
+    // Pass the 0-based loop counter (iter__=0..N-1) as '<%iter_%>_+1' so subIterator's
+    // name_arr[parent_iter-1] resolves to name_arr[iter__], selecting the right element.
+    let subIterDecls = (sub_iter |> si => subIterator(si, '<%iter_%>_+1', context, &preExp, &varDecls, &auxFunction, &sub); separator="\n")
     <<
     static const int <%iter_%>_lst[<%size%>] = {<%arr%>};
     for(int <%iter_%>_=0; <%iter_%>_<<%size%>; <%iter_%>_++){
       modelica_integer <%iter_%> = <%iter_%>_lst[<%iter_%>_];
+    <%if subIterDecls then subIterDecls%>
     >>
 end forIterator;
 
@@ -8421,18 +8717,6 @@ template forIteratorName(SimIterator iter, Context context, Text &preExp, Text &
   case SIM_ITERATOR_LIST() then contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
 end forIteratorName;
 
-template subIterator(tuple<DAE.ComponentRef, array<DAE.Exp>> iter, String parent_iter, Context context, Text &preExp, Text &varDecls, Text &auxFunction, Text &sub)
-::= match iter
-  case (name, range) then
-    let type_ = 'modelica_<%crefShortType(name)%>'
-    let name_ = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
-    let range_ = (arrayList(range) |> elem => daeExp(elem, context, &preExp, &varDecls, &auxFunction); separator=", ")
-    let size_ = arrayLength(range)
-    <<
-    static const <%type_%> <%name_%>_arr[<%size_%>] = {<%range_%>};
-    <%type_%> <%name_%> = <%name_%>_arr[<%parent_iter%>-1];
-    >>
-end subIterator;
 
 template genericCallHeaders(list<SimGenericCall> genericCalls, Context context)
  "Generates the header for a set of generic calls."

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -3522,6 +3522,19 @@ case RANGE(__) then
 end algStmtParForRangeInterface_impl;
 
 
+template subIterator(tuple<DAE.ComponentRef, array<DAE.Exp>> iter, String parent_iter, Context context, Text &preExp, Text &varDecls, Text &auxFunction, Text &sub)
+::= match iter
+  case (name, range) then
+    let type_ = 'modelica_<%crefShortType(name)%>'
+    let name_ = contextCref(name, contextOther, &preExp, &varDecls, &auxFunction, &sub)
+    let range_ = (arrayList(range) |> elem => daeExp(elem, context, &preExp, &varDecls, &auxFunction); separator=", ")
+    let size_ = arrayLength(range)
+    <<
+    static const <%type_%> <%name_%>_arr[<%size_%>] = {<%range_%>};
+    <%type_%> <%name_%> = <%name_%>_arr[<%parent_iter%>-1];
+    >>
+end subIterator;
+
 template algStmtFor(DAE.Statement stmt, Context context, Text &varDecls, Text &auxFunction)
  "Generates a for algorithm statement."
 ::=
@@ -3541,7 +3554,11 @@ case STMT_FOR(range=rng as RANGE(__)) then
   let identTypeShort = expTypeShort(type_)
   let stmtStr = (statementLst |> stmt => algStatement(stmt, context, &varDecls, &auxFunction)
                  ;separator="\n")
-  algStmtForRange_impl(rng, iter, identType, identTypeShort, stmtStr, context, &varDecls, &auxFunction)
+  let iterName = contextIteratorName(iter, context)
+  let &preExp_si = buffer ""
+  let &sub_si = buffer ""
+  let subIterDecls = (sub_iters |> si => subIterator(si, iterName, context, &preExp_si, &varDecls, &auxFunction, &sub_si); separator="\n")
+  algStmtForRange_impl(rng, iter, identType, identTypeShort, '<%subIterDecls%><%\n%><%stmtStr%>', context, &varDecls, &auxFunction)
 end algStmtForRange;
 
 template algStmtForRange_impl(Exp range, Ident iterator, String type, String shortType, Text body, Context context, Text &varDecls, Text &auxFunction)
@@ -4745,10 +4762,12 @@ match cr
     functionContextCref(cr.componentRef, context, newpref, &preExp, &varDecls, &auxFunction)
 
   case cr as CREF_QUAL(identType = T_ARRAY(), subscriptLst = {}) then
-    error(sourceInfo(), 'functionContextCref got a prefix cref with array type and no subs. <%crefStrNoUnderscore(cr)%>')
-    // let fullname = pref + '_' + System.unquoteIdentifier(cr.ident)
-    // let newpref = fullname + '.'
-    // functionContextCref(cr.componentRef, context, newpref, &preExp, &varDecls, &auxFunction)
+    // Array-type prefix with no subscripts: access as a whole-array field in function context.
+    // OpenModelica flattens record arrays to per-field arrays in C function parameters,
+    // so the component name is used as a prefix just like the non-array case.
+    let fullname = pref + '_' + System.unquoteIdentifier(cr.ident)
+    let newpref = fullname + '.'
+    functionContextCref(cr.componentRef, context, newpref, &preExp, &varDecls, &auxFunction)
 
   case cr as CREF_QUAL() then
     let fullname = pref + '_' + System.unquoteIdentifier(cr.ident)
@@ -7939,7 +7958,9 @@ template daeSubscript(Subscript sub, Context context, Text &preExp, Text &varDec
 ::=
   match sub
   case sub as INDEX() then daeSubscriptExp(exp,context,&preExp,&varDecls,&auxFunction)
-  else error(sourceInfo(), 'non INDEX(_) (i.e., slice) subscripts probably should not reach here. Check indexedAssign template.')
+  case sub as SLICE() then error(sourceInfo(), 'non INDEX(_) (i.e., SLICE) subscripts should not reach here. Check indexedAssign template. SLICE exp: <%ExpressionDumpTpl.dumpExp(exp,"\"")%>')
+  case sub as WHOLEDIM() then error(sourceInfo(), 'non INDEX(_) (i.e., WHOLEDIM) subscripts should not reach here. Check indexedAssign template.')
+  else error(sourceInfo(), 'non INDEX(_) (i.e., unknown) subscripts should not reach here. Check indexedAssign template.')
   end match
 end daeSubscript;
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -661,7 +661,7 @@ end SparsityRow;
     record SES_FOR_RESIDUAL
       Integer index;
       Integer res_index;
-      list<tuple<DAE.ComponentRef, DAE.Exp>> iterators;
+      list<BackendDAE.SimIterator> iterators;
       DAE.Exp exp;
       DAE.ElementSource source;
       BackendDAE.EquationAttributes eqAttr;
@@ -671,7 +671,7 @@ end SparsityRow;
       Integer index;
       Integer res_index;
       list<Integer> scal_indices;
-      list<tuple<DAE.ComponentRef, DAE.Exp>> iterators;
+      list<BackendDAE.SimIterator> iterators;
       DAE.Exp exp;
       DAE.ElementSource source;
       BackendDAE.EquationAttributes eqAttr;
@@ -2722,6 +2722,7 @@ package DAE
       Exp range;
       list<Statement> statementLst;
       ElementSource source;
+      list<tuple<ComponentRef, array<Exp>>> sub_iters;
     end STMT_FOR;
     record STMT_PARFOR
       Type type_;

--- a/OMCompiler/Compiler/Util/VarTransform.mo
+++ b/OMCompiler/Compiler/Util/VarTransform.mo
@@ -525,6 +525,7 @@ algorithm
       list<DAE.ComponentRef> conditions;
       Boolean initialCall,iterIsArray;
       DAE.Else el,el_1;
+      list<tuple<DAE.ComponentRef, array<DAE.Exp>>> sub_iters;
 
     case {} then ({},false);
     case DAE.STMT_ASSIGN(type_ = tp,exp1 = e2,exp = e,source = source) :: xs
@@ -571,7 +572,7 @@ algorithm
         (xs_1,_) := replaceEquationsStmts(xs, repl,condExpFunc);
       then
         (DAE.STMT_IF(e_1,stmts2,el_1,source) :: xs_1,true);
-    case (DAE.STMT_FOR(type_=tp,iterIsArray=iterIsArray,iter=id1,range=e,statementLst=stmts,source = source)) :: xs
+    case (DAE.STMT_FOR(type_=tp,iterIsArray=iterIsArray,iter=id1,range=e,statementLst=stmts,source = source,sub_iters=sub_iters)) :: xs
       algorithm
         (stmts2,b1) := replaceEquationsStmts(stmts,repl,condExpFunc);
         (e_1,b2) := replaceExp(e, repl, condExpFunc);
@@ -579,7 +580,7 @@ algorithm
         /* TODO: Add operation to source; do simplify? */
         (xs_1,_) := replaceEquationsStmts(xs, repl,condExpFunc);
       then
-        (DAE.STMT_FOR(tp,iterIsArray,id1,e_1,stmts2,source) :: xs_1,true);
+        (DAE.STMT_FOR(tp,iterIsArray,id1,e_1,stmts2,source,sub_iters) :: xs_1,true);
     case (DAE.STMT_WHILE(exp = e,statementLst=stmts,source = source)) :: xs
       algorithm
         (stmts2,b1) := replaceEquationsStmts(stmts,repl,condExpFunc);

--- a/testsuite/simulation/modelica/NBackend/array_handling/slice_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/slice_for.mos
@@ -57,11 +57,11 @@ simulate(slice_for); getErrorString();
 //   (5) Nonlinear System (size = 6, homotopy = false, mixed = false, torn = true)
 //   --Iteration Vars:{x[2], x[3], x[4], y[1], y[2], y[3]}
 //   --(1) For-Loop-Residual:
-//   --for {$i1 in 1:3} loop
+//   --for {{$i1 | start:1, step:1, stop:3, size: 3}} loop
 //   --  0 = (x[$i1] + x[1 + $i1]) - y[$i1];
 //   --end for;
 //   --(2) For-Loop-Residual:
-//   --for {$i1 in 1:3} loop
+//   --for {{$i1 | start:1, step:1, stop:3, size: 3}} loop
 //   --  0 = 1.0 - (y[4 - $i1] + x[1 + $i1]);
 //   --end for;
 //

--- a/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
@@ -218,15 +218,15 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //   (43) Nonlinear System (size = 15, homotopy = false, mixed = false, torn = true)
 //   --Iteration Vars:{plant.T[2], plant.T[3], plant.T[4], plant.T[5], plant.T[6], plant.Q[1], plant.Q[2], plant.Q[3], plant.Q[4], plant.Q[5], ...}
 //   --(37) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * plant.G[$i1] - plant.Q[$i1];
 //   --end for;
 //   --(38) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1];
 //   --end for;
 //   --(39) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) - plant.Q[$i1];
 //   --end for;
 //   (36) plant.TIT := plant.T[6]
@@ -249,7 +249,7 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //   (22) Nonlinear System (size = 25, homotopy = true, mixed = false, torn = true)
 //   --Iteration Vars:{plant.w, plant.wfg, plant.Tfg[2], plant.Tfg[3], plant.Tfg[4], plant.Tfg[5], plant.TIT, plant.TIP, plant.p[6], $FUN_1, ...}
 //   --(4) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) - plant.Q[$i1];
 //   --end for;
 //   --(5) 0 = plant.T[6] - plant.TIT
@@ -258,15 +258,15 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //   --(8) 0 = (plant.p[6] * plant.Kt) / $FUN_1 - plant.w
 //   --(9) 0 = sqrt(plant.TIT / plant.Tnom) - $FUN_1
 //   --(10) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1];
 //   --end for;
 //   --(11) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * plant.G[$i1] - plant.Q[$i1];
 //   --end for;
 //   --(12) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = (0.2 * plant.NTU) * plant.w ^ 0.8 - plant.G[$i1];
 //   --end for;
 //   (3) resizable call [index  0]
@@ -280,7 +280,7 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //   (75) Nonlinear System (size = 28, homotopy = true, mixed = false, torn = true)
 //   --Iteration Vars:{plant.wfg, plant.w, plant.TIT, $FUN_1, plant.p[6], plant.TIP, plant.P, plant.T[2], plant.T[3], plant.T[4], ...}
 //   --(51) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) - plant.Q[$i1];
 //   --end for;
 //   --(52) 0 = plant.T[6] - plant.TIT
@@ -290,15 +290,15 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //   --(56) 0 = plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) - plant.P
 //   --(57) 0 = plant.Pnom * load - plant.P
 //   --(58) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * plant.G[$i1] - plant.Q[$i1];
 //   --end for;
 //   --(59) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = (0.2 * plant.NTU) * plant.w ^ 0.8 - plant.G[$i1];
 //   --end for;
 //   --(60) For-Loop-Residual:
-//   --for {$i1 in 1:5} loop
+//   --for {{$i1 | start:1, step:1, stop:5, size: 5}} loop
 //   --  0 = plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1];
 //   --end for;
 //   --(61) 0 = plant.Tfg[6] - plant.Ts


### PR DESCRIPTION
When an array variable participates only partially in a linear or nonlinear system as an iteration variable (e.g. one element per module inside a for-equation), the new backend generated invalid C code — unsigned int _wc-2; — in the resizable Jacobian sparsity pattern, causing compilation failure.

The root cause was that simVarFromHT returned an error fallback SimVar (index = −2) because the seed variable hash table was keyed on full-array crefs, but the scalarized per-element seeds produced by partial-slice expansion weren't found under those keys.

The fix spans the full pipeline from backend to codegen:

- Seed creation (NBVariable): skip the shared base-ptr cache for subscripted element crefs so each element gets its own independent scalar seed
- Jacobian builder (NBJacobian): expand partial-slice iter vars to scalar element pointers; snapshot diff_map before inner LS tmp-pder writes overwrite shared base keys; build adjacencyVars from unique base var pointers
- Sparsity pattern (NBAdjacency): check both subscripted and stripped crefs in filterSet; base-key fallback for inner LS deps; subscripted-key-first seed resolution
- Differentiation (NBDifferentiate): strip subscripts from partial-slice seeds before copySubscripts/applySubscripts to avoid subscript clashes
- For-statement sub-iterators (DAE, NFStatement, NBEquation, NFConvertDAE, codegen): added sub_iters field to carry inner iterator data through the lowering pipeline so generated for-loops declare sub-iterator variables correctly
- SimCode (SimCode, NSimStrongComponent, templates): migrated SES_FOR_RESIDUAL/SES_GENERIC_RESIDUAL iterator field to list<BackendDAE.SimIterator>; added new sparsity codegen cases for SLICE+WHOLEDIM and WHOLEDIM+WHOLEDIM patterns

Fixes SOFCPoliMi.Tests.BenchmarkCammarataIndex1 (builds and simulates to completion).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>