### PR TITLE
wasm-jit: recoverable model errors

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -325,9 +325,15 @@ pub(crate) fn record_error(msg: String) {
 /// reported itself.
 fn with_engine_detail(e: &str) -> String {
     let detail = openmodelica_wasm_jit::take_engine_error_detail();
+    let e = match (sim_driver::init_failed_lambda(), sim_driver::failed_nls_system()) {
+        (Some(l), Some(k)) if e.ends_with("at lambda") => {
+            format!("{e} = {l} (nonlinear system {k})")
+        }
+        _ => e.to_string(),
+    };
     match detail {
         Some(d) if e != sim_driver::ASSERT_ERR => format!("{e}\n{d}"),
-        _ => e.to_string(),
+        _ => e,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -303,6 +303,8 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_array_total", &[WTy::I32], &[WTy::I32]),
     ("rt_array_dim", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_array_elem_ptr", &[WTy::I32, WTy::I32], &[WTy::I32]),
+    // The out-of-range arm of the inlined element-address computation.
+    ("rt_elem_ptr_oob", &[], &[WTy::I32]),
     ("rt_array_release", &[WTy::I32], &[]),
     // Value-semantics copy (for whole-array assignment from a variable source).
     ("rt_array_copy", &[WTy::I32], &[WTy::I32]),
@@ -351,7 +353,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // integer powers stay byte-identical instead of going through generic pow).
     ("rt_real_int_pow", &[WTy::F64, WTy::I32], &[WTy::F64]),
     // `base ^ exp` generic scalar power matching the C target's negative-base /
-    // odd-root / nan-inf handling (traps on an invalid root, surfacing fail()).
+    // odd-root / nan-inf handling (an invalid root is a model error).
     ("rt_real_pow", &[WTy::F64, WTy::F64], &[WTy::F64]),
     // Integer `mod(x,y)` — floored modulo (result takes the divisor's sign).
     ("rt_mod_int", &[WTy::I32, WTy::I32], &[WTy::I32]),
@@ -6205,8 +6207,11 @@ fn emit_str_literal(ctx: &mut FnCtx, bytes: &[u8]) -> Result<()> {
 /// same host import a failed `assert()` uses, so the simulation drivers surface it
 /// instead of a bare `unreachable` trap) then trap. For failures with no source
 /// location (a singular/non-converged solver system, an invalid `sqrt`, an
-/// out-of-range index) the source info is zeroed.
+/// out-of-range index) the source info is zeroed. C reports these with
+/// `throwStreamPrint`, which a nonlinear solver catches, so the recoverable
+/// escape comes first.
 fn emit_runtime_error(ctx: &mut FnCtx, msg: &str) -> Result<()> {
+    emit_nls_recoverable_return(ctx)?;
     emit_str_literal(ctx, msg.as_bytes())?; // message String handle
     for _ in 0..6 {
         ctx.emit(we::Instruction::I32Const(0)); // file handle (null) + zeroed line/col
@@ -6373,7 +6378,7 @@ fn emit_real_string(ctx: &mut FnCtx, arg: &DAE::Exp) -> Result<SigTy> {
 // -------------------------------------------------------------------------
 
 /// Inline what `rt_array_elem_ptr` computes: the byte address of the element at
-/// row-major linear position `index` (1-based), with the same out-of-range trap.
+/// row-major linear position `index` (1-based), with the same out-of-range arm.
 /// Stack is `[obj, index] -> [addr]`.
 ///
 /// Inlined rather than called because element access is the hottest operation in
@@ -6389,7 +6394,8 @@ fn emit_elem_ptr(ctx: &mut FnCtx, elem: &SigTy) -> Result<()> {
     };
     ctx.emit(I::LocalSet(it));
     ctx.emit(I::LocalSet(ot));
-    // index < 1 || index > total -> trap.
+    ctx.emit(I::Block(we::BlockType::Result(we::ValType::I32)));
+    // index < 1 || index > total -> the runtime's out-of-range arm.
     ctx.emit(I::LocalGet(it));
     ctx.emit(I::I32Const(1));
     ctx.emit(I::I32LtS);
@@ -6399,7 +6405,8 @@ fn emit_elem_ptr(ctx: &mut FnCtx, elem: &SigTy) -> Result<()> {
     ctx.emit(I::I32GtS);
     ctx.emit(I::I32Or);
     ctx.emit(I::If(we::BlockType::Empty));
-    ctx.emit(I::Unreachable);
+    ctx.emit(I::Call(rt_index("rt_elem_ptr_oob")?));
+    ctx.emit(I::Br(1));
     ctx.emit(I::End);
     // obj + align8(ARR_DIMS_OFF + ndims*4) + (index - 1) * stride
     ctx.emit(I::LocalGet(ot));
@@ -6418,6 +6425,7 @@ fn emit_elem_ptr(ctx: &mut FnCtx, elem: &SigTy) -> Result<()> {
     ctx.emit(I::I32Const(shift));
     ctx.emit(I::I32Shl);
     ctx.emit(I::I32Add);
+    ctx.emit(I::End);
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -404,10 +404,17 @@ pub extern "C" fn rt_array_total(obj: u32) -> u32 {
 pub extern "C" fn rt_array_dim(obj: u32, axis: i32) -> u32 {
     let ndims = rt_array_ndims(obj) as i32;
     if axis < 1 || axis > ndims {
-        trap();
+        nls::model_error();
+        return 0;
     }
     unsafe { load_u32(obj + ARR_DIMS_OFF + (axis as u32 - 1) * 4) }
 }
+
+/// Storage handed out in place of an out-of-range element address, so the
+/// caller's load/store lands somewhere harmless.
+#[repr(align(8))]
+struct ElemDiscard([u8; 8]);
+static mut ELEM_DISCARD: ElemDiscard = ElemDiscard([0; 8]);
 
 /// Byte address of the element at row-major linear position `index` (1-based).
 /// Traps on an out-of-range index (→ META_FAIL), matching the bounds check the
@@ -419,10 +426,18 @@ pub extern "C" fn rt_array_elem_ptr(obj: u32, index: i32) -> u32 {
     stat_inc(STAT_ELEM_PTR);
     let total = rt_array_total(obj) as i32;
     if index < 1 || index > total {
-        trap();
+        return rt_elem_ptr_oob();
     }
     let kind = unsafe { load_u32(obj + ARR_KIND_OFF) };
     arr_data(obj) + (index as u32 - 1) * elem_stride(kind)
+}
+
+/// The out-of-range arm of [`rt_array_elem_ptr`], also used by the inlined
+/// address computation the codegen emits.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_elem_ptr_oob() -> u32 {
+    nls::model_error();
+    &raw const ELEM_DISCARD as usize as u32
 }
 
 /// Copy every element of `src` into `dst` starting at the 0-based element
@@ -988,7 +1003,8 @@ pub extern "C" fn rt_real_int_pow(mut base: f64, mut n: i32) -> f64 {
     let neg = n < 0;
     if neg {
         if base == 0.0 {
-            trap();
+            nls::model_error();
+            return 0.0;
         }
         n = -n;
     }
@@ -1051,8 +1067,8 @@ rt_math2!(fmod);
 /// byte-identical. A negative base with an (effectively) integer exponent or an
 /// odd-root fractional exponent gives a real value; any other negative-base
 /// fractional exponent is an "invalid root"; and any nan/inf result is rejected.
-/// All the error cases trap, surfacing as `fail()` (META_FAIL) exactly as the C
-/// `throwStreamPrint` path does in the function-evaluation context.
+/// The error cases go through [`nls::model_error`], as C's `throwStreamPrint`
+/// does: fatal unless a nonlinear solver can back off.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_real_pow(base: f64, exp: f64) -> f64 {
     let result;
@@ -1087,14 +1103,16 @@ pub extern "C" fn rt_real_pow(base: f64, exp: f64) -> f64 {
             if libm::fabs(ifrac) < 1e-10 && ((iint as i64 as u64) & 1) != 0 {
                 result = -libm::pow(-base, frac) * libm::pow(base, int);
             } else {
-                trap();
+                nls::model_error();
+                return 0.0;
             }
         }
     } else {
         result = libm::pow(base, exp);
     }
     if result.is_nan() || result.is_infinite() {
-        trap();
+        nls::model_error();
+        return 0.0;
     }
     result
 }
@@ -1105,7 +1123,8 @@ pub extern "C" fn rt_real_pow(base: f64, exp: f64) -> f64 {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_mod_int(x: i32, y: i32) -> i32 {
     if y == 0 {
-        trap();
+        nls::model_error();
+        return 0;
     }
     let r = x.wrapping_rem(y);
     if r != 0 && (r < 0) != (y < 0) { r + y } else { r }
@@ -1340,7 +1359,8 @@ fn ew_i32(x: i32, y: i32, op: u32) -> i32 {
         OP_OR => x | y,
         _ => {
             if y == 0 {
-                trap();
+                nls::model_error();
+                return 0;
             }
             x.wrapping_div(y)
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -64,6 +64,18 @@ pub extern "C" fn rt_nls_note_assert() {
     NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
 }
 
+/// A model error where C's generated code calls `throwStreamPrint` — an invalid
+/// root, a zero divisor, an index out of range. C's `longjmp` lands in the solver's
+/// `MMC_TRY_INTERNAL`, so inside a residual note the trial and let the caller return
+/// a dummy `eval` discards. Outside one the error is fatal.
+pub(crate) fn model_error() {
+    if NLS_DEPTH.load(Ordering::Relaxed) > 0 {
+        rt_nls_note_assert();
+        return;
+    }
+    crate::trap()
+}
+
 /// Build the Jacobian-assemble closure used by both kinsol and newton sparse paths.
 /// `gather` is the pattern block where `jac` fills a dense `n×n` rather than the CSC
 /// values — a system `-nls=kinsol` solves sparsely though the codegen chose dense.
@@ -2226,7 +2238,9 @@ pub extern "C" fn rt_solve_nls(
             unsafe { store_u32(rel_fresh_addr, 0) };
         }
         eval(&warm, &mut scratch);
-        unsafe { store_u32(nls_fail_addr, 1) };
+        // The flag names the system (index + 1) so the driver can report which one
+        // failed; `lss_handle` is that index with a tag bit (`nls_lss_handle`).
+        unsafe { store_u32(nls_fail_addr, (lss_handle & 0x7fff_ffff) + 1) };
         stat_inc(STAT_NLS_FAIL);
         1
     };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -549,14 +549,21 @@ fn write_i32(e: &mut dyn SimEngine, addr: u32, v: i32) -> Result<()> {
 /// equation call in a context that cannot back off (initialisation, an output
 /// point, the Euler loop). The DASSL residual handles this recoverably instead.
 fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
-    if read_i32(e, sim_data + layout.nls_fail_off)? != 0 {
+    let failed = read_i32(e, sim_data + layout.nls_fail_off)?;
+    if failed != 0 {
+        init_report::set_failed_system(failed - 1);
         return Err("CodegenWasmJit: nonlinear system did not converge");
     }
     Ok(())
 }
 
-/// Number of equidistant homotopy steps (C's `init_lambda_steps`).
+/// Number of equidistant homotopy steps: C's `init_lambda_steps`, which `-ils`
+/// overrides.
 const HOMOTOPY_STEPS: i32 = 3;
+
+fn homotopy_steps() -> i32 {
+    crate::simflags::with_flags(|f| f.init_lambda_steps).unwrap_or(HOMOTOPY_STEPS).max(1)
+}
 
 // Parameter / start `-override`s for the next run, resolved to `(SimData offset,
 // type, value)`. Params are applied right after `functionParameters` (so
@@ -692,11 +699,32 @@ mod chatter_store {
 mod init_report {
     use core::sync::atomic::{AtomicU32, Ordering};
     static HOMOTOPY_STEPS: AtomicU32 = AtomicU32::new(0);
+    /// The homotopy step a failed initialization gave up at, and the system that
+    /// did not converge there, both biased by one.
+    static FAILED_STEP: AtomicU32 = AtomicU32::new(0);
+    static FAILED_SYSTEM: AtomicU32 = AtomicU32::new(0);
+    pub fn reset() {
+        HOMOTOPY_STEPS.store(0, Ordering::Relaxed);
+        FAILED_STEP.store(0, Ordering::Relaxed);
+        FAILED_SYSTEM.store(0, Ordering::Relaxed);
+    }
+    pub fn set_failed_system(k: i32) {
+        FAILED_SYSTEM.store(k as u32 + 1, Ordering::Relaxed);
+    }
+    pub fn failed_system() -> Option<u32> {
+        FAILED_SYSTEM.load(Ordering::Relaxed).checked_sub(1)
+    }
     pub fn set_homotopy_steps(n: u32) {
         HOMOTOPY_STEPS.store(n, Ordering::Relaxed);
     }
     pub fn homotopy_steps() -> u32 {
         HOMOTOPY_STEPS.load(Ordering::Relaxed)
+    }
+    pub fn set_failed_step(step: i32) {
+        FAILED_STEP.store(step as u32 + 1, Ordering::Relaxed);
+    }
+    pub fn failed_step() -> Option<u32> {
+        FAILED_STEP.load(Ordering::Relaxed).checked_sub(1)
     }
 }
 
@@ -704,6 +732,17 @@ mod init_report {
 /// to format the initialization success message like the C runtime.
 pub fn init_homotopy_steps() -> u32 {
     init_report::homotopy_steps()
+}
+
+/// `lambda` of the homotopy step the last initialization failed at, for the host
+/// to name in the error the driver could only return as a `&'static str`.
+pub fn init_failed_lambda() -> Option<f64> {
+    init_report::failed_step().map(|s| s as f64 / homotopy_steps() as f64)
+}
+
+/// Index of the nonlinear system the last failed solve gave up on.
+pub fn failed_nls_system() -> Option<u32> {
+    init_report::failed_system()
 }
 
 /// The per-site keys already reported, so a warning-level violation warns only
@@ -1019,7 +1058,7 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
 }
 
 fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
-    init_report::set_homotopy_steps(0);
+    init_report::reset();
     assert_warn_store::reset();
     // Initialization throws on a failed assert (C clears `noThrowAsserts` here).
     let _ = rethrow_store::take();
@@ -1046,7 +1085,7 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     // report. A model without homotopy is solved directly.
     if layout.has_homotopy {
         run_homotopy_continuation(e, sim_data, layout)?;
-        init_report::set_homotopy_steps(HOMOTOPY_STEPS as u32);
+        init_report::set_homotopy_steps(homotopy_steps() as u32);
         return Ok(());
     }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
@@ -1061,8 +1100,9 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
 /// `functionInitialEquations_lambda0`, each step seeded by the previous solution.
 /// Leaves lambda = 1.
 fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
-    for step in 0..=HOMOTOPY_STEPS {
-        let lambda = step as f64 / HOMOTOPY_STEPS as f64;
+    let steps = homotopy_steps();
+    for step in 0..=steps {
+        let lambda = step as f64 / steps as f64;
         write_f64(e, sim_data + layout.lambda_off, lambda)?;
         write_i32(e, sim_data + layout.nls_fail_off, 0)?;
         if step == 0 {
@@ -1071,7 +1111,8 @@ fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimL
             e.call1("functionInitialEquations", sim_data)?;
         }
         if check_nls(e, sim_data, layout).is_err() {
-            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda=");
+            init_report::set_failed_step(step);
+            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda");
         }
     }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -79,6 +79,9 @@ pub struct SimFlags {
     /// `-lv` streams, uppercased.
     pub log: Vec<String>,
     pub abort_slow: bool,
+    /// `-ils`: equidistant homotopy steps of the initial solve (C's
+    /// `init_lambda_steps`, default 3).
+    pub init_lambda_steps: Option<i32>,
     /// `-override=name=value,…` unresolved: mapping a name to its `SimData` slot
     /// needs the model, which only the caller has.
     pub overrides: Vec<(String, f64)>,
@@ -234,6 +237,10 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "abortSlowSimulation" => f.abort_slow = true,
+            "ils" => {
+                f.init_lambda_steps =
+                    Some(value(name)?.parse::<i32>().map_err(|_| "-ils needs an integer".to_string())?)
+            }
             _ => f.unknown.push(arg.to_string()),
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -249,6 +249,7 @@ fn define_external_imports(
     memory: wasmtime::Memory,
     rt_str_new: wasmtime::TypedFunc<u32, u32>,
     rt_str_data: wasmtime::TypedFunc<u32, u32>,
+    nls: NlsHooks,
 ) -> Result<()> {
     registry_reset();
     openmodelica_util::dynload::install_modelica_message_interception(
@@ -268,9 +269,10 @@ fn define_external_imports(
         let sig = sig.clone();
         let rt_str_new = rt_str_new.clone();
         let rt_str_data = rt_str_data.clone();
+        let nls = nls.clone();
         wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
             // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-            unsafe { call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, args, rets) }
+            unsafe { call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &nls, args, rets) }
                 .map_err(|e| wasmtime::Error::msg(format!("{e}")))
         }))?;
     }
@@ -297,6 +299,46 @@ fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: wasmtime:
     Ok(())
 }
 
+/// Checkpoint bracketing one external "C" call, so a `ModelicaError` the
+/// nonlinear solver recovers from leaves no message behind.
+const EXT_CHECKPOINT: arcstr::ArcStr = arcstr::literal!("wasm-jit external \"C\"");
+
+/// The runtime's recoverable-model-error state, reached from the host so an
+/// external "C" `ModelicaError` inside a residual backs the trial off.
+#[derive(Clone)]
+struct NlsHooks {
+    recovering: wasmtime::TypedFunc<(), i32>,
+    note: wasmtime::TypedFunc<(), ()>,
+}
+
+impl NlsHooks {
+    fn recovering(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> Result<bool> {
+        Ok(wt(self.recovering.call(&mut *caller, ()))? != 0)
+    }
+    fn note(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> Result<()> {
+        wt(self.note.call(&mut *caller, ()))
+    }
+}
+
+/// Zeroed results (an empty String for `char*`) after a recovered `ModelicaError`.
+/// The solver discards the residual they feed, but they must be valid handles.
+fn zero_results(
+    sig: &crate::sig::ExtCallSig,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    rt_str_new: &wasmtime::TypedFunc<u32, u32>,
+    rets: &mut [wasmtime::Val],
+) -> Result<()> {
+    use crate::sig::SigTy;
+    for (slot, ty) in rets.iter_mut().zip(sig.wasm_results()) {
+        *slot = match ty {
+            SigTy::Real => wasmtime::Val::F64(0.0f64.to_bits()),
+            SigTy::Str => wasmtime::Val::I32(wt(rt_str_new.call(&mut *caller, 0))? as i32),
+            _ => wasmtime::Val::I32(0),
+        };
+    }
+    Ok(())
+}
+
 /// Call native external `addr` through libffi, marshalling by the C-call
 /// [`ExtCallSig`]. Input args (in `extArgs` order) come from the wasm parameters:
 /// scalars (Real→f64, Integer/Boolean→i64) by value; `Str` as a NUL-terminated
@@ -315,6 +357,7 @@ unsafe fn call_external(
     memory: wasmtime::Memory,
     rt_str_new: &wasmtime::TypedFunc<u32, u32>,
     rt_str_data: &wasmtime::TypedFunc<u32, u32>,
+    nls: &NlsHooks,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
 ) -> Result<()> {
@@ -430,6 +473,7 @@ unsafe fn call_external(
     // from our arena (never the C runtime); freed by `sim_external_end` once the
     // results below are copied into in-wasm strings.
     openmodelica_modelica_utilities::sim_external_begin();
+    openmodelica_error::ErrorExt::setCheckpoint(EXT_CHECKPOINT);
     let ok = openmodelica_error::ErrorExt::catch_runtime_error(|| unsafe {
         ffi_call(cif_ptr, Some(target), rvalue_ptr, avalue_ptr);
     });
@@ -437,9 +481,17 @@ unsafe fn call_external(
     if ok.is_err() {
         openmodelica_modelica_utilities::sim_external_end();
         // A `ModelicaError` recorded its message in the Error buffer and unwound
-        // here as a panic; surface a failure to the host.
+        // here as a panic. C's `throwStreamPrint` is caught by a nonlinear solver,
+        // so back the trial off first, dropping the message it will not fail on.
+        if nls.recovering(caller)? {
+            openmodelica_error::ErrorExt::rollBack(EXT_CHECKPOINT);
+            nls.note(caller)?;
+            return zero_results(sig, caller, rt_str_new, rets);
+        }
+        openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
         return Err("CodegenWasmJit: external \"C\" raised a runtime error");
     }
+    openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
 
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
     // offset. Re-enters the runtime (`rt_str_new` may grow memory, so `data_mut` is
@@ -597,7 +649,11 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     // outputs.
     let rt_str_new = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?;
     let rt_str_data = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
-    define_external_imports(&mut linker, model, memory, rt_str_new, rt_str_data)?;
+    let nls = NlsHooks {
+        recovering: wts(rt_inst.get_typed_func::<(), i32>(&mut store, "rt_nls_recovering"))?,
+        note: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_nls_note_assert"))?,
+    };
+    define_external_imports(&mut linker, model, memory, rt_str_new, rt_str_data, nls)?;
     define_print_import(&mut linker, memory)?;
     // `rt_row_asserts` is called by the model, which only imports `memory`.
     crate::host::set_sim_memory(memory);


### PR DESCRIPTION
A model error the C runtime reports with throwStreamPrint - an invalid root, a zero divisor, an index out of range, an external "C" ModelicaError - longjmps into the nonlinear solver's MMC_TRY_INTERNAL, which backs the trial off and retries from another point. wasm-jit trapped instead, so Modelica.Fluid.Examples.BranchingDynamicPipes died inside MoistAir.saturationPressureLiquid, which evaluates r1^1.5 with r1 = 1 - Tsat/647.096 < 0 at the wild trial points the initialization visits. C logs 13 such invalid roots and still initializes in three homotopy steps.

nls::model_error() gives the runtime's own errors that shape: inside a residual note the trial and return a dummy, outside one trap as before. An out-of-range element address comes back as rt_elem_ptr_oob(), a discard cell, so the caller's load or store stays harmless. The codegen's emit_runtime_error and the inlined element-address bounds arm take the same escape.

An external "C" ModelicaError unwinds to the host as a panic rather than a wasm trap, so the wasmtime engine routes it through the same state, bracketing the call with an Error-buffer checkpoint that a recovered error rolls back - otherwise a run that goes on to succeed still leaves the message in getErrorString.

Alongside, -ils=N (C's init_lambda_steps) is accepted, and the truncated "did not converge at lambda=" now names lambda and the nonlinear system that failed, which the runtime reports by storing the system index in the nls_fail flag.

BranchingDynamicPipes on MSL 3.2.3 goes from an unrecoverable trap to matching its reference file; RobotR3.fullRobot is unchanged at 1.24s. With MSL 3.2.1, which the testsuite loads, initialization now reaches the last homotopy step and fails there instead of trapping at the first; -ils=4 converges and matches the reference.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
