### PR TITLE
wasm-jit: -alarm, and a kinsol nan livelock

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -538,6 +538,8 @@ const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     // same CMake option, so one const covers both.
     cvode: openmodelica_sim_meta::CVODE,
     gbode: false,
+    // Served by the driver's per-step deadline, so every engine has it.
+    alarm: true,
 };
 
 /// The solver values a caller may offer for this build, so a menu built from it
@@ -619,6 +621,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     sim_driver::set_param_overrides(param_ov, start_ov);
     // `-abortSlowSimulation`: stop the run when chattering is detected.
     sim_driver::set_abort_slow(flags.abort_slow);
+    // The hard `-alarm`, if asked for: set before the modules are instantiated.
+    sim_runtime::set_alarm(flags.alarm);
     INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
     sim_driver::set_init_done_hook(on_init_done);
     SPLIT_ARMED.with(|a| a.set(true));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1945,6 +1945,16 @@ pub extern "C" fn rt_solve_nls(
     stat_inc(STAT_NLS_SOLVE);
     let mut eval = |xs: &[f64], r: &mut [f64]| {
         stat_inc(STAT_NLS_RES);
+        // C's generated `residualFunc`: an inf/nan iteration variable fails the
+        // evaluation instead of reaching the model. Feed kinsol the nan residual
+        // and its line search takes a nan step length, which no exit test catches.
+        if xs.iter().any(|v| !v.is_finite()) {
+            NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
+            for v in r.iter_mut() {
+                *v = 1e60;
+            }
+            return;
+        }
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -132,8 +132,9 @@ fn run() {
     let sim_data = crate::rt_alloc(m.layout.total);
     let mut engine = StandaloneEngine;
 
-    // `+inf` budget = run to completion; no clock/cancel hooks needed (the driver
-    // short-circuits the deadline and polls no cancel flag here).
+    // wasip1 has a monotonic clock, so `-alarm` works; nothing cancels a command.
+    driver::set_clock(now_ms);
+    // `+inf` budget = run to completion; the driver short-circuits that deadline.
     let (result, _label) = match driver::drive(&mut engine, &m, sim_data, m.method.as_str(), false, false) {
         Ok(v) => v,
         Err(e) => {
@@ -170,6 +171,13 @@ fn run() {
         &result.params,
     );
     std::fs::write(format!("{}_res.mat", m.prefix), bytes).expect("wasm-jit standalone: cannot write result file");
+}
+
+/// Wall clock for the driver, in ms since the first reading.
+fn now_ms() -> f64 {
+    use std::time::Instant;
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_secs_f64() * 1000.0
 }
 
 /// The command entry point. Runs wasi-libc ctors (preopen/stdio init), takes the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -18,6 +18,8 @@ pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
         ida: false,
         cvode: openmodelica_sim_meta::CVODE,
         gbode: false,
+        // Served by the driver's per-step deadline; both runtimes install a clock.
+        alarm: true,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -453,6 +453,57 @@ fn past_deadline(deadline: f64) -> bool {
     deadline.is_finite() && now_ms() >= deadline
 }
 
+/// `-alarm=N` as an absolute `now_ms` deadline (`+inf` = no alarm). C's `SIGALRM`
+/// stops the executable wherever it is; the drivers poll this once per step,
+/// where they already poll for cancellation. A run wedged *inside* one call into
+/// wasm never gets back here — `OMC_WASM_HARD_ALARM` is for that.
+mod alarm_store {
+    #[cfg(feature = "std")]
+    mod imp {
+        use core::cell::Cell;
+        std::thread_local! {
+            static DEADLINE: Cell<f64> = const { Cell::new(f64::INFINITY) };
+        }
+        pub fn set(v: f64) {
+            DEADLINE.with(|d| d.set(v));
+        }
+        pub fn get() -> f64 {
+            DEADLINE.with(|d| d.get())
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use core::cell::UnsafeCell;
+        // The in-wasm runtime is single-threaded, so a plain cell is sound.
+        struct Store(UnsafeCell<f64>);
+        unsafe impl Sync for Store {}
+        static DEADLINE: Store = Store(UnsafeCell::new(f64::INFINITY));
+        pub fn set(v: f64) {
+            unsafe { *DEADLINE.0.get() = v };
+        }
+        pub fn get() -> f64 {
+            unsafe { *DEADLINE.0.get() }
+        }
+    }
+
+    pub use imp::{get, set};
+}
+
+fn arm_alarm() {
+    alarm_store::set(match crate::simflags::with_flags(|f| f.alarm) {
+        Some(secs) => now_ms() + secs as f64 * 1000.0,
+        None => f64::INFINITY,
+    });
+}
+
+fn check_alarm() -> Result<()> {
+    match past_deadline(alarm_store::get()) {
+        true => Err(ALARM_ABORT_ERR),
+        false => Ok(()),
+    }
+}
+
 // Cancellation is a host concern (the native atomic flag, the wasm
 // SharedArrayBuffer poll, or the in-wasm session's own cancel flag). The driver
 // only polls it, so a host installs a hook; unset means "never cancelled". The
@@ -650,6 +701,8 @@ fn apply_start_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
 
 /// Returned to abort a run on detected chattering (`-abortSlowSimulation`).
 pub const CHATTER_ABORT_ERR: &str = "CodegenWasmJit: aborting simulation due to chattering";
+/// Returned when the `-alarm` deadline expires.
+pub const ALARM_ABORT_ERR: &str = "CodegenWasmJit: simulation aborted (-alarm)";
 /// What [`enrich_trap`] returns for a trap that was a failed model `assert()`.
 pub const ASSERT_ERR: &str = "assertion failed";
 
@@ -1572,6 +1625,8 @@ pub fn make_driver(
     method: &str,
 ) -> Result<(Box<dyn Driver>, &'static str)> {
     let method = effective_method(method);
+    // Both `drive` and the in-wasm `rt_sim_start` build their driver here.
+    arm_alarm();
     let layout = &model.layout;
     set_zc_tolerance(e, sim_data, layout, model.tolerance)?;
     // A model compiled with `method="cvode"` reaches here without passing through
@@ -1767,6 +1822,7 @@ impl Driver for EulerDriver {
             if did_step && past_deadline(deadline) {
                 return Ok(Advance::Running);
             }
+            check_alarm()?;
             if cancel_requested() {
                 return Ok(Advance::Cancelled);
             }
@@ -2269,6 +2325,7 @@ impl Driver for DasslDriver {
                 if did_step && past_deadline(deadline) {
                     return Ok(Advance::Running);
                 }
+                check_alarm()?;
                 if cancel_requested() {
                     return Ok(Advance::Cancelled);
                 }
@@ -2334,6 +2391,7 @@ impl Driver for DasslDriver {
             if did_step && past_deadline(deadline) {
                 break Advance::Running;
             }
+            check_alarm()?;
             if cancel_requested() {
                 break Advance::Cancelled;
             }
@@ -2818,6 +2876,7 @@ impl SolverCore {
             if *did_step && past_deadline(deadline) {
                 return Ok(Solved::Yielded);
             }
+            check_alarm()?;
             if cancel_requested() {
                 return Ok(Solved::Cancelled);
             }
@@ -2924,6 +2983,7 @@ impl SolverCore {
                 self.nfe = ctx.nfe;
                 return Ok(Step::Yielded);
             }
+            check_alarm()?;
             if cancel_requested() {
                 self.nfe = ctx.nfe;
                 return Ok(Step::Cancelled);
@@ -3425,6 +3485,7 @@ impl Driver for EventsDriver {
                 if did_step && past_deadline(deadline) {
                     return Ok(Advance::Running);
                 }
+                check_alarm()?;
                 if cancel_requested() {
                     return Ok(Advance::Cancelled);
                 }
@@ -3527,6 +3588,7 @@ impl Driver for EventsDriver {
             if did_step && past_deadline(deadline) {
                 break Advance::Running;
             }
+            check_alarm()?;
             if cancel_requested() {
                 break Advance::Cancelled;
             }
@@ -3779,6 +3841,7 @@ impl Driver for CvodeDriver {
                 if did_step && past_deadline(deadline) {
                     return Ok(Advance::Running);
                 }
+                check_alarm()?;
                 if cancel_requested() {
                     return Ok(Advance::Cancelled);
                 }
@@ -3830,6 +3893,7 @@ impl Driver for CvodeDriver {
             if did_step && past_deadline(deadline) {
                 break Advance::Running;
             }
+            check_alarm()?;
             if cancel_requested() {
                 break Advance::Cancelled;
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -79,6 +79,9 @@ pub struct SimFlags {
     /// `-lv` streams, uppercased.
     pub log: Vec<String>,
     pub abort_slow: bool,
+    /// `-alarm`: seconds after which the run is aborted (C's `FLAG_ALARM`, where
+    /// it is a `SIGALRM` on the simulation executable). 0 disables it, as in C.
+    pub alarm: Option<u32>,
     /// `-ils`: equidistant homotopy steps of the initial solve (C's
     /// `init_lambda_steps`, default 3).
     pub init_lambda_steps: Option<i32>,
@@ -129,6 +132,8 @@ pub struct Capabilities {
     pub ida: bool,
     pub cvode: bool,
     pub gbode: bool,
+    /// This runtime has a wall clock, so `-alarm` can be honoured.
+    pub alarm: bool,
 }
 
 /// Reject flag values this runtime cannot honour.
@@ -143,6 +148,9 @@ pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
                 return Err(format!("-{flag}=klu: this runtime has no KLU linear solver"));
             }
         }
+    }
+    if f.alarm.is_some() && !cap.alarm {
+        return Err("-alarm: this runtime has no wall clock".to_string());
     }
     let unsupported = match f.solver {
         Some(Solver::Ida) if !cap.ida => "ida",
@@ -237,6 +245,12 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "abortSlowSimulation" => f.abort_slow = true,
+            "alarm" => {
+                let secs = value(name)?
+                    .parse::<u32>()
+                    .map_err(|_| "-alarm takes an integer argument".to_string())?;
+                f.alarm = (secs > 0).then_some(secs);
+            }
             "ils" => {
                 f.init_lambda_steps =
                     Some(value(name)?.parse::<i32>().map_err(|_| "-ils needs an integer".to_string())?)
@@ -389,7 +403,7 @@ mod tests {
     }
 
     const NOTHING: Capabilities =
-        Capabilities { klu: false, ida: false, cvode: false, gbode: false };
+        Capabilities { klu: false, ida: false, cvode: false, gbode: false, alarm: false };
 
     #[test]
     fn defaults_are_all_unset() {
@@ -436,7 +450,7 @@ mod tests {
     // both the parser and the capability check of the build that offered it.
     #[test]
     fn everything_supported_parses_and_checks() {
-        for cap in [NOTHING, Capabilities { klu: true, ida: true, cvode: true, gbode: true }] {
+        for cap in [NOTHING, Capabilities { klu: true, ida: true, cvode: true, gbode: true, alarm: true }] {
             for (flag, values) in supported(cap) {
                 for v in values {
                     let f = parse(&argv(&[&format!("-{flag}={v}")])).expect(&format!("-{flag}={v}"));
@@ -504,6 +518,14 @@ mod tests {
     #[test]
     fn missing_value_is_an_error() {
         assert!(parse(&argv(&["-nls"])).is_err());
+    }
+
+    // C's `-alarm=0` disables the alarm rather than setting a zero-second one.
+    #[test]
+    fn alarm_zero_disables() {
+        assert_eq!(parse(&argv(&["-alarm=30"])).expect("parses").alarm, Some(30));
+        assert_eq!(parse(&argv(&["-alarm=0"])).expect("parses").alarm, None);
+        assert!(parse(&argv(&["-alarm=soon"])).is_err());
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
@@ -28,6 +28,8 @@ pub fn compile_model_module(_wasm: &[u8]) -> std::result::Result<Module, String>
 
 pub fn start_runtime_compile() {}
 
+pub fn set_alarm(_seconds: Option<u32>) {}
+
 pub fn take_compiled_model(_model: &SimModel) -> std::result::Result<Module, String> {
     return Err(NO_ENGINE.to_string())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -187,6 +187,9 @@ fn load_or_compile_runtime() -> std::result::Result<wasmer::Module, String> {
 /// JIT-compile a generated model module on the shared engine. Called either on a
 /// background thread from `translateModel` (overlapping the rest of the OMC
 /// pipeline) or inline from `run` as a fallback.
+/// wasmer has no epoch interruption, so there is no hard `-alarm` to install.
+pub fn set_alarm(_seconds: Option<u32>) {}
+
 pub fn compile_model_module(wasm: &[u8]) -> std::result::Result<wasmer::Module, String> {
     wts(wasmer::Module::from_binary(sim_engine(), wasm))
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -49,33 +49,91 @@ fn runtime_blob() -> &'static [u8] {
 /// it backend-agnostically as `sim_runtime::Module`.
 pub(crate) type Module = wasmtime::Module;
 
+/// Seconds before wasm is interrupted, 0 = no hard alarm. `-alarm` is normally
+/// served by the driver's per-step deadline; this is the bound C gets from
+/// `SIGALRM`, for a run wedged inside one call into wasm. The epoch checks
+/// Cranelift then emits cost ~20% of the integration, hence the env var.
+static ALARM_SECS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Install the run's `-alarm`, before the modules are instantiated: a hard alarm
+/// selects the other engine.
+pub fn set_alarm(seconds: Option<u32>) {
+    let hard = seconds.filter(|_| std::env::var("OMC_WASM_HARD_ALARM").is_ok());
+    ALARM_SECS.store(hard.unwrap_or(0), std::sync::atomic::Ordering::Relaxed);
+}
+
+fn alarm_secs() -> u32 {
+    ALARM_SECS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Report an expired alarm as the driver's own deadline does; the trap it unwinds
+/// as no longer says. The engine detail stays: its backtrace is where it stuck.
+fn map_alarm(e: String) -> String {
+    match ALARM_FIRED.with(|f| f.replace(false)) {
+        true => sim_driver::ALARM_ABORT_ERR.to_string(),
+        false => e,
+    }
+}
+
+std::thread_local! {
+    /// Set by the epoch-deadline callback, for [`map_alarm`].
+    static ALARM_FIRED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Bump the alarm engine's epoch once a second, so a deadline is a second count.
+fn start_epoch_ticker(engine: wasmtime::Engine) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        engine.increment_epoch();
+    });
+}
+
 /// One process-wide wasmtime `Engine`, so the (model-independent) runtime module
 /// can be JIT-compiled once and reused, and so model modules built on background
 /// threads share the same engine the run instantiates them on.
+/// Two of them: see [`ALARM_SECS`].
 pub fn sim_engine() -> &'static wasmtime::Engine {
+    if alarm_secs() != 0 { alarm_engine() } else { plain_engine() }
+}
+
+fn alarm_engine() -> &'static wasmtime::Engine {
     static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
     ENGINE.get_or_init(|| {
-        let mut cfg = wasmtime::Config::new();
-        crate::tune_memory(&mut cfg);
-        // Compile module functions across threads (off by default with
-        // default-features=false) — ~4x faster module compilation here.
-        cfg.parallel_compilation(true);
-        // Experimental opt-level override; default is wasmtime's `Speed`.
-        match std::env::var("OMC_WASM_OPT_LEVEL").as_deref() {
-            Ok("none") => { cfg.cranelift_opt_level(wasmtime::OptLevel::None); }
-            Ok("speed_and_size") => { cfg.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize); }
-            _ => {}
-        }
-        // Inline across the model/runtime boundary. Generated code reaches the
-        // `rt_*` helpers as *imported* functions, and wasmtime's default is no
-        // inlining at all, so a handful of instructions cost a call; `Yes` also
-        // covers inter-module. Costs module compilation time, which the on-disk
-        // AOT cache pays once for the runtime.
-        if std::env::var("OMC_WASM_NO_INLINE").is_err() {
-            cfg.compiler_inlining(wasmtime::Inlining::Yes);
-        }
-        wasmtime::Engine::new(&cfg).expect("wasm-jit: failed to build wasmtime engine")
+        let engine = build_engine_cfg(|cfg| {
+            cfg.epoch_interruption(true);
+        });
+        start_epoch_ticker(engine.clone());
+        engine
     })
+}
+
+fn plain_engine() -> &'static wasmtime::Engine {
+    static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
+    ENGINE.get_or_init(|| build_engine_cfg(|_| {}))
+}
+
+fn build_engine_cfg(extra: impl FnOnce(&mut wasmtime::Config)) -> wasmtime::Engine {
+    let mut cfg = wasmtime::Config::new();
+    crate::tune_memory(&mut cfg);
+    // Compile module functions across threads (off by default with
+    // default-features=false) — ~4x faster module compilation here.
+    cfg.parallel_compilation(true);
+    // Experimental opt-level override; default is wasmtime's `Speed`.
+    match std::env::var("OMC_WASM_OPT_LEVEL").as_deref() {
+        Ok("none") => { cfg.cranelift_opt_level(wasmtime::OptLevel::None); }
+        Ok("speed_and_size") => { cfg.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize); }
+        _ => {}
+    }
+    // Inline across the model/runtime boundary. Generated code reaches the
+    // `rt_*` helpers as *imported* functions, and wasmtime's default is no
+    // inlining at all, so a handful of instructions cost a call; `Yes` also
+    // covers inter-module. Costs module compilation time, which the on-disk
+    // AOT cache pays once for the runtime.
+    if std::env::var("OMC_WASM_NO_INLINE").is_err() {
+        cfg.compiler_inlining(wasmtime::Inlining::Yes);
+    }
+    extra(&mut cfg);
+    wasmtime::Engine::new(&cfg).expect("wasm-jit: failed to build wasmtime engine")
 }
 
 /// The compiled runtime module, obtained once per process and shared across all
@@ -85,10 +143,13 @@ pub fn sim_engine() -> &'static wasmtime::Engine {
 /// microseconds. `deserialize` validates the artifact against the current
 /// wasmtime version / engine config / target, so a stale or incompatible cache
 /// is rejected and we transparently fall back to JIT (then refresh the cache).
+/// One cache per engine: a module belongs to the engine that compiled it.
 pub fn runtime_module() -> std::result::Result<&'static wasmtime::Module, String> {
-    static MODULE: OnceLock<std::result::Result<wasmtime::Module, String>> = OnceLock::new();
-    MODULE
-        .get_or_init(|| load_or_compile_runtime())
+    static PLAIN: OnceLock<std::result::Result<wasmtime::Module, String>> = OnceLock::new();
+    static ALARM: OnceLock<std::result::Result<wasmtime::Module, String>> = OnceLock::new();
+    let armed = alarm_secs() != 0;
+    if armed { &ALARM } else { &PLAIN }
+        .get_or_init(|| load_or_compile_runtime(armed))
         .as_ref()
         .map_err(|e| format!("obtaining runtime module: {e}"))
 }
@@ -102,13 +163,14 @@ pub fn runtime_module() -> std::result::Result<&'static wasmtime::Module, String
 /// reboots and not shared between users (unlike a world-writable temp dir, where
 /// the sticky bit would stop other users refreshing it). Falls back to the
 /// system temp dir if `$HOME` is unset or the cache dir can't be created.
-fn runtime_cache_path() -> std::path::PathBuf {
+fn runtime_cache_path(epoch: bool) -> std::path::PathBuf {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     runtime_blob().len().hash(&mut h);
     runtime_blob().hash(&mut h);
     std::env::var("OMC_WASM_OPT_LEVEL").unwrap_or_default().hash(&mut h);
     std::env::var("OMC_WASM_NO_INLINE").is_ok().hash(&mut h);
+    epoch.hash(&mut h);
     let key = h.finish();
 
     let home = openmodelica_util::Settings::getHomeDir(false);
@@ -122,9 +184,9 @@ fn runtime_cache_path() -> std::path::PathBuf {
     dir.join(format!("wasmjit-runtime-{key:016x}.cwasm"))
 }
 
-fn load_or_compile_runtime() -> std::result::Result<wasmtime::Module, String> {
-    let engine = sim_engine();
-    let path = runtime_cache_path();
+fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module, String> {
+    let engine = if epoch { alarm_engine() } else { plain_engine() };
+    let path = runtime_cache_path(epoch);
     // Try the AOT artifact first (microseconds). `deserialize_file` is unsafe
     // because it trusts the artifact; it is one we produced under temp_dir, and
     // wasmtime validates version/config compatibility (erroring otherwise).
@@ -544,7 +606,7 @@ pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, Strin
         match sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench) {
             Ok(v) => v,
             Err(e) => {
-                return Err(e.to_string());
+                return Err(map_alarm(e.to_string()));
             }
         };
     // The solves ran host-side (`rt_host_lin_solve`) or in-wasm (KLU/rsparse);
@@ -566,7 +628,7 @@ fn run_inwasm(model: &SimModel, bench: bool) -> std::result::Result<sim_driver::
     let t0 = Instant::now();
     let mut sess = build_inwasm_session(model)?;
     loop {
-        match sess.advance(f64::INFINITY)? {
+        match sess.advance(f64::INFINITY).map_err(|e| map_alarm(e.to_string()))? {
             0 => continue,
             3 => return Err("CodegenWasmJit: in-wasm simulation cancelled".to_string()),
             _ => break, // 1 done, 2 terminated
@@ -625,6 +687,12 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         Some(m) => m,
         None => take_compiled_model(model)?,
     };
+    // A hard alarm armed after the compile switches engines under the module.
+    let model_module = if wasmtime::Engine::same(model_module.engine(), engine) {
+        model_module
+    } else {
+        wts(wasmtime::Module::new(engine, &model.wasm))?
+    };
     let model_compile = t_model.elapsed();
     let compile_time = t_compile.elapsed();
     if bench {
@@ -637,6 +705,14 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     // Phase 2: instantiate (sharing the runtime's linear memory).
     let t_inst = Instant::now();
     let mut store = wasmtime::Store::new(engine, WasiCtx::new(".", Vec::new()));
+    if let secs @ 1.. = alarm_secs() {
+        ALARM_FIRED.with(|f| f.set(false));
+        store.set_epoch_deadline(secs as u64);
+        store.epoch_deadline_callback(move |_| {
+            ALARM_FIRED.with(|f| f.set(true));
+            Err(wasmtime::Error::msg(sim_driver::ALARM_ABORT_ERR))
+        });
+    }
     let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
     // The generated module imports the runtime's exports under module name "rt".
     wts(linker.instance(&mut store, "rt", rt_inst))?;


### PR DESCRIPTION
Two unrelated hangs, both reachable from the testsuite.

`-nls=kinsol` could spin forever inside one KINSol call. Trial points drove an iteration variable to inf/nan, the residual was evaluated there anyway and came back nan, and KINLineSearch's ALPHA loop then computed rl = SUNMAX(POINT1*rl, nan). SUNMAX returns the nan, and the loop's only exit, rl < rlmin, is false for nan. C never gets there: the generated residualFunc<N> tests isinf/isnan on the iteration variables first and throws, which nlsKinsolResiduals reports as the recoverable iflag = 1. rt_solve_nls's eval now does the same, so KINSOL halves the step instead. nonlinear_system/problem2_kinsol goes from an unbounded spin to failing in 0.4 s, as it does in C.

-alarm was parsed into SimFlags::unknown and dropped, although ModelTesting.mos appends it to every non-Cpp simulation test. C arms a SIGALRM on the simulation executable; in-process there are two halves:

  * The drivers poll a deadline once per step, where they already poll for cancellation. One clock read per step, so FullRobot integrates in the same 1.7 s with -alarm=600 as without.
  * OMC_WASM_HARD_ALARM=1 additionally compiles the model on a wasmtime engine with epoch interruption, the only thing that stops a run wedged inside one call into wasm. Those checks cost ~20% of the integration, so it is a separate engine and module cache.

Verified over simulation/modelica/nonlinear_system with RTEST_OMCFLAGS=--simCodeTarget=wasm-jit: the only change against the previous build is problem2_kinsol, from a 240 s timeout to a 0.4 s failure.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
