### PR TITLE
wasm-jit: abandon an NLS attempt on a model assert

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/minpack/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/minpack/src/lib.rs
@@ -448,6 +448,17 @@ pub enum Status {
     XtolTooSmall,
     /// Iteration is not making good progress (info = 4 or 5).
     Stalled,
+    /// [`Hooks::abort`] asked to stop (MINPACK's negative `iflag`).
+    Aborted,
+}
+
+/// `abort` is MINPACK's negative-`iflag` early exit, polled after every residual
+/// batch. `fjacobian` receives each Jacobian before [`qrfac`] destroys it (C's
+/// `hybrdData->fjacobian`).
+#[derive(Default)]
+pub struct Hooks<'a> {
+    pub abort: Option<&'a dyn Fn() -> bool>,
+    pub fjacobian: Option<&'a mut [f64]>,
 }
 
 /// Solve `f(x) = 0` for `n` equations in `n` unknowns with MINPACK's `hybrd`
@@ -469,7 +480,39 @@ pub fn hybrd(
     epsfcn: f64,
     factor: f64,
 ) -> Status {
-    hybrd_common(eval, None, n, x, fvec, xtol, maxfev, epsfcn, factor)
+    hybrd_common(eval, None, &mut Hooks::default(), n, x, fvec, xtol, maxfev, epsfcn, factor)
+}
+
+/// [`hybrd`] with [`Hooks`].
+#[allow(clippy::too_many_arguments)]
+pub fn hybrd_hooked(
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    hooks: &mut Hooks,
+    n: usize,
+    x: &mut [f64],
+    fvec: &mut [f64],
+    xtol: f64,
+    maxfev: usize,
+    epsfcn: f64,
+    factor: f64,
+) -> Status {
+    hybrd_common(eval, None, hooks, n, x, fvec, xtol, maxfev, epsfcn, factor)
+}
+
+/// [`hybrj`] with [`Hooks`].
+#[allow(clippy::too_many_arguments)]
+pub fn hybrj_hooked(
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    jac: &mut dyn FnMut(&[f64], &mut [f64]),
+    hooks: &mut Hooks,
+    n: usize,
+    x: &mut [f64],
+    fvec: &mut [f64],
+    xtol: f64,
+    maxfev: usize,
+    factor: f64,
+) -> Status {
+    hybrd_common(eval, Some(jac), hooks, n, x, fvec, xtol, maxfev, 0.0, factor)
 }
 
 /// Solve `f(x) = 0` with MINPACK's `hybrj` (user-supplied analytic Jacobian).
@@ -486,7 +529,7 @@ pub fn hybrj(
     maxfev: usize,
     factor: f64,
 ) -> Status {
-    hybrd_common(eval, Some(jac), n, x, fvec, xtol, maxfev, 0.0, factor)
+    hybrd_common(eval, Some(jac), &mut Hooks::default(), n, x, fvec, xtol, maxfev, 0.0, factor)
 }
 
 /// Shared dogleg/trust-region driver for [`hybrd`] (numeric Jacobian via
@@ -495,6 +538,7 @@ pub fn hybrj(
 fn hybrd_common(
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
     mut jac: Option<&mut dyn FnMut(&[f64], &mut [f64])>,
+    hooks: &mut Hooks,
     n: usize,
     x: &mut [f64],
     fvec: &mut [f64],
@@ -521,8 +565,13 @@ fn hybrd_common(
     let mut info = Status::Stalled;
     let mut nfev;
 
+    let aborted = |hooks: &Hooks| hooks.abort.is_some_and(|a| a());
+
     eval(x, fvec);
     nfev = 1;
+    if aborted(hooks) {
+        return Status::Aborted;
+    }
     let mut fnorm = enorm(&fvec[..n]);
 
     let mut iter = 1;
@@ -539,6 +588,12 @@ fn hybrd_common(
                 fdjac1(eval, n, x, fvec, &mut fjac, epsfcn, &mut wa1);
                 nfev += n;
             }
+        }
+        if aborted(hooks) {
+            return Status::Aborted;
+        }
+        if let Some(out) = hooks.fjacobian.as_deref_mut() {
+            out.copy_from_slice(&fjac);
         }
         qrfac(n, n, &mut fjac, &mut wa1, &mut wa2, &mut wa3);
 
@@ -604,6 +659,9 @@ fn hybrd_common(
 
             eval(&wa2, &mut wa4);
             nfev += 1;
+            if aborted(hooks) {
+                return Status::Aborted;
+            }
             let fnorm1 = enorm(&wa4[..n]);
 
             let actred = if fnorm1 < fnorm {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2527,7 +2527,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // shared-table job and thread the map through `var_map`. The systems' own
     // `residual`/`load` callbacks are emitted after the equation functions.
     let nls_nominal_map = build_nls_nominal_map(vars);
-    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_patterns) =
+    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) =
         collect_nls_jobs(&[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs], &nls_nominal_map);
     // Register the analytic-Jacobian seed/result crefs before the equation
     // functions are lowered, so the column equations resolve their slots.
@@ -2919,7 +2919,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         let start_idx = import_base + bodies.len() as u32;
         let mut f = we::Function::new([]);
         if let Some((fn_indices, _)) = &nls_wiring {
-            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals, &nls_patterns);
+            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals, &nls_bounds, &nls_patterns);
         }
         if !thunk_indices.is_empty() {
             crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
@@ -3027,9 +3027,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     if start_wiring.is_some() {
         let mut globals = we::GlobalSection::new();
         // NLS_BASE_GLOBAL (shared-table base), NLS_HIST_GLOBAL (history block base),
-        // NLS_NOMINAL_GLOBAL (nominal block base) and NLS_PAT_GLOBAL (sparse-pattern
-        // block base) when the model has nonlinear systems, then the closure-thunk
-        // table base; all set by `start`.
+        // NLS_NOMINAL_GLOBAL (nominal block base), NLS_PAT_GLOBAL (sparse-pattern
+        // block base) and NLS_BOUNDS_GLOBAL (min/max block base) when the model has
+        // nonlinear systems, then the closure-thunk table base; all set by `start`.
         let n_globals = if thunk_indices.is_empty() { closure_global } else { closure_global + 1 };
         for _ in 0..n_globals {
             globals.global(
@@ -4293,8 +4293,8 @@ fn nls_parts(
 /// threaded to the equation lowering via `SimVarMap`/`SimCtx`.
 fn collect_nls_jobs(
     eq_lists: &[&[Arc<SimCode::SimEqSystem>]],
-    nominal_of: &HashMap<String, f64>,
-) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<i32>) {
+    nominal_of: &HashMap<String, (f64, f64, f64)>,
+) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<f64>, Vec<i32>) {
     use SimCode::SimEqSystem as E;
     let mut systems: Vec<Arc<SimCode::NonlinearSystem>> = Vec::new();
     let mut jobs: HashMap<i32, NlsJob> = HashMap::new();
@@ -4307,6 +4307,8 @@ fn collect_nls_jobs(
     // Concatenated nominal values, in system order; the module `start` writes them
     // into the nominal block, and each job's `nominal_off` indexes into it.
     let mut nominals: Vec<f64> = Vec::new();
+    // `min`/`max` pairs alongside them, in the same order.
+    let mut bounds: Vec<f64> = Vec::new();
     for list in eq_lists {
         for e in *list {
             if let E::SES_NONLINEAR { nlSystem, .. } = &**e {
@@ -4344,19 +4346,24 @@ fn collect_nls_jobs(
                 hist_off += crate::CodegenWasmJitFunctions::nls_hist_bytes(n);
                 nominal_off += 8 * n;
                 for cr in lst(&nlSystem.crefs) {
-                    let nom = sim_cref_key(cr).ok().and_then(|k| nominal_of.get(&k).copied()).unwrap_or(1.0);
+                    let (nom, lo, hi) = sim_cref_key(cr)
+                        .ok()
+                        .and_then(|k| nominal_of.get(&k).copied())
+                        .unwrap_or((1.0, f64::NEG_INFINITY, f64::INFINITY));
                     nominals.push(nom);
+                    bounds.push(lo);
+                    bounds.push(hi);
                 }
                 systems.push(nlSystem.clone());
             }
         }
     }
-    (systems, jobs, hist_off, nominals, patterns)
+    (systems, jobs, hist_off, nominals, bounds, patterns)
 }
 
-/// Map each scalar real variable's cref key to its nominal attribute, defaulting to
-/// 1.0 when unset or non-constant. Feeds the NLS x-scaling nominal block.
-fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, f64> {
+/// Map each scalar real variable's cref key to its `(nominal, min, max)` attributes,
+/// defaulting to `(1.0, -inf, +inf)` where unset or non-constant.
+fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f64, f64)> {
     let mut map = HashMap::new();
     let all = lst(&vars.stateVars)
         .chain(lst(&vars.algVars))
@@ -4366,7 +4373,9 @@ fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, f64> {
     for sv in all {
         if let Ok(key) = sim_cref_key(&sv.name) {
             let nom = const_value(&sv.nominalValue).map(|v| v.abs()).filter(|v| *v > 0.0).unwrap_or(1.0);
-            map.entry(key).or_insert(nom);
+            let lo = const_value(&sv.minValue).unwrap_or(f64::NEG_INFINITY);
+            let hi = const_value(&sv.maxValue).unwrap_or(f64::INFINITY);
+            map.entry(key).or_insert((nom, lo, hi));
         }
     }
     map
@@ -4898,10 +4907,11 @@ fn emit_nls_start(
     fn_indices: &[(u32, u32, Option<u32>)],
     hist_bytes: u32,
     nominals: &[f64],
+    bounds: &[f64],
     patterns: &[i32],
 ) {
     use we::Instruction as I;
-    use crate::CodegenWasmJitFunctions::{NLS_NOMINAL_GLOBAL, NLS_PAT_GLOBAL};
+    use crate::CodegenWasmJitFunctions::{NLS_BOUNDS_GLOBAL, NLS_NOMINAL_GLOBAL, NLS_PAT_GLOBAL};
     // history block (zeroed by rt_alloc, so every system's count starts 0).
     if hist_bytes > 0 {
         f.instruction(&I::I32Const(hist_bytes as i32));
@@ -4917,6 +4927,17 @@ fn emit_nls_start(
         for (i, nom) in nominals.iter().enumerate() {
             f.instruction(&I::GlobalGet(NLS_NOMINAL_GLOBAL));
             f.instruction(&I::F64Const((*nom).into()));
+            f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg((i * 8) as u32, 3)));
+        }
+    }
+    // bounds block: the `min`/`max` pair per iteration variable, same order.
+    if !bounds.is_empty() {
+        f.instruction(&I::I32Const((bounds.len() * 8) as i32));
+        f.instruction(&I::Call(rt_index("rt_alloc").expect("rt_alloc is a runtime builtin")));
+        f.instruction(&I::GlobalSet(NLS_BOUNDS_GLOBAL));
+        for (i, v) in bounds.iter().enumerate() {
+            f.instruction(&I::GlobalGet(NLS_BOUNDS_GLOBAL));
+            f.instruction(&I::F64Const((*v).into()));
             f.instruction(&I::F64Store(crate::CodegenWasmJitFunctions::mem_arg((i * 8) as u32, 3)));
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -409,7 +409,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
     ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
@@ -426,10 +426,10 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
 pub(crate) const NLS_BASE_GLOBAL: u32 = 0;
 
 /// Module global holding the base index this module's closure thunks were
-/// appended to the shared table at (set by `start`): after the four
+/// appended to the shared table at (set by `start`): after the five
 /// nonlinear-solver globals, or the only global when there are none.
 pub(crate) fn closure_base_global(has_nls: bool) -> u32 {
-    if has_nls { NLS_PAT_GLOBAL + 1 } else { 0 }
+    if has_nls { NLS_BOUNDS_GLOBAL + 1 } else { 0 }
 }
 
 /// Absolute wasm function index of a runtime import (after all [`BUILTINS`]).
@@ -1089,6 +1089,10 @@ pub(crate) const NLS_NOMINAL_GLOBAL: u32 = 2;
 /// Model global holding the base address of the sparse-NLS pattern block
 /// (`colptr[n+1]` then `rowidx[nnz]`, `i32`, per sparsely-solved system).
 pub(crate) const NLS_PAT_GLOBAL: u32 = 3;
+
+/// Model global holding the base address of the NLS bounds block: the `min`/`max`
+/// pair per iteration variable, which the solver constrains its restarts to.
+pub(crate) const NLS_BOUNDS_GLOBAL: u32 = 4;
 
 /// The contiguous `SimData` slot range backing one scalarized array model
 /// variable. The backend lays an array's scalar elements out consecutively in

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1459,9 +1459,12 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::LocalGet(data));
     ctx.emit(I::I32Const(rel_fresh_off as i32));
     ctx.emit(I::I32Add);
-    // nominal block address (x-scaling).
+    // nominal block address (x-scaling), and the matching min/max pairs.
     ctx.emit(I::GlobalGet(NLS_NOMINAL_GLOBAL));
     ctx.emit(I::I32Const(job.nominal_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::GlobalGet(NLS_BOUNDS_GLOBAL));
+    ctx.emit(I::I32Const(2 * job.nominal_off as i32));
     ctx.emit(I::I32Add);
     // analytic-Jacobian table index, or `u32::MAX` when the system has none.
     if job.has_jac {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -44,10 +44,50 @@ fn context_stores_guess() -> bool {
 /// trapping; `eval` then turns that trial into a huge residual so the solver backs off.
 static NLS_DEPTH: AtomicU32 = AtomicU32::new(0);
 static NLS_ASSERT_HIT: AtomicU32 = AtomicU32::new(0);
+/// Outcome of the last *completed* evaluation, read after `eval` returns.
+static NLS_EVAL_HIT: AtomicU32 = AtomicU32::new(0);
+/// C's `assertCalled`, sticky over one solver attempt.
+static NLS_ASSERT_SEEN: AtomicU32 = AtomicU32::new(0);
+
+/// The residual a rejected trial reports; [`newton_c`] damps its step on it.
+const ASSERT_RESIDUAL: f64 = 1e60;
 
 /// Whether the last residual evaluation hit a recoverable model assert.
 pub(crate) fn assert_hit() -> bool {
-    NLS_ASSERT_HIT.load(Ordering::Relaxed) != 0
+    NLS_EVAL_HIT.load(Ordering::Relaxed) != 0
+}
+
+/// Take over the hit flag: a residual routinely runs a nested `rt_solve_nls`, whose
+/// evaluations must not consume the enclosing one's.
+fn enter_eval() -> u32 {
+    NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+    NLS_ASSERT_HIT.swap(0, Ordering::Relaxed)
+}
+
+/// Restore the enclosing evaluation's flag; reports this one's hit.
+fn leave_eval(saved: u32) -> bool {
+    NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
+    let hit = NLS_ASSERT_HIT.swap(saved, Ordering::Relaxed) != 0;
+    note_eval_hit(hit);
+    hit
+}
+
+fn note_eval_hit(hit: bool) {
+    NLS_EVAL_HIT.store(hit as u32, Ordering::Relaxed);
+    if hit {
+        NLS_ASSERT_SEEN.store(1, Ordering::Relaxed);
+    }
+}
+
+/// Open C's `MMC_TRY_INTERNAL` around one solver attempt.
+fn arm_attempt() {
+    NLS_ASSERT_SEEN.store(0, Ordering::Relaxed);
+}
+
+/// The `abort` MINPACK polls. Without it the dogleg grinds against
+/// [`ASSERT_RESIDUAL`] to `maxfev`, where C's `longjmp` leaves at once.
+fn attempt_aborted() -> bool {
+    NLS_ASSERT_SEEN.load(Ordering::Relaxed) != 0
 }
 
 /// Model side (emitted by `emit_assert`): is a failed assert currently recoverable
@@ -92,10 +132,9 @@ fn make_assemble(
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
-        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+        let saved = enter_eval();
         jacf(sim_data, x_ptr, val_ptr);
-        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
-        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        leave_eval(saved);
         match &gather {
             Some(pat) => {
                 for c in 0..n {
@@ -847,7 +886,9 @@ fn hybrd_scaled(
         }
         eval(&real, r);
     };
-    let status = minpack::hybrd(&mut seval, n, x, fvec, 1e-12, maxfev, 1e-12, 100.0);
+    arm_attempt();
+    let mut hooks = minpack::Hooks { abort: Some(&attempt_aborted), fjacobian: None };
+    let status = minpack::hybrd_hooked(&mut seval, &mut hooks, n, x, fvec, 1e-12, maxfev, 1e-12, 100.0);
     drop(seval);
     for i in 0..n {
         x[i] *= scale[i];
@@ -862,32 +903,17 @@ fn nls_accept(status: minpack::Status, fvec: &[f64]) -> bool {
     status == minpack::Status::Converged || enorm(fvec) <= 1.0e-12
 }
 
-/// Residual-scaled norm (C's `xerror_scaled`): divide each residual by the row max
-/// of an FD Jacobian at `x`, then take the 2-norm. Lets a solver accept a stalled
-/// iterate whose residual is negligible relative to the system's own magnitudes.
-fn scaled_res_norm(
-    n: usize,
-    x: &[f64],
-    fvec: &[f64],
-    eval: &mut dyn FnMut(&[f64], &mut [f64]),
-) -> f64 {
-    let mut xw = x.to_vec();
-    let mut rp = vec![0.0f64; n];
+/// C's `xerror_scaled`: `‖fvec / resScaling‖` over the Jacobian `hybrd` last formed.
+/// C reads `fjacobian[i*n + j]` for the whole slice `j`, so `resScaling[i]` is the max
+/// of *column* `i`, not of residual `i`'s row.
+fn scaled_res_norm(n: usize, fvec: &[f64], fjac: &[f64]) -> f64 {
     let mut scaled = vec![0.0f64; n];
     for i in 0..n {
-        let mut row = 1e-16f64;
-        for j in 0..n {
-            let h = SQRT_EPS * (x[j].abs() + 1.0);
-            let saved = xw[j];
-            xw[j] = saved + h;
-            eval(&xw, &mut rp);
-            xw[j] = saved;
-            let d = ((rp[i] - fvec[i]) / h).abs();
-            if d > row {
-                row = d;
-            }
+        let mut m = 1e-16f64;
+        for v in &fjac[i * n..(i + 1) * n] {
+            m = m.max(libm::fabs(*v));
         }
-        scaled[i] = fvec[i] / row;
+        scaled[i] = fvec[i] / m;
     }
     enorm(&scaled)
 }
@@ -901,6 +927,7 @@ fn hybrd_c(
     n: usize,
     x: &mut [f64],
     nominal: &[f64],
+    bounds: &[f64],
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
     const LOCAL_TOL: f64 = 1e-12;
@@ -909,13 +936,17 @@ fn hybrd_c(
     let mut factor = initial_factor;
     let guess = x.to_vec(); // C's nlsxExtrapolation (=start values at init)
     let mut xscale = vec![1.0f64; n];
-    for i in 0..n {
-        xscale[i] = x[i].abs().max(nominal[i]).max(1e-16);
-    }
     let mut use_xscaling = true;
     let mut fvec = vec![0.0f64; n];
+    let mut fjac = vec![0.0f64; n * n];
     let mut retries = 0i32;
+    let mut assert_retries = 0usize;
     loop {
+        // C's "constrain x": no attempt starts outside the declared range.
+        for i in 0..n {
+            x[i] = x[i].max(bounds[2 * i]).min(bounds[2 * i + 1]);
+            xscale[i] = x[i].abs().max(nominal[i]).max(1e-16);
+        }
         let mut xw = vec![0.0f64; n];
         for i in 0..n {
             xw[i] = if use_xscaling { x[i] / xscale[i] } else { x[i] };
@@ -927,20 +958,39 @@ fn hybrd_c(
             }
             eval(&real, r);
         };
-        let status = minpack::hybrd(&mut seval, n, &mut xw, &mut fvec, 1e-12, maxfev, 1e-12, factor);
+        arm_attempt();
+        let mut hooks =
+            minpack::Hooks { abort: Some(&attempt_aborted), fjacobian: Some(&mut fjac) };
+        let status = minpack::hybrd_hooked(
+            &mut seval, &mut hooks, n, &mut xw, &mut fvec, 1e-12, maxfev, 1e-12, factor,
+        );
         drop(seval);
         for i in 0..n {
             x[i] = if use_xscaling { xw[i] * xscale[i] } else { xw[i] };
         }
         let xerror = enorm(&fvec);
-        let xerror_scaled = scaled_res_norm(n, x, &fvec, eval);
+        let xerror_scaled = scaled_res_norm(n, &fvec, &fjac);
         if status == minpack::Status::Converged || xerror <= LOCAL_TOL || xerror_scaled <= LOCAL_TOL {
             return true;
         }
         // C retries on info 4/5 (stall); we also escalate on the trust-region /
         // step-bound terminations, which are the same "no progress" condition here.
         let no_progress = status != minpack::Status::Converged;
-        if no_progress && retries < 3 {
+        // C's `assertRetries` ladder, ahead of the step-bound retries: collapsed
+        // unknowns lifted to nominal, then one variable at a time by 1% of it.
+        if status == minpack::Status::Aborted && assert_retries <= n {
+            x.copy_from_slice(&guess);
+            if assert_retries == 0 {
+                for i in 0..n {
+                    if x[i] == 0.0 {
+                        x[i] = nominal[i];
+                    }
+                }
+            } else {
+                x[assert_retries - 1] += 0.01 * nominal[assert_retries - 1];
+            }
+            assert_retries += 1;
+        } else if no_progress && retries < 3 {
             x.copy_from_slice(&guess);
             factor /= 10.0;
             retries += 1;
@@ -951,10 +1001,9 @@ fn hybrd_c(
             factor = initial_factor;
             retries += 1;
         } else if no_progress && retries < 5 {
+            // C's "try old values as x-Scaling factors"; the constrain-x block above
+            // overwrites them again, in C too, so this is a plain restart.
             x.copy_from_slice(&guess);
-            for i in 0..n {
-                xscale[i] = guess[i].abs().max(nominal[i]).max(1e-16);
-            }
             retries += 1;
         } else if no_progress && retries < 6 {
             x.copy_from_slice(&guess);
@@ -1006,7 +1055,10 @@ fn hybrj_scaled(
             }
         }
     };
-    let status = minpack::hybrj(&mut seval, &mut sjac, n, x, fvec, 1e-12, maxfev, 100.0);
+    arm_attempt();
+    let mut hooks = minpack::Hooks { abort: Some(&attempt_aborted), fjacobian: None };
+    let status =
+        minpack::hybrj_hooked(&mut seval, &mut sjac, &mut hooks, n, x, fvec, 1e-12, maxfev, 100.0);
     drop(seval);
     drop(sjac);
     for i in 0..n {
@@ -1217,10 +1269,14 @@ fn newton_c(
     //
     // The first one comes from C's `solveHomotopy` pre-phase and the loop re-forms it
     // at its *bottom*, so the iteration that converges never pays for a Jacobian.
+    //
+    // False when an assert fired while forming it: C ends the solve there rather
+    // than stepping on a poisoned matrix.
     let form_jac = |x: &mut [f64], fvec: &[f64], jac: &mut [f64], rp: &mut [f64],
                     xscaling: &[f64],
                     eval: &mut dyn FnMut(&[f64], &mut [f64]),
                     jaceval: &mut dyn FnMut(&[f64], &mut [f64])| {
+        arm_attempt();
         if has_jac {
             jaceval(x, jac);
             for col in 0..n {
@@ -1241,8 +1297,11 @@ fn newton_c(
                 x[col] = saved;
             }
         }
+        !attempt_aborted()
     };
-    form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval);
+    if !form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval) {
+        return (false, false);
+    }
     row_scaling(n, &jac, res_scaling);
     let mut error_f_sqrd_scaled = scaled_sq(n, &fvec, res_scaling);
 
@@ -1366,7 +1425,9 @@ fn newton_c(
         }
 
         x.copy_from_slice(&x1);
-        form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval);
+        if !form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval) {
+            return (false, false);
+        }
         row_scaling(n, &jac, res_scaling);
     }
 }
@@ -1905,6 +1966,7 @@ pub extern "C" fn rt_solve_nls(
     time: f64,
     rel_fresh_addr: u32,
     nominal_addr: u32,
+    bounds_addr: u32,
     jac_idx: u32,
     rel_addr: u32,
     n_rel: u32,
@@ -1919,6 +1981,9 @@ pub extern "C" fn rt_solve_nls(
     // is smooth; mode 2 (init) is fresh throughout; mode 1 (event) re-solves with
     // fresh relations until the discrete state stabilizes (mixed-system iteration).
     let saved_rel_fresh = unsafe { load_u32(rel_fresh_addr) };
+    // A nested solve (a medium inversion inside a flow residual) must not end the
+    // enclosing attempt.
+    let saved_assert_seen = NLS_ASSERT_SEEN.swap(0, Ordering::Relaxed);
     // Scratch buffers in the shared linear memory so the model callbacks (which
     // take wasm pointers) can read `x` / write `r`.
     let x_ptr = rt_alloc((n * 8) as u32);
@@ -1936,10 +2001,15 @@ pub extern "C" fn rt_solve_nls(
         warm[i] = unsafe { load_f64(x_ptr + (i * 8) as u32) };
     }
 
-    // Per-variable nominal values for x-scaling.
+    // Per-variable nominal values for x-scaling, and the min/max the solver holds
+    // its restart points inside (C's `solveHybrd` "constrain x").
     let mut nominal = vec![0.0f64; n];
     for i in 0..n {
         nominal[i] = unsafe { load_f64(nominal_addr + (i * 8) as u32) };
+    }
+    let mut bounds = vec![0.0f64; 2 * n];
+    for i in 0..2 * n {
+        bounds[i] = unsafe { load_f64(bounds_addr + (i * 8) as u32) };
     }
 
     stat_inc(STAT_NLS_SOLVE);
@@ -1949,9 +2019,9 @@ pub extern "C" fn rt_solve_nls(
         // evaluation instead of reaching the model. Feed kinsol the nan residual
         // and its line search takes a nan step length, which no exit test catches.
         if xs.iter().any(|v| !v.is_finite()) {
-            NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
-            for v in r.iter_mut() {
-                *v = 1e60;
+            note_eval_hit(true);
+            for i in 0..n {
+                r[i] = ASSERT_RESIDUAL;
             }
             return;
         }
@@ -1959,15 +2029,13 @@ pub extern "C" fn rt_solve_nls(
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
         // Asserts are recoverable while the residual runs (C's ERROR_NONLINEARSOLVER).
-        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
-        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+        let saved = enter_eval();
         residual(sim_data, x_ptr, r_ptr);
-        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
-        if NLS_ASSERT_HIT.load(Ordering::Relaxed) != 0 {
+        if leave_eval(saved) {
             // A model assert failed at this trial (e.g. length < s_small): reject the
             // step with a huge residual so the solver backtracks (C caught the longjmp).
             for i in 0..n {
-                r[i] = 1e60;
+                r[i] = ASSERT_RESIDUAL;
             }
         } else {
             for i in 0..n {
@@ -2005,12 +2073,11 @@ pub extern "C" fn rt_solve_nls(
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
         }
-        // The Jacobian is evaluated at accepted iterates; keep asserts recoverable
-        // here too so a probe never traps, and drop any hit (the residual guards `r`).
-        NLS_DEPTH.fetch_add(1, Ordering::Relaxed);
+        // Keep asserts recoverable here too so a probe never traps. C's
+        // `MMC_TRY_INTERNAL` spans `hybrj_`, so one here ends the attempt.
+        let saved = enter_eval();
         jacf(sim_data, x_ptr, jac_ptr);
-        NLS_DEPTH.fetch_sub(1, Ordering::Relaxed);
-        NLS_ASSERT_HIT.store(0, Ordering::Relaxed);
+        leave_eval(saved);
         if scatter {
             fj.fill(0.0);
             for c in 0..n {
@@ -2155,7 +2222,7 @@ pub extern "C" fn rt_solve_nls(
         }
         if !converged && saved_rel_fresh == 2 {
             x.copy_from_slice(&guess);
-            converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+            converged = hybrd_c(n, &mut x, &nominal, &bounds, &mut eval);
         }
         // Seed collapsed zero unknowns (e.g. the spring-loop s_rel) to nominal, off the
         // degenerate residual plateau, then re-solve — C's "zero start values to nominal".
@@ -2166,7 +2233,7 @@ pub extern "C" fn rt_solve_nls(
                     x[i] = nominal[i];
                 }
             }
-            converged = hybrd_c(n, &mut x, &nominal, &mut eval);
+            converged = hybrd_c(n, &mut x, &nominal, &bounds, &mut eval);
         }
         // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
         if !converged {
@@ -2258,6 +2325,7 @@ pub extern "C" fn rt_solve_nls(
     if saved_rel_fresh != 2 {
         unsafe { store_u32(rel_fresh_addr, saved_rel_fresh) };
     }
+    NLS_ASSERT_SEEN.store(saved_assert_seen, Ordering::Relaxed);
 
     rt_free(x_ptr);
     rt_free(r_ptr);

--- a/testsuite/simulation/modelica/events/ChatteringNoEventsTest1.mos
+++ b/testsuite/simulation/modelica/events/ChatteringNoEventsTest1.mos
@@ -1,7 +1,7 @@
 // name:     ChatteringNoEvents1
 // keywords: EventHandling, Chattering
 // status: correct
-// teardown_command: rm -rf ChatteringNoEventsTest1* output.log
+// teardown_command: rm -rf Chattering.ChatteringNoEvents1* output.log
 // cflags: -d=-newInst
 // 
 //  Simulate model containing EventIterations

--- a/testsuite/simulation/modelica/events/ChatteringNoEventsTest2.mos
+++ b/testsuite/simulation/modelica/events/ChatteringNoEventsTest2.mos
@@ -1,7 +1,7 @@
 // name:     ChatteringNoEvents2
 // keywords: EventHandling, Chattering
 // status: correct
-// teardown_command: rm -rf ChatteringNoEventsTest2* output.log
+// teardown_command: rm -rf Chattering.ChatteringNoEvents2* output.log
 // cflags: -d=-newInst
 // 
 //  Simulate model containing EventIterations

--- a/testsuite/simulation/modelica/nonlinear_system/NonlinearSolverFailureInitial.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/NonlinearSolverFailureInitial.mos
@@ -1,6 +1,6 @@
 // name: NonlinearSolverFailureInitial
 // status: correct
-// teardown_command: rm -f NonlinearSolverFailureInitial* output.log
+// teardown_command: rm -f SolverFailure.NonlinearSolverFailureInitial* output.log
 // cflags: -d=-newInst
 
 loadModel(Modelica, {"3.2.3"});

--- a/testsuite/simulation/modelica/nonlinear_system/NonlinearSolverSimulation.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/NonlinearSolverSimulation.mos
@@ -1,6 +1,6 @@
 // name: NonlinearSolverSimulation
 // status: correct
-// teardown_command: rm -f NonlinearSolverSimulation* output.log
+// teardown_command: rm -f SolverFailure.NonlinearSolverSimulation* output.log
 // cflags: -d=-newInst
 
 loadModel(Modelica, {"3.2.3"});

--- a/testsuite/simulation/modelica/nonlinear_system/WrongInitialSolutionSelected.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/WrongInitialSolutionSelected.mos
@@ -1,6 +1,6 @@
 // name: WrongInitialSolutionSelected
 // status: correct
-// teardown_command: rm -f WrongInitialSolutionSelected* output.log
+// teardown_command: rm -f SolverFailure.WrongInitialSolutionSelected* output.log
 // cflags: -d=-newInst
 
 loadModel(Modelica, {"3.2.3"});


### PR DESCRIPTION
The four held-back C-parity solver pieces cost 6.7x because a rejected trial was only a 1e60 residual, and MINPACK has no way out of one: the dogleg grinds against the cliff to maxfev, where C's longjmp abandons the whole hybrj_ call. minpack gains Hooks{abort, fjacobian} and every hybrd/hybrj rung now ends its attempt at the first assert, the way solveHybrd's MMC_TRY_INTERNAL does. With that the pieces are affordable and go in: solveHybrd's "constrain x" (min/max plumbed through a new NLS_BOUNDS_GLOBAL block) and its assertRetries ladder.

Handing the Jacobian back also removes an n^2 residual scaling. xerror_scaled differenced a fresh FD Jacobian per row -- n^2 model evaluations, 6241 per hybrd_c iteration on BranchingDynamicPipes -- where C reads the one hybrj_ already formed, for none. Its column indexing now matches C's fjacobian[i*n+j] too.

Asserts are scoped per evaluation, so a nested rt_solve_nls (a medium inversion inside a flow residual) neither consumes nor clears the enclosing solve's flag, while kinsol keeps reading the last completed evaluation's outcome. An assert while newtonAlgorithm forms its Jacobian ends that solve rather than stepping on a poisoned matrix.

BranchingDynamicPipes on MSL 3.2.3: 110s -> 79s with a byte-identical result file. simulation/modelica/nonlinear_system is unchanged, the same 9 of 50 as before.

Also fixes five testsuite teardowns that deleted their own test. Their teardown_command globs the test's own name, so running the test -- even one that fails to launch omc -- lost it from the checkout, and the glob matched nothing it was meant to, since simulate() prefixes its output with the enclosing package. Prefixing the package fixes both, as the neighbouring FiniteEscapeTime and Chattering.ChatteringEvents tests already do.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
