### PR TITLE
Dev container for Jenkins stage cmake-rust-clang

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,13 +23,15 @@ dependencies needed to compile OpenModelica.
 - [build-deps-almalinux-10][el-10-dev]: Enterprise Linux Almalinux 10.
 - [build-deps-fedora-43][fedora-43-dev]: Fedora 43.
 - [build-deps-fedora-44][fedora-44-dev]: Fedora 44.
+- [build-deps-ubuntu-26-rust][ubuntu-resolute-rust-dev]: Ubuntu 26.04 with the
+  Rust/clang/wasm toolchain, reproducing the `cmake-rust-clang` CI stage.
 
 There are two flavors:
 
 - `alpine-3.22`, `debian-12`, `debian-13`, `ubuntu-22`, `almalinux-10`,
-  `fedora-43` and `fedora-44` build a small wrapper `Dockerfile` that creates a
-  non-root user matching your local user name and UID so files created in the
-  container are owned by you.
+  `fedora-43`, `fedora-44` and `ubuntu-26-rust` build a small wrapper
+  `Dockerfile` that creates a non-root user matching your local user name and
+  UID so files created in the container are owned by you.
 - `ubuntu-24` and `ubuntu-26` use the base image directly and connect as the
   pre-existing `ubuntu` user.
 
@@ -42,6 +44,33 @@ and running.
 Open command pallet (`Strg+Shift+P`) and run
 `>Dev Containers: Open Folder in Container...`, select the OpenModelica
 directory. Then select a devcontainer.json file to start.
+
+## Reproducing the cmake-rust-clang CI stage
+
+`build-deps-ubuntu-26-rust` pins the same image the `cmake-rust-clang` stage in
+[../Jenkinsfile][jenkinsfile] uses and mounts the same cargo/sccache/omlibrary
+cache volumes. Inside the container run:
+
+```bash
+.devcontainer/build-deps-ubuntu-26-rust/build-rust-clang.sh
+```
+
+which performs the same configure and the same `install`, `rust_wasm_runtime`
+and `testsuite-depends` builds as `common.buildRustOMC()` in
+[../.CI/common.groovy][common-groovy]. Pass `--clean` to also run the
+`git clean -ffdx` that the CI agent does first — that deletes every untracked
+and ignored file in the worktree and all submodules, so it is opt-in.
+
+Two deliberate differences from CI:
+
+- **sccache backend.** CI shares an S3 bucket behind a Jenkins credential. The
+  container keeps the same compiler-launcher wiring but caches to disk in the
+  mounted volume instead.
+- **`CARGO_HOME`.** The image ships `CARGO_HOME=/opt/rust/cargo`, which is
+  root-owned, and cargo has to write it. The `Dockerfile` moves `CARGO_HOME` to
+  `~/.cargo` instead of taking ownership of `/opt/rust`, which would copy the
+  whole Rust toolchain into another image layer. `RUSTUP_HOME` is untouched;
+  running `rustc`/`cargo` only reads it.
 
 ## New Dev Container
 
@@ -78,9 +107,12 @@ The following only applies to the `Dockerfile`-based containers
 [ubuntu-jammy-dev]: ./build-deps-ubuntu-22/devcontainer.json
 [ubuntu-noble-dev]: ./build-deps-ubuntu-24/devcontainer.json
 [ubuntu-resolute-dev]: ./build-deps-ubuntu-26/devcontainer.json
+[ubuntu-resolute-rust-dev]: ./build-deps-ubuntu-26-rust/devcontainer.json
 [el-10-dev]: ./build-deps-almalinux-10/devcontainer.json
 [fedora-43-dev]: ./build-deps-fedora-43/devcontainer.json
 [fedora-44-dev]: ./build-deps-fedora-44/devcontainer.json
 [remote-containers-url]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
 [ci-dir]: ./../.CI/
+[jenkinsfile]: ./../Jenkinsfile
+[common-groovy]: ./../.CI/common.groovy
 [dev-json-ref-url]: https://containers.dev/implementors/json_reference/

--- a/.devcontainer/build-deps-ubuntu-26-rust/Dockerfile
+++ b/.devcontainer/build-deps-ubuntu-26-rust/Dockerfile
@@ -1,0 +1,41 @@
+FROM docker.openmodelica.org/build-deps:ubuntu-26.04-rust
+
+ENV SHELL=/bin/bash
+
+ARG USERNAME=openmodelica-user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user. Unlike the older build-deps images, Ubuntu >= 24.04 bases
+# already ship a user on UID 1000 ('ubuntu'), which collides with the usual host
+# UID, so drop that one first.
+RUN set -eux; \
+    if getent passwd "$USER_UID" >/dev/null; then \
+      userdel -r "$(getent passwd "$USER_UID" | cut -d: -f1)" 2>/dev/null || true; \
+    fi; \
+    getent group "$USER_GID" >/dev/null || groupadd --gid "$USER_GID" "$USERNAME"; \
+    useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME"
+
+# [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# The image ships CARGO_HOME=/opt/rust/cargo, which is root-owned; cargo needs
+# to write it. Move CARGO_HOME into the user's home rather than chown -R'ing
+# /opt/rust, which would copy the whole toolchain into another image layer.
+# RUSTUP_HOME is left alone: running rustc/cargo only reads it.
+ENV CARGO_HOME=/home/$USERNAME/.cargo
+
+# These are also the mount points of the cache volumes in devcontainer.json. A
+# fresh named volume inherits the ownership of the image directory it is mounted
+# over, so they have to exist and be owned by the user here.
+RUN mkdir -p /home/$USERNAME/.cargo/registry \
+             /home/$USERNAME/.cache/sccache \
+             /cache/omlibrary \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME /cache
+
+ENV USER=$USERNAME

--- a/.devcontainer/build-deps-ubuntu-26-rust/build-rust-clang.sh
+++ b/.devcontainer/build-deps-ubuntu-26-rust/build-rust-clang.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Reproduce the Jenkins `cmake-rust-clang` stage locally.
+#
+# This mirrors common.buildRustOMC() in ../../.CI/common.groovy: same cmake
+# flags, same build targets, same order. Run it from inside the
+# build-deps-ubuntu-26-rust dev container.
+#
+# Usage:
+#   ./build-rust-clang.sh              # configure + build
+#   ./build-rust-clang.sh --clean      # standardSetup() first (DESTRUCTIVE)
+#
+# Environment:
+#   JOBS  build parallelism (default: nproc, matching numPhysicalCPU() on CI)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+JOBS="${JOBS:-$(nproc)}"
+WASM_OUT="${RUST_OMC_WASM_RUNTIME_OUT:-${REPO_ROOT}/runtime.wasm}"
+
+if [ "${1:-}" = "--clean" ]; then
+  # This is what standardSetup() runs on the CI agent before configuring.
+  # It deletes every untracked and ignored file in the worktree and in every
+  # submodule -- build_cmake/, build/, and any local scratch files included.
+  # Opt-in only: a dev container is normally reused, and a full clean means a
+  # full rebuild.
+  echo "==> git clean -ffdx (worktree + submodules)"
+  git clean -ffdx
+  git submodule foreach --recursive git clean -ffdx
+fi
+
+# CI wraps the build in withSccache(['CARGO_PROFILE_RELEASE_OPT_LEVEL=2']):
+# O3 is the default release opt-level, CI drops to O2 to cut build time. The
+# rest of the sccache environment is set in devcontainer.json.
+export CARGO_PROFILE_RELEASE_OPT_LEVEL=2
+
+echo "==> configure (build_cmake)"
+cmake -S . -B build_cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DOM_OMC_ENABLE_RUST=ON \
+  -DRUST_OMC_CI=ON \
+  -DOM_ENABLE_GUI_CLIENTS=OFF \
+  -DRUST_OMC_SCRIPTING_API=ON \
+  -DOM_USE_CCACHE=OFF \
+  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_INSTALL_PREFIX=build \
+  -DRUST_OMC_TIMINGS=ON \
+  -DRUST_OMC_THREADS=4 \
+  -DRUST_OMC_WASM_RUNTIME_OUT="${WASM_OUT}"
+
+# `install` builds the whole tree (incl. rust_omc + the cdylib) and installs in
+# one pass. Don't also pass rust_omc as a goal: recursive sub-makes would re-run
+# the always-run cdylib custom target a second time (a redundant cargo pass).
+echo "==> build + install"
+cmake --build build_cmake --parallel "${JOBS}" --target install
+
+build/bin/omc --version
+
+echo "==> rust_wasm_runtime"
+cmake --build build_cmake --parallel "${JOBS}" --target rust_wasm_runtime
+
+echo "==> testsuite-depends"
+cmake --build build_cmake --parallel "${JOBS}" --target testsuite-depends
+
+echo "==> done; wasm runtime at ${WASM_OUT}"

--- a/.devcontainer/build-deps-ubuntu-26-rust/devcontainer.json
+++ b/.devcontainer/build-deps-ubuntu-26-rust/devcontainer.json
@@ -1,0 +1,63 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+//
+// Reproduces the Jenkins `cmake-rust-clang` stage (see ../../Jenkinsfile and
+// common.buildRustOMC in ../../.CI/common.groovy). Run ./build-rust-clang.sh
+// inside the container to execute the same configure + build the stage does.
+{
+  "name": "build-deps:ubuntu-26.04-rust (cmake-rust-clang)",
+
+  // Thin wrapper over the image the cmake-rust-clang stage pulls, adding a
+  // non-root user so the build output stays yours on the host.
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+        // On Windows USERNAME is set, on Linux USER is set
+        // We hope only one is set
+        "USERNAME": "${localEnv:USER}${localEnv:USERNAME}"
+    }
+  },
+
+  // The same caches the stage mounts, so a rebuild reuses the cargo registry
+  // and the compiler cache instead of starting cold every time. CARGO_HOME is
+  // moved into the user's home by the Dockerfile, hence the paths below.
+  "mounts": [
+    "source=om-rust-cargo-registry,target=/home/${localEnv:USER}${localEnv:USERNAME}/.cargo/registry,type=volume",
+    "source=om-rust-sccache,target=/home/${localEnv:USER}${localEnv:USERNAME}/.cache/sccache,type=volume",
+    "source=om-omlibrary-cache,target=/cache/omlibrary,type=volume"
+  ],
+
+  "containerEnv": {
+    // CI points sccache at a shared S3 bucket guarded by the
+    // 'sccache-ci-secret-key' credential, which is not available outside
+    // Jenkins. Keep the same wiring (compiler launcher + RUSTC_WRAPPER) but
+    // back it with a plain on-disk cache in the mounted volume. To use the
+    // real bucket instead, set SCCACHE_BUCKET/SCCACHE_ENDPOINT/SCCACHE_REGION
+    // and the AWS credentials as described in sccacheEnv() in common.groovy.
+    "SCCACHE_DIR": "/home/${localEnv:USER}${localEnv:USERNAME}/.cache/sccache",
+    "RUSTC_WRAPPER": "sccache",
+    "CARGO_INCREMENTAL": "0"
+  },
+
+  // A named volume is created empty on first use and a UID remap may have
+  // happened after the image was built, so re-assert ownership of the caches.
+  "postCreateCommand": "sudo chown -R \"$(id -u):$(id -g)\" \"$HOME/.cargo\" \"$HOME/.cache\" /cache || true",
+
+  // Additional VSCode extensions
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "AnHeuermann.metamodelica",
+        "ms-vscode.cpptools-extension-pack",
+        "rust-lang.rust-analyzer",
+        "njpwerner.autodocstring",
+        "lextudio.restructuredtext",
+        "trond-snekvik.simple-rst",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+
+  "remoteUser": "${localEnv:USER}${localEnv:USERNAME}"
+}


### PR DESCRIPTION
### Related Issues

Sometime the OpenModelica.rs `cmake-rust-clang` stage in Jenkins fails to build. Especially after I touched stuff.

### Purpose

Add developoment container for easy reproduction of Jenkins errors.

### Approach

* Use Docker container `docker.openmodelica.org/build-deps:ubuntu-26.04-rust` and re-create Jenkins calls in `build-rust-clang.sh`.
