### PR TITLE
wasm-jit: NLS eq index, -output, error buffer

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -188,6 +188,51 @@ fn last_sim() -> &'static Mutex<Option<CapturedSim>> {
     LAST.get_or_init(|| Mutex::new(None))
 }
 
+/// C's `writeOutputVars` (`solver_main.c`): `time=<t>` then `,<name>=<value>` at the
+/// last row, Reals as `%.20g`. An unknown name contributes nothing, as in C.
+fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[String]) -> String {
+    let n_reals = run.n_reals as usize;
+    if n_reals == 0 || run.rows.is_empty() {
+        return String::new();
+    }
+    let last = run.rows.len() - n_reals;
+    let n_real_cols = model.layout.n_reals_row();
+    let g20 = |v: f64| sim_driver::format_g(v, 20);
+    let mut out = format!("time={}", g20(run.rows[last]));
+    for name in names {
+        let mut param_idx = 0usize;
+        for v in &model.result_vars {
+            let hit = v.name == *name;
+            match &v.kind {
+                ResultKind::Column { col, negate } if hit => {
+                    let raw = run.rows[last + *col as usize];
+                    let raw = if *negate { -raw } else { raw };
+                    if *col < n_real_cols {
+                        out.push_str(&format!(",{name}={}", g20(raw)));
+                    } else {
+                        out.push_str(&format!(",{name}={}", raw as i64));
+                    }
+                }
+                ResultKind::Param { off: _, wty, negate } => {
+                    let raw = run.params.get(param_idx).copied().unwrap_or(0.0);
+                    param_idx += 1;
+                    if hit {
+                        let raw = if *negate { -raw } else { raw };
+                        match wty {
+                            WTy::F64 => out.push_str(&format!(",{name}={}", g20(raw))),
+                            _ => out.push_str(&format!(",{name}={}", raw as i64)),
+                        }
+                    }
+                }
+                ResultKind::Const { value } if hit => out.push_str(&format!(",{name}={}", g20(*value))),
+                _ => {}
+            }
+        }
+    }
+    out.push('\n');
+    out
+}
+
 /// Resolve a finished [`sim_driver::RunResult`] into per-signal value arrays
 /// (reusing the result-var metadata the `.mat` writer uses) and stash it for the
 /// host to read directly.
@@ -375,8 +420,15 @@ fn init_success_line() -> String {
     }
 }
 
+/// A run reports itself through `<prefix>.log` alone, which `simulate` returns as
+/// `messages` — as C's separate simulation executable does. Whatever it left in the
+/// Error buffer would also surface from `getErrorString()`, where C returns "".
+const RUN_CHECKPOINT: ArcStr = arcstr::literal!("wasm-jit simulation run");
+
 pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcStr) -> i32 {
+    openmodelica_error::ErrorExt::setCheckpoint(RUN_CHECKPOINT);
     let (res, init_output, sim_output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
+    openmodelica_error::ErrorExt::rollBack(RUN_CHECKPOINT);
     // `simulate` reads `<prefix>.log` after a run; the model's captured stdout
     // (`print`, LOG_STATS, ...) is folded in so it shows in the log rather than the
     // process console.
@@ -636,6 +688,10 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
             return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)".to_string());
         }
         let run = sim_runtime::run(&model)?;
+        // C's `finishSimulation` prints these ahead of the LOG_STATS block.
+        if !flags.output_vars.is_empty() {
+            extra.push_str(&write_output_vars(&model, &run, &flags.output_vars));
+        }
         if log_stats {
             extra.push_str(&log_stats_block(&run.stats));
         }
@@ -4339,7 +4395,7 @@ fn collect_nls_jobs(
                     patterns.extend_from_slice(&p.colptr);
                     patterns.extend_from_slice(&p.rowidx);
                 }
-                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default });
+                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, eq_index: nlSystem.index as u32, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default });
                 if nnz != 0 {
                     pat_off += 4 * (n + 1 + nnz);
                 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -409,7 +409,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
     ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
@@ -1050,6 +1050,8 @@ pub(crate) struct SimCtx {
 pub(crate) struct NlsJob {
     pub(crate) k: u32,
     pub(crate) n: u32,
+    /// C's `NONLINEAR_SYSTEM_DATA::equationIndex`: the number its messages quote.
+    pub(crate) eq_index: u32,
     pub(crate) hist_off: u32,
     /// Byte offset of this system's `n` nominal values into the nominal block
     /// (`NLS_NOMINAL_GLOBAL`), read by `rt_solve_nls` for x-scaling.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1495,6 +1495,7 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::I32Const(job.nnz as i32));
     ctx.emit(I::I32Const(job.sparse_default as i32));
     ctx.emit(I::I32Const(nls_lss_handle(job.k) as i32));
+    ctx.emit(I::I32Const(job.eq_index as i32));
     ctx.emit(I::Call(rt_index("rt_solve_nls")?));
     ctx.emit(I::Drop);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -148,7 +148,8 @@ pub const STAT_NLS_NEWTON_FAIL: u32 = 11;
 pub const STAT_NLS_GUESS_HIT: u32 = 12;
 pub const STAT_NLS_ACCEPT: u32 = 13;
 pub const STAT_NLS_STORE_BACK: u32 = 14;
-pub const N_STATS: usize = 15;
+pub const STAT_NLS_VARY_START: u32 = 15;
+pub const N_STATS: usize = 16;
 
 static STATS: [core::sync::atomic::AtomicU64; N_STATS] =
     [const { core::sync::atomic::AtomicU64::new(0) }; N_STATS];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use crate::{
     load_f64, load_u32, rt_alloc, rt_free, stat_inc, store_f64, store_u32, STAT_NLS_FAIL,
     STAT_NLS_ACCEPT, STAT_NLS_GUESS_HIT, STAT_NLS_ITER, STAT_NLS_JAC, STAT_NLS_NEWTON_FAIL,
-    STAT_NLS_RES, STAT_NLS_RETRY, STAT_NLS_SOLVE, STAT_NLS_STORE_BACK,
+    STAT_NLS_RES, STAT_NLS_RETRY, STAT_NLS_SOLVE, STAT_NLS_STORE_BACK, STAT_NLS_VARY_START,
 };
 
 /// C's `EVAL_CONTEXT` (`util/context.h`), set by the driver. `updateInitialGuessDB`
@@ -1218,16 +1218,16 @@ fn scaled_sq(n: usize, v: &[f64], res_scaling: &[f64]) -> f64 {
     s
 }
 
-/// C's `newtonAlgorithm` (`nonlinearSolverHomotopy.c`): damped Newton with a
+/// C's `solveHomotopy` entry phase and its `newtonAlgorithm`
+/// (`nonlinearSolverHomotopy.c`): a start point already at tolerance is taken
+/// outright, else the Jacobian formed there feeds a damped Newton with a
 /// Numerical-Recipes cubic line search and two-tier residual-gated convergence.
 /// Analytic Jacobian when `has_jac`, else FD; `x` = guess in / last iterate out.
-/// Returns `(root found, last residual eval was at the returned `x`)`. `f0` is the
-/// residual at the incoming `x` when the caller already has it.
+/// Returns `(root found, last residual eval was at the returned `x`)`.
 fn newton_c(
     n: usize,
     x: &mut [f64],
     nominal: &[f64],
-    f0: Option<&[f64]>,
     res_scaling: &mut [f64],
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
     jaceval: &mut dyn FnMut(&[f64], &mut [f64]),
@@ -1242,6 +1242,8 @@ fn newton_c(
         e * e
     };
 
+    // C's `xStart`: the retries below vary off this, not off the last varied point.
+    let x_start = x.to_vec();
     let mut xscaling = vec![1.0f64; n];
     for i in 0..n {
         xscaling[i] = nominal[i].abs().max(x[i].abs());
@@ -1255,12 +1257,6 @@ fn newton_c(
     let mut rp = vec![0.0f64; n];
     let mut step = vec![0.0f64; n]; // C's dy0 (the full Newton step −J⁻¹f)
     let mut jac = vec![0.0f64; n * n];
-
-    match f0 {
-        Some(f) => fvec.copy_from_slice(f),
-        None => eval(x, &mut fvec),
-    }
-    let mut error_f_sqrd = nsq(&fvec);
 
     // The Jacobian is w.r.t. *scaled* unknowns: both of C's paths scale column `j` by
     // `xScaling[j]`, and the step is unscaled after the solve. `resScaling` is a row
@@ -1299,10 +1295,42 @@ fn newton_c(
         }
         !attempt_aborted()
     };
-    if !form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval) {
+
+    // C's `tries <= 2` loop: the point is regular only if the residual, the Jacobian
+    // *and* the first linear solve all come through. Otherwise C breaks the symmetry
+    // of the guess by `xScaling[i]·i/n` of 1%, then 10%, before giving up.
+    let mut regular = false;
+    for tries in 0..3 {
+        arm_attempt();
+        eval(x, &mut fvec);
+        if !attempt_aborted() {
+            // A start point already at tolerance is the solution; C forms no Jacobian.
+            // ~40% of calls, nearly all of them an exact time hit whose residual is 0.
+            if nsq(&fvec) < ftol_sq * 1e-4 || scaled_sq(n, &fvec, res_scaling) < ftol_sq * 1e-4 {
+                stat_inc(STAT_NLS_ACCEPT);
+                return (true, true);
+            }
+            if form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval) {
+                row_scaling(n, &jac, res_scaling);
+                regular = total_pivot_step(n, &jac, &fvec, &xscaling, &mut step);
+                if regular {
+                    break;
+                }
+            }
+        }
+        if tries == 2 {
+            break;
+        }
+        stat_inc(STAT_NLS_VARY_START);
+        let vary = if tries == 0 { 0.01 } else { 0.1 };
+        for i in 0..n {
+            x[i] = x_start[i] + xscaling[i] * (i as f64) / (n as f64) * vary;
+        }
+    }
+    if !regular {
         return (false, false);
     }
-    row_scaling(n, &jac, res_scaling);
+    let mut error_f_sqrd = nsq(&fvec);
     let mut error_f_sqrd_scaled = scaled_sq(n, &fvec, res_scaling);
 
     let mut iter = 0i32;
@@ -1310,16 +1338,6 @@ fn newton_c(
     let mut small_steps = 0i32;
     loop {
         stat_inc(STAT_NLS_ITER);
-        // Newton step: solve J·d = f in scaled unknowns, unscale (C's
-        // `vecMultScaling`), then step = −d (so x1 = x + step).
-        step.copy_from_slice(&fvec);
-        if !lu_solve(&jac, &mut step, n) {
-            return (false, false);
-        }
-        for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
-            *s = -*s * sc;
-        }
-
         let grad_f = -2.0 * error_f_sqrd;
         let grad_f_scaled = -2.0 * error_f_sqrd_scaled;
 
@@ -1429,7 +1447,44 @@ fn newton_c(
             return (false, false);
         }
         row_scaling(n, &jac, res_scaling);
+        // C's `linearSolverWrapper` at the head of the next iteration: solve J·d = f
+        // in scaled unknowns, unscale, negate so `x1 = x + step`.
+        step.copy_from_slice(&fvec);
+        if !lu_solve(&jac, &mut step, n) {
+            return (false, false);
+        }
+        for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
+            *s = -*s * sc;
+        }
     }
+}
+
+/// The Newton step at the start point; failing it is what makes the point
+/// "irregular". C always runs `solveSystemWithTotalPivotSearch`, but an LU decides
+/// the same way wherever it succeeds (a nonsingular system has one solution) and
+/// skips the O(n²)-per-column pivot search, so the total pivot is kept only for the
+/// rank-deficient-but-consistent case it exists for. Step comes back unscaled.
+fn total_pivot_step(n: usize, jac: &[f64], fvec: &[f64], xscaling: &[f64], step: &mut [f64]) -> bool {
+    step.copy_from_slice(fvec);
+    if lu_solve(jac, step, n) {
+        for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
+            *s = -*s * sc;
+        }
+        return true;
+    }
+    let mut aug = vec![0.0f64; n * (n + 1)];
+    aug[..n * n].copy_from_slice(jac);
+    aug[n * n..].copy_from_slice(fvec);
+    scale_matrix_rows_aug(n, &mut aug);
+    let mut sol = vec![0.0f64; n + 1];
+    let mut pos = n as i32;
+    if total_pivot_augmented(n, &mut sol, &mut aug, &mut pos) != 0 {
+        return false;
+    }
+    for i in 0..n {
+        step[i] = sol[i] * xscaling[i];
+    }
+    true
 }
 
 // `-nls=newton`: C's `solveNewton` (nonlinearSolverNewton.c) over `_omc_newton`
@@ -1975,6 +2030,7 @@ pub extern "C" fn rt_solve_nls(
     nnz: u32,
     sparse_default: u32,
     lss_handle: u32,
+    eq_index: u32,
 ) -> i32 {
     let n = n as usize;
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
@@ -2169,27 +2225,11 @@ pub extern "C" fn rt_solve_nls(
         let start = x.clone();
         let mut converged = false;
         if matches!(pick, Nls::Default | Nls::Mixed) {
-            // `solveHomotopy`'s pre-phase: a start point whose residual is already
-            // tiny is taken outright, forming no Jacobian. ~40% of calls, nearly all
-            // of them an exact time hit whose residual is therefore 0.
-            eval(&x, &mut fvec);
-            let e = enorm(&fvec);
-            let ftol_accept = NEWTON_FTOL * NEWTON_FTOL * 1e-4;
-            converged = e * e < ftol_accept || scaled_sq(n, &fvec, &res_scaling) < ftol_accept;
-            settled = converged;
-            if converged {
-                stat_inc(STAT_NLS_ACCEPT);
-            }
+            (converged, settled) =
+                newton_c(n, &mut x, &nominal, &mut res_scaling, &mut eval, &mut jaceval, has_jac);
             if !converged {
-                let f0 = fvec.clone();
-                (converged, settled) = newton_c(
-                    n, &mut x, &nominal, Some(&f0), &mut res_scaling, &mut eval, &mut jaceval,
-                    has_jac,
-                );
-                if !converged {
-                    stat_inc(STAT_NLS_NEWTON_FAIL);
-                    x.copy_from_slice(&start);
-                }
+                stat_inc(STAT_NLS_NEWTON_FAIL);
+                x.copy_from_slice(&start);
             }
         }
         settled &= converged;
@@ -2218,7 +2258,7 @@ pub extern "C" fn rt_solve_nls(
         if !converged && saved_rel_fresh == 2 {
             x.copy_from_slice(&guess);
             converged =
-                newton_c(n, &mut x, &nominal, None, &mut res_scaling, &mut eval, &mut jaceval, has_jac).0;
+                newton_c(n, &mut x, &nominal, &mut res_scaling, &mut eval, &mut jaceval, has_jac).0;
         }
         if !converged && saved_rel_fresh == 2 {
             x.copy_from_slice(&guess);
@@ -2315,9 +2355,14 @@ pub extern "C" fn rt_solve_nls(
             unsafe { store_u32(rel_fresh_addr, 0) };
         }
         eval(&warm, &mut scratch);
-        // The flag names the system (index + 1) so the driver can report which one
-        // failed; `lss_handle` is that index with a tag bit (`nls_lss_handle`).
-        unsafe { store_u32(nls_fail_addr, (lss_handle & 0x7fff_ffff) + 1) };
+        // C's equation index, +1 so nonzero still means "failed". First-writer-wins:
+        // C throws out of the equation list at the first failure, never reporting a
+        // later one.
+        unsafe {
+            if load_u32(nls_fail_addr) == 0 {
+                store_u32(nls_fail_addr, eq_index + 1);
+            }
+        }
         stat_inc(STAT_NLS_FAIL);
         1
     };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -263,11 +263,12 @@ fn set_context(e: &mut dyn SimEngine, addr: u32, ctx: i32) {
 }
 
 /// Must match the runtime's `N_STATS`.
-pub const RT_STATS: usize = 15;
+pub const RT_STATS: usize = 16;
 
 pub const RT_STAT_NAMES: [&str; RT_STATS] = [
     "alloc", "array_new", "record_new", "str_new", "nls_solve", "nls_res", "nls_jac", "nls_fail", "nls_retry",
     "elem_ptr", "nls_iter", "nls_newton_fail", "nls_guess_hit", "nls_accept", "nls_store_back",
+    "nls_vary_start",
 ];
 
 /// Read a runtime String heap value (`[refcount:u32][len:u32][utf8]`, handle at
@@ -603,9 +604,32 @@ fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()>
     let failed = read_i32(e, sim_data + layout.nls_fail_off)?;
     if failed != 0 {
         init_report::set_failed_system(failed - 1);
+        report_nls_failure(e, sim_data, layout);
         return Err("CodegenWasmJit: nonlinear system did not converge");
     }
     Ok(())
+}
+
+/// C's `equationNonlinear` (`CodegenC.tpl`) after a non-converged
+/// `solve_nonlinear_system`. The flag carries `equationIndex + 1`; C's `longjmp` is
+/// the caller's `Err` (or, in an integrator residual, `IRES = -1`).
+fn report_nls_failure(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) {
+    report_nls_failure_at(e, sim_data, layout.nls_fail_off);
+}
+
+fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
+    let failed = read_i32(e, sim_data + nls_fail_off).unwrap_or(0);
+    if failed == 0 {
+        return;
+    }
+    let time = read_f64(e, sim_data + TIME_OFF).unwrap_or(0.0);
+    log_line(&alloc::format!(
+        "{}Solving non-linear system {} failed at time={}.\n{}For more information please use -lv LOG_NLS.\n",
+        log_prefix("LOG_ASSERT", "debug"),
+        failed - 1,
+        format_g15(time),
+        log_prefix("|", "|"),
+    ));
 }
 
 /// Number of equidistant homotopy steps: C's `init_lambda_steps`, which `-ils`
@@ -884,6 +908,30 @@ fn format_f(v: f64) -> String {
     alloc::format!("{v:.6}")
 }
 
+fn format_g15(v: f64) -> String {
+    format_g(v, 15)
+}
+
+/// C's `%.<p>g`: `p` significant digits, `%e` outside `[1e-4, 10^p)`, trailing
+/// zeros and a bare decimal point trimmed.
+pub fn format_g(v: f64, p: i32) -> String {
+    if !v.is_finite() || v == 0.0 {
+        return alloc::format!("{v}");
+    }
+    let exp = libm::floor(libm::log10(libm::fabs(v))) as i32;
+    let trim = |s: String| -> String {
+        if !s.contains('.') {
+            return s;
+        }
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    };
+    if exp < -4 || exp >= p {
+        let m = trim(alloc::format!("{:.*}", (p - 1) as usize, v / libm::pow(10.0, exp as f64)));
+        return alloc::format!("{m}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs());
+    }
+    trim(alloc::format!("{:.*}", (p - 1 - exp).max(0) as usize, v))
+}
+
 /// Evaluate `functionCheckAsserts` (C's `checkForAsserts`) at the current point and
 /// format any `AssertionLevel.warning` violation it recorded into a `LOG_ASSERT`
 /// block, once per site. Called by the drivers after each accepted output step.
@@ -1154,21 +1202,23 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
 /// Leaves lambda = 1.
 fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     let steps = homotopy_steps();
+    // C runs every step unconditionally and checks the systems once at the end
+    // (`check_nonlinear_solutions`), so a system that misses at lambda = 1/3 and
+    // lands at lambda = 1 is not a failure. A model assert still aborts.
     for step in 0..=steps {
-        let lambda = step as f64 / steps as f64;
-        write_f64(e, sim_data + layout.lambda_off, lambda)?;
+        write_f64(e, sim_data + layout.lambda_off, (step as f64 / steps as f64).min(1.0))?;
         write_i32(e, sim_data + layout.nls_fail_off, 0)?;
         if step == 0 {
             e.call1("functionInitialEquations_lambda0", sim_data)?;
         } else {
             e.call1("functionInitialEquations", sim_data)?;
         }
-        if check_nls(e, sim_data, layout).is_err() {
-            init_report::set_failed_step(step);
-            return Err("CodegenWasmJit: homotopy initialization did not converge at lambda");
-        }
     }
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
+    if check_nls(e, sim_data, layout).is_err() {
+        init_report::set_failed_step(steps);
+        return Err("CodegenWasmJit: homotopy initialization did not converge at lambda");
+    }
     Ok(())
 }
 
@@ -1698,14 +1748,18 @@ pub fn drive(
     let use_events = layout.n_samples > 0 || layout.n_zc > 0;
     let method = effective_method(method);
 
-    let (rows, label) = if !use_events && method == "euler" && !host_driven {
-        // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
-        set_zc_tolerance(e, sim_data, layout, model.tolerance)?;
-        (run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)?, "euler-wasm")
-    } else {
+    let mut label = "";
+    let outcome = (|| -> Result<Vec<f64>> {
+        if !use_events && method == "euler" && !host_driven {
+            // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
+            label = "euler-wasm";
+            set_zc_tolerance(e, sim_data, layout, model.tolerance)?;
+            return run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats);
+        }
         // enrich_trap: a trap in init/integration is usually a failed model assert().
-        let (mut driver, label) =
+        let (mut driver, l) =
             make_driver(e, model, sim_data, method).map_err(|err| enrich_trap_init(e, err, model.start_time))?;
+        label = l;
         // Infinite budget runs to completion; the per-step cancel poll still lets a
         // native embedder interrupt. `OMC_WASM_SIM_YIELD_MS` forces a finite budget to
         // self-test yield/resume (must be `.mat`-identical to the un-yielded run).
@@ -1720,10 +1774,10 @@ pub fn drive(
             }
         }
         driver.fill_stats(model, &mut stats);
-        (driver.take_rows(), label)
-    };
-    stats.method = label;
+        Ok(driver.take_rows())
+    })();
     let _ = bench;
+    // Before `outcome?`: a failed run is when the counters matter most.
     #[cfg(feature = "std")]
     if bench {
         eprintln!(
@@ -1737,6 +1791,8 @@ pub fn drive(
             eprintln!("wasm-jit sim [{label}]: {}", line.join(" "));
         }
     }
+    let rows = outcome?;
+    stats.method = label;
 
     let params = finalize_run(e, model, sim_data)?;
     Ok((RunResult { rows, n_reals, params, stats }, label))
@@ -2030,6 +2086,7 @@ unsafe fn dassl_res(
             // A nonlinear system did not converge: recoverable — ask DASKR to
             // retry at a smaller step (the guess was restored by the codegen).
             if read_i32(e, ctx.sim_data + ctx.nls_fail_off).unwrap_or(0) != 0 {
+                report_nls_failure_at(e, ctx.sim_data, ctx.nls_fail_off);
                 unsafe { *ires = -1 };
             }
         }
@@ -3697,7 +3754,13 @@ unsafe extern "C" fn cvode_rhs(
             ctx.err = Some(err);
             -1
         }
-        Ok(()) => i32::from(read_i32(e, ctx.sim_data + ctx.nls_fail_off).unwrap_or(0) != 0),
+        Ok(()) => {
+            if read_i32(e, ctx.sim_data + ctx.nls_fail_off).unwrap_or(0) == 0 {
+                return 0;
+            }
+            report_nls_failure_at(e, ctx.sim_data, ctx.nls_fail_off);
+            1
+        }
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -88,6 +88,9 @@ pub struct SimFlags {
     /// `-override=name=value,…` unresolved: mapping a name to its `SimData` slot
     /// needs the model, which only the caller has.
     pub overrides: Vec<(String, f64)>,
+    /// `-output=a,b,c`: variables printed at the stop time (C's
+    /// `outputVariablesAtEnd` / `writeOutputVars`).
+    pub output_vars: Vec<String>,
     /// Flags this runtime does not model, kept so a caller can report them.
     pub unknown: Vec<String>,
     /// The argv this was parsed from, so a host forwards the same bytes rather than
@@ -244,6 +247,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                     }
                 }
             }
+            "output" => f.output_vars = split_top_level(&value(name)?),
             "abortSlowSimulation" => f.abort_slow = true,
             "alarm" => {
                 let secs = value(name)?
@@ -259,6 +263,28 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
         }
     }
     Ok(f)
+}
+
+/// C's `parseVariableStr`: split on commas outside `[...]`, so `x[1,2]` stays one name.
+fn split_top_level(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut cur = String::new();
+    for c in s.chars() {
+        match c {
+            '[' => depth += 1,
+            ']' => depth -= 1,
+            ',' if depth == 0 => {
+                out.push(core::mem::take(&mut cur));
+                continue;
+            }
+            _ => {}
+        }
+        cur.push(c);
+    }
+    out.push(cur);
+    out.retain(|v| !v.is_empty());
+    out
 }
 
 fn bad(flag: &str, got: &str, accepted: &str) -> String {


### PR DESCRIPTION
Six pieces of C-runtime parity for the wasm-jit nonlinear solver. In testsuite/simulation/modelica/nonlinear_system this takes the wasm-jit failures from 9 of 50 to 5 of 50.

rt_solve_nls now takes the system's equation index (nlSystem.index, what CodegenC.tpl assigns to NONLINEAR_SYSTEM_DATA::equationIndex) and the nls_fail flag carries it rather than the job ordinal, so messages quote C's number.  The flag is first-writer-wins because C longjmps out of the equation list at the first failure and never reports a later one.

A failed solve logs C's "Solving non-linear system N failed at time=..." on LOG_ASSERT, from check_nls and from both integrator residuals.  That needs a %.15g, so driver::format_g ports C's %.<p>g.

The global homotopy continuation runs every lambda step and checks the systems once at the end, as initialization.c does: a system that misses at lambda=1/3 and lands at lambda=1 is not a failure.

newton_c gains solveHomotopy's "tries <= 2" entry phase.  A start point is regular only if the residual, the Jacobian and the first linear solve all come through; otherwise the guess is varied by xScaling[i]*i/n of 1% then 10%.  That first solve is an LU with the total pivot kept as the fallback: C always runs solveSystemWithTotalPivotSearch, but an LU decides the same way wherever it succeeds, and running the total pivot unconditionally cost 18% of fullRobot's integration (1.83s -> 2.16s) for no measured benefit.  As committed, fullRobot integrates in 1.82s with rt_stats counters identical to before.

-output=a,b,c is implemented (C's writeOutputVars), and runSimulation is bracketed by an Error-buffer checkpoint so a run reports itself only through <prefix>.log, leaving getErrorString() empty as C does.

The OMC_WASM_SIM_BENCH counters now print for a failed run too, which showed nls_vary_start=0 on BranchingDynamicPipes: the entry phase is not what that model's remaining homotopy failure needs.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
