### PR TITLE
wasm-jit: fix the DASSL Jacobian FD step

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2994,7 +2994,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             f.instruction(&we::Instruction::Call(i));
         }
         if let Some((fn_indices, _)) = &nls_wiring {
-            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &nls_nominals, &nls_bounds, &nls_patterns);
+            let sizes: Vec<u32> = nls_systems.iter().map(|s| lst(&s.crefs).count() as u32).collect();
+            emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &sizes, &nls_nominals, &nls_bounds, &nls_patterns);
         }
         if !thunk_indices.is_empty() {
             crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
@@ -4984,6 +4985,7 @@ fn emit_nls_start(
     f: &mut we::Function,
     fn_indices: &[(u32, u32, Option<u32>)],
     hist_bytes: u32,
+    sizes: &[u32],
     nominals: &[f64],
     bounds: &[f64],
     patterns: &[i32],
@@ -4995,6 +4997,17 @@ fn emit_nls_start(
         f.instruction(&I::I32Const(hist_bytes as i32));
         f.instruction(&I::Call(rt_index("rt_alloc").expect("rt_alloc is a runtime builtin")));
         f.instruction(&I::GlobalSet(NLS_HIST_GLOBAL));
+    }
+    // Hand each system's slice of it to the runtime's roster.
+    let mut hist_off = 0u32;
+    for (k, n) in sizes.iter().enumerate() {
+        f.instruction(&I::I32Const(k as i32));
+        f.instruction(&I::GlobalGet(NLS_HIST_GLOBAL));
+        f.instruction(&I::I32Const(hist_off as i32));
+        f.instruction(&I::I32Add);
+        f.instruction(&I::I32Const(*n as i32));
+        f.instruction(&I::Call(rt_index("rt_nls_register").expect("rt_nls_register is a runtime builtin")));
+        hist_off += crate::CodegenWasmJitFunctions::nls_hist_bytes(*n);
     }
     // nominal block: rt_alloc, then store each system's iteration-variable nominal
     // constants (concatenated in system order) for `rt_solve_nls`'s x-scaling.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -418,6 +418,8 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // Recoverable-assert hooks for a nonlinear-solver residual (see `nls.rs`).
     ("rt_nls_recovering", &[], &[WTy::I32]),
     ("rt_nls_note_assert", &[], &[]),
+    // System `k`'s solver state (address, size), for `rt_nls_clean_history`.
+    ("rt_nls_register", &[WTy::I32, WTy::I32, WTy::I32], &[]),
 ];
 
 /// Model global holding the base index at which this module's per-system

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -42,7 +42,7 @@ extern crate alloc;
 
 mod delay;
 mod nls;
-pub use nls::rt_set_step_size;
+pub use nls::{rt_nls_clean_history, rt_set_step_size};
 #[cfg(test)]
 mod nls_c_trace;
 mod solvers;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -6,6 +6,7 @@
 use alloc::vec;
 
 use crate::solvers::Nls;
+use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::{
@@ -1242,6 +1243,7 @@ pub(crate) trait History {
     fn shift(&mut self, from: usize, to: usize);
     /// Overwrite entry `k` and set the count to `len`.
     fn put(&mut self, k: usize, len: usize, time: f64, x: &[f64]);
+    fn set_len(&mut self, len: usize);
 }
 
 /// Count at `count_addr`, then `HIST_DEPTH` × (time, `n` values) from `base`.
@@ -1279,6 +1281,9 @@ impl History for MemHistory {
         for (i, v) in x.iter().enumerate() {
             unsafe { store_f64(at + 8 + (i * 8) as u32, *v) };
         }
+        unsafe { store_u32(self.count_addr, len as u32) };
+    }
+    fn set_len(&mut self, len: usize) {
         unsafe { store_u32(self.count_addr, len as u32) };
     }
 }
@@ -1350,6 +1355,43 @@ pub(crate) fn history_store(h: &mut dyn History, time: f64, x: &[f64]) {
         h.shift(k, k + 1);
     }
     h.put(0, (count + 1).min(HIST_DEPTH), time, x);
+}
+
+/// `cleanValueListbyTime`: keep only the newest entry at or before `time`.
+pub(crate) fn history_clean(h: &mut dyn History, time: f64) {
+    for k in 0..h.len() {
+        if h.time(k) <= time {
+            if k > 0 {
+                h.shift(k, 0);
+            }
+            return h.set_len(1);
+        }
+    }
+    h.set_len(0);
+}
+
+/// C's `simulationInfo->nonlinearSystemData`: each system's (state address, size),
+/// filled by the module `start`.
+struct RosterCell(UnsafeCell<alloc::vec::Vec<(u32, usize)>>);
+// Single-threaded wasm: no concurrent access.
+unsafe impl Sync for RosterCell {}
+static ROSTER: RosterCell = RosterCell(UnsafeCell::new(alloc::vec::Vec::new()));
+
+/// `k == 0` starts a fresh roster, so a second model replaces the first.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_register(k: u32, hist_addr: u32, n: u32) {
+    let roster = unsafe { &mut *ROSTER.0.get() };
+    roster.truncate(k as usize);
+    roster.push((hist_addr, n as usize));
+}
+
+/// C's `cleanUpOldValueListAfterEvent`, called once per event.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_clean_history(time: f64) {
+    for &(addr, n) in unsafe { &*ROSTER.0.get() } {
+        let mut hist = MemHistory { count_addr: addr, base: addr + 16 + (n * 8) as u32, n };
+        history_clean(&mut hist, time);
+    }
 }
 
 /// Row abs-sum of `J` (`matVecMultAbsBB` + `vecMakeFinite`). A zero row stays 0,
@@ -2614,6 +2656,9 @@ mod tests {
             self.entries.truncate(len);
             assert_eq!(self.entries.len(), len);
         }
+        fn set_len(&mut self, len: usize) {
+            self.entries.truncate(len);
+        }
     }
 
     // Replay the C runtime's own `oldValueList` trace (`nls_c_trace`): for every
@@ -2677,6 +2722,19 @@ mod tests {
         assert_eq!((pick.old, pick.old2, pick.exact), (Some(0), Some(1), false));
         history_guess(&h, &pick, 4.0, &mut guess);
         assert_eq!(guess, [40.0, 5.0]);
+    }
+
+    // An event before every stored entry empties the list.
+    #[test]
+    fn history_clean_keeps_one_entry() {
+        let mut h = VecHistory::default();
+        for (t, v) in [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)] {
+            history_store(&mut h, t, &[v]);
+        }
+        history_clean(&mut h, 2.5);
+        assert_eq!((h.len(), h.time(0), h.value(0, 0)), (1, 2.0, 20.0));
+        history_clean(&mut h, 0.5);
+        assert_eq!(h.len(), 0);
     }
 
     /// `initializationTests.singularJacobian_05`: five monomial equations whose

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -158,6 +158,9 @@ impl SimEngine for InWasmEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn clean_nls_history(&mut self, time: f64) {
+        crate::nls::rt_nls_clean_history(time);
+    }
 }
 
 /// One resumable in-wasm run: engine, driver, decoded model view, and the result

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -123,6 +123,9 @@ impl SimEngine for StandaloneEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn clean_nls_history(&mut self, time: f64) {
+        crate::nls::rt_nls_clean_history(time);
+    }
 }
 
 /// Run the prepared model with the shared driver and write its result file.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -138,6 +138,9 @@ impl SimEngine for Engine {
     fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         None
     }
+    fn clean_nls_history(&mut self, time: f64) {
+        openmodelica_codegen_wasm_jit_runtime::rt_nls_clean_history(time);
+    }
 }
 
 // ── Value references ─────────────────────────────────────────────────────────

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -246,6 +246,9 @@ pub trait SimEngine {
     fn context_addr(&mut self) -> u32 {
         0
     }
+    /// C's `cleanUpOldValueListAfterEvent`. Default: none (an engine that never
+    /// integrates).
+    fn clean_nls_history(&mut self, _time: f64) {}
 }
 
 /// C's `EVAL_CONTEXT`, mirrored from the runtime's `nls.rs`. `unsetContext` restores
@@ -418,20 +421,6 @@ fn now_ms() -> f64 {
     }
     #[cfg(not(all(feature = "std", not(target_arch = "wasm32"))))]
     0.0
-}
-
-/// `f64::sqrt` (the one transcendental the driver uses); `core` has no inherent
-/// `sqrt`, so no_std routes through `libm`.
-#[inline]
-fn sqrt(x: f64) -> f64 {
-    #[cfg(feature = "std")]
-    {
-        x.sqrt()
-    }
-    #[cfg(not(feature = "std"))]
-    {
-        libm::sqrt(x)
-    }
 }
 
 /// Read an env var (host/std only; the in-wasm runtime has no environment, so the
@@ -1668,6 +1657,8 @@ pub fn event_update(
         }
     }
 
+    e.clean_nls_history(time);
+
     let next = samples.as_ref().map(|s| s.next_time()).filter(|t| t.is_finite());
     Ok(EventUpdate { states_changed, terminate: terminated(e, sim_data, layout)?, next_event_time: next })
 }
@@ -2007,6 +1998,9 @@ struct ResCtx {
     nje: u64,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
     ctx_addr: u32,
+    /// The FD step's floor: `n_states` nominals owned by the driver, scaled.
+    nominals: *const f64,
+    nominal_factor: f64,
 }
 
 /// DASKR root (constraint) function: fills `rval[i]` with `g_i(t, y)`, the value
@@ -2139,7 +2133,7 @@ unsafe fn dassl_jac(
     pd: *mut f64,
     cj: *mut f64,
     h: *mut f64,
-    wt: *mut f64,
+    _wt: *mut f64,
     _rpar: *mut f64,
     _ipar: *mut i32,
 ) {
@@ -2156,7 +2150,6 @@ unsafe fn dassl_jac(
     let n = ctx.n_states;
     let cj = unsafe { *cj };
     let h = unsafe { *h };
-    let sqrt_uround = sqrt(f64::EPSILON);
     ctx.jac_ders.resize(n * 8, 0);
     // One assembly, however many colours it takes, as C's DASSL counts it.
     ctx.nje += 1;
@@ -2169,12 +2162,13 @@ unsafe fn dassl_jac(
                 let ci = col as usize;
                 let yi = unsafe { *y.add(ci) };
                 let ypi = unsafe { *yprime.add(ci) };
-                let d6 = (h * ypi).abs();
-                let mag = (sqrt_uround * yi.abs().max(d6)).max(1.0 / unsafe { *wt.add(ci) });
-                let mut del = if h * ypi >= 0.0 { mag } else { -mag };
+                let d6 = h * ypi;
+                let mag = DELTA_X_SOLVER
+                    * yi.abs().max(d6.abs()).max(ctx.nominal_factor * unsafe { *ctx.nominals.add(ci) });
+                let mut del = if d6 >= 0.0 { mag } else { -mag };
                 del = yi + del - yi; // floating-point rounding, as in the C runtime
                 if del == 0.0 {
-                    del = sqrt_uround;
+                    del = DELTA_X_SOLVER;
                 }
                 ctx.jac_ysave[ci] = yi;
                 ctx.jac_del[ci] = 1.0 / del;
@@ -2217,6 +2211,47 @@ unsafe fn dassl_jac(
     }
 }
 
+/// C's `numericalDifferentiationDeltaXsolver` (`model_help.c`).
+const DELTA_X_SOLVER: f64 = 1e-8;
+
+/// C's `-lv=LOG_DASSL`, printed by `dassl.c` around every `DDASKR` call.
+fn log_dassl() -> bool {
+    crate::simflags::with_flags(|f| f.has_log("LOG_DASSL"))
+}
+
+fn log_dassl_step(t: f64) {
+    log_line(&alloc::format!("{}new step at time = {}\n", log_prefix("LOG_DASSL", "info"), format_g(t, 15)));
+}
+
+/// The `dassl call statistics:` block, from the work-array indices `dassl.c` reads.
+/// A restart zeroes the counters, as in C.
+fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
+    let cont = alloc::format!("{}| ", log_prefix("|", "|"));
+    let g = |v: f64| format_g(v, 4);
+    let r = |k: usize| rwork.get(k).copied().unwrap_or(0.0);
+    let i = |k: usize| iwork.get(k).copied().unwrap_or(0);
+    log_line(&alloc::format!(
+        "{}dassl call statistics: \n\
+         {cont}value of idid: {idid}\n\
+         {cont}current time value: {}\n\
+         {cont}current integration time value: {}\n\
+         {cont}step size H to be attempted on next step: {}\n\
+         {cont}step size used on last successful step: {}\n\
+         {cont}the order of the method used on the last step: {}\n\
+         {cont}the order of the method to be attempted on the next step: {}\n\
+         {cont}number of steps taken so far: {}\n\
+         {cont}number of calls of functionODE() : {}\n\
+         {cont}number of calculation of jacobian : {}\n\
+         {cont}total number of convergence test failures: {}\n\
+         {cont}total number of error test failures: {}\n\
+         {}Finished DASSL step.\n",
+        log_prefix("LOG_DASSL", "info"),
+        g(t), g(r(3)), g(r(2)), g(r(6)),
+        i(7), i(8), i(10), i(11), i(12), i(14), i(13),
+        log_prefix("LOG_DASSL", "info"),
+    ));
+}
+
 /// Per-state DASSL tolerances as in `dassl.c`: rtol `tol`, atol `tol·nominal[i]`
 /// (`state_nominals` is already floored). Length ≥ 1 so daskr never sees an empty array.
 fn dassl_tolerances(tol: f64, state_nominals: &[f64], n_states: usize) -> (Vec<f64>, Vec<f64>) {
@@ -2224,6 +2259,14 @@ fn dassl_tolerances(tol: f64, state_nominals: &[f64], n_states: usize) -> (Vec<f
     let rtol = vec![tol; n];
     let atol = (0..n).map(|i| tol * state_nominals.get(i).copied().unwrap_or(1.0)).collect();
     (rtol, atol)
+}
+
+fn nominal_factor() -> f64 {
+    crate::simflags::with_flags(|f| f.jacobian_nominal_factor).unwrap_or(1.0)
+}
+
+fn state_nominals(state_nominals: &[f64], n_states: usize) -> Vec<f64> {
+    (0..n_states.max(1)).map(|i| state_nominals.get(i).copied().unwrap_or(1.0)).collect()
 }
 
 /// Resumable DASSL (daskr) driver, event-free path. Owns the DASKR work arrays
@@ -2241,6 +2284,7 @@ struct DasslDriver {
     info: [i32; 24],
     rtol: Vec<f64>,
     atol: Vec<f64>,
+    nominals: Vec<f64>,
     rwork: Vec<f64>,
     iwork: Vec<i32>,
     rpar: [f64; 1],
@@ -2358,6 +2402,7 @@ impl DasslDriver {
             info,
             rtol,
             atol,
+            nominals: state_nominals(&model.state_nominals, n_states),
             rwork: vec![0.0f64; lrw],
             iwork: vec![0i32; liw],
             rpar: [0.0f64],
@@ -2464,6 +2509,8 @@ impl Driver for DasslDriver {
             jac_ders: Vec::new(),
             nje: self.nje,
             ctx_addr: e.context_addr(),
+            nominals: self.nominals.as_ptr(),
+            nominal_factor: nominal_factor(),
         };
         let _guard = ResCtxGuard;
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
@@ -2499,6 +2546,10 @@ impl Driver for DasslDriver {
                 self.row += 1;
                 continue;
             }
+            let logging = log_dassl();
+            if logging {
+                log_dassl_step(self.t);
+            }
             unsafe {
                 solver::ddaskr(
                     dassl_res, neq, &mut self.t, self.y.as_mut_ptr(), self.yp.as_mut_ptr(),
@@ -2507,6 +2558,9 @@ impl Driver for DasslDriver {
                     self.rpar.as_mut_ptr(), self.ipar.as_mut_ptr(), jacfn, solver::dummy_jack,
                     solver::dummy_psol, solver::dummy_rt, nrt, self.jroot.as_mut_ptr(),
                 );
+            }
+            if logging && self.idid != -1 {
+                log_dassl_stats(self.idid, self.t, &self.rwork, &self.iwork);
             }
             self.nfe = ctx.nfe;
             self.nje = ctx.nje;
@@ -2666,6 +2720,10 @@ impl DaskrState {
         let rt_fn: solver::RtFn = if self.nrt > 0 { dassl_rt } else { solver::dummy_rt };
         let jacfn: solver::JacFn = if self.jac_a.is_none() { solver::dummy_jacd } else { dassl_jac };
         let mut tt = target;
+        let logging = log_dassl();
+        if logging {
+            log_dassl_step(*t);
+        }
         unsafe {
             solver::ddaskr(
                 dassl_res, neq, t, y.as_mut_ptr(), yp.as_mut_ptr(), &mut tt,
@@ -2675,6 +2733,9 @@ impl DaskrState {
                 solver::dummy_jack, solver::dummy_psol, rt_fn, self.nrt,
                 self.jroot.as_mut_ptr(),
             );
+        }
+        if logging && self.idid != -1 {
+            log_dassl_stats(self.idid, *t, &self.rwork, &self.iwork);
         }
         // IDID=-1: the work quota expended before TOUT — resume with INFO(1)=1.
         if self.idid == -1 && self.ev_retries < 10_000 {
@@ -2764,6 +2825,7 @@ struct SolverCore {
     nje: u64,
     state_events: u64,
     time_events: u64,
+    nominals: Vec<f64>,
     /// Chattering detector: a ring of the last [`CHATTER_LIMIT`] state-event times
     /// + a consecutive-event counter. Fires once.
     chatter_times: [f64; CHATTER_LIMIT],
@@ -2853,6 +2915,7 @@ impl SolverCore {
             nje: 0,
             state_events: 0,
             time_events: 0,
+            nominals: state_nominals(&model.state_nominals, n_states),
             chatter_times: [0.0; CHATTER_LIMIT],
             chatter_idx: 0,
             chatter_consec: 0,
@@ -2943,6 +3006,8 @@ impl SolverCore {
             jac_ders: Vec::new(),
             nje: self.nje,
             ctx_addr: e.context_addr(),
+            nominals: self.nominals.as_ptr(),
+            nominal_factor: nominal_factor(),
         }
     }
 
@@ -3174,6 +3239,7 @@ impl SolverCore {
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
                 refresh_relations(e, sim_data, layout)?;
+                e.clean_nls_history(te);
                 self.time_events += 1;
                 if let Some(r) = rows.as_deref_mut() {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?;
@@ -3618,6 +3684,7 @@ impl Driver for EventsDriver {
                         write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh
                         self.samp.fire(e, sim_data, te)?;
                         refresh_relations(e, sim_data, layout)?;
+                        e.clean_nls_history(te);
                         self.core.time_events += 1;
                         emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?; // post-event row
                         if terminated(e, sim_data, layout)? {
@@ -3834,6 +3901,7 @@ const CVODE_WORK_RETRIES: u32 = 10_000;
 struct CvodeDriver {
     sim_data: u32,
     n_states: usize,
+    nominals: Vec<f64>,
     states_base: u32,
     ders_base: u32,
     /// Next output row to produce (row 0 was emitted in `new`).
@@ -3889,6 +3957,7 @@ impl CvodeDriver {
         Ok(CvodeDriver {
             sim_data,
             n_states,
+            nominals: state_nominals(&model.state_nominals, n_states),
             states_base,
             ders_base: states_base + layout.n_states * 8,
             row: 1,
@@ -3970,6 +4039,8 @@ impl Driver for CvodeDriver {
             jac_ders: Vec::new(),
             nje: 0,
             ctx_addr: e.context_addr(),
+            nominals: self.nominals.as_ptr(),
+            nominal_factor: nominal_factor(),
         };
         if !cv.set_user_data(&mut ctx as *mut ResCtx as *mut core::ffi::c_void) {
             return Err("CodegenWasmJit: CVODE setup failed");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -87,6 +87,8 @@ pub struct SimFlags {
     pub init_lambda_steps: Option<i32>,
     /// `-stepSize`: overrides what `SimMeta::step_size` derives from the model.
     pub step_size: Option<f64>,
+    /// `-jacobianNominalFactor`: scales the ODE Jacobian's FD step floor.
+    pub jacobian_nominal_factor: Option<f64>,
     /// `-homotopyOnFirstTry` / `-noHomotopyOnFirstTry`. `None` is C's default,
     /// which sets `FLAG_HOMOTOPY_ON_FIRST_TRY` whenever the model supports
     /// homotopy.
@@ -268,6 +270,13 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "stepSize" => {
                 f.step_size = Some(
                     value(name)?.parse::<f64>().map_err(|_| "-stepSize needs a number".to_string())?,
+                )
+            }
+            "jacobianNominalFactor" => {
+                f.jacobian_nominal_factor = Some(
+                    value(name)?
+                        .parse::<f64>()
+                        .map_err(|_| "-jacobianNominalFactor needs a number".to_string())?,
                 )
             }
             "homotopyOnFirstTry" => f.homotopy_on_first_try = Some(true),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -896,6 +896,11 @@ impl sim_driver::SimEngine for WasmerEngine {
             Err(_) => 0,
         }
     }
+    fn clean_nls_history(&mut self, time: f64) {
+        if let Ok(f) = self.rt_inst.exports.get_typed_function::<f64, ()>(&self.store, "rt_nls_clean_history") {
+            let _ = f.call(&mut self.store, time);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -898,6 +898,11 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             .and_then(|f| f.call(&mut self.store, ()).ok())
             .unwrap_or(0)
     }
+    fn clean_nls_history(&mut self, time: f64) {
+        if let Ok(f) = self.rt_inst.get_typed_func::<f64, ()>(&mut self.store, "rt_nls_clean_history") {
+            let _ = f.call(&mut self.store, time);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
C's jacA_numColored perturbs column i by

    delta_h * fmax(fmax(fabs(y[i]), fabs(h*yprime[i])), fabs(1./wt[i]))

so the relative step delta_h scales all three candidate magnitudes. The port scaled only the first two and took the max against a bare 1/wt.  1/wt is 1/(rtol*|y| + atol), a large number, so it won the max for every state small relative to its nominal and that column was differenced over an absurd perturbation.  delta_h was sqrt(DBL_EPSILON) where C uses numericalDifferentiationDeltaXsolver = 1e-8.

The bad columns only bite where the model turns nonlinear.  On HeatExchangerSimulation the corrector then collapsed inside one output interval after the flow reversal at t=52.5: 4823 convergence test failures, h down to 1.8e-3, and the run never recovered its step size. Round 6's "newton_c robustness gap" was the same cause seen from the algebraic loops, which were being handed wild trial states.

HeatExchangerSimulation, stop time 54, against the C runtime:

|                      | before | after |   C |
| ---                  | ---    | ---   | --- |
| steps                |  10018 |    64 |  64 |
| calls of functionODE |  26051 |   126 | 126 |
| jacobian evals       |  14913 |    42 |  42 |
| integrate            |  155 s | 1.1 s |   - |

The full run is 160 steps with 0 convergence test failures, C's own figures.  simulation/libraries/msl32's Modelica.Fluid set goes from 10 of 23 failing to 7, gaining HeatExchangerSimulation, that model's -addDerAlias variant and RoomCO2WithControls; no other verdict moves. nonlinear_system 5/50, initialization 37/90, tearing 5/107, events 12/33, solver 33/41, start_value_selection 5/9 are all unchanged, and fullRobot integrates in 1.6-1.9 s over 4937 steps (C: 5247).

Two more C behaviours come with it.

cleanUpOldValueListAfterEvent (nonlinearSystem.c): an event invalidates the stored NLS solutions on the far side of it, so every system keeps only its newest entry at or before the event time.  The runtime needs a roster of the systems to walk, which the module start now hands it through rt_nls_register.  Measured on its own this changes almost nothing on the model above; it is in because it is what C does.

-lv=LOG_DASSL: the "new step at time" line and the "dassl call statistics" block, from the same DASKR work-array indices dassl.c reads.  Comparing that stream against the C executable's is how the collapse was localised to one output interval.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
