### PR TITLE
wasm-jit: reject an unimplemented method=

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -1710,9 +1710,11 @@ pub fn make_driver(
     arm_alarm();
     let layout = &model.layout;
     set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
-    // A model compiled with `method="cvode"` reaches here without passing through
-    // `simflags::check`, so this build's lack of CVODE is caught here too.
-    if method == "cvode" && !cfg!(sundials) {
+    // Ahead of the events path below, which returns before the match.
+    // `dassljac` is dassl with a symbolic Jacobian, which C also falls back from.
+    let supported = matches!(method, "dassl" | "dasslrt" | "dassljac" | "euler" | "")
+        || (method == "cvode" && cfg!(sundials));
+    if !supported {
         return Err(UNSUPPORTED_METHOD);
     }
 
@@ -1721,7 +1723,7 @@ pub fn make_driver(
         return Ok((Box::new(EventsDriver::new(e, model, sim_data, method)?), label));
     }
     match method {
-        "dassl" | "dasslrt" | "ida" | "" => Ok((Box::new(DasslDriver::new(e, model, sim_data)?), "dassl")),
+        "dassl" | "dasslrt" | "dassljac" | "" => Ok((Box::new(DasslDriver::new(e, model, sim_data)?), "dassl")),
         // Uniform host-driven Euler so it is resumable/cancellable like DASSL.
         "euler" => Ok((Box::new(EulerDriver::new(e, model, sim_data)?), "euler-host")),
         #[cfg(sundials)]


### PR DESCRIPTION
make_driver mapped method="ida" onto the DASKR driver, so a model built with it ran to completion under a solver it never asked for.  Four tests passed that way -- simulation/modelica/solver's problem1-ida, problem2-ida, problem2-idaLinearSolver and problem2-idaJacobian, the last two of which exist to exercise IDA options the port discards.

-s=ida was already rejected: simflags::check reads Capabilities::ida, which the wasm-jit runtime sets to false.  Only the compiled-in method= slipped through, and it slipped through twice, because a model with samples or zero crossings returns from make_driver before the match that would have caught anything unhandled.  The check is now ahead of both, so "rungekutta" and friends are rejected on the events path too.

dassljac goes the other way and is accepted: it is dassl asking for the symbolic Jacobian, and setJacobianMethod in the C runtime falls back to the colored numerical one when that is unavailable, which is the only one this runtime has.  It was reachable only through the events path before, so the four siemens tests that use it keep working.

IDA is not implemented here and does not need to be; the point is that the failure says so.  simulation/modelica/solver goes from 33 of 41 failing to 37 under --simCodeTarget=wasm-jit, which is those four turning honest.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
