### PR TITLE
wasm-jit: the IDA solver, with sensitivities

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -375,7 +375,7 @@ if(RUST_OMC_ENABLE_SUNDIALS)
       -DSUITESPARSECONFIG_LIBRARY=${_suitesparse_ep_build}/SuiteSparse_config/libsuitesparseconfig.a
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_sundials_ep_build} --parallel
       --target
-      sundials_kinsol_static sundials_ida_static sundials_cvode_static
+      sundials_kinsol_static sundials_idas_static sundials_cvode_static
       sundials_nvecserial_static sundials_sunmatrixdense_static
       sundials_sunmatrixsparse_static sundials_sunlinsoldense_static
       sundials_sunlinsolklu_static
@@ -394,7 +394,7 @@ if(RUST_OMC_ENABLE_SUNDIALS)
       ${_suitesparse_ep_build}/BTF/libbtf.a
       ${_suitesparse_ep_build}/SuiteSparse_config/libsuitesparseconfig.a
       ${_sundials_ep_build}/src/kinsol/libsundials_kinsol.a
-      ${_sundials_ep_build}/src/ida/libsundials_ida.a
+      ${_sundials_ep_build}/src/idas/libsundials_idas.a
       ${_sundials_ep_build}/src/cvode/libsundials_cvode.a
       ${_sundials_ep_build}/src/nvector/serial/libsundials_nvecserial.a
       ${_sundials_ep_build}/src/sunmatrix/dense/libsundials_sunmatrixdense.a
@@ -406,19 +406,27 @@ if(RUST_OMC_ENABLE_SUNDIALS)
     VERBATIM)
   add_dependencies(rust_sundials_collect rust_sundials_wasm)
 
-  # The host CVODE the host-driven wasm-jit driver links is the C runtime's own
-  # archive (3rdParty), not a second build: it is already position-independent
-  # (`libSimulationRuntimeC.so` links it), and reusing it leaves the two copies
-  # identical should both end up in one process. Collected into a fixed directory
-  # because the cargo env cannot carry a generator expression.
+  # The host CVODE/IDAS the host-driven wasm-jit driver links are the C runtime's
+  # own archives (3rdParty), not a second build: they are already
+  # position-independent (`libSimulationRuntimeC.so` links them), and reusing them
+  # leaves the two copies identical should both end up in one process. Collected
+  # into a fixed directory because the cargo env cannot carry a generator
+  # expression. IDA's default linear solver is KLU, so SuiteSparse comes too.
   if(TARGET sundials_cvode_static)
     set(RUST_SUNDIALS_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-sundials-native
         CACHE PATH "Directory the host SUNDIALS archives are collected into.")
+    set(_native_sundials_libs
+      sundials_cvode_static sundials_idas_static sundials_sunlinsolklu_static
+      KLU_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static)
+    set(_native_sundials_files "")
+    foreach(_lib IN LISTS _native_sundials_libs)
+      list(APPEND _native_sundials_files $<TARGET_FILE:${_lib}>)
+    endforeach()
     add_custom_target(rust_sundials_native_collect
       COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_NATIVE_DIR}/lib
       COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:sundials_cvode_static> ${RUST_SUNDIALS_NATIVE_DIR}/lib/
-      DEPENDS sundials_cvode_static
+        ${_native_sundials_files} ${RUST_SUNDIALS_NATIVE_DIR}/lib/
+      DEPENDS ${_native_sundials_libs}
       COMMENT "Rust: collecting host SUNDIALS archives -> ${RUST_SUNDIALS_NATIVE_DIR}/lib/"
       VERBATIM)
   endif()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -585,9 +585,9 @@ fn run_wasmtime_inner(_prefix: &str, _result_file: &str, _simflags: &str) -> Res
 /// parse, where a rejection still has a message channel to report on.
 const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     klu: openmodelica_wasm_jit::SUNDIALS,
-    ida: false,
-    // The driver runs here (host-driven) or in-wasm (web); both get CVODE from the
-    // same CMake option, so one const covers both.
+    // The driver runs here (host-driven) or in-wasm (web); both get CVODE and IDA
+    // from the same CMake option, so one const covers both.
+    ida: openmodelica_sim_meta::IDA,
     cvode: openmodelica_sim_meta::CVODE,
     gbode: false,
     // Served by the driver's per-step deadline, so every engine has it.
@@ -1699,8 +1699,10 @@ fn col_to_off(col: u32, layout: &SimLayout) -> u32 {
         REAL_OFF + (col - 1) * 8
     } else if col < nr + layout.n_int_alg() {
         layout.int_off + (col - nr) * 4
-    } else {
+    } else if col < layout.sens_col0() {
         layout.bool_off + (col - nr - layout.n_int_alg()) * 4
+    } else {
+        layout.sens_off + (col - layout.sens_col0()) * 8
     }
 }
 
@@ -1857,6 +1859,43 @@ fn reindex_aliasvar(av: &SimCodeVar::AliasVariable, idx: &[i32]) -> SimCodeVar::
         A::NEGATEDALIAS { varName } => A::NEGATEDALIAS { varName: cref_with_indices(varName, idx) },
         A::NOALIAS => A::NOALIAS,
     }
+}
+
+/// Append the `$Sensitivities.<par>.<state>` result variables — the layout's
+/// sensitivity block, in its order — and return the `SimData` offsets of the
+/// parameters they differentiate against (C's `sensitivityParList`, resolved
+/// through the `paramVars` order the real-parameter region follows). The names
+/// bypass [`result_name`], which filters `$`-prefixed ones; C keeps them.
+fn push_sensitivity_vars(
+    sens_vars: &[&SimCodeVar::SimVar],
+    n_sens_par: usize,
+    vars: &SimCodeVar::SimVars,
+    layout: &SimLayout,
+    result_vars: &mut Vec<ResultVar>,
+) -> Result<Vec<u32>> {
+    if sens_vars.is_empty() {
+        return Ok(Vec::new());
+    }
+    let params: HashMap<String, u32> = lst(&vars.paramVars)
+        .enumerate()
+        .map(|(k, sv)| Ok((cref_display(&sv.name)?, layout.rparam_off + (k as u32) * 8)))
+        .collect::<Result<_>>()?;
+    let mut offs = Vec::with_capacity(n_sens_par);
+    for sv in &sens_vars[..n_sens_par] {
+        let name = cref_display(&sv.name)?;
+        let off = *params
+            .get(&name)
+            .ok_or("CodegenWasmJit: a sensitivity parameter is not a real parameter of the model")?;
+        offs.push(off);
+    }
+    for (i, sv) in sens_vars[n_sens_par..].iter().enumerate() {
+        result_vars.push(ResultVar {
+            name: cref_display(&sv.name)?,
+            comment: sv.comment.to_string(),
+            kind: ResultKind::Column { col: layout.sens_col0() + i as u32, negate: false },
+        });
+    }
+    Ok(offs)
 }
 
 /// Build the cref->slot map and the result-variable list from the model's
@@ -2439,6 +2478,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // The backend only emits a lambda-0 initial system when the model uses
     // `homotopy()`; its presence is the signal to wire up the continuation.
     let has_homotopy = (&*sim_code.initialEquations_lambda0).into_iter().next().is_some();
+    // `--calculateSensitivities`: `sensitivityVars` is the `Ns` differentiated
+    // parameters followed by the `Ns * nStates` `$Sensitivities.<par>.<state>`
+    // signals (C's `rSen` init-XML category, split by `numSensitivityParameters`).
+    let n_sens_par = vi.numSensitivityParameters.max(0) as usize;
+    let sens_vars: Vec<&SimCodeVar::SimVar> = lst(&mi.vars.sensitivityVars).collect();
+    let n_sens = sens_vars.len().saturating_sub(n_sens_par) as u32;
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -2456,11 +2501,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         stateset_scratch_f64,
         nls_jac_scratch_f64,
         vi.numMathEventFunctions.max(0) as u32,
+        n_sens,
         has_when,
         has_homotopy,
     );
 
-    let (mut var_map, result_vars, editable_params) = build_var_map(vars, &layout)?;
+    let (mut var_map, mut result_vars, editable_params) = build_var_map(vars, &layout)?;
+    let sens_params = push_sensitivity_vars(&sens_vars, n_sens_par, vars, &layout, &mut result_vars)?;
     let var_units = collect_var_units(vars)?;
     // Sample event index -> its slot `k` (position in `samples`), for the
     // `sample(index,…)` builtin and the driver's per-sample state.
@@ -2702,6 +2749,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // `parameterEquations` for any computed parameters.
     // Equation functions.
     let stateset_diag = stateset_diag_offsets(&sim_code.stateSets, &var_map)?;
+    let param_eqs_dep = param_eqs.clone();
     bodies.push(build_eq_fn_with_prelude("parameterEquations", &param_bindings, param_eqs, &var_map, &eq_index, &by_name, &mut literals, &[], &stateset_diag)?);
     // Seed `relationsPre := relations` at the end of init (the in-wasm `simulate`
     // path skips the host `run_initialization`).
@@ -2747,7 +2795,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let fmi_vrs = if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { Vec::new() };
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets, &state_nominals,
-        fmi_vrs, zc_descriptions(&zero_crossings),
+        fmi_vrs, zc_descriptions(&zero_crossings), sens_params,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -2921,6 +2969,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         });
         idx
     };
+    // C's `updateBoundParameters`: `parameterEquations` *without* the constant
+    // bindings, so re-evaluating the dependent parameters does not undo a
+    // perturbation IDAS made to a sensitivity parameter.
+    let update_bound_params_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(build_eq_fn("updateBoundParameters", param_eqs_dep, &var_map, &eq_index, &by_name, &mut literals)?);
+        idx
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -2958,6 +3014,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
     functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
+    functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
 
     // --- Shared literals, closure thunks and the module `start`. Both come after
     // every other body — their indices are only known here. ---
@@ -3046,6 +3103,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionUpdateRelations", we::ExportKind::Func, update_relations_idx);
     exports.export("functionStoreDelayed", we::ExportKind::Func, store_delayed_idx);
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
+    exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
 
     // --- Name section: without it a trap backtrace is bare function indices. The
     // unnamed remainder is the NLS callbacks, the closure thunks and `start`. ---
@@ -3083,6 +3141,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("functionUpdateRelations", update_relations_idx),
         ("functionStoreDelayed", store_delayed_idx),
         ("functionInitDelay", init_delay_idx),
+        ("functionUpdateBoundParameters", update_bound_params_idx),
     ] {
         names.push((idx, name.to_string()));
     }
@@ -3546,6 +3605,7 @@ fn build_sim_meta(
     state_nominals: &[f64],
     fmi_vrs: Vec<FmiVr>,
     zc_desc: Vec<String>,
+    sens_params: Vec<u32>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -3563,6 +3623,7 @@ fn build_sim_meta(
         state_nominals: state_nominals.to_vec(),
         fmi_vrs,
         zc_desc,
+        sens_params,
     }
 }
 
@@ -5300,6 +5361,15 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>
     for j in 0..layout.n_bool_alg() {
         store_islot(&mut f, layout.bool_off + j * 4, n_reals + layout.n_int_alg() + j);
     }
+    // Only IDA fills the sensitivity block, and this loop is Euler's.
+    if layout.n_sens > 0 {
+        f.instruction(&I::LocalGet(DEST));
+        f.instruction(&I::I32Const((layout.sens_col0() * 8) as i32));
+        f.instruction(&I::I32Add);
+        f.instruction(&I::I32Const(0));
+        f.instruction(&I::I32Const((layout.n_sens * 8) as i32));
+        f.instruction(&I::MemoryFill(0));
+    }
 
     // The driver's per-row `check_asserts`: evaluate the min/max checks, then let
     // the host format what they recorded while `time` still holds this row's.
@@ -5452,6 +5522,7 @@ mod standalone_tests {
             "functionCheckAsserts",
             "functionStoreDelayed",
             "functionInitDelay",
+            "functionUpdateBoundParameters",
         ];
 
         let mut funcs = we::FunctionSection::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
@@ -14,7 +14,9 @@ use std::path::Path;
 /// resolves archives in the order given, so a wrong order is an undefined symbol.
 const LIBS: &[&str] = &[
     "sundials_kinsol",
-    "sundials_ida",
+    // IDAS, not IDA: same entry points plus the forward-sensitivity ones, as the
+    // C runtime links it.
+    "sundials_idas",
     "sundials_cvode",
     "sundials_sunlinsolklu",
     "sundials_sunlinsoldense",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -47,6 +47,7 @@ unsafe extern "C" {
     fn functionCheckAsserts(sim_data: u32);
     fn functionStoreDelayed(sim_data: u32);
     fn functionInitDelay(sim_data: u32);
+    fn functionUpdateBoundParameters(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
@@ -101,6 +102,7 @@ impl SimEngine for StandaloneEngine {
                 "functionCheckAsserts" => functionCheckAsserts(arg),
                 "functionStoreDelayed" => functionStoreDelayed(arg),
                 "functionInitDelay" => functionInitDelay(arg),
+                "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("wasm-jit standalone: unknown model function"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -15,7 +15,7 @@ pub extern "C" fn rt_sundials_available() -> i32 {
 pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
     openmodelica_sim_meta::simflags::Capabilities {
         klu: cfg!(sundials),
-        ida: false,
+        ida: openmodelica_sim_meta::IDA,
         cvode: openmodelica_sim_meta::CVODE,
         gbode: false,
         // Served by the driver's per-step deadline; both runtimes install a clock.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/build.rs
@@ -1,4 +1,4 @@
-//! Decides whether the driver gets the real CVODE (`cfg(sundials)`).
+//! Decides whether the driver gets the real CVODE and IDA (`cfg(sundials)`).
 //!
 //! Two sources, both prepared by `.cmake/rust_omc.cmake`:
 //!   * wasip1 — `OMC_SUNDIALS_WASM_DIR`. The archives are linked by the runtime
@@ -6,12 +6,28 @@
 //!     the variable only selects the cfg.
 //!   * host — `OMC_SUNDIALS_NATIVE_DIR`, linked here: the host-driven driver
 //!     lives in `libOpenModelicaCompiler`, which nothing else links SUNDIALS into.
-//!     This is the C runtime's own archive, so its index size is whatever that
-//!     build chose (64) rather than the wasm archives' 32 — hence `sundials_i64`.
+//!     These are the C runtime's own archives, so their index size is whatever
+//!     that build chose (64) rather than the wasm archives' 32 — hence
+//!     `sundials_i64`.
 //!
-//! Unset means no CVODE; `simflags::check` then rejects `-s=cvode` up front.
+//! Unset means no CVODE/IDA; `simflags::check` then rejects `-s=cvode`/`-s=ida`
+//! up front.
 
 use std::path::Path;
+
+/// Archives in link order: each entry may only depend on later ones. Every
+/// SUNDIALS solver archive bundles the shared N_Vector/SUNMatrix/SUNLinearSolver
+/// sources, so the first one listed satisfies them for the rest.
+const NATIVE_LIBS: &[&str] = &[
+    "sundials_cvode",
+    "sundials_idas",
+    "sundials_sunlinsolklu",
+    "klu",
+    "amd",
+    "colamd",
+    "btf",
+    "suitesparseconfig",
+];
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(sundials)");
@@ -32,12 +48,18 @@ fn main() {
     }
     let Some(dir) = std::env::var_os("OMC_SUNDIALS_NATIVE_DIR") else { return };
     let lib = Path::new(&dir).join("lib");
-    if !["libsundials_cvode.a", "sundials_cvode.lib"].iter().any(|n| lib.join(n).exists()) {
-        panic!("OMC_SUNDIALS_NATIVE_DIR={} has no sundials_cvode archive; the host \
-                SUNDIALS build failed (check the rust_sundials_native CMake target)", lib.display());
+    let missing: Vec<_> = NATIVE_LIBS
+        .iter()
+        .filter(|l| ![format!("lib{l}.a"), format!("{l}.lib")].iter().any(|n| lib.join(n).exists()))
+        .collect();
+    if !missing.is_empty() {
+        panic!("OMC_SUNDIALS_NATIVE_DIR={} is missing {missing:?}; the host SUNDIALS \
+                build failed (check the rust_sundials_native_collect CMake target)", lib.display());
     }
     println!("cargo:rustc-link-search=native={}", lib.display());
-    println!("cargo:rustc-link-lib=static=sundials_cvode");
+    for l in NATIVE_LIBS {
+        println!("cargo:rustc-link-lib=static={l}");
+    }
     println!("cargo:rustc-cfg=sundials");
     match std::env::var("OMC_SUNDIALS_NATIVE_INDEX_SIZE").as_deref() {
         Ok("64") => println!("cargo:rustc-cfg=sundials_i64"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -202,6 +202,7 @@ pub const MODEL_FNS: &[&str] = &[
     "functionCheckAsserts",
     "functionStoreDelayed",
     "functionInitDelay",
+    "functionUpdateBoundParameters",
 ];
 
 /// The per-run capabilities a backend must expose: read/write the instance's
@@ -1257,6 +1258,10 @@ fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &S
     for j in 0..layout.n_bool_alg() {
         rows.push(read_i32(e, sim_data + layout.bool_off + j * 4)? as f64);
     }
+    // Zero for every solver but IDA, which refreshes it from `IDAGetSens`.
+    for k in 0..layout.n_sens {
+        rows.push(read_f64(e, sim_data + layout.sens_off + k * 8)?);
+    }
     Ok(())
 }
 
@@ -1678,14 +1683,15 @@ pub fn set_zc_tolerance(
 
 /// Build the resumable driver (init + row 0 + the zero-crossing band); shared by
 /// [`drive`] and the session. `method` empty = DASSL.
-/// `-s=` wins over the method compiled into the model's metadata. `ida`/`gbode`
-/// never reach here — `simflags::check` rejects them at startup rather than let
-/// them silently run as DASSL, and so does `cvode` without `cfg(sundials)`.
+/// `-s=` wins over the method compiled into the model's metadata. `gbode` never
+/// reaches here — `simflags::check` rejects it at startup rather than let it
+/// silently run as DASSL, and so do `cvode`/`ida` without `cfg(sundials)`.
 pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
     match crate::simflags::with_flags(|f| f.solver) {
         Some(crate::simflags::Solver::Euler) => "euler",
         Some(crate::simflags::Solver::Dassl) => "dassl",
         Some(crate::simflags::Solver::Cvode) => "cvode",
+        Some(crate::simflags::Solver::Ida) => "ida",
         _ => method,
     }
 }
@@ -1701,16 +1707,23 @@ pub fn make_driver(
     arm_alarm();
     let layout = &model.layout;
     set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
+    for k in 0..layout.n_sens {
+        write_f64(e, sim_data + layout.sens_off + k * 8, 0.0)?;
+    }
     // Ahead of the events path below, which returns before the match.
     // `dassljac` is dassl with a symbolic Jacobian, which C also falls back from.
     let supported = matches!(method, "dassl" | "dasslrt" | "dassljac" | "euler" | "")
-        || (method == "cvode" && cfg!(sundials));
+        || (matches!(method, "cvode" | "ida") && cfg!(sundials));
     if !supported {
         return Err(UNSUPPORTED_METHOD);
     }
 
     if layout.n_samples > 0 || layout.n_zc > 0 {
-        let label = if method == "cvode" { "cvode-events" } else { "dassl-events" };
+        let label = match method {
+            "cvode" => "cvode-events",
+            "ida" => "ida-events",
+            _ => "dassl-events",
+        };
         return Ok((Box::new(EventsDriver::new(e, model, sim_data, method)?), label));
     }
     match method {
@@ -1719,6 +1732,8 @@ pub fn make_driver(
         "euler" => Ok((Box::new(EulerDriver::new(e, model, sim_data)?), "euler-host")),
         #[cfg(sundials)]
         "cvode" => Ok((Box::new(CvodeDriver::new(e, model, sim_data)?), "cvode")),
+        #[cfg(sundials)]
+        "ida" => Ok((Box::new(IdaDriver::new(e, model, sim_data)?), "ida")),
         _ => Err(UNSUPPORTED_METHOD),
     }
 }
@@ -1726,7 +1741,7 @@ pub fn make_driver(
 /// Listing what `make_driver` accepts; `simflags::check` rejects the rest earlier,
 /// so this is only reached by a `method=` the model was compiled with.
 const UNSUPPORTED_METHOD: &str = if cfg!(sundials) {
-    "CodegenWasmJit: unsupported integration method (supported: `dassl`, `cvode`, `euler`)"
+    "CodegenWasmJit: unsupported integration method (supported: `dassl`, `cvode`, `ida`, `euler`)"
 } else {
     "CodegenWasmJit: unsupported integration method (supported: `dassl`, `euler`)"
 };
@@ -2003,6 +2018,46 @@ struct ResCtx {
     /// The FD step's floor: `n_states` nominals owned by the driver, scaled.
     nominals: *const f64,
     nominal_factor: f64,
+    /// What IDA's Jacobian callback needs on top of the above; all-null otherwise.
+    #[cfg(sundials)]
+    ida: IdaCtx,
+}
+
+/// `-idaSensitivity`: the parameters IDAS perturbs to difference `dF/dp`. The
+/// residual pushes `values` into `offs` and re-evaluates the dependent
+/// parameters, which is the only way a perturbation reaches the model (C's
+/// `updateBoundParameters` call in `residualFunctionIDA`).
+#[cfg(sundials)]
+#[derive(Clone, Copy)]
+struct SensPush {
+    offs: *const u32,
+    values: *const f64,
+    n: usize,
+}
+
+#[cfg(sundials)]
+impl Default for SensPush {
+    fn default() -> Self {
+        SensPush { offs: core::ptr::null(), values: core::ptr::null(), n: 0 }
+    }
+}
+
+/// The IDA memory block (for the step size the difference quotient scales by)
+/// and the CSC layout its sparse Jacobian is filled in, both owned by the driver
+/// and outliving the `ResCtx` that points at them.
+#[cfg(sundials)]
+#[derive(Clone, Copy)]
+struct IdaCtx {
+    mem: *mut core::ffi::c_void,
+    pattern: *const IdaPattern,
+    sens: SensPush,
+}
+
+#[cfg(sundials)]
+impl Default for IdaCtx {
+    fn default() -> Self {
+        IdaCtx { mem: core::ptr::null_mut(), pattern: core::ptr::null(), sens: SensPush::default() }
+    }
 }
 
 /// DASKR root (constraint) function: fills `rval[i]` with `g_i(t, y)`, the value
@@ -2513,6 +2568,8 @@ impl Driver for DasslDriver {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            #[cfg(sundials)]
+            ida: IdaCtx::default(),
         };
         let _guard = ResCtxGuard;
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
@@ -2654,6 +2711,9 @@ enum Solver {
     /// core exists, and a model with no states never integrates at all.
     #[cfg(sundials)]
     Cvode(CvodeState),
+    /// Built on first use, as [`Solver::Cvode`].
+    #[cfg(sundials)]
+    Ida(IdaState),
 }
 
 /// DASKR's work arrays and options.
@@ -2804,6 +2864,67 @@ impl CvodeState {
     }
 }
 
+#[cfg(sundials)]
+struct IdaState {
+    ida: Option<crate::sundials::Ida>,
+    rtol: f64,
+    atol: Vec<f64>,
+    n_roots: usize,
+    work_retries: u32,
+    setup: IdaSetup,
+}
+
+#[cfg(sundials)]
+impl IdaState {
+    /// The IDA block is built on the first step, when `y`/`yp` first hold the
+    /// state to start from. `ctx` is the callbacks' `user_data`, which lives on
+    /// one `advance`'s stack, so it is rebound per call rather than stored.
+    #[allow(clippy::too_many_arguments)]
+    fn step(
+        &mut self,
+        e: &mut dyn SimEngine,
+        sim_data: u32,
+        t: &mut f64,
+        y: &mut [f64],
+        yp: &mut [f64],
+        target: f64,
+        ctx: *mut ResCtx,
+    ) -> Result<Progress> {
+        let ida = match self.ida.as_mut() {
+            Some(ida) => ida,
+            None => self.ida.insert(self.setup.build(
+                e, sim_data, *t, y, yp, self.rtol, &self.atol, self.n_roots,
+            )?),
+        };
+        unsafe { (*ctx).ida = self.setup.ctx(Some(ida)) };
+        if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
+            return Err("CodegenWasmJit: IDA setup failed");
+        }
+        let stop = ida.step(t, target);
+        y.copy_from_slice(ida.y());
+        yp.copy_from_slice(ida.yp());
+        if !matches!(stop, crate::sundials::Stop::Failed(_)) {
+            self.setup.store_sens(e, sim_data, ida)?;
+        }
+        Ok(match stop {
+            crate::sundials::Stop::Failed(flag)
+                if flag == crate::sundials::IDA_TOO_MUCH_WORK && self.work_retries < IDA_WORK_RETRIES =>
+            {
+                self.work_retries += 1;
+                Progress::WorkQuota
+            }
+            crate::sundials::Stop::Failed(_) => Progress::Failed("CodegenWasmJit: IDA failed"),
+            other => {
+                self.work_retries = 0;
+                match other {
+                    crate::sundials::Stop::Root => Progress::Root,
+                    _ => Progress::Reached,
+                }
+            }
+        })
+    }
+}
+
 /// The integrator state and the one integration path over it: [`integrate_to`]
 /// runs the solver to a time, handling the state events it roots out and the
 /// samples due on the way. `EventsDriver` drives it to each output row and
@@ -2885,26 +3006,35 @@ impl SolverCore {
     /// (`run_initialization`).
     ///
     /// [`read_states`]: SolverCore::read_states
-    fn new(model: &SimModel, sim_data: u32, t: f64, method: &str) -> Self {
+    fn new(model: &SimModel, sim_data: u32, t: f64, method: &str) -> Result<Self> {
         let layout = &model.layout;
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
         let ders_base = states_base + layout.n_states * 8;
         let nrt = layout.n_zc as i32;
         let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
-        // Per-state nominal-scaled tolerances (see `dassl_tolerances`); CVODE takes
-        // the same ones, as `cvode_solver_initial` does.
+        // Per-state nominal-scaled tolerances (see `dassl_tolerances`); CVODE and
+        // IDA take the same ones, as `cvode_solver_initial`/`ida_solver_initial` do.
         let (rtol, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
         let _ = method;
         #[cfg(sundials)]
-        let solver = if method == "cvode" {
-            Solver::Cvode(CvodeState { cv: None, rtol: tol, atol, n_roots: nrt as usize, work_retries: 0 })
-        } else {
-            Solver::Daskr(DaskrState::new(model, n_states, nrt, rtol, atol))
+        let solver = match method {
+            "cvode" => {
+                Solver::Cvode(CvodeState { cv: None, rtol: tol, atol, n_roots: nrt as usize, work_retries: 0 })
+            }
+            "ida" => Solver::Ida(IdaState {
+                ida: None,
+                rtol: tol,
+                atol,
+                n_roots: nrt as usize,
+                work_retries: 0,
+                setup: IdaSetup::new(model)?,
+            }),
+            _ => Solver::Daskr(DaskrState::new(model, n_states, nrt, rtol, atol)),
         };
         #[cfg(not(sundials))]
         let solver = Solver::Daskr(DaskrState::new(model, n_states, nrt, rtol, atol));
-        SolverCore {
+        Ok(SolverCore {
             sim_data,
             n_states,
             states_base,
@@ -2922,6 +3052,16 @@ impl SolverCore {
             chatter_idx: 0,
             chatter_consec: 0,
             chatter_emitted: false,
+        })
+    }
+
+    /// The IDA memory and sparse layout the Jacobian callback reads through;
+    /// all-null unless this core runs IDA.
+    #[cfg(sundials)]
+    fn ida_ctx(&self) -> IdaCtx {
+        match &self.solver {
+            Solver::Ida(s) => s.setup.ctx(s.ida.as_ref()),
+            _ => IdaCtx::default(),
         }
     }
 
@@ -2966,6 +3106,16 @@ impl SolverCore {
                     }
                 }
             }
+            #[cfg(sundials)]
+            Solver::Ida(s) => {
+                if let Some(ida) = s.ida.as_mut() {
+                    ida.y_mut().copy_from_slice(&self.y);
+                    ida.yp_mut().copy_from_slice(&self.yp);
+                    if !ida.reinit(self.t) {
+                        return Err("CodegenWasmJit: IDA re-initialization failed");
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -3001,6 +3151,8 @@ impl SolverCore {
                 Solver::Daskr(d) => d.jac_a.as_ref().map_or(core::ptr::null(), |j| j as *const JacAInfo),
                 #[cfg(sundials)]
                 Solver::Cvode(_) => core::ptr::null(),
+                #[cfg(sundials)]
+                Solver::Ida(s) => s.setup.jac_a.as_ref().map_or(core::ptr::null(), |j| j as *const JacAInfo),
             },
             jac_gp: vec![0.0; self.n_states],
             jac_ysave: vec![0.0; self.n_states],
@@ -3010,6 +3162,8 @@ impl SolverCore {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            #[cfg(sundials)]
+            ida: self.ida_ctx(),
         }
     }
 
@@ -3025,6 +3179,7 @@ impl SolverCore {
         deadline: f64,
         did_step: &mut bool,
     ) -> Result<Solved> {
+        let sim_data = self.sim_data;
         loop {
             // Yield inside the work-quota loop too, so a stuck stiff interval is
             // interruptible; resume re-enters with the same target.
@@ -3039,6 +3194,12 @@ impl SolverCore {
                 Solver::Daskr(d) => d.step(&mut self.t, &mut self.y, &mut self.yp, target),
                 #[cfg(sundials)]
                 Solver::Cvode(c) => c.step(&mut self.t, &mut self.y, target, ctx as *mut ResCtx)?,
+                #[cfg(sundials)]
+                Solver::Ida(s) => {
+                    let e = unsafe { &mut *ctx.engine };
+                    let ctx_ptr = ctx as *mut ResCtx;
+                    s.step(e, sim_data, &mut self.t, &mut self.y, &mut self.yp, target, ctx_ptr)?
+                }
             };
             self.nfe = ctx.nfe;
             self.nje = ctx.nje;
@@ -3080,12 +3241,13 @@ impl SolverCore {
             #[cfg(sundials)]
             Solver::Cvode(c) => {
                 if let Some(cv) = c.cv.as_ref() {
-                    let n = cv.counters();
-                    stats.steps = n.steps;
-                    stats.res_evals = n.rhs_evals;
-                    stats.jac_evals = n.jac_evals;
-                    stats.err_test_fails = n.err_test_fails;
-                    stats.conv_test_fails = n.conv_test_fails;
+                    fill_sundials_stats(stats, cv.counters());
+                }
+            }
+            #[cfg(sundials)]
+            Solver::Ida(s) => {
+                if let Some(ida) = s.ida.as_ref() {
+                    fill_sundials_stats(stats, ida.counters());
                 }
             }
         }
@@ -3103,6 +3265,10 @@ impl SolverCore {
                 .as_ref()
                 .and_then(|cv| cv.roots().iter().position(|&r| r != 0))
                 .unwrap_or(0),
+            #[cfg(sundials)]
+            Solver::Ida(s) => {
+                s.ida.as_ref().and_then(|ida| ida.roots().iter().position(|&r| r != 0)).unwrap_or(0)
+            }
         }
     }
 
@@ -3312,7 +3478,7 @@ impl CsDriver {
         let layout = &model.layout;
         store_relations(e, sim_data, layout)?;
         let samp = Samples::load(e, sim_data, layout)?;
-        let mut core = SolverCore::new(model, sim_data, t, "dassl");
+        let mut core = SolverCore::new(model, sim_data, t, "dassl")?;
         let mut pivots = init_state_pivots(&model.state_sets);
         if core.n_states > 0 {
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
@@ -3566,7 +3732,7 @@ impl EventsDriver {
 
         let mut samp = Samples::load(e, sim_data, layout)?;
         let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-        let mut core = SolverCore::new(model, sim_data, start, method);
+        let mut core = SolverCore::new(model, sim_data, start, method)?;
         // A sample scheduled exactly at the start time fires before row 0.
         if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
             samp.fire(e, sim_data, start)?;
@@ -3860,8 +4026,24 @@ unsafe extern "C" fn cvode_rhs(
     }
 }
 
-/// `CVRootFn`: `gout[i] := g_i(t, y)`, the zero-crossing values whose sign
-/// changes are state events. Mirrors [`dassl_rt`].
+/// `gout[i] := g_i(t, y)`, the zero-crossing values whose sign changes are state
+/// events. The body of [`dassl_rt`], shared by the CVODE and IDA root callbacks.
+#[cfg(sundials)]
+unsafe fn eval_roots(ctx: &mut ResCtx, t: f64, y: *const f64, gout: *mut f64) -> Result<()> {
+    let e = unsafe { &mut *ctx.engine };
+    write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
+    write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+    let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, ctx.n_states * 8) };
+    e.write_bytes(ctx.states_base, y_bytes)?;
+    set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
+    e.call1("functionODE", ctx.sim_data)?;
+    e.call1("functionZeroCrossings", ctx.sim_data)?;
+    set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
+    let out = unsafe { core::slice::from_raw_parts_mut(gout as *mut u8, ctx.n_zc * 8) };
+    e.read_bytes(ctx.sim_data + ctx.zc_off, out)
+}
+
+/// `CVRootFn`.
 #[cfg(sundials)]
 unsafe extern "C" fn cvode_root(
     t: f64,
@@ -3870,25 +4052,13 @@ unsafe extern "C" fn cvode_root(
     user_data: *mut core::ffi::c_void,
 ) -> core::ffi::c_int {
     let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
-    let e = unsafe { &mut *ctx.engine };
-    let run = (|| -> Result<()> {
-        write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
-        write_f64(e, ctx.sim_data + TIME_OFF, t)?;
-        let y_bytes =
-            unsafe { core::slice::from_raw_parts(crate::sundials::nv_data(y) as *const u8, ctx.n_states * 8) };
-        e.write_bytes(ctx.states_base, y_bytes)?;
-        set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
-        e.call1("functionODE", ctx.sim_data)?;
-        e.call1("functionZeroCrossings", ctx.sim_data)?;
-        set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
-        let out = unsafe { core::slice::from_raw_parts_mut(gout as *mut u8, ctx.n_zc * 8) };
-        e.read_bytes(ctx.sim_data + ctx.zc_off, out)
-    })();
-    if let Err(err) = run {
-        ctx.err = Some(err);
-        return -1;
+    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(y), gout) } {
+        Err(err) => {
+            ctx.err = Some(err);
+            -1
+        }
+        Ok(()) => 0,
     }
-    0
 }
 
 /// How many times one interval may be resumed after `CV_TOO_MUCH_WORK` (1000
@@ -4043,6 +4213,8 @@ impl Driver for CvodeDriver {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            #[cfg(sundials)]
+            ida: IdaCtx::default(),
         };
         if !cv.set_user_data(&mut ctx as *mut ResCtx as *mut core::ffi::c_void) {
             return Err("CodegenWasmJit: CVODE setup failed");
@@ -4119,12 +4291,629 @@ impl Driver for CvodeDriver {
     }
 
     fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
-        let Some(cv) = self.cv.as_ref() else { return };
-        let c = cv.counters();
-        stats.steps = c.steps;
-        stats.res_evals = c.rhs_evals;
-        stats.jac_evals = c.jac_evals;
-        stats.err_test_fails = c.err_test_fails;
-        stats.conv_test_fails = c.conv_test_fails;
+        if let Some(cv) = self.cv.as_ref() {
+            fill_sundials_stats(stats, cv.counters());
+        }
+    }
+}
+
+/// The five run totals every SUNDIALS integrator reports the same way.
+#[cfg(sundials)]
+fn fill_sundials_stats(stats: &mut SolveStats, c: crate::sundials::Counters) {
+    stats.steps = c.steps;
+    stats.res_evals = c.rhs_evals;
+    stats.jac_evals = c.jac_evals;
+    stats.err_test_fails = c.err_test_fails;
+    stats.conv_test_fails = c.conv_test_fails;
+}
+
+// ===========================================================================
+// IDA driver
+// ===========================================================================
+//
+// The real SUNDIALS IDA, configured as `ida_solver.c` does for a model compiled
+// without `--daeMode`: the explicit ODE goes to IDA as the residual
+// `F(t, y, y') = f(t, y) - y'`, differentiated by a colored numerical FD into
+// KLU's sparse iteration matrix (C's default `-idaLS=klu`), with per-state
+// nominal-scaled tolerances and IDA's root finding on the zero-crossings. The
+// callbacks reach wasm through the same `ResCtx` the DASSL ones use, received as
+// IDA's `user_data`.
+
+/// The CSC layout IDA's sparse Jacobian is filled in: the model's `A` sparsity
+/// widened by the diagonal, which `J = ∂F/∂y - cj·I` needs whether or not the
+/// pattern carries it (C allocates `nnz + N` and lets `SUNMatScaleIAdd_Sparse`
+/// insert what is missing).
+#[cfg(sundials)]
+struct IdaPattern {
+    colptr: Vec<crate::sundials::SunIndex>,
+    rowidx: Vec<crate::sundials::SunIndex>,
+    /// Value index of each column's diagonal entry.
+    diag: Vec<usize>,
+    /// `slots[col][k]` is where `rows_by_col[col][k]`'s difference quotient goes.
+    slots: Vec<Vec<usize>>,
+}
+
+#[cfg(sundials)]
+impl IdaPattern {
+    fn new(jac: &JacAInfo) -> IdaPattern {
+        let n = jac.n as usize;
+        let mut p = IdaPattern {
+            colptr: Vec::with_capacity(n + 1),
+            rowidx: Vec::new(),
+            diag: Vec::with_capacity(n),
+            slots: Vec::with_capacity(n),
+        };
+        p.colptr.push(0);
+        for col in 0..n {
+            let base = p.rowidx.len();
+            let mut rows = jac.rows_by_col[col].clone();
+            rows.push(col as u32);
+            rows.sort_unstable();
+            rows.dedup();
+            let at = |r: u32| base + rows.binary_search(&r).expect("row is in the widened column");
+            p.diag.push(at(col as u32));
+            p.slots.push(jac.rows_by_col[col].iter().map(|&r| at(r)).collect());
+            p.rowidx.extend(rows.iter().map(|&r| r as crate::sundials::SunIndex));
+            p.colptr.push(p.rowidx.len() as crate::sundials::SunIndex);
+        }
+        p
+    }
+
+    fn nnz(&self) -> usize {
+        self.rowidx.len()
+    }
+}
+
+/// What `-idaLS` and the model's Jacobian availability settled on, shared by the
+/// event-free [`IdaDriver`] and the [`SolverCore`] one.
+#[cfg(sundials)]
+struct IdaSetup {
+    ls: crate::sundials::IdaLs,
+    /// Sparsity + coloring for the FD Jacobian; `None` ⇒ IDA's own dense
+    /// difference-quotient Jacobian (C's `INTERNALNUMJAC`).
+    jac_a: Option<JacAInfo>,
+    /// Present exactly when `ls` is KLU.
+    pattern: Option<IdaPattern>,
+    opts: crate::sundials::IdaOptions,
+    /// `SimData` offsets of the differentiated parameters; empty unless
+    /// `-idaSensitivity` was given and the model carries them.
+    sens_offs: Vec<u32>,
+    /// Where `IDAGetSens` deposits `n_sens` values for the next row to capture.
+    sens_off: u32,
+    sens_scratch: Vec<f64>,
+}
+
+#[cfg(sundials)]
+impl IdaSetup {
+    fn new(model: &SimModel) -> Result<IdaSetup> {
+        use crate::sundials::IdaLs;
+        let ls = match crate::simflags::with_flags(|f| f.ida_ls) {
+            Some(crate::simflags::IdaLs::Dense) => IdaLs::Dense,
+            Some(crate::simflags::IdaLs::Spgmr) => IdaLs::Spgmr,
+            Some(crate::simflags::IdaLs::Spbcg) => IdaLs::Spbcg,
+            Some(crate::simflags::IdaLs::Sptfqmr) => IdaLs::Sptfqmr,
+            _ => IdaLs::Klu,
+        };
+        // Nothing to factorize without states, so KLU's demand for a pattern does
+        // not apply — the driver never steps such a model anyway.
+        let ls = if model.layout.n_states == 0 && ls == IdaLs::Klu { IdaLs::Dense } else { ls };
+        // The Krylov solvers assemble no matrix (C pins them to INTERNALNUMJAC).
+        let jac_a = match () {
+            _ if ls.matrix_free() || env_var("OMC_WASM_NO_ANALYTIC_JAC").is_some() => None,
+            _ => model.jac_a.clone(),
+        };
+        let pattern = match (&jac_a, ls) {
+            // C throws here rather than fall back: KLU has nothing to factorize.
+            (None, IdaLs::Klu) => return Err(IDA_NO_SPARSE_PATTERN),
+            (Some(j), IdaLs::Klu) => Some(IdaPattern::new(j)),
+            _ => None,
+        };
+        let opts = crate::simflags::with_flags(|f| crate::sundials::IdaOptions {
+            max_order: f.max_order,
+            max_err_test_fails: f.ida_max_err_test_fails,
+            max_nonlin_iters: f.ida_max_nonlin_iters,
+            max_conv_fails: f.ida_max_conv_fails,
+            nonlin_conv_coef: f.ida_nonlin_conv_coef,
+            init_step: f.initial_step_size,
+        });
+        let sens_offs = match crate::simflags::with_flags(|f| f.ida_sensitivity) {
+            true => model.sens_params.clone(),
+            false => Vec::new(),
+        };
+        let n_sens = if sens_offs.is_empty() { 0 } else { model.layout.n_sens as usize };
+        Ok(IdaSetup {
+            ls,
+            jac_a,
+            pattern,
+            opts,
+            sens_offs,
+            sens_off: model.layout.sens_off,
+            sens_scratch: vec![0.0; n_sens],
+        })
+    }
+
+    /// The sensitivities at the point IDA last returned, into the layout's
+    /// block for [`capture_row`] to append to the next result row.
+    fn store_sens(&mut self, e: &mut dyn SimEngine, sim_data: u32, ida: &mut crate::sundials::Ida) -> Result<()> {
+        if self.sens_scratch.is_empty() {
+            return Ok(());
+        }
+        if !ida.sens_values(&mut self.sens_scratch) {
+            return Err("CodegenWasmJit: IDAGetSens failed");
+        }
+        for (i, x) in self.sens_scratch.iter().enumerate() {
+            write_f64(e, sim_data + self.sens_off + (i as u32) * 8, *x)?;
+        }
+        Ok(())
+    }
+
+    /// Build the IDA block for `n_roots` zero-crossings, starting from `(t, y, yp)`.
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        &self,
+        e: &mut dyn SimEngine,
+        sim_data: u32,
+        t: f64,
+        y: &[f64],
+        yp: &[f64],
+        rtol: f64,
+        atol: &[f64],
+        n_roots: usize,
+    ) -> Result<crate::sundials::Ida> {
+        let mut ida = crate::sundials::Ida::new(
+            t,
+            y,
+            yp,
+            rtol,
+            atol,
+            n_roots,
+            ida_res,
+            (n_roots > 0).then_some(ida_root as crate::sundials::IdaRootFn),
+            self.ls,
+            self.pattern.as_ref().map_or(0, |p| p.nnz()),
+            self.jac_a.as_ref().map(|_| ida_jac as crate::sundials::IdaJacFn),
+            &self.opts,
+        )
+        .ok_or("CodegenWasmJit: IDA initialization failed")?;
+        if !self.sens_offs.is_empty() {
+            let p0: Vec<f64> =
+                self.sens_offs.iter().map(|&off| read_f64(e, sim_data + off)).collect::<Result<_>>()?;
+            if !ida.init_sensitivities(&p0) {
+                return Err("CodegenWasmJit: IDA sensitivity initialization failed");
+            }
+        }
+        Ok(ida)
+    }
+
+    fn ctx(&self, ida: Option<&crate::sundials::Ida>) -> IdaCtx {
+        IdaCtx {
+            mem: ida.map_or(core::ptr::null_mut(), |i| i.mem()),
+            pattern: self.pattern.as_ref().map_or(core::ptr::null(), |p| p as *const IdaPattern),
+            sens: match ida.and_then(|i| i.sens_params()) {
+                Some(p) => SensPush { offs: self.sens_offs.as_ptr(), values: p.as_ptr(), n: p.len() },
+                None => SensPush::default(),
+            },
+        }
+    }
+}
+
+#[cfg(sundials)]
+const IDA_NO_SPARSE_PATTERN: &str = "CodegenWasmJit: -s=ida with the KLU linear solver needs the model's \
+     Jacobian sparsity pattern, which this model has none of (use -idaLS=dense)";
+
+/// `F(t, y, y') := f(t, y) - y'`, the residual `residualFunctionIDA` builds
+/// outside DAE mode: `t` and the candidate states into `SimData`, the wasm
+/// `functionODE`, the derivative slots back out.
+#[cfg(sundials)]
+unsafe fn ida_residual(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, out: *mut f64) -> Result<()> {
+    let e = unsafe { &mut *ctx.engine };
+    let n = ctx.n_states;
+    let sens = ctx.ida.sens;
+    for i in 0..sens.n {
+        write_f64(e, ctx.sim_data + unsafe { *sens.offs.add(i) }, unsafe { *sens.values.add(i) })?;
+    }
+    if sens.n > 0 {
+        e.call1("functionUpdateBoundParameters", ctx.sim_data)?;
+    }
+    write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+    let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
+    e.write_bytes(ctx.states_base, y_bytes)?;
+    e.call1("functionODE", ctx.sim_data)?;
+    let out_bytes = unsafe { core::slice::from_raw_parts_mut(out as *mut u8, n * 8) };
+    e.read_bytes(ctx.ders_base, out_bytes)?;
+    for i in 0..n {
+        unsafe { *out.add(i) -= *yp.add(i) };
+    }
+    Ok(())
+}
+
+/// `IDAResFn`. A wasm trap is unrecoverable (-1); a non-converging nonlinear
+/// system is recoverable (+1), which makes IDA retry from a smaller step.
+#[cfg(sundials)]
+unsafe extern "C" fn ida_res(
+    t: f64,
+    yy: crate::sundials::NVector,
+    yp: crate::sundials::NVector,
+    rr: crate::sundials::NVector,
+    user_data: *mut core::ffi::c_void,
+) -> core::ffi::c_int {
+    let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
+    let e = unsafe { &mut *ctx.engine };
+    let run = (|| -> Result<()> {
+        write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
+        set_context(e, ctx.ctx_addr, CONTEXT_ODE);
+        let r = unsafe {
+            ida_residual(ctx, t, crate::sundials::nv_data(yy), crate::sundials::nv_data(yp), crate::sundials::nv_data(rr))
+        };
+        set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
+        r
+    })();
+    ctx.nfe += 1;
+    match run {
+        Err(err) => {
+            ctx.err = Some(err);
+            -1
+        }
+        Ok(()) => {
+            if read_i32(e, ctx.sim_data + ctx.nls_fail_off).unwrap_or(0) == 0 {
+                return 0;
+            }
+            report_nls_failure_at(e, ctx.sim_data, ctx.nls_fail_off);
+            1
+        }
+    }
+}
+
+/// `IDARootFn`: `gout[i] := g_i(t, y)`. `y'` is unused, as in `rootsFunctionIDA`
+/// outside DAE mode.
+#[cfg(sundials)]
+unsafe extern "C" fn ida_root(
+    t: f64,
+    yy: crate::sundials::NVector,
+    _yp: crate::sundials::NVector,
+    gout: *mut f64,
+    user_data: *mut core::ffi::c_void,
+) -> core::ffi::c_int {
+    let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
+    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(yy), gout) } {
+        Err(err) => {
+            ctx.err = Some(err);
+            -1
+        }
+        Ok(()) => 0,
+    }
+}
+
+/// `IDALsJacFn`: fill `J = ∂F/∂y - cj·I` by a colored numerical FD, one
+/// `functionODE` per color — `ida_solver.c`'s `jacoColoredNumericalSparse` and
+/// `jacColoredNumericalDense`, which differ only in where an entry lands.
+#[cfg(sundials)]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn ida_jac(
+    t: f64,
+    cj: f64,
+    yy: crate::sundials::NVector,
+    yp: crate::sundials::NVector,
+    rr: crate::sundials::NVector,
+    j: crate::sundials::SunMatrix,
+    user_data: *mut core::ffi::c_void,
+    _t1: crate::sundials::NVector,
+    _t2: crate::sundials::NVector,
+    _t3: crate::sundials::NVector,
+) -> core::ffi::c_int {
+    let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
+    if ctx.jac.is_null() {
+        return -1;
+    }
+    let jac = unsafe { &*ctx.jac };
+    let e = unsafe { &mut *ctx.engine };
+    let n = ctx.n_states;
+    let y = crate::sundials::nv_data(yy);
+    let ypv = crate::sundials::nv_data(yp);
+    let base = crate::sundials::nv_data(rr);
+    let h = crate::sundials::ida_current_step(ctx.ida.mem);
+    let pattern = unsafe { ctx.ida.pattern.as_ref() };
+    let vals = match pattern {
+        Some(p) => unsafe {
+            let (data, colptr, rowidx) = crate::sundials::sparse_arrays(j);
+            core::ptr::copy_nonoverlapping(p.colptr.as_ptr(), colptr, n + 1);
+            core::ptr::copy_nonoverlapping(p.rowidx.as_ptr(), rowidx, p.nnz());
+            core::slice::from_raw_parts_mut(data, p.nnz())
+        },
+        None => unsafe { core::slice::from_raw_parts_mut(crate::sundials::dense_data(j), n * n) },
+    };
+    ctx.jac_gp.resize(n, 0.0);
+    ctx.nje += 1;
+    set_context(e, ctx.ctx_addr, CONTEXT_JACOBIAN);
+    let run = (|| -> Result<()> {
+        for color in &jac.colors {
+            for &col in color {
+                let ci = col as usize;
+                let yi = unsafe { *y.add(ci) };
+                let d6 = h * unsafe { *ypv.add(ci) };
+                let mag = DELTA_X_SOLVER
+                    * yi.abs().max(d6.abs()).max(ctx.nominal_factor * unsafe { *ctx.nominals.add(ci) });
+                let mut del = if d6 >= 0.0 { mag } else { -mag };
+                del = yi + del - yi; // floating-point rounding, as in the C runtime
+                ctx.jac_ysave[ci] = yi;
+                ctx.jac_del[ci] = 1.0 / del;
+                unsafe { *y.add(ci) = yi + del };
+            }
+            write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
+            // Detached so the residual can borrow `ctx`; same buffer.
+            let mut gp = core::mem::take(&mut ctx.jac_gp);
+            let r = unsafe { ida_residual(ctx, t, y, ypv, gp.as_mut_ptr()) };
+            ctx.jac_gp = gp;
+            r?;
+            for &col in color {
+                let ci = col as usize;
+                let inv_del = ctx.jac_del[ci];
+                for (k, &row) in jac.rows_by_col[ci].iter().enumerate() {
+                    let ri = row as usize;
+                    let d = (ctx.jac_gp[ri] - unsafe { *base.add(ri) }) * inv_del;
+                    vals[match pattern {
+                        Some(p) => p.slots[ci][k],
+                        None => ci * n + ri,
+                    }] = d;
+                }
+                unsafe { *y.add(ci) = ctx.jac_ysave[ci] };
+            }
+        }
+        // -cj·∂F/∂y' = -cj·I, the diagonal the ∂F/∂y difference does not carry.
+        for col in 0..n {
+            vals[pattern.map_or(col * n + col, |p| p.diag[col])] -= cj;
+        }
+        let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
+        e.write_bytes(ctx.states_base, y_bytes)?;
+        Ok(())
+    })();
+    set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
+    match run {
+        Err(err) => {
+            ctx.err = Some(err);
+            -1
+        }
+        Ok(()) => 0,
+    }
+}
+
+/// How many times one interval may be resumed after `IDA_TOO_MUCH_WORK` (IDA's
+/// 500 internal steps per call). C warns and calls `IDASolve` again with no
+/// limit; resuming continues the same trajectory, this only bounds it.
+#[cfg(sundials)]
+const IDA_WORK_RETRIES: u32 = 10_000;
+
+/// Resumable IDA driver, event-free path. [`CvodeDriver`] with `y'` carried
+/// alongside `y`, IDA needing a consistent derivative at every restart.
+#[cfg(sundials)]
+struct IdaDriver {
+    sim_data: u32,
+    n_states: usize,
+    nominals: Vec<f64>,
+    states_base: u32,
+    ders_base: u32,
+    /// Next output row to produce (row 0 was emitted in `new`).
+    row: u32,
+    /// `None` when the model has no states (nothing to integrate).
+    ida: Option<crate::sundials::Ida>,
+    setup: IdaSetup,
+    t: f64,
+    pivots: Vec<StateSetPivot>,
+    rows: Vec<f64>,
+    /// Resumes an output interval left unfinished by a work-quota return or a yield.
+    work_retries: u32,
+    pending_terminate: bool,
+    finished: bool,
+}
+
+#[cfg(sundials)]
+impl IdaDriver {
+    fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
+        let layout = &model.layout;
+        let setup = IdaSetup::new(model)?;
+        run_initialization(e, sim_data, layout, model.start_time)?;
+
+        let n_states = layout.n_states as usize;
+        let states_base = sim_data + REAL_OFF;
+        let ders_base = states_base + layout.n_states * 8;
+        let n_rows = model.n_output_rows();
+        let n_reals = layout.n_row_total();
+        let start = model.start_time;
+
+        let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
+        emit_initial_row(e, &mut rows, sim_data, layout, start)?;
+        let pending_terminate = terminated(e, sim_data, layout)?;
+
+        // Dynamic state selection at the initial point, as in `DasslDriver::new`.
+        // For an explicit ODE the consistent `y'` is f(t0, y0), which the row above
+        // has already left in the derivative slots.
+        let mut pivots = init_state_pivots(&model.state_sets);
+        let (mut y, mut yp) = (Vec::new(), Vec::new());
+        if n_states > 0 && !pending_terminate {
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+                e.call1("functionODE", sim_data)?;
+            }
+            y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;
+            yp = (0..n_states).map(|i| read_f64(e, ders_base + (i as u32) * 8)).collect::<Result<_>>()?;
+        }
+
+        let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+        let (_, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
+        let ida = if y.is_empty() {
+            None
+        } else {
+            Some(setup.build(e, sim_data, start, &y, &yp, tol, &atol, 0)?)
+        };
+
+        Ok(IdaDriver {
+            sim_data,
+            n_states,
+            nominals: state_nominals(&model.state_nominals, n_states),
+            states_base,
+            ders_base,
+            row: 1,
+            ida,
+            setup,
+            t: start,
+            pivots,
+            rows,
+            work_retries: 0,
+            pending_terminate,
+            finished: false,
+        })
+    }
+}
+
+#[cfg(sundials)]
+impl Driver for IdaDriver {
+    fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance> {
+        if self.finished {
+            return Ok(Advance::Done);
+        }
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        if self.pending_terminate {
+            self.pending_terminate = false;
+            self.finished = true;
+            return Ok(Advance::Terminated);
+        }
+        let n_rows = model.n_output_rows();
+        let n_steps = n_rows - 1;
+        let start = model.start_time;
+        let stop = model.stop_time;
+        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let deadline = deadline_from(budget_ms);
+
+        // No integration — evaluate outputs on the grid — with no states or an
+        // empty time span.
+        let Some(ida) = self.ida.as_mut().filter(|_| stop > start) else {
+            let mut did_step = false;
+            while self.row < n_rows {
+                if did_step && past_deadline(deadline) {
+                    return Ok(Advance::Running);
+                }
+                check_alarm()?;
+                if cancel_requested() {
+                    return Ok(Advance::Cancelled);
+                }
+                did_step = true;
+                let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                open_assert_window();
+                let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
+                close_assert_window(e, sim_data).and(emitted)?;
+                if terminated(e, sim_data, layout)? {
+                    self.finished = true;
+                    return Ok(Advance::Terminated);
+                }
+                self.row += 1;
+            }
+            self.finished = true;
+            return Ok(Advance::Done);
+        };
+
+        let n_states = self.n_states;
+        let states_base = self.states_base;
+        let mut ctx = ResCtx {
+            engine: &mut *e as *mut dyn SimEngine,
+            sim_data,
+            states_base,
+            ders_base: self.ders_base,
+            n_states,
+            nls_fail_off: layout.nls_fail_off,
+            nfe: 0,
+            zc_off: 0,
+            n_zc: 0,
+            err: None,
+            jac: self.setup.jac_a.as_ref().map_or(core::ptr::null(), |j| j as *const JacAInfo),
+            jac_gp: Vec::new(),
+            jac_ysave: vec![0.0; n_states],
+            jac_del: vec![0.0; n_states],
+            jac_ders: Vec::new(),
+            nje: 0,
+            ctx_addr: e.context_addr(),
+            nominals: self.nominals.as_ptr(),
+            nominal_factor: nominal_factor(),
+            ida: self.setup.ctx(Some(ida)),
+        };
+        if !ida.set_user_data(&mut ctx as *mut ResCtx as *mut core::ffi::c_void) {
+            return Err("CodegenWasmJit: IDA setup failed");
+        }
+
+        let mut did_step = false;
+        let outcome = loop {
+            if self.row >= n_rows {
+                break Advance::Done;
+            }
+            if did_step && past_deadline(deadline) {
+                break Advance::Running;
+            }
+            check_alarm()?;
+            if cancel_requested() {
+                break Advance::Cancelled;
+            }
+            did_step = true;
+            let tout = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            // Zero-length final interval: emit the held state rather than step.
+            if tout <= self.t {
+                for (i, v) in ida.y().iter().enumerate() {
+                    write_f64(e, states_base + (i as u32) * 8, *v)?;
+                }
+                emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)?;
+                self.row += 1;
+                continue;
+            }
+            let stop_reason = ida.step(&mut self.t, tout);
+            if let Some(err) = ctx.err.take() {
+                return Err(err);
+            }
+            match stop_reason {
+                crate::sundials::Stop::Reached | crate::sundials::Stop::Root => {}
+                crate::sundials::Stop::Failed(flag)
+                    if flag == crate::sundials::IDA_TOO_MUCH_WORK && self.work_retries < IDA_WORK_RETRIES =>
+                {
+                    self.work_retries += 1;
+                    continue;
+                }
+                crate::sundials::Stop::Failed(_) => return Err("CodegenWasmJit: IDA failed"),
+            }
+            self.work_retries = 0;
+            self.setup.store_sens(e, sim_data, ida)?;
+            for (i, v) in ida.y().iter().enumerate() {
+                write_f64(e, states_base + (i as u32) * 8, *v)?;
+            }
+            open_assert_window();
+            let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
+            close_assert_window(e, sim_data).and(emitted)?;
+            if terminated(e, sim_data, layout)? {
+                break Advance::Terminated;
+            }
+            // A state-set switch changes the meaning of the state vector, so
+            // re-read it and restart IDA (see `DasslDriver`).
+            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
+                e.call1("functionODE", sim_data)?;
+                for i in 0..n_states {
+                    ida.y_mut()[i] = read_f64(e, states_base + (i as u32) * 8)?;
+                    ida.yp_mut()[i] = read_f64(e, self.ders_base + (i as u32) * 8)?;
+                }
+                if !ida.reinit(self.t) {
+                    return Err("CodegenWasmJit: IDA re-initialization failed");
+                }
+            }
+            self.row += 1;
+        };
+        if matches!(outcome, Advance::Done | Advance::Terminated) {
+            self.finished = true;
+        }
+        Ok(outcome)
+    }
+
+    fn take_rows(&mut self) -> Vec<f64> {
+        core::mem::take(&mut self.rows)
+    }
+
+    fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
+        if let Some(ida) = self.ida.as_ref() {
+            fill_sundials_stats(stats, ida.counters());
+        }
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -29,9 +29,10 @@ pub mod simflags;
 #[cfg(sundials)]
 pub mod sundials;
 
-/// Whether this build's driver has the real CVODE linked in (`build.rs`), so a
-/// `-s=cvode` / `method="cvode"` run can be served.
+/// Whether this build's driver has the real CVODE and IDA linked in (`build.rs`),
+/// so a `-s=cvode`/`-s=ida` (or `method=`) run can be served.
 pub const CVODE: bool = cfg!(sundials);
+pub const IDA: bool = cfg!(sundials);
 
 /// Byte offset of `time` within `SimData`.
 pub const TIME_OFF: u32 = 0;
@@ -135,6 +136,11 @@ pub struct Layout {
     pub zctol_off: u32,
     /// Base of the overridable start-value region (one f64 per state).
     pub start_off: u32,
+    /// C's `simulationInfo->sensitivityMatrix`: `d(state)/d(parameter)`,
+    /// parameter-major, written by the IDA driver from `IDAGetSens` and captured
+    /// as a result row's last columns.
+    pub n_sens: u32,
+    pub sens_off: u32,
     pub total: u32,
 }
 
@@ -160,6 +166,7 @@ impl Layout {
         n_stateset_f64: u32,
         n_nlsjac_f64: u32,
         n_math: u32,
+        n_sens: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -196,13 +203,14 @@ impl Layout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let zctol_off = mathevents_off + n_math_slots * 8;
         let start_off = zctol_off + 8;
-        let total = start_off + n_states * 8;
+        let sens_off = start_off + n_states * 8;
+        let total = sens_off + n_sens * 8;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
-            mathevents_off, zctol_off, start_off, total,
+            mathevents_off, zctol_off, start_off, n_sens, sens_off, total,
         }
     }
 
@@ -238,9 +246,13 @@ impl Layout {
     pub fn n_bool_alg(&self) -> u32 {
         (self.bparam_off - self.bool_off) / 4
     }
-    /// Total f64 columns in a result row: the real part plus the integer and
-    /// boolean algebraics (captured per row as f64).
+    /// Total f64 columns in a result row: the real part, the integer and boolean
+    /// algebraics (captured per row as f64), then the sensitivities.
     pub fn n_row_total(&self) -> u32 {
+        self.n_reals_row() + self.n_int_alg() + self.n_bool_alg() + self.n_sens
+    }
+    /// First result-row column of the sensitivity block.
+    pub fn sens_col0(&self) -> u32 {
         self.n_reals_row() + self.n_int_alg() + self.n_bool_alg()
     }
 }
@@ -367,6 +379,9 @@ pub struct SimMeta {
     /// `x > 0.0`), 1:1 with the layout's zero-crossings — the driver names the
     /// culprit crossing in the chattering message. Empty ⇒ descriptions absent.
     pub zc_desc: Vec<String>,
+    /// C's `simulationInfo->sensitivityParList`: the `SimData` offsets of the
+    /// parameters `--calculateSensitivities` selected, in block order.
+    pub sens_params: Vec<u32>,
 }
 
 impl SimMeta {
@@ -401,7 +416,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 5;
+const VERSION: u32 = 6;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -431,7 +446,8 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.bparam_off, l.str_off, l.sparam_off, l.eobj_off, l.pre_real_off, l.pre_int_off, l.pre_bool_off,
         l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
-        l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off, l.total,
+        l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
+        l.n_sens, l.sens_off, l.total,
     ] {
         put_u32(o, v);
     }
@@ -516,6 +532,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     for d in &m.zc_desc {
         put_str(&mut o, d);
     }
+    put_u32s(&mut o, &m.sens_params);
     o
 }
 
@@ -598,6 +615,8 @@ impl<'a> Reader<'a> {
             mathevents_off: self.u32()?,
             zctol_off: self.u32()?,
             start_off: self.u32()?,
+            n_sens: self.u32()?,
+            sens_off: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -684,9 +703,10 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     for _ in 0..ndesc {
         zc_desc.push(r.string()?);
     }
+    let sens_params = r.u32s()?;
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
-        model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs, zc_desc,
+        model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs, zc_desc, sens_params,
     })
 }
 
@@ -698,7 +718,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -736,6 +756,7 @@ mod tests {
                 FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true },
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
+            sens_params: vec![88],
         }
     }
 
@@ -755,7 +776,9 @@ mod tests {
         assert_eq!(l.n_reals_row(), 1 + 2 * 2 + 1); // time + 2 states + 2 ders + 1 alg
         assert_eq!(l.n_int_alg(), 1);
         assert_eq!(l.n_bool_alg(), 1);
-        assert_eq!(l.n_row_total(), 6 + 1 + 1);
+        assert_eq!(l.n_sens, 2);
+        assert_eq!(l.n_row_total(), 6 + 1 + 1 + 2);
+        assert_eq!(l.sens_col0(), 6 + 1 + 1);
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -69,6 +69,17 @@ pub enum Lss {
     Rsparse = 3,
 }
 
+/// `-idaLS`, the linear solver IDA's Newton iteration uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdaLs {
+    Dense,
+    /// C's default.
+    Klu,
+    Spgmr,
+    Spbcg,
+    Sptfqmr,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SimFlags {
     pub solver: Option<Solver>,
@@ -89,6 +100,21 @@ pub struct SimFlags {
     pub step_size: Option<f64>,
     /// `-jacobianNominalFactor`: scales the ODE Jacobian's FD step floor.
     pub jacobian_nominal_factor: Option<f64>,
+    /// `-idaLS`
+    pub ida_ls: Option<IdaLs>,
+    /// `-idaSensitivity`: IDAS forward sensitivities w.r.t. the parameters
+    /// `--calculateSensitivities` selected.
+    pub ida_sensitivity: bool,
+    /// The `IDASet*` tunables (`-idaMaxErrorTestFails`, `-idaMaxNonLinIters`,
+    /// `-idaMaxConvFails`, `-idaNonLinConvCoef`).
+    pub ida_max_err_test_fails: Option<i32>,
+    pub ida_max_nonlin_iters: Option<i32>,
+    pub ida_max_conv_fails: Option<i32>,
+    pub ida_nonlin_conv_coef: Option<f64>,
+    /// `-maxIntegrationOrder`: caps the BDF order (5 by default).
+    pub max_order: Option<i32>,
+    /// `-initialStepSize`
+    pub initial_step_size: Option<f64>,
     /// `-homotopyOnFirstTry` / `-noHomotopyOnFirstTry`. `None` is C's default,
     /// which sets `FLAG_HOMOTOPY_ON_FIRST_TRY` whenever the model supports
     /// homotopy.
@@ -195,13 +221,17 @@ pub fn supported(cap: Capabilities) -> Vec<(&'static str, Vec<&'static str>)> {
         ls.push("klu");
         lss.push("klu");
     }
-    alloc::vec![
+    let mut menu = alloc::vec![
         ("s", solver),
         ("nls", alloc::vec!["hybrid", "kinsol", "newton", "mixed", "homotopy"]),
         ("nlsLS", nls_ls),
         ("ls", ls),
         ("lss", lss),
-    ]
+    ];
+    if cap.ida {
+        menu.push(("idaLS", alloc::vec!["klu", "dense", "spgmr", "spbcg", "sptfqmr"]));
+    }
+    menu
 }
 
 /// Parse an argv slice (`argv[0]` is the program name and is skipped).
@@ -279,6 +309,14 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                         .map_err(|_| "-jacobianNominalFactor needs a number".to_string())?,
                 )
             }
+            "idaLS" => f.ida_ls = Some(ida_ls(&value(name)?)?),
+            "idaSensitivity" => f.ida_sensitivity = true,
+            "idaMaxErrorTestFails" => f.ida_max_err_test_fails = Some(int(name, &value(name)?)?),
+            "idaMaxNonLinIters" => f.ida_max_nonlin_iters = Some(int(name, &value(name)?)?),
+            "idaMaxConvFails" => f.ida_max_conv_fails = Some(int(name, &value(name)?)?),
+            "idaNonLinConvCoef" => f.ida_nonlin_conv_coef = Some(real(name, &value(name)?)?),
+            "maxIntegrationOrder" => f.max_order = Some(int(name, &value(name)?)?),
+            "initialStepSize" => f.initial_step_size = Some(real(name, &value(name)?)?),
             "homotopyOnFirstTry" => f.homotopy_on_first_try = Some(true),
             "noHomotopyOnFirstTry" => f.homotopy_on_first_try = Some(false),
             _ => f.unknown.push(arg.to_string()),
@@ -311,6 +349,14 @@ fn split_top_level(s: &str) -> Vec<String> {
 
 fn bad(flag: &str, got: &str, accepted: &str) -> String {
     format!("unrecognized value `{got}` for -{flag} (accepted: {accepted})")
+}
+
+fn int(flag: &str, v: &str) -> Result<i32, String> {
+    v.parse().map_err(|_| format!("-{flag} needs an integer"))
+}
+
+fn real(flag: &str, v: &str) -> Result<f64, String> {
+    v.parse().map_err(|_| format!("-{flag} needs a number"))
 }
 
 fn solver(v: &str) -> Result<Solver, String> {
@@ -353,6 +399,17 @@ fn ls(v: &str) -> Result<Ls, String> {
         "totalpivot" => Ls::TotalPivot,
         "klu" => Ls::Klu,
         _ => return Err(bad("ls", v, "default, lapack, totalpivot, klu")),
+    })
+}
+
+fn ida_ls(v: &str) -> Result<IdaLs, String> {
+    Ok(match v {
+        "dense" => IdaLs::Dense,
+        "klu" => IdaLs::Klu,
+        "spgmr" => IdaLs::Spgmr,
+        "spbcg" => IdaLs::Spbcg,
+        "sptfqmr" => IdaLs::Sptfqmr,
+        _ => return Err(bad("idaLS", v, "dense, klu, spgmr, spbcg, sptfqmr")),
     })
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
@@ -1,22 +1,22 @@
-//! CVODE bindings for the wasm-jit driver.
+//! CVODE and IDA bindings for the wasm-jit driver.
 //!
-//! Linked from `libsundials_cvode.a`: the wasm32-wasip1 cross-build for the
-//! in-wasm runtimes, the C runtime's own archive for the native host-driven
-//! driver. Their `SUNDIALS_INDEX_SIZE` differs (32 vs 64), so `build.rs` reports
-//! which one this build got. It reaches only the two dimension arguments below —
-//! CVODE with a dense matrix hands SUNDIALS no index array.
+//! Linked from `libsundials_cvode.a` / `libsundials_idas.a`: the wasm32-wasip1
+//! cross-build for the in-wasm runtimes, the C runtime's own archives for the
+//! native host-driven driver. Their `SUNDIALS_INDEX_SIZE` differs (32 vs 64), so
+//! `build.rs` reports which one this build got — [`SunIndex`] follows it, and
+//! IDA's sparse matrix is indexed with it.
 
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::{c_int, c_long, c_void};
 
 #[cfg(sundials_i64)]
-type SunIndex = i64;
+pub type SunIndex = i64;
 #[cfg(not(sundials_i64))]
-type SunIndex = i32;
+pub type SunIndex = i32;
 
 pub type NVector = *mut c_void;
-type SunMatrix = *mut c_void;
+pub type SunMatrix = *mut c_void;
 type SunLinearSolver = *mut c_void;
 
 /// `int f(realtype t, N_Vector y, N_Vector ydot, void *user_data)`.
@@ -39,9 +39,20 @@ unsafe extern "C" {
     fn N_VGetArrayPointer(v: NVector) -> *mut f64;
 
     fn SUNDenseMatrix(m: SunIndex, n: SunIndex) -> SunMatrix;
+    fn SUNDenseMatrix_Data(a: SunMatrix) -> *mut f64;
     fn SUNMatDestroy(a: SunMatrix);
     fn SUNLinSol_Dense(y: NVector, a: SunMatrix) -> SunLinearSolver;
     fn SUNLinSolFree(s: SunLinearSolver) -> c_int;
+
+    fn SUNSparseMatrix(m: SunIndex, n: SunIndex, nnz: SunIndex, sparsetype: c_int) -> SunMatrix;
+    fn SUNSparseMatrix_Data(a: SunMatrix) -> *mut f64;
+    fn SUNSparseMatrix_IndexPointers(a: SunMatrix) -> *mut SunIndex;
+    fn SUNSparseMatrix_IndexValues(a: SunMatrix) -> *mut SunIndex;
+    fn SUNLinSol_KLU(y: NVector, a: SunMatrix) -> SunLinearSolver;
+
+    fn SUNLinSol_SPGMR(y: NVector, pretype: c_int, maxl: c_int) -> SunLinearSolver;
+    fn SUNLinSol_SPBCGS(y: NVector, pretype: c_int, maxl: c_int) -> SunLinearSolver;
+    fn SUNLinSol_SPTFQMR(y: NVector, pretype: c_int, maxl: c_int) -> SunLinearSolver;
 
     fn CVodeCreate(lmm: c_int) -> *mut c_void;
     fn CVodeFree(mem: *mut *mut c_void);
@@ -283,4 +294,426 @@ impl Drop for Cvode {
 /// An `N_Vector`'s data as a raw pointer, for the callbacks.
 pub fn nv_data(v: NVector) -> *mut f64 {
     unsafe { N_VGetArrayPointer(v) }
+}
+
+/// `int F(realtype t, N_Vector yy, N_Vector yp, N_Vector rr, void *user_data)`.
+pub type IdaResFn = unsafe extern "C" fn(f64, NVector, NVector, NVector, *mut c_void) -> c_int;
+/// `int g(realtype t, N_Vector yy, N_Vector yp, realtype *gout, void *user_data)`.
+pub type IdaRootFn = unsafe extern "C" fn(f64, NVector, NVector, *mut f64, *mut c_void) -> c_int;
+/// `IDALsJacFn`: `J = ∂F/∂y + cj·∂F/∂y'`.
+#[rustfmt::skip]
+pub type IdaJacFn = unsafe extern "C" fn(
+    f64, f64, NVector, NVector, NVector, SunMatrix, *mut c_void, NVector, NVector, NVector,
+) -> c_int;
+
+/// `mxstep` internal steps taken without reaching `tout`; resuming continues.
+pub const IDA_TOO_MUCH_WORK: c_int = -1;
+
+const IDA_NORMAL: c_int = 1;
+const IDA_SUCCESS: c_int = 0;
+const IDA_TSTOP_RETURN: c_int = 1;
+const IDA_ROOT_RETURN: c_int = 2;
+const CSC_MAT: c_int = 0;
+/// The Krylov solvers run unpreconditioned, as `ida_solver.c` builds them.
+const PREC_NONE: c_int = 0;
+
+unsafe extern "C" {
+    fn IDACreate() -> *mut c_void;
+    fn IDAFree(mem: *mut *mut c_void);
+    fn IDAInit(mem: *mut c_void, res: IdaResFn, t0: f64, yy0: NVector, yp0: NVector) -> c_int;
+    fn IDAReInit(mem: *mut c_void, t0: f64, yy0: NVector, yp0: NVector) -> c_int;
+    fn IDASVtolerances(mem: *mut c_void, reltol: f64, abstol: NVector) -> c_int;
+    fn IDASetUserData(mem: *mut c_void, user_data: *mut c_void) -> c_int;
+    fn IDASetLinearSolver(mem: *mut c_void, ls: SunLinearSolver, a: SunMatrix) -> c_int;
+    fn IDASetJacFn(mem: *mut c_void, jac: Option<IdaJacFn>) -> c_int;
+    fn IDARootInit(mem: *mut c_void, nrtfn: c_int, g: IdaRootFn) -> c_int;
+    fn IDAGetRootInfo(mem: *mut c_void, rootsfound: *mut c_int) -> c_int;
+    fn IDASetMaxOrd(mem: *mut c_void, maxord: c_int) -> c_int;
+    fn IDASetMaxErrTestFails(mem: *mut c_void, maxnef: c_int) -> c_int;
+    fn IDASetMaxNonlinIters(mem: *mut c_void, maxcor: c_int) -> c_int;
+    fn IDASetMaxConvFails(mem: *mut c_void, maxncf: c_int) -> c_int;
+    fn IDASetNonlinConvCoef(mem: *mut c_void, epcon: f64) -> c_int;
+    fn IDASetInitStep(mem: *mut c_void, hin: f64) -> c_int;
+    fn IDASolve(mem: *mut c_void, tout: f64, tret: *mut f64, yret: NVector, ypret: NVector, itask: c_int) -> c_int;
+    fn IDAGetCurrentStep(mem: *mut c_void, hcur: *mut f64) -> c_int;
+
+    fn IDAGetNumSteps(mem: *mut c_void, n: *mut c_long) -> c_int;
+    fn IDAGetNumResEvals(mem: *mut c_void, n: *mut c_long) -> c_int;
+    fn IDAGetNumJacEvals(mem: *mut c_void, n: *mut c_long) -> c_int;
+    fn IDAGetNumErrTestFails(mem: *mut c_void, n: *mut c_long) -> c_int;
+    fn IDAGetNumNonlinSolvConvFails(mem: *mut c_void, n: *mut c_long) -> c_int;
+
+    fn N_VCloneVectorArray(count: c_int, w: NVector) -> *mut NVector;
+    fn N_VDestroyVectorArray(vs: *mut NVector, count: c_int);
+    fn N_VConst(c: f64, z: NVector);
+    fn IDASensInit(mem: *mut c_void, ns: c_int, ism: c_int, res: *const c_void, ys0: *mut NVector, yps0: *mut NVector) -> c_int;
+    fn IDASensReInit(mem: *mut c_void, ism: c_int, ys0: *mut NVector, yps0: *mut NVector) -> c_int;
+    fn IDASetSensParams(mem: *mut c_void, p: *mut f64, pbar: *mut f64, plist: *mut c_int) -> c_int;
+    fn IDASetSensDQMethod(mem: *mut c_void, dqtype: c_int, dqrhomax: f64) -> c_int;
+    fn IDASensEEtolerances(mem: *mut c_void) -> c_int;
+    fn IDAGetSens(mem: *mut c_void, tret: *mut f64, ys: *mut NVector) -> c_int;
+}
+
+const IDA_SIMULTANEOUS: c_int = 1;
+const IDA_FORWARD: c_int = 2;
+
+/// `-idaLS`. The Krylov ones are matrix-free: no `SUNMatrix`, no Jacobian, IDA's
+/// own difference-quotient Jacobian-vector product instead.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IdaLs {
+    Dense,
+    /// C's default. Needs the model's Jacobian sparsity pattern.
+    Klu,
+    Spgmr,
+    Spbcg,
+    Sptfqmr,
+}
+
+impl IdaLs {
+    pub fn matrix_free(self) -> bool {
+        matches!(self, IdaLs::Spgmr | IdaLs::Spbcg | IdaLs::Sptfqmr)
+    }
+}
+
+/// The `IDASet*` tunables `ida_solver_initial` takes from simulation flags;
+/// `None` leaves the default.
+#[derive(Clone, Copy, Default)]
+pub struct IdaOptions {
+    pub max_order: Option<c_int>,
+    pub max_err_test_fails: Option<c_int>,
+    pub max_nonlin_iters: Option<c_int>,
+    pub max_conv_fails: Option<c_int>,
+    pub nonlin_conv_coef: Option<f64>,
+    pub init_step: Option<f64>,
+}
+
+/// IDA state for one model: BDF over the residual `F(t, y, y')`, per-state
+/// nominal-scaled tolerances, KLU or dense direct linear solver, and IDA's own
+/// root finding on the zero-crossings — the configuration `ida_solver.c` builds.
+pub struct Ida {
+    mem: *mut c_void,
+    y: NVector,
+    yp: NVector,
+    atol: NVector,
+    /// Iteration matrix and its solver, owned for the lifetime of `mem`.
+    jac: SunMatrix,
+    lin_sol: SunLinearSolver,
+    n: usize,
+    n_roots: usize,
+    roots: Vec<c_int>,
+    /// Run totals; the `IDAGet*` counters restart with every `IDAReInit`.
+    past: Counters,
+    sens: Option<Sens>,
+}
+
+/// IDAS forward sensitivity state (`-idaSensitivity`). `p` is what IDAS perturbs
+/// to difference `dF/dp`; `plist`/`pbar` are left at their defaults (identity,
+/// 1), so it holds exactly the differentiated parameters in block order.
+struct Sens {
+    ns: usize,
+    ys: *mut NVector,
+    yps: *mut NVector,
+    /// Where `IDAGetSens` deposits the result; `ys` stays the restart value.
+    out: *mut NVector,
+    p: Vec<f64>,
+}
+
+impl Ida {
+    /// `nnz` is the sparse pattern's nonzero count ([`IdaLs::Klu`] only); `jac`
+    /// is `None` for IDA's internal difference-quotient Jacobian. `user_data` is
+    /// bound separately, by [`set_user_data`](Ida::set_user_data).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        t0: f64,
+        y0: &[f64],
+        yp0: &[f64],
+        rtol: f64,
+        atol: &[f64],
+        n_roots: usize,
+        res: IdaResFn,
+        root: Option<IdaRootFn>,
+        ls: IdaLs,
+        nnz: usize,
+        jac: Option<IdaJacFn>,
+        opts: &IdaOptions,
+    ) -> Option<Ida> {
+        let n = y0.len();
+        let mut ida = unsafe {
+            let y = N_VNew_Serial(n as SunIndex);
+            let yp = N_VNew_Serial(n as SunIndex);
+            let atol_v = N_VNew_Serial(n as SunIndex);
+            let j = match ls {
+                IdaLs::Dense => SUNDenseMatrix(n as SunIndex, n as SunIndex),
+                IdaLs::Klu => SUNSparseMatrix(n as SunIndex, n as SunIndex, nnz as SunIndex, CSC_MAT),
+                _ => core::ptr::null_mut(),
+            };
+            if [y, yp, atol_v].iter().any(|p| p.is_null()) || (j.is_null() && !ls.matrix_free()) {
+                return None;
+            }
+            // Krylov `maxl` is the system size, as `ida_solver.c` passes it.
+            let lin_sol = match ls {
+                IdaLs::Dense => SUNLinSol_Dense(y, j),
+                IdaLs::Klu => SUNLinSol_KLU(y, j),
+                IdaLs::Spgmr => SUNLinSol_SPGMR(y, PREC_NONE, n as c_int),
+                IdaLs::Spbcg => SUNLinSol_SPBCGS(y, PREC_NONE, n as c_int),
+                IdaLs::Sptfqmr => SUNLinSol_SPTFQMR(y, PREC_NONE, n as c_int),
+            };
+            let mem = IDACreate();
+            if lin_sol.is_null() || mem.is_null() {
+                return None;
+            }
+            Ida {
+                mem,
+                y,
+                yp,
+                atol: atol_v,
+                jac: j,
+                lin_sol,
+                n,
+                n_roots,
+                roots: vec![0; n_roots.max(1)],
+                past: Counters::default(),
+                sens: None,
+            }
+        };
+        ida.y_mut().copy_from_slice(y0);
+        ida.yp_mut().copy_from_slice(yp0);
+        unsafe {
+            core::ptr::copy_nonoverlapping(atol.as_ptr(), N_VGetArrayPointer(ida.atol), n);
+        }
+        let ok = unsafe {
+            IDAInit(ida.mem, res, t0, ida.y, ida.yp) == IDA_SUCCESS
+                && IDASVtolerances(ida.mem, rtol, ida.atol) == IDA_SUCCESS
+                && IDASetLinearSolver(ida.mem, ida.lin_sol, ida.jac) == IDA_SUCCESS
+                && IDASetJacFn(ida.mem, jac) == IDA_SUCCESS
+                && match root {
+                    Some(g) => IDARootInit(ida.mem, n_roots as c_int, g) == IDA_SUCCESS,
+                    None => true,
+                }
+        };
+        let ok = ok && ida.apply(opts);
+        ok.then_some(ida)
+    }
+
+    fn apply(&mut self, o: &IdaOptions) -> bool {
+        let set = |flag: c_int| flag == IDA_SUCCESS;
+        unsafe {
+            o.max_order.is_none_or(|v| set(IDASetMaxOrd(self.mem, v)))
+                && o.max_err_test_fails.is_none_or(|v| set(IDASetMaxErrTestFails(self.mem, v)))
+                && o.max_nonlin_iters.is_none_or(|v| set(IDASetMaxNonlinIters(self.mem, v)))
+                && o.max_conv_fails.is_none_or(|v| set(IDASetMaxConvFails(self.mem, v)))
+                && o.nonlin_conv_coef.is_none_or(|v| set(IDASetNonlinConvCoef(self.mem, v)))
+                && o.init_step.is_none_or(|v| set(IDASetInitStep(self.mem, v)))
+        }
+    }
+
+    /// The IDA memory block, for the `IDAGet*` a callback needs.
+    pub fn mem(&self) -> *mut c_void {
+        self.mem
+    }
+
+    /// Start forward sensitivity analysis over `p0`, the differentiated
+    /// parameters' current values, in `ida_solver_initial`'s configuration:
+    /// sensitivities from zero, IDAS's own forward difference quotients.
+    pub fn init_sensitivities(&mut self, p0: &[f64]) -> bool {
+        let ns = p0.len();
+        let mut sens = unsafe {
+            Sens {
+                ns,
+                ys: N_VCloneVectorArray(ns as c_int, self.y),
+                yps: N_VCloneVectorArray(ns as c_int, self.yp),
+                out: N_VCloneVectorArray(ns as c_int, self.y),
+                p: p0.to_vec(),
+            }
+        };
+        if [sens.ys, sens.yps, sens.out].iter().any(|a| a.is_null()) {
+            return false;
+        }
+        sens.zero();
+        let ok = unsafe {
+            IDASensInit(self.mem, ns as c_int, IDA_SIMULTANEOUS, core::ptr::null(), sens.ys, sens.yps)
+                == IDA_SUCCESS
+                && IDASetSensParams(self.mem, sens.p.as_mut_ptr(), core::ptr::null_mut(), core::ptr::null_mut())
+                    == IDA_SUCCESS
+                && IDASetSensDQMethod(self.mem, IDA_FORWARD, 0.0) == IDA_SUCCESS
+                && IDASensEEtolerances(self.mem) == IDA_SUCCESS
+        };
+        self.sens = Some(sens);
+        ok
+    }
+
+    /// The parameter values IDAS is currently differencing over; the residual
+    /// writes them into the model, which is how a perturbation reaches `f`.
+    pub fn sens_params(&self) -> Option<&[f64]> {
+        self.sens.as_ref().map(|s| s.p.as_slice())
+    }
+
+    /// `d(state)/d(parameter)` at the last accepted point, parameter-major
+    /// (`out.len() == ns * n`).
+    pub fn sens_values(&mut self, out: &mut [f64]) -> bool {
+        let Some(sens) = self.sens.as_ref() else { return false };
+        let mut t = 0.0;
+        if unsafe { IDAGetSens(self.mem, &mut t, sens.out) } != IDA_SUCCESS {
+            return false;
+        }
+        for i in 0..sens.ns {
+            let src = unsafe { core::slice::from_raw_parts(N_VGetArrayPointer(*sens.out.add(i)), self.n) };
+            out[i * self.n..(i + 1) * self.n].copy_from_slice(src);
+        }
+        true
+    }
+
+    pub fn y(&self) -> &[f64] {
+        unsafe { core::slice::from_raw_parts(N_VGetArrayPointer(self.y), self.n) }
+    }
+
+    pub fn yp(&self) -> &[f64] {
+        unsafe { core::slice::from_raw_parts(N_VGetArrayPointer(self.yp), self.n) }
+    }
+
+    /// The state vector, to write a new starting point into before
+    /// [`reinit`](Ida::reinit).
+    pub fn y_mut(&mut self) -> &mut [f64] {
+        unsafe { core::slice::from_raw_parts_mut(N_VGetArrayPointer(self.y), self.n) }
+    }
+
+    /// The derivative vector; IDA needs a consistent `y'` at every restart.
+    pub fn yp_mut(&mut self) -> &mut [f64] {
+        unsafe { core::slice::from_raw_parts_mut(N_VGetArrayPointer(self.yp), self.n) }
+    }
+
+    /// Restart at `t` from the current `y`/`y'` — after an event, a state-set
+    /// switch, or anything else that moved a state behind IDA's back. Banks the
+    /// counters, which `IDAReInit` resets.
+    pub fn reinit(&mut self, t: f64) -> bool {
+        self.bank();
+        if unsafe { IDAReInit(self.mem, t, self.y, self.yp) } != IDA_SUCCESS {
+            return false;
+        }
+        // C restarts the sensitivities from zero at every event too.
+        match self.sens.as_ref() {
+            None => true,
+            Some(s) => {
+                s.zero();
+                unsafe { IDASensReInit(self.mem, IDA_SIMULTANEOUS, s.ys, s.yps) == IDA_SUCCESS }
+            }
+        }
+    }
+
+    /// Rebind the pointer handed to the `res`/`root`/`jac` callbacks. The
+    /// driver's context lives on the stack of one `advance`, so it is set per
+    /// chunk.
+    pub fn set_user_data(&mut self, user_data: *mut c_void) -> bool {
+        unsafe { IDASetUserData(self.mem, user_data) == IDA_SUCCESS }
+    }
+
+    /// Integrate to `tout`, stopping early on a root. `t` is updated to where the
+    /// integration actually stopped and `y()`/`yp()` hold the state there. No
+    /// `IDASetStopTime`, as in `ida_solver.c`: IDA may step past `tout` internally
+    /// and interpolate back to it.
+    pub fn step(&mut self, t: &mut f64, tout: f64) -> Stop {
+        unsafe {
+            match IDASolve(self.mem, tout, t, self.y, self.yp, IDA_NORMAL) {
+                IDA_SUCCESS | IDA_TSTOP_RETURN => Stop::Reached,
+                IDA_ROOT_RETURN => {
+                    IDAGetRootInfo(self.mem, self.roots.as_mut_ptr());
+                    Stop::Root
+                }
+                flag => Stop::Failed(flag),
+            }
+        }
+    }
+
+    /// Which root functions fired at the last [`Stop::Root`] (`IDAGetRootInfo`).
+    pub fn roots(&self) -> &[c_int] {
+        &self.roots[..self.n_roots]
+    }
+
+    fn get(&self, f: unsafe extern "C" fn(*mut c_void, *mut c_long) -> c_int) -> u64 {
+        let mut n: c_long = 0;
+        unsafe { f(self.mem, &mut n) };
+        n.max(0) as u64
+    }
+
+    /// Fold the current segment's counters into the run totals.
+    fn bank(&mut self) {
+        let c = self.segment();
+        self.past.steps += c.steps;
+        self.past.rhs_evals += c.rhs_evals;
+        self.past.jac_evals += c.jac_evals;
+        self.past.err_test_fails += c.err_test_fails;
+        self.past.conv_test_fails += c.conv_test_fails;
+    }
+
+    fn segment(&self) -> Counters {
+        Counters {
+            steps: self.get(IDAGetNumSteps),
+            rhs_evals: self.get(IDAGetNumResEvals),
+            jac_evals: self.get(IDAGetNumJacEvals),
+            err_test_fails: self.get(IDAGetNumErrTestFails),
+            conv_test_fails: self.get(IDAGetNumNonlinSolvConvFails),
+        }
+    }
+
+    pub fn counters(&self) -> Counters {
+        let c = self.segment();
+        Counters {
+            steps: self.past.steps + c.steps,
+            rhs_evals: self.past.rhs_evals + c.rhs_evals,
+            jac_evals: self.past.jac_evals + c.jac_evals,
+            err_test_fails: self.past.err_test_fails + c.err_test_fails,
+            conv_test_fails: self.past.conv_test_fails + c.conv_test_fails,
+        }
+    }
+}
+
+impl Sens {
+    fn zero(&self) {
+        for i in 0..self.ns {
+            unsafe {
+                N_VConst(0.0, *self.ys.add(i));
+                N_VConst(0.0, *self.yps.add(i));
+            }
+        }
+    }
+}
+
+impl Drop for Ida {
+    fn drop(&mut self) {
+        if let Some(s) = self.sens.take() {
+            unsafe {
+                for a in [s.ys, s.yps, s.out] {
+                    N_VDestroyVectorArray(a, s.ns as c_int);
+                }
+            }
+        }
+        unsafe {
+            IDAFree(&mut self.mem);
+            SUNLinSolFree(self.lin_sol);
+            SUNMatDestroy(self.jac);
+            N_VDestroy(self.atol);
+            N_VDestroy(self.yp);
+            N_VDestroy(self.y);
+        }
+    }
+}
+
+/// The step size IDA is currently attempting, the scale `ida_solver.c`'s
+/// difference quotient measures `y'` against.
+pub fn ida_current_step(mem: *mut c_void) -> f64 {
+    let mut h = 0.0;
+    unsafe { IDAGetCurrentStep(mem, &mut h) };
+    h
+}
+
+/// A dense `SUNMatrix`'s column-major data, `n*n` in length.
+pub fn dense_data(a: SunMatrix) -> *mut f64 {
+    unsafe { SUNDenseMatrix_Data(a) }
+}
+
+/// The three arrays of a CSC `SUNMatrix`, for a Jacobian callback to fill.
+pub fn sparse_arrays(a: SunMatrix) -> (*mut f64, *mut SunIndex, *mut SunIndex) {
+    unsafe {
+        (SUNSparseMatrix_Data(a), SUNSparseMatrix_IndexPointers(a), SUNSparseMatrix_IndexValues(a))
+    }
 }


### PR DESCRIPTION
make_driver rejected method="ida" since #16167, which was honest but left four tests failing.  This wires up the real SUNDIALS IDA, next to the CVODE that was already there, following ida_solver.c for a model compiled without --daeMode: the explicit ODE goes to IDA as the residual F(t, y, y') = f(t, y) - y', with per-state nominal-scaled tolerances, IDA's own root finding on the zero-crossings, and no IDASetStopTime, so it may step past tout and interpolate back as C lets it.

The Jacobian is C's default: a colored numerical FD into KLU's sparse matrix, over the same sparsity + coloring DASSL uses.  The pattern is widened by the diagonal, since J = dF/dy - cj*I needs it whether or not the model's has it (C allocates nnz + N and lets SUNMatScaleIAdd_Sparse insert what is missing).  The FD step is dassl_jac's, which is ida_solver.c's after #16166.  All five -idaLS values work: dense takes the same colored FD, and the three Krylov ones are matrix-free, pinned to IDA's internal Jacobian-vector product as C pins them to INTERNALNUMJAC.  A model with no sparsity pattern under KLU is the error C throws rather than a silent fall back to dense.  -idaMaxErrorTestFails, -idaMaxNonLinIters, -idaMaxConvFails, -idaNonLinConvCoef, -maxIntegrationOrder and -initialStepSize are parsed and applied.

-idaSensitivity comes with it.  The layout gains a block for d(state)/d(parameter) -- C's simulationInfo->sensitivityMatrix -- captured as a result row's last columns, so the mat writer needs nothing special and a non-IDA solver reports the zeros C's calloc'd matrix gives.  The codegen splits sensitivityVars at numSensitivityParameters: the leading entries are the differentiated parameters, resolved by name to their SimData slots, and the rest become the $Sensitivities.<par>.<state> signals.  A perturbation reaches the model only through those slots, so the residual writes IDAS's p into them and calls a new functionUpdateBoundParameters -- parameterEquations without the constant bindings, which is what C's updateBoundParameters is; calling the existing entry point would reset the parameter IDAS had just perturbed.

The wasm and native SUNDIALS collections carry sundials_idas rather than sundials_ida (same entry points plus the sensitivity ones, as the C runtime links it), and the native one gains sunlinsolklu + SuiteSparse so IDA's default linear solver links into libOpenModelicaCompiler.

simulation/modelica/solver goes from 37 of 41 failing to 32: problem1-ida, problem2-ida, problem2-idaJacobian,
problem2-idaLinearSolver and Ticket15649, the last being the only test that checks sensitivity values rather than that the run finished.  openmodelica/cruntime/sensitivities is at 0 of 4.  IDA was also diffed against DASSL on a bouncing ball (state event with reinit, plus a sample), CoupledClutches and FullRobot, and against the C runtime's sensitivities on VanDerPol and a model with a state event -- all clean.

One disagreement is left standing.  On testLotkaVoltera's LotkaVolterra the two runtimes differ, and finite differences say this one is right: re-simulating with lambda1 and mu1 each nudged by 1e-6 gives dx/dlambda1 = -2.377905e-01 and dx/dmu1 = +1.545122e-01, which is what $Sensitivities.lambda1.x and .mu1.x hold here, while C files the lambda1 values under mu1 and leaves lambda1 and lambda2 at zero.  C's sensitivityParList logs correctly (lambda1 at index 2 ... mu2 at index 5), so the shift is downstream of it, and it shows only when the differentiated parameters are not the leading entries of realParameter -- here a and b come first, and their perturbation is undone by updateBoundParameters, which is the pair of zero blocks. That is why the tests with committed references agree.  Not fixed here.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
