### PR TITLE
wasm-jit: -lv=LOG_NLS and strict simflags

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -160,6 +160,7 @@ openmodelica_codegen_wasm_jit_runtime/build.rs
 openmodelica_codegen_wasm_jit_runtime/src/delay.rs
 openmodelica_codegen_wasm_jit_runtime/src/lib.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls_c_trace.rs
 openmodelica_codegen_wasm_jit_runtime/src/session.rs
 openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -225,6 +226,7 @@ openmodelica_sim_meta/Cargo.toml
 openmodelica_sim_meta/build.rs
 openmodelica_sim_meta/src/driver.rs
 openmodelica_sim_meta/src/lib.rs
+openmodelica_sim_meta/src/omclog.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs
 openmodelica_simcode_types/Cargo.toml

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6525,6 +6525,7 @@ dependencies = [
  "openmodelica_frontend_types",
  "openmodelica_mat_writer",
  "openmodelica_modelica_utilities",
+ "openmodelica_script_util",
  "openmodelica_sim_meta",
  "openmodelica_simcode_types",
  "openmodelica_tpl",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -12,6 +12,9 @@ openmodelica_wasm_jit.workspace = true
 # External-"C" wasm-FMU artifacts, consumed by the FMU linker.
 openmodelica_wasi_libc.workspace = true
 openmodelica_mat_writer.workspace = true
+# `-iif=<file>`: C's `importStartValues` reads the initialization file with the
+# MATLAB v4 reader, which lives with the other result readers.
+openmodelica_script_util.workspace = true
 openmodelica_sim_meta.workspace = true
 metamodelica.workspace = true
 openmodelica_ast.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -454,6 +454,12 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
             with_engine_detail(e)
         ),
     };
+    // C's `freeNonlinearSystems`, the last thing a simulation executable logs.
+    let log = if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::NLS) {
+        format!("{log}LOG_NLS           | info    | free non-linear system solvers\n")
+    } else {
+        log
+    };
     let _ = write_output(&format!("{fileNamePrefix}.log"), log.as_bytes());
     // Error is in `<prefix>.log` (hence the result `messages`); no stderr.
     match res {
@@ -618,15 +624,53 @@ fn install_sim_flags(simflags: &str) -> std::result::Result<simflags::SimFlags, 
 /// Unknown names are skipped (an unknown override is a no-op, as in the C runtime).
 /// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
 /// values, applied at different points of initialization (see `run_initialization`).
+///
+/// `-iif=<file>` contributes first, so an explicit `-override` of the same quantity
+/// wins — C skips whatever `isQuantityOverridden` reports (ticket #15807).
 fn resolve_overrides(model: &SimModel, flags: &simflags::SimFlags) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
     let mut params = Vec::new();
     let mut starts = Vec::new();
+    let mut push = |p: &EditableParam, v: f64, params: &mut Vec<_>, starts: &mut Vec<_>| {
+        if p.is_start { starts } else { params }.push((p.off, p.wty, v));
+    };
+    if let Some(file) = &flags.init_file {
+        for (p, v) in import_start_values(model, file, &flags.overrides) {
+            push(p, v, &mut params, &mut starts);
+        }
+    }
     for (name, val) in &flags.overrides {
         if let Some(p) = model.editable_params.iter().find(|p| &p.name == name) {
-            if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, *val));
+            push(p, *val, &mut params, &mut starts);
         }
     }
     (params, starts)
+}
+
+/// C's `importStartValues`: every quantity the file names, at the start time,
+/// except the overridden ones. C sets the `start` attribute of every variable;
+/// reachable here are the editable parameters and state start values.
+fn import_start_values<'a>(
+    model: &'a SimModel,
+    file: &str,
+    overrides: &[(String, f64)],
+) -> Vec<(&'a EditableParam, f64)> {
+    let mut reader = match openmodelica_script_util::SimulationResults::read_matlab4::MatReader::open(file) {
+        Ok(r) => r,
+        Err(e) => {
+            record_error(format!("wasm-jit: unable to read input-file <{file}> [{e}]"));
+            return Vec::new();
+        }
+    };
+    let t0 = model.meta.start_time;
+    model
+        .editable_params
+        .iter()
+        .filter(|p| !overrides.iter().any(|(n, _)| *n == p.name))
+        .filter_map(|p| {
+            let idx = reader.find_var(&p.name)?;
+            Some((p, reader.val(idx, t0)?))
+        })
+        .collect()
 }
 
 thread_local! {
@@ -667,8 +711,21 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
     let log_stats = flags.has_log("LOG_STATS");
-    // `-override=name=value,...`: resolve each editable parameter to its SimData
-    // slot and hand the list to the driver (applied after `functionParameters`).
+    // C refuses to seed a run from the file it is about to overwrite.
+    if let Some(init) = &flags.init_file
+        && init == flags.result_file.as_deref().unwrap_or(result_file)
+    {
+        return (
+            Err(format!(
+                "Cannot import a result file for initialization that is also the current output \
+                 file <{init}>.\nConsider redirecting the output result file (-r=<new_res.mat>) or \
+                 renaming the result file that is used for initialization import."
+            )
+            ),
+            None,
+            String::new(),
+        );
+    }
     let (param_ov, start_ov) = resolve_overrides(&model, &flags);
     sim_driver::set_param_overrides(param_ov, start_ov);
     // `-abortSlowSimulation`: stop the run when chattering is detected.
@@ -697,7 +754,9 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         }
         capture_last_sim(&model, &run);
         if fmt == "mat" {
-            write_mat4(&model, result_file, &run.rows, run.n_reals, &run.params)?;
+            // C's `-r=<file>` overrides the name the caller derived from the model.
+            let out = flags.result_file.as_deref().unwrap_or(result_file);
+            write_mat4(&model, out, &run.rows, run.n_reals, &run.params)?;
         }
         Ok(())
     })();
@@ -709,10 +768,11 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
     // C prints the sparse-solver announcements (initializeLinear/NonlinearSystems)
     // ahead of the init-success line; prepend our pre-rendered copy to the init output.
-    let init_output = if model.sparse_solver_log.is_empty() {
+    let head = format!("{}{}", flag_change_log(&flags), sparse_solver_log(&model, &flags));
+    let init_output = if head.is_empty() {
         init_output
     } else {
-        Some(format!("{}{}", model.sparse_solver_log, init_output.unwrap_or_default()))
+        Some(format!("{head}{}", init_output.unwrap_or_default()))
     };
     (res, init_output, sim_output)
 }
@@ -880,9 +940,11 @@ mod session {
         })();
         // Disarm in case init failed before the hook fired.
         SPLIT_ARMED.with(|a| a.set(false));
+        let flags = simflags::flags();
         let init_log = format!(
-            "{}{}",
-            model.sparse_solver_log,
+            "{}{}{}",
+            flag_change_log(&flags),
+            sparse_solver_log(&model, &flags),
             INIT_OUTPUT.with(|c| c.borrow_mut().take()).unwrap_or_default()
         );
         let backend = match built {
@@ -2793,9 +2855,20 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // Only the FMU export needs the vr table; a plain simulation would just carry
     // it around unused.
     let fmi_vrs = if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { Vec::new() };
+    // C labels its `-lv=LOG_NLS` unknowns from the `_info.json` `defines` array,
+    // which `SerializeModelInfo` writes from these same `crefs`.
+    let nls_vars = nls_systems
+        .iter()
+        .map(|sys| {
+            Ok(openmodelica_sim_meta::NlsVars {
+                eq_index: sys.index as u32,
+                names: lst(&sys.crefs).map(cref_display).collect::<Result<Vec<_>>>()?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets, &state_nominals,
-        fmi_vrs, zc_descriptions(&zero_crossings), sens_params,
+        fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -3235,7 +3308,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         editable_params,
         var_units,
         meta,
-        sparse_solver_log: format!("{}{}", build_sparse_lss_log(sim_code), build_sparse_nls_log(sim_code)),
+        sparse_solver_log: build_sparse_lss_log(sim_code),
+        nls_systems: collect_nls_systems(sim_code),
     })
 }
 
@@ -3321,11 +3395,10 @@ fn build_sparse_lss_log(sim_code: &SimCode::SimCode) -> String {
 /// (`nonlinearSystem.c`): one message per system handed to kinsol+KLU, keyed on
 /// why (density and/or size), then one aggregate flag-hint. Systems are in
 /// `indexNonLinearSystem` order (C's array order), matching the `sysNum` printed.
-fn build_sparse_nls_log(sim_code: &SimCode::SimCode) -> String {
-    use crate::CodegenWasmJitFunctions::{nls_use_sparse, NLSS_MAX_DENSITY, NLSS_MIN_SIZE};
+fn collect_nls_systems(sim_code: &SimCode::SimCode) -> Vec<(i32, i32, u32, u32)> {
     let mut seen: HashSet<i32> = HashSet::new();
     // (sysNum, equationIndex, size, nnz), deduped, in system-number order.
-    let mut systems: Vec<(i32, i32, usize, usize)> = Vec::new();
+    let mut systems: Vec<(i32, i32, u32, u32)> = Vec::new();
     let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
         for e in &eqs {
             if let SimCode::SimEqSystem::SES_NONLINEAR { nlSystem, .. } = &**e {
@@ -3334,8 +3407,8 @@ fn build_sparse_nls_log(sim_code: &SimCode::SimCode) -> String {
                     systems.push((
                         nlSystem.indexNonLinearSystem,
                         nlSystem.index,
-                        size,
-                        nls_system_nnz(nlSystem),
+                        size as u32,
+                        nls_system_nnz(nlSystem) as u32,
                     ));
                 }
             }
@@ -3346,31 +3419,60 @@ fn build_sparse_nls_log(sim_code: &SimCode::SimCode) -> String {
     scan(flatten_eqs_ll(&sim_code.odeEquations));
     scan(flatten_eqs_ll(&sim_code.algebraicEquations));
     systems.sort_by_key(|&(idx, _, _, _)| idx);
+    systems
+}
 
+/// C's `LOG_STDOUT` "… changed to …" lines, ahead of everything the run prints.
+fn flag_change_log(flags: &simflags::SimFlags) -> String {
+    let mut out = String::new();
+    if let Some(d) = flags.nlss_max_density {
+        out.push_str(&format_log_stdout(&format!(
+            "Maximum density for using non-linear sparse solver changed to {d:.6}"
+        )));
+    }
+    if let Some(n) = flags.nlss_min_size {
+        out.push_str(&format_log_stdout(&format!(
+            "Minimum system size for using non-linear sparse solver changed to {n}"
+        )));
+    }
+    out
+}
+
+/// The linear half is fixed at codegen; the nonlinear half moves with the flags.
+fn sparse_solver_log(model: &SimModel, flags: &simflags::SimFlags) -> String {
+    let (min_size, max_density) = simflags::nlss_thresholds(flags);
+    format!("{}{}", model.sparse_solver_log, sparse_nls_log(&model.nls_systems, min_size, max_density))
+}
+
+/// C's `initializeNonlinearSystems` announcement: `-nlssMinSize`/`-nlssMaxDensity`
+/// move both the choice and the numbers it quotes, so it is rendered per run.
+fn sparse_nls_log(systems: &[(i32, i32, u32, u32)], min_size: u32, max_density: f64) -> String {
     let mut out = String::new();
     let mut some_small_density = false;
     let mut some_big_size = false;
-    for &(idx, eq_index, size, nnz) in &systems {
-        if size == 0 || nnz == 0 || !nls_use_sparse(size, nnz) {
+    for &(idx, eq_index, size, nnz) in systems {
+        let (size, nnz) = (size as usize, nnz as usize);
+        let density = nnz as f64 / (size * size) as f64;
+        let big_size = size > min_size as usize;
+        if size == 0 || nnz == 0 || !(density < max_density || big_size) {
             continue;
         }
-        let density = nnz as f64 / (size * size) as f64;
-        let big_size = size > NLSS_MIN_SIZE;
-        let body = if density < NLSS_MAX_DENSITY {
+        let (nlss_max_density, nlss_min_size) = (max_density, min_size);
+        let body = if density < nlss_max_density {
             some_small_density = true;
             if big_size {
                 some_big_size = true;
                 format!(
-                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {NLSS_MAX_DENSITY:.2}\nand size of {size} exceeds threshold of {NLSS_MIN_SIZE}."
+                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {nlss_max_density:.2}\nand size of {size} exceeds threshold of {nlss_min_size}."
                 )
             } else {
                 format!(
-                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {NLSS_MAX_DENSITY:.2}."
+                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {nlss_max_density:.2}."
                 )
             }
         } else {
             some_big_size = true;
-            format!("Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause size of {size} exceeds threshold of {NLSS_MIN_SIZE}.")
+            format!("Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause size of {size} exceeds threshold of {nlss_min_size}.")
         };
         out.push_str(&format_log_stdout(&body));
     }
@@ -3606,6 +3708,7 @@ fn build_sim_meta(
     fmi_vrs: Vec<FmiVr>,
     zc_desc: Vec<String>,
     sens_params: Vec<u32>,
+    nls_vars: Vec<openmodelica_sim_meta::NlsVars>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -3624,6 +3727,7 @@ fn build_sim_meta(
         fmi_vrs,
         zc_desc,
         sens_params,
+        nls_vars,
     }
 }
 
@@ -5317,14 +5421,8 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>
     f.instruction(&I::LocalGet(ROW));
     f.instruction(&I::If(we::BlockType::Empty));
 
-    // terminal = (row == n_steps): C's `finishSimulation` evaluates the last
-    // point with `terminal()` true. This path has no events, so raising the flag
-    // is the whole discrete update.
-    f.instruction(&I::LocalGet(SIM_DATA));
-    f.instruction(&I::LocalGet(ROW));
-    f.instruction(&I::LocalGet(N_STEPS));
-    f.instruction(&I::I32Eq);
-    f.instruction(&I::I32Store(crate::CodegenWasmJitFunctions::mem_arg(layout.terminal_off, 2)));
+    // C's terminal step is a row of its own (`emit_terminal_row`), so no row here
+    // raises the flag.
 
     // functionODE(sim_data); functionAlgebraics(sim_data)
     f.instruction(&I::LocalGet(SIM_DATA));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -22,9 +22,9 @@ crate-type = ["cdylib", "rlib"]
 # for the no_std JIT and web interactive runtimes; off for the native host-driven
 # runtime, so daskr/sim_meta are not linked there. The FMI3 adapter disables it.
 default = ["session"]
-session = ["dep:daskr", "dep:openmodelica_sim_meta"]
+session = ["dep:daskr"]
 # Standalone-export driver (src/standalone.rs, `_start` + model-importing), wasip1 only.
-standalone = ["dep:daskr", "dep:openmodelica_sim_meta", "dep:openmodelica_mat_writer", "inwasm_solve"]
+standalone = ["dep:daskr", "dep:openmodelica_mat_writer", "inwasm_solve"]
 # In-wasm sparse solve (rsparse). Off for the native interactive runtime, which
 # delegates to the host (`host_lin_solve`) instead of linking rsparse.
 inwasm_solve = ["dep:rsparse"]
@@ -32,6 +32,9 @@ inwasm_solve = ["dep:rsparse"]
 host_lin_solve = []
 
 [dependencies]
+# The shared `-lv` stream table + `omc_error.c` message layout the NLS solver logs
+# through. `no_std` here; the wasi build below adds `std` back.
+openmodelica_sim_meta = { path = "../openmodelica_sim_meta", default-features = false }
 dlmalloc = { version = "0.2.14", features = ["global"] }
 # MINPACK hybrd for the in-wasm nonlinear solver (`nls.rs`): converges to `xtol`
 # like C's default solver, unlike the crude Newton it replaces. no_std + libm.
@@ -50,14 +53,13 @@ nalgebra = { version = "0.35", default-features = false, features = ["alloc", "l
 # false`); math routes through libm. mat_writer is not needed here (rows go into
 # an rt_alloc buffer, not a `.mat`).
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-openmodelica_sim_meta = { path = "../openmodelica_sim_meta", default-features = false, optional = true }
 daskr = { path = "../daskr", default-features = false, optional = true }
 
 # Standalone-export (wasm32-wasip1) only: the in-wasm driver (`src/standalone.rs`)
 # decodes the model metadata, runs DASSL (daskr) / Euler, and serialises the
 # `.mat`. wasip1 has std, so these keep their default (`std`) features.
 [target.'cfg(target_os = "wasi")'.dependencies]
-openmodelica_sim_meta = { path = "../openmodelica_sim_meta", optional = true }
+openmodelica_sim_meta = { path = "../openmodelica_sim_meta", features = ["std"] }
 openmodelica_mat_writer = { path = "../openmodelica_mat_writer", optional = true }
 daskr = { path = "../daskr", optional = true }
 # Sparse direct solver (CSparse port, AMD fill-reducing ordering) for torn linear

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -42,6 +42,7 @@ extern crate alloc;
 
 mod delay;
 mod nls;
+mod omclog;
 pub use nls::{rt_nls_clean_history, rt_set_step_size};
 #[cfg(test)]
 mod nls_c_trace;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1385,6 +1385,135 @@ pub extern "C" fn rt_nls_register(k: u32, hist_addr: u32, n: u32) {
     roster.push((hist_addr, n as usize));
 }
 
+/// C's `NONLINEAR_SYSTEM_DATA::numberOf{Iterations,FEval,JEval}`: per system,
+/// cumulative over the run, keyed by equation index.
+struct CountersCell(UnsafeCell<alloc::vec::Vec<(u32, [u64; 3])>>);
+unsafe impl Sync for CountersCell {}
+static COUNTERS: CountersCell = CountersCell(UnsafeCell::new(alloc::vec::Vec::new()));
+
+/// Nonzero while a Jacobian is being formed: C counts `numberOfFEval` in
+/// `wrapper_fvec`, which the FD Jacobian does not go through.
+static JAC_DEPTH: AtomicU32 = AtomicU32::new(0);
+
+/// C's `numberOfJEval`: `wrapper_fvec_der` counts an analytic and an FD Jacobian
+/// alike. `rt_solve_nls` takes the difference over its own call.
+static JAC_EVALS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+fn note_jac_eval() {
+    JAC_EVALS.fetch_add(1, Ordering::Relaxed);
+}
+
+fn counters_of(eq_index: u32) -> &'static mut [u64; 3] {
+    let v = unsafe { &mut *COUNTERS.0.get() };
+    let pos = match v.iter().position(|(i, _)| *i == eq_index) {
+        Some(p) => p,
+        None => {
+            v.push((eq_index, [0; 3]));
+            v.len() - 1
+        }
+    };
+    &mut v[pos].1
+}
+
+/// C's `modelInfoGetEquation(...).vars[i]`, keyed by `equationIndex`. Pushed in
+/// from the decoded `SimMeta`, and only when the stream is on.
+struct NamesCell(UnsafeCell<alloc::vec::Vec<(u32, alloc::vec::Vec<alloc::string::String>)>>);
+unsafe impl Sync for NamesCell {}
+static NAMES: NamesCell = NamesCell(UnsafeCell::new(alloc::vec::Vec::new()));
+
+/// `eq_index`'s iteration-variable names, or `[]` when they were not pushed in.
+fn var_names(eq_index: u32) -> &'static [alloc::string::String] {
+    match unsafe { &*NAMES.0.get() }.iter().find(|(i, _)| *i == eq_index) {
+        Some((_, v)) => v.as_slice(),
+        None => &[],
+    }
+}
+
+/// C's `[%2ld] %30s  = ` prefix; the name column is empty for a system the blob
+/// does not cover.
+fn var_label(names: &[alloc::string::String], i: usize) -> alloc::string::String {
+    let name = names.get(i).map(|s| s.as_str()).unwrap_or("");
+    alloc::format!("[{:2}] {name:>30}  = ", i + 1)
+}
+
+/// Replace the name roster. `set` is `(eq_index, names)` in any order.
+pub fn set_var_names(set: alloc::vec::Vec<(u32, alloc::vec::Vec<alloc::string::String>)>) {
+    *unsafe { &mut *NAMES.0.get() } = set;
+}
+
+/// [`set_var_names`] across the module boundary: `ptr`/`len` are a NUL-separated
+/// UTF-8 list. `eq_index == u32::MAX` clears the roster.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_set_names(eq_index: u32, ptr: u32, len: u32) {
+    let names = unsafe { &mut *NAMES.0.get() };
+    if eq_index == u32::MAX {
+        names.clear();
+        unsafe { &mut *COUNTERS.0.get() }.clear();
+        return;
+    }
+    let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    let list = bytes
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| alloc::string::String::from_utf8_lossy(s).into_owned())
+        .collect();
+    names.push((eq_index, list));
+}
+
+/// C's `printNonLinearInitialInfo`, under the `solve_nonlinear_system` header.
+fn log_nls_enter(eq_index: u32, time: f64, x: &[f64], nominal: &[f64]) {
+    use crate::omclog;
+    omclog::info(
+        omclog::NLS,
+        true,
+        &alloc::format!(
+            "############ Solve nonlinear system {eq_index} at time {} ############",
+            openmodelica_sim_meta::driver::format_g(time, 6)
+        ),
+    );
+    omclog::info(omclog::NLS, true, "initial variable values:");
+    let names = var_names(eq_index);
+    for i in 0..x.len() {
+        omclog::info(
+            omclog::NLS,
+            false,
+            &alloc::format!(
+                "{}{}\t\t nom = {}",
+                var_label(names, i),
+                omclog::g(x[i], 16, 8),
+                omclog::g(nominal[i], 16, 8)
+            ),
+        );
+    }
+    omclog::close(omclog::NLS);
+}
+
+/// C's `printNonLinearFinishInfo` plus the `messageClose` that ends the block
+/// `log_nls_enter` opened.
+fn log_nls_leave(eq_index: u32, solved: bool, x: &[f64]) {
+    use crate::omclog;
+    let c = counters_of(eq_index);
+    omclog::info(
+        omclog::NLS,
+        true,
+        if solved { "Solution status: SOLVED" } else { "Solution status: FAILED" },
+    );
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of iterations           : {}", c[0]));
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of function evaluations : {}", c[1]));
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of jacobian evaluations : {}", c[2]));
+    omclog::info(omclog::NLS, false, "solution values:");
+    let names = var_names(eq_index);
+    for i in 0..x.len() {
+        omclog::info(
+            omclog::NLS,
+            false,
+            &alloc::format!("{}{}", var_label(names, i), omclog::g(x[i], 16, 8)),
+        );
+    }
+    omclog::close(omclog::NLS);
+    omclog::close(omclog::NLS);
+}
+
 /// C's `cleanUpOldValueListAfterEvent`, called once per event.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_clean_history(time: f64) {
@@ -1475,6 +1604,10 @@ fn newton_c(
                     eval: &mut dyn FnMut(&[f64], &mut [f64]),
                     jaceval: &mut dyn FnMut(&[f64], &mut [f64])| {
         arm_attempt();
+        JAC_DEPTH.fetch_add(1, Ordering::Relaxed);
+        if !has_jac {
+            note_jac_eval();
+        }
         if has_jac {
             jaceval(x, jac);
             for col in 0..n {
@@ -1498,6 +1631,7 @@ fn newton_c(
                 x[col] = saved;
             }
         }
+        JAC_DEPTH.fetch_sub(1, Ordering::Relaxed);
         !attempt_aborted()
     };
 
@@ -2283,8 +2417,14 @@ pub extern "C" fn rt_solve_nls(
     }
 
     stat_inc(STAT_NLS_SOLVE);
+    let n_feval = core::cell::Cell::new(0u64);
+    let iter0 = crate::rt_stat(STAT_NLS_ITER);
+    let jac0 = JAC_EVALS.load(Ordering::Relaxed);
     let mut eval = |xs: &[f64], r: &mut [f64]| {
         stat_inc(STAT_NLS_RES);
+        if JAC_DEPTH.load(Ordering::Relaxed) == 0 {
+            n_feval.set(n_feval.get() + 1);
+        }
         // C's generated `residualFunc`: an inf/nan iteration variable fails the
         // evaluation instead of reaching the model. Feed kinsol the nan residual
         // and its line search takes a nan step length, which no exit test catches.
@@ -2329,7 +2469,8 @@ pub extern "C" fn rt_solve_nls(
     let sparse = has_jac
         && nnz != 0
         && match pick {
-            Nls::Default => sparse_default != 0,
+            // With neither `-nlss*` flag this is the codegen's own answer.
+            Nls::Default => crate::solvers::nls_use_sparse(n, nnz as usize),
             Nls::Kinsol => true,
             _ => false,
         };
@@ -2339,6 +2480,7 @@ pub extern "C" fn rt_solve_nls(
         if scatter { read_pattern(pat_addr, n, nnz as usize) } else { alloc::vec::Vec::new() };
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
         stat_inc(STAT_NLS_JAC);
+        note_jac_eval();
         let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
         for i in 0..n {
             unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
@@ -2412,6 +2554,12 @@ pub extern "C" fn rt_solve_nls(
         unsafe { store_u32(rel_fresh_addr, 0) };
     } else if saved_rel_fresh == 0 {
         unsafe { store_u32(rel_fresh_addr, 0) };
+    }
+    // C prints over `nlsx` (the stored solution), not the extrapolation the solver
+    // starts from.
+    let log_nls = crate::omclog::active(crate::omclog::NLS);
+    if log_nls {
+        log_nls_enter(eq_index, time, &nlsx_old, &nominal);
     }
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
@@ -2605,6 +2753,14 @@ pub extern "C" fn rt_solve_nls(
         stat_inc(STAT_NLS_FAIL);
         1
     };
+
+    if log_nls {
+        let c = counters_of(eq_index);
+        c[0] += crate::rt_stat(STAT_NLS_ITER) - iter0;
+        c[1] += n_feval.get();
+        c[2] += JAC_EVALS.load(Ordering::Relaxed) - jac0;
+        log_nls_leave(eq_index, converged, &x);
+    }
 
     if saved_rel_fresh != 2 {
         unsafe { store_u32(rel_fresh_addr, saved_rel_fresh) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
@@ -1,0 +1,42 @@
+//! Reaching [`openmodelica_sim_meta::omclog`] from inside the runtime module.
+//!
+//! The nonlinear solver runs in wasm whichever driver owns the run, so its lines
+//! have to leave it: `rt_host_log` hands them to the host, which writes them to the
+//! stdout the model's `print` and the driver's own lines share, keeping call order.
+//! The standalone module has no host and writes its own stdout.
+//!
+//! The per-stream indentation stays module-local. That is exact as long as no line
+//! from outside lands inside a block, which holds: a `rt_solve_nls` call closes
+//! every block it opens and the host driver does not print during it.
+
+pub use openmodelica_sim_meta::omclog::*;
+
+#[cfg(all(target_arch = "wasm32", not(feature = "standalone")))]
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    /// The host's stdout: `len` bytes of UTF-8 at `ptr` in this module's memory.
+    fn rt_host_log(ptr: u32, len: u32);
+}
+
+#[cfg(all(target_arch = "wasm32", not(feature = "standalone")))]
+pub(crate) fn sink(s: &str) {
+    unsafe { rt_host_log(s.as_ptr() as u32, s.len() as u32) };
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "standalone"))]
+pub(crate) fn sink(s: &str) {
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    let _ = out.write_all(s.as_bytes());
+    let _ = out.flush();
+}
+
+/// Install the run's active streams and route the module's log lines out: the
+/// counterpart of `rt_set_solvers`, since this build has no flag store of its own.
+/// The in-wasm session sets the mask from its own argv and calls this for the sink.
+#[cfg(target_arch = "wasm32")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_log_streams(lo: u32, hi: u32) {
+    openmodelica_sim_meta::driver::set_log_sink(sink);
+    set_mask(((hi as Mask) << 32) | lo as Mask);
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -38,20 +38,6 @@ unsafe extern "C" {
     fn rt_host_init_done();
 }
 
-/// The driver's log lines go to stdout, the channel the model's own `print`
-/// output travels and the host captures.
-#[cfg(target_os = "wasi")]
-fn log_line(s: &str) {
-    use std::io::Write;
-    let mut out = std::io::stdout();
-    let _ = out.write_all(s.as_bytes());
-    let _ = out.flush();
-}
-
-/// The no_std fallback runtime has no stdout to write them to.
-#[cfg(not(target_os = "wasi"))]
-fn log_line(_s: &str) {}
-
 fn init_done_hook() {
     unsafe { rt_host_init_done() };
 }
@@ -261,12 +247,18 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     };
 
     crate::nls::rt_set_step_size(model.step_size());
+    // `-lv=LOG_NLS` names the iteration variables; only the metadata has them.
+    crate::nls::set_var_names(if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::NLS) {
+        model.nls_vars.iter().map(|s| (s.eq_index, s.names.clone())).collect()
+    } else {
+        Vec::new()
+    });
 
     driver::set_clock(now_ms_hook);
     driver::set_cancel_hook(cancel_hook);
     driver::set_init_done_hook(init_done_hook);
     driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
-    driver::set_log_sink(log_line);
+    driver::set_log_sink(crate::omclog::sink);
 
     let mut engine = InWasmEngine { fn_base, present_mask };
     let sim_data = crate::rt_alloc(model.layout.total);
@@ -325,6 +317,13 @@ fn finish(s: &mut Session) {
     s.stats = SolveStats::default();
     s.driver.fill_stats(&s.model, &mut s.stats);
     s.rows = s.driver.take_rows();
+    let _ = driver::emit_terminal_row(
+        &mut s.engine,
+        &mut s.rows,
+        s.sim_data,
+        &s.model.layout,
+        s.n_reals,
+    );
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
     s.finished = true;
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -59,6 +59,11 @@ static NLS: AtomicU32 = AtomicU32::new(0);
 static NLS_LS: AtomicU32 = AtomicU32::new(0);
 static LS: AtomicU32 = AtomicU32::new(0);
 static LSS: AtomicU32 = AtomicU32::new(0);
+/// `-nlssMinSize` / `-nlssMaxDensity`, C's `nonlinearSparseSolverMinSize` /
+/// `nonlinearSparseSolverMaxDensity`, at their defaults until a run sets them.
+static NLSS_MIN_SIZE: AtomicU32 = AtomicU32::new(1000);
+static NLSS_MAX_DENSITY: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0x3FB999999999999A); // 0.1
 
 /// Set the four selectors for the next run. Host-driven builds call this through
 /// the export; the in-wasm session calls [`apply_flags`] instead.
@@ -70,10 +75,26 @@ pub extern "C" fn rt_set_solvers(nls: u32, nls_ls: u32, ls: u32, lss: u32) {
     LSS.store(lss, Ordering::Relaxed);
 }
 
+/// C's `initializeNonlinearSystemData` rule: kinsol+KLU when the density is under
+/// `nlssMaxDensity` or the size over `nlssMinSize`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_nlss_thresholds(min_size: u32, max_density: f64) {
+    NLSS_MIN_SIZE.store(min_size, Ordering::Relaxed);
+    NLSS_MAX_DENSITY.store(max_density.to_bits(), Ordering::Relaxed);
+}
+
+pub(crate) fn nls_use_sparse(size: usize, nnz: usize) -> bool {
+    let density = nnz as f64 / (size * size) as f64;
+    density < f64::from_bits(NLSS_MAX_DENSITY.load(Ordering::Relaxed))
+        || size > NLSS_MIN_SIZE.load(Ordering::Relaxed) as usize
+}
+
 #[cfg(any(feature = "session", feature = "standalone"))]
 pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     let (nls, nls_ls, ls, lss) = f.solver_codes();
     rt_set_solvers(nls, nls_ls, ls, lss);
+    let (min_size, max_density) = openmodelica_sim_meta::simflags::nlss_thresholds(f);
+    rt_set_nlss_thresholds(min_size, max_density);
 }
 
 pub(crate) fn nls() -> Nls {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -16,6 +16,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
+use crate::omclog;
 use crate::{
     JacAInfo, Layout as SimLayout, MetaKind as ResultKind, REAL_OFF, SimMeta, SolveStats, StateSetInfo, TIME_OFF,
     WTy,
@@ -339,10 +340,7 @@ fn enrich_trap_impl(e: &mut dyn SimEngine, err: &'static str, init_time: Option<
     };
     if let Some(t) = init_time {
         log_assert_block(&info, &cond, t, true);
-        log_line(&alloc::format!(
-            "{}simulation terminated by an assertion at initialization\n",
-            log_prefix("LOG_ASSERT", "info")
-        ));
+        omclog::info(omclog::ASSERT, false, "simulation terminated by an assertion at initialization");
     }
     let p = ASSERT_REPORTER.load(Ordering::Relaxed);
     if p != 0 {
@@ -552,7 +550,7 @@ static LOG_SINK: AtomicUsize = AtomicUsize::new(0);
 pub fn set_log_sink(f: fn(&str)) {
     LOG_SINK.store(f as usize, Ordering::Relaxed);
 }
-fn log_line(s: &str) {
+pub(crate) fn log_line(s: &str) {
     let p = LOG_SINK.load(Ordering::Relaxed);
     if p != 0 {
         let f: fn(&str) = unsafe { core::mem::transmute(p) };
@@ -614,13 +612,16 @@ fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
         return;
     }
     let time = read_f64(e, sim_data + TIME_OFF).unwrap_or(0.0);
-    log_line(&alloc::format!(
-        "{}Solving non-linear system {} failed at time={}.\n{}For more information please use -lv LOG_NLS.\n",
-        log_prefix("LOG_ASSERT", "debug"),
-        failed - 1,
-        format_g15(time),
-        log_prefix("|", "|"),
-    ));
+    omclog::message_text(
+        omclog::DEBUG_TYPE,
+        omclog::ASSERT,
+        false,
+        &alloc::format!(
+            "Solving non-linear system {} failed at time={}.\nFor more information please use -lv LOG_NLS.",
+            failed - 1,
+            format_g15(time),
+        ),
+    );
 }
 
 /// Number of equidistant homotopy steps: C's `init_lambda_steps`, which `-ils`
@@ -720,11 +721,6 @@ pub const CHATTER_ABORT_ERR: &str = "CodegenWasmJit: aborting simulation due to 
 pub const ALARM_ABORT_ERR: &str = "CodegenWasmJit: simulation aborted (-alarm)";
 /// What [`enrich_trap`] returns for a trap that was a failed model `assert()`.
 pub const ASSERT_ERR: &str = "assertion failed";
-
-/// Log-line prefix `<stream>| <level>| ` at the runtime's column widths.
-fn log_prefix(stream: &str, level: &str) -> String {
-    format!("{stream:<18}| {level:<8}| ")
-}
 
 /// `-abortSlowSimulation` flag + the driver's chattering log lines, set on the host
 /// before a run (the driver can only return a `&'static str`).
@@ -930,7 +926,7 @@ pub fn format_g(v: f64, p: i32) -> String {
 /// `level`: C reports a violation met while the integrator updates the system
 /// (`simulationUpdate`, which sets `noThrowAsserts`) as `info`, one met anywhere
 /// else — initialization, the terminal step — as `warning`.
-fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, _layout: &SimLayout, level: &str) -> Result<()> {
+fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, _layout: &SimLayout, level: omclog::LogType) -> Result<()> {
     e.call1_if_present("functionCheckAsserts", sim_data)?;
     drain_asserts(e, sim_data, level)?;
     Ok(())
@@ -939,7 +935,7 @@ fn check_asserts(e: &mut dyn SimEngine, sim_data: u32, _layout: &SimLayout, leve
 /// Log the violations recorded since the last call. A warning goes once per site;
 /// a suppressed error goes every time (as in C) and arms the re-throw, which the
 /// `true` return reports.
-fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: &str) -> Result<bool> {
+fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: omclog::LogType) -> Result<bool> {
     let pending = e.take_pending_warnings();
     if pending.is_empty() {
         return Ok(false);
@@ -961,15 +957,16 @@ fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: &str) -> Result<bo
             line_end: el,
             col_end: ec,
         };
-        let line = assert_block(&info, &cond, time, false, if suppressed { "info" } else { level });
+        let line = assert_block(&info, &cond, time, false);
+        let ty = if suppressed { omclog::INFO } else { level };
         if suppressed {
-            log_line(&line);
+            omclog::message_text(ty, omclog::ASSERT, false, &line);
             rethrow_store::arm(info);
             armed = true;
         } else {
             let key = alloc::format!("{}:{sl}:{sc}-{el}:{ec}|{cond}", info.file);
             if assert_warn_store::first_time(key) {
-                log_line(&line);
+                omclog::message_text(ty, omclog::ASSERT, false, &line);
             }
         }
     }
@@ -981,26 +978,24 @@ fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: &str) -> Result<bo
 /// level as [`emit_row`] does. Nonzero means a suppressed `assert()` ends the run,
 /// which [`run_wasm`] settles once the loop is out.
 pub fn row_asserts(e: &mut dyn SimEngine, sim_data: u32, warn: i32) -> i32 {
-    let level = if warn != 0 { "warning" } else { "info" };
+    let level = if warn != 0 { omclog::WARNING } else { omclog::INFO };
     drain_asserts(e, sim_data, level).unwrap_or(true) as i32
 }
 
 /// C's `LOG_ASSERT` block (`omc_error.c` messageText + printInfo). C wraps the
 /// already-parenthesised `assert_cond` in its own `(%s)`, hence the doubled
 /// parentheses; without a source position only the message is printed.
-fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool, level: &str) -> String {
-    let head = log_prefix("LOG_ASSERT", level);
-    let cont = log_prefix("|", "|");
+fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> String {
     let during = if initial { "during initialization " } else { "" };
     let t = format_f(time);
     if info.file.is_empty() {
-        return alloc::format!("{head}The following assertion has been violated {during}at time {t}\n");
+        return alloc::format!("The following assertion has been violated {during}at time {t}");
     }
     let ro_str = if info.read_only { "readonly" } else { "writable" };
     alloc::format!(
-        "{head}[{}:{}:{}-{}:{}:{ro_str}]\n\
-         {cont}The following assertion has been violated {during}at time {t}\n\
-         {cont}(({cond})) --> \"{}\"\n",
+        "[{}:{}:{}-{}:{}:{ro_str}]\n\
+         The following assertion has been violated {during}at time {t}\n\
+         (({cond})) --> \"{}\"",
         info.file, info.line_start, info.col_start, info.line_end, info.col_end, info.msg,
     )
 }
@@ -1009,11 +1004,11 @@ fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
     // C's `assertCommonVar` (the math-domain guards, no source position): the warning
     // names the time, a debug line carries the message.
     if info.file.is_empty() {
-        log_line(&assert_block(info, cond, time, initial, "warning"));
-        log_line(&alloc::format!("{}{}\n", log_prefix("LOG_ASSERT", "debug"), info.msg));
+        omclog::warning(omclog::ASSERT, false, &assert_block(info, cond, time, initial));
+        omclog::message_text(omclog::DEBUG_TYPE, omclog::ASSERT, false, &info.msg);
         return;
     }
-    log_line(&assert_block(info, cond, time, initial, "error"));
+    omclog::error(omclog::ASSERT, false, &assert_block(info, cond, time, initial));
 }
 
 /// What the open window has seen: the first assertion suppressed in it, and
@@ -1081,22 +1076,16 @@ fn open_assert_window() {
 /// makes the point they were raised at obsolete, otherwise the run fails now.
 fn close_assert_window(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
     set_no_throw(false);
-    drain_asserts(e, sim_data, "info")?;
+    drain_asserts(e, sim_data, omclog::INFO)?;
     let (info, found_event) = rethrow_store::take();
     let Some(info) = info else {
         return Ok(());
     };
     if found_event {
-        log_line(&alloc::format!(
-            "{}Found event, previous asserts are ignored.\n",
-            log_prefix("LOG_ASSERT", "info")
-        ));
+        omclog::info(omclog::ASSERT, false, "Found event, previous asserts are ignored.");
         return Ok(());
     }
-    log_line(&alloc::format!(
-        "{}No event found, but assert was triggered. Throwing now!\n",
-        log_prefix("LOG_ASSERT", "error")
-    ));
+    omclog::error(omclog::ASSERT, false, "No event found, but assert was triggered. Throwing now!");
     let p = ASSERT_REPORTER.load(Ordering::Relaxed);
     if p != 0 {
         let f: fn(&AssertInfo) = unsafe { core::mem::transmute(p) };
@@ -1139,7 +1128,7 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
     }
     // C's `initializeModel` ends with `checkForAsserts` — before the
     // initialization-success line.
-    check_asserts(e, sim_data, layout, "warning")?;
+    check_asserts(e, sim_data, layout, omclog::WARNING)?;
     // Initialization output is complete; the next model output is the simulation
     // phase. Let the host close the init segment of the capture.
     signal_init_done();
@@ -1147,6 +1136,9 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
 }
 
 fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    // C's `updateStaticDataOfNonlinearSystems`.
+    omclog::info(omclog::NLS, true, "update static data of non-linear system solvers");
+    omclog::close(omclog::NLS);
     init_report::reset();
     assert_warn_store::reset();
     // Initialization throws on a failed assert (C clears `noThrowAsserts` here).
@@ -1169,11 +1161,12 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     if direct_initial_solve(e, sim_data, layout).is_ok() {
         return Ok(());
     }
-    log_line(&alloc::format!(
-        "{}Failed to solve the initialization problem without homotopy method. \
-         If homotopy is available the homotopy method is used now.\n",
-        log_prefix("LOG_ASSERT", "warning")
-    ));
+    omclog::warning(
+        omclog::ASSERT,
+        false,
+        "Failed to solve the initialization problem without homotopy method. \
+         If homotopy is available the homotopy method is used now.",
+    );
     // C's catch arm resets everything to start before the continuation runs.
     init_report::reset();
     let _ = rethrow_store::take();
@@ -1275,19 +1268,19 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
         let w = |i: u32| read_i32(e, sim_data + layout.term_info_off + i * 4);
         let msg = read_rt_string(e, w(0)?)?;
         let file = read_rt_string(e, w(1)?)?;
-        let mut line = String::new();
+        // C prints the source position raw (`printInfo`), outside the message system.
         if !file.is_empty() {
             let ro = if w(6)? != 0 { "readonly" } else { "writable" };
-            line = alloc::format!("[{file}:{}:{}-{}:{}:{ro}]\n", w(2)?, w(3)?, w(4)?, w(5)?);
+            log_line(&alloc::format!("[{file}:{}:{}-{}:{}:{ro}]\n", w(2)?, w(3)?, w(4)?, w(5)?));
         }
-        line.push_str(&alloc::format!(
-            "{}Simulation call terminate() at time {}\n{}Message : {msg}",
-            log_prefix("LOG_STDOUT", "info"),
-            format_f(read_f64(e, sim_data + TIME_OFF)?),
-            log_prefix("|", "|"),
-        ));
-        line.push('\n');
-        log_line(&line);
+        omclog::info(
+            omclog::STDOUT,
+            false,
+            &alloc::format!(
+                "Simulation call terminate() at time {}\nMessage : {msg}",
+                format_f(read_f64(e, sim_data + TIME_OFF)?),
+            ),
+        );
     }
     Ok(true)
 }
@@ -1306,21 +1299,37 @@ fn emit_row(
 ) -> Result<()> {
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_f64(e, sim_data + TIME_OFF, time)?;
-    if time >= stop {
-        // C's `finishSimulation`: the row at the stop time is the terminal step,
-        // a *discrete* update with `terminal()` true, so a `when terminal()`
-        // body fires and reaches the result file. (C emits the stop time twice,
-        // before and after; we keep one row per output point, the updated one.)
-        write_i32(e, sim_data + layout.terminal_off, 1)?;
-        iterate_discrete(e, sim_data, layout)?;
-        write_i32(e, sim_data + layout.terminal_off, 0)?;
-    } else {
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
-    }
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)?;
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
-    check_asserts(e, sim_data, layout, if time >= stop { "warning" } else { "info" })
+    check_asserts(e, sim_data, layout, if time >= stop { omclog::WARNING } else { omclog::INFO })
+}
+
+/// C's `finishSimulation`: a discrete update with `terminal()` true and one more
+/// row at the same time, so a `when terminal()` body reaches the result file.
+pub fn emit_terminal_row(
+    e: &mut dyn SimEngine,
+    rows: &mut Vec<f64>,
+    sim_data: u32,
+    layout: &SimLayout,
+    n_reals: u32,
+) -> Result<()> {
+    let Some(time) = rows.len().checked_sub(n_reals as usize).map(|i| rows[i]) else {
+        return Ok(());
+    };
+    if no_event_emit() {
+        return Ok(());
+    }
+    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_i32(e, sim_data + layout.terminal_off, 1)?;
+    let updated = iterate_discrete(e, sim_data, layout);
+    write_i32(e, sim_data + layout.terminal_off, 0)?;
+    updated?;
+    check_nls(e, sim_data, layout)?;
+    capture_row(e, rows, sim_data, layout)?;
+    check_asserts(e, sim_data, layout, omclog::WARNING)
 }
 
 /// The initial result row. C emits it straight after `initializeModel` with no
@@ -1335,7 +1344,7 @@ fn emit_initial_row(
 ) -> Result<()> {
     write_f64(e, sim_data + TIME_OFF, time)?;
     capture_row(e, rows, sim_data, layout)?;
-    check_asserts(e, sim_data, layout, "warning")
+    check_asserts(e, sim_data, layout, omclog::WARNING)
 }
 
 /// Pre-event snapshot row (state just before a discrete update). Skips
@@ -1705,6 +1714,25 @@ pub fn make_driver(
     let method = effective_method(method);
     // Both `drive` and the in-wasm `rt_sim_start` build their driver here.
     arm_alarm();
+    // `dassl_initial`'s flag warnings, before initialization as in C.
+    let (freq, out_time) =
+        crate::simflags::with_flags(|f| (f.no_equidistant_freq, f.no_equidistant_time));
+    if freq.is_some() && out_time.is_some() && no_equidistant_grid() {
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            "The flags are  \"noEquidistantOutputFrequency\" and \"noEquidistantOutputTime\" \
+             are in opposition to each other. The flag \"noEquidistantOutputFrequency\" superiors.",
+        );
+    }
+    // C's `initializeNonlinearSystems`.
+    omclog::info(omclog::NLS, true, "initialize non-linear system solvers");
+    omclog::info(
+        omclog::NLS,
+        false,
+        &alloc::format!("{} non-linear systems", model.nls_vars.len()),
+    );
+    omclog::close(omclog::NLS);
     let layout = &model.layout;
     set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
     for k in 0..layout.n_sens {
@@ -1793,7 +1821,9 @@ pub fn drive(
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
-            return run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats);
+            let mut rows = run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)?;
+            emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+            return Ok(rows);
         }
         // enrich_trap: a trap in init/integration is usually a failed model assert().
         let (mut driver, l) =
@@ -1813,7 +1843,9 @@ pub fn drive(
             }
         }
         driver.fill_stats(model, &mut stats);
-        Ok(driver.take_rows())
+        let mut rows = driver.take_rows();
+        emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+        Ok(rows)
     })();
     let _ = bench;
     // Before `outcome?`: a failed run is when the counters matter most.
@@ -2271,42 +2303,121 @@ unsafe fn dassl_jac(
 /// C's `numericalDifferentiationDeltaXsolver` (`model_help.c`).
 const DELTA_X_SOLVER: f64 = 1e-8;
 
+/// C's `-noEquidistantTimeGrid` (`dassl.c`'s `dasslSteps`): DASKR's own steps are
+/// the output points, not an interpolated equidistant grid.
+fn no_equidistant_grid() -> bool {
+    crate::simflags::with_flags(|f| f.no_equidistant_grid)
+}
+
+/// C's `-noEventEmit`: the rows a step that handled an event produces are dropped.
+fn no_event_emit() -> bool {
+    crate::simflags::with_flags(|f| f.no_event_emit)
+}
+
+/// C's `do_emit`: under `-noEventEmit` a post-event row survives only if the
+/// equidistant grid puts an output point on `time`. The left-limit row never does.
+fn emit_post_event_row(model: &SimModel, time: f64) -> bool {
+    if !no_event_emit() {
+        return true;
+    }
+    if no_equidistant_grid() || model.n_intervals == 0 {
+        return false;
+    }
+    let (start, stop, n) = (model.start_time, model.stop_time, model.n_intervals as f64);
+    let step_no = libm::round(n * (time - start) / (stop - start));
+    let grid = step_no * (stop - start) / n + start;
+    grid == time || libm::fabs(grid - time) / (libm::fabs(grid) + libm::fabs(time)) < 1e-15
+}
+
+/// `-maxIntegrationOrder` (INFO(9)/IWORK(3)) and the step-size cap
+/// (INFO(7)/RWORK(2)), which `-noEquidistantOutputTime` also sets, as `dassl.c` does.
+fn daskr_limits(info: &mut [i32; 24], rwork: &mut [f64], iwork: &mut [i32]) {
+    let (order, h_max, out_time) = crate::simflags::with_flags(|f| {
+        (f.max_order, f.max_step_size, f.no_equidistant_time)
+    });
+    if let Some(n) = order {
+        info[8] = 1;
+        iwork[2] = n;
+    }
+    if let Some(h) = h_max.or(out_time) {
+        info[6] = 1;
+        rwork[1] = h;
+    }
+}
+
+/// `dassl.c`'s `dasslStepsFreq` / `dasslStepsTime`: every n-th step, or the first
+/// step past each multiple of `t`. Neither set = every step.
+#[derive(Default)]
+struct StepEmit {
+    freq: Option<u32>,
+    time: Option<f64>,
+    counter: u32,
+}
+
+impl StepEmit {
+    fn new() -> Self {
+        let (freq, time) =
+            crate::simflags::with_flags(|f| (f.no_equidistant_freq, f.no_equidistant_time));
+        // C: the frequency wins when both are given; `make_driver` warns.
+        StepEmit { freq, time: if freq.is_some() { None } else { time }, counter: 1 }
+    }
+
+    fn take(&mut self, t: f64) -> bool {
+        match (self.freq, self.time) {
+            (Some(n), _) => {
+                if self.counter >= n.max(1) {
+                    self.counter = 1;
+                    return true;
+                }
+                self.counter += 1;
+                false
+            }
+            (None, Some(dt)) => {
+                if t > self.counter as f64 * dt {
+                    self.counter += 1;
+                    return true;
+                }
+                false
+            }
+            _ => true,
+        }
+    }
+}
+
 /// C's `-lv=LOG_DASSL`, printed by `dassl.c` around every `DDASKR` call.
 fn log_dassl() -> bool {
-    crate::simflags::with_flags(|f| f.has_log("LOG_DASSL"))
+    omclog::active(omclog::DASSL)
 }
 
 fn log_dassl_step(t: f64) {
-    log_line(&alloc::format!("{}new step at time = {}\n", log_prefix("LOG_DASSL", "info"), format_g(t, 15)));
+    omclog::info(omclog::DASSL, false, &alloc::format!("new step at time = {}", format_g(t, 15)));
 }
 
 /// The `dassl call statistics:` block, from the work-array indices `dassl.c` reads.
 /// A restart zeroes the counters, as in C.
 fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
-    let cont = alloc::format!("{}| ", log_prefix("|", "|"));
     let g = |v: f64| format_g(v, 4);
     let r = |k: usize| rwork.get(k).copied().unwrap_or(0.0);
     let i = |k: usize| iwork.get(k).copied().unwrap_or(0);
-    log_line(&alloc::format!(
-        "{}dassl call statistics: \n\
-         {cont}value of idid: {idid}\n\
-         {cont}current time value: {}\n\
-         {cont}current integration time value: {}\n\
-         {cont}step size H to be attempted on next step: {}\n\
-         {cont}step size used on last successful step: {}\n\
-         {cont}the order of the method used on the last step: {}\n\
-         {cont}the order of the method to be attempted on the next step: {}\n\
-         {cont}number of steps taken so far: {}\n\
-         {cont}number of calls of functionODE() : {}\n\
-         {cont}number of calculation of jacobian : {}\n\
-         {cont}total number of convergence test failures: {}\n\
-         {cont}total number of error test failures: {}\n\
-         {}Finished DASSL step.\n",
-        log_prefix("LOG_DASSL", "info"),
-        g(t), g(r(3)), g(r(2)), g(r(6)),
-        i(7), i(8), i(10), i(11), i(12), i(14), i(13),
-        log_prefix("LOG_DASSL", "info"),
-    ));
+    omclog::info(omclog::DASSL, true, "dassl call statistics: ");
+    for l in [
+        alloc::format!("value of idid: {idid}"),
+        alloc::format!("current time value: {}", g(t)),
+        alloc::format!("current integration time value: {}", g(r(3))),
+        alloc::format!("step size H to be attempted on next step: {}", g(r(2))),
+        alloc::format!("step size used on last successful step: {}", g(r(6))),
+        alloc::format!("the order of the method used on the last step: {}", i(7)),
+        alloc::format!("the order of the method to be attempted on the next step: {}", i(8)),
+        alloc::format!("number of steps taken so far: {}", i(10)),
+        alloc::format!("number of calls of functionODE() : {}", i(11)),
+        alloc::format!("number of calculation of jacobian : {}", i(12)),
+        alloc::format!("total number of convergence test failures: {}", i(14)),
+        alloc::format!("total number of error test failures: {}", i(13)),
+    ] {
+        omclog::info(omclog::DASSL, false, &l);
+    }
+    omclog::close(omclog::DASSL);
+    omclog::info(omclog::DASSL, false, "Finished DASSL step.");
 }
 
 /// Per-state DASSL tolerances as in `dassl.c`: rtol `tol`, atol `tol·nominal[i]`
@@ -2359,6 +2470,10 @@ struct DasslDriver {
     /// DASKR continuations spent on the in-progress interval (persisted so the
     /// runaway cap bounds one interval across yields).
     work_retries: i32,
+    /// `-noEquidistantOutput{Frequency,Time}` over the integrator's own steps.
+    step_emit: StepEmit,
+    /// C's degenerate first `-noEquidistantTimeGrid` iteration has been emitted.
+    no_grid_primed: bool,
     /// `terminate()` fired at the initial point; the first `advance` reports it.
     pending_terminate: bool,
     finished: bool,
@@ -2445,6 +2560,12 @@ impl DasslDriver {
         if n_states > 0 {
             info[1] = 1; // INFO(2)=1: per-state (vector) rtol/atol
         }
+        if no_equidistant_grid() && n_states > 0 {
+            info[2] = 1; // INFO(3)=1: return after every internal step
+        }
+        let mut rwork = vec![0.0f64; lrw];
+        let mut iwork = vec![0i32; liw];
+        daskr_limits(&mut info, &mut rwork, &mut iwork);
         Ok(DasslDriver {
             sim_data,
             n_states,
@@ -2460,8 +2581,8 @@ impl DasslDriver {
             rtol,
             atol,
             nominals: state_nominals(&model.state_nominals, n_states),
-            rwork: vec![0.0f64; lrw],
-            iwork: vec![0i32; liw],
+            rwork,
+            iwork,
             rpar: [0.0f64],
             ipar: [0i32],
             jroot: [0i32],
@@ -2471,6 +2592,8 @@ impl DasslDriver {
             pivots,
             rows,
             pending_tout: None,
+            step_emit: StepEmit::new(),
+            no_grid_primed: false,
             work_retries: 0,
             pending_terminate,
             finished: false,
@@ -2506,6 +2629,16 @@ impl Driver for DasslDriver {
         let stop = model.stop_time;
         let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
         let deadline = deadline_from(budget_ms);
+        // `-noEquidistantTimeGrid`: one interval spans the run, rows come from the
+        // IDID=1 returns below.
+        let no_grid = no_equidistant_grid() && self.n_states > 0 && stop > start;
+        let n_rows = if no_grid { 2 } else { n_rows };
+        // C's first iteration here is a zero-length step (`lastdesiredStep` starts an
+        // output interval ahead) and emits a second row at the start time.
+        if no_grid && !self.no_grid_primed {
+            self.no_grid_primed = true;
+            emit_row(e, &mut self.rows, sim_data, layout, self.t, stop)?;
+        }
 
         // No integration — just evaluate outputs on the grid — with no states or an
         // empty time span (`stopTime <= startTime`; a zero-width `ddaskr` step errors).
@@ -2593,8 +2726,11 @@ impl Driver for DasslDriver {
             // IDID=-1: DASKR hit its per-call work quota before TOUT — resume with
             // INFO(1)=1 (a stiff interval hits this repeatedly), up to a cap.
             // `pending_tout`/`work_retries` persist an interval unfinished at a yield.
-            let mut tout =
-                self.pending_tout.unwrap_or(if self.row == n_steps { stop } else { start + self.row as f64 * h });
+            let mut tout = self.pending_tout.unwrap_or(if no_grid || self.row == n_steps {
+                stop
+            } else {
+                start + self.row as f64 * h
+            });
             // Zero-length final interval (stop == start): daskr rejects TOUT == T,
             // so emit the held state directly instead of stepping.
             if tout <= self.t {
@@ -2636,6 +2772,24 @@ impl Driver for DasslDriver {
             }
             if self.idid < 0 {
                 return Err("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
+            }
+            // IDID=1 (INFO(3)=1): one internal step, TOUT still ahead.
+            if self.idid == 1 {
+                self.pending_tout = Some(tout);
+                self.work_retries = 0;
+                if self.step_emit.take(self.t) {
+                    for i in 0..n_states {
+                        write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
+                    }
+                    open_assert_window();
+                    let emitted =
+                        emit_row(e, &mut self.rows, sim_data, layout, self.t, model.stop_time);
+                    close_assert_window(e, sim_data).and(emitted)?;
+                    if terminated(e, sim_data, layout)? {
+                        break Advance::Terminated;
+                    }
+                }
+                continue;
             }
             // Interval complete: reset the resume state, write the interpolated state
             // back, and emit the row.
@@ -2739,6 +2893,8 @@ struct DaskrState {
 /// What one call into the integrator did.
 enum Progress {
     Reached,
+    /// INFO(3)=1 only: one internal step taken, the target not yet reached.
+    Stepped,
     Root,
     /// The per-call work quota ran out before the target; call again to continue.
     WorkQuota,
@@ -2758,12 +2914,18 @@ impl DaskrState {
         if n_states > 0 {
             info[1] = 1; // INFO(2)=1: per-state (vector) rtol/atol
         }
+        if no_equidistant_grid() {
+            info[2] = 1; // INFO(3)=1: return after every internal step
+        }
+        let mut rwork = vec![0.0f64; lrw];
+        let mut iwork = vec![0i32; liw];
+        daskr_limits(&mut info, &mut rwork, &mut iwork);
         DaskrState {
             info,
             rtol,
             atol,
-            rwork: vec![0.0f64; lrw],
-            iwork: vec![0i32; liw],
+            rwork,
+            iwork,
             rpar: [0.0f64],
             ipar: [0i32],
             jroot: vec![0i32; (nrt as usize).max(1)],
@@ -2809,8 +2971,12 @@ impl DaskrState {
         if self.idid < 0 {
             return Progress::Failed("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
         }
-        // IDID=5: stopped at a zero-crossing root.
-        if self.idid == 5 { Progress::Root } else { Progress::Reached }
+        // IDID=5: stopped at a zero-crossing root; IDID=1: intermediate-output step.
+        match self.idid {
+            5 => Progress::Root,
+            1 => Progress::Stepped,
+            _ => Progress::Reached,
+        }
     }
 }
 
@@ -2857,6 +3023,7 @@ impl CvodeState {
                 self.work_retries = 0;
                 match other {
                     crate::sundials::Stop::Root => Progress::Root,
+                    crate::sundials::Stop::Stepped => Progress::Stepped,
                     _ => Progress::Reached,
                 }
             }
@@ -2900,7 +3067,7 @@ impl IdaState {
         if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
             return Err("CodegenWasmJit: IDA setup failed");
         }
-        let stop = ida.step(t, target);
+        let stop = ida.step(t, target, no_equidistant_grid());
         y.copy_from_slice(ida.y());
         yp.copy_from_slice(ida.yp());
         if !matches!(stop, crate::sundials::Stop::Failed(_)) {
@@ -2955,6 +3122,8 @@ struct SolverCore {
     chatter_idx: usize,
     chatter_consec: u32,
     chatter_emitted: bool,
+    /// `-noEquidistantOutput{Frequency,Time}` over the integrator's own steps.
+    step_emit: StepEmit,
 }
 
 /// Consecutive state events within one output step that count as chattering.
@@ -2963,6 +3132,8 @@ const CHATTER_LIMIT: usize = 100;
 /// How far one [`SolverCore::solve_toward`] got.
 enum Solved {
     Reached,
+    /// `-noEquidistantTimeGrid`: one integrator step ended at `SolverCore::t`.
+    Stepped,
     /// A root function changed sign; `SolverCore::t` is where.
     Root,
     Yielded,
@@ -2996,6 +3167,8 @@ struct EventsDriver {
     /// Resume state for a yield mid output row, so `grid_covered` is not reset.
     mid_row: bool,
     grid_covered: bool,
+    /// C's degenerate first iteration under `-noEquidistantTimeGrid` is emitted.
+    no_grid_primed: bool,
     pending_terminate: bool,
     finished: bool,
 }
@@ -3052,6 +3225,7 @@ impl SolverCore {
             chatter_idx: 0,
             chatter_consec: 0,
             chatter_emitted: false,
+            step_emit: StepEmit::new(),
         })
     }
 
@@ -3212,6 +3386,7 @@ impl SolverCore {
                 Progress::WorkQuota => continue,
                 Progress::Failed(err) => return Err(err),
                 Progress::Reached => return Ok(Solved::Reached),
+                Progress::Stepped => return Ok(Solved::Stepped),
                 Progress::Root => return Ok(Solved::Root),
             }
         }
@@ -3253,6 +3428,18 @@ impl SolverCore {
         }
         stats.state_events = self.state_events;
         stats.time_events = self.time_events;
+    }
+
+    /// Whether the solver returns after each internal step, which
+    /// `-noEquidistantTimeGrid` needs. CVODE here does not.
+    fn reports_steps(&self) -> bool {
+        match &self.solver {
+            Solver::Daskr(_) => true,
+            #[cfg(sundials)]
+            Solver::Cvode(_) => false,
+            #[cfg(sundials)]
+            Solver::Ida(_) => true,
+        }
     }
 
     /// The first root function that fired, for the chattering message.
@@ -3317,7 +3504,8 @@ impl SolverCore {
             // Integrate from the current t toward `target` (the caller's time or the
             // next scheduled sample). DASKR may stop early at a zero-crossing root.
             if target - self.t > eps {
-                let rooted = match self.solve_toward(target, ctx, deadline, did_step)? {
+                let solved = self.solve_toward(target, ctx, deadline, did_step)?;
+                let rooted = match solved {
                     Solved::Yielded => {
                         self.nfe = ctx.nfe;
                         return Ok(Step::Yielded);
@@ -3326,11 +3514,24 @@ impl SolverCore {
                         self.nfe = ctx.nfe;
                         return Ok(Step::Cancelled);
                     }
-                    Solved::Reached => false,
+                    Solved::Reached | Solved::Stepped => false,
                     Solved::Root => true,
                 };
                 for i in 0..n_states {
                     write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
+                }
+                // C emits from `perform_simulation` once `solver_step` returns.
+                if let Solved::Stepped = solved {
+                    if let Some(r) = rows.as_deref_mut()
+                        && self.step_emit.take(self.t)
+                    {
+                        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+                        emit_row(e, r, sim_data, layout, self.t, model.stop_time)?;
+                        if terminated(e, sim_data, layout)? {
+                            return Ok(Step::Terminated);
+                        }
+                    }
+                    continue;
                 }
                 // A zero-crossing root at `t` (< target). Handle the state event
                 // here, then restart the integrator and keep going.
@@ -3345,31 +3546,40 @@ impl SolverCore {
                     if let Some((t0, t1)) = self.note_chatter_event(troot, step_size) {
                         let zc = self.root_index();
                         let desc = model.zc_desc.get(zc).map(String::as_str).unwrap_or("<zero-crossing>");
-                        log_line(&format!(
-                            "{}Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state \
-                             events in a row with a total time delta less than the step size \
-                             {step_size}). This can be a performance bottleneck. Use -lv LOG_EVENTS \
-                             for more information. The zero-crossing was: {desc}\n",
-                            log_prefix("LOG_STDOUT", "info"),
-                        ));
+                        omclog::info(
+                            omclog::STDOUT,
+                            false,
+                            &format!(
+                                "Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state \
+                                 events in a row with a total time delta less than the step size \
+                                 {step_size}). This can be a performance bottleneck. Use -lv LOG_EVENTS \
+                                 for more information. The zero-crossing was: {desc}"
+                            ),
+                        );
                         if chatter_store::abort() {
-                            log_line(&format!(
-                                "{}Aborting simulation due to chattering being detected and the \
-                                 simulation flags requesting we do not continue further.\n",
-                                log_prefix("LOG_ASSERT", "debug"),
-                            ));
+                            omclog::message_text(
+                                omclog::DEBUG_TYPE,
+                                omclog::ASSERT,
+                                false,
+                                "Aborting simulation due to chattering being detected and the \
+                                 simulation flags requesting we do not continue further.",
+                            );
                             return Err(CHATTER_ABORT_ERR);
                         }
                     }
                     // pre-event row (before the discrete update), then event +
                     // post-event row.
-                    if let Some(r) = rows.as_deref_mut() {
+                    if let Some(r) = rows.as_deref_mut()
+                        && !no_event_emit()
+                    {
                         capture_pre(e, r, sim_data, layout, troot)?;
                     }
                     event_update(e, sim_data, layout, None, troot)?;
                     if let Some(r) = rows.as_deref_mut() {
-                        capture_row(e, r, sim_data, layout)?;
-                        check_asserts(e, sim_data, layout, "info")?;
+                        if emit_post_event_row(model, troot) {
+                            capture_row(e, r, sim_data, layout)?;
+                        }
+                        check_asserts(e, sim_data, layout, omclog::INFO)?;
                     }
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
@@ -3401,7 +3611,9 @@ impl SolverCore {
                     write_f64(e, sim_data + TIME_OFF, te)?;
                     return Ok(Step::Event { time: te });
                 }
-                if let Some(r) = rows.as_deref_mut() {
+                if let Some(r) = rows.as_deref_mut()
+                    && !no_event_emit()
+                {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?; // pre-event row (held)
                 }
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
@@ -3409,7 +3621,9 @@ impl SolverCore {
                 refresh_relations(e, sim_data, layout)?;
                 e.clean_nls_history(te);
                 self.time_events += 1;
-                if let Some(r) = rows.as_deref_mut() {
+                if let Some(r) = rows.as_deref_mut()
+                    && emit_post_event_row(model, te)
+                {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?;
                 }
                 if terminated(e, sim_data, layout)? {
@@ -3760,6 +3974,7 @@ impl EventsDriver {
             rows,
             mid_row: false,
             grid_covered: false,
+            no_grid_primed: false,
             pending_terminate,
             finished: false,
         })
@@ -3785,7 +4000,19 @@ impl Driver for EventsDriver {
         let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
         let deadline = deadline_from(budget_ms);
         let n_states = self.core.n_states;
-        let tout_of = |row: u32| if row == n_steps { stop } else { start + row as f64 * h };
+        // `-noEquidistantTimeGrid`: the rows come from `integrate_to`, so one "row"
+        // spans the run; `Samples` still bounds each solve.
+        let no_grid =
+            no_equidistant_grid() && n_states > 0 && stop > start && self.core.reports_steps();
+        let n_rows = if no_grid { 2 } else { n_rows };
+        // See `DasslDriver`: C's degenerate first iteration in this mode.
+        if no_grid && !self.no_grid_primed {
+            self.no_grid_primed = true;
+            emit_row(e, &mut self.rows, sim_data, layout, self.core.t, stop)?;
+        }
+        let tout_of = |row: u32| {
+            if no_grid || row == n_steps { stop } else { start + row as f64 * h }
+        };
 
         // No continuous states: nothing to integrate, but zero-crossings on `time`
         // (e.g. a timer `time >= t_start + waitTime`) are still continuous events
@@ -3827,11 +4054,15 @@ impl Driver for EventsDriver {
                         }
                     }
                     if let Some(tr) = troot {
-                        capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
+                        if !no_event_emit() {
+                            capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
+                        }
                         event_update(e, sim_data, layout, None, tr)?;
                         self.core.state_events += 1;
-                        capture_row(e, &mut self.rows, sim_data, layout)?; // post-event row
-                        check_asserts(e, sim_data, layout, "info")?;
+                        if emit_post_event_row(model, tr) {
+                            capture_row(e, &mut self.rows, sim_data, layout)?; // post-event row
+                        }
+                        check_asserts(e, sim_data, layout, omclog::INFO)?;
                         if terminated(e, sim_data, layout)? {
                             self.finished = true;
                             return Ok(Advance::Terminated);
@@ -3848,13 +4079,17 @@ impl Driver for EventsDriver {
                     if te <= tout + eps {
                         let te = if (te - tout).abs() <= eps { tout } else { te };
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?; // held pre row
-                        emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?; // pre-event row
+                        if !no_event_emit() {
+                            emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?;
+                        }
                         write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh
                         self.samp.fire(e, sim_data, te)?;
                         refresh_relations(e, sim_data, layout)?;
                         e.clean_nls_history(te);
                         self.core.time_events += 1;
-                        emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?; // post-event row
+                        if emit_post_event_row(model, te) {
+                            emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?;
+                        }
                         if terminated(e, sim_data, layout)? {
                             self.finished = true;
                             return Ok(Advance::Terminated);
@@ -4248,7 +4483,9 @@ impl Driver for CvodeDriver {
                 return Err(err);
             }
             match stop_reason {
-                crate::sundials::Stop::Reached | crate::sundials::Stop::Root => {}
+                crate::sundials::Stop::Reached
+                | crate::sundials::Stop::Stepped
+                | crate::sundials::Stop::Root => {}
                 crate::sundials::Stop::Failed(flag)
                     if flag == crate::sundials::CV_TOO_MUCH_WORK && self.work_retries < CVODE_WORK_RETRIES =>
                 {
@@ -4702,6 +4939,10 @@ struct IdaDriver {
     rows: Vec<f64>,
     /// Resumes an output interval left unfinished by a work-quota return or a yield.
     work_retries: u32,
+    /// `-noEquidistantOutput{Frequency,Time}` over IDA's own steps.
+    step_emit: StepEmit,
+    /// C's degenerate first `-noEquidistantTimeGrid` iteration has been emitted.
+    no_grid_primed: bool,
     pending_terminate: bool,
     finished: bool,
 }
@@ -4758,6 +4999,8 @@ impl IdaDriver {
             pivots,
             rows,
             work_retries: 0,
+            step_emit: StepEmit::new(),
+            no_grid_primed: false,
             pending_terminate,
             finished: false,
         })
@@ -4783,6 +5026,14 @@ impl Driver for IdaDriver {
         let stop = model.stop_time;
         let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
         let deadline = deadline_from(budget_ms);
+        // `-noEquidistantTimeGrid`: one interval spans the run, rows come from the
+        // one-step returns below (`ida_solver.c`'s `idaSmode`).
+        let no_grid = no_equidistant_grid() && self.n_states > 0 && stop > start;
+        let n_rows = if no_grid { 2 } else { n_rows };
+        if no_grid && !self.no_grid_primed {
+            self.no_grid_primed = true;
+            emit_row(e, &mut self.rows, sim_data, layout, self.t, stop)?;
+        }
 
         // No integration — evaluate outputs on the grid — with no states or an
         // empty time span.
@@ -4852,7 +5103,7 @@ impl Driver for IdaDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
-            let tout = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            let tout = if no_grid || self.row == n_steps { stop } else { start + self.row as f64 * h };
             // Zero-length final interval: emit the held state rather than step.
             if tout <= self.t {
                 for (i, v) in ida.y().iter().enumerate() {
@@ -4862,12 +5113,15 @@ impl Driver for IdaDriver {
                 self.row += 1;
                 continue;
             }
-            let stop_reason = ida.step(&mut self.t, tout);
+            let stop_reason = ida.step(&mut self.t, tout, no_grid);
             if let Some(err) = ctx.err.take() {
                 return Err(err);
             }
+            let stepped = matches!(stop_reason, crate::sundials::Stop::Stepped);
             match stop_reason {
-                crate::sundials::Stop::Reached | crate::sundials::Stop::Root => {}
+                crate::sundials::Stop::Reached
+                | crate::sundials::Stop::Stepped
+                | crate::sundials::Stop::Root => {}
                 crate::sundials::Stop::Failed(flag)
                     if flag == crate::sundials::IDA_TOO_MUCH_WORK && self.work_retries < IDA_WORK_RETRIES =>
                 {
@@ -4877,6 +5131,24 @@ impl Driver for IdaDriver {
                 crate::sundials::Stop::Failed(_) => return Err("CodegenWasmJit: IDA failed"),
             }
             self.work_retries = 0;
+            // One-step mode: the step that just ended is an output point of its own
+            // and `tout` is still ahead.
+            if stepped {
+                if self.step_emit.take(self.t) {
+                    self.setup.store_sens(e, sim_data, ida)?;
+                    for (i, v) in ida.y().iter().enumerate() {
+                        write_f64(e, states_base + (i as u32) * 8, *v)?;
+                    }
+                    open_assert_window();
+                    let emitted =
+                        emit_row(e, &mut self.rows, sim_data, layout, self.t, model.stop_time);
+                    close_assert_window(e, sim_data).and(emitted)?;
+                    if terminated(e, sim_data, layout)? {
+                        break Advance::Terminated;
+                    }
+                }
+                continue;
+            }
             self.setup.store_sens(e, sim_data, ida)?;
             for (i, v) in ida.y().iter().enumerate() {
                 write_f64(e, states_base + (i as u32) * 8, *v)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -25,6 +25,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub mod driver;
+pub mod omclog;
 pub mod simflags;
 #[cfg(sundials)]
 pub mod sundials;
@@ -382,17 +383,29 @@ pub struct SimMeta {
     /// C's `simulationInfo->sensitivityParList`: the `SimData` offsets of the
     /// parameters `--calculateSensitivities` selected, in block order.
     pub sens_params: Vec<u32>,
+    /// Per nonlinear system, its equation index and the iteration variables in
+    /// solver order — C reads the same list out of the `_info.json` `defines` array
+    /// to name the unknowns in its `-lv=LOG_NLS` blocks.
+    pub nls_vars: Vec<NlsVars>,
+}
+
+/// [`SimMeta::nls_vars`] entry.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct NlsVars {
+    pub eq_index: u32,
+    pub names: Vec<String>,
 }
 
 impl SimMeta {
-    /// Number of equidistant output rows the run writes. `n_intervals + 1` for a
-    /// real interval; a zero-length run (`stop <= start`) writes the start and stop
-    /// points only — 2 rows, regardless of `numberOfIntervals`.
+    /// Number of equidistant output rows the run writes, before C's terminal step
+    /// adds its own. `n_intervals + 1` for a real interval; a zero-length run
+    /// (`stop <= start`) writes the start point only, regardless of
+    /// `numberOfIntervals`.
     pub fn n_output_rows(&self) -> u32 {
         if self.stop_time > self.start_time {
             self.n_intervals + 1
         } else {
-            2
+            1
         }
     }
 
@@ -416,7 +429,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 6;
+const VERSION: u32 = 7;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -533,6 +546,14 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_str(&mut o, d);
     }
     put_u32s(&mut o, &m.sens_params);
+    put_u32(&mut o, m.nls_vars.len() as u32);
+    for v in &m.nls_vars {
+        put_u32(&mut o, v.eq_index);
+        put_u32(&mut o, v.names.len() as u32);
+        for n in &v.names {
+            put_str(&mut o, n);
+        }
+    }
     o
 }
 
@@ -704,9 +725,21 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         zc_desc.push(r.string()?);
     }
     let sens_params = r.u32s()?;
+    let nsys = r.u32()? as usize;
+    let mut nls_vars = Vec::with_capacity(nsys);
+    for _ in 0..nsys {
+        let eq_index = r.u32()?;
+        let nn = r.u32()? as usize;
+        let mut names = Vec::with_capacity(nn);
+        for _ in 0..nn {
+            names.push(r.string()?);
+        }
+        nls_vars.push(NlsVars { eq_index, names });
+    }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs, zc_desc, sens_params,
+        nls_vars,
     })
 }
 
@@ -757,6 +790,10 @@ mod tests {
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             sens_params: vec![88],
+            nls_vars: vec![NlsVars {
+                eq_index: 1074,
+                names: vec!["pipe.medium.T".to_string(), "pipe.medium.p".to_string()],
+            }],
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -1,0 +1,549 @@
+//! C's `util/omc_error.c`: the `-lv` stream table and the message layout.
+//!
+//! The layout is stateful, so it is not a per-line prefix: a stream carries an
+//! indentation level that `indent_next` raises and [`close`] lowers, and the
+//! stream/type columns collapse to `|` when the previous line came from the same
+//! stream at a level above zero. [`message_text`] is C's `messageText`, subline
+//! recursion over embedded newlines included.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+
+/// Index into [`STREAM_NAME`], i.e. C's `OMC_LOG_*` enumerators.
+pub type Stream = u8;
+
+/// C's `OMC_LOG_STREAM_NAME`, in the order the `-lv` parser and the mask index by.
+pub const STREAM_NAME: [&str; 57] = [
+    "LOG_UNKNOWN",
+    "LOG_STDOUT",
+    "LOG_ASSERT",
+    "LOG_DASSL",
+    "LOG_DASSL_STATES",
+    "LOG_DEBUG",
+    "LOG_DELAY",
+    "LOG_DIVISION",
+    "LOG_DSS",
+    "LOG_DSS_JAC",
+    "LOG_DT",
+    "LOG_DT_CONS",
+    "LOG_EVENTS",
+    "LOG_EVENTS_V",
+    "LOG_GBODE",
+    "LOG_GBODE_V",
+    "LOG_GBODE_NLS",
+    "LOG_GBODE_NLS_V",
+    "LOG_GBODE_STATES",
+    "LOG_INIT",
+    "LOG_INIT_HOMOTOPY",
+    "LOG_INIT_V",
+    "LOG_IPOPT",
+    "LOG_IPOPT_FULL",
+    "LOG_IPOPT_JAC",
+    "LOG_IPOPT_HESSE",
+    "LOG_IPOPT_ERROR",
+    "LOG_JAC",
+    "LOG_LS",
+    "LOG_LS_V",
+    "LOG_MIXED",
+    "LOG_MOO",
+    "LOG_NLS",
+    "LOG_NLS_V",
+    "LOG_NLS_HOMOTOPY",
+    "LOG_NLS_JAC",
+    "LOG_NLS_JAC_TEST",
+    "LOG_NLS_JAC_SUMS",
+    "LOG_NLS_NEWTON_DIAGNOSTICS",
+    "LOG_NLS_DERIVATIVE_TEST",
+    "LOG_NLS_SVD",
+    "LOG_NLS_SVD_V",
+    "LOG_NLS_RES",
+    "LOG_NLS_EXTRAPOLATE",
+    "LOG_RES_INIT",
+    "LOG_RT",
+    "LOG_SIMULATION",
+    "LOG_SOLVER",
+    "LOG_SOLVER_V",
+    "LOG_SOLVER_CONTEXT",
+    "LOG_SOTI",
+    "LOG_SPATIALDISTR",
+    "LOG_STATS",
+    "LOG_STATS_V",
+    "LOG_SUCCESS",
+    "LOG_SYNCHRONOUS",
+    "LOG_ZEROCROSSINGS",
+];
+
+pub const N_STREAMS: usize = STREAM_NAME.len();
+
+pub const UNKNOWN: Stream = 0;
+pub const STDOUT: Stream = 1;
+pub const ASSERT: Stream = 2;
+pub const DASSL: Stream = 3;
+pub const DEBUG: Stream = 5;
+pub const DELAY: Stream = 6;
+pub const DIVISION: Stream = 7;
+pub const DSS: Stream = 8;
+pub const EVENTS: Stream = 12;
+pub const EVENTS_V: Stream = 13;
+pub const INIT: Stream = 19;
+pub const INIT_HOMOTOPY: Stream = 20;
+pub const INIT_V: Stream = 21;
+pub const JAC: Stream = 27;
+pub const LS: Stream = 28;
+pub const LS_V: Stream = 29;
+pub const NLS: Stream = 32;
+pub const NLS_V: Stream = 33;
+pub const NLS_HOMOTOPY: Stream = 34;
+pub const NLS_JAC: Stream = 35;
+pub const NLS_RES: Stream = 42;
+pub const NLS_EXTRAPOLATE: Stream = 43;
+pub const SOLVER: Stream = 47;
+pub const SOLVER_V: Stream = 48;
+pub const SOTI: Stream = 50;
+pub const STATS: Stream = 52;
+pub const STATS_V: Stream = 53;
+pub const SUCCESS: Stream = 54;
+pub const ZEROCROSSINGS: Stream = 56;
+
+/// C's `OMC_LOG_TYPE_*` / `OMC_LOG_TYPE_DESC`.
+pub type LogType = u8;
+pub const INFO: LogType = 1;
+pub const WARNING: LogType = 2;
+pub const ERROR: LogType = 3;
+pub const DEBUG_TYPE: LogType = 5;
+const TYPE_DESC: [&str; 6] = ["unknown", "info", "warning", "error", "assert", "debug"];
+
+/// Bit `s` set = stream `s` is on: C's `omc_useStream`, packed so a run can push it
+/// into the wasm runtime as one value.
+pub type Mask = u64;
+
+/// The three streams C activates without `-lv`, and which [`deactivate`] leaves.
+pub const ALWAYS_ON: Mask = (1 << STDOUT) | (1 << ASSERT) | (1 << SUCCESS);
+
+pub fn mask_has(m: Mask, s: Stream) -> bool {
+    m & (1 << s) != 0
+}
+
+/// C's `setGlobalVerboseLevel`: `LOG_ALL`, the `-`-prefixed disable form, then the
+/// implications below. An unrecognized name is C's fatal `unrecognized option -lv`.
+pub fn mask_from_streams<S: AsRef<str>>(streams: &[S]) -> Result<Mask, String> {
+    let mut m = ALWAYS_ON;
+    if streams.is_empty() {
+        return Ok(m);
+    }
+    // C re-enables only these two, so `-lv=-LOG_SUCCESS` does what it promises.
+    m |= (1 << STDOUT) | (1 << ASSERT);
+    if streams.iter().any(|s| s.as_ref().contains("LOG_ALL")) {
+        return Ok(finish(!0 << 1));
+    }
+    for s in streams {
+        let s = s.as_ref();
+        let (on, name) = match s.strip_prefix('-') {
+            Some(rest) => (false, rest),
+            None => (true, s),
+        };
+        // C searches from `firstOMCErrorStream`, so `LOG_UNKNOWN` is not selectable.
+        let Some(i) = STREAM_NAME.iter().skip(1).position(|n| *n == name).map(|p| p + 1) else {
+            return Err(format!("unrecognized option -lv {s}"));
+        };
+        if on {
+            m |= 1 << i;
+        } else {
+            m &= !(1 << i);
+        }
+    }
+    Ok(finish(m))
+}
+
+/// `setGlobalVerboseLevel`'s "print X if Y is active" implications, in its order
+/// (`LOG_INIT_V` reaches `LOG_INIT_HOMOTOPY` through `LOG_INIT`).
+fn finish(mut m: Mask) -> Mask {
+    const GBODE: Stream = 14;
+    const GBODE_V: Stream = 15;
+    const GBODE_NLS: Stream = 16;
+    const GBODE_NLS_V: Stream = 17;
+    const DSS_JAC: Stream = 9;
+    for (from, to) in [
+        (GBODE_V, GBODE),
+        (GBODE_NLS_V, GBODE_NLS),
+        (INIT_V, INIT),
+        (INIT_V, SOTI),
+        (INIT, INIT_HOMOTOPY),
+        (SOLVER_V, SOLVER),
+        (SOLVER, STATS),
+        (STATS_V, STATS),
+        (NLS_V, NLS),
+        (NLS_RES, NLS),
+        (NLS_JAC, NLS),
+        (EVENTS_V, EVENTS),
+        (DSS_JAC, DSS),
+    ] {
+        if mask_has(m, from) {
+            m |= 1 << to;
+        }
+    }
+    m
+}
+
+/// C's `omc_level`/`omc_lastType`/`omc_lastStream`/`omc_useStream` + its backup.
+struct State {
+    use_stream: Mask,
+    backup: Mask,
+    streams_active: bool,
+    level: [i16; N_STREAMS],
+    last_type: [LogType; N_STREAMS],
+    last_stream: Stream,
+}
+
+impl State {
+    const fn new() -> Self {
+        State {
+            use_stream: ALWAYS_ON,
+            backup: 0,
+            streams_active: true,
+            level: [0; N_STREAMS],
+            last_type: [0; N_STREAMS],
+            last_stream: UNKNOWN,
+        }
+    }
+}
+
+mod store {
+    use super::State;
+
+    #[cfg(feature = "std")]
+    mod imp {
+        use super::State;
+        use core::cell::RefCell;
+        std::thread_local! {
+            static STATE: RefCell<State> = const { RefCell::new(State::new()) };
+        }
+        pub fn with<R>(f: impl FnOnce(&mut State) -> R) -> R {
+            STATE.with(|c| f(&mut c.borrow_mut()))
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use super::State;
+        use core::cell::UnsafeCell;
+        // Single-threaded in-wasm runtime, as `driver::overrides_store`.
+        struct Store(UnsafeCell<State>);
+        unsafe impl Sync for Store {}
+        static STATE: Store = Store(UnsafeCell::new(State::new()));
+        pub fn with<R>(f: impl FnOnce(&mut State) -> R) -> R {
+            f(unsafe { &mut *STATE.0.get() })
+        }
+    }
+
+    pub use imp::with;
+}
+
+/// Install the run's active streams, and reset the indentation state so a run never
+/// inherits an unclosed block.
+pub fn set_mask(m: Mask) {
+    store::with(|s| {
+        *s = State::new();
+        s.use_stream = m;
+    });
+}
+
+pub fn mask() -> Mask {
+    store::with(|s| s.use_stream)
+}
+
+/// C's `OMC_ACTIVE_STREAM`.
+pub fn active(stream: Stream) -> bool {
+    store::with(|s| mask_has(s.use_stream, stream))
+}
+
+/// C's `deactivateLogging`: everything but stdout/assert/success off until
+/// [`reactivate`].
+pub fn deactivate() {
+    store::with(|s| {
+        if !s.streams_active {
+            return;
+        }
+        s.backup = s.use_stream;
+        s.use_stream = ALWAYS_ON;
+        s.streams_active = false;
+    });
+}
+
+pub fn reactivate() {
+    store::with(|s| {
+        if s.streams_active {
+            return;
+        }
+        s.use_stream = (s.backup & !ALWAYS_ON) | (s.use_stream & ALWAYS_ON);
+        s.streams_active = true;
+    });
+}
+
+pub fn info(stream: Stream, indent_next: bool, msg: &str) {
+    if active(stream) {
+        message_text(INFO, stream, indent_next, msg);
+    }
+}
+
+pub fn warning(stream: Stream, indent_next: bool, msg: &str) {
+    if active(stream) {
+        message_text(WARNING, stream, indent_next, msg);
+    }
+}
+
+pub fn error(stream: Stream, indent_next: bool, msg: &str) {
+    message_text(ERROR, stream, indent_next, msg);
+}
+
+/// C's `messageClose`: end a block opened with `indent_next`.
+pub fn close(stream: Stream) {
+    store::with(|s| {
+        if mask_has(s.use_stream, stream) {
+            s.level[stream as usize] -= 1;
+        }
+    });
+}
+
+/// C's `messageText`. A newline in `msg` starts a `subline`: `|` in both header
+/// columns and no level indent, as C's recursive call gives.
+pub fn message_text(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
+    let mut out = String::new();
+    store::with(|s| {
+        let i = stream as usize;
+        for (n, line) in msg.split('\n').enumerate() {
+            let subline = n > 0;
+            let collapse = subline || (s.last_stream == stream && s.level[i] > 0);
+            let name = if collapse { "|" } else { STREAM_NAME[i] };
+            let ty_col = if subline || (s.last_stream == stream && s.last_type[i] == ty && s.level[i] > 0)
+            {
+                "|"
+            } else {
+                TYPE_DESC[ty as usize]
+            };
+            out.push_str(&format!("{name:<17} | {ty_col:<7} | "));
+            if !subline {
+                for _ in 0..s.level[i] {
+                    out.push_str("| ");
+                }
+            }
+            out.push_str(line);
+            out.push('\n');
+            s.last_type[i] = ty;
+            s.last_stream = stream;
+        }
+        if indent_next {
+            s.level[i] += 1;
+        }
+    });
+    crate::driver::log_line(&out);
+}
+
+/// C's `%<width>.<prec>g`.
+pub fn g(v: f64, width: usize, prec: i32) -> String {
+    pad(crate::driver::format_g(v, prec), width)
+}
+
+/// C's `%<width>.<prec>e`: always an exponent, at least two exponent digits.
+pub fn e(v: f64, width: usize, prec: usize) -> String {
+    pad(exp_str(v, prec), width)
+}
+
+fn pad(s: String, width: usize) -> String {
+    if s.len() >= width { s } else { format!("{s:>width$}") }
+}
+
+fn exp_str(v: f64, prec: usize) -> String {
+    if !v.is_finite() {
+        return alloc::format!("{v}");
+    }
+    // Round in the mantissa's own scale, and carry when it rounds up to 10.
+    let mut exp = if v == 0.0 { 0 } else { libm::floor(libm::log10(libm::fabs(v))) as i32 };
+    let mut m = if v == 0.0 { 0.0 } else { v / libm::pow(10.0, exp as f64) };
+    if libm::fabs(m) >= 10.0 {
+        m /= 10.0;
+        exp += 1;
+    } else if v != 0.0 && libm::fabs(m) < 1.0 {
+        m *= 10.0;
+        exp -= 1;
+    }
+    let mut s = alloc::format!("{m:.prec$}");
+    if s.trim_start_matches('-').starts_with("10") {
+        exp += 1;
+        s = alloc::format!("{:.prec$}", m / 10.0);
+    }
+    alloc::format!("{s}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
+}
+
+/// C's `debugString`: one plain line.
+pub fn debug_string(stream: Stream, msg: &str) {
+    info(stream, false, msg);
+}
+
+/// C's `debugInt`: `"%s %d"`.
+pub fn debug_int(stream: Stream, msg: &str, v: i32) {
+    info(stream, false, &format!("{msg} {v}"));
+}
+
+/// C's `debugDouble`: `"%s %18.10e"`.
+pub fn debug_double(stream: Stream, msg: &str, v: f64) {
+    info(stream, false, &format!("{msg} {}", e(v, 18, 10)));
+}
+
+/// C's `debugVectorDouble`: a `name [n-dim]` block holding one line of
+/// space-separated `%16.8g`, with `±INF` for anything past `1e300`.
+pub fn debug_vector_double(stream: Stream, name: &str, v: &[f64]) {
+    if !active(stream) {
+        return;
+    }
+    info(stream, true, &format!("{name} [{}-dim]", v.len()));
+    let mut line = String::new();
+    for (i, x) in v.iter().enumerate() {
+        if i > 0 {
+            line.push(' ');
+        }
+        let cell = if *x < -1e300 {
+            "-INF".to_string()
+        } else if *x > 1e300 {
+            "+INF".to_string()
+        } else {
+            g(*x, 16, 8)
+        };
+        line.push_str(&cell);
+    }
+    info(stream, false, &line);
+    close(stream);
+}
+
+/// C's `debugVectorInt`: the same block over `%d`.
+pub fn debug_vector_int(stream: Stream, name: &str, v: &[i32]) {
+    if !active(stream) {
+        return;
+    }
+    info(stream, true, &format!("{name} [{}-dim]", v.len()));
+    let mut line = String::new();
+    for (i, x) in v.iter().enumerate() {
+        if i > 0 {
+            line.push(' ');
+        }
+        line.push_str(&alloc::format!("{x}"));
+    }
+    info(stream, false, &line);
+    close(stream);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    fn capture(f: impl FnOnce()) -> String {
+        crate::driver::set_log_sink(sink);
+        SINK.with(|s| s.borrow_mut().clear());
+        f();
+        SINK.with(|s| s.borrow().clone())
+    }
+
+    std::thread_local! {
+        static SINK: core::cell::RefCell<String> = const { core::cell::RefCell::new(String::new()) };
+    }
+    fn sink(s: &str) {
+        SINK.with(|c| c.borrow_mut().push_str(s));
+    }
+
+    #[test]
+    fn header_columns_collapse_inside_a_block() {
+        set_mask(ALWAYS_ON | (1 << NLS));
+        let out = capture(|| {
+            info(NLS, true, "############ Solve nonlinear system 7 at time 0 ############");
+            info(NLS, true, "initial variable values:");
+            info(NLS, false, "[ 1] y");
+            close(NLS);
+            close(NLS);
+        });
+        assert_eq!(
+            out,
+            "LOG_NLS           | info    | ############ Solve nonlinear system 7 at time 0 ############\n\
+             |                 | |       | | initial variable values:\n\
+             |                 | |       | | | [ 1] y\n"
+        );
+    }
+
+    #[test]
+    fn level_zero_never_collapses() {
+        set_mask(ALWAYS_ON);
+        let out = capture(|| {
+            info(STDOUT, false, "a");
+            info(STDOUT, false, "b");
+        });
+        assert_eq!(
+            out,
+            "LOG_STDOUT        | info    | a\nLOG_STDOUT        | info    | b\n"
+        );
+    }
+
+    #[test]
+    fn an_embedded_newline_is_a_subline() {
+        set_mask(ALWAYS_ON);
+        let out = capture(|| info(ASSERT, false, "first\nsecond"));
+        assert_eq!(
+            out,
+            "LOG_ASSERT        | info    | first\n|                 | |       | second\n"
+        );
+    }
+
+    #[test]
+    fn inactive_streams_print_nothing() {
+        set_mask(ALWAYS_ON);
+        let out = capture(|| info(NLS, false, "nope"));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn verbose_streams_imply_their_plain_one() {
+        let m = mask_from_streams(&["LOG_NLS_V"]).expect("parses");
+        assert!(mask_has(m, NLS_V) && mask_has(m, NLS));
+        let m = mask_from_streams(&["LOG_INIT_V"]).expect("parses");
+        for s in [INIT_V, INIT, SOTI, INIT_HOMOTOPY] {
+            assert!(mask_has(m, s), "{}", STREAM_NAME[s as usize]);
+        }
+        let m = mask_from_streams(&["LOG_ALL"]).expect("parses");
+        assert!(mask_has(m, NLS_V) && mask_has(m, ZEROCROSSINGS));
+        assert!(!mask_has(m, UNKNOWN));
+    }
+
+    #[test]
+    fn a_minus_prefix_turns_a_stream_off() {
+        let m = mask_from_streams(&["-LOG_SUCCESS"]).expect("parses");
+        assert!(!mask_has(m, SUCCESS) && mask_has(m, STDOUT));
+        assert!(mask_has(mask_from_streams::<&str>(&[]).expect("parses"), SUCCESS));
+    }
+
+    #[test]
+    fn an_unknown_stream_is_an_error() {
+        let e = mask_from_streams(&["LOG_NOPE"]).expect_err("must reject");
+        assert!(e.contains("LOG_NOPE"), "{e}");
+    }
+
+    #[test]
+    fn c_printf_conversions() {
+        assert_eq!(g(5e-06, 16, 8), "           5e-06");
+        assert_eq!(g(50000.0, 16, 8), "           50000");
+        assert_eq!(g(-0.51701271234, 16, 8), "     -0.51701271");
+        assert_eq!(e(-4.3608668960, 18, 10), " -4.3608668960e+00");
+        assert_eq!(e(1.0, 18, 10), "  1.0000000000e+00");
+        assert_eq!(e(2.2204460493e-16, 18, 10), "  2.2204460493e-16");
+        assert_eq!(e(0.0, 18, 10), "  0.0000000000e+00");
+        assert_eq!(alloc::format!("error_f        = {}", e(2.2204460493e-16, 18, 10)),
+                   "error_f        =   2.2204460493e-16");
+    }
+
+    #[test]
+    fn vector_blocks_match_cs_layout() {
+        set_mask(ALWAYS_ON | (1 << NLS_V));
+        let out = capture(|| debug_vector_double(NLS_V, "System values", &[5e-06, 50000.0]));
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "LOG_NLS_V         | info    | System values [2-dim]");
+        assert_eq!(lines[1], "|                 | |       | |            5e-06            50000");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -89,6 +89,10 @@ pub struct SimFlags {
     pub lss: Option<Lss>,
     /// `-lv` streams, uppercased.
     pub log: Vec<String>,
+    /// [`log`](Self::log) through C's `setGlobalVerboseLevel`, so an unrecognized
+    /// name fails at parse time as in C and no reader re-derives the implications.
+    /// [`parse`] fills it; a default-constructed `SimFlags` has no stream on.
+    pub log_mask: crate::omclog::Mask,
     pub abort_slow: bool,
     /// `-alarm`: seconds after which the run is aborted (C's `FLAG_ALARM`, where
     /// it is a `SIGALRM` on the simulation executable). 0 disables it, as in C.
@@ -125,6 +129,28 @@ pub struct SimFlags {
     /// `-output=a,b,c`: variables printed at the stop time (C's
     /// `outputVariablesAtEnd` / `writeOutputVars`).
     pub output_vars: Vec<String>,
+    /// `-r=<file>`: where the result is written, overriding the name derived from
+    /// the model.
+    pub result_file: Option<String>,
+    /// `-iif=<file>`: a result file whose values at the start time seed the start
+    /// attributes and parameters (C's `importStartValues`).
+    pub init_file: Option<String>,
+    /// `-noEquidistantTimeGrid`: emit the integrator's own steps instead of
+    /// interpolating onto the output grid.
+    pub no_equidistant_grid: bool,
+    /// `-noEquidistantOutputFrequency=n`: with the above, emit every n-th step.
+    pub no_equidistant_freq: Option<u32>,
+    /// `-noEquidistantOutputTime=t`: with the above, emit once `time > k*t`. C's
+    /// dassl also caps its step at `t` (`RWORK(2)`, `INFO(7)`).
+    pub no_equidistant_time: Option<f64>,
+    /// `-maxStepSize=h`: DASKR's `INFO(7)` / `RWORK(2)`.
+    pub max_step_size: Option<f64>,
+    /// `-noEventEmit`: drop the result rows a step that handled an event produces.
+    pub no_event_emit: bool,
+    /// `-nlssMinSize=n` / `-nlssMaxDensity=d`: C's `nonlinearSparseSolverMinSize` /
+    /// `nonlinearSparseSolverMaxDensity`, the rule that hands a system to kinsol+KLU.
+    pub nlss_min_size: Option<u32>,
+    pub nlss_max_density: Option<f64>,
     /// Flags this runtime does not model, kept so a caller can report them.
     pub unknown: Vec<String>,
     /// The argv this was parsed from, so a host forwards the same bytes rather than
@@ -134,7 +160,10 @@ pub struct SimFlags {
 
 impl SimFlags {
     pub fn has_log(&self, stream: &str) -> bool {
-        self.log.iter().any(|s| s == stream || s == "LOG_ALL")
+        crate::omclog::STREAM_NAME
+            .iter()
+            .position(|n| *n == stream)
+            .is_some_and(|i| crate::omclog::mask_has(self.log_mask, i as crate::omclog::Stream))
     }
 
     /// `(-nls, -nlsLS, -ls, -lss)` as the wire codes the wasm-jit runtime's
@@ -234,10 +263,190 @@ pub fn supported(cap: Capabilities) -> Vec<(&'static str, Vec<&'static str>)> {
     menu
 }
 
+
+/// C's `FLAG_NAME` / `FLAG_TYPE` (`util/simulation_options.c`): every flag the C
+/// runtime knows, and whether it takes a value. A name outside it is C's
+/// `invalid command line option`; one inside it that [`parse`] does not handle is a
+/// flag this runtime cannot honour. Both are errors — ignoring either runs
+/// something the caller did not ask for.
+const C_FLAGS: &[(&str, bool)] = &[
+    ("abortSlowSimulation", false),
+    ("alarm", true),
+    ("clock", true),
+    ("cpu", false),
+    ("csvOstep", true),
+    ("cvodeNonlinearSolverIteration", true),
+    ("cvodeLinearMultistepMethod", true),
+    ("cx", true),
+    ("daeMode", false),
+    ("deltaXLinearize", true),
+    ("deltaXSolver", true),
+    ("embeddedServer", true),
+    ("embeddedServerPort", true),
+    ("mat_sync", true),
+    ("emit_protected", false),
+    ("eps", true),
+    ("f", true),
+    ("help", true),
+    ("homAdaptBend", true),
+    ("homBacktraceStrategy", true),
+    ("homHEps", true),
+    ("homMaxLambdaSteps", true),
+    ("homMaxNewtonSteps", true),
+    ("homMaxTries", true),
+    ("homNegStartDir", false),
+    ("homotopyOnFirstTry", false),
+    ("noHomotopyOnFirstTry", false),
+    ("homTauDecFac", true),
+    ("homTauDecFacPredictor", true),
+    ("homTauIncFac", true),
+    ("homTauIncThreshold", true),
+    ("homTauMax", true),
+    ("homTauMin", true),
+    ("homTauStart", true),
+    ("idaMaxErrorTestFails", true),
+    ("idaMaxNonLinIters", true),
+    ("idaMaxConvFails", true),
+    ("idaNonLinConvCoef", true),
+    ("idaLS", true),
+    ("idaScaling", false),
+    ("idaSensitivity", false),
+    ("ignoreHideResult", false),
+    ("iif", true),
+    ("iim", true),
+    ("iit", true),
+    ("ils", true),
+    ("initialStepSize", true),
+    ("csvInput", true),
+    ("stateFile", true),
+    ("inputPath", true),
+    ("ipopt_hesse", true),
+    ("ipopt_init", true),
+    ("ipopt_jac", true),
+    ("ipopt_max_iter", true),
+    ("ipopt_warm_start", true),
+    ("jacobian", true),
+    ("jacobianNominalFactor", true),
+    ("jacobianThreads", true),
+    ("l", true),
+    ("l_datarec", false),
+    ("logFormat", true),
+    ("ls", true),
+    ("ls_ipopt", true),
+    ("lss", true),
+    ("lssMaxDensity", true),
+    ("lssMinSize", true),
+    ("lv", true),
+    ("lvMaxWarn", true),
+    ("lv_time", true),
+    ("lv_system", true),
+    ("mbi", true),
+    ("mei", true),
+    ("maxIntegrationOrder", true),
+    ("maxStepSize", true),
+    ("measureTimePlotFormat", true),
+    ("moo", false),
+    ("moo_l2bn_p1_it", true),
+    ("moo_l2bn_p2_it", true),
+    ("moo_l2bn_p2_lvl", true),
+    ("newtonFTol", true),
+    ("newtonMaxSteps", true),
+    ("newtonMaxStepFactor", true),
+    ("newtonXTol", true),
+    ("newtonJacUpdates", true),
+    ("newton", true),
+    ("nls", true),
+    ("nlsInfo", false),
+    ("nlsLS", true),
+    ("nlssMaxDensity", true),
+    ("nlssMinSize", true),
+    ("nlsJacTestATol", true),
+    ("nlsJacTestRTol", true),
+    ("noemit", false),
+    ("noEquidistantTimeGrid", false),
+    ("noEquidistantOutputFrequency", true),
+    ("noEquidistantOutputTime", true),
+    ("noEventEmit", false),
+    ("noRestart", false),
+    ("noRootFinding", false),
+    ("noScaling", false),
+    ("noSuppressAlg", false),
+    ("optDebugJac", true),
+    ("optimizerNP", true),
+    ("optimizerTimeGrid", true),
+    ("output", true),
+    ("outputFormat", true),
+    ("outputPath", true),
+    ("override", true),
+    ("overrideFile", true),
+    ("port", true),
+    ("r", true),
+    ("reconcile", false),
+    ("reconcileBoundaryConditions", false),
+    ("reconcileState", false),
+    ("gbm", true),
+    ("gbctrl", true),
+    ("gbctrl_evnt_reinit", false),
+    ("gbctrl_filter", true),
+    ("gbctrl_fhr", false),
+    ("gberr", true),
+    ("gbint", true),
+    ("gbnls", true),
+    ("gbnls_internal_damping", true),
+    ("gbnls_internal_jackeep", true),
+    ("gbfm", true),
+    ("gbfctrl", true),
+    ("gbferr", true),
+    ("gbfint", true),
+    ("gbfnls", true),
+    ("gbratio", true),
+    ("rt", true),
+    ("s", true),
+    ("saveInitialGuess_system", true),
+    ("single", false),
+    ("steps", false),
+    ("startTime", true),
+    ("steadyState", false),
+    ("steadyStateTol", true),
+    ("stepSize", true),
+    ("stopAtSystem", true),
+    ("stopTime", true),
+    ("svdCount", true),
+    ("svdSigma", true),
+    ("sx", true),
+    ("tolerance", true),
+    ("keepHessian", true),
+    ("variableFilter", true),
+    ("w", false),
+    ("parmodNumThreads", true),
+    ("parmodScheduler", true),
+    ("parmodClustering", true),
+    ("parmodClustersPerLevel", true),
+    ("parmodExportTaskGraph", true),
+    ("parmodImportClustering", true),
+    ("parmodDumpStages", true),
+];
+
+/// C's `JACOBIAN_METHOD_NAME` (`simulation_options.c`).
+const JACOBIAN_METHODS: &[&str] = &[
+    "coloredNumerical",
+    "internalNumerical",
+    "coloredSymbolical",
+    "coloredSymbolicalAdjoint",
+    "numerical",
+    "symbolical",
+    "bicoloredSymbolical",
+];
+
+/// C flags deliberately let through. The wasm-jit codegen drops protected variables
+/// when it generates the module, so `emit_protected` has nothing to switch on — a
+/// real gap, but every library test passes it and erroring would say nothing new.
+const IGNORED_FLAGS: &[&str] = &["emit_protected"];
+
 /// Parse an argv slice (`argv[0]` is the program name and is skipped).
 /// `-flag=value` and `-flag value` are both accepted, as in the C runtime.
 /// An unrecognized *value* for a recognized flag is an error listing what is
-/// accepted; an unrecognized *flag* is collected into [`SimFlags::unknown`].
+/// accepted; so is a flag this runtime does not implement (see [`C_FLAGS`]).
 pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
     let mut f = SimFlags {
         argv: argv.iter().map(|a| a.as_ref().to_string()).collect(),
@@ -286,6 +495,43 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "output" => f.output_vars = split_top_level(&value(name)?),
+            "r" => f.result_file = Some(value(name)?),
+            "iif" => f.init_file = Some(value(name)?),
+            "noEquidistantTimeGrid" => f.no_equidistant_grid = true,
+            "noEquidistantOutputFrequency" => {
+                f.no_equidistant_freq = Some(
+                    value(name)?
+                        .parse::<u32>()
+                        .map_err(|_| "-noEquidistantOutputFrequency needs an integer".to_string())?,
+                )
+            }
+            "noEventEmit" => f.no_event_emit = true,
+            // Every value this runtime can serve is the colored numerical one, which
+            // is also C's `setJacobianMethod` fallback where only the sparsity
+            // pattern is available -- which is all the wasm-jit backend emits.
+            "jacobian" => {
+                let v = value(name)?;
+                if !JACOBIAN_METHODS.contains(&v.as_str()) {
+                    return Err(format!("Unknown value `{v}` for flag `-jacobian`"));
+                }
+            }
+            "nlssMinSize" => f.nlss_min_size = Some(int(name, &value(name)?)?.max(0) as u32),
+            "nlssMaxDensity" => f.nlss_max_density = Some(real(name, &value(name)?)?),
+            "maxStepSize" => f.max_step_size = Some(real(name, &value(name)?)?),
+            "noEquidistantOutputTime" => {
+                f.no_equidistant_time = Some(
+                    value(name)?
+                        .parse::<f64>()
+                        .map_err(|_| "-noEquidistantOutputTime needs a number".to_string())?,
+                )
+            }
+            // The only method this runtime has is C's default.
+            "iim" => {
+                let v = value(name)?;
+                if v != "symbolic" {
+                    return Err(format!("-iim={v}: this runtime only has the symbolic method"));
+                }
+            }
             "abortSlowSimulation" => f.abort_slow = true,
             "alarm" => {
                 let secs = value(name)?
@@ -319,10 +565,34 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "initialStepSize" => f.initial_step_size = Some(real(name, &value(name)?)?),
             "homotopyOnFirstTry" => f.homotopy_on_first_try = Some(true),
             "noHomotopyOnFirstTry" => f.homotopy_on_first_try = Some(false),
-            _ => f.unknown.push(arg.to_string()),
+            _ => {
+                let known = C_FLAGS.iter().find(|(n, _)| *n == name);
+                if known.is_some_and(|(_, takes_value)| *takes_value) && inline.is_none() {
+                    // Consume the separate value, so it is not read as a flag itself.
+                    i += 1;
+                }
+                match known {
+                    None => return Err(format!("invalid command line option: {arg}")),
+                    Some((n, _)) if !IGNORED_FLAGS.contains(n) => {
+                        f.unknown.push(arg.to_string());
+                        return Err(format!(
+                            "-{n}: this runtime does not implement the flag, so the run would \
+                             silently ignore it"
+                        ));
+                    }
+                    Some(_) => {}
+                }
+            }
         }
     }
+    f.log_mask = crate::omclog::mask_from_streams(&f.log)?;
     Ok(f)
+}
+
+/// C's `nonlinearSparseSolverMinSize` / `nonlinearSparseSolverMaxDensity`, with
+/// C's defaults (`simulation_options.h`) where the flags are absent.
+pub fn nlss_thresholds(f: &SimFlags) -> (u32, f64) {
+    (f.nlss_min_size.unwrap_or(1000), f.nlss_max_density.unwrap_or(0.1))
 }
 
 /// C's `parseVariableStr`: split on commas outside `[...]`, so `x[1,2]` stays one name.
@@ -472,6 +742,7 @@ mod store {
 }
 
 pub fn set_flags(f: SimFlags) {
+    crate::omclog::set_mask(f.log_mask);
     store::set(f);
 }
 
@@ -602,10 +873,29 @@ mod tests {
     }
 
     #[test]
-    fn unknown_flags_are_collected_not_rejected() {
-        let f = parse(&argv(&["-noEquidistantTimeGrid", "-lv=LOG_STATS"])).expect("parses");
-        assert_eq!(f.unknown, ["-noEquidistantTimeGrid"]);
+    fn unimplemented_and_invalid_flags_are_rejected() {
+        let e = parse(&argv(&["-noSuchFlag"])).expect_err("must reject");
+        assert!(e.contains("invalid command line option"), "{e}");
+        // `emit_protected` is the one C flag deliberately let through.
+        let f = parse(&argv(&["-emit_protected", "-lv=LOG_STATS"])).expect("parses");
         assert!(f.has_log("LOG_STATS"));
+    }
+
+    // The value of a rejected option must not be read as a flag of its own.
+    #[test]
+    fn the_no_equidistant_grid_family_parses() {
+        let f = parse(&argv(&["-noEquidistantTimeGrid", "-noEquidistantOutputFrequency=5"]))
+            .expect("parses");
+        assert!(f.no_equidistant_grid && f.no_equidistant_freq == Some(5));
+        let f = parse(&argv(&["-noEquidistantTimeGrid", "-noEquidistantOutputTime=0.5"]))
+            .expect("parses");
+        assert_eq!(f.no_equidistant_time, Some(0.5));
+    }
+
+    #[test]
+    fn a_rejected_options_value_is_not_read_as_a_flag() {
+        let e = parse(&argv(&["-csvInput", "in.csv"])).expect_err("must reject");
+        assert!(e.contains("csvInput"), "{e}");
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
@@ -87,6 +87,8 @@ unsafe extern "C" {
 pub enum Stop {
     /// `tout` reached.
     Reached,
+    /// One-step mode only: an internal step ended before `tout`.
+    Stepped,
     /// A root function changed sign at the returned `t` (< `tout`).
     Root,
     Failed(c_int),
@@ -310,6 +312,7 @@ pub type IdaJacFn = unsafe extern "C" fn(
 pub const IDA_TOO_MUCH_WORK: c_int = -1;
 
 const IDA_NORMAL: c_int = 1;
+const IDA_ONE_STEP: c_int = 2;
 const IDA_SUCCESS: c_int = 0;
 const IDA_TSTOP_RETURN: c_int = 1;
 const IDA_ROOT_RETURN: c_int = 2;
@@ -610,10 +613,13 @@ impl Ida {
     /// Integrate to `tout`, stopping early on a root. `t` is updated to where the
     /// integration actually stopped and `y()`/`yp()` hold the state there. No
     /// `IDASetStopTime`, as in `ida_solver.c`: IDA may step past `tout` internally
-    /// and interpolate back to it.
-    pub fn step(&mut self, t: &mut f64, tout: f64) -> Stop {
+    /// and interpolate back to it. `one_step` is `ida_solver.c`'s `idaSmode` under
+    /// `-noEquidistantTimeGrid`: return after each internal step.
+    pub fn step(&mut self, t: &mut f64, tout: f64, one_step: bool) -> Stop {
+        let mode = if one_step { IDA_ONE_STEP } else { IDA_NORMAL };
         unsafe {
-            match IDASolve(self.mem, tout, t, self.y, self.yp, IDA_NORMAL) {
+            match IDASolve(self.mem, tout, t, self.y, self.yp, mode) {
+                IDA_SUCCESS if one_step && *t < tout => Stop::Stepped,
                 IDA_SUCCESS | IDA_TSTOP_RETURN => Stop::Reached,
                 IDA_ROOT_RETURN => {
                     IDAGetRootInfo(self.mem, self.roots.as_mut_ptr());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -284,6 +284,19 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
             )
         },
     ))?;
+    // The runtime module's `-lv` log lines (the nonlinear solver's), onto the same
+    // stdout the model's `print` and the host driver's own lines use.
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_log",
+        |mut caller: wasmtime::Caller<'_, T>, ptr: u32, len: u32| {
+            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return };
+            let off = ptr as usize;
+            if let Some(b) = mem.data(&caller).get(off..off + len as usize) {
+                openmodelica_wasi::wasi::stdout_write(b);
+            }
+        },
+    ))?;
     wt(linker.func_wrap("env", "rt_host_now_ms", || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }))?;
     wt(linker.func_wrap("env", "rt_host_cancel", || -> i32 { metamodelica::cancel::check_cancel() as i32 }))?;
     wt(linker.func_wrap("env", "rt_host_init_done", || openmodelica_sim_meta::driver::signal_init_done()))?;
@@ -363,6 +376,22 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
                 let Some(memory) = env.data().clone() else { return 1 };
                 let view = memory.view(&env);
                 row_asserts(&|addr: u32, buf: &mut [u8]| view.read(addr as u64, buf).is_ok(), sim_data, warn)
+            },
+        ),
+    );
+    // See the wasmtime counterpart.
+    imports.define(
+        "env",
+        "rt_host_log",
+        Function::new_typed_with_env(
+            store,
+            &mem_env,
+            |env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, len: u32| {
+                let Some(memory) = env.data().clone() else { return };
+                let mut buf = vec![0u8; len as usize];
+                if memory.view(&env).read(ptr as u64, &mut buf).is_ok() {
+                    openmodelica_wasi::wasi::stdout_write(&buf);
+                }
             },
         ),
     );

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -48,10 +48,13 @@ pub struct SimModel {
     pub var_units: HashMap<String, String>,
     /// Driver-facing metadata shared with the in-wasm driver (passed to `sim_driver::drive`).
     pub meta: SimMeta,
-    /// Pre-rendered `LOG_STDOUT` lines announcing which linear and nonlinear systems
-    /// use a sparse solver (C's `initializeLinearSystems` / `initializeNonlinearSystems`
-    /// messages), prepended to the sim log. Empty when no system is sparse.
+    /// Pre-rendered `LOG_STDOUT` lines announcing which *linear* systems use a
+    /// sparse solver (C's `initializeLinearSystems`), prepended to the sim log.
     pub sparse_solver_log: String,
+    /// `(sysNum, equationIndex, size, nnz)` per nonlinear system, in C's array
+    /// order. The nonlinear half of that announcement is rendered per run instead,
+    /// because `-nlssMinSize`/`-nlssMaxDensity` move the threshold it reports.
+    pub nls_systems: Vec<(i32, i32, u32, u32)>,
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -812,6 +812,36 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         let (nls, nls_ls, ls, lss) = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
         wts(set.call(&mut store, nls, nls_ls, ls, lss))?;
     }
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, f64), ()>(&store, "rt_set_nlss_thresholds") {
+        let (min_size, max_density) = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::nlss_thresholds(f)
+        });
+        wts(set.call(&mut store, min_size, max_density))?;
+    }
+    let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_log_streams") {
+        wts(set.call(&mut store, log_mask as u32, (log_mask >> 32) as u32))?;
+    }
+    // See the wasmtime counterpart.
+    if openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS)
+        && let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32), ()>(&store, "rt_nls_set_names")
+    {
+        let free = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_free").ok();
+        wts(set.call(&mut store, u32::MAX, 0, 0))?;
+        for sys in &model.meta.nls_vars {
+            let mut blob = Vec::new();
+            for n in &sys.names {
+                blob.extend_from_slice(n.as_bytes());
+                blob.push(0);
+            }
+            let ptr = wts(rt_alloc.call(&mut store, blob.len() as u32))?;
+            wts(memory.view(&store).write(ptr as u64, &blob))?;
+            wts(set.call(&mut store, sys.eq_index, ptr, blob.len() as u32))?;
+            if let Some(f) = &free {
+                wts(f.call(&mut store, ptr))?;
+            }
+        }
+    }
     if let Ok(set) = rt_inst.exports.get_typed_function::<f64, ()>(&store, "rt_set_step_size") {
         wts(set.call(&mut store, model.meta.step_size()))?;
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -743,6 +743,39 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         let codes = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
         wts(set.call(&mut store, codes))?;
     }
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, f64), ()>(&mut store, "rt_set_nlss_thresholds") {
+        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::nlss_thresholds(f)
+        });
+        wts(set.call(&mut store, t))?;
+    }
+    // Same for `-lv`: the nonlinear solver logs from inside the module.
+    let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_log_streams") {
+        wts(set.call(&mut store, (log_mask as u32, (log_mask >> 32) as u32)))?;
+    }
+    // `-lv=LOG_NLS` names the iteration variables, which only the metadata has. The
+    // roster is per model, so it is cleared first and pushed only when the stream is
+    // on: an ordinary run carries no names.
+    if openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS)
+        && let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32), ()>(&mut store, "rt_nls_set_names")
+    {
+        let free = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free").ok();
+        wts(set.call(&mut store, (u32::MAX, 0, 0)))?;
+        for sys in &model.meta.nls_vars {
+            let mut blob = Vec::new();
+            for n in &sys.names {
+                blob.extend_from_slice(n.as_bytes());
+                blob.push(0);
+            }
+            let ptr = wts(rt_alloc.call(&mut store, blob.len() as u32))?;
+            wts(memory.write(&mut store, ptr as usize, &blob))?;
+            wts(set.call(&mut store, (sys.eq_index, ptr, blob.len() as u32)))?;
+            if let Some(f) = &free {
+                wts(f.call(&mut store, ptr))?;
+            }
+        }
+    }
     // The driver that owns the `SimMeta` stays on the host in this build.
     if let Ok(set) = rt_inst.get_typed_func::<f64, ()>(&mut store, "rt_set_step_size") {
         wts(set.call(&mut store, model.meta.step_size()))?;


### PR DESCRIPTION
The port formatted log lines with a stateless per-line prefix. C's `messageText` is stateful: a stream carries an indentation level that `indentNext` raises and `messageClose` lowers, the stream/type columns collapse to `|` when the previous line came from the same stream at a level above zero, and an embedded newline recurses as a `subline` with both columns `|` and no level indent — so a multi-line message is not the same as N single-line ones.

`openmodelica_sim_meta::omclog` is that machine, together with C's `OMC_LOG_STREAM_NAME` table, its `debugVectorDouble`/`debugDouble` helpers and the `%16.8g` / `%18.10e` conversions. `-lv` is resolved at parse time by `setGlobalVerboseLevel`'s rules — `LOG_ALL`, the `-LOG_X` disable form and the twelve "print X if Y is active" implications — into a `u64` mask, so `-lv=LOG_NLS_V` now implies `LOG_NLS` and an unknown stream name is C's fatal
`unrecognized option -lv`.

`rt_solve_nls` runs inside wasm whichever driver owns the run, so the mask is pushed in through `rt_set_log_streams` and the lines come back out through `env.rt_host_log` onto the stdout the driver and the model's `print` already share. The iteration variables are named from `NONLINEARSYSTEM` crefs, which is the same list `SerializeModelInfo` writes to the `_info.json` `defines` array C reads them from; they ride in `SimMeta` and are pushed into the runtime only when the stream is on.

`LOG_NLS` itself is the three initialize/update/free lines and, per solve, C's `Solve nonlinear system N at time t` header, `printNonLinearInitialInfo` and `printNonLinearFinishInfo`, with C's per-system cumulative counters (`numberOfFEval` is counted in `wrapper_fvec`, which the FD Jacobian does not go through). Verified byte-for-byte against the C runtime on `nonlinearSolverTests.bug_2841`.

## Unknown simflags are now an error

C's `_omc_ScanCommandLineArguments` warns `invalid command line option` and returns 1, which makes the simulation executable exit before the run; the port collected them and simulated anyway. `C_FLAGS` mirrors C's `FLAG_NAME`/`FLAG_TYPE`, so a name C does not know is C's error and a name it does know that this runtime cannot honour is one too — ignoring either runs something the caller did not ask for.

That turned up eight flags worth implementing rather than rejecting:

- `-r=<file>`.
- `-iif=<file>` — `importStartValues`, with `-override` winning as in ticket #15807.
- `-noEquidistantTimeGrid` with its `-noEquidistantOutputFrequency` and `-noEquidistantOutputTime` companions: DASKR with `INFO(3)=1` and IDA with `IDA_ONE_STEP`, one row per returned step, `dassl.c`'s `dasslSteps`.
- `-maxStepSize`.
- `-noEventEmit` — the left-limit row unconditionally, the post-event row unless the grid puts an output point on it, and C's terminal row.
- `-nlssMinSize` / `-nlssMaxDensity`, which the port could not honour at all because it decided C's kinsol+KLU rule at codegen. `solvers::nls_use_sparse` decides it in the runtime now, and the "Using sparse solver kinsol" block moved with it, since the thresholds it quotes are the ones the flags move.

`-jacobian=<method>` is accepted and only an unknown value rejected: every value this runtime can serve is the colored numerical one, which is what C's `setJacobianMethod` falls back to where only the sparsity pattern is available, and that is all the wasm-jit backend emits.

## C's terminal step

Chasing the row counts that exposed also gave C's terminal step, which the port had folded into its last grid row: `finishSimulation` raises `simulationInfo->terminal` at the stop time, runs `updateDiscreteSystem` and emits one more row at the same time value. `emit_row` is an ordinary row again, `emit_terminal_row` is the extra one, and `n_output_rows` for a zero-length run is 1 — the second of its two rows had been standing in for exactly this. C's first `-noEquidistantTimeGrid` iteration is a zero-length step, because `lastdesiredStep` starts an output interval ahead, and emits a second row at the start time; every driver primes that the same way. Row counts and times now match C's in either mode.

## Over #16168

`SimMeta`'s wire version goes to 7 for `nls_vars` next to `sens_params`, `-maxIntegrationOrder` is master's `max_order` (mine was a duplicate), and CVODE keeps the equidistant grid since it has no one-step mode.

| suite | before | after |
| --- | --- | --- |
| `modelica/nonlinear_system` | 5/50 | 5/50 |
| `modelica/events` | 12/33 | 12/33 |
| `modelica/tearing` | 5/107 | 5/107 |
| `modelica/solver` | 32/41 | 32/41 |
| `modelica/start_value_selection` | 5/9 | 5/9 |
| `modelica/initialization` | 37/90 | **35/90** |
| `libraries/msl32` `Modelica.Fluid.*` | 7/22 | 7/22 | | `cruntime/simoptions` | 9/9 | **3/9** |
| `cruntime/sensitivities` | 0/4 | 0/4 |

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
