### PR TITLE
wasm-jit: evaluate bound variable attributes

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5689,27 +5689,16 @@ mod standalone_tests {
 
         // The standalone runtime imports every driver entry point from `model`; the
         // emitter always exports them, so the stub must too or the merge leaves
-        // unresolved `model.*` imports.
-        let one_arg: &[&str] = &[
-            "functionParameters",
-            "functionInitStartValues",
-            "functionInitialEquations",
-            "functionODE",
-            "functionAlgebraics",
-            "callExternalObjectDestructors",
-            "initSample",
-            "functionZeroCrossings",
-            "functionStateSetJacobians",
-            "functionInitialEquations_lambda0",
-            "functionUpdateRelations",
-            "functionCheckAsserts",
-            "functionStoreDelayed",
-            "functionInitDelay",
-            "functionUpdateBoundParameters",
-        ];
+        // unresolved `model.*` imports. Taken from the canonical list rather than
+        // copied, so adding an entry point cannot leave this stub behind.
+        let one_arg: Vec<&str> = openmodelica_sim_meta::driver::MODEL_FNS
+            .iter()
+            .copied()
+            .filter(|n| *n != "simulate")
+            .collect();
 
         let mut funcs = we::FunctionSection::new();
-        for _ in one_arg {
+        for _ in &one_arg {
             funcs.function(1); // (i32)->()
         }
         funcs.function(2); // om_meta_ptr
@@ -5729,7 +5718,7 @@ mod standalone_tests {
         m.section(&exports);
 
         let mut code = we::CodeSection::new();
-        for _ in one_arg {
+        for _ in &one_arg {
             let mut f = we::Function::new([]);
             f.instruction(&I::End);
             code.function(&f);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -55,7 +55,7 @@ use openmodelica_simcode_types::SimCodeFunction;
 use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
-    ArrayGroup, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
+    ArrayGroup, Attr, AttrTargets, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     NlsResidual, emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
@@ -2692,8 +2692,22 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // shared-table job and thread the map through `var_map`. The systems' own
     // `residual`/`load` callbacks are emitted after the equation functions.
     let nls_nominal_map = build_nls_nominal_map(vars);
-    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) =
-        collect_nls_jobs(&[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs], &nls_nominal_map);
+    let mut attr_targets: HashMap<String, AttrTargets> = HashMap::new();
+    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) = collect_nls_jobs(
+        &[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs],
+        &nls_nominal_map,
+        &mut attr_targets,
+    );
+    // The integrator's per-state atol and the Jacobian's FD step floor.
+    let state_nominals: Vec<f64> = lst(&vars.stateVars)
+        .take(n_states as usize)
+        .map(|sv| const_value(&sv.nominalValue).unwrap_or(1.0).abs().max(1e-32))
+        .collect();
+    for (i, sv) in lst(&vars.stateVars).take(n_states as usize).enumerate() {
+        if let Ok(k) = sim_cref_key(&sv.name) {
+            attr_targets.entry(k).or_default().state = Some(i as u32);
+        }
+    }
     // Register the analytic-Jacobian seed/result crefs before the equation
     // functions are lowered, so the column equations resolve their slots.
     let nls_jac_infos = build_nls_jac_infos(&nls_systems, &layout, &mut var_map)?;
@@ -2846,10 +2860,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let model_name = openmodelica_frontend_dump::AbsynUtil::pathString(mi.name.clone(), arcstr::literal!("."), true, false)?.to_string();
     // Solver metadata, shared by the embedded blob and the host `SimModel`.
     let jac_a = build_jac_a_info(sim_code, n_states);
-    let state_nominals: Vec<f64> = lst(&vars.stateVars)
-        .take(n_states as usize)
-        .map(|sv| const_value(&sv.nominalValue).unwrap_or(1.0).abs().max(1e-32))
-        .collect();
     // Build the driver metadata once: embedded in the module (for the in-wasm
     // driver / standalone) and kept on the `SimModel` (for the host driver).
     // Only the FMU export needs the vr table; a plain simulation would just carry
@@ -2867,7 +2877,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         })
         .collect::<Result<Vec<_>>>()?;
     let meta = build_sim_meta(
-        &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets, &state_nominals,
+        &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
@@ -3050,6 +3060,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         bodies.push(build_eq_fn("updateBoundParameters", param_eqs_dep, &var_map, &eq_index, &by_name, &mut literals)?);
         idx
     };
+    let update_bound_attrs_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(build_update_bound_attrs_fn(
+            sim_code, &state_nominals, &attr_targets, &layout, &var_map, &by_name, &mut literals,
+        )?);
+        idx
+    };
 
     // --- Function section (type index per body, in body order). ---
     let mut functions = we::FunctionSection::new();
@@ -3088,6 +3105,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
+    functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
 
     // --- Shared literals, closure thunks and the module `start`. Both come after
     // every other body — their indices are only known here. ---
@@ -3177,6 +3195,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionStoreDelayed", we::ExportKind::Func, store_delayed_idx);
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
+    exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
 
     // --- Name section: without it a trap backtrace is bare function indices. The
     // unnamed remainder is the NLS callbacks, the closure thunks and `start`. ---
@@ -3215,6 +3234,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("functionStoreDelayed", store_delayed_idx),
         ("functionInitDelay", init_delay_idx),
         ("functionUpdateBoundParameters", update_bound_params_idx),
+        ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
     ] {
         names.push((idx, name.to_string()));
     }
@@ -3304,7 +3324,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         tolerance: settings.tolerance.into_inner(),
         state_sets,
         jac_a,
-        state_nominals,
         editable_params,
         var_units,
         meta,
@@ -3704,7 +3723,6 @@ fn build_sim_meta(
     prefix: &str,
     jac_a: Option<JacAInfo>,
     state_sets: &[StateSetInfo],
-    state_nominals: &[f64],
     fmi_vrs: Vec<FmiVr>,
     zc_desc: Vec<String>,
     sens_params: Vec<u32>,
@@ -3723,7 +3741,6 @@ fn build_sim_meta(
         vars: result_vars.to_vec(),
         jac_a,
         state_sets: state_sets.to_vec(),
-        state_nominals: state_nominals.to_vec(),
         fmi_vrs,
         zc_desc,
         sens_params,
@@ -4004,6 +4021,69 @@ fn build_init_start_values_fn(
         pairs.push((sv.initialValue.clone(), REAL_OFF + (2 * layout.n_states + j as u32) * 8, None));
     }
     ctx.emit_init_start_values(&pairs)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionUpdateBoundVariableAttributes(SimData*)`. An attribute bound to a
+/// parameter is not a constant, so the backend hands it over as an equation; only
+/// here, after `functionParameters`, does it have a value. Attributes nothing reads
+/// back are skipped.
+fn build_update_bound_attrs_fn(
+    sim_code: &SimCode::SimCode,
+    state_nominals: &[f64],
+    attr_targets: &HashMap<String, AttrTargets>,
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets)> = Vec::new();
+    for (attr, eqs) in [
+        (Attr::Min, &sim_code.minValueEquations),
+        (Attr::Max, &sim_code.maxValueEquations),
+        (Attr::Nominal, &sim_code.nominalValueEquations),
+    ] {
+        for eq in lst(eqs) {
+            let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { continue };
+            let Some(t) = sim_cref_key(cref).ok().and_then(|k| attr_targets.get(&k)) else { continue };
+            if t.nls.is_empty() && !matches!((attr, t.state), (Attr::Nominal, Some(_))) {
+                continue;
+            }
+            attrs.push((attr, exp.clone(), t.clone()));
+        }
+    }
+    let sim = SimCtx {
+        data_local: 0,
+        vars: var_map.vars.clone(),
+        starts: var_map.starts.clone(),
+        start_slots: var_map.start_slots.clone(),
+        array_groups: var_map.array_groups.clone(),
+        terminate_off: var_map.terminate_off,
+        terminal_off: var_map.terminal_off,
+        term_info_off: var_map.term_info_off,
+        nls_fail_off: var_map.nls_fail_off,
+        nls_jobs: var_map.nls_jobs.clone(),
+        sample_map: var_map.sample_map.clone(),
+        sample_active_off: var_map.sample_active_off,
+        relations_off: var_map.relations_off,
+        rel_fresh_off: var_map.rel_fresh_off,
+        stored_rel_off: var_map.stored_rel_off,
+        relations_pre_off: var_map.relations_pre_off,
+        n_relations: var_map.n_relations,
+        mathevents_off: var_map.mathevents_off,
+        n_mathevents: var_map.n_mathevents,
+        lambda_off: var_map.lambda_off,
+        zctol_off: var_map.zctol_off,
+        zc_pre_off: var_map.zc_pre_off,
+        zc_context: false,
+    };
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    ctx.emit_update_bound_attrs(state_nominals, layout.state_nom_off, &attrs)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -4538,6 +4618,7 @@ fn nls_parts(
 fn collect_nls_jobs(
     eq_lists: &[&[Arc<SimCode::SimEqSystem>]],
     nominal_of: &HashMap<String, (f64, f64, f64)>,
+    attr_targets: &mut HashMap<String, AttrTargets>,
 ) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<f64>, Vec<i32>) {
     use SimCode::SimEqSystem as E;
     let mut systems: Vec<Arc<SimCode::NonlinearSystem>> = Vec::new();
@@ -4590,10 +4671,14 @@ fn collect_nls_jobs(
                 hist_off += crate::CodegenWasmJitFunctions::nls_hist_bytes(n);
                 nominal_off += 8 * n;
                 for cr in lst(&nlSystem.crefs) {
-                    let (nom, lo, hi) = sim_cref_key(cr)
-                        .ok()
-                        .and_then(|k| nominal_of.get(&k).copied())
+                    let key = sim_cref_key(cr).ok();
+                    let (nom, lo, hi) = key
+                        .as_ref()
+                        .and_then(|k| nominal_of.get(k).copied())
                         .unwrap_or((1.0, f64::NEG_INFINITY, f64::INFINITY));
+                    if let Some(k) = key {
+                        attr_targets.entry(k).or_default().nls.push(nominals.len() as u32);
+                    }
                     nominals.push(nom);
                     bounds.push(lo);
                     bounds.push(hi);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1127,6 +1127,23 @@ pub(crate) const NLS_PAT_GLOBAL: u32 = 3;
 /// pair per iteration variable, which the solver constrains its restarts to.
 pub(crate) const NLS_BOUNDS_GLOBAL: u32 = 4;
 
+/// A variable attribute the solvers read back at run time.
+#[derive(Clone, Copy)]
+pub(crate) enum Attr {
+    Nominal,
+    Min,
+    Max,
+}
+
+/// Where one variable's attribute lands: its entry in each nonlinear system that
+/// iterates on it (indexing the nominal block, and the `min`/`max` pair at twice
+/// that in the bounds block), and its state slot.
+#[derive(Clone, Default)]
+pub(crate) struct AttrTargets {
+    pub(crate) nls: Vec<u32>,
+    pub(crate) state: Option<u32>,
+}
+
 /// The contiguous `SimData` slot range backing one scalarized array model
 /// variable. The backend lays an array's scalar elements out consecutively in
 /// row-major order; this records the start offset and shape so a whole-array
@@ -1311,6 +1328,70 @@ impl<'a> FnCtx<'a> {
                 let w = compile_exp(self, exp)?;
                 coerce(self, w, WTy::F64);
                 self.emit(we::Instruction::F64Store(mem_arg(off, 3)));
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit `functionUpdateBoundVariableAttributes`: the constant per-state
+    /// `nominal`, then each attribute equation, into the slots the solvers read
+    /// (C's `updateBoundVariableAttributes` + `updateStaticDataOfNonlinearSystems`).
+    pub(crate) fn emit_update_bound_attrs(
+        &mut self,
+        state_nominals: &[f64],
+        state_nom_off: u32,
+        attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets)],
+    ) -> Result<()> {
+        let data = self.sim()?.data_local;
+        for (i, nom) in state_nominals.iter().enumerate() {
+            self.emit(we::Instruction::LocalGet(data));
+            self.emit(we::Instruction::F64Const((*nom).into()));
+            self.emit(we::Instruction::F64Store(mem_arg(state_nom_off + i as u32 * 8, 3)));
+        }
+        if attrs.is_empty() {
+            return Ok(());
+        }
+        let (raw, val) = (self.alloc_temp(WTy::F64), self.alloc_temp(WTy::F64));
+        for (attr, exp, targets) in attrs {
+            let w = compile_exp(self, exp)?;
+            coerce(self, w, WTy::F64);
+            self.emit(we::Instruction::LocalSet(raw));
+            if let (Attr::Nominal, Some(i)) = (attr, targets.state) {
+                // C's `dassl.c`: `atol[i] = tol * fmax(fabs(nominal), 1e-32)`.
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::LocalGet(raw));
+                self.emit(we::Instruction::F64Abs);
+                self.emit(we::Instruction::F64Const(1e-32f64.into()));
+                self.emit(we::Instruction::F64Max);
+                self.emit(we::Instruction::F64Store(mem_arg(state_nom_off + i * 8, 3)));
+            }
+            if targets.nls.is_empty() {
+                continue;
+            }
+            self.emit(we::Instruction::LocalGet(raw));
+            match attr {
+                // A nonpositive nominal would collapse the x-scaling; 1 stands in.
+                Attr::Nominal => {
+                    self.emit(we::Instruction::F64Abs);
+                    self.emit(we::Instruction::LocalTee(val));
+                    self.emit(we::Instruction::F64Const(1.0f64.into()));
+                    self.emit(we::Instruction::LocalGet(val));
+                    self.emit(we::Instruction::F64Const(0.0f64.into()));
+                    self.emit(we::Instruction::F64Gt);
+                    self.emit(we::Instruction::Select);
+                }
+                Attr::Min | Attr::Max => {}
+            }
+            self.emit(we::Instruction::LocalSet(val));
+            let (global, stride, slot) = match attr {
+                Attr::Nominal => (NLS_NOMINAL_GLOBAL, 8, 0),
+                Attr::Min => (NLS_BOUNDS_GLOBAL, 16, 0),
+                Attr::Max => (NLS_BOUNDS_GLOBAL, 16, 8),
+            };
+            for idx in &targets.nls {
+                self.emit(we::Instruction::GlobalGet(global));
+                self.emit(we::Instruction::LocalGet(val));
+                self.emit(we::Instruction::F64Store(mem_arg(idx * stride + slot, 3)));
             }
         }
         Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -48,6 +48,7 @@ unsafe extern "C" {
     fn functionStoreDelayed(sim_data: u32);
     fn functionInitDelay(sim_data: u32);
     fn functionUpdateBoundParameters(sim_data: u32);
+    fn functionUpdateBoundVariableAttributes(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
@@ -103,6 +104,7 @@ impl SimEngine for StandaloneEngine {
                 "functionStoreDelayed" => functionStoreDelayed(arg),
                 "functionInitDelay" => functionInitDelay(arg),
                 "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
+                "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("wasm-jit standalone: unknown model function"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -48,6 +48,11 @@ unsafe extern "C" {
     fn functionStateSetJacobians(sim_data: u32);
     fn functionZeroCrossings(sim_data: u32);
     fn functionUpdateRelations(sim_data: u32);
+    fn functionCheckAsserts(sim_data: u32);
+    fn functionStoreDelayed(sim_data: u32);
+    fn functionInitDelay(sim_data: u32);
+    fn functionUpdateBoundParameters(sim_data: u32);
+    fn functionUpdateBoundVariableAttributes(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn om_meta_ptr() -> u32;
@@ -122,6 +127,11 @@ impl SimEngine for Engine {
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
                 "functionZeroCrossings" => functionZeroCrossings(arg),
                 "functionUpdateRelations" => functionUpdateRelations(arg),
+                "functionCheckAsserts" => functionCheckAsserts(arg),
+                "functionStoreDelayed" => functionStoreDelayed(arg),
+                "functionInitDelay" => functionInitDelay(arg),
+                "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
+                "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 _ => return Err("fmi3-me: unknown model function"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -204,6 +204,7 @@ pub const MODEL_FNS: &[&str] = &[
     "functionStoreDelayed",
     "functionInitDelay",
     "functionUpdateBoundParameters",
+    "functionUpdateBoundVariableAttributes",
 ];
 
 /// The per-run capabilities a backend must expose: read/write the instance's
@@ -1184,6 +1185,7 @@ fn seed_start_values(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -
     // Params first (a start expression may read one), then fill start slots, then
     // start overrides (replacing the just-computed start).
     apply_param_overrides(e, sim_data)?;
+    e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
     e.call1("functionInitStartValues", sim_data)?;
     apply_start_overrides(e, sim_data)?;
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
@@ -2420,21 +2422,22 @@ fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
     omclog::info(omclog::DASSL, false, "Finished DASSL step.");
 }
 
-/// Per-state DASSL tolerances as in `dassl.c`: rtol `tol`, atol `tol·nominal[i]`
-/// (`state_nominals` is already floored). Length ≥ 1 so daskr never sees an empty array.
-fn dassl_tolerances(tol: f64, state_nominals: &[f64], n_states: usize) -> (Vec<f64>, Vec<f64>) {
-    let n = n_states.max(1);
-    let rtol = vec![tol; n];
-    let atol = (0..n).map(|i| tol * state_nominals.get(i).copied().unwrap_or(1.0)).collect();
-    (rtol, atol)
+/// C's `realVarsData[i].attribute.nominal` for the states, floored at 1e-32 by
+/// `functionUpdateBoundVariableAttributes` and so only readable after
+/// initialization. Length ≥ 1 so daskr never sees an empty array.
+fn read_state_nominals(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<f64>> {
+    (0..layout.n_states.max(1))
+        .map(|i| if i < layout.n_states { read_f64(e, sim_data + layout.state_nom_off + i * 8) } else { Ok(1.0) })
+        .collect()
+}
+
+/// Per-state DASSL tolerances as in `dassl.c`: rtol `tol`, atol `tol·nominal[i]`.
+fn dassl_tolerances(tol: f64, nominals: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    (vec![tol; nominals.len()], nominals.iter().map(|n| tol * n).collect())
 }
 
 fn nominal_factor() -> f64 {
     crate::simflags::with_flags(|f| f.jacobian_nominal_factor).unwrap_or(1.0)
-}
-
-fn state_nominals(state_nominals: &[f64], n_states: usize) -> Vec<f64> {
-    (0..n_states.max(1)).map(|i| state_nominals.get(i).copied().unwrap_or(1.0)).collect()
 }
 
 /// Resumable DASSL (daskr) driver, event-free path. Owns the DASKR work arrays
@@ -2556,7 +2559,8 @@ impl DasslDriver {
         }
         // Per-state tolerances scaled by nominal, matching the C runtime
         // (`dassl.c`: INFO(2)=1, atol[i]=tol·max(|nominal_i|,1e-32)).
-        let (rtol, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
+        let nominals = read_state_nominals(e, sim_data, layout)?;
+        let (rtol, atol) = dassl_tolerances(tol, &nominals);
         if n_states > 0 {
             info[1] = 1; // INFO(2)=1: per-state (vector) rtol/atol
         }
@@ -2580,7 +2584,7 @@ impl DasslDriver {
             info,
             rtol,
             atol,
-            nominals: state_nominals(&model.state_nominals, n_states),
+            nominals,
             rwork,
             iwork,
             rpar: [0.0f64],
@@ -3179,7 +3183,7 @@ impl SolverCore {
     /// (`run_initialization`).
     ///
     /// [`read_states`]: SolverCore::read_states
-    fn new(model: &SimModel, sim_data: u32, t: f64, method: &str) -> Result<Self> {
+    fn new(e: &dyn SimEngine, model: &SimModel, sim_data: u32, t: f64, method: &str) -> Result<Self> {
         let layout = &model.layout;
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -3188,7 +3192,8 @@ impl SolverCore {
         let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
         // Per-state nominal-scaled tolerances (see `dassl_tolerances`); CVODE and
         // IDA take the same ones, as `cvode_solver_initial`/`ida_solver_initial` do.
-        let (rtol, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
+        let nominals = read_state_nominals(e, sim_data, layout)?;
+        let (rtol, atol) = dassl_tolerances(tol, &nominals);
         let _ = method;
         #[cfg(sundials)]
         let solver = match method {
@@ -3220,7 +3225,7 @@ impl SolverCore {
             nje: 0,
             state_events: 0,
             time_events: 0,
-            nominals: state_nominals(&model.state_nominals, n_states),
+            nominals,
             chatter_times: [0.0; CHATTER_LIMIT],
             chatter_idx: 0,
             chatter_consec: 0,
@@ -3692,7 +3697,7 @@ impl CsDriver {
         let layout = &model.layout;
         store_relations(e, sim_data, layout)?;
         let samp = Samples::load(e, sim_data, layout)?;
-        let mut core = SolverCore::new(model, sim_data, t, "dassl")?;
+        let mut core = SolverCore::new(&*e, model, sim_data, t, "dassl")?;
         let mut pivots = init_state_pivots(&model.state_sets);
         if core.n_states > 0 {
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
@@ -3946,7 +3951,7 @@ impl EventsDriver {
 
         let mut samp = Samples::load(e, sim_data, layout)?;
         let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-        let mut core = SolverCore::new(model, sim_data, start, method)?;
+        let mut core = SolverCore::new(&*e, model, sim_data, start, method)?;
         // A sample scheduled exactly at the start time fires before row 0.
         if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
             samp.fire(e, sim_data, start)?;
@@ -4351,7 +4356,8 @@ impl CvodeDriver {
         }
 
         let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
-        let (_, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
+        let nominals = read_state_nominals(e, sim_data, layout)?;
+        let (_, atol) = dassl_tolerances(tol, &nominals);
         let cv = if y.is_empty() {
             None
         } else {
@@ -4364,7 +4370,7 @@ impl CvodeDriver {
         Ok(CvodeDriver {
             sim_data,
             n_states,
-            nominals: state_nominals(&model.state_nominals, n_states),
+            nominals,
             states_base,
             ders_base: states_base + layout.n_states * 8,
             row: 1,
@@ -4979,7 +4985,8 @@ impl IdaDriver {
         }
 
         let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
-        let (_, atol) = dassl_tolerances(tol, &model.state_nominals, n_states);
+        let nominals = read_state_nominals(e, sim_data, layout)?;
+        let (_, atol) = dassl_tolerances(tol, &nominals);
         let ida = if y.is_empty() {
             None
         } else {
@@ -4989,7 +4996,7 @@ impl IdaDriver {
         Ok(IdaDriver {
             sim_data,
             n_states,
-            nominals: state_nominals(&model.state_nominals, n_states),
+            nominals,
             states_base,
             ders_base,
             row: 1,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -137,6 +137,9 @@ pub struct Layout {
     pub zctol_off: u32,
     /// Base of the overridable start-value region (one f64 per state).
     pub start_off: u32,
+    /// Base of the per-state `nominal` attribute (one f64 per state), written by
+    /// `functionUpdateBoundVariableAttributes` once the parameters are computed.
+    pub state_nom_off: u32,
     /// C's `simulationInfo->sensitivityMatrix`: `d(state)/d(parameter)`,
     /// parameter-major, written by the IDA driver from `IDAGetSens` and captured
     /// as a result row's last columns.
@@ -204,14 +207,15 @@ impl Layout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let zctol_off = mathevents_off + n_math_slots * 8;
         let start_off = zctol_off + 8;
-        let sens_off = start_off + n_states * 8;
+        let state_nom_off = start_off + n_states * 8;
+        let sens_off = state_nom_off + n_states * 8;
         let total = sens_off + n_sens * 8;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
-            mathevents_off, zctol_off, start_off, n_sens, sens_off, total,
+            mathevents_off, zctol_off, start_off, state_nom_off, n_sens, sens_off, total,
         }
     }
 
@@ -370,9 +374,6 @@ pub struct SimMeta {
     pub jac_a: Option<JacAInfo>,
     /// Dynamic state selection metadata (one per `$STATESET`); empty otherwise.
     pub state_sets: Vec<StateSetInfo>,
-    /// Per-state nominal magnitude `max(|nominal|, 1e-32)` for per-state atol;
-    /// `1.0` if absent. Empty ⇒ all-ones.
-    pub state_nominals: Vec<f64>,
     /// FMI value reference -> `SimData` slot, sorted by `vr`. Only filled for the
     /// FMU export; empty for a plain simulation.
     pub fmi_vrs: Vec<FmiVr>,
@@ -429,7 +430,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 7;
+const VERSION: u32 = 8;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -460,7 +461,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
-        l.n_sens, l.sens_off, l.total,
+        l.state_nom_off, l.n_sens, l.sens_off, l.total,
     ] {
         put_u32(o, v);
     }
@@ -527,10 +528,6 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_u32s(&mut o, &s.a_offs);
         put_u32s(&mut o, &s.seed_offs);
         put_u32s(&mut o, &s.result_offs);
-    }
-    put_u32(&mut o, m.state_nominals.len() as u32);
-    for &v in &m.state_nominals {
-        put_f64(&mut o, v);
     }
     put_u32(&mut o, m.fmi_vrs.len() as u32);
     for v in &m.fmi_vrs {
@@ -636,6 +633,7 @@ impl<'a> Reader<'a> {
             mathevents_off: self.u32()?,
             zctol_off: self.u32()?,
             start_off: self.u32()?,
+            state_nom_off: self.u32()?,
             n_sens: self.u32()?,
             sens_off: self.u32()?,
             total: self.u32()?,
@@ -703,11 +701,6 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             result_offs: r.u32s()?,
         });
     }
-    let nnom = r.u32()? as usize;
-    let mut state_nominals = Vec::with_capacity(nnom);
-    for _ in 0..nnom {
-        state_nominals.push(r.f64()?);
-    }
     let nvr = r.u32()? as usize;
     let mut fmi_vrs = Vec::with_capacity(nvr);
     for _ in 0..nvr {
@@ -738,7 +731,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
-        model_name, vars, jac_a, state_sets, state_nominals, fmi_vrs, zc_desc, sens_params,
+        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
         nls_vars,
     })
 }
@@ -783,7 +776,6 @@ mod tests {
                 seed_offs: vec![200, 208, 216],
                 result_offs: vec![224],
             }],
-            state_nominals: vec![1.0, 2.5],
             fmi_vrs: vec![
                 FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: false, start_off: 96, is_string: false },
                 FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true },

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -40,8 +40,6 @@ pub struct SimModel {
     pub state_sets: Vec<StateSetInfo>,
     /// ODE state Jacobian ∂f/∂x sparsity + coloring; `None` ⇒ daskr's numerical Jacobian.
     pub jac_a: Option<JacAInfo>,
-    /// Per-state nominal magnitude for the per-state atol; `1.0` if absent.
-    pub state_nominals: Vec<f64>,
     /// User-settable initial conditions (changeable parameters), for `-override`.
     pub editable_params: Vec<EditableParam>,
     /// Result-variable display name -> unit, for a host to label plotted signals.


### PR DESCRIPTION
A `nominal=` / `min=` / `max=` bound to a parameter is not a constant, so the backend hands it over as an attribute equation instead.  The wasm-jit codegen ignored those three SimCode lists and const-folded the attribute, silently making it 1.0 / +-inf: on bug_2841 the whole nonlinear x-scaling was 1 where C has 1e5 / 1e-5.

Emit `functionUpdateBoundVariableAttributes`, C's function of that name followed by its `updateStaticDataOfNonlinearSystems`.  It evaluates the equations after `functionParameters` and writes each value into the slots the solvers read: the NLS nominal/bounds block entries for that cref, and the state's `nominal`.

The per-state nominal therefore moves into SimData (`Layout::state_nom_off`), since the driver can only read it once initialization has run; `SimMeta::state_nominals` goes with it and the wire version becomes 8.

The FMI3 adapter was missing five of `MODEL_FNS`, and its `call1` errors on an unknown name, so `run_initialization` could not have completed there.  All five are added.

bug_2841's `-lv=LOG_NLS` stream now matches the C runtime's byte for byte apart from the one known extra residual evaluation per solve. RobotR3.fullRobot, whose axis{1,2,3}.gear.spring.phi_rel have a parameter nominal, goes from 4909 steps to 4332 against C's 4433.

nonlinear_system 5/50, initialization 35/90, tearing 5/107, events 12/33, solver 32/41, start_value_selection 5/9 and msl32 Modelica.Fluid.* 7/22 are unchanged; msl32 Modelica.{Mechanics,Fluid}.* fails the same 11 of 84 with and without the change.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
