### PR TITLE
wasm-jit: the result-file variable filter

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -69,8 +69,8 @@ use crate::CodegenWasmJitFunctions::{
 // historical host names.
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{
-    FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind, MetaVar as ResultVar, SimMeta,
-    StateSetInfo,
+    var_filter, FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind, MetaVar as ResultVar,
+    SimMeta, StateSetInfo,
 };
 
 // Engine selected at compile time; same module interface across all three
@@ -236,7 +236,7 @@ fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[Str
 /// Resolve a finished [`sim_driver::RunResult`] into per-signal value arrays
 /// (reusing the result-var metadata the `.mat` writer uses) and stash it for the
 /// host to read directly.
-fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
+fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]) {
     let n_reals = run.n_reals as usize;
     let n_rows = if n_reals == 0 { 0 } else { run.rows.len() / n_reals };
     let column = |col: usize, negate: bool| -> Vec<f64> {
@@ -261,7 +261,13 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
     let mut seen_cols = HashSet::new();
     let mut seen_param_offs = HashSet::new();
     let mut param_value_by_off: HashMap<u32, f64> = HashMap::new();
-    for v in &model.result_vars {
+    // Every signal is resolved (the editable parameters below read their values from
+    // here regardless of the filter); `keep` is applied to `series` at the end.
+    let mut series_keep: Vec<bool> = Vec::new();
+    for (v, &keep) in model.result_vars.iter().zip(keep) {
+        if !matches!(v.kind, ResultKind::Time) {
+            series_keep.push(keep);
+        }
         match &v.kind {
             ResultKind::Time => time = column(0, false),
             ResultKind::Column { col, negate } => {
@@ -298,7 +304,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
     // A start value shows the state's t0 value; a plain parameter shows its slot.
     let row0_by_name: HashMap<&str, f64> =
         series.iter().map(|s| (s.name.as_str(), s.values.first().copied().unwrap_or(0.0))).collect();
-    let params = model
+    let params: Vec<CapturedParam> = model
         .editable_params
         .iter()
         .map(|p| CapturedParam {
@@ -313,6 +319,8 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult) {
             enum_names: p.enum_names.clone(),
         })
         .collect();
+    let mut kept = series_keep.into_iter();
+    series.retain(|_| kept.next().unwrap_or(true));
     *last_sim().lock().unwrap_or_else(|e| e.into_inner()) = Some(CapturedSim {
         model_name: model.model_name.clone(),
         start_time: model.start_time,
@@ -598,6 +606,8 @@ const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     gbode: false,
     // Served by the driver's per-step deadline, so every engine has it.
     alarm: true,
+    // The `.mat` is written here, where a regex engine is available.
+    variable_filter: true,
 };
 
 /// The solver values a caller may offer for this build, so a menu built from it
@@ -607,17 +617,49 @@ pub fn solver_options() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 
 /// Parse `simflags` as an argv and install the result for this run. omc hands the
-/// flags over as one whitespace-separated string; `argv[0]` stands in for the
-/// program name a WASI command would see, so the same parser serves this path and a
-/// standalone `wasmtime model.wasm …` run.
+/// flags over as one string, which for every other target a shell splits into the
+/// executable's argv; `argv[0]` stands in for the program name a WASI command would
+/// see, so the same parser serves this path and a standalone `wasmtime model.wasm …`
+/// run.
 fn install_sim_flags(simflags: &str) -> std::result::Result<simflags::SimFlags, String> {
-    let argv: Vec<String> = core::iter::once("model".to_string())
-        .chain(simflags.split_whitespace().map(str::to_string))
-        .collect();
+    let argv: Vec<String> = core::iter::once("model".to_string()).chain(split_simflags(simflags)).collect();
     let f = simflags::parse(&argv)?;
     simflags::check(&f, CAPABILITIES)?;
     simflags::set_flags(f.clone());
     Ok(f)
+}
+
+/// Split `simflags` as the shell splits `CevalScriptBackend`'s `sim_call` for every
+/// other target: on whitespace outside quotes, `'…'`/`"…"` removed.
+fn split_simflags(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+    let mut started = false;
+    for c in s.chars() {
+        match (quote, c) {
+            (Some(q), c) if c == q => quote = None,
+            (Some(_), c) => cur.push(c),
+            (None, '\'' | '"') => {
+                quote = Some(c);
+                started = true;
+            }
+            (None, c) if c.is_whitespace() => {
+                if started {
+                    out.push(core::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            (None, c) => {
+                cur.push(c);
+                started = true;
+            }
+        }
+    }
+    if started {
+        out.push(cur);
+    }
+    out
 }
 
 /// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
@@ -752,11 +794,12 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         if log_stats {
             extra.push_str(&log_stats_block(&run.stats));
         }
-        capture_last_sim(&model, &run);
+        let keep = output_selection(&model);
+        capture_last_sim(&model, &run, &keep);
         if fmt == "mat" {
             // C's `-r=<file>` overrides the name the caller derived from the model.
             let out = flags.result_file.as_deref().unwrap_or(result_file);
-            write_mat4(&model, out, &run.rows, run.n_reals, &run.params)?;
+            write_mat4(&model, out, &run.rows, run.n_reals, &run.params, &keep)?;
         }
         Ok(())
     })();
@@ -882,9 +925,10 @@ mod session {
 
     /// Capture results for the `omc_sim_*` getters and write the `.mat`.
     fn finalize_and_capture(model: &SimModel, result_file: &str, run: &sim_driver::RunResult) -> Result<()> {
-        capture_last_sim(model, run);
+        let keep = output_selection(model);
+        capture_last_sim(model, run, &keep);
         if model.output_format == "mat" {
-            write_mat4(model, result_file, &run.rows, run.n_reals, &run.params)?;
+            write_mat4(model, result_file, &run.rows, run.n_reals, &run.params, &keep)?;
         }
         Ok(())
     }
@@ -1671,10 +1715,45 @@ fn cref_display(cr: &Arc<DAE::ComponentRef>) -> Result<String> {
     Ok(ComponentReferenceBasics::printComponentRefStr(cr.clone())?.to_string())
 }
 
-/// Whether a variable is emitted to the result file, matching the C runtime's
-/// default selection: drop protected variables and `annotation(HideResult=true)`.
+/// C's `shouldFilterOutput`: protected variables and `HideResult=true`, each
+/// switched back on by its own simflag.
+fn filter_bits(sv: &SimCodeVar::SimVar) -> u8 {
+    let mut f = 0;
+    if sv.isProtected {
+        f |= var_filter::PROTECTED;
+        if sv.isEncrypted {
+            f |= var_filter::ENCRYPTED;
+        }
+    }
+    if sv.hideResult == Some(true) {
+        f |= var_filter::HIDE_RESULT;
+    }
+    f
+}
+
+/// In the result file with no simflag asked for it — the `-override` reachable set.
 fn is_result_output(sv: &SimCodeVar::SimVar) -> bool {
-    !sv.isProtected && sv.hideResult != Some(true)
+    filter_bits(sv) == 0
+}
+
+/// Resolve `simulate(..., variableFilter=)` — C's `initializeOutputFilter`, which
+/// filters every name that does not match `^(<filter>)$`. C matches per run; the
+/// runtimes have no regex engine, so it is settled here into
+/// [`var_filter::FILTERED`], protected variables included (`-emit_protected`
+/// can reach them).
+fn apply_variable_filter(result_vars: &mut [ResultVar], filter: &str) {
+    if filter == ".*" || filter.is_empty() {
+        return;
+    }
+    let Ok(re) = openmodelica_util::System::Regex::new(&format!("^({filter})$")) else {
+        eprintln!("Failed to compile regular expression: {filter}. Defaulting to outputting all variables.");
+        return;
+    };
+    for v in result_vars.iter_mut() {
+        if !matches!(v.kind, ResultKind::Time) && !re.is_match(&v.name) {
+            v.filter |= var_filter::FILTERED;
+        }
+    }
 }
 
 /// Literal names of an enumeration type (through subtype/array wrappers), or
@@ -1751,21 +1830,6 @@ fn kind_from_slot(off: u32, wty: WTy, negate: bool, heap: bool, layout: &SimLayo
         return Some(ResultKind::Param { off, wty, negate });
     }
     None // string slots
-}
-
-/// Inverse of the `Column` assignment in [`kind_from_slot`]: the SimData byte
-/// offset a result-buffer column reads from.
-fn col_to_off(col: u32, layout: &SimLayout) -> u32 {
-    let nr = layout.n_reals_row();
-    if col < nr {
-        REAL_OFF + (col - 1) * 8
-    } else if col < nr + layout.n_int_alg() {
-        layout.int_off + (col - nr) * 4
-    } else if col < layout.sens_col0() {
-        layout.bool_off + (col - nr - layout.n_int_alg()) * 4
-    } else {
-        layout.sens_off + (col - layout.sens_col0()) * 8
-    }
 }
 
 /// Expand every whole-array `SimVar` (`--simCodeScalarize=false`) into its
@@ -1955,6 +2019,7 @@ fn push_sensitivity_vars(
             name: cref_display(&sv.name)?,
             comment: sv.comment.to_string(),
             kind: ResultKind::Column { col: layout.sens_col0() + i as u32, negate: false },
+            filter: filter_bits(sv),
         });
     }
     Ok(offs)
@@ -2019,31 +2084,27 @@ fn build_var_map(
         name: "time".to_string(),
         comment: "Simulation time [s]".to_string(),
         kind: ResultKind::Time,
+        filter: 0,
     });
 
     let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
     let ders: Vec<&SimCodeVar::SimVar> = lst(&vars.derivativeVars).collect();
 
-    // Protected/hidden primaries that were filtered out, kept as (name, comment,
-    // off, wty, heap) so they can be re-emitted at the end if a non-protected
-    // output ends up sharing their data slot (an alias-group member the C runtime
-    // keeps in the result).
-    let mut filtered: Vec<(String, String, u32, WTy, bool)> = Vec::new();
-
-    // Push a primary (non-alias) variable: always register its slot (equations
-    // reference even protected/internal vars), but only emit it as a result
-    // signal if it passes the C-compatible filter (else stash it in `filtered`).
+    // Push a primary (non-alias) variable: register its slot (equations reference
+    // even protected ones) and list it as a result signal carrying why a run would
+    // filter it — the overriding flags are not known here.
     let mut push_primary =
-        |map: &mut SimVarMap, result_vars: &mut Vec<ResultVar>, filtered: &mut Vec<(String, String, u32, WTy, bool)>,
+        |map: &mut SimVarMap, result_vars: &mut Vec<ResultVar>,
          sv: &SimCodeVar::SimVar, off: u32, wty: WTy, heap: bool, raw_name: String| -> Result<()> {
             insert_var(map, sv, off, wty, heap)?;
             if let Some(name) = result_name(&raw_name) {
-                if is_result_output(sv) {
-                    if let Some(kind) = kind_from_slot(off, wty, false, heap, layout) {
-                        result_vars.push(ResultVar { name, comment: sv.comment.to_string(), kind });
-                    }
-                } else {
-                    filtered.push((name, sv.comment.to_string(), off, wty, heap));
+                if let Some(kind) = kind_from_slot(off, wty, false, heap, layout) {
+                    result_vars.push(ResultVar {
+                        name,
+                        comment: sv.comment.to_string(),
+                        kind,
+                        filter: filter_bits(sv),
+                    });
                 }
             }
             Ok(())
@@ -2068,7 +2129,7 @@ fn build_var_map(
                 });
             }
         }
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, REAL_OFF + (i as u32) * 8, WTy::F64, false, name)?;
+        push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (i as u32) * 8, WTy::F64, false, name)?;
     }
     for (i, sv) in ders.iter().enumerate() {
         // der(x) is displayed as `der(<state name>)`.
@@ -2076,13 +2137,13 @@ fn build_var_map(
             Some(s) => format!("der({})", cref_display(&s.name)?),
             None => cref_display(&sv.name)?,
         };
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, REAL_OFF + (layout.n_states + i as u32) * 8, WTy::F64, false, name)?;
+        push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (layout.n_states + i as u32) * 8, WTy::F64, false, name)?;
     }
     let real_algs: Vec<&SimCodeVar::SimVar> =
         lst(&vars.algVars).chain(lst(&vars.discreteAlgVars)).collect();
     for (j, sv) in real_algs.iter().enumerate() {
         let name = cref_display(&sv.name)?;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, REAL_OFF + (2 * layout.n_states + j as u32) * 8, WTy::F64, false, name)?;
+        push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (2 * layout.n_states + j as u32) * 8, WTy::F64, false, name)?;
     }
 
     // Real / Integer / Boolean parameters -> data_1. Integer & Boolean algebraic
@@ -2091,27 +2152,27 @@ fn build_var_map(
     for (k, sv) in lst(&vars.paramVars).enumerate() {
         let name = cref_display(&sv.name)?;
         let off = layout.rparam_off + (k as u32) * 8;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, off, WTy::F64, false, name.clone())?;
+        push_primary(&mut map, &mut result_vars, sv, off, WTy::F64, false, name.clone())?;
         push_editable(sv, &name, off, WTy::F64);
     }
     for (i, sv) in lst(&vars.intAlgVars).enumerate() {
         let name = cref_display(&sv.name)?;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, layout.int_off + (i as u32) * 4, WTy::I32, false, name)?;
+        push_primary(&mut map, &mut result_vars, sv, layout.int_off + (i as u32) * 4, WTy::I32, false, name)?;
     }
     for (k, sv) in lst(&vars.intParamVars).enumerate() {
         let name = cref_display(&sv.name)?;
         let off = layout.iparam_off + (k as u32) * 4;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, off, WTy::I32, false, name.clone())?;
+        push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
         push_editable(sv, &name, off, WTy::I32);
     }
     for (i, sv) in lst(&vars.boolAlgVars).enumerate() {
         let name = cref_display(&sv.name)?;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, layout.bool_off + (i as u32) * 4, WTy::I32, false, name)?;
+        push_primary(&mut map, &mut result_vars, sv, layout.bool_off + (i as u32) * 4, WTy::I32, false, name)?;
     }
     for (k, sv) in lst(&vars.boolParamVars).enumerate() {
         let name = cref_display(&sv.name)?;
         let off = layout.bparam_off + (k as u32) * 4;
-        push_primary(&mut map, &mut result_vars, &mut filtered, sv, off, WTy::I32, false, name.clone())?;
+        push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
         push_editable(sv, &name, off, WTy::I32);
     }
     for (i, sv) in lst(&vars.stringAlgVars).enumerate() {
@@ -2135,10 +2196,13 @@ fn build_var_map(
     for sv in lst(&vars.constVars).chain(lst(&vars.intConstVars)).chain(lst(&vars.boolConstVars)) {
         let Some(value) = const_value(&sv.initialValue) else { continue };
         const_of.insert(sim_cref_key(&sv.name)?, value);
-        if is_result_output(sv) {
-            if let Some(name) = result_name(&cref_display(&sv.name)?) {
-                result_vars.push(ResultVar { name, comment: sv.comment.to_string(), kind: ResultKind::Const { value } });
-            }
+        if let Some(name) = result_name(&cref_display(&sv.name)?) {
+            result_vars.push(ResultVar {
+                name,
+                comment: sv.comment.to_string(),
+                kind: ResultKind::Const { value },
+                filter: filter_bits(sv),
+            });
         }
     }
 
@@ -2156,11 +2220,14 @@ fn build_var_map(
         let Some(tslot) = map.vars.get(&tkey).copied() else {
             // Target has no slot: it may be a compile-time constant.
             if let Some(&cval) = const_of.get(&tkey) {
-                if is_result_output(av) {
-                    if let Some(name) = result_name(&cref_display(&av.name)?) {
-                        let value = if negate { -cval } else { cval };
-                        result_vars.push(ResultVar { name, comment: av.comment.to_string(), kind: ResultKind::Const { value } });
-                    }
+                if let Some(name) = result_name(&cref_display(&av.name)?) {
+                    let value = if negate { -cval } else { cval };
+                    result_vars.push(ResultVar {
+                        name,
+                        comment: av.comment.to_string(),
+                        kind: ResultKind::Const { value },
+                        filter: filter_bits(av) | var_filter::ALIAS,
+                    });
                 }
             }
             continue;
@@ -2172,33 +2239,16 @@ fn build_var_map(
             heap: tslot.heap,
         };
         map.vars.insert(sim_cref_key(&av.name)?, slot);
-        if is_result_output(av) {
-            if let (Some(name), Some(kind)) = (
-                result_name(&cref_display(&av.name)?),
-                kind_from_slot(slot.off, slot.wty, slot.negate, slot.heap, layout),
-            ) {
-                result_vars.push(ResultVar { name, comment: av.comment.to_string(), kind });
-            }
-        }
-    }
-
-    // Re-emit a filtered (protected/hidden) variable if a non-protected output
-    // references its data slot — i.e. it is an alias-group member of an output
-    // variable, which the C runtime keeps in the result (e.g. a protected
-    // parameter aliased by a public connector variable).
-    let referenced: std::collections::HashSet<u32> = result_vars
-        .iter()
-        .filter_map(|v| match &v.kind {
-            ResultKind::Column { col, .. } => Some(col_to_off(*col, layout)),
-            ResultKind::Param { off, .. } => Some(*off),
-            _ => None,
-        })
-        .collect();
-    for (name, comment, off, wty, heap) in filtered {
-        if referenced.contains(&off) {
-            if let Some(kind) = kind_from_slot(off, wty, false, heap, layout) {
-                result_vars.push(ResultVar { name, comment, kind });
-            }
+        if let (Some(name), Some(kind)) = (
+            result_name(&cref_display(&av.name)?),
+            kind_from_slot(slot.off, slot.wty, slot.negate, slot.heap, layout),
+        ) {
+            result_vars.push(ResultVar {
+                name,
+                comment: av.comment.to_string(),
+                kind,
+                filter: filter_bits(av) | var_filter::ALIAS,
+            });
         }
     }
 
@@ -2857,6 +2907,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         .simulationSettingsOpt
         .as_ref()
         .ok_or_else(|| "CodegenWasmJit: model has no simulation settings")?;
+    apply_variable_filter(&mut result_vars, &settings.variableFilter);
     let model_name = openmodelica_frontend_dump::AbsynUtil::pathString(mi.name.clone(), arcstr::literal!("."), true, false)?.to_string();
     // Solver metadata, shared by the embedded blob and the host `SimModel`.
     let jac_a = build_jac_a_info(sim_code, n_states);
@@ -5629,12 +5680,29 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>
 /// serialization itself lives in `openmodelica_mat_writer` (`no_std` + `alloc`,
 /// shared with the standalone wasip1 runtime's `_start`); here we only map the
 /// result-var metadata onto its `MatVar`/`MatKind` and write the bytes out.
-fn write_mat4(model: &SimModel, path: &str, rows: &[f64], n_reals: u32, params: &[f64]) -> Result<()> {
+fn write_mat4(
+    model: &SimModel,
+    path: &str,
+    rows: &[f64],
+    n_reals: u32,
+    params: &[f64],
+    keep: &[bool],
+) -> Result<()> {
     use openmodelica_mat_writer::{MatKind, MatVar};
-    let vars: Vec<MatVar> = model
-        .result_vars
-        .iter()
-        .map(|v| MatVar {
+    // `params` is positional over the unfiltered `Param` signals.
+    let mut kept_params: Vec<f64> = Vec::new();
+    let mut param_idx = 0usize;
+    let mut vars: Vec<MatVar> = Vec::new();
+    for (v, &keep) in model.result_vars.iter().zip(keep) {
+        let is_param = matches!(v.kind, ResultKind::Param { .. });
+        if is_param && keep {
+            kept_params.push(params.get(param_idx).copied().unwrap_or(0.0));
+        }
+        param_idx += is_param as usize;
+        if !keep {
+            continue;
+        }
+        vars.push(MatVar {
             name: &v.name,
             comment: &v.comment,
             kind: match &v.kind {
@@ -5643,11 +5711,32 @@ fn write_mat4(model: &SimModel, path: &str, rows: &[f64], n_reals: u32, params: 
                 ResultKind::Param { negate, .. } => MatKind::Param { negate: *negate },
                 ResultKind::Const { value } => MatKind::Const { value: *value },
             },
-        })
-        .collect();
-    let bytes = openmodelica_mat_writer::write_mat4(&vars, model.start_time, model.stop_time, rows, n_reals, params);
+        });
+    }
+    let bytes =
+        openmodelica_mat_writer::write_mat4(&vars, model.start_time, model.stop_time, rows, n_reals, &kept_params);
     let _ = &model.model_name; // (kept for diagnostics)
     write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write")
+}
+
+/// Which result variables this run emits, one flag per [`SimModel::result_vars`]
+/// entry. An uncompilable `-variableFilter` is C's "Defaulting to outputting all
+/// variables": it has already replaced the model's filter, so nothing remains to
+/// fall back on.
+fn output_selection(model: &SimModel) -> Vec<bool> {
+    let Some(pattern) = simflags::with_flags(|f| f.variable_filter.clone()) else {
+        return model.meta.output_keep(None);
+    };
+    match openmodelica_util::System::Regex::new(&format!("^({pattern})$")) {
+        Ok(re) => model.meta.output_keep(Some(&|name: &str| re.is_match(name))),
+        Err(e) => {
+            eprintln!(
+                "Failed to compile regular expression: {pattern} with error: {e}. \
+                 Defaulting to outputting all variables."
+            );
+            model.meta.output_keep(Some(&|_: &str| true))
+        }
+    }
 }
 
 // The standalone-export merge uses `wasmtime::Module` to validate the result, so

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -181,8 +181,10 @@ fn session() -> &'static mut Option<Session> {
 pub extern "C" fn rt_sim_set_args(ptr: u32, len: u32) -> i32 {
     let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
     let argv = simflags::argv_from_bytes(bytes);
+    // The host writes the result file for a session run, so it serves `-variableFilter`.
     match simflags::parse(&argv).and_then(|f| {
-        simflags::check(&f, crate::sundials::capabilities()).map(|()| f)
+        let cap = simflags::Capabilities { variable_filter: true, ..crate::sundials::capabilities() };
+        simflags::check(&f, cap).map(|()| f)
     }) {
         Ok(f) => {
             crate::solvers::apply_flags(&f);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -155,10 +155,22 @@ fn run() {
         return; // "empty": run only (benchmarking), no file
     }
 
-    let matvars: Vec<MatVar> = m
-        .vars
-        .iter()
-        .map(|v| MatVar {
+    // A run-time `-variableFilter` was refused at the flag check (no regex engine);
+    // the model's own filter is the codegen's verdict.
+    let keep = m.output_keep(None);
+    let mut params: Vec<f64> = Vec::new();
+    let mut param_idx = 0usize;
+    let mut matvars: Vec<MatVar> = Vec::new();
+    for (v, &keep) in m.vars.iter().zip(&keep) {
+        let is_param = matches!(v.kind, MetaKind::Param { .. });
+        if is_param && keep {
+            params.push(result.params.get(param_idx).copied().unwrap_or(0.0));
+        }
+        param_idx += is_param as usize;
+        if !keep {
+            continue;
+        }
+        matvars.push(MatVar {
             name: &v.name,
             comment: &v.comment,
             kind: match &v.kind {
@@ -167,8 +179,8 @@ fn run() {
                 MetaKind::Param { negate, .. } => MatKind::Param { negate: *negate },
                 MetaKind::Const { value } => MatKind::Const { value: *value },
             },
-        })
-        .collect();
+        });
+    }
 
     let bytes = openmodelica_mat_writer::write_mat4(
         &matvars,
@@ -176,7 +188,7 @@ fn run() {
         m.stop_time,
         &result.rows,
         result.n_reals,
-        &result.params,
+        &params,
     );
     std::fs::write(format!("{}_res.mat", m.prefix), bytes).expect("wasm-jit standalone: cannot write result file");
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -20,6 +20,8 @@ pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
         gbode: false,
         // Served by the driver's per-step deadline; both runtimes install a clock.
         alarm: true,
+        // No regex engine in wasm; the model's own filter is resolved at codegen.
+        variable_filter: false,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "libm",
  "minpack",
  "nalgebra",
+ "openmodelica_sim_meta",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -286,6 +286,26 @@ pub struct MetaVar {
     pub name: String,
     pub comment: String,
     pub kind: MetaKind,
+    /// C's `filterOutput`, split into its reasons ([`var_filter`]).
+    pub filter: u8,
+}
+
+/// [`MetaVar::filter`] bits: what keeps a variable out of the result file, and
+/// which flag lets it back in (C's `shouldFilterOutput` +
+/// `initializeOutputFilter`).
+pub mod var_filter {
+    /// `protected` variable; `-emit_protected` emits it.
+    pub const PROTECTED: u8 = 1;
+    /// `annotation(HideResult=true)`; `-ignoreHideResult` emits it.
+    pub const HIDE_RESULT: u8 = 2;
+    /// The model's `variableFilter` did not match the name; `-variableFilter`
+    /// replaces that decision.
+    pub const FILTERED: u8 = 4;
+    /// An alias reading another variable's slot. Not a filter reason: it gives C's
+    /// un-filter rule its direction (an emitted alias keeps its base variable).
+    pub const ALIAS: u8 = 8;
+    /// Protected and encrypted, which `-emit_protected` does not reach.
+    pub const ENCRYPTED: u8 = 16;
 }
 
 /// ODE state-Jacobian ∂f/∂x ("A") sparsity + coloring for the colored-FD path.
@@ -410,6 +430,57 @@ impl SimMeta {
         }
     }
 
+    /// Which of [`vars`](Self::vars) the result file holds, in order: C's
+    /// `filterOutput` as the file is opened.
+    ///
+    /// `matcher` is a compiled `-variableFilter` (wrapped in C's `^(…)$`) and
+    /// *replaces* [`var_filter::FILTERED`]; `None` keeps it.
+    pub fn output_keep(&self, matcher: Option<&dyn Fn(&str) -> bool>) -> Vec<bool> {
+        let (emit_protected, ignore_hide) =
+            crate::simflags::with_flags(|f| (f.emit_protected, f.ignore_hide_result));
+        let mut keep: Vec<bool> = self
+            .vars
+            .iter()
+            .map(|v| {
+                if matches!(v.kind, MetaKind::Time) {
+                    return true; // never filtered
+                }
+                if v.filter & var_filter::PROTECTED != 0
+                    && !(emit_protected && v.filter & var_filter::ENCRYPTED == 0)
+                {
+                    return false;
+                }
+                if v.filter & var_filter::HIDE_RESULT != 0 && !ignore_hide {
+                    return false;
+                }
+                match matcher {
+                    Some(m) => m(&v.name),
+                    None => v.filter & var_filter::FILTERED == 0,
+                }
+            })
+            .collect();
+        // `Const` has no slot to share.
+        let slot_of = |v: &MetaVar| match v.kind {
+            MetaKind::Column { col, .. } => Some((0u8, col)),
+            MetaKind::Param { off, .. } => Some((1u8, off)),
+            _ => None,
+        };
+        let mut needed = alloc::collections::BTreeSet::new();
+        for (i, v) in self.vars.iter().enumerate() {
+            if keep[i] && v.filter & var_filter::ALIAS != 0 {
+                needed.extend(slot_of(v));
+            }
+        }
+        if !needed.is_empty() {
+            for (i, v) in self.vars.iter().enumerate() {
+                if !keep[i] && v.filter & var_filter::ALIAS == 0 {
+                    keep[i] = slot_of(v).is_some_and(|s| needed.contains(&s));
+                }
+            }
+        }
+        keep
+    }
+
     /// C's `simulationInfo->stepSize`: the output interval `SimCodeMain` writes into
     /// the init XML, or the `-stepSize` override. Solver policy reads it too (the NLS
     /// initial-guess window, the chattering limit), so it is not only the grid.
@@ -508,6 +579,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_str(&mut o, &v.name);
         put_str(&mut o, &v.comment);
         put_kind(&mut o, &v.kind);
+        o.push(v.filter);
     }
     match &m.jac_a {
         None => o.push(0),
@@ -681,7 +753,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let nvars = r.u32()? as usize;
     let mut vars = Vec::with_capacity(nvars);
     for _ in 0..nvars {
-        vars.push(MetaVar { name: r.string()?, comment: r.string()?, kind: r.kind()? });
+        vars.push(MetaVar { name: r.string()?, comment: r.string()?, kind: r.kind()?, filter: r.u8()? });
     }
     let jac_a = match r.u8()? {
         0 => None,
@@ -754,12 +826,12 @@ mod tests {
             prefix: "MyModel".to_string(),
             model_name: "MyModel".to_string(),
             vars: vec![
-                MetaVar { name: "time".to_string(), comment: "Time in s".to_string(), kind: MetaKind::Time },
-                MetaVar { name: "x".to_string(), comment: "".to_string(), kind: MetaKind::Column { col: 1, negate: false } },
-                MetaVar { name: "y".to_string(), comment: "neg alias".to_string(), kind: MetaKind::Column { col: 1, negate: true } },
-                MetaVar { name: "p".to_string(), comment: "a param".to_string(), kind: MetaKind::Param { off: 88, wty: WTy::F64, negate: false } },
-                MetaVar { name: "n".to_string(), comment: "".to_string(), kind: MetaKind::Param { off: 92, wty: WTy::I32, negate: false } },
-                MetaVar { name: "k".to_string(), comment: "".to_string(), kind: MetaKind::Const { value: 9.5 } },
+                MetaVar { name: "time".to_string(), comment: "Time in s".to_string(), kind: MetaKind::Time, filter: 0 },
+                MetaVar { name: "x".to_string(), comment: "".to_string(), kind: MetaKind::Column { col: 1, negate: false }, filter: var_filter::PROTECTED },
+                MetaVar { name: "y".to_string(), comment: "neg alias".to_string(), kind: MetaKind::Column { col: 1, negate: true }, filter: var_filter::ALIAS },
+                MetaVar { name: "p".to_string(), comment: "a param".to_string(), kind: MetaKind::Param { off: 88, wty: WTy::F64, negate: false }, filter: 0 },
+                MetaVar { name: "n".to_string(), comment: "".to_string(), kind: MetaKind::Param { off: 92, wty: WTy::I32, negate: false }, filter: var_filter::HIDE_RESULT },
+                MetaVar { name: "k".to_string(), comment: "".to_string(), kind: MetaKind::Const { value: 9.5 }, filter: var_filter::FILTERED },
             ],
             jac_a: Some(JacAInfo {
                 n: 2,
@@ -808,6 +880,28 @@ mod tests {
         assert_eq!(l.n_sens, 2);
         assert_eq!(l.n_row_total(), 6 + 1 + 1 + 2);
         assert_eq!(l.sens_col0(), 6 + 1 + 1);
+    }
+
+    /// The sample's `x` is protected and its alias `y` is not, so `x` rides along.
+    #[test]
+    fn output_keep_follows_the_flags() {
+        let m = sample();
+        let names = |keep: Vec<bool>| -> Vec<&str> {
+            m.vars.iter().zip(keep).filter(|(_, k)| *k).map(|(v, _)| v.name.as_str()).collect()
+        };
+        simflags::set_flags(simflags::SimFlags::default());
+        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p"]);
+
+        let mut f = simflags::SimFlags { ignore_hide_result: true, ..Default::default() };
+        simflags::set_flags(f.clone());
+        assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p", "n"]);
+
+        // A `-variableFilter` replaces the model's verdict, so `k` is reachable;
+        // `time` is never filtered.
+        f.ignore_hide_result = false;
+        simflags::set_flags(f);
+        let only_k = |n: &str| n == "k";
+        assert_eq!(names(m.output_keep(Some(&only_k))), ["time", "k"]);
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -151,6 +151,13 @@ pub struct SimFlags {
     /// `nonlinearSparseSolverMaxDensity`, the rule that hands a system to kinsol+KLU.
     pub nlss_min_size: Option<u32>,
     pub nlss_max_density: Option<f64>,
+    /// `-emit_protected`: keep `protected` variables in the result file.
+    pub emit_protected: bool,
+    /// `-ignoreHideResult`: keep `annotation(HideResult=true)` variables too.
+    pub ignore_hide_result: bool,
+    /// `-variableFilter=<regex>`: replaces the model's own filter. The caller
+    /// compiles it — this crate is `no_std` and has no engine.
+    pub variable_filter: Option<String>,
     /// Flags this runtime does not model, kept so a caller can report them.
     pub unknown: Vec<String>,
     /// The argv this was parsed from, so a host forwards the same bytes rather than
@@ -200,6 +207,8 @@ pub struct Capabilities {
     pub gbode: bool,
     /// This runtime has a wall clock, so `-alarm` can be honoured.
     pub alarm: bool,
+    /// This runtime can compile a regex, so `-variableFilter` can be honoured.
+    pub variable_filter: bool,
 }
 
 /// Reject flag values this runtime cannot honour.
@@ -217,6 +226,9 @@ pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
     }
     if f.alarm.is_some() && !cap.alarm {
         return Err("-alarm: this runtime has no wall clock".to_string());
+    }
+    if f.variable_filter.is_some() && !cap.variable_filter {
+        return Err("-variableFilter: this runtime has no regex engine".to_string());
     }
     let unsupported = match f.solver {
         Some(Solver::Ida) if !cap.ida => "ida",
@@ -438,10 +450,8 @@ const JACOBIAN_METHODS: &[&str] = &[
     "bicoloredSymbolical",
 ];
 
-/// C flags deliberately let through. The wasm-jit codegen drops protected variables
-/// when it generates the module, so `emit_protected` has nothing to switch on — a
-/// real gap, but every library test passes it and erroring would say nothing new.
-const IGNORED_FLAGS: &[&str] = &["emit_protected"];
+/// C flags deliberately let through.
+const IGNORED_FLAGS: &[&str] = &[];
 
 /// Parse an argv slice (`argv[0]` is the program name and is skipped).
 /// `-flag=value` and `-flag value` are both accepted, as in the C runtime.
@@ -495,6 +505,9 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "output" => f.output_vars = split_top_level(&value(name)?),
+            "emit_protected" => f.emit_protected = true,
+            "ignoreHideResult" => f.ignore_hide_result = true,
+            "variableFilter" => f.variable_filter = Some(value(name)?),
             "r" => f.result_file = Some(value(name)?),
             "iif" => f.init_file = Some(value(name)?),
             "noEquidistantTimeGrid" => f.no_equidistant_grid = true,
@@ -779,7 +792,7 @@ mod tests {
     }
 
     const NOTHING: Capabilities =
-        Capabilities { klu: false, ida: false, cvode: false, gbode: false, alarm: false };
+        Capabilities { klu: false, ida: false, cvode: false, gbode: false, alarm: false, variable_filter: false };
 
     #[test]
     fn defaults_are_all_unset() {
@@ -826,7 +839,7 @@ mod tests {
     // both the parser and the capability check of the build that offered it.
     #[test]
     fn everything_supported_parses_and_checks() {
-        for cap in [NOTHING, Capabilities { klu: true, ida: true, cvode: true, gbode: true, alarm: true }] {
+        for cap in [NOTHING, Capabilities { klu: true, ida: true, cvode: true, gbode: true, alarm: true, variable_filter: true }] {
             for (flag, values) in supported(cap) {
                 for v in values {
                     let f = parse(&argv(&[&format!("-{flag}={v}")])).expect(&format!("-{flag}={v}"));
@@ -876,9 +889,8 @@ mod tests {
     fn unimplemented_and_invalid_flags_are_rejected() {
         let e = parse(&argv(&["-noSuchFlag"])).expect_err("must reject");
         assert!(e.contains("invalid command line option"), "{e}");
-        // `emit_protected` is the one C flag deliberately let through.
         let f = parse(&argv(&["-emit_protected", "-lv=LOG_STATS"])).expect("parses");
-        assert!(f.has_log("LOG_STATS"));
+        assert!(f.emit_protected && f.has_log("LOG_STATS"));
     }
 
     // The value of a rejected option must not be read as a flag of its own.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -335,6 +335,68 @@ fn posix_to_rust(re: &str, extended: bool) -> String {
     out
 }
 
+/// A compiled POSIX ERE, so one pattern can be tested against many strings
+/// ([`regex`] compiles per call). Same backends, so a match means what it does in
+/// the C runtime: libc `regcomp`/`regexec`, the `regex` crate on wasm/Windows.
+pub struct Regex {
+    #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
+    re: regex::Regex,
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
+    preg: Box<libc::regex_t>,
+}
+
+impl Regex {
+    /// No captures (`REG_NOSUB`); the error is the backend's own message.
+    pub fn new(re: &str) -> Result<Self, String> {
+        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
+        {
+            regex::RegexBuilder::new(&posix_to_rust(re, true))
+                .dot_matches_new_line(true)
+                .build()
+                .map(|re| Regex { re })
+                .map_err(|e| e.to_string())
+        }
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
+        {
+            let c_re = std::ffi::CString::new(re.as_bytes()).map_err(|e| e.to_string())?;
+            let mut preg: Box<libc::regex_t> = Box::new(unsafe { std::mem::zeroed() });
+            let rc = unsafe {
+                libc::regcomp(&mut *preg, c_re.as_ptr(), libc::REG_EXTENDED | libc::REG_NOSUB)
+            };
+            if rc != 0 {
+                let mut buf = vec![0 as core::ffi::c_char; 2048];
+                unsafe { libc::regerror(rc, &*preg, buf.as_mut_ptr(), buf.len()) };
+                let msg = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }.to_string_lossy().into_owned();
+                unsafe { libc::regfree(&mut *preg) };
+                return Err(msg);
+            }
+            Ok(Regex { preg })
+        }
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
+        {
+            self.re.is_match(s)
+        }
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
+        {
+            // regexec takes no NUL; OMC's subjects have none.
+            match std::ffi::CString::new(s.as_bytes()) {
+                Ok(c) => unsafe { libc::regexec(&*self.preg, c.as_ptr(), 0, core::ptr::null_mut(), 0) == 0 },
+                Err(_) => false,
+            }
+        }
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
+impl Drop for Regex {
+    fn drop(&mut self) {
+        unsafe { libc::regfree(&mut *self.preg) };
+    }
+}
+
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
 pub fn regex(
     str: ArcStr,


### PR DESCRIPTION
PR16170 made an unimplemented simflag an error, which turned two tests that had been passing by luck into failures: `others/world` passes `-emit_protected -ignoreHideResult` and
`ThermoSysPro...TestControlValve` passes `-variableFilter=<regex>`. Rather than ignore them again, implement C's output filter.

C decides per run, in `shouldFilterOutput` (protected, HideResult, with each flag that overrides it) and `initializeOutputFilter` (the model's `variableFilter` regex, `^(...)$`). The port dropped protected and HideResult variables at codegen and ignored `variableFilter` entirely — including `simulate(..., variableFilter=)`, which every library test with `compareVars` sets, so their result files held every variable instead of the compared ones.

`MetaVar::filter` now records *why* a variable would be filtered, and `SimMeta::output_keep` applies that per run against the flags: protected (unless `-emit_protected`, and never when the class is encrypted, as in C), HideResult (unless `-ignoreHideResult`), and the model's filter (replaced by a run-time `-variableFilter`). `time` is never filtered, and an emitted alias keeps the base variable it reads, which is what C's un-filter rule does and what the codegen's own re-emit pass used to.

Only the model's filter needs a regex, so the codegen resolves it and records the verdict; a plain run needs no engine, and the in-wasm runtimes stay engine-free. A run-time `-variableFilter` is compiled where the `.mat` is written, through a new `System::Regex` — the two backends `System::regex` already has (libc `regcomp`/`regexec`; the `regex` crate on wasm and Windows), kept compiled so one pattern can be matched against thousands of names. The standalone wasip1 runtime has no engine and so declines the flag through `Capabilities`.

`simflags` also has to be split as the shell splits it for every other target: `-variableFilter="a[.](b|c)"` arrives quoted.

Verified against the recorded wasm-jit baselines, all unchanged: nonlinear_system 5/50, initialization 35/90, tearing 5/107, events 12/33, solver 32/41, start_value_selection 5/9, simoptions 3/9, msl32 `Modelica.Fluid.*` 7/22 (the same names). `world` and `TestControlValve` pass.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
