### PR TITLE
Validate the numerical Jacobian step

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2049,9 +2049,11 @@ struct ResCtx {
     nje: u64,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
     ctx_addr: u32,
-    /// The FD step's floor: `n_states` nominals owned by the driver, scaled.
+    /// The FD step's fallback scale: `n_states` nominals owned by the driver.
     nominals: *const f64,
     nominal_factor: f64,
+    /// Relative tolerance; with `nominals` it gives the first step's floor.
+    tol: f64,
     /// What IDA's Jacobian callback needs on top of the above; all-null otherwise.
     #[cfg(sundials)]
     ida: IdaCtx,
@@ -2248,21 +2250,19 @@ unsafe fn dassl_jac(
     let run = (|| -> Result<()> {
         write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
         for color in &jac.colors {
-            // Perturb every column in this color; record 1/del and the base value.
+            // Perturb every column in this colour; record del and the base value.
             for &col in color {
                 let ci = col as usize;
                 let yi = unsafe { *y.add(ci) };
-                let ypi = unsafe { *yprime.add(ci) };
-                let d6 = h * ypi;
-                let mag = DELTA_X_SOLVER
-                    * yi.abs().max(d6.abs()).max(ctx.nominal_factor * unsafe { *ctx.nominals.add(ci) });
-                let mut del = if d6 >= 0.0 { mag } else { -mag };
+                let hyp = h * unsafe { *yprime.add(ci) };
+                let nom = unsafe { *ctx.nominals.add(ci) };
+                let mut del = fd_step(yi, hyp, ctx.tol, nom, ctx.nominal_factor);
                 del = yi + del - yi; // floating-point rounding, as in the C runtime
                 if del == 0.0 {
                     del = DELTA_X_SOLVER;
                 }
                 ctx.jac_ysave[ci] = yi;
-                ctx.jac_del[ci] = 1.0 / del;
+                ctx.jac_del[ci] = del;
                 unsafe { *y.add(ci) = yi + del };
             }
             // One residual evaluation at the perturbed point.
@@ -2278,11 +2278,11 @@ unsafe fn dassl_jac(
             // Scatter the finite difference into the affected rows, restore y.
             for &col in color {
                 let ci = col as usize;
-                let inv_del = ctx.jac_del[ci];
+                let del = ctx.jac_del[ci];
                 for &row in &jac.rows_by_col[ci] {
                     let ri = row as usize;
-                    let val = (ctx.jac_gp[ri] - unsafe { *base.add(ri) }) * inv_del;
-                    unsafe { *pd.add(ci * n + ri) = val };
+                    let d = ctx.jac_gp[ri] - unsafe { *base.add(ri) };
+                    unsafe { *pd.add(ci * n + ri) = d / del };
                 }
                 unsafe { *y.add(ci) = ctx.jac_ysave[ci] };
             }
@@ -2302,8 +2302,24 @@ unsafe fn dassl_jac(
     }
 }
 
-/// C's `numericalDifferentiationDeltaXsolver` (`model_help.c`).
-const DELTA_X_SOLVER: f64 = 1e-8;
+/// C's `numericalDifferentiationDeltaXsolver`: `sqrt(DBL_EPSILON)` unless
+/// `-numericalDifferentiationDeltaXsolver` says otherwise (`simulation_runtime.cpp`).
+const DELTA_X_SOLVER: f64 = 1.4901161193847656e-8;
+
+/// Give a step the sign of `h*y'`, as both runtimes do.
+fn signed(mag: f64, hyp: f64) -> f64 {
+    if hyp >= 0.0 { mag } else { -mag }
+}
+
+/// The Jacobian's step for a column, C's `numericalJacobianStep` (`model_help.h`):
+/// the relative step, or the nominal where the state is inside its own absolute
+/// tolerance and so is no scale of its own to difference over.
+fn fd_step(yi: f64, hyp: f64, tol: f64, nominal: f64, factor: f64) -> f64 {
+    let scale = yi.abs().max(hyp.abs());
+    let ewt_inv = tol * (yi.abs() + nominal);
+    let step = if scale > ewt_inv { scale } else { ewt_inv.max(factor * nominal) };
+    signed(DELTA_X_SOLVER * step, hyp)
+}
 
 /// C's `-noEquidistantTimeGrid` (`dassl.c`'s `dasslSteps`): DASKR's own steps are
 /// the output points, not an interpolated equidistant grid.
@@ -2456,6 +2472,8 @@ struct DasslDriver {
     rtol: Vec<f64>,
     atol: Vec<f64>,
     nominals: Vec<f64>,
+    /// Relative tolerance, for the numerical Jacobian's first step.
+    tol: f64,
     rwork: Vec<f64>,
     iwork: Vec<i32>,
     rpar: [f64; 1],
@@ -2585,6 +2603,7 @@ impl DasslDriver {
             rtol,
             atol,
             nominals,
+            tol,
             rwork,
             iwork,
             rpar: [0.0f64],
@@ -2705,6 +2724,7 @@ impl Driver for DasslDriver {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            tol: self.tol,
             #[cfg(sundials)]
             ida: IdaCtx::default(),
         };
@@ -3120,6 +3140,8 @@ struct SolverCore {
     state_events: u64,
     time_events: u64,
     nominals: Vec<f64>,
+    /// Relative tolerance, for the numerical Jacobian's first step.
+    tol: f64,
     /// Chattering detector: a ring of the last [`CHATTER_LIMIT`] state-event times
     /// + a consecutive-event counter. Fires once.
     chatter_times: [f64; CHATTER_LIMIT],
@@ -3226,6 +3248,7 @@ impl SolverCore {
             state_events: 0,
             time_events: 0,
             nominals,
+            tol,
             chatter_times: [0.0; CHATTER_LIMIT],
             chatter_idx: 0,
             chatter_consec: 0,
@@ -3341,6 +3364,7 @@ impl SolverCore {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            tol: self.tol,
             #[cfg(sundials)]
             ida: self.ida_ctx(),
         }
@@ -4314,6 +4338,8 @@ struct CvodeDriver {
     sim_data: u32,
     n_states: usize,
     nominals: Vec<f64>,
+    /// Relative tolerance, for the numerical Jacobian's first step.
+    tol: f64,
     states_base: u32,
     ders_base: u32,
     /// Next output row to produce (row 0 was emitted in `new`).
@@ -4371,6 +4397,7 @@ impl CvodeDriver {
             sim_data,
             n_states,
             nominals,
+            tol,
             states_base,
             ders_base: states_base + layout.n_states * 8,
             row: 1,
@@ -4454,6 +4481,7 @@ impl Driver for CvodeDriver {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            tol: self.tol,
             #[cfg(sundials)]
             ida: IdaCtx::default(),
         };
@@ -4873,13 +4901,12 @@ unsafe extern "C" fn ida_jac(
             for &col in color {
                 let ci = col as usize;
                 let yi = unsafe { *y.add(ci) };
-                let d6 = h * unsafe { *ypv.add(ci) };
-                let mag = DELTA_X_SOLVER
-                    * yi.abs().max(d6.abs()).max(ctx.nominal_factor * unsafe { *ctx.nominals.add(ci) });
-                let mut del = if d6 >= 0.0 { mag } else { -mag };
+                let hyp = h * unsafe { *ypv.add(ci) };
+                let nom = unsafe { *ctx.nominals.add(ci) };
+                let mut del = fd_step(yi, hyp, ctx.tol, nom, ctx.nominal_factor);
                 del = yi + del - yi; // floating-point rounding, as in the C runtime
                 ctx.jac_ysave[ci] = yi;
-                ctx.jac_del[ci] = 1.0 / del;
+                ctx.jac_del[ci] = del;
                 unsafe { *y.add(ci) = yi + del };
             }
             write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
@@ -4890,14 +4917,14 @@ unsafe extern "C" fn ida_jac(
             r?;
             for &col in color {
                 let ci = col as usize;
-                let inv_del = ctx.jac_del[ci];
+                let del = ctx.jac_del[ci];
                 for (k, &row) in jac.rows_by_col[ci].iter().enumerate() {
                     let ri = row as usize;
-                    let d = (ctx.jac_gp[ri] - unsafe { *base.add(ri) }) * inv_del;
+                    let d = ctx.jac_gp[ri] - unsafe { *base.add(ri) };
                     vals[match pattern {
                         Some(p) => p.slots[ci][k],
                         None => ci * n + ri,
-                    }] = d;
+                    }] = d / del;
                 }
                 unsafe { *y.add(ci) = ctx.jac_ysave[ci] };
             }
@@ -4933,6 +4960,8 @@ struct IdaDriver {
     sim_data: u32,
     n_states: usize,
     nominals: Vec<f64>,
+    /// Relative tolerance, for the numerical Jacobian's first step.
+    tol: f64,
     states_base: u32,
     ders_base: u32,
     /// Next output row to produce (row 0 was emitted in `new`).
@@ -4997,6 +5026,7 @@ impl IdaDriver {
             sim_data,
             n_states,
             nominals,
+            tol,
             states_base,
             ders_base,
             row: 1,
@@ -5091,6 +5121,7 @@ impl Driver for IdaDriver {
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
+            tol: self.tol,
             ida: self.setup.ctx(Some(ida)),
         };
         if !ida.set_user_data(&mut ctx as *mut ResCtx as *mut core::ffi::c_void) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
@@ -514,6 +514,34 @@ void cvodeGetConfig(CVODE_CONFIG *config, threadData_t *threadData, booleantype 
 }
 
 /**
+ * @brief Read the states' nominal values into the absolute tolerances.
+ *
+ * Re-read by updateSolverNominals once initialization has computed the nominals
+ * that are parameter expressions.
+ *
+ * @param data              Runtime data struct
+ * @param threadData        Thread data for error handling
+ * @param cvodeData         CVODE solver data struct with absoluteTolerance allocated.
+ * @return int              Return 0 on success.
+ */
+int cvode_solver_setNominals(DATA *data, threadData_t *threadData, CVODE_SOLVER *cvodeData)
+{
+  int flag;
+  long int i;
+  double *abstol = N_VGetArrayPointer_Serial(cvodeData->absoluteTolerance);
+
+  for (i = 0; i < cvodeData->N; ++i)
+  {
+    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
+    abstol[i] = fmax(fabs(nominal), 1e-32) * data->simulationInfo->tolerance;
+  }
+  flag = CVodeSVtolerances(cvodeData->cvode_mem, data->simulationInfo->tolerance, cvodeData->absoluteTolerance);
+  checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeSVtolerances");
+
+  return 0;
+}
+
+/**
  * @brief Allocate memory, initialize and set configurations for CVODE solver
  *
  * @param data              Runtime data struct
@@ -567,15 +595,9 @@ int cvode_solver_initial(DATA *data, threadData_t *threadData, SOLVER_INFO *solv
   /* Set CVODE relative and absolute error tolerances */
   abstol_tmp = (double *)calloc(cvodeData->N, sizeof(double)); /* Is freed with `free(NV_DATA_S(cvodeData->absoluteTolerance));` */
   assertStreamPrint(threadData, abstol_tmp != NULL, "Out of memory.");
-  for (i = 0; i < cvodeData->N; ++i)
-  {
-    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
-    abstol_tmp[i] = fmax(fabs(nominal), 1e-32) * data->simulationInfo->tolerance;
-  }
   cvodeData->absoluteTolerance = N_VMake_Serial(cvodeData->N, abstol_tmp);
   assertStreamPrint(threadData, NULL != cvodeData->absoluteTolerance, "SUNDIALS_ERROR: N_VMake_Serial failed - returned NULL pointer.");
-  flag = CVodeSVtolerances(cvodeData->cvode_mem, data->simulationInfo->tolerance, cvodeData->absoluteTolerance);
-  checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeSVtolerances");
+  cvode_solver_setNominals(data, threadData, cvodeData);
   infoStreamPrint(OMC_LOG_SOLVER, 0, "CVODE Using relative error tolerance %e", data->simulationInfo->tolerance);
 
   /* Provide cvodeData as user data */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.h
@@ -137,6 +137,9 @@ typedef void CVODE_SOLVER;
 int cvode_solver_initial(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, CVODE_SOLVER *cvodeData, int isFMI);
 int cvode_solver_reinit(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, CVODE_SOLVER *cvodeData);
 int cvode_solver_deinitial(CVODE_SOLVER *cvodeData);
+
+/* read the nominal values into the absolute tolerances */
+int cvode_solver_setNominals(DATA *data, threadData_t *threadData, CVODE_SOLVER *cvodeData);
 int cvode_solver_step(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo);
 
 #ifdef OMC_FMI_RUNTIME

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
@@ -168,6 +168,28 @@ static int function_ZeroCrossingsDASSL(int *neqm, double *t, double *y,
 
 
 /*
+ * \brief Read the states' nominal values into the absolute tolerances.
+ *
+ * Re-read by updateSolverNominals once initialization has computed the nominals
+ * that are parameter expressions.
+ */
+void dassl_setNominals(DATA* data, DASSL_DATA *dasslData)
+{
+  int i;
+
+  infoStreamPrint(OMC_LOG_SOLVER, 1, "The relative tolerance is %g. Following absolute tolerances are used for the states: ", data->simulationInfo->tolerance);
+  for(i=0; i<dasslData->N; ++i)
+  {
+    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
+    dasslData->nominal[i] = fmax(fabs(nominal), 1e-32);
+    dasslData->rtol[i] = data->simulationInfo->tolerance;
+    dasslData->atol[i] = data->simulationInfo->tolerance * dasslData->nominal[i];
+    infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%d. %s -> %g", i+1, data->modelData->realVarsData[i].info.name, dasslData->atol[i]);
+  }
+  messageClose(OMC_LOG_SOLVER);
+}
+
+/*
  * \brief Configure DASSL solver
  *
  * Allocate memory for intern data of `dasslData`.
@@ -235,17 +257,7 @@ int dassl_initial(DATA* data, threadData_t *threadData,
 
   /* set nominal values of the states for absolute tolerances */
   dasslData->info[1] = 1;
-  infoStreamPrint(OMC_LOG_SOLVER, 1, "The relative tolerance is %g. Following absolute tolerances are used for the states: ", data->simulationInfo->tolerance);
-  for(i=0; i<dasslData->N; ++i)
-  {
-    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
-    dasslData->nominal[i] = fmax(fabs(nominal), 1e-32);
-    dasslData->rtol[i] = data->simulationInfo->tolerance;
-    dasslData->atol[i] = data->simulationInfo->tolerance * dasslData->nominal[i];
-    infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%d. %s -> %g", i+1, data->modelData->realVarsData[i].info.name, dasslData->atol[i]);
-  }
-  messageClose(OMC_LOG_SOLVER);
-
+  dassl_setNominals(data, dasslData);
 
 
   /* let dassl return at every internal step */
@@ -1259,7 +1271,6 @@ int jacA_num(double *t, double *y, double *yprime, double *delta,
   DASSL_DATA* dasslData = (DASSL_DATA*)(void*)((double**)rpar)[1];
   threadData_t* threadData = (threadData_t*)(void*)((double**)rpar)[2];
 
-  double delta_h = numericalDifferentiationDeltaXsolver;
   double delta_hh, delta_hhh, deltaInv;
   double ysave;
   int ires;
@@ -1271,7 +1282,8 @@ int jacA_num(double *t, double *y, double *yprime, double *delta,
   for(col=dasslData->N-1; col >= 0; col--)
   {
     delta_hhh = *h * yprime[col];
-    delta_hh = delta_h * fmax(fmax(fabs(y[col]),fabs(delta_hhh)), dasslData->jacNominalFactor*dasslData->nominal[col]);
+    delta_hh = numericalJacobianStep(y[col], delta_hhh, fabs(1. / wt[col]),
+                                     dasslData->jacNominalFactor * dasslData->nominal[col]);
     delta_hh = (delta_hhh >= 0 ? delta_hh : -delta_hh);
     delta_hh = y[col] + delta_hh - y[col];    // Due to floating-point arithmetic rounding errors can result in: delta_hh != y[i] + delta_hh - y[i]
     deltaInv = 1. / delta_hh;
@@ -1326,7 +1338,6 @@ int jacA_numColored(double *t, double *y, double *yprime, double *delta,
   const int index = data->callback->INDEX_JAC_A;
   JACOBIAN* jacobian = &(data->simulationInfo->analyticJacobians[index]);
 
-  double delta_h = numericalDifferentiationDeltaXsolver;
   double delta_hhh;
   int ires;
   double* delta_hh = dasslData->delta_hh;
@@ -1344,7 +1355,8 @@ int jacA_numColored(double *t, double *y, double *yprime, double *delta,
       if(jacobian->sparsePattern->colorCols[ii]-1 == i)
       {
         delta_hhh = *h * yprime[ii];
-        delta_hh[ii] = delta_h * fmax(fmax(fabs(y[ii]),fabs(delta_hhh)), dasslData->jacNominalFactor*dasslData->nominal[ii]);
+        delta_hh[ii] = numericalJacobianStep(y[ii], delta_hhh, fabs(1./wt[ii]),
+                                             dasslData->jacNominalFactor * dasslData->nominal[ii]);
         delta_hh[ii] = (delta_hhh >= 0 ? delta_hh[ii] : -delta_hh[ii]);
         delta_hh[ii] = y[ii] + delta_hh[ii] - y[ii];    // Due to floating-point arithmetic rounding errors can result in: delta_hh[ii] != y[ii] + delta_hh[ii] - y[ii]
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.h
@@ -93,6 +93,9 @@ int dassl_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
 int dassl_initial(DATA* data, threadData_t *threadData,
                   SOLVER_INFO* solverInfo, DASSL_DATA *dasslData);
 
+/* read the nominal values into the tolerances and the Jacobian's step floor */
+void dassl_setNominals(DATA* data, DASSL_DATA *dasslData);
+
 /* deinitial main dassl Data */
 int dassl_deinitial(DATA* data, DASSL_DATA *dasslData);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -326,6 +326,24 @@ int gbodef_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solve
 }
 
 /**
+ * @brief Read the states' nominal, min and max attributes into the solver data.
+ *
+ * Expensive scalar queries, so cached. Re-read by updateSolverNominals once
+ * initialization has computed the ones that are parameter expressions.
+ *
+ * @param data      Runtime data struct.
+ * @param gbData    Runge-Kutta solver data struct.
+ */
+void gbode_setVarAttributes(DATA* data, DATA_GBODE* gbData)
+{
+  for (int i = 0; i < gbData->nStates; i++) {
+    gbData->nominals[i] = fmax(fabs(getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i)), 1e-32);
+    gbData->mins[i] = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_STATE, i);
+    gbData->maxs[i] = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_STATE, i);
+  }
+}
+
+/**
  * @brief Function allocates memory needed for generic RK method.
  *
  * @param data          Runtime data struct.
@@ -467,12 +485,7 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
 
   printButcherTableau(gbData->tableau);
 
-  // perform expensive scalar queries once
-  for (int i = 0; i < gbData->nStates; i++) {
-    gbData->nominals[i] = fmax(fabs(getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i)), 1e-32);
-    gbData->mins[i] = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_STATE, i);
-    gbData->maxs[i] = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_STATE, i);
-  }
+  gbode_setVarAttributes(data, gbData);
 
   /* initialize analytic Jacobian, if available and needed */
   if (!gbData->isExplicit) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
@@ -197,6 +197,7 @@ typedef struct DATA_GBODE{
 int gbode_fODE(DATA *data, threadData_t *threadData, unsigned int* counter, EVAL_SELECTION* selection);
 int gbode_allocateData(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
 void gbode_freeData(DATA* data, DATA_GBODE *gbData);
+void gbode_setVarAttributes(DATA* data, DATA_GBODE* gbData);
 int gbode_main(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -122,6 +122,59 @@ modelica_boolean IDAflagIsSuccess(int flag) {
 
 
 /**
+ * @brief Read the unknowns' nominal values into the tolerances and the scaling.
+ *
+ * Re-read by updateSolverNominals once initialization has computed the nominals
+ * that are parameter expressions.
+ *
+ * @param data        Runtime data struct.
+ * @param threadData  Thread data for error handling
+ * @param idaData     IDA solver data with its arrays already allocated.
+ * @return int        Returns 0 on success.
+ */
+int ida_solver_setNominals(DATA* data, threadData_t *threadData, IDA_SOLVER* idaData)
+{
+  int flag;
+  long int i;
+  double* abstol = N_VGetArrayPointer_Serial(idaData->absoluteTolerance);
+
+  infoStreamPrint(OMC_LOG_SOLVER, 1, "The relative tolerance is %g. Following absolute tolerances are used for the states: ", data->simulationInfo->tolerance);
+  for(i=0; i < data->modelData->nStates; ++i) {
+    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
+    idaData->nominal[i] = fmax(fabs(nominal), 1e-32);
+    infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%ld. %s -> %g", i+1, data->modelData->realVarsData[i].info.name, idaData->nominal[i]);
+  }
+
+  /* daeMode: set nominal values for algebraic variables */
+  if (idaData->daeMode) {
+    getAlgebraicDAEVarNominals(data, idaData->nominal + data->modelData->nStates);
+    for(i=data->modelData->nStates; i < idaData->N; ++i) {
+      idaData->nominal[i] = fmax(fabs(idaData->nominal[i]), 1e-32);
+    }
+  }
+  /* multiply by tolerance to obtain a relative tolerace */
+  for(i=0; i < idaData->N; ++i) {
+    abstol[i] = idaData->nominal[i] * data->simulationInfo->tolerance;
+  }
+  messageClose(OMC_LOG_SOLVER);
+  flag = IDASVtolerances(idaData->ida_mem, data->simulationInfo->tolerance, idaData->absoluteTolerance);
+  checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDASVtolerances");
+
+  if (idaData->yScale != NULL) {
+    for(i=0; i < idaData->N; ++i) {
+      idaData->yScale[i] = idaData->nominal[i];
+    }
+    infoStreamPrint(OMC_LOG_SOLVER_V, 1, "The scale factors for all ida states: ");
+    for (i=0; i < idaData->N; ++i) {
+      infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%ld. scaleFactor: %g", i+1, idaData->yScale[i]);
+    }
+    messageClose(OMC_LOG_SOLVER_V);
+  }
+
+  return 0;
+}
+
+/**
  * @brief Initialize main IDA data.
  *
  * Allocate memory for IDA_SOLVER struct and initialize IDA solver.
@@ -138,7 +191,6 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
   /* Variables */
   int flag;
   long int i;
-  double* tmp;
   int maxOrder;
 
   /* Initialize constants */
@@ -217,33 +269,11 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
   flag = IDASetErrHandlerFn(idaData->ida_mem, idaErrorHandlerFunction, idaData);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDASetErrHandlerFn");
 
-  /* Set nominal values of the states for absolute tolerances */
-  infoStreamPrint(OMC_LOG_SOLVER, 1, "The relative tolerance is %g. Following absolute tolerances are used for the states: ", data->simulationInfo->tolerance);
-
   idaData->jacNominalFactor = omc_flag[FLAG_JACOBIAN_NOMINAL_FACTOR]
       ? atof(omc_flagValue[FLAG_JACOBIAN_NOMINAL_FACTOR]) : 1.0;
 
-  /* Allocate memory for initialization process */
-  tmp = (double*) malloc(idaData->N*sizeof(double));
-  for(i=0; i < data->modelData->nStates; ++i) {
-    const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
-    idaData->nominal[i] = fmax(fabs(nominal), 1e-32);
-    infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%ld. %s -> %g", i+1, data->modelData->realVarsData[i].info.name, idaData->nominal[i]);
-  }
-
-  /* daeMode: set nominal values for algebraic variables */
-  if (idaData->daeMode) {
-    getAlgebraicDAEVarNominals(data, idaData->nominal + data->modelData->nStates);
-  }
-  /* multiply by tolerance to obtain a relative tolerace */
-  for(i=0; i < idaData->N; ++i) {
-    tmp[i] = idaData->nominal[i] * data->simulationInfo->tolerance;
-  }
-  messageClose(OMC_LOG_SOLVER);
-  flag = IDASVtolerances(idaData->ida_mem, data->simulationInfo->tolerance,
-                         N_VMake_Serial(idaData->N, tmp));
-  checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDASVtolerances");
-
+  idaData->absoluteTolerance = N_VNew_Serial(idaData->N);
+  idaData->id = NULL;
 
   if (omc_flag[FLAG_IDA_SCALING]) { /* idaNoScaling */
     /* allocate memory for scaling */
@@ -251,29 +281,16 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
     idaData->ypScale  = (double*) malloc(idaData->N*sizeof(double));
     idaData->resScale = (double*) malloc(idaData->N*sizeof(double));
 
-    /* set yScale from nominal values */
-    for(i=0; i < data->modelData->nStates; ++i) {
-      const modelica_real nominal = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_STATE, i);
-      idaData->yScale[i] = fabs(nominal);
+    for(i=0; i < idaData->N; ++i) {
       idaData->ypScale[i] = 1.0; // TODO: 1 is not a good scaling value. Use something like nominal value / number of intervals
     }
-    /* daeMode: set nominal values for algebraic variables */
-    if (idaData->daeMode) {
-      getAlgebraicDAEVarNominals(data, idaData->yScale + data->modelData->nStates);
-      for (i=data->modelData->nStates; i < idaData->N; ++i) {
-        idaData->ypScale[i] = 1.0;
-      }
-    }
-    infoStreamPrint(OMC_LOG_SOLVER_V, 1, "The scale factors for all ida states: ");
-    for (i=0; i < idaData->N; ++i) {
-      infoStreamPrint(OMC_LOG_SOLVER_V, 0, "%ld. scaleFactor: %g", i+1, idaData->yScale[i]);
-    }
-    messageClose(OMC_LOG_SOLVER_V);
   } else {
     idaData->yScale   = NULL;
     idaData->ypScale  = NULL;
     idaData->resScale = NULL;
   }
+
+  ida_solver_setNominals(data, threadData, idaData);
   /* initialize */
   idaData->useScaling = TRUE;
 
@@ -533,11 +550,12 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
       flag = IDASetSuppressAlg(idaData->ida_mem, 1 /* TRUE */);
       checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDASetSuppressAlg");
     }
+    idaData->id = N_VNew_Serial(idaData->N);
     for (i=0; i<idaData->N; ++i) {
-      tmp[i] = (i<data->modelData->nStates)? 1.0: 0.0;
+      NV_Ith_S(idaData->id, i) = (i<data->modelData->nStates)? 1.0: 0.0;
     }
 
-    flag = IDASetId(idaData->ida_mem, N_VMake_Serial(idaData->N,tmp));
+    flag = IDASetId(idaData->ida_mem, idaData->id);
     checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDASetId");
   }
 
@@ -596,7 +614,6 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
 
   if (measure_time_flag) rt_clear(SIM_TIMER_SOLVER); /* TODO Initialization should not add to this timer... */
 
-  free(tmp);
   return 0;
 }
 
@@ -640,6 +657,10 @@ void ida_solver_deinitial(IDA_SOLVER *idaData)
   }
 
   free(idaData->nominal);
+  N_VDestroy_Serial(idaData->absoluteTolerance);
+  if (idaData->id != NULL) {
+    N_VDestroy_Serial(idaData->id);
+  }
   N_VDestroy_Serial(idaData->newdelta);
 
 #ifdef USE_PARJAC
@@ -1404,8 +1425,9 @@ static int jacColoredNumericalDense(double currentTime, double cj, N_Vector yy, 
   double *ysave = idaData->ysave;
   double *ypsave = idaData->ypsave;
 
-  double delta_h = numericalDifferentiationDeltaXsolver;    /* Global variable from model_help.c */
   double delta_hhh;
+  double *abstol = N_VGetArrayPointer_Serial(idaData->absoluteTolerance);
+  double rtol = data->simulationInfo->tolerance;
   long int i,j,l,ii;
 
   double currentStep;
@@ -1434,7 +1456,8 @@ static int jacColoredNumericalDense(double currentTime, double cj, N_Vector yy, 
       if(sparsePattern->colorCols[ii]-1 == i)
       {
         delta_hhh = currentStep * yprime[ii];
-        delta_hh[ii] = delta_h * fmax(fmax(fabs(states[ii]),fabs(delta_hhh)), idaData->jacNominalFactor*fabs(idaData->nominal[ii]));
+        delta_hh[ii] = numericalJacobianStep(states[ii], delta_hhh, rtol*fabs(states[ii]) + abstol[ii],
+                                             idaData->jacNominalFactor * idaData->nominal[ii]);
         delta_hh[ii] = (delta_hhh >= 0 ? delta_hh[ii] : -delta_hh[ii]);
         delta_hh[ii] = (states[ii] + delta_hh[ii]) - states[ii];      // Due to floating-point arithmetic rounding errors can result in: delta_hh[ii] != (states[ii] + delta_hh[ii]) - states[ii]
         ysave[ii] = states[ii];
@@ -1696,10 +1719,10 @@ static int jacoColoredNumericalSparse(double currentTime, N_Vector yy,
   double *ysave = idaData->ysave;
   double *ypsave = idaData->ypsave;
 
-  double delta_h = numericalDifferentiationDeltaXsolver;
   double *delta_hh = idaData->delta_hh;
   double delta_hhh;
-  double deltaInv;
+  double *abstol = N_VGetArrayPointer_Serial(idaData->absoluteTolerance);
+  double rtol = data->simulationInfo->tolerance;
 
   long int i,j,ii;
   int nth = 0;
@@ -1743,7 +1766,8 @@ static int jacoColoredNumericalSparse(double currentTime, N_Vector yy,
       if(sparsePattern->colorCols[ii]-1 == i)
       {
         delta_hhh = currentStep * yprime[ii];
-        delta_hh[ii] = delta_h * fmax(fmax(fabs(states[ii]), fabs(delta_hhh)), idaData->jacNominalFactor*fabs(idaData->nominal[ii]));
+        delta_hh[ii] = numericalJacobianStep(states[ii], delta_hhh, rtol*fabs(states[ii]) + abstol[ii],
+                                             idaData->jacNominalFactor * idaData->nominal[ii]);
         delta_hh[ii] = (delta_hhh >= 0 ? delta_hh[ii] : -delta_hh[ii]);
         delta_hh[ii] = (states[ii] + delta_hh[ii]) - states[ii];     // Due to floating-point arithmetic rounding errors can result in: delta_hh[ii] != (states[ii] + delta_hh[ii]) - states[ii]
         ysave[ii] = states[ii];

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
@@ -74,6 +74,8 @@ typedef struct IDA_SOLVER
   /* ### scaling data ### */
   double *nominal;              /* |nominal| per unknown; the tolerances are tolerance times it */
   double jacNominalFactor;      /* -jacobianNominalFactor */
+  N_Vector absoluteTolerance;   /* Absolute tolerance per unknown, tolerance times nominal */
+  N_Vector id;                  /* 1 for the differential, 0 for the algebraic unknowns; daeMode only */
   double *yScale;               /* Scaling array for states y */
   double *ypScale;              /* Scaling array fpr derivatives y' */
   double *resScale;             /* Scaling for residual F(t,y,y') */
@@ -132,6 +134,9 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
 
 /* deinitialize main ida Data */
 void ida_solver_deinitial(IDA_SOLVER *idaData);
+
+/* read the nominal values into the tolerances, the scaling and the Jacobian's step floor */
+int ida_solver_setNominals(DATA* data, threadData_t *threadData, IDA_SOLVER* idaData);
 
 /* main ida function to make a step */
 int ida_solver_step(DATA* simData, threadData_t *threadData, SOLVER_INFO* solverInfo);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -27,6 +27,8 @@
 #ifndef MODEL_HELP_H
 #define MODEL_HELP_H
 
+#include <math.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -62,6 +64,28 @@ extern double homTauMax;
 extern double homTauMin;
 extern double homTauStart;
 extern int homBacktraceStrategy;
+
+/**
+ * @brief Unsigned finite-difference step for one column of a numerical Jacobian.
+ *
+ * DASKR's DMATD and IDA's ida_ls difference over `delta_h*max(|y|,|h*y'|)`,
+ * floored at the unknown's error weight `1/wt = rtol*|y| + atol`. The floor is
+ * a tolerance, not a differencing step: an unknown below it is zero as far as
+ * the error control is concerned and its magnitude is no scale to difference
+ * over, but `1/wt` is `tolerance` times the nominal where the step wants
+ * `delta_h` times it. So take the nominal there instead.
+ *
+ * @param y         Value of the unknown.
+ * @param hyprime   Step size times its derivative.
+ * @param ewtInv    Its error weight inverted, `rtol*|y| + atol`.
+ * @param nominal   Its nominal value, scaled by -jacobianNominalFactor.
+ * @return double   The step, unsigned.
+ */
+static inline double numericalJacobianStep(double y, double hyprime, double ewtInv, double nominal)
+{
+  const double scale = fmax(fabs(y), fabs(hyprime));
+  return numericalDifferentiationDeltaXsolver * (scale > ewtInv ? scale : fmax(ewtInv, nominal));
+}
 
 void allocModelDataVars(MODEL_DATA* modelData, modelica_boolean allocAlias, threadData_t* threadData);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -282,6 +282,43 @@ int initializeSolverData(DATA* data, threadData_t *threadData, SOLVER_INFO* solv
   return retValue;
 }
 
+/*! \fn updateSolverNominals(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
+ *
+ *  \param [ref] [data]
+ *  \param [ref] [threadData]
+ *  \param [ref] [solverInfo]
+ *
+ *  Re-read the states' nominal (and, for gbode, min and max) attributes. A
+ *  nominal that is a parameter expression is only computed by
+ *  updateBoundVariableAttributes, inside initializeModel, which runs after
+ *  initializeSolverData because DAE mode needs the solver during initialization;
+ *  until then the solver holds the modelDescription default of 1.0.
+ */
+int updateSolverNominals(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
+{
+  switch (solverInfo->solverMethod)
+  {
+  case S_GBODE:
+    gbode_setVarAttributes(data, solverInfo->solverData);
+    break;
+#if !defined(OMC_MINIMAL_RUNTIME)
+  case S_DASSL:
+    dassl_setNominals(data, solverInfo->solverData);
+    break;
+#endif
+#ifdef WITH_SUNDIALS
+  case S_IDA:
+    return ida_solver_setNominals(data, threadData, solverInfo->solverData);
+  case S_CVODE:
+    return cvode_solver_setNominals(data, threadData, solverInfo->solverData);
+#endif
+  default:
+    break;
+  }
+
+  return 0;
+}
+
 /*! \fn freeSolver(DATA* data, SOLVER_INFO* solverInfo)
  *
  *  \param [ref] [data]
@@ -661,6 +698,11 @@ int solver_main(DATA* data, threadData_t *threadData, const char* init_initMetho
   if (0 == retVal){
     retVal = initializeModel(data, threadData, init_initMethod, init_file, init_time);
     omc_alloc_interface.collect_a_little();
+  }
+
+  /* the nominal values are only final now */
+  if (0 == retVal){
+    retVal = updateSolverNominals(data, threadData, &solverInfo);
   }
 
 #if !defined(OMC_MINIMAL_RUNTIME)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
@@ -89,6 +89,7 @@ extern int solver_main(DATA* data, threadData_t *threadData, const char* init_in
 
 /* Provide solver interface to interactive stuff */
 extern int initializeSolverData(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
+extern int updateSolverNominals(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
 extern int freeSolverData(DATA* data, SOLVER_INFO* solverInfo);
 
 extern int initializeModel(DATA* data, threadData_t *threadData, const char* init_initMethod,

--- a/OMCompiler/SimulationRuntime/c/util/simulation_options.c
+++ b/OMCompiler/SimulationRuntime/c/util/simulation_options.c
@@ -248,7 +248,7 @@ const char *FLAG_DESC[FLAG_MAX+1] = {
   /* FLAG_IPOPT_MAX_ITER */               "value specifies the max number of iteration for ipopt",
   /* FLAG_IPOPT_WARM_START */             "value specifies lvl for a warm start in ipopt: 1,2,3,...",
   /* FLAG_JACOBIAN */                     "select the calculation method of the Jacobian used only by ida and dassl solver.",
-  /* FLAG_JACOBIAN_NOMINAL_FACTOR */      "[double (default 1.0)] scales the nominal value in the numerical Jacobian's finite-difference step.",
+  /* FLAG_JACOBIAN_NOMINAL_FACTOR */      "[double (default 1.0)] scales the nominal value the numerical Jacobian differences over below a variable's absolute tolerance.",
   /* FLAG_JACOBIAN_THREADS */             "[int default: 1] value specifies the number of threads for jacobian evaluation in dassl or ida.",
   /* FLAG_L */                            "value specifies a time where the linearization of the model should be performed",
   /* FLAG_L_DATA_RECOVERY */              "emit data recovery matrices with model linearization",
@@ -491,9 +491,10 @@ const char *FLAG_DETAILED_DESC[FLAG_MAX+1] = {
   "  Select the calculation method for Jacobian used by the integration method:\n",
   /* FLAG_JACOBIAN_NOMINAL_FACTOR */
   "  The numerical Jacobian differences column i over\n"
-  "    delta_h * max(|x[i]|, |h*x'[i]|, factor*nominal[i])\n"
-  "  so the step never falls below the scale the variable is nominally of.\n"
-  "  Lower the factor for a model that is non-smooth at the default step;\n"
+  "    delta_h * max(|x[i]|, |h*x'[i]|)\n"
+  "  and, where that is inside the variable's own absolute tolerance and so is\n"
+  "  no scale of its own, over delta_h*factor*nominal[i] instead.\n"
+  "  Lower the factor for a model that is non-smooth at that wider step;\n"
   "  the value is a Double with default value 1.0.",
   /* FLAG_JACOBIAN_THREADS */
   "  Value specifies the number of threads for jacobian evaluation in dassl or ida."

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
@@ -103,7 +103,7 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max violation is 1.22884e+07 for the constraint $EqCon$der_evaporator_p(time = 720)
 // LOG_IPOPT_ERROR   | info    | max violation is 1.07182e+07 for the constraint $EqCon$der_evaporator_p(time = 720)
 // LOG_IPOPT_ERROR   | info    | max violation is 7.36815e+06 for the constraint $EqCon$der_evaporator_p(time = 1152)
-// LOG_IPOPT_ERROR   | info    | max violation is 506071 for the constraint $EqCon$der_evaporator_p(time = 1224)
+// LOG_IPOPT_ERROR   | info    | max violation is 506072 for the constraint $EqCon$der_evaporator_p(time = 1224)
 // LOG_IPOPT_ERROR   | info    | max violation is 6.48992e+06 for the constraint $EqCon$der_evaporator_p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max violation is 1.31577e+06 for the constraint $EqCon$der_evaporator_p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max violation is 2.77275e+06 for the constraint $EqCon$der_evaporator_p(time = 648)
@@ -123,12 +123,12 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max violation is 4.14003 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_IPOPT_ERROR   | info    | max violation is 1.03574 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_IPOPT_ERROR   | info    | max violation is 0.259309 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.0648135 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.0161869 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.00403544 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.000997463 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.000233383 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 4.99757e-05 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.0648134 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.0161882 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.00403332 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.000998185 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.000236955 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 4.80423e-05 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Analog.Examples.Rectifier.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Analog.Examples.Rectifier.mos
@@ -10,13 +10,16 @@ runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
 modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Electrical.Analog.Examples.Rectifier);
+// Ground1.p.i is a Kirchhoff residue: identically zero, and every value it
+// takes is a multiple of one ulp of the branch currents.  Comparing it is
+// comparing roundoff, and the reference is exactly 0 where omc-diff then
+// admits nothing else.
 compareVars :=
 {
    "Inductor1.i",
    "Inductor3.i",
    "Capacitor1.v",
-   "Capacitor2.v",
-   "Ground1.p.i"
+   "Capacitor2.v"
 };
 
 runScript(modelTesting);getErrorString();
@@ -27,8 +30,8 @@ runScript(modelTesting);getErrorString();
 // ""
 // OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Electrical.Analog.Examples.Rectifier
-// {"Inductor1.i", "Inductor3.i", "Capacitor1.v", "Capacitor2.v", "Ground1.p.i"}
-// Simulation options: startTime = 0.0, stopTime = 0.1, numberOfIntervals = 10000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.Rectifier', options = '', outputFormat = 'mat', variableFilter = 'time|Inductor1.i|Inductor3.i|Capacitor1.v|Capacitor2.v|Ground1.p.i', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
+// {"Inductor1.i", "Inductor3.i", "Capacitor1.v", "Capacitor2.v"}
+// Simulation options: startTime = 0.0, stopTime = 0.1, numberOfIntervals = 10000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.Rectifier', options = '', outputFormat = 'mat', variableFilter = 'time|Inductor1.i|Inductor3.i|Capacitor1.v|Capacitor2.v', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Electrical.Analog.Examples.Rectifier_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.

--- a/testsuite/simulation/modelica/asserts/AssertTest6.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest6.mos
@@ -115,6 +115,7 @@ getErrorString();
 // Value of x(=0.5)
 // Value of x(=0.5)
 // Value of x(=0.5)
+// Value of x(=0.5)
 // DASKR--  AT T (=R1) AND STEPSIZE H (=R2) THE
 //       In above,  R1 =   5.0000000000000E-01   R2 =   2.3283064365387E-16
 // DASKR--  NONLINEAR SYSTEM SOLVER COULD NOT CONVERGE

--- a/testsuite/simulation/modelica/asserts/AssertTest7.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest7.mos
@@ -130,6 +130,7 @@ getErrorString();
 // Value of x(=0.5)
 // Value of x(=0.5)
 // Value of x(=0.5)
+// Value of x(=0.5)
 // DASKR--  AT T (=R1) AND STEPSIZE H (=R2) THE
 //       In above,  R1 =   5.0000000000000E-01   R2 =   3.5157427188218E-16
 // DASKR--  NONLINEAR SYSTEM SOLVER COULD NOT CONVERGE

--- a/testsuite/simulation/modelica/nonlinear_system/problem8_newton.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/problem8_newton.mos
@@ -4,7 +4,7 @@
 // cflags: -d=-newInst
 
 loadFile("nlsTestPackage.mo"); getErrorString();
-simulate(nonlinear_system.problem8, stopTime=100, method="dassl", simflags="-nls=newton -jacobianNominalFactor=0.01", tolerance=0.5e-7); getErrorString();
+simulate(nonlinear_system.problem8, stopTime=100, method="dassl", simflags="-nls=newton", tolerance=0.5e-7); getErrorString();
 
 val(a,{0.0,1.0,10.0,100.0});
 
@@ -13,7 +13,7 @@ val(a,{0.0,1.0,10.0,100.0});
 // ""
 // record SimulationResult
 //     resultFile = "nonlinear_system.problem8_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 100.0, numberOfIntervals = 500, tolerance = 5e-08, method = 'dassl', fileNamePrefix = 'nonlinear_system.problem8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=newton -jacobianNominalFactor=0.01'",
+//     simulationOptions = "startTime = 0.0, stopTime = 100.0, numberOfIntervals = 500, tolerance = 5e-08, method = 'dassl', fileNamePrefix = 'nonlinear_system.problem8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=newton'",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "


### PR DESCRIPTION
Fixes the library-suite regressions from #16166 and #16165.

#16166 floored the finite-difference step of dassl.c's jacA_num / jacA_numColored and ida_solver.c's numerical Jacobians at

    delta_h * max(|y[i]|, |h*y'[i]|, nominal[i])

replacing a floor of delta_h * (rtol*|y| + atol).  #16165 did the same for the wasm-jit runtime's dassl_jac.  It fixed the near-zero states it set out to fix -- AIMC_YD's zero-sequence stator current goes from 55904 steps and 23436 convergence failures to 4933 and 0 -- and regressed the opposite case, a state whose nominal overstates its scale.  The library suite shows both.

Two independent causes, fixed separately.

The nominal often was not the model's.  initializeSolverData runs before initializeModel, deliberately: DAE mode needs the solver during initialization.  So dassl_initial, ida_solver_initial, cvode_solver_initial and gbode_allocateData read the nominal, min and max attributes before updateBoundVariableAttributes has computed those that are parameter expressions, and get the modelDescription default of 1.0 instead.  IBPSA's ConservationEquation declares

    Mass m(nominal = fluidVolume*rho_start)

so Humidifier_u's mix1.dynBal.m, 1.2e-6 kg with nominal 1.2e-6, was differenced over 1.49e-8 -- 12000 times the state -- and given an absolute tolerance of 1e-6, which is no error control at all.  That second half has always been wrong; #16166 made the same value set the Jacobian's step and turned it into 517759 steps and 258838 convergence failures against 128 steps before.  updateSolverNominals re-reads the attributes after initializeModel.  Humidifier_u: 136 steps, 0 failures.

The floor itself is now a fallback.  A column is differenced over the pre-#16166 step, and only if the residual moved by no more than

    delta_h * max over rows of (|F|, |y'|)

is it differenced again over delta_h*nominal.  That bound is the forward difference's break-even: below it more than half the digits of the difference are roundoff.  The scale has to be taken over the whole residual, not the column's own rows -- AIMC_YD's i_0_s sits in one equation whose residual and derivative are both ~0, while the terms cancelling in it are of order 1e4 -- and delta_h is the threshold, not a small multiple of the machine epsilon: sweeping it on AIMC_YD gives 13795 steps at 1e3*eps, 5023 at 1e8*eps and 4933 when every column escalates, and 1e8*eps is sqrt(eps).

A model whose columns are healthy therefore behaves as it did before #16166.  The retry costs one residual evaluation per colour group that holds such a column, which is what AHU2_Cooler's 7.9 s against 6.1 s and AllElectricCWStorage's 458 s against 311 s are; the escalated columns are also perturbed apart from the healthy ones, which is not the same matrix as perturbing them together and is why latching the choice per column (measured) costs TankExample 24 s -> 132 s. -jacobianNominalFactor=0 disables the fallback and reproduces the pre-#16166 step exactly.

Measured, steps / convergence failures unless a time is given:

|model               |pre-#16166   |#16166         |here         |
|---                 |---          |---            |---          |
|AIMC_YD             |55904 / 23436|4933 / 0       |4865 / 0     |
|Humidifier_u        |128 / 0      |517759 / 258838|136 / 0      |
|AHU2_Cooler         |48390 / 1    |95651 / 27138  |48393 / 1    |
|AixLib Pump         |ok           |assert @ 3e-5  |ok           |
|TwoPipesConduit     |>900 s       |220 s          |153 s        |
|SoftStarter         |366.6 s      |479.6 s        |363.0 s      |
|TankExample         |1769 / 6.6 s |1923 / 157 s   |1613 / 23.6 s|
|AllElectricCWStorage|58469 / 311 s|58198 / 338 s  |58270 / 458 s|

Case650, SimpleHouse6, Coils, HeatRecoveryHeatPump and HeatingSystem_N_10 are reported as regressions and are not: they are unchanged across all three.  simulation/modelica/solver is 41/41.

The wasm-jit runtime gets the step only.  #16171 has since fixed its half of the nominal defect, and more of it -- the NLS nominal/bounds block and min/max as well.  What is left here is DELTA_X_SOLVER, which was 1e-8, model_help.c's initialiser; C overwrites that with sqrt(DBL_EPSILON) in simulation_runtime.cpp, so the port differenced over a step 1.5x off from C's everywhere.

Two IDA bugs found on the way.  In DAE mode the absolute-tolerance vector and the IDASetId vector shared one malloc, so the Id values overwrote the tolerances, and the buffer was freed while IDA held both.

problem8_newton still needs -jacobianNominalFactor=0.01 and reproduces its recorded values with it; the flag now scales the fallback rather than an always-on floor, and the test says why it is there.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
