### PR TITLE
wasm-jit: --daeMode support

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -408,7 +408,10 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
     });
     if let Err(e) = &outcome {
         if openmodelica_util::Error::getNumErrorMessages() == errs_before {
-            record_error(format!("CodegenWasmJit: cannot build simulation module for `{prefix}`: {e:#}"));
+            record_error(format!(
+                "CodegenWasmJit: cannot build simulation module for `{prefix}`: {}",
+                with_engine_detail(e)
+            ));
         }
     }
     outcome
@@ -2576,10 +2579,24 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // Jacobian scratch region: nonlinear-system slots + torn-linear slots (after).
     let nls_jac_scratch_f64 = nls_jac_scratch_f64(sim_code) + lin_jac_scratch_f64(sim_code);
     let all_eqs = flatten_eqs(&sim_code.allEquations);
+    // `--daeMode`: `allEquations`/`odeEquations` are empty and the whole continuous
+    // system is `daeModeData.daeEquations`, the residual `F(t, y, y') = 0`.
+    let dae_mode = sim_code.daeModeData.as_ref();
+    let dae_eqs: Vec<(Arc<SimCode::SimEqSystem>, u32)> =
+        dae_mode.map(|d| dae_residual_equations(d)).unwrap_or_default();
+    let dae_res_vars: Vec<&SimCodeVar::SimVar> =
+        dae_mode.map(|d| lst(&d.residualVars).collect()).unwrap_or_default();
+    let dae_aux_vars: Vec<&SimCodeVar::SimVar> =
+        dae_mode.map(|d| lst(&d.auxiliaryVars).collect()).unwrap_or_default();
+    let dae_alg_vars: Vec<&SimCodeVar::SimVar> =
+        dae_mode.map(|d| lst(&d.algebraicVars).collect()).unwrap_or_default();
+    if dae_mode.is_some() && dae_res_vars.len() != (n_states as usize + dae_alg_vars.len()) {
+        return Err("CodegenWasmJit: DAE mode residual count does not match states + algebraic unknowns");
+    }
     // A model has discrete `when` behaviour through when-equations (SES_WHEN) or
     // when-statements inside an algorithm — both need the per-step pre-value save
     // and the full `allEquations` list as the per-step function.
-    let has_when = all_eqs.iter().any(|e| match &**e {
+    let has_when = dae_eqs.iter().map(|(e, _)| e).chain(all_eqs.iter()).any(|e| match &**e {
         SimCode::SimEqSystem::SES_WHEN { .. } => true,
         SimCode::SimEqSystem::SES_ALGORITHM { statements, .. } => {
             (&**statements).into_iter().any(|s| matches!(&**s, DAE::Statement::STMT_WHEN { .. }))
@@ -2613,11 +2630,27 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         nls_jac_scratch_f64,
         vi.numMathEventFunctions.max(0) as u32,
         n_sens,
+        dae_res_vars.len() as u32,
+        dae_aux_vars.len() as u32,
+        dae_alg_vars.len() as u32,
         has_when,
         has_homotopy,
     );
 
     let (mut var_map, mut result_vars, editable_params) = build_var_map(vars, &layout)?;
+    // DAE-mode residual/auxiliary variables: their own `SimData` regions, indexed by
+    // the SimVar's `index` as C's `crefToCStr` does. Solver workspace, not results.
+    for (svs, base) in [(&dae_res_vars, layout.dae_res_off), (&dae_aux_vars, layout.dae_aux_off)] {
+        for sv in svs.iter() {
+            let i = u32::try_from(sv.index).map_err(|_| "CodegenWasmJit: DAE mode variable has no index")?;
+            insert_var(&mut var_map, sv, base + i * 8, WTy::F64, false)?;
+        }
+    }
+    // An auxiliary variable can be a whole array (`$AUX.w = f(…)`), so its element
+    // group needs finalizing too.
+    if dae_mode.is_some() {
+        finalize_array_groups(&mut var_map)?;
+    }
     let sens_params = push_sensitivity_vars(&sens_vars, n_sens_par, vars, &layout, &mut result_vars)?;
     let var_units = collect_var_units(vars)?;
     // Sample event index -> its slot `k` (position in `samples`), for the
@@ -2652,6 +2685,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     index_list(&sim_code.removedEquations, &mut eq_index);
     index_list(&sim_code.startValueEquations, &mut eq_index);
     index_list(&sim_code.algorithmAndEquationAsserts, &mut eq_index);
+    for e in dae_eqs.iter() {
+        index_eq_recursive(&e.0, &mut eq_index);
+    }
     for part in lst(&sim_code.odeEquations).chain(lst(&sim_code.algebraicEquations)) {
         index_list(part, &mut eq_index);
     }
@@ -2742,19 +2778,25 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // `residual`/`load` callbacks are emitted after the equation functions.
     let nls_nominal_map = build_nls_nominal_map(vars);
     let mut attr_targets: HashMap<String, AttrTargets> = HashMap::new();
+    let dae_only_eqs: Vec<Arc<SimCode::SimEqSystem>> = dae_eqs.iter().map(|(e, _)| e.clone()).collect();
     let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) = collect_nls_jobs(
-        &[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs],
+        &[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs, &dae_only_eqs],
         &nls_nominal_map,
         &mut attr_targets,
     );
-    // The integrator's per-state atol and the Jacobian's FD step floor.
-    let state_nominals: Vec<f64> = lst(&vars.stateVars)
-        .take(n_states as usize)
-        .map(|sv| const_value(&sv.nominalValue).unwrap_or(1.0).abs().max(1e-32))
-        .collect();
-    for (i, sv) in lst(&vars.stateVars).take(n_states as usize).enumerate() {
-        if let Ok(k) = sim_cref_key(&sv.name) {
-            attr_targets.entry(k).or_default().state = Some(i as u32);
+    // The integrator's per-unknown atol and the Jacobian's FD step floor: the states,
+    // then in DAE mode the algebraic unknowns (C's `getAlgebraicDAEVarNominals`).
+    let mut nominal_defaults: Vec<(u32, f64)> = Vec::new();
+    for (svs, base) in [
+        (lst(&vars.stateVars).take(n_states as usize).collect::<Vec<_>>(), layout.state_nom_off),
+        (dae_alg_vars.clone(), layout.dae_alg_nom_off),
+    ] {
+        for (i, sv) in svs.iter().enumerate() {
+            let off = base + (i as u32) * 8;
+            nominal_defaults.push((off, const_value(&sv.nominalValue).unwrap_or(1.0).abs().max(1e-32)));
+            if let Ok(k) = sim_cref_key(&sv.name) {
+                attr_targets.entry(k).or_default().nom_offs.push(off);
+            }
         }
     }
     // Register the analytic-Jacobian seed/result crefs before the equation
@@ -2822,6 +2864,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         types.ty().function([we::ValType::I32, we::ValType::I32], []);
         Some((residual_type, load_type))
     };
+    // `evaluateDAEResiduals(SimData*, stage)`: (i32,i32) -> (), for a DAE-mode model.
+    let dae_fn_type = (!dae_eqs.is_empty()).then(|| {
+        let ti = types.len();
+        types.ty().function([we::ValType::I32, we::ValType::I32], []);
+        ti
+    });
     // Function references met while lowering the bodies add thunks to the closure
     // pool; this global holds their shared-table base.
     let closure_global = crate::CodegenWasmJitFunctions::closure_base_global(nls_types.is_some());
@@ -2926,9 +2974,30 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             })
         })
         .collect::<Result<Vec<_>>>()?;
+    // The residual Jacobian's sparsity is a matrix of its own, not the ODE `A` that
+    // the backend leaves empty in DAE mode.
+    let dae = dae_mode
+        .map(|d| -> Result<openmodelica_sim_meta::DaeInfo> {
+            let alg_offs = dae_alg_vars
+                .iter()
+                .map(|sv| {
+                    let key = sim_cref_key(&sv.name)?;
+                    var_map
+                        .vars
+                        .get(&key)
+                        .map(|s| s.off)
+                        .ok_or("CodegenWasmJit: DAE mode algebraic unknown has no SimData slot")
+                })
+                .collect::<Result<Vec<u32>>>()?;
+            Ok(openmodelica_sim_meta::DaeInfo {
+                alg_offs,
+                sparsity: d.sparsityPattern.as_ref().and_then(|jm| jac_pattern_info(jm, dae_res_vars.len())),
+            })
+        })
+        .transpose()?;
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
-        fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars,
+        fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars, dae,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -3113,9 +3182,19 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let update_bound_attrs_idx = {
         let idx = import_base + bodies.len() as u32;
         bodies.push(build_update_bound_attrs_fn(
-            sim_code, &state_nominals, &attr_targets, &layout, &var_map, &by_name, &mut literals,
+            sim_code, &nominal_defaults, &attr_targets, &var_map, &by_name, &mut literals,
         )?);
         idx
+    };
+    // Emitted only for a DAE-mode model: its absence is how the standalone export and
+    // the FMU adapters know the model is an explicit ODE.
+    let dae_residuals_idx = match dae_eqs.is_empty() {
+        true => None,
+        false => {
+            let idx = import_base + bodies.len() as u32;
+            bodies.push(build_dae_residuals_fn(&dae_eqs, &var_map, &eq_index, &by_name, &mut literals)?);
+            Some(idx)
+        }
     };
 
     // --- Function section (type index per body, in body order). ---
@@ -3156,6 +3235,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
+    if let Some(ti) = dae_fn_type {
+        functions.function(ti); // evaluateDAEResiduals: (i32, i32) -> ()
+    }
 
     // --- Shared literals, closure thunks and the module `start`. Both come after
     // every other body — their indices are only known here. ---
@@ -3246,6 +3328,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
     exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
+    if let Some(idx) = dae_residuals_idx {
+        exports.export("evaluateDAEResiduals", we::ExportKind::Func, idx);
+    }
 
     // --- Name section: without it a trap backtrace is bare function indices. The
     // unnamed remainder is the NLS callbacks, the closure thunks and `start`. ---
@@ -3287,6 +3372,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
     ] {
         names.push((idx, name.to_string()));
+    }
+    if let Some(idx) = dae_residuals_idx {
+        names.push((idx, "evaluateDAEResiduals".to_string()));
     }
     names.sort_by_key(|(idx, _)| *idx);
     let mut fn_names = we::NameMap::new();
@@ -3695,8 +3783,22 @@ fn build_jac_a_info(sim_code: &SimCode::SimCode, n_states: u32) -> Option<JacAIn
     if n_states == 0 {
         return None;
     }
-    let n = n_states as usize;
     let jac = lst(&sim_code.jacobianMatrices).find(|j| &*j.matrixName == "A")?;
+    let info = jac_pattern_info(jac, n_states as usize)?;
+    if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
+        let nnz: usize = info.rows_by_col.iter().map(|r| r.len()).sum();
+        eprintln!("wasm-jit jac-A: n={n_states} colors={} nnz={nnz}", info.colors.len());
+    }
+    Some(info)
+}
+
+/// One Jacobian matrix's `n × n` sparsity + coloring, or `None` when the backend
+/// left either out (or produced indices out of range), in which case the caller
+/// falls back to a solver-internal numerical Jacobian.
+fn jac_pattern_info(jac: &SimCode::JacobianMatrix, n: usize) -> Option<JacAInfo> {
+    if n == 0 {
+        return None;
+    }
     // sparsity: positional per column → 0-based nonzero rows (CSC), one entry per
     // column (empty columns carry an empty row list).
     let rows_by_col: Vec<Vec<u32>> = lst(&jac.sparsity)
@@ -3706,8 +3808,6 @@ fn build_jac_a_info(sim_code: &SimCode::SimCode, n_states: u32) -> Option<JacAIn
     let colors: Vec<Vec<u32>> = lst(&jac.coloredCols)
         .map(|grp| lst(grp).map(|c| *c as u32).collect())
         .collect();
-    // Only usable when the pattern covers exactly the n states, the coloring is
-    // present, and every index is in range; otherwise fall back to numerical.
     if rows_by_col.len() != n
         || colors.is_empty()
         || colors.iter().flatten().any(|&c| c as usize >= n)
@@ -3715,11 +3815,7 @@ fn build_jac_a_info(sim_code: &SimCode::SimCode, n_states: u32) -> Option<JacAIn
     {
         return None;
     }
-    if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
-        let nnz: usize = rows_by_col.iter().map(|r| r.len()).sum();
-        eprintln!("wasm-jit jac-A: n={n} colors={} nnz={nnz}", colors.len());
-    }
-    Some(JacAInfo { n: n_states, colors, rows_by_col })
+    Some(JacAInfo { n: n as u32, colors, rows_by_col })
 }
 
 /// Map each result variable's display name to its unit (`h` -> `m`, `der(h)` ->
@@ -3777,6 +3873,7 @@ fn build_sim_meta(
     zc_desc: Vec<String>,
     sens_params: Vec<u32>,
     nls_vars: Vec<openmodelica_sim_meta::NlsVars>,
+    dae: Option<openmodelica_sim_meta::DaeInfo>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -3795,6 +3892,7 @@ fn build_sim_meta(
         zc_desc,
         sens_params,
         nls_vars,
+        dae,
     }
 }
 
@@ -3907,29 +4005,10 @@ fn assigned_cref_keys(eqs: &[Arc<SimCode::SimEqSystem>]) -> std::collections::Ha
     set
 }
 
-fn build_eq_fn(
-    which: &str,
-    eqs: Vec<Arc<SimCode::SimEqSystem>>,
-    var_map: &SimVarMap,
-    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
-    by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
-) -> Result<we::Function> {
-    build_eq_fn_with_prelude(which, &[], eqs, var_map, eq_index, by_name, literals, &[], &[])
-}
-
-fn build_eq_fn_with_prelude(
-    which: &str,
-    prelude: &[(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)],
-    eqs: Vec<Arc<SimCode::SimEqSystem>>,
-    var_map: &SimVarMap,
-    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
-    by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
-    save_pre: &[(u32, u32, u32)],
-    stateset_diag: &[u32],
-) -> Result<we::Function> {
-    let sim = SimCtx {
+/// The lowering context every generated `SimData*` function shares: local 0 is the
+/// `SimData` pointer, and every slot comes from the one variable map.
+fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
+    SimCtx {
         data_local: 0,
         vars: var_map.vars.clone(),
         starts: var_map.starts.clone(),
@@ -3953,7 +4032,117 @@ fn build_eq_fn_with_prelude(
         zctol_off: var_map.zctol_off,
         zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
-    };
+    }
+}
+
+/// `daeModeData.daeEquations` flattened over its partitions, each equation paired with
+/// the `EVAL_*` stage mask it runs in. Mirrors C's `equationNames_` for
+/// `contextDAEmode`: an equation with no evaluation attributes inherits the preceding
+/// one's mask (C leaves `evalStages` unassigned there), starting from every stage.
+fn dae_residual_equations(dae: &SimCode::DaeModeData) -> Vec<(Arc<SimCode::SimEqSystem>, u32)> {
+    use openmodelica_sim_meta::driver::eval_stage as stage;
+    let all = stage::DYNAMIC | stage::ALGEBRAIC | stage::ZEROCROSS | stage::DISCRETE;
+    let mut stages = all;
+    let mut out = Vec::new();
+    for part in lst(&dae.daeEquations) {
+        for eq in lst(part) {
+            let mut discrete = false;
+            if let Some(attr) = eq_attr_of(eq) {
+                let ev = &attr.evalStages;
+                stages = (ev.dynamicEval as u32) * stage::DYNAMIC
+                    | (ev.algebraicEval as u32) * stage::ALGEBRAIC
+                    | (ev.zerocrossEval as u32) * stage::ZEROCROSS
+                    | (ev.discreteEval as u32) * stage::DISCRETE;
+                discrete = matches!(attr.kind, openmodelica_backend_types::BackendDAE::EquationKind::DISCRETE_EQUATION);
+            }
+            // A discrete-kind equation runs in the discrete stage only.
+            let stages = if discrete { stages & stage::DISCRETE } else { stages };
+            if stages != 0 {
+                out.push((eq.clone(), stages));
+            }
+        }
+    }
+    out
+}
+
+/// The equation's `BackendDAE.EquationAttributes`, absent for the few systems that
+/// carry none (`SES_ALIAS` and friends).
+fn eq_attr_of(eq: &SimCode::SimEqSystem) -> Option<&openmodelica_backend_types::BackendDAE::EquationAttributes> {
+    use SimCode::SimEqSystem as E;
+    match eq {
+        E::SES_RESIDUAL { eqAttr, .. }
+        | E::SES_FOR_RESIDUAL { eqAttr, .. }
+        | E::SES_GENERIC_RESIDUAL { eqAttr, .. }
+        | E::SES_SIMPLE_ASSIGN { eqAttr, .. }
+        | E::SES_SIMPLE_ASSIGN_CONSTRAINTS { eqAttr, .. }
+        | E::SES_ARRAY_CALL_ASSIGN { eqAttr, .. }
+        | E::SES_RESIZABLE_ASSIGN { eqAttr, .. }
+        | E::SES_GENERIC_ASSIGN { eqAttr, .. }
+        | E::SES_ENTWINED_ASSIGN { eqAttr, .. }
+        | E::SES_IFEQUATION { eqAttr, .. }
+        | E::SES_ALGORITHM { eqAttr, .. }
+        | E::SES_INVERSE_ALGORITHM { eqAttr, .. }
+        | E::SES_LINEAR { eqAttr, .. }
+        | E::SES_NONLINEAR { eqAttr, .. }
+        | E::SES_MIXED { eqAttr, .. }
+        | E::SES_WHEN { eqAttr, .. }
+        | E::SES_FOR_LOOP { eqAttr, .. }
+        | E::SES_FOR_EQUATION { eqAttr, .. }
+        | E::SES_ALGEBRAIC_SYSTEM { eqAttr, .. } => Some(eqAttr),
+        E::SES_ALIAS { .. } => None,
+    }
+}
+
+/// Build `evaluateDAEResiduals(SimData*, stage)`, one guarded block per equation. C
+/// tests `evalStages & currentEvalStage` against a per-equation assignment; here the
+/// mask is a constant, so the guard is a single `and`/`if`.
+fn build_dae_residuals_fn(
+    eqs: &[(Arc<SimCode::SimEqSystem>, u32)],
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, literals, 2);
+    for (i, (eq, stages)) in eqs.iter().enumerate() {
+        if i & 63 == 0 {
+            metamodelica::cancel::bail_if_cancelled()?;
+        }
+        ctx.sim_stage_guard(*stages);
+        lower_equation(&mut ctx, eq, eq_index)?;
+        ctx.sim_end_block();
+    }
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+fn build_eq_fn(
+    which: &str,
+    eqs: Vec<Arc<SimCode::SimEqSystem>>,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    build_eq_fn_with_prelude(which, &[], eqs, var_map, eq_index, by_name, literals, &[], &[])
+}
+
+fn build_eq_fn_with_prelude(
+    which: &str,
+    prelude: &[(Arc<DAE::ComponentRef>, Arc<DAE::Exp>)],
+    eqs: Vec<Arc<SimCode::SimEqSystem>>,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+    save_pre: &[(u32, u32, u32)],
+    stateset_diag: &[u32],
+) -> Result<we::Function> {
+    let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_stateset_diag_init(stateset_diag)?;
     for (cref, exp) in prelude {
@@ -3987,31 +4176,7 @@ fn build_init_sample_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: var_map.start_slots.clone(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: false,
-    };
+    let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     let pairs: Vec<(Arc<DAE::Exp>, Arc<DAE::Exp>)> =
         samples.iter().map(|s| (s.start.clone(), s.interval.clone())).collect();
@@ -4037,31 +4202,7 @@ fn build_init_start_values_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: HashMap::new(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: false,
-    };
+    let sim = SimCtx { start_slots: HashMap::new(), ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32, Option<u32>)> = Vec::with_capacity(states.len() + real_algs.len());
     for (i, sv) in states.iter().enumerate() {
@@ -4085,9 +4226,8 @@ fn build_init_start_values_fn(
 /// back are skipped.
 fn build_update_bound_attrs_fn(
     sim_code: &SimCode::SimCode,
-    state_nominals: &[f64],
+    nominal_defaults: &[(u32, f64)],
     attr_targets: &HashMap<String, AttrTargets>,
-    layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
@@ -4101,39 +4241,15 @@ fn build_update_bound_attrs_fn(
         for eq in lst(eqs) {
             let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { continue };
             let Some(t) = sim_cref_key(cref).ok().and_then(|k| attr_targets.get(&k)) else { continue };
-            if t.nls.is_empty() && !matches!((attr, t.state), (Attr::Nominal, Some(_))) {
+            if t.nls.is_empty() && !(matches!(attr, Attr::Nominal) && !t.nom_offs.is_empty()) {
                 continue;
             }
             attrs.push((attr, exp.clone(), t.clone()));
         }
     }
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: var_map.start_slots.clone(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: false,
-    };
+    let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    ctx.emit_update_bound_attrs(state_nominals, layout.state_nom_off, &attrs)?;
+    ctx.emit_update_bound_attrs(nominal_defaults, &attrs)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -4152,31 +4268,7 @@ fn build_zero_crossings_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: var_map.start_slots.clone(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: true,
-    };
+    let sim = SimCtx { zc_context: true, ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_zero_crossings(crossings, layout.zc_off)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -4195,31 +4287,7 @@ fn build_update_relations_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: var_map.start_slots.clone(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: true,
-    };
+    let sim = SimCtx { zc_context: true, ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_update_relations(relations, var_map.relations_off)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -4242,31 +4310,7 @@ fn build_store_delayed_fn(
         lst(&sim_code.delayedExps.delayedExps)
             .map(|(i, (e, d, dmax))| (*i, e.clone(), d.clone(), dmax.clone()))
             .collect();
-    let sim = SimCtx {
-        data_local: 0,
-        vars: var_map.vars.clone(),
-        starts: var_map.starts.clone(),
-        start_slots: var_map.start_slots.clone(),
-        array_groups: var_map.array_groups.clone(),
-        terminate_off: var_map.terminate_off,
-        terminal_off: var_map.terminal_off,
-        term_info_off: var_map.term_info_off,
-        nls_fail_off: var_map.nls_fail_off,
-        nls_jobs: var_map.nls_jobs.clone(),
-        sample_map: var_map.sample_map.clone(),
-        sample_active_off: var_map.sample_active_off,
-        relations_off: var_map.relations_off,
-        rel_fresh_off: var_map.rel_fresh_off,
-        stored_rel_off: var_map.stored_rel_off,
-        relations_pre_off: var_map.relations_pre_off,
-        n_relations: var_map.n_relations,
-        mathevents_off: var_map.mathevents_off,
-        n_mathevents: var_map.n_mathevents,
-        lambda_off: var_map.lambda_off,
-        zctol_off: var_map.zctol_off,
-        zc_pre_off: var_map.zc_pre_off,
-        zc_context: false,
-    };
+    let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_store_delayed(&delayed)?;
     let (locals, instrs) = ctx.finish_sim();
@@ -5779,10 +5823,13 @@ mod standalone_tests {
         // emitter always exports them, so the stub must too or the merge leaves
         // unresolved `model.*` imports. Taken from the canonical list rather than
         // copied, so adding an entry point cannot leave this stub behind.
+        // `evaluateDAEResiduals` is left out with `simulate`: the standalone runtime
+        // imports neither with this shape (the DAE residual takes two arguments and
+        // only a `--daeMode` model has one).
         let one_arg: Vec<&str> = openmodelica_sim_meta::driver::MODEL_FNS
             .iter()
             .copied()
-            .filter(|n| *n != "simulate")
+            .filter(|n| *n != "simulate" && *n != openmodelica_sim_meta::driver::MODEL_FN_DAE)
             .collect();
 
         let mut funcs = we::FunctionSection::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -726,7 +726,9 @@ fn supported_external(ext_name: &str, ins: &[SigTy], out: &SigTy) -> bool {
         // `Modelica.Utilities.Strings.substring` → `rt_substring` (1-based incl.).
         "ModelicaStrings_substring" => matches!(ins, [SigTy::Str, SigTy::Int, SigTy::Int]) && matches!(out, SigTy::Str),
         // Scalar math: a host transcendental or single-instruction math function.
-        _ if builtin_index(ext_name).is_some() || matches!(ext_name, "sqrt" | "fabs" | "floor" | "ceil") => {
+        _ if builtin_index(ext_name).is_some()
+            || matches!(ext_name, "sqrt" | "fabs" | "floor" | "ceil" | "abs" | "div" | "mod") =>
+        {
             ins.iter().all(scalar) && scalar(out)
         }
         _ => false,
@@ -1136,12 +1138,13 @@ pub(crate) enum Attr {
 }
 
 /// Where one variable's attribute lands: its entry in each nonlinear system that
-/// iterates on it (indexing the nominal block, and the `min`/`max` pair at twice
-/// that in the bounds block), and its state slot.
+/// iterates on it (indexing the nominal block, and the `min`/`max` pair at twice that
+/// in the bounds block), and the `SimData` nominal slots the integrator scales by (a
+/// state's, and in DAE mode an algebraic unknown's).
 #[derive(Clone, Default)]
 pub(crate) struct AttrTargets {
     pub(crate) nls: Vec<u32>,
-    pub(crate) state: Option<u32>,
+    pub(crate) nom_offs: Vec<u32>,
 }
 
 /// The contiguous `SimData` slot range backing one scalarized array model
@@ -1279,6 +1282,19 @@ impl<'a> FnCtx<'a> {
         }
     }
 
+    /// Open `if (stage & mask)` around the next equation, `stage` being the DAE-mode
+    /// residual's second parameter; `sim_end_block` closes it.
+    pub(crate) fn sim_stage_guard(&mut self, mask: u32) {
+        self.emit(we::Instruction::LocalGet(1));
+        self.emit(we::Instruction::I32Const(mask as i32));
+        self.emit(we::Instruction::I32And);
+        self.emit(we::Instruction::If(we::BlockType::Empty));
+    }
+
+    pub(crate) fn sim_end_block(&mut self) {
+        self.emit(we::Instruction::End);
+    }
+
     /// Lower one equation `cref := rhs` into this context.
     pub(crate) fn sim_assign(&mut self, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()> {
         compile_assign(self, lhs, rhs)
@@ -1338,15 +1354,14 @@ impl<'a> FnCtx<'a> {
     /// (C's `updateBoundVariableAttributes` + `updateStaticDataOfNonlinearSystems`).
     pub(crate) fn emit_update_bound_attrs(
         &mut self,
-        state_nominals: &[f64],
-        state_nom_off: u32,
+        nominal_defaults: &[(u32, f64)],
         attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
-        for (i, nom) in state_nominals.iter().enumerate() {
+        for (off, nom) in nominal_defaults {
             self.emit(we::Instruction::LocalGet(data));
             self.emit(we::Instruction::F64Const((*nom).into()));
-            self.emit(we::Instruction::F64Store(mem_arg(state_nom_off + i as u32 * 8, 3)));
+            self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
         }
         if attrs.is_empty() {
             return Ok(());
@@ -1356,14 +1371,16 @@ impl<'a> FnCtx<'a> {
             let w = compile_exp(self, exp)?;
             coerce(self, w, WTy::F64);
             self.emit(we::Instruction::LocalSet(raw));
-            if let (Attr::Nominal, Some(i)) = (attr, targets.state) {
-                // C's `dassl.c`: `atol[i] = tol * fmax(fabs(nominal), 1e-32)`.
-                self.emit(we::Instruction::LocalGet(data));
-                self.emit(we::Instruction::LocalGet(raw));
-                self.emit(we::Instruction::F64Abs);
-                self.emit(we::Instruction::F64Const(1e-32f64.into()));
-                self.emit(we::Instruction::F64Max);
-                self.emit(we::Instruction::F64Store(mem_arg(state_nom_off + i * 8, 3)));
+            if matches!(attr, Attr::Nominal) {
+                for off in &targets.nom_offs {
+                    // C's `dassl.c`: `atol[i] = tol * fmax(fabs(nominal), 1e-32)`.
+                    self.emit(we::Instruction::LocalGet(data));
+                    self.emit(we::Instruction::LocalGet(raw));
+                    self.emit(we::Instruction::F64Abs);
+                    self.emit(we::Instruction::F64Const(1e-32f64.into()));
+                    self.emit(we::Instruction::F64Max);
+                    self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+                }
             }
             if targets.nls.is_empty() {
                 continue;
@@ -1739,8 +1756,12 @@ fn compile_external_function(
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
-    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { funArgs, outVars, extName, extArgs, .. } = f else {
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, funArgs, outVars, extName, extArgs, .. } = f else {
         return Err("CodegenWasmJit: compile_external_function on a non-external function");
+    };
+    // Only for the mismatch diagnostics below.
+    let fn_path = || {
+        AbsynUtil::pathString(name.clone(), arcstr::literal!("."), true, false).unwrap_or_default()
     };
 
     let mut locals: HashMap<String, (u32, SigTy)> = HashMap::new();
@@ -1804,8 +1825,8 @@ fn compile_external_function(
 
     if external_known(f) {
         // Known math/string externals: a single return value, no output pointers.
-        let result = emit_known_external_call(&mut ctx, extName, &input_args)?;
         let (out_idx, out_sty) = ctx.outputs[0].clone();
+        let result = emit_known_external_call(&mut ctx, extName, &input_args, &out_sty)?;
         coerce(&mut ctx, result.wty(), out_sty.wty());
         ctx.emit(we::Instruction::LocalSet(out_idx));
     } else {
@@ -1822,11 +1843,25 @@ fn compile_external_function(
             .filter(|&i| !matches!(ctx.outputs[i].1, SigTy::Array { .. }))
             .collect();
         if results.len() != scalar_outs.len() {
+            openmodelica_wasm_jit::set_engine_error_detail(format!(
+                "  {}, external `{extName}`: the call returns {} value(s), the function \
+                 declares {} scalar output(s)",
+                fn_path(),
+                results.len(),
+                scalar_outs.len(),
+            ));
             return Err("CodegenWasmJit: external scalar-return/output count mismatch");
         }
         for k in (0..scalar_outs.len()).rev() {
             let (out_idx, out_sty) = ctx.outputs[scalar_outs[k]].clone();
             if results[k].wty() != out_sty.wty() {
+                openmodelica_wasm_jit::set_engine_error_detail(format!(
+                    "  {}, external `{extName}`: output {k} is {:?} in the C call but \
+                     {:?} in the function declaration",
+                    fn_path(),
+                    results[k],
+                    out_sty,
+                ));
                 return Err("CodegenWasmJit: external output type mismatch");
             }
             ctx.emit(we::Instruction::LocalSet(out_idx));
@@ -1846,11 +1881,29 @@ fn compile_external_function(
     Ok(func)
 }
 
-/// Emit a call to a known math `extName` over already-lowered argument
-/// expressions, leaving the (scalar Real) result on the stack. Mirrors the
-/// host-builtin path of [`compile_math_builtin`]: an imported transcendental
-/// ([`BUILTINS`]) or a single-instruction math function emitted inline.
-fn emit_known_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Exp>]) -> Result<SigTy> {
+/// Emit a call to a known math/string `extName` over already-lowered arguments,
+/// leaving its result on the stack (the returned `SigTy` says of which type). Mirrors
+/// the host-builtin path of [`compile_math_builtin`]: an imported transcendental
+/// ([`BUILTINS`]) or a single-instruction math function inline. `out` is the declared
+/// output type, which the `external "builtin"` operators are overloaded on.
+fn emit_known_external_call(
+    ctx: &mut FnCtx,
+    ext_name: &str,
+    args: &[Arc<DAE::Exp>],
+    out: &SigTy,
+) -> Result<SigTy> {
+    // `external "builtin" o = abs(v)` and the `div`/`mod` pairs
+    // (`OpenModelica.Internal.{int,real}{Abs,Div,Mod}`) are the tool's own operators,
+    // not C symbols. Their Integer and Real overloads share one `extName`, so a host
+    // import would bind both to the same signature and hand libc's `abs(int)` a double.
+    if matches!(ext_name, "abs" | "div" | "mod") {
+        let args = Arc::new(args.iter().cloned().collect::<List<Arc<DAE::Exp>>>());
+        let attr = match out {
+            SigTy::Int => DAE::callAttrBuiltinInteger(),
+            _ => DAE::callAttrBuiltinReal(),
+        };
+        return compile_math_builtin(ctx, ext_name, &args, &attr);
+    }
     // `ModelicaStrings_*` functions that map directly to existing runtime string
     // ops (same lowering as the corresponding Modelica string builtins, so the
     // argument ARC is handled identically).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -108,6 +108,15 @@ impl SimEngine for InWasmEngine {
         }
         Ok(())
     }
+    fn call2(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
+        let slot = slot_of(name).ok_or("in-wasm engine: unknown model function")?;
+        if !self.present(slot) {
+            return Err("in-wasm engine: required model function not exported");
+        }
+        let f: extern "C" fn(u32, u32) = unsafe { core::mem::transmute((self.fn_base + slot) as usize) };
+        f(a, b);
+        Ok(())
+    }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
         let slot = slot_of("simulate").ok_or("in-wasm engine: `simulate` has no table slot")?;
         if !self.present(slot) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -117,6 +117,11 @@ impl SimEngine for StandaloneEngine {
         // call is a no-op when the feature is absent.
         self.call1(name, arg)
     }
+    // Importing `evaluateDAEResiduals` would leave every non-DAE model with an
+    // unresolved `model.*` import, so the standalone export has no DAE mode.
+    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> driver::Result<()> {
+        Err("wasm-jit standalone: --daeMode models are not supported by the standalone export")
+    }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
         Ok(unsafe { simulate(sim_data, start, stop, n_steps) })
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -139,6 +139,11 @@ impl SimEngine for Engine {
         }
         Ok(())
     }
+    // Importing `evaluateDAEResiduals` would leave every non-DAE model with an
+    // unresolved `model.*` import.
+    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> driver::Result<()> {
+        Err("fmi3-me: --daeMode models cannot be exported as an FMU")
+    }
     fn call1_if_present(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         self.call1(name, arg)
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -205,7 +205,22 @@ pub const MODEL_FNS: &[&str] = &[
     "functionInitDelay",
     "functionUpdateBoundParameters",
     "functionUpdateBoundVariableAttributes",
+    "evaluateDAEResiduals",
 ];
+
+/// The one model entry point that is not `fn(SimData*)`: `--daeMode`'s residual
+/// takes the evaluation stage as a second argument (C's `currentEvalStage`).
+pub const MODEL_FN_DAE: &str = "evaluateDAEResiduals";
+
+/// C's `EVAL_*` (`dae_mode.c`): which stage of the step an equation belongs to.
+/// `evaluateDAEResiduals` runs exactly those whose `evalStages` intersect it.
+pub mod eval_stage {
+    pub const DYNAMIC: u32 = 1;
+    pub const ALGEBRAIC: u32 = 2;
+    pub const ZEROCROSS: u32 = 4;
+    /// The only stage that runs `when`-bodies.
+    pub const DISCRETE: u32 = 8;
+}
 
 /// The per-run capabilities a backend must expose: read/write the instance's
 /// linear memory and call its exported functions. Object-safe so the drivers can
@@ -221,6 +236,9 @@ pub trait SimEngine {
     /// Like [`call1`] but a no-op if `name` is not exported (optional teardown
     /// hooks such as `callExternalObjectDestructors`).
     fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()>;
+    /// Call the exported `fn(u32, u32) -> ()` `name` — only [`MODEL_FN_DAE`],
+    /// whose second argument is the evaluation stage.
+    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()>;
     /// Call the exported `simulate(sim_data, start, stop, n_steps) -> buf`, the
     /// in-wasm Euler driver; returns the result-buffer pointer.
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32>;
@@ -1301,6 +1319,43 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
     Ok(true)
 }
 
+/// C's `updateContinuousSystem`: recompute everything an output row reads. A
+/// `--daeMode` model has no explicit ODE, so that is one algebraic-stage residual.
+fn eval_continuous(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.dae_mode() {
+        return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ALGEBRAIC);
+    }
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)
+}
+
+/// `functionODE` alone: the derivative slots for the state the integrator last
+/// wrote. In DAE mode `y'` is an unknown, so the dynamic residual stage stands in.
+fn eval_ode(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.dae_mode() {
+        return e.call2(MODEL_FN_DAE, sim_data, eval_stage::DYNAMIC);
+    }
+    e.call1("functionODE", sim_data)
+}
+
+/// One pass of C's `functionDAE`: the discrete update.
+fn eval_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.dae_mode() {
+        return e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE);
+    }
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)
+}
+
+/// C's `function_ZeroCrossingsEquations`: what the crossing functions read.
+fn eval_zc_equations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.dae_mode() {
+        return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ZEROCROSS);
+    }
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)
+}
+
 /// Emit one result row from SimData at `time`, recomputing `functionODE`/
 /// `functionAlgebraics` first so the reported derivatives/algebraics are consistent.
 /// The integrator has accepted the state, so a non-converging NLS here is a genuine
@@ -1315,8 +1370,7 @@ fn emit_row(
 ) -> Result<()> {
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_f64(e, sim_data + TIME_OFF, time)?;
-    e.call1("functionODE", sim_data)?;
-    e.call1("functionAlgebraics", sim_data)?;
+    eval_continuous(e, sim_data, layout)?;
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
     check_asserts(e, sim_data, layout, if time >= stop { omclog::WARNING } else { omclog::INFO })
@@ -1368,9 +1422,10 @@ fn emit_initial_row(
 /// would break the post-event edge test.
 fn capture_pre(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout, time: f64) -> Result<()> {
     write_f64(e, sim_data + TIME_OFF, time)?;
-    e.call1("functionODE", sim_data)?;
-    if !layout.has_when {
-        e.call1("functionAlgebraics", sim_data)?;
+    if layout.has_when {
+        eval_ode(e, sim_data, layout)?;
+    } else {
+        eval_continuous(e, sim_data, layout)?;
     }
     capture_row(e, rows, sim_data, layout)
 }
@@ -1472,8 +1527,7 @@ fn eval_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout,
     // re-evaluates relations regardless of this flag.
     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
     write_f64(e, sim_data + TIME_OFF, time)?;
-    e.call1("functionODE", sim_data)?;
-    e.call1("functionAlgebraics", sim_data)?;
+    eval_zc_equations(e, sim_data, layout)?;
     e.call1("functionZeroCrossings", sim_data)?;
     for (i, v) in out.iter_mut().enumerate() {
         *v = read_f64(e, sim_data + layout.zc_off + (i as u32) * 8)?;
@@ -1550,8 +1604,7 @@ fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
             seed_pre_from_live(e, sim_data, layout)?;
         }
         update_relations_pre(e, sim_data, layout)?;
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
+        eval_discrete(e, sim_data, layout)?;
         if discrete_snapshot(e, sim_data, layout)? == prev {
             break;
         }
@@ -1570,6 +1623,8 @@ pub struct Samples {
     interval: Vec<f64>,
     /// Absolute address of the `active` flag array (`sim_data + sample_active_off`).
     active_off: u32,
+    /// Which model call a firing evaluates (see [`eval_discrete`]).
+    dae: bool,
 }
 
 impl Samples {
@@ -1583,7 +1638,12 @@ impl Samples {
             next.push(read_f64(e, base)?);
             interval.push(read_f64(e, base + 8)?);
         }
-        Ok(Samples { next, interval, active_off: sim_data + layout.sample_active_off })
+        Ok(Samples {
+            next,
+            interval,
+            active_off: sim_data + layout.sample_active_off,
+            dae: layout.dae_mode(),
+        })
     }
 
     /// Time of the next sample event (min of `next`), or +inf if there are none.
@@ -1607,7 +1667,11 @@ impl Samples {
             }
         }
         write_f64(e, sim_data + TIME_OFF, t)?;
-        e.call1("functionAlgebraics", sim_data)?;
+        if self.dae {
+            e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE)?;
+        } else {
+            e.call1("functionAlgebraics", sim_data)?;
+        }
         for k in 0..self.next.len() {
             if fired[k] {
                 write_i32(e, self.active_off + k as u32 * 4, 0)?;
@@ -1666,8 +1730,7 @@ pub fn event_update(
         refresh_relations(e, sim_data, layout)?;
         // `fire` cleared the `active` flag; re-evaluate so the condition reads
         // false and `pre` records it, or the next firing sees no edge.
-        e.call1("functionODE", sim_data)?;
-        e.call1("functionAlgebraics", sim_data)?;
+        eval_discrete(e, sim_data, layout)?;
     } else {
         // `pre(x)` of a continuous variable must be its value at the crossing.
         save_pre_real(e, sim_data, layout)?;
@@ -1676,7 +1739,7 @@ pub fn event_update(
         store_relations(e, sim_data, layout)?;
         check_nls(e, sim_data, layout)?;
         // A reinit changes the state the derivatives are computed from.
-        e.call1("functionODE", sim_data)?;
+        eval_ode(e, sim_data, layout)?;
     }
 
     let mut states_changed = false;
@@ -1769,6 +1832,10 @@ pub fn make_driver(
     if !supported {
         return Err(UNSUPPORTED_METHOD);
     }
+    // C leaves the choice to the user and then evaluates an empty `functionODE`.
+    if layout.dae_mode() && method != "ida" {
+        return Err("CodegenWasmJit: a model translated with --daeMode can only be simulated with -s=ida");
+    }
 
     // C allocates the solver before it initializes the model, and gbode logs its
     // configuration there, so it is built here rather than inside the driver.
@@ -1788,10 +1855,26 @@ pub fn make_driver(
         None
     };
 
-    if layout.n_samples > 0 || layout.n_zc > 0 || method == "gbode" {
+    // C's `setJacobianMethod` reports INTERNALNUMJAC in DAE mode (no symbolic `A` is
+    // generated) and announces the colored-FD fallback. C configures IDA before
+    // `initializeModel`, so this precedes the initialization messages.
+    #[cfg(sundials)]
+    if layout.dae_mode() && ida_linear_solver(layout) == crate::sundials::IdaLs::Klu {
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            "Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. \
+             Colored numerical Jacobian will be used.",
+        );
+    }
+    // DAE mode always takes the `SolverCore` path: the consistent-restart its
+    // discrete update needs lives there.
+    let events = layout.n_samples > 0 || layout.n_zc > 0;
+    if events || method == "gbode" || layout.dae_mode() {
         let label = match method {
             "cvode" => "cvode-events",
-            "ida" => "ida-events",
+            "ida" if events => "ida-events",
+            "ida" => "ida",
             "gbode" => "gbode",
             _ => "dassl-events",
         };
@@ -2085,12 +2168,14 @@ struct ResCtx {
     /// ODE Jacobian sparsity+coloring for the colored-FD `jacd`; null ⇒ the
     /// analytic path is off and daskr's own numerical Jacobian is used.
     jac: *const JacAInfo,
-    /// Scratch reused across `dassl_jac` colors (sized `n_states`): perturbed
-    /// residual, saved states, reciprocal steps, and the der read buffer.
+    /// Scratch reused across `dassl_jac` colors (sized by the unknown count):
+    /// perturbed residual, saved states, reciprocal steps, and the der read buffer.
     jac_gp: Vec<f64>,
     jac_ysave: Vec<f64>,
     jac_del: Vec<f64>,
     jac_ders: Vec<u8>,
+    /// DAE mode: the saved `y'` the Jacobian perturbs alongside `y`.
+    jac_ypsave: Vec<f64>,
     /// Jacobian evaluations (colors summed over all Jacobian assemblies).
     nje: u64,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
@@ -2133,12 +2218,19 @@ struct IdaCtx {
     mem: *mut core::ffi::c_void,
     pattern: *const IdaPattern,
     sens: SensPush,
+    /// `--daeMode` only; null for an explicit ODE.
+    dae: *const DaeSolve,
 }
 
 #[cfg(sundials)]
 impl Default for IdaCtx {
     fn default() -> Self {
-        IdaCtx { mem: core::ptr::null_mut(), pattern: core::ptr::null(), sens: SensPush::default() }
+        IdaCtx {
+            mem: core::ptr::null_mut(),
+            pattern: core::ptr::null(),
+            sens: SensPush::default(),
+            dae: core::ptr::null(),
+        }
     }
 }
 
@@ -2486,11 +2578,20 @@ fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
 
 /// C's `realVarsData[i].attribute.nominal` for the states, floored at 1e-32 by
 /// `functionUpdateBoundVariableAttributes` and so only readable after
-/// initialization. Length ≥ 1 so daskr never sees an empty array.
+/// initialization. In DAE mode the algebraic unknowns' nominals follow (C's
+/// `getAlgebraicDAEVarNominals`), one per extra component of IDA's `y`. Length ≥ 1
+/// so daskr never sees an empty array.
 fn read_state_nominals(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<f64>> {
-    (0..layout.n_states.max(1))
-        .map(|i| if i < layout.n_states { read_f64(e, sim_data + layout.state_nom_off + i * 8) } else { Ok(1.0) })
-        .collect()
+    let mut nominals: Vec<f64> = (0..layout.n_states)
+        .map(|i| read_f64(e, sim_data + layout.state_nom_off + i * 8))
+        .collect::<Result<_>>()?;
+    for k in 0..layout.n_dae_alg {
+        nominals.push(read_f64(e, sim_data + layout.dae_alg_nom_off + k * 8)?);
+    }
+    if nominals.is_empty() {
+        nominals.push(1.0);
+    }
+    Ok(nominals)
 }
 
 /// Per-state DASSL tolerances as in `dassl.c`: rtol `tol`, atol `tol·nominal[i]`.
@@ -2766,6 +2867,7 @@ impl Driver for DasslDriver {
             jac_ysave: vec![0.0; n_states],
             jac_del: vec![0.0; n_states],
             jac_ders: Vec::new(),
+            jac_ypsave: Vec::new(),
             nje: self.nje,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
@@ -3119,6 +3221,40 @@ struct IdaState {
 
 #[cfg(sundials)]
 impl IdaState {
+    /// The IDA block, built on first use — when `y`/`yp` first hold the state to
+    /// start from. In DAE mode that also runs one `IDACalcIC`: C's initialization
+    /// ends with `updateDiscreteSystem`, whose `functionDAE` is `ida_event_update`,
+    /// and that is what makes the algebraic unknowns and `y'` consistent.
+    #[allow(clippy::too_many_arguments)]
+    fn ensure(
+        &mut self,
+        e: &mut dyn SimEngine,
+        sim_data: u32,
+        t: f64,
+        y: &mut [f64],
+        yp: &mut [f64],
+        ctx: *mut ResCtx,
+    ) -> Result<()> {
+        if self.ida.is_some() {
+            return Ok(());
+        }
+        let fresh = self.setup.build(e, sim_data, t, y, yp, self.rtol, &self.atol, self.n_roots)?;
+        let ida = self.ida.insert(fresh);
+        // `IDACalcIC` below calls them, so bind `user_data` first.
+        unsafe { (*ctx).ida = self.setup.ctx(Some(ida)) };
+        if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
+            return Err("CodegenWasmJit: IDA setup failed");
+        }
+        if self.setup.dae.is_some() {
+            dae_calc_ic(ida, t)?;
+            y.copy_from_slice(ida.y());
+            yp.copy_from_slice(ida.yp());
+            self.setup.dae_store(e, sim_data, y, yp)?;
+            e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE)?;
+        }
+        Ok(())
+    }
+
     /// The IDA block is built on the first step, when `y`/`yp` first hold the
     /// state to start from. `ctx` is the callbacks' `user_data`, which lives on
     /// one `advance`'s stack, so it is rebound per call rather than stored.
@@ -3133,12 +3269,8 @@ impl IdaState {
         target: f64,
         ctx: *mut ResCtx,
     ) -> Result<Progress> {
-        let ida = match self.ida.as_mut() {
-            Some(ida) => ida,
-            None => self.ida.insert(self.setup.build(
-                e, sim_data, *t, y, yp, self.rtol, &self.atol, self.n_roots,
-            )?),
-        };
+        self.ensure(e, sim_data, *t, y, yp, ctx)?;
+        let ida = self.ida.as_mut().expect("built by `ensure`");
         unsafe { (*ctx).ida = self.setup.ctx(Some(ida)) };
         if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
             return Err("CodegenWasmJit: IDA setup failed");
@@ -3180,6 +3312,13 @@ impl IdaState {
 struct SolverCore {
     sim_data: u32,
     n_states: usize,
+    /// Components of the integrator's `y`: the states, plus in DAE mode the
+    /// algebraic unknowns that follow them.
+    n_unknowns: usize,
+    /// `SimData` slot of each algebraic DAE unknown, empty for an explicit ODE.
+    dae_alg_offs: Vec<u32>,
+    /// The model was translated with `--daeMode`, so `y'` is a solver result.
+    dae: bool,
     states_base: u32,
     ders_base: u32,
     y: Vec<f64>,
@@ -3353,6 +3492,9 @@ impl SolverCore {
         Ok(SolverCore {
             sim_data,
             n_states,
+            n_unknowns: n_states + layout.n_dae_alg as usize,
+            dae_alg_offs: model.dae.as_ref().map(|d| d.alg_offs.clone()).unwrap_or_default(),
+            dae: layout.dae_mode(),
             states_base,
             ders_base,
             y: Vec::new(),
@@ -3383,6 +3525,53 @@ impl SolverCore {
             Solver::Ida(s) => s.setup.ctx(s.ida.as_ref()),
             _ => IdaCtx::default(),
         }
+    }
+
+    /// The `IDACalcIC` half of C's `ida_event_update`, run after `restart` has
+    /// re-initialized IDA at the post-event state: consistent algebraic unknowns and
+    /// derivatives, pushed back into `SimData`. `ctx` must be the live callback
+    /// context — `IDACalcIC` evaluates the residual.
+    fn dae_restart(&mut self, e: &mut (dyn SimEngine + 'static), ctx: *mut ResCtx) -> Result<()> {
+        if !self.dae {
+            return Ok(());
+        }
+        let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
+        #[cfg(sundials)]
+        if let Solver::Ida(s) = &mut self.solver {
+            let Some(ida) = s.ida.as_mut() else { return Ok(()) };
+            if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
+                return Err("CodegenWasmJit: IDA setup failed");
+            }
+            dae_calc_ic(ida, self.t)?;
+            self.y.copy_from_slice(ida.y());
+            self.yp.copy_from_slice(ida.yp());
+            self.write_states(e)?;
+            e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
+        }
+        Ok(())
+    }
+
+    /// The `IDACalcIC` C's initialization performs before the first output row —
+    /// which already reports the algebraic unknowns and derivatives IDA solves for.
+    fn prime(&mut self, e: &mut (dyn SimEngine + 'static), layout: &SimLayout) -> Result<()> {
+        if !self.dae {
+            return Ok(());
+        }
+        self.read_states(e)?;
+        let mut ctx = self.res_ctx(e, layout);
+        let ctx_ptr = &mut ctx as *mut ResCtx;
+        RES_CTX.store(ctx_ptr, Ordering::Relaxed);
+        let _guard = ResCtxGuard;
+        let (t, sim_data) = (self.t, self.sim_data);
+        #[cfg(sundials)]
+        if let Solver::Ida(state) = &mut self.solver {
+            let e = unsafe { &mut *ctx.engine };
+            state.ensure(e, sim_data, t, &mut self.y, &mut self.yp, ctx_ptr)?;
+        }
+        if let Some(err) = ctx.err.take() {
+            return Err(err);
+        }
+        Ok(())
     }
 
     /// Record a state event at `time`. `Some((t0, time))` once [`CHATTER_LIMIT`]
@@ -3452,14 +3641,45 @@ impl SolverCore {
     }
 
     /// Latch `(y, yp)` from `SimData` — after initialization, or after anything
-    /// that moved a state behind DASKR's back.
+    /// that moved a state behind DASKR's back. In DAE mode the algebraic unknowns
+    /// follow the states in `y` (C's `getAlgebraicDAEVars`); their `y'` entries stay
+    /// zero, as C's `calloc`'d `statesDer` leaves them.
     fn read_states(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
-        self.y = (0..self.n_states)
-            .map(|i| read_f64(e, self.states_base + (i as u32) * 8))
-            .collect::<Result<_>>()?;
+        self.read_y(e)?;
         self.yp = (0..self.n_states)
             .map(|i| read_f64(e, self.ders_base + (i as u32) * 8))
             .collect::<Result<_>>()?;
+        self.yp.resize(self.n_unknowns, 0.0);
+        Ok(())
+    }
+
+    /// The `y` half of [`read_states`](SolverCore::read_states), for the callers
+    /// that must not disturb the integrator's own `y'`.
+    fn read_y(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+        self.y = (0..self.n_states)
+            .map(|i| read_f64(e, self.states_base + (i as u32) * 8))
+            .collect::<Result<_>>()?;
+        for &off in &self.dae_alg_offs {
+            self.y.push(read_f64(e, self.sim_data + off)?);
+        }
+        Ok(())
+    }
+
+    /// The integrator's accepted point back into `SimData`. For an explicit ODE only
+    /// the states move (the model computes `y'`); in DAE mode `y'` and the algebraic
+    /// unknowns are solver results too.
+    fn write_states(&self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+        for i in 0..self.n_states {
+            write_f64(e, self.states_base + (i as u32) * 8, self.y[i])?;
+        }
+        for (k, &off) in self.dae_alg_offs.iter().enumerate() {
+            write_f64(e, self.sim_data + off, self.y[self.n_states + k])?;
+        }
+        if self.dae {
+            for i in 0..self.n_states {
+                write_f64(e, self.ders_base + (i as u32) * 8, self.yp[i])?;
+            }
+        }
         Ok(())
     }
 
@@ -3489,10 +3709,11 @@ impl SolverCore {
                 Solver::Gbode(_) => self.jac_a.as_ref().map_or(core::ptr::null(), |j| j as *const JacAInfo),
                 Solver::Fixed(_) => core::ptr::null(),
             },
-            jac_gp: vec![0.0; self.n_states],
-            jac_ysave: vec![0.0; self.n_states],
-            jac_del: vec![0.0; self.n_states],
+            jac_gp: vec![0.0; self.n_unknowns],
+            jac_ysave: vec![0.0; self.n_unknowns],
+            jac_del: vec![0.0; self.n_unknowns],
             jac_ders: Vec::new(),
+            jac_ypsave: vec![0.0; self.n_unknowns],
             nje: self.nje,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
@@ -3678,7 +3899,7 @@ impl SolverCore {
         let layout = &model.layout;
         let sim_data = self.sim_data;
         let n_states = self.n_states;
-        let (states_base, ders_base) = (self.states_base, self.ders_base);
+        let ders_base = self.ders_base;
         let eps = tout.abs().max(1.0) * 1e-10;
         let mut grid_covered = false;
 
@@ -3715,9 +3936,7 @@ impl SolverCore {
                     Solved::Reached | Solved::Stepped => false,
                     Solved::Root => true,
                 };
-                for i in 0..n_states {
-                    write_f64(e, states_base + (i as u32) * 8, self.y[i])?;
-                }
+                self.write_states(e)?;
                 // C emits from `perform_simulation` once `solver_step` returns.
                 if let Solved::Stepped = solved {
                     if let Some(r) = rows.as_deref_mut()
@@ -3784,14 +4003,15 @@ impl SolverCore {
                     }
                     // Re-read states (a reinit may have jumped one), recompute the
                     // consistent derivative, and restart DASKR at troot (INFO(1)=0).
-                    for i in 0..n_states {
-                        self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
-                    }
-                    e.call1("functionODE", sim_data)?;
-                    for i in 0..n_states {
-                        self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                    self.read_states(e)?;
+                    if !self.dae {
+                        e.call1("functionODE", sim_data)?;
+                        for i in 0..n_states {
+                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                        }
                     }
                     self.restart()?;
+                    self.dae_restart(e, ctx)?;
                     continue;
                 }
                 // Reached the target with no state event: breaks a chattering run.
@@ -3827,17 +4047,18 @@ impl SolverCore {
                 if terminated(e, sim_data, layout)? {
                     return Ok(Step::Terminated);
                 }
-                for i in 0..n_states {
-                    self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
-                }
+                self.read_y(e)?;
                 // A sample may change discrete state the derivative depends on;
                 // recompute yp and restart so the integrator continues consistently.
-                if layout.n_zc > 0 || self.restart_after_time_event() {
-                    e.call1("functionODE", sim_data)?;
-                    for i in 0..n_states {
-                        self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                if layout.n_zc > 0 || self.dae || self.restart_after_time_event() {
+                    if !self.dae {
+                        e.call1("functionODE", sim_data)?;
+                        for i in 0..n_states {
+                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                        }
                     }
                     self.restart()?;
+                    self.dae_restart(e, ctx)?;
                 }
                 if te >= tout - eps {
                     grid_covered = true;
@@ -4153,6 +4374,7 @@ impl EventsDriver {
         let mut samp = Samples::load(e, sim_data, layout)?;
         let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
         let mut core = SolverCore::new(&*e, model, sim_data, start, method, gbode)?;
+        core.prime(e, layout)?;
         // A sample scheduled exactly at the start time fires before row 0.
         if samp.next_time() <= start + start.abs().max(1.0) * 1e-10 {
             samp.fire(e, sim_data, start)?;
@@ -4205,11 +4427,12 @@ impl Driver for EventsDriver {
         let stop = model.stop_time;
         let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
         let deadline = deadline_from(budget_ms);
-        let n_states = self.core.n_states;
         // `-noEquidistantTimeGrid`: the rows come from `integrate_to`, so one "row"
         // spans the run; `Samples` still bounds each solve.
-        let no_grid =
-            no_equidistant_grid() && n_states > 0 && stop > start && self.core.reports_steps();
+        let no_grid = no_equidistant_grid()
+            && self.core.n_unknowns > 0
+            && stop > start
+            && self.core.reports_steps();
         let n_rows = if no_grid { 2 } else { n_rows };
         // See `DasslDriver`: C's degenerate first iteration in this mode.
         if no_grid && !self.no_grid_primed {
@@ -4225,7 +4448,9 @@ impl Driver for EventsDriver {
         // that must be located between grid points. Walk grid point to grid point,
         // bracketing each state event on a zero-crossing sign change and bisecting to
         // its exact time, interleaved with the sample (time) events in time order.
-        if n_states == 0 {
+        // A DAE-mode model still has its algebraic unknowns for IDA to solve, so it
+        // takes the integrating path even with no states.
+        if self.core.n_unknowns == 0 {
             let mut did_step = false;
             let mut zc0 = vec![0.0f64; layout.n_zc as usize];
             let mut scratch = vec![0.0f64; layout.n_zc as usize];
@@ -4389,10 +4614,7 @@ impl Driver for EventsDriver {
             // Re-select states at the accepted output point (see `DasslDriver`).
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
                 e.call1("functionODE", sim_data)?;
-                for i in 0..n_states {
-                    self.core.y[i] = read_f64(e, self.core.states_base + (i as u32) * 8)?;
-                    self.core.yp[i] = read_f64(e, self.core.ders_base + (i as u32) * 8)?;
-                }
+                self.core.read_states(e)?;
                 self.core.restart()?;
             }
             self.row += 1;
@@ -4470,14 +4692,17 @@ unsafe extern "C" fn cvode_rhs(
 /// `gout[i] := g_i(t, y)`, the zero-crossing values whose sign changes are state
 /// events. The body of [`dassl_rt`], shared by the CVODE and IDA root callbacks.
 #[cfg(sundials)]
-unsafe fn eval_roots(ctx: &mut ResCtx, t: f64, y: *const f64, gout: *mut f64) -> Result<()> {
+unsafe fn eval_roots(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, gout: *mut f64) -> Result<()> {
     let e = unsafe { &mut *ctx.engine };
     write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
     write_f64(e, ctx.sim_data + TIME_OFF, t)?;
-    let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, ctx.n_states * 8) };
-    e.write_bytes(ctx.states_base, y_bytes)?;
+    unsafe { ida_push_unknowns(ctx, y, yp) }?;
     set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
-    e.call1("functionODE", ctx.sim_data)?;
+    if unsafe { ctx.ida.dae.as_ref() }.is_some() {
+        e.call2(MODEL_FN_DAE, ctx.sim_data, eval_stage::ZEROCROSS)?;
+    } else {
+        e.call1("functionODE", ctx.sim_data)?;
+    }
     e.call1("functionZeroCrossings", ctx.sim_data)?;
     set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
     let out = unsafe { core::slice::from_raw_parts_mut(gout as *mut u8, ctx.n_zc * 8) };
@@ -4493,7 +4718,7 @@ unsafe extern "C" fn cvode_root(
     user_data: *mut core::ffi::c_void,
 ) -> core::ffi::c_int {
     let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
-    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(y), gout) } {
+    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(y), core::ptr::null(), gout) } {
         Err(err) => {
             ctx.err = Some(err);
             -1
@@ -4654,6 +4879,7 @@ impl Driver for CvodeDriver {
             jac_ysave: Vec::new(),
             jac_del: Vec::new(),
             jac_ders: Vec::new(),
+            jac_ypsave: Vec::new(),
             nje: 0,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
@@ -4767,15 +4993,16 @@ fn fill_sundials_stats(stats: &mut SolveStats, c: crate::sundials::Counters) {
 // callbacks reach wasm through the same `ResCtx` the DASSL ones use, received as
 // IDA's `user_data`.
 
-/// The CSC layout IDA's sparse Jacobian is filled in: the model's `A` sparsity
-/// widened by the diagonal, which `J = ∂F/∂y - cj·I` needs whether or not the
-/// pattern carries it (C allocates `nnz + N` and lets `SUNMatScaleIAdd_Sparse`
-/// insert what is missing).
+/// The CSC layout IDA's sparse Jacobian is filled in: the model's sparsity, widened
+/// by the diagonal for an ODE model, which `J = ∂F/∂y - cj·I` needs whether or not
+/// the pattern carries it (C allocates `nnz + N` and lets `SUNMatScaleIAdd_Sparse`
+/// insert what is missing). A DAE-mode residual needs no widening — `∂F/∂y'` is
+/// differenced along with `∂F/∂y`.
 #[cfg(sundials)]
 struct IdaPattern {
     colptr: Vec<crate::sundials::SunIndex>,
     rowidx: Vec<crate::sundials::SunIndex>,
-    /// Value index of each column's diagonal entry.
+    /// Value index of each column's diagonal entry; empty when not widened.
     diag: Vec<usize>,
     /// `slots[col][k]` is where `rows_by_col[col][k]`'s difference quotient goes.
     slots: Vec<Vec<usize>>,
@@ -4783,23 +5010,27 @@ struct IdaPattern {
 
 #[cfg(sundials)]
 impl IdaPattern {
-    fn new(jac: &JacAInfo) -> IdaPattern {
+    fn new(jac: &JacAInfo, widen_diagonal: bool) -> IdaPattern {
         let n = jac.n as usize;
         let mut p = IdaPattern {
             colptr: Vec::with_capacity(n + 1),
             rowidx: Vec::new(),
-            diag: Vec::with_capacity(n),
+            diag: Vec::with_capacity(if widen_diagonal { n } else { 0 }),
             slots: Vec::with_capacity(n),
         };
         p.colptr.push(0);
         for col in 0..n {
             let base = p.rowidx.len();
             let mut rows = jac.rows_by_col[col].clone();
-            rows.push(col as u32);
+            if widen_diagonal {
+                rows.push(col as u32);
+            }
             rows.sort_unstable();
             rows.dedup();
-            let at = |r: u32| base + rows.binary_search(&r).expect("row is in the widened column");
-            p.diag.push(at(col as u32));
+            let at = |r: u32| base + rows.binary_search(&r).expect("row is in the column");
+            if widen_diagonal {
+                p.diag.push(at(col as u32));
+            }
             p.slots.push(jac.rows_by_col[col].iter().map(|&r| at(r)).collect());
             p.rowidx.extend(rows.iter().map(|&r| r as crate::sundials::SunIndex));
             p.colptr.push(p.rowidx.len() as crate::sundials::SunIndex);
@@ -4829,31 +5060,98 @@ struct IdaSetup {
     /// Where `IDAGetSens` deposits `n_sens` values for the next row to capture.
     sens_off: u32,
     sens_scratch: Vec<f64>,
+    /// `--daeMode`: the residual and the unknown vector this IDA solves over;
+    /// `None` for an explicit ODE.
+    dae: Option<Box<DaeSolve>>,
+}
+
+/// What the DAE-mode residual and Jacobian need beyond an ODE model's: the shape of
+/// `y = [states | algebraic unknowns]` and where each half lives in `SimData`. Boxed
+/// so the raw pointer the callbacks reach it through outlives every call.
+#[cfg(sundials)]
+struct DaeSolve {
+    /// `nResidualVars` — also `n_states + alg_offs.len()`.
+    n: usize,
+    n_states: usize,
+    /// Base of `daeModeData->residualVars` in `SimData`.
+    res_off: u32,
+    /// `SimData` slot of each algebraic unknown (C's `algIndexes`).
+    alg_offs: Vec<u32>,
+    /// `IDASetId`: 1 for a state, 0 for an algebraic unknown.
+    id: Vec<f64>,
+}
+
+/// `IDACalcIC` over the algebraic unknowns and every derivative, directed by the
+/// step IDA would take next (floored, so a zero step still gives a direction). A
+/// failed first attempt is retried with the line search off, as C does.
+#[cfg(sundials)]
+fn dae_calc_ic(ida: &mut crate::sundials::Ida, t: f64) -> Result<()> {
+    let mut h = ida.actual_init_step();
+    if h < f64::EPSILON {
+        h = f64::EPSILON;
+        ida.set_init_step(h);
+    }
+    if !ida.calc_ic(t + h, true) && !ida.calc_ic(t + h, false) {
+        return Err("CodegenWasmJit: IDA could not find consistent initial conditions (IDACalcIC)");
+    }
+    if !ida.consistent_ic() {
+        return Err("CodegenWasmJit: IDAGetConsistentIC failed");
+    }
+    // C resets the initial step to automatic afterwards.
+    ida.set_init_step(0.0);
+    Ok(())
+}
+
+/// `-idaLS`, defaulting to KLU as `ida_solver.c` does. Without states there is
+/// nothing to factorize, so KLU's demand for a pattern does not apply — the driver
+/// never steps such a model anyway (a DAE-mode one still has algebraic unknowns).
+#[cfg(sundials)]
+fn ida_linear_solver(layout: &SimLayout) -> crate::sundials::IdaLs {
+    use crate::sundials::IdaLs;
+    let ls = match crate::simflags::with_flags(|f| f.ida_ls) {
+        Some(crate::simflags::IdaLs::Dense) => IdaLs::Dense,
+        Some(crate::simflags::IdaLs::Spgmr) => IdaLs::Spgmr,
+        Some(crate::simflags::IdaLs::Spbcg) => IdaLs::Spbcg,
+        Some(crate::simflags::IdaLs::Sptfqmr) => IdaLs::Sptfqmr,
+        _ => IdaLs::Klu,
+    };
+    if layout.n_states == 0 && !layout.dae_mode() && ls == IdaLs::Klu { IdaLs::Dense } else { ls }
 }
 
 #[cfg(sundials)]
 impl IdaSetup {
     fn new(model: &SimModel) -> Result<IdaSetup> {
         use crate::sundials::IdaLs;
-        let ls = match crate::simflags::with_flags(|f| f.ida_ls) {
-            Some(crate::simflags::IdaLs::Dense) => IdaLs::Dense,
-            Some(crate::simflags::IdaLs::Spgmr) => IdaLs::Spgmr,
-            Some(crate::simflags::IdaLs::Spbcg) => IdaLs::Spbcg,
-            Some(crate::simflags::IdaLs::Sptfqmr) => IdaLs::Sptfqmr,
-            _ => IdaLs::Klu,
+        let layout = &model.layout;
+        let ls = ida_linear_solver(layout);
+        let dae = match layout.dae_mode() {
+            false => None,
+            true => {
+                let info = model.dae.as_ref().ok_or("CodegenWasmJit: DAE-mode model without DAE metadata")?;
+                let n_states = layout.n_states as usize;
+                let mut id = vec![1.0; n_states];
+                id.resize(layout.n_dae_res as usize, 0.0);
+                Some(Box::new(DaeSolve {
+                    n: layout.n_dae_res as usize,
+                    n_states,
+                    res_off: layout.dae_res_off,
+                    alg_offs: info.alg_offs.clone(),
+                    id,
+                }))
+            }
         };
-        // Nothing to factorize without states, so KLU's demand for a pattern does
-        // not apply — the driver never steps such a model anyway.
-        let ls = if model.layout.n_states == 0 && ls == IdaLs::Klu { IdaLs::Dense } else { ls };
         // The Krylov solvers assemble no matrix (C pins them to INTERNALNUMJAC).
+        // In DAE mode the pattern is the residual Jacobian's, not the ODE `A`'s
+        // (which the backend leaves empty there).
         let jac_a = match () {
             _ if ls.matrix_free() || env_var("OMC_WASM_NO_ANALYTIC_JAC").is_some() => None,
+            _ if dae.is_some() => model.dae.as_ref().and_then(|d| d.sparsity.clone()),
             _ => model.jac_a.clone(),
         };
         let pattern = match (&jac_a, ls) {
             // C throws here rather than fall back: KLU has nothing to factorize.
             (None, IdaLs::Klu) => return Err(IDA_NO_SPARSE_PATTERN),
-            (Some(j), IdaLs::Klu) => Some(IdaPattern::new(j)),
+            (Some(j), IdaLs::Klu) => Some(IdaPattern::new(j, dae.is_none())),
             _ => None,
         };
         let opts = crate::simflags::with_flags(|f| crate::sundials::IdaOptions {
@@ -4868,15 +5166,16 @@ impl IdaSetup {
             true => model.sens_params.clone(),
             false => Vec::new(),
         };
-        let n_sens = if sens_offs.is_empty() { 0 } else { model.layout.n_sens as usize };
+        let n_sens = if sens_offs.is_empty() { 0 } else { layout.n_sens as usize };
         Ok(IdaSetup {
             ls,
             jac_a,
             pattern,
             opts,
             sens_offs,
-            sens_off: model.layout.sens_off,
+            sens_off: layout.sens_off,
             sens_scratch: vec![0.0; n_sens],
+            dae,
         })
     }
 
@@ -4930,7 +5229,26 @@ impl IdaSetup {
                 return Err("CodegenWasmJit: IDA sensitivity initialization failed");
             }
         }
+        if let Some(d) = self.dae.as_deref() {
+            let suppress_alg = crate::simflags::with_flags(|f| f.ida_no_suppress_alg);
+            if !ida.set_id(&d.id, suppress_alg) {
+                return Err("CodegenWasmJit: IDASetId failed");
+            }
+        }
         Ok(ida)
+    }
+
+    /// The DAE-mode unknown vector back into `SimData` (C's `setAlgebraicDAEVars`).
+    fn dae_store(&self, e: &mut dyn SimEngine, sim_data: u32, y: &[f64], yp: &[f64]) -> Result<()> {
+        let Some(d) = self.dae.as_deref() else { return Ok(()) };
+        for i in 0..d.n_states {
+            write_f64(e, sim_data + REAL_OFF + (i as u32) * 8, y[i])?;
+            write_f64(e, sim_data + REAL_OFF + ((d.n_states + i) as u32) * 8, yp[i])?;
+        }
+        for (k, &off) in d.alg_offs.iter().enumerate() {
+            write_f64(e, sim_data + off, y[d.n_states + k])?;
+        }
+        Ok(())
     }
 
     fn ctx(&self, ida: Option<&crate::sundials::Ida>) -> IdaCtx {
@@ -4941,6 +5259,7 @@ impl IdaSetup {
                 Some(p) => SensPush { offs: self.sens_offs.as_ptr(), values: p.as_ptr(), n: p.len() },
                 None => SensPush::default(),
             },
+            dae: self.dae.as_deref().map_or(core::ptr::null(), |d| d as *const DaeSolve),
         }
     }
 }
@@ -4949,13 +5268,31 @@ impl IdaSetup {
 const IDA_NO_SPARSE_PATTERN: &str = "CodegenWasmJit: -s=ida with the KLU linear solver needs the model's \
      Jacobian sparsity pattern, which this model has none of (use -idaLS=dense)";
 
-/// `F(t, y, y') := f(t, y) - y'`, the residual `residualFunctionIDA` builds
-/// outside DAE mode: `t` and the candidate states into `SimData`, the wasm
-/// `functionODE`, the derivative slots back out.
+/// The unknown vector into `SimData` without evaluating anything.
+#[cfg(sundials)]
+unsafe fn ida_push_unknowns(ctx: &mut ResCtx, y: *const f64, yp: *const f64) -> Result<()> {
+    let dae = unsafe { ctx.ida.dae.as_ref() };
+    let e = unsafe { &mut *ctx.engine };
+    let n_states = dae.map_or(ctx.n_states, |d| d.n_states);
+    let states = unsafe { core::slice::from_raw_parts(y as *const u8, n_states * 8) };
+    e.write_bytes(ctx.states_base, states)?;
+    if let Some(d) = dae {
+        let ders = unsafe { core::slice::from_raw_parts(yp as *const u8, d.n_states * 8) };
+        e.write_bytes(ctx.ders_base, ders)?;
+        for (k, &off) in d.alg_offs.iter().enumerate() {
+            write_f64(e, ctx.sim_data + off, unsafe { *y.add(d.n_states + k) })?;
+        }
+    }
+    Ok(())
+}
+
+/// `F(t, y, y') := f(t, y) - y'`, the residual `residualFunctionIDA` builds outside
+/// DAE mode: `t` and the candidate states into `SimData`, the wasm `functionODE`, the
+/// derivative slots back out. In DAE mode the model computes the residual itself —
+/// `evaluateDAEResiduals` at the dynamic stage leaves `nResidualVars` values behind.
 #[cfg(sundials)]
 unsafe fn ida_residual(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, out: *mut f64) -> Result<()> {
     let e = unsafe { &mut *ctx.engine };
-    let n = ctx.n_states;
     let sens = ctx.ida.sens;
     for i in 0..sens.n {
         write_f64(e, ctx.sim_data + unsafe { *sens.offs.add(i) }, unsafe { *sens.values.add(i) })?;
@@ -4964,8 +5301,13 @@ unsafe fn ida_residual(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, 
         e.call1("functionUpdateBoundParameters", ctx.sim_data)?;
     }
     write_f64(e, ctx.sim_data + TIME_OFF, t)?;
-    let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
-    e.write_bytes(ctx.states_base, y_bytes)?;
+    unsafe { ida_push_unknowns(ctx, y, yp) }?;
+    if let Some(d) = unsafe { ctx.ida.dae.as_ref() } {
+        e.call2(MODEL_FN_DAE, ctx.sim_data, eval_stage::DYNAMIC)?;
+        let out_bytes = unsafe { core::slice::from_raw_parts_mut(out as *mut u8, d.n * 8) };
+        return e.read_bytes(ctx.sim_data + d.res_off, out_bytes);
+    }
+    let n = ctx.n_states;
     e.call1("functionODE", ctx.sim_data)?;
     let out_bytes = unsafe { core::slice::from_raw_parts_mut(out as *mut u8, n * 8) };
     e.read_bytes(ctx.ders_base, out_bytes)?;
@@ -5018,12 +5360,12 @@ unsafe extern "C" fn ida_res(
 unsafe extern "C" fn ida_root(
     t: f64,
     yy: crate::sundials::NVector,
-    _yp: crate::sundials::NVector,
+    yp: crate::sundials::NVector,
     gout: *mut f64,
     user_data: *mut core::ffi::c_void,
 ) -> core::ffi::c_int {
     let ctx = unsafe { &mut *(user_data as *mut ResCtx) };
-    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(yy), gout) } {
+    match unsafe { eval_roots(ctx, t, crate::sundials::nv_data(yy), crate::sundials::nv_data(yp), gout) } {
         Err(err) => {
             ctx.err = Some(err);
             -1
@@ -5054,8 +5396,9 @@ unsafe extern "C" fn ida_jac(
         return -1;
     }
     let jac = unsafe { &*ctx.jac };
+    let dae = unsafe { ctx.ida.dae.as_ref() };
     let e = unsafe { &mut *ctx.engine };
-    let n = ctx.n_states;
+    let n = dae.map_or(ctx.n_states, |d| d.n);
     let y = crate::sundials::nv_data(yy);
     let ypv = crate::sundials::nv_data(yp);
     let base = crate::sundials::nv_data(rr);
@@ -5085,6 +5428,12 @@ unsafe extern "C" fn ida_jac(
                 ctx.jac_ysave[ci] = yi;
                 ctx.jac_del[ci] = del;
                 unsafe { *y.add(ci) = yi + del };
+                // In DAE mode the same difference carries `cj·∂F/∂y'`, so there is
+                // no `-cj·I` term to add afterwards.
+                if dae.is_some() {
+                    ctx.jac_ypsave[ci] = unsafe { *ypv.add(ci) };
+                    unsafe { *ypv.add(ci) += cj * del };
+                }
             }
             write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
             // Detached so the residual can borrow `ctx`; same buffer.
@@ -5104,15 +5453,19 @@ unsafe extern "C" fn ida_jac(
                     }] = d / del;
                 }
                 unsafe { *y.add(ci) = ctx.jac_ysave[ci] };
+                if dae.is_some() {
+                    unsafe { *ypv.add(ci) = ctx.jac_ypsave[ci] };
+                }
             }
         }
         // -cj·∂F/∂y' = -cj·I, the diagonal the ∂F/∂y difference does not carry.
-        for col in 0..n {
-            vals[pattern.map_or(col * n + col, |p| p.diag[col])] -= cj;
+        if dae.is_none() {
+            for col in 0..n {
+                vals[pattern.map_or(col * n + col, |p| p.diag[col])] -= cj;
+            }
         }
-        let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
-        e.write_bytes(ctx.states_base, y_bytes)?;
-        Ok(())
+        // Restore the base point; the last colour left a perturbed one.
+        unsafe { ida_push_unknowns(ctx, y, ypv) }
     })();
     set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
     match run {
@@ -5294,6 +5647,7 @@ impl Driver for IdaDriver {
             jac_ysave: vec![0.0; n_states],
             jac_del: vec![0.0; n_states],
             jac_ders: Vec::new(),
+            jac_ypsave: Vec::new(),
             nje: 0,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -147,6 +147,19 @@ pub struct Layout {
     /// as a result row's last columns.
     pub n_sens: u32,
     pub sens_off: u32,
+    /// `--daeMode`: C's `daeModeData->nResidualVars`, also the size of the implicit
+    /// system IDA solves. 0 ⇒ an explicit ODE, and no `dae_*` region exists.
+    pub n_dae_res: u32,
+    /// Base of `daeModeData->residualVars` (f64 each).
+    pub dae_res_off: u32,
+    pub n_dae_aux: u32,
+    /// Base of `daeModeData->auxiliaryVars` (f64 each).
+    pub dae_aux_off: u32,
+    /// `daeModeData->nAlgebraicDAEVars`: the unknowns IDA carries after the states,
+    /// so `n_dae_res == n_states + n_dae_alg`.
+    pub n_dae_alg: u32,
+    /// Base of their `nominal` attributes, written like `state_nom_off`.
+    pub dae_alg_nom_off: u32,
     pub total: u32,
 }
 
@@ -173,6 +186,9 @@ impl Layout {
         n_nlsjac_f64: u32,
         n_math: u32,
         n_sens: u32,
+        n_dae_res: u32,
+        n_dae_aux: u32,
+        n_dae_alg: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -211,19 +227,29 @@ impl Layout {
         let start_off = zctol_off + 8;
         let state_nom_off = start_off + n_states * 8;
         let sens_off = state_nom_off + n_states * 8;
-        let total = sens_off + n_sens * 8;
+        let dae_res_off = sens_off + n_sens * 8;
+        let dae_aux_off = dae_res_off + n_dae_res * 8;
+        let dae_alg_nom_off = dae_aux_off + n_dae_aux * 8;
+        let total = dae_alg_nom_off + n_dae_alg * 8;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
-            mathevents_off, zctol_off, start_off, state_nom_off, n_sens, sens_off, total,
+            mathevents_off, zctol_off, start_off, state_nom_off, n_sens, sens_off,
+            n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off, total,
         }
     }
 
     /// Byte offset of state `i`'s overridable start-value slot.
     pub fn state_start_off(&self, i: u32) -> u32 {
         self.start_off + i * 8
+    }
+
+    /// C's `compiledInDAEMode`: the integrator solves `F(t, y, y') = 0` over states
+    /// *and* algebraic unknowns through `evaluateDAEResiduals`, not `functionODE`.
+    pub fn dae_mode(&self) -> bool {
+        self.n_dae_res > 0
     }
 
     /// Offset of the `pre()` slot mirroring a live variable slot at byte offset
@@ -320,6 +346,17 @@ pub struct JacAInfo {
     pub rows_by_col: Vec<Vec<u32>>,
 }
 
+/// `--daeMode` metadata the [`Layout`]'s scalars cannot carry.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct DaeInfo {
+    /// C's `daeModeData->algIndexes` as `SimData` offsets, in the order they follow
+    /// the states in IDA's `y`.
+    pub alg_offs: Vec<u32>,
+    /// `daeModeData->sparsePattern`: `∂F/∂(y, y')` with its coloring. `None` ⇒ no
+    /// pattern, which the KLU linear solver cannot work without.
+    pub sparsity: Option<JacAInfo>,
+}
+
 /// Dynamic state-selection metadata for one `$STATESET`. All offsets are
 /// SimData-relative bytes.
 #[derive(Clone, PartialEq, Debug)]
@@ -410,6 +447,8 @@ pub struct SimMeta {
     /// solver order — C reads the same list out of the `_info.json` `defines` array
     /// to name the unknowns in its `-lv=LOG_NLS` blocks.
     pub nls_vars: Vec<NlsVars>,
+    /// `--daeMode` solver metadata; `Some` exactly when [`Layout::dae_mode`].
+    pub dae: Option<DaeInfo>,
 }
 
 /// [`SimMeta::nls_vars`] entry.
@@ -503,7 +542,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 8;
+const VERSION: u32 = 9;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -534,12 +573,24 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
-        l.state_nom_off, l.n_sens, l.sens_off, l.total,
+        l.state_nom_off, l.n_sens, l.sens_off,
+        l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off, l.total,
     ] {
         put_u32(o, v);
     }
     o.push(l.has_when as u8);
     o.push(l.has_homotopy as u8);
+}
+fn put_jac(o: &mut Vec<u8>, j: &Option<JacAInfo>) {
+    match j {
+        None => o.push(0),
+        Some(j) => {
+            o.push(1);
+            put_u32(o, j.n);
+            put_u32s2(o, &j.colors);
+            put_u32s2(o, &j.rows_by_col);
+        }
+    }
 }
 fn put_kind(o: &mut Vec<u8>, k: &MetaKind) {
     match k {
@@ -583,15 +634,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_kind(&mut o, &v.kind);
         o.push(v.filter);
     }
-    match &m.jac_a {
-        None => o.push(0),
-        Some(j) => {
-            o.push(1);
-            put_u32(&mut o, j.n);
-            put_u32s2(&mut o, &j.colors);
-            put_u32s2(&mut o, &j.rows_by_col);
-        }
-    }
+    put_jac(&mut o, &m.jac_a);
     put_u32(&mut o, m.state_sets.len() as u32);
     for s in &m.state_sets {
         put_u32(&mut o, s.n_candidates);
@@ -623,6 +666,14 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_u32(&mut o, v.names.len() as u32);
         for n in &v.names {
             put_str(&mut o, n);
+        }
+    }
+    match &m.dae {
+        None => o.push(0),
+        Some(d) => {
+            o.push(1);
+            put_u32s(&mut o, &d.alg_offs);
+            put_jac(&mut o, &d.sparsity);
         }
     }
     o
@@ -669,6 +720,12 @@ impl<'a> Reader<'a> {
         }
         Ok(v)
     }
+    fn jac(&mut self) -> Result<Option<JacAInfo>, &'static str> {
+        Ok(match self.u8()? {
+            0 => None,
+            _ => Some(JacAInfo { n: self.u32()?, colors: self.u32s2()?, rows_by_col: self.u32s2()? }),
+        })
+    }
     fn layout(&mut self) -> Result<Layout, &'static str> {
         let mut l = Layout {
             n_states: self.u32()?,
@@ -710,6 +767,12 @@ impl<'a> Reader<'a> {
             state_nom_off: self.u32()?,
             n_sens: self.u32()?,
             sens_off: self.u32()?,
+            n_dae_res: self.u32()?,
+            dae_res_off: self.u32()?,
+            n_dae_aux: self.u32()?,
+            dae_aux_off: self.u32()?,
+            n_dae_alg: self.u32()?,
+            dae_alg_nom_off: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -757,10 +820,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     for _ in 0..nvars {
         vars.push(MetaVar { name: r.string()?, comment: r.string()?, kind: r.kind()?, filter: r.u8()? });
     }
-    let jac_a = match r.u8()? {
-        0 => None,
-        _ => Some(JacAInfo { n: r.u32()?, colors: r.u32s2()?, rows_by_col: r.u32s2()? }),
-    };
+    let jac_a = r.jac()?;
     let nsets = r.u32()? as usize;
     let mut state_sets = Vec::with_capacity(nsets);
     for _ in 0..nsets {
@@ -803,10 +863,14 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         }
         nls_vars.push(NlsVars { eq_index, names });
     }
+    let dae = match r.u8()? {
+        0 => None,
+        _ => Some(DaeInfo { alg_offs: r.u32s()?, sparsity: r.jac()? }),
+    };
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
-        nls_vars,
+        nls_vars, dae,
     })
 }
 
@@ -818,7 +882,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -860,6 +924,14 @@ mod tests {
                 eq_index: 1074,
                 names: vec!["pipe.medium.T".to_string(), "pipe.medium.p".to_string()],
             }],
+            dae: Some(DaeInfo {
+                alg_offs: vec![32, 40],
+                sparsity: Some(JacAInfo {
+                    n: 4,
+                    colors: vec![vec![0, 2], vec![1, 3]],
+                    rows_by_col: vec![vec![0], vec![0, 1], vec![2], vec![2, 3]],
+                }),
+            }),
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -118,6 +118,9 @@ pub struct SimFlags {
     pub ida_max_nonlin_iters: Option<i32>,
     pub ida_max_conv_fails: Option<i32>,
     pub ida_nonlin_conv_coef: Option<f64>,
+    /// `-noSuppressAlg`, which C reads inverted: setting it is what makes C call
+    /// `IDASetSuppressAlg(TRUE)`.
+    pub ida_no_suppress_alg: bool,
     /// `-maxIntegrationOrder`: caps the BDF order (5 by default).
     pub max_order: Option<i32>,
     /// `-initialStepSize`
@@ -594,6 +597,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "idaMaxNonLinIters" => f.ida_max_nonlin_iters = Some(int(name, &value(name)?)?),
             "idaMaxConvFails" => f.ida_max_conv_fails = Some(int(name, &value(name)?)?),
             "idaNonLinConvCoef" => f.ida_nonlin_conv_coef = Some(real(name, &value(name)?)?),
+            "noSuppressAlg" => f.ida_no_suppress_alg = true,
             "maxIntegrationOrder" => f.max_order = Some(int(name, &value(name)?)?),
             "initialStepSize" => f.initial_step_size = Some(real(name, &value(name)?)?),
             "homotopyOnFirstTry" => f.homotopy_on_first_try = Some(true),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
@@ -314,6 +314,8 @@ pub const IDA_TOO_MUCH_WORK: c_int = -1;
 const IDA_NORMAL: c_int = 1;
 const IDA_ONE_STEP: c_int = 2;
 const IDA_SUCCESS: c_int = 0;
+/// `IDACalcIC`'s `icopt`: solve for the algebraic components of `y` and all of `y'`.
+const IDA_YA_YDP_INIT: c_int = 1;
 const IDA_TSTOP_RETURN: c_int = 1;
 const IDA_ROOT_RETURN: c_int = 2;
 const CSC_MAT: c_int = 0;
@@ -345,6 +347,16 @@ unsafe extern "C" {
     fn IDAGetNumJacEvals(mem: *mut c_void, n: *mut c_long) -> c_int;
     fn IDAGetNumErrTestFails(mem: *mut c_void, n: *mut c_long) -> c_int;
     fn IDAGetNumNonlinSolvConvFails(mem: *mut c_void, n: *mut c_long) -> c_int;
+    // `--daeMode`: mark the algebraic unknowns and solve for consistent values.
+    fn IDASetId(mem: *mut c_void, id: NVector) -> c_int;
+    fn IDASetSuppressAlg(mem: *mut c_void, suppressalg: c_int) -> c_int;
+    fn IDACalcIC(mem: *mut c_void, icopt: c_int, tout1: f64) -> c_int;
+    fn IDAGetConsistentIC(mem: *mut c_void, yy0: NVector, yp0: NVector) -> c_int;
+    fn IDAGetActualInitStep(mem: *mut c_void, hinused: *mut f64) -> c_int;
+    fn IDASetLineSearchOffIC(mem: *mut c_void, lsoff: c_int) -> c_int;
+    fn IDASetMaxNumStepsIC(mem: *mut c_void, maxnh: c_int) -> c_int;
+    fn IDASetMaxNumJacsIC(mem: *mut c_void, maxnj: c_int) -> c_int;
+    fn IDASetMaxNumItersIC(mem: *mut c_void, maxnit: c_int) -> c_int;
 
     fn N_VCloneVectorArray(count: c_int, w: NVector) -> *mut NVector;
     fn N_VDestroyVectorArray(vs: *mut NVector, count: c_int);
@@ -407,6 +419,8 @@ pub struct Ida {
     /// Run totals; the `IDAGet*` counters restart with every `IDAReInit`.
     past: Counters,
     sens: Option<Sens>,
+    /// Kept so [`set_user_data`](Ida::set_user_data) can re-arm it.
+    jac_fn: Option<IdaJacFn>,
 }
 
 /// IDAS forward sensitivity state (`-idaSensitivity`). `p` is what IDAS perturbs
@@ -477,6 +491,7 @@ impl Ida {
                 roots: vec![0; n_roots.max(1)],
                 past: Counters::default(),
                 sens: None,
+                jac_fn: jac,
             }
         };
         ida.y_mut().copy_from_slice(y0);
@@ -513,6 +528,54 @@ impl Ida {
     /// The IDA memory block, for the `IDAGet*` a callback needs.
     pub fn mem(&self) -> *mut c_void {
         self.mem
+    }
+
+    /// `--daeMode`: which unknowns are differential (`1`) and which algebraic (`0`),
+    /// so `IDACalcIC` can solve for the latter and (with `suppress_alg`) the local
+    /// error test can leave them out.
+    pub fn set_id(&mut self, id: &[f64], suppress_alg: bool) -> bool {
+        let v = unsafe { N_VNew_Serial(self.n as SunIndex) };
+        if v.is_null() {
+            return false;
+        }
+        unsafe {
+            core::ptr::copy_nonoverlapping(id.as_ptr(), N_VGetArrayPointer(v), self.n);
+            let ok = (!suppress_alg || IDASetSuppressAlg(self.mem, 1) == IDA_SUCCESS)
+                && IDASetId(self.mem, v) == IDA_SUCCESS;
+            // IDA keeps its own copy of `id`.
+            N_VDestroy(v);
+            ok
+        }
+    }
+
+    /// The step IDA would take first; `IDACalcIC` needs a nonzero one.
+    pub fn actual_init_step(&self) -> f64 {
+        let mut h = 0.0;
+        unsafe { IDAGetActualInitStep(self.mem, &mut h) };
+        h
+    }
+
+    pub fn set_init_step(&mut self, h: f64) -> bool {
+        unsafe { IDASetInitStep(self.mem, h) == IDA_SUCCESS }
+    }
+
+    /// `IDACalcIC(IDA_YA_YDP_INIT)`: solve for the algebraic unknowns and every
+    /// derivative, `tout1` giving the direction. Raised iteration limits as in
+    /// `ida_event_update`; `line_search` off is C's retry.
+    pub fn calc_ic(&mut self, tout1: f64, line_search: bool) -> bool {
+        unsafe {
+            let lim = (2 * self.n * 10) as c_int;
+            IDASetMaxNumStepsIC(self.mem, lim);
+            IDASetMaxNumJacsIC(self.mem, lim);
+            IDASetMaxNumItersIC(self.mem, lim);
+            IDASetLineSearchOffIC(self.mem, !line_search as c_int);
+            IDACalcIC(self.mem, IDA_YA_YDP_INIT, tout1) == IDA_SUCCESS
+        }
+    }
+
+    /// Read what [`calc_ic`](Ida::calc_ic) settled on back into `y`/`yp`.
+    pub fn consistent_ic(&mut self) -> bool {
+        unsafe { IDAGetConsistentIC(self.mem, self.y, self.yp) == IDA_SUCCESS }
     }
 
     /// Start forward sensitivity analysis over `p0`, the differentiated
@@ -606,8 +669,18 @@ impl Ida {
     /// Rebind the pointer handed to the `res`/`root`/`jac` callbacks. The
     /// driver's context lives on the stack of one `advance`, so it is set per
     /// chunk.
+    /// Bind the callbacks' context, re-arming the Jacobian with it: the linear solver
+    /// caches `user_data` as its `J_data` in `IDASetJacFn` (and in `idaLsInitialize`,
+    /// which only runs on the first solve after an `IDAReInit`), so a plain
+    /// `IDASetUserData` would leave the Jacobian callback on the previous context.
     pub fn set_user_data(&mut self, user_data: *mut c_void) -> bool {
-        unsafe { IDASetUserData(self.mem, user_data) == IDA_SUCCESS }
+        unsafe {
+            IDASetUserData(self.mem, user_data) == IDA_SUCCESS
+                && match self.jac_fn {
+                    Some(f) => IDASetJacFn(self.mem, Some(f)) == IDA_SUCCESS,
+                    None => true,
+                }
+        }
     }
 
     /// Integrate to `tout`, stopping early on a root. `t` is updated to where the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -104,6 +104,9 @@ impl openmodelica_sim_meta::driver::SimEngine for MemEngine<'_> {
     fn call1_if_present(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
         Err("wasm-jit: MemEngine cannot call the model")
     }
+    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> metamodelica::Result<()> {
+        Err("wasm-jit: MemEngine cannot call the model")
+    }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> metamodelica::Result<u32> {
         Err("wasm-jit: MemEngine cannot call the model")
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -860,7 +860,7 @@ pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver
     // Allocate the shared SimData block.
     let sim_data = wts(rt_alloc.call(&mut store, layout.total))?;
 
-    let engine = WasmerEngine { store, memory, instance, rt_inst, funcs: HashMap::new() };
+    let engine = WasmerEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), dae_func: None };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -873,6 +873,8 @@ struct WasmerEngine {
     instance: wasmer::Instance,
     rt_inst: wasmer::Instance,
     funcs: HashMap<String, wasmer::TypedFunction<u32, ()>>,
+    /// The DAE-mode residual, the one `fn(u32, u32) -> ()` entry point.
+    dae_func: Option<wasmer::TypedFunction<(u32, u32), ()>>,
 }
 
 impl WasmerEngine {
@@ -902,6 +904,16 @@ impl sim_driver::SimEngine for WasmerEngine {
             return Ok(());
         }
         self.call1(name, arg)
+    }
+    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
+        let f = match self.dae_func.clone() {
+            Some(f) => f,
+            None => {
+                let f = wt(self.instance.exports.get_typed_function::<(u32, u32), ()>(&self.store, name))?;
+                self.dae_func.insert(f).clone()
+            }
+        };
+        wt(f.call(&mut self.store, a, b))
     }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32> {
         let f: wasmer::TypedFunction<(u32, f64, f64, u32), u32> =
@@ -1046,6 +1058,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn call1_if_present(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Ok(())
+    }
+    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
+        Err("CodegenWasmJit: call2 on in-wasm session (unreachable)")
     }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -806,7 +806,7 @@ pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver
         run_table_probe(&mut store, rt_inst, instance, memory, sim_data, layout.total)?;
     }
 
-    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new() };
+    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), dae_func: None };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -869,6 +869,8 @@ struct WasmtimeEngine {
     instance: wasmtime::Instance,
     rt_inst: wasmtime::Instance,
     funcs: HashMap<String, wasmtime::TypedFunc<u32, ()>>,
+    /// The DAE-mode residual, the one `fn(u32, u32) -> ()` entry point.
+    dae_func: Option<wasmtime::TypedFunc<(u32, u32), ()>>,
 }
 
 impl WasmtimeEngine {
@@ -898,6 +900,16 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             return Ok(());
         }
         self.call1(name, arg)
+    }
+    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
+        let f = match self.dae_func.clone() {
+            Some(f) => f,
+            None => {
+                let f = wt(self.instance.get_typed_func::<(u32, u32), ()>(&mut self.store, name))?;
+                self.dae_func.insert(f).clone()
+            }
+        };
+        wt(f.call(&mut self.store, (a, b)))
     }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32> {
         let f = wt(self.instance.get_typed_func::<(u32, f64, f64, u32), u32>(&mut self.store, "simulate"))?;
@@ -1048,6 +1060,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn call1_if_present(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Ok(())
+    }
+    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
+        Err("CodegenWasmJit: call2 on in-wasm session (unreachable)")
     }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")

--- a/testsuite/simulation/modelica/daemode/testDAEModeFileSplit_Issue4851.mos
+++ b/testsuite/simulation/modelica/daemode/testDAEModeFileSplit_Issue4851.mos
@@ -1,7 +1,10 @@
 // name: testDAEModeFileSplit_Issue4851.mos
 // status: correct
 // teardown_command: rm -f PowerGrids.Examples.IEEE14bus.IEEE14busGen2Disconnection* output.log
+// cflags: --simCodeTarget=C
 // tests that we split the big 16dae.c files into parts
+// The generated C files are what this checks, so it pins the C target rather
+// than following a corpus-wide --simCodeTarget override.
 
 loadFile("pg.mo");
 getErrorString();


### PR DESCRIPTION
A model translated with `--daeMode` has no explicit ODE: `allEquations` is empty and the whole continuous system is `daeModeData.daeEquations`, the residual `F(t, y, y') = 0` over the states *and* the algebraic unknowns. The wasm-jit target ignored all of it and simulated an empty ODE, so the 13 `simulation/modelica/daemode` tests produced garbage or failed to build. They now pass, and still pass on the C target.

Following `ida_solver.c`/`dae_mode.c`:

| piece | where |
| --- | --- |
| residual + stage masks | `evaluateDAEResiduals(SimData*, stage)` | | unknowns, sparsity | `Layout` dae regions + `SimMeta.dae` | | `IDA` over `[states \| alg]` | `IdaSetup`/`DaeSolve`, `IDASetId` | | consistent restart | `IDACalcIC` (`prime` / `dae_restart`) |

C tests `evalStages & currentEvalStage` at run time against a per-equation assignment; the mask is a constant here, so each equation's guard is one `and`/`if` and discrete-kind equations collapse to the discrete stage. The four model-evaluation points
(`updateContinuousSystem`, `functionDAE`,
`function_ZeroCrossingsEquations` and `functionODE`) now route through stage helpers, leaving the ODE path byte-for-byte as it was. The colored-FD Jacobian perturbs `y` *and* `y'`, so it carries `cj·∂F/∂y'` and needs neither a `-cj·I` term nor diagonal widening.

Two bugs surfaced on the way, both fixed here:

* SUNDIALS copies `user_data` into the linear solver's own `J_data` only in `IDASetJacFn` and `idaLsInitialize` (first solve after a `ReInit`). Rebinding the context with `IDASetUserData` alone left the *Jacobian* callback on the previous, by then dead, `ResCtx` — a segfault in `ida_jac` under `idaLsSetup`. `Ida::set_user_data` re-arms the Jacobian function; this was latent on the ODE path too.
* `OpenModelica.Internal.{int,real}Abs` (same for `Div`/`Mod`) are `external "builtin" o = abs(v)` and share one `extName`, so the `ext.<name>` host-import dedup bound both overloads to whichever came first and handed libc's `int abs(int)` a double. They lower through `compile_math_builtin` now, like the builtins they are. This is what broke DAE-mode DrumBoiler; in ODE mode it was silently wrong.

`testDAEModeFileSplit_Issue4851.mos` checks the generated `*_16dae_part*.c`, so it pins `--simCodeTarget=C` instead of following a corpus-wide override.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
