### PR TITLE
wasm-jit: fix module caching and obey -n=1

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -390,6 +390,12 @@ fn with_engine_detail(e: &str) -> String {
     }
 }
 
+/// Mirror `-n` into the engine, before anything reaches the JIT.
+fn sync_engine_threading() -> Result<()> {
+    openmodelica_wasm_jit::model::set_single_threaded(openmodelica_util::Config::noProc()? == 1);
+    Ok(())
+}
+
 /// `CodegenWasmJit.translateModel`: lower `simCode` to a model wasm module, write
 /// `<prefix>.wasm`, and stash the prepared [`SimModel`] for the later
 /// `runSimulation`. On a lowering error the message is recorded to the Error
@@ -397,6 +403,7 @@ fn with_engine_detail(e: &str) -> String {
 /// translation fails — as the other codegen targets do — never a stderr print or
 /// a panic (a panic would trap the wasm instance and lose the buffered message).
 pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
+    sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let prefix = simCode.fileNamePrefix.to_string();
     let _ = std::fs::remove_file(format!("{prefix}.wasm"));
@@ -1601,6 +1608,7 @@ fn emit_fmu(
     adapter: &[u8],
     kind: &str,
 ) -> Result<()> {
+    sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
     let outcome = (|| -> Result<()> {
@@ -3439,10 +3447,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let compile_wasm = wasm.clone();
     // Native: compile on a background thread to overlap the rest of the pipeline.
     // wasm: no threads — compile eagerly and store the result for take_compiled_model.
+    // `-n=1`: no job, so `take_compiled_model` compiles inline where it is timed.
     #[cfg(not(target_arch = "wasm32"))]
-    let compiled = Mutex::new(Some(std::thread::spawn(move || {
-        sim_runtime::compile_model_module(&compile_wasm)
-    })));
+    let compiled = Mutex::new(match openmodelica_wasm_jit::model::single_threaded() {
+        true => None,
+        false => Some(std::thread::spawn(move || {
+            sim_runtime::compile_model_module(&compile_wasm)
+        })),
+    });
     #[cfg(target_arch = "wasm32")]
     let compiled = Mutex::new(Some(sim_runtime::compile_model_module(&compile_wasm)));
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -76,6 +76,8 @@ pub struct EditableParam {
 static INWASM_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 #[cfg(feature = "jit")]
 static SIM_BENCH_FORCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+#[cfg(feature = "jit")]
+static SINGLE_THREADED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Force the driver choice: `1` in-wasm, `0` host, `-1` default. Wins over the env
 /// var and the target default — wasm has no environment.
@@ -94,6 +96,18 @@ pub fn set_sim_bench(on: bool) {
 pub fn sim_bench_enabled() -> bool {
     SIM_BENCH_FORCE.load(std::sync::atomic::Ordering::Relaxed)
         || std::env::var("OMC_WASM_SIM_BENCH").is_ok()
+}
+
+/// Set from `-n`: one processor means no background precompile and no parallel
+/// module compilation, so each phase is timed where it runs.
+#[cfg(feature = "jit")]
+pub fn set_single_threaded(on: bool) {
+    SINGLE_THREADED.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(feature = "jit")]
+pub fn single_threaded() -> bool {
+    SINGLE_THREADED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Whether to run through the in-wasm session driver (`rt_sim_*`) instead of the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -87,7 +87,8 @@ pub fn sim_engine() -> &'static wasmer::Engine {
     ENGINE.get_or_init(|| {
         let mut compiler = Cranelift::default();
         // Experimental opt-level override; default is cranelift's `Speed`.
-        // (wasmer compiles module functions in parallel by default.)
+        // (wasmer compiles module functions in parallel and exposes no knob for it,
+        // so `-n=1` only stops the precompile, not this.)
         match std::env::var("OMC_WASM_OPT_LEVEL").as_deref() {
             Ok("none") => { compiler.opt_level(CraneliftOptLevel::None); }
             Ok("speed_and_size") => { compiler.opt_level(CraneliftOptLevel::SpeedAndSize); }
@@ -207,6 +208,10 @@ pub fn start_runtime_compile() {
     return;
     #[cfg(not(target_arch = "wasm32"))]
     {
+        // Same under `-n=1`.
+        if crate::model::single_threaded() {
+            return;
+        }
         static STARTED: std::sync::Once = std::sync::Once::new();
         STARTED.call_once(|| {
             std::thread::spawn(|| {
@@ -764,6 +769,9 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         Some(m) => m,
         None => take_compiled_model(model)?,
     };
+    // `take_compiled_model` consumes the job, so cache it here too: `finishCompile`
+    // does not run for a resimulate, which would then recompile on every run.
+    *model.prepared.lock().unwrap() = Some(model_module.clone());
     let model_compile = t_model.elapsed();
     let compile_time = t_compile.elapsed();
     if bench {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -117,7 +117,7 @@ fn build_engine_cfg(extra: impl FnOnce(&mut wasmtime::Config)) -> wasmtime::Engi
     crate::tune_memory(&mut cfg);
     // Compile module functions across threads (off by default with
     // default-features=false) — ~4x faster module compilation here.
-    cfg.parallel_compilation(true);
+    cfg.parallel_compilation(!crate::model::single_threaded());
     // Experimental opt-level override; default is wasmtime's `Speed`.
     match std::env::var("OMC_WASM_OPT_LEVEL").as_deref() {
         Ok("none") => { cfg.cranelift_opt_level(wasmtime::OptLevel::None); }
@@ -222,6 +222,10 @@ pub fn compile_model_module(wasm: &[u8]) -> std::result::Result<wasmtime::Module
 /// entry) — it then compiles while `build_sim_model` generates the model bytes,
 /// and `run` only waits for whatever did not overlap. Idempotent.
 pub fn start_runtime_compile() {
+    // Under `-n=1` compile it on first use instead, where it is timed.
+    if crate::model::single_threaded() {
+        return;
+    }
     static STARTED: std::sync::Once = std::sync::Once::new();
     STARTED.call_once(|| {
         std::thread::spawn(|| {
@@ -693,6 +697,9 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     } else {
         wts(wasmtime::Module::new(engine, &model.wasm))?
     };
+    // `take_compiled_model` consumes the job, so cache it here too: `finishCompile`
+    // does not run for a resimulate, which would then recompile on every run.
+    *model.prepared.lock().unwrap() = Some(model_module.clone());
     let model_compile = t_model.elapsed();
     let compile_time = t_compile.elapsed();
     if bench {


### PR DESCRIPTION
Two things kept the JIT compile from being measured where it happens.

`instantiate_modules` preferred `model.prepared`, but only `finishCompile` ever filled it, and that runs in `buildModel`'s compile phase. A `simulate(resimulateExecutable=)` skips `buildModel`, so the first run fell through to `take_compiled_model` — which *takes* the background compile job — and every run after it found neither a job nor a prepared module, and recompiled the model from scratch. Repeating a simulation in one session was therefore slower than the first, by the whole model-module JIT:

| Model                          | run 1  | runs 2+    |
|--------------------------------|--------|------------|
| `der(x) = -x`                  | 4.1 us | 6.1-7.9 ms |
| VehicleInterfaces.SeriesHybrid | 4.8 us | 44-54 ms   |
| Fluid HeatExchangerSimulation  | 4.5 us | 422-507 ms |

Store the module in `prepared` after obtaining it, so the cache is filled on whichever path got there first. Repeat runs now fetch it in ~1 us. In the wasmtime backend this happens after the engine-mismatch recompile, so what is cached always belongs to the current engine.

Neither the precompile nor cranelift consulted `-n`, so a target asked for one processor still spawned two background threads per translation and compiled module functions across the machine. Beyond ignoring what the caller asked for, that hides the JIT cost: `translateModel` starts the compile and the rest of the pipeline overlaps it, so by the time anything measures, the work is already done and reports as microseconds. It is the right default — free parallelism — but it leaves the library testing tool, which runs `-n=1` and 12 tests at once, unable to either bound a test's CPU use or measure what the JIT costs.

With one processor: no `start_runtime_compile`, no background model-module job (`take_compiled_model` compiles inline in the build phase instead), and `parallel_compilation` off. SeriesHybrid then reports a 216 ms model compile where it previously reported 5 us.

wasmer is left as it was: it compiles module functions in parallel with no knob to turn it off, so `-n=1` only stops the precompile there.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
