### PR TITLE
fmi3-wasm: messages go to the FMI logger

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5782,11 +5782,10 @@ fn output_selection(model: &SimModel) -> Vec<bool> {
     }
 }
 
-// The standalone-export merge uses `wasmtime::Module` to validate the result, so
-// this test runs only under the default (wasmtime) engine on a native host.
+// Both link paths (standalone merge, FMU component) are native-only.
 #[cfg(test)]
-#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
-mod standalone_tests {
+#[cfg(not(target_arch = "wasm32"))]
+mod link_tests {
     use super::*;
     use wasm_encoder as we;
 
@@ -5879,6 +5878,30 @@ mod standalone_tests {
         m.finish()
     }
 
+    /// Every adapter `env` import must be satisfied by the model or by the runtime
+    /// linked into the adapter itself; an `env` host callback (`rt_host_log`) is an
+    /// unresolved symbol here.
+    #[test]
+    fn fmu_component_links_without_a_host() {
+        for (label, adapter) in [
+            ("ME", FMI3_ME_ADAPTER),
+            ("CS", FMI3_CS_ADAPTER),
+            ("me_cs", FMI3_MECS_ADAPTER),
+        ] {
+            if adapter.is_empty() {
+                continue; // omc built without the wasm32 toolchain
+            }
+            assert!(
+                link_fmu_component(&build_stub_model(), adapter).is_ok(),
+                "{label} adapter does not link into a component: {}",
+                openmodelica_util::Error::printMessagesStr(false)
+            );
+        }
+    }
+
+    // The standalone-export merge validates the result with `wasmtime::Module`, so
+    // it runs only under the default (wasmtime) engine.
+    #[cfg(all(feature = "jit", not(feature = "engine-wasmer")))]
     #[test]
     fn merge_leaves_only_wasi_imports() {
         let merged = merge_standalone(&build_stub_model()).expect("wasm-merge should succeed");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -21,8 +21,11 @@ crate-type = ["cdylib", "rlib"]
 # In-wasm `rt_sim_*` session driver (src/session.rs) + its DAE solver (daskr). On
 # for the no_std JIT and web interactive runtimes; off for the native host-driven
 # runtime, so daskr/sim_meta are not linked there. The FMI3 adapter disables it.
-default = ["session"]
+default = ["session", "host_log"]
 session = ["dep:daskr"]
+# Route `-lv` log lines out through `env.rt_host_log`. Every runtime a wasm host
+# instantiates has it; the FMI3 adapter has no `env` host, and installs its own sink.
+host_log = []
 # Standalone-export driver (src/standalone.rs, `_start` + model-importing), wasip1 only.
 standalone = ["dep:daskr", "dep:openmodelica_mat_writer", "inwasm_solve"]
 # In-wasm sparse solve (rsparse). Off for the native interactive runtime, which

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
@@ -1,9 +1,11 @@
 //! Reaching [`openmodelica_sim_meta::omclog`] from inside the runtime module.
 //!
 //! The nonlinear solver runs in wasm whichever driver owns the run, so its lines
-//! have to leave it: `rt_host_log` hands them to the host, which writes them to the
-//! stdout the model's `print` and the driver's own lines share, keeping call order.
-//! The standalone module has no host and writes its own stdout.
+//! have to leave it: with `host_log`, `rt_host_log` hands them to the host, which
+//! writes them to the stdout the model's `print` and the driver's own lines share,
+//! keeping call order. The standalone module has no host and writes its own stdout.
+//! A build with neither installs no sink of its own — the FMI3 adapter has a host
+//! logger but no `env` to import from, and sets [`driver::set_log_sink`] itself.
 //!
 //! The per-stream indentation stays module-local. That is exact as long as no line
 //! from outside lands inside a block, which holds: a `rt_solve_nls` call closes
@@ -11,17 +13,20 @@
 
 pub use openmodelica_sim_meta::omclog::*;
 
-#[cfg(all(target_arch = "wasm32", not(feature = "standalone")))]
+#[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
 #[link(wasm_import_module = "env")]
 unsafe extern "C" {
     /// The host's stdout: `len` bytes of UTF-8 at `ptr` in this module's memory.
     fn rt_host_log(ptr: u32, len: u32);
 }
 
-#[cfg(all(target_arch = "wasm32", not(feature = "standalone")))]
+#[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
 pub(crate) fn sink(s: &str) {
     unsafe { rt_host_log(s.as_ptr() as u32, s.len() as u32) };
 }
+
+#[cfg(all(target_arch = "wasm32", not(feature = "host_log"), not(feature = "standalone")))]
+pub(crate) fn sink(_s: &str) {}
 
 #[cfg(all(target_arch = "wasm32", feature = "standalone"))]
 pub(crate) fn sink(s: &str) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
@@ -5,7 +5,8 @@
 # and drives the model through the kernel functions imported from module `model`.
 #
 # It links `openmodelica_codegen_wasm_jit_runtime` (default-features off, so the
-# `rt_sim_*` session driver and its `env` table import are dropped) purely for the
+# `rt_sim_*` session driver and its `env` table import are dropped, as is the
+# `host_log` sink — there is no `env` host to import one from) purely for the
 # shared dlmalloc allocator + `rt_*` primitives + linear memory: the merged module
 # then has ONE allocator/heap shared by the model's `rt_alloc` and wit-bindgen's
 # `cabi_realloc`. See openmodelica_codegen_wasm_jit/build.rs for how it is built

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -32,7 +32,7 @@ use openmodelica_sim_meta::driver::{
 };
 #[cfg(feature = "cs")]
 use openmodelica_sim_meta::driver::{CsDriver, CsStep};
-use openmodelica_sim_meta::{decode, FmiVr, Layout, WTy, REAL_OFF, TIME_OFF};
+use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, WTy, REAL_OFF, TIME_OFF};
 
 // ── Model kernel imports ─────────────────────────────────────────────────────
 // `env` is the dylink convention: the Linker resolves these against the model
@@ -59,43 +59,162 @@ unsafe extern "C" {
     fn om_meta_len() -> u32;
 }
 
-/// The runtime leaves `rt_assert` to the host on this target. A failed assertion
-/// traps, aborting the FMI call; the master surfaces it as a fatal status.
+// ── Messages ─────────────────────────────────────────────────────────────────
+// A component has no stdout, so the `log-message` callback (`fmi3LogMessage`) is
+// the FMU's only channel: `print`, assertions and the `-lv` solver lines all leave
+// through it, with the statuses and categories C's FMU gives them
+// (`fmu3_model_interface.c`).
+
+/// C's `logCategoriesNames`, which is also what `CodegenFMU3` declares in
+/// `modelDescription.xml`. `logFmi3Call` is unused: the adapter logs no call trace.
+const CATEGORIES: [&str; 11] = [
+    "logEvents",
+    "logSingularLinearSystems",
+    "logNonlinearSystems",
+    "logDynamicStateSelection",
+    "logStatusWarning",
+    "logStatusDiscard",
+    "logStatusError",
+    "logStatusFatal",
+    "logStatusPending",
+    "logAll",
+    "logFmi3Call",
+];
+const CAT_EVENTS: u32 = 0;
+const CAT_SINGULAR_LS: u32 = 1;
+const CAT_NLS: u32 = 2;
+const CAT_DSS: u32 = 3;
+const CAT_WARNING: u32 = 4;
+const CAT_ERROR: u32 = 6;
+const CAT_ALL: u32 = 9;
+
+struct Logger {
+    /// `instanceName`, which the callback reports alongside the message.
+    name: String,
+    /// `loggingOn`.
+    on: bool,
+    /// Bit per [`CATEGORIES`] index.
+    cats: u32,
+}
+
+static mut LOGGER: Logger = Logger { name: String::new(), on: false, cats: 0 };
+
+/// The sink is a bare `fn(&str)`, so its context is a static (wasm, single-threaded).
+fn logger() -> &'static mut Logger {
+    unsafe { &mut *core::ptr::addr_of_mut!(LOGGER) }
+}
+
+fn log_raw(status: Status, cat: u32, msg: &str) {
+    let l = logger();
+    fmi::fmi3::callbacks::log_message(&l.name, status, CATEGORIES[cat as usize], msg.trim_end_matches('\n'));
+}
+
+/// C's `FILTERED_LOG` / `isCategoryLogged`.
+fn fmi_log(status: Status, cat: u32, msg: &str) {
+    let cats = logger().cats;
+    if cats & (1 << cat) != 0 || cats & (1 << CAT_ALL) != 0 {
+        log_raw(status, cat, msg);
+    }
+}
+
+/// The runtime's and driver's log lines. They exist only because [`stream_mask`]
+/// switched their stream on, so the category is `logAll` rather than a per-line one.
+fn log_sink(s: &str) {
+    if logger().on {
+        log_raw(Status::Ok, CAT_ALL, s);
+    }
+}
+
+/// The `-lv` streams the model-diagnostics categories stand for.
+fn stream_mask(cats: u32) -> omclog::Mask {
+    let mut streams: Vec<&str> = Vec::new();
+    for (cat, stream) in [
+        (CAT_EVENTS, "LOG_EVENTS"),
+        (CAT_SINGULAR_LS, "LOG_LS"),
+        (CAT_NLS, "LOG_NLS"),
+        (CAT_DSS, "LOG_DSS"),
+    ] {
+        if cats & (1 << cat) != 0 || cats & (1 << CAT_ALL) != 0 {
+            streams.push(stream);
+        }
+    }
+    omclog::mask_from_streams(&streams).unwrap_or(omclog::ALWAYS_ON)
+}
+
+/// C's `omcInstantiate`: every category follows `loggingOn` until
+/// `set-debug-logging` picks specific ones.
+fn init_logging(name: String, logging_on: bool) {
+    let l = logger();
+    l.name = name;
+    l.on = logging_on;
+    l.cats = if logging_on { !0 } else { 0 };
+    driver::set_log_sink(log_sink);
+    omclog::set_mask(stream_mask(l.cats));
+}
+
+/// The runtime `String` behind a handle, empty for the null handle.
+fn rt_string(handle: i32) -> String {
+    use openmodelica_codegen_wasm_jit_runtime as rt;
+    let h = handle as u32;
+    if h == 0 {
+        return String::new();
+    }
+    let len = rt::rt_str_len(h) as usize;
+    let bytes = unsafe { core::slice::from_raw_parts(rt::rt_str_data(h) as *const u8, len) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// C's `omc_assert_fmi_common`: the source position, then the message.
+fn assert_message(msg: i32, file: i32, sline: i32) -> String {
+    let msg = rt_string(msg);
+    let file = rt_string(file);
+    if file.is_empty() || sline == 0 {
+        return msg;
+    }
+    alloc::format!("{file}:{sline}: {msg}")
+}
+
+/// The runtime leaves `rt_assert` to the host on this target. C's FMU logs and then
+/// throws; the throw is a trap here, aborting the FMI call, which the master
+/// surfaces as a fatal status.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_assert(
-    _msg: i32,
-    _file: i32,
-    _sline: i32,
+    msg: i32,
+    file: i32,
+    sline: i32,
     _scol: i32,
     _eline: i32,
     _ecol: i32,
     _read_only: i32,
     _cond: i32,
 ) -> i32 {
+    fmi_log(Status::Error, CAT_ERROR, &assert_message(msg, file, sline));
     core::arch::wasm32::unreachable()
 }
 
-/// Warning-level assertion: non-fatal, so continue. No host logger here, so the
-/// message is dropped.
+/// Warning-level assertion: non-fatal, so continue (C's `omc_assert_fmi_warning`).
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_assert_warning(
     _cond: i32,
-    _msg: i32,
-    _file: i32,
-    _sline: i32,
+    msg: i32,
+    file: i32,
+    sline: i32,
     _scol: i32,
     _eline: i32,
     _ecol: i32,
     _read_only: i32,
 ) {
+    fmi_log(Status::Warning, CAT_WARNING, &assert_message(msg, file, sline));
 }
 
-/// The `print` builtin. No host stdout here, so the output is discarded.
+/// The `print` builtin.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_print(_str: i32) {}
+pub extern "C" fn rt_print(str: i32) {
+    log_sink(&rt_string(str));
+}
 
-/// Per-row assert formatting: no logger, and the FMI master steps the model
-/// instead of the emitted `simulate` loop that calls this.
+/// Per-row assert formatting: the FMI master steps the model instead of the emitted
+/// `simulate` loop that calls this.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_row_asserts(_sim_data: i32, _warn: i32) -> i32 {
     0
@@ -225,17 +344,9 @@ impl MeState {
         let mut e = Engine;
         let _ = e.write_bytes(self.sim_data + off, &v.to_le_bytes());
     }
-    /// Read the runtime `String` referenced by the i32 handle in slot `off`. Empty
-    /// for the null handle (an unset String).
+    /// Read the runtime `String` referenced by the i32 handle in slot `off`.
     fn read_string(&self, off: u32) -> String {
-        use openmodelica_codegen_wasm_jit_runtime as rt;
-        let h = self.read_i32(off) as u32;
-        if h == 0 {
-            return String::new();
-        }
-        let len = rt::rt_str_len(h) as usize;
-        let bytes = unsafe { core::slice::from_raw_parts(rt::rt_str_data(h) as *const u8, len) };
-        String::from_utf8_lossy(bytes).into_owned()
+        rt_string(self.read_i32(off))
     }
     /// Store `s` as a fresh runtime `String` handle in slot `off`, releasing the
     /// handle it replaces (a no-op on the null handle).
@@ -356,7 +467,31 @@ fn read_meta() -> openmodelica_sim_meta::SimMeta {
 macro_rules! shared_instance_methods {
     () => {
 
-    fn set_debug_logging(&self, _logging_on: bool, _categories: Vec<String>) -> Status {
+    /// C's `omcSetDebugLogging`: every category off, then the named ones follow
+    /// `logging_on`. An unknown name is reported unfiltered, as in C.
+    fn set_debug_logging(&self, logging_on: bool, categories: Vec<String>) -> Status {
+        let mut cats = 0u32;
+        let mut unknown: Vec<String> = Vec::new();
+        for c in categories {
+            match CATEGORIES.iter().position(|n| *n == c) {
+                Some(i) if logging_on => cats |= 1 << i,
+                Some(_) => {}
+                None => unknown.push(c),
+            }
+        }
+        {
+            let l = logger();
+            l.on = logging_on;
+            l.cats = cats;
+        }
+        omclog::set_mask(stream_mask(cats));
+        for c in unknown {
+            log_raw(
+                Status::Warning,
+                CAT_ERROR,
+                &alloc::format!("logging category '{c}' is not supported by model"),
+            );
+        }
         Status::Ok
     }
 
@@ -823,12 +958,13 @@ macro_rules! shared_instance_methods {
 impl GuestModelExchangeInstance for Instance {
     shared_instance_methods!();
     fn instantiate_model_exchange(
-        _instance_name: String,
+        instance_name: String,
         _instantiation_token: String,
         _resource_path: String,
         _visible: bool,
-        _logging_on: bool,
+        logging_on: bool,
     ) -> Option<ModelExchangeInstance> {
+        init_logging(instance_name, logging_on);
         let st = new_state()?;
         Some(ModelExchangeInstance::new(Instance { st: RefCell::new(st) }))
     }
@@ -925,15 +1061,16 @@ impl GuestCoSimulationInstance for Instance {
     shared_instance_methods!();
 
     fn instantiate_co_simulation(
-        _instance_name: String,
+        instance_name: String,
         _instantiation_token: String,
         _resource_path: String,
         _visible: bool,
-        _logging_on: bool,
+        logging_on: bool,
         event_mode_used: bool,
         _early_return_allowed: bool,
         _required_intermediate_variables: Vec<u32>,
     ) -> Option<CoSimulationInstance> {
+        init_logging(instance_name, logging_on);
         let mut st = new_state()?;
         st.event_mode = event_mode_used;
         Some(CoSimulationInstance::new(Instance { st: RefCell::new(st) }))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -548,9 +548,9 @@ fn build_wasip1_interactive_runtime(
     let wasmer = std::env::var("CARGO_FEATURE_ENGINE_WASMER").is_ok();
     let inwasm_driver = std::env::var("CARGO_FEATURE_INWASM_DRIVER").is_ok();
     let features = if native && !wasmer && !inwasm_driver {
-        "host_lin_solve"
+        "host_lin_solve,host_log"
     } else {
-        "session,inwasm_solve"
+        "session,inwasm_solve,host_log"
     };
     // The feature set is part of the cache key: toggling the engine must rebuild.
     let stamp_val = format!("{hash}:{features}");


### PR DESCRIPTION
`rt_host_log`, added with the `-lv=LOG_NLS` work, was imported from `env` on every wasm32 build but the standalone one. The FMI3 adapter links the runtime in and its FMU has no `env` host, so `wit_component::Linker` had nothing to resolve it against and every wasm FMU export failed:

    Internal error CodegenWasmJit: FMI3 component link failed:
    unresolved symbol(s):
        adapter needs rt_host_log (function [I32, I32] -> [])

The import is now the opt-in `host_log` feature, which every runtime a wasm host instantiates sets and the adapter does not.

An FMU is not without a logger, though: the `model-exchange-fmu` world imports `fmi:fmi3/callbacks.log-message`, i.e. `fmi3LogMessage`, so the adapter installs its own `driver::set_log_sink` and `print`, assertions and the `-lv` solver lines leave through the callback instead of being dropped. Statuses, categories and the category filter are C's (`fmu3_model_interface.c`), over the same category list `CodegenFMU3` declares in `modelDescription.xml`:

| message                     | status  | category         |
| --------------------------- | ------- | ---------------- |
| `assert` (fatal, then trap) | error   | logStatusError   |
| `assert` (warning)          | warning | logStatusWarning |
| `print`, runtime log lines  | ok      | logAll           |

`set-debug-logging` mirrors `omcSetDebugLogging`, and its four model-diagnostics categories additionally switch on the `-lv` streams they stand for (`logNonlinearSystems` -> `LOG_NLS`, `logEvents` -> `LOG_EVENTS`, `logSingularLinearSystems` -> `LOG_LS`, `logDynamicStateSelection` -> `LOG_DSS`), so those lines are produced at all.

`fmu_component_links_without_a_host` links each embedded adapter against the stub model module the standalone-merge test already builds, so an `env` host callback that leaks back into the adapter fails a unit test rather than an FMU export.