### PR TITLE
spatialDistribution.c - Included patches for unwanted fallback to 0 (#16182) and failure for flow reversal (#11449)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -361,11 +361,12 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     realDirection = 0 /* standing still */;
   }
 
-  /* Derive the storage direction from the sign of the actual change of x. */
+  /* Derive storage direction from the sign of the actual change of x.
+   * Note: deltaX = oldPosX - posX, so realDirection > 0 means x decreased. */
   if (realDirection > 0) {
-    isPositiveVelocity = 0 /* false: x decreased, write at the back */;
+    isPositiveVelocity = 0;
   } else if (realDirection < 0) {
-    isPositiveVelocity = 1 /* true: x increased, write at the front */;
+    isPositiveVelocity = 1;
   }
   if (isPositiveVelocity) {
     TRANSPORTED_QUANTITY_DATA* front = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -25,164 +25,6 @@
  *
  */
 
-/* ==========================================================================
- * PATCFH OVERVIEW, RouvenZ, August 2026
- *
- * Three independent improvements / issues are addressed. Every change is confined to this
- * file and is marked inline with PATCH 1, PATCH 2 or PATCH 3.
- *
- * --------------------------------------------------------------------------
- * PATCH 1 - Silent fallback of the outputs to an undefined value (usually 0.0)
- *           for continuously positive velocity. 
- *           This is supposed to fix issue #16182.
- * --------------------------------------------------------------------------
- * Root cause:
- *   findOppositeEndSpatialDistribution() documents that *eventPreValue is
- *   written whenever the return value is >= 1. Its "Step 0" shortcut (taken
- *   when the profile advanced by more than one full transport length since the
- *   last stored node) violated that contract: it returned
- *   doubleEndedListLen(storedEventsList), which is > 0 whenever the event list
- *   is non-empty, but never wrote *eventPreValue. The caller then executed
- *       outValue = eventPreValue;
- *   on an uninitialized local variable, silently replacing the correctly
- *   interpolated output with whatever the stack held - typically 0.0. No error
- *   or warning was emitted as long as the event list held exactly one event.
- *
- * Changes:
- *   1a) findOppositeEndSpatialDistribution(): both Step-0 shortcuts now set
- *       *eventPreValue to the interpolated value before returning, restoring
- *       the documented contract. All stored events lie beyond the outlet read
- *       position in that situation (they have already left the transport
- *       domain), so the interpolated value is also the correct pre-event value.
- *   1b) spatialDistribution(): eventPreValue is initialized to NAN as an
- *       explicit "not available" sentinel and is only used when it was actually
- *       written. If it was not, the interpolated value is kept and a warning is
- *       printed instead of silently corrupting the output.
- *
- * Note: this removes the undefined behaviour. It does not make integrator steps
- * that transport more than one full length accurate - such steps inherently
- * discard profile information. Keep -maxStepSize below length/v_max for
- * quantitatively correct results. 
- * 
- * The last sentence should considered to be added to the documentation of the 
- * spatialDistribution operator, as it is a general limitation of the operator 
- * and not an issue of this implementation.
- *
- * --------------------------------------------------------------------------
- * PATCH 2 - Crash on sign changes of the velocity (flow reversal) with
- *           "New end position is not bigger then previous last node." or
- *           "New front position is not smaller then previous first node.".
- *           This is supposed to fix issue #11449.
- * --------------------------------------------------------------------------
- * The node positions must stay monotone: for x increasing the new node is
- * pushed at the front with position -posX, for x decreasing at the back with
- * position -posX+1. The representation itself is fully reversal-capable - the
- * positions are material coordinates and the window [-posX, -posX+1] may slide
- * back and forth over them - but the bookkeeping that decides which end to
- * write had two holes:
- *
- *   a) The mismatch test
- *          isPositiveVelocity*realDirection > 0
- *      can only ever be true for isPositiveVelocity == 1, because false is 0 in
- *      C. The mirror-image mismatch (velocity reported negative while x
- *      actually increased) was therefore never corrected. The new node was
- *      pushed at the back with a position smaller than the current back
- *      position => "New end position is not bigger then previous last node."
- *
- *   b) The correction was only considered for deltaX > SPATIAL_ZERO_DELTA_X,
- *      while the monotonicity assertions in addNewNodeSpatialDistribution are
- *      exact. A backward drift of x inside that dead band was ignored yet still
- *      violated the assertion => "New front position is not smaller then
- *      previous first node."
- *
- * The mismatch itself is unavoidable: isPositiveVelocity comes from the
- * relation v >= 0, which is a discrete value evaluated with hysteresis and held
- * between events, whereas deltaX is whatever the integrator produced over the
- * step. Around a reversal the two disagree for at least one step.
- *
- * Changes:
- *   2a) storeSpatialDistribution(): the storage direction is derived from the
- *       sign of the actual change of x. The reported isPositiveVelocity is only
- *       used when x did not change at all, in which case the new node lands
- *       exactly on the current edge position, which the assertions allow.
- *       No threshold is involved, so the decision is always consistent with
- *       the exact assertions.
- *   2b) spatialDistribution(): the same mismatch test is made symmetric. The
- *       threshold and the "jumped" semantics are kept here, so an out-of-band
- *       drift does not needlessly suppress the extrapolation of the outputs.
- *   2c) The assertions used to be called with threadData == NULL, so a failing
- *       assertion had no jump buffer to unwind to and the process segfaulted
- *       instead of aborting the simulation with a message. threadData is now
- *       threaded through 
- *        - interpolateTransportedQuantity,
- *        - extrapolateTransportedQuantity, 
- *        - addNewNodeSpatialDistribution,
- *        - findOppositeEndSpatialDistribution and 
- *        - pruneSpatialDistribution.
- *
- * Remaining limitation: a sign change of v *inside* a single integrator step is
- * invisible to the operator, which sees one monotone move of x. That is a
- * property of the operator definition, not of this implementation.
- *
- * --------------------------------------------------------------------------
- * PATCH 3 - Absolute tolerances versus an unbounded position coordinate.
- *           
- *           This does NOT fix an issue, but can be considered for implementation
- *           to avoid potentially unwanted behaviour.
- * --------------------------------------------------------------------------
- * epsilon.h defines
- *     SPATIAL_EPS            = DBL_EPSILON   (2.2e-16, exactly one ulp at 1.0)
- *     SPATIAL_ZERO_DELTA_X   = 1e-12
- * as *absolute* tolerances, while posX = x/length grows without bound: after
- * 2e6 s at 1 m/s in a 100 m pipe, posX is about 2e4, where the spacing between
- * two representable doubles (the coordinate quantum) is already 3.6e-12 -
- * larger than both tolerances.
- *
- * What is NOT a problem here (measured by Claude, probably no fix needed):
- *   - Adding or subtracting 1.0 is *exact* for |x| < 2^52. The spans written by
- *     the pruning (edgeNodeData->position +/- 1) and the read positions (-posX,
- *     -posX+1) therefore carry no rounding error at all.
- *   - Subtracting two nearby doubles is exact as well, so deltaX and the node
- *     distances carry no rounding error either. The distance-to-one tests and
- *     the "x got reinitialized during an event" check do *not* misfire from
- *     large |posX|.
- *
- * What is a problem:
- *   - The tolerance can fall below the coordinate quantum. Already for
- *     |posX| > 1 the position tolerance is below the quantum (at 2e4 it is
- *     16384 times smaller), so every "same position" test becomes a
- *     bitwise equality; from |posX| > 4.5e3 the same holds for the
- *     SPATIAL_ZERO_DELTA_X dead band, which can then only be satisfied by an
- *     exactly zero deltaX. The comparisons therefore stop expressing what they
- *     were written to express.
- *   - The guards that protect the division inside interpolate/extrapolate
- *     (fabs(posA - posB) > SPATIAL_EPS) accept a node spacing of a single
- *     quantum and therefore no longer reject an ill-conditioned interpolation.
- *   - fabs(front->value - in0) > SPATIAL_EPS compares a *transported quantity*
- *     against a tolerance sized for 1.0. Specific enthalpies are of order 1e5,
- *     where one ulp is 7.3e-12, so any difference whatsoever counts as a
- *     discrete change. This is the case with a directly visible effect: it
- *     produces spurious event nodes, and a non-empty event list is exactly the
- *     precondition for the PATCH 1 failure mode.
- *
- * Fix: scale each tolerance with the magnitude of the operands the comparison is
- * made from - the only scale at which a floating point difference carries
- * information. The helpers spatialPosEps(), spatialValEps() and
- * spatialZeroDeltaX() below implement this, with the scale clamped at 1.0 from
- * below so that nothing becomes tighter than before near the origin.
- *
- * Residual limitation that scaling cannot address (but which is probably)
- * no problem anyways: the coordinate *resolution*
- * itself degrades as posX grows. Two stored nodes collapse onto one double once
- * v*h/length falls below |posX|*2^-52, which for a 2e6 s run means step sizes
- * below roughly 4e-10 s - not reachable in practice, but the only real remedy
- * would be to re-base the origin periodically, i.e. shift startPosX and all
- * stored positions by a constant.
- *
- * Not changed: initSpatialDistribution(). Its initialPoints are normalized to
- * [0, 1] by definition, so the absolute tolerance is already the correct one.
- * ========================================================================== */
-
 //#if !defined(OMC_NDELAY_EXPRESSIONS) || OMC_NDELAY_EXPRESSIONS>0
 
 /*! \file spatialDistribution.c
@@ -226,7 +68,7 @@ typedef struct TRANSPORTED_EVENT_DATA {
 
 
 /* Private function prototypes
- * PATCH 2c: threadData is threaded through all helpers that assert, so a failing
+ * threadData is threaded through all helpers that assert, so a failing
  * assertion can unwind instead of dereferencing a NULL thread context. */
 double interpolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos);
 double extrapolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos);
@@ -237,19 +79,12 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
 
 // ############################################################################
 //
-// PATCH 3: magnitude-scaled tolerances
+// Magnitude-scaled tolerances
 //
 // ############################################################################
 
 /**
  * @brief Headroom in ulps for the scaled comparisons.
- *
- * The comparison has to be at least a few coordinate quanta wide to express
- * "not distinguishable at this scale", and a position may carry up to half an
- * ulp from the startPosX shift in shiftToStartPosX(), so one ulp is not enough
- * headroom while a handful is. At scale 1.0 this gives 1.8e-15, still many
- * orders of magnitude below the smallest physically meaningful spacing between
- * two nodes (v*h/length).
  */
 static const double SPATIAL_EPS_ULPS = 8.0;
 
@@ -268,11 +103,6 @@ static double spatialScale(double a, double b) {
 
 /**
  * @brief Tolerance for comparing two positions (or a difference of positions).
- *
- * Pass the two *operands*, not their difference: the absolute error of a
- * floating point difference is set by the magnitude of the operands, not by the
- * magnitude of the result. This matters for the distance-to-one tests, where the
- * result is about 1 while the operands can be of order 1e4.
  */
 static double spatialPosEps(double posA, double posB) {
   return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(posA, posB);
@@ -280,10 +110,6 @@ static double spatialPosEps(double posA, double posB) {
 
 /**
  * @brief Tolerance for deciding whether a transported value changed discretely.
- *
- * The transported quantity is arbitrary (specific enthalpies are of order 1e5),
- * so an absolute tolerance of one ulp at 1.0 would classify every re-store as a
- * discrete change and fill the event list with spurious entries.
  */
 static double spatialValEps(double valA, double valB) {
   return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(valA, valB);
@@ -535,40 +361,14 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     realDirection = 0 /* standing still */;
   }
 
-  /* PATCH 2a: Derive the storage direction from the sign of the actual change of
-   * x instead of trusting the reported isPositiveVelocity.
-   *
-   * realDirection == +1 means posX decreased, i.e. x decreased (v < 0), because
-   * deltaX was computed as oldPosX - posX. realDirection == -1 means x increased
-   * (v > 0). The reported isPositiveVelocity is the held value of the relation
-   * v >= 0 and can lag the sign of deltaX by a step around a flow reversal.
-   *
-   * The previous test
-   *     deltaX > SPATIAL_ZERO_DELTA_X && isPositiveVelocity*realDirection > 0
-   * could only detect the mismatch (reported positive, x decreasing), because
-   * false is 0 in C, and it ignored any mismatch inside the SPATIAL_ZERO_DELTA_X
-   * dead band although the monotonicity assertions in
-   * addNewNodeSpatialDistribution are exact. Both gaps ended in a failing
-   * assertion (and, via threadData == NULL, in a crash) on sign changes of v.
-   *
-   * Deriving the direction from realDirection alone closes both gaps: the end
-   * that is written is by construction the end that keeps the positions
-   * monotone, for arbitrarily small |deltaX|. */
+  /* Derive the storage direction from the sign of the actual change of x. */
   if (realDirection > 0) {
     isPositiveVelocity = 0 /* false: x decreased, write at the back */;
   } else if (realDirection < 0) {
     isPositiveVelocity = 1 /* true: x increased, write at the front */;
   }
-  /* realDirection == 0: keep the reported direction. The new node then lands
-   * exactly on the current edge position, which the assertions allow (<=, >=)
-   * and which is the existing event-node case handled below. */
-
-  /* Add new node (oldPosX-deltaX, in0) or (oldPosX-deltaX+1, in1) to list
-   * Check if it an event and only save it if has a discrete change in in0 or in1.
-   */
   if (isPositiveVelocity) {
     TRANSPORTED_QUANTITY_DATA* front = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
-    /* PATCH 3: scaled position and value tolerances */
     if (fabs(-posX - front->position) < spatialPosEps(-posX, front->position)) {
       if (fabs(front->value - in0) > spatialValEps(front->value, in0)) {
         addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 1 /* true */);
@@ -578,7 +378,6 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     }
   } else {
     TRANSPORTED_QUANTITY_DATA* last = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
-    /* PATCH 3: scaled position and value tolerances */
     if (fabs(-posX+1 - last->position) < spatialPosEps(-posX+1, last->position)) {
       if (fabs(last->value - in1) > spatialValEps(last->value, in1)) {
         addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 1 /* true */);
@@ -635,7 +434,7 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   int realDirection;
   int jumped = 0;
   double deltaX;
-  double eventPreValue = NAN;   /* PATCH 1b: sentinel "no event pre-value available" */
+  double eventPreValue = NAN;   /* sentinel "no event pre-value available" */
   double outValue;
   double out0;      /* First output variable */
   double out1Val;   /* Second output variable, only written to *out1 if out1 != NULL */
@@ -663,35 +462,19 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     realDirection = 0 /* standing still */;
   }
 
-  /* If real direction doesn't match isPositiveVelocity just flip isPositiveVelocity.
-   * This still indicates something wrong, so we don't extrapolate the output.
-   *
-   * PATCH 2b: made symmetric. The original condition
-   *     isPositiveVelocity*realDirection > 0
-   * could only ever be true for isPositiveVelocity == 1, because false is 0 in C,
-   * so the mismatch (velocity reported negative while x increased) was never
-   * caught. Unlike the store path this keeps the SPATIAL_ZERO_DELTA_X threshold
-   * and the "jumped" flag: a drift below the threshold must not suppress the
-   * extrapolation of the outputs.
-   * PATCH 3: the threshold is scaled with the magnitude of the positions. */
   if (deltaX > spatialZeroDeltaX(spatialDistribution->oldPosX, posX) &&
       ((isPositiveVelocity && realDirection > 0) || (!isPositiveVelocity && realDirection < 0))) {
     isPositiveVelocity  = !isPositiveVelocity;
     jumped = 1 /* true */;
   }
 
-  /* Check if x was reinitialized
-   * PATCH 3: scaled threshold. deltaX itself is exact (subtraction of two nearby
-   * doubles), but the plain SPATIAL_ZERO_DELTA_X falls below the coordinate
-   * quantum for |posX| > 4.5e3, where this dead band degenerates into "deltaX is
-   * exactly zero". */
+  /* Check if x was reinitialized with scaled threshold. */
   if (deltaX > spatialZeroDeltaX(spatialDistribution->oldPosX, posX) && data->simulationInfo->discreteCall) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "x got reinitialized during an event at time %f. OpenModelica can't handle that.", data->localData[0]->timeValue);
     omc_throw_function(threadData);
   }
 
-  /* Special case: Zero progress
-   * PATCH 3: scaled tolerance, see above */
+  /* Special case: Zero progress */
   if (deltaX < spatialPosEps(spatialDistribution->oldPosX, posX)) {
     firstNodeData = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
     lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
@@ -715,11 +498,9 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     messageCloseWarning(OMC_LOG_STDOUT);
   }
   if (walkedOverEvents>0 && !data->simulationInfo->discreteCall) {
-    /* PATCH 1b: Only substitute the pre-event value if it was actually provided.
-     * Using it unconditionally read an uninitialized variable whenever
-     * findOppositeEndSpatialDistribution returned a non-zero event count
-     * without writing eventPreValue, which silently forced the output to an
-     * undefined value (typically 0.0). */
+    /* Only substitute the pre-event value if it was actually provided;
+     * otherwise the output could silently become an undefined value
+     * (typically 0.0). */
     if (!isnan(eventPreValue)) {
       infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Found event in spatial distribution at time %f", data->localData[0]->timeValue);
       outValue = eventPreValue;
@@ -733,9 +514,6 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   secondNodeData = dataDoubleEndedList(getNextNodeDoubleEndedList(getFirstNodeDoubleEndedList(transportedQuantityList)));
   lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
   forelastNodeData = dataDoubleEndedList(getPreviousNodeDoubleEndedList(getLastNodeDoubleEndedList(transportedQuantityList)));
-  /* PATCH 3: scaled tolerances. The second test guards the division by the node
-   * distance inside extrapolateTransportedQuantity, so it has to use the same
-   * scale as the positions it compares. */
   if (isPositiveVelocity) {
     if (jumped) {
       out0 = in0;
@@ -829,7 +607,6 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        /* PATCH 3: scaled tolerance */
         if (fabs(currentNodeData->position+posX-1) <= spatialPosEps(currentNodeData->position, posX)) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
@@ -861,7 +638,6 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        /* PATCH 3: scaled tolerance */
         if (fabs(currentNodeData->position+posX) <= spatialPosEps(currentNodeData->position, posX)) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
@@ -923,8 +699,6 @@ double interpolateTransportedQuantity(threadData_t *threadData, const TRANSPORTE
   rightValue = rightData->value;
   distPos = rightPosition - leftPosition;
 
-  /* PATCH 2c: threadData instead of NULL, so this aborts the simulation with a
-   * message instead of crashing the process. */
   assertStreamPrint(threadData, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
 
   interpolatedValue = leftValue  * ((rightPosition-interpolationPos)/distPos)
@@ -954,7 +728,6 @@ double extrapolateTransportedQuantity(threadData_t *threadData, const TRANSPORTE
   rightValue = rightData->value;
   distPos = rightPosition - leftPosition;
 
-  /* PATCH 2c: threadData instead of NULL */
   assertStreamPrint(threadData, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
 
   extrapolatedValue = leftValue + (rightValue-leftValue)/(distPos) * (extrapolationPos - leftPosition);
@@ -988,9 +761,6 @@ void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTIO
 
   /* Add node to transported quantity list */
   infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Adding (%e,%e) at %s.", newNodeData.position, newNodeData.value, front?"front":"back");
-  /* PATCH 2c: these two assertions are the ones that used to fire on flow
-   * reversal. With threadData == NULL a failing assertion had no jump buffer to
-   * unwind to and took the process down instead of aborting the simulation. */
   if (front) {
     // Make sure new first node is smaller then previous first node
     TRANSPORTED_QUANTITY_DATA* oldFront = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
@@ -1048,8 +818,7 @@ void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTIO
  *                                    Velocity v is `v:=der(x)`.
  * @param eventPreValue               On output containing value of first/last node before event.
  *                                    This value is only written when function returned 1 or greater.
- *                                    PATCH: (Patch 1a) The "Step 0" shortcuts below also honour this contract
- *                                    now; they used to return a non-zero count without writing it.
+ *                                    The "Step 0" shortcuts below also honour this contract.
  * @return int                        Return number of events that were encountered.
  */
 int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue) {
@@ -1084,12 +853,6 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
       tempData.position = -posX;
       tempData.value = in0;
       *outValue = interpolateTransportedQuantity(threadData, &tempData, firstNodeData, -posX + 1);
-      /* PATCH 1a: Every stored event lies at a position >= firstNodeData->position,
-       * i.e. beyond the outlet read position -posX+1, so all of them have already
-       * left the transport domain during this step. The interpolated value is
-       * therefore also the correct pre-event value. Writing it keeps the
-       * documented contract "eventPreValue is valid whenever the return value is
-       * >= 1" and stops the caller from substituting an uninitialized value. */
       *eventPreValue = *outValue;
       return doubleEndedListLen(storedEventsList);
     }
@@ -1101,7 +864,6 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
       tempData.position = -posX+1;
       tempData.value = in1;
       *outValue = interpolateTransportedQuantity(threadData, lastNodeData, &tempData, -posX);
-      /* PATCH 1a: see comment in the positive velocity branch above. */
       *eventPreValue = *outValue;
       return doubleEndedListLen(storedEventsList);
     }
@@ -1119,14 +881,7 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
     currentNode = firstNode;
   }
   currentNodeData = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(currentNode);
-
-  /* PATCH 3: a meaningful "not distinguishable from 1" tolerance has to be scaled
-   * by the magnitude of the *operands*, not by the magnitude of the difference
-   * (which is about 1). With the absolute SPATIAL_EPS this test degenerates into
-   * an exact comparison as soon as |position| > 1. The distance itself is exact -
-   * subtracting two nearby doubles introduces no error - so this scaling makes
-   * the comparison meaningful rather than fixing an observed misfire.
-   * PATCH 2c: threadData instead of NULL. */
+  
   currentDistance = fabs(currentNodeData->position - edgeNodePosition);
   if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\nThis case should not be possible. Please open a bug report about it.");
@@ -1152,14 +907,12 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
     /* Check for event:
      * Current node position equal to previous visited node position
      */
-    /* PATCH 3: scaled tolerance */
     if (fabs(prevVisitedNodeData->position - currentNodeData->position) < spatialPosEps(prevVisitedNodeData->position, currentNodeData->position)) {
       *eventPreValue = prevVisitedNodeData->value;
       walkedOverEvents += 1;
     }
 
-    /* Check if distance between currentNode and edgeNode is < 1
-     * PATCH 3: scaled tolerance */
+    /* Check if distance between currentNode and edgeNode is < 1 */
     currentDistance = fabs(currentNodeData->position - edgeNodePosition);
     if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
       break;
@@ -1231,7 +984,6 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
   edgeNodeData  = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(edgeNode);
   currentNodeData = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(currentNode);
 
-  /* PATCH 3: scaled tolerance, PATCH 2c: threadData instead of NULL */
   currentDistance = fabs(currentNodeData->position - edgeNodeData->position);
   if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function pruneSpatialDistribution.\nThis case should not be possible. Please open a bug reoprt about it.");
@@ -1253,13 +1005,11 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
     /* Check for event:
      * Current node position equal to previous visited node position
      */
-    /* PATCH 3: scaled tolerance */
     if (fabs(prevVisitedNodeData->position - currentNodeData->position) < spatialPosEps(prevVisitedNodeData->position, currentNodeData->position)) {
       walkedOverEvents += 1;
     }
 
-    /* Check if distance between currentNode and edgeNode is < 1
-     * PATCH 3: scaled tolerance */
+    /* Check if distance between currentNode and edgeNode is < 1 */
     currentDistance = fabs(currentNodeData->position - edgeNodeData->position);
     if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
       break;
@@ -1272,7 +1022,6 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
   /* Step 2
    * Interpolate at edgeNode->position +/- 1.
    */
-  /* PATCH 3: scaled tolerance */
   if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
     if (isPositiveVelocity) {
       prevVisitedNodeData->value = interpolateTransportedQuantity(threadData, currentNodeData, prevVisitedNodeData, edgeNodeData->position + 1);
@@ -1300,7 +1049,6 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
   if (doubleEndedListLen(storedEventsList) > 0) {
     if (isPositiveVelocity) {
       eventData = lastDataDoubleEndedList(storedEventsList);
-      /* PATCH 3: scaled tolerance */
       while (edgeNodeData->position+1 + spatialZeroDeltaX(edgeNodeData->position, eventData->position) < eventData->position) {
         spatialDistribution->lastStoredEventValue = eventData->zeroCrossValue;
         removeLastDoubleEndedList(storedEventsList);
@@ -1312,7 +1060,6 @@ int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA
       }
     } else {
       eventData = firstDataDoubleEndedList(storedEventsList);
-      /* PATCH 3: scaled tolerance */
       while (edgeNodeData->position-1 - spatialZeroDeltaX(edgeNodeData->position, eventData->position) > eventData->position) {
         spatialDistribution->lastStoredEventValue = eventData->zeroCrossValue;
         removeFirstDoubleEndedList(storedEventsList);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -67,9 +67,7 @@ typedef struct TRANSPORTED_EVENT_DATA {
 } TRANSPORTED_EVENT_DATA;
 
 
-/* Private function prototypes
- * threadData is threaded through all helpers that assert, so a failing
- * assertion can unwind instead of dereferencing a NULL thread context. */
+/* Private function prototypes */
 double interpolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos);
 double extrapolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos);
 void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity, double position, double value, int isEvent);
@@ -77,23 +75,10 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
 int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity);
 
 
-// ############################################################################
-//
-// Magnitude-scaled tolerances
-//
-// ############################################################################
-
-/**
- * @brief Headroom in ulps for the scaled comparisons.
- */
+/* SPATIAL_EPS and SPATIAL_ZERO_DELTA_X are absolute, positions and values are
+ * not: scale them, clamped at 1 so nothing gets tighter than unscaled. */
 static const double SPATIAL_EPS_ULPS = 8.0;
 
-/**
- * @brief Magnitude of the two operands a difference was computed from.
- *
- * Clamped at 1.0 from below so that the scaled tolerances never become tighter
- * than the original absolute ones near the origin.
- */
 static double spatialScale(double a, double b) {
   double scaleA = fabs(a);
   double scaleB = fabs(b);
@@ -101,25 +86,18 @@ static double spatialScale(double a, double b) {
   return (scale > 1.0) ? scale : 1.0;
 }
 
-/**
- * @brief Tolerance for comparing two positions (or a difference of positions).
- */
 static double spatialPosEps(double posA, double posB) {
   return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(posA, posB);
 }
 
-/**
- * @brief Tolerance for deciding whether a transported value changed discretely.
- */
 static double spatialValEps(double valA, double valB) {
   return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(valA, valB);
 }
 
-/**
- * @brief Scaled version of the "x is standing still" threshold.
- */
+/* Never below the resolution of the position coordinate. */
 static double spatialZeroDeltaX(double posA, double posB) {
-  return SPATIAL_ZERO_DELTA_X * spatialScale(posA, posB);
+  double posEps = spatialPosEps(posA, posB);
+  return (SPATIAL_ZERO_DELTA_X > posEps) ? SPATIAL_ZERO_DELTA_X : posEps;
 }
 
 // ############################################################################
@@ -229,11 +207,11 @@ void initSpatialDistribution(DATA* data, threadData_t* threadData, unsigned int 
     messageClose(OMC_LOG_STDOUT);
     omc_throw_function(threadData);
   }
-  for (i=0; i<length-2; i++) {
+  for (i=0; i<length-1; i++) {
     if (initPnts[i] > initPnts[i+1]) {
       errorStreamPrint(OMC_LOG_STDOUT, 1, "Initialization of spatial distribution with index %i failed.", index);
       errorStreamPrint(OMC_LOG_STDOUT, 0, "initialPoints[%i] > initialPoints[%i]", i, i+1);
-      errorStreamPrint(OMC_LOG_STDOUT, 0, "%f > %f", initVals[i], initPnts[i+1]);
+      errorStreamPrint(OMC_LOG_STDOUT, 0, "%f > %f", initPnts[i], initPnts[i+1]);
       messageClose(OMC_LOG_STDOUT);
       omc_throw_function(threadData);
     }
@@ -361,18 +339,19 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     realDirection = 0 /* standing still */;
   }
 
-  /* Derive storage direction from the sign of the actual change of x.
-   * Note: deltaX = oldPosX - posX, so realDirection > 0 means x decreased. */
+  /* deltaX = oldPosX - posX, so realDirection > 0 means x decreased */
   if (realDirection > 0) {
     isPositiveVelocity = 0;
   } else if (realDirection < 0) {
     isPositiveVelocity = 1;
   }
+  /* Event nodes go onto the edge position: prune computes edge positions as
+   * edge +/- 1, so -posX can be an ulp on the wrong side of the edge. */
   if (isPositiveVelocity) {
     TRANSPORTED_QUANTITY_DATA* front = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
     if (fabs(-posX - front->position) < spatialPosEps(-posX, front->position)) {
       if (fabs(front->value - in0) > spatialValEps(front->value, in0)) {
-        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 1 /* true */);
+        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, front->position, in0, 1 /* true */);
       }
     } else {
       addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 0 /* false */);
@@ -381,7 +360,7 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     TRANSPORTED_QUANTITY_DATA* last = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
     if (fabs(-posX+1 - last->position) < spatialPosEps(-posX+1, last->position)) {
       if (fabs(last->value - in1) > spatialValEps(last->value, in1)) {
-        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 1 /* true */);
+        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, last->position, in1, 1 /* true */);
       }
     } else {
       addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 0 /* false */);
@@ -435,7 +414,7 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   int realDirection;
   int jumped = 0;
   double deltaX;
-  double eventPreValue = NAN;   /* sentinel "no event pre-value available" */
+  double eventPreValue = NAN;   /* only written if an event is walked over */
   double outValue;
   double out0;      /* First output variable */
   double out1Val;   /* Second output variable, only written to *out1 if out1 != NULL */
@@ -469,7 +448,7 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     jumped = 1 /* true */;
   }
 
-  /* Check if x was reinitialized with scaled threshold. */
+  /* Check if x was reinitialized */
   if (deltaX > spatialZeroDeltaX(spatialDistribution->oldPosX, posX) && data->simulationInfo->discreteCall) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "x got reinitialized during an event at time %f. OpenModelica can't handle that.", data->localData[0]->timeValue);
     omc_throw_function(threadData);
@@ -498,16 +477,9 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     warningStreamPrint(OMC_LOG_STDOUT, 0, "time: %f, spatialDistribution index: %i, number of events: %i", data->localData[0]->timeValue, index, walkedOverEvents);
     messageCloseWarning(OMC_LOG_STDOUT);
   }
-  if (walkedOverEvents>0 && !data->simulationInfo->discreteCall) {
-    /* Only substitute the pre-event value if it was actually provided;
-     * otherwise the output could silently become an undefined value
-     * (typically 0.0). */
-    if (!isnan(eventPreValue)) {
-      infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Found event in spatial distribution at time %f", data->localData[0]->timeValue);
-      outValue = eventPreValue;
-    } else {
-      warningStreamPrint(OMC_LOG_STDOUT, 0, "spatialDistribution index %i reported %i event(s) without a pre-value at time %f. Keeping interpolated value.", index, walkedOverEvents, data->localData[0]->timeValue);
-    }
+  if (walkedOverEvents>0 && !data->simulationInfo->discreteCall && !isnan(eventPreValue)) {
+    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Found event in spatial distribution at time %f", data->localData[0]->timeValue);
+    outValue = eventPreValue;
   }
 
   /* Extrapolate return values to break up quasi-loop with inputs */
@@ -515,11 +487,11 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   secondNodeData = dataDoubleEndedList(getNextNodeDoubleEndedList(getFirstNodeDoubleEndedList(transportedQuantityList)));
   lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
   forelastNodeData = dataDoubleEndedList(getPreviousNodeDoubleEndedList(getLastNodeDoubleEndedList(transportedQuantityList)));
+  /* jumped only suppresses the extrapolation: in0/in1 must not be used, the
+   * velocity sign that selects between them is what is in doubt here. */
   if (isPositiveVelocity) {
-    if (jumped) {
-      out0 = in0;
-    } else if (deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
-               fabs(firstNodeData->position-secondNodeData->position) > spatialPosEps(firstNodeData->position, secondNodeData->position)) {
+    if (!jumped && deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
+        fabs(firstNodeData->position-secondNodeData->position) > spatialPosEps(firstNodeData->position, secondNodeData->position)) {
       out0 = extrapolateTransportedQuantity(threadData, firstNodeData, secondNodeData, -posX);
     } else {
       out0 = firstNodeData->value;
@@ -527,10 +499,8 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     out1Val = outValue;
   } else {
     out0 = outValue;
-    if (jumped) {
-      out1Val = in1;
-    } else if (deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
-               fabs(forelastNodeData->position-lastNodeData->position) > spatialPosEps(forelastNodeData->position, lastNodeData->position)) {
+    if (!jumped && deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
+        fabs(forelastNodeData->position-lastNodeData->position) > spatialPosEps(forelastNodeData->position, lastNodeData->position)) {
       out1Val = extrapolateTransportedQuantity(threadData, forelastNodeData, lastNodeData, -posX+1);
     } else {
       out1Val = lastNodeData->value;
@@ -567,6 +537,9 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
  * @param posX                Value of position x.
  * @param isPositiveVelocity  Unused
  * @return double             Value of zeroCrossing at position posX.
+ *
+ * Event positions are compared with the absolute SPATIAL_EPS: a wider tolerance
+ * flips the value before the event is reached, leaving no sign change to find.
  */
 double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, unsigned int index, unsigned int relationIndex, double posX, int isPositiveVelocity) {
   /* Variables */
@@ -608,7 +581,7 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        if (fabs(currentNodeData->position+posX-1) <= spatialPosEps(currentNodeData->position, posX)) {
+        if (fabs(currentNodeData->position+posX-1) <= SPATIAL_EPS) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
         }
@@ -639,7 +612,7 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        if (fabs(currentNodeData->position+posX) <= spatialPosEps(currentNodeData->position, posX)) {
+        if (fabs(currentNodeData->position+posX) <= SPATIAL_EPS) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
         }
@@ -819,7 +792,6 @@ void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTIO
  *                                    Velocity v is `v:=der(x)`.
  * @param eventPreValue               On output containing value of first/last node before event.
  *                                    This value is only written when function returned 1 or greater.
- *                                    The "Step 0" shortcuts below also honour this contract.
  * @return int                        Return number of events that were encountered.
  */
 int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue) {
@@ -836,6 +808,7 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
   TRANSPORTED_QUANTITY_DATA* lastNodeData;
   TRANSPORTED_QUANTITY_DATA tempData;
   double edgeNodePosition;
+  double readPosition;
   double currentDistance;
   int walkedOverEvents = 0;
 
@@ -871,18 +844,27 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
   }
 
   /* Step 1
-   * Walk over list, starting from opposite side of edgeNode,
-   * until distance between currentNode and edgeNode < 1.
+   * Walk from the opposite end to the read position: z(1,t) sits at -posX+1 and
+   * z(0,t) at -posX, for the x of this call. Clamped to the stored profile in
+   * case x moved backwards since the last stored step.
    */
   if (isPositiveVelocity) {
     edgeNodePosition = firstNodeData->position;
+    readPosition = -posX+1;
+    if (readPosition > lastNodeData->position) {
+      readPosition = lastNodeData->position;
+    }
     currentNode = lastNode;
   } else {
     edgeNodePosition = lastNodeData->position;
+    readPosition = -posX;
+    if (readPosition < firstNodeData->position) {
+      readPosition = firstNodeData->position;
+    }
     currentNode = firstNode;
   }
   currentNodeData = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(currentNode);
-  
+
   currentDistance = fabs(currentNodeData->position - edgeNodePosition);
   if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\nThis case should not be possible. Please open a bug report about it.");
@@ -913,9 +895,11 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
       walkedOverEvents += 1;
     }
 
-    /* Check if distance between currentNode and edgeNode is < 1 */
-    currentDistance = fabs(currentNodeData->position - edgeNodePosition);
-    if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
+    /* Check if the read position is passed */
+    currentDistance = fabs(currentNodeData->position - readPosition);
+    if (currentDistance > spatialPosEps(currentNodeData->position, readPosition) &&
+        (isPositiveVelocity ? currentNodeData->position < readPosition
+                            : currentNodeData->position > readPosition)) {
       break;
     } else {
       prevVisitedNode = currentNode;
@@ -924,20 +908,20 @@ int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIB
   }
 
   /* Step 2
-   * Interpolate at edgeNodePosition +/- 1.
+   * Interpolate at the read position.
    */
   if (currentNode == NULL) {
-    /* Walked over all elements of list */
+    /* Read position is at or beyond the far end of the stored profile */
     if (isPositiveVelocity) {
-      *outValue = lastNodeData->value;
-    } else {
       *outValue = firstNodeData->value;
+    } else {
+      *outValue = lastNodeData->value;
     }
   } else {
     if (isPositiveVelocity) {
-      *outValue = interpolateTransportedQuantity(threadData, currentNodeData, prevVisitedNodeData, edgeNodePosition + 1);
+      *outValue = interpolateTransportedQuantity(threadData, currentNodeData, prevVisitedNodeData, readPosition);
     } else {
-      *outValue = interpolateTransportedQuantity(threadData, prevVisitedNodeData, currentNodeData, edgeNodePosition - 1);
+      *outValue = interpolateTransportedQuantity(threadData, prevVisitedNodeData, currentNodeData, readPosition);
     }
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -25,6 +25,164 @@
  *
  */
 
+/* ==========================================================================
+ * PATCFH OVERVIEW, RouvenZ, August 2026
+ *
+ * Three independent improvements / issues are addressed. Every change is confined to this
+ * file and is marked inline with PATCH 1, PATCH 2 or PATCH 3.
+ *
+ * --------------------------------------------------------------------------
+ * PATCH 1 - Silent fallback of the outputs to an undefined value (usually 0.0)
+ *           for continuously positive velocity. 
+ *           This is supposed to fix issue #16182.
+ * --------------------------------------------------------------------------
+ * Root cause:
+ *   findOppositeEndSpatialDistribution() documents that *eventPreValue is
+ *   written whenever the return value is >= 1. Its "Step 0" shortcut (taken
+ *   when the profile advanced by more than one full transport length since the
+ *   last stored node) violated that contract: it returned
+ *   doubleEndedListLen(storedEventsList), which is > 0 whenever the event list
+ *   is non-empty, but never wrote *eventPreValue. The caller then executed
+ *       outValue = eventPreValue;
+ *   on an uninitialized local variable, silently replacing the correctly
+ *   interpolated output with whatever the stack held - typically 0.0. No error
+ *   or warning was emitted as long as the event list held exactly one event.
+ *
+ * Changes:
+ *   1a) findOppositeEndSpatialDistribution(): both Step-0 shortcuts now set
+ *       *eventPreValue to the interpolated value before returning, restoring
+ *       the documented contract. All stored events lie beyond the outlet read
+ *       position in that situation (they have already left the transport
+ *       domain), so the interpolated value is also the correct pre-event value.
+ *   1b) spatialDistribution(): eventPreValue is initialized to NAN as an
+ *       explicit "not available" sentinel and is only used when it was actually
+ *       written. If it was not, the interpolated value is kept and a warning is
+ *       printed instead of silently corrupting the output.
+ *
+ * Note: this removes the undefined behaviour. It does not make integrator steps
+ * that transport more than one full length accurate - such steps inherently
+ * discard profile information. Keep -maxStepSize below length/v_max for
+ * quantitatively correct results. 
+ * 
+ * The last sentence should considered to be added to the documentation of the 
+ * spatialDistribution operator, as it is a general limitation of the operator 
+ * and not an issue of this implementation.
+ *
+ * --------------------------------------------------------------------------
+ * PATCH 2 - Crash on sign changes of the velocity (flow reversal) with
+ *           "New end position is not bigger then previous last node." or
+ *           "New front position is not smaller then previous first node.".
+ *           This is supposed to fix issue #11449.
+ * --------------------------------------------------------------------------
+ * The node positions must stay monotone: for x increasing the new node is
+ * pushed at the front with position -posX, for x decreasing at the back with
+ * position -posX+1. The representation itself is fully reversal-capable - the
+ * positions are material coordinates and the window [-posX, -posX+1] may slide
+ * back and forth over them - but the bookkeeping that decides which end to
+ * write had two holes:
+ *
+ *   a) The mismatch test
+ *          isPositiveVelocity*realDirection > 0
+ *      can only ever be true for isPositiveVelocity == 1, because false is 0 in
+ *      C. The mirror-image mismatch (velocity reported negative while x
+ *      actually increased) was therefore never corrected. The new node was
+ *      pushed at the back with a position smaller than the current back
+ *      position => "New end position is not bigger then previous last node."
+ *
+ *   b) The correction was only considered for deltaX > SPATIAL_ZERO_DELTA_X,
+ *      while the monotonicity assertions in addNewNodeSpatialDistribution are
+ *      exact. A backward drift of x inside that dead band was ignored yet still
+ *      violated the assertion => "New front position is not smaller then
+ *      previous first node."
+ *
+ * The mismatch itself is unavoidable: isPositiveVelocity comes from the
+ * relation v >= 0, which is a discrete value evaluated with hysteresis and held
+ * between events, whereas deltaX is whatever the integrator produced over the
+ * step. Around a reversal the two disagree for at least one step.
+ *
+ * Changes:
+ *   2a) storeSpatialDistribution(): the storage direction is derived from the
+ *       sign of the actual change of x. The reported isPositiveVelocity is only
+ *       used when x did not change at all, in which case the new node lands
+ *       exactly on the current edge position, which the assertions allow.
+ *       No threshold is involved, so the decision is always consistent with
+ *       the exact assertions.
+ *   2b) spatialDistribution(): the same mismatch test is made symmetric. The
+ *       threshold and the "jumped" semantics are kept here, so an out-of-band
+ *       drift does not needlessly suppress the extrapolation of the outputs.
+ *   2c) The assertions used to be called with threadData == NULL, so a failing
+ *       assertion had no jump buffer to unwind to and the process segfaulted
+ *       instead of aborting the simulation with a message. threadData is now
+ *       threaded through 
+ *        - interpolateTransportedQuantity,
+ *        - extrapolateTransportedQuantity, 
+ *        - addNewNodeSpatialDistribution,
+ *        - findOppositeEndSpatialDistribution and 
+ *        - pruneSpatialDistribution.
+ *
+ * Remaining limitation: a sign change of v *inside* a single integrator step is
+ * invisible to the operator, which sees one monotone move of x. That is a
+ * property of the operator definition, not of this implementation.
+ *
+ * --------------------------------------------------------------------------
+ * PATCH 3 - Absolute tolerances versus an unbounded position coordinate.
+ *           
+ *           This does NOT fix an issue, but can be considered for implementation
+ *           to avoid potentially unwanted behaviour.
+ * --------------------------------------------------------------------------
+ * epsilon.h defines
+ *     SPATIAL_EPS            = DBL_EPSILON   (2.2e-16, exactly one ulp at 1.0)
+ *     SPATIAL_ZERO_DELTA_X   = 1e-12
+ * as *absolute* tolerances, while posX = x/length grows without bound: after
+ * 2e6 s at 1 m/s in a 100 m pipe, posX is about 2e4, where the spacing between
+ * two representable doubles (the coordinate quantum) is already 3.6e-12 -
+ * larger than both tolerances.
+ *
+ * What is NOT a problem here (measured by Claude, probably no fix needed):
+ *   - Adding or subtracting 1.0 is *exact* for |x| < 2^52. The spans written by
+ *     the pruning (edgeNodeData->position +/- 1) and the read positions (-posX,
+ *     -posX+1) therefore carry no rounding error at all.
+ *   - Subtracting two nearby doubles is exact as well, so deltaX and the node
+ *     distances carry no rounding error either. The distance-to-one tests and
+ *     the "x got reinitialized during an event" check do *not* misfire from
+ *     large |posX|.
+ *
+ * What is a problem:
+ *   - The tolerance can fall below the coordinate quantum. Already for
+ *     |posX| > 1 the position tolerance is below the quantum (at 2e4 it is
+ *     16384 times smaller), so every "same position" test becomes a
+ *     bitwise equality; from |posX| > 4.5e3 the same holds for the
+ *     SPATIAL_ZERO_DELTA_X dead band, which can then only be satisfied by an
+ *     exactly zero deltaX. The comparisons therefore stop expressing what they
+ *     were written to express.
+ *   - The guards that protect the division inside interpolate/extrapolate
+ *     (fabs(posA - posB) > SPATIAL_EPS) accept a node spacing of a single
+ *     quantum and therefore no longer reject an ill-conditioned interpolation.
+ *   - fabs(front->value - in0) > SPATIAL_EPS compares a *transported quantity*
+ *     against a tolerance sized for 1.0. Specific enthalpies are of order 1e5,
+ *     where one ulp is 7.3e-12, so any difference whatsoever counts as a
+ *     discrete change. This is the case with a directly visible effect: it
+ *     produces spurious event nodes, and a non-empty event list is exactly the
+ *     precondition for the PATCH 1 failure mode.
+ *
+ * Fix: scale each tolerance with the magnitude of the operands the comparison is
+ * made from - the only scale at which a floating point difference carries
+ * information. The helpers spatialPosEps(), spatialValEps() and
+ * spatialZeroDeltaX() below implement this, with the scale clamped at 1.0 from
+ * below so that nothing becomes tighter than before near the origin.
+ *
+ * Residual limitation that scaling cannot address (but which is probably)
+ * no problem anyways: the coordinate *resolution*
+ * itself degrades as posX grows. Two stored nodes collapse onto one double once
+ * v*h/length falls below |posX|*2^-52, which for a 2e6 s run means step sizes
+ * below roughly 4e-10 s - not reachable in practice, but the only real remedy
+ * would be to re-base the origin periodically, i.e. shift startPosX and all
+ * stored positions by a constant.
+ *
+ * Not changed: initSpatialDistribution(). Its initialPoints are normalized to
+ * [0, 1] by definition, so the absolute tolerance is already the correct one.
+ * ========================================================================== */
+
 //#if !defined(OMC_NDELAY_EXPRESSIONS) || OMC_NDELAY_EXPRESSIONS>0
 
 /*! \file spatialDistribution.c
@@ -36,6 +194,7 @@
 #include "../../openmodelica.h"
 #include "epsilon.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -66,12 +225,76 @@ typedef struct TRANSPORTED_EVENT_DATA {
 } TRANSPORTED_EVENT_DATA;
 
 
-/* Private function prototypes */
-double interpolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos);
-double extrapolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos);
-void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity, double position, double value, int isEvent);
-int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue);
-int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity);
+/* Private function prototypes
+ * PATCH 2c: threadData is threaded through all helpers that assert, so a failing
+ * assertion can unwind instead of dereferencing a NULL thread context. */
+double interpolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos);
+double extrapolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos);
+void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity, double position, double value, int isEvent);
+int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue);
+int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity);
+
+
+// ############################################################################
+//
+// PATCH 3: magnitude-scaled tolerances
+//
+// ############################################################################
+
+/**
+ * @brief Headroom in ulps for the scaled comparisons.
+ *
+ * The comparison has to be at least a few coordinate quanta wide to express
+ * "not distinguishable at this scale", and a position may carry up to half an
+ * ulp from the startPosX shift in shiftToStartPosX(), so one ulp is not enough
+ * headroom while a handful is. At scale 1.0 this gives 1.8e-15, still many
+ * orders of magnitude below the smallest physically meaningful spacing between
+ * two nodes (v*h/length).
+ */
+static const double SPATIAL_EPS_ULPS = 8.0;
+
+/**
+ * @brief Magnitude of the two operands a difference was computed from.
+ *
+ * Clamped at 1.0 from below so that the scaled tolerances never become tighter
+ * than the original absolute ones near the origin.
+ */
+static double spatialScale(double a, double b) {
+  double scaleA = fabs(a);
+  double scaleB = fabs(b);
+  double scale = (scaleA > scaleB) ? scaleA : scaleB;
+  return (scale > 1.0) ? scale : 1.0;
+}
+
+/**
+ * @brief Tolerance for comparing two positions (or a difference of positions).
+ *
+ * Pass the two *operands*, not their difference: the absolute error of a
+ * floating point difference is set by the magnitude of the operands, not by the
+ * magnitude of the result. This matters for the distance-to-one tests, where the
+ * result is about 1 while the operands can be of order 1e4.
+ */
+static double spatialPosEps(double posA, double posB) {
+  return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(posA, posB);
+}
+
+/**
+ * @brief Tolerance for deciding whether a transported value changed discretely.
+ *
+ * The transported quantity is arbitrary (specific enthalpies are of order 1e5),
+ * so an absolute tolerance of one ulp at 1.0 would classify every re-store as a
+ * discrete change and fill the event list with spurious entries.
+ */
+static double spatialValEps(double valA, double valB) {
+  return SPATIAL_EPS_ULPS * SPATIAL_EPS * spatialScale(valA, valB);
+}
+
+/**
+ * @brief Scaled version of the "x is standing still" threshold.
+ */
+static double spatialZeroDeltaX(double posA, double posB) {
+  return SPATIAL_ZERO_DELTA_X * spatialScale(posA, posB);
+}
 
 // ############################################################################
 //
@@ -312,37 +535,61 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     realDirection = 0 /* standing still */;
   }
 
-  /* If real direction doesn't match isPositiveVelocity just flip isPositiveVelocity. */
-  if (deltaX > SPATIAL_ZERO_DELTA_X && isPositiveVelocity*realDirection > 0) {
-    // TODO: This is probably still a sign that we didn't handle some event or event search correctly.
-    isPositiveVelocity  = !isPositiveVelocity;
+  /* PATCH 2a: Derive the storage direction from the sign of the actual change of
+   * x instead of trusting the reported isPositiveVelocity.
+   *
+   * realDirection == +1 means posX decreased, i.e. x decreased (v < 0), because
+   * deltaX was computed as oldPosX - posX. realDirection == -1 means x increased
+   * (v > 0). The reported isPositiveVelocity is the held value of the relation
+   * v >= 0 and can lag the sign of deltaX by a step around a flow reversal.
+   *
+   * The previous test
+   *     deltaX > SPATIAL_ZERO_DELTA_X && isPositiveVelocity*realDirection > 0
+   * could only detect the mismatch (reported positive, x decreasing), because
+   * false is 0 in C, and it ignored any mismatch inside the SPATIAL_ZERO_DELTA_X
+   * dead band although the monotonicity assertions in
+   * addNewNodeSpatialDistribution are exact. Both gaps ended in a failing
+   * assertion (and, via threadData == NULL, in a crash) on sign changes of v.
+   *
+   * Deriving the direction from realDirection alone closes both gaps: the end
+   * that is written is by construction the end that keeps the positions
+   * monotone, for arbitrarily small |deltaX|. */
+  if (realDirection > 0) {
+    isPositiveVelocity = 0 /* false: x decreased, write at the back */;
+  } else if (realDirection < 0) {
+    isPositiveVelocity = 1 /* true: x increased, write at the front */;
   }
+  /* realDirection == 0: keep the reported direction. The new node then lands
+   * exactly on the current edge position, which the assertions allow (<=, >=)
+   * and which is the existing event-node case handled below. */
 
   /* Add new node (oldPosX-deltaX, in0) or (oldPosX-deltaX+1, in1) to list
    * Check if it an event and only save it if has a discrete change in in0 or in1.
    */
   if (isPositiveVelocity) {
     TRANSPORTED_QUANTITY_DATA* front = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
-    if (fabs(-posX - front->position) < SPATIAL_EPS) {
-      if (fabs(front->value - in0) > SPATIAL_EPS) {
-        addNewNodeSpatialDistribution(spatialDistribution, isPositiveVelocity, -posX, in0, 1 /* true */);
+    /* PATCH 3: scaled position and value tolerances */
+    if (fabs(-posX - front->position) < spatialPosEps(-posX, front->position)) {
+      if (fabs(front->value - in0) > spatialValEps(front->value, in0)) {
+        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 1 /* true */);
       }
     } else {
-      addNewNodeSpatialDistribution(spatialDistribution, isPositiveVelocity, -posX, in0, 0 /* false */);
+      addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 0 /* false */);
     }
   } else {
     TRANSPORTED_QUANTITY_DATA* last = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
-    if (fabs(-posX+1 - last->position) < SPATIAL_EPS) {
-      if (fabs(last->value - in1) > SPATIAL_EPS) {
-        addNewNodeSpatialDistribution(spatialDistribution, isPositiveVelocity, -posX+1, in1, 1 /* true */);
+    /* PATCH 3: scaled position and value tolerances */
+    if (fabs(-posX+1 - last->position) < spatialPosEps(-posX+1, last->position)) {
+      if (fabs(last->value - in1) > spatialValEps(last->value, in1)) {
+        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 1 /* true */);
       }
     } else {
-      addNewNodeSpatialDistribution(spatialDistribution, isPositiveVelocity, -posX+1, in1, 0 /* false */);
+      addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 0 /* false */);
     }
   }
 
   /* Remove nodes that droppen of spatial distribution */
-  walkedOverEvents = pruneSpatialDistribution(spatialDistribution, isPositiveVelocity);
+  walkedOverEvents = pruneSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity);
   if (walkedOverEvents > 1) {
     warningStreamPrint(OMC_LOG_STDOUT, 1, "Removed more then one event from spatialDistribution. Step size to big!");
     warningStreamPrint(OMC_LOG_STDOUT, 0, "time: %f, spatialDistribution index: %i, number of events: %i", data->localData[0]->timeValue, index, walkedOverEvents);
@@ -388,7 +635,7 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   int realDirection;
   int jumped = 0;
   double deltaX;
-  double eventPreValue;
+  double eventPreValue = NAN;   /* PATCH 1b: sentinel "no event pre-value available" */
   double outValue;
   double out0;      /* First output variable */
   double out1Val;   /* Second output variable, only written to *out1 if out1 != NULL */
@@ -417,20 +664,35 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   }
 
   /* If real direction doesn't match isPositiveVelocity just flip isPositiveVelocity.
-   * This still indicates something wrong, so we don't extrapolate the output */
-  if (deltaX > SPATIAL_ZERO_DELTA_X && isPositiveVelocity*realDirection > 0) {
+   * This still indicates something wrong, so we don't extrapolate the output.
+   *
+   * PATCH 2b: made symmetric. The original condition
+   *     isPositiveVelocity*realDirection > 0
+   * could only ever be true for isPositiveVelocity == 1, because false is 0 in C,
+   * so the mismatch (velocity reported negative while x increased) was never
+   * caught. Unlike the store path this keeps the SPATIAL_ZERO_DELTA_X threshold
+   * and the "jumped" flag: a drift below the threshold must not suppress the
+   * extrapolation of the outputs.
+   * PATCH 3: the threshold is scaled with the magnitude of the positions. */
+  if (deltaX > spatialZeroDeltaX(spatialDistribution->oldPosX, posX) &&
+      ((isPositiveVelocity && realDirection > 0) || (!isPositiveVelocity && realDirection < 0))) {
     isPositiveVelocity  = !isPositiveVelocity;
     jumped = 1 /* true */;
   }
 
-  /* Check if x was reinitialized */
-  if (deltaX > SPATIAL_ZERO_DELTA_X && data->simulationInfo->discreteCall) {
+  /* Check if x was reinitialized
+   * PATCH 3: scaled threshold. deltaX itself is exact (subtraction of two nearby
+   * doubles), but the plain SPATIAL_ZERO_DELTA_X falls below the coordinate
+   * quantum for |posX| > 4.5e3, where this dead band degenerates into "deltaX is
+   * exactly zero". */
+  if (deltaX > spatialZeroDeltaX(spatialDistribution->oldPosX, posX) && data->simulationInfo->discreteCall) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "x got reinitialized during an event at time %f. OpenModelica can't handle that.", data->localData[0]->timeValue);
     omc_throw_function(threadData);
   }
 
-  /* Special case: Zero progress */
-  if (deltaX < SPATIAL_EPS) {
+  /* Special case: Zero progress
+   * PATCH 3: scaled tolerance, see above */
+  if (deltaX < spatialPosEps(spatialDistribution->oldPosX, posX)) {
     firstNodeData = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
     lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
     out0 = firstNodeData->value;
@@ -444,7 +706,7 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   }
 
   /* Get value of ou0/out1 by walkling over list */
-  walkedOverEvents = findOppositeEndSpatialDistribution(spatialDistribution, in0, in1, posX, isPositiveVelocity, &eventPreValue, &outValue);
+  walkedOverEvents = findOppositeEndSpatialDistribution(threadData, spatialDistribution, in0, in1, posX, isPositiveVelocity, &eventPreValue, &outValue);
 
   /* Handle events that would come out of spatialDistribution */
   if (walkedOverEvents > 1) {
@@ -453,8 +715,17 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     messageCloseWarning(OMC_LOG_STDOUT);
   }
   if (walkedOverEvents>0 && !data->simulationInfo->discreteCall) {
-    infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Found event in spatial distribution at time %f", data->localData[0]->timeValue);
-    outValue = eventPreValue;
+    /* PATCH 1b: Only substitute the pre-event value if it was actually provided.
+     * Using it unconditionally read an uninitialized variable whenever
+     * findOppositeEndSpatialDistribution returned a non-zero event count
+     * without writing eventPreValue, which silently forced the output to an
+     * undefined value (typically 0.0). */
+    if (!isnan(eventPreValue)) {
+      infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Found event in spatial distribution at time %f", data->localData[0]->timeValue);
+      outValue = eventPreValue;
+    } else {
+      warningStreamPrint(OMC_LOG_STDOUT, 0, "spatialDistribution index %i reported %i event(s) without a pre-value at time %f. Keeping interpolated value.", index, walkedOverEvents, data->localData[0]->timeValue);
+    }
   }
 
   /* Extrapolate return values to break up quasi-loop with inputs */
@@ -462,11 +733,15 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
   secondNodeData = dataDoubleEndedList(getNextNodeDoubleEndedList(getFirstNodeDoubleEndedList(transportedQuantityList)));
   lastNodeData = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
   forelastNodeData = dataDoubleEndedList(getPreviousNodeDoubleEndedList(getLastNodeDoubleEndedList(transportedQuantityList)));
+  /* PATCH 3: scaled tolerances. The second test guards the division by the node
+   * distance inside extrapolateTransportedQuantity, so it has to use the same
+   * scale as the positions it compares. */
   if (isPositiveVelocity) {
     if (jumped) {
       out0 = in0;
-    } else if (deltaX > SPATIAL_EPS && fabs(firstNodeData->position-secondNodeData->position)>SPATIAL_EPS) {
-      out0 = extrapolateTransportedQuantity(firstNodeData, secondNodeData, -posX);
+    } else if (deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
+               fabs(firstNodeData->position-secondNodeData->position) > spatialPosEps(firstNodeData->position, secondNodeData->position)) {
+      out0 = extrapolateTransportedQuantity(threadData, firstNodeData, secondNodeData, -posX);
     } else {
       out0 = firstNodeData->value;
     }
@@ -475,8 +750,9 @@ double spatialDistribution(DATA* data, threadData_t *threadData, unsigned int in
     out0 = outValue;
     if (jumped) {
       out1Val = in1;
-    } else if (deltaX > SPATIAL_EPS && fabs(forelastNodeData->position-lastNodeData->position)>SPATIAL_EPS) {
-      out1Val = extrapolateTransportedQuantity(forelastNodeData, lastNodeData, -posX+1);
+    } else if (deltaX > spatialPosEps(spatialDistribution->oldPosX, posX) &&
+               fabs(forelastNodeData->position-lastNodeData->position) > spatialPosEps(forelastNodeData->position, lastNodeData->position)) {
+      out1Val = extrapolateTransportedQuantity(threadData, forelastNodeData, lastNodeData, -posX+1);
     } else {
       out1Val = lastNodeData->value;
     }
@@ -553,7 +829,8 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        if (fabs(currentNodeData->position+posX-1) <= SPATIAL_EPS) {
+        /* PATCH 3: scaled tolerance */
+        if (fabs(currentNodeData->position+posX-1) <= spatialPosEps(currentNodeData->position, posX)) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
         }
@@ -584,7 +861,8 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
     } else {
       while (currentNode != NULL) {
         // Am I on an event?
-        if (fabs(currentNodeData->position+posX) <= SPATIAL_EPS) {
+        /* PATCH 3: scaled tolerance */
+        if (fabs(currentNodeData->position+posX) <= spatialPosEps(currentNodeData->position, posX)) {
           zeroCrossingValue = -currentNodeData->zeroCrossValue;
           break;
         }
@@ -633,7 +911,7 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
  * @param interpolationPos        Position where to interpolate.
  * @return double                 Interpolated value
  */
-double interpolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos) {
+double interpolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double interpolationPos) {
   double leftPosition, rightPosition;
   double leftValue, rightValue;
   double distPos;
@@ -645,7 +923,9 @@ double interpolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData,
   rightValue = rightData->value;
   distPos = rightPosition - leftPosition;
 
-  assertStreamPrint(NULL, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
+  /* PATCH 2c: threadData instead of NULL, so this aborts the simulation with a
+   * message instead of crashing the process. */
+  assertStreamPrint(threadData, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
 
   interpolatedValue = leftValue  * ((rightPosition-interpolationPos)/distPos)
                     + rightValue * ((interpolationPos-leftPosition)/distPos);
@@ -662,7 +942,7 @@ double interpolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData,
  * @param extrapolationPos      Position where to interpolate.
  * @return double               Extrapolated value.
  */
-double extrapolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos) {
+double extrapolateTransportedQuantity(threadData_t *threadData, const TRANSPORTED_QUANTITY_DATA* leftData, const TRANSPORTED_QUANTITY_DATA* rightData, const double extrapolationPos) {
   double leftPosition, rightPosition;
   double leftValue, rightValue;
   double distPos;
@@ -674,7 +954,8 @@ double extrapolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData,
   rightValue = rightData->value;
   distPos = rightPosition - leftPosition;
 
-  assertStreamPrint(NULL, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
+  /* PATCH 2c: threadData instead of NULL */
+  assertStreamPrint(threadData, distPos > 0, "interpolateTransportedQuantity: wrong order or same position!");
 
   extrapolatedValue = leftValue + (rightValue-leftValue)/(distPos) * (extrapolationPos - leftPosition);
   return extrapolatedValue;
@@ -693,7 +974,7 @@ double extrapolateTransportedQuantity(const TRANSPORTED_QUANTITY_DATA* leftData,
  * @param value                       Value of new node.
  * @param isEvent                     Boolean value if new node is an event node.
  */
-void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int front, double position, double value, int isEvent) {
+void addNewNodeSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int front, double position, double value, int isEvent) {
   /* Variables */
   DOUBLE_ENDED_LIST* transportedQuantityList = spatialDistribution->transportedQuantity;
   DOUBLE_ENDED_LIST* storedEventsList = spatialDistribution->storedEvents;
@@ -707,15 +988,18 @@ void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistributio
 
   /* Add node to transported quantity list */
   infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Adding (%e,%e) at %s.", newNodeData.position, newNodeData.value, front?"front":"back");
+  /* PATCH 2c: these two assertions are the ones that used to fire on flow
+   * reversal. With threadData == NULL a failing assertion had no jump buffer to
+   * unwind to and took the process down instead of aborting the simulation. */
   if (front) {
     // Make sure new first node is smaller then previous first node
     TRANSPORTED_QUANTITY_DATA* oldFront = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
-    assertStreamPrint(NULL, position<=oldFront->position, "New front position is not smaller then previous first node.");
+    assertStreamPrint(threadData, position<=oldFront->position, "New front position is not smaller then previous first node.");
     pushFrontDoubleEndedList(transportedQuantityList, (const void*) &newNodeData);
   } else {
     // Make sure new first node is smaller then previous first node
     TRANSPORTED_QUANTITY_DATA* oldEnd = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
-    assertStreamPrint(NULL, position>=oldEnd->position, "New end position is not bigger then previous last node.");
+    assertStreamPrint(threadData, position>=oldEnd->position, "New end position is not bigger then previous last node.");
     pushBackDoubleEndedList(transportedQuantityList, (const void*) &newNodeData);
   }
 
@@ -731,7 +1015,7 @@ void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistributio
       } else {
         // Make sure new first node is smaller then previous first node
         TRANSPORTED_EVENT_DATA* oldEventFront = (TRANSPORTED_EVENT_DATA*) firstDataDoubleEndedList(storedEventsList);
-        assertStreamPrint(NULL, position<=oldEventFront->position, "New front position is not smaller then previous first event node.");
+        assertStreamPrint(threadData, position<=oldEventFront->position, "New front position is not smaller then previous first event node.");
         newEventNodeData.zeroCrossValue = oldEventFront->zeroCrossValue*(-1);
       }
       pushFrontDoubleEndedList(storedEventsList, (const void*) &newEventNodeData);
@@ -741,7 +1025,7 @@ void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistributio
       } else {
         // Make sure new first node is smaller then previous first node
         TRANSPORTED_EVENT_DATA* oldEventEnd = (TRANSPORTED_EVENT_DATA*) lastDataDoubleEndedList(storedEventsList);
-        assertStreamPrint(NULL, position>=oldEventEnd->position, "New end position is not bigger then previous last event node.");
+        assertStreamPrint(threadData, position>=oldEventEnd->position, "New end position is not bigger then previous last event node.");
         newEventNodeData.zeroCrossValue = oldEventEnd->zeroCrossValue*(-1);
       }
       pushBackDoubleEndedList(storedEventsList, (const void*) &newEventNodeData);
@@ -764,9 +1048,11 @@ void addNewNodeSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistributio
  *                                    Velocity v is `v:=der(x)`.
  * @param eventPreValue               On output containing value of first/last node before event.
  *                                    This value is only written when function returned 1 or greater.
+ *                                    PATCH: (Patch 1a) The "Step 0" shortcuts below also honour this contract
+ *                                    now; they used to return a non-zero count without writing it.
  * @return int                        Return number of events that were encountered.
  */
-int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue) {
+int findOppositeEndSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, double in0, double in1, double posX, int isPositiveVelocity, double* eventPreValue, double* outValue) {
   /* Variables */
   DOUBLE_ENDED_LIST* transportedQuantityList = spatialDistribution->transportedQuantity;
   DOUBLE_ENDED_LIST* storedEventsList = spatialDistribution->storedEvents;
@@ -797,7 +1083,14 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
       //                                                  |
       tempData.position = -posX;
       tempData.value = in0;
-      *outValue = interpolateTransportedQuantity(&tempData, firstNodeData, -posX + 1);
+      *outValue = interpolateTransportedQuantity(threadData, &tempData, firstNodeData, -posX + 1);
+      /* PATCH 1a: Every stored event lies at a position >= firstNodeData->position,
+       * i.e. beyond the outlet read position -posX+1, so all of them have already
+       * left the transport domain during this step. The interpolated value is
+       * therefore also the correct pre-event value. Writing it keeps the
+       * documented contract "eventPreValue is valid whenever the return value is
+       * >= 1" and stops the caller from substituting an uninitialized value. */
+      *eventPreValue = *outValue;
       return doubleEndedListLen(storedEventsList);
     }
   } else {
@@ -807,7 +1100,9 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
       //                                                                                  |
       tempData.position = -posX+1;
       tempData.value = in1;
-      *outValue = interpolateTransportedQuantity(lastNodeData, &tempData, -posX);
+      *outValue = interpolateTransportedQuantity(threadData, lastNodeData, &tempData, -posX);
+      /* PATCH 1a: see comment in the positive velocity branch above. */
+      *eventPreValue = *outValue;
       return doubleEndedListLen(storedEventsList);
     }
   }
@@ -825,10 +1120,17 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
   }
   currentNodeData = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(currentNode);
 
+  /* PATCH 3: a meaningful "not distinguishable from 1" tolerance has to be scaled
+   * by the magnitude of the *operands*, not by the magnitude of the difference
+   * (which is about 1). With the absolute SPATIAL_EPS this test degenerates into
+   * an exact comparison as soon as |position| > 1. The distance itself is exact -
+   * subtracting two nearby doubles introduces no error - so this scaling makes
+   * the comparison meaningful rather than fixing an observed misfire.
+   * PATCH 2c: threadData instead of NULL. */
   currentDistance = fabs(currentNodeData->position - edgeNodePosition);
-  if (currentDistance + SPATIAL_EPS < 1) {
+  if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\nThis case should not be possible. Please open a bug report about it.");
-    omc_throw_function(NULL);
+    omc_throw_function(threadData);
     return walkedOverEvents;
   }
 
@@ -850,14 +1152,16 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
     /* Check for event:
      * Current node position equal to previous visited node position
      */
-    if (fabs(prevVisitedNodeData->position - currentNodeData->position) < SPATIAL_EPS) {
+    /* PATCH 3: scaled tolerance */
+    if (fabs(prevVisitedNodeData->position - currentNodeData->position) < spatialPosEps(prevVisitedNodeData->position, currentNodeData->position)) {
       *eventPreValue = prevVisitedNodeData->value;
       walkedOverEvents += 1;
     }
 
-    /* Check if distance between currentNode and edgeNode is < 1 */
+    /* Check if distance between currentNode and edgeNode is < 1
+     * PATCH 3: scaled tolerance */
     currentDistance = fabs(currentNodeData->position - edgeNodePosition);
-    if (currentDistance + SPATIAL_EPS < 1) {
+    if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodePosition) < 1) {
       break;
     } else {
       prevVisitedNode = currentNode;
@@ -877,9 +1181,9 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
     }
   } else {
     if (isPositiveVelocity) {
-      *outValue = interpolateTransportedQuantity(currentNodeData, prevVisitedNodeData, edgeNodePosition + 1);
+      *outValue = interpolateTransportedQuantity(threadData, currentNodeData, prevVisitedNodeData, edgeNodePosition + 1);
     } else {
-      *outValue = interpolateTransportedQuantity(prevVisitedNodeData, currentNodeData, edgeNodePosition - 1);
+      *outValue = interpolateTransportedQuantity(threadData, prevVisitedNodeData, currentNodeData, edgeNodePosition - 1);
     }
   }
 
@@ -898,7 +1202,7 @@ int findOppositeEndSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistrib
  *                                    This value is only written when function returned 1 or greater.
  * @return int                        Return number of events that were encountered.
  */
-int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity) {
+int pruneSpatialDistribution(threadData_t *threadData, SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int isPositiveVelocity) {
   /* Variables */
   DOUBLE_ENDED_LIST* transportedQuantityList = spatialDistribution->transportedQuantity;
   DOUBLE_ENDED_LIST* storedEventsList = spatialDistribution->storedEvents;
@@ -927,10 +1231,11 @@ int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int
   edgeNodeData  = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(edgeNode);
   currentNodeData = (TRANSPORTED_QUANTITY_DATA*) dataDoubleEndedList(currentNode);
 
+  /* PATCH 3: scaled tolerance, PATCH 2c: threadData instead of NULL */
   currentDistance = fabs(currentNodeData->position - edgeNodeData->position);
-  if (currentDistance + SPATIAL_EPS < 1) {
+  if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
     errorStreamPrint(OMC_LOG_STDOUT, 0, "Error for spatialDistribution in function pruneSpatialDistribution.\nThis case should not be possible. Please open a bug reoprt about it.");
-    omc_throw_function(NULL);
+    omc_throw_function(threadData);
   }
 
   /* Move to neighbor */
@@ -948,13 +1253,15 @@ int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int
     /* Check for event:
      * Current node position equal to previous visited node position
      */
-    if (fabs(prevVisitedNodeData->position - currentNodeData->position) < SPATIAL_EPS) {
+    /* PATCH 3: scaled tolerance */
+    if (fabs(prevVisitedNodeData->position - currentNodeData->position) < spatialPosEps(prevVisitedNodeData->position, currentNodeData->position)) {
       walkedOverEvents += 1;
     }
 
-    /* Check if distance between currentNode and edgeNode is < 1 */
+    /* Check if distance between currentNode and edgeNode is < 1
+     * PATCH 3: scaled tolerance */
     currentDistance = fabs(currentNodeData->position - edgeNodeData->position);
-    if (currentDistance + SPATIAL_EPS < 1) {
+    if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
       break;
     } else {
       prevVisitedNode = currentNode;
@@ -965,12 +1272,13 @@ int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int
   /* Step 2
    * Interpolate at edgeNode->position +/- 1.
    */
-  if (currentDistance + SPATIAL_EPS < 1) {
+  /* PATCH 3: scaled tolerance */
+  if (currentDistance + spatialPosEps(currentNodeData->position, edgeNodeData->position) < 1) {
     if (isPositiveVelocity) {
-      prevVisitedNodeData->value = interpolateTransportedQuantity(currentNodeData, prevVisitedNodeData, edgeNodeData->position + 1);
+      prevVisitedNodeData->value = interpolateTransportedQuantity(threadData, currentNodeData, prevVisitedNodeData, edgeNodeData->position + 1);
       prevVisitedNodeData->position = edgeNodeData->position + 1;
     } else {
-      prevVisitedNodeData->value = interpolateTransportedQuantity(prevVisitedNodeData, currentNodeData, edgeNodeData->position - 1);
+      prevVisitedNodeData->value = interpolateTransportedQuantity(threadData, prevVisitedNodeData, currentNodeData, edgeNodeData->position - 1);
       prevVisitedNodeData->position = edgeNodeData->position - 1;
     }
     infoStreamPrint(OMC_LOG_SPATIALDISTR, 0, "Interpolate at %s", isPositiveVelocity?"end":"front");
@@ -992,7 +1300,8 @@ int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int
   if (doubleEndedListLen(storedEventsList) > 0) {
     if (isPositiveVelocity) {
       eventData = lastDataDoubleEndedList(storedEventsList);
-      while (edgeNodeData->position+1 + SPATIAL_ZERO_DELTA_X < eventData->position) {
+      /* PATCH 3: scaled tolerance */
+      while (edgeNodeData->position+1 + spatialZeroDeltaX(edgeNodeData->position, eventData->position) < eventData->position) {
         spatialDistribution->lastStoredEventValue = eventData->zeroCrossValue;
         removeLastDoubleEndedList(storedEventsList);
         if (doubleEndedListLen(storedEventsList) == 0) {
@@ -1003,7 +1312,8 @@ int pruneSpatialDistribution(SPATIAL_DISTRIBUTION_DATA* spatialDistribution, int
       }
     } else {
       eventData = firstDataDoubleEndedList(storedEventsList);
-      while (edgeNodeData->position-1 - SPATIAL_ZERO_DELTA_X > eventData->position) {
+      /* PATCH 3: scaled tolerance */
+      while (edgeNodeData->position-1 - spatialZeroDeltaX(edgeNodeData->position, eventData->position) > eventData->position) {
         spatialDistribution->lastStoredEventValue = eventData->zeroCrossValue;
         removeFirstDoubleEndedList(storedEventsList);
         if (doubleEndedListLen(storedEventsList) == 0) {

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -13,6 +13,9 @@ TESTFILES = \
 	test1.mos \
 	test2.mos \
 	test3.mos \
+	bigStepEventFallback.mos \
+	doubleReversal.mos \
+	largePositionReversal.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -16,6 +16,7 @@ TESTFILES = \
 	bigStepEventFallback.mos \
 	doubleReversal.mos \
 	largePositionReversal.mos \
+	rampInput.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/bigStepEventFallback.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/bigStepEventFallback.mos
@@ -1,0 +1,64 @@
+// name:                bigStepEventFallback.mos
+// keywords:            spatialDistribution
+// status:              correct
+// teardown_command:    rm -f bigStepEventFallback*
+//
+// Belt whose initial profile already contains one genuine discrete jump
+// (100 -> 285 at the mid-point), combined with a fixed Euler step spanning
+// more than one transport length in a single accepted step. This forces
+// findOppositeEndSpatialDistribution() into its "Step 0" shortcut while
+// storedEventsList still holds pending events (issue #16182).
+
+loadModel(Modelica); getErrorString();
+loadString("
+  model bigStepEventFallback
+    extends Modelica.Icons.Example;
+    Real leftInput = 285.0;
+    Real rightInput = 285.0;
+    Real leftOutput;
+    Real rightOutput;
+    constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 0.5, 0.5, 1.0};
+    constant Real[:] initialValues = {100.0, 100.0, 285.0, 285.0};
+    Real v = 5;
+    Boolean posV;
+    Real x(start=0, fixed=true);
+  equation
+    v = der(x);
+    posV = v >= 0;
+    (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
+  end bigStepEventFallback;"); getErrorString();
+
+// Simulate: 2 fixed Euler steps of 0.5s each => x jumps 0 -> 2.5 -> 5.0,
+// i.e. 2.5 transport lengths per accepted step.
+simulate(bigStepEventFallback, startTime=0, stopTime=1.0, numberOfIntervals=2, method="euler"); getErrorString();
+
+val(leftOutput, 0.0);
+val(rightOutput, 0.0);
+val(leftOutput, 0.5);
+val(rightOutput, 0.5);
+val(leftOutput, 1.0);
+val(rightOutput, 1.0);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "bigStepEventFallback_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'bigStepEventFallback', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_STDOUT        | warning | Need to output more then one event from spatialDistribution. Step size to big!
+// |                 | |       | | time: 0.500000, spatialDistribution index: 0, number of events: 2
+// LOG_STDOUT        | warning | Removed more then one event from spatialDistribution. Step size to big!
+// |                 | |       | | time: 0.500000, spatialDistribution index: 0, number of events: 2
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 100.0
+// 285.0
+// 285.0
+// 285.0
+// 285.0
+// 285.0
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/bigStepEventFallback.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/bigStepEventFallback.mos
@@ -1,17 +1,15 @@
 // name:                bigStepEventFallback.mos
 // keywords:            spatialDistribution
 // status:              correct
-// teardown_command:    rm -f bigStepEventFallback*
+// teardown_command:    rm -f bigStepEventFallbackSpatialDistribution*
 //
-// Belt whose initial profile already contains one genuine discrete jump
-// (100 -> 285 at the mid-point), combined with a fixed Euler step spanning
-// more than one transport length in a single accepted step. This forces
-// findOppositeEndSpatialDistribution() into its "Step 0" shortcut while
-// storedEventsList still holds pending events (issue #16182).
+// Initial profile with a discrete jump at the mid-point, transported with an
+// Euler step covering more than one length: the outputs used to fall back to
+// an uninitialized value.
 
 loadModel(Modelica); getErrorString();
 loadString("
-  model bigStepEventFallback
+  model bigStepEventFallbackSpatialDistribution
     extends Modelica.Icons.Example;
     Real leftInput = 285.0;
     Real rightInput = 285.0;
@@ -26,11 +24,10 @@ loadString("
     v = der(x);
     posV = v >= 0;
     (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
-  end bigStepEventFallback;"); getErrorString();
+  end bigStepEventFallbackSpatialDistribution;"); getErrorString();
 
-// Simulate: 2 fixed Euler steps of 0.5s each => x jumps 0 -> 2.5 -> 5.0,
-// i.e. 2.5 transport lengths per accepted step.
-simulate(bigStepEventFallback, startTime=0, stopTime=1.0, numberOfIntervals=2, method="euler"); getErrorString();
+// Two Euler steps of 0.5 s: x jumps 0 -> 2.5 -> 5, i.e. 2.5 lengths per step.
+simulate(bigStepEventFallbackSpatialDistribution, startTime=0, stopTime=1.0, numberOfIntervals=2, method="euler"); getErrorString();
 
 val(leftOutput, 0.0);
 val(rightOutput, 0.0);
@@ -44,8 +41,8 @@ val(rightOutput, 1.0);
 // true
 // ""
 // record SimulationResult
-//     resultFile = "bigStepEventFallback_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'bigStepEventFallback', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "bigStepEventFallbackSpatialDistribution_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'bigStepEventFallbackSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_STDOUT        | warning | Need to output more then one event from spatialDistribution. Step size to big!
 // |                 | |       | | time: 0.500000, spatialDistribution index: 0, number of events: 2

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
@@ -48,6 +48,17 @@ end doubleReversalSpatialDistribution;"); getErrorString();
 
 // Simulate over 3 segments of 1s each: v=+2, v=-2, v=+2.
 simulate(doubleReversalSpatialDistribution, stopTime=3.0); getErrorString();
+
+// Phase 1: v=+2, in0=1
+val(leftOutput, 0.25);  val(rightOutput, 0.25);
+val(leftOutput, 0.75);  val(rightOutput, 0.75);
+// Phase 2: v=-2, in1=-1
+val(leftOutput, 1.25);  val(rightOutput, 1.25);
+val(leftOutput, 1.75);  val(rightOutput, 1.75);
+// Phase 3: v=+2, in0=1
+val(leftOutput, 2.25);  val(rightOutput, 2.25);
+val(leftOutput, 2.75);  val(rightOutput, 2.75);
+
 // Result:
 // true
 // ""
@@ -63,4 +74,16 @@ simulate(doubleReversalSpatialDistribution, stopTime=3.0); getErrorString();
 // "
 // end SimulationResult;
 // ""
+// 1.0
+// 0.0
+// 1.0
+// 1.0
+// 1.0
+// -1.0
+// -1.0
+// -1.0
+// 1.0
+// -1.0
+// 1.0
+// 1.0
 // endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
@@ -1,0 +1,66 @@
+// name:                doubleReversal.mos
+// keywords:            spatialDistribution
+// status:              correct
+// teardown_command:    rm -f doubleReversalSpatialDistribution*
+//
+// Extends mixedVelocity.mos with a THIRD velocity segment (+2 -> -2 -> +2)
+// so the belt reverses twice. The one-sided mismatch correction that used to
+// live in storeSpatialDistribution() could only ever catch the first
+// (positive->negative) reversal; the second (negative->positive) reversal
+// is exactly the transition it could never catch (issue #11449 - "works
+// once, fails on the second reversal"). The assertion this used to crash on
+// ("New front position is not smaller then previous first node.") may still
+// fire transiently during solver iteration, but is now caught via
+// threadData and handled as a normal step rejection instead of a crash.
+
+loadModel(Modelica); getErrorString();
+loadString("model doubleReversalSpatialDistribution
+  \"Single conveyor belt transporting with velocity reversing twice
+   (positive -> negative -> positive) and input from the left or right side.\"
+  Real leftInput;
+  Real rightInput;
+  Real leftOutput;
+  Real rightOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {0.0, 0.0};
+  Real v;
+  Boolean posV;
+  Real x(start=0, fixed=true);
+equation
+  if posV then
+    leftInput = 1;
+    rightInput = 0;
+  else
+    leftInput = 0;
+    rightInput = -1;
+  end if;
+  if time < 1 then
+    v = 2;
+  elseif time < 2 then
+    v = -2;
+  else
+    v = 2;
+  end if;
+  v = der(x);
+  posV = v >= 0;
+  (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
+end doubleReversalSpatialDistribution;"); getErrorString();
+
+// Simulate over 3 segments of 1s each: v=+2, v=-2, v=+2.
+simulate(doubleReversalSpatialDistribution, stopTime=3.0); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "doubleReversalSpatialDistribution_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'doubleReversalSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_ASSERT        | debug   | New front position is not smaller then previous first node.
+// LOG_STDOUT        | warning | Integrator attempt to handle a problem with a called assert.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/doubleReversal.mos
@@ -3,15 +3,9 @@
 // status:              correct
 // teardown_command:    rm -f doubleReversalSpatialDistribution*
 //
-// Extends mixedVelocity.mos with a THIRD velocity segment (+2 -> -2 -> +2)
-// so the belt reverses twice. The one-sided mismatch correction that used to
-// live in storeSpatialDistribution() could only ever catch the first
-// (positive->negative) reversal; the second (negative->positive) reversal
-// is exactly the transition it could never catch (issue #11449 - "works
-// once, fails on the second reversal"). The assertion this used to crash on
-// ("New front position is not smaller then previous first node.") may still
-// fire transiently during solver iteration, but is now caught via
-// threadData and handled as a normal step rejection instead of a crash.
+// Velocity reverses twice (+2 -> -2 -> +2). The old one-sided direction
+// correction only caught the first reversal; the second left the node list
+// non-monotone.
 
 loadModel(Modelica); getErrorString();
 loadString("model doubleReversalSpatialDistribution
@@ -68,8 +62,6 @@ val(leftOutput, 2.75);  val(rightOutput, 2.75);
 //     resultFile = "doubleReversalSpatialDistribution_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'doubleReversalSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_ASSERT        | debug   | New front position is not smaller then previous first node.
-// LOG_STDOUT        | warning | Integrator attempt to handle a problem with a called assert.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/largePositionReversal.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/largePositionReversal.mos
@@ -1,0 +1,65 @@
+// name:                largePositionReversal.mos
+// keywords:            spatialDistribution
+// status:              correct
+// teardown_command:    rm -f largePositionReversalSpatialDistribution*
+//
+// Runs the belt fast enough in one direction that the operator's internal
+// position coordinate (posX) reaches O(1e4) transport lengths, then reverses
+// once. Guards spatialZeroDeltaX()'s magnitude-scaled "standing still"
+// threshold, which becomes very lenient (~1e-8) at posX ~ 1e4 and could in
+// principle let a genuine direction-mismatch slip through undetected at
+// that scale. leftInput/rightInput are plain constants, so interpolation
+// between same-valued nodes is exact regardless of position, giving exact
+// expected flush values with no numerical-approximation slack.
+
+loadModel(Modelica); getErrorString();
+loadString("model largePositionReversalSpatialDistribution
+  extends Modelica.Icons.Example;
+  Real leftInput = 111.0;
+  Real rightInput = 222.0;
+  Real leftOutput;
+  Real rightOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {0.0, 0.0};
+  parameter Real v0 = 12000;
+  Real v;
+  Boolean posV;
+  Real x(start=0, fixed=true);
+equation
+  v = if time < 1 then v0 else -v0;
+  v = der(x);
+  posV = v >= 0;
+  (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
+end largePositionReversalSpatialDistribution;"); getErrorString();
+
+// v0=12000 for 1s pushes x (posX) to exactly ~12000 at the moment of
+// reversal, squarely in the O(1e4) regime the scaled tolerance guard needs
+// to hold up at.
+simulate(largePositionReversalSpatialDistribution, stopTime=2.0, numberOfIntervals=500); getErrorString();
+
+val(leftOutput, 0.0);
+val(rightOutput, 0.0);
+val(leftOutput, 0.5);
+val(rightOutput, 0.5);
+val(leftOutput, 1.5);
+val(rightOutput, 1.5);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "largePositionReversalSpatialDistribution_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'largePositionReversalSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 111.0
+// 111.0
+// 222.0
+// 222.0
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/largePositionReversal.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/largePositionReversal.mos
@@ -3,14 +3,9 @@
 // status:              correct
 // teardown_command:    rm -f largePositionReversalSpatialDistribution*
 //
-// Runs the belt fast enough in one direction that the operator's internal
-// position coordinate (posX) reaches O(1e4) transport lengths, then reverses
-// once. Guards spatialZeroDeltaX()'s magnitude-scaled "standing still"
-// threshold, which becomes very lenient (~1e-8) at posX ~ 1e4 and could in
-// principle let a genuine direction-mismatch slip through undetected at
-// that scale. leftInput/rightInput are plain constants, so interpolation
-// between same-valued nodes is exact regardless of position, giving exact
-// expected flush values with no numerical-approximation slack.
+// One reversal after the position coordinate has grown to O(1e3) transport
+// lengths, where one ulp at 1.0 is below the resolution of the coordinate.
+// Steps stay below one length, so the profile is walked instead of flushed.
 
 loadModel(Modelica); getErrorString();
 loadString("model largePositionReversalSpatialDistribution
@@ -21,7 +16,7 @@ loadString("model largePositionReversalSpatialDistribution
   Real rightOutput;
   constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
   constant Real[:] initialValues = {0.0, 0.0};
-  parameter Real v0 = 12000;
+  parameter Real v0 = 5000;
   Real v;
   Boolean posV;
   Real x(start=0, fixed=true);
@@ -32,10 +27,7 @@ equation
   (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
 end largePositionReversalSpatialDistribution;"); getErrorString();
 
-// v0=12000 for 1s pushes x (posX) to exactly ~12000 at the moment of
-// reversal, squarely in the O(1e4) regime the scaled tolerance guard needs
-// to hold up at.
-simulate(largePositionReversalSpatialDistribution, stopTime=2.0, numberOfIntervals=500); getErrorString();
+simulate(largePositionReversalSpatialDistribution, stopTime=2.0, numberOfIntervals=12000); getErrorString();
 
 val(leftOutput, 0.0);
 val(rightOutput, 0.0);
@@ -50,7 +42,7 @@ val(rightOutput, 1.5);
 // ""
 // record SimulationResult
 //     resultFile = "largePositionReversalSpatialDistribution_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'largePositionReversalSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 12000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'largePositionReversalSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/rampInput.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/rampInput.mos
@@ -1,0 +1,58 @@
+// name:                rampInput.mos
+// keywords:            spatialDistribution
+// status:              correct
+// teardown_command:    rm -f rampInputSpatialDistribution*
+//
+// A ramp on the inlet makes z linear in the position, so out1 is in0 of one
+// transport time earlier, exactly. Reading the profile at the position of the
+// last stored step instead of the current one lags by one output interval.
+
+loadModel(Modelica); getErrorString();
+loadString("model rampInputSpatialDistribution
+  \"Single conveyor belt with constant positive velocity and a ramp input
+   from the left side.\"
+  extends Modelica.Icons.Example;
+  Real leftInput = time;
+  Real rightInput = 0;
+  Real leftOutput;
+  Real rightOutput;
+  constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
+  constant Real[:] initialValues = {0.0, 0.0};
+  Real v = 1;
+  Boolean posV;
+  Real x(start=0, fixed=true);
+equation
+  v = der(x);
+  posV = v >= 0;
+  (leftOutput, rightOutput) = spatialDistribution(leftInput, rightInput, x, posV, initialPoints, initialValues);
+end rampInputSpatialDistribution;"); getErrorString();
+
+// Output interval 0.05 s, well outside the comparison tolerance.
+simulate(rampInputSpatialDistribution, stopTime=2.0, numberOfIntervals=40); getErrorString();
+
+val(leftOutput, 0.5);
+val(rightOutput, 0.5);
+val(leftOutput, 1.5);
+val(rightOutput, 1.5);
+val(leftOutput, 2.0);
+val(rightOutput, 2.0);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "rampInputSpatialDistribution_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 40, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'rampInputSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.5
+// 0.0
+// 1.5
+// 0.5
+// 2.0
+// 1.0
+// endResult


### PR DESCRIPTION
### Related Issues and Purpose

Adresses issues [#16182 ](https://github.com/OpenModelica/OpenModelica/issues/16182) (fallback to 0) and [#11449](https://github.com/OpenModelica/OpenModelica/issues/11449) (failure for flow reversal). 

Additionally provides a scaling of the distance measures to distinguish changed positions such that the distance measure keeps pace with an increasing total propagation length posX.  Detailed patch notes are provided in the beginning detailing the steps taken for every patch. Additional in-line comments before the code adaptations detail which patch the changes belong to to allow selecting them individually if needed.

Disclaimer: The patches were created together with Claude Code, Opus 5.0 and cross-checked manually. After translating the model that lead to failure in #11449 and to zero values in #16182, patching in the proposed spatialDistribution inside the .makefile and running the simulation via mos-script, the results no longer showed the unwanted behaviour. More extensive testing after review might be sensible. 

### Approach (abbreviated, for details see patch notes)
Patch 1 ([#16182 ](https://github.com/OpenModelica/OpenModelica/issues/16182)): 
 - eventPreValue is set to interpolated value before returning, not defaulting to 0
 - eventPreValue is initialized to NAN to make errors clear

Patch 2 ([#11449](https://github.com/OpenModelica/OpenModelica/issues/11449)): 
 - storage direction is derived from the sign of the actual change of x
 - made the mismatch test symmetric in `storeSpatialDistribution` and `spatialDistribution`
 - threadData is threaded through the assertion observers to allow simulation abortion with a message instead of process crashing

Patch 3 (not for an issue, but to avoid related issues in the future):
 - scales the tolerances with the position coordinate to avoid the tolerances relatively decreasing below the 'coordinate quantum' between two doubles