### PR TITLE
Add back/forward cursor position navigation to the text editor

### DIFF
--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -22,6 +22,8 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       Util/StringHandler.cpp
                       Util/OutputPlainTextEdit.cpp
                       Util/DirectoryOrFileSelector.cpp
+                      Util/NavigationManager.cpp
+                      Util/NavigationManagerView.cpp
                       MainWindow.cpp
                       LoadCompiledModelDialog.cpp
                       OMC/OMCProxy.cpp
@@ -155,6 +157,8 @@ set(OMEDITLIB_HEADERS Util/Helper.h
                       Util/StringHandler.h
                       Util/OutputPlainTextEdit.h
                       Util/DirectoryOrFileSelector.h
+                      Util/NavigationManager.h
+                      Util/NavigationManagerView.h
                       MainWindow.h
                       LoadCompiledModelDialog.h
                       OMC/OMCProxy.h

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -65,7 +65,7 @@ struct NavigationPoint {
   int position;
 };
 /*! The global navigation history shared by all editors. */
-QList<NavigationPoint> gNavigationPoints;
+QVector<NavigationPoint> gNavigationPoints;
 /*! Index of the current position in the global navigation history. */
 int gNavigationPos = -1;
 /*! True while a programmatic back/forward navigation is in progress.

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -43,38 +43,15 @@
 #include "Modeling/ModelWidgetContainer.h"
 #include "Modeling/DocumentationWidget.h"
 #include "Util/Helper.h"
+#include "Util/NavigationManager.h"
 #include "Debugger/Breakpoints/BreakpointsWidget.h"
 #include "Util/ResourceCache.h"
 
 #include <QMenu>
 #include <QCompleter>
 #include <QMessageBox>
-#include <QPointer>
 #include <QTextDocumentFragment>
 #include <QDockWidget>
-
-namespace {
-
-/*!
- * \brief The NavigationPoint struct
- * Stores an editor and the cursor position to jump to when navigating back
- * and forward through the cursor position history.
- */
-struct NavigationPoint {
-  QPointer<PlainTextEdit> editor;
-  int position;
-};
-/*! The global navigation history shared by all editors. */
-QVector<NavigationPoint> gNavigationPoints;
-/*! Index of the current position in the global navigation history. */
-int gNavigationPos = -1;
-/*! True while a programmatic back/forward navigation is in progress.
- * Used to avoid recording new points when the navigation activates a tab. */
-bool gNavigationActive = false;
-/*! Maximum number of points kept in the global navigation history. */
-const int gNavigationHistorySize = 50;
-
-}
 
 /*!
  * \class TabSettings
@@ -1143,169 +1120,23 @@ void PlainTextEdit::goToLineNumber(int lineNumber)
     QTextCursor cursor(block);
     cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, 0);
     setTextCursor(cursor);
-    recordNavigationPoint();
+    NavigationManager::instance()->recordNavigationPoint(this);
     centerCursor();
   }
 }
 
 /*!
- * \brief PlainTextEdit::recordNavigationPoint
- * Records the current cursor position in the global navigation history. Used
- * to implement the back/forward cursor navigation (mouse buttons 4/5 and
- * Alt+Left/Alt+Right). The history is shared between all editors so the
- * navigation works across different tabs, models and editors. A new point
- * truncates any forward points and the history is limited to
- * gNavigationHistorySize points.
- */
-void PlainTextEdit::recordNavigationPoint()
-{
-  if (gNavigationActive) {
-    return;
-  }
-  pruneStaleNavigationPoints();
-  const int position = textCursor().position();
-  if (gNavigationPos >= 0 && gNavigationPos < gNavigationPoints.size()
-      && gNavigationPoints.at(gNavigationPos).editor == this && gNavigationPoints.at(gNavigationPos).position == position) {
-    return;
-  }
-  if (gNavigationPos >= 0 && gNavigationPos < gNavigationPoints.size() - 1) {
-    gNavigationPoints.resize(gNavigationPos + 1);
-  }
-  NavigationPoint navigationPoint;
-  navigationPoint.editor = this;
-  navigationPoint.position = position;
-  gNavigationPoints.append(navigationPoint);
-  gNavigationPos = gNavigationPoints.size() - 1;
-  while (gNavigationPoints.size() > gNavigationHistorySize) {
-    gNavigationPoints.removeFirst();
-    --gNavigationPos;
-  }
-}
-
-/*!
- * \brief PlainTextEdit::goBack
- * Moves the cursor to the previous navigation point, activating the tab of
- * the editor the point belongs to if needed. Returns true if the cursor was
- * moved.
- */
-bool PlainTextEdit::goBack()
-{
-  pruneStaleNavigationPoints();
-  if (gNavigationPos <= 0) {
-    return false;
-  }
-  --gNavigationPos;
-  PlainTextEdit::navigateToNavigationPoint(gNavigationPoints.at(gNavigationPos).editor, gNavigationPoints.at(gNavigationPos).position);
-  return true;
-}
-
-/*!
- * \brief PlainTextEdit::goForward
- * Moves the cursor to the next navigation point, activating the tab of the
- * editor the point belongs to if needed. Returns true if the cursor was
- * moved.
- */
-bool PlainTextEdit::goForward()
-{
-  pruneStaleNavigationPoints();
-  if (gNavigationPos < 0 || gNavigationPos >= gNavigationPoints.size() - 1) {
-    return false;
-  }
-  ++gNavigationPos;
-  PlainTextEdit::navigateToNavigationPoint(gNavigationPoints.at(gNavigationPos).editor, gNavigationPoints.at(gNavigationPos).position);
-  return true;
-}
-
-/*!
- * \brief PlainTextEdit::navigateToNavigationPoint
- * Activates the tab of the editor the navigation point belongs to and moves
- * its cursor to the given position without recording a new navigation point.
- * \param pEditor - the editor the navigation point belongs to.
- * \param position - the document position to move to.
- */
-void PlainTextEdit::navigateToNavigationPoint(PlainTextEdit *pEditor, int position)
-{
-  if (!pEditor) {
-    return;
-  }
-  gNavigationActive = true;
-  ModelWidget *pModelWidget = pEditor->mpBaseEditor->getModelWidget();
-  if (pModelWidget) {
-    ModelWidgetContainer *pModelWidgetContainer = MainWindow::instance()->getModelWidgetContainer();
-    if (pModelWidgetContainer) {
-      QMdiSubWindow *pSubWindow = pModelWidgetContainer->getMdiSubWindow(pModelWidget);
-      if (pSubWindow) {
-        pModelWidgetContainer->setActiveSubWindow(pSubWindow);
-      }
-    }
-  }
-  pEditor->moveToNavigationPoint(position);
-  pEditor->setFocus(Qt::ActiveWindowFocusReason);
-  gNavigationActive = false;
-}
-
-/*!
  * \brief PlainTextEdit::moveToNavigationPoint
- * Moves the cursor to the given position without recording a new navigation
- * point. The position is clamped to the document so it is safe to visit even
- * if the document changed after the position was recorded.
- * \param position - the document position to move to.
+ * Moves the text cursor to the given position.
+ * \param position - the position to move to.
  */
 void PlainTextEdit::moveToNavigationPoint(int position)
 {
-  position = qBound(0, position, document()->characterCount() - 1);
-  QTextCursor cursor = textCursor();
-  cursor.setPosition(position);
-  setTextCursor(cursor);
-  ensureCursorVisible();
-  centerCursor();
-}
-
-/*!
- * \brief PlainTextEdit::clearNavigationHistory
- * Removes the navigation points of this editor from the global navigation
- * history. Used when the content of the editor is replaced so stale points
- * do not point to the old content.
- */
-void PlainTextEdit::clearNavigationHistory()
-{
-  for (int i = 0; i < gNavigationPoints.size(); ++i) {
-    if (gNavigationPoints.at(i).editor == this) {
-      gNavigationPoints.removeAt(i);
-      if (i <= gNavigationPos) {
-        --gNavigationPos;
-      }
-      --i;
-    }
-  }
-  if (gNavigationPoints.isEmpty()) {
-    gNavigationPos = -1;
-  } else {
-    gNavigationPos = qBound(0, gNavigationPos, gNavigationPoints.size() - 1);
-  }
-}
-
-/*!
- * \brief PlainTextEdit::pruneStaleNavigationPoints
- * Removes the navigation points of editors that have been destroyed from the
- * global navigation history and keeps gNavigationPos pointing to the same
- * logical position.
- */
-void PlainTextEdit::pruneStaleNavigationPoints()
-{
-  for (int i = 0; i < gNavigationPoints.size(); ++i) {
-    if (gNavigationPoints.at(i).editor.isNull()) {
-      gNavigationPoints.removeAt(i);
-      if (i <= gNavigationPos) {
-        --gNavigationPos;
-      }
-      --i;
-    }
-  }
-  if (gNavigationPoints.isEmpty()) {
-    gNavigationPos = -1;
-  } else {
-    gNavigationPos = qBound(0, gNavigationPos, gNavigationPoints.size() - 1);
+  if (position >= 0 && position <= textCursor().document()->characterCount()) {
+    QTextCursor textCursor = this->textCursor();
+    textCursor.setPosition(position);
+    setTextCursor(textCursor);
+    centerCursor();
   }
 }
 
@@ -1858,7 +1689,6 @@ void PlainTextEdit::keyPressEvent(QKeyEvent *pEvent)
 {
   bool shiftModifier = pEvent->modifiers().testFlag(Qt::ShiftModifier);
   bool controlModifier = pEvent->modifiers().testFlag(Qt::ControlModifier);
-  bool altModifier = pEvent->modifiers().testFlag(Qt::AltModifier);
   bool isCompleterShortcut = controlModifier && (pEvent->key() == Qt::Key_Space); // CTRL+space
   bool isCompleterChar = !pEvent->text().isEmpty() && mCompletionCharacters.indexOf(pEvent->text().front()) != -1;
   /* Ticket #4404. hide the completer on Esc and enter text based on Tab */
@@ -1930,14 +1760,6 @@ void PlainTextEdit::keyPressEvent(QKeyEvent *pEvent)
   } else if (shiftModifier && (pEvent->key() == Qt::Key_Enter || pEvent->key() == Qt::Key_Return)) {
     /* Ticket #2273. Change shift+enter to enter. */
     pEvent->setModifiers(Qt::NoModifier);
-  } else if (altModifier && !controlModifier && !shiftModifier && pEvent->key() == Qt::Key_Left) {
-    // alt+left is pressed. Navigate back in the cursor position history.
-    goBack();
-    return;
-  } else if (altModifier && !controlModifier && !shiftModifier && pEvent->key() == Qt::Key_Right) {
-    // alt+right is pressed. Navigate forward in the cursor position history.
-    goForward();
-    return;
   }
   /* do not change the order of execution as the indentation event will fail when completer is on */
   if (!mpCompleter || !isCompleterShortcut) { // do not process the shortcut when we have a completer
@@ -2276,15 +2098,6 @@ void PlainTextEdit::wheelEvent(QWheelEvent *event)
  */
 void PlainTextEdit::mousePressEvent(QMouseEvent *event)
 {
-  if (event->button() == Qt::BackButton) {
-    goBack();
-    event->accept();
-    return;
-  } else if (event->button() == Qt::ForwardButton) {
-    goForward();
-    event->accept();
-    return;
-  }
   bool controlModifier = event->modifiers().testFlag(Qt::ControlModifier);
   if (controlModifier) {
     mpBaseEditor->symbolAtPosition(event->pos());
@@ -2292,7 +2105,7 @@ void PlainTextEdit::mousePressEvent(QMouseEvent *event)
   }
   QPlainTextEdit::mousePressEvent(event);
   if (event->button() == Qt::LeftButton) {
-    recordNavigationPoint();
+    NavigationManager::instance()->recordNavigationPoint(this);
   }
 }
 
@@ -3009,7 +2822,7 @@ void FindReplaceWidget::findText(bool forward)
     }
   }
   mpBaseEditor->getPlainTextEdit()->setTextCursor(newTextCursor);
-  mpBaseEditor->getPlainTextEdit()->recordNavigationPoint();
+  NavigationManager::instance()->recordNavigationPoint(mpBaseEditor->getPlainTextEdit());
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -49,8 +49,32 @@
 #include <QMenu>
 #include <QCompleter>
 #include <QMessageBox>
+#include <QPointer>
 #include <QTextDocumentFragment>
 #include <QDockWidget>
+
+namespace {
+
+/*!
+ * \brief The NavigationPoint struct
+ * Stores an editor and the cursor position to jump to when navigating back
+ * and forward through the cursor position history.
+ */
+struct NavigationPoint {
+  QPointer<PlainTextEdit> editor;
+  int position;
+};
+/*! The global navigation history shared by all editors. */
+QList<NavigationPoint> gNavigationPoints;
+/*! Index of the current position in the global navigation history. */
+int gNavigationPos = -1;
+/*! True while a programmatic back/forward navigation is in progress.
+ * Used to avoid recording new points when the navigation activates a tab. */
+bool gNavigationActive = false;
+/*! Maximum number of points kept in the global navigation history. */
+const int gNavigationHistorySize = 50;
+
+}
 
 /*!
  * \class TabSettings
@@ -1126,55 +1150,98 @@ void PlainTextEdit::goToLineNumber(int lineNumber)
 
 /*!
  * \brief PlainTextEdit::recordNavigationPoint
- * Records the current cursor position in the navigation history. Used to
- * implement the back/forward cursor navigation (mouse buttons 4/5 and
- * Alt+Left/Alt+Right). A new point truncates any forward points and the
- * history is limited to NavigationHistorySize points.
+ * Records the current cursor position in the global navigation history. Used
+ * to implement the back/forward cursor navigation (mouse buttons 4/5 and
+ * Alt+Left/Alt+Right). The history is shared between all editors so the
+ * navigation works across different tabs, models and editors. A new point
+ * truncates any forward points and the history is limited to
+ * gNavigationHistorySize points.
  */
 void PlainTextEdit::recordNavigationPoint()
 {
-  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size() && mNavigationPoints[mNavigationPos] == textCursor().position()) {
+  if (gNavigationActive) {
     return;
   }
-  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size() - 1) {
-    mNavigationPoints.resize(mNavigationPos + 1);
+  pruneStaleNavigationPoints();
+  const int position = textCursor().position();
+  if (gNavigationPos >= 0 && gNavigationPos < gNavigationPoints.size()
+      && gNavigationPoints.at(gNavigationPos).editor == this && gNavigationPoints.at(gNavigationPos).position == position) {
+    return;
   }
-  mNavigationPoints.append(textCursor().position());
-  mNavigationPos = mNavigationPoints.size() - 1;
-  while (mNavigationPoints.size() > NavigationHistorySize) {
-    mNavigationPoints.removeFirst();
-    --mNavigationPos;
+  if (gNavigationPos >= 0 && gNavigationPos < gNavigationPoints.size() - 1) {
+    gNavigationPoints.resize(gNavigationPos + 1);
+  }
+  NavigationPoint navigationPoint;
+  navigationPoint.editor = this;
+  navigationPoint.position = position;
+  gNavigationPoints.append(navigationPoint);
+  gNavigationPos = gNavigationPoints.size() - 1;
+  while (gNavigationPoints.size() > gNavigationHistorySize) {
+    gNavigationPoints.removeFirst();
+    --gNavigationPos;
   }
 }
 
 /*!
  * \brief PlainTextEdit::goBack
- * Moves the cursor to the previous navigation point. Returns true if the
- * cursor was moved.
+ * Moves the cursor to the previous navigation point, activating the tab of
+ * the editor the point belongs to if needed. Returns true if the cursor was
+ * moved.
  */
 bool PlainTextEdit::goBack()
 {
-  if (mNavigationPos <= 0) {
+  pruneStaleNavigationPoints();
+  if (gNavigationPos <= 0) {
     return false;
   }
-  --mNavigationPos;
-  moveToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  --gNavigationPos;
+  PlainTextEdit::navigateToNavigationPoint(gNavigationPoints.at(gNavigationPos).editor, gNavigationPoints.at(gNavigationPos).position);
   return true;
 }
 
 /*!
  * \brief PlainTextEdit::goForward
- * Moves the cursor to the next navigation point. Returns true if the cursor
- * was moved.
+ * Moves the cursor to the next navigation point, activating the tab of the
+ * editor the point belongs to if needed. Returns true if the cursor was
+ * moved.
  */
 bool PlainTextEdit::goForward()
 {
-  if (mNavigationPos < 0 || mNavigationPos >= mNavigationPoints.size() - 1) {
+  pruneStaleNavigationPoints();
+  if (gNavigationPos < 0 || gNavigationPos >= gNavigationPoints.size() - 1) {
     return false;
   }
-  ++mNavigationPos;
-  moveToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  ++gNavigationPos;
+  PlainTextEdit::navigateToNavigationPoint(gNavigationPoints.at(gNavigationPos).editor, gNavigationPoints.at(gNavigationPos).position);
   return true;
+}
+
+/*!
+ * \brief PlainTextEdit::navigateToNavigationPoint
+ * Activates the tab of the editor the navigation point belongs to and moves
+ * its cursor to the given position without recording a new navigation point.
+ * \param pEditor - the editor the navigation point belongs to.
+ * \param position - the document position to move to.
+ */
+void PlainTextEdit::navigateToNavigationPoint(PlainTextEdit *pEditor, int position)
+{
+  if (!pEditor) {
+    return;
+  }
+  gNavigationActive = true;
+  ModelWidget *pModelWidget = pEditor->mpBaseEditor->getModelWidget();
+  if (pModelWidget) {
+    ModelWidgetContainer *pModelWidgetContainer = MainWindow::instance()->getModelWidgetContainer();
+    if (pModelWidgetContainer) {
+      QMdiSubWindow *pSubWindow = pModelWidgetContainer->getMdiSubWindow(pModelWidget);
+      if (pSubWindow) {
+        pModelWidgetContainer->setActiveSubWindow(pSubWindow);
+      }
+    }
+  }
+  pEditor->moveToNavigationPoint(position);
+  pEditor->setFocus(Qt::ActiveWindowFocusReason);
+  gNavigationActive = false;
 }
 
 /*!
@@ -1196,12 +1263,50 @@ void PlainTextEdit::moveToNavigationPoint(int position)
 
 /*!
  * \brief PlainTextEdit::clearNavigationHistory
- * Clears all recorded navigation points.
+ * Removes the navigation points of this editor from the global navigation
+ * history. Used when the content of the editor is replaced so stale points
+ * do not point to the old content.
  */
 void PlainTextEdit::clearNavigationHistory()
 {
-  mNavigationPoints.clear();
-  mNavigationPos = -1;
+  for (int i = 0; i < gNavigationPoints.size(); ++i) {
+    if (gNavigationPoints.at(i).editor == this) {
+      gNavigationPoints.removeAt(i);
+      if (i <= gNavigationPos) {
+        --gNavigationPos;
+      }
+      --i;
+    }
+  }
+  if (gNavigationPoints.isEmpty()) {
+    gNavigationPos = -1;
+  } else {
+    gNavigationPos = qBound(0, gNavigationPos, gNavigationPoints.size() - 1);
+  }
+}
+
+/*!
+ * \brief PlainTextEdit::pruneStaleNavigationPoints
+ * Removes the navigation points of editors that have been destroyed from the
+ * global navigation history and keeps gNavigationPos pointing to the same
+ * logical position.
+ */
+void PlainTextEdit::pruneStaleNavigationPoints()
+{
+  for (int i = 0; i < gNavigationPoints.size(); ++i) {
+    if (gNavigationPoints.at(i).editor.isNull()) {
+      gNavigationPoints.removeAt(i);
+      if (i <= gNavigationPos) {
+        --gNavigationPos;
+      }
+      --i;
+    }
+  }
+  if (gNavigationPoints.isEmpty()) {
+    gNavigationPos = -1;
+  } else {
+    gNavigationPos = qBound(0, gNavigationPos, gNavigationPoints.size() - 1);
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -1119,8 +1119,89 @@ void PlainTextEdit::goToLineNumber(int lineNumber)
     QTextCursor cursor(block);
     cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, 0);
     setTextCursor(cursor);
+    recordNavigationPoint();
     centerCursor();
   }
+}
+
+/*!
+ * \brief PlainTextEdit::recordNavigationPoint
+ * Records the current cursor position in the navigation history. Used to
+ * implement the back/forward cursor navigation (mouse buttons 4/5 and
+ * Alt+Left/Alt+Right). A new point truncates any forward points and the
+ * history is limited to NavigationHistorySize points.
+ */
+void PlainTextEdit::recordNavigationPoint()
+{
+  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size() && mNavigationPoints[mNavigationPos] == textCursor().position()) {
+    return;
+  }
+  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size() - 1) {
+    mNavigationPoints.resize(mNavigationPos + 1);
+  }
+  mNavigationPoints.append(textCursor().position());
+  mNavigationPos = mNavigationPoints.size() - 1;
+  while (mNavigationPoints.size() > NavigationHistorySize) {
+    mNavigationPoints.removeFirst();
+    --mNavigationPos;
+  }
+}
+
+/*!
+ * \brief PlainTextEdit::goBack
+ * Moves the cursor to the previous navigation point. Returns true if the
+ * cursor was moved.
+ */
+bool PlainTextEdit::goBack()
+{
+  if (mNavigationPos <= 0) {
+    return false;
+  }
+  --mNavigationPos;
+  moveToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  return true;
+}
+
+/*!
+ * \brief PlainTextEdit::goForward
+ * Moves the cursor to the next navigation point. Returns true if the cursor
+ * was moved.
+ */
+bool PlainTextEdit::goForward()
+{
+  if (mNavigationPos < 0 || mNavigationPos >= mNavigationPoints.size() - 1) {
+    return false;
+  }
+  ++mNavigationPos;
+  moveToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  return true;
+}
+
+/*!
+ * \brief PlainTextEdit::moveToNavigationPoint
+ * Moves the cursor to the given position without recording a new navigation
+ * point. The position is clamped to the document so it is safe to visit even
+ * if the document changed after the position was recorded.
+ * \param position - the document position to move to.
+ */
+void PlainTextEdit::moveToNavigationPoint(int position)
+{
+  position = qBound(0, position, document()->characterCount() - 1);
+  QTextCursor cursor = textCursor();
+  cursor.setPosition(position);
+  setTextCursor(cursor);
+  ensureCursorVisible();
+  centerCursor();
+}
+
+/*!
+ * \brief PlainTextEdit::clearNavigationHistory
+ * Clears all recorded navigation points.
+ */
+void PlainTextEdit::clearNavigationHistory()
+{
+  mNavigationPoints.clear();
+  mNavigationPos = -1;
 }
 
 /*!
@@ -1672,6 +1753,7 @@ void PlainTextEdit::keyPressEvent(QKeyEvent *pEvent)
 {
   bool shiftModifier = pEvent->modifiers().testFlag(Qt::ShiftModifier);
   bool controlModifier = pEvent->modifiers().testFlag(Qt::ControlModifier);
+  bool altModifier = pEvent->modifiers().testFlag(Qt::AltModifier);
   bool isCompleterShortcut = controlModifier && (pEvent->key() == Qt::Key_Space); // CTRL+space
   bool isCompleterChar = !pEvent->text().isEmpty() && mCompletionCharacters.indexOf(pEvent->text().front()) != -1;
   /* Ticket #4404. hide the completer on Esc and enter text based on Tab */
@@ -1743,6 +1825,14 @@ void PlainTextEdit::keyPressEvent(QKeyEvent *pEvent)
   } else if (shiftModifier && (pEvent->key() == Qt::Key_Enter || pEvent->key() == Qt::Key_Return)) {
     /* Ticket #2273. Change shift+enter to enter. */
     pEvent->setModifiers(Qt::NoModifier);
+  } else if (altModifier && !controlModifier && !shiftModifier && pEvent->key() == Qt::Key_Left) {
+    // alt+left is pressed. Navigate back in the cursor position history.
+    goBack();
+    return;
+  } else if (altModifier && !controlModifier && !shiftModifier && pEvent->key() == Qt::Key_Right) {
+    // alt+right is pressed. Navigate forward in the cursor position history.
+    goForward();
+    return;
   }
   /* do not change the order of execution as the indentation event will fail when completer is on */
   if (!mpCompleter || !isCompleterShortcut) { // do not process the shortcut when we have a completer
@@ -2081,12 +2171,24 @@ void PlainTextEdit::wheelEvent(QWheelEvent *event)
  */
 void PlainTextEdit::mousePressEvent(QMouseEvent *event)
 {
+  if (event->button() == Qt::BackButton) {
+    goBack();
+    event->accept();
+    return;
+  } else if (event->button() == Qt::ForwardButton) {
+    goForward();
+    event->accept();
+    return;
+  }
   bool controlModifier = event->modifiers().testFlag(Qt::ControlModifier);
   if (controlModifier) {
     mpBaseEditor->symbolAtPosition(event->pos());
     viewport()->unsetCursor();
   }
   QPlainTextEdit::mousePressEvent(event);
+  if (event->button() == Qt::LeftButton) {
+    recordNavigationPoint();
+  }
 }
 
 /*!
@@ -2802,6 +2904,7 @@ void FindReplaceWidget::findText(bool forward)
     }
   }
   mpBaseEditor->getPlainTextEdit()->setTextCursor(newTextCursor);
+  mpBaseEditor->getPlainTextEdit()->recordNavigationPoint();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.h
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.h
@@ -285,9 +285,8 @@ private:
   bool mIsUndoAvailable;
   bool mIsRedoAvailable;
   QString mCompletionCharacters;
-  QList<int> mNavigationPoints;
-  int mNavigationPos = -1;
-  static const int NavigationHistorySize = 50;
+  static void navigateToNavigationPoint(PlainTextEdit *pEditor, int position);
+  void pruneStaleNavigationPoints();
 
   void highlightCurrentLine();
   void highlightParentheses();

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.h
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.h
@@ -48,6 +48,7 @@
 #include <QCheckBox>
 #include <QToolButton>
 #include <QStandardItemModel>
+#include <QList>
 
 class ModelWidget;
 class InfoBar;
@@ -262,6 +263,10 @@ public:
   void lineNumberAreaPaintEvent(QPaintEvent *event);
   void lineNumberAreaMouseEvent(QMouseEvent *event);
   void goToLineNumber(int lineNumber);
+  void recordNavigationPoint();
+  bool goBack();
+  bool goForward();
+  void clearNavigationHistory();
   QCompleter *completer();
   bool isUndoAvailable() {return mIsUndoAvailable;}
   bool isRedoAvailable() {return mIsRedoAvailable;}
@@ -280,6 +285,9 @@ private:
   bool mIsUndoAvailable;
   bool mIsRedoAvailable;
   QString mCompletionCharacters;
+  QList<int> mNavigationPoints;
+  int mNavigationPos = -1;
+  static const int NavigationHistorySize = 50;
 
   void highlightCurrentLine();
   void highlightParentheses();
@@ -293,6 +301,7 @@ private:
   void foldOrUnfold(bool unFold);
   void handleHomeKey(bool keepAnchor);
   void toggleBlockVisible(const QTextBlock &block);
+  void moveToNavigationPoint(int position);
 private slots:
   void showCompletionItemToolTip(const QModelIndex & index);
   void insertCompletionItem(const QModelIndex & index);

--- a/OMEdit/OMEditLIB/Editors/BaseEditor.h
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.h
@@ -263,15 +263,13 @@ public:
   void lineNumberAreaPaintEvent(QPaintEvent *event);
   void lineNumberAreaMouseEvent(QMouseEvent *event);
   void goToLineNumber(int lineNumber);
-  void recordNavigationPoint();
-  bool goBack();
-  bool goForward();
-  void clearNavigationHistory();
+  void moveToNavigationPoint(int position);
   QCompleter *completer();
   bool isUndoAvailable() {return mIsUndoAvailable;}
   bool isRedoAvailable() {return mIsRedoAvailable;}
   void setCompletionCharacters(QString chars) { mCompletionCharacters = chars; }
   void setReadOnlyStyleSheet();
+  BaseEditor *getBaseEditor() const {return mpBaseEditor;}
 private:
   BaseEditor *mpBaseEditor;
   LineNumberArea *mpLineNumberArea;
@@ -285,8 +283,6 @@ private:
   bool mIsUndoAvailable;
   bool mIsRedoAvailable;
   QString mCompletionCharacters;
-  static void navigateToNavigationPoint(PlainTextEdit *pEditor, int position);
-  void pruneStaleNavigationPoints();
 
   void highlightCurrentLine();
   void highlightParentheses();
@@ -300,7 +296,6 @@ private:
   void foldOrUnfold(bool unFold);
   void handleHomeKey(bool keepAnchor);
   void toggleBlockVisible(const QTextBlock &block);
-  void moveToNavigationPoint(int position);
 private slots:
   void showCompletionItemToolTip(const QModelIndex & index);
   void insertCompletionItem(const QModelIndex & index);

--- a/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
@@ -45,6 +45,7 @@
 #include "Options/OptionsDialog.h"
 #include "Debugger/Breakpoints/BreakpointMarker.h"
 #include "Util/Helper.h"
+#include "Util/NavigationManager.h"
 #include "Options/NotificationsDialog.h"
 
 #include <QCompleter>
@@ -648,7 +649,7 @@ void ModelicaEditor::setPlainText(const QString &text, bool useInserText)
      */
     OptionsDialog::instance()->emitModelicaEditorSettingsChanged();
     mpPlainTextEdit->foldAll();
-    mpPlainTextEdit->clearNavigationHistory();
+    NavigationManager::instance()->clearNavigationHistory(mpPlainTextEdit);
   }
 }
 

--- a/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
@@ -648,6 +648,7 @@ void ModelicaEditor::setPlainText(const QString &text, bool useInserText)
      */
     OptionsDialog::instance()->emitModelicaEditorSettingsChanged();
     mpPlainTextEdit->foldAll();
+    mpPlainTextEdit->clearNavigationHistory();
   }
 }
 

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -57,6 +57,8 @@
 #include "Plotting/VariablesWidget.h"
 #include "Search/SearchWidget.h"
 #include "Util/Helper.h"
+#include "Util/NavigationManager.h"
+#include "Util/NavigationManagerView.h"
 #include "Simulation/ArchivedSimulationsWidget.h"
 #include "Simulation/SimulationOutputWidget.h"
 #include "CRML/CRMLTranslatorOutputWidget.h"
@@ -223,6 +225,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // Create an object of OptionsDialog
   mpLibrariesMenu = 0;
   OptionsDialog::create();
+  // Create the NavigationManager which detects the back/forward navigation globally
+  NavigationManager::instance();
 #if !defined(__EMSCRIPTEN__)
   SplashScreen::instance()->showMessage(tr("Loading Widgets"), Qt::AlignRight, Qt::white);
 #else
@@ -315,6 +319,15 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpSearchDockWidget->setWidget(mpSearchWidget);
   addDockWidget(Qt::BottomDockWidgetArea, mpSearchDockWidget);
   mpSearchDockWidget->hide();
+  // Create NavigationManagerDockWidget dock
+  if (isDebug()) {
+    mpNavigationManagerDockWidget = new QDockWidget(tr("Navigation Manager"), this);
+    mpNavigationManagerDockWidget->setObjectName("NavigationManager");
+    mpNavigationManagerDockWidget->setAllowedAreas(Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
+    mpNavigationManagerView = new NavigationManagerView(this);
+    mpNavigationManagerDockWidget->setWidget(mpNavigationManagerView);
+    addDockWidget(Qt::BottomDockWidgetArea, mpNavigationManagerDockWidget);
+  }
 #if !defined(__EMSCRIPTEN__)
   // create the GDB adapter instance
   GDBAdapter::create();
@@ -2089,6 +2102,20 @@ void MainWindow::switchToAlgorithmicDebuggingPerspectiveSlot()
 }
 
 /*!
+ * \brief MainWindow::switchToPerspectiveTab
+ * Switches to the perspective tab with the given index. Used by the global
+ * back/forward navigation history to restore a perspective switch.
+ * \param tabIndex
+ */
+void MainWindow::switchToPerspectiveTab(int tabIndex)
+{
+  if (tabIndex < 0 || tabIndex >= mpPerspectiveTabbar->count()) {
+    tabIndex = 0;
+  }
+  mpPerspectiveTabbar->setCurrentIndex(tabIndex);
+}
+
+/*!
  * \brief MainWindow::showSearchBrowser
  * Shows the Search Browser, selects the search text if any and sets the focus on it.
  */
@@ -3732,6 +3759,7 @@ void MainWindow::cancelOmcOperation()
  */
 void MainWindow::perspectiveTabChanged(int tabIndex)
 {
+  NavigationManager::instance()->recordNavigationPoint(tabIndex);
   switch (tabIndex) {
     case 0:
       switchToWelcomePerspective();
@@ -4678,6 +4706,9 @@ void MainWindow::createMenus()
   pViewWindowsMenu->addAction(mpMessagesDockWidget->toggleViewAction());
   pViewWindowsMenu->addAction(mpFindUsageDockWidget->toggleViewAction());
   pViewWindowsMenu->addAction(mpSearchDockWidget->toggleViewAction());
+  if (isDebug()) {
+    pViewWindowsMenu->addAction(mpNavigationManagerDockWidget->toggleViewAction());
+  }
 #if !defined(__EMSCRIPTEN__)
   pViewWindowsMenu->addAction(mpStackFramesDockWidget->toggleViewAction());
   pViewWindowsMenu->addAction(mpBreakpointsDockWidget->toggleViewAction());

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -101,6 +101,7 @@ class StatusBar;
 class TraceabilityGraphViewWidget;
 class SearchWidget;
 class MessageTab;
+class NavigationManagerView;
 
 class MainWindow : public QMainWindow
 {
@@ -291,6 +292,8 @@ private:
   SearchWidget *mpSearchWidget;
   QDockWidget *mpSearchDockWidget;
   QDockWidget *mpMessagesDockWidget;
+  NavigationManagerView *mpNavigationManagerView = nullptr;
+  QDockWidget *mpNavigationManagerDockWidget = nullptr;
   LibraryWidget *mpLibraryWidget;
   QDockWidget *mpLibraryDockWidget;
   ElementWidget *mpElementWidget;
@@ -498,6 +501,7 @@ public slots:
   void switchToModelingPerspectiveSlot();
   void switchToPlottingPerspectiveSlot();
   void switchToAlgorithmicDebuggingPerspectiveSlot();
+  void switchToPerspectiveTab(int tabIndex);
   void showSearchBrowser();
   void createNewModelicaClass();
   void createNewMOSFile();

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -55,6 +55,7 @@
 #include "OMS/ModelDialog.h"
 #include "OMS/SystemSimulationInformationDialog.h"
 #include "Util/ResourceCache.h"
+#include "Util/NavigationManager.h"
 #include "Plotting/PlotWindowContainer.h"
 #include "Util/NetworkAccessManager.h"
 #include "QuickInsertWidget.h"
@@ -7501,6 +7502,7 @@ void ModelWidget::showIconView(bool checked)
   if (!checked || (checked && mpIconGraphicsView->isVisible())) {
     return;
   }
+  NavigationManager::instance()->recordNavigationPoint(this, StringHandler::Icon);
   mpViewTypeLabel->setText(StringHandler::getViewType(StringHandler::Icon));
   mpDiagramGraphicsView->hide();
   if (mpEditor) {
@@ -7535,6 +7537,7 @@ void ModelWidget::showDiagramView(bool checked)
   if (!checked || (checked && mpDiagramGraphicsView->isVisible())) {
     return;
   }
+  NavigationManager::instance()->recordNavigationPoint(this, StringHandler::Diagram);
   mpViewTypeLabel->setText(StringHandler::getViewType(StringHandler::Diagram));
   if (mpIconGraphicsView) {
     mpIconGraphicsView->hide();
@@ -7559,6 +7562,7 @@ void ModelWidget::showTextView(bool checked)
   if (!checked || (checked && mpEditor->isVisible())) {
     return;
   }
+  NavigationManager::instance()->recordNavigationPoint(this, StringHandler::ModelicaText);
   processPendingModelUpdate();
   if (QMdiSubWindow *pSubWindow = mpModelWidgetContainer->getCurrentMdiSubWindow()) {
     pSubWindow->setWindowIcon(ResourceCache::getIcon(":/Resources/icons/modeltext.svg"));
@@ -8416,6 +8420,16 @@ void ModelWidgetContainer::currentModelWidgetChanged(QMdiSubWindow *pSubWindow)
     return;
   }
   mpLastActiveSubWindow = pSubWindow;
+  // record the navigation point when a different model widget is shown so the back/forward navigation can restore it.
+  if (pModelWidget) {
+    StringHandler::ViewType viewType = StringHandler::Diagram;
+    if (iconGraphicsView) {
+      viewType = StringHandler::Icon;
+    } else if (textView) {
+      viewType = StringHandler::ModelicaText;
+    }
+    NavigationManager::instance()->recordNavigationPoint(pModelWidget, viewType);
+  }
   // update the model if its require update flag is set.
   // reDrawModelWidget updates the documentation and element browser so only try to update them in the else
   if (pModelWidget && pModelWidget->requiresUpdate()) {

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -93,6 +93,8 @@ SOURCES += Util/Helper.cpp \
   Util/StringHandler.cpp \
   Util/OutputPlainTextEdit.cpp \
   Util/DirectoryOrFileSelector.cpp \
+  Util/NavigationManager.cpp \
+  Util/NavigationManagerView.cpp \
   MainWindow.cpp \
   LoadCompiledModelDialog.cpp \
   $$OPENMODELICAHOME/include/omc/scripting-API/OpenModelicaScriptingAPIQt.cpp \
@@ -213,6 +215,8 @@ HEADERS  += Util/Helper.h \
   Util/StringHandler.h \
   Util/OutputPlainTextEdit.h \
   Util/DirectoryOrFileSelector.h \
+  Util/NavigationManager.h \
+  Util/NavigationManagerView.h \
   MainWindow.h \
   LoadCompiledModelDialog.h \
   $$OPENMODELICAHOME/include/omc/scripting-API/OpenModelicaScriptingAPIQt.h \

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -51,6 +51,7 @@
 #include "Simulation/SimulationOutputWidget.h"
 #include "TransformationalDebugger/TransformationsWidget.h"
 #include "PlotCurve.h"
+#include "Util/NavigationManager.h"
 
 #include <QObject>
 #include <QDockWidget>
@@ -2988,6 +2989,8 @@ void VariablesWidget::updateVariablesTree(QMdiSubWindow *pSubWindow)
     return;
   }
   mpLastActiveSubWindow = pSubWindow;
+  // record the navigation point when a different plot window is shown so the back/forward navigation can restore it.
+  NavigationManager::instance()->recordNavigationPoint(pSubWindow);
   /* update the tree variables to last active PlotWindow
    * This is done to fix issue #12911.
    * See also VariablesWidget::plotVariables

--- a/OMEdit/OMEditLIB/Util/NavigationManager.cpp
+++ b/OMEdit/OMEditLIB/Util/NavigationManager.cpp
@@ -1,0 +1,471 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#include "Util/NavigationManager.h"
+
+#include "MainWindow.h"
+#include "Editors/BaseEditor.h"
+#include "Modeling/ModelWidgetContainer.h"
+#include "Plotting/PlotWindowContainer.h"
+#include "Modeling/DocumentationWidget.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QMdiSubWindow>
+
+NavigationManager *NavigationManager::mpInstance = nullptr;
+
+/*!
+ * \brief NavigationManager::NavigationManager
+ * \param pParent
+ */
+NavigationManager::NavigationManager(QObject *pParent)
+  : QObject(pParent)
+{
+  // detect the back/forward navigation globally no matter which widget has the focus
+  qApp->installEventFilter(this);
+}
+
+/*!
+ * \brief NavigationManager::instance
+ * Returns the singleton instance of NavigationManager.
+ * \return
+ */
+NavigationManager *NavigationManager::instance()
+{
+  if (!mpInstance) {
+    mpInstance = new NavigationManager;
+  }
+  return mpInstance;
+}
+
+/*!
+ * \brief NavigationManager::eventFilter
+ * Handles the Alt+Left/Alt+Right keys and the mouse buttons 4/5 globally so the
+ * back/forward navigation works no matter which widget currently has the focus.
+ * The events are left untouched when they occur inside the documentation viewer
+ * so the web engine can handle its own back/forward navigation.
+ * \param pObject
+ * \param pEvent
+ * \return
+ */
+bool NavigationManager::eventFilter(QObject *pObject, QEvent *pEvent)
+{
+  if (pEvent->type() == QEvent::MouseButtonPress) {
+    QMouseEvent *pMouseEvent = static_cast<QMouseEvent*>(pEvent);
+    if (pMouseEvent->button() == Qt::BackButton || pMouseEvent->button() == Qt::ForwardButton) {
+      if (!isInsideDocumentationViewer(pObject)) {
+        if (pMouseEvent->button() == Qt::BackButton) {
+          goBack();
+        } else {
+          goForward();
+        }
+        pEvent->accept();
+        return true;
+      }
+    }
+  } else if (pEvent->type() == QEvent::KeyPress) {
+    QKeyEvent *pKeyEvent = static_cast<QKeyEvent*>(pEvent);
+    bool altModifier = pKeyEvent->modifiers().testFlag(Qt::AltModifier);
+    bool controlModifier = pKeyEvent->modifiers().testFlag(Qt::ControlModifier);
+    bool shiftModifier = pKeyEvent->modifiers().testFlag(Qt::ShiftModifier);
+    if (altModifier && !controlModifier && !shiftModifier && (pKeyEvent->key() == Qt::Key_Left || pKeyEvent->key() == Qt::Key_Right)) {
+      if (!isInsideDocumentationViewer(pObject)) {
+        if (pKeyEvent->key() == Qt::Key_Left) {
+          goBack();
+        } else {
+          goForward();
+        }
+        pEvent->accept();
+        return true;
+      }
+    }
+  }
+  return QObject::eventFilter(pObject, pEvent);
+}
+
+/*!
+ * \brief NavigationManager::isInsideDocumentationViewer
+ * Returns true if the given object is part of the documentation viewer. The
+ * documentation viewer is a web engine view and handles its own back/forward
+ * navigation so the navigation history must not interfere with it.
+ * \param pObject
+ * \return
+ */
+bool NavigationManager::isInsideDocumentationViewer(QObject *pObject) const
+{
+  QObject *pCurrentObject = pObject;
+  while (pCurrentObject) {
+    if (qobject_cast<DocumentationViewer*>(pCurrentObject)) {
+      return true;
+    }
+    pCurrentObject = pCurrentObject->parent();
+  }
+  return false;
+}
+
+/*!
+ * \brief NavigationManager::recordNavigationPoint
+ * Records the current cursor position of the given editor in the navigation
+ * history. Used to implement the back/forward cursor navigation (mouse buttons
+ * 4/5 and Alt+Left/Alt+Right). The history is shared between all editors so the
+ * navigation works across different tabs, models and editors. A new point
+ * truncates any forward points and the history is limited to
+ * mNavigationHistorySize points.
+ * \param pEditor
+ */
+void NavigationManager::recordNavigationPoint(PlainTextEdit *pEditor)
+{
+  NavigationPoint navigationPoint;
+  navigationPoint.type = NavigationPoint::Type::Editor;
+  navigationPoint.editor = pEditor;
+  navigationPoint.position = pEditor->textCursor().position();
+  recordNavigationPoint(navigationPoint);
+}
+
+/*!
+ * \brief NavigationManager::recordNavigationPoint
+ * Records a model widget in the given view in the navigation history. Used to
+ * remember switches between the icon, diagram and text views so they can be
+ * restored with the back/forward navigation.
+ * \param pModelWidget - the model widget the navigation point belongs to.
+ * \param viewType - the view of the model widget.
+ */
+void NavigationManager::recordNavigationPoint(ModelWidget *pModelWidget, StringHandler::ViewType viewType)
+{
+  NavigationPoint navigationPoint;
+  navigationPoint.type = NavigationPoint::Type::View;
+  navigationPoint.modelWidget = pModelWidget;
+  navigationPoint.viewType = viewType;
+  recordNavigationPoint(navigationPoint);
+}
+
+/*!
+ * \brief NavigationManager::recordNavigationPoint
+ * Records a perspective tab in the navigation history. Used to remember
+ * switches between the welcome, modeling, plotting and debugging perspectives
+ * so they can be restored with the back/forward navigation.
+ * \param perspectiveIndex - the index of the perspective tab.
+ */
+void NavigationManager::recordNavigationPoint(int perspectiveIndex)
+{
+  NavigationPoint navigationPoint;
+  navigationPoint.type = NavigationPoint::Type::Perspective;
+  navigationPoint.perspectiveIndex = perspectiveIndex;
+  recordNavigationPoint(navigationPoint);
+}
+
+/*!
+ * \brief NavigationManager::recordNavigationPoint
+ * Records a plot subwindow in the navigation history. Used to remember switches
+ * between the plot windows so they can be restored with the back/forward
+ * navigation.
+ * \param pPlotSubWindow - the plot subwindow the navigation point belongs to.
+ */
+void NavigationManager::recordNavigationPoint(QMdiSubWindow *pPlotSubWindow)
+{
+  NavigationPoint navigationPoint;
+  navigationPoint.type = NavigationPoint::Type::Plot;
+  navigationPoint.plotSubWindow = pPlotSubWindow;
+  recordNavigationPoint(navigationPoint);
+}
+
+/*!
+ * \brief NavigationManager::recordNavigationPoint
+ * Appends the given navigation point to the navigation history. A new point
+ * truncates any forward points and the history is limited to
+ * mNavigationHistorySize points.
+ * \param navigationPoint - the navigation point to record.
+ */
+void NavigationManager::recordNavigationPoint(const NavigationPoint &navigationPoint)
+{
+  if (mNavigationActive) {
+    return;
+  }
+  pruneStaleNavigationPoints();
+  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size()
+      && navigationPointEquals(navigationPoint, mNavigationPoints.at(mNavigationPos))) {
+    return;
+  }
+  if (mNavigationPos >= 0 && mNavigationPos < mNavigationPoints.size() - 1) {
+    mNavigationPoints.resize(mNavigationPos + 1);
+  }
+  mNavigationPoints.append(navigationPoint);
+  mNavigationPos = mNavigationPoints.size() - 1;
+  while (mNavigationPoints.size() > mNavigationHistorySize) {
+    mNavigationPoints.removeFirst();
+    --mNavigationPos;
+  }
+  emit navigationChanged();
+}
+
+/*!
+ * \brief NavigationManager::goBack
+ * Moves to the previous navigation point, activating the tab of the editor the
+ * point belongs to if needed. Returns true if the navigation happened.
+ * \return
+ */
+bool NavigationManager::goBack()
+{
+  pruneStaleNavigationPoints();
+  if (mNavigationPos <= 0) {
+    return false;
+  }
+  --mNavigationPos;
+  navigateToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  emit navigationChanged();
+  return true;
+}
+
+/*!
+ * \brief NavigationManager::goForward
+ * Moves to the next navigation point, activating the tab of the editor the
+ * point belongs to if needed. Returns true if the navigation happened.
+ * \return
+ */
+bool NavigationManager::goForward()
+{
+  pruneStaleNavigationPoints();
+  if (mNavigationPos < 0 || mNavigationPos >= mNavigationPoints.size() - 1) {
+    return false;
+  }
+  ++mNavigationPos;
+  navigateToNavigationPoint(mNavigationPoints.at(mNavigationPos));
+  emit navigationChanged();
+  return true;
+}
+
+/*!
+ * \brief NavigationManager::navigateToNavigationPoint
+ * Restores the state described by the given navigation point without recording
+ * a new navigation point. The function activates the perspective, the model
+ * widget and/or the editor and moves the cursor as required.
+ * \param navigationPoint - the navigation point to restore.
+ */
+void NavigationManager::navigateToNavigationPoint(const NavigationPoint &navigationPoint)
+{
+  mNavigationActive = true;
+  MainWindow *pMainWindow = MainWindow::instance();
+  switch (navigationPoint.type) {
+    case NavigationPoint::Type::Editor: {
+      PlainTextEdit *pEditor = navigationPoint.editor;
+      if (!pEditor) {
+        break;
+      }
+      ModelWidget *pModelWidget = pEditor->getBaseEditor()->getModelWidget();
+      if (pModelWidget) {
+        ModelWidgetContainer *pModelWidgetContainer = pMainWindow->getModelWidgetContainer();
+        if (pModelWidgetContainer) {
+          QMdiSubWindow *pSubWindow = pModelWidgetContainer->getMdiSubWindow(pModelWidget);
+          if (pSubWindow) {
+            pModelWidgetContainer->setActiveSubWindow(pSubWindow);
+          }
+        }
+      }
+      pEditor->moveToNavigationPoint(navigationPoint.position);
+      pEditor->setFocus(Qt::ActiveWindowFocusReason);
+      break;
+    }
+    case NavigationPoint::Type::View: {
+      ModelWidget *pModelWidget = navigationPoint.modelWidget;
+      if (!pModelWidget) {
+        break;
+      }
+      // make sure the modeling perspective is active so the model widget is visible
+      if (!pMainWindow->isModelingPerspectiveActive()) {
+        pMainWindow->switchToModelingPerspectiveSlot();
+      }
+      ModelWidgetContainer *pModelWidgetContainer = pMainWindow->getModelWidgetContainer();
+      if (pModelWidgetContainer) {
+        QMdiSubWindow *pSubWindow = pModelWidgetContainer->getMdiSubWindow(pModelWidget);
+        if (pSubWindow) {
+          pModelWidgetContainer->setActiveSubWindow(pSubWindow);
+        }
+      }
+      switch (navigationPoint.viewType) {
+        case StringHandler::Icon:
+          pModelWidget->getIconViewToolButton()->setChecked(true);
+          break;
+        case StringHandler::ModelicaText:
+          pModelWidget->getTextViewToolButton()->setChecked(true);
+          break;
+        case StringHandler::Diagram:
+        default:
+          pModelWidget->getDiagramViewToolButton()->setChecked(true);
+          break;
+      }
+      break;
+    }
+    case NavigationPoint::Type::Perspective:
+      if (navigationPoint.perspectiveIndex >= 0) {
+        pMainWindow->switchToPerspectiveTab(navigationPoint.perspectiveIndex);
+      }
+      break;
+    case NavigationPoint::Type::Plot: {
+      QMdiSubWindow *pSubWindow = navigationPoint.plotSubWindow;
+      if (!pSubWindow) {
+        break;
+      }
+      // make sure the plotting perspective is active so the plot window is visible
+      if (!pMainWindow->isPlottingPerspectiveActive()) {
+        pMainWindow->switchToPlottingPerspectiveSlot();
+      }
+      PlotWindowContainer *pPlotWindowContainer = pMainWindow->getPlotWindowContainer();
+      if (pPlotWindowContainer) {
+        pPlotWindowContainer->setActiveSubWindow(pSubWindow);
+      }
+      break;
+    }
+  }
+  mNavigationActive = false;
+}
+
+/*!
+ * \brief NavigationManager::clearNavigationHistory
+ * Removes the navigation points of the given editor from the navigation history
+ * but keeps a single point at the current cursor position. Used when the content
+ * of the editor is replaced (e.g. the text view is regenerated with the diff API)
+ * so stale points do not point to the old content while the current position
+ * remains available for the back/forward navigation to the text view.
+ * \param pEditor
+ */
+void NavigationManager::clearNavigationHistory(PlainTextEdit *pEditor)
+{
+  int currentPosition = pEditor->textCursor().position();
+  int firstRemovedIndex = -1;
+  bool currentPositionRemoved = false;
+  for (int i = 0; i < mNavigationPoints.size(); ++i) {
+    if (mNavigationPoints.at(i).editor == pEditor) {
+      if (firstRemovedIndex == -1) {
+        firstRemovedIndex = i;
+      }
+      if (i == mNavigationPos) {
+        currentPositionRemoved = true;
+      }
+      mNavigationPoints.removeAt(i);
+      if (i <= mNavigationPos) {
+        --mNavigationPos;
+      }
+      --i;
+    }
+  }
+  if (firstRemovedIndex >= 0) {
+    NavigationPoint navigationPoint;
+    navigationPoint.type = NavigationPoint::Type::Editor;
+    navigationPoint.editor = pEditor;
+    navigationPoint.position = currentPosition;
+    mNavigationPoints.insert(firstRemovedIndex, navigationPoint);
+    if (currentPositionRemoved) {
+      mNavigationPos = firstRemovedIndex;
+    } else if (firstRemovedIndex <= mNavigationPos) {
+      ++mNavigationPos;
+    }
+  } else if (mNavigationPoints.isEmpty()) {
+    mNavigationPos = -1;
+  } else {
+    mNavigationPos = qBound(0, mNavigationPos, mNavigationPoints.size() - 1);
+  }
+  emit navigationChanged();
+}
+
+/*!
+ * \brief NavigationManager::navigationPointEquals
+ * Returns true if the two navigation points represent the same navigation state.
+ * \param navigationPoint1
+ * \param navigationPoint2
+ * \return
+ */
+bool NavigationManager::navigationPointEquals(const NavigationPoint &navigationPoint1, const NavigationPoint &navigationPoint2)
+{
+  if (navigationPoint1.type != navigationPoint2.type) {
+    return false;
+  }
+  switch (navigationPoint1.type) {
+    case NavigationPoint::Type::Editor:
+      return navigationPoint1.editor == navigationPoint2.editor && navigationPoint1.position == navigationPoint2.position;
+    case NavigationPoint::Type::View:
+      return navigationPoint1.modelWidget == navigationPoint2.modelWidget && navigationPoint1.viewType == navigationPoint2.viewType;
+    case NavigationPoint::Type::Perspective:
+      return navigationPoint1.perspectiveIndex == navigationPoint2.perspectiveIndex;
+    case NavigationPoint::Type::Plot:
+      return navigationPoint1.plotSubWindow == navigationPoint2.plotSubWindow;
+  }
+  return false;
+}
+
+/*!
+ * \brief NavigationManager::pruneStaleNavigationPoints
+ * Removes the navigation points of editors or model widgets that have been
+ * destroyed from the navigation history and keeps mNavigationPos pointing to
+ * the same logical position.
+ */
+void NavigationManager::pruneStaleNavigationPoints()
+{
+  for (int i = 0; i < mNavigationPoints.size(); ++i) {
+    NavigationPoint navigationPoint = mNavigationPoints.at(i);
+    bool stale = false;
+    switch (navigationPoint.type) {
+      case NavigationPoint::Type::Editor:
+        stale = navigationPoint.editor.isNull();
+        break;
+      case NavigationPoint::Type::View:
+        stale = navigationPoint.modelWidget.isNull();
+        break;
+      case NavigationPoint::Type::Perspective:
+        stale = false;
+        break;
+      case NavigationPoint::Type::Plot:
+        stale = navigationPoint.plotSubWindow.isNull();
+        break;
+    }
+    if (stale) {
+      mNavigationPoints.removeAt(i);
+      if (i <= mNavigationPos) {
+        --mNavigationPos;
+      }
+      --i;
+    }
+  }
+  if (mNavigationPoints.isEmpty()) {
+    mNavigationPos = -1;
+  } else {
+    mNavigationPos = qBound(0, mNavigationPos, mNavigationPoints.size() - 1);
+  }
+}

--- a/OMEdit/OMEditLIB/Util/NavigationManager.h
+++ b/OMEdit/OMEditLIB/Util/NavigationManager.h
@@ -1,0 +1,126 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#ifndef NAVIGATIONMANAGER_H
+#define NAVIGATIONMANAGER_H
+
+#include "Util/StringHandler.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QVector>
+
+class ModelWidget;
+class PlainTextEdit;
+class QMdiSubWindow;
+
+/*!
+ * \class NavigationManager
+ * \brief Manages the global back/forward navigation history.
+ * The navigation history is shared between all editors, model widgets and
+ * perspectives so the back/forward navigation (Alt+Left/Alt+Right and the
+ * mouse buttons 4/5) works across different tabs, models and perspectives
+ * no matter which widget currently has the focus.
+ */
+class NavigationManager : public QObject
+{
+  Q_OBJECT
+public:
+  static NavigationManager *instance();
+
+  /*!
+   * \brief The NavigationPoint struct
+   * Stores the navigation target to jump to when navigating back and forward
+   * through the navigation history. A point can either be an editor with a
+   * cursor position, a model widget in a specific view or a perspective tab.
+   */
+  struct NavigationPoint {
+    enum class Type {Editor, View, Perspective, Plot};
+    Type type = Type::Editor;
+    /*! The editor and cursor position used for Editor points. */
+    QPointer<PlainTextEdit> editor;
+    int position = -1;
+    /*! The model widget and view type used for View points. */
+    QPointer<ModelWidget> modelWidget;
+    StringHandler::ViewType viewType = StringHandler::NoView;
+    /*! The perspective tab index used for Perspective points. */
+    int perspectiveIndex = -1;
+    /*! The plot subwindow used for Plot points. */
+    QPointer<QMdiSubWindow> plotSubWindow;
+  };
+
+  /*! Records the current cursor position of the given editor in the navigation history. */
+  void recordNavigationPoint(PlainTextEdit *pEditor);
+  /*! Records the given model widget in the given view in the navigation history. */
+  void recordNavigationPoint(ModelWidget *pModelWidget, StringHandler::ViewType viewType);
+  /*! Records a switch to the perspective tab with the given index in the navigation history. */
+  void recordNavigationPoint(int perspectiveIndex);
+  /*! Records the given plot subwindow in the navigation history. */
+  void recordNavigationPoint(QMdiSubWindow *pPlotSubWindow);
+  /*! Navigates to the previous navigation point. Returns true if the navigation happened. */
+  bool goBack();
+  /*! Navigates to the next navigation point. Returns true if the navigation happened. */
+  bool goForward();
+  /*! Removes the navigation points of the given editor from the navigation history but keeps a single point at the current cursor position. */
+  void clearNavigationHistory(PlainTextEdit *pEditor);
+  /*! Returns the navigation history points. */
+  QVector<NavigationPoint> getNavigationPoints() const {return mNavigationPoints;}
+  /*! Returns the current position in the navigation history. */
+  int getNavigationPosition() const {return mNavigationPos;}
+signals:
+  /*! Emitted whenever the navigation history changes. */
+  void navigationChanged();
+protected:
+  bool eventFilter(QObject *pObject, QEvent *pEvent) override;
+private:
+  NavigationManager(QObject *pParent = 0);
+  static NavigationManager *mpInstance;
+  void recordNavigationPoint(const NavigationPoint &navigationPoint);
+  void navigateToNavigationPoint(const NavigationPoint &navigationPoint);
+  void pruneStaleNavigationPoints();
+  bool navigationPointEquals(const NavigationPoint &navigationPoint1, const NavigationPoint &navigationPoint2);
+  bool isInsideDocumentationViewer(QObject *pObject) const;
+
+  QVector<NavigationPoint> mNavigationPoints;
+  int mNavigationPos = -1;
+  bool mNavigationActive = false;
+  const int mNavigationHistorySize = 50;
+};
+
+#endif // NAVIGATIONMANAGER_H

--- a/OMEdit/OMEditLIB/Util/NavigationManagerView.cpp
+++ b/OMEdit/OMEditLIB/Util/NavigationManagerView.cpp
@@ -1,0 +1,159 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#include "Util/NavigationManagerView.h"
+
+#include "Editors/BaseEditor.h"
+#include "Modeling/ModelWidgetContainer.h"
+#include "Util/StringHandler.h"
+
+#include <QLabel>
+#include <QListWidget>
+#include <QMdiSubWindow>
+#include <QVBoxLayout>
+
+/*!
+ * \class NavigationManagerView
+ * \brief A debug view for the navigation history of the NavigationManager.
+ */
+
+/*!
+ * \brief NavigationManagerView::NavigationManagerView
+ * \param pParent
+ */
+NavigationManagerView::NavigationManagerView(QWidget *pParent)
+  : QWidget(pParent)
+{
+  mpPositionLabel = new QLabel(this);
+  mpListWidget = new QListWidget(this);
+  mpListWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  // layout
+  QVBoxLayout *pMainLayout = new QVBoxLayout;
+  pMainLayout->setContentsMargins(0, 0, 0, 0);
+  pMainLayout->addWidget(mpPositionLabel);
+  pMainLayout->addWidget(mpListWidget);
+  setLayout(pMainLayout);
+  // keep the view updated whenever the navigation history changes
+  connect(NavigationManager::instance(), SIGNAL(navigationChanged()), SLOT(refresh()));
+  refresh();
+}
+
+/*!
+ * \brief NavigationManagerView::refresh
+ * Repopulates the list from the current navigation history and highlights the
+ * current position.
+ */
+void NavigationManagerView::refresh()
+{
+  mpListWidget->clear();
+  NavigationManager *pNavigationManager = NavigationManager::instance();
+  const QVector<NavigationManager::NavigationPoint> navigationPoints = pNavigationManager->getNavigationPoints();
+  const int navigationPosition = pNavigationManager->getNavigationPosition();
+  mpPositionLabel->setText(QString("Position: %1 of %2").arg(navigationPosition + 1).arg(navigationPoints.size()));
+  QPalette palette = mpListWidget->palette();
+  for (int i = 0; i < navigationPoints.size(); ++i) {
+    QListWidgetItem *pItem = new QListWidgetItem(navigationPointText(navigationPoints.at(i)), mpListWidget);
+    if (i == navigationPosition) {
+      QFont font = pItem->font();
+      font.setBold(true);
+      pItem->setFont(font);
+      pItem->setBackground(palette.highlight());
+      pItem->setForeground(palette.highlightedText());
+    }
+  }
+}
+
+/*!
+ * \brief NavigationManagerView::navigationPointText
+ * Returns a human readable description of the given navigation point.
+ * \param navigationPoint
+ * \return
+ */
+QString NavigationManagerView::navigationPointText(const NavigationManager::NavigationPoint &navigationPoint) const
+{
+  switch (navigationPoint.type) {
+    case NavigationManager::NavigationPoint::Type::Editor: {
+      PlainTextEdit *pEditor = navigationPoint.editor;
+      QString name;
+      if (pEditor) {
+        BaseEditor *pBaseEditor = pEditor->getBaseEditor();
+        if (pBaseEditor && pBaseEditor->getModelWidget() && pBaseEditor->getModelWidget()->getLibraryTreeItem()) {
+          name = pBaseEditor->getModelWidget()->getLibraryTreeItem()->getNameStructure();
+        } else {
+          name = "Editor";
+        }
+      } else {
+        name = "Deleted editor";
+      }
+      return QString("Editor: %1 @ %2").arg(name).arg(navigationPoint.position);
+    }
+    case NavigationManager::NavigationPoint::Type::View: {
+      ModelWidget *pModelWidget = navigationPoint.modelWidget;
+      QString name;
+      if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
+        name = pModelWidget->getLibraryTreeItem()->getNameStructure();
+      } else {
+        name = "Deleted model";
+      }
+      return QString("View: %1 (%2)").arg(name, StringHandler::getViewType(navigationPoint.viewType));
+    }
+    case NavigationManager::NavigationPoint::Type::Perspective: {
+      QStringList perspectiveNames;
+      perspectiveNames << "Welcome" << "Modeling" << "Plotting" << "Debugging";
+      QString name;
+      if (navigationPoint.perspectiveIndex >= 0 && navigationPoint.perspectiveIndex < perspectiveNames.size()) {
+        name = perspectiveNames.at(navigationPoint.perspectiveIndex);
+      } else {
+        name = QString::number(navigationPoint.perspectiveIndex);
+      }
+      return QString("Perspective: %1").arg(name);
+    }
+    case NavigationManager::NavigationPoint::Type::Plot: {
+      QMdiSubWindow *pSubWindow = navigationPoint.plotSubWindow;
+      QString name;
+      if (pSubWindow && pSubWindow->widget()) {
+        name = pSubWindow->widget()->windowTitle();
+      } else {
+        name = "Deleted plot window";
+      }
+      return QString("Plot: %1").arg(name);
+    }
+  }
+  return QString();
+}

--- a/OMEdit/OMEditLIB/Util/NavigationManagerView.h
+++ b/OMEdit/OMEditLIB/Util/NavigationManagerView.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#ifndef NAVIGATIONMANAGERVIEW_H
+#define NAVIGATIONMANAGERVIEW_H
+
+#include "Util/NavigationManager.h"
+
+#include <QWidget>
+
+class QLabel;
+class QListWidget;
+
+/*!
+ * \class NavigationManagerView
+ * \brief A debug view for the navigation history of the NavigationManager.
+ * Shows the navigation points in a list with the current position highlighted.
+ * The view is updated whenever the navigation history changes.
+ */
+class NavigationManagerView : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit NavigationManagerView(QWidget *pParent = 0);
+  QListWidget *getListWidget() const {return mpListWidget;}
+private slots:
+  void refresh();
+private:
+  QString navigationPointText(const NavigationManager::NavigationPoint &navigationPoint) const;
+  QLabel *mpPositionLabel;
+  QListWidget *mpListWidget;
+};
+
+#endif // NAVIGATIONMANAGERVIEW_H


### PR DESCRIPTION
### Related Issues

#16123

### Purpose

Support back/forward navigation.

### Approach

Add global back/forward navigation across editors, views, perspectives and plots. NavigationManager singleton that records navigation points for editors, model widget views, perspective tabs and plot windows. Back/forward (Alt+Left/Alt+Right and mouse buttons 4/5) is handled by a global event filter so it works regardless of focus, and the documentation viewer is excluded so the web engine keeps its own history. A debug-only dock widget visualizes the navigation history.