### PR TITLE
[OB] fix symbolic differentiation of calls with record inputs

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1045,7 +1045,7 @@ algorithm
       BackendDAE.VarKind kind;
 
       list<BackendDAE.Var> scalarLst;
-      DAE.Type tp, arrayType;
+      DAE.Type tp, arrayType, compType;
       DAE.Exp e, e1, zero, one;
       DAE.Exp res, res1;
       DAE.ComponentRef cr, cr1;
@@ -1074,8 +1074,22 @@ algorithm
     case ((DAE.CREF(componentRef = cr,ty = tp as DAE.T_COMPLEX(varLst=varLst,complexClassType=ClassInf.RECORD(path)))), _, _, _)
       algorithm
         expl := List.map1(varLst,Expression.generateCrefsExpFromExpVar,cr);
-        (expl_1, outFunctionTree) := List.map3Fold(expl, function differentiateExp(maxIter=maxIter), inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
-        res := DAE.CALL(path,expl_1,DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
+        expl_1 := {};
+        outFunctionTree := inFunctionTree;
+        for comp in expl loop
+          (e1, outFunctionTree) := differentiateExp(comp, inDiffwrtCref, inInputData, inDiffType, outFunctionTree, maxIter);
+          compType := Expression.typeof(comp);
+          if Expression.isZero(e1) and (Types.isString(compType) or Types.isBoolean(compType) or Types.isEnumeration(compType)) then
+            // a String, Boolean or enumeration component has no derivative and
+            // is differentiated to a real zero, which is not type correct in
+            // its slot. Use a zero of its own type instead.
+            // Only the constant is replaced, a differentiation that yields a
+            // seed variable, as the Jacobian does, has to be kept as it is.
+            e1 := zeroOfType(compType);
+          end if;
+          expl_1 := e1 :: expl_1;
+        end for;
+        res := DAE.CALL(path,listReverse(expl_1),DAE.CALL_ATTR(tp,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL(),DAE.NoReturn.RETURNS));
       then
         (res, outFunctionTree);
 
@@ -2340,6 +2354,7 @@ algorithm
         diffFuncData := BackendDAE.emptyInputData;
          diffFuncData.matrixName := SOME(funcname);
         (dexplZero, functions) := List.map3Fold(expl1, function differentiateExp(maxIter=maxIter), DAE.CREF_IDENT("$",DAE.T_REAL_DEFAULT,{}), diffFuncData, BackendDAE.GENERIC_GRADIENT(false), functions);
+        dexplZero := list(typedZeroSeed(a, z) threaded for a in expl1, z in dexplZero);
         // debug dump
         if Flags.isSet(Flags.DEBUG_DIFFERENTIATION) then
           print("### differentiated argument list:\n");
@@ -2496,9 +2511,12 @@ function tryZeroDiff
   input output AvlTreePathFunction.Tree functions;
   input Integer maxIter;
   output Boolean success;
+protected
+  list<DAE.Exp> args = explist;
 algorithm
   try
    (explist, functions) := List.map3Fold(explist, function differentiateExp(maxIter=maxIter), DAE.CREF_IDENT("$",DAE.T_REAL_DEFAULT,{}), BackendDAE.emptyInputData, BackendDAE.GENERIC_GRADIENT(false), functions);
+   explist := list(typedZeroSeed(a, z) threaded for a in args, z in explist);
    success := true;
   else
    explist := {};
@@ -2607,9 +2625,18 @@ for de in inDiffExpl loop
     case (_, DAE.CALL(path=path, attr=attr))
     guard(Types.isRecord(Expression.typeof(de)))
       algorithm
-      dexpLst := List.set(inDiffExplZero, i, de);
-      expLst := listAppend(inOrginalExpl,dexpLst);
-      e := DAE.CALL(path, expLst, attr);
+      // A record valued argument cannot be seeded component-wise with a one,
+      // the derivative of the record itself is passed as seed instead. The
+      // resulting term has to be added to the partial derivatives collected so
+      // far, it must not replace them.
+      if isZeroDerivative(de) then
+        // this argument does not contribute to the derivative
+        e := outExp;
+      else
+        dexpLst := List.set(inDiffExplZero, i, de);
+        expLst := listAppend(inOrginalExpl,dexpLst);
+        e := Expression.expAdd(outExp, DAE.CALL(path, expLst, attr));
+      end if;
     then e;
 
     case (DAE.ARRAY(ty = tp,scalar = b,array = expl), _) algorithm
@@ -3073,7 +3100,7 @@ algorithm
           e := listGet(expl, i);
           // Differentiate exp.
           (e, functionTree) := differentiateExp(e, diffwrtCref, inputData, diffType, functionTree, defaultMaxIter);
-          true := Expression.isZero(e);
+          true := isZeroDerivative(e);
         then
           ();
 
@@ -3102,6 +3129,88 @@ algorithm
 
   outblst := arrayList(ba);
 end checkDerFunctionConds;
+
+protected function zeroOfType
+  "Zero seed of the given type, for arguments and record components that have no
+   derivative of their own. Differentiation yields a real zero for those, which
+   is not type correct in a String, Boolean, enumeration or record slot."
+  input DAE.Type inType;
+  output DAE.Exp outZero;
+algorithm
+  outZero := match inType
+    local
+      Absyn.Path path;
+      String name;
+      list<DAE.Var> varLst;
+
+    case DAE.T_STRING() then DAE.SCONST("");
+    case DAE.T_BOOL() then DAE.BCONST(false);
+
+    case DAE.T_ENUMERATION(path = path, names = name :: _)
+      then DAE.ENUM_LITERAL(AbsynUtil.suffixPath(path, name), 1);
+
+    case DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path = path), varLst = varLst)
+      then DAE.CALL(path, list(zeroOfType(DAEUtil.varType(v)) for v in varLst),
+                    DAE.CALL_ATTR(inType, false, false, false, false, DAE.NO_INLINE(), DAE.NO_TAIL(), DAE.NoReturn.RETURNS));
+
+    else Expression.makeConstZero(inType);
+  end match;
+end zeroOfType;
+
+protected function typedZeroSeed
+  "The zero seeds of the arguments of a partially differentiated call are made
+   by differentiating them with respect to a dummy variable, which yields a real
+   zero for an argument that has no derivative of its own. A record, String,
+   Boolean or enumeration argument needs a seed of its own type, a real zero in
+   such a slot does not compile."
+  input DAE.Exp inArg;
+  input DAE.Exp inZero;
+  output DAE.Exp outZero = inZero;
+protected
+  DAE.Type ty;
+algorithm
+  if Expression.isZero(inZero) then
+    ty := Expression.typeof(inArg);
+    if Types.isRecord(ty) or Types.isString(ty) or Types.isBoolean(ty) or Types.isEnumeration(ty) then
+      outZero := zeroOfType(ty);
+    end if;
+  end if;
+end typedZeroSeed;
+
+protected function isZeroDerivative
+  "Returns true if the given differentiated expression is zero. In contrast to
+   Expression.isZero this also handles record valued derivatives, which are
+   built as record constructors with one zero per component, and the seeds of
+   String, Boolean and enumeration components, which have no derivative."
+  input DAE.Exp inExp;
+  output Boolean outZero;
+algorithm
+  outZero := match inExp
+    local
+      list<DAE.Exp> expl;
+      Absyn.Path path, rpath;
+
+    case DAE.RECORD(exps = expl)
+      then List.all(expl, isZeroDerivative);
+
+    // a record constructor call, i.e. the call path is the record path
+    case DAE.CALL(path = path, expLst = expl, attr = DAE.CALL_ATTR(ty = DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path = rpath))))
+      guard AbsynUtil.pathEqual(path, rpath)
+      then List.all(expl, isZeroDerivative);
+
+    case DAE.ARRAY(array = expl)
+      then List.all(expl, isZeroDerivative);
+
+    // the seed of a String, Boolean or enumeration component, which has no
+    // derivative of its own. A component reference is not one of these, a
+    // Jacobian differentiates such a component to a seed variable.
+    case DAE.SCONST() then true;
+    case DAE.BCONST() then true;
+    case DAE.ENUM_LITERAL() then true;
+
+    else Expression.isZero(inExp);
+  end match;
+end isZeroDerivative;
 
 protected function getlowerOrderDerivative "Author: Frenkel TUD"
   input Absyn.Path fname;

--- a/testsuite/simulation/modelica/algorithms_functions/Issue16192.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/Issue16192.mos
@@ -1,0 +1,84 @@
+// name:     Issue16192
+// keywords: Function Annotations, derivative, zeroDerivative, record
+// status:   correct
+// teardown_command: rm -rf Issue16192.M Issue16192.M.* Issue16192.M_* output.log
+//
+// Symbolic time differentiation of function calls that have a record input:
+//  - a derivative annotation with zeroDerivative on a record input has to be used
+//  - the partial derivatives of the remaining inputs must not be dropped when a
+//    record input is present
+//
+
+loadString("
+package Issue16192
+  record Material
+    parameter String name = \"m\";
+    parameter Integer n = 2;
+    parameter Real a = 3.0;
+  end Material;
+
+  function f \"the derivative is given by the annotation, not by differentiating the body\"
+    input Real x;
+    input Material m;
+    output Real y;
+  algorithm
+    y := x^2*m.a;
+    annotation(derivative(zeroDerivative = m) = df);
+  end f;
+
+  function df \"deliberately different from the derivative of f, so that we see it is used\"
+    input Real x;
+    input Material m;
+    input Real dx;
+    output Real dy;
+  algorithm
+    dy := 999*dx;
+  end df;
+
+  function g \"no derivative annotation and not inlinable, is differentiated symbolically\"
+    input Real x;
+    input Material m;
+    output Real y;
+  algorithm
+    y := 0;
+    for i in 1:m.n loop
+      y := y + x^2*m.a;
+    end for;
+  end g;
+
+  model M
+    parameter Material m;
+    Real x = 2*time;
+    Real y1 = f(x, Material(\"m\", 2, 3.0));
+    Real dy1 = der(y1) \"df is used: 999*der(x) = 1998\";
+    Real y2 = g(x, m);
+    Real dy2 = der(y2) \"symbolic derivative: 2*m.n*m.a*x*der(x) = 24*x\";
+  end M;
+end Issue16192;
+"); getErrorString();
+
+simulate(Issue16192.M, stopTime=1.0, numberOfIntervals=2); getErrorString();
+
+val(dy1, 0.0);
+val(dy1, 0.5);
+val(dy2, 0.0);
+val(dy2, 0.5);
+val(dy2, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Issue16192.M_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue16192.M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1998.0
+// 1998.0
+// 0.0
+// 24.0
+// 48.0
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Issue16198.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/Issue16198.mos
@@ -1,0 +1,88 @@
+// name:     Issue16198
+// keywords: Function Annotations, derivative, zeroDerivative, record, array
+// status:   correct
+// teardown_command: rm -rf Issue16198.M Issue16198.M.* Issue16198.M_* output.log
+//
+// Symbolic time differentiation of function calls that have a record input with
+// String, Integer and array components:
+//  - the derivative annotation with zeroDerivative on the record input has to be
+//    used, the body, which calls a function without a derivative annotation, must
+//    not be differentiated instead
+//  - the zero seed record built for a record input that is differentiated
+//    symbolically has to be type correct, otherwise the generated C does not compile
+//
+
+loadString("
+package Issue16198
+  record Material
+    parameter String name = \"m\";
+    parameter Integer n = 3;
+    parameter Real HD[3] = {1.0, 2.0, 3.0};
+    parameter Real JD[3] = {0.5, 1.5, 2.5};
+  end Material;
+
+  function helper \"no derivative annotation and not inlinable, is differentiated symbolically\"
+    input Real x;
+    input Material m;
+    output Real y;
+  algorithm
+    y := 0;
+    for i in 1:m.n loop
+      y := y + m.HD[i]*x^2 + m.JD[i]*x;
+    end for;
+  end helper;
+
+  function app \"the derivative is given by the annotation, the body is never differentiated\"
+    input Real x;
+    input Material m;
+    output Real y;
+  algorithm
+    y := helper(x, m);
+    annotation(derivative(zeroDerivative = m) = der_app);
+  end app;
+
+  function der_app \"deliberately different from the derivative of app, so that we see it is used\"
+    input Real x;
+    input Material m;
+    input Real dx;
+    output Real dy;
+  algorithm
+    dy := 999*dx;
+  end der_app;
+
+  model M
+    parameter Material m;
+    Real x = 2*time;
+    Real y1 = app(x, Material(\"m\", 3, {1.0, 2.0, 3.0}, {0.5, 1.5, 2.5}));
+    Real dy1 = der(y1) \"der_app is used: 999*der(x) = 1998\";
+    Real y2 = helper(x, m);
+    Real dy2 = der(y2) \"symbolic derivative: (2*sum(m.HD)*x + sum(m.JD))*der(x) = 48*time + 9\";
+  end M;
+end Issue16198;
+"); getErrorString();
+
+simulate(Issue16198.M, stopTime=1.0, numberOfIntervals=2); getErrorString();
+
+val(dy1, 0.0);
+val(dy1, 1.0);
+val(dy2, 0.0);
+val(dy2, 0.5);
+val(dy2, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Issue16198.M_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue16198.M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1998.0
+// 1998.0
+// 9.0
+// 33.0
+// 57.0
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -31,6 +31,8 @@ InverseAlgorithm1.mos \
 InverseAlgorithm2.mos \
 InverseAlgorithm3.mos \
 InverseAlgorithm4.mos \
+Issue16192.mos \
+Issue16198.mos \
 LocalVariableInit.mos \
 ModelicaTest.Fluid.Dissipation.Verifications.HeatTransfer.Channel.kc_evenGapLaminar.mos \
 SimplePeriodicSampler.mos \


### PR DESCRIPTION
Fixes #16192
Fixes #16198

Time differentiation of a function call that has a record input was broken in three ways in the old backend. #16192 computed `-der(psi)` completely wrong (100% off) because of the first two, #16198 does not compile because of the first and the third.

1. `derivative(zeroDerivative=<record input>)` was ignored

   `checkDerFunctionConds` verifies the zeroDerivative condition by differentiating the actual argument and asking `Expression.isZero`. For a record argument the derivative is a record constructor with one zero per component, which `Expression.isZero` does not recognize, so the condition was considered violated and the whole derivative annotation was silently dropped. The backend then fell back to inlining the function body and differentiating it symbolically, which is not what the annotation asks for.

   The new `isZeroDerivative` handles record constructors, arrays and the seeds of components that have no derivative. It only accepts literals there, a Boolean component reference is a seed variable, not a zero.

2. partial derivatives were dropped when a record input was present

   `createPartialDifferentiatedExp` sums up d/dx_i * df/dx_i over all inputs. A record input cannot be seeded component-wise with a one, so the derivative of the record is passed as seed directly. That branch assigned the resulting call to the accumulator instead of adding to it, so it discarded every partial derivative collected before it. For `f(x, m)` with a record `m` the derivative of `x` was replaced by a call seeded with zero, i.e. the result was zero.

3. the zero seeds were not type correct

   `differentiateCrefs` differentiated every component of a record cref, including String, Boolean and enumeration ones, and put `0.0` in their slot, and `tryZeroDiff` did the same for a whole record argument.

   C only rejects the String slot, which is what #16198 reports. Because of 1. the annotated functions `app_J` and `app_mu_r` were inlined and their bodies differentiated, which pulled in the `Internal` helper functions that carry no derivative annotation, and the seed record built for their material record put `0.0` into the `String Type` slot:

   ```
   error: passing 'double' to parameter of incompatible type 'modelica_string'
     omc_..._SSEE_BaseData(threadData, 0.0, 0.0, ..., tmp8, ...)
   ```

   C++ also rejects the record argument seed:

   ```
   error: reference to type 'const Modelica_Media_Common_IF97PhaseBoundaryPropertiesType'
   could not bind to an rvalue of type 'double'
   ```

   That one was hidden by 2., the term carrying it was the one being discarded.

   The new `zeroOfType` builds a zero of the type at hand: `""`, `false`, the first enumeration literal, or a record constructor of such zeros. Only a differentiation that yielded a real zero is replaced. Where it yields a seed variable, as a Jacobian does for every component of a record, the seed has to be kept, otherwise the Jacobian system loses an unknown and index reduction fails on it.

   With the fix the annotation is honoured, so neither a `$DER$...` helper nor a `BaseData` constructor call is generated at all, and all four `FluxTubesPart.Examples.BasicExamples` models of #16198 build and simulate.

The new backend is not affected, it already produced the correct result.

## Tests

Two tests in `testsuite/simulation/modelica/algorithms_functions`, both fail on master:

- `Issue16192.mos` covers all three, with a wrong derivative value for 1. and 2. and a record of String, Integer and Real components
- `Issue16198.mos` covers 1. and 3. for a record that also has array components, with the annotated function calling a helper function that has no derivative annotation:

```mo
record Material
  parameter String name = "m";
  parameter Integer n = 3;
  parameter Real HD[3] = {1.0, 2.0, 3.0};
  parameter Real JD[3] = {0.5, 1.5, 2.5};
end Material;

function helper "no derivative annotation and not inlinable, is differentiated symbolically"
  input Real x;
  input Material m;
  output Real y;
algorithm
  y := 0;
  for i in 1:m.n loop
    y := y + m.HD[i]*x^2 + m.JD[i]*x;
  end for;
end helper;

function app "the derivative is given by the annotation, the body is never differentiated"
  input Real x;
  input Material m;
  output Real y;
algorithm
  y := helper(x, m);
  annotation(derivative(zeroDerivative = m) = der_app);
end app;
```

Green with the fix, all of these had a failure in the first round of this PR or cover the same code:

| directory | |
| --- | --- |
| `simulation/modelica/algorithms_functions` | 48/48 |
| `simulation/modelica/jacobian` | 1/1 |
| `openmodelica/linearization` | 23/23 |
| `openmodelica/cruntime/optimization/benchmark` | 2/2 |
| `openmodelica/cppruntime/fmu/modelExchange/2.0` | 14/14 |
| `openmodelica/fmi/ModelExchange/2.0` | 65/65 |
| `simulation/modelica/others` | 80/80 |
| `simulation/modelica/inlineFunction` | 24/24 |
| `simulation/modelica/records` | 15/15 |
| `simulation/modelica/indexreduction` | 4/4 |

-----

generated by Claude Code
