### PR TITLE
wasm-jit: fix whole-array refs in record arrays

### DIFF
--- a/.CI/scripts/SimulationRuntime-license-exceptions.txt
+++ b/.CI/scripts/SimulationRuntime-license-exceptions.txt
@@ -273,6 +273,7 @@ testsuite/
 doc/
 OMCompiler/Examples/
 OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/examples/
+OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/
 !OMCompiler/Examples/GenerateDoc.mos
 
 # =============================================================================

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2362,10 +2362,9 @@ fn insert_var(map: &mut SimVarMap, sv: &SimCodeVar::SimVar, off: u32, wty: WTy, 
 }
 
 /// If `cr` is a scalarized array element `base[c1,…,cn]` — the subscripts on the
-/// *final* component, all constant integers, with every ancestor component
-/// unsubscripted — return `(base cref key, subscripts)`. Returns `None` for a
-/// plain scalar, a non-constant subscript, or a subscript on an intermediate
-/// component (an array of records, handled element-wise instead).
+/// *final* component, all constant integers — return `(base cref key, subscripts)`.
+/// Intermediate subscripts (an array of records) belong to the base key. `None` for
+/// a plain scalar or a non-constant subscript.
 fn array_element_of(cr: &Arc<DAE::ComponentRef>) -> Result<Option<(String, Vec<i32>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -2380,10 +2379,10 @@ fn array_element_of(cr: &Arc<DAE::ComponentRef>) -> Result<Option<(String, Vec<i
                 return Ok(const_int_subscripts(subscriptLst)?.map(|subs| (base, subs)));
             }
             C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
-                if !subscriptLst.is_empty() {
+                base.push_str(ident);
+                if !crate::CodegenWasmJitFunctions::push_qual_subs(subscriptLst, &mut base) {
                     return Ok(None);
                 }
-                base.push_str(ident);
                 base.push('.');
                 node = componentRef;
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -3955,6 +3955,26 @@ fn sim_subs_into(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> Resul
     Ok(())
 }
 
+/// Append an intermediate component's subscripts to an array base key, spelled as
+/// [`sim_cref_key`] spells them (`bodybox[1].body.R_start.T`). `false` when a
+/// subscript is not a constant index, so there is no static base key.
+pub(crate) fn push_qual_subs(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> bool {
+    for sub in &**subs {
+        match &**sub {
+            DAE::Subscript::INDEX { exp } => match const_index_value(exp) {
+                Some(ix) => {
+                    s.push('[');
+                    s.push_str(&ix.to_string());
+                    s.push(']');
+                }
+                None => return false,
+            },
+            _ => return false,
+        }
+    }
+    true
+}
+
 /// If `exp` is a constant index (`ICONST`/enum literal), its 1-based value.
 fn const_index_value(exp: &DAE::Exp) -> Option<i32> {
     match exp {
@@ -3964,11 +3984,10 @@ fn const_index_value(exp: &DAE::Exp) -> Option<i32> {
     }
 }
 
-/// If `cr` is `base[e1,…,en]` — subscripts on the *final* component, every
-/// ancestor unsubscripted — return `(base cref key, subscript index expressions)`.
-/// Unlike [`sim_cref_key`], the subscripts need not be constant; this backs the
-/// dynamic array-element path (e.g. a `for`-loop iterator index). Returns `None`
-/// for a plain scalar, a slice/`:` subscript, or a subscripted intermediate.
+/// If `cr` is `base[e1,…,en]` — subscripts on the *final* component — return
+/// `(base cref key, subscript index expressions)`. Unlike [`sim_cref_key`], those
+/// subscripts need not be constant; this backs the dynamic array-element path
+/// (e.g. a `for`-loop iterator index). `None` for a plain scalar or a slice.
 fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::Exp>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -3990,10 +4009,10 @@ fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
                 return Ok(Some((base, exps)));
             }
             C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
-                if !subscriptLst.is_empty() {
+                base.push_str(ident);
+                if !push_qual_subs(subscriptLst, &mut base) {
                     return Ok(None);
                 }
-                base.push_str(ident);
                 base.push('.');
                 node = componentRef;
             }
@@ -4002,10 +4021,10 @@ fn array_ref_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
-/// `base[i1,…,ik, :, …, :]` (leading `INDEX` subscripts, then whole dims; final
-/// component subscripted, ancestors bare) -> `(base key, leading index exprs)`.
-/// Such a selection is a contiguous row-major block. `None` for a scalar, a
-/// `SLICE`, or an `INDEX` after a whole dim.
+/// `base[i1,…,ik, :, …, :]` (leading `INDEX` subscripts, then whole dims, on the
+/// final component) -> `(base key, leading index exprs)`. Such a selection is a
+/// contiguous row-major block. `None` for a scalar, a `SLICE`, or an `INDEX` after
+/// a whole dim.
 fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::Exp>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -4029,10 +4048,10 @@ fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
                 return Ok(Some((base, leading)));
             }
             C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
-                if !subscriptLst.is_empty() {
+                base.push_str(ident);
+                if !push_qual_subs(subscriptLst, &mut base) {
                     return Ok(None);
                 }
-                base.push_str(ident);
                 base.push('.');
                 node = componentRef;
             }
@@ -4041,8 +4060,8 @@ fn sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<DAE::E
     }
 }
 
-/// `base[subs]` (final component subscripted, ancestors bare) -> `(base key, raw
-/// subscript list)`. Unlike [`sim_slice_of`], any `INDEX`/`SLICE`/whole mix.
+/// `base[subs]` (subscripts on the final component) -> `(base key, raw subscript
+/// list)`. Unlike [`sim_slice_of`], any `INDEX`/`SLICE`/whole mix.
 fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<List<Arc<DAE::Subscript>>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
@@ -4057,10 +4076,10 @@ fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<Lis
                 return Ok(Some((base, subscriptLst.clone())));
             }
             C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
-                if !subscriptLst.is_empty() {
+                base.push_str(ident);
+                if !push_qual_subs(subscriptLst, &mut base) {
                     return Ok(None);
                 }
-                base.push_str(ident);
                 base.push('.');
                 node = componentRef;
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestRecordArrayParam.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestRecordArrayParam.mo
@@ -1,0 +1,27 @@
+// Whole-array reference to a matrix field of a record inside an array
+// (`part[1].R.T`), as MultiBody's `bodybox[1].body.R_start.T`.
+model TestRecordArrayParam
+  record Orientation
+    Real T[3, 3];
+  end Orientation;
+
+  function traceT
+    input Real T[3, 3];
+    output Real s;
+  algorithm
+    s := T[1, 1] + T[2, 2] + T[3, 3];
+  end traceT;
+
+  model Part
+    parameter Real d = 1.0;
+    parameter Orientation R = Orientation(d * identity(3));
+    Real y;
+  equation
+    y = traceT(R.T);
+  end Part;
+
+  Part part[2](d = {2.0, 5.0});
+  Real x(start = 0.0, fixed = true);
+equation
+  der(x) = part[1].y + part[2].y; // expect der(x) = 3*2 + 3*5 = 21
+end TestRecordArrayParam;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_recordarray.mos
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_recordarray.mos
@@ -1,0 +1,6 @@
+// An ancestor subscript used to disqualify the array-group base key, so the
+// whole-array reference failed with `simulation reference to unknown variable`.
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("TestRecordArrayParam.mo"); getErrorString();
+simulate(TestRecordArrayParam, stopTime = 1.0, numberOfIntervals = 10); getErrorString();
+val(x, 1.0); // expect 21 (der(x) = 3*2 + 3*5)


### PR DESCRIPTION
The array-group base key dropped any component carrying a subscript, so a record inside an array never got its scalarized matrix field grouped. `bodybox[1].body.R_start.T` then failed to resolve, while the unsubscripted `bodyboxN.body.R_start.T` in the same model worked:

```
Internal error CodegenWasmJit: simulation reference to unknown
variable `bodybox[1].body.R_start.T`
```

Fold constant intermediate subscripts into the base key, spelled as `sim_cref_key` spells them, in all four helpers that build one.

ScalableTestSuite's `FlexibleBeamModelica_N_2` now simulates and matches the C target (`diffSimulationResults`: 0 differing variables).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
