### PR TITLE
wasm-jit: tell Tearing about its sparse solvers

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -382,8 +382,8 @@ protected function checkTearingSettings
   input Integer numVars;
   output Boolean activateTearing = false;
 protected
-  constant list<String> withLSS = {"C"} "targets that provide a linear sparse solver";
-  constant list<String> withNSS = {"C"} "targets that provide a nonlinear sparse solver";
+  constant list<String> withLSS = {"C", "wasm-jit", "wasm"} "targets that provide a linear sparse solver";
+  constant list<String> withNSS = {"C", "wasm-jit", "wasm"} "targets that provide a nonlinear sparse solver";
   Boolean debugFlag = Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE);
   Integer maxSize;
   Boolean isDense;


### PR DESCRIPTION
`checkTearingSettings` forces tearing on every strong component when the target has no sparse solver and the matrix format is dense, which bypasses the `maxSizeLinearTearing` guard entirely. wasm-jit was not listed, so systems the C target leaves untorn were torn instead.

The runtime has had both solvers for a while:
`rt_solve_lin_sparse_cached` over rsparse for linear systems, and KINSOL/KLU (or the sparse Newton fallback) for nonlinear ones. The standalone `wasm` target runs the same runtime.

On `DistributionSystemLinearIndividual_N_20_M_20` (one 3277-equation linear system) the forced tearing cost 6.6 s plus 4.1 s of strong-component Jacobians, and the resulting Jacobian column list overflowed the stack in `SimCodeUtil.createJacSimVarsColumn`.

| phase                | before   | after   | C target |
| -------------------- | -------- | ------- | -------- |
| tearingSystem        | 6.6 s    | 0.002 s | 0.002 s  |
| strong-comp Jacobian | 4.1 s    | -       | 0.002 s  |
| Templates            | 9.1 s    | 8.0 s   | 19.5 s   |
| C compile            | -        | -       | 7.4 s    |
| simulation           | -        | 7.9 s   | 20.6 s   |
| total                | overflow | 45.3 s  | 79.7 s   |

Results are unchanged against the C target: `diffSimulationResults` reports no differences over all 29146 variables and 1002 rows.

rtest under `--simCodeTarget=wasm-jit` gains five tests and loses none: `Ticket4254` (linear_system) plus `TestInputIteration`, `inverseTest` and `nonlinearFailed` (nonlinear_system).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
