### PR TITLE
wasm-jit: support slicing on the left-hand side

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -339,6 +339,9 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // (src, nspec, spec) where `spec` is an Integer array of (kind, value) pairs
     // per source axis (kind 0 INDEX, 1 WHOLE, 2 SLICE). Returns a fresh array.
     ("rt_array_slice", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // Sliced left-hand side `a[i, :, lo:hi, ...] := src`: (dst, nspec, spec, src),
+    // same spec encoding. `src` holds the selected positions in selection order.
+    ("rt_array_indexed_assign", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[]),
     // `cat(dim, a1, ..., an)`: (dim, n, handles) where `handles` is an Integer
     // array of the `n` input array handles. Returns a fresh concatenated array.
     ("rt_array_cat", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
@@ -2203,6 +2206,9 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
         let SigTy::Array { elem, rank } = dst_sty else {
             return Err("CodegenWasmJit: subscripting non-array local");
         };
+        if !is_scalar_index(subscriptLst, rank) {
+            return compile_slice_assign(ctx, idx, subscriptLst, RhsSource::Exp(rhs));
+        }
         let idx_exps = index_subscripts(subscriptLst, rank)?;
         return compile_elem_assign(ctx, idx, &elem, &idx_exps, rhs);
     }
@@ -2313,6 +2319,9 @@ fn store_fresh_into_cref(ctx: &mut FnCtx, cref: &DAE::ComponentRef, wty: WTy, vt
             ctx.emit(we::Instruction::LocalGet(rec));
             field_load(ctx, WTy::I32, off);
             ctx.emit(we::Instruction::LocalSet(arr_t));
+            if !is_scalar_index(lsubs, rank) {
+                return compile_slice_assign(ctx, arr_t, lsubs, RhsSource::Temp { local: vt, wty });
+            }
             let idx_exps = index_subscripts(lsubs, rank)?;
             store_fresh_into_elem(ctx, arr_t, &elem, &idx_exps, vt)?;
         }
@@ -2333,6 +2342,9 @@ fn store_fresh_into_cref(ctx: &mut FnCtx, cref: &DAE::ComponentRef, wty: WTy, vt
     let SigTy::Array { elem, rank } = dst_sty else {
         return Err("CodegenWasmJit: subscripting non-array local");
     };
+    if !is_scalar_index(subscriptLst, rank) {
+        return compile_slice_assign(ctx, idx, subscriptLst, RhsSource::Temp { local: vt, wty });
+    }
     let idx_exps = index_subscripts(subscriptLst, rank)?;
     store_fresh_into_elem(ctx, idx, &elem, &idx_exps, vt)
 }
@@ -2987,6 +2999,9 @@ fn compile_cref_assign_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: &DAE
         ctx.emit(we::Instruction::LocalGet(rec));
         field_load(ctx, WTy::I32, off);
         ctx.emit(we::Instruction::LocalSet(arr_t));
+        if !is_scalar_index(lsubs, rank) {
+            return compile_slice_assign(ctx, arr_t, lsubs, RhsSource::Exp(rhs));
+        }
         let idx_exps = index_subscripts(lsubs, rank)?;
         compile_elem_assign(ctx, arr_t, &elem, &idx_exps, rhs)?;
     }
@@ -7358,10 +7373,9 @@ fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: 
     Ok(WTy::I32)
 }
 
-/// Lower `a[i, j, ...]` (full subscripting of an N-D array to a scalar element).
-/// `base` produces the owned array handle; `subs` must be one `INDEX` per
-/// dimension (slicing / partial indexing is not yet supported). Returns the
-/// element's wasm type.
+/// Lower `a[i, j, ...]`: one `INDEX` per dimension reads a scalar element,
+/// anything else slices to a lower-rank sub-array. `base` produces the owned
+/// array handle. Returns the result's wasm type.
 fn compile_index(ctx: &mut FnCtx, base: &DAE::Exp, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
     let SigTy::Array { elem, rank } = exp_sigty(base)? else {
         return Err("CodegenWasmJit: subscripting a non-array expression");
@@ -7391,18 +7405,18 @@ fn is_scalar_index(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> bool {
     all_index && n == rank
 }
 
-/// Extract one `INDEX` expression per dimension from a subscript list, or fail
-/// for slicing / whole-dimension / wrong arity (not yet supported).
+/// Extract one `INDEX` expression per dimension from a subscript list. Callers
+/// gate on [`is_scalar_index`] first, so anything else is a codegen bug.
 fn index_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> Result<Vec<Arc<DAE::Exp>>> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
     if subs.len() as u32 != rank {
-        return Err("CodegenWasmJit: array slicing / partial indexing not supported");
+        return Err("CodegenWasmJit: partial indexing on the scalar-index path");
     }
     let mut out = Vec::with_capacity(subs.len());
     for s in subs {
         match &**s {
             DAE::Subscript::INDEX { exp } => out.push(exp.clone()),
-            other => return Err("CodegenWasmJit: non-scalar subscript (slicing not supported)"),
+            other => return Err("CodegenWasmJit: non-scalar subscript on the scalar-index path"),
         }
     }
     Ok(out)
@@ -7467,29 +7481,18 @@ fn spec_elem_addr(ctx: &mut FnCtx, spec_t: u32, slot: i32) -> Result<()> {
     Ok(())
 }
 
-/// Given an owned source-array handle on top of the stack and a subscript list
-/// that slices / partially indexes it (any `WHOLEDIM`/`SLICE`, or fewer
-/// subscripts than the rank), build the per-axis spec and call `rt_array_slice`,
-/// leaving a fresh (owned) lower-rank sub-array handle. The source array and any
-/// `SLICE` index arrays are released. Returns `WTy::I32` (an array handle).
-fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
-    let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
-    let nspec = subs.len() as u32;
-
-    let arr_t = ctx.alloc_temp(WTy::I32);
-    ctx.emit(we::Instruction::LocalSet(arr_t));
-
-    // The spec is an Integer[2*nspec] array of (kind, value) pairs, one per axis:
-    // kind 0 INDEX (value = 1-based index), 1 WHOLE (value unused), 2 SLICE
-    // (value = handle to an Integer index array). Read by `rt_array_slice`.
+/// Build the per-axis spec `rt_array_slice` / `rt_array_indexed_assign` read: an
+/// `Integer[2*nspec]` of (kind, value) pairs, one pair per subscript. Returns the
+/// temps holding the spec and the owned SLICE index arrays; the caller releases
+/// both.
+fn emit_slice_spec(ctx: &mut FnCtx, subs: &[&Arc<DAE::Subscript>]) -> Result<(u32, Vec<u32>)> {
     let spec_t = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::I32Const(0)); // EK_INT
     ctx.emit(we::Instruction::I32Const(1)); // ndims
-    ctx.emit(we::Instruction::I32Const(2 * nspec as i32)); // total
+    ctx.emit(we::Instruction::I32Const(2 * subs.len() as i32)); // total
     ctx.emit(we::Instruction::Call(rt_index("rt_array_new")?));
     ctx.emit(we::Instruction::LocalSet(spec_t));
 
-    // SLICE index arrays are owned (a fresh range/array); release them after.
     let mut slice_idx_temps: Vec<u32> = Vec::new();
     for (ax, s) in subs.iter().enumerate() {
         let kind_slot = 2 * ax as i32 + 1;
@@ -7526,6 +7529,21 @@ fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Resul
             }
         }
     }
+    Ok((spec_t, slice_idx_temps))
+}
+
+/// Given an owned source-array handle on top of the stack and a subscript list
+/// that slices / partially indexes it (any `WHOLEDIM`/`SLICE`, or fewer
+/// subscripts than the rank), build the per-axis spec and call `rt_array_slice`,
+/// leaving a fresh (owned) lower-rank sub-array handle. The source array and any
+/// `SLICE` index arrays are released. Returns `WTy::I32` (an array handle).
+fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
+    let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
+    let nspec = subs.len() as u32;
+
+    let arr_t = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(arr_t));
+    let (spec_t, slice_idx_temps) = emit_slice_spec(ctx, &subs)?;
 
     // result = rt_array_slice(src, nspec, spec)
     ctx.emit(we::Instruction::LocalGet(arr_t));
@@ -7544,6 +7562,40 @@ fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Resul
 
     ctx.emit(we::Instruction::LocalGet(result_t));
     Ok(WTy::I32)
+}
+
+/// Slice assignment `a[i, :, lo:hi, …] := rhs`, written in place into the array
+/// in `arr_idx` (which privately owns its buffer, as for element assignment).
+/// The rhs is an array holding the selected positions in selection order;
+/// `rt_array_indexed_assign` copies it in, so the rhs reference is released.
+fn compile_slice_assign(
+    ctx: &mut FnCtx,
+    arr_idx: u32,
+    subs: &Arc<List<Arc<DAE::Subscript>>>,
+    rhs: RhsSource,
+) -> Result<()> {
+    let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
+    let nspec = subs.len() as u32;
+    let (spec_t, slice_idx_temps) = emit_slice_spec(ctx, &subs)?;
+
+    let src_t = ctx.alloc_temp(WTy::I32);
+    if rhs.push(ctx)? != WTy::I32 {
+        return Err("CodegenWasmJit: slice assignment rhs is not an array");
+    }
+    ctx.emit(we::Instruction::LocalSet(src_t));
+
+    ctx.emit(we::Instruction::LocalGet(arr_idx));
+    ctx.emit(we::Instruction::I32Const(nspec as i32));
+    ctx.emit(we::Instruction::LocalGet(spec_t));
+    ctx.emit(we::Instruction::LocalGet(src_t));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_indexed_assign")?));
+
+    release_temp_array(ctx, src_t)?;
+    for s_t in slice_idx_temps {
+        release_temp_array(ctx, s_t)?;
+    }
+    release_temp_array(ctx, spec_t)?;
+    Ok(())
 }
 
 /// Release an owned array handle held in scratch local `t`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -1127,6 +1127,78 @@ mod tests {
         assert_eq!((rf(&mut store, pick, 1), rf(&mut store, pick, 2)), (3.0, 1.0));
     }
 
+    /// `rt_array_indexed_assign` on a 3x3 Real matrix: a row lhs `m[2,:] :=
+    /// {40,50,60}`, a strided column lhs `m[:,3] := {70,80,90}`, and an
+    /// index-array lhs `m[1,{3,1}] := {11,12}` (the source is consumed in
+    /// selection order, so 11 lands in column 3).
+    #[test]
+    fn precompiled_runtime_array_indexed_assign() {
+        let (mut store, inst) = runtime_instance();
+        let mem = inst.exports.get_memory("memory").unwrap().clone();
+        let arr_new = inst.exports.get_typed_function::<(i32, i32, i32), i32>(&store, "rt_array_new").unwrap();
+        let set_dim = inst.exports.get_typed_function::<(i32, i32, i32), ()>(&store, "rt_array_set_dim").unwrap();
+        let elem_ptr = inst.exports.get_typed_function::<(i32, i32), i32>(&store, "rt_array_elem_ptr").unwrap();
+        let assign = inst
+            .exports
+            .get_typed_function::<(i32, i32, i32, i32), ()>(&store, "rt_array_indexed_assign")
+            .unwrap();
+
+        // m = [[1,2,3],[4,5,6],[7,8,9]] Real, row-major.
+        let m = arr_new.call(&mut store, 1, 2, 9).unwrap();
+        set_dim.call(&mut store, m, 0, 3).unwrap();
+        set_dim.call(&mut store, m, 1, 3).unwrap();
+        for k in 0..9 {
+            let addr = elem_ptr.call(&mut store, m, k + 1).unwrap() as usize;
+            mem.view(&store).write(addr as u64, &((k + 1) as f64).to_le_bytes()).unwrap();
+        }
+        let rf = |store: &mut Store, h: i32, k: i32| {
+            let addr = elem_ptr.call(&mut *store, h, k).unwrap() as usize;
+            let mut b = [0u8; 8];
+            mem.view(&*store).read(addr as u64, &mut b).unwrap();
+            f64::from_le_bytes(b)
+        };
+        let make_spec = |store: &mut Store, pairs: &[(i32, i32)]| -> i32 {
+            let s = arr_new.call(&mut *store, 0, 1, pairs.len() as i32 * 2).unwrap();
+            for (i, (k, v)) in pairs.iter().enumerate() {
+                let ka = elem_ptr.call(&mut *store, s, i as i32 * 2 + 1).unwrap() as usize;
+                mem.view(&*store).write(ka as u64, &k.to_le_bytes()).unwrap();
+                let va = elem_ptr.call(&mut *store, s, i as i32 * 2 + 2).unwrap() as usize;
+                mem.view(&*store).write(va as u64, &v.to_le_bytes()).unwrap();
+            }
+            s
+        };
+        let make_real_vec = |store: &mut Store, vals: &[f64]| -> i32 {
+            let v = arr_new.call(&mut *store, 1, 1, vals.len() as i32).unwrap();
+            set_dim.call(&mut *store, v, 0, vals.len() as i32).unwrap();
+            for (i, x) in vals.iter().enumerate() {
+                let a = elem_ptr.call(&mut *store, v, i as i32 + 1).unwrap() as usize;
+                mem.view(&*store).write(a as u64, &x.to_le_bytes()).unwrap();
+            }
+            v
+        };
+
+        let sp = make_spec(&mut store, &[(0, 2), (1, 0)]);
+        let v = make_real_vec(&mut store, &[40.0, 50.0, 60.0]);
+        assign.call(&mut store, m, 2, sp, v).unwrap();
+
+        let sp = make_spec(&mut store, &[(1, 0), (0, 3)]);
+        let v = make_real_vec(&mut store, &[70.0, 80.0, 90.0]);
+        assign.call(&mut store, m, 2, sp, v).unwrap();
+
+        let idx = arr_new.call(&mut store, 0, 1, 2).unwrap();
+        set_dim.call(&mut store, idx, 0, 2).unwrap();
+        for (k, i) in [3i32, 1].iter().enumerate() {
+            let a = elem_ptr.call(&mut store, idx, k as i32 + 1).unwrap() as usize;
+            mem.view(&store).write(a as u64, &i.to_le_bytes()).unwrap();
+        }
+        let sp = make_spec(&mut store, &[(0, 1), (2, idx)]);
+        let v = make_real_vec(&mut store, &[11.0, 12.0]);
+        assign.call(&mut store, m, 2, sp, v).unwrap();
+
+        let got: Vec<f64> = (1..=9).map(|k| rf(&mut store, m, k)).collect();
+        assert_eq!(got, vec![12.0, 2.0, 11.0, 40.0, 50.0, 80.0, 7.0, 8.0, 90.0]);
+    }
+
     /// `rt_array_cat` on Real arrays: a 1-D 3-way concat along dim 1, and a 2-D
     /// concat along dim 2 (strided copy into the result).
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -1127,6 +1127,77 @@ mod tests {
         assert_eq!((rf(&mut store, pick, 1), rf(&mut store, pick, 2)), (3.0, 1.0));
     }
 
+    /// `rt_array_indexed_assign` on a 3x3 Real matrix: a row lhs `m[2,:] :=
+    /// {40,50,60}`, a strided column lhs `m[:,3] := {70,80,90}`, and an
+    /// index-array lhs `m[1,{3,1}] := {11,12}` (the source is consumed in
+    /// selection order, so 11 lands in column 3).
+    #[test]
+    fn precompiled_runtime_array_indexed_assign() {
+        let (mut store, inst) = runtime_instance();
+        let mem = inst.get_memory(&mut store, "memory").unwrap();
+        let arr_new = inst.get_typed_func::<(i32, i32, i32), i32>(&mut store, "rt_array_new").unwrap();
+        let set_dim = inst.get_typed_func::<(i32, i32, i32), ()>(&mut store, "rt_array_set_dim").unwrap();
+        let elem_ptr = inst.get_typed_func::<(i32, i32), i32>(&mut store, "rt_array_elem_ptr").unwrap();
+        let assign = inst
+            .get_typed_func::<(i32, i32, i32, i32), ()>(&mut store, "rt_array_indexed_assign")
+            .unwrap();
+
+        // m = [[1,2,3],[4,5,6],[7,8,9]] Real, row-major.
+        let m = arr_new.call(&mut store, (1, 2, 9)).unwrap();
+        set_dim.call(&mut store, (m, 0, 3)).unwrap();
+        set_dim.call(&mut store, (m, 1, 3)).unwrap();
+        for k in 0..9 {
+            let addr = elem_ptr.call(&mut store, (m, k + 1)).unwrap() as usize;
+            mem.write(&mut store, addr, &((k + 1) as f64).to_le_bytes()).unwrap();
+        }
+        let rf = |store: &mut Store, h: i32, k: i32| {
+            let addr = elem_ptr.call(&mut *store, (h, k)).unwrap() as usize;
+            let mut b = [0u8; 8];
+            mem.read(&*store, addr, &mut b).unwrap();
+            f64::from_le_bytes(b)
+        };
+        let make_spec = |store: &mut Store, pairs: &[(i32, i32)]| -> i32 {
+            let s = arr_new.call(&mut *store, (0, 1, pairs.len() as i32 * 2)).unwrap();
+            for (i, (k, v)) in pairs.iter().enumerate() {
+                let ka = elem_ptr.call(&mut *store, (s, i as i32 * 2 + 1)).unwrap() as usize;
+                mem.write(&mut *store, ka, &k.to_le_bytes()).unwrap();
+                let va = elem_ptr.call(&mut *store, (s, i as i32 * 2 + 2)).unwrap() as usize;
+                mem.write(&mut *store, va, &v.to_le_bytes()).unwrap();
+            }
+            s
+        };
+        let make_real_vec = |store: &mut Store, vals: &[f64]| -> i32 {
+            let v = arr_new.call(&mut *store, (1, 1, vals.len() as i32)).unwrap();
+            set_dim.call(&mut *store, (v, 0, vals.len() as i32)).unwrap();
+            for (i, x) in vals.iter().enumerate() {
+                let a = elem_ptr.call(&mut *store, (v, i as i32 + 1)).unwrap() as usize;
+                mem.write(&mut *store, a, &x.to_le_bytes()).unwrap();
+            }
+            v
+        };
+
+        let sp = make_spec(&mut store, &[(0, 2), (1, 0)]);
+        let v = make_real_vec(&mut store, &[40.0, 50.0, 60.0]);
+        assign.call(&mut store, (m, 2, sp, v)).unwrap();
+
+        let sp = make_spec(&mut store, &[(1, 0), (0, 3)]);
+        let v = make_real_vec(&mut store, &[70.0, 80.0, 90.0]);
+        assign.call(&mut store, (m, 2, sp, v)).unwrap();
+
+        let idx = arr_new.call(&mut store, (0, 1, 2)).unwrap();
+        set_dim.call(&mut store, (idx, 0, 2)).unwrap();
+        for (k, i) in [3i32, 1].iter().enumerate() {
+            let a = elem_ptr.call(&mut store, (idx, k as i32 + 1)).unwrap() as usize;
+            mem.write(&mut store, a, &i.to_le_bytes()).unwrap();
+        }
+        let sp = make_spec(&mut store, &[(0, 1), (2, idx)]);
+        let v = make_real_vec(&mut store, &[11.0, 12.0]);
+        assign.call(&mut store, (m, 2, sp, v)).unwrap();
+
+        let got: Vec<f64> = (1..=9).map(|k| rf(&mut store, m, k)).collect();
+        assert_eq!(got, vec![12.0, 2.0, 11.0, 40.0, 50.0, 80.0, 7.0, 8.0, 90.0]);
+    }
+
     /// `rt_array_cat` on Real arrays: a 1-D 3-way concat along dim 1, and a 2-D
     /// concat along dim 2 (strided copy into the result).
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -539,20 +539,108 @@ pub extern "C" fn rt_array_release(obj: u32) {
     rt_free(obj);
 }
 
+const SPEC_INDEX: u32 = 0;
+const SPEC_WHOLE: u32 = 1;
+
+/// Per-axis view of a subscript spec: an Integer array of `2 * nspec` words
+/// describing the first `nspec` axes (0-based) of the array it applies to.
+/// `spec[2*s]` is the axis kind and `spec[2*s+1]` its value —
+///   * 0 INDEX: value is the fixed 1-based index; the axis selects one position
+///     and is dropped from a slice's result (rank-reducing).
+///   * 1 WHOLE: value unused; the axis is kept at full size.
+///   * 2 SLICE: value is a handle to an Integer array of 1-based indices; the
+///     axis is kept, sized to that array's length.
+/// Axes at or past `nspec` are WHOLE (a trailing `a[i]` on a matrix).
+struct SliceSpec {
+    nspec: u32,
+    data: u32,
+}
+
+impl SliceSpec {
+    fn new(nspec: u32, spec: u32) -> SliceSpec {
+        SliceSpec { nspec, data: arr_data(spec) }
+    }
+
+    fn kind(&self, axis: u32) -> u32 {
+        if axis < self.nspec { unsafe { load_u32(self.data + 2 * axis * 4) } } else { SPEC_WHOLE }
+    }
+
+    fn val(&self, axis: u32) -> u32 {
+        if axis < self.nspec { unsafe { load_u32(self.data + (2 * axis + 1) * 4) } } else { 0 }
+    }
+
+    /// How many positions of `arr`'s `axis` (0-based) the spec selects.
+    fn axis_len(&self, arr: u32, axis: u32) -> u32 {
+        match self.kind(axis) {
+            SPEC_INDEX => 1,
+            SPEC_WHOLE => rt_array_dim(arr, axis as i32 + 1),
+            _ => rt_array_total(self.val(axis)),
+        }
+    }
+
+    /// The 0-based coordinate of the `pos`-th selected position of `axis`.
+    fn coord(&self, axis: u32, pos: u32) -> u32 {
+        match self.kind(axis) {
+            SPEC_INDEX => self.val(axis) - 1,
+            SPEC_WHOLE => pos,
+            _ => (unsafe { load_u32(arr_data(self.val(axis)) + pos * 4) }) - 1,
+        }
+    }
+}
+
+/// The row-major linear indices into `arr` of every position `spec` selects, in
+/// selection order. Returns the scratch holding them and their count; the caller
+/// frees it. An out-of-range index is a model error (C asserts) and is clamped
+/// so the caller's copy stays in bounds.
+fn spec_positions(arr: u32, spec: &SliceSpec) -> (u32, u32) {
+    let ndims = rt_array_ndims(arr);
+    let arr_total = rt_array_total(arr);
+    let mut count = 1u32;
+    for axis in 0..ndims {
+        count *= spec.axis_len(arr, axis);
+    }
+    if arr_total == 0 {
+        if count != 0 {
+            nls::model_error();
+        }
+        return (rt_alloc(0), 0);
+    }
+
+    let out = rt_alloc(count * 4);
+    let pos = rt_alloc(ndims * 4);
+    unsafe { core::ptr::write_bytes(pos as *mut u8, 0, (ndims * 4) as usize) };
+    for i in 0..count {
+        let mut lin = 0u32;
+        for axis in 0..ndims {
+            let p = unsafe { load_u32(pos + axis * 4) };
+            lin = lin * rt_array_dim(arr, axis as i32 + 1) + spec.coord(axis, p);
+        }
+        if lin >= arr_total {
+            nls::model_error();
+            lin = arr_total - 1;
+        }
+        unsafe { store_u32(out + i * 4, lin) };
+        // Advance the per-axis position vector, last axis fastest.
+        let mut axis = ndims;
+        while axis > 0 {
+            axis -= 1;
+            let p = unsafe { load_u32(pos + axis * 4) } + 1;
+            if p < spec.axis_len(arr, axis) {
+                unsafe { store_u32(pos + axis * 4, p) };
+                break;
+            }
+            unsafe { store_u32(pos + axis * 4, 0) };
+        }
+    }
+    rt_free(pos);
+    (out, count)
+}
+
 /// Slice / partial-index a source array into a fresh (refcount-1) array, the
 /// runtime counterpart of `a[i, :, lo:hi, ...]` on an array whose dimensions
 /// are not known at codegen time (constant-dimension slices are scalarized by
-/// the frontend and lowered element-by-element instead).
-///
-/// `spec` is an Integer array of `2 * nspec` words describing the first `nspec`
-/// source axes (0-based): `spec[2*s]` is the axis kind and `spec[2*s+1]` its
-/// value —
-///   * kind 0 = INDEX  → value is the fixed 1-based index; the axis is dropped
-///     from the result (rank-reducing).
-///   * kind 1 = WHOLE  → value unused; the axis is kept at full size.
-///   * kind 2 = SLICE  → value is a handle to an Integer array of 1-based
-///     indices; the axis is kept, sized to that index array's length.
-/// Source axes `>= nspec` are treated as WHOLE (trailing `a[i]` on a matrix).
+/// the frontend and lowered element-by-element instead). `spec` is a
+/// [`SliceSpec`] over the source axes.
 ///
 /// The result's element kind matches the source; heap elements are deep-copied
 /// (`copy_kind`, matching `rt_array_copy`) so the slice shares no mutable
@@ -562,99 +650,31 @@ pub extern "C" fn rt_array_release(obj: u32) {
 pub extern "C" fn rt_array_slice(src: u32, nspec: u32, spec: u32) -> u32 {
     let kind = unsafe { load_u32(src + ARR_KIND_OFF) };
     let src_ndims = rt_array_ndims(src);
-    let spec_data = arr_data(spec);
-    // Per-source-axis kind/value, with axes past `nspec` defaulting to WHOLE.
-    let ax_kind = |s: u32| -> u32 {
-        if s < nspec { unsafe { load_u32(spec_data + (2 * s) * 4) } } else { 1 }
-    };
-    let ax_val = |s: u32| -> u32 {
-        if s < nspec { unsafe { load_u32(spec_data + (2 * s + 1) * 4) } } else { 0 }
-    };
+    let spec = SliceSpec::new(nspec, spec);
+    let (positions, total) = spec_positions(src, &spec);
 
-    // Result rank/shape: one axis per kept (WHOLE/SLICE) source axis.
+    // Result shape: one axis per kept (WHOLE/SLICE) source axis.
     let mut res_ndims = 0u32;
-    let mut res_total = 1u32;
     for s in 0..src_ndims {
-        match ax_kind(s) {
-            0 => {} // INDEX: dropped
-            1 => {
-                res_total *= rt_array_dim(src, s as i32 + 1);
-                res_ndims += 1;
-            }
-            _ => {
-                res_total *= rt_array_total(ax_val(s)); // SLICE index-array length
-                res_ndims += 1;
-            }
+        if spec.kind(s) != SPEC_INDEX {
+            res_ndims += 1;
         }
     }
-    let result = rt_array_new(kind, res_ndims, res_total);
-    {
-        let mut rk = 0u32;
-        for s in 0..src_ndims {
-            match ax_kind(s) {
-                0 => {}
-                1 => {
-                    rt_array_set_dim(result, rk, rt_array_dim(src, s as i32 + 1));
-                    rk += 1;
-                }
-                _ => {
-                    rt_array_set_dim(result, rk, rt_array_total(ax_val(s)));
-                    rk += 1;
-                }
-            }
-        }
-    }
-
-    // Scratch: 0-based source coordinate per source axis (INDEX axes fixed once)
-    // followed by the result coordinate per result axis (recomputed per element).
-    let scratch = rt_alloc((src_ndims + res_ndims) * 4);
-    let src_coord = scratch;
-    let res_coord = scratch + src_ndims * 4;
+    let result = rt_array_new(kind, res_ndims, total);
+    let mut rk = 0u32;
     for s in 0..src_ndims {
-        let c = if ax_kind(s) == 0 { ax_val(s) - 1 } else { 0 };
-        unsafe { store_u32(src_coord + s * 4, c) };
+        if spec.kind(s) != SPEC_INDEX {
+            rt_array_set_dim(result, rk, spec.axis_len(src, s));
+            rk += 1;
+        }
     }
 
     let stride = elem_stride(kind);
     let src_base = arr_data(src);
     let dst_base = arr_data(result);
     let heap = matches!(kind, EK_STR | EK_ARRAY | EK_RECORD);
-    for r in 0..res_total {
-        // Decompose `r` into per-result-axis coordinates (row-major).
-        let mut rem = r;
-        let mut rk = res_ndims;
-        while rk > 0 {
-            rk -= 1;
-            let d = unsafe { load_u32(result + ARR_DIMS_OFF + rk * 4) };
-            unsafe { store_u32(res_coord + rk * 4, rem % d) };
-            rem /= d;
-        }
-        // Map result coordinates back onto the source axes.
-        let mut rk = 0u32;
-        for s in 0..src_ndims {
-            match ax_kind(s) {
-                0 => {} // fixed
-                1 => {
-                    let c = unsafe { load_u32(res_coord + rk * 4) };
-                    unsafe { store_u32(src_coord + s * 4, c) };
-                    rk += 1;
-                }
-                _ => {
-                    let idx_arr = ax_val(s);
-                    let pos = unsafe { load_u32(res_coord + rk * 4) };
-                    // SLICE index array holds 1-based source indices (Integer).
-                    let one_based = unsafe { load_u32(arr_data(idx_arr) + pos * 4) };
-                    unsafe { store_u32(src_coord + s * 4, one_based - 1) };
-                    rk += 1;
-                }
-            }
-        }
-        // Row-major source linear index from the source coordinates.
-        let mut lin = 0u32;
-        for s in 0..src_ndims {
-            lin = lin * rt_array_dim(src, s as i32 + 1) + unsafe { load_u32(src_coord + s * 4) };
-        }
-        let sp = src_base + lin * stride;
+    for r in 0..total {
+        let sp = src_base + unsafe { load_u32(positions + r * 4) } * stride;
         let dp = dst_base + r * stride;
         unsafe {
             core::ptr::copy_nonoverlapping(sp as *const u8, dp as *mut u8, stride as usize);
@@ -664,8 +684,47 @@ pub extern "C" fn rt_array_slice(src: u32, nspec: u32, spec: u32) -> u32 {
         }
     }
 
-    rt_free(scratch);
+    rt_free(positions);
     result
+}
+
+/// Indexed assignment `dst[i, :, lo:hi, ...] := src` — C's
+/// `indexed_assign_<type>_array`. `src` supplies the positions [`SliceSpec`]
+/// selects, in selection order, and must hold exactly that many elements.
+///
+/// `dst` is written in place; an overwritten heap element is released and the
+/// new one deep-copied (`copy_kind`) for value semantics. `src` and the SLICE
+/// index arrays are read only — the caller still owns and releases them.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_array_indexed_assign(dst: u32, nspec: u32, spec: u32, src: u32) {
+    let kind = unsafe { load_u32(dst + ARR_KIND_OFF) };
+    let spec = SliceSpec::new(nspec, spec);
+    let (positions, count) = spec_positions(dst, &spec);
+    if count != rt_array_total(src) {
+        rt_free(positions);
+        nls::model_error();
+        return;
+    }
+
+    let stride = elem_stride(kind);
+    let src_base = arr_data(src);
+    let dst_base = arr_data(dst);
+    let heap = matches!(kind, EK_STR | EK_ARRAY | EK_RECORD);
+    for r in 0..count {
+        let sp = src_base + r * stride;
+        let dp = dst_base + unsafe { load_u32(positions + r * 4) } * stride;
+        unsafe {
+            if heap {
+                release_kind(kind, load_u32(dp));
+            }
+            core::ptr::copy_nonoverlapping(sp as *const u8, dp as *mut u8, stride as usize);
+            if heap {
+                store_u32(dp, copy_kind(kind, load_u32(dp)));
+            }
+        }
+    }
+
+    rt_free(positions);
 }
 
 /// Concatenate `n` arrays along dimension `dim` (1-based) into a fresh


### PR DESCRIPTION
`Modelica.Blocks.Examples.Noise.ImpureGenerator` failed to build with "non-scalar subscript (slicing not supported)". It reaches `Random.Utilities.initialStateWithXorshift64star`, which assigns to a sliced lhs (`state[1:2] := aux`); the state vector is sized from a function input, so the frontend cannot scalarize the subscripts.

Slice *reads* went through `rt_array_slice`, but every assignment site called `index_subscripts`, which rejects anything that is not one INDEX per dimension. Add the missing direction, mirroring the C runtime's `indexed_assign_<type>_array`:

| runtime | `rt_array_indexed_assign(dst, nspec, spec, src)` | | --- | --- |
| codegen | `compile_slice_assign` over a shared `emit_slice_spec` |

The per-axis spec walking in `rt_array_slice` is factored into a `SliceSpec` view plus `spec_positions`, which yields the linear indices of the selected positions in selection order — the order both a read and an assignment see the elements in, matching C's `next_index` / `calc_base_index_spec`. Both entry points now share it.

An out-of-range index or an arity mismatch raises a model error where C asserts, instead of walking off the array; that also closes an unchecked index on the existing read path.

Codegen gates all four assignment sites on `is_scalar_index`: a plain local, a record field, and both tuple-assignment targets.

Verified against the C target: ImpureGenerator and a model covering range slices, index-array slices, `m[i,:]` / `m[:,j]` / partial `m[i]`, String elements, sliced tuple targets and record fields all match with no differing variables.