### PR TITLE
wasm-jit: implement the missing runtime flags

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -705,6 +705,36 @@ fn split_simflags(s: &str) -> Vec<String> {
     out
 }
 
+/// This run's scalars, and what `read_experiment` printed getting them — captured
+/// separately because C prints it ahead of every other startup notice.
+fn run_experiment(model: &SimModel, flags: &simflags::SimFlags) -> (SimMeta, String) {
+    openmodelica_wasi::wasi::start_stdout_capture();
+    let meta = model.meta.with_flags(flags);
+    (meta, openmodelica_wasi::wasi::take_stdout_capture())
+}
+
+/// C's `initializeResultData`: the formats this runtime has a writer for, over the
+/// model's own `outputFormat` as `-outputFormat` may have replaced it.
+fn check_output_format(meta: &SimMeta) -> std::result::Result<(), String> {
+    match meta.output_format.as_str() {
+        "mat" | "empty" => Ok(()),
+        other => Err(format!(
+            "CodegenWasmJit: this runtime writes `mat` results, or `empty` for none (got `{other}`)"
+        )),
+    }
+}
+
+/// C's result-file resolution (`simulation_runtime.cpp`): `-r` outright, else
+/// `<prefix>_res.<format>` under `-outputPath`, else what the caller derived from
+/// the model.
+fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> String {
+    match (&flags.result_file, &flags.output_path) {
+        (Some(r), _) => r.clone(),
+        (None, Some(dir)) => format!("{dir}/{}_res.{}", meta.prefix, meta.output_format),
+        (None, None) => derived.to_string(),
+    }
+}
+
 /// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
 /// Unknown names are skipped (an unknown override is a no-op, as in the C runtime).
 /// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
@@ -712,14 +742,19 @@ fn split_simflags(s: &str) -> Vec<String> {
 ///
 /// `-iif=<file>` contributes first, so an explicit `-override` of the same quantity
 /// wins — C skips whatever `isQuantityOverridden` reports (ticket #15807).
-fn resolve_overrides(model: &SimModel, flags: &simflags::SimFlags) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
+fn resolve_overrides(
+    model: &SimModel,
+    meta: &SimMeta,
+    flags: &simflags::SimFlags,
+) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
     let mut params = Vec::new();
     let mut starts = Vec::new();
     let mut push = |p: &EditableParam, v: f64, params: &mut Vec<_>, starts: &mut Vec<_>| {
         if p.is_start { starts } else { params }.push((p.off, p.wty, v));
     };
     if let Some(file) = &flags.init_file {
-        for (p, v) in import_start_values(model, file, &flags.overrides) {
+        let t = flags.init_time.unwrap_or(meta.start_time);
+        for (p, v) in import_start_values(model, file, t, &flags.overrides) {
             push(p, v, &mut params, &mut starts);
         }
     }
@@ -731,12 +766,14 @@ fn resolve_overrides(model: &SimModel, flags: &simflags::SimFlags) -> (Vec<(u32,
     (params, starts)
 }
 
-/// C's `importStartValues`: every quantity the file names, at the start time,
-/// except the overridden ones. C sets the `start` attribute of every variable;
-/// reachable here are the editable parameters and state start values.
+/// C's `importStartValues`: every quantity the file names, at `t0` (`-iit`, the
+/// start time by default), except the overridden ones. C sets the `start` attribute
+/// of every variable; reachable here are the editable parameters and state start
+/// values.
 fn import_start_values<'a>(
     model: &'a SimModel,
     file: &str,
+    t0: f64,
     overrides: &[(String, f64)],
 ) -> Vec<(&'a EditableParam, f64)> {
     let mut reader = match openmodelica_script_util::SimulationResults::read_matlab4::MatReader::open(file) {
@@ -746,7 +783,6 @@ fn import_start_values<'a>(
             return Vec::new();
         }
     };
-    let t0 = model.meta.start_time;
     model
         .editable_params
         .iter()
@@ -811,25 +847,24 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
             String::new(),
         );
     }
-    let (param_ov, start_ov) = resolve_overrides(&model, &flags);
+    INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
+    sim_driver::set_init_done_hook(on_init_done);
+    SPLIT_ARMED.with(|a| a.set(true));
+    sim_driver::init_host_hooks();
+    let (meta, experiment_log) = run_experiment(&model, &flags);
+    openmodelica_wasi::wasi::start_stdout_capture();
+    let (param_ov, start_ov) = resolve_overrides(&model, &meta, &flags);
     sim_driver::set_param_overrides(param_ov, start_ov);
     // `-abortSlowSimulation`: stop the run when chattering is detected.
     sim_driver::set_abort_slow(flags.abort_slow);
     // The hard `-alarm`, if asked for: set before the modules are instantiated.
     sim_runtime::set_alarm(flags.alarm);
-    INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
-    sim_driver::set_init_done_hook(on_init_done);
-    SPLIT_ARMED.with(|a| a.set(true));
-    openmodelica_wasi::wasi::start_stdout_capture();
     let mut extra = String::new();
     let res = (|| -> std::result::Result<(), String> {
-        // `empty` runs the integration but writes no result file — useful for
-        // benchmarking the solver in isolation from the `.mat` writer.
-        let fmt = model.output_format.as_str();
-        if fmt != "mat" && fmt != "empty" {
-            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)".to_string());
-        }
-        let run = sim_runtime::run(&model)?;
+        // `empty` (and `-noemit`) runs the integration but writes no result file —
+        // useful for benchmarking the solver in isolation from the `.mat` writer.
+        check_output_format(&meta)?;
+        let run = sim_runtime::run(&model, &meta)?;
         // C's `finishSimulation` prints these ahead of the LOG_STATS block.
         if !flags.output_vars.is_empty() {
             extra.push_str(&write_output_vars(&model, &run, &flags.output_vars));
@@ -839,10 +874,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         }
         let keep = output_selection(&model);
         capture_last_sim(&model, &run, &keep);
-        if fmt == "mat" {
-            // C's `-r=<file>` overrides the name the caller derived from the model.
-            let out = flags.result_file.as_deref().unwrap_or(result_file);
-            write_mat4(&model, out, &run.rows, run.n_reals, &run.params, &keep)?;
+        if meta.output_format == "mat" {
+            write_mat4(&model, &meta, &result_path(&flags, &meta, result_file), &run.rows, run.n_reals, &run.params, &keep)?;
         }
         Ok(())
     })();
@@ -854,7 +887,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
     // C prints the sparse-solver announcements (initializeLinear/NonlinearSystems)
     // ahead of the init-success line; prepend our pre-rendered copy to the init output.
-    let head = format!("{}{}", flag_change_log(&flags), sparse_solver_log(&model, &flags));
+    let head =
+        format!("{experiment_log}{}{}", flag_change_log(&flags), sparse_solver_log(&model, &flags));
     let init_output = if head.is_empty() {
         init_output
     } else {
@@ -915,6 +949,8 @@ mod session {
     /// per process).
     pub(super) struct SimSession {
         model: Arc<SimModel>,
+        /// This run's scalars: the model's metadata with the run's flags applied.
+        meta: SimMeta,
         result_file: String,
         backend: SessionBackend,
         /// Wall-clock inside `advance`, summed over chunks: excludes the yields
@@ -967,11 +1003,16 @@ mod session {
     }
 
     /// Capture results for the `omc_sim_*` getters and write the `.mat`.
-    fn finalize_and_capture(model: &SimModel, result_file: &str, run: &sim_driver::RunResult) -> Result<()> {
+    fn finalize_and_capture(
+        model: &SimModel,
+        meta: &SimMeta,
+        result_file: &str,
+        run: &sim_driver::RunResult,
+    ) -> Result<()> {
         let keep = output_selection(model);
         capture_last_sim(model, run, &keep);
-        if model.output_format == "mat" {
-            write_mat4(model, result_file, &run.rows, run.n_reals, &run.params, &keep)?;
+        if meta.output_format == "mat" {
+            write_mat4(model, meta, result_file, &run.rows, run.n_reals, &run.params, &keep)?;
         }
         Ok(())
     }
@@ -987,16 +1028,10 @@ mod session {
             .get(prefix)
             .cloned()
             .ok_or_else(|| "no prepared wasm-jit model for (translateModel not run?)")?;
-        let fmt = model.output_format.as_str();
-        if fmt != "mat" && fmt != "empty" {
-            return Err("CodegenWasmJit: only the `mat` and `empty` output formats are supported (got)");
-        }
         let flags = install_sim_flags(simflags).map_err(|e| {
             record_error(format!("wasm-jit: {e}"));
             "CodegenWasmJit: unusable simulation flags"
         })?;
-        let (param_ov, start_ov) = resolve_overrides(&model, &flags);
-        sim_driver::set_param_overrides(param_ov, start_ov);
         sim_driver::clear_cancel();
         // Split init from simulation output as `run_simulation_inner` does; the
         // hook fires while the backend below is built, which is what initializes.
@@ -1004,7 +1039,15 @@ mod session {
         INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
         sim_driver::set_init_done_hook(on_init_done);
         SPLIT_ARMED.with(|a| a.set(true));
+        sim_driver::init_host_hooks();
+        let (meta, experiment_log) = run_experiment(&model, &flags);
+        check_output_format(&meta).map_err(|e| {
+            record_error(e);
+            "CodegenWasmJit: unsupported output format"
+        })?;
         openmodelica_wasi::wasi::start_stdout_capture();
+        let (param_ov, start_ov) = resolve_overrides(&model, &meta, &flags);
+        sim_driver::set_param_overrides(param_ov, start_ov);
         // Build the backend (instantiate, init, emit row 0). An init trap is usually
         // a failed `assert()`; the host driver routes it via `enrich_trap`.
         let inwasm = inwasm_driver_enabled();
@@ -1012,10 +1055,9 @@ mod session {
             if inwasm {
                 Ok(SessionBackend::InWasm(sim_runtime::build_inwasm_session(&model)?))
             } else {
-                let (mut engine, sim_data) = sim_runtime::build_engine(&model)?;
-                let made =
-                    sim_driver::make_driver(&mut *engine, &model.meta, sim_data, model.method.as_str())
-                        .map_err(|err| sim_driver::enrich_trap_init(&mut *engine, err, model.start_time));
+                let (mut engine, sim_data) = sim_runtime::build_engine(&model, &meta)?;
+                let made = sim_driver::make_driver(&mut *engine, &meta, sim_data, meta.method.as_str())
+                    .map_err(|err| sim_driver::enrich_trap_init(&mut *engine, err, meta.start_time));
                 let (driver, _label) = match made {
                     Ok(v) => v,
                     Err(e) => {
@@ -1029,7 +1071,7 @@ mod session {
         SPLIT_ARMED.with(|a| a.set(false));
         let flags = simflags::flags();
         let init_log = format!(
-            "{}{}{}",
+            "{experiment_log}{}{}{}",
             flag_change_log(&flags),
             sparse_solver_log(&model, &flags),
             INIT_OUTPUT.with(|c| c.borrow_mut().take()).unwrap_or_default()
@@ -1045,7 +1087,8 @@ mod session {
         SIM_SESSION.with(|s| {
             *s.borrow_mut() = Some(SimSession {
                 model,
-                result_file: result_file.to_string(),
+                result_file: result_path(&flags, &meta, result_file),
+                meta,
                 backend,
                 integrate_ms: 0.0,
                 log: init_log,
@@ -1069,6 +1112,7 @@ mod session {
             let model = sess.model.clone();
             let result_file = sess.result_file.clone();
             let log_stats = sess.log_stats;
+            let n_intervals = sess.meta.n_intervals;
             // Stopped before the finalize/`.mat` work in each arm below.
             let mut adv_ms = 0.0f64;
             // Filled by whichever arm finishes the run, appended to the log below.
@@ -1080,21 +1124,21 @@ mod session {
                 SessionBackend::Host { engine, driver, sim_data } => {
                     let t = sim_driver::now_ms_host();
                     let advanced = driver
-                        .advance(&mut **engine, &model.meta, budget_ms)
+                        .advance(&mut **engine, &sess.meta, budget_ms)
                         .map_err(|err| sim_driver::enrich_trap(&mut **engine, err));
                     adv_ms = sim_driver::now_ms_host() - t;
                     match advanced {
                         Ok(sim_driver::Advance::Running) => Ok(SimStatus::Running),
                         Ok(sim_driver::Advance::Cancelled) => {
                             // Free external objects so the cancelled run leaks nothing.
-                            let _ = sim_driver::finalize_run(&mut **engine, &model.meta, *sim_data);
+                            let _ = sim_driver::finalize_run(&mut **engine, &sess.meta, *sim_data);
                             Ok(SimStatus::Cancelled)
                         }
                         Ok(done) => {
                             let rows = driver.take_rows();
                             let mut stats = SolveStats::default();
-                            driver.fill_stats(&model.meta, &mut stats);
-                            let params = sim_driver::finalize_run(&mut **engine, &model.meta, *sim_data)?;
+                            driver.fill_stats(&sess.meta, &mut stats);
+                            let params = sim_driver::finalize_run(&mut **engine, &sess.meta, *sim_data)?;
                             let run = sim_driver::RunResult {
                                 rows,
                                 n_reals: model.layout.n_row_total(),
@@ -1104,7 +1148,7 @@ mod session {
                             if log_stats {
                                 stats_block = log_stats_block(&run.stats);
                             }
-                            finalize_and_capture(&model, &result_file, &run)?;
+                            finalize_and_capture(&model, &sess.meta, &result_file, &run)?;
                             Ok(if matches!(done, sim_driver::Advance::Terminated) {
                                 SimStatus::Terminated
                             } else {
@@ -1127,7 +1171,7 @@ mod session {
                             if log_stats {
                                 stats_block = log_stats_block(&run.stats);
                             }
-                            finalize_and_capture(&model, &result_file, &run)?;
+                            finalize_and_capture(&model, &sess.meta, &result_file, &run)?;
                             Ok(if rc == 2 { SimStatus::Terminated } else { SimStatus::Done })
                         }
                         Err(e) => Err(e),
@@ -1151,7 +1195,7 @@ mod session {
                         eprintln!(
                             "wasm-jit session [{}]: integrate {integrate_ms:.1} ms ({} intervals)",
                             if inwasm_driver_enabled() { "in-wasm" } else { "host" },
-                            model.n_intervals,
+                            n_intervals,
                         );
                     }
                     publish_log(run_log.unwrap_or_default());
@@ -1176,9 +1220,9 @@ mod session {
                 // Cancel path: end the capture, keeping what was printed.
                 publish_log(core::mem::take(&mut sess.log));
                 // The in-wasm session frees itself on `Drop` (`rt_sim_free`).
-                let SimSession { model, backend, .. } = &mut sess;
+                let SimSession { meta, backend, .. } = &mut sess;
                 if let SessionBackend::Host { engine, sim_data, .. } = backend {
-                    let _ = sim_driver::finalize_run(&mut **engine, &model.meta, *sim_data);
+                    let _ = sim_driver::finalize_run(&mut **engine, meta, *sim_data);
                 }
             }
         });
@@ -3670,16 +3714,15 @@ fn collect_nls_systems(sim_code: &SimCode::SimCode) -> Vec<(i32, i32, u32, u32)>
 
 /// C's `LOG_STDOUT` "… changed to …" lines, ahead of everything the run prints.
 fn flag_change_log(flags: &simflags::SimFlags) -> String {
+    use openmodelica_modelica_utilities::{LOG_STDOUT_INFO, LOG_STDOUT_WARNING};
     let mut out = String::new();
-    if let Some(d) = flags.nlss_max_density {
-        out.push_str(&format_log_stdout(&format!(
-            "Maximum density for using non-linear sparse solver changed to {d:.6}"
-        )));
-    }
-    if let Some(n) = flags.nlss_min_size {
-        out.push_str(&format_log_stdout(&format!(
-            "Minimum system size for using non-linear sparse solver changed to {n}"
-        )));
+    for (ty, msg) in simflags::notices(flags) {
+        let prefix = if ty == openmodelica_sim_meta::omclog::WARNING {
+            LOG_STDOUT_WARNING
+        } else {
+            LOG_STDOUT_INFO
+        };
+        out.push_str(&openmodelica_modelica_utilities::format_log_stdout(&msg, prefix));
     }
     out
 }
@@ -5943,6 +5986,7 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>
 /// result-var metadata onto its `MatVar`/`MatKind` and write the bytes out.
 fn write_mat4(
     model: &SimModel,
+    meta: &SimMeta,
     path: &str,
     rows: &[f64],
     n_reals: u32,
@@ -5975,7 +6019,7 @@ fn write_mat4(
         });
     }
     let bytes =
-        openmodelica_mat_writer::write_mat4(&vars, model.start_time, model.stop_time, rows, n_reals, &kept_params);
+        openmodelica_mat_writer::write_mat4(&vars, meta.start_time, meta.stop_time, rows, n_reals, &kept_params);
     let _ = &model.model_name; // (kept for diagnostics)
     write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -183,12 +183,17 @@ const SQRT_EPS: f64 = 1.4901161193847656e-08;
 const FD_DELTA: f64 = 6.664001874625056e-08;
 /// Newton/LM convergence tolerance: stop once a residual / step measure drops below.
 const NEWTON_EPS: f64 = 1.0e-6;
-/// C's `newtonFTol`/`newtonXTol` (nonlinearSolverHomotopy.c). `newton_solve`
-/// mirrors C's residual-gated convergence: a step-stall counts as success only
-/// when the residual is also small (`< NEWTON_FTOL*1e3`), else it fails so the
-/// homotopy globaliser engages instead of accepting a non-root.
-const NEWTON_FTOL: f64 = 1.0e-12;
-const NEWTON_XTOL: f64 = 1.0e-12;
+/// C's `newtonFTol`/`newtonXTol` (nonlinearSolverHomotopy.c), which `-newtonFTol` /
+/// `-newtonXTol` move. `newton_solve` mirrors C's residual-gated convergence: a
+/// step-stall counts as success only when the residual is also small
+/// (`< ftol*1e3`), else it fails so the homotopy globaliser engages instead of
+/// accepting a non-root.
+fn newton_ftol() -> f64 {
+    crate::solvers::newton_ftol()
+}
+fn newton_xtol() -> f64 {
+    crate::solvers::newton_xtol()
+}
 const MAX_ITER: i32 = 100;
 /// Line-search damping floor (2^-10): below this, keep the small step and let the
 /// outer iteration retry (or hit the iteration limit → recoverable failure).
@@ -558,7 +563,7 @@ fn homotopy_solve(
 
         // ---- Corrector: Newton with coordinate `pos` fixed ----
         let last_step = y1[n] >= 1.0;
-        let h_eps = if last_step { NEWTON_FTOL } else { H_EPS };
+        let h_eps = if last_step { newton_ftol() } else { H_EPS };
         let mut pos = if last_step { n as i32 } else { tangent_pos };
         let mut step_accept = false;
         let mut corrector_ok = true;
@@ -672,7 +677,7 @@ pub(crate) fn newton_solve(
 
     eval(x, &mut fvec);
     let mut error_f = enorm(&fvec);
-    if error_f < NEWTON_FTOL {
+    if error_f < newton_ftol() {
         return true;
     }
     f_old.copy_from_slice(&fvec);
@@ -758,15 +763,16 @@ pub(crate) fn newton_solve(
         if neg_steps > 20 {
             return false;
         }
-        let f_small = error_f < NEWTON_FTOL || scaled_error_f < NEWTON_FTOL;
-        let x_small = delta_x < NEWTON_XTOL || delta_x_scaled < NEWTON_XTOL;
+        let (ftol, xtol) = (newton_ftol(), newton_xtol());
+        let f_small = error_f < ftol || scaled_error_f < ftol;
+        let x_small = delta_x < xtol || delta_x_scaled < xtol;
         if f_small && x_small {
             return true;
         }
-        small_steps += (delta_x < NEWTON_XTOL * 100.0 || delta_x_scaled < NEWTON_XTOL * 100.0) as i32;
+        small_steps += (delta_x < xtol * 100.0 || delta_x_scaled < xtol * 100.0) as i32;
         if x_small || small_steps > 20 {
             // Stalled step: accept only with a small residual (C's ftol*1e3), else fail.
-            return error_f < NEWTON_FTOL * 1.0e3 || scaled_error_f < NEWTON_FTOL * 1.0e3;
+            return error_f < ftol * 1.0e3 || scaled_error_f < ftol * 1.0e3;
         }
         iter += 1;
         if iter > MAX_ITER {
@@ -1566,8 +1572,8 @@ fn newton_c(
 ) -> (bool, bool) {
     const ALPHA: f64 = 1.0e-1;
     const LAMBDA_MIN_C: f64 = 1.0e-4;
-    let ftol_sq = NEWTON_FTOL * NEWTON_FTOL;
-    let xtol_sq = NEWTON_XTOL * NEWTON_XTOL;
+    let ftol_sq = newton_ftol() * newton_ftol();
+    let xtol_sq = newton_xtol() * newton_xtol();
     let nsq = |v: &[f64]| -> f64 {
         let e = enorm(v);
         e * e
@@ -2147,11 +2153,9 @@ fn solve_newton_c(
     }
 }
 
-/// KINSOL function-norm / scaled-step stopping tolerances (C's `newtonFTol` /
-/// `newtonXTol`, `model_help.c`) and the norm below which C accepts a less
-/// accurate solution rather than failing (`FTOL_WITH_LESS_ACCURACY`).
-const KIN_FNORMTOL: f64 = 1.0e-12;
-const KIN_SCSTEPTOL: f64 = 1.0e-12;
+/// The norm below which C accepts a less accurate solution rather than failing
+/// (`FTOL_WITH_LESS_ACCURACY`). KINSOL's own stopping tolerances are C's
+/// `newtonFTol`/`newtonXTol`, i.e. [`newton_ftol`]/[`newton_xtol`].
 const KIN_FTOL_LESS_ACCURACY: f64 = 1.0e-6;
 
 /// `‖diag(scale)·v‖∞`, the norm KINSOL's stopping tests use.
@@ -2289,7 +2293,7 @@ fn newton_sparse_solve(
             if !fnorm.is_finite() {
                 break;
             }
-            if fnorm <= KIN_FNORMTOL {
+            if fnorm <= newton_ftol() {
                 solved = true;
                 break;
             }
@@ -2332,7 +2336,7 @@ fn newton_sparse_solve(
             }
             x.copy_from_slice(&xnew);
             fnorm = fnew;
-            if step <= KIN_SCSTEPTOL {
+            if step <= newton_xtol() {
                 solved = fnorm < KIN_FTOL_LESS_ACCURACY;
                 break;
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -252,10 +252,15 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     crate::sundials::reset_caches();
 
     let bytes = unsafe { core::slice::from_raw_parts(meta_ptr as *const u8, meta_len as usize) };
-    let model = match openmodelica_sim_meta::decode(bytes) {
+    let mut model = match openmodelica_sim_meta::decode(bytes) {
         Ok(m) => m,
         Err(_) => return -1,
     };
+    // A session always has a host, which renders `read_experiment`'s notices from
+    // the same flags; saying it again here would double every line.
+    driver::set_log_sink(|_| {});
+    simflags::with_flags(|f| model.apply_flags(f));
+    driver::set_log_sink(crate::omclog::sink);
 
     crate::nls::rt_set_step_size(model.step_size());
     // `-lv=LOG_NLS` names the iteration variables; only the metadata has them.
@@ -269,7 +274,6 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     driver::set_cancel_hook(cancel_hook);
     driver::set_init_done_hook(init_done_hook);
     driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
-    driver::set_log_sink(crate::omclog::sink);
 
     let mut engine = InWasmEngine { fn_base, present_mask };
     let sim_data = crate::rt_alloc(model.layout.total);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -65,6 +65,33 @@ static NLSS_MIN_SIZE: AtomicU32 = AtomicU32::new(1000);
 static NLSS_MAX_DENSITY: core::sync::atomic::AtomicU64 =
     core::sync::atomic::AtomicU64::new(0x3FB999999999999A); // 0.1
 
+/// C's `newtonFTol` / `newtonXTol` / `maxStepFactor` (`model_help.c`), which
+/// `-newtonFTol` / `-newtonXTol` / `-newtonMaxStepFactor` move. The homotopy Newton
+/// and KINSOL both read them, so they live here rather than in either solver.
+static NEWTON_FTOL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0x3D719799812DEA11); // 1e-12
+static NEWTON_XTOL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0x3D719799812DEA11);
+static MAX_STEP_FACTOR: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0x426D1A94A2000000); // 1e12
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_newton_tuning(ftol: f64, xtol: f64, max_step_factor: f64) {
+    NEWTON_FTOL.store(ftol.to_bits(), Ordering::Relaxed);
+    NEWTON_XTOL.store(xtol.to_bits(), Ordering::Relaxed);
+    MAX_STEP_FACTOR.store(max_step_factor.to_bits(), Ordering::Relaxed);
+}
+
+pub(crate) fn newton_ftol() -> f64 {
+    f64::from_bits(NEWTON_FTOL.load(Ordering::Relaxed))
+}
+
+pub(crate) fn newton_xtol() -> f64 {
+    f64::from_bits(NEWTON_XTOL.load(Ordering::Relaxed))
+}
+
+#[cfg(sundials)]
+pub(crate) fn max_step_factor() -> f64 {
+    f64::from_bits(MAX_STEP_FACTOR.load(Ordering::Relaxed))
+}
+
 /// Set the four selectors for the next run. Host-driven builds call this through
 /// the export; the in-wasm session calls [`apply_flags`] instead.
 #[unsafe(no_mangle)]
@@ -95,6 +122,8 @@ pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     rt_set_solvers(nls, nls_ls, ls, lss);
     let (min_size, max_density) = openmodelica_sim_meta::simflags::nlss_thresholds(f);
     rt_set_nlss_thresholds(min_size, max_density);
+    let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::newton_tuning(f);
+    rt_set_newton_tuning(ftol, xtol, msf);
 }
 
 pub(crate) fn nls() -> Nls {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -140,7 +140,12 @@ impl SimEngine for StandaloneEngine {
 /// Run the prepared model with the shared driver and write its result file.
 /// A failure traps (the command then exits nonzero).
 fn run() {
-    let m = read_meta();
+    let mut m = read_meta();
+    driver::set_log_sink(crate::omclog::sink);
+    simflags::with_flags(|f| {
+        simflags::print_notices(f);
+        m.apply_flags(f);
+    });
     let sim_data = crate::rt_alloc(m.layout.total);
     let mut engine = StandaloneEngine;
     crate::nls::rt_set_step_size(m.step_size());
@@ -195,7 +200,17 @@ fn run() {
         result.n_reals,
         &params,
     );
-    std::fs::write(format!("{}_res.mat", m.prefix), bytes).expect("wasm-jit standalone: cannot write result file");
+    std::fs::write(result_file(&m.prefix), bytes).expect("wasm-jit standalone: cannot write result file");
+}
+
+/// C's result-file resolution (`simulation_runtime.cpp`): `-r` outright, else
+/// `<prefix>_res.mat` under `-outputPath`.
+fn result_file(prefix: &str) -> String {
+    simflags::with_flags(|f| match (&f.result_file, &f.output_path) {
+        (Some(r), _) => r.clone(),
+        (None, Some(dir)) => format!("{dir}/{prefix}_res.mat"),
+        (None, None) => format!("{prefix}_res.mat"),
+    })
 }
 
 /// Wall clock for the driver, in ms since the first reading.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -311,11 +311,9 @@ pub(crate) mod kinsol {
     const KIN_LSOLVE_FAIL: c_int = -12;
     const KIN_REPTD_SYSFUNC_ERR: c_int = -15;
 
-    /// C's `newtonFTol`/`newtonXTol`, `maxStepFactor` and `FTOL_WITH_LESS_ACCURACY`
-    /// defaults, and `RETRY_MAX`.
-    const FNORMTOL: f64 = 1.0e-12;
-    const SCSTEPTOL: f64 = 1.0e-12;
-    const MAXSTEPFACTOR: f64 = 1.0e12;
+    /// C's `FTOL_WITH_LESS_ACCURACY` and `RETRY_MAX`; the stopping tolerances and
+    /// the step factor are C's `newtonFTol`/`newtonXTol`/`maxStepFactor`, which
+    /// `crate::solvers` holds because `-newtonFTol` and friends move them.
     const FTOL_LESS_ACCURACY: f64 = 1.0e-6;
     const RETRY_MAX: i32 = 5;
 
@@ -425,7 +423,7 @@ pub(crate) mod kinsol {
                 n,
                 nnz,
                 strategy: KIN_LINESEARCH,
-                maxstepfactor: MAXSTEPFACTOR,
+                maxstepfactor: crate::solvers::max_step_factor(),
                 numeric_jac: false,
             };
             if s.kin.is_null()
@@ -446,8 +444,8 @@ pub(crate) mod kinsol {
                 {
                     return None;
                 }
-                KINSetFuncNormTol(s.kin, FNORMTOL);
-                KINSetScaledStepTol(s.kin, SCSTEPTOL);
+                KINSetFuncNormTol(s.kin, crate::solvers::newton_ftol());
+                KINSetScaledStepTol(s.kin, crate::solvers::newton_xtol());
                 KINSetNumMaxIters(s.kin, 100 * n as c_long);
                 KINSetNoInitSetup(s.kin, 0);
             }
@@ -583,8 +581,8 @@ pub(crate) mod kinsol {
             }
             if reset_tol {
                 unsafe {
-                    KINSetFuncNormTol(self.kin, FNORMTOL);
-                    KINSetScaledStepTol(self.kin, SCSTEPTOL);
+                    KINSetFuncNormTol(self.kin, crate::solvers::newton_ftol());
+                    KINSetScaledStepTol(self.kin, crate::solvers::newton_xtol());
                 }
             }
             if success {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -923,6 +923,44 @@ mod term_report {
     pub use imp::{mark, reset};
 }
 
+/// Whether `-steadyState` was ever satisfied, for the warning C prints when the run
+/// reaches `stopTime` without it. Same shape as [`term_report`].
+mod steady_report {
+    #[cfg(feature = "std")]
+    mod imp {
+        use core::cell::Cell;
+        std::thread_local! {
+            static HIT: Cell<bool> = const { Cell::new(false) };
+        }
+        pub fn reset() {
+            HIT.with(|d| d.set(false));
+        }
+        pub fn mark() {
+            HIT.with(|d| d.set(true));
+        }
+        pub fn hit() -> bool {
+            HIT.with(|d| d.get())
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    mod imp {
+        use core::cell::UnsafeCell;
+        struct Store(UnsafeCell<bool>);
+        unsafe impl Sync for Store {}
+        static HIT: Store = Store(UnsafeCell::new(false));
+        pub fn reset() {
+            unsafe { *HIT.0.get() = false };
+        }
+        pub fn mark() {
+            unsafe { *HIT.0.get() = true };
+        }
+        pub fn hit() -> bool {
+            unsafe { *HIT.0.get() }
+        }
+    }
+    pub use imp::{hit, mark, reset};
+}
+
 /// Format `%f`-style (C's `%f`: 6 fractional digits), for the assertion time value.
 fn format_f(v: f64) -> String {
     alloc::format!("{v:.6}")
@@ -1178,6 +1216,7 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     let _ = rethrow_store::take();
     set_no_throw(false);
     term_report::reset();
+    steady_report::reset();
     seed_start_values(e, sim_data, layout)?;
 
     // C's `symbolic_initialization`: a model with `homotopy()` goes straight to the
@@ -1292,11 +1331,13 @@ fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &S
     Ok(())
 }
 
-/// True if `terminate()` raised the `SimData` flag during the last step. The
-/// first observation reports it (C's `checkSimulationTerminated`).
+/// Whether the run stops here rather than at `stopTime`: `terminate()` raised the
+/// `SimData` flag during the last step (C's `checkSimulationTerminated`), or
+/// `-steadyState` is satisfied. Every driver asks after each output row, so both
+/// C stop conditions are served in one place. The first observation reports it.
 fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bool> {
     if read_i32(e, sim_data + layout.terminate_off)? == 0 {
-        return Ok(false);
+        return steady_state_reached(e, sim_data, layout);
     }
     if term_report::mark() {
         let w = |i: u32| read_i32(e, sim_data + layout.term_info_off + i * 4);
@@ -1316,6 +1357,42 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
             ),
         );
     }
+    Ok(true)
+}
+
+/// C's `-steadyState` (`perform_simulation.c.inc`): the run ends once every state
+/// derivative is under `-steadyStateTol` relative to that state's nominal.
+fn steady_state_reached(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bool> {
+    let Some(tol) = crate::simflags::with_flags(crate::simflags::steady_state_tol) else {
+        return Ok(false);
+    };
+    if layout.n_states == 0 {
+        return Err("No states in model. Flag -steadyState can only be used if states are present.");
+    }
+    let ders = sim_data + REAL_OFF + layout.n_states * 8;
+    let mut max_der = 0.0f64;
+    for i in 0..layout.n_states {
+        let nominal = read_f64(e, sim_data + layout.state_nom_off + i * 8)?;
+        let d = libm::fabs(read_f64(e, ders + i * 8)? / nominal);
+        if max_der < d {
+            max_der = d;
+        }
+    }
+    if max_der >= tol {
+        return Ok(false);
+    }
+    steady_report::mark();
+    omclog::info(
+        omclog::STDOUT,
+        false,
+        &alloc::format!(
+            "steady state reached at time = {}\n  * max(|d(x_i)/dt|/nominal(x_i)) = {}\n  * \
+             relative tolerance = {}",
+            format_g(read_f64(e, sim_data + TIME_OFF)?, 6),
+            format_g(max_der, 6),
+            format_g(tol, 6),
+        ),
+    );
     Ok(true)
 }
 
@@ -1466,8 +1543,22 @@ fn seed_pre_from_live(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) 
     Ok(())
 }
 
-/// Upper bound on discrete-update iterations at one event (C's `maxEventIterations`).
+/// Upper bound on discrete-update iterations at one event: C's `maxEventIterations`
+/// default, which `-mei` replaces.
 const MAX_EVENT_ITER: usize = 20;
+
+fn max_event_iter() -> usize {
+    crate::simflags::with_flags(|f| f.max_event_iter).map_or(MAX_EVENT_ITER, |n| n as usize)
+}
+
+/// C's `bisection` iteration bound (`events.c`, `gbode_events.c`): `-mbi` when it is
+/// set to a positive value, else what halving the bracket down to `ttol` takes.
+pub(crate) fn bisection_iterations(width: f64, ttol: f64) -> i64 {
+    match crate::simflags::with_flags(|f| f.max_bisection_iter) {
+        Some(n) if n > 0 => n as i64,
+        _ => 1 + libm::ceil(libm::log(libm::fabs(width) / ttol) / libm::log(2.0)) as i64,
+    }
+}
 
 /// Snapshot the zero-crossing g-values into `zeroCrossingsPre` (C's
 /// `saveZeroCrossings`); `delayZeroCrossing` reads it as the held g-value.
@@ -1596,7 +1687,7 @@ fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
     // this pass's relations, then re-evaluates the continuous system; the discrete
     // state settles across passes. Comparing the snapshot before and after the
     // evaluation lets an already-settled system stop after a single evaluation.
-    for iter in 0..MAX_EVENT_ITER {
+    for iter in 0..max_event_iter() {
         let prev = discrete_snapshot(e, sim_data, layout)?;
         // C's `updateDiscreteSystem` `storePreValues`: make this pass's discrete
         // values visible as `pre()` to the next (e.g. a clutch's `pre(mode)`).
@@ -1917,6 +2008,20 @@ const UNSUPPORTED_METHOD: &str = if cfg!(sundials) {
 /// Free external objects (so repeated runs don't leak) and read back parameter
 /// values (result `Param` order) after a run.
 pub fn finalize_run(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Result<Vec<f64>> {
+    if let Some(tol) = crate::simflags::with_flags(crate::simflags::steady_state_tol)
+        && !steady_report::hit()
+    {
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            &alloc::format!(
+                "Steady state has not been reached.\nThis may be due to too restrictive relative \
+                 tolerance ({}) or short stopTime ({}).",
+                format_g(tol, 6),
+                format_g(model.stop_time, 6),
+            ),
+        );
+    }
     e.call1_if_present("callExternalObjectDestructors", sim_data)?;
     let mut params = Vec::new();
     for v in &model.vars {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/fixedstep.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/fixedstep.rs
@@ -155,7 +155,7 @@ impl FixedStep {
     fn find_root(&mut self, ode: &mut Ode, mut a: f64, mut b: f64) -> Result<f64> {
         let n = self.n_states;
         let ttol = MINIMAL_STEP_SIZE + MINIMAL_STEP_SIZE * abs(b - a);
-        let mut iters = 1 + ceil(ln(abs(b - a) / ttol) / ln(2.0)) as i64;
+        let mut iters = crate::driver::bisection_iterations(b - a, ttol);
         self.zc_backup.copy_from_slice(&self.zc);
         let mut mid = vec![0.0; n];
         while abs(b - a) > MINIMAL_STEP_SIZE && iters > 0 {
@@ -255,4 +255,4 @@ fn no_root_finding() -> bool {
     crate::simflags::with_flags(|f| f.no_root_finding)
 }
 
-use libm::{ceil, fabs as abs, log as ln};
+use libm::fabs as abs;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/events.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/events.rs
@@ -5,7 +5,7 @@
 
 use super::{Gbode, Ode, MINIMAL_STEP_SIZE};
 use crate::driver::Result;
-use crate::gbode::math::{abs, ceil, ln};
+use crate::gbode::math::abs;
 
 impl Gbode {
     fn zc_at(&mut self, ode: &mut Ode, t: f64) -> Result<()> {
@@ -38,7 +38,7 @@ impl Gbode {
     /// bracket, so the event is not missed).
     fn find_root(&mut self, ode: &mut Ode, mut a: f64, mut b: f64) -> Result<f64> {
         let ttol = MINIMAL_STEP_SIZE + MINIMAL_STEP_SIZE * abs(b - a);
-        let mut n = 1 + ceil(ln(abs(b - a) / ttol) / ln(2.0)) as i64;
+        let mut n = crate::driver::bisection_iterations(b - a, ttol);
         self.zc_backup.copy_from_slice(&self.zc);
         while abs(b - a) > MINIMAL_STEP_SIZE && n > 0 {
             n -= 1;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/math.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/math.rs
@@ -1,4 +1,4 @@
 //! Short names for the libm calls gbode needs; the crate is `no_std` in the
 //! in-wasm build, where the inherent float methods are not all available.
 
-pub use libm::{ceil, fabs as abs, log as ln, pow, sqrt};
+pub use libm::{fabs as abs, log as ln, pow, sqrt};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -529,8 +529,100 @@ impl SimMeta {
         if let Some(h) = crate::simflags::with_flags(|f| f.step_size) {
             return h;
         }
+        self.translated_step_size()
+    }
+
+    /// [`step_size`](Self::step_size) as the model was translated, ignoring
+    /// `-stepSize`: what C reads out of the init XML.
+    fn translated_step_size(&self) -> f64 {
         let n = if self.n_intervals > 0 { self.n_intervals } else { 500 };
         (self.stop_time - self.start_time) / n as f64
+    }
+
+    /// C's `read_experiment` (`simulation_input_xml.c`) plus the step-size checks
+    /// `solver_main.c` makes right after it: the run scalars the model was translated
+    /// with, overridden by the command line. [`n_intervals`](Self::n_intervals) is C's
+    /// `numSteps`, which the output grid is cut from, so a moved step size lands there.
+    ///
+    /// Called once per run by whichever entry point owns the driver.
+    pub fn apply_flags(&mut self, f: &crate::simflags::SimFlags) {
+        use crate::omclog::{self, STDOUT};
+        let translated = self.translated_step_size();
+        let mut recalc = false;
+        if let Some(t) = f.start_time {
+            self.start_time = t;
+            recalc = true;
+        }
+        if let Some(t) = f.stop_time {
+            self.stop_time = t;
+            recalc = true;
+        }
+        let span = self.stop_time - self.start_time;
+        let mut step = match f.step_size {
+            Some(h) => h,
+            None if recalc => {
+                omclog::warning(
+                    STDOUT,
+                    true,
+                    "Start or stop time was overwritten, but no new integrator step size was \
+                     provided.",
+                );
+                omclog::info(STDOUT, false, "Re-calculating step size for 500 intervals.");
+                omclog::info(STDOUT, false, "Use `-stepSize=<value>` to silence this warning.");
+                omclog::close_warning(STDOUT);
+                span / 500.0
+            }
+            None => translated,
+        };
+        let min_step = 4.0 * f64::EPSILON * libm::fmax(libm::fabs(self.start_time), libm::fabs(self.stop_time));
+        if step < min_step && span > 0.0 {
+            omclog::warning(
+                STDOUT,
+                false,
+                &alloc::format!(
+                    "The step-size {} is too small. Adjust the step-size to {}.",
+                    crate::driver::format_g(step, 6),
+                    crate::driver::format_g(min_step, 6)
+                ),
+            );
+            step = min_step;
+        }
+        if step > span + 1e-7 {
+            omclog::warning(STDOUT, true, "Integrator step size greater than length of experiment");
+            omclog::info(
+                STDOUT,
+                false,
+                &alloc::format!(
+                    "start time: {:.6}, stop time: {:.6}, integrator step size: {:.6}",
+                    self.start_time,
+                    self.stop_time,
+                    step
+                ),
+            );
+            omclog::close_warning(STDOUT);
+        }
+        // Only when a flag moved it: `n_intervals` is exact where C re-derives it
+        // from the step size the init XML carries.
+        if (recalc || f.step_size.is_some()) && span > 0.0 && step > 0.0 {
+            self.n_intervals = libm::round(span / step) as u32;
+        }
+        if let Some(t) = f.tolerance {
+            self.tolerance = t;
+        }
+        if let Some(fmt) = &f.output_format {
+            self.output_format = fmt.clone();
+        }
+        if f.noemit {
+            self.output_format = String::from("empty");
+        }
+    }
+
+    /// [`apply_flags`](Self::apply_flags) on a copy, for a caller whose metadata is
+    /// shared between runs.
+    pub fn with_flags(&self, f: &crate::simflags::SimFlags) -> SimMeta {
+        let mut m = self.clone();
+        m.apply_flags(f);
+        m
     }
 }
 
@@ -976,6 +1068,37 @@ mod tests {
         simflags::set_flags(f);
         let only_k = |n: &str| n == "k";
         assert_eq!(names(m.output_keep(Some(&only_k))), ["time", "k"]);
+    }
+
+    /// C's `read_experiment`: the command line replaces what the model was
+    /// translated with, and `numSteps` follows the step size.
+    #[test]
+    fn apply_flags_is_cs_read_experiment() {
+        let flags = |args: &[&str]| {
+            let argv: Vec<String> =
+                core::iter::once("model".into()).chain(args.iter().map(|a| a.to_string())).collect();
+            simflags::parse(&argv).expect("parses")
+        };
+        // Untouched by an empty command line.
+        let m = sample().with_flags(&simflags::SimFlags::default());
+        assert_eq!((m.start_time, m.stop_time, m.n_intervals), (0.0, 1.0, 500));
+
+        // Moving the interval alone re-cuts it into 500 intervals, as C does.
+        let m = sample().with_flags(&flags(&["-startTime=1", "-stopTime=3"]));
+        assert_eq!((m.start_time, m.stop_time, m.n_intervals), (1.0, 3.0, 500));
+
+        // `-stepSize` is what `numSteps` is derived from.
+        let f = flags(&["-stopTime=2", "-stepSize=0.01", "-tolerance=1e-9", "-outputFormat=empty"]);
+        let m = sample().with_flags(&f);
+        assert_eq!((m.stop_time, m.n_intervals, m.tolerance), (2.0, 200, 1e-9));
+        assert_eq!(m.output_format, "empty");
+        // ... and `step_size()` still reports the exact value asked for.
+        simflags::set_flags(f);
+        assert_eq!(m.step_size(), 0.01);
+        simflags::set_flags(simflags::SimFlags::default());
+
+        // `-noemit` is `-outputFormat=empty`.
+        assert_eq!(sample().with_flags(&flags(&["-noemit"])).output_format, "empty");
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -120,6 +120,11 @@ pub type Mask = u64;
 /// The three streams C activates without `-lv`, and which [`deactivate`] leaves.
 pub const ALWAYS_ON: Mask = (1 << STDOUT) | (1 << ASSERT) | (1 << SUCCESS);
 
+/// C's `omc_showAllWarnings` (`-w`): a warning prints even on an inactive stream.
+/// It rides in the mask, above every stream index, so the single value a run pushes
+/// into the wasm runtime carries it too.
+pub const SHOW_ALL_WARNINGS: Mask = 1 << 63;
+
 pub fn mask_has(m: Mask, s: Stream) -> bool {
     m & (1 << s) != 0
 }
@@ -134,7 +139,7 @@ pub fn mask_from_streams<S: AsRef<str>>(streams: &[S]) -> Result<Mask, String> {
     // C re-enables only these two, so `-lv=-LOG_SUCCESS` does what it promises.
     m |= (1 << STDOUT) | (1 << ASSERT);
     if streams.iter().any(|s| s.as_ref().contains("LOG_ALL")) {
-        return Ok(finish(!0 << 1));
+        return Ok(finish(((1 << N_STREAMS) - 1) & !1));
     }
     for s in streams {
         let s = s.as_ref();
@@ -265,7 +270,7 @@ pub fn deactivate() {
             return;
         }
         s.backup = s.use_stream;
-        s.use_stream = ALWAYS_ON;
+        s.use_stream = ALWAYS_ON | (s.use_stream & SHOW_ALL_WARNINGS);
         s.streams_active = false;
     });
 }
@@ -286,8 +291,9 @@ pub fn info(stream: Stream, indent_next: bool, msg: &str) {
     }
 }
 
+/// C's `OMC_ACTIVE_WARNING_STREAM`.
 pub fn warning(stream: Stream, indent_next: bool, msg: &str) {
-    if active(stream) {
+    if active(stream) || store::with(|s| s.use_stream & SHOW_ALL_WARNINGS != 0) {
         message_text(WARNING, stream, indent_next, msg);
     }
 }
@@ -300,6 +306,16 @@ pub fn error(stream: Stream, indent_next: bool, msg: &str) {
 pub fn close(stream: Stream) {
     store::with(|s| {
         if mask_has(s.use_stream, stream) {
+            s.level[stream as usize] -= 1;
+        }
+    });
+}
+
+/// C's `messageCloseWarning`: [`close`] for a block [`warning`] opened, so `-w`
+/// keeps the level balanced on an inactive stream.
+pub fn close_warning(stream: Stream) {
+    store::with(|s| {
+        if mask_has(s.use_stream, stream) || s.use_stream & SHOW_ALL_WARNINGS != 0 {
             s.level[stream as usize] -= 1;
         }
     });
@@ -517,6 +533,19 @@ mod tests {
         let m = mask_from_streams(&["-LOG_SUCCESS"]).expect("parses");
         assert!(!mask_has(m, SUCCESS) && mask_has(m, STDOUT));
         assert!(mask_has(mask_from_streams::<&str>(&[]).expect("parses"), SUCCESS));
+    }
+
+    /// `-w`: a warning prints on an inactive stream, an info still does not.
+    #[test]
+    fn show_all_warnings_only_lifts_warnings() {
+        set_mask(ALWAYS_ON);
+        assert!(capture(|| warning(NLS, false, "quiet")).is_empty());
+        set_mask(ALWAYS_ON | SHOW_ALL_WARNINGS);
+        let out = capture(|| {
+            info(NLS, false, "still quiet");
+            warning(NLS, false, "loud");
+        });
+        assert_eq!(out, "LOG_NLS           | warning | loud\n");
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -86,6 +86,42 @@ pub enum IdaLs {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SimFlags {
     pub solver: Option<Solver>,
+    /// C's `read_experiment` overrides, folded into the metadata by
+    /// [`SimMeta::apply_flags`](crate::SimMeta::apply_flags).
+    pub start_time: Option<f64>,
+    pub stop_time: Option<f64>,
+    pub tolerance: Option<f64>,
+    pub output_format: Option<String>,
+    /// `-noemit`: no result file, C's `sim_noemit` (which it treats as `empty`).
+    pub noemit: bool,
+    /// `-outputPath=<dir>`: holds `<prefix>_res.<format>` unless `-r` names a file.
+    pub output_path: Option<String>,
+    /// `-iit=<t>`: where `-iif`'s result file is read (C's `init_time`, default the
+    /// start time).
+    pub init_time: Option<f64>,
+    /// `-mei`: discrete-update iterations allowed at one event (C's
+    /// `maxEventIterations`, default 20).
+    pub max_event_iter: Option<u32>,
+    /// `-mbi`: bisection steps allowed when locating a state event, 0 = C's own
+    /// bound from the bracket width (`maxBisectionIterations`).
+    pub max_bisection_iter: Option<u32>,
+    /// `-newtonFTol` / `-newtonXTol` / `-newtonMaxStepFactor`: C's `newtonFTol`,
+    /// `newtonXTol` and `maxStepFactor`, shared by the homotopy Newton and KINSOL.
+    pub newton_ftol: Option<f64>,
+    pub newton_xtol: Option<f64>,
+    pub newton_max_step_factor: Option<f64>,
+    /// `-steadyState` / `-steadyStateTol` (C's default 1e-3), read through
+    /// [`steady_state_tol`].
+    pub steady_state: bool,
+    pub steady_state_tol: Option<f64>,
+    /// `-w`: print warnings whose stream is inactive. Carried in
+    /// [`log_mask`](Self::log_mask) as [`omclog::SHOW_ALL_WARNINGS`](crate::omclog::SHOW_ALL_WARNINGS).
+    pub show_all_warnings: bool,
+    /// `-daeMode`, deprecated in C: `--daeMode` at translation is what selects it.
+    pub dae_mode: bool,
+    /// `-jacobianThreads`: this runtime evaluates Jacobians single-threaded, as a C
+    /// runtime built without `--enable-parjac` does.
+    pub jacobian_threads: Option<i32>,
     pub nls: Option<Nls>,
     pub nls_ls: Option<NlsLs>,
     pub ls: Option<Ls>,
@@ -514,6 +550,30 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "output" => f.output_vars = split_top_level(&value(name)?),
+            "startTime" => f.start_time = Some(real(name, &value(name)?)?),
+            "stopTime" => f.stop_time = Some(real(name, &value(name)?)?),
+            "tolerance" => f.tolerance = Some(real(name, &value(name)?)?),
+            "outputFormat" => f.output_format = Some(output_format(&value(name)?)?),
+            "noemit" => f.noemit = true,
+            "outputPath" => f.output_path = Some(value(name)?),
+            "iit" => f.init_time = Some(real(name, &value(name)?)?),
+            "mei" => f.max_event_iter = Some(int(name, &value(name)?)?.max(0) as u32),
+            "mbi" => f.max_bisection_iter = Some(int(name, &value(name)?)?.max(0) as u32),
+            "newtonFTol" => f.newton_ftol = Some(real(name, &value(name)?)?),
+            "newtonXTol" => f.newton_xtol = Some(real(name, &value(name)?)?),
+            "newtonMaxStepFactor" => f.newton_max_step_factor = Some(real(name, &value(name)?)?),
+            "steadyState" => f.steady_state = true,
+            "steadyStateTol" => f.steady_state_tol = Some(real(name, &value(name)?)?),
+            "w" => f.show_all_warnings = true,
+            "daeMode" => f.dae_mode = true,
+            "jacobianThreads" => f.jacobian_threads = Some(int(name, &value(name)?)?),
+            // C's only other formats are the XML ones its `-port` server speaks.
+            "logFormat" => {
+                let v = value(name)?;
+                if v != "text" {
+                    return Err(format!("-logFormat={v}: this runtime writes plain text logs only"));
+                }
+            }
             "emit_protected" => f.emit_protected = true,
             "ignoreHideResult" => f.ignore_hide_result = true,
             "variableFilter" => f.variable_filter = Some(value(name)?),
@@ -608,10 +668,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                     None => return Err(format!("invalid command line option: {arg}")),
                     Some((n, _)) if !IGNORED_FLAGS.contains(n) => {
                         f.unknown.push(arg.to_string());
-                        return Err(format!(
-                            "-{n}: this runtime does not implement the flag, so the run would \
-                             silently ignore it"
-                        ));
+                        return Err(format!("-{n}: not implemented by this runtime"));
                     }
                     Some(_) => {}
                 }
@@ -619,13 +676,127 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
         }
     }
     f.log_mask = crate::omclog::mask_from_streams(&f.log)?;
+    if f.show_all_warnings {
+        f.log_mask |= crate::omclog::SHOW_ALL_WARNINGS;
+    }
     Ok(f)
+}
+
+/// C's `initializeResultData` formats. `mat` and `empty` are the ones this runtime
+/// has a writer for; `csv`/`plt`/`ia` are C's and would need one of their own.
+fn output_format(v: &str) -> Result<String, String> {
+    match v {
+        "mat" | "empty" => Ok(v.to_string()),
+        "csv" | "plt" | "ia" => Err(format!(
+            "-outputFormat={v}: this runtime writes `mat` results, or `empty` for none"
+        )),
+        _ => Err(format!("Unknown output format: {v}")),
+    }
+}
+
+/// C's `simulation_runtime.cpp` startup notices for the flags that move a solver
+/// constant, in its order. Rendered by the caller, which owns the run's log.
+pub fn notices(f: &SimFlags) -> Vec<(crate::omclog::LogType, String)> {
+    let g = |v: f64| crate::driver::format_g(v, 6);
+    let mut out = Vec::new();
+    if let Some(d) = f.nlss_max_density {
+        out.push((
+            crate::omclog::INFO,
+            format!("Maximum density for using non-linear sparse solver changed to {d:.6}"),
+        ));
+    }
+    if let Some(n) = f.nlss_min_size {
+        out.push((
+            crate::omclog::INFO,
+            format!("Minimum system size for using non-linear sparse solver changed to {n}"),
+        ));
+    }
+    if let Some(v) = f.newton_xtol {
+        out.push((
+            crate::omclog::INFO,
+            format!("Tolerance for updating solution vector in Newton solver changed to {}", g(v)),
+        ));
+    }
+    if let Some(v) = f.newton_ftol {
+        out.push((
+            crate::omclog::INFO,
+            format!("Tolerance for accepting accuracy in Newton solver changed to {}", g(v)),
+        ));
+    }
+    if let Some(v) = f.newton_max_step_factor {
+        out.push((
+            crate::omclog::INFO,
+            format!("Maximum step size factor for a Newton step changed to {}", g(v)),
+        ));
+    }
+    if f.dae_mode {
+        out.push((
+            crate::omclog::WARNING,
+            "The daeMode flag is *deprecated*, because it is not needed any more.\nIf a model is \
+             compiled in \"DAEmode\" with compiler flag --daeMode, then it simulates automatically \
+             in DAE mode."
+                .to_string(),
+        ));
+    }
+    if f.jacobian_threads.is_some() {
+        out.push((
+            crate::omclog::WARNING,
+            "Simulation flag jacobianThreads not available. This runtime evaluates Jacobians \
+             single-threaded."
+                .to_string(),
+        ));
+    }
+    if let Some(v) = f.steady_state_tol {
+        out.push((
+            crate::omclog::INFO,
+            format!("Tolerance for steady state detection changed to {}", g(v)),
+        ));
+    }
+    if let Some(n) = f.max_bisection_iter {
+        out.push((
+            crate::omclog::INFO,
+            format!("Maximum number of bisection iterations changed to {n}"),
+        ));
+    }
+    if let Some(n) = f.max_event_iter {
+        out.push((
+            crate::omclog::INFO,
+            format!("Maximum number of event iterations changed to {n}"),
+        ));
+    }
+    out
+}
+
+/// [`notices`] through the log, for a caller that renders nothing itself.
+pub fn print_notices(f: &SimFlags) {
+    for (ty, msg) in notices(f) {
+        match ty {
+            crate::omclog::WARNING => crate::omclog::warning(crate::omclog::STDOUT, false, &msg),
+            _ => crate::omclog::info(crate::omclog::STDOUT, false, &msg),
+        }
+    }
 }
 
 /// C's `nonlinearSparseSolverMinSize` / `nonlinearSparseSolverMaxDensity`, with
 /// C's defaults (`simulation_options.h`) where the flags are absent.
 pub fn nlss_thresholds(f: &SimFlags) -> (u32, f64) {
     (f.nlss_min_size.unwrap_or(1000), f.nlss_max_density.unwrap_or(0.1))
+}
+
+/// The `-steadyState` bound (C's default without `-steadyStateTol`), `None` when
+/// the run is not looking for a steady state.
+pub fn steady_state_tol(f: &SimFlags) -> Option<f64> {
+    f.steady_state.then(|| f.steady_state_tol.unwrap_or(1e-3))
+}
+
+/// C's `newtonFTol` / `newtonXTol` / `maxStepFactor` (`model_help.c`), with C's
+/// defaults where the flags are absent.
+pub fn newton_tuning(f: &SimFlags) -> (f64, f64, f64) {
+    (
+        f.newton_ftol.unwrap_or(1e-12),
+        f.newton_xtol.unwrap_or(1e-12),
+        f.newton_max_step_factor.unwrap_or(1e12),
+    )
 }
 
 /// C's `parseVariableStr`: split on commas outside `[...]`, so `x[1,2]` stays one name.
@@ -1017,6 +1188,69 @@ mod tests {
     #[test]
     fn missing_value_is_an_error() {
         assert!(parse(&argv(&["-nls"])).is_err());
+    }
+
+    // What OMEdit always sends (`SimulationDialog::createSimulationOptions`), which
+    // has to parse as a whole.
+    #[test]
+    fn the_omedit_command_line_parses() {
+        let f = parse(&argv(&[
+            "-startTime=0",
+            "-stopTime=1.5",
+            "-stepSize=0.002",
+            "-tolerance=1e-06",
+            "-s=dassl",
+            "-outputFormat=mat",
+            "-variableFilter=.*",
+            "-r=/tmp/M_res.mat",
+            "-jacobian=coloredNumerical",
+            "-w",
+        ]))
+        .expect("parses");
+        assert_eq!((f.start_time, f.stop_time), (Some(0.0), Some(1.5)));
+        assert_eq!((f.step_size, f.tolerance), (Some(0.002), Some(1e-6)));
+        assert_eq!(f.output_format.as_deref(), Some("mat"));
+        assert_eq!(f.result_file.as_deref(), Some("/tmp/M_res.mat"));
+        assert!(f.show_all_warnings && f.log_mask & crate::omclog::SHOW_ALL_WARNINGS != 0);
+    }
+
+    #[test]
+    fn only_the_writable_output_formats_are_accepted() {
+        assert_eq!(parse(&argv(&["-outputFormat=empty"])).expect("parses").output_format.as_deref(),
+                   Some("empty"));
+        assert!(parse(&argv(&["-outputFormat=csv"])).expect_err("no csv writer").contains("mat"));
+        assert!(parse(&argv(&["-outputFormat=nope"])).expect_err("unknown").contains("Unknown"));
+        // `-noemit` is C's `sim_noemit`, which it treats exactly as `empty`.
+        assert!(parse(&argv(&["-noemit"])).expect("parses").noemit);
+    }
+
+    #[test]
+    fn the_solver_tunables_carry_their_values() {
+        let f = parse(&argv(&["-mei=7", "-mbi=3", "-newtonFTol=1e-10", "-newtonXTol=1e-9",
+                              "-newtonMaxStepFactor=1e6", "-iit=0.5", "-outputPath=/tmp/out"]))
+            .expect("parses");
+        assert_eq!((f.max_event_iter, f.max_bisection_iter), (Some(7), Some(3)));
+        assert_eq!(newton_tuning(&f), (1e-10, 1e-9, 1e6));
+        assert_eq!(f.init_time, Some(0.5));
+        assert_eq!(f.output_path.as_deref(), Some("/tmp/out"));
+        // `-steadyStateTol` alone tunes nothing: `-steadyState` is what arms it.
+        assert_eq!(steady_state_tol(&parse(&argv(&["-steadyStateTol=1e-5"])).expect("parses")), None);
+        let f = parse(&argv(&["-steadyState", "-steadyStateTol=1e-5"])).expect("parses");
+        assert_eq!(steady_state_tol(&f), Some(1e-5));
+        assert_eq!(steady_state_tol(&parse(&argv(&["-steadyState"])).expect("parses")), Some(1e-3));
+        // Absent, every tunable is C's default.
+        assert_eq!(newton_tuning(&parse(&argv(&[])).expect("parses")), (1e-12, 1e-12, 1e12));
+    }
+
+    // C warns about these rather than refusing them, so they must parse.
+    #[test]
+    fn deprecated_and_unavailable_flags_only_warn() {
+        let f = parse(&argv(&["-daeMode", "-jacobianThreads=4", "-logFormat=text"])).expect("parses");
+        assert!(f.dae_mode && f.jacobian_threads == Some(4));
+        let msgs = notices(&f);
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs.iter().all(|(ty, _)| *ty == crate::omclog::WARNING));
+        assert!(parse(&argv(&["-logFormat=xml"])).is_err());
     }
 
     // C's `-alarm=0` disables the alarm rather than setting a zero-second one.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -55,6 +55,15 @@ pub struct SimModel {
     pub nls_systems: Vec<(i32, i32, u32, u32)>,
 }
 
+impl SimModel {
+    /// C's `read_experiment`: this run's scalars, i.e. the model's metadata with the
+    /// flags installed for the run applied. The model is shared between runs, so the
+    /// run works off a copy.
+    pub fn run_meta(&self) -> SimMeta {
+        openmodelica_sim_meta::simflags::with_flags(|f| self.meta.with_flags(f))
+    }
+}
+
 /// A user-settable parameter (an editable initial condition): display name, unit,
 /// and `SimData` slot so an `-override=name=value` can write it.
 #[derive(Clone)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
@@ -34,6 +34,6 @@ pub fn take_compiled_model(_model: &SimModel) -> std::result::Result<Module, Str
     return Err(NO_ENGINE.to_string())
 }
 
-pub fn run(_model: &SimModel) -> std::result::Result<RunResult, String> {
+pub fn run(_model: &SimModel, _meta: &openmodelica_sim_meta::SimMeta) -> std::result::Result<RunResult, String> {
     return Err(NO_ENGINE.to_string())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -40,6 +40,7 @@ impl Instant {
 
 use crate::sim_driver;
 use crate::model::SimModel;
+use openmodelica_sim_meta::SimMeta;
 use crate::sig::WTy;
 use crate::host::add_host_builtins;
 
@@ -687,19 +688,19 @@ fn read_side_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, off: u3
     Ok(out)
 }
 
-pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, String> {
+pub fn run(model: &SimModel, meta: &SimMeta) -> std::result::Result<sim_driver::RunResult, String> {
     let bench = crate::model::sim_bench_enabled();
     if crate::model::inwasm_driver_enabled() {
         return run_inwasm(model, bench);
     }
-    let (mut engine, sim_data) = build_engine(model)?;
+    let (mut engine, sim_data) = build_engine(model, meta)?;
     // `OMC_WASM_SIM_DRIVER=host` forces the native Euler loop over the in-wasm one.
     let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
-    let n_steps = model.n_intervals;
+    let n_steps = meta.n_intervals;
     let n_rows = n_steps + 1;
     let t0 = Instant::now();
     let (mut result, driver_label) =
-        sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench)?;
+        sim_driver::drive(&mut *engine, meta, sim_data, meta.method.as_str(), host_driven, bench)?;
     // The solves ran in-wasm, where the driver's stats cannot see them.
     result.stats.lin_solves = engine.lin_solves();
     if bench {
@@ -747,7 +748,7 @@ struct Instantiated {
 
 /// Compile/join the modules and instantiate them (runtime first, then model,
 /// sharing the runtime's `memory`).
-fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, String> {
+fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<Instantiated, String> {
     let bench = crate::model::sim_bench_enabled();
     let engine = sim_engine();
 
@@ -826,6 +827,13 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         });
         wts(set.call(&mut store, min_size, max_density))?;
     }
+    // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(f64, f64, f64), ()>(&store, "rt_set_newton_tuning") {
+        let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::newton_tuning(f)
+        });
+        wts(set.call(&mut store, ftol, xtol, msf))?;
+    }
     let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
     if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_log_streams") {
         wts(set.call(&mut store, log_mask as u32, (log_mask >> 32) as u32))?;
@@ -836,7 +844,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     {
         let free = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_free").ok();
         wts(set.call(&mut store, u32::MAX, 0, 0))?;
-        for sys in &model.meta.nls_vars {
+        for sys in &meta.nls_vars {
             let mut blob = Vec::new();
             for n in &sys.names {
                 blob.extend_from_slice(n.as_bytes());
@@ -851,7 +859,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         }
     }
     if let Ok(set) = rt_inst.exports.get_typed_function::<f64, ()>(&store, "rt_set_step_size") {
-        wts(set.call(&mut store, model.meta.step_size()))?;
+        wts(set.call(&mut store, meta.step_size()))?;
     }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
@@ -860,9 +868,9 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     Ok(Instantiated { store, rt_inst, instance, memory, rt_alloc })
 }
 
-pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
+pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
     sim_driver::init_host_hooks(); // cancel poll + model-assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, meta)?;
 
     let layout = &model.layout;
     // Allocate the shared SimData block.
@@ -977,7 +985,7 @@ pub struct InWasmSession {
 /// metadata blob, and `rt_sim_start` a resumable in-wasm run.
 pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSession, String> {
     sim_driver::init_host_hooks(); // cancel poll + assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, &model.meta)?;
 
     // Append N contiguous table slots and set each to the model's export funcref
     // (null + cleared mask bit if the model doesn't export it).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 
 use crate::sim_driver;
 use crate::model::SimModel;
+use openmodelica_sim_meta::SimMeta;
 use crate::host::add_host_builtins;
 
 /// The runtime module, embedded the same way the function half embeds it.
@@ -593,21 +594,21 @@ unsafe fn call_external(
 }
 
 
-pub fn run(model: &SimModel) -> std::result::Result<sim_driver::RunResult, String> {
+pub fn run(model: &SimModel, meta: &SimMeta) -> std::result::Result<sim_driver::RunResult, String> {
     let bench = crate::model::sim_bench_enabled();
     // The in-wasm session driver (`rt_sim_*`) reaches the model wasm->wasm; see
     // `crate::model::inwasm_driver_enabled` for when it is used.
     if crate::model::inwasm_driver_enabled() {
         return run_inwasm(model, bench);
     }
-    let (mut engine, sim_data) = build_engine(model)?;
+    let (mut engine, sim_data) = build_engine(model, meta)?;
     // `OMC_WASM_SIM_DRIVER=host` forces the native Euler loop over the in-wasm one.
     let host_driven = std::env::var("OMC_WASM_SIM_DRIVER").map(|v| v == "host").unwrap_or(false);
-    let n_steps = model.n_intervals;
+    let n_steps = meta.n_intervals;
     let n_rows = n_steps + 1;
     let t0 = Instant::now();
     let (mut result, driver_label) =
-        match sim_driver::drive(&mut *engine, &model.meta, sim_data, model.method.as_str(), host_driven, bench) {
+        match sim_driver::drive(&mut *engine, meta, sim_data, meta.method.as_str(), host_driven, bench) {
             Ok(v) => v,
             Err(e) => {
                 return Err(map_alarm(e.to_string()));
@@ -662,7 +663,7 @@ struct Instantiated {
 
 /// Compile/join the modules and instantiate them (runtime first, then model,
 /// sharing the runtime's `memory`).
-fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, String> {
+fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<Instantiated, String> {
     let bench = crate::model::sim_bench_enabled();
     crate::host::lin_solve::reset(); // drop the previous run's host-side LSS cache
     let engine = sim_engine();
@@ -756,6 +757,14 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
         });
         wts(set.call(&mut store, t))?;
     }
+    // `-newtonFTol`/`-newtonXTol`/`-newtonMaxStepFactor`: the nonlinear solvers that
+    // read them run in-wasm whichever driver owns the run.
+    if let Ok(set) = rt_inst.get_typed_func::<(f64, f64, f64), ()>(&mut store, "rt_set_newton_tuning") {
+        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::newton_tuning(f)
+        });
+        wts(set.call(&mut store, t))?;
+    }
     // Same for `-lv`: the nonlinear solver logs from inside the module.
     let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
     if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_log_streams") {
@@ -769,7 +778,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     {
         let free = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free").ok();
         wts(set.call(&mut store, (u32::MAX, 0, 0)))?;
-        for sys in &model.meta.nls_vars {
+        for sys in &meta.nls_vars {
             let mut blob = Vec::new();
             for n in &sys.names {
                 blob.extend_from_slice(n.as_bytes());
@@ -785,7 +794,7 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
     }
     // The driver that owns the `SimMeta` stays on the host in this build.
     if let Ok(set) = rt_inst.get_typed_func::<f64, ()>(&mut store, "rt_set_step_size") {
-        wts(set.call(&mut store, model.meta.step_size()))?;
+        wts(set.call(&mut store, meta.step_size()))?;
     }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
@@ -797,9 +806,9 @@ fn instantiate_modules(model: &SimModel) -> std::result::Result<Instantiated, St
 /// Build the engine (compile/join modules, instantiate, allocate `SimData`), boxed
 /// with the `SimData` pointer; owned by the session across `advance` calls, reused
 /// by [`run`] one-shot.
-pub fn build_engine(model: &SimModel) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
+pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
     sim_driver::init_host_hooks(); // cancel poll + model-assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, meta)?;
 
     let layout = &model.layout;
     // Allocate the shared SimData block.
@@ -982,7 +991,7 @@ pub struct InWasmSession {
 /// metadata blob, and `rt_sim_start` a resumable in-wasm run.
 pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSession, String> {
     sim_driver::init_host_hooks(); // cancel poll + assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, &model.meta)?;
 
     // Append N contiguous table slots and set each to the model's export funcref
     // (null + cleared mask bit if the model doesn't export it).


### PR DESCRIPTION
OMEdit sends `-startTime`/`-stopTime`/`-tolerance`/`-outputFormat` on every run, none of which the wasm-jit runtime implemented, so every simulation started from it was refused outright.

`SimMeta::apply_flags` is C's `read_experiment` (plus the step-size checks `solver_main.c` makes right after it): the run scalars the model was translated with, overridden by the command line. `n_intervals` is C's `numSteps`, so a moved step size lands on the output grid. Whichever entry point owns the driver applies it once per run to its own copy — the host through `SimModel::run_meta`, `rt_sim_start` in-wasm, `_start` in the standalone.

Implemented at the same time:

- `-outputPath` and `-r`: result-file resolution. The standalone honoured neither.
- `-noemit`: C's `sim_noemit`, i.e. `-outputFormat=empty`.
- `-iit`: the time `-iif`'s result file is read at.
- `-mei` / `-mbi`: the event-iteration and bisection caps, the latter in both `fixedstep` and gbode.
- `-newtonFTol` / `-newtonXTol` / `-newtonMaxStepFactor`: a new `rt_set_newton_tuning` export, since the homotopy Newton and KINSOL both read them as C's globals do.
- `-steadyState` / `-steadyStateTol`: reported through `terminated`, so every driver's stop path serves it.
- `-w`: rides the `-lv` mask as `SHOW_ALL_WARNINGS`, so the one value pushed into the wasm runtime carries it.
- `-logFormat=text`, `-daeMode` and `-jacobianThreads`: accepted with C's warnings.

`-outputFormat=csv|plt|ia` stays refused: no writer here yet.

The rejection an unimplemented flag gets no longer explains itself with "so the run would silently ignore it" — that rationale is about the design, not about the flag, and it belongs on `C_FLAGS`.

Verified against the C runtime with `diffSimulationResults` over dassl, euler and gbode with the moved scalars: no differing variables. The startup log matches C line for line, in C's order.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
