### PR TITLE
partest: select tests by suite

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -574,20 +574,16 @@ void assembleWeb() {
   archiveArtifacts artifacts: webZip, fingerprint: true
   stash name: 'web', includes: webZip
 
-  // Merge the three Rust-partest partition shards into one sorted failure list,
+  // Merge the Rust-partest partition shards into one sorted failure list,
   // archived so regressions are easy to diff between runs. Here (not a dedicated
-  // agent) since the web deliverable is already assembled; shards may be absent.
+  // agent) since the web deliverable is already assembled. Same guard as the
+  // testsuite-rust stages, so a missing shard is a hard error rather than the
+  // normal case of those stages not having run.
   sh 'rm -f testsuite/partest-failed-*.txt partest-rust-failed.txt'
-  def haveShard = false
-  for (p in [1, 2, 3]) {
-    try {
+  if (shouldWeRunRustTests() && !shouldWeDisableAllCMakeBuilds()) {
+    for (p in [1,2]) {
       unstash "partest-failed-${p}"
-      haveShard = true
-    } catch (ignored) {
-      echo "partest-failed-${p}: no shard (rust partest disabled or run failed)"
     }
-  }
-  if (haveShard) {
     sh 'cat testsuite/partest-failed-*.txt | sort -u > partest-rust-failed.txt && wc -l partest-rust-failed.txt'
     archiveArtifacts artifacts: 'partest-rust-failed.txt', allowEmptyArchive: true, fingerprint: true
   }
@@ -640,6 +636,11 @@ void partestRust(partition) {
     build/bin/omc-diff -v1.4
   """
   String simCodeTargetArg = params.RUST_PARTEST_SIMCODETARGET ? " -simCodeTarget=${params.RUST_PARTEST_SIMCODETARGET}" : ''
+  // cpp/hpcom: the Rust omc is built without the C++ runtime. metamodelica:
+  // MetaModelica code generation only works against the C runtime. 63bit/antlr:
+  // the port's Integer is i32 and its parser is winnow, not ANTLR; see
+  // testsuite/rust-ignore-tests.txt.
+  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr'
   try {
     sh """#!/bin/bash
       set -o pipefail
@@ -648,7 +649,7 @@ void partestRust(partition) {
       rm -f testsuite/partest-failed-${partition}.txt
       cd testsuite/partest
       set -x
-      ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/3 -nocolour -with-xml${simCodeTargetArg} 2>&1 | tee runtests-${partition}.log
+      ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/2 -nocolour -with-xml${suitesArg}${simCodeTargetArg} 2>&1 | tee runtests-${partition}.log
       CODE=\${PIPESTATUS[0]}
       set +x
       # 0/7 == the run completed (7 means some tests failed); only fail the step on

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -355,7 +355,7 @@ pipeline {
       parallel {
         // partest against the Rust-built omc; dedicated runtest cache. See
         // common.partestRust().
-        stage('01 testsuite-rust 1/3') {
+        stage('01 testsuite-rust 1/2') {
           agent {
             docker {
               alwaysPull true
@@ -382,7 +382,7 @@ pipeline {
             }
           }
         }
-        stage('02 testsuite-rust 2/3') {
+        stage('02 testsuite-rust 2/2') {
           agent {
             docker {
               alwaysPull true
@@ -406,33 +406,6 @@ pipeline {
           steps {
             script {
               common.partestRust(2)
-            }
-          }
-        }
-        stage('03 testsuite-rust 3/3') {
-          agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-26.04-rust'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-rust-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
-          }
-          environment {
-            RUNTESTDB = "/cache/runtest/"
-            LIBRARIES = "/cache/omlibrary"
-          }
-          when {
-            beforeAgent true
-            expression { shouldWeRunRustTests && !shouldWeDisableAllCMakeBuilds }
-          }
-          steps {
-            script {
-              common.partestRust(3)
             }
           }
         }

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -19,6 +19,11 @@ rtest special directives added to help creating testcases:
   Will execute the provided command before running omc.
 * teardown_command: rm -f ...  
   Will execute the provided command after running omc.
+* suite: metamodelica, 63bit  
+  Puts the test in one or more test suites, so that a run which cannot support
+  them can deselect it: `partest/runtests.pl -suites=-metamodelica,-63bit`.
+  Run `runtests.pl -h` for the suites and their defaults. The directive must be
+  in the test's header, i.e. before the first line of code.
 
 **NOTE**:  
 A test MUST have the finishing "end ..." at the same indentation level as the "model ..." otherwise there will be a warning(perl -w rtest file) for the next test that are executed.

--- a/testsuite/flattening/modelica/mosfiles/IntMulOverflow.mos
+++ b/testsuite/flattening/modelica/mosfiles/IntMulOverflow.mos
@@ -2,6 +2,7 @@
 // keywords:
 // status:   correct
 // cflags: -d=-newInst
+// suite: 63bit
 //
 //  Making sure that multiplication is correct when multiplying large integers
 //

--- a/testsuite/flattening/modelica/scodeinst/CevalReduction1.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalReduction1.mo
@@ -1,6 +1,7 @@
 // name: CevalReduction1
 // keywords:
 // status: correct
+// suite: 63bit
 //
 //
 

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinMax.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinMax.mo
@@ -1,6 +1,7 @@
 // name: FuncBuiltinMax
 // keywords: max
 // status: correct
+// suite: 63bit
 //
 // Tests the builtin max operator.
 //

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinMax2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinMax2.mo
@@ -1,6 +1,7 @@
 // name: FuncBuiltinMax2
 // keywords: max
 // status: correct
+// suite: 63bit
 //
 // Tests the builtin max operator.
 //

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinMin.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinMin.mo
@@ -1,6 +1,7 @@
 // name: FuncBuiltinMin
 // keywords: min
 // status: correct
+// suite: 63bit
 //
 // Tests the builtin min operator.
 //

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinMin2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinMin2.mo
@@ -1,6 +1,7 @@
 // name: FuncBuiltinMin2
 // keywords: min
 // status: correct
+// suite: 63bit
 //
 // Tests the builtin min operator.
 //

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
@@ -1,6 +1,7 @@
 // name: FuncBuiltinReduction
 // keywords: reduction
 // status: correct
+// suite: 63bit
 //
 // Tests the builtin reduction operators.
 //

--- a/testsuite/metamodelica/meta/AlgPatternm.mos
+++ b/testsuite/metamodelica/meta/AlgPatternm.mos
@@ -1,6 +1,7 @@
 // name: AlgPatternm
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadFile("AlgPatternm.mo");

--- a/testsuite/metamodelica/meta/AllWild.mos
+++ b/testsuite/metamodelica/meta/AllWild.mos
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
 // teardown_command: rm -rf AllWild_*
+// suite: metamodelica
 
 loadFile("AllWild.mo");
 list();

--- a/testsuite/metamodelica/meta/ArraySubscripting.mos
+++ b/testsuite/metamodelica/meta/ArraySubscripting.mos
@@ -2,6 +2,7 @@
 // keywords: builtin, array, subscript
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Checks that subscripting of arrays works correctly.
 //

--- a/testsuite/metamodelica/meta/AssignMatchVar.mos
+++ b/testsuite/metamodelica/meta/AssignMatchVar.mos
@@ -1,6 +1,7 @@
 // name: AssignMatchVar
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
+// suite: metamodelica
 //
 // Checks that it's allowed to assign to a non-input variable that's used in a
 // match expression.

--- a/testsuite/metamodelica/meta/AssignMetaRecordField.mos
+++ b/testsuite/metamodelica/meta/AssignMetaRecordField.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("--grammar=MetaModelica -d=gen");
 loadString("

--- a/testsuite/metamodelica/meta/BuiltinArray.mos
+++ b/testsuite/metamodelica/meta/BuiltinArray.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/BuiltinBoolean.mos
+++ b/testsuite/metamodelica/meta/BuiltinBoolean.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/BuiltinInteger.mos
+++ b/testsuite/metamodelica/meta/BuiltinInteger.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/BuiltinList.mos
+++ b/testsuite/metamodelica/meta/BuiltinList.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //
@@ -29,7 +30,7 @@ getErrorString();
 // Result:
 // true
 //
-// "[metamodelica/meta/BuiltinList.mos:10:1-10:30:writable] Error: Could not solve the polymorphism in the function call to .listAppend
+// "[metamodelica/meta/BuiltinList.mos:11:1-11:30:writable] Error: Could not solve the polymorphism in the function call to .listAppend
 //   Input bindings:
 //     $A:
 //       #Real

--- a/testsuite/metamodelica/meta/BuiltinMisc.mos
+++ b/testsuite/metamodelica/meta/BuiltinMisc.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/BuiltinReal.mos
+++ b/testsuite/metamodelica/meta/BuiltinReal.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   -g=MetaModelica -d=noevalfunc,gen -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/BuiltinString.mos
+++ b/testsuite/metamodelica/meta/BuiltinString.mos
@@ -2,6 +2,7 @@
 // keywords: Builtin
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Builtin function testing
 //

--- a/testsuite/metamodelica/meta/CheckPatternScope.mo
+++ b/testsuite/metamodelica/meta/CheckPatternScope.mo
@@ -1,5 +1,6 @@
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 model CheckInputScope
 
@@ -22,7 +23,7 @@ end CheckInputScope;
 
 // Result:
 // Error processing file: CheckPatternScope.mo
-// [metamodelica/meta/CheckPatternScope.mo:11:3-14:12:writable] Error: Variable y not found in scope CheckInputScope.P.test.
+// [metamodelica/meta/CheckPatternScope.mo:12:3-15:12:writable] Error: Variable y not found in scope CheckInputScope.P.test.
 // Error: Error occurred while flattening model CheckInputScope
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ComplicatedInteractive.mos
+++ b/testsuite/metamodelica/meta/ComplicatedInteractive.mos
@@ -2,6 +2,7 @@
 // keywords: MetaModelica
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Testing nested complex datatypes, like tuple, list, option...
 loadFile("ComplicatedInteractive.mo");
@@ -47,16 +48,16 @@ getErrorString();
 // end ComplicatedInteractive.LI2.RecordWithComplicatedTypes;)
 // {(2, 3.5), (2, 3.5), (2, 3.5), (1, 7.5), (2, 3.5), (2, 3.5)}
 //
-// "[metamodelica/meta/ComplicatedInteractive.mos:20:1-20:93:writable] Error: Type mismatch for positional argument 1 in ComplicatedInteractive.LI2(rcf=Tuple(#(1), List(Tuple(#(1.0), NONE()), Tuple(#(1.0), SOME(List(#(true))))))). The argument has type:
+// "[metamodelica/meta/ComplicatedInteractive.mos:21:1-21:93:writable] Error: Type mismatch for positional argument 1 in ComplicatedInteractive.LI2(rcf=Tuple(#(1), List(Tuple(#(1.0), NONE()), Tuple(#(1.0), SOME(List(#(true))))))). The argument has type:
 //   tuple<#Integer, list<tuple<#Real, Option<list<#Boolean>>>>>
 // expected type:
 //   tuple<#Real, list<tuple<#Real, Option<list<#Integer>>>>>
-// [metamodelica/meta/ComplicatedInteractive.mos:20:1-20:93:writable] Error: In record constructor ComplicatedInteractive.LI2.RecordWithComplicatedTypes: Failed to match types:
+// [metamodelica/meta/ComplicatedInteractive.mos:21:1-21:93:writable] Error: In record constructor ComplicatedInteractive.LI2.RecordWithComplicatedTypes: Failed to match types:
 //     actual:   tuple<#Integer, list<tuple<#Real, Option<list<#Boolean>>>>>
 //     expected: (tuple<#Real, list<tuple<#Real, Option<list<#Integer>>>>>)
 // "
 //
-// "[metamodelica/meta/ComplicatedInteractive.mos:22:1-22:58:writable] Error: Type mismatch for positional argument 1 in ComplicatedInteractive.NewComplicatedThingy(opt=SOME(List(#(true)))). The argument has type:
+// "[metamodelica/meta/ComplicatedInteractive.mos:23:1-23:58:writable] Error: Type mismatch for positional argument 1 in ComplicatedInteractive.NewComplicatedThingy(opt=SOME(List(#(true)))). The argument has type:
 //   Option<list<#Boolean>>
 // expected type:
 //   Option<list<#Integer>>

--- a/testsuite/metamodelica/meta/Continue.mo
+++ b/testsuite/metamodelica/meta/Continue.mo
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 
 model TestContinue
   function f

--- a/testsuite/metamodelica/meta/EqPatternm.mos
+++ b/testsuite/metamodelica/meta/EqPatternm.mos
@@ -2,6 +2,7 @@
 // keywords: EqPatternm
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Pattern matching in equations
 //

--- a/testsuite/metamodelica/meta/Equality.mos
+++ b/testsuite/metamodelica/meta/Equality.mos
@@ -2,6 +2,7 @@
 // keywords: Equality
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Equality Testing
 //

--- a/testsuite/metamodelica/meta/ErrorInteractiveCallFunctionPtr.mos
+++ b/testsuite/metamodelica/meta/ErrorInteractiveCallFunctionPtr.mos
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f ErrorInteractiveCallFunctionPtr_*
 // status: correct
+// suite: metamodelica
 
 loadFile("ErrorInteractiveCallFunctionPtr.mo");
 ErrorInteractiveCallFunctionPtr.func(intAdd,1,2);

--- a/testsuite/metamodelica/meta/ErrorInvalidComplexType.mo
+++ b/testsuite/metamodelica/meta/ErrorInvalidComplexType.mo
@@ -1,6 +1,7 @@
 // name: ErrorInvalidComplexType
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 package ErrorInvalidComplexType
 
 constant option<String> str = NONE();
@@ -9,8 +10,8 @@ end ErrorInvalidComplexType;
 
 // Result:
 // Error processing file: ErrorInvalidComplexType.mo
-// [metamodelica/meta/ErrorInvalidComplexType.mo:6:1-6:37:writable] Error: Class option not found in scope ErrorInvalidComplexType.option.
-// [metamodelica/meta/ErrorInvalidComplexType.mo:6:1-6:37:writable] Error: Invalid complex type name: option<String>
+// [metamodelica/meta/ErrorInvalidComplexType.mo:7:1-7:37:writable] Error: Class option not found in scope ErrorInvalidComplexType.option.
+// [metamodelica/meta/ErrorInvalidComplexType.mo:7:1-7:37:writable] Error: Invalid complex type name: option<String>
 // Error: Error occurred while flattening model ErrorInvalidComplexType
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorInvalidMetarecord.mo
+++ b/testsuite/metamodelica/meta/ErrorInvalidMetarecord.mo
@@ -1,6 +1,7 @@
 // name: ErrorInvalidMetarecord
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 model ErrorInvalidMetarecord
   uniontype Ut
@@ -12,7 +13,7 @@ end ErrorInvalidMetarecord;
 
 // Result:
 // Error processing file: ErrorInvalidMetarecord.mo
-// [metamodelica/meta/ErrorInvalidMetarecord.mo:10:3-10:30:writable] Error: The called uniontype record (ErrorInvalidMetarecord.Ut.DEF) contains a member (abc) that has a uniontype record as its type instead of a uniontype.
+// [metamodelica/meta/ErrorInvalidMetarecord.mo:11:3-11:30:writable] Error: The called uniontype record (ErrorInvalidMetarecord.Ut.DEF) contains a member (abc) that has a uniontype record as its type instead of a uniontype.
 // Error: Error occurred while flattening model ErrorInvalidMetarecord
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorInvalidPattern1.mo
+++ b/testsuite/metamodelica/meta/ErrorInvalidPattern1.mo
@@ -1,6 +1,7 @@
 // name: ErrorInvalidPattern1
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 package ErrorInvalidPattern1
 
@@ -19,7 +20,7 @@ end ErrorInvalidPattern1;
 
 // Result:
 // Error processing file: ErrorInvalidPattern1.mo
-// [metamodelica/meta/ErrorInvalidPattern1.mo:12:10-12:19:writable] Error: Invalid pattern: str + "" of type String
+// [metamodelica/meta/ErrorInvalidPattern1.mo:13:10-13:19:writable] Error: Invalid pattern: str + "" of type String
 // Error: Error occurred while flattening model ErrorInvalidPattern1
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorInvalidPattern2.mo
+++ b/testsuite/metamodelica/meta/ErrorInvalidPattern2.mo
@@ -1,6 +1,7 @@
 // name: ErrorInvalidPattern2
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 package ErrorInvalidPattern2
 
@@ -25,7 +26,7 @@ end ErrorInvalidPattern2;
 
 // Result:
 // Error processing file: ErrorInvalidPattern2.mo
-// [metamodelica/meta/ErrorInvalidPattern2.mo:17:10-17:22:writable] Error: Invalid named fields: exp. Valid field names: .
+// [metamodelica/meta/ErrorInvalidPattern2.mo:18:10-18:22:writable] Error: Invalid named fields: exp. Valid field names: .
 // Error: Error occurred while flattening model ErrorInvalidPattern2
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorInvalidPattern3.mo
+++ b/testsuite/metamodelica/meta/ErrorInvalidPattern3.mo
@@ -1,6 +1,7 @@
 // name: ErrorInvalidPattern3
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 package ErrorInvalidPattern3
 
 uniontype Ut
@@ -25,7 +26,7 @@ end ErrorInvalidPattern3;
 
 // Result:
 // Error processing file: ErrorInvalidPattern3.mo
-// [metamodelica/meta/ErrorInvalidPattern3.mo:17:10-17:40:writable] Error: Invalid named fields: exp,exp. Valid field names: exp.
+// [metamodelica/meta/ErrorInvalidPattern3.mo:18:10-18:40:writable] Error: Invalid named fields: exp,exp. Valid field names: exp.
 // Error: Error occurred while flattening model ErrorInvalidPattern3
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorLocalElement1.mo
+++ b/testsuite/metamodelica/meta/ErrorLocalElement1.mo
@@ -1,6 +1,7 @@
 // name: ErrorLocalElement1
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 class ErrorLocalElement1
   function fn
@@ -20,7 +21,7 @@ end ErrorLocalElement1;
 
 // Result:
 // Error processing file: ErrorLocalElement1.mo
-// [metamodelica/meta/ErrorLocalElement1.mo:10:5-15:14:writable] Error: Only components without direction are allowed in local declarations, got: type T = Integer
+// [metamodelica/meta/ErrorLocalElement1.mo:11:5-16:14:writable] Error: Only components without direction are allowed in local declarations, got: type T = Integer
 // Error: Error occurred while flattening model ErrorLocalElement1
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorLocalElement2.mo
+++ b/testsuite/metamodelica/meta/ErrorLocalElement2.mo
@@ -1,6 +1,7 @@
 // name: ErrorLocalElement2
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 class ErrorLocalElement2
   function fn
@@ -19,7 +20,7 @@ end ErrorLocalElement2;
 
 // Result:
 // Error processing file: ErrorLocalElement2.mo
-// [metamodelica/meta/ErrorLocalElement2.mo:10:5-14:14:writable] Error: Only components without direction are allowed in local declarations, got: input Integer t
+// [metamodelica/meta/ErrorLocalElement2.mo:11:5-15:14:writable] Error: Only components without direction are allowed in local declarations, got: input Integer t
 // Error: Error occurred while flattening model ErrorLocalElement2
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorLocalElement3.mo
+++ b/testsuite/metamodelica/meta/ErrorLocalElement3.mo
@@ -1,6 +1,7 @@
 // name: ErrorLocalElement3
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 class ErrorLocalElement3
   function fn
@@ -19,10 +20,10 @@ end ErrorLocalElement3;
 
 // Result:
 // Error processing file: ErrorLocalElement3.mo
-// [metamodelica/meta/ErrorLocalElement3.mo:12:9-12:20:writable] Error: Class int not found in scope ErrorLocalElement3.fn.$match scope$.list.
-// [metamodelica/meta/ErrorLocalElement3.mo:10:5-14:14:writable] Error: Internal error Patternm.addLocalDecls failed
-// [metamodelica/meta/ErrorLocalElement3.mo:12:9-12:20:writable] Error: Class int not found in scope ErrorLocalElement3.fn.$match scope$.list.
-// [metamodelica/meta/ErrorLocalElement3.mo:10:5-14:14:writable] Error: Internal error Patternm.addLocalDecls failed
+// [metamodelica/meta/ErrorLocalElement3.mo:13:9-13:20:writable] Error: Class int not found in scope ErrorLocalElement3.fn.$match scope$.list.
+// [metamodelica/meta/ErrorLocalElement3.mo:11:5-15:14:writable] Error: Internal error Patternm.addLocalDecls failed
+// [metamodelica/meta/ErrorLocalElement3.mo:13:9-13:20:writable] Error: Class int not found in scope ErrorLocalElement3.fn.$match scope$.list.
+// [metamodelica/meta/ErrorLocalElement3.mo:11:5-15:14:writable] Error: Internal error Patternm.addLocalDecls failed
 // Error: Error occurred while flattening model ErrorLocalElement3
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorMatchInOut1.mo
+++ b/testsuite/metamodelica/meta/ErrorMatchInOut1.mo
@@ -1,6 +1,7 @@
 // name: ErrorMatchInOut1.mo
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 package ErrorMatchInOut1
 
 function fn
@@ -17,7 +18,7 @@ constant String str = fn("");
 end ErrorMatchInOut1;
 // Result:
 // Error processing file: ErrorMatchInOut1.mo
-// [metamodelica/meta/ErrorMatchInOut1.mo:10:3-12:12:writable] Error: Variable strx not found in scope ErrorMatchInOut1.fn.
+// [metamodelica/meta/ErrorMatchInOut1.mo:11:3-13:12:writable] Error: Variable strx not found in scope ErrorMatchInOut1.fn.
 // Error: Error occurred while flattening model ErrorMatchInOut1
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ErrorMatchNumOutput.mos
+++ b/testsuite/metamodelica/meta/ErrorMatchNumOutput.mos
@@ -1,6 +1,7 @@
 // name: ErrorMatchNumOutput
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 //
 // Tests the error message for imbalanced number of actual/expected output in
 // match expressions.

--- a/testsuite/metamodelica/meta/ErrorNone.mos
+++ b/testsuite/metamodelica/meta/ErrorNone.mos
@@ -1,6 +1,7 @@
 // name: ErrorNone
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 match NONE()
   case NONE then 1;
@@ -10,6 +11,6 @@ getErrorString();
 
 // Result:
 //
-// "[metamodelica/meta/ErrorNone.mos:6:8-6:13:writable] Error: NONE is not acceptable syntax. Use NONE() instead.
+// "[metamodelica/meta/ErrorNone.mos:7:8-7:13:writable] Error: NONE is not acceptable syntax. Use NONE() instead.
 // "
 // endResult

--- a/testsuite/metamodelica/meta/Failure.mos
+++ b/testsuite/metamodelica/meta/Failure.mos
@@ -2,6 +2,7 @@
 // keywords: Failure
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Failure Testing
 //

--- a/testsuite/metamodelica/meta/ForIterArray.mos
+++ b/testsuite/metamodelica/meta/ForIterArray.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("function forIterArray

--- a/testsuite/metamodelica/meta/ForIterList.mos
+++ b/testsuite/metamodelica/meta/ForIterList.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("package ForIterList

--- a/testsuite/metamodelica/meta/FunctionPartialApplicationAsGeneralExp.mos
+++ b/testsuite/metamodelica/meta/FunctionPartialApplicationAsGeneralExp.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("package FunctionPartialApplicationAsGeneralExp

--- a/testsuite/metamodelica/meta/FunctionReturningArray.mos
+++ b/testsuite/metamodelica/meta/FunctionReturningArray.mos
@@ -1,5 +1,6 @@
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
+// suite: metamodelica
 
 loadString("package FunctionReturningArray
 

--- a/testsuite/metamodelica/meta/InvalidWild1.mos
+++ b/testsuite/metamodelica/meta/InvalidWild1.mos
@@ -1,6 +1,7 @@
 // name: InvalidWild1
 // cflags: -g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 loadString("
   function test

--- a/testsuite/metamodelica/meta/IsPresent.mos
+++ b/testsuite/metamodelica/meta/IsPresent.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=noevalfunc,gen");
 

--- a/testsuite/metamodelica/meta/List1.mos
+++ b/testsuite/metamodelica/meta/List1.mos
@@ -2,6 +2,7 @@
 // keywords: Lists
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // List Testing
 //

--- a/testsuite/metamodelica/meta/List2.mos
+++ b/testsuite/metamodelica/meta/List2.mos
@@ -2,6 +2,7 @@
 // keywords: Lists
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // List Testing
 //

--- a/testsuite/metamodelica/meta/List3.mos
+++ b/testsuite/metamodelica/meta/List3.mos
@@ -2,6 +2,7 @@
 // keywords: Lists
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // List Testing
 //

--- a/testsuite/metamodelica/meta/List4.mo
+++ b/testsuite/metamodelica/meta/List4.mo
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=noevalfunc,gen -d=-newInst
 // status: correct
 // teardown_command: rm -f List4_*
+// suite: metamodelica
 model List4
 
   function func2

--- a/testsuite/metamodelica/meta/List5.mo
+++ b/testsuite/metamodelica/meta/List5.mo
@@ -1,6 +1,7 @@
 // name: List5
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 package P
 uniontype UT
   record R1 end R1;

--- a/testsuite/metamodelica/meta/ListInteractive.mos
+++ b/testsuite/metamodelica/meta/ListInteractive.mos
@@ -2,6 +2,7 @@
 // keywords: Lists
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // List Testing
 loadFile("ListInteractive.mo");

--- a/testsuite/metamodelica/meta/ListReductionCodegen.mo
+++ b/testsuite/metamodelica/meta/ListReductionCodegen.mo
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=noevalfunc,gen -d=-newInst
 // status: correct
 // teardown_command: rm -rf ListReduction_*
+// suite: metamodelica
 
 class ListReduction
   function myMin

--- a/testsuite/metamodelica/meta/ListReductionDimError.mo
+++ b/testsuite/metamodelica/meta/ListReductionDimError.mo
@@ -1,6 +1,7 @@
 // name: ListReductionDimError
 // cflags: +g=MetaModelica -d=-newInst
 // status: incorrect
+// suite: metamodelica
 
 class ListReductionDimError
   Real r[3];
@@ -10,7 +11,7 @@ end ListReductionDimError;
 
 // Result:
 // Error processing file: ListReductionDimError.mo
-// [metamodelica/meta/ListReductionDimError.mo:8:3-8:26:writable] Error: Type mismatch in equation {r[1], r[2], r[3]}={-3, 3} of type Real[3]=Integer[2].
+// [metamodelica/meta/ListReductionDimError.mo:9:3-9:26:writable] Error: Type mismatch in equation {r[1], r[2], r[3]}={-3, 3} of type Real[3]=Integer[2].
 // Error: Error occurred while flattening model ListReductionDimError
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/ListReductionInterpret.mo
+++ b/testsuite/metamodelica/meta/ListReductionInterpret.mo
@@ -2,6 +2,7 @@
 // cflags: +g=MetaModelica +d=nogen -d=-newInst
 // status: correct
 // teardown_command: rm -rf ListReduction_*
+// suite: metamodelica
 
 class ListReduction
   function myMin

--- a/testsuite/metamodelica/meta/MatchCase1.mos
+++ b/testsuite/metamodelica/meta/MatchCase1.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase10.mos
+++ b/testsuite/metamodelica/meta/MatchCase10.mos
@@ -3,6 +3,7 @@
 // cflags: +g=MetaModelica -d=-newInst
 // status:   correct
 // teardown_command: rm -rf MatchCase10_*
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase11.mos
+++ b/testsuite/metamodelica/meta/MatchCase11.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f MatchCase11_*
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase12.mos
+++ b/testsuite/metamodelica/meta/MatchCase12.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f MatchCase12_*
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase13.mos
+++ b/testsuite/metamodelica/meta/MatchCase13.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f MatchCase13_*
+// suite: metamodelica
 //
 // Match Testing. Tests tuple output of match expressions.
 //

--- a/testsuite/metamodelica/meta/MatchCase14.mo
+++ b/testsuite/metamodelica/meta/MatchCase14.mo
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
 // teardown_command: rm -f MatchCase14_*
+// suite: metamodelica
 package MatchCase14
 
 function fn

--- a/testsuite/metamodelica/meta/MatchCase15.mo
+++ b/testsuite/metamodelica/meta/MatchCase15.mo
@@ -1,6 +1,7 @@
 // name: MatchCase15
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
+// suite: metamodelica
 
 package MatchCase15
 

--- a/testsuite/metamodelica/meta/MatchCase16.mo
+++ b/testsuite/metamodelica/meta/MatchCase16.mo
@@ -1,6 +1,7 @@
 // name: MatchCase16
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // status: correct
+// suite: metamodelica
 
 package MatchCase16
 

--- a/testsuite/metamodelica/meta/MatchCase17.mo
+++ b/testsuite/metamodelica/meta/MatchCase17.mo
@@ -1,6 +1,7 @@
 // name: MatchCase17
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 package MatchCase17
 

--- a/testsuite/metamodelica/meta/MatchCase2.mos
+++ b/testsuite/metamodelica/meta/MatchCase2.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase3.mos
+++ b/testsuite/metamodelica/meta/MatchCase3.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase4.mos
+++ b/testsuite/metamodelica/meta/MatchCase4.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase5.mos
+++ b/testsuite/metamodelica/meta/MatchCase5.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase6.mos
+++ b/testsuite/metamodelica/meta/MatchCase6.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase7.mos
+++ b/testsuite/metamodelica/meta/MatchCase7.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase8.mos
+++ b/testsuite/metamodelica/meta/MatchCase8.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCase9.mos
+++ b/testsuite/metamodelica/meta/MatchCase9.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCaseGuard.mos
+++ b/testsuite/metamodelica/meta/MatchCaseGuard.mos
@@ -1,6 +1,7 @@
 // name: MatchCaseGuard
 // cflags: -g=MetaModelica -d=tail,gen -d=-newInst
 // status: correct
+// suite: metamodelica
 
 loadString("function fac
   input Integer i;

--- a/testsuite/metamodelica/meta/MatchCaseInteractive1.mos
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive1.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCaseInteractive2.mos
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive2.mos
@@ -2,6 +2,7 @@
 // keywords: Match Cases
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchCaseInteractive3.mos
+++ b/testsuite/metamodelica/meta/MatchCaseInteractive3.mos
@@ -2,6 +2,7 @@
 // keywords: MatchCase
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // MatchCase Testing
 //

--- a/testsuite/metamodelica/meta/MatchDotNotation.mos
+++ b/testsuite/metamodelica/meta/MatchDotNotation.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();
 setCFlags(getCFlags() + " -g");getErrorString();

--- a/testsuite/metamodelica/meta/MatchElse1.mos
+++ b/testsuite/metamodelica/meta/MatchElse1.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f MatchElse1_*
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchIfEquation1.mos
+++ b/testsuite/metamodelica/meta/MatchIfEquation1.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f MatchIfEquation1_*
+// suite: metamodelica
 //
 // Match Testing
 //

--- a/testsuite/metamodelica/meta/MatchNoRetCall.mos
+++ b/testsuite/metamodelica/meta/MatchNoRetCall.mos
@@ -2,6 +2,7 @@
 // keywords: match noretcall #3633
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Checks that using a match as a non-returning call works.
 //

--- a/testsuite/metamodelica/meta/MatchShadowing.mo
+++ b/testsuite/metamodelica/meta/MatchShadowing.mo
@@ -1,6 +1,7 @@
 // name: MatchShadowing
 // status: incorrect
 // cflags: +g=MetaModelica -d=-newInst
+// suite: metamodelica
 
 model MatchShadowing
 
@@ -21,7 +22,7 @@ end MatchShadowing;
 
 // Result:
 // Error processing file: MatchShadowing.mo
-// [metamodelica/meta/MatchShadowing.mo:13:7-13:13:writable] Error: Local variable 'x' shadows another variable.
+// [metamodelica/meta/MatchShadowing.mo:14:7-14:13:writable] Error: Local variable 'x' shadows another variable.
 // Error: Error occurred while flattening model MatchShadowing
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/OptimizeContinue.mo
+++ b/testsuite/metamodelica/meta/OptimizeContinue.mo
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=patternmAllInfo,gen -d=-newInst
 // status: correct
 // teardown_command: rm -f OptimizeContinue_*
+// suite: metamodelica
 
 model OptimizeContinue
   uniontype Ut
@@ -64,12 +65,12 @@ end OptimizeContinue;
 // class OptimizeContinue
 //   constant Real r = 1.0;
 // end OptimizeContinue;
-// [metamodelica/meta/OptimizeContinue.mo:21:5-25:22:writable] Notification: This matchcontinue expression has no overlapping patterns and should be using match instead of matchcontinue.
-// [metamodelica/meta/OptimizeContinue.mo:21:5-25:22:writable] Notification: Converted match expression to switch of type #T_UNKNOWN#.
-// [metamodelica/meta/OptimizeContinue.mo:21:5-25:22:writable] Notification: Match input OptimizeContinue.Ut.UT1() is a constant value.
-// [metamodelica/meta/OptimizeContinue.mo:26:5-29:22:writable] Notification: This matchcontinue expression has no overlapping patterns and should be using match instead of matchcontinue.
-// [metamodelica/meta/OptimizeContinue.mo:26:5-29:22:writable] Notification: Match input OptimizeContinue.Ut2.UT4(#(1)) is a constant value.
-// [metamodelica/meta/OptimizeContinue.mo:30:5-33:22:writable] Notification: Match input OptimizeContinue.Ut.UT1() is a constant value.
-// [metamodelica/meta/OptimizeContinue.mo:34:5-37:22:writable] Notification: Match input OptimizeContinue.Ut2.UT4(#(1)) is a constant value.
+// [metamodelica/meta/OptimizeContinue.mo:22:5-26:22:writable] Notification: This matchcontinue expression has no overlapping patterns and should be using match instead of matchcontinue.
+// [metamodelica/meta/OptimizeContinue.mo:22:5-26:22:writable] Notification: Converted match expression to switch of type #T_UNKNOWN#.
+// [metamodelica/meta/OptimizeContinue.mo:22:5-26:22:writable] Notification: Match input OptimizeContinue.Ut.UT1() is a constant value.
+// [metamodelica/meta/OptimizeContinue.mo:27:5-30:22:writable] Notification: This matchcontinue expression has no overlapping patterns and should be using match instead of matchcontinue.
+// [metamodelica/meta/OptimizeContinue.mo:27:5-30:22:writable] Notification: Match input OptimizeContinue.Ut2.UT4(#(1)) is a constant value.
+// [metamodelica/meta/OptimizeContinue.mo:31:5-34:22:writable] Notification: Match input OptimizeContinue.Ut.UT1() is a constant value.
+// [metamodelica/meta/OptimizeContinue.mo:35:5-38:22:writable] Notification: Match input OptimizeContinue.Ut2.UT4(#(1)) is a constant value.
 //
 // endResult

--- a/testsuite/metamodelica/meta/OptimizeMatchToIfExp.mo
+++ b/testsuite/metamodelica/meta/OptimizeMatchToIfExp.mo
@@ -1,6 +1,7 @@
 // name: OptimizeMatchToIfExp
 // status: correct
 // cflags: +g=MetaModelica +d=noevalfunc,nogen -d=-newInst
+// suite: metamodelica
 // Checks that we are able to convert a match-expression into if
 // and inlining it with a non-boxed function that is in turn also
 // correctly inlined.

--- a/testsuite/metamodelica/meta/OptionInteractive.mos
+++ b/testsuite/metamodelica/meta/OptionInteractive.mos
@@ -2,6 +2,7 @@
 // keywords: Option Type
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Option Testing
 //

--- a/testsuite/metamodelica/meta/PackageConst1.mos
+++ b/testsuite/metamodelica/meta/PackageConst1.mos
@@ -2,6 +2,7 @@
 // keywords: package const recursion
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Tests self recursive constants inside of packages
 //

--- a/testsuite/metamodelica/meta/PartialFn1.mo
+++ b/testsuite/metamodelica/meta/PartialFn1.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:  correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Using function pointers.
 //

--- a/testsuite/metamodelica/meta/PartialFn10.mos
+++ b/testsuite/metamodelica/meta/PartialFn10.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn11.mos
+++ b/testsuite/metamodelica/meta/PartialFn11.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn12.mos
+++ b/testsuite/metamodelica/meta/PartialFn12.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn13.mos
+++ b/testsuite/metamodelica/meta/PartialFn13.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn14.mos
+++ b/testsuite/metamodelica/meta/PartialFn14.mos
@@ -3,6 +3,7 @@
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
 // status:   correct
 // teardown_command: rm -rf PartialFn14_*
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn15.mo
+++ b/testsuite/metamodelica/meta/PartialFn15.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:  correct
 // cflags: -g=MetaModelica -d=noevalfunc,gen -d=-newInst
+// suite: metamodelica
 //
 // Using lists of function pointers
 //

--- a/testsuite/metamodelica/meta/PartialFn16.mos
+++ b/testsuite/metamodelica/meta/PartialFn16.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 // bug #2675
 
 setCommandLineOptions({"-g=MetaModelica","-d=noevalfunc,gen"});getErrorString();

--- a/testsuite/metamodelica/meta/PartialFn2.mo
+++ b/testsuite/metamodelica/meta/PartialFn2.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:  correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Using pointers to functions pointing to other functions.
 //

--- a/testsuite/metamodelica/meta/PartialFn3.mos
+++ b/testsuite/metamodelica/meta/PartialFn3.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   incorrect
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn4.mo
+++ b/testsuite/metamodelica/meta/PartialFn4.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:  correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Using function pointers to non-returning functions
 //

--- a/testsuite/metamodelica/meta/PartialFn5.mo
+++ b/testsuite/metamodelica/meta/PartialFn5.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:  correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Using function pointers to builtin functions
 //

--- a/testsuite/metamodelica/meta/PartialFn6.mo
+++ b/testsuite/metamodelica/meta/PartialFn6.mo
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
 // depends:  PartialFn6.ext_f.c
+// suite: metamodelica
 //
 // Passing external functions as arguments to function calls
 

--- a/testsuite/metamodelica/meta/PartialFn7.mo
+++ b/testsuite/metamodelica/meta/PartialFn7.mo
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Passing record constructors
 //

--- a/testsuite/metamodelica/meta/PartialFn8.mos
+++ b/testsuite/metamodelica/meta/PartialFn8.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFn9.mos
+++ b/testsuite/metamodelica/meta/PartialFn9.mos
@@ -2,6 +2,7 @@
 // keywords: PartialFn
 // status:   correct
 // cflags: -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Partial Function Testing
 //

--- a/testsuite/metamodelica/meta/PartialFnDefaultBinding.mos
+++ b/testsuite/metamodelica/meta/PartialFnDefaultBinding.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 // Bug #2889
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();

--- a/testsuite/metamodelica/meta/PatternMatchInvalidType.mo
+++ b/testsuite/metamodelica/meta/PatternMatchInvalidType.mo
@@ -1,5 +1,6 @@
 // status: incorrect
 // cflags: +g=MetaModelica -d=-newInst
+// suite: metamodelica
 
 model PatternMatchInvalidType
 
@@ -17,7 +18,7 @@ end PatternMatchInvalidType;
 
 // Result:
 // Error processing file: PatternMatchInvalidType.mo
-// [metamodelica/meta/PatternMatchInvalidType.mo:9:10-9:15:writable] Error: Type mismatch in pattern {}
+// [metamodelica/meta/PatternMatchInvalidType.mo:10:10-10:15:writable] Error: Type mismatch in pattern {}
 // expression type:
 //   Integer
 // pattern type:

--- a/testsuite/metamodelica/meta/Polymorphic.mos
+++ b/testsuite/metamodelica/meta/Polymorphic.mos
@@ -2,6 +2,7 @@
 // keywords: Polymorphism
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Polymorphic functions
 //

--- a/testsuite/metamodelica/meta/Polymorphic2.mos
+++ b/testsuite/metamodelica/meta/Polymorphic2.mos
@@ -2,6 +2,7 @@
 // keywords: Polymorphism
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Polymorphic functions
 //

--- a/testsuite/metamodelica/meta/PolymorphicCallTypeSpec1.mos
+++ b/testsuite/metamodelica/meta/PolymorphicCallTypeSpec1.mos
@@ -1,6 +1,7 @@
 // name: PolymorphicCallTypeSpec1
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("

--- a/testsuite/metamodelica/meta/PolymorphicCallTypeSpec2.mos
+++ b/testsuite/metamodelica/meta/PolymorphicCallTypeSpec2.mos
@@ -1,6 +1,7 @@
 // name: PolymorphicCallTypeSpec2
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("
@@ -28,6 +29,6 @@ getErrorString();
 // ""
 //
 // "[<interactive>:13:5-13:59:writable] Error: Too many type variables given in call to '.U.new'.
-// [metamodelica/meta/PolymorphicCallTypeSpec2.mos:22:1-22:7:writable] Error: Class test not found in scope <global scope> (looking for a function or record).
+// [metamodelica/meta/PolymorphicCallTypeSpec2.mos:23:1-23:7:writable] Error: Class test not found in scope <global scope> (looking for a function or record).
 // "
 // endResult

--- a/testsuite/metamodelica/meta/PolymorphicCallTypeSpec3.mos
+++ b/testsuite/metamodelica/meta/PolymorphicCallTypeSpec3.mos
@@ -1,6 +1,7 @@
 // name: PolymorphicCallTypeSpec3
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("

--- a/testsuite/metamodelica/meta/PolymorphicReduction.mos
+++ b/testsuite/metamodelica/meta/PolymorphicReduction.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("+g=MetaModelica");loadString("function polymorphicReduction
   input list<list<Integer>> ll = {{1}, {2}};

--- a/testsuite/metamodelica/meta/Recursive.mos
+++ b/testsuite/metamodelica/meta/Recursive.mos
@@ -2,6 +2,7 @@
 // keywords: Recursive
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Recursive function testing
 //

--- a/testsuite/metamodelica/meta/ReturnInTryBlock.mos
+++ b/testsuite/metamodelica/meta/ReturnInTryBlock.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=noevalfunc,gen");
 loadString("

--- a/testsuite/metamodelica/meta/ScalarArrayOperations.mos
+++ b/testsuite/metamodelica/meta/ScalarArrayOperations.mos
@@ -3,6 +3,7 @@
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
 //
 // ticket:4382
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=noevalfunc,gen"); getErrorString();
 

--- a/testsuite/metamodelica/meta/Shadowing1.mos
+++ b/testsuite/metamodelica/meta/Shadowing1.mos
@@ -2,6 +2,7 @@
 // keywords: Shadowing
 // status:   incorrect
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Local Declaration Shadowing
 //

--- a/testsuite/metamodelica/meta/Shadowing2.mos
+++ b/testsuite/metamodelica/meta/Shadowing2.mos
@@ -2,6 +2,7 @@
 // keywords: Shadowing
 // status:   incorrect
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Local Delcaration Shadowing
 //

--- a/testsuite/metamodelica/meta/Simplify1.mos
+++ b/testsuite/metamodelica/meta/Simplify1.mos
@@ -3,6 +3,7 @@
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
 // teardown_command: rm -f Simplify1.c* Simplify1.h Simplify1.libs Simplify1.log Simplify1.makefile Simplify1_records.c Simplify1.so
+// suite: metamodelica
 //
 // Checks that terms are not removed in simplification that shouldn't be.
 //

--- a/testsuite/metamodelica/meta/StringBoxed.mos
+++ b/testsuite/metamodelica/meta/StringBoxed.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 // Based on ticket #3653
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();

--- a/testsuite/metamodelica/meta/SwitchString.mos
+++ b/testsuite/metamodelica/meta/SwitchString.mos
@@ -1,6 +1,7 @@
 // status: correct
 // ticket: #3063
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=noevalfunc,gen");getErrorString();
 loadFile("SwitchString.mo");getErrorString();

--- a/testsuite/metamodelica/meta/TailRecursion.mo
+++ b/testsuite/metamodelica/meta/TailRecursion.mo
@@ -1,6 +1,7 @@
 // name: TailRecursion
 // cflags: -d=noevalfunc,tail,gen -g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 model TailRecursion
 function last
@@ -68,8 +69,8 @@ end TailRecursion;
 //   Real r2 = 200000.5;
 //   Real r3 = 200000.5;
 // end TailRecursion;
-// [metamodelica/meta/TailRecursion.mo:11:3-11:19:writable] Notification: Tail recursion of: TailRecursion.last(1.0 + x) with input vars: x
-// [metamodelica/meta/TailRecursion.mo:18:3-18:46:writable] Notification: Tail recursion of: TailRecursion.if_(1.0 + x) with input vars: x
-// [metamodelica/meta/TailRecursion.mo:25:3-29:12:writable] Notification: Tail recursion of: TailRecursion.match_(1.0 + x) with input vars: x
+// [metamodelica/meta/TailRecursion.mo:12:3-12:19:writable] Notification: Tail recursion of: TailRecursion.last(1.0 + x) with input vars: x
+// [metamodelica/meta/TailRecursion.mo:19:3-19:46:writable] Notification: Tail recursion of: TailRecursion.if_(1.0 + x) with input vars: x
+// [metamodelica/meta/TailRecursion.mo:26:3-30:12:writable] Notification: Tail recursion of: TailRecursion.match_(1.0 + x) with input vars: x
 //
 // endResult

--- a/testsuite/metamodelica/meta/TailRecursionNoretcall.mos
+++ b/testsuite/metamodelica/meta/TailRecursionNoretcall.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("+g=MetaModelica +d=noevalfunc");getErrorString();
 loadString("

--- a/testsuite/metamodelica/meta/ThreadedReduction.mos
+++ b/testsuite/metamodelica/meta/ThreadedReduction.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("+g=MetaModelica");
 loadString("function testThreadedReduction

--- a/testsuite/metamodelica/meta/Ticket2974.mos
+++ b/testsuite/metamodelica/meta/Ticket2974.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();
 loadString("

--- a/testsuite/metamodelica/meta/Ticket3005.mos
+++ b/testsuite/metamodelica/meta/Ticket3005.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();
 loadString("

--- a/testsuite/metamodelica/meta/Try.mos
+++ b/testsuite/metamodelica/meta/Try.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");getErrorString();
 loadString("package Try

--- a/testsuite/metamodelica/meta/TryExtends.mos
+++ b/testsuite/metamodelica/meta/TryExtends.mos
@@ -1,6 +1,7 @@
 // name: TryExtends
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Checks that the compiler handles try in inherited functions correctly.
 //

--- a/testsuite/metamodelica/meta/TupleInteractive.mos
+++ b/testsuite/metamodelica/meta/TupleInteractive.mos
@@ -2,6 +2,7 @@
 // keywords: Tuple
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Tuple Testing
 //

--- a/testsuite/metamodelica/meta/UnboundLocal.mo
+++ b/testsuite/metamodelica/meta/UnboundLocal.mo
@@ -1,5 +1,6 @@
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 model UnboundLocal
   function g
@@ -96,15 +97,15 @@ end UnboundLocal;
 // equation
 //   r = UnboundLocal.f(time);
 // end UnboundLocal;
-// [metamodelica/meta/UnboundLocal.mo:17:5-17:11:writable] Warning: y was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:18:5-18:19:writable] Warning: o was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:18:5-18:19:writable] Warning: ix1 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:19:5-19:15:writable] Warning: ix3 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:20:5-20:20:writable] Warning: ix2 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:24:7-24:17:writable] Warning: ix4 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:34:7-34:18:writable] Warning: ix6 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:36:5-43:14:writable] Warning: j was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:39:14-40:7:writable] Warning: i was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// [metamodelica/meta/UnboundLocal.mo:42:14-43:5:writable] Warning: i was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:18:5-18:11:writable] Warning: y was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:19:5-19:19:writable] Warning: o was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:19:5-19:19:writable] Warning: ix1 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:20:5-20:15:writable] Warning: ix3 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:21:5-21:20:writable] Warning: ix2 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:25:7-25:17:writable] Warning: ix4 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:35:7-35:18:writable] Warning: ix6 was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:37:5-44:14:writable] Warning: j was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:40:14-41:7:writable] Warning: i was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
+// [metamodelica/meta/UnboundLocal.mo:43:14-44:5:writable] Warning: i was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 //
 // endResult

--- a/testsuite/metamodelica/meta/UnboxCond.mo
+++ b/testsuite/metamodelica/meta/UnboxCond.mo
@@ -1,5 +1,6 @@
 // cflags: +g=MetaModelica +d=noevalfunc,nogen -d=-newInst
 // status: correct
+// suite: metamodelica
 
 model UnboxCond
 

--- a/testsuite/metamodelica/meta/Uniontype1.mos
+++ b/testsuite/metamodelica/meta/Uniontype1.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype10.mos
+++ b/testsuite/metamodelica/meta/Uniontype10.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype11.mos
+++ b/testsuite/metamodelica/meta/Uniontype11.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype12.mos
+++ b/testsuite/metamodelica/meta/Uniontype12.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype13.mos
+++ b/testsuite/metamodelica/meta/Uniontype13.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype14.mos
+++ b/testsuite/metamodelica/meta/Uniontype14.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Test matching of list constructor in Uniontype
 //

--- a/testsuite/metamodelica/meta/Uniontype15.mos
+++ b/testsuite/metamodelica/meta/Uniontype15.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Test type aliasing of uniontypes
 //

--- a/testsuite/metamodelica/meta/Uniontype2.mos
+++ b/testsuite/metamodelica/meta/Uniontype2.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype3.mos
+++ b/testsuite/metamodelica/meta/Uniontype3.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype4.mos
+++ b/testsuite/metamodelica/meta/Uniontype4.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype5.mos
+++ b/testsuite/metamodelica/meta/Uniontype5.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype6.mos
+++ b/testsuite/metamodelica/meta/Uniontype6.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags: -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype7.mos
+++ b/testsuite/metamodelica/meta/Uniontype7.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype8.mos
+++ b/testsuite/metamodelica/meta/Uniontype8.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/Uniontype9.mos
+++ b/testsuite/metamodelica/meta/Uniontype9.mos
@@ -2,6 +2,7 @@
 // keywords: Uniontype
 // status:   correct
 // cflags:   +g=MetaModelica -d=-newInst
+// suite: metamodelica
 //
 // Uniontype Testing
 //

--- a/testsuite/metamodelica/meta/UniontypeConst1.mos
+++ b/testsuite/metamodelica/meta/UniontypeConst1.mos
@@ -2,6 +2,7 @@
 // keywords: uniontype const
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Tests constants inside of uniontypes.
 //

--- a/testsuite/metamodelica/meta/UniontypeConst2.mos
+++ b/testsuite/metamodelica/meta/UniontypeConst2.mos
@@ -2,6 +2,7 @@
 // keywords: uniontype const recursion
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Tests self recursive constants inside of uniontypes.
 //

--- a/testsuite/metamodelica/meta/UniontypeConst3.mos
+++ b/testsuite/metamodelica/meta/UniontypeConst3.mos
@@ -2,6 +2,7 @@
 // keywords: uniontype const recursion
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Tests self recursive constants inside of uniontypes.
 //

--- a/testsuite/metamodelica/meta/UniontypeFunc1.mos
+++ b/testsuite/metamodelica/meta/UniontypeFunc1.mos
@@ -2,6 +2,7 @@
 // keywords: uniontype function
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // Tests functions inside of uniontypes.
 //

--- a/testsuite/metamodelica/meta/UniontypeNestedSingelton.mos
+++ b/testsuite/metamodelica/meta/UniontypeNestedSingelton.mos
@@ -2,6 +2,7 @@
 // keywords: uniontype singelton record
 // status:   correct
 // cflags:   -g=MetaModelica -d=gen -d=-newInst
+// suite: metamodelica
 //
 // This tests check that asserts that singelton uniontype
 // that contains non singelton subuniontypes are treated as singeltons.

--- a/testsuite/metamodelica/meta/cref.mos
+++ b/testsuite/metamodelica/meta/cref.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen");
 loadString("

--- a/testsuite/openmodelica/bootstrapping/DiffAlgorithm.mos
+++ b/testsuite/openmodelica/bootstrapping/DiffAlgorithm.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -n=1 -d=noevalfunc,gen");
 echo(false);

--- a/testsuite/openmodelica/bootstrapping/DumpTest.mos
+++ b/testsuite/openmodelica/bootstrapping/DumpTest.mos
@@ -1,6 +1,7 @@
 // name: DumpTest
 // cflags: +g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 
 runScript("LoadCompilerSources.mos");getErrorString();
 loadFile("DumpTest.mo");getErrorString();

--- a/testsuite/openmodelica/bootstrapping/ExpandableArrayTest.mos
+++ b/testsuite/openmodelica/bootstrapping/ExpandableArrayTest.mos
@@ -1,6 +1,7 @@
 // name: ExpandableArray Unit Testing
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 runScript("LoadCompilerSources.mos"); getErrorString();
 

--- a/testsuite/openmodelica/bootstrapping/ExpressionTest.mos
+++ b/testsuite/openmodelica/bootstrapping/ExpressionTest.mos
@@ -1,6 +1,7 @@
 // name: ExpressionTest
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 runScript("LoadCompilerSources.mos");getErrorString();
 loadFile("ExpressionTest.mo");getErrorString();

--- a/testsuite/openmodelica/bootstrapping/GraphTest.mos
+++ b/testsuite/openmodelica/bootstrapping/GraphTest.mos
@@ -2,6 +2,7 @@
 // cflags: -g=MetaModelica -d=rml,gen,noevalfunc -d=-newInst
 // status: correct
 // teardown_command: rm -f GraphTest_*
+// suite: metamodelica
 
 echo(false);
 pathPrefix := "../../../OMCompiler/Compiler/Util/";

--- a/testsuite/openmodelica/bootstrapping/HashTableTest.mos
+++ b/testsuite/openmodelica/bootstrapping/HashTableTest.mos
@@ -2,6 +2,7 @@
 // status: correct
 // teardown_command: rm -f HashTableTest_*
 // cflags: -d=-newInst
+// suite: metamodelica
 
 runScript("LoadCompilerSources.mos");getErrorString();
 loadFile("HashTableTest.mo");getErrorString();

--- a/testsuite/openmodelica/bootstrapping/JSONParser.mos
+++ b/testsuite/openmodelica/bootstrapping/JSONParser.mos
@@ -2,6 +2,7 @@
 // depends: test.json
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=gen,rml,noevalfunc");
 echo(false);

--- a/testsuite/openmodelica/bootstrapping/PriorityQueue.mos
+++ b/testsuite/openmodelica/bootstrapping/PriorityQueue.mos
@@ -1,6 +1,7 @@
 // name: PriorityQueue
 // cflags: -g=MetaModelica -d=-newInst
 // status: correct
+// suite: metamodelica
 //
 // TODO: Make me faster; I'm slow
 

--- a/testsuite/openmodelica/bootstrapping/SimplifyTest.mos
+++ b/testsuite/openmodelica/bootstrapping/SimplifyTest.mos
@@ -1,6 +1,7 @@
 // name: SimplifyTest
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 runScript("LoadCompilerSources.mos");getErrorString();
 loadFile("SimplifyTest.mo");getErrorString();

--- a/testsuite/openmodelica/bootstrapping/System.mos
+++ b/testsuite/openmodelica/bootstrapping/System.mos
@@ -1,6 +1,7 @@
 // name: System
 // status: correct
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -d=rml,noevalfunc,gen");
 loadFile("../../../OMCompiler/Compiler/Util/System.mo");

--- a/testsuite/openmodelica/bootstrapping/UtilTest.mos
+++ b/testsuite/openmodelica/bootstrapping/UtilTest.mos
@@ -2,6 +2,7 @@
 // status: correct
 // teardown_command: rm -f Util_* UtilTest_*
 // cflags: -d=-newInst
+// suite: metamodelica
 
 setCommandLineOptions("-g=MetaModelica -n=1");
 echo(false);

--- a/testsuite/openmodelica/conversion/ConvertModifiersMissingValue1.mos
+++ b/testsuite/openmodelica/conversion/ConvertModifiersMissingValue1.mos
@@ -2,6 +2,7 @@
 // status: correct
 // cflags: -d=newInst
 // depends: scripts
+// suite: antlr
 
 loadString("
   package ConvertModifiersMissingValue1

--- a/testsuite/openmodelica/interactive-API/Obfuscation1.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation1.mos
@@ -3,6 +3,7 @@
 // status: correct
 // cflags: -d=newInst
 // teardown_command: rm BranchingDynamicPipes.mo BranchingDynamicPipes_mapping.json
+// suite: 63bit
 //
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();

--- a/testsuite/openmodelica/parser/Class4.mo
+++ b/testsuite/openmodelica/parser/Class4.mo
@@ -1,6 +1,7 @@
 // name:     Class4
 // keywords:
 // status:   incorrect
+// suite: antlr
 //
 // end should be followed by Class4.
 //
@@ -14,7 +15,7 @@ end;
 // Error processing file: Class4.mo
 // Failed to parse file: Class4.mo!
 //
-// [openmodelica/parser/Class4.mo:11:1-11:3:writable] Error: No viable alternative near token: end
+// [openmodelica/parser/Class4.mo:12:1-12:3:writable] Error: No viable alternative near token: end
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/Declaration1.mo
+++ b/testsuite/openmodelica/parser/Declaration1.mo
@@ -1,6 +1,7 @@
 // name:     Declaration1
 // keywords: declaration
 // status:   incorrect
+// suite: antlr
 //
 // Misuse of component attributes.
 //
@@ -14,7 +15,7 @@ end Declaration1;
 // Error processing file: Declaration1.mo
 // Failed to parse file: Declaration1.mo!
 //
-// [openmodelica/parser/Declaration1.mo:9:12-9:20:writable] Error: No viable alternative near token: constant
+// [openmodelica/parser/Declaration1.mo:10:12-10:20:writable] Error: No viable alternative near token: constant
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/Declaration2.mo
+++ b/testsuite/openmodelica/parser/Declaration2.mo
@@ -1,6 +1,7 @@
 // name:     Declaration2
 // keywords: declaration
 // status:   incorrect
+// suite: antlr
 //
 // Misuse of component attributes.
 //
@@ -14,7 +15,7 @@ end Declaration2;
 // Error processing file: Declaration2.mo
 // Failed to parse file: Declaration2.mo!
 //
-// [openmodelica/parser/Declaration2.mo:9:12-9:20:writable] Error: No viable alternative near token: discrete
+// [openmodelica/parser/Declaration2.mo:10:12-10:20:writable] Error: No viable alternative near token: discrete
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/Declaration3.mo
+++ b/testsuite/openmodelica/parser/Declaration3.mo
@@ -1,6 +1,7 @@
 // name:     Declaration3
 // keywords: declaration
 // status:   incorrect
+// suite: antlr
 //
 // Misuse of component attributes.
 //
@@ -14,7 +15,7 @@ end Declaration3;
 // Error processing file: Declaration3.mo
 // Failed to parse file: Declaration3.mo!
 //
-// [openmodelica/parser/Declaration3.mo:9:12-9:21:writable] Error: No viable alternative near token: parameter
+// [openmodelica/parser/Declaration3.mo:10:12-10:21:writable] Error: No viable alternative near token: parameter
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/Identifier.mo
+++ b/testsuite/openmodelica/parser/Identifier.mo
@@ -1,6 +1,7 @@
 // name: Identifier
 // keywords: identifier
 // status: incorrect
+// suite: antlr
 //
 // Using reserved words as identifiers
 //
@@ -16,7 +17,7 @@ end Identifier;
 // Error processing file: Identifier.mo
 // Failed to parse file: Identifier.mo!
 //
-// [openmodelica/parser/Identifier.mo:9:3-9:7:writable] Error: No viable alternative near token: Real
+// [openmodelica/parser/Identifier.mo:10:3-10:7:writable] Error: No viable alternative near token: Real
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/IntegerLiterals64.mo
+++ b/testsuite/openmodelica/parser/IntegerLiterals64.mo
@@ -1,6 +1,7 @@
 // name: IntegerLiterals (64-bit)
 // keywords: integer
 // status: correct
+// suite: 63bit
 //
 // Tests declaration of integers
 //

--- a/testsuite/openmodelica/parser/MetaModelicaStringOpModelicaLexer.mo
+++ b/testsuite/openmodelica/parser/MetaModelicaStringOpModelicaLexer.mo
@@ -1,6 +1,7 @@
 // name: MetaModelicaStringOpModelicaLexer
 // keywords: string, lexing
 // status: incorrect
+// suite: antlr
 //
 // tests that the lexer/parser handles proper Modelica syntax for string operations
 
@@ -13,7 +14,7 @@ end MetaModelicaStringOpModelicaLexer;
 // Error processing file: MetaModelicaStringOpModelicaLexer.mo
 // Failed to parse file: MetaModelicaStringOpModelicaLexer.mo!
 //
-// [openmodelica/parser/MetaModelicaStringOpModelicaLexer.mo:8:28-8:28:writable] Error: Lexer got '& ' but failed to recognize the rest: '"2";
+// [openmodelica/parser/MetaModelicaStringOpModelicaLexer.mo:9:28-9:28:writable] Error: Lexer got '& ' but failed to recognize the rest: '"2";
 //   anno'
 //
 // # Error encountered! Exiting...

--- a/testsuite/openmodelica/parser/ParseError2.mo
+++ b/testsuite/openmodelica/parser/ParseError2.mo
@@ -1,6 +1,7 @@
 // name:     ParseError2
 // keywords: parse error
 // status:   incorrect
+// suite: antlr
 //
 // Parsing error message.
 //
@@ -14,7 +15,7 @@ end ParseError2;
 // Error processing file: ParseError2.mo
 // Failed to parse file: ParseError2.mo!
 //
-// [openmodelica/parser/ParseError2.mo:9:3-9:7:writable] Error: No viable alternative near token: Real
+// [openmodelica/parser/ParseError2.mo:10:3-10:7:writable] Error: No viable alternative near token: Real
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/ParseString.mos
+++ b/testsuite/openmodelica/parser/ParseString.mos
@@ -1,6 +1,7 @@
 // name: ParseString
 // status: correct
 // cflags: -d=-newInst
+// suite: antlr
 
 parseString("class A end A;");getErrorString();
 parseString("within D.C; class A end A;");getErrorString();

--- a/testsuite/openmodelica/parser/PureImpure3.mo
+++ b/testsuite/openmodelica/parser/PureImpure3.mo
@@ -2,6 +2,7 @@
 // keywords:
 // status: incorrect
 // cflags: -d=newInst --std=3.2 --strict
+// suite: antlr
 //
 // Checks that pure/impure are not allowed in Modelica 3.2 when using --strict.
 //
@@ -19,7 +20,7 @@ end PureImpure3;
 // Error processing file: PureImpure3.mo
 // Failed to parse file: PureImpure3.mo!
 //
-// [openmodelica/parser/PureImpure3.mo:9:1-9:5:writable] Error: Parser error: Unexpected token near: pure (IDENT)
+// [openmodelica/parser/PureImpure3.mo:10:1-10:5:writable] Error: Parser error: Unexpected token near: pure (IDENT)
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/RealOpLexerModelica.mo
+++ b/testsuite/openmodelica/parser/RealOpLexerModelica.mo
@@ -1,6 +1,7 @@
 // name: RealOpLexerModelica
 // keywords: real, lexing
 // status: incorrect
+// suite: antlr
 //
 // tests that the lexer/parser handles proper Modelica syntax for real operations
 // also tests that the MetaModelica realAdd operator works
@@ -17,7 +18,7 @@ end A;
 // Error processing file: RealOpLexerModelica.mo
 // Failed to parse file: RealOpLexerModelica.mo!
 //
-// [openmodelica/parser/RealOpLexerModelica.mo:11:23-11:24:writable] Error: No viable alternative near token: 2
+// [openmodelica/parser/RealOpLexerModelica.mo:12:23-12:24:writable] Error: No viable alternative near token: 2
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/openmodelica/parser/WildLexerMetaModelica.mo
+++ b/testsuite/openmodelica/parser/WildLexerMetaModelica.mo
@@ -1,6 +1,7 @@
 // name: WildLexerMetaModelica
 // status: incorrect
 // cflags: -g=MetaModelica -d=-newInst
+// suite: antlr
 //
 
 class WildLexerModelica
@@ -11,7 +12,7 @@ end WildLexerModelica;
 // Error processing file: WildLexerMetaModelica.mo
 // Failed to parse file: WildLexerMetaModelica.mo!
 //
-// [openmodelica/parser/WildLexerMetaModelica.mo:7:1-7:5:writable] Error: No viable alternative near token: Real
+// [openmodelica/parser/WildLexerMetaModelica.mo:8:1-8:5:writable] Error: No viable alternative near token: Real
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -10,7 +10,8 @@
 #
 # Usage: Run without any arguments to run the whole testsuite, or with -f to
 #        run a fast test, i.e. skipping the libraries directory. Or with
-#        -nocpp to only skip those parts.
+#        -nocpp to only skip those parts. -suites=[+-]name,... turns individual
+#        test suites on and off; see %suite_enabled below.
 #
 # NOTE: This is the official OpenModelica way of running the testsuite, so
 #       you should run this before committing any changes.
@@ -47,8 +48,6 @@ my $count_tests = 0;
 my $print_tests = 0;
 my $veryfew = 0;
 my $run_failing = 0;
-my $cppruntime = 0;
-my $nocpp = 0;
 my $file;
 my $slowest:shared = 0;
 my $slowest_name:shared = "";
@@ -81,6 +80,72 @@ my $osname = $^O;
 }
 
 
+# Every test belongs to exactly one category suite, decided by the directory it
+# lives in, plus any number of tag suites, which the test file names itself with
+# a '// suite: <name>' line in its header. A test runs only if all of the suites
+# it belongs to are enabled.
+my @category_suites = qw(default cpp cppmsl tearing hpcom);
+my @tag_suites = qw(metamodelica 63bit antlr);
+my %suite_enabled = (
+  default      => 1,  # Everything not claimed by another category.
+  cpp          => 1,  # */cppruntime/*
+  cppmsl       => 0,  # simulation/libraries/msl32_cpp; slow, so opt-in.
+  tearing      => 1,  # */tearing/*
+  hpcom        => 1,  # */hpcom/*
+  metamodelica => 1,  # Needs MetaModelica code generation, i.e. the C runtime.
+  '63bit'      => 1,  # Needs a 63/64-bit Modelica Integer.
+  antlr        => 1,  # Expects ANTLR's syntax error positions and wording.
+);
+
+sub set_suites {
+  for my $spec (split(/[,\s]+/, shift)) {
+    next if $spec eq "";
+    my ($sign, $name) = $spec =~ /^([-+]?)(.*)$/;
+
+    if (!exists $suite_enabled{$name}) {
+      print STDERR "Unknown test suite '$name'. Known suites: " .
+                   join(" ", sort keys %suite_enabled) . "\n";
+      exit 1;
+    }
+
+    $suite_enabled{$name} = $sign eq "-" ? 0 : 1;
+  }
+}
+
+# The category suite a test directory belongs to.
+sub dir_suite {
+  my $dir = shift;
+
+  return "cppmsl"  if $dir =~ m"/simulation/libraries/msl32_cpp\b";
+  return "cpp"     if $dir =~ m"/cppruntime\b";
+  return "hpcom"   if $dir =~ m"/hpcom\b";
+  return "tearing" if $dir =~ m"/tearing\b";
+  return "default";
+}
+
+# The '// suite: a, b' tags a test names in its header. rtest parses such lines
+# as ordinary test metadata, so they are inert there.
+sub test_suites {
+  my $test = shift;
+  my @suites;
+
+  open(my $in, "<", $test) or return @suites;
+  while(my $line = <$in>) {
+    last unless $line =~ /^\s*$|^\s*\/\//; # Header only: stop at the first code line.
+    push @suites, split(/[,\s]+/, $1) if $line =~ /^\/\/[ \\|]*suite:[ \\|]*(.*?)\s*$/;
+  }
+  close($in);
+
+  for my $suite (@suites) {
+    if (!exists $suite_enabled{$suite}) {
+      print STDERR "$test: unknown test suite '$suite'\n";
+      exit 1;
+    }
+  }
+
+  return @suites;
+}
+
 # Check the flags.
 for(@ARGV){
   if(/^-h|--help$/) {
@@ -88,6 +153,10 @@ for(@ARGV){
     print("\nOptions are:\n");
     print("  -cppruntime    Run ONLY the slow cppruntime tests.\n");
     print("  -nocpp         Do not run any cppruntime tests.\n");
+    print("  -suites=LIST   Comma-separated [+-]suite list turning suites on/off.\n");
+    print("                 Defaults: " .
+          join(" ", map { "$_=" . ($suite_enabled{$_} ? "on" : "off") }
+                        (@category_suites, @tag_suites)) . "\n");
     print("  -f             Only run fast tests.\n");
     print("  -file=file     Reads testcases from the given file instead of from a makefile.\n");
     print("  -jN            Use N threads.\n");
@@ -110,12 +179,16 @@ for(@ARGV){
   }
   if(/^-f$/) {
     $fast = 1;
+    set_suites("-cpp,-cppmsl,-tearing,-hpcom");
   }
   elsif(/^-cppruntime$/) {
-    $cppruntime = 1;
+    set_suites("-default,-cpp,-tearing,-hpcom,+cppmsl");
   }
   elsif(/^-nocpp$/) {
-    $nocpp = 1;
+    set_suites("-cpp,-cppmsl");
+  }
+  elsif(/^-suites=(.*)$/) {
+    set_suites($1);
   }
   elsif(/^-j([0-9]+)$/) {
     $check_proc_cpu = 0;
@@ -224,12 +297,7 @@ sub read_makefile {
   return if($fast == 1 and $dir =~ m"/metamodelica"); # Skip libraries if -f is given.
   return if($fast == 1 and $dir =~ m"/3rdParty/"); # Skip libraries if -f is given.
   return if($fast == 1 and $dir =~ m"/openmodelica/fmi"); # Skip libraries if -f is given.
-  return if($nocpp == 1 and $dir =~ m"/cppruntime"); # Skip cppruntime if -nocpp is given.
-  return if($fast == 1 and $dir =~ m"/cppruntime"); # Skip libraries if -f is given.
-  return if($fast == 1 and $dir =~ m"/hpcom"); # Skip libraries if -f is given.
-  return if($fast == 1 and $dir =~ m"/tearing"); # Skip libraries if -f is given.
   return if($gitlibs == 0 and $dir =~ m"/GitLibraries"); # Skip libraries unless -gitlibs is given.
-  return if($cppruntime == 0 and $dir eq "./simulation/libraries/msl32_cpp");
 
   open(my $in, "<", "$dir/Makefile") or die "Couldn't open $dir/Makefile: $!";
 
@@ -278,6 +346,8 @@ sub add_tests {
   my @tests = split(/\s|=|\\/, shift);
   my $path = shift;
 
+  return unless $suite_enabled{dir_suite($path)};
+
   @tests = grep(/\.mo|\.mof|\.mos/, @tests);
   @tests = map { $_ = ("$path/$_" =~ s/\/\//\//rg) } @tests;
 
@@ -321,9 +391,7 @@ if (!defined($file)) {
   # parse the makefile there.
   chdir("..");
 
-  if ($cppruntime == 1) {
-    read_makefile("./simulation/libraries/msl32_cpp", "TESTFILES");
-  } elsif ($parmodexp == 1) {
+  if ($parmodexp == 1) {
     read_makefile("./parmodelica/explicit", "TESTFILES");
   } elsif($veryfew == 1) {
     read_makefile("./flattening/modelica/modification", "TESTFILES");
@@ -332,6 +400,12 @@ if (!defined($file)) {
   } else {
     read_makefile(".", "FAILINGTESTFILES|WRONGRESULTTEST|NOTCOMPILETEST|NOTSIMULATETEST");
   }
+  # Categories were filtered while parsing the makefiles; tags need the test
+  # files. Not done for -file=: an explicit list of tests is not a selection.
+  @test_list = grep {
+    my @suites = test_suites($_);
+    !grep { !$suite_enabled{$_} } @suites;
+  } @test_list;
 } else {
   read_file($file);
   chdir("..");

--- a/testsuite/rust-ignore-tests.txt
+++ b/testsuite/rust-ignore-tests.txt
@@ -1,6 +1,10 @@
 # Tests known to fail in the Rust port for reasons we accept (not codegen bugs).
 # Used to filter failed.frontend-refactor-deps before triaging.
 #
+# The parser-position and Integer-width groups below are also marked in the test
+# files themselves with '// suite: antlr' and '// suite: 63bit', so partest can
+# deselect them with -suites=-antlr,-63bit. Keep the two in sync.
+#
 # Rust aborts the process on stack overflow (no catchable recursion limit),
 # unlike MMC which unwinds. Any test that deliberately drives deep recursion
 # to hit a recursion-limit / stack-overflow error message will differ.
@@ -12,12 +16,10 @@
 # ANTLR's error recovery picked. The error is still raised and the file still
 # fails to parse; only which token/line:col is named differs.
 ./openmodelica/parser/Class4.mo
-./openmodelica/parser/ConstructParameters1.mo
 ./openmodelica/parser/Declaration1.mo
 ./openmodelica/parser/Declaration2.mo
 ./openmodelica/parser/Declaration3.mo
 ./openmodelica/parser/Identifier.mo
-./openmodelica/parser/ParseError1.mo
 ./openmodelica/parser/ParseError2.mo
 ./openmodelica/parser/RealOpLexerModelica.mo
 ./openmodelica/parser/WildLexerMetaModelica.mo
@@ -55,7 +57,8 @@
 # IntegerTest passes with the Rust port on the C runtime (modelica_integer is
 # 64-bit there). It only differs under --simCodeTarget=wasm-jit, whose runtime
 # Integer is i32, so `2147483647 * 2` wraps to -2 instead of 4294967294. Not an
-# ignore entry — left commented so it is not filtered out on the C-runtime path.
+# ignore entry — it carries '// suite: 63bit', which the wasm-jit run deselects
+# and the C-runtime run keeps.
 #./simulation/modelica/types/IntegerTest.mos
 # saveTotalModel(obfuscate=true) replaces assert/terminate messages with
 # "<fn> message <stringHashDjb2(msg)>"; C's stringHashDjb2 accumulates djb2 in a

--- a/testsuite/simulation/modelica/others/TestSolve18.mos
+++ b/testsuite/simulation/modelica/others/TestSolve18.mos
@@ -1,5 +1,6 @@
 // name: Test ExpressionSolve fail
 // status: correct
+// suite: antlr
 //
 // Checks that ExpressionSolve failed
 //

--- a/testsuite/simulation/modelica/types/IntegerTest.mos
+++ b/testsuite/simulation/modelica/types/IntegerTest.mos
@@ -2,6 +2,7 @@
 // keywords: Test that Integer works fine
 // status:   correct
 // teardown_command: rm -rf IntegerTest_* IntegerTest.exe IntegerTest.bat IntegerTest.cpp IntegerTest.makefile IntegerTest.libs IntegerTest.log output.log
+// suite: 63bit
 
 
 loadFile("IntegerTest.mo"); getErrorString();


### PR DESCRIPTION
Every test now belongs to exactly one *category* suite, decided by the directory it lives in, plus any number of *tag* suites, which the test file names itself with a `// suite: <name>` header line. A test runs only if all of the suites it belongs to are enabled.

| suite          | kind | default | selected by                     |
| -------------- | ---- | ------- | ------------------------------- |
| `default`      | cat  | on      | anything not claimed below      |
| `cpp`          | cat  | on      | `*/cppruntime/*`                |
| `cppmsl`       | cat  | off     | simulation/libraries/msl32_cpp  |
| `tearing`      | cat  | on      | `*/tearing/*`                   |
| `hpcom`        | cat  | on      | `*/hpcom/*`                     |
| `metamodelica` | tag  | on      | `// suite: metamodelica`        |
| `63bit`        | tag  | on      | `// suite: 63bit`               |
| `antlr`        | tag  | on      | `// suite: antlr`               |

`-suites=[+-]name,...` turns them on and off; `-cppruntime`, `-nocpp` and `-f` become aliases for it, so their ad-hoc directory skips and the `$cppruntime`/`$nocpp` special cases in the makefile walk are gone. `-printtests` is unchanged for all four existing modes. An unknown suite name, on the command line or in a test header, is a hard error. `-file=` is not filtered: an explicit list of tests is not a selection.

Tags let a run deselect tests that need something it cannot provide without keeping a list of test paths outside the tests. The Rust partest uses `-suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr` (5303 -> 5028 tests) and drops from three shards to two.

The `63bit` and `antlr` tags mirror the groups in rust-ignore-tests.txt, which stays as the triage aid for full runs. ConstructParameters1.mo and ParseError1.mo pass with the Rust port now, so they are neither tagged nor ignored; IntegerTest.mos becomes a `63bit` tag rather than a commented-out ignore entry, which is what its comment asked for.

Markers go in the header next to `// name:`. For the tests whose expected output records their own `file:line:col`, those line numbers are shifted to match. Running the 174 touched tests through partest before and after gives the same set of failures.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
