### PR TITLE
wasm-jit: implement the Synchronous features

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -245,6 +245,7 @@ openmodelica_sim_meta/src/lib.rs
 openmodelica_sim_meta/src/omclog.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs
+openmodelica_sim_meta/src/sync.rs
 openmodelica_simcode_types/Cargo.toml
 openmodelica_simcode_util/Cargo.toml
 openmodelica_susan/Cargo.toml

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -48,6 +48,7 @@ use arcstr::ArcStr;
 use metamodelica::List;
 use wasm_encoder as we;
 
+use openmodelica_backend_types::BackendDAE;
 use openmodelica_frontend_types::DAE;
 use openmodelica_simcode_types::SimCode;
 use openmodelica_simcode_types::SimCodeVar;
@@ -58,6 +59,7 @@ use crate::CodegenWasmJitFunctions::{
     ArrayGroup, Attr, AttrTargets, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
+    ClockInit, ClockUpdate,
     NlsResidual, emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
     external_general, function_signature, rt_index, sim_cref_key, sim_const_store,
@@ -70,8 +72,8 @@ use crate::CodegenWasmJitFunctions::{
 // historical host names.
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{
-    var_filter, FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind, MetaVar as ResultVar,
-    SimMeta, StateSetInfo,
+    var_filter, BaseClockMeta, FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind,
+    MetaVar as ResultVar, SimMeta, StateSetInfo, SubClockMeta,
 };
 
 // Engine selected at compile time; same module interface across all three
@@ -717,9 +719,9 @@ fn run_experiment(model: &SimModel, flags: &simflags::SimFlags) -> (SimMeta, Str
 /// model's own `outputFormat` as `-outputFormat` may have replaced it.
 fn check_output_format(meta: &SimMeta) -> std::result::Result<(), String> {
     match meta.output_format.as_str() {
-        "mat" | "empty" => Ok(()),
+        "mat" | "csv" | "empty" => Ok(()),
         other => Err(format!(
-            "CodegenWasmJit: this runtime writes `mat` results, or `empty` for none (got `{other}`)"
+            "CodegenWasmJit: this runtime writes `mat`/`csv` results, or `empty` for none (got `{other}`)"
         )),
     }
 }
@@ -731,7 +733,15 @@ fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> Str
     match (&flags.result_file, &flags.output_path) {
         (Some(r), _) => r.clone(),
         (None, Some(dir)) => format!("{dir}/{}_res.{}", meta.prefix, meta.output_format),
-        (None, None) => derived.to_string(),
+        // C names the file after the format `-outputFormat` settled on, while the
+        // caller keeps the name it derived from the model — swap the extension in
+        // `derived` to land on C's name without losing its directory.
+        (None, None) => match derived.rsplit_once('.') {
+            Some((stem, _)) if flags.output_format.is_some() => {
+                format!("{stem}.{}", meta.output_format)
+            }
+            _ => derived.to_string(),
+        },
     }
 }
 
@@ -874,9 +884,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         }
         let keep = output_selection(&model);
         capture_last_sim(&model, &run, &keep);
-        if meta.output_format == "mat" {
-            write_mat4(&model, &meta, &result_path(&flags, &meta, result_file), &run.rows, run.n_reals, &run.params, &keep)?;
-        }
+        write_result(&model, &meta, &result_path(&flags, &meta, result_file), &run, &keep)?;
         Ok(())
     })();
     // Disarm in case init failed before the hook fired.
@@ -1011,9 +1019,7 @@ mod session {
     ) -> Result<()> {
         let keep = output_selection(model);
         capture_last_sim(model, run, &keep);
-        if meta.output_format == "mat" {
-            write_mat4(model, meta, result_file, &run.rows, run.n_reals, &run.params, &keep)?;
-        }
+        write_result(model, meta, result_file, run, &keep)?;
         Ok(())
     }
 
@@ -1825,6 +1831,8 @@ struct SimVarMap {
     zctol_off: u32,
     /// `SimData` byte offset of `zeroCrossingsPre` (`SimLayout::zc_pre_off`).
     zc_pre_off: u32,
+    /// `SimData` byte offset of the `$_clkfire` flags (`SimLayout::clock_fire_off`).
+    clock_fire_off: u32,
     /// Number of `delay(...)` expression buffers (`delayedExps.maxDelayedIndex + 1`).
     n_delays: u32,
 }
@@ -2176,6 +2184,7 @@ fn build_var_map(
         lambda_off: layout.lambda_off,
         zctol_off: layout.zctol_off,
         zc_pre_off: layout.zc_pre_off,
+        clock_fire_off: layout.clock_fire_off,
         n_delays: 0,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
@@ -2677,6 +2686,61 @@ fn collect_samples(
     Ok(out)
 }
 
+/// One synchronous base clock: the [`BaseClockMeta`] the driver needs, plus the
+/// `ClockKind` expressions and sub-partition equations the three emitted
+/// functions are built from (C's `baseClockInit`/`updatePartition`/
+/// `functionEquationsSynchronous`).
+struct ClockInfo {
+    meta: BaseClockMeta,
+    kind: Arc<DAE::ClockKind>,
+    /// Equations of each sub-partition (`equations ++ removedEquations`).
+    sub_eqs: Vec<Vec<Arc<SimCode::SimEqSystem>>>,
+}
+
+/// Split a `ClockedPartition` list into per-base-clock info, assigning the flat
+/// sub-clock indices the `SimData` sub-clock region is addressed by.
+fn collect_clocks(partitions: &Arc<List<SimCode::ClockedPartition>>) -> Result<Vec<ClockInfo>> {
+    let mut out = Vec::new();
+    let mut sub_base = 0u32;
+    for part in lst(partitions) {
+        let mut sub = Vec::new();
+        let mut sub_eqs = Vec::new();
+        for sp in lst(&part.subPartitions) {
+            let BackendDAE::SubClock::SUBCLOCK { factor, shift, solver } = &sp.subClock else {
+                return Err("CodegenWasmJit: sub-partition still has an inferred sub-clock");
+            };
+            sub.push(SubClockMeta {
+                shift_num: shift.nom as i64,
+                shift_den: shift.denom as i64,
+                factor_num: factor.nom as i64,
+                factor_den: factor.denom as i64,
+                hold_events: sp.holdEvents,
+                external_solver: solver.is_some(),
+            });
+            sub_eqs.push(lst(&sp.equations).chain(lst(&sp.removedEquations)).cloned().collect());
+        }
+        // C's "fake" sub-partition 0 for an empty clocked partition, which its
+        // base-clock handling then activates like any other.
+        if sub.is_empty() {
+            sub.push(SubClockMeta { shift_den: 1, factor_num: 1, factor_den: 1, ..SubClockMeta::default() });
+            sub_eqs.push(Vec::new());
+        }
+        let n_sub = sub.len() as u32;
+        out.push(ClockInfo {
+            meta: BaseClockMeta {
+                is_event_clock: matches!(&*part.baseClock, DAE::ClockKind::EVENT_CLOCK { .. }),
+                inferred: matches!(&*part.baseClock, DAE::ClockKind::INFERRED_CLOCK),
+                sub_base,
+                sub,
+            },
+            kind: part.baseClock.clone(),
+            sub_eqs,
+        });
+        sub_base += n_sub;
+    }
+    Ok(out)
+}
+
 /// `fmi_vrs`: also record the FMI value-reference table (FMU export only).
 fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimModel> {
     crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
@@ -2729,6 +2793,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let n_sens_par = vi.numSensitivityParameters.max(0) as usize;
     let sens_vars: Vec<&SimCodeVar::SimVar> = lst(&mi.vars.sensitivityVars).collect();
     let n_sens = sens_vars.len().saturating_sub(n_sens_par) as u32;
+    let clocks = collect_clocks(&sim_code.clockedPartitions)?;
+    let n_sub_clocks: u32 = clocks.iter().map(|c| c.meta.sub.len() as u32).sum();
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -2750,6 +2816,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         dae_res_vars.len() as u32,
         dae_aux_vars.len() as u32,
         dae_alg_vars.len() as u32,
+        clocks.len() as u32,
+        n_sub_clocks,
         has_when,
         has_homotopy,
     );
@@ -2987,6 +3055,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         types.ty().function([we::ValType::I32, we::ValType::I32], []);
         ti
     });
+    // `functionUpdateSynchronous`/`functionEquationsSynchronous`: (i32,i32) -> ().
+    let sync_fn_type = (!clocks.is_empty()).then(|| {
+        let ti = types.len();
+        types.ty().function([we::ValType::I32, we::ValType::I32], []);
+        ti
+    });
     // Function references met while lowering the bodies add thunks to the closure
     // pool; this global holds their shared-table base.
     let closure_global = crate::CodegenWasmJitFunctions::closure_base_global(nls_types.is_some());
@@ -3117,6 +3191,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars, dae,
+        clocks.iter().map(|c| c.meta.clone()).collect(),
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -3297,6 +3372,20 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         )?);
         idx
     };
+    // Synchronous features: emitted only for a model with clocked partitions, so a
+    // clock-free model's module is unchanged.
+    let sync_idx = match clocks.is_empty() {
+        true => None,
+        false => {
+            let init = import_base + bodies.len() as u32;
+            bodies.push(build_init_synchronous_fn(&clocks, &layout, &var_map, &by_name, &mut literals)?);
+            bodies.push(build_update_synchronous_fn(&clocks, &layout, &var_map, &by_name, &mut literals)?);
+            bodies.push(build_equations_synchronous_fn(
+                &clocks, &layout, &var_map, &eq_index, &by_name, &mut literals,
+            )?);
+            Some((init, init + 1, init + 2))
+        }
+    };
     // Emitted only for a DAE-mode model: its absence is how the standalone export and
     // the FMU adapters know the model is an explicit ODE.
     let dae_residuals_idx = match dae_fn_type {
@@ -3354,6 +3443,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
+    if let Some(ti) = sync_fn_type {
+        functions.function(eqfn_type); // functionInitSynchronous: (i32) -> ()
+        functions.function(ti); // functionUpdateSynchronous: (i32, i32) -> ()
+        functions.function(ti); // functionEquationsSynchronous: (i32, i32) -> ()
+    }
     if let Some(ti) = dae_fn_type {
         functions.function(ti); // evaluateDAEResiduals: (i32, i32) -> ()
     }
@@ -3452,6 +3546,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
     exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
+    if let Some((init, update, eqs)) = sync_idx {
+        exports.export("functionInitSynchronous", we::ExportKind::Func, init);
+        exports.export("functionUpdateSynchronous", we::ExportKind::Func, update);
+        exports.export("functionEquationsSynchronous", we::ExportKind::Func, eqs);
+    }
     if let Some(idx) = dae_residuals_idx {
         exports.export("evaluateDAEResiduals", we::ExportKind::Func, idx);
     }
@@ -3496,6 +3595,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
     ] {
         names.push((idx, name.to_string()));
+    }
+    if let Some((init, update, eqs)) = sync_idx {
+        names.push((init, "functionInitSynchronous".to_string()));
+        names.push((update, "functionUpdateSynchronous".to_string()));
+        names.push((eqs, "functionEquationsSynchronous".to_string()));
     }
     if let Some(idx) = dae_residuals_idx {
         names.push((idx, "evaluateDAEResiduals".to_string()));
@@ -4006,6 +4110,7 @@ fn build_sim_meta(
     sens_params: Vec<u32>,
     nls_vars: Vec<openmodelica_sim_meta::NlsVars>,
     dae: Option<openmodelica_sim_meta::DaeInfo>,
+    clocks: Vec<BaseClockMeta>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -4025,6 +4130,7 @@ fn build_sim_meta(
         sens_params,
         nls_vars,
         dae,
+        clocks,
     }
 }
 
@@ -4164,6 +4270,8 @@ fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         zctol_off: var_map.zctol_off,
         zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
+        clock_fire_off: var_map.clock_fire_off,
+        sub_clock_off: None,
     }
 }
 
@@ -4442,6 +4550,106 @@ fn build_init_sample_fn(
     let pairs: Vec<(Arc<DAE::Exp>, Arc<DAE::Exp>)> =
         samples.iter().map(|s| (s.start.clone(), s.interval.clone())).collect();
     ctx.emit_init_sample(&pairs, layout.sample_off)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionInitSynchronous(SimData*)` — C's `function_initSynchronous`.
+fn build_init_synchronous_fn(
+    clocks: &[ClockInfo],
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
+    let inits: Vec<ClockInit> = clocks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| ClockInit {
+            off: layout.base_clock_off(i as u32),
+            resolution: match &*c.kind {
+                DAE::ClockKind::RATIONAL_CLOCK { resolution, .. } => Some(resolution.clone()),
+                _ => None,
+            },
+            start_interval: match &*c.kind {
+                DAE::ClockKind::EVENT_CLOCK { startInterval, .. } => Some(startInterval.clone()),
+                _ => None,
+            },
+            sub_offs: (0..c.meta.sub.len() as u32)
+                .map(|k| layout.sub_clock_off(c.meta.sub_base + k))
+                .collect(),
+        })
+        .collect();
+    ctx.emit_init_synchronous(&inits)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionUpdateSynchronous(SimData*, base_idx)` — C's
+/// `function_updateSynchronous`, whose `switch` becomes one `if` per base clock.
+fn build_update_synchronous_fn(
+    clocks: &[ClockInfo],
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, literals, 2);
+    for (i, c) in clocks.iter().enumerate() {
+        let update = match &*c.kind {
+            DAE::ClockKind::RATIONAL_CLOCK { intervalCounter, .. } => ClockUpdate::Rational(intervalCounter.clone()),
+            DAE::ClockKind::REAL_CLOCK { interval } => ClockUpdate::Real(interval.clone()),
+            DAE::ClockKind::INFERRED_CLOCK => ClockUpdate::Inferred,
+            DAE::ClockKind::EVENT_CLOCK { .. } | DAE::ClockKind::SOLVER_CLOCK { .. } => ClockUpdate::Nothing,
+        };
+        if matches!(update, ClockUpdate::Nothing) {
+            continue;
+        }
+        ctx.sim_index_guard(i as u32);
+        ctx.emit_update_synchronous(layout.base_clock_off(i as u32), &update)?;
+        ctx.sim_end_block();
+    }
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionEquationsSynchronous(SimData*, sub_idx)` — C's
+/// `function_equationsSynchronous`, with the (base, sub) pair flattened to the
+/// sub-clock's index in the `SimData` sub-clock region.
+fn build_equations_synchronous_fn(
+    clocks: &[ClockInfo],
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, literals, 2);
+    for c in clocks {
+        for (k, eqs) in c.sub_eqs.iter().enumerate() {
+            let flat = c.meta.sub_base + k as u32;
+            ctx.sim_index_guard(flat);
+            ctx.set_sub_clock(Some(layout.sub_clock_off(flat)));
+            for eq in eqs {
+                lower_equation(&mut ctx, eq, eq_index)?;
+            }
+            ctx.set_sub_clock(None);
+            ctx.sim_end_block();
+        }
+    }
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -5501,6 +5709,8 @@ fn build_nls_fns(
         zctol_off: var_map.zctol_off,
         zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
+        clock_fire_off: var_map.clock_fire_off,
+        sub_clock_off: None,
     };
     let finish = |ctx: FnCtx| -> we::Function {
         let (locals, instrs) = ctx.finish_sim();
@@ -5983,6 +6193,72 @@ fn build_simulate(layout: &SimLayout, eqfn: &EqFnIdx, check_asserts: Option<u32>
 /// `[time, realVars...]`); `params` come from the [`SimModel`] result vars. The
 /// serialization itself lives in `openmodelica_mat_writer` (`no_std` + `alloc`,
 /// shared with the standalone wasip1 runtime's `_start`); here we only map the
+/// Write the run's results in the format `-outputFormat` settled on; `empty`
+/// writes none. The one place a result writer is chosen.
+fn write_result(
+    model: &SimModel,
+    meta: &SimMeta,
+    path: &str,
+    run: &sim_driver::RunResult,
+    keep: &[bool],
+) -> Result<()> {
+    match meta.output_format.as_str() {
+        "mat" => write_mat4(model, meta, path, &run.rows, run.n_reals, &run.params, keep),
+        "csv" => write_csv(model, meta, path, &run.rows, run.n_reals, keep),
+        _ => Ok(()),
+    }
+}
+
+/// Write the run as C's `simulation_result_csv`: a quoted-name header row, then
+/// one line per output row with `%.16g` reals and `%i` integers/booleans. As in
+/// C, time-invariant signals are not columns.
+fn write_csv(
+    model: &SimModel,
+    meta: &SimMeta,
+    path: &str,
+    rows: &[f64],
+    n_reals: u32,
+    keep: &[bool],
+) -> Result<()> {
+    let layout = &meta.layout;
+    let int_col0 = layout.n_reals_row();
+    let bool_col0 = int_col0 + layout.n_int_alg();
+    let sens_col0 = layout.sens_col0();
+    // Integers and booleans are captured as f64 but printed as integers.
+    let cols: Vec<(&str, u32, bool, bool)> = model
+        .result_vars
+        .iter()
+        .zip(keep)
+        .filter_map(|(v, &k)| match v.kind {
+            ResultKind::Column { col, negate } if k => {
+                Some((v.name.as_str(), col, negate, col >= int_col0 && col < sens_col0))
+            }
+            _ => None,
+        })
+        .collect();
+    let mut out = String::from("\"time\"");
+    for (name, ..) in &cols {
+        out.push_str(&format!(",\"{}\"", name.replace('"', "\"\"")));
+    }
+    out.push('\n');
+    let n_reals = n_reals as usize;
+    for row in rows.chunks_exact(n_reals.max(1)) {
+        out.push_str(&sim_driver::format_g(row[0], 16));
+        for &(_, col, negate, is_int) in &cols {
+            let v = row.get(col as usize).copied().unwrap_or(0.0);
+            let v = if negate { -v } else { v };
+            out.push(',');
+            if is_int {
+                out.push_str(&format!("{}", v as i64));
+            } else {
+                out.push_str(&sim_driver::format_g(v, 16));
+            }
+        }
+        out.push('\n');
+    }
+    write_output(path, out.as_bytes()).map_err(|e| "CodegenWasmJit: cannot write")
+}
+
 /// result-var metadata onto its `MatVar`/`MatKind` and write the bytes out.
 fn write_mat4(
     model: &SimModel,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -95,6 +95,7 @@ fn unknown_variable(name: &str) -> &'static str {
 // wasm-encoder `ValType` mapping is host-only, so it lives here as an extension
 // trait rather than an inherent method.
 pub(crate) use openmodelica_sim_meta::WTy;
+use openmodelica_sim_meta::clock_field;
 pub(crate) use openmodelica_wasm_jit::sig::{ExtCallSig, FnSig, SigTy, WTyVal};
 
 /// Parse one `.wasm.sig` line into a list of [`SigTy`]s (see [`SigTy::write_code`]
@@ -1078,6 +1079,34 @@ pub(crate) struct SimCtx {
     /// `SimData` byte offset of `zeroCrossingsPre` — the previous accepted
     /// g-values, read by the `delayZeroCrossing` builtin in `zc_context`.
     pub(crate) zc_pre_off: u32,
+    /// `SimData` byte offset of the per-base-clock `$_clkfire` flags.
+    pub(crate) clock_fire_off: u32,
+    /// Sub-clock block of the clocked partition being lowered — C's
+    /// `baseClockIndex`/`subClockIndex`, resolved to an address. `None` outside one.
+    pub(crate) sub_clock_off: Option<u32>,
+}
+
+/// One base clock's `SimData` slots and its parameter-dependent init expressions
+/// (see [`FnCtx::emit_init_synchronous`]).
+pub(crate) struct ClockInit {
+    pub(crate) off: u32,
+    /// `RATIONAL_CLOCK`'s `resolution`; `None` is C's default of 1.
+    pub(crate) resolution: Option<Arc<DAE::Exp>>,
+    /// `EVENT_CLOCK`'s `startInterval`, C's initial `stats.previousInterval`.
+    pub(crate) start_interval: Option<Arc<DAE::Exp>>,
+    pub(crate) sub_offs: Vec<u32>,
+}
+
+/// What one base clock's arm of `functionUpdateSynchronous` recomputes.
+pub(crate) enum ClockUpdate {
+    /// `RATIONAL_CLOCK`: `intervalCounter`, and `interval` from it.
+    Rational(Arc<DAE::Exp>),
+    /// `REAL_CLOCK`: `interval` directly.
+    Real(Arc<DAE::Exp>),
+    /// `INFERRED_CLOCK`, defaulted to `Clock(1, 1)`.
+    Inferred,
+    /// An event or solver clock has no interval to recompute.
+    Nothing,
 }
 
 /// One nonlinear system's `rt_solve_nls` wiring: `k` is the job ordinal (its
@@ -1302,8 +1331,25 @@ impl<'a> FnCtx<'a> {
         self.emit(we::Instruction::If(we::BlockType::Empty));
     }
 
+    /// Open `if (idx == v)` on the second parameter, where C dispatches with a
+    /// `switch`; `sim_end_block` closes it.
+    pub(crate) fn sim_index_guard(&mut self, v: u32) {
+        self.emit(we::Instruction::LocalGet(1));
+        self.emit(we::Instruction::I32Const(v as i32));
+        self.emit(we::Instruction::I32Eq);
+        self.emit(we::Instruction::If(we::BlockType::Empty));
+    }
+
     pub(crate) fn sim_end_block(&mut self) {
         self.emit(we::Instruction::End);
+    }
+
+    /// Point the clock builtins at sub-clock `off` (a `SimData` byte offset) while
+    /// the partition it belongs to is lowered.
+    pub(crate) fn set_sub_clock(&mut self, off: Option<u32>) {
+        if let Some(s) = self.sim.as_mut() {
+            s.sub_clock_off = off;
+        }
     }
 
     /// Lower one equation `cref := rhs` into this context.
@@ -1355,6 +1401,102 @@ impl<'a> FnCtx<'a> {
                 let w = compile_exp(self, exp)?;
                 coerce(self, w, WTy::F64);
                 self.emit(we::Instruction::F64Store(mem_arg(off, 3)));
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit `functionInitSynchronous`: C's `function_initSynchronous` minus the
+    /// compile-time constants. Called after `functionParameters`, since
+    /// `resolution` / `startInterval` may be parameter-dependent.
+    pub(crate) fn emit_init_synchronous(&mut self, clocks: &[ClockInit]) -> Result<()> {
+        let data = self.sim()?.data_local;
+        for c in clocks {
+            self.emit(we::Instruction::LocalGet(data));
+            match &c.resolution {
+                Some(e) => {
+                    let w = compile_exp(self, e)?;
+                    coerce(self, w, WTy::I32);
+                }
+                None => self.emit(we::Instruction::I32Const(1)),
+            }
+            self.emit(we::Instruction::I32Store(mem_arg(c.off + clock_field::RESOLUTION, 2)));
+            // C's `(CLOCK_STATS){<startInterval>, 0, -1}`.
+            self.emit(we::Instruction::LocalGet(data));
+            match &c.start_interval {
+                Some(e) => {
+                    let w = compile_exp(self, e)?;
+                    coerce(self, w, WTy::F64);
+                }
+                None => self.emit(we::Instruction::F64Const(0.0.into())),
+            }
+            self.emit(we::Instruction::F64Store(mem_arg(c.off + clock_field::PREV_INTERVAL, 3)));
+            for (off, v) in [
+                (c.off + clock_field::INTERVAL, -1.0),
+                (c.off + clock_field::LAST_ACTIVATION, -1.0),
+            ] {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::F64Const(v.into()));
+                self.emit(we::Instruction::F64Store(mem_arg(off, 3)));
+            }
+            for (off, v) in [
+                (c.off + clock_field::COUNT, 0),
+                (c.off + clock_field::INTERVAL_COUNTER, -1),
+            ] {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::I32Const(v));
+                self.emit(we::Instruction::I32Store(mem_arg(off, 2)));
+            }
+            for &sub in &c.sub_offs {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::F64Const(0.0.into()));
+                self.emit(we::Instruction::F64Store(mem_arg(sub + clock_field::SUB_PREV_INTERVAL, 3)));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::F64Const((-1.0).into()));
+                self.emit(we::Instruction::F64Store(mem_arg(sub + clock_field::SUB_LAST_ACTIVATION, 3)));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::I32Const(0));
+                self.emit(we::Instruction::I32Store(mem_arg(sub + clock_field::SUB_COUNT, 2)));
+            }
+        }
+        Ok(())
+    }
+
+    /// One base clock's arm of `functionUpdateSynchronous` (C's `updatePartition`):
+    /// re-evaluate the clock's interval, which may depend on a variable.
+    pub(crate) fn emit_update_synchronous(&mut self, off: u32, update: &ClockUpdate) -> Result<()> {
+        let data = self.sim()?.data_local;
+        match update {
+            ClockUpdate::Nothing => {}
+            ClockUpdate::Rational(counter) => {
+                self.emit(we::Instruction::LocalGet(data));
+                let w = compile_exp(self, counter)?;
+                coerce(self, w, WTy::I32);
+                self.emit(we::Instruction::I32Store(mem_arg(off + clock_field::INTERVAL_COUNTER, 2)));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::I32Load(mem_arg(off + clock_field::INTERVAL_COUNTER, 2)));
+                self.emit(we::Instruction::F64ConvertI32S);
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::I32Load(mem_arg(off + clock_field::RESOLUTION, 2)));
+                self.emit(we::Instruction::F64ConvertI32S);
+                self.emit(we::Instruction::F64Div);
+                self.emit(we::Instruction::F64Store(mem_arg(off + clock_field::INTERVAL, 3)));
+            }
+            ClockUpdate::Real(interval) => {
+                self.emit(we::Instruction::LocalGet(data));
+                let w = compile_exp(self, interval)?;
+                coerce(self, w, WTy::F64);
+                self.emit(we::Instruction::F64Store(mem_arg(off + clock_field::INTERVAL, 3)));
+            }
+            // C's `INFERRED_CLOCK` default `Clock(intervalCounter=1, resolution=1)`.
+            ClockUpdate::Inferred => {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::I32Const(1));
+                self.emit(we::Instruction::I32Store(mem_arg(off + clock_field::INTERVAL_COUNTER, 2)));
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::F64Const(1.0.into()));
+                self.emit(we::Instruction::F64Store(mem_arg(off + clock_field::INTERVAL, 3)));
             }
         }
         Ok(())
@@ -3916,6 +4058,27 @@ fn pre_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
     })
 }
 
+/// The `previous(cr)` component reference: `cr` wrapped in `DAE.previousNamePrefix`,
+/// the variable the backend introduced for it (key `$CLKPRE.<cr>`).
+fn clkpre_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
+    use DAE::ComponentRef as C;
+    let identType = match cr {
+        C::CREF_IDENT { identType, .. } | C::CREF_QUAL { identType, .. } => identType.clone(),
+        _ => crate::CodegenWasmJit::t_real(),
+    };
+    Arc::new(C::CREF_QUAL {
+        ident: arcstr::literal!("$CLKPRE"),
+        identType,
+        subscriptLst: metamodelica::nil(),
+        componentRef: Arc::new(cr.clone()),
+    })
+}
+
+/// Address of the sub-clock block `interval()`/`firstTick()` read.
+fn sub_clock_off(sim: &SimCtx) -> Result<u32> {
+    sim.sub_clock_off.ok_or("CodegenWasmJit: clock builtin outside a clocked partition")
+}
+
 /// The `der(cr)` component reference: `cr` wrapped in a `$DER` qualifier, as the
 /// backend names the derivative variable (key `$DER.<cr>`).
 fn der_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
@@ -6354,6 +6517,59 @@ fn compile_math_builtin(
             ctx.emit(we::Instruction::LocalGet(data));
             ctx.emit(we::Instruction::I32Load(mem_arg(off, 2)));
             Ok(SigTy::Bool)
+        }
+        // `interval()` and `interval(clk)` alike read the active sub-clock, as C's
+        // `daeExpCall` does: the backend already put the reference in that partition.
+        "interval" if argv.len() <= 1 => {
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s)?) };
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::F64Load(mem_arg(off + clock_field::SUB_PREV_INTERVAL, 3)));
+            Ok(SigTy::Real)
+        }
+        "firstTick" if argv.len() <= 1 => {
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s)?) };
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::I32Load(mem_arg(off + clock_field::SUB_COUNT, 2)));
+            ctx.emit(we::Instruction::I32Const(1));
+            ctx.emit(we::Instruction::I32Eq);
+            Ok(SigTy::Bool)
+        }
+        // C's `crefPrefixPrevious`: the `$CLKPRE.x` variable the partition assigns.
+        "previous" => {
+            need_args(&argv, 1, name)?;
+            let DAE::Exp::CREF { componentRef, .. } = &**argv[0] else {
+                return Err("CodegenWasmJit: `previous` expects a variable reference");
+            };
+            let prev = clkpre_cref(componentRef);
+            match compile_sim_cref_read(ctx, &prev)? {
+                Some(WTy::F64) => Ok(SigTy::Real),
+                Some(WTy::I32) => Ok(SigTy::Int),
+                None => return Err("CodegenWasmJit: `previous` of a non-model variable"),
+            }
+        }
+        // C's `handleBaseClock(data, threadData, i-1, time)`. The timer list is on
+        // the driver's side of the wasm boundary, so raise the clock's flag instead
+        // and let the driver fire it when the model call returns.
+        "$_clkfire" => {
+            need_args(&argv, 1, name)?;
+            let DAE::Exp::ICONST { integer } = &**argv[0] else {
+                return Err("CodegenWasmJit: `$_clkfire` index must be an integer literal");
+            };
+            let base = (*integer - 1).max(0) as u32;
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, s.clock_fire_off) };
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::I32Const(1));
+            ctx.emit(we::Instruction::I32Store(mem_arg(off + base * 4, 2)));
+            // Only ever reached through `noReturnCall`, which drops one result.
+            ctx.emit(we::Instruction::I32Const(0));
+            Ok(SigTy::Bool)
+        }
+        // `hold(e)` / `sample(e, clk)` after partitioning: just `e` here.
+        "$getPart" => {
+            need_args(&argv, 1, name)?;
+            let w = compile_exp(ctx, argv[0])?;
+            Ok(exp_sigty(argv[0])
+                .unwrap_or(if w == WTy::F64 { SigTy::Real } else { SigTy::Int }))
         }
         // der(cref): an explicit derivative left in an equation. Read the
         // derivative variable's slot ($DER.<cref>), as the C target does.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -107,6 +107,7 @@ impl SimEngine for StandaloneEngine {
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
+                "functionInitSynchronous" => return Err(SYNC_UNSUPPORTED),
                 _ => return Err("wasm-jit standalone: unknown model function"),
             }
         }
@@ -117,10 +118,16 @@ impl SimEngine for StandaloneEngine {
         // call is a no-op when the feature is absent.
         self.call1(name, arg)
     }
-    // Importing `evaluateDAEResiduals` would leave every non-DAE model with an
-    // unresolved `model.*` import, so the standalone export has no DAE mode.
-    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> driver::Result<()> {
-        Err("wasm-jit standalone: --daeMode models are not supported by the standalone export")
+    // Importing `evaluateDAEResiduals` (or the two synchronous dispatchers) would
+    // leave every model without that feature with an unresolved `model.*` import,
+    // so the standalone export supports neither.
+    fn call2(&mut self, name: &str, _a: u32, _b: u32) -> driver::Result<()> {
+        Err(match name {
+            driver::MODEL_FN_DAE => {
+                "wasm-jit standalone: --daeMode models are not supported by the standalone export"
+            }
+            _ => SYNC_UNSUPPORTED,
+        })
     }
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
         Ok(unsafe { simulate(sim_data, start, stop, n_steps) })
@@ -136,6 +143,9 @@ impl SimEngine for StandaloneEngine {
         crate::nls::rt_nls_clean_history(time);
     }
 }
+
+const SYNC_UNSUPPORTED: &str =
+    "wasm-jit standalone: synchronous (clocked) models are not supported by the standalone export";
 
 /// Run the prepared model with the shared driver and write its result file.
 /// A failure traps (the command then exits nonzero).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -206,11 +206,17 @@ pub const MODEL_FNS: &[&str] = &[
     "functionUpdateBoundParameters",
     "functionUpdateBoundVariableAttributes",
     "evaluateDAEResiduals",
+    "functionInitSynchronous",
+    "functionUpdateSynchronous",
+    "functionEquationsSynchronous",
 ];
 
-/// The one model entry point that is not `fn(SimData*)`: `--daeMode`'s residual
-/// takes the evaluation stage as a second argument (C's `currentEvalStage`).
+/// The model entry points that are not `fn(SimData*)`: `--daeMode`'s residual
+/// takes the evaluation stage as a second argument (C's `currentEvalStage`), and
+/// the two synchronous dispatchers take a clock index.
 pub const MODEL_FN_DAE: &str = "evaluateDAEResiduals";
+pub const MODEL_FN_UPDATE_SYNC: &str = "functionUpdateSynchronous";
+pub const MODEL_FN_EQS_SYNC: &str = "functionEquationsSynchronous";
 
 /// C's `EVAL_*` (`dae_mode.c`): which stage of the step an equation belongs to.
 /// `evaluateDAEResiduals` runs exactly those whose `evalStages` intersect it.
@@ -962,7 +968,7 @@ mod steady_report {
 }
 
 /// Format `%f`-style (C's `%f`: 6 fractional digits), for the assertion time value.
-fn format_f(v: f64) -> String {
+pub(crate) fn format_f(v: f64) -> String {
     alloc::format!("{v:.6}")
 }
 
@@ -1176,6 +1182,28 @@ pub fn set_abort_slow(v: bool) {
 /// `run_initialization_impl`. Leaves lambda = 1, then seeds `relationsPre` for the
 /// continuous phase's held relations.
 pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
+    init_model(e, sim_data, layout, start_time)?;
+    signal_init_done();
+    Ok(())
+}
+
+/// [`run_initialization`] plus C's `initSynchronous`, which `initializeModel` runs
+/// before it reports success — so the clock dump lands in the log's init segment.
+pub fn run_initialization_with_clocks(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    model: &SimMeta,
+) -> Result<crate::sync::Sync> {
+    init_model(e, sim_data, &model.layout, model.start_time)?;
+    let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
+    // An event clock whose `when` already fired during the initial discrete update
+    // is only *scheduled* here (C's `data->simulationInfo->initial` case).
+    sync.take_fired(e, model.start_time)?;
+    signal_init_done();
+    Ok(sync)
+}
+
+fn init_model(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
@@ -1200,9 +1228,6 @@ pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayo
     // C's `initializeModel` ends with `checkForAsserts` — before the
     // initialization-success line.
     check_asserts(e, sim_data, layout, omclog::WARNING)?;
-    // Initialization output is complete; the next model output is the simulation
-    // phase. Let the host close the init segment of the capture.
-    signal_init_done();
     Ok(())
 }
 
@@ -1314,7 +1339,7 @@ fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimL
 /// matching `SimLayout::n_row_total()` and the column layout `kind_from_slot`
 /// assigns. Used by the host-driven drivers; the in-wasm `simulate` emits the
 /// same layout.
-fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub(crate) fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout) -> Result<()> {
     for i in 0..layout.n_reals_row() {
         rows.push(read_f64(e, sim_data + i * 8)?);
     }
@@ -1779,6 +1804,71 @@ impl Samples {
     }
 }
 
+/// The clock half of C's `simulationUpdate`: fire every timer due at `time`,
+/// running the discrete update in between whenever one asks for an event, until
+/// nothing more fires. `SimData` must already hold the state at `time` — a tick
+/// emits its result row *before* evaluating its partition. Returns whether any
+/// ticked, which makes the caller restart the integrator (`hold()` may have moved).
+fn fire_clocks(
+    e: &mut dyn SimEngine,
+    sync: &mut crate::sync::Sync,
+    model: &SimModel,
+    sim_data: u32,
+    time: f64,
+    eps: f64,
+    mut rows: Option<&mut Vec<f64>>,
+) -> Result<bool> {
+    use crate::sync::Fired;
+    if sync.is_empty() {
+        return Ok(false);
+    }
+    let layout = &model.layout;
+    let mut any = false;
+    let mut did_event = false;
+    for _ in 0..MAX_EVENT_ITER {
+        sync.take_fired(e, time)?;
+        write_f64(e, sim_data + TIME_OFF, time)?;
+        let fired = sync.handle_timers(e, time, eps, rows.as_deref_mut())?;
+        if fired == Fired::None {
+            break;
+        }
+        any = true;
+        rethrow_store::note_event();
+        did_event |= fired == Fired::Event;
+        if fired == Fired::Event {
+            // C's pre-event row: after the partition ran, unlike the tick's own row.
+            if let Some(r) = rows.as_deref_mut()
+                && !no_event_emit()
+            {
+                capture_row(e, r, sim_data, layout)?;
+            }
+            write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
+            iterate_discrete(e, sim_data, layout)?;
+            store_relations(e, sim_data, layout)?;
+        }
+        seed_pre_from_live(e, sim_data, layout)?;
+    }
+    if any {
+        // C: "Update continous system because hold() needs to be re-evaluated".
+        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+        eval_continuous(e, sim_data, layout)?;
+        // C truncates the step to the activation time, so its output row lands here.
+        if let Some(r) = rows
+            && (!did_event || emit_post_event_row(model, time))
+        {
+            capture_row(e, r, sim_data, layout)?;
+        }
+    }
+    Ok(any)
+}
+
+/// Output point `row` of the equidistant grid, as C's `perform_simulation`
+/// computes it: `row*(stop-start)/numSteps + start`, *not* `start + row*h` —
+/// the two round differently and the result files must agree bit for bit.
+fn grid_time(row: u32, start: f64, stop: f64, n_steps: u32) -> f64 {
+    if n_steps == 0 { start } else { row as f64 * (stop - start) / n_steps as f64 + start }
+}
+
 /// Outcome of one [`event_update`] pass.
 pub struct EventUpdate {
     /// A `reinit` moved a continuous state, so the integrator must re-read them.
@@ -1969,7 +2059,9 @@ pub fn make_driver(
     }
     // DAE mode always takes the `SolverCore` path: the consistent-restart its
     // discrete update needs lives there.
-    let events = layout.n_samples > 0 || layout.n_zc > 0;
+    // A clocked partition is an event source too, and only `EventsDriver` has the
+    // timer list and the consistent restart a tick needs.
+    let events = layout.n_samples > 0 || layout.n_zc > 0 || !model.clocks.is_empty();
     if events || method == "gbode" || layout.dae_mode() {
         let label = match method {
             "cvode" => "cvode-events",
@@ -2057,7 +2149,7 @@ pub fn drive(
     let stop = model.stop_time;
 
     let mut stats = SolveStats::default();
-    let use_events = layout.n_samples > 0 || layout.n_zc > 0;
+    let use_events = layout.n_samples > 0 || layout.n_zc > 0 || !model.clocks.is_empty();
     let method = effective_method(method);
 
     let mut label = "";
@@ -2184,7 +2276,7 @@ impl Driver for EulerDriver {
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
-        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let grid = |row: u32| grid_time(row, start, stop, n_steps);
         let states_base = sim_data + REAL_OFF;
         let ders_base = states_base + n_states * 8;
 
@@ -2200,7 +2292,7 @@ impl Driver for EulerDriver {
             }
             did_step = true;
             // The last row lands exactly on `stop`: the terminal step.
-            let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            let time = if self.row == n_steps { stop } else { grid(self.row) };
             // Euler locates no events, so a suppressed assert always throws; the
             // window is what gets it reported like C's.
             open_assert_window();
@@ -2227,7 +2319,8 @@ impl Driver for EulerDriver {
             {
                 e.call1("functionODE", sim_data)?;
             }
-            // Forward-Euler update of the states.
+            // Forward-Euler update of the states, over this row's own step.
+            let h = grid(self.row + 1) - grid(self.row);
             for i in 0..n_states {
                 let s = read_f64(e, states_base + i * 8)?;
                 let d = read_f64(e, ders_base + i * 8)?;
@@ -2911,7 +3004,7 @@ impl Driver for DasslDriver {
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
-        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let grid = |row: u32| grid_time(row, start, stop, n_steps);
         let deadline = deadline_from(budget_ms);
         // `-noEquidistantTimeGrid`: one interval spans the run, rows come from the
         // IDID=1 returns below.
@@ -2937,7 +3030,7 @@ impl Driver for DasslDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
-                let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                let time = if self.row == n_steps { stop } else { grid(self.row) };
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
@@ -3015,7 +3108,7 @@ impl Driver for DasslDriver {
             let mut tout = self.pending_tout.unwrap_or(if no_grid || self.row == n_steps {
                 stop
             } else {
-                start + self.row as f64 * h
+                grid(self.row)
             });
             // Zero-length final interval (stop == start): daskr rejects TOUT == T,
             // so emit the held state directly instead of stepping.
@@ -3542,6 +3635,7 @@ struct EventsDriver {
     row: u32,
     pivots: Vec<StateSetPivot>,
     samp: Samples,
+    sync: crate::sync::Sync,
     rows: Vec<f64>,
     /// Resume state for a yield mid output row, so `grid_covered` is not reset.
     mid_row: bool,
@@ -4004,6 +4098,7 @@ impl SolverCore {
         model: &SimModel,
         ctx: &mut ResCtx,
         samp: &mut Samples,
+        sync: &mut crate::sync::Sync,
         tout: f64,
         deadline: f64,
         mut rows: Option<&mut Vec<f64>>,
@@ -4032,8 +4127,14 @@ impl SolverCore {
             // probes are smooth (C's `solveContinuous`); events/outputs refresh them.
             write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
             let te = samp.next_time();
-            let target = tout.min(te);
-            self.sample_limit = te;
+            // C's `checkForSynchronous`: never step past the next activation. Snapped
+            // onto `tout` (as samples are) so the last row's time is exactly `stop`.
+            let mut tc = sync.next_time();
+            if (tc - tout).abs() <= eps {
+                tc = tout;
+            }
+            let target = tout.min(te).min(tc);
+            self.sample_limit = te.min(tc);
             // Integrate from the current t toward `target` (the caller's time or the
             // next scheduled sample). DASKR may stop early at a zero-crossing root.
             if target - self.t > eps {
@@ -4115,6 +4216,10 @@ impl SolverCore {
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
                     }
+                    fire_clocks(e, sync, model, sim_data, troot, eps, rows.as_deref_mut())?;
+                    if terminated(e, sim_data, layout)? {
+                        return Ok(Step::Terminated);
+                    }
                     // Re-read states (a reinit may have jumped one), recompute the
                     // consistent derivative, and restart DASKR at troot (INFO(1)=0).
                     self.read_states(e)?;
@@ -4133,7 +4238,7 @@ impl SolverCore {
             }
             // Reached `target`. Fire a sample event at `te` if it lands at or
             // before `tout` (pre-event row, fire, post-event row).
-            if te <= tout + eps {
+            if te <= target + eps {
                 // Snap an event near `tout` onto it (keeps the final row at `stop`
                 // despite float drift).
                 let te = if (te - tout).abs() <= eps { tout } else { te };
@@ -4178,6 +4283,33 @@ impl SolverCore {
                     grid_covered = true;
                 }
             }
+            // C's `handleTimers`, plus any event clock a `when` body above just fired.
+            if !sync.is_empty() {
+                write_f64(e, sim_data + TIME_OFF, target)?;
+                sync.take_fired(e, target)?;
+            }
+            if sync.next_time() <= target + eps {
+                *did_step = true;
+                write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+                eval_continuous(e, sim_data, layout)?;
+                if fire_clocks(e, sync, model, sim_data, target, eps, rows.as_deref_mut())? {
+                    if terminated(e, sim_data, layout)? {
+                        return Ok(Step::Terminated);
+                    }
+                    self.read_y(e)?;
+                    if !self.dae {
+                        e.call1("functionODE", sim_data)?;
+                        for i in 0..n_states {
+                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
+                        }
+                    }
+                    self.restart()?;
+                    self.dae_restart(e, ctx)?;
+                    if target >= tout - eps {
+                        grid_covered = true;
+                    }
+                }
+            }
             if target >= tout - eps {
                 return Ok(Step::Reached { grid_covered });
             }
@@ -4196,6 +4328,7 @@ impl SolverCore {
 pub struct CsDriver {
     core: SolverCore,
     samp: Samples,
+    sync: crate::sync::Sync,
     pivots: Vec<StateSetPivot>,
     /// The step `euler`/`rungekutta` take (the model's own output step); `None` for a
     /// variable-step method, which is handed the whole interval.
@@ -4225,6 +4358,8 @@ impl CsDriver {
         check_method(method, layout)?;
         store_relations(e, sim_data, layout)?;
         let samp = Samples::load(e, sim_data, layout)?;
+        let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
+        sync.take_fired(e, t)?;
         let mut core = SolverCore::new(&*e, model, sim_data, t, method, alloc_gbode(model, method)?)?;
         let mut pivots = init_state_pivots(&model.state_sets);
         if core.n_states > 0 {
@@ -4235,7 +4370,7 @@ impl CsDriver {
         }
         let h = model.step_size();
         let fixed_h = fixed_kind(method).map(|_| if h > 0.0 { h } else { f64::INFINITY });
-        Ok(CsDriver { core, samp, pivots, fixed_h, resume_reinit: false })
+        Ok(CsDriver { core, samp, sync, pivots, fixed_h, resume_reinit: false })
     }
 
     /// The time reached so far (FMI's `last-successful-time`).
@@ -4410,8 +4545,8 @@ impl CsDriver {
                 None => t_target,
             };
             let outcome = self.core.integrate_to(
-                e, model, &mut ctx, &mut self.samp, target, f64::INFINITY, None, &mut did_step,
-                stop_at_event,
+                e, model, &mut ctx, &mut self.samp, &mut self.sync, target, f64::INFINITY, None,
+                &mut did_step, stop_at_event,
             )?;
             if !matches!(outcome, Step::Reached { .. }) || self.core.t >= t_target - eps {
                 self.core.nfe = ctx.nfe;
@@ -4439,7 +4574,8 @@ impl EventsDriver {
         let layout = &model.layout;
         // Init (with homotopy fallback). Relation mode 2 and `initSample` are handled
         // inside run_initialization; seed the hysteresis direction from the relations.
-        run_initialization(e, sim_data, layout, model.start_time)?;
+        crate::sync::clear_fire_flags(e, sim_data, layout)?;
+        let sync = run_initialization_with_clocks(e, sim_data, model)?;
         store_relations(e, sim_data, layout)?;
 
         let n_states = layout.n_states as usize;
@@ -4476,6 +4612,7 @@ impl EventsDriver {
             row: 1,
             pivots,
             samp,
+            sync,
             rows,
             mid_row: false,
             grid_covered: false,
@@ -4502,7 +4639,7 @@ impl Driver for EventsDriver {
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
-        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let grid = |row: u32| grid_time(row, start, stop, n_steps);
         let deadline = deadline_from(budget_ms);
         // `-noEquidistantTimeGrid`: the rows come from `integrate_to`, so one "row"
         // spans the run; `Samples` still bounds each solve.
@@ -4517,7 +4654,7 @@ impl Driver for EventsDriver {
             emit_row(e, &mut self.rows, sim_data, layout, self.core.t, stop)?;
         }
         let tout_of = |row: u32| {
-            if no_grid || row == n_steps { stop } else { start + row as f64 * h }
+            if no_grid || row == n_steps { stop } else { grid(row) }
         };
 
         // No continuous states: nothing to integrate, but zero-crossings on `time`
@@ -4550,7 +4687,11 @@ impl Driver for EventsDriver {
                 // Handle every event (state or sample) up to `tout`, earliest first.
                 loop {
                     let te = self.samp.next_time();
-                    let subtarget = tout.min(te);
+                    let mut tc = self.sync.next_time();
+                    if (tc - tout).abs() <= eps {
+                        tc = tout;
+                    }
+                    let subtarget = tout.min(te).min(tc);
                     // A state event bracketed in (t, subtarget]?
                     let mut troot = None;
                     if layout.n_zc > 0 && subtarget - self.core.t > eps {
@@ -4576,6 +4717,13 @@ impl Driver for EventsDriver {
                             return Ok(Advance::Terminated);
                         }
                         self.core.t = tr;
+                        // The discrete update may have fired an event clock.
+                        if fire_clocks(e, &mut self.sync, model, sim_data, tr, eps, Some(&mut self.rows))?
+                            && terminated(e, sim_data, layout)?
+                        {
+                            self.finished = true;
+                            return Ok(Advance::Terminated);
+                        }
                         e.call1_if_present("functionStoreDelayed", sim_data)?;
                         eval_zero_crossings(e, sim_data, layout, tr, &mut zc0)?;
                         save_zc_pre(e, sim_data, layout)?;
@@ -4584,7 +4732,7 @@ impl Driver for EventsDriver {
                     // No state event before the next sample time. Fire the sample if
                     // it is due at or before this grid point; otherwise the interval
                     // is clean up to `tout`.
-                    if te <= tout + eps {
+                    if te <= subtarget + eps {
                         let te = if (te - tout).abs() <= eps { tout } else { te };
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?; // held pre row
                         if !no_event_emit() {
@@ -4611,7 +4759,30 @@ impl Driver for EventsDriver {
                         if te >= tout - eps {
                             grid_covered = true;
                         }
-                    } else {
+                    }
+                    if !self.sync.is_empty() {
+                        write_f64(e, sim_data + TIME_OFF, subtarget)?;
+                        self.sync.take_fired(e, subtarget)?;
+                    }
+                    if self.sync.next_time() <= subtarget + eps {
+                        self.core.t = subtarget;
+                        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+                        eval_continuous(e, sim_data, layout)?;
+                        if fire_clocks(e, &mut self.sync, model, sim_data, subtarget, eps, Some(&mut self.rows))? {
+                            if terminated(e, sim_data, layout)? {
+                                self.finished = true;
+                                return Ok(Advance::Terminated);
+                            }
+                            e.call1_if_present("functionStoreDelayed", sim_data)?;
+                            if layout.n_zc > 0 {
+                                eval_zero_crossings(e, sim_data, layout, subtarget, &mut zc0)?;
+                                save_zc_pre(e, sim_data, layout)?;
+                            }
+                            if subtarget >= tout - eps {
+                                grid_covered = true;
+                            }
+                        }
+                    } else if te > subtarget + eps {
                         break;
                     }
                 }
@@ -4662,7 +4833,8 @@ impl Driver for EventsDriver {
             // the state the model is evaluated at may still be discarded.
             open_assert_window();
             match self.core.integrate_to(
-                e, model, &mut ctx, &mut self.samp, tout, deadline, Some(&mut self.rows), &mut did_step, false,
+                e, model, &mut ctx, &mut self.samp, &mut self.sync, tout, deadline,
+                Some(&mut self.rows), &mut did_step, false,
             )? {
                 Step::Yielded => {
                     // Resume on the same row; `mid_row` keeps `grid_covered`.
@@ -4908,7 +5080,7 @@ impl Driver for CvodeDriver {
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
-        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let grid = |row: u32| grid_time(row, start, stop, n_steps);
         let deadline = deadline_from(budget_ms);
 
         // No integration — evaluate outputs on the grid — with no states or an
@@ -4924,7 +5096,7 @@ impl Driver for CvodeDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
-                let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                let time = if self.row == n_steps { stop } else { grid(self.row) };
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
@@ -4982,7 +5154,7 @@ impl Driver for CvodeDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
-            let tout = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+            let tout = if self.row == n_steps { stop } else { grid(self.row) };
             // Zero-length final interval: emit the held state rather than step.
             if tout <= self.t {
                 for (i, v) in cv.y().iter().enumerate() {
@@ -5668,7 +5840,7 @@ impl Driver for IdaDriver {
         let n_steps = n_rows - 1;
         let start = model.start_time;
         let stop = model.stop_time;
-        let h = if n_steps == 0 { 0.0 } else { (stop - start) / n_steps as f64 };
+        let grid = |row: u32| grid_time(row, start, stop, n_steps);
         let deadline = deadline_from(budget_ms);
         // `-noEquidistantTimeGrid`: one interval spans the run, rows come from the
         // one-step returns below (`ida_solver.c`'s `idaSmode`).
@@ -5692,7 +5864,7 @@ impl Driver for IdaDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
-                let time = if self.row == n_steps { stop } else { start + self.row as f64 * h };
+                let time = if self.row == n_steps { stop } else { grid(self.row) };
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
@@ -5749,7 +5921,7 @@ impl Driver for IdaDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
-            let tout = if no_grid || self.row == n_steps { stop } else { start + self.row as f64 * h };
+            let tout = if no_grid || self.row == n_steps { stop } else { grid(self.row) };
             // Zero-length final interval: emit the held state rather than step.
             if tout <= self.t {
                 for (i, v) in ida.y().iter().enumerate() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -29,6 +29,7 @@ pub mod fixedstep;
 pub mod gbode;
 pub mod omclog;
 pub mod simflags;
+pub mod sync;
 #[cfg(sundials)]
 pub mod sundials;
 
@@ -46,6 +47,26 @@ pub const REAL_OFF: u32 = 8;
 /// i32 words in the fired-`terminate` info block at [`Layout::term_info_off`]:
 /// `msg`, `file`, `lineStart`, `colStart`, `lineEnd`, `colEnd`, `readOnly`.
 pub const TERM_INFO_WORDS: u32 = 7;
+
+/// Bytes per base clock / sub-clock in `SimData` — the mutable half of C's
+/// `BASECLOCK_DATA` / `SUBCLOCK_DATA`; the constant half is in [`BaseClockMeta`].
+pub const BASECLOCK_BYTES: u32 = 40;
+pub const SUBCLOCK_BYTES: u32 = 24;
+
+/// Field offsets inside those blocks, baked into the emitted module and read back
+/// by the driver.
+pub mod clock_field {
+    pub const INTERVAL: u32 = 0;
+    pub const PREV_INTERVAL: u32 = 8;
+    pub const LAST_ACTIVATION: u32 = 16;
+    pub const COUNT: u32 = 24;
+    pub const INTERVAL_COUNTER: u32 = 28;
+    pub const RESOLUTION: u32 = 32;
+
+    pub const SUB_PREV_INTERVAL: u32 = 0;
+    pub const SUB_LAST_ACTIVATION: u32 = 8;
+    pub const SUB_COUNT: u32 = 16;
+}
 
 /// The wasm value type a scalar occupies in `SimData` (4-byte `i32` for
 /// Integer/Boolean, 8-byte `f64` for Real). The single definition used by both
@@ -160,6 +181,18 @@ pub struct Layout {
     pub n_dae_alg: u32,
     /// Base of their `nominal` attributes, written like `state_nom_off`.
     pub dae_alg_nom_off: u32,
+    /// Number of synchronous base clocks (`SimCode.clockedPartitions`).
+    pub n_base_clocks: u32,
+    /// Base of the per-base-clock state ([`BASECLOCK_BYTES`] each).
+    pub clock_off: u32,
+    /// Total number of sub-clocks over all base clocks.
+    pub n_sub_clocks: u32,
+    /// Base of the per-sub-clock state ([`SUBCLOCK_BYTES`] each), flattened in
+    /// base-clock order — [`BaseClockMeta::sub_base`] indexes into it.
+    pub subclock_off: u32,
+    /// Base of the per-base-clock `$_clkfire` flags (one i32 each): an event
+    /// clock's `when`-body raises its flag, the driver fires and clears it.
+    pub clock_fire_off: u32,
     pub total: u32,
 }
 
@@ -189,6 +222,8 @@ impl Layout {
         n_dae_res: u32,
         n_dae_aux: u32,
         n_dae_alg: u32,
+        n_base_clocks: u32,
+        n_sub_clocks: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -230,15 +265,28 @@ impl Layout {
         let dae_res_off = sens_off + n_sens * 8;
         let dae_aux_off = dae_res_off + n_dae_res * 8;
         let dae_alg_nom_off = dae_aux_off + n_dae_aux * 8;
-        let total = dae_alg_nom_off + n_dae_alg * 8;
+        let clock_off = dae_alg_nom_off + n_dae_alg * 8;
+        let subclock_off = clock_off + n_base_clocks * BASECLOCK_BYTES;
+        let clock_fire_off = subclock_off + n_sub_clocks * SUBCLOCK_BYTES;
+        let total = clock_fire_off + n_base_clocks * 4;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
             mathevents_off, zctol_off, start_off, state_nom_off, n_sens, sens_off,
-            n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off, total,
+            n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
+            n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, total,
         }
+    }
+
+    /// Byte offset of base clock `i`'s state block.
+    pub fn base_clock_off(&self, i: u32) -> u32 {
+        self.clock_off + i * BASECLOCK_BYTES
+    }
+    /// Byte offset of the sub-clock at flat index `k`.
+    pub fn sub_clock_off(&self, k: u32) -> u32 {
+        self.subclock_off + k * SUBCLOCK_BYTES
     }
 
     /// Byte offset of state `i`'s overridable start-value slot.
@@ -357,6 +405,34 @@ pub struct DaeInfo {
     pub sparsity: Option<JacAInfo>,
 }
 
+/// The compile-time half of C's `SUBCLOCK_DATA` (its `CLOCK_STATS` live in `SimData`).
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct SubClockMeta {
+    /// `shiftCounter/resolution` of `shiftSample`/`backSample`, relative to the
+    /// base clock.
+    pub shift_num: i64,
+    pub shift_den: i64,
+    /// `subSample(u, f)` is `f/1`, `superSample(u, f)` is `1/f`.
+    pub factor_num: i64,
+    pub factor_den: i64,
+    /// Trigger an event at the sub-clock's activation time.
+    pub hold_events: bool,
+    /// The sub-clock names a `solverMethod` (C's `"External"`). Only the
+    /// `LOG_SYNCHRONOUS` dump distinguishes it; it is driven like any other.
+    pub external_solver: bool,
+}
+
+/// The compile-time half of C's `BASECLOCK_DATA`.
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct BaseClockMeta {
+    pub is_event_clock: bool,
+    /// An `INFERRED_CLOCK` base clock, defaulted to `Clock(1, 1)` with a warning.
+    pub inferred: bool,
+    /// Flat index of this clock's first sub-clock in the sub-clock region.
+    pub sub_base: u32,
+    pub sub: Vec<SubClockMeta>,
+}
+
 /// Dynamic state-selection metadata for one `$STATESET`. All offsets are
 /// SimData-relative bytes.
 #[derive(Clone, PartialEq, Debug)]
@@ -449,6 +525,9 @@ pub struct SimMeta {
     pub nls_vars: Vec<NlsVars>,
     /// `--daeMode` solver metadata; `Some` exactly when [`Layout::dae_mode`].
     pub dae: Option<DaeInfo>,
+    /// Synchronous base clocks in `base_idx` order; empty for a model with no
+    /// clocked partitions.
+    pub clocks: Vec<BaseClockMeta>,
 }
 
 /// [`SimMeta::nls_vars`] entry.
@@ -634,7 +713,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 9;
+const VERSION: u32 = 10;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -666,7 +745,8 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
         l.state_nom_off, l.n_sens, l.sens_off,
-        l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off, l.total,
+        l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off,
+        l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off, l.total,
     ] {
         put_u32(o, v);
     }
@@ -768,6 +848,20 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             put_jac(&mut o, &d.sparsity);
         }
     }
+    put_u32(&mut o, m.clocks.len() as u32);
+    for c in &m.clocks {
+        o.push(c.is_event_clock as u8);
+        o.push(c.inferred as u8);
+        put_u32(&mut o, c.sub_base);
+        put_u32(&mut o, c.sub.len() as u32);
+        for s in &c.sub {
+            for v in [s.shift_num, s.shift_den, s.factor_num, s.factor_den] {
+                o.extend_from_slice(&v.to_le_bytes());
+            }
+            o.push(s.hold_events as u8);
+            o.push(s.external_solver as u8);
+        }
+    }
     o
 }
 
@@ -787,6 +881,9 @@ impl<'a> Reader<'a> {
     }
     fn f64(&mut self) -> Result<f64, &'static str> {
         Ok(f64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+    fn i64(&mut self) -> Result<i64, &'static str> {
+        Ok(i64::from_le_bytes(self.take(8)?.try_into().unwrap()))
     }
     fn u8(&mut self) -> Result<u8, &'static str> {
         Ok(self.take(1)?[0])
@@ -865,6 +962,11 @@ impl<'a> Reader<'a> {
             dae_aux_off: self.u32()?,
             n_dae_alg: self.u32()?,
             dae_alg_nom_off: self.u32()?,
+            n_base_clocks: self.u32()?,
+            clock_off: self.u32()?,
+            n_sub_clocks: self.u32()?,
+            subclock_off: self.u32()?,
+            clock_fire_off: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -959,10 +1061,30 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         0 => None,
         _ => Some(DaeInfo { alg_offs: r.u32s()?, sparsity: r.jac()? }),
     };
+    let nclocks = r.u32()? as usize;
+    let mut clocks = Vec::with_capacity(nclocks);
+    for _ in 0..nclocks {
+        let is_event_clock = r.u8()? != 0;
+        let inferred = r.u8()? != 0;
+        let sub_base = r.u32()?;
+        let nsub = r.u32()? as usize;
+        let mut sub = Vec::with_capacity(nsub);
+        for _ in 0..nsub {
+            sub.push(SubClockMeta {
+                shift_num: r.i64()?,
+                shift_den: r.i64()?,
+                factor_num: r.i64()?,
+                factor_den: r.i64()?,
+                hold_events: r.u8()? != 0,
+                external_solver: r.u8()? != 0,
+            });
+        }
+        clocks.push(BaseClockMeta { is_event_clock, inferred, sub_base, sub });
+    }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
-        nls_vars, dae,
+        nls_vars, dae, clocks,
     })
 }
 
@@ -974,7 +1096,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -1024,6 +1146,15 @@ mod tests {
                     rows_by_col: vec![vec![0], vec![0, 1], vec![2], vec![2, 3]],
                 }),
             }),
+            clocks: vec![BaseClockMeta {
+                is_event_clock: false,
+                inferred: false,
+                sub_base: 0,
+                sub: vec![
+                    SubClockMeta { shift_num: 0, shift_den: 1, factor_num: 1, factor_den: 1, hold_events: false, external_solver: false },
+                    SubClockMeta { shift_num: 1, shift_den: 3, factor_num: 4, factor_den: 1, hold_events: true, external_solver: false },
+                ],
+            }],
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -103,6 +103,7 @@ pub const SOTI: Stream = 50;
 pub const STATS: Stream = 52;
 pub const STATS_V: Stream = 53;
 pub const SUCCESS: Stream = 54;
+pub const SYNCHRONOUS: Stream = 55;
 pub const ZEROCROSSINGS: Stream = 56;
 
 /// C's `OMC_LOG_TYPE_*` / `OMC_LOG_TYPE_DESC`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -682,13 +682,13 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
     Ok(f)
 }
 
-/// C's `initializeResultData` formats. `mat` and `empty` are the ones this runtime
-/// has a writer for; `csv`/`plt`/`ia` are C's and would need one of their own.
+/// C's `initializeResultData` formats. `mat`, `csv` and `empty` are the ones this
+/// runtime has a writer for; `plt`/`ia` are C's and would need one of their own.
 fn output_format(v: &str) -> Result<String, String> {
     match v {
-        "mat" | "empty" => Ok(v.to_string()),
-        "csv" | "plt" | "ia" => Err(format!(
-            "-outputFormat={v}: this runtime writes `mat` results, or `empty` for none"
+        "mat" | "csv" | "empty" => Ok(v.to_string()),
+        "plt" | "ia" => Err(format!(
+            "-outputFormat={v}: this runtime writes `mat`/`csv` results, or `empty` for none"
         )),
         _ => Err(format!("Unknown output format: {v}")),
     }
@@ -1218,7 +1218,8 @@ mod tests {
     fn only_the_writable_output_formats_are_accepted() {
         assert_eq!(parse(&argv(&["-outputFormat=empty"])).expect("parses").output_format.as_deref(),
                    Some("empty"));
-        assert!(parse(&argv(&["-outputFormat=csv"])).expect_err("no csv writer").contains("mat"));
+        assert_eq!(parse(&argv(&["-outputFormat=csv"])).expect("csv writer").output_format.as_deref(), Some("csv"));
+        assert!(parse(&argv(&["-outputFormat=plt"])).expect_err("no plt writer").contains("mat"));
         assert!(parse(&argv(&["-outputFormat=nope"])).expect_err("unknown").contains("Unknown"));
         // `-noemit` is C's `sim_noemit`, which it treats exactly as `empty`.
         assert!(parse(&argv(&["-noemit"])).expect("parses").noemit);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sync.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sync.rs
@@ -1,0 +1,389 @@
+//! Synchronous (clocked) partitions: the wasm-jit counterpart of the C runtime's
+//! `simulation/solver/synchronous.c`.
+//!
+//! Clocked partitions are driven by a sorted list of activation timers: a
+//! base-clock tick advances its own timer by `interval` and schedules the
+//! sub-clock ticks falling inside it. The integrator never steps past the
+//! earliest timer ([`Sync::next_time`], C's `checkForSynchronous`).
+//!
+//! One departure from C: `$_clkfire` cannot call back across the wasm boundary
+//! into this list, so the model raises a flag in `SimData` and
+//! [`Sync::take_fired`] turns it into a timer once the model call returns.
+
+use alloc::format;
+use alloc::vec::Vec;
+
+use crate::driver::{
+    self, MODEL_FN_EQS_SYNC, MODEL_FN_UPDATE_SYNC, Result, SimEngine, read_f64, read_i32, write_f64,
+    write_i32,
+};
+use crate::omclog;
+use crate::{BaseClockMeta, Layout, clock_field};
+
+/// C's `SYNC_EPS` (`epsilon.h`).
+const SYNC_EPS: f64 = 1e-14;
+
+/// C's `RATIONAL`, kept exact: sub-clock activation is `shift + count*factor`
+/// relative to the base clock, and only the ticks landing on an integer count.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct Rat {
+    num: i64,
+    den: i64,
+}
+
+fn gcd(mut a: i64, mut b: i64) -> i64 {
+    while a != 0 {
+        let tmp = a;
+        a = b % a;
+        b = tmp;
+    }
+    b.abs()
+}
+
+impl Rat {
+    fn new(num: i64, den: i64) -> Rat {
+        let g = gcd(num, den);
+        let (num, den) = if g != 0 { (num / g, den / g) } else { (num, den) };
+        if den < 0 { Rat { num: -num, den: -den } } else { Rat { num, den } }
+    }
+    fn int(n: i64) -> Rat {
+        Rat { num: n, den: 1 }
+    }
+    fn add(self, o: Rat) -> Rat {
+        Rat::new(self.num * o.den + o.num * self.den, self.den * o.den)
+    }
+    fn sub(self, o: Rat) -> Rat {
+        Rat::new(self.num * o.den - o.num * self.den, self.den * o.den)
+    }
+    fn mul(self, o: Rat) -> Rat {
+        Rat::new(self.num * o.num, self.den * o.den)
+    }
+    /// Largest integer `<= self`.
+    fn floor(self) -> i64 {
+        self.num / self.den - i64::from(self.num < 0 && self.num % self.den != 0)
+    }
+    fn to_real(self) -> f64 {
+        self.num as f64 / self.den as f64
+    }
+}
+
+/// C's `assertStreamPrint` inside `initSynchronous`: log the violated condition,
+/// then the termination notice, and fail the run with the error the host reports
+/// without adding a reason of its own.
+fn init_assert(msg: &str) -> &'static str {
+    omclog::message_text(omclog::DEBUG_TYPE, omclog::ASSERT, false, msg);
+    omclog::info(omclog::ASSERT, false, "simulation terminated by an assertion at initialization");
+    driver::ASSERT_ERR
+}
+
+/// C's `SYNC_TIMER`. `sub` is `None` for a base-clock timer (C's `sub_idx = -1`).
+#[derive(Clone, Copy, Debug)]
+struct Timer {
+    base: u32,
+    sub: Option<u32>,
+    time: f64,
+}
+
+/// What one [`Sync::handle_timers`] pass did, C's `fire_timer_t`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Fired {
+    None,
+    /// A clock ticked, without asking for an event.
+    Timer,
+    /// A clock with `holdEvents` ticked: the step is an event step.
+    Event,
+}
+
+/// The clocked half of a run: the clock metadata and the ordered timer list.
+/// Empty (and inert) for a model without clocked partitions.
+pub struct Sync {
+    clocks: Vec<BaseClockMeta>,
+    /// Ordered by activation time, earliest first (C's `intvlTimers`).
+    timers: Vec<Timer>,
+    sim_data: u32,
+    layout: Layout,
+}
+
+impl Sync {
+    /// C's `initSynchronous`: run the model's `functionInitSynchronous`, check the
+    /// sub-clocks, then give every non-event base clock its first timer.
+    pub fn new(e: &mut dyn SimEngine, model: &crate::SimMeta, sim_data: u32) -> Result<Sync> {
+        let mut s = Sync {
+            clocks: model.clocks.clone(),
+            timers: Vec::new(),
+            sim_data,
+            layout: model.layout,
+        };
+        if s.clocks.is_empty() {
+            return Ok(s);
+        }
+        e.call1("functionInitSynchronous", sim_data)?;
+        // C emits this from the generated `function_initSynchronous`, ahead of the
+        // checks below.
+        for _ in s.clocks.iter().filter(|c| c.inferred) {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                "Inferred clock, using default clock 'Clock(intervalCounter=1, resolution=1)'",
+            );
+        }
+        for c in &s.clocks {
+            // C's "Continuous clocked systems aren't supported yet." assert tests
+            // `solverMethod != NULL`, and the generated code always sets it (""
+            // or "External"), so it never fires — a solver clock runs as an
+            // ordinary sub-clock. Not reproduced here for the same reason.
+            for sub in &c.sub {
+                if Rat::new(sub.shift_num, sub.shift_den).floor() < 0 {
+                    return Err(init_assert(
+                        "Shift of sub-clock is negative. Sub-clocks aren't allowed to fire before base-clock.",
+                    ));
+                }
+                if c.is_event_clock && Rat::new(sub.factor_num, sub.factor_den).den != 1 {
+                    return Err(init_assert(
+                        "Factor of sub-clock of event-clock is not an integer, this is not allowed.",
+                    ));
+                }
+            }
+        }
+        for i in 0..s.clocks.len() as u32 {
+            e.call2(MODEL_FN_UPDATE_SYNC, sim_data, i)?;
+            if !s.clocks[i as usize].is_event_clock {
+                // C's `listPushFront`, so the clocks fire in reverse index order.
+                s.timers.insert(0, Timer { base: i, sub: None, time: model.start_time });
+            }
+        }
+        s.print_clocks(e)?;
+        Ok(s)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.clocks.is_empty()
+    }
+
+    /// C's `checkForSynchronous`: the earliest activation time still scheduled, so
+    /// the integrator can cut its step short and land on it. `+inf` when idle.
+    pub fn next_time(&self) -> f64 {
+        self.timers.first().map_or(f64::INFINITY, |t| t.time)
+    }
+
+    /// Insert keeping the list ordered by activation time, after any timer with the
+    /// same time (C's `insertTimer`).
+    fn insert(&mut self, timer: Timer) {
+        let at = self.timers.iter().position(|t| t.time > timer.time).unwrap_or(self.timers.len());
+        self.timers.insert(at, timer);
+    }
+
+    /// Turn the `$_clkfire` flags a discrete update raised into base-clock
+    /// activations at `time`, and clear them.
+    pub fn take_fired(&mut self, e: &mut dyn SimEngine, time: f64) -> Result<()> {
+        for i in 0..self.clocks.len() as u32 {
+            let off = self.sim_data + self.layout.clock_fire_off + i * 4;
+            if read_i32(e, off)? == 0 {
+                continue;
+            }
+            write_i32(e, off, 0)?;
+            self.insert(Timer { base: i, sub: None, time });
+        }
+        Ok(())
+    }
+
+    /// C's `handleTimers`: fire every timer due at `time`, earliest first. `rows`
+    /// receives the pre-tick result row C's `sim_result.emit` writes before each
+    /// clocked partition is evaluated.
+    ///
+    /// `eps` is the caller's time tolerance: the driver made this activation its
+    /// integration target, so a timer within `eps` of `time` must fire or the step
+    /// makes no progress.
+    pub fn handle_timers(
+        &mut self,
+        e: &mut dyn SimEngine,
+        time: f64,
+        eps: f64,
+        mut rows: Option<&mut Vec<f64>>,
+    ) -> Result<Fired> {
+        let eps = eps.max(SYNC_EPS);
+        let mut ret = Fired::None;
+        while self.timers.first().is_some_and(|t| t.time <= time + eps) {
+            let timer = self.timers.remove(0);
+            let fired = match timer.sub {
+                None => {
+                    let first_is_base = self.handle_base_clock(e, timer.base, timer.time, rows.as_deref_mut())?;
+                    let hold = first_is_base && self.clocks[timer.base as usize].sub[0].hold_events;
+                    if hold { Fired::Event } else { Fired::Timer }
+                }
+                Some(sub) => self.handle_sub_clock(e, timer.base, sub, time, rows.as_deref_mut())?,
+            };
+            ret = fired;
+        }
+        Ok(ret)
+    }
+
+    /// C's `handleBaseClock`: update the clock's statistics, evaluate its first
+    /// sub-partition when that *is* the base clock, reschedule the base clock, and
+    /// queue the sub-clock ticks falling inside this interval.
+    fn handle_base_clock(
+        &mut self,
+        e: &mut dyn SimEngine,
+        base: u32,
+        time: f64,
+        mut rows: Option<&mut Vec<f64>>,
+    ) -> Result<bool> {
+        let clock = self.clocks[base as usize].clone();
+        let off = self.sim_data + self.layout.base_clock_off(base);
+        let count = read_i32(e, off + clock_field::COUNT)? + 1;
+        write_i32(e, off + clock_field::COUNT, count)?;
+        // An event clock has no interval to derive the previous one from.
+        if clock.is_event_clock {
+            if count > 1 {
+                let last = read_f64(e, off + clock_field::LAST_ACTIVATION)?;
+                write_f64(e, off + clock_field::PREV_INTERVAL, time - last)?;
+            }
+        } else {
+            let interval = read_f64(e, off + clock_field::INTERVAL)?;
+            write_f64(e, off + clock_field::PREV_INTERVAL, interval)?;
+        }
+        write_f64(e, off + clock_field::LAST_ACTIVATION, time)?;
+
+        let sub0 = &clock.sub[0];
+        let first_is_base = sub0.shift_num == 0 && sub0.factor_num == 1 && sub0.factor_den == 1;
+        if first_is_base {
+            if let Some(r) = rows.as_deref_mut() {
+                driver::capture_row(e, r, self.sim_data, &self.layout)?;
+            }
+            let s_off = self.sim_data + self.layout.sub_clock_off(clock.sub_base);
+            let n = read_i32(e, s_off + clock_field::SUB_COUNT)? + 1;
+            write_i32(e, s_off + clock_field::SUB_COUNT, n)?;
+            let prev = read_f64(e, off + clock_field::PREV_INTERVAL)?;
+            write_f64(e, s_off + clock_field::SUB_PREV_INTERVAL, prev)?;
+            write_f64(e, s_off + clock_field::SUB_LAST_ACTIVATION, time)?;
+            e.call2(MODEL_FN_EQS_SYNC, self.sim_data, clock.sub_base)?;
+        }
+
+        if !clock.is_event_clock {
+            e.call2(MODEL_FN_UPDATE_SYNC, self.sim_data, base)?;
+            let interval = read_f64(e, off + clock_field::INTERVAL)?;
+            self.insert(Timer { base, sub: None, time: time + interval });
+            omclog::info(
+                omclog::SYNCHRONOUS,
+                false,
+                &format!("Activated base-clock {base} at time {}", driver::format_f(time)),
+            );
+        } else {
+            omclog::info(
+                omclog::SYNCHRONOUS,
+                false,
+                &format!("Activated event-clock {base} at time {}", driver::format_f(time)),
+            );
+        }
+
+        // The sub-clock ticks inside this base interval:
+        //   s = shift + subCount*factor - (baseCount - 1)
+        // fires whenever `floor(s) == 0`, at `time + s*interval` — the interval
+        // `updateSynchronous` just recomputed, as in C.
+        let interval = read_f64(e, off + clock_field::INTERVAL)?;
+        for k in usize::from(first_is_base)..clock.sub.len() {
+            let sub = &clock.sub[k];
+            let s_off = self.sim_data + self.layout.sub_clock_off(clock.sub_base + k as u32);
+            let sub_count = read_i32(e, s_off + clock_field::SUB_COUNT)? as i64;
+            let factor = Rat::new(sub.factor_num, sub.factor_den);
+            let mut t = Rat::new(sub.shift_num, sub.shift_den)
+                .sub(Rat::int(count as i64 - 1))
+                .add(Rat::int(sub_count).mul(factor));
+            while t.floor() == 0 {
+                self.insert(Timer {
+                    base,
+                    sub: Some(k as u32),
+                    time: time + t.to_real() * interval,
+                });
+                t = t.add(factor);
+            }
+        }
+        Ok(first_is_base)
+    }
+
+    /// The `SYNC_SUB_CLOCK` arm of C's `handleTimers`.
+    fn handle_sub_clock(
+        &mut self,
+        e: &mut dyn SimEngine,
+        base: u32,
+        sub: u32,
+        time: f64,
+        rows: Option<&mut Vec<f64>>,
+    ) -> Result<Fired> {
+        let clock = &self.clocks[base as usize];
+        let flat = clock.sub_base + sub;
+        let hold = clock.sub[sub as usize].hold_events;
+        if let Some(r) = rows {
+            driver::capture_row(e, r, self.sim_data, &self.layout)?;
+        }
+        let s_off = self.sim_data + self.layout.sub_clock_off(flat);
+        let n = read_i32(e, s_off + clock_field::SUB_COUNT)? + 1;
+        write_i32(e, s_off + clock_field::SUB_COUNT, n)?;
+        let last = read_f64(e, s_off + clock_field::SUB_LAST_ACTIVATION)?;
+        write_f64(e, s_off + clock_field::SUB_PREV_INTERVAL, time - last)?;
+        write_f64(e, s_off + clock_field::SUB_LAST_ACTIVATION, time)?;
+        e.call2(MODEL_FN_EQS_SYNC, self.sim_data, flat)?;
+        let what = if hold { "which triggered event " } else { "" };
+        omclog::info(
+            omclog::SYNCHRONOUS,
+            false,
+            &format!("Activated sub-clock ({base},{sub}) {what}at time {}", driver::format_f(time)),
+        );
+        Ok(if hold { Fired::Event } else { Fired::Timer })
+    }
+
+    /// C's `printClocks`, the `LOG_SYNCHRONOUS` dump after initialization.
+    fn print_clocks(&self, e: &dyn SimEngine) -> Result<()> {
+        if !omclog::active(omclog::SYNCHRONOUS) {
+            return Ok(());
+        }
+        omclog::info(omclog::SYNCHRONOUS, true, "Initialized synchronous timers.");
+        omclog::info(omclog::SYNCHRONOUS, false, &format!("Number of base clocks: {}", self.clocks.len()));
+        for (i, c) in self.clocks.iter().enumerate() {
+            omclog::info(omclog::SYNCHRONOUS, true, &format!("Base clock {}", i + 1));
+            let off = self.sim_data + self.layout.base_clock_off(i as u32);
+            let interval = read_f64(e, off + clock_field::INTERVAL)?;
+            let counter = read_i32(e, off + clock_field::INTERVAL_COUNTER)?;
+            if c.is_event_clock {
+                omclog::info(omclog::SYNCHRONOUS, false, "is event clock");
+            } else {
+                if counter != -1 {
+                    let res = read_i32(e, off + clock_field::RESOLUTION)?;
+                    omclog::info(
+                        omclog::SYNCHRONOUS,
+                        false,
+                        &format!("intervalCounter/resolution = : {counter}/{res}"),
+                    );
+                }
+                omclog::info(omclog::SYNCHRONOUS, false, &format!("interval: {}", omclog::e(interval, 0, 6)));
+            }
+            omclog::info(omclog::SYNCHRONOUS, false, &format!("Number of sub-clocks: {}", c.sub.len()));
+            for (j, s) in c.sub.iter().enumerate() {
+                omclog::info(
+                    omclog::SYNCHRONOUS,
+                    true,
+                    &format!("Sub-clock {} of base clock {}", j + 1, i + 1),
+                );
+                omclog::info(omclog::SYNCHRONOUS, false, &format!("shift: {}/{}", s.shift_num, s.shift_den));
+                omclog::info(omclog::SYNCHRONOUS, false, &format!("factor: {}/{}", s.factor_num, s.factor_den));
+                let method = if s.external_solver { "External" } else { "none" };
+                omclog::info(omclog::SYNCHRONOUS, false, &format!("solverMethod: {method}"));
+                omclog::info(omclog::SYNCHRONOUS, false, &format!("holdEvents: {}", s.hold_events));
+                omclog::close(omclog::SYNCHRONOUS);
+            }
+            omclog::close(omclog::SYNCHRONOUS);
+        }
+        omclog::close(omclog::SYNCHRONOUS);
+        Ok(())
+    }
+}
+
+/// Clear the `$_clkfire` flags. Run before initialization: `SimData` comes from a
+/// recycled `rt_alloc` block, and the initial system's discrete update may already
+/// raise a flag, which [`Sync::new`] then collects.
+pub fn clear_fire_flags(e: &mut dyn SimEngine, sim_data: u32, layout: &Layout) -> Result<()> {
+    for i in 0..layout.n_base_clocks {
+        write_i32(e, sim_data + layout.clock_fire_off + i * 4, 0)?;
+    }
+    Ok(())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -876,7 +876,7 @@ pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Bo
     // Allocate the shared SimData block.
     let sim_data = wts(rt_alloc.call(&mut store, layout.total))?;
 
-    let engine = WasmerEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), dae_func: None };
+    let engine = WasmerEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), funcs2: HashMap::new() };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -890,7 +890,9 @@ struct WasmerEngine {
     rt_inst: wasmer::Instance,
     funcs: HashMap<String, wasmer::TypedFunction<u32, ()>>,
     /// The DAE-mode residual, the one `fn(u32, u32) -> ()` entry point.
-    dae_func: Option<wasmer::TypedFunction<(u32, u32), ()>>,
+    /// Resolved two-argument exports by name (`evaluateDAEResiduals` and the
+    /// synchronous dispatchers), so one cached entry cannot answer for another.
+    funcs2: HashMap<String, wasmer::TypedFunction<(u32, u32), ()>>,
 }
 
 impl WasmerEngine {
@@ -922,11 +924,12 @@ impl sim_driver::SimEngine for WasmerEngine {
         self.call1(name, arg)
     }
     fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
-        let f = match self.dae_func.clone() {
-            Some(f) => f,
+        let f = match self.funcs2.get(name) {
+            Some(f) => f.clone(),
             None => {
                 let f = wt(self.instance.exports.get_typed_function::<(u32, u32), ()>(&self.store, name))?;
-                self.dae_func.insert(f).clone()
+                self.funcs2.insert(name.to_string(), f.clone());
+                f
             }
         };
         wt(f.call(&mut self.store, a, b))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -822,7 +822,7 @@ pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Bo
         run_table_probe(&mut store, rt_inst, instance, memory, sim_data, layout.total)?;
     }
 
-    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), dae_func: None };
+    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), funcs2: HashMap::new() };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -886,7 +886,9 @@ struct WasmtimeEngine {
     rt_inst: wasmtime::Instance,
     funcs: HashMap<String, wasmtime::TypedFunc<u32, ()>>,
     /// The DAE-mode residual, the one `fn(u32, u32) -> ()` entry point.
-    dae_func: Option<wasmtime::TypedFunc<(u32, u32), ()>>,
+    /// Resolved two-argument exports by name (`evaluateDAEResiduals` and the
+    /// synchronous dispatchers), so one cached entry cannot answer for another.
+    funcs2: HashMap<String, wasmtime::TypedFunc<(u32, u32), ()>>,
 }
 
 impl WasmtimeEngine {
@@ -918,11 +920,12 @@ impl sim_driver::SimEngine for WasmtimeEngine {
         self.call1(name, arg)
     }
     fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
-        let f = match self.dae_func.clone() {
-            Some(f) => f,
+        let f = match self.funcs2.get(name) {
+            Some(f) => f.clone(),
             None => {
                 let f = wt(self.instance.get_typed_func::<(u32, u32), ()>(&mut self.store, name))?;
-                self.dae_func.insert(f).clone()
+                self.funcs2.insert(name.to_string(), f.clone());
+                f
             }
         };
         wt(f.call(&mut self.store, (a, b)))


### PR DESCRIPTION
Port the C runtime's `simulation/solver/synchronous.c` and CodegenC's `function_{init,update,equations}Synchronous` to the `wasm-jit` simCodeTarget. It silently ignored every clocked partition: those equations were never emitted, so clocked variables kept their start values and the run "succeeded" with wrong results.

| Piece | C | wasm-jit |
| --- | --- | --- |
| Clock constants | `function_initSynchronous` | `SimMeta::clocks` | | Clock state | `BASECLOCK_DATA` | `SimData` clock region | | Interval update | `function_updateSynchronous` | emitted export | | Clocked equations | `function_equationsSynchronous` | emitted export | | Timer list | `simulationInfo->intvlTimers` | `sim_meta::sync::Sync` | | Step clamping | `checkForSynchronous` | folded into `integrate_to` |

The `(base, sub)` pair C dispatches on is flattened to the sub-clock's index in the `SimData` sub-clock region, so the dispatcher fits `call2`. The three functions, the clock region and the metadata are emitted only for a model with clocked partitions, leaving every other module byte- identical.

Two departures from C:

* `$_clkfire` cannot call back across the wasm boundary into the timer list, so the emitted code raises a flag in `SimData` and the driver turns it into a timer as soon as the model call returns. `fire_clocks` runs that to a fixed point around the discrete update, so a clock a `when` body fires is still evaluated within the same step.
* `function_savePreSynchronous` has no counterpart. C needs it because `data->localData` is a ring buffer that rotates each step; wasm-jit has one non-rotating `SimData` block, so nothing needs restoring.

Three fixes those tests needed, none of them clock-specific:

* The host engines' `call2` cached the first two-argument export it resolved and answered every later name with it. Harmless while `evaluateDAEResiduals` was the only one; it made the new dispatcher run `functionUpdateSynchronous` instead. Keyed by name now.
* Output-grid times used `start + row*h` where C uses `row*(stop-start)/numSteps + start`. The two round differently, and the ~1 ulp gap made `val(x, stopTime)` miss the last row entirely. Also fixes one pre-existing `simulation/modelica/events` failure.
* `outputFormat="csv"` was rejected outright; there is a writer now, and `-outputFormat=csv` is accepted with it. `result_path` then names the file after the format the flag settled on, as C does (the `resultFile` the script layer reports still carries the model's own extension — that mismatch is C's too, and wants fixing on both sides at once).

`simulation/modelica/synchronous` (20) and `synchronous_c` (18) now pass under wasm-jit. `simulation/modelica/{events,equations}` were compared against a pre-change baseline build: no regressions.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
