### PR TITLE
wasm-jit: implement linearization

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -144,6 +144,7 @@ openmodelica_codegen_fmu_omsi/Cargo.toml
 openmodelica_codegen_graphml/Cargo.toml
 openmodelica_codegen_wasm_jit/Cargo.toml
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
@@ -242,6 +243,7 @@ openmodelica_sim_meta/src/gbode/step.rs
 openmodelica_sim_meta/src/gbode/tableau.rs
 openmodelica_sim_meta/src/gbode/tableau_data.rs
 openmodelica_sim_meta/src/lib.rs
+openmodelica_sim_meta/src/linearize.rs
 openmodelica_sim_meta/src/omclog.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -92,9 +92,12 @@ pub(crate) use openmodelica_wasm_jit::model::{
     encode_overrides, inwasm_driver_enabled, sim_bench_enabled, INWASM_SLOT_NAMES,
 };
 
+#[path = "CodegenWasmJit/linearize.rs"]
+pub(crate) mod linearize;
+
 /// Iterate a MetaModelica `List` (which is `IntoIterator` by reference, not via
 /// an `.iter()` method).
-fn lst<T: Clone>(l: &Arc<List<T>>) -> impl Iterator<Item = &T> {
+pub(crate) fn lst<T: Clone>(l: &Arc<List<T>>) -> impl Iterator<Item = &T> {
     (&**l).into_iter()
 }
 
@@ -448,7 +451,7 @@ const RUN_CHECKPOINT: ArcStr = arcstr::literal!("wasm-jit simulation run");
 
 pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcStr) -> i32 {
     openmodelica_error::ErrorExt::setCheckpoint(RUN_CHECKPOINT);
-    let (res, init_output, sim_output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
+    let (res, init_output, sim_output, post_output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
     openmodelica_error::ErrorExt::rollBack(RUN_CHECKPOINT);
     // `simulate` reads `<prefix>.log` after a run; the model's captured stdout
     // (`print`, LOG_STATS, ...) is folded in so it shows in the log rather than the
@@ -462,7 +465,7 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
         // Init prints, the init line, then the sim prints and the final success.
         Ok(()) => format!(
             "{init_seg}{sim_output}\
-             LOG_SUCCESS       | info    | The simulation finished successfully.\n"
+             LOG_SUCCESS       | info    | The simulation finished successfully.\n{post_output}"
         ),
         // Chattering abort (`-abortSlowSimulation`): the driver's output carries the
         // chattering + aborting lines.
@@ -826,19 +829,48 @@ fn on_init_done() {
 
 /// Run the model, returning the result and the model's stdout split into the
 /// initialization segment (`Some` once init completed) and the simulation segment.
-fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std::result::Result<(), String>, Option<String>, String) {
+/// Write `-l`'s linearized model where C's `linearize` puts it and render its
+/// notice, which the caller appends after the run's success line.
+fn write_lin_file(meta: &SimMeta, run: &sim_driver::RunResult, flags: &simflags::SimFlags) -> String {
+    let (Some(f), Some(lin)) = (&run.lin, &meta.lin) else { return String::new() };
+    let path = match &flags.output_path {
+        Some(dir) => format!("{dir}/{}", f.name),
+        None => f.name.clone(),
+    };
+    if write_output(&path, f.content.as_bytes()).is_err() {
+        return openmodelica_modelica_utilities::format_log_stdout(
+            &format!("Cannot open File {path}"),
+            openmodelica_modelica_utilities::LOG_STDOUT_ERROR,
+        );
+    }
+    let full = std::fs::canonicalize(&path).map(|p| p.display().to_string()).unwrap_or(path);
+    let (msgs, is_error) = openmodelica_sim_meta::linearize::write_notice(lin, f, &full);
+    let prefix = if is_error {
+        openmodelica_modelica_utilities::LOG_STDOUT_ERROR
+    } else {
+        openmodelica_modelica_utilities::LOG_STDOUT_INFO
+    };
+    msgs.iter().map(|m| openmodelica_modelica_utilities::format_log_stdout(m, prefix)).collect()
+}
+
+fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std::result::Result<(), String>, Option<String>, String, String) {
     let model = sim_models()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .get(prefix)
         .cloned();
     let Some(model) = model else {
-        return (Err("no prepared wasm-jit model for (translateModel not run?)".to_string()), None, String::new());
+        return (
+            Err("no prepared wasm-jit model for (translateModel not run?)".to_string()),
+            None,
+            String::new(),
+            String::new(),
+        );
     };
     // The caller prefixes the failure, so this is the bare reason.
     let flags = match install_sim_flags(simflags) {
         Ok(f) => f,
-        Err(e) => return (Err(e), None, String::new()),
+        Err(e) => return (Err(e), None, String::new(), String::new()),
     };
     // The `-lv=` runtime flag list selects log streams, as for the C executable.
     let log_stats = flags.has_log("LOG_STATS");
@@ -855,6 +887,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
             ),
             None,
             String::new(),
+            String::new(),
         );
     }
     INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
@@ -870,6 +903,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     // The hard `-alarm`, if asked for: set before the modules are instantiated.
     sim_runtime::set_alarm(flags.alarm);
     let mut extra = String::new();
+    let mut post = String::new();
     let res = (|| -> std::result::Result<(), String> {
         // `empty` (and `-noemit`) runs the integration but writes no result file —
         // useful for benchmarking the solver in isolation from the `.mat` writer.
@@ -885,6 +919,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         let keep = output_selection(&model);
         capture_last_sim(&model, &run, &keep);
         write_result(&model, &meta, &result_path(&flags, &meta, result_file), &run, &keep)?;
+        post = write_lin_file(&meta, &run, &flags);
         Ok(())
     })();
     // Disarm in case init failed before the hook fired.
@@ -902,7 +937,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     } else {
         Some(format!("{head}{}", init_output.unwrap_or_default()))
     };
-    (res, init_output, sim_output)
+    (res, init_output, sim_output, post)
 }
 
 // ===========================================================================
@@ -1016,11 +1051,11 @@ mod session {
         meta: &SimMeta,
         result_file: &str,
         run: &sim_driver::RunResult,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let keep = output_selection(model);
         capture_last_sim(model, run, &keep);
         write_result(model, meta, result_file, run, &keep)?;
-        Ok(())
+        Ok(write_lin_file(meta, run, &simflags::flags()))
     }
 
     /// Start a resumable run of a model already prepared by `buildModel`
@@ -1144,17 +1179,24 @@ mod session {
                             let rows = driver.take_rows();
                             let mut stats = SolveStats::default();
                             driver.fill_stats(&sess.meta, &mut stats);
+                            let lin = openmodelica_sim_meta::linearize::linearize(
+                                &mut **engine,
+                                &sess.meta,
+                                *sim_data,
+                            )?;
                             let params = sim_driver::finalize_run(&mut **engine, &sess.meta, *sim_data)?;
                             let run = sim_driver::RunResult {
                                 rows,
                                 n_reals: model.layout.n_row_total(),
                                 params,
                                 stats,
+                                lin,
                             };
                             if log_stats {
                                 stats_block = log_stats_block(&run.stats);
                             }
-                            finalize_and_capture(&model, &sess.meta, &result_file, &run)?;
+                            stats_block
+                                .push_str(&finalize_and_capture(&model, &sess.meta, &result_file, &run)?);
                             Ok(if matches!(done, sim_driver::Advance::Terminated) {
                                 SimStatus::Terminated
                             } else {
@@ -1177,7 +1219,8 @@ mod session {
                             if log_stats {
                                 stats_block = log_stats_block(&run.stats);
                             }
-                            finalize_and_capture(&model, &sess.meta, &result_file, &run)?;
+                            stats_block
+                                .push_str(&finalize_and_capture(&model, &sess.meta, &result_file, &run)?);
                             Ok(if rc == 2 { SimStatus::Terminated } else { SimStatus::Done })
                         }
                         Err(e) => Err(e),
@@ -2795,6 +2838,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let n_sens = sens_vars.len().saturating_sub(n_sens_par) as u32;
     let clocks = collect_clocks(&sim_code.clockedPartitions)?;
     let n_sub_clocks: u32 = clocks.iter().map(|c| c.meta.sub.len() as u32).sum();
+    // `-l`: the symbolic A/B/C/D and the scratch their column equations need.
+    let linz = build_linz_plan(sim_code, vars, n_states)?;
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -2818,6 +2863,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         dae_alg_vars.len() as u32,
         clocks.len() as u32,
         n_sub_clocks,
+        linz.n_scratch_f64(),
         has_when,
         has_homotopy,
     );
@@ -2984,11 +3030,22 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             }
         }
     }
+    // C's `functionJacAC_num` reads each state's `max` to sign its step.
+    let mut max_defaults: Vec<(u32, f64)> = Vec::new();
+    for (i, sv) in lst(&vars.stateVars).take(n_states as usize).enumerate() {
+        let off = layout.state_max_off + (i as u32) * 8;
+        max_defaults.push((off, const_value(&sv.maxValue).unwrap_or(f64::INFINITY)));
+        if let Ok(k) = sim_cref_key(&sv.name) {
+            attr_targets.entry(k).or_default().max_offs.push(off);
+        }
+    }
     // Register the analytic-Jacobian seed/result crefs before the equation
     // functions are lowered, so the column equations resolve their slots.
     let nls_jac_infos = build_nls_jac_infos(&nls_systems, &layout, &mut var_map)?;
     // Same, for torn linear systems that assemble A analytically.
     build_lin_jac_infos(sim_code, &layout, &mut var_map)?;
+    // Same, for the `-l` linearization matrices.
+    let linz_jac_infos = build_linz_jac_infos(&linz, &layout, &mut var_map)?;
     var_map.nls_jobs = Arc::new(nls_jobs);
 
     // --- Type section: one type per import, per model function, per equation
@@ -3192,6 +3249,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars, dae,
         clocks.iter().map(|c| c.meta.clone()).collect(),
+        build_lin_info(&linz, vars, &var_map)?,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -3367,10 +3425,28 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     };
     let update_bound_attrs_idx = {
         let idx = import_base + bodies.len() as u32;
+        let defaults: Vec<(u32, f64)> =
+            nominal_defaults.iter().chain(max_defaults.iter()).copied().collect();
         bodies.push(build_update_bound_attrs_fn(
-            sim_code, &nominal_defaults, &attr_targets, &var_map, &by_name, &mut literals,
+            sim_code, &defaults, &attr_targets, &var_map, &by_name, &mut literals,
         )?);
         idx
+    };
+    // Always exported (empty when the backend generated none) so the standalone
+    // merge resolves regardless of the model.
+    let linz_jac_idx = {
+        let base = import_base + bodies.len() as u32;
+        let mut out_off = layout.linz_off;
+        for k in 0..4 {
+            bodies.push(match linz_jac_infos.get(k).and_then(Option::as_ref) {
+                Some(info) => build_linz_jac_fn(
+                    &linz, info, k, out_off, &var_map, &eq_index, &by_name, &mut literals,
+                )?,
+                None => empty_eqfn(),
+            });
+            out_off += linz.rows[k] * linz.cols[k] * 8;
+        }
+        base
     };
     // Synchronous features: emitted only for a model with clocked partitions, so a
     // clock-free model's module is unchanged.
@@ -3443,6 +3519,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
+    for _ in 0..4 {
+        functions.function(eqfn_type); // linearJacA..linearJacD: (i32) -> ()
+    }
     if let Some(ti) = sync_fn_type {
         functions.function(eqfn_type); // functionInitSynchronous: (i32) -> ()
         functions.function(ti); // functionUpdateSynchronous: (i32, i32) -> ()
@@ -3546,6 +3625,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
     exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
+    for (k, name) in ["linearJacA", "linearJacB", "linearJacC", "linearJacD"].iter().enumerate() {
+        exports.export(name, we::ExportKind::Func, linz_jac_idx + k as u32);
+    }
     if let Some((init, update, eqs)) = sync_idx {
         exports.export("functionInitSynchronous", we::ExportKind::Func, init);
         exports.export("functionUpdateSynchronous", we::ExportKind::Func, update);
@@ -3593,6 +3675,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("functionInitDelay", init_delay_idx),
         ("functionUpdateBoundParameters", update_bound_params_idx),
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
+        ("linearJacA", linz_jac_idx),
+        ("linearJacB", linz_jac_idx + 1),
+        ("linearJacC", linz_jac_idx + 2),
+        ("linearJacD", linz_jac_idx + 3),
     ] {
         names.push((idx, name.to_string()));
     }
@@ -4111,6 +4197,7 @@ fn build_sim_meta(
     nls_vars: Vec<openmodelica_sim_meta::NlsVars>,
     dae: Option<openmodelica_sim_meta::DaeInfo>,
     clocks: Vec<BaseClockMeta>,
+    lin: Option<openmodelica_sim_meta::LinInfo>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -4131,6 +4218,7 @@ fn build_sim_meta(
         nls_vars,
         dae,
         clocks,
+        lin,
     }
 }
 
@@ -4155,7 +4243,7 @@ pub(crate) fn t_real() -> Arc<DAE::Type> {
     Arc::new(DAE::Type::T_REAL { varLst: metamodelica::nil() })
 }
 
-fn count<T: Clone>(list: &Arc<List<T>>) -> usize {
+pub(crate) fn count<T: Clone>(list: &Arc<List<T>>) -> usize {
     lst(list).count()
 }
 
@@ -4695,7 +4783,7 @@ fn build_init_start_values_fn(
 /// back are skipped.
 fn build_update_bound_attrs_fn(
     sim_code: &SimCode::SimCode,
-    nominal_defaults: &[(u32, f64)],
+    defaults: &[(u32, f64)],
     attr_targets: &HashMap<String, AttrTargets>,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
@@ -4710,7 +4798,12 @@ fn build_update_bound_attrs_fn(
         for eq in lst(eqs) {
             let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { continue };
             let Some(t) = sim_cref_key(cref).ok().and_then(|k| attr_targets.get(&k)) else { continue };
-            if t.nls.is_empty() && !(matches!(attr, Attr::Nominal) && !t.nom_offs.is_empty()) {
+            let wanted = match attr {
+                Attr::Nominal => !t.nom_offs.is_empty(),
+                Attr::Max => !t.max_offs.is_empty(),
+                Attr::Min => false,
+            };
+            if t.nls.is_empty() && !wanted {
                 continue;
             }
             attrs.push((attr, exp.clone(), t.clone()));
@@ -4718,7 +4811,7 @@ fn build_update_bound_attrs_fn(
     }
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    ctx.emit_update_bound_attrs(nominal_defaults, &attrs)?;
+    ctx.emit_update_bound_attrs(defaults, &attrs)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -5284,7 +5377,7 @@ struct NlsJacInfo {
 
 /// The residual row a Jacobian result var maps to: its `SimVar.index`, which is
 /// what the C template indexes `jacobian->resultVars[]` with.
-fn jac_result_row(sv: &SimCodeVar::SimVar) -> Option<usize> {
+pub(crate) fn jac_result_row(sv: &SimCodeVar::SimVar) -> Option<usize> {
     usize::try_from(sv.index).ok()
 }
 
@@ -5292,7 +5385,7 @@ fn jac_result_row(sv: &SimCodeVar::SimVar) -> Option<usize> {
 /// seeds: the `$pDER` results and the temporaries. The old backend lists them in
 /// `columnVars`; the new backend leaves that empty and registers them (together
 /// with the seeds, which are filtered out here) in `crefsHT` only.
-fn jac_column_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
+pub(crate) fn jac_column_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
     use openmodelica_backend_types::BackendDAE::VarKind;
     let mut seen: HashSet<String> = HashSet::new();
     let mut out: Vec<SimCodeVar::SimVar> = Vec::new();
@@ -5322,7 +5415,7 @@ fn jac_column_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
 /// assignment whose crefs do too. An array-valued Jacobian (whole-dimension seeds,
 /// sliced results) needs the run-time loops the C template emits, so such a system
 /// keeps the numerical Jacobian instead.
-fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
+pub(crate) fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
     use SimCode::SimEqSystem as E;
     let Some(col) = lst(&jm.columns).next() else { return false };
     if lst(&jm.seedVars).any(|sv| sim_cref_key(&sv.name).is_err()) {
@@ -5492,6 +5585,192 @@ fn build_nls_jac_infos(
         infos.insert(sys.index, NlsJacInfo { seed_offs, result_offs });
     }
     Ok(infos)
+}
+
+/// The `-l` plan: the frames, and the symbolic `A`/`B`/`C`/`D` the flat emitter
+/// can lower.
+pub(crate) struct LinzPlan {
+    frames: linearize::Frames,
+    /// `[A, B, C, D]` dimensions.
+    rows: [u32; 4],
+    cols: [u32; 4],
+    jacs: [Option<Arc<SimCode::JacobianMatrix>>; 4],
+}
+
+impl LinzPlan {
+    /// C's `initialAnalyticJacobian<X>` availability, as [`LinInfo::sym_mask`].
+    fn sym_mask(&self) -> u8 {
+        (0..4).filter(|&k| self.jacs[k].is_some()).fold(0u8, |m, k| m | 1 << k)
+    }
+
+    /// f64 slots the matrices occupy at the head of the region — all four, so an
+    /// offset does not move with availability.
+    fn n_matrix_f64(&self) -> u32 {
+        (0..4).map(|k| self.rows[k] * self.cols[k]).sum()
+    }
+
+    /// Those plus every seed / column variable the available columns assign.
+    fn n_scratch_f64(&self) -> u32 {
+        if self.sym_mask() == 0 {
+            return 0;
+        }
+        self.n_matrix_f64()
+            + self
+                .jacs
+                .iter()
+                .flatten()
+                .map(|jm| count(&jm.seedVars) as u32 + jac_column_vars(jm).len() as u32)
+                .sum::<u32>()
+    }
+}
+
+fn build_linz_plan(
+    sim_code: &SimCode::SimCode,
+    vars: &SimCodeVar::SimVars,
+    n_states: u32,
+) -> Result<LinzPlan> {
+    let n_in = count(&vars.inputVars) as u32;
+    let n_out = count(&vars.outputVars) as u32;
+    let n_alg = count(&vars.algVars) as u32;
+    let prefix = model_name_prefix(sim_code);
+    let frames = linearize::build_frames(vars, n_states, n_in, n_out, n_alg, &prefix)?;
+    let rows = [n_states, n_states, n_out, n_out];
+    let cols = [n_states, n_in, n_states, n_in];
+    let jacs = linearize::symbolic_jacobians(sim_code, rows, cols);
+    Ok(LinzPlan { frames, rows, cols, jacs })
+}
+
+/// C's `modelNamePrefix`, which the frames quote as the model's description.
+fn model_name_prefix(sim_code: &SimCode::SimCode) -> String {
+    openmodelica_util::System::makeC89Identifier(sim_code.fileNamePrefix.clone()).to_string()
+}
+
+/// Register the Jacobians' seed / column-variable crefs behind the matrices, and
+/// return each matrix's seed and result slots.
+fn build_linz_jac_infos(
+    plan: &LinzPlan,
+    layout: &SimLayout,
+    var_map: &mut SimVarMap,
+) -> Result<Vec<Option<LinzJacInfo>>> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
+    let mut cursor = layout.linz_off + plan.n_matrix_f64() * 8;
+    let mut infos = Vec::with_capacity(4);
+    for (k, jm) in plan.jacs.iter().enumerate() {
+        let Some(jm) = jm else {
+            infos.push(None);
+            continue;
+        };
+        let (rows, cols) = (plan.rows[k] as usize, plan.cols[k] as usize);
+        let mut listed = Vec::new();
+        for sv in lst(&jm.seedVars) {
+            Arc::make_mut(&mut var_map.vars)
+                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+            listed.push(cursor);
+            cursor += 8;
+        }
+        // A row the backend left out is structurally zero, so it gets no slot.
+        let mut result_offs = vec![None; rows];
+        for sv in &jac_column_vars(jm) {
+            Arc::make_mut(&mut var_map.vars)
+                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+            if matches!(sv.varKind, VarKind::JAC_VAR)
+                && let Some(row) = jac_result_row(sv).filter(|&r| r < rows)
+            {
+                result_offs[row] = Some(cursor);
+            }
+            cursor += 8;
+        }
+        let seed_offs = jac_seed_offs_by_column(jm, &listed, cols)
+            .ok_or("CodegenWasmJit: linearization Jacobian seed columns are not a permutation")?;
+        infos.push(Some(LinzJacInfo { seed_offs, result_offs }));
+    }
+    Ok(infos)
+}
+
+/// One matrix's seed slots (column order) and result slots (row order; `None` is
+/// a structural zero).
+struct LinzJacInfo {
+    seed_offs: Vec<u32>,
+    result_offs: Vec<Option<u32>>,
+}
+
+/// The runtime half of the plan, once the variable map exists.
+fn build_lin_info(
+    plan: &LinzPlan,
+    vars: &SimCodeVar::SimVars,
+    var_map: &SimVarMap,
+) -> Result<Option<openmodelica_sim_meta::LinInfo>> {
+    use openmodelica_sim_meta::LinVar;
+    // A compile-time-constant input/output has no slot to perturb or read, so the
+    // model cannot be linearized (nor can C's); `-l` reports it rather than
+    // translation failing.
+    let slots = |list: &Arc<List<SimCodeVar::SimVar>>| -> Result<Option<Vec<LinVar>>> {
+        let mut out = Vec::new();
+        for sv in lst(list) {
+            let Some(slot) = var_map.vars.get(&sim_cref_key(&sv.name)?) else { return Ok(None) };
+            out.push(LinVar { off: slot.off, negate: slot.negate });
+        }
+        Ok(Some(out))
+    };
+    let (Some(input_vars), Some(output_vars)) = (slots(&vars.inputVars)?, slots(&vars.outputVars)?)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(openmodelica_sim_meta::LinInfo {
+        input_vars,
+        output_vars,
+        language: plan.frames.language,
+        frame: plan.frames.frame.clone(),
+        frame_datarec: plan.frames.frame_datarec.clone(),
+        disabled_reason: plan.frames.disabled_reason.clone(),
+        sym_mask: plan.sym_mask(),
+        run_testsuite: openmodelica_util::Testsuite::isRunning()?,
+        jac_rows: plan.rows,
+        jac_cols: plan.cols,
+    }))
+}
+
+/// Build one `linearJac<X>(SimData*)`: C's `functionJacX` loop moved into the
+/// model, so the driver reads a finished matrix.
+#[allow(clippy::too_many_arguments)]
+fn build_linz_jac_fn(
+    plan: &LinzPlan,
+    info: &LinzJacInfo,
+    k: usize,
+    out_off: u32,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Vec<Vec<u8>>,
+) -> Result<we::Function> {
+    let jm = plan.jacs[k].as_ref().ok_or("CodegenWasmJit: no linearization Jacobian")?;
+    let col = lst(&jm.columns).next();
+    let constant_eqns: Vec<Arc<SimCode::SimEqSystem>> =
+        col.map(|c| lst(&c.constantEqns).cloned().collect()).unwrap_or_default();
+    let column_eqns: Vec<Arc<SimCode::SimEqSystem>> =
+        col.map(|c| lst(&c.columnEqns).cloned().collect()).unwrap_or_default();
+    let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
+    let mut lower = |c: &mut FnCtx, eqs: &[Arc<SimCode::SimEqSystem>]| -> Result<()> {
+        for eq in eqs {
+            lower_equation(c, eq, eq_index)?;
+        }
+        Ok(())
+    };
+    lower(&mut ctx, &constant_eqns)?;
+    crate::CodegenWasmJitFunctions::emit_linz_jac_body(
+        &mut ctx,
+        out_off,
+        plan.rows[k] as usize,
+        &info.seed_offs,
+        &info.result_offs,
+        &mut |c: &mut FnCtx| lower(c, &column_eqns),
+    )?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
 }
 
 /// Number of scalar `SES_RESIDUAL` in a linear system (its `A x = b` row count).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
@@ -1,0 +1,328 @@
+//! `--linearizationDumpLanguage`: the `linear_model_frame()` half of the C
+//! target's `simulationFile_lnz` / `functionlinearmodel*` templates.
+//!
+//! `openmodelica_sim_meta::linearize` fills the `printf` conversions at run time,
+//! so these are the C templates' string *values*, `%s`/`%g`/`%%` included.
+
+use metamodelica::List;
+use openmodelica_backend_types::BackendDAE;
+use openmodelica_frontend_types::DAE;
+use openmodelica_simcode_types::{SimCode, SimCodeVar};
+use openmodelica_sim_meta::LinLanguage;
+use std::fmt::Write;
+use std::sync::Arc;
+
+use crate::CodegenWasmJit::lst;
+
+/// The four frames plus the diagnostic C prints when linearization is off.
+pub(crate) struct Frames {
+    pub language: LinLanguage,
+    pub frame: String,
+    pub frame_datarec: String,
+    /// C's message ahead of the empty frame; empty when a frame was built.
+    pub disabled_reason: String,
+}
+
+/// C's `crefStrNoUnderscore`.
+fn cref_str(cr: &Arc<DAE::ComponentRef>) -> String {
+    use DAE::ComponentRef as C;
+    match &**cr {
+        C::CREF_IDENT { ident, subscriptLst, .. } => format!("{ident}{}", subscripts(subscriptLst, false)),
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$DER" => {
+            format!("der({})", cref_str(componentRef))
+        }
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$CLKPRE" => {
+            format!("previous({})", cref_str(componentRef))
+        }
+        C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
+            format!("{ident}{}.{}", subscripts(subscriptLst, false), cref_str(componentRef))
+        }
+        _ => "CREF_NOT_IDENT_OR_QUAL".to_string(),
+    }
+}
+
+/// C's `crefStrMatlabSafe`: an identifier for the target language's name list.
+fn cref_str_safe(cr: &Arc<DAE::ComponentRef>) -> String {
+    use DAE::ComponentRef as C;
+    match &**cr {
+        C::CREF_IDENT { ident, subscriptLst, .. } => format!("{ident}{}", subscripts(subscriptLst, true)),
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$DER" => {
+            format!("der_{}", cref_str_safe(componentRef))
+        }
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$CLKPRE" => {
+            format!("pre_{}", cref_str_safe(componentRef))
+        }
+        C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
+            format!("{ident}{}_{}", subscripts(subscriptLst, true), cref_str_safe(componentRef))
+        }
+        _ => "CREF_NOT_IDENT_OR_QUAL".to_string(),
+    }
+}
+
+fn subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, matlab_safe: bool) -> String {
+    let items: Vec<String> = lst(subs).map(|s| subscript_str(s)).collect();
+    if items.is_empty() {
+        return String::new();
+    }
+    let (open, close) = if matlab_safe { ('(', ')') } else { ('[', ']') };
+    format!("{open}{}{close}", items.join(","))
+}
+
+/// C's `subscriptStr`: only the constant-index forms a scalarized name carries.
+fn subscript_str(s: &DAE::Subscript) -> String {
+    use DAE::Exp as E;
+    use DAE::Subscript as S;
+    let exp = match s {
+        S::INDEX { exp } | S::SLICE { exp } => exp,
+        S::WHOLEDIM => return "WHOLEDIM".to_string(),
+        S::WHOLE_NONEXP { .. } => return "WHOLE_NONEXP".to_string(),
+    };
+    match &**exp {
+        E::ICONST { integer } => integer.to_string(),
+        E::BCONST { bool } => bool.to_string(),
+        E::ENUM_LITERAL { name, .. } => openmodelica_frontend_dump::AbsynUtil::pathString(
+            name.clone(),
+            arcstr::literal!("."),
+            true,
+            false,
+        )
+        .map(|p| p.to_string())
+        .unwrap_or_default(),
+        E::CREF { .. } => openmodelica_frontend_dump::ExpressionBasics::printExpStr(exp.clone())
+            .map(|p| p.to_string())
+            .unwrap_or_default(),
+        _ => "UNKNOWN_SUBSCRIPT".to_string(),
+    }
+}
+
+/// C's `escapeSingleQuoteIdent`.
+fn escape_quoted(ident: &str) -> String {
+    ident.replace("\\'", "\\\\'").replace('\'', "\\'")
+}
+
+/// C's `genMatrix` family. A zero dimension leaves a `zeros(...)` literal — the
+/// `%s` stays so the (empty) argument is still consumed.
+fn gen_matrix(lang: LinLanguage, name: &str, row: &str, col: &str, row_n: u32, col_n: u32) -> String {
+    let empty = row_n == 0 || col_n == 0;
+    match (lang, empty) {
+        (LinLanguage::Modelica, true) => format!("  parameter Real {name}[{row}, {col}] = zeros({row}, {col});%s\n\n"),
+        (LinLanguage::Modelica, false) => format!("  parameter Real {name}[{row}, {col}] =\n\t[%s];\n\n"),
+        (LinLanguage::Matlab, true) => format!("  {name} = zeros({row}, {col});%s\n\n"),
+        (LinLanguage::Matlab, false) => format!("  {name} =\t[%s];\n\n"),
+        (LinLanguage::Julia, true) => format!("  local {name} = zeros({row}, {col})%s\n"),
+        (LinLanguage::Julia, false) => format!("  local {name} = [%s]\n\n"),
+        (LinLanguage::Python, _) => format!("    {name} = %s\n\n"),
+    }
+}
+
+/// C's `genVector`; `flag` is C's 0 = plain, 1 = input, 2 = output.
+fn gen_vector(name: &str, num: &str, num_n: u32, flag: u32) -> String {
+    match flag {
+        0 if num_n == 0 => format!("  Real {name}[{num}];\n"),
+        0 => format!("  Real {name}[{num}](start={name}0);\n"),
+        1 if num_n == 0 => format!("  input Real {name}[{num}];\n"),
+        1 => format!("  input Real {name}[{num}](start={name}0);\n"),
+        _ => format!("  output Real {name}[{num}];\n"),
+    }
+}
+
+/// C's `getVarNameC`: keeps the original names in the linearized model.
+fn var_names_modelica(vars: &[&SimCodeVar::SimVar], array: &str) -> String {
+    let mut out = String::new();
+    for (i, sv) in vars.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "  Real '{array}_{}' = {array}[{}];",
+            escape_quoted(&cref_str(&sv.name)),
+            i + 1
+        );
+    }
+    out
+}
+
+/// C's `getVarNameMatlab`/`Python`/`Julia`; Julia quotes with `"`.
+fn var_names_list(vars: &[&SimCodeVar::SimVar], lang: LinLanguage) -> String {
+    let q = if lang == LinLanguage::Julia { '"' } else { '\'' };
+    vars.iter().map(|sv| format!("{q}{}{q}", cref_str_safe(&sv.name))).collect::<Vec<_>>().join(",")
+}
+
+/// C's `simulationFile_lnz`: `none`, an oversized system and `--daeMode` each
+/// leave empty frames behind a diagnostic.
+pub(crate) fn build_frames(
+    vars: &SimCodeVar::SimVars,
+    n_states: u32,
+    n_in: u32,
+    n_out: u32,
+    n_alg: u32,
+    prefix: &str,
+) -> metamodelica::Result<Frames> {
+    use openmodelica_util::Flags;
+    let disabled = |reason: &str| Frames {
+        language: LinLanguage::Modelica,
+        frame: String::new(),
+        frame_datarec: String::new(),
+        disabled_reason: reason.to_string(),
+    };
+    let language = match &*Flags::getConfigString(Flags::LINEARIZATION_DUMP_LANGUAGE.clone())? {
+        "none" => {
+            return Ok(disabled(
+                "Linearization disabled. Use compiler flag `--linearizationDumpLanguage` to change target language.",
+            ));
+        }
+        "modelica" => LinLanguage::Modelica,
+        "matlab" => LinLanguage::Matlab,
+        "julia" => LinLanguage::Julia,
+        "python" => LinLanguage::Python,
+        _ => return Err("CodegenWasmJit: unknown linearization language"),
+    };
+    let max_size = Flags::getConfigInt(Flags::MAX_SIZE_LINEARIZATION.clone())?;
+    if (n_states + n_in + n_out + n_alg) as i32 > max_size {
+        return Ok(disabled("System too big. Use compiler flag `--maxSizeLinearization` to change threshold."));
+    }
+    if Flags::getConfigBool(Flags::DAE_MODE.clone())? {
+        return Ok(disabled("Linearization not available with `--daeMode`."));
+    }
+
+    let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
+    let inputs: Vec<&SimCodeVar::SimVar> = lst(&vars.inputVars).collect();
+    let outputs: Vec<&SimCodeVar::SimVar> = lst(&vars.outputVars).collect();
+    let algs: Vec<&SimCodeVar::SimVar> = lst(&vars.algVars).collect();
+    let m = |name: &str, row: &str, col: &str, r: u32, c: u32| gen_matrix(language, name, row, col, r, c);
+    let (a, b, c, d) = (
+        m("A", "n", "n", n_states, n_states),
+        m("B", "n", "m", n_states, n_in),
+        m("C", "p", "n", n_out, n_states),
+        m("D", "p", "m", n_out, n_in),
+    );
+    let (cz, dz) = (m("Cz", "nz", "n", n_alg, n_states), m("Dz", "nz", "m", n_alg, n_in));
+
+    let (frame, frame_datarec) = match language {
+        LinLanguage::Modelica => {
+            let head = |extra: &str| {
+                format!(
+                    "model linearized_model \"{prefix}\"\n\
+                     \x20 parameter Integer n = {n_states} \"number of states\";\n\
+                     \x20 parameter Integer m = {n_in} \"number of inputs\";\n\
+                     \x20 parameter Integer p = {n_out} \"number of outputs\";\n{extra}\n"
+                )
+            };
+            let vec_x = gen_vector("x", "n", n_states, 0);
+            let vec_u = gen_vector("u", "m", n_in, 1);
+            let vec_y = gen_vector("y", "p", n_out, 2);
+            let vec_z = gen_vector("z", "nz", n_alg, 2);
+            let nm_x = var_names_modelica(&states, "x");
+            let nm_u = var_names_modelica(&inputs, "u");
+            let nm_y = var_names_modelica(&outputs, "y");
+            let nm_z = var_names_modelica(&algs, "z");
+            (
+                format!(
+                    "{}  parameter Real x0[n] = %s;\n  parameter Real u0[m] = %s;\n\n\
+                     {a}{b}{c}{d}\n{vec_x}{vec_u}{vec_y}\n{nm_x}{nm_u}{nm_y}\
+                     equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\nend linearized_model;\n",
+                    head("")
+                ),
+                format!(
+                    "{}  parameter Real x0[n] = %s;\n  parameter Real u0[m] = %s;\n  parameter Real z0[nz] = %s;\n\n\
+                     {a}{b}{c}{d}{cz}{dz}\n{vec_x}{vec_u}{vec_y}{vec_z}\n{nm_x}{nm_u}{nm_y}{nm_z}\
+                     equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\n  z = Cz * x + Dz * u;\nend linearized_model;\n",
+                    head(&format!("  parameter Integer nz = {n_alg} \"data recovery variables\";\n"))
+                ),
+            )
+        }
+        LinLanguage::Matlab => (
+            format!(
+                "function [A, B, C, D, stateVars, inputVars, outputVars] = linearized_model()\n\
+                 %% {prefix}\n%% der(x) = A * x + B * u\n%% y = C * x + D * u\n\
+                 \x20 n = {n_states}; %% number of states\n\
+                 \x20 m = {n_in}; %% number of inputs\n\
+                 \x20 p = {n_out}; %% number of outputs\n\n\
+                 \x20 x0 = %s;\n  u0 = %s;\n\n{a}{b}{c}{d}\
+                 \x20 stateVars  = {{{}}};\n  inputVars  = {{{}}};\n  outputVars = {{{}}};\n\
+                 \x20 Ts = %g; %% stop time\n\nend",
+                var_names_list(&states, language),
+                var_names_list(&inputs, language),
+                var_names_list(&outputs, language),
+            ),
+            String::new(),
+        ),
+        LinLanguage::Julia => (
+            format!(
+                "function linearized_model()\n  # {prefix} #\n\
+                 \x20 local n = {n_states} # number of states\n\
+                 \x20 local m = {n_in} # number of inputs\n\
+                 \x20 local p = {n_out} # number of outputs\n\n\
+                 \x20 local x0 = %s\n  local u0 = %s\n\n{a}{b}{c}{d}\
+                 \x20 stateVars  = [{}]\n  inputVars  = [{}]\n  outputVars = [{}]\n\
+                 \x20 Ts = %g; #stop time\n\n\n\
+                 \x20 return (n, m, p, x0, u0, A, B, C, D, stateVars, inputVars, outputVars)\nend",
+                var_names_list(&states, language),
+                var_names_list(&inputs, language),
+                var_names_list(&outputs, language),
+            ),
+            String::new(),
+        ),
+        LinLanguage::Python => (
+            format!(
+                "def linearized_model():\n    # {prefix}\n    # der(x) = A * x + B * u\n    # y = C * x + D * u\n\
+                 \x20   n = {n_states} # number of states\n\
+                 \x20   m = {n_in} # number of inputs\n\
+                 \x20   p = {n_out} # number of outputs\n\n\
+                 \x20   x0 = %s\n    u0 = %s\n\n{a}{b}{c}{d}\
+                 \x20   stateVars  = [{}]\n    inputVars  = [{}]\n    outputVars = [{}]\n\n\
+                 \x20   return (n, m, p, x0, u0, A, B, C, D, stateVars, inputVars, outputVars)\n",
+                var_names_list(&states, language),
+                var_names_list(&inputs, language),
+                var_names_list(&outputs, language),
+            ),
+            String::new(),
+        ),
+    };
+    let datarec_reason = match language {
+        LinLanguage::Modelica => String::new(),
+        LinLanguage::Matlab => "Linearization with data recovery not implemented for Matlab.".to_string(),
+        LinLanguage::Julia => "Linearization with data recovery not implemented for Julia.".to_string(),
+        LinLanguage::Python => "Linearization with data recovery not implemented for Python.".to_string(),
+    };
+    Ok(Frames { language, frame, frame_datarec, disabled_reason: datarec_reason })
+}
+
+/// Every row the sparsity pattern says can be nonzero has a `JAC_VAR` result to
+/// read it from. A row without one is a structural zero (C reads it back from its
+/// `calloc`d `resultVars`); a row the pattern claims but the lowering cannot
+/// produce — an array-valued `$pDER` result — would silently zero the matrix.
+fn covers_sparsity(jm: &SimCode::JacobianMatrix, rows: u32) -> bool {
+    let produced: Vec<usize> = crate::CodegenWasmJit::jac_column_vars(jm)
+        .iter()
+        .filter(|v| matches!(v.varKind, BackendDAE::VarKind::JAC_VAR))
+        .filter_map(crate::CodegenWasmJit::jac_result_row)
+        .collect();
+    lst(&jm.sparsity)
+        .flat_map(|(_, nz)| lst(nz))
+        .all(|r| (*r as u32) < rows && produced.contains(&(*r as usize)))
+}
+
+/// The `A`,`B`,`C`,`D` Jacobians, `Some` only where the flat emitter can lower
+/// one: C's per-matrix `initialAnalyticJacobian<X>` availability.
+pub(crate) fn symbolic_jacobians(
+    sim_code: &SimCode::SimCode,
+    rows: [u32; 4],
+    cols: [u32; 4],
+) -> [Option<Arc<SimCode::JacobianMatrix>>; 4] {
+    let names = ["A", "B", "C", "D"];
+    core::array::from_fn(|k| {
+        if rows[k] == 0 || cols[k] == 0 {
+            return None;
+        }
+        let jm = lst(&sim_code.jacobianMatrices).find(|j| &*j.matrixName == names[k])?.clone();
+        // A sparsity-only matrix carries seeds but no equations; C reports it as
+        // `JACOBIAN_NOT_AVAILABLE`.
+        let has_equations = lst(&jm.columns)
+            .next()
+            .is_some_and(|c| lst(&c.columnEqns).next().is_some());
+        let usable = has_equations
+            && covers_sparsity(&jm, rows[k])
+            && crate::CodegenWasmJit::jac_lowerable(&jm)
+            && crate::CodegenWasmJit::count(&jm.seedVars) as u32 == cols[k];
+        usable.then_some(jm)
+    })
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1180,6 +1180,8 @@ pub(crate) enum Attr {
 pub(crate) struct AttrTargets {
     pub(crate) nls: Vec<u32>,
     pub(crate) nom_offs: Vec<u32>,
+    /// A state's `SimData` `max` slot, which the numeric linearization reads.
+    pub(crate) max_offs: Vec<u32>,
 }
 
 /// The contiguous `SimData` slot range backing one scalarized array model
@@ -1507,13 +1509,13 @@ impl<'a> FnCtx<'a> {
     /// (C's `updateBoundVariableAttributes` + `updateStaticDataOfNonlinearSystems`).
     pub(crate) fn emit_update_bound_attrs(
         &mut self,
-        nominal_defaults: &[(u32, f64)],
+        defaults: &[(u32, f64)],
         attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
-        for (off, nom) in nominal_defaults {
+        for (off, value) in defaults {
             self.emit(we::Instruction::LocalGet(data));
-            self.emit(we::Instruction::F64Const((*nom).into()));
+            self.emit(we::Instruction::F64Const((*value).into()));
             self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
         }
         if attrs.is_empty() {
@@ -1532,6 +1534,13 @@ impl<'a> FnCtx<'a> {
                     self.emit(we::Instruction::F64Abs);
                     self.emit(we::Instruction::F64Const(1e-32f64.into()));
                     self.emit(we::Instruction::F64Max);
+                    self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+                }
+            }
+            if matches!(attr, Attr::Max) {
+                for off in &targets.max_offs {
+                    self.emit(we::Instruction::LocalGet(data));
+                    self.emit(we::Instruction::LocalGet(raw));
                     self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
                 }
             }
@@ -5032,8 +5041,9 @@ mod sim_systems;
 pub(crate) use sim_systems::{
     LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual,
     compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
-    compile_linear_system_symbolic, emit_nls_jac_body, emit_nls_jac_csc_body, emit_nls_load_body,
-    emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring, lin_use_sparse, nls_use_sparse,
+    compile_linear_system_symbolic, emit_linz_jac_body, emit_nls_jac_body, emit_nls_jac_csc_body,
+    emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring,
+    lin_use_sparse, nls_use_sparse,
 };
 
 fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1498,3 +1498,48 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::Drop);
     Ok(())
 }
+
+/// Emit a linearization matrix's `linearJac<X>(sim_data)` body (wasm local 0 =
+/// `SimData`): per seed column, seed it, zero the result slots, run the column
+/// equations and store the rows as column `j` at `out_off` (`out[j*rows + i]`).
+/// C's `functionJacX` loop; the constant equations run in the caller.
+pub(crate) fn emit_linz_jac_body(
+    ctx: &mut FnCtx,
+    out_off: u32,
+    rows: usize,
+    seed_offs: &[u32],
+    result_offs: &[Option<u32>],
+    lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    if result_offs.len() != rows {
+        return Err("CodegenWasmJit: linearization Jacobian row count mismatch");
+    }
+    let store_const = |ctx: &mut FnCtx, off: u32, val: f64| {
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::F64Const(val.into()));
+        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    };
+    for j in 0..seed_offs.len() {
+        for (k, &soff) in seed_offs.iter().enumerate() {
+            store_const(ctx, soff, if k == j { 1.0 } else { 0.0 });
+        }
+        for &roff in result_offs.iter().flatten() {
+            store_const(ctx, roff, 0.0);
+        }
+        lower_column(ctx)?;
+        for (i, roff) in result_offs.iter().enumerate() {
+            let out = out_off + ((j * rows + i) as u32) * 8;
+            match roff {
+                Some(roff) => {
+                    ctx.emit(I::LocalGet(0));
+                    ctx.emit(I::LocalGet(0));
+                    ctx.emit(I::F64Load(mem_arg(*roff, 3)));
+                    ctx.emit(I::F64Store(mem_arg(out, 3)));
+                }
+                None => store_const(ctx, out, 0.0),
+            }
+        }
+    }
+    Ok(())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -171,6 +171,8 @@ struct Session {
     rows: Vec<f64>,
     params: Vec<f64>,
     stats: SolveStats,
+    /// `-l`'s linearized model as `<file name>\0<content>`, for the host to write.
+    lin: Vec<u8>,
 }
 
 struct SessionCell(UnsafeCell<Option<Session>>);
@@ -295,6 +297,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
         rows: Vec::new(),
         params: Vec::new(),
         stats: SolveStats::default(),
+        lin: Vec::new(),
     });
     0
 }
@@ -339,6 +342,11 @@ fn finish(s: &mut Session) {
         &s.model.layout,
         s.n_reals,
     );
+    if let Ok(Some(f)) = openmodelica_sim_meta::linearize::linearize(&mut s.engine, &s.model, s.sim_data) {
+        s.lin.extend_from_slice(f.name.as_bytes());
+        s.lin.push(0);
+        s.lin.extend_from_slice(f.content.as_bytes());
+    }
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
     s.finished = true;
 }
@@ -367,6 +375,17 @@ pub extern "C" fn rt_sim_rows_len() -> u32 {
 pub extern "C" fn rt_sim_n_reals() -> u32 {
     session().as_ref().map_or(0, |s| s.n_reals)
 }
+/// `-l`'s linearized model as `<file name>\0<content>`; the host writes the file
+/// (this runtime's WASI is the browser's VFS).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_lin_ptr() -> u32 {
+    session().as_ref().map_or(0, |s| s.lin.as_ptr() as u32)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_lin_len() -> u32 {
+    session().as_ref().map_or(0, |s| s.lin.len() as u32)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_sim_params_ptr() -> u32 {
     session().as_ref().map_or(0, |s| s.params.as_ptr() as u32)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -51,6 +51,10 @@ unsafe extern "C" {
     fn functionUpdateBoundVariableAttributes(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
+    fn linearJacA(sim_data: u32);
+    fn linearJacB(sim_data: u32);
+    fn linearJacC(sim_data: u32);
+    fn linearJacD(sim_data: u32);
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
     /// Pointer to / length of the encoded `SimMeta` blob in linear memory.
     fn om_meta_ptr() -> u32;
@@ -107,6 +111,10 @@ impl SimEngine for StandaloneEngine {
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
+                "linearJacA" => linearJacA(arg),
+                "linearJacB" => linearJacB(arg),
+                "linearJacC" => linearJacC(arg),
+                "linearJacD" => linearJacD(arg),
                 "functionInitSynchronous" => return Err(SYNC_UNSUPPORTED),
                 _ => return Err("wasm-jit standalone: unknown model function"),
             }
@@ -171,6 +179,19 @@ fn run() {
         }
     };
 
+    if let Some(f) = &result.lin {
+        let path = lin_file(&f.name);
+        std::fs::write(&path, &f.content)
+            .expect("wasm-jit standalone: cannot write the linearized model");
+        if let Some(lin) = &m.lin {
+            use openmodelica_sim_meta::omclog::{STDOUT, error, info};
+            let (msgs, is_error) = openmodelica_sim_meta::linearize::write_notice(lin, f, &path);
+            for msg in &msgs {
+                if is_error { error(STDOUT, false, msg) } else { info(STDOUT, false, msg) }
+            }
+        }
+    }
+
     if m.output_format != "mat" {
         return; // "empty": run only (benchmarking), no file
     }
@@ -220,6 +241,14 @@ fn result_file(prefix: &str) -> String {
         (Some(r), _) => r.clone(),
         (None, Some(dir)) => format!("{dir}/{prefix}_res.mat"),
         (None, None) => format!("{prefix}_res.mat"),
+    })
+}
+
+/// C's `linearize`: `linearized_model.<ext>` under `-outputPath`.
+fn lin_file(name: &str) -> String {
+    simflags::with_flags(|f| match &f.output_path {
+        Some(dir) => format!("{dir}/{name}"),
+        None => name.to_string(),
     })
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
@@ -128,6 +128,7 @@ pub extern "C" fn omrs_sim_external_end() {
 /// message's first line and for its wrapped lines.
 pub const LOG_STDOUT_INFO: &str = "LOG_STDOUT        | info    | ";
 pub const LOG_STDOUT_WARNING: &str = "LOG_STDOUT        | warning | ";
+pub const LOG_STDOUT_ERROR: &str = "LOG_STDOUT        | error   | ";
 const LOG_CONT: &str = "|                 | |       | ";
 
 /// Prefix each line of a `\n`-separated message, the first with `prefix`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -209,6 +209,10 @@ pub const MODEL_FNS: &[&str] = &[
     "functionInitSynchronous",
     "functionUpdateSynchronous",
     "functionEquationsSynchronous",
+    "linearJacA",
+    "linearJacB",
+    "linearJacC",
+    "linearJacD",
 ];
 
 /// The model entry points that are not `fn(SimData*)`: `--daeMode`'s residual
@@ -401,6 +405,8 @@ pub struct RunResult {
     pub params: Vec<f64>,
     /// Solver statistics (steps, evaluations, events).
     pub stats: SolveStats,
+    /// `-l`'s linearized model, for the caller to write out.
+    pub lin: Option<crate::linearize::LinFile>,
 }
 
 /// Outcome of one [`Driver::advance`] chunk.
@@ -2202,8 +2208,9 @@ pub fn drive(
     let rows = outcome?;
     stats.method = label;
 
+    let lin = crate::linearize::linearize(e, model, sim_data)?;
     let params = finalize_run(e, model, sim_data)?;
-    Ok((RunResult { rows, n_reals, params, stats }, label))
+    Ok((RunResult { rows, n_reals, params, stats, lin }, label))
 }
 
 /// In-wasm driver: initialize here (so the run initializes like every other

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -27,6 +27,7 @@ use alloc::vec::Vec;
 pub mod driver;
 pub mod fixedstep;
 pub mod gbode;
+pub mod linearize;
 pub mod omclog;
 pub mod simflags;
 pub mod sync;
@@ -163,6 +164,13 @@ pub struct Layout {
     /// Base of the per-state `nominal` attribute (one f64 per state), written by
     /// `functionUpdateBoundVariableAttributes` once the parameters are computed.
     pub state_nom_off: u32,
+    /// Base of the per-state `max` attribute, written the same way; C's
+    /// `functionJacAC_num` flips its difference quotient at the bound.
+    pub state_max_off: u32,
+    /// Base of the linearization scratch (f64): the symbolic `A|B|C|D` the
+    /// `linearJac*` fill (column-major), then their seed/`$pDER` slots.
+    pub linz_off: u32,
+    pub n_linz: u32,
     /// C's `simulationInfo->sensitivityMatrix`: `d(state)/d(parameter)`,
     /// parameter-major, written by the IDA driver from `IDAGetSens` and captured
     /// as a result row's last columns.
@@ -224,6 +232,7 @@ impl Layout {
         n_dae_alg: u32,
         n_base_clocks: u32,
         n_sub_clocks: u32,
+        n_linz: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -261,22 +270,24 @@ impl Layout {
         let zctol_off = mathevents_off + n_math_slots * 8;
         let start_off = zctol_off + 8;
         let state_nom_off = start_off + n_states * 8;
-        let sens_off = state_nom_off + n_states * 8;
+        let state_max_off = state_nom_off + n_states * 8;
+        let sens_off = state_max_off + n_states * 8;
         let dae_res_off = sens_off + n_sens * 8;
         let dae_aux_off = dae_res_off + n_dae_res * 8;
         let dae_alg_nom_off = dae_aux_off + n_dae_aux * 8;
         let clock_off = dae_alg_nom_off + n_dae_alg * 8;
         let subclock_off = clock_off + n_base_clocks * BASECLOCK_BYTES;
         let clock_fire_off = subclock_off + n_sub_clocks * SUBCLOCK_BYTES;
-        let total = clock_fire_off + n_base_clocks * 4;
+        let linz_off = (clock_fire_off + n_base_clocks * 4 + 7) & !7;
+        let total = linz_off + n_linz * 8;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
-            mathevents_off, zctol_off, start_off, state_nom_off, n_sens, sens_off,
+            mathevents_off, zctol_off, start_off, state_nom_off, state_max_off, n_sens, sens_off,
             n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
-            n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, total,
+            n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, linz_off, n_linz, total,
         }
     }
 
@@ -405,6 +416,64 @@ pub struct DaeInfo {
     pub sparsity: Option<JacAInfo>,
 }
 
+/// `--linearizationDumpLanguage`: the frame, the matrix rendering and the
+/// file name.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum LinLanguage {
+    #[default]
+    Modelica,
+    Matlab,
+    Julia,
+    Python,
+}
+
+impl LinLanguage {
+    /// The extension `linearized_model` gets.
+    pub fn ext(self) -> &'static str {
+        match self {
+            LinLanguage::Modelica => ".mo",
+            LinLanguage::Matlab => ".m",
+            LinLanguage::Julia => ".jl",
+            LinLanguage::Python => ".py",
+        }
+    }
+}
+
+/// One `input`/`output` variable's `SimData` slot.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub struct LinVar {
+    pub off: u32,
+    pub negate: bool,
+}
+
+/// What `-l` needs beyond the ODE: C's `nInputVars`/`nOutputVars` as `SimData`
+/// slots (standing in for its `input_function`/`output_function`), and the
+/// `linear_model_frame()` the code generator baked the dump language into.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct LinInfo {
+    /// Slots of the top-level `input` variables, in `u`/`B` column order.
+    pub input_vars: Vec<LinVar>,
+    /// Slots of the top-level `output` variables, in `y`/`C` row order.
+    pub output_vars: Vec<LinVar>,
+    pub language: LinLanguage,
+    /// C's `linear_model_frame()` / `linear_model_datarecovery_frame()`: a printf
+    /// frame with `%s` per matrix/vector (and `%g` for the stop time). Empty is
+    /// what the template emits when linearization is disabled or too big.
+    pub frame: String,
+    pub frame_datarec: String,
+    /// What C's empty frame prints before it.
+    pub disabled_reason: String,
+    /// Bit `k` ⇒ matrix `k` (`A`,`B`,`C`,`D`) has a symbolic `linearJac*` export,
+    /// C's `initialAnalyticJacobian<X>` availability. Bit 0 is also C's
+    /// `sizeTmpVars > 0`, which decides whether the numeric pass runs.
+    pub sym_mask: u8,
+    /// C's `modelData->runTestsuite`: shortens the created-model notice.
+    pub run_testsuite: bool,
+    /// Rows of each matrix: `nStates` for `A`/`B`, `nOutputVars` for `C`/`D`.
+    pub jac_rows: [u32; 4],
+    pub jac_cols: [u32; 4],
+}
+
 /// The compile-time half of C's `SUBCLOCK_DATA` (its `CLOCK_STATS` live in `SimData`).
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct SubClockMeta {
@@ -528,6 +597,8 @@ pub struct SimMeta {
     /// Synchronous base clocks in `base_idx` order; empty for a model with no
     /// clocked partitions.
     pub clocks: Vec<BaseClockMeta>,
+    /// What `-l` needs; `None` for a target that emits no linearization support.
+    pub lin: Option<LinInfo>,
 }
 
 /// [`SimMeta::nls_vars`] entry.
@@ -694,6 +765,15 @@ impl SimMeta {
         if f.noemit {
             self.output_format = String::from("empty");
         }
+        // C's `startNonInteractiveSimulation`, after `read_experiment`.
+        if let Some(t) = f.linearize {
+            self.stop_time = t;
+            omclog::info(
+                STDOUT,
+                false,
+                &alloc::format!("Linearization will be performed at point of time: {t:.6}"),
+            );
+        }
     }
 
     /// [`apply_flags`](Self::apply_flags) on a copy, for a caller whose metadata is
@@ -713,7 +793,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 10;
+const VERSION: u32 = 11;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -744,9 +824,10 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
-        l.state_nom_off, l.n_sens, l.sens_off,
+        l.state_nom_off, l.state_max_off, l.n_sens, l.sens_off,
         l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off,
-        l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off, l.total,
+        l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off,
+        l.linz_off, l.n_linz, l.total,
     ] {
         put_u32(o, v);
     }
@@ -862,6 +943,28 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             o.push(s.external_solver as u8);
         }
     }
+    match &m.lin {
+        None => o.push(0),
+        Some(l) => {
+            o.push(1);
+            for g in [&l.input_vars, &l.output_vars] {
+                put_u32(&mut o, g.len() as u32);
+                for v in g {
+                    put_u32(&mut o, v.off);
+                    o.push(v.negate as u8);
+                }
+            }
+            o.push(l.language as u8);
+            put_str(&mut o, &l.frame);
+            put_str(&mut o, &l.frame_datarec);
+            put_str(&mut o, &l.disabled_reason);
+            o.push(l.sym_mask);
+            o.push(l.run_testsuite as u8);
+            for v in l.jac_rows.iter().chain(l.jac_cols.iter()) {
+                put_u32(&mut o, *v);
+            }
+        }
+    }
     o
 }
 
@@ -954,6 +1057,7 @@ impl<'a> Reader<'a> {
             zctol_off: self.u32()?,
             start_off: self.u32()?,
             state_nom_off: self.u32()?,
+            state_max_off: self.u32()?,
             n_sens: self.u32()?,
             sens_off: self.u32()?,
             n_dae_res: self.u32()?,
@@ -967,6 +1071,8 @@ impl<'a> Reader<'a> {
             n_sub_clocks: self.u32()?,
             subclock_off: self.u32()?,
             clock_fire_off: self.u32()?,
+            linz_off: self.u32()?,
+            n_linz: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -1081,10 +1187,54 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         }
         clocks.push(BaseClockMeta { is_event_clock, inferred, sub_base, sub });
     }
+    let lin = match r.u8()? {
+        0 => None,
+        _ => {
+            let mut group = || -> Result<Vec<LinVar>, &'static str> {
+                let n = r.u32()? as usize;
+                let mut out = Vec::with_capacity(n);
+                for _ in 0..n {
+                    out.push(LinVar { off: r.u32()?, negate: r.u8()? != 0 });
+                }
+                Ok(out)
+            };
+            let input_vars = group()?;
+            let output_vars = group()?;
+            let language = match r.u8()? {
+                0 => LinLanguage::Modelica,
+                1 => LinLanguage::Matlab,
+                2 => LinLanguage::Julia,
+                3 => LinLanguage::Python,
+                _ => return Err("sim_meta: bad LinLanguage tag"),
+            };
+            let frame = r.string()?;
+            let frame_datarec = r.string()?;
+            let disabled_reason = r.string()?;
+            let sym_mask = r.u8()?;
+            let run_testsuite = r.u8()? != 0;
+            let mut dims = [0u32; 8];
+            for d in &mut dims {
+                *d = r.u32()?;
+            }
+            let (rows, cols) = dims.split_at(4);
+            Some(LinInfo {
+                input_vars,
+                output_vars,
+                language,
+                frame,
+                frame_datarec,
+                disabled_reason,
+                sym_mask,
+                run_testsuite,
+                jac_rows: rows.try_into().unwrap(),
+                jac_cols: cols.try_into().unwrap(),
+            })
+        }
+    };
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
-        nls_vars, dae, clocks,
+        nls_vars, dae, clocks, lin,
     })
 }
 
@@ -1096,7 +1246,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -1155,6 +1305,18 @@ mod tests {
                     SubClockMeta { shift_num: 1, shift_den: 3, factor_num: 4, factor_den: 1, hold_events: true, external_solver: false },
                 ],
             }],
+            lin: Some(LinInfo {
+                input_vars: vec![LinVar { off: 40, negate: false }],
+                output_vars: vec![LinVar { off: 48, negate: true }],
+                language: LinLanguage::Julia,
+                frame: "function linearized_model()\n%s%s%s%s%s%s\nend".to_string(),
+                frame_datarec: String::new(),
+                disabled_reason: String::new(),
+                sym_mask: 0b1011,
+                run_testsuite: false,
+                jac_rows: [2, 2, 1, 1],
+                jac_cols: [2, 1, 2, 1],
+            }),
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
@@ -1,0 +1,399 @@
+//! `-l=<t>`: linearize the model around the point the run stopped at, C's
+//! `linearization/linearize.cpp`.
+//!
+//! `der(x) = A x + B u`, `y = C x + D u`, plus `z = Cz x + Dz u` under
+//! `-l_datarec`. The matrices come from the symbolic `linearJac*` exports or from
+//! C's scaled forward difference quotients, and are rendered into the
+//! [`LinInfo::frame`] the code generator baked the dump language into. The file is
+//! handed back for whichever entry point owns the file system.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::driver::{Result, SimEngine, format_g, read_f64, write_f64};
+use crate::{LinInfo, LinLanguage, LinVar, REAL_OFF, SimMeta};
+
+/// The linearized model, for the caller to write where its file system is.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LinFile {
+    /// `linearized_model` plus the language's extension.
+    pub name: String,
+    pub content: String,
+}
+
+
+/// C's `numericalDifferentiationDeltaXlinearize` default.
+fn default_delta_x() -> f64 {
+    libm::sqrt(f64::EPSILON * 2e1)
+}
+
+/// The four symbolic matrices, in `MODEL_FNS`/[`LinInfo::jac_rows`] order.
+const JAC_FNS: [&str; 4] = ["linearJacA", "linearJacB", "linearJacC", "linearJacD"];
+
+/// `SimData` offset of matrix `k`: one region, `A|B|C|D`, each column-major.
+fn jac_off(lin: &LinInfo, layout: &crate::Layout, k: usize) -> u32 {
+    let mut off = layout.linz_off;
+    for j in 0..k {
+        off += lin.jac_rows[j] * lin.jac_cols[j] * 8;
+    }
+    off
+}
+
+fn read_lin_var(e: &dyn SimEngine, sim_data: u32, v: &LinVar) -> Result<f64> {
+    let raw = read_f64(e, sim_data + v.off)?;
+    Ok(if v.negate { -raw } else { raw })
+}
+
+fn write_lin_var(e: &mut dyn SimEngine, sim_data: u32, v: &LinVar, value: f64) -> Result<()> {
+    write_f64(e, sim_data + v.off, if v.negate { -value } else { value })
+}
+
+/// C's `functionODE_residual`.
+fn ode_residual(
+    e: &mut dyn SimEngine,
+    model: &SimMeta,
+    lin: &LinInfo,
+    sim_data: u32,
+    u: &[f64],
+    dx: &mut [f64],
+    dy: &mut [f64],
+    dz: Option<&mut [f64]>,
+) -> Result<()> {
+    let layout = &model.layout;
+    for (i, v) in lin.input_vars.iter().enumerate() {
+        write_lin_var(e, sim_data, v, u[i])?;
+    }
+    e.call1("functionODE", sim_data)?;
+    e.call1("functionAlgebraics", sim_data)?;
+    for (i, slot) in dx.iter_mut().enumerate() {
+        *slot = read_f64(e, sim_data + REAL_OFF + (layout.n_states + i as u32) * 8)?;
+    }
+    for (i, slot) in dy.iter_mut().enumerate() {
+        *slot = read_lin_var(e, sim_data, &lin.output_vars[i])?;
+    }
+    if let Some(dz) = dz {
+        for (i, slot) in dz.iter_mut().enumerate() {
+            *slot = read_f64(e, sim_data + REAL_OFF + (2 * layout.n_states + i as u32) * 8)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_states(e: &dyn SimEngine, sim_data: u32, n: u32) -> Result<Vec<f64>> {
+    (0..n).map(|i| read_f64(e, sim_data + REAL_OFF + i * 8)).collect()
+}
+
+/// C's `functionJacAC_num`: perturb each state, difference `A`, `C` and `Cz`.
+#[allow(clippy::too_many_arguments)]
+fn jac_ac_num(
+    e: &mut dyn SimEngine,
+    model: &SimMeta,
+    lin: &LinInfo,
+    sim_data: u32,
+    delta_h: f64,
+    u: &[f64],
+    a: &mut [f64],
+    c: &mut [f64],
+    cz: Option<&mut [f64]>,
+) -> Result<()> {
+    let layout = &model.layout;
+    let (n_x, n_y, n_z) = (layout.n_states as usize, lin.output_vars.len(), layout.n_real_alg as usize);
+    let do_z = cz.is_some();
+    let (mut x0, mut x1) = (vec![0.0; n_x], vec![0.0; n_x]);
+    let (mut y0, mut y1) = (vec![0.0; n_y], vec![0.0; n_y]);
+    let (mut z0, mut z1) = (vec![0.0; n_z], vec![0.0; n_z]);
+    let mut cz = cz;
+
+    ode_residual(e, model, lin, sim_data, u, &mut x0, &mut y0, do_z.then_some(&mut z0[..]))?;
+    let mut scaling = Vec::with_capacity(n_x);
+    for i in 0..n_x as u32 {
+        let nominal = read_f64(e, sim_data + layout.state_nom_off + i * 8)?;
+        let x = read_f64(e, sim_data + REAL_OFF + i * 8)?;
+        scaling.push(libm::fmax(nominal, libm::fabs(x)));
+    }
+    for i in 0..n_x {
+        let addr = sim_data + REAL_OFF + (i as u32) * 8;
+        let xsave = read_f64(e, addr)?;
+        let mut delta_hh = delta_h * (libm::fabs(xsave) + 1.0);
+        if xsave + delta_hh >= read_f64(e, sim_data + layout.state_max_off + (i as u32) * 8)? {
+            delta_hh = -delta_hh;
+        }
+        write_f64(e, addr, xsave + delta_hh / scaling[i])?;
+        delta_hh = 1.0 / delta_hh * scaling[i];
+
+        ode_residual(e, model, lin, sim_data, u, &mut x1, &mut y1, do_z.then_some(&mut z1[..]))?;
+
+        for j in 0..n_x {
+            a[i * n_x + j] = (x1[j] - x0[j]) * delta_hh;
+        }
+        for j in 0..n_y {
+            c[i * n_y + j] = (y1[j] - y0[j]) * delta_hh;
+        }
+        if let Some(cz) = cz.as_deref_mut() {
+            for j in 0..n_z {
+                cz[i * n_z + j] = (z1[j] - z0[j]) * delta_hh;
+            }
+        }
+        write_f64(e, addr, xsave)?;
+    }
+    Ok(())
+}
+
+/// C's `functionJacBD_num`: the same difference quotients over the inputs.
+#[allow(clippy::too_many_arguments)]
+fn jac_bd_num(
+    e: &mut dyn SimEngine,
+    model: &SimMeta,
+    lin: &LinInfo,
+    sim_data: u32,
+    delta_h: f64,
+    u: &[f64],
+    b: &mut [f64],
+    d: &mut [f64],
+    dz: Option<&mut [f64]>,
+) -> Result<()> {
+    let layout = &model.layout;
+    let (n_x, n_u, n_y, n_z) =
+        (layout.n_states as usize, u.len(), lin.output_vars.len(), layout.n_real_alg as usize);
+    let do_z = dz.is_some();
+    let (mut x0, mut x1) = (vec![0.0; n_x], vec![0.0; n_x]);
+    let (mut y0, mut y1) = (vec![0.0; n_y], vec![0.0; n_y]);
+    let (mut z0, mut z1) = (vec![0.0; n_z], vec![0.0; n_z]);
+    let mut dz = dz;
+    let mut u = u.to_vec();
+
+    ode_residual(e, model, lin, sim_data, &u, &mut x0, &mut y0, do_z.then_some(&mut z0[..]))?;
+    for i in 0..n_u {
+        let usave = u[i];
+        let mut delta_hh = delta_h * (libm::fabs(usave) + 1.0);
+        u[i] = usave + delta_hh;
+        delta_hh = 1.0 / delta_hh;
+
+        ode_residual(e, model, lin, sim_data, &u, &mut x1, &mut y1, do_z.then_some(&mut z1[..]))?;
+
+        for j in 0..n_x {
+            b[i * n_x + j] = (x1[j] - x0[j]) * delta_hh;
+        }
+        for j in 0..n_y {
+            d[i * n_y + j] = (y1[j] - y0[j]) * delta_hh;
+        }
+        if let Some(dz) = dz.as_deref_mut() {
+            for j in 0..n_z {
+                dz[i * n_z + j] = (z1[j] - z0[j]) * delta_hh;
+            }
+        }
+        u[i] = usave;
+    }
+    Ok(())
+}
+
+/// C's `array2string`: row-major text of a column-major `row × col` matrix.
+fn array2string(a: &[f64], row: usize, col: usize, lang: LinLanguage) -> String {
+    let sep = if lang == LinLanguage::Julia { " " } else { ", " };
+    let mut out = String::new();
+    for i in 0..row {
+        let mut k = i;
+        for _ in 0..col.saturating_sub(1) {
+            out.push_str(&format_g(a[k], 16));
+            out.push_str(sep);
+            k += row;
+        }
+        if col > 0 {
+            out.push_str(&format_g(a[k], 16));
+        }
+        if i + 1 != row && col != 0 {
+            out.push_str(";\n\t");
+        }
+    }
+    out
+}
+
+/// C's `array2PythonString`: a list of row lists.
+fn array2python(a: &[f64], row: usize, col: usize) -> String {
+    if row == 0 || col == 0 {
+        return "[]\n".to_string();
+    }
+    let mut out = String::from("[");
+    for i in 0..row {
+        let mut k = i;
+        out.push('[');
+        for _ in 0..col - 1 {
+            out.push_str(&format_g(a[k], 16));
+            out.push_str(", ");
+            k += row;
+        }
+        out.push_str(&format_g(a[k], 16));
+        if i + 1 != row {
+            out.push_str("],\n\t");
+        }
+    }
+    out.push_str("]]\n");
+    out
+}
+
+/// The frame's `x0`/`u0`/`z0`: `{}` is not valid Modelica, hence `zeros(0)`.
+fn vector_literal(v: &[f64], lang: LinLanguage) -> String {
+    let body = || array2string(v, 1, v.len(), lang);
+    match (v.is_empty(), lang) {
+        (true, LinLanguage::Python) => "[0]".to_string(),
+        (true, _) => "zeros(0)".to_string(),
+        (false, LinLanguage::Julia | LinLanguage::Python) => format!("[{}]", body()),
+        (false, _) => format!("{{{}}}", body()),
+    }
+}
+
+/// Substitute the frame's `printf` conversions: `%s` the next matrix/vector text,
+/// `%g` the stop time.
+fn fill_frame(frame: &str, args: &[String], stop_time: f64) -> String {
+    let mut out = String::with_capacity(frame.len());
+    let mut next = 0;
+    let mut it = frame.chars();
+    while let Some(c) = it.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match it.next() {
+            Some('s') => {
+                if let Some(a) = args.get(next) {
+                    out.push_str(a);
+                }
+                next += 1;
+            }
+            Some('g') => out.push_str(&format_g(stop_time, 6)),
+            Some('%') => out.push('%'),
+            Some(other) => {
+                out.push('%');
+                out.push(other);
+            }
+            None => out.push('%'),
+        }
+    }
+    out
+}
+
+/// Run `linearJac<k>` and read the matrix it left in the linearization region.
+fn read_symbolic(
+    e: &mut dyn SimEngine,
+    model: &SimMeta,
+    lin: &LinInfo,
+    sim_data: u32,
+    k: usize,
+    out: &mut [f64],
+) -> Result<()> {
+    e.call1(JAC_FNS[k], sim_data)?;
+    let base = sim_data + jac_off(lin, &model.layout, k);
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = read_f64(e, base + (i as u32) * 8)?;
+    }
+    Ok(())
+}
+
+/// C's report once the file has been written; an empty frame is the one the
+/// template emits when linearization was disabled. `(messages, is_error)`.
+pub fn write_notice(lin: &LinInfo, file: &LinFile, path: &str) -> (Vec<String>, bool) {
+    if !file.content.is_empty() {
+        return (created_notice(lin, path), false);
+    }
+    let mut msgs = Vec::new();
+    if !lin.disabled_reason.is_empty() {
+        msgs.push(lin.disabled_reason.clone());
+    }
+    msgs.push("Linear model could not be created.".to_string());
+    (msgs, true)
+}
+
+/// C's `LOG_STDOUT` notice, as plain messages: the callers own their log.
+pub fn created_notice(lin: &LinInfo, path: &str) -> Vec<String> {
+    if lin.run_testsuite {
+        return vec!["Linear model is created.".to_string()];
+    }
+    vec![
+        format!("Linear model is created at {path}"),
+        "The output format can be changed with the command line option --linearizationDumpLanguage."
+            .to_string(),
+        "The options are: --linearizationDumpLanguage=none, modelica, matlab, julia, python."
+            .to_string(),
+        "In OMEdit Simulation Setup->Linearize->Target language for linearized model.".to_string(),
+    ]
+}
+
+/// C's `linearize`, once the run reached the linearization point. `None` when
+/// `-l` was not asked for.
+pub fn linearize(e: &mut dyn SimEngine, model: &SimMeta, sim_data: u32) -> Result<Option<LinFile>> {
+    let (asked, datarec, delta_h) = crate::simflags::with_flags(|f| {
+        (f.linearize.is_some(), f.linearize_datarec, f.delta_x_linearize.unwrap_or_else(default_delta_x))
+    });
+    if !asked {
+        return Ok(None);
+    }
+    let Some(lin) = &model.lin else {
+        return Err("linearization is not available for this model");
+    };
+    let layout = &model.layout;
+    let (n_x, n_u, n_y, n_z) =
+        (layout.n_states as usize, lin.input_vars.len(), lin.output_vars.len(), layout.n_real_alg as usize);
+
+    let mut a = vec![0.0; n_x * n_x];
+    let mut b = vec![0.0; n_x * n_u];
+    let mut c = vec![0.0; n_y * n_x];
+    let mut d = vec![0.0; n_y * n_u];
+    let mut cz = vec![0.0; n_z * n_x];
+    let mut dz = vec![0.0; n_z * n_u];
+
+    let x0 = read_states(e, sim_data, layout.n_states)?;
+    let u0: Vec<f64> =
+        lin.input_vars.iter().map(|v| read_lin_var(e, sim_data, v)).collect::<Result<_>>()?;
+    // C reads z0 before anything perturbs the model.
+    let z0: Vec<f64> = if datarec {
+        (0..n_z as u32)
+            .map(|i| read_f64(e, sim_data + REAL_OFF + (2 * layout.n_states + i) * 8))
+            .collect::<Result<_>>()?
+    } else {
+        Vec::new()
+    };
+
+    // `Cz`/`Dz` are only ever numeric. C skips the numeric pass as soon as `A` is
+    // symbolic — it generates all four together, so the rest are too; here a single
+    // matrix can fail to lower, and one that did is differenced rather than left at
+    // C's `calloc` zero.
+    if datarec || lin.sym_mask != 0b1111 {
+        jac_ac_num(e, model, lin, sim_data, delta_h, &u0, &mut a, &mut c, datarec.then_some(&mut cz[..]))?;
+        jac_bd_num(e, model, lin, sim_data, delta_h, &u0, &mut b, &mut d, datarec.then_some(&mut dz[..]))?;
+    }
+    for (k, m) in [&mut a, &mut b, &mut c, &mut d].into_iter().enumerate() {
+        if lin.sym_mask & (1 << k) != 0 {
+            read_symbolic(e, model, lin, sim_data, k, m)?;
+        }
+    }
+
+    // C writes the (empty) file either way and reports it afterwards.
+    let frame = if datarec { &lin.frame_datarec } else { &lin.frame };
+    let lang = lin.language;
+    if frame.is_empty() {
+        return Ok(Some(LinFile { name: format!("linearized_model{}", lang.ext()), content: String::new() }));
+    }
+
+    let mat = |m: &[f64], row: usize, col: usize| match lang {
+        LinLanguage::Python => array2python(m, row, col),
+        _ => array2string(m, row, col, lang),
+    };
+    let mut args = vec![vector_literal(&x0, lang), vector_literal(&u0, lang)];
+    if datarec {
+        args.push(vector_literal(&z0, lang));
+    }
+    args.push(mat(&a, n_x, n_x));
+    args.push(mat(&b, n_x, n_u));
+    args.push(mat(&c, n_y, n_x));
+    args.push(mat(&d, n_y, n_u));
+    if datarec {
+        args.push(mat(&cz, n_z, n_x));
+        args.push(mat(&dz, n_z, n_u));
+    }
+    Ok(Some(LinFile {
+        name: format!("linearized_model{}", lang.ext()),
+        content: fill_frame(frame, &args, model.stop_time),
+    }))
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -204,6 +204,12 @@ pub struct SimFlags {
     pub no_restart: bool,
     /// `-noRootFinding`: take the end of the step as the event time.
     pub no_root_finding: bool,
+    /// `-l=<t>`: linearize at `t`, which also becomes the run's stop time.
+    pub linearize: Option<f64>,
+    /// `-l_datarec`: also emit the data-recovery matrices `Cz`/`Dz`.
+    pub linearize_datarec: bool,
+    /// `-deltaXLinearize`: C's `numericalDifferentiationDeltaXlinearize`.
+    pub delta_x_linearize: Option<f64>,
     /// The `-gb*` flags, `(name, value)`; a value-less one is stored as `""`.
     /// gbode reads these by name the way C reads `omc_flagValue`, so the whole
     /// family does not have to be mirrored as struct fields.
@@ -650,6 +656,9 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "noHomotopyOnFirstTry" => f.homotopy_on_first_try = Some(false),
             "noRestart" => f.no_restart = true,
             "noRootFinding" => f.no_root_finding = true,
+            "l" => f.linearize = Some(real(name, &value(name)?)?),
+            "l_datarec" => f.linearize_datarec = true,
+            "deltaXLinearize" => f.delta_x_linearize = Some(real(name, &value(name)?)?),
             // The `-gb*` family is stored by name; gbode validates the values when
             // it is built, so an unused one is still rejected (C ignores it).
             _ if name.starts_with("gb") && C_FLAGS.iter().any(|(n, _)| *n == name) => {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -54,6 +54,15 @@ mod engine_config;
 #[cfg(all(feature = "jit", not(target_arch = "wasm32")))]
 pub use engine_config::tune_memory;
 
+/// Split the runtime's `-l` blob (`<file name>\0<content>`) into a [`LinFile`].
+pub fn split_lin_blob(bytes: &[u8]) -> Option<openmodelica_sim_meta::linearize::LinFile> {
+    let i = bytes.iter().position(|&b| b == 0)?;
+    Some(openmodelica_sim_meta::linearize::LinFile {
+        name: String::from_utf8_lossy(&bytes[..i]).into_owned(),
+        content: String::from_utf8_lossy(&bytes[i + 1..]).into_owned(),
+    })
+}
+
 // A thin facade over openmodelica_sim_meta::driver; present even in the no-jit
 // stub build, which reads its result types.
 pub mod sim_driver;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -981,6 +981,8 @@ pub struct InWasmSession {
     params_ptr: wasmer::TypedFunction<(), u32>,
     params_len: wasmer::TypedFunction<(), u32>,
     stat_f: wasmer::TypedFunction<u32, u64>,
+    lin_ptr: wasmer::TypedFunction<(), u32>,
+    lin_len: wasmer::TypedFunction<(), u32>,
     free_f: wasmer::TypedFunction<(), ()>,
 }
 
@@ -1045,6 +1047,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         params_ptr: gf(&store, "rt_sim_params_ptr")?,
         params_len: gf(&store, "rt_sim_params_len")?,
         stat_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_stat"))?,
+        lin_ptr: gf(&store, "rt_sim_lin_ptr")?,
+        lin_len: gf(&store, "rt_sim_lin_len")?,
         free_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_free"))?,
         store,
         memory,
@@ -1127,7 +1131,22 @@ impl InWasmSession {
         stats.conv_test_fails = stat(4)?;
         stats.state_events = stat(5)?;
         stats.time_events = stat(6)?;
-        Ok(sim_driver::RunResult { rows, n_reals, params, stats })
+        let lin = self.take_lin()?;
+        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+    }
+
+    /// The runtime's `-l` blob (`<file name>\0<content>`), empty when unasked.
+    fn take_lin(&mut self) -> Result<Option<openmodelica_sim_meta::linearize::LinFile>> {
+        let p = wt(self.lin_ptr.call(&mut self.store))?;
+        let n = wt(self.lin_len.call(&mut self.store))? as usize;
+        let mut bytes = vec![0u8; n];
+        if n > 0 {
+            self.memory
+                .view(&self.store)
+                .read(p as u64, &mut bytes)
+                .map_err(|_| "CodegenWasmJit: linearization read")?;
+        }
+        Ok(crate::split_lin_blob(&bytes))
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -987,6 +987,8 @@ pub struct InWasmSession {
     params_ptr: wasmtime::TypedFunc<(), u32>,
     params_len: wasmtime::TypedFunc<(), u32>,
     stat_f: wasmtime::TypedFunc<u32, u64>,
+    lin_ptr: wasmtime::TypedFunc<(), u32>,
+    lin_len: wasmtime::TypedFunc<(), u32>,
     free_f: wasmtime::TypedFunc<(), ()>,
 }
 
@@ -1047,6 +1049,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         params_ptr: gf(&mut store, "rt_sim_params_ptr")?,
         params_len: gf(&mut store, "rt_sim_params_len")?,
         stat_f: wts(rt_inst.get_typed_func::<u32, u64>(&mut store, "rt_sim_stat"))?,
+        lin_ptr: gf(&mut store, "rt_sim_lin_ptr")?,
+        lin_len: gf(&mut store, "rt_sim_lin_len")?,
         free_f: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_sim_free"))?,
         store,
         memory,
@@ -1132,7 +1136,21 @@ impl InWasmSession {
         stats.state_events = stat(5)?;
         stats.time_events = stat(6)?;
         stats.lin_solves = stat(7)?;
-        Ok(sim_driver::RunResult { rows, n_reals, params, stats })
+        let lin = self.take_lin()?;
+        Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+    }
+
+    /// The runtime's `-l` blob (`<file name>\0<content>`), empty when unasked.
+    fn take_lin(&mut self) -> Result<Option<openmodelica_sim_meta::linearize::LinFile>> {
+        let p = wt(self.lin_ptr.call(&mut self.store, ()))?;
+        let n = wt(self.lin_len.call(&mut self.store, ()))? as usize;
+        let mut bytes = vec![0u8; n];
+        if n > 0 {
+            self.memory
+                .read(&self.store, p as usize, &mut bytes)
+                .map_err(|_| "CodegenWasmJit: linearization read")?;
+        }
+        Ok(crate::split_lin_blob(&bytes))
     }
 }
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1609,11 +1609,19 @@ algorithm
             0 := System.removeFile(logFile);
           end if;
           strlinearizeTime := realString(linearizeTime);
-          sim_call := stringAppendList({"\"",compileDir,executableSuffixedExe,"\""," ","-l=",strlinearizeTime," ",simflags});
+          simflags := "-l=" + strlinearizeTime + " " + simflags;
+          sim_call := stringAppendList({"\"",compileDir,executableSuffixedExe,"\""," ",simflags});
           System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_SIMULATION);
           SimulationResults.close() "Windows cannot handle reading and writing to the same file from different processes like any real OS :(";
 
-          if 0 == System.systemCallRestrictedEnv(sim_call, logFile) then
+          // The wasm-jit target runs the JIT-compiled model in-process, as `simulate` does.
+          if Config.simCodeTarget() == "wasm-jit" then
+            result_file := stringAppendList(List.consOnTrue(not Testsuite.isRunning(),compileDir,{executable,"_res.",outputFormat_str}));
+            resI := CodegenWasmJit.runSimulation(executable, result_file, simflags);
+          else
+            resI := System.systemCallRestrictedEnv(sim_call, logFile);
+          end if;
+          if 0 == resI then
             result_file := stringAppendList(List.consOnTrue(not Testsuite.isRunning(),compileDir,{executable,"_res.",outputFormat_str}));
             timeSimulation := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_SIMULATION);
             timeTotal := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);


### PR DESCRIPTION
Port of the C runtime's `linearization/linearize.cpp` together with the `simulationFile_lnz` / `functionlinearmodel*` half of `CodegenC.tpl`, so `linearize()` and `simulate(..., simflags="-l=...")` work for the wasm-jit target: `der(x) = A x + B u`, `y = C x + D u`, and `z = Cz x + Dz u` under `-l_datarec`, written as `linearized_model.<ext>` in the language `--linearizationDumpLanguage` selects.

The matrices come from the symbolic `linearJac*` model exports where the backend produced ones the flat emitter can lower, else from C's scaled forward difference quotients. `-l`, `-l_datarec` and `-deltaXLinearize` join the runtime flags; `-l` moves the stop time to the linearization point as `startNonInteractiveSimulation` does.

C's `input_function`/`output_function` are not emitted: they are only `cref = inputVars[i]` / `outputVars[i] = cref`, so the driver writes and reads the variable's `SimData` slot directly (sign-flipped for a negated alias). The symbolic matrices are computed in the model instead: one `linearJac<X>(SimData*)` runs C's whole `functionJacX` column loop and leaves the finished column-major matrix in a `SimData` region, so the driver reads it back rather than crossing into wasm per column.

Two places deviate from C, both because our lowering can fail on a single matrix where C generates all four together:

  * a Jacobian counts as available only when every row its sparsity pattern claims has a `JAC_VAR` result to read; a sparsity-only matrix or an array-valued `$pDER` result would otherwise lower to a silently zero matrix,
  * the numeric pass therefore runs unless all four are symbolic, rather than leaving the unlowerable ones at C's `calloc` zero.

`openmodelica/linearization` with `--simCodeTarget=wasm-jit` now passes 20 of 23. The rest are blocked elsewhere: `testDrumBoiler` does not translate for wasm-jit at all, and `test_01`/`test_07` differ because `sample(0,1)` fires before row 0 in this runtime, which their plain `simulate()` already shows.