### PR TITLE
wasm-jit: run optimize() with the Ipopt solver

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -438,6 +438,29 @@ if(RUST_OMC_ENABLE_SUNDIALS)
 endif()
 
 # ---------------------------------------------------------------------------
+# Ipopt for `method="optimization"` (the classic dynamic-optimization runtime),
+# collected like the host SUNDIALS archives above. Host-only: MUMPS is Fortran 90,
+# so there is no wasm build and an in-wasm runtime reports the same
+# "Ipopt is needed but not available" a C runtime without OMC_HAVE_IPOPT does.
+# ---------------------------------------------------------------------------
+if(OM_OMC_ENABLE_OPTIMIZATION AND TARGET ipopt)
+  set(RUST_IPOPT_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-ipopt-native
+      CACHE PATH "Directory the host Ipopt archives are collected into.")
+  set(_native_ipopt_libs ipopt dmumps mumps_common seq metis)
+  set(_native_ipopt_files "")
+  foreach(_lib IN LISTS _native_ipopt_libs)
+    list(APPEND _native_ipopt_files $<TARGET_FILE:${_lib}>)
+  endforeach()
+  add_custom_target(rust_ipopt_native_collect
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_IPOPT_NATIVE_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${_native_ipopt_files} ${RUST_IPOPT_NATIVE_DIR}/lib/
+    DEPENDS ${_native_ipopt_libs}
+    COMMENT "Rust: collecting host Ipopt archives -> ${RUST_IPOPT_NATIVE_DIR}/lib/"
+    VERBATIM)
+endif()
+
+# ---------------------------------------------------------------------------
 # Preview1→preview2 reactor adapter (mandatory for FMI wasm FMU export).
 # ---------------------------------------------------------------------------
 set(_wasi_p1_adapter ${CMAKE_BINARY_DIR}/downloads/wasi_snapshot_preview1.reactor.wasm)
@@ -491,6 +514,10 @@ if(RUST_OMC_ENABLE_SUNDIALS)
          "OMC_SUNDIALS_NATIVE_DIR=${RUST_SUNDIALS_NATIVE_DIR}"
          "OMC_SUNDIALS_NATIVE_INDEX_SIZE=${SUNDIALS_INDEX_SIZE}")
   endif()
+endif()
+
+if(TARGET rust_ipopt_native_collect)
+  list(APPEND CARGO_ENV "OMC_IPOPT_NATIVE_DIR=${RUST_IPOPT_NATIVE_DIR}")
 endif()
 
 # Source paths (fallback for raw cargo builds without CMake).
@@ -859,6 +886,9 @@ function(omc_rust_setup_codegen)
     if(TARGET rust_sundials_native_collect)
       add_dependencies(rust_libopenmodelica rust_sundials_native_collect)
     endif()
+  endif()
+  if(TARGET rust_ipopt_native_collect)
+    add_dependencies(rust_libopenmodelica rust_ipopt_native_collect)
   endif()
 
   add_custom_target(rust_omc ALL

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -145,6 +145,7 @@ openmodelica_codegen_graphml/Cargo.toml
 openmodelica_codegen_wasm_jit/Cargo.toml
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
+openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
@@ -245,6 +246,13 @@ openmodelica_sim_meta/src/gbode/tableau_data.rs
 openmodelica_sim_meta/src/lib.rs
 openmodelica_sim_meta/src/linearize.rs
 openmodelica_sim_meta/src/omclog.rs
+openmodelica_sim_meta/src/optimization/eval.rs
+openmodelica_sim_meta/src/extinput.rs
+openmodelica_sim_meta/src/optimization/ipopt.rs
+openmodelica_sim_meta/src/optimization/ipopt_out.rs
+openmodelica_sim_meta/src/optimization/mod.rs
+openmodelica_sim_meta/src/optimization/model.rs
+openmodelica_sim_meta/src/optimization/setup.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs
 openmodelica_sim_meta/src/sync.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -96,6 +96,9 @@ pub(crate) use openmodelica_wasm_jit::model::{
 #[path = "CodegenWasmJit/linearize.rs"]
 pub(crate) mod linearize;
 
+#[path = "CodegenWasmJit/optimization.rs"]
+pub(crate) mod optimization;
+
 /// Iterate a MetaModelica `List` (which is `IntoIterator` by reference, not via
 /// an `.iter()` method).
 pub(crate) fn lst<T: Clone>(l: &Arc<List<T>>) -> impl Iterator<Item = &T> {
@@ -628,6 +631,8 @@ const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     alarm: true,
     // The `.mat` is written here, where a regex engine is available.
     variable_filter: true,
+    // `optimize()`'s solver: the host-driven driver's Ipopt.
+    optimization: openmodelica_sim_meta::optimization::AVAILABLE,
 };
 
 /// The solver values a caller may offer for this build, so a menu built from it
@@ -648,6 +653,8 @@ fn fmu_capabilities() -> simflags::Capabilities {
         // The driver's per-step deadline comes along; a regex engine does not.
         alarm: true,
         variable_filter: false,
+        // An FMU has no notion of an optimization problem.
+        optimization: false,
     }
 }
 
@@ -768,9 +775,9 @@ fn resolve_overrides(
     };
     if let Some(file) = &flags.init_file {
         let t = flags.init_time.unwrap_or(meta.start_time);
-        for (p, v) in import_start_values(model, file, t, &flags.overrides) {
-            push(p, v, &mut params, &mut starts);
-        }
+        let (p, s) = import_start_values(model, file, t, &flags.overrides);
+        params.extend(p);
+        starts.extend(s);
     }
     for (name, val) in &flags.overrides {
         if let Some(p) = model.editable_params.iter().find(|p| &p.name == name) {
@@ -780,35 +787,74 @@ fn resolve_overrides(
     (params, starts)
 }
 
-/// C's `importStartValues`: every quantity the file names, at `t0` (`-iit`, the
-/// start time by default), except the overridden ones. C sets the `start` attribute
-/// of every variable; reachable here are the editable parameters and state start
-/// values.
-fn import_start_values<'a>(
-    model: &'a SimModel,
+/// C's `importStartValues`: the `start` attribute of every quantity the file names,
+/// at `t0` (`-iit`, the start time by default), except the overridden ones
+/// (`isQuantityOverridden`). Returns the parameter and start-slot writes.
+fn import_start_values(
+    model: &SimModel,
     file: &str,
     t0: f64,
     overrides: &[(String, f64)],
-) -> Vec<(&'a EditableParam, f64)> {
+) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
     let mut reader = match openmodelica_script_util::SimulationResults::read_matlab4::MatReader::open(file) {
         Ok(r) => r,
         Err(e) => {
             record_error(format!("wasm-jit: unable to read input-file <{file}> [{e}]"));
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
     };
-    model
-        .editable_params
+    let overridden = |n: &str| overrides.iter().any(|(o, _)| o == n);
+    let mut value = |name: &str| -> Option<f64> {
+        if overridden(name) {
+            return None;
+        }
+        let idx = reader.find_var(name)?;
+        reader.val(idx, t0)
+    };
+    let params = model
+        .import_slots
         .iter()
-        .filter(|p| !overrides.iter().any(|(n, _)| *n == p.name))
-        .filter_map(|p| {
-            let idx = reader.find_var(&p.name)?;
-            Some((p, reader.val(idx, t0)?))
-        })
-        .collect()
+        .filter_map(|(name, off, wty)| value(name).map(|v| (*off, *wty, v)))
+        .collect();
+    let starts = model
+        .real_starts
+        .iter()
+        .filter_map(|(name, off)| value(name).map(|v| (*off, WTy::F64, v)))
+        .collect();
+    (params, starts)
+}
+
+/// The driver's [`sim_driver::ResultFileReader`]: C's `importStartValues` for the
+/// real variables, which the optimizer's `-ipopt_init=file` repeats at every
+/// collocation point. A name the file does not carry keeps the start it has.
+fn read_result_values(
+    file: &str,
+    names: &[&str],
+    t: f64,
+    out: &mut [f64],
+) -> std::result::Result<(), String> {
+    GUESS_READER.with(|c| {
+        let mut c = c.borrow_mut();
+        if c.as_ref().is_none_or(|(f, _)| f != file) {
+            let r = openmodelica_script_util::SimulationResults::read_matlab4::MatReader::open(file)
+                .map_err(|e| format!("unable to read input-file <{file}> [{e}]"))?;
+            *c = Some((file.to_string(), r));
+        }
+        let (_, reader) = c.as_mut().expect("just filled");
+        for (name, slot) in names.iter().zip(out) {
+            if let Some(v) = reader.find_var(name).and_then(|i| reader.val(i, t)) {
+                *slot = v;
+            }
+        }
+        Ok(())
+    })
 }
 
 thread_local! {
+    /// The result file `-ipopt_init=file` reads, opened once for the whole run.
+    static GUESS_READER: std::cell::RefCell<
+        Option<(String, openmodelica_script_util::SimulationResults::read_matlab4::MatReader)>,
+    > = const { std::cell::RefCell::new(None) };
     /// Model stdout captured during initialization, split from the simulation-phase
     /// output so the log stays ordered. `None` until initialization completes.
     static INIT_OUTPUT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
@@ -895,6 +941,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     sim_driver::set_init_done_hook(on_init_done);
     SPLIT_ARMED.with(|a| a.set(true));
     sim_driver::init_host_hooks();
+    sim_driver::set_result_file_reader(read_result_values);
     let (meta, experiment_log) = run_experiment(&model, &flags);
     openmodelica_wasi::wasi::start_stdout_capture();
     let (param_ov, start_ov) = resolve_overrides(&model, &meta, &flags);
@@ -1082,6 +1129,7 @@ mod session {
         sim_driver::set_init_done_hook(on_init_done);
         SPLIT_ARMED.with(|a| a.set(true));
         sim_driver::init_host_hooks();
+        sim_driver::set_result_file_reader(read_result_values);
         let (meta, experiment_log) = run_experiment(&model, &flags);
         check_output_format(&meta).map_err(|e| {
             record_error(e);
@@ -1558,8 +1606,8 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
         let vr: u32 = SimCodeUtil::getFMI3ValueReference(sv.clone(), sim_code.clone())?
             .parse()
             .map_err(|_| "CodegenWasmJit: FMI3 value reference is not a number")?;
-        // A state's start slot: an init-mode set must go to `$START.<x>`, not to
-        // the live slot that `functionInitStartValues` is about to rewrite.
+        // A real variable's start slot: an init-mode set must go to the `start`
+        // attribute, not to the live slot `setAllVarsToStart` is about to rewrite.
         let start_off = map.start_slots.get(&key).copied().unwrap_or(0);
         out.push(FmiVr { vr, off: slot.off, wty: slot.wty, negate: slot.negate, start_off, is_string: false });
     }
@@ -1825,10 +1873,10 @@ fn emit_fmu(
 
 /// The data the equation-function lowering needs to resolve component
 /// references: the cref->slot map and the per-variable start expressions.
-struct SimVarMap {
+pub(crate) struct SimVarMap {
     /// Shared with every [`SimCtx`] rather than copied per generated function, so
     /// filled through `Arc::make_mut` (single owner until emission starts).
-    vars: Arc<HashMap<String, SimSlot>>,
+    pub(crate) vars: Arc<HashMap<String, SimSlot>>,
     starts: Arc<HashMap<String, Option<Arc<DAE::Exp>>>>,
     /// State cref key -> its start-value slot; when present, `$START.<key>` reads the
     /// slot instead of the inline expression. Empty when building
@@ -1843,6 +1891,7 @@ struct SimVarMap {
     /// `SimData` byte offset of the `terminate` flag (see [`SimLayout`]).
     terminate_off: u32,
     terminal_off: u32,
+    initial_off: u32,
     /// `SimData` byte offset of the fired `terminate`'s message + source position.
     term_info_off: u32,
     /// `SimData` byte offset of the nonlinear-solver failure flag (see [`SimLayout`]).
@@ -1883,7 +1932,7 @@ struct SimVarMap {
 
 /// Display name of a model variable's component reference (OMC `.`-separated
 /// form, e.g. `body.r[1]`).
-fn cref_display(cr: &Arc<DAE::ComponentRef>) -> Result<String> {
+pub(crate) fn cref_display(cr: &Arc<DAE::ComponentRef>) -> Result<String> {
     Ok(ComponentReferenceBasics::printComponentRefStr(cr.clone())?.to_string())
 }
 
@@ -1946,17 +1995,24 @@ fn enumeration_names(ty: &DAE::Type) -> Option<Vec<String>> {
 fn result_name(raw: &str) -> Option<String> {
     if let Some(rest) = raw.strip_prefix("$DER.") {
         Some(format!("der({rest})"))
-    } else if raw.starts_with('$') {
+    } else if raw.starts_with('$') && !OPT_RESULT_PREFIXES.iter().any(|p| raw.starts_with(p)) {
         None
     } else {
         Some(raw.to_string())
     }
 }
 
+/// The `$`-prefixed variables C's result file *does* carry: an `optimization`
+/// model's objective terms (`BackendDAE.optimization{Mayer,Lagrange}TermName`) and
+/// its constraint residuals (`DynamicOptimization`'s `$con$` / `$finalCon$` /
+/// `$EqCon$`). The rest of the `$` namespace is the backend's own bookkeeping,
+/// which C hides through `hideResult` and this port drops by name.
+const OPT_RESULT_PREFIXES: [&str; 4] = ["$OMC$object", "$con$", "$finalCon$", "$EqCon$"];
+
 /// Evaluate a constant variable's binding to a scalar, for the `*ConstVars`
 /// lists (which have no SimData slot). Handles the literal forms model constants
 /// actually take (numbers, booleans, enums, and unary minus thereof).
-fn const_value(exp: &Option<Arc<DAE::Exp>>) -> Option<f64> {
+pub(crate) fn const_value(exp: &Option<Arc<DAE::Exp>>) -> Option<f64> {
     fn eval(e: &DAE::Exp) -> Option<f64> {
         use DAE::Exp as E;
         match e {
@@ -2017,6 +2073,8 @@ fn scalarize_sim_vars(vars: &SimCodeVar::SimVars) -> Result<SimCodeVar::SimVars>
     out.derivativeVars = scalarize_var_list(&vars.derivativeVars)?;
     out.algVars = scalarize_var_list(&vars.algVars)?;
     out.discreteAlgVars = scalarize_var_list(&vars.discreteAlgVars)?;
+    out.realOptimizeConstraintsVars = scalarize_var_list(&vars.realOptimizeConstraintsVars)?;
+    out.realOptimizeFinalConstraintsVars = scalarize_var_list(&vars.realOptimizeFinalConstraintsVars)?;
     out.intAlgVars = scalarize_var_list(&vars.intAlgVars)?;
     out.boolAlgVars = scalarize_var_list(&vars.boolAlgVars)?;
     out.inputVars = scalarize_var_list(&vars.inputVars)?;
@@ -2204,7 +2262,7 @@ fn push_sensitivity_vars(
 fn build_var_map(
     vars: &SimCodeVar::SimVars,
     layout: &SimLayout,
-) -> Result<(SimVarMap, Vec<ResultVar>, Vec<EditableParam>)> {
+) -> Result<(SimVarMap, Vec<ResultVar>, Vec<EditableParam>, Vec<(String, u32)>, Vec<(String, u32, WTy)>)> {
     let mut map = SimVarMap {
         vars: Arc::default(),
         starts: Arc::default(),
@@ -2213,6 +2271,7 @@ fn build_var_map(
         array_acc: HashMap::new(),
         terminate_off: layout.terminate_off,
         terminal_off: layout.terminal_off,
+        initial_off: layout.initial_off,
         term_info_off: layout.term_info_off,
         nls_fail_off: layout.nls_fail_off,
         nls_jobs: Arc::new(HashMap::new()),
@@ -2283,14 +2342,16 @@ fn build_var_map(
             Ok(())
         };
 
-    // States | derivatives | real algebraics -> the realVars region (data_2).
-    for (i, sv) in states.iter().enumerate() {
-        let name = cref_display(&sv.name)?;
-        // Every state gets a start slot; value-changeable ones are also editable.
-        let start_off = layout.state_start_off(i as u32);
+    // States | derivatives | real algebraics -> the realVars region (data_2). Each
+    // also owns a `start` attribute slot (C's `realVarsData[i].attribute.start`).
+    let mut real_starts: Vec<(String, u32)> = Vec::new();
+    let mut import_slots: Vec<(String, u32, WTy)> = Vec::new();
+    let mut push_start = |map: &mut SimVarMap, sv: &SimCodeVar::SimVar, i: u32, name: &str| -> Result<()> {
+        let start_off = layout.real_start_off(i);
         Arc::make_mut(&mut map.start_slots).insert(sim_cref_key(&sv.name)?, start_off);
+        real_starts.push((name.to_string(), start_off));
         if sv.isValueChangeable && is_result_output(sv) {
-            if let Some(disp) = result_name(&name) {
+            if let Some(disp) = result_name(name) {
                 start_editable.push(EditableParam {
                     name: disp,
                     comment: sv.comment.to_string(),
@@ -2302,6 +2363,11 @@ fn build_var_map(
                 });
             }
         }
+        Ok(())
+    };
+    for (i, sv) in states.iter().enumerate() {
+        let name = cref_display(&sv.name)?;
+        push_start(&mut map, sv, i as u32, &name)?;
         push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (i as u32) * 8, WTy::F64, false, name)?;
     }
     for (i, sv) in ders.iter().enumerate() {
@@ -2310,12 +2376,13 @@ fn build_var_map(
             Some(s) => format!("der({})", cref_display(&s.name)?),
             None => cref_display(&sv.name)?,
         };
+        push_start(&mut map, sv, layout.n_states + i as u32, &name)?;
         push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (layout.n_states + i as u32) * 8, WTy::F64, false, name)?;
     }
-    let real_algs: Vec<&SimCodeVar::SimVar> =
-        lst(&vars.algVars).chain(lst(&vars.discreteAlgVars)).collect();
+    let real_algs = real_alg_vars(vars);
     for (j, sv) in real_algs.iter().enumerate() {
         let name = cref_display(&sv.name)?;
+        push_start(&mut map, sv, 2 * layout.n_states + j as u32, &name)?;
         push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (2 * layout.n_states + j as u32) * 8, WTy::F64, false, name)?;
     }
 
@@ -2327,26 +2394,33 @@ fn build_var_map(
         let off = layout.rparam_off + (k as u32) * 8;
         push_primary(&mut map, &mut result_vars, sv, off, WTy::F64, false, name.clone())?;
         push_editable(sv, &name, off, WTy::F64);
+        import_slots.push((name, off, WTy::F64));
     }
     for (i, sv) in lst(&vars.intAlgVars).enumerate() {
         let name = cref_display(&sv.name)?;
-        push_primary(&mut map, &mut result_vars, sv, layout.int_off + (i as u32) * 4, WTy::I32, false, name)?;
+        let off = layout.int_off + (i as u32) * 4;
+        push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
+        import_slots.push((name, off, WTy::I32));
     }
     for (k, sv) in lst(&vars.intParamVars).enumerate() {
         let name = cref_display(&sv.name)?;
         let off = layout.iparam_off + (k as u32) * 4;
         push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
         push_editable(sv, &name, off, WTy::I32);
+        import_slots.push((name, off, WTy::I32));
     }
     for (i, sv) in lst(&vars.boolAlgVars).enumerate() {
         let name = cref_display(&sv.name)?;
-        push_primary(&mut map, &mut result_vars, sv, layout.bool_off + (i as u32) * 4, WTy::I32, false, name)?;
+        let off = layout.bool_off + (i as u32) * 4;
+        push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
+        import_slots.push((name, off, WTy::I32));
     }
     for (k, sv) in lst(&vars.boolParamVars).enumerate() {
         let name = cref_display(&sv.name)?;
         let off = layout.bparam_off + (k as u32) * 4;
         push_primary(&mut map, &mut result_vars, sv, off, WTy::I32, false, name.clone())?;
         push_editable(sv, &name, off, WTy::I32);
+        import_slots.push((name, off, WTy::I32));
     }
     for (i, sv) in lst(&vars.stringAlgVars).enumerate() {
         insert_var(&mut map, sv, layout.str_off + (i as u32) * 4, WTy::I32, true)?;
@@ -2444,7 +2518,7 @@ fn build_var_map(
 
     finalize_array_groups(&mut map)?;
     editable.extend(start_editable);
-    Ok((map, result_vars, editable))
+    Ok((map, result_vars, editable, real_starts, import_slots))
 }
 
 /// Register one variable's slot (by canonical cref key) and its start value. If
@@ -2795,7 +2869,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
 
     let n_states = count(&vars.stateVars) as u32;
-    let n_real_alg = (count(&vars.algVars) + count(&vars.discreteAlgVars)) as u32;
+    let n_real_alg = real_alg_vars(vars).len() as u32;
     let n_real_param = count(&vars.paramVars) as u32;
     let samples = collect_samples(&sim_code.timeEvents)?;
     let zero_crossings = collect_zero_crossings(&sim_code.zeroCrossings)?;
@@ -2828,9 +2902,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         }
         _ => false,
     });
-    // The backend only emits a lambda-0 initial system when the model uses
-    // `homotopy()`; its presence is the signal to wire up the continuation.
-    let has_homotopy = (&*sim_code.initialEquations_lambda0).into_iter().next().is_some();
+    let has_homotopy = nls_homotopy_support(sim_code);
     // `--calculateSensitivities`: `sensitivityVars` is the `Ns` differentiated
     // parameters followed by the `Ns * nStates` `$Sensitivities.<par>.<state>`
     // signals (C's `rSen` init-XML category, split by `numSensitivityParameters`).
@@ -2840,7 +2912,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let clocks = collect_clocks(&sim_code.clockedPartitions)?;
     let n_sub_clocks: u32 = clocks.iter().map(|c| c.meta.sub.len() as u32).sum();
     // `-l`: the symbolic A/B/C/D and the scratch their column equations need.
-    let linz = build_linz_plan(sim_code, vars, n_states)?;
+    let mut linz = build_linz_plan(sim_code, vars, n_states)?;
     let layout = SimLayout::new(
         n_states,
         n_real_alg,
@@ -2865,11 +2937,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         clocks.len() as u32,
         n_sub_clocks,
         linz.n_scratch_f64(),
+        // The optimizer's attribute arrays: one entry per real variable, only for a
+        // model that carries an optimization problem.
+        if optimization::is_optimization(sim_code) { 2 * n_states + n_real_alg } else { 0 },
         has_when,
         has_homotopy,
     );
 
-    let (mut var_map, mut result_vars, editable_params) = build_var_map(vars, &layout)?;
+    let (mut var_map, mut result_vars, editable_params, real_starts, import_slots) =
+        build_var_map(vars, &layout)?;
     // DAE-mode residual/auxiliary variables: their own `SimData` regions, indexed by
     // the SimVar's `index` as C's `crefToCStr` does. Solver workspace, not results.
     for (svs, base) in [(&dae_res_vars, layout.dae_res_off), (&dae_aux_vars, layout.dae_aux_off)] {
@@ -3194,9 +3270,21 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
     splits.push(build_split_fn("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
     // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
-    let real_algs: Vec<&SimCodeVar::SimVar> =
-        lst(&vars.algVars).chain(lst(&vars.discreteAlgVars)).collect();
-    bodies.push(build_init_start_values_fn(&states, &real_algs, &layout, &var_map, &by_name, &mut literals)?);
+    let all_reals: Vec<&SimCodeVar::SimVar> = states
+        .iter()
+        .copied()
+        .chain(lst(&vars.derivativeVars))
+        .chain(real_alg_vars(vars))
+        .collect();
+    bodies.push(build_init_start_values_fn(&all_reals, &layout, &var_map, &by_name, &mut literals)?);
+    // A start bound to a parameter arrives as a `$START.<var>` equation instead of
+    // an expression on the variable; `functionUpdateBoundVariableAttributes` runs
+    // it after the pass above and overwrites the slot, as C's does.
+    for (i, sv) in all_reals.iter().enumerate() {
+        if let Ok(k) = sim_cref_key(&sv.name) {
+            attr_targets.entry(k).or_default().start_offs.push(layout.real_start_off(i as u32));
+        }
+    }
     // The integrator loop calls `functionCheckAsserts`, whose index is only known
     // once the nonlinear systems below have taken theirs; keep its fixed slot
     // (`simulate_idx`) and fill it in there.
@@ -3254,11 +3342,65 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             })
         })
         .transpose()?;
+    // Lowering the columns is what decides which matrices survive; everything below
+    // reads `linz.jacs` after this.
+    let (linz_jac_fns, opt_jac_fns) = build_jac_fns(
+        &mut linz, &linz_jac_infos, optimization::is_optimization(sim_code), &layout, &var_map,
+        &eq_index, &by_name, &mut literals,
+    )?;
+    // `method="optimization"`: B, C and D with the slots the optimizer seeds and
+    // reads, plus the problem's own metadata.
+    let opt_info = {
+        let jacs: [Option<openmodelica_sim_meta::OptJac>; 3] = core::array::from_fn(|i| {
+            let k = i + 1; // B, C, D
+            let (jm, info) = (linz.jacs[k].as_ref()?, linz_jac_infos.get(k)?.as_ref()?);
+            Some(optimization::opt_jac(
+                jm,
+                linz.real_rows[k],
+                linz.real_cols[k],
+                &info.seed_offs,
+                &info.result_offs,
+                OPT_JAC_FNS[2 * i + 1],
+                match lst(&jm.columns).next().is_some_and(|c| lst(&c.constantEqns).next().is_some()) {
+                    true => OPT_JAC_FNS[2 * i],
+                    false => "",
+                },
+            ))
+        });
+        let reals: Vec<&SimCodeVar::SimVar> = states
+            .iter()
+            .copied()
+            .chain(lst(&vars.derivativeVars))
+            .chain(real_alg_vars(vars))
+            .collect();
+        optimization::build_opt_info(sim_code, vars, &reals, jacs, &var_map)?
+    };
+    // C's `inputNames` / `nInputVars`. A real input takes the file's value through
+    // its `start` attribute; another type has none here, so it takes it in its own
+    // slot, where C's `input_function` puts it. No slot ⇒ no column to receive.
+    let mut input_vars: Vec<openmodelica_sim_meta::InputVar> = Vec::new();
+    for sv in lst(&vars.inputVars) {
+        let key = sim_cref_key(&sv.name)?;
+        let name = cref_display(&sv.name)?;
+        match all_reals.iter().position(|r| sim_cref_key(&r.name).ok().as_deref() == Some(key.as_str())) {
+            Some(i) => input_vars.push(openmodelica_sim_meta::InputVar {
+                off: layout.real_start_off(i as u32),
+                wty: WTy::F64,
+                name,
+            }),
+            None => {
+                if let Some(slot) = var_map.vars.get(&key) {
+                    input_vars.push(openmodelica_sim_meta::InputVar { off: slot.off, wty: slot.wty, name });
+                }
+            }
+        }
+    }
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars, dae,
         clocks.iter().map(|c| c.meta.clone()).collect(),
         build_lin_info(&linz, vars, &var_map)?,
+        opt_info, input_vars,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -3431,12 +3573,30 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
         idx
     };
+    // The optimizer's per-real-variable attributes (C reads them out of the
+    // `_init.xml`): constants here, parameter-dependent ones through `attr_targets`.
+    let opt_attrs = match layout.n_opt_attr {
+        0 => optimization::AttrDefaults { reals: Vec::new(), ints: Vec::new() },
+        _ => {
+            let reals: Vec<&SimCodeVar::SimVar> = states
+                .iter()
+                .copied()
+                .chain(lst(&vars.derivativeVars))
+                .chain(real_alg_vars(vars))
+                .collect();
+            optimization::attr_defaults(&reals, &layout, &mut attr_targets)
+        }
+    };
     let update_bound_attrs_idx = {
         let idx = import_base + bodies.len() as u32;
-        let defaults: Vec<(u32, f64)> =
-            nominal_defaults.iter().chain(max_defaults.iter()).copied().collect();
+        let defaults: Vec<(u32, f64)> = nominal_defaults
+            .iter()
+            .chain(max_defaults.iter())
+            .chain(opt_attrs.reals.iter())
+            .copied()
+            .collect();
         bodies.push(build_update_bound_attrs_fn(
-            sim_code, &defaults, &attr_targets, &var_map, &by_name, &mut literals,
+            sim_code, &defaults, &opt_attrs.ints, &attr_targets, &var_map, &by_name, &mut literals,
         )?);
         idx
     };
@@ -3444,16 +3604,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // merge resolves regardless of the model.
     let linz_jac_idx = {
         let base = import_base + bodies.len() as u32;
-        let mut out_off = layout.linz_off;
-        for k in 0..4 {
-            bodies.push(match linz_jac_infos.get(k).and_then(Option::as_ref) {
-                Some(info) => build_linz_jac_fn(
-                    &linz, info, k, out_off, &var_map, &eq_index, &by_name, &mut literals,
-                )?,
-                None => empty_eqfn(),
-            });
-            out_off += linz.rows[k] * linz.cols[k] * 8;
-        }
+        bodies.extend(linz_jac_fns);
+        base
+    };
+    let opt_jac_idx = {
+        let base = import_base + bodies.len() as u32;
+        bodies.extend(opt_jac_fns);
         base
     };
     // Synchronous features: emitted only for a model with clocked partitions, so a
@@ -3529,6 +3685,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
     for _ in 0..4 {
         functions.function(eqfn_type); // linearJacA..linearJacD: (i32) -> ()
+    }
+    for _ in 0..OPT_JAC_FNS.len() {
+        functions.function(eqfn_type); // optJac{B,C,D}{_const,}: (i32) -> ()
     }
     if let Some(ti) = sync_fn_type {
         functions.function(eqfn_type); // functionInitSynchronous: (i32) -> ()
@@ -3636,6 +3795,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     for (k, name) in ["linearJacA", "linearJacB", "linearJacC", "linearJacD"].iter().enumerate() {
         exports.export(name, we::ExportKind::Func, linz_jac_idx + k as u32);
     }
+    for (k, name) in OPT_JAC_FNS.iter().enumerate() {
+        exports.export(*name, we::ExportKind::Func, opt_jac_idx + k as u32);
+    }
     if let Some((init, update, eqs)) = sync_idx {
         exports.export("functionInitSynchronous", we::ExportKind::Func, init);
         exports.export("functionUpdateSynchronous", we::ExportKind::Func, update);
@@ -3687,6 +3849,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         ("linearJacB", linz_jac_idx + 1),
         ("linearJacC", linz_jac_idx + 2),
         ("linearJacD", linz_jac_idx + 3),
+        (OPT_JAC_FNS[0], opt_jac_idx),
+        (OPT_JAC_FNS[1], opt_jac_idx + 1),
+        (OPT_JAC_FNS[2], opt_jac_idx + 2),
+        (OPT_JAC_FNS[3], opt_jac_idx + 3),
+        (OPT_JAC_FNS[4], opt_jac_idx + 4),
+        (OPT_JAC_FNS[5], opt_jac_idx + 5),
     ] {
         names.push((idx, name.to_string()));
     }
@@ -3792,6 +3960,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         state_sets,
         jac_a,
         editable_params,
+        real_starts,
+        import_slots,
         var_units,
         meta,
         sparse_solver_log: build_sparse_lss_log(sim_code),
@@ -3906,6 +4076,21 @@ fn collect_nls_systems(sim_code: &SimCode::SimCode) -> Vec<(i32, i32, u32, u32)>
     scan(flatten_eqs_ll(&sim_code.algebraicEquations));
     systems.sort_by_key(|&(idx, _, _, _)| idx);
     systems
+}
+
+/// C's `homotopySupport` loop over `nonlinearSystemData`: whether a nonlinear
+/// system carries the operator, not whether the model uses `homotopy()` at all.
+fn nls_homotopy_support(sim_code: &SimCode::SimCode) -> bool {
+    let has = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
+        eqs.iter().any(|e| match &**e {
+            SimCode::SimEqSystem::SES_NONLINEAR { nlSystem, .. } => nlSystem.homotopySupport,
+            _ => false,
+        })
+    };
+    has(flatten_eqs(&sim_code.parameterEquations))
+        || has(flatten_eqs(&sim_code.initialEquations))
+        || has(flatten_eqs_ll(&sim_code.odeEquations))
+        || has(flatten_eqs_ll(&sim_code.algebraicEquations))
 }
 
 /// C's `LOG_STDOUT` "… changed to …" lines, ahead of everything the run prints.
@@ -4204,6 +4389,8 @@ fn build_sim_meta(
     dae: Option<openmodelica_sim_meta::DaeInfo>,
     clocks: Vec<BaseClockMeta>,
     lin: Option<openmodelica_sim_meta::LinInfo>,
+    opt: Option<openmodelica_sim_meta::OptInfo>,
+    inputs: Vec<openmodelica_sim_meta::InputVar>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -4225,6 +4412,8 @@ fn build_sim_meta(
         dae,
         clocks,
         lin,
+        opt,
+        inputs,
     }
 }
 
@@ -4348,6 +4537,7 @@ fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         terminal_off: var_map.terminal_off,
+        initial_off: var_map.initial_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),
@@ -4752,14 +4942,14 @@ fn build_equations_synchronous_fn(
     Ok(func)
 }
 
-/// Build `functionInitStartValues(SimData*)`: seed each state's `$START` slot and
-/// each real algebraic's live slot from its `start` expression (C's
-/// `setAllVarsToStart`, initialization.c:809), so an NLS iteration variable's
-/// Newton guess is its start value. Called after `functionParameters` and before
-/// the initial equations. Empty `start_slots` so start expressions compile inline.
+/// Build `functionInitStartValues(SimData*)`: every real variable's `start`
+/// attribute slot from its start expression, in real-variable index order — C's
+/// `_init.xml` values plus the `updateBoundVariableAttributes` ones in one pass.
+/// The driver copies the slots over the live region afterwards (C's
+/// `setAllVarsToStart`), so `-iif`/`-override` land in between.
+/// Empty `start_slots` so start expressions compile inline.
 fn build_init_start_values_fn(
-    states: &[&SimCodeVar::SimVar],
-    real_algs: &[&SimCodeVar::SimVar],
+    reals: &[&SimCodeVar::SimVar],
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
@@ -4767,13 +4957,11 @@ fn build_init_start_values_fn(
 ) -> Result<we::Function> {
     let sim = SimCtx { start_slots: Arc::default(), ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    let mut pairs: Vec<(Option<Arc<DAE::Exp>>, u32, Option<u32>)> = Vec::with_capacity(states.len() + real_algs.len());
-    for (i, sv) in states.iter().enumerate() {
-        pairs.push((sv.initialValue.clone(), layout.state_start_off(i as u32), Some(REAL_OFF + (i as u32) * 8)));
-    }
-    for (j, sv) in real_algs.iter().enumerate() {
-        pairs.push((sv.initialValue.clone(), REAL_OFF + (2 * layout.n_states + j as u32) * 8, None));
-    }
+    let pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = reals
+        .iter()
+        .enumerate()
+        .map(|(i, sv)| (sv.initialValue.clone(), layout.real_start_off(i as u32)))
+        .collect();
     ctx.emit_init_start_values(&pairs)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
@@ -4790,6 +4978,7 @@ fn build_init_start_values_fn(
 fn build_update_bound_attrs_fn(
     sim_code: &SimCode::SimCode,
     defaults: &[(u32, f64)],
+    int_defaults: &[(u32, i32)],
     attr_targets: &HashMap<String, AttrTargets>,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
@@ -4800,14 +4989,24 @@ fn build_update_bound_attrs_fn(
         (Attr::Min, &sim_code.minValueEquations),
         (Attr::Max, &sim_code.maxValueEquations),
         (Attr::Nominal, &sim_code.nominalValueEquations),
+        (Attr::Start, &sim_code.startValueEquations),
     ] {
         for eq in lst(eqs) {
             let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { continue };
-            let Some(t) = sim_cref_key(cref).ok().and_then(|k| attr_targets.get(&k)) else { continue };
+            // A start-value equation assigns `$START.<var>` (C writes it into the
+            // variable's `start` attribute); the others name the variable itself.
+            let Some(t) = sim_cref_key(cref)
+                .ok()
+                .map(|k| k.strip_prefix("$START.").unwrap_or(&k).to_string())
+                .and_then(|k| attr_targets.get(&k))
+            else {
+                continue;
+            };
             let wanted = match attr {
-                Attr::Nominal => !t.nom_offs.is_empty(),
-                Attr::Max => !t.max_offs.is_empty(),
-                Attr::Min => false,
+                Attr::Nominal => !t.nom_offs.is_empty() || !t.opt_nom_offs.is_empty(),
+                Attr::Max => !t.max_offs.is_empty() || !t.opt_max_offs.is_empty(),
+                Attr::Min => !t.opt_min_offs.is_empty(),
+                Attr::Start => !t.start_offs.is_empty(),
             };
             if t.nls.is_empty() && !wanted {
                 continue;
@@ -4817,7 +5016,7 @@ fn build_update_bound_attrs_fn(
     }
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    ctx.emit_update_bound_attrs(defaults, &attrs)?;
+    ctx.emit_update_bound_attrs(defaults, int_defaults, &attrs)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -5352,6 +5551,26 @@ fn collect_nls_jobs(
     (systems, jobs, hist_off, nominals, bounds, patterns)
 }
 
+/// The optimizer's Jacobian entry points, in emission order: for B, C and D the
+/// seed-independent equations and then one column. Matched by
+/// `OptJac::{const_fn, column_fn}`.
+pub(crate) const OPT_JAC_FNS: [&str; 6] = [
+    "optJacB_const", "optJacB", "optJacC_const", "optJacC", "optJacD_const", "optJacD",
+];
+
+/// The real variables after the states and their derivatives, in C's
+/// `realVars` order: the algebraics, then the discrete ones, then an
+/// `optimization` model's path and final constraint variables (C's
+/// `nVariablesReal` counts those last, which is what the optimizer's
+/// `index_con = nReal - (nc + ncf)` relies on).
+fn real_alg_vars(vars: &SimCodeVar::SimVars) -> Vec<&SimCodeVar::SimVar> {
+    lst(&vars.algVars)
+        .chain(lst(&vars.discreteAlgVars))
+        .chain(lst(&vars.realOptimizeConstraintsVars))
+        .chain(lst(&vars.realOptimizeFinalConstraintsVars))
+        .collect()
+}
+
 /// Map each scalar real variable's cref key to its `(nominal, min, max)` attributes,
 /// defaulting to `(1.0, -inf, +inf)` where unset or non-constant.
 fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f64, f64)> {
@@ -5405,40 +5624,191 @@ pub(crate) fn jac_column_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::S
             }
         }
     };
-    for sv in lst(&jm.columns).next().into_iter().flat_map(|c| lst(&c.columnVars)) {
-        push(sv);
-    }
-    if let Some((_, (_, _, entries), _, _)) = &jm.crefsHT {
-        for e in entries.borrow().iter().flatten() {
-            push(&e.1);
-        }
+    for sv in jac_listed_vars(jm) {
+        push(&sv);
     }
     out
 }
 
-/// Whether a symbolic Jacobian can be lowered at all: every seed / column
-/// variable resolves to a scratch slot, and every column equation is a scalar
-/// assignment whose crefs do too. An array-valued Jacobian (whole-dimension seeds,
-/// sliced results) needs the run-time loops the C template emits, so such a system
-/// keeps the numerical Jacobian instead.
-pub(crate) fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
-    use SimCode::SimEqSystem as E;
-    let Some(col) = lst(&jm.columns).next() else { return false };
-    if lst(&jm.seedVars).any(|sv| sim_cref_key(&sv.name).is_err()) {
-        return false;
-    }
-    if lst(&col.columnVars).any(|sv| sim_cref_key(&sv.name).is_err()) {
-        return false;
-    }
-    lst(&col.constantEqns).chain(lst(&col.columnEqns)).all(|eq| {
-        let E::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { return false };
-        sim_cref_key(cref).is_ok()
-            && openmodelica_frontend_base::Expression::extractCrefsFromExp(exp.clone())
-                .is_ok_and(|crs| lst(&crs).all(|c| sim_cref_key(c).is_ok()))
-    })
+/// Every variable a Jacobian matrix lists, nothing dropped — what
+/// [`jac_column_vars`] filters. One it cannot name (an array slice) gets no slot,
+/// so [`jac_lowerable`] has to see it.
+fn jac_listed_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
+    let columns = lst(&jm.columns).next().into_iter().flat_map(|c| lst(&c.columnVars).cloned());
+    let ht = jm
+        .crefsHT
+        .iter()
+        .flat_map(|(_, (_, _, entries), _, _)| {
+            entries.borrow().iter().flatten().map(|e| e.1.clone()).collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    columns.chain(ht).collect()
 }
 
-/// The residual rows of the Jacobian's `JAC_VAR` result variables, in/// The residual rows of the Jacobian's `JAC_VAR` result variables, in
+/// The Jacobian variables with a scratch slot each, and the array bases those slots
+/// scalarize from (`u.$pDER.dummyVar` for `u.$pDER.dummyVar[1]`, `[2]`).
+struct JacSlots {
+    keys: HashSet<String>,
+    bases: HashSet<String>,
+}
+
+impl JacSlots {
+    fn of(jm: &SimCode::JacobianMatrix) -> JacSlots {
+        let mut out = JacSlots { keys: HashSet::new(), bases: HashSet::new() };
+        for sv in lst(&jm.seedVars).chain(jac_column_vars(jm).iter()) {
+            if let Ok(key) = sim_cref_key(&sv.name) {
+                out.keys.insert(key);
+            }
+            if let Ok(Some((base, _))) = array_element_of(&sv.name) {
+                out.bases.insert(base);
+            }
+        }
+        out
+    }
+
+    /// Whether the emitter can name `cr`. A Jacobian variable has to *be* one of the
+    /// slots: the whole array whose elements hold them has none of its own (no
+    /// scratch array group exists), nor has an element behind a loop index.
+    /// Anything else is a model variable, which lowering resolves by itself.
+    fn resolvable(&self, cr: &Arc<DAE::ComponentRef>) -> bool {
+        match sim_cref_key(cr) {
+            Ok(key) => self.keys.contains(&key) || !self.bases.contains(&key),
+            Err(_) => !cref_base_name(cr).is_some_and(|b| self.bases.contains(&b)),
+        }
+    }
+}
+
+/// A cref's name with its final subscripts dropped, spelled as [`array_element_of`]
+/// spells an element's base.
+fn cref_base_name(cr: &Arc<DAE::ComponentRef>) -> Option<String> {
+    use DAE::ComponentRef as C;
+    let mut base = String::new();
+    let mut node: &Arc<DAE::ComponentRef> = cr;
+    loop {
+        match &**node {
+            C::CREF_IDENT { ident, .. } => {
+                base.push_str(ident);
+                return Some(base);
+            }
+            C::CREF_QUAL { ident, subscriptLst, componentRef, .. } => {
+                base.push_str(ident);
+                if !crate::CodegenWasmJitFunctions::push_qual_subs(subscriptLst, &mut base) {
+                    return None;
+                }
+                base.push('.');
+                node = componentRef;
+            }
+            _ => return None,
+        }
+    }
+}
+
+/// Whether a symbolic Jacobian can be lowered at all: every seed / column variable
+/// resolves to a scratch slot, and every column equation is one [`lower_equation`]
+/// handles and names nothing but those slots. An array-valued Jacobian needs the
+/// run-time loops the C template emits, so it keeps the numerical Jacobian instead.
+pub(crate) fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
+    let Some(col) = lst(&jm.columns).next() else { return false };
+    let listed = jac_listed_vars(jm);
+    if lst(&jm.seedVars).chain(listed.iter()).any(|sv| sim_cref_key(&sv.name).is_err()) {
+        return false;
+    }
+    let slots = JacSlots::of(jm);
+    lst(&col.constantEqns).chain(lst(&col.columnEqns)).all(|eq| jac_eq_lowerable(eq, &slots))
+}
+
+/// One column equation of a symbolic Jacobian, against what [`lower_equation`]
+/// accepts: a differentiated algebraic loop is a `SES_LINEAR`, a differentiated
+/// external or table call a `SES_ALGORITHM`.
+fn jac_eq_lowerable(eq: &SimCode::SimEqSystem, slots: &JacSlots) -> bool {
+    use SimCode::SimEqSystem as E;
+    match eq {
+        // `lower_linear_system` needs either a usable `simJac` or the residuals of a
+        // torn system; the inner equations run through `lower_equation` too.
+        E::SES_LINEAR { lSystem, .. } => {
+            let torn = lst(&lSystem.residual).any(|e| matches!(&**e, E::SES_RESIDUAL { .. }));
+            let sim_jac = lst(&lSystem.simJac).next().is_some()
+                && lst(&lSystem.simJac).all(|(_, _, e)| matches!(&**e, E::SES_RESIDUAL { .. }))
+                && count(&lSystem.beqs) == count(&lSystem.vars);
+            (torn || sim_jac)
+                && lst(&lSystem.residual).all(|e| jac_eq_lowerable(e, slots))
+                && lst(&lSystem.simJac).all(|(_, _, e)| jac_eq_lowerable(e, slots))
+                && lst(&lSystem.beqs).all(|e| exp_crefs_resolvable(e, slots))
+        }
+        // The aliased equation is a model equation, which lowering handles anyway.
+        E::SES_ALIAS { .. } => true,
+        _ => jac_eq_crefs(eq).is_some_and(|crs| crs.iter().all(|c| slots.resolvable(c))),
+    }
+}
+
+/// Every cref a Jacobian column equation names, `None` for a kind
+/// [`lower_equation`] does not handle at all.
+fn jac_eq_crefs(eq: &SimCode::SimEqSystem) -> Option<Vec<Arc<DAE::ComponentRef>>> {
+    use SimCode::SimEqSystem as E;
+    use openmodelica_backend_types::BackendDAE::WhenOperator as W;
+    let mut out = Vec::new();
+    let exp = |e: &Arc<DAE::Exp>, out: &mut Vec<_>| -> bool {
+        match openmodelica_frontend_base::Expression::extractCrefsFromExp(e.clone()) {
+            Ok(crs) => {
+                out.extend(lst(&crs).cloned());
+                true
+            }
+            Err(_) => false,
+        }
+    };
+    match eq {
+        E::SES_SIMPLE_ASSIGN { cref, exp: rhs, .. } => {
+            out.push(cref.clone());
+            exp(rhs, &mut out).then_some(out)
+        }
+        E::SES_ARRAY_CALL_ASSIGN { lhs, exp: rhs, .. } => {
+            (exp(lhs, &mut out) && exp(rhs, &mut out)).then_some(out)
+        }
+        E::SES_RESIDUAL { exp: e, .. } => exp(e, &mut out).then_some(out),
+        // `traverseDAEEquationsStmts` visits a statement's left-hand side too.
+        E::SES_ALGORITHM { statements, .. } => {
+            let alg = Arc::new(DAE::Algorithm { statementLst: statements.clone() });
+            let exps = openmodelica_frontend_base::Algorithm::getAllExps(alg).ok()?;
+            lst(&exps).all(|e| exp(e, &mut out)).then_some(out)
+        }
+        E::SES_WHEN { conditions, whenStmtLst, elseWhen, .. } => {
+            out.extend(lst(conditions).cloned());
+            for op in lst(whenStmtLst) {
+                let ok = match op {
+                    W::ASSIGN { left, right, .. } => exp(left, &mut out) && exp(right, &mut out),
+                    W::REINIT { stateVar, value, .. } => {
+                        out.push(stateVar.clone());
+                        exp(value, &mut out)
+                    }
+                    W::ASSERT { condition, message, .. } => {
+                        exp(condition, &mut out) && exp(message, &mut out)
+                    }
+                    W::TERMINATE { message, .. } => exp(message, &mut out),
+                    W::NORETCALL { exp: e, .. } => exp(e, &mut out),
+                };
+                if !ok {
+                    return None;
+                }
+            }
+            match elseWhen {
+                Some(ew) => {
+                    out.extend(jac_eq_crefs(ew)?);
+                    Some(out)
+                }
+                None => Some(out),
+            }
+        }
+        _ => None,
+    }
+}
+
+/// [`JacSlots::resolvable`] for every cref of an expression.
+fn exp_crefs_resolvable(e: &Arc<DAE::Exp>, slots: &JacSlots) -> bool {
+    openmodelica_frontend_base::Expression::extractCrefsFromExp(e.clone())
+        .is_ok_and(|crs| lst(&crs).all(|c| slots.resolvable(c)))
+}
+
+/// The residual rows of the Jacobian's `JAC_VAR` result variables, in
 /// [`jac_column_vars`] order, iff they form a valid permutation of `0..n` (so the
 /// Jacobian rows can be placed unambiguously); otherwise `None`.
 fn nls_jac_result_rows(jm: &SimCode::JacobianMatrix, n: usize) -> Option<Vec<usize>> {
@@ -5601,23 +5971,44 @@ pub(crate) struct LinzPlan {
     rows: [u32; 4],
     cols: [u32; 4],
     jacs: [Option<Arc<SimCode::JacobianMatrix>>; 4],
+    /// The shape each matrix really has (`symbolic_jacobians`), which differs from
+    /// `rows`/`cols` when `DynamicOptimization` reshaped it for an `optimization`
+    /// model. The slots and the results follow these.
+    real_rows: [u32; 4],
+    real_cols: [u32; 4],
 }
 
 impl LinzPlan {
-    /// C's `initialAnalyticJacobian<X>` availability, as [`LinInfo::sym_mask`].
+    /// C's `initialAnalyticJacobian<X>` availability, as [`LinInfo::sym_mask`]: a
+    /// matrix is the linearization's only if it fits the shape `-l` expects — one
+    /// column per seed, and no more rows than the output region (a row the backend
+    /// left out is structurally zero, which `emit_linz_jac_body` stores). An
+    /// `optimization` model's reshaped B/C/D are lowered for the optimizer but left
+    /// off the linearization's difference-quotient fallback.
     fn sym_mask(&self) -> u8 {
-        (0..4).filter(|&k| self.jacs[k].is_some()).fold(0u8, |m, k| m | 1 << k)
+        (0..4)
+            .filter(|&k| {
+                self.jacs[k].is_some()
+                    && self.real_rows[k] <= self.rows[k]
+                    && self.real_cols[k] == self.cols[k]
+            })
+            .fold(0u8, |m, k| m | 1 << k)
     }
 
-    /// f64 slots the matrices occupy at the head of the region — all four, so an
-    /// offset does not move with availability.
+    /// Whether matrix `k` fills the linearization's output region.
+    fn lin_ok(&self, k: usize) -> bool {
+        self.sym_mask() & (1 << k) != 0
+    }
+
+    /// f64 slots the matrices occupy at the head of the region — all four at the
+    /// linearization's shape, so an offset does not move with availability.
     fn n_matrix_f64(&self) -> u32 {
         (0..4).map(|k| self.rows[k] * self.cols[k]).sum()
     }
 
     /// Those plus every seed / column variable the available columns assign.
     fn n_scratch_f64(&self) -> u32 {
-        if self.sym_mask() == 0 {
+        if self.jacs.iter().all(Option::is_none) {
             return 0;
         }
         self.n_matrix_f64()
@@ -5642,8 +6033,11 @@ fn build_linz_plan(
     let frames = linearize::build_frames(vars, n_states, n_in, n_out, n_alg, &prefix)?;
     let rows = [n_states, n_states, n_out, n_out];
     let cols = [n_states, n_in, n_states, n_in];
-    let jacs = linearize::symbolic_jacobians(sim_code, rows, cols);
-    Ok(LinzPlan { frames, rows, cols, jacs })
+    let found = linearize::symbolic_jacobians(sim_code);
+    let jacs = core::array::from_fn(|k| found[k].as_ref().map(|(jm, _, _)| jm.clone()));
+    let real_rows = core::array::from_fn(|k| found[k].as_ref().map_or(0, |&(_, r, _)| r));
+    let real_cols = core::array::from_fn(|k| found[k].as_ref().map_or(0, |&(_, _, c)| c));
+    Ok(LinzPlan { frames, rows, cols, jacs, real_rows, real_cols })
 }
 
 /// C's `modelNamePrefix`, which the frames quote as the model's description.
@@ -5666,7 +6060,10 @@ fn build_linz_jac_infos(
             infos.push(None);
             continue;
         };
-        let (rows, cols) = (plan.rows[k] as usize, plan.cols[k] as usize);
+        // `emit_linz_jac_body` stores a slot or a structural zero for every row of
+        // the output region, so cover both shapes.
+        let rows = plan.real_rows[k].max(plan.rows[k]) as usize;
+        let cols = plan.real_cols[k] as usize;
         let mut listed = Vec::new();
         for sv in lst(&jm.seedVars) {
             Arc::make_mut(&mut var_map.vars)
@@ -5734,6 +6131,68 @@ fn build_lin_info(
         jac_rows: plan.rows,
         jac_cols: plan.cols,
     }))
+}
+
+/// A Jacobian the emitter cannot lower is not an error, so its attempt reports here.
+const JAC_CHECKPOINT: ArcStr = arcstr::literal!("wasm-jit symbolic Jacobian");
+
+/// Lower the symbolic Jacobians' columns: `linearJac<X>` for `-l`, and for an
+/// `optimization` model the `optJac<X>{_const,}` pair the optimizer drives one
+/// colour at a time. A matrix that does not lower is dropped from the plan, so
+/// `sym_mask` reports it unavailable and the run differentiates numerically —
+/// availability is what the emitter can lower, not a prediction of it.
+#[allow(clippy::too_many_arguments)]
+fn build_jac_fns(
+    plan: &mut LinzPlan,
+    infos: &[Option<LinzJacInfo>],
+    is_optimization: bool,
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<(Vec<we::Function>, Vec<we::Function>)> {
+    let (mut linz_fns, mut opt_fns) = (Vec::new(), Vec::new());
+    let mut out_off = layout.linz_off;
+    for k in 0..4 {
+        let mut built = None;
+        if let (Some(jm), Some(info)) = (plan.jacs[k].clone(), infos.get(k).and_then(Option::as_ref)) {
+            openmodelica_error::ErrorExt::setCheckpoint(JAC_CHECKPOINT);
+            let attempt = (|| -> Result<(we::Function, [we::Function; 2])> {
+                // A reshaped matrix has no linearization output region to fill.
+                let lin = match plan.lin_ok(k) {
+                    true => build_linz_jac_fn(plan, info, k, out_off, var_map, eq_index, by_name, literals)?,
+                    false => empty_eqfn(),
+                };
+                // The optimizer never reads A, and no other run reads these at all.
+                if !is_optimization || k == 0 {
+                    return Ok((lin, [empty_eqfn(), empty_eqfn()]));
+                }
+                let (constant, column) = optimization::jac_eqns(&jm);
+                Ok((lin, [
+                    build_eq_fn_single(&eq_units(&constant), var_map, eq_index, by_name, literals)?,
+                    build_eq_fn_single(&eq_units(&column), var_map, eq_index, by_name, literals)?,
+                ]))
+            })();
+            match attempt {
+                Ok(fns) => {
+                    openmodelica_error::ErrorExt::delCheckpoint(JAC_CHECKPOINT);
+                    built = Some(fns);
+                }
+                Err(_) => {
+                    openmodelica_error::ErrorExt::rollBack(JAC_CHECKPOINT);
+                    plan.jacs[k] = None;
+                }
+            }
+        }
+        let (lin, opt) = built.unwrap_or_else(|| (empty_eqfn(), [empty_eqfn(), empty_eqfn()]));
+        linz_fns.push(lin);
+        if k > 0 {
+            opt_fns.extend(opt);
+        }
+        out_off += plan.rows[k] * plan.cols[k] * 8;
+    }
+    Ok((linz_fns, opt_fns))
 }
 
 /// Build one `linearJac<X>(SimData*)`: C's `functionJacX` loop moved into the
@@ -5806,6 +6265,16 @@ fn lin_jac_systems(sim_code: &SimCode::SimCode) -> Vec<Arc<SimCode::LinearSystem
     scan(flatten_eqs_ll(&sim_code.odeEquations));
     scan(flatten_eqs_ll(&sim_code.algebraicEquations));
     scan(flatten_eqs(&sim_code.allEquations));
+    // A differentiated algebraic loop is a torn linear system in a Jacobian column.
+    for jm in lst(&sim_code.jacobianMatrices) {
+        if !jac_lowerable(jm) {
+            continue;
+        }
+        for col in lst(&jm.columns) {
+            scan(flatten_eqs(&col.constantEqns));
+            scan(flatten_eqs(&col.columnEqns));
+        }
+    }
     out
 }
 
@@ -5978,6 +6447,7 @@ fn build_nls_fns(
         array_groups: var_map.array_groups.clone(),
         terminate_off: var_map.terminate_off,
         terminal_off: var_map.terminal_off,
+        initial_off: var_map.initial_off,
         term_info_off: var_map.term_info_off,
         nls_fail_off: var_map.nls_fail_off,
         nls_jobs: var_map.nls_jobs.clone(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
@@ -301,28 +301,52 @@ fn covers_sparsity(jm: &SimCode::JacobianMatrix, rows: u32) -> bool {
         .all(|r| (*r as u32) < rows && produced.contains(&(*r as usize)))
 }
 
-/// The `A`,`B`,`C`,`D` Jacobians, `Some` only where the flat emitter can lower
-/// one: C's per-matrix `initialAnalyticJacobian<X>` availability.
+/// The `A`,`B`,`C`,`D` Jacobians the flat emitter can lower, with the shape each
+/// one actually has (C's per-matrix `initialAnalyticJacobian<X>`: `sizeCols` is the
+/// seed count, `sizeRows` covers every row the results and the sparsity mention).
+///
+/// The shape is read off the matrix rather than derived from
+/// `nStates`/`nInputVars`/`nOutputVars`, because `DynamicOptimization` reshapes
+/// these same matrices for an `optimization` model — B and C then have
+/// `nStates+nInputVars` columns and a row per state, path constraint and objective
+/// term. [`crate::CodegenWasmJit::LinzPlan`] compares the shape against what `-l`
+/// expects and only lets the linearization use the ones that match.
 pub(crate) fn symbolic_jacobians(
     sim_code: &SimCode::SimCode,
-    rows: [u32; 4],
-    cols: [u32; 4],
-) -> [Option<Arc<SimCode::JacobianMatrix>>; 4] {
+) -> [Option<(Arc<SimCode::JacobianMatrix>, u32, u32)>; 4] {
     let names = ["A", "B", "C", "D"];
     core::array::from_fn(|k| {
-        if rows[k] == 0 || cols[k] == 0 {
+        let jm = lst(&sim_code.jacobianMatrices).find(|j| &*j.matrixName == names[k])?.clone();
+        let cols = crate::CodegenWasmJit::count(&jm.seedVars) as u32;
+        let rows = matrix_rows(&jm);
+        if rows == 0 || cols == 0 {
             return None;
         }
-        let jm = lst(&sim_code.jacobianMatrices).find(|j| &*j.matrixName == names[k])?.clone();
         // A sparsity-only matrix carries seeds but no equations; C reports it as
         // `JACOBIAN_NOT_AVAILABLE`.
         let has_equations = lst(&jm.columns)
             .next()
             .is_some_and(|c| lst(&c.columnEqns).next().is_some());
-        let usable = has_equations
-            && covers_sparsity(&jm, rows[k])
-            && crate::CodegenWasmJit::jac_lowerable(&jm)
-            && crate::CodegenWasmJit::count(&jm.seedVars) as u32 == cols[k];
-        usable.then_some(jm)
+        let usable =
+            has_equations && covers_sparsity(&jm, rows) && crate::CodegenWasmJit::jac_lowerable(&jm);
+        usable.then_some((jm, rows, cols))
     })
+}
+
+/// C's `sizeRows`: one past the last row either a `JAC_VAR` result or the sparsity
+/// pattern names.
+fn matrix_rows(jm: &SimCode::JacobianMatrix) -> u32 {
+    let results = crate::CodegenWasmJit::jac_column_vars(jm)
+        .iter()
+        .filter(|v| matches!(v.varKind, BackendDAE::VarKind::JAC_VAR))
+        .filter_map(crate::CodegenWasmJit::jac_result_row)
+        .map(|r| r as u32 + 1)
+        .max()
+        .unwrap_or(0);
+    let sparse = lst(&jm.sparsity)
+        .flat_map(|(_, nz)| lst(nz))
+        .map(|r| *r as u32 + 1)
+        .max()
+        .unwrap_or(0);
+    results.max(sparse)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
@@ -1,0 +1,250 @@
+//! `method="optimization"`: what the ported Ipopt collocation solver needs from the
+//! model, i.e. `CodegenC.tpl`'s `optimizationComponents` (`<model>_13opt.c`) and the
+//! `realVarsData[i].attribute` values C reads out of the `_init.xml`.
+//!
+//! The symbolic B/C/D themselves come from the same lowering the `-l` linearization
+//! uses (`LinzPlan`); this module adds the per-column entry point the optimizer
+//! drives them through, and assembles [`OptInfo`].
+
+use std::collections::HashMap;
+use std::string::String;
+use std::sync::Arc;
+
+use openmodelica_backend_types::BackendDAE;
+use openmodelica_simcode_types::{SimCode, SimCodeVar};
+use openmodelica_sim_meta::{OptInfo, OptJac, OptTerm};
+
+use crate::CodegenWasmJit::{count, lst};
+
+/// C's `BackendDAE.optimizationMayerTermName` / `optimizationLagrangeTermName`.
+const MAYER_TERM: &str = "$OMC$objectMayerTerm";
+const LAGRANGE_TERM: &str = "$OMC$objectLagrangeTerm";
+
+/// Whether the model carries an optimization problem: the backend emitted the
+/// class attributes `optimize()` sets `+gDynOpt` for. `ClassAttributes` has the
+/// single record `OPTIMIZATION_ATTRS`, so a non-empty list *is* the answer.
+pub(crate) fn is_optimization(sim_code: &SimCode::SimCode) -> bool {
+    lst(&sim_code.classAttributes).next().is_some()
+}
+
+/// The real variables C appends after the algebraics: the path and then the final
+/// constraints.
+pub(crate) fn constraint_vars(
+    vars: &SimCodeVar::SimVars,
+) -> Vec<&SimCodeVar::SimVar> {
+    lst(&vars.realOptimizeConstraintsVars)
+        .chain(lst(&vars.realOptimizeFinalConstraintsVars))
+        .collect()
+}
+
+/// The per-real-variable attribute values C reads from the `_init.xml`, as the
+/// constant defaults the emitted `functionUpdateBoundVariableAttributes` stores.
+/// A parameter-dependent attribute overwrites its slot there; these are the
+/// literals (and C's fallbacks for an attribute the model never gives).
+pub(crate) struct AttrDefaults {
+    /// `(offset, value)` for the three f64 regions.
+    pub reals: Vec<(u32, f64)>,
+    /// `(offset, value)` for the `useNominal` i32 region.
+    pub ints: Vec<(u32, i32)>,
+}
+
+/// Collect them for `reals` in real-variable index order (states, derivatives,
+/// algebraics, constraints) and register the parameter-dependent ones in
+/// `attr_targets` so they are updated after `functionParameters`.
+pub(crate) fn attr_defaults(
+    reals: &[&SimCodeVar::SimVar],
+    layout: &openmodelica_sim_meta::Layout,
+    attr_targets: &mut HashMap<String, crate::CodegenWasmJitFunctions::AttrTargets>,
+) -> AttrDefaults {
+    let mut out = AttrDefaults { reals: Vec::new(), ints: Vec::new() };
+    for (i, sv) in reals.iter().enumerate() {
+        let i = i as u32;
+        // C's `dummyREAL_ATTRIBUTE` / the xml reader's defaults.
+        for (base, exp, fallback) in [
+            (layout.opt_min_off, &sv.minValue, -f64::MAX),
+            (layout.opt_max_off, &sv.maxValue, f64::MAX),
+            (layout.opt_nom_off, &sv.nominalValue, 1.0),
+        ] {
+            let off = base + i * 8;
+            out.reals.push((off, crate::CodegenWasmJit::const_value(exp).unwrap_or(fallback)));
+            if let Ok(k) = crate::CodegenWasmJit::sim_cref_key(&sv.name) {
+                let t = attr_targets.entry(k).or_default();
+                if base == layout.opt_min_off {
+                    t.opt_min_offs.push(off);
+                } else if base == layout.opt_max_off {
+                    t.opt_max_offs.push(off);
+                } else {
+                    t.opt_nom_offs.push(off);
+                }
+            }
+        }
+        out.ints.push((layout.opt_use_nom_off + i * 4, use_nominal(sv) as i32));
+    }
+    out
+}
+
+/// C's `attribute.useNominal`: the model declared a `nominal`.
+fn use_nominal(sv: &SimCodeVar::SimVar) -> bool {
+    sv.nominalValue.is_some()
+}
+
+/// [`OptInfo`] for the model, or `None` when it carries no optimization problem.
+/// `reals` is the real-variable list in index order and `jacs` the lowered B/C/D
+/// with their slots, as `build_linz_jac_infos` registered them.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_opt_info(
+    sim_code: &SimCode::SimCode,
+    vars: &SimCodeVar::SimVars,
+    reals: &[&SimCodeVar::SimVar],
+    jacs: [Option<OptJac>; 3],
+    var_map: &crate::CodegenWasmJit::SimVarMap,
+) -> Result<Option<OptInfo>, &'static str> {
+    if !is_optimization(sim_code) {
+        return Ok(None);
+    }
+    let index_of = |sv: &SimCodeVar::SimVar| -> Option<u32> {
+        let key = crate::CodegenWasmJit::sim_cref_key(&sv.name).ok()?;
+        reals
+            .iter()
+            .position(|r| crate::CodegenWasmJit::sim_cref_key(&r.name).ok().as_deref() == Some(key.as_str()))
+            .map(|i| i as u32)
+    };
+    // The optimizer's `u`, as C's `pickUpBoundsForInputsInOptimization` collects it:
+    // the real inputs, whose bounds it reads out of the real region.
+    let mut inputs: Vec<u32> = Vec::new();
+    // C's `OPT_LOOP_INPUT`: the input takes another variable's value when the guess
+    // comes from a file (`setInputData(data, 1)`).
+    let mut loop_inputs = Vec::new();
+    for sv in lst(&vars.inputVars) {
+        let Some(index) = index_of(sv) else { continue };
+        if let BackendDAE::VarKind::OPT_LOOP_INPUT { replaceExp } = &sv.varKind
+            && let Some(src) = reals.iter().position(|r| {
+                crate::CodegenWasmJit::sim_cref_key(&r.name).ok()
+                    == crate::CodegenWasmJit::sim_cref_key(replaceExp).ok()
+            })
+        {
+            loop_inputs.push((inputs.len() as u32, src as u32));
+        }
+        inputs.push(index);
+    }
+    // The objective terms: their own real index, and the Jacobian row their
+    // derivative lands in — C reads the row off the `$pDER` cref's `SimVar.index`.
+    let term = |name: &str| -> Option<OptTerm> {
+        let index = reals.iter().position(|r| {
+            crate::CodegenWasmJit::sim_cref_key(&r.name).is_ok_and(|k| k == name)
+        })? as u32;
+        Some(OptTerm {
+            index,
+            row_b: term_row(sim_code, "B", name),
+            row_c: term_row(sim_code, "C", name),
+        })
+    };
+    // C's `getTimeGrid`: the `$OPT_TGRID` parameters, in parameter order.
+    let tgrid: Vec<u32> = lst(&vars.paramVars)
+        .filter(|sv| matches!(sv.varKind, BackendDAE::VarKind::OPT_TGRID { .. }))
+        .filter_map(|sv| {
+            crate::CodegenWasmJit::sim_cref_key(&sv.name)
+                .ok()
+                .and_then(|k| var_map.vars.get(&k).map(|s| s.off))
+        })
+        .collect();
+    // C's `realVarsData[i].info.name`, which the optimizer's messages quote.
+    let real_names: Vec<String> = reals
+        .iter()
+        .map(|sv| {
+            let n = crate::CodegenWasmJit::cref_display(&sv.name).unwrap_or_default();
+            match n.strip_prefix("$DER.") {
+                Some(base) => format!("der({base})"),
+                None => n,
+            }
+        })
+        .collect();
+    let [jac_b, jac_c, jac_d] = jacs;
+    Ok(Some(OptInfo {
+        n_con: count(&vars.realOptimizeConstraintsVars) as u32,
+        n_final_con: count(&vars.realOptimizeFinalConstraintsVars) as u32,
+        inputs,
+        loop_inputs,
+        real_names,
+        mayer: term(MAYER_TERM),
+        lagrange: term(LAGRANGE_TERM),
+        tgrid,
+        // The Optimica `startTime` class attribute would start a pre-simulation;
+        // not emitted yet, so the optimizer uses C's `startTime - 1.0` default.
+        start_time_opt: None,
+        jac_b,
+        jac_c,
+        jac_d,
+    }))
+}
+
+/// The row of matrix `matrix` holding `term`'s derivative: the `JAC_VAR` result
+/// whose cref is `<term>.$pDER<matrix>.dummyVar<matrix>`, which is what C's
+/// template looks up with `crefToIndex(createDifferentiatedCrefName(...))`.
+fn term_row(sim_code: &SimCode::SimCode, matrix: &str, term: &str) -> Option<u32> {
+    let jm = lst(&sim_code.jacobianMatrices).find(|j| &*j.matrixName == matrix)?;
+    let prefix = format!("{term}.$pDER{matrix}.");
+    crate::CodegenWasmJit::jac_column_vars(jm)
+        .iter()
+        .filter(|v| matches!(v.varKind, BackendDAE::VarKind::JAC_VAR))
+        .find(|v| {
+            crate::CodegenWasmJit::sim_cref_key(&v.name).is_ok_and(|k| k.starts_with(&prefix))
+        })
+        .and_then(crate::CodegenWasmJit::jac_result_row)
+        .map(|r| r as u32)
+}
+
+/// One matrix's [`OptJac`]: its shape, sparsity, colouring and the slots the
+/// optimizer seeds and reads, plus the names of the two exports that evaluate it.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn opt_jac(
+    jm: &SimCode::JacobianMatrix,
+    rows: u32,
+    cols: u32,
+    seed_offs: &[u32],
+    result_offs: &[Option<u32>],
+    column_fn: &str,
+    const_fn: &str,
+) -> OptJac {
+    // `sparsity` is positional per column; a column with no entry is structurally
+    // zero. C reads the same pattern out of the `_JacX.bin` file.
+    let mut rows_by_col: Vec<Vec<u32>> = vec![Vec::new(); cols as usize];
+    for (i, (_, nz)) in lst(&jm.sparsity).enumerate() {
+        if let Some(slot) = rows_by_col.get_mut(i) {
+            *slot = lst(nz).map(|r| *r as u32).filter(|r| *r < rows).collect();
+        }
+    }
+    let colors: Vec<Vec<u32>> = lst(&jm.coloredCols)
+        .map(|grp| lst(grp).map(|c| *c as u32).filter(|c| *c < cols).collect())
+        .collect();
+    // C evaluates one column per colour when the backend gave no colouring.
+    let colors = if colors.iter().all(Vec::is_empty) {
+        (0..cols).map(|c| vec![c]).collect()
+    } else {
+        colors
+    };
+    OptJac {
+        n_cols: cols,
+        n_rows: rows,
+        colors,
+        rows_by_col,
+        seed_offs: seed_offs.to_vec(),
+        // A structurally-zero row is never read, so its slot is irrelevant; 0 keeps
+        // the vector dense (the optimizer indexes it by row).
+        result_offs: result_offs.iter().map(|o| o.unwrap_or(0)).collect(),
+        column_fn: column_fn.to_string(),
+        const_fn: const_fn.to_string(),
+    }
+}
+
+/// The equations of one Jacobian's column, split as the optimizer calls them:
+/// `constantEqns` once per evaluation point, `columnEqns` once per colour.
+pub(crate) fn jac_eqns(
+    jm: &SimCode::JacobianMatrix,
+) -> (Vec<Arc<SimCode::SimEqSystem>>, Vec<Arc<SimCode::SimEqSystem>>) {
+    let Some(col) = lst(&jm.columns).next() else { return (Vec::new(), Vec::new()) };
+    (
+        lst(&col.constantEqns).cloned().collect(),
+        lst(&col.columnEqns).cloned().collect(),
+    )
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -819,7 +819,7 @@ pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> s
         let ty = match &**a {
             A::SIMEXTARGSIZE { .. } => SigTy::Int,
             A::SIMEXTARG { type_, .. } | A::SIMEXTARGEXP { type_, .. } => {
-                sig_ty(type_).map_err(|e| e.to_string())?
+                sig_ty_quiet(type_).map_err(|e| e.to_string())?
             }
             _ => return Err("unsupported external-call argument".to_string()),
         };
@@ -833,7 +833,7 @@ pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> s
     match &**extReturn {
         A::SIMNOEXTARG => {}
         A::SIMEXTARG { type_, outputIndex, .. } => {
-            let t = sig_ty(type_).map_err(|e| e.to_string())?;
+            let t = sig_ty_quiet(type_).map_err(|e| e.to_string())?;
             if !ret_ok(&t) || !claim((*outputIndex).max(0) as usize) {
                 return Err(format!("return type {t:?} cannot be marshalled"));
             }
@@ -911,7 +911,9 @@ fn var_sigtys(vars: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>) -> Res
 /// `ty` is authoritative (its `dims` are complete); otherwise a non-empty
 /// `instDims` makes the scalar `ty` the element type of a rank-`|instDims|` array.
 fn variable_sigty(ty: &DAE::Type, inst_dims: &Arc<List<Arc<DAE::Dimension>>>) -> Result<SigTy> {
-    let base = sig_ty(ty)?;
+    // Quiet: `external_known`/`external_general` map a function's variables only to
+    // decide whether they can lower the call at all.
+    let base = sig_ty_quiet(ty)?;
     if matches!(base, SigTy::Array { .. }) {
         return Ok(base);
     }
@@ -923,8 +925,10 @@ fn variable_sigty(ty: &DAE::Type, inst_dims: &Arc<List<Arc<DAE::Dimension>>>) ->
     }
 }
 
-/// Map a `DAE.Type` to a `SigTy`, or fail for types not yet supported.
-pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
+/// Map a `DAE.Type` to a `SigTy`, or fail for types not yet supported. Without
+/// the diagnostic: callers that only *probe* a type must not report the ones they
+/// go on to handle.
+pub(crate) fn sig_ty_quiet(ty: &DAE::Type) -> Result<SigTy> {
     Ok(match ty {
         DAE::Type::T_INTEGER { .. } => SigTy::Int,
         DAE::Type::T_REAL { .. } => SigTy::Real,
@@ -938,7 +942,7 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
         // since Modelica arrays are rectangular.
         DAE::Type::T_ARRAY { ty, dims } => {
             let ndims = (&**dims).into_iter().count() as u32;
-            match sig_ty(ty)? {
+            match sig_ty_quiet(ty)? {
                 SigTy::Array { elem, rank } => SigTy::Array { elem, rank: rank + ndims },
                 elem => SigTy::Array { elem: Arc::new(elem), rank: ndims },
             }
@@ -957,12 +961,12 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
             match record_decl_fields(&path_str) {
                 Some(decl) => {
                     for (name, ty) in decl.iter() {
-                        fields.push((name.clone(), sig_ty(ty)?));
+                        fields.push((name.clone(), sig_ty_quiet(ty)?));
                     }
                 }
                 None => {
                     for v in &**varLst {
-                        fields.push((v.name.clone(), sig_ty(&v.ty)?));
+                        fields.push((v.name.clone(), sig_ty_quiet(&v.ty)?));
                     }
                 }
             }
@@ -971,14 +975,24 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
         // A function reference's argument/result types arrive MetaModelica-boxed
         // (C calls one boxed `boxptr_` shape); our closures are typed and pass
         // values unboxed, so the box is nothing.
-        DAE::Type::T_METABOXED { ty } => sig_ty(ty)?,
+        DAE::Type::T_METABOXED { ty } => sig_ty_quiet(ty)?,
         // A function reference: a closure handle, callable with the wrapped
         // function type's signature.
         DAE::Type::T_FUNCTION_REFERENCE_VAR { .. } | DAE::Type::T_FUNCTION_REFERENCE_FUNC { .. } => {
             closures::reference_sigty(ty)?
         }
         DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
-        other => return Err("CodegenWasmJit: type not supported"),
+        _ => return Err("CodegenWasmJit: type not supported"),
+    })
+}
+
+/// The wasm signature type of a DAE type, reporting the type it cannot handle.
+pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
+    sig_ty_quiet(ty).inspect_err(|_| {
+        let name = openmodelica_frontend_dump::TypesDump::unparseType(Arc::new(ty.clone()))
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        crate::CodegenWasmJit::record_error(format!("CodegenWasmJit: type not supported: {name}"));
     })
 }
 
@@ -1131,6 +1145,9 @@ pub(crate) struct SimCtx {
     /// `SimData` byte offset of the `terminal()` flag, raised by the driver for
     /// the run's final discrete update.
     pub(crate) terminal_off: u32,
+    /// `SimData` byte offset of the `initial()` flag, raised by the driver for
+    /// the initialization phase.
+    pub(crate) initial_off: u32,
     /// `SimData` byte offset of the fired `terminate(...)`'s message + source
     /// position (C's `TermMsg`/`TermInfo`).
     pub(crate) term_info_off: u32,
@@ -1266,6 +1283,8 @@ pub(crate) enum Attr {
     Nominal,
     Min,
     Max,
+    /// `start`, which the optimizer reads for the input variables (C's `u0`).
+    Start,
 }
 
 /// Where one variable's attribute lands: its entry in each nonlinear system that
@@ -1278,6 +1297,15 @@ pub(crate) struct AttrTargets {
     pub(crate) nom_offs: Vec<u32>,
     /// A state's `SimData` `max` slot, which the numeric linearization reads.
     pub(crate) max_offs: Vec<u32>,
+    /// The optimizer's per-real-variable attribute slots (C's
+    /// `realVarsData[i].attribute`, which it reads for every state, input and
+    /// constrained variable). Unlike the two above these take the value as it is:
+    /// no `fmax(|nominal|, 1e-32)` clamp, since the optimizer applies its own
+    /// heuristic.
+    pub(crate) opt_min_offs: Vec<u32>,
+    pub(crate) opt_max_offs: Vec<u32>,
+    pub(crate) opt_nom_offs: Vec<u32>,
+    pub(crate) start_offs: Vec<u32>,
 }
 
 /// The contiguous `SimData` slot range backing one scalarized array model
@@ -1606,6 +1634,7 @@ impl<'a> FnCtx<'a> {
     pub(crate) fn emit_update_bound_attrs(
         &mut self,
         defaults: &[(u32, f64)],
+        int_defaults: &[(u32, i32)],
         attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
@@ -1613,6 +1642,11 @@ impl<'a> FnCtx<'a> {
             self.emit(we::Instruction::LocalGet(data));
             self.emit(we::Instruction::F64Const((*value).into()));
             self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+        }
+        for (off, value) in int_defaults {
+            self.emit(we::Instruction::LocalGet(data));
+            self.emit(we::Instruction::I32Const(*value));
+            self.emit(we::Instruction::I32Store(mem_arg(*off, 2)));
         }
         if attrs.is_empty() {
             return Ok(());
@@ -1640,11 +1674,25 @@ impl<'a> FnCtx<'a> {
                     self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
                 }
             }
+            // The optimizer's attribute arrays take the value verbatim.
+            let opt_offs: &[u32] = match attr {
+                Attr::Min => &targets.opt_min_offs,
+                Attr::Max => &targets.opt_max_offs,
+                Attr::Nominal => &targets.opt_nom_offs,
+                Attr::Start => &targets.start_offs,
+            };
+            for off in opt_offs {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::LocalGet(raw));
+                self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+            }
             if targets.nls.is_empty() {
                 continue;
             }
             self.emit(we::Instruction::LocalGet(raw));
             match attr {
+                // `start` has no nonlinear-solver slot; it only feeds the optimizer.
+                Attr::Start => {}
                 // A nonpositive nominal would collapse the x-scaling; 1 stands in.
                 Attr::Nominal => {
                     self.emit(we::Instruction::F64Abs);
@@ -1662,6 +1710,8 @@ impl<'a> FnCtx<'a> {
                 Attr::Nominal => (NLS_NOMINAL_GLOBAL, 8, 0),
                 Attr::Min => (NLS_BOUNDS_GLOBAL, 16, 0),
                 Attr::Max => (NLS_BOUNDS_GLOBAL, 16, 8),
+                // Not a solver input; `targets.nls` is empty for a `start`.
+                Attr::Start => continue,
             };
             for idx in &targets.nls {
                 self.emit(we::Instruction::GlobalGet(global));
@@ -1672,17 +1722,14 @@ impl<'a> FnCtx<'a> {
         Ok(())
     }
 
-    /// Store each variable's `start` expression (`0.0` when it has none) at `off`,
-    /// and at `live_off` when the variable also has a live slot (a state, whose
-    /// `off` is its start attribute). The second store is C's `setAllVarsToStart`:
-    /// an initial equation reading a state before the initial system solves it
-    /// must see `start`, not zero.
+    /// Store each real variable's `start` expression (`0.0` when it has none) in
+    /// its start attribute slot at `off`.
     pub(crate) fn emit_init_start_values(
         &mut self,
-        starts: &[(Option<Arc<DAE::Exp>>, u32, Option<u32>)],
+        starts: &[(Option<Arc<DAE::Exp>>, u32)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
-        for (exp, off, live_off) in starts {
+        for (exp, off) in starts {
             self.emit(we::Instruction::LocalGet(data));
             match exp {
                 Some(e) => {
@@ -1691,16 +1738,7 @@ impl<'a> FnCtx<'a> {
                 }
                 None => self.emit(we::Instruction::F64Const(0.0f64.into())),
             }
-            if let Some(live) = live_off {
-                let v = self.alloc_temp(WTy::F64);
-                self.emit(we::Instruction::LocalTee(v));
-                self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
-                self.emit(we::Instruction::LocalGet(data));
-                self.emit(we::Instruction::LocalGet(v));
-                self.emit(we::Instruction::F64Store(mem_arg(*live, 3)));
-            } else {
-                self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
-            }
+            self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
         }
         Ok(())
     }
@@ -2077,7 +2115,7 @@ fn compile_external_function(
         let is_out = ext_arg_output_index(a) != 0;
         Ok(match a {
             // An output array is pre-allocated and passed by pointer, like an input.
-            A::SIMEXTARG { cref, type_, .. } if !is_out || matches!(sig_ty(type_), Ok(SigTy::Array { .. })) => {
+            A::SIMEXTARG { cref, type_, .. } if !is_out || matches!(sig_ty_quiet(type_), Ok(SigTy::Array { .. })) => {
                 Some(Arc::new(DAE::Exp::CREF { componentRef: cref.clone(), ty: type_.clone() }))
             }
             A::SIMEXTARG { .. } => None,
@@ -2133,7 +2171,7 @@ fn compile_external_function(
         }
         for a in &**extArgs {
             let oi = ext_arg_output_index(a);
-            let scalar = !matches!(&**a, A::SIMEXTARG { type_, .. } if matches!(sig_ty(type_), Ok(SigTy::Array { .. })));
+            let scalar = !matches!(&**a, A::SIMEXTARG { type_, .. } if matches!(sig_ty_quiet(type_), Ok(SigTy::Array { .. })));
             if oi != 0 && scalar {
                 targets.push(oi - 1);
             }
@@ -3802,7 +3840,7 @@ fn compile_for(
     ty: &DAE::Type,
 ) -> Result<()> {
     if let DAE::Exp::RANGE { .. } = range {
-        if matches!(sig_ty(ty), Ok(SigTy::Int)) {
+        if matches!(sig_ty_quiet(ty), Ok(SigTy::Int)) {
             return compile_for_int_range(ctx, iter, range, body);
         }
     }
@@ -5450,7 +5488,10 @@ fn exp_wty_hint(ctx: &FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::BINARY { operator, .. } => operator_wty(operator)?,
         E::UNARY { operator, .. } => operator_wty(operator)?,
         E::IFEXP { expThen, .. } => exp_wty_hint(ctx, expThen)?,
-        E::CALL { attr, .. } => sig_ty(&attr.ty)?.wty(),
+        E::CALL { attr, .. } => match identity_builtin_arg(exp) {
+            Some(inner) if sig_ty_quiet(&attr.ty).is_err() => exp_wty_hint(ctx, &inner)?,
+            _ => sig_ty(&attr.ty)?.wty(),
+        },
         E::SHARED_LITERAL { exp, .. } => exp_wty_hint(ctx, exp)?,
         // Array/record handles and `size(a, d)` are `i32`; an array element's /
         // record field's wasm type comes from its element / field type.
@@ -5516,9 +5557,35 @@ fn operator_sigty(op: &DAE::Operator) -> Result<SigTy> {
         | O::POW_SCALAR_ARRAY { ty }
         | O::POW_ARR { ty }
         | O::POW_ARR2 { ty } => ty,
-        other => return Err("CodegenWasmJit: cannot determine type of operator"),
+        _ => return Err("CodegenWasmJit: cannot determine type of operator"),
     };
-    sig_ty(ty)
+    sig_ty_quiet(ty)
+}
+
+/// The type an operator the frontend left untyped works on: whichever of String,
+/// Real or Integer an operand carries, in Modelica's promotion order.
+fn operand_sigty(e1: &DAE::Exp, e2: &DAE::Exp) -> Result<SigTy> {
+    let ops = [exp_sigty(e1).ok(), exp_sigty(e2).ok()];
+    for want in [SigTy::Str, SigTy::Real, SigTy::Int] {
+        if ops.iter().flatten().any(|s| *s == want) {
+            return Ok(want);
+        }
+    }
+    Err("CodegenWasmJit: cannot determine type of operator")
+}
+
+/// The value expression an identity builtin wraps. C's `daeExpCall` returns the
+/// argument's own expression for these, so the call's type *is* the argument's --
+/// which matters where the frontend left the call itself untyped.
+fn identity_builtin_arg(exp: &DAE::Exp) -> Option<Arc<DAE::Exp>> {
+    let DAE::Exp::CALL { path, expLst, .. } = exp else { return None };
+    let name = AbsynUtil::pathLastIdent(path.clone()).ok()?;
+    let args: Vec<&Arc<DAE::Exp>> = (&**expLst).into_iter().collect();
+    match (name.as_str(), args.len()) {
+        ("smooth", 2) => Some(args[1].clone()),
+        ("noEvent", 1) | ("$getPart", 1) => Some(args[0].clone()),
+        _ => None,
+    }
 }
 
 /// The `SigTy` of an expression, from the DAE type annotations it carries (the
@@ -5533,17 +5600,23 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         E::BCONST { .. } => SigTy::Bool,
         E::RCONST { .. } => SigTy::Real,
         E::SCONST { .. } => SigTy::Str,
-        E::CREF { ty, .. } => sig_ty(ty)?,
-        E::CALL { attr, .. } => sig_ty(&attr.ty)?,
-        E::CAST { ty, .. } => sig_ty(ty)?,
+        E::CREF { ty, .. } => sig_ty_quiet(ty)?,
+        E::CALL { attr, .. } => match sig_ty_quiet(&attr.ty) {
+            Ok(s) => s,
+            Err(e) => match identity_builtin_arg(exp) {
+                Some(inner) => exp_sigty(&inner)?,
+                None => return Err(e),
+            },
+        },
+        E::CAST { ty, .. } => sig_ty_quiet(ty)?,
         E::BINARY { operator, .. } | E::UNARY { operator, .. } => operator_sigty(operator)?,
         E::RELATION { .. } | E::LBINARY { .. } | E::LUNARY { .. } => SigTy::Bool,
         E::IFEXP { expThen, .. } => exp_sigty(expThen)?,
         E::SHARED_LITERAL { exp, .. } => exp_sigty(exp)?,
         // Array-valued expressions carry their (array) type directly.
-        E::ARRAY { ty, .. } | E::MATRIX { ty, .. } | E::RANGE { ty, .. } => sig_ty(ty)?,
+        E::ARRAY { ty, .. } | E::MATRIX { ty, .. } | E::RANGE { ty, .. } => sig_ty_quiet(ty)?,
         // A reduction's result type is its element/fold type.
-        E::REDUCTION { reductionInfo, .. } => sig_ty(&reductionInfo.exprType)?,
+        E::REDUCTION { reductionInfo, .. } => sig_ty_quiet(&reductionInfo.exprType)?,
         // `a[subs]`: subscripting reduces the rank by the number of subscripts
         // (a full index yields the scalar element).
         E::ASUB { exp, sub } => {
@@ -5560,12 +5633,12 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
         E::SIZE { sz: Some(_), .. } => SigTy::Int,
         E::SIZE { sz: None, .. } => SigTy::Array { elem: Arc::new(SigTy::Int), rank: 1 },
         // A record constructor / field access carry their type directly.
-        E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty(ty)?,
-        E::TSUB { ty, .. } => sig_ty(ty)?,
+        E::RECORD { ty, .. } | E::RSUB { ty, .. } => sig_ty_quiet(ty)?,
+        E::TSUB { ty, .. } => sig_ty_quiet(ty)?,
         // A function reference: what the value it produces may be called with.
         E::PARTEVALFUNCTION { ty, .. } => closures::reference_sigty(ty)?,
         E::BOX { exp } => exp_sigty(exp)?,
-        E::UNBOX { ty, .. } => sig_ty(ty)?,
+        E::UNBOX { ty, .. } => sig_ty_quiet(ty)?,
         other => return Err("CodegenWasmJit: cannot determine type of expression"),
     })
 }
@@ -5573,7 +5646,7 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
 fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<WTy> {
     // Array negation `-a`: negate every element into a fresh array.
     if let DAE::Operator::UMINUS_ARR { ty } = op {
-        let SigTy::Array { elem, .. } = sig_ty(ty)? else {
+        let SigTy::Array { elem, .. } = sig_ty_quiet(ty)? else {
             return Err("CodegenWasmJit: UMINUS_ARR with non-array type");
         };
         let rt = if elem.wty() == WTy::F64 { "rt_array_neg_f64" } else { "rt_array_neg_i32" };
@@ -5588,7 +5661,7 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
     let DAE::Operator::UMINUS { ty } = op else {
         return Err("CodegenWasmJit: unsupported unary operator");
     };
-    let wty = sig_ty(ty)?.wty();
+    let wty = sig_ty_quiet(ty)?.wty();
     let w = compile_exp(ctx, exp)?;
     coerce(ctx, w, wty);
     match wty {
@@ -5633,16 +5706,35 @@ fn compile_binary(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::
         O::POW_SCALAR_ARRAY { ty } => return compile_array_scalar(ctx, e1, e2, OP_POW, true, ty),
         _ => {}
     }
+    // C's `daeExpBinary` reads the operator's own type only to tell a String `+`
+    // from arithmetic, and otherwise works off the operands' C types; the new
+    // frontend leaves some operators `T_UNKNOWN`, so fall back the same way.
+    let sig = match operator_sigty(op) {
+        Ok(s) => s,
+        Err(_) => operand_sigty(e1, e2).map_err(|e| {
+            let show = |x: &DAE::Exp| {
+                openmodelica_frontend_dump::ExpressionBasics::printExpStr(Arc::new(x.clone()))
+                    .map(|s| s.to_string())
+                    .unwrap_or_default()
+            };
+            crate::CodegenWasmJit::record_error(format!(
+                "CodegenWasmJit: untyped binary operator between `{}` and `{}`",
+                show(e1),
+                show(e2)
+            ));
+            e
+        })?,
+    };
     // String `+` is concatenation: both operands are String handles, the result
     // is a fresh String handle from the runtime.
-    if operator_sigty(op)? == SigTy::Str {
+    if sig == SigTy::Str {
         let O::ADD { .. } = op else {
             return Err("CodegenWasmJit: unsupported String operator");
         };
         str_binop(ctx, e1, e2, "rt_concat")?;
         return Ok(WTy::I32);
     }
-    let wty = operator_wty(op)?;
+    let wty = sig.wty();
     // POW has no wasm instruction. Mirror the C target's scalar-power dispatch
     // exactly: a literal `0.5` exponent is `sqrt` (with a negative-base check),
     // an integer-literal exponent is exponentiation by squaring
@@ -5714,8 +5806,13 @@ fn compile_relation(
 ) -> Result<WTy> {
     use DAE::Operator as O;
     // String comparisons go through the runtime: equality via `rt_streq`,
-    // ordering via `rt_strcmp` (which returns -1/0/1) compared against 0.
-    if relation_operand_sigty(op)? == SigTy::Str {
+    // ordering via `rt_strcmp` (which returns -1/0/1) compared against 0. As for
+    // the arithmetic operators, an untyped relation takes its operands' type.
+    let sig = match relation_operand_sigty(op) {
+        Ok(s) => s,
+        Err(_) => operand_sigty(e1, e2)?,
+    };
+    if sig == SigTy::Str {
         match op {
             O::EQUAL { .. } => str_binop(ctx, e1, e2, "rt_streq")?,
             O::NEQUAL { .. } => {
@@ -5961,9 +6058,9 @@ fn relation_operand_sigty(op: &DAE::Operator) -> Result<SigTy> {
     use DAE::Operator as O;
     let ty = match op {
         O::LESS { ty } | O::LESSEQ { ty } | O::GREATER { ty } | O::GREATEREQ { ty } | O::EQUAL { ty } | O::NEQUAL { ty } => ty,
-        other => return Err("CodegenWasmJit: not a relational operator"),
+        _ => return Err("CodegenWasmJit: not a relational operator"),
     };
-    sig_ty(ty)
+    sig_ty_quiet(ty)
 }
 
 /// Compile a `CALL`, leaving its result value(s) on the stack; returns their
@@ -6006,7 +6103,7 @@ fn compile_call(
     // A call whose result is a record and which is not a generated function is a
     // record constructor `R(v1, …)` (the constructor function itself is not
     // emitted — construction is lowered inline).
-    if let Ok(rty @ SigTy::Record { .. }) = sig_ty(&attr.ty) {
+    if let Ok(rty @ SigTy::Record { .. }) = sig_ty_quiet(&attr.ty) {
         compile_record_call(ctx, &attr.ty, args)?;
         return Ok(vec![rty]);
     }
@@ -6228,7 +6325,7 @@ fn compile_math_builtin(
         return Ok(sig);
     }
 
-    let result_sig = sig_ty(&attr.ty).unwrap_or(SigTy::Real);
+    let result_sig = sig_ty_quiet(&attr.ty).unwrap_or(SigTy::Real);
     let result_wty = result_sig.wty();
 
     // Event forms (trailing index) get held/refresh semantics; plain arities fall
@@ -6648,6 +6745,15 @@ fn compile_math_builtin(
         "terminal" => {
             need_args(&argv, 0, name)?;
             let (data, off) = { let s = ctx.sim()?; (s.data_local, s.terminal_off) };
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::I32Load(mem_arg(off, 2)));
+            Ok(SigTy::Bool)
+        }
+        // `initial()` — C's `simulationInfo->initial`, true for the whole
+        // initialization phase.
+        "initial" => {
+            need_args(&argv, 0, name)?;
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, s.initial_off) };
             ctx.emit(we::Instruction::LocalGet(data));
             ctx.emit(we::Instruction::I32Load(mem_arg(off, 2)));
             Ok(SigTy::Bool)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -912,19 +912,18 @@ fn hybrd_scaled(
     arm_attempt();
     let mut hooks =
         minpack::Hooks { abort: Some(&attempt_aborted), fjacobian: None, diag: None };
-    let status = minpack::hybrd_hooked(&mut seval, &mut hooks, n, x, fvec, 1e-12, maxfev, 1e-12, 100.0);
+    minpack::hybrd_hooked(&mut seval, &mut hooks, n, x, fvec, 1e-12, maxfev, 1e-12, 100.0);
     drop(seval);
     for i in 0..n {
         x[i] *= scale[i];
     }
-    nls_accept(status, fvec)
+    nls_accept(fvec)
 }
 
-/// A solve succeeds when MINPACK reports convergence or the residual is already at
-/// the tolerance (an exact Jacobian can reach the root before the step test fires,
-/// leaving `Stalled` with a machine-zero residual).
-fn nls_accept(status: minpack::Status, fvec: &[f64]) -> bool {
-    status == minpack::Status::Converged || enorm(fvec) <= 1.0e-12
+/// A solve succeeds only when the residual is at C's `local_tol`: MINPACK's
+/// `info == 1` is a step test (the trust region collapsed), not a root.
+fn nls_accept(fvec: &[f64]) -> bool {
+    enorm(fvec) <= 1.0e-12
 }
 
 /// C's `resScaling` over the Jacobian `hybrd` last formed. C reads
@@ -1053,12 +1052,14 @@ fn hybrd_c(
             }
             (enorm(&fvec), enorm(&scaled))
         };
+        // C's `if (info < 4 && xerror > local_tol && xerror_scaled > local_tol) info = 4`:
+        // only the residual decides, and a rejected run advances a rung.
         let accurate = xerror <= local_tol || xerror_scaled <= local_tol;
         if non_continuous && !accurate {
             non_continuous = false;
         }
 
-        if status == minpack::Status::Converged || accurate {
+        if accurate {
             nlsx.copy_from_slice(&xv);
             x.copy_from_slice(&xv);
             // C confirms the solution by evaluating there once more; an assert at it
@@ -1212,14 +1213,13 @@ fn hybrj_scaled(
     arm_attempt();
     let mut hooks =
         minpack::Hooks { abort: Some(&attempt_aborted), fjacobian: None, diag: None };
-    let status =
-        minpack::hybrj_hooked(&mut seval, &mut sjac, &mut hooks, n, x, fvec, 1e-12, maxfev, 100.0);
+    minpack::hybrj_hooked(&mut seval, &mut sjac, &mut hooks, n, x, fvec, 1e-12, maxfev, 100.0);
     drop(seval);
     drop(sjac);
     for i in 0..n {
         x[i] *= scale[i];
     }
-    nls_accept(status, fvec)
+    nls_accept(fvec)
 }
 
 /// `-nlsLS`: which backend the linear solve inside the sparse nonlinear solver
@@ -1690,14 +1690,15 @@ fn newton_c(
         let grad_f = -2.0 * error_f_sqrd;
         let grad_f_scaled = -2.0 * error_f_sqrd_scaled;
 
-        // λ1: back off from the full step until the residual eval is finite.
+        // λ1: back off from the full step while the residual asserts (C's `longjmp`);
+        // an overflowed but finite one goes to the damping below, which collapses λ.
         let mut lambda1 = 1.0;
         loop {
             for i in 0..n {
                 x1[i] = x[i] + lambda1 * step[i];
             }
             eval(&x1, &mut fvec);
-            if fvec.iter().all(|v| v.abs() < 1e30) {
+            if !assert_hit() {
                 break;
             }
             lambda1 *= 0.655;
@@ -2616,31 +2617,29 @@ pub extern "C" fn rt_solve_nls(
             }
         }
         settled &= converged;
-        let mut solve = |x: &mut [f64], fvec: &mut [f64]| {
-            if has_jac {
-                hybrj_scaled(n, x, fvec, &nominal, maxfev, &mut eval, &mut jaceval)
-            } else {
-                hybrd_scaled(n, x, fvec, &nominal, maxfev, &mut eval)
-            }
-        };
-        if !converged {
-            // `solveHybrd` reads whichever vector `solveHomotopy` overwrote with the
-            // point its entry phase settled on, so it restarts from that either way.
-            x.copy_from_slice(&nlsx);
-            converged = solve(&mut x, &mut fvec);
-        }
+        // C's `solveHomotopy` on `newtonAlgorithm`'s `info == -1`.
         if !converged {
             stat_inc(STAT_NLS_RETRY);
-            x.copy_from_slice(&warm);
-            converged = solve(&mut x, &mut fvec);
+            // C's `discreteCall` is set for an initial system too; only an event call
+            // has relations to hold, so only there does the continuity flag move.
+            let mut set_cont = |c: bool| {
+                if saved_rel_fresh == 1 {
+                    unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
+                }
+            };
+            converged = hybrd_c(
+                n, &mut x, &nlsx, &warm, &nominal, &bounds, saved_rel_fresh != 0, &mut eval,
+                &mut set_cont,
+            );
         }
-        drop(solve);
+        // The rungs below are not `solveHomotopy`'s; they catch what C gives up on.
+        // `nls_accept` takes only a point at tolerance, so none can report a non-root.
         if !converged {
             stat_inc(STAT_NLS_RETRY);
             x.copy_from_slice(&warm);
             converged = newton_solve(n, &mut x, &mut eval);
         }
-        // C's init ladder: newtonAlgorithm, then solveHybrd (retry ladder) from x0.
+        // An initial system gets a second `newtonAlgorithm`, from `x0`.
         if !converged && saved_rel_fresh == 2 {
             x.copy_from_slice(&guess);
             converged = newton_c(
@@ -2649,7 +2648,6 @@ pub extern "C" fn rt_solve_nls(
             )
             .0;
         }
-        // Numeric-Jacobian hybrd, then LM, from the last iterate and from the guess.
         if !converged {
             stat_inc(STAT_NLS_RETRY);
             converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
@@ -2677,22 +2675,6 @@ pub extern "C" fn rt_solve_nls(
                     break;
                 }
             }
-        }
-        // C's `NLS_MIXED`: whatever `solveHomotopy` leaves unsolved goes to the full
-        // `solveHybrd` ladder, which is where the hardest systems are actually solved.
-        if !converged {
-            stat_inc(STAT_NLS_RETRY);
-            // C's `discreteCall` is set for an initial system too; only an event call
-            // has relations to hold, so only there does the continuity flag move.
-            let mut set_cont = |c: bool| {
-                if saved_rel_fresh == 1 {
-                    unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
-                }
-            };
-            converged = hybrd_c(
-                n, &mut x, &nlsx, &warm, &nominal, &bounds, saved_rel_fresh != 0, &mut eval,
-                &mut set_cont,
-            );
         }
         converged
     };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -21,6 +21,9 @@ pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
         alarm: true,
         // No regex engine in wasm; the model's own filter is resolved at codegen.
         variable_filter: false,
+        // Ipopt has no wasm build (MUMPS is Fortran), so `method="optimization"`
+        // reports "Ipopt is needed but not available." here.
+        optimization: false,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -522,7 +522,8 @@ macro_rules! shared_instance_methods {
         set_param_overrides(params, starts);
         let mut e = Engine;
         let start_time = st.read_f64(TIME_OFF);
-        if run_initialization(&mut e, st.sim_data, &st.layout, start_time).is_err() {
+        // No `-csvInput` on the FMI path: the importer drives the inputs.
+        if run_initialization(&mut e, st.sim_data, &st.layout, &[], start_time).is_err() {
             return Status::Error;
         }
         // Apply deferred String parameter sets now that init equations have run, so

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
@@ -921,7 +921,8 @@ fn cmp_data(
                     }
                     if !refevent {
                         j -= 1;
-                        if j == 0 {
+                        // C tests `j == 0`, and reads `reftime[-1]` when it started at 0.
+                        if j <= 0 {
                             break;
                         }
                         tr = reftime[j as usize];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/build.rs
@@ -12,6 +12,12 @@
 //!
 //! Unset means no CVODE/IDA; `simflags::check` then rejects `-s=cvode`/`-s=ida`
 //! up front.
+//!
+//! Ipopt (`cfg(ipopt)`) follows the host SUNDIALS pattern: `OMC_IPOPT_NATIVE_DIR`
+//! holds the C runtime's own archives, linked here because the optimization driver
+//! lives in `libOpenModelicaCompiler` too. There is no wasm build — MUMPS is
+//! Fortran 90 — so an in-wasm runtime never gets one and reports the same
+//! "Ipopt is needed but not available" a C runtime without `OMC_HAVE_IPOPT` does.
 
 use std::path::Path;
 
@@ -29,13 +35,56 @@ const NATIVE_LIBS: &[&str] = &[
     "suitesparseconfig",
 ];
 
+/// Ipopt and its linear solver, in link order (the C runtime's own order): each
+/// entry may only depend on later ones. `seq` is MUMPS' sequential MPI stub, which
+/// `mumps_common` needs for `mumps_elapse_`; `metis` is its fill-reducing ordering.
+const IPOPT_LIBS: &[&str] = &["ipopt", "dmumps", "mumps_common", "seq", "metis"];
+
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(sundials)");
     println!("cargo::rustc-check-cfg=cfg(sundials_i64)");
+    println!("cargo::rustc-check-cfg=cfg(ipopt)");
     println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
     println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_NATIVE_DIR");
     println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_NATIVE_INDEX_SIZE");
+    println!("cargo:rerun-if-env-changed=OMC_IPOPT_NATIVE_DIR");
+    sundials();
+    ipopt();
+}
 
+/// The classic `optimize()` runtime's NLP solver, host-only.
+fn ipopt() {
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        return;
+    }
+    let Some(dir) = std::env::var_os("OMC_IPOPT_NATIVE_DIR") else { return };
+    let lib = Path::new(&dir).join("lib");
+    let missing: Vec<_> = IPOPT_LIBS
+        .iter()
+        .filter(|l| ![format!("lib{l}.a"), format!("{l}.lib")].iter().any(|n| lib.join(n).exists()))
+        .collect();
+    if !missing.is_empty() {
+        panic!(
+            "OMC_IPOPT_NATIVE_DIR={} is missing {missing:?}; the Ipopt build failed \
+             (check the rust_ipopt_native_collect CMake target)",
+            lib.display()
+        );
+    }
+    println!("cargo:rustc-link-search=native={}", lib.display());
+    for l in IPOPT_LIBS {
+        println!("cargo:rustc-link-lib=static={l}");
+    }
+    // Ipopt's dense algebra and MUMPS' rank-revealing QR call LAPACK/BLAS; Ipopt is
+    // C++; MUMPS is Fortran (whose runtime needs quadmath). Named `lapack`/`blas`
+    // like `openmodelica_util` does rather than a specific implementation, so both
+    // resolve to whatever this system installed.
+    for l in ["lapack", "blas", "stdc++", "gfortran", "quadmath"] {
+        println!("cargo:rustc-link-lib=dylib={l}");
+    }
+    println!("cargo:rustc-cfg=ipopt");
+}
+
+fn sundials() {
     // The FMI3 adapter's build: the calls stay undefined and become wasm imports the
     // FMU linker resolves, so there is nothing to link and no target to check.
     if std::env::var_os("CARGO_FEATURE_SUNDIALS_EXTERN").is_some() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -603,6 +603,29 @@ pub(crate) fn log_line(s: &str) {
     }
 }
 
+// C's `importStartValues`, which `-ipopt_init=file` repeats at every collocation
+// point. Opening a result file is the host's job (on the web it has to go through
+// the VFS), so the host installs the reader. `out` arrives holding the current
+// start values and keeps them for a name the file does not carry, as C's does.
+pub type ResultFileReader = fn(&str, &[&str], f64, &mut [f64]) -> core::result::Result<(), String>;
+static RESULT_FILE_READER: AtomicUsize = AtomicUsize::new(0);
+pub fn set_result_file_reader(f: ResultFileReader) {
+    RESULT_FILE_READER.store(f as usize, Ordering::Relaxed);
+}
+pub(crate) fn read_result_file(
+    file: &str,
+    names: &[&str],
+    t: f64,
+    out: &mut [f64],
+) -> core::result::Result<(), String> {
+    let p = RESULT_FILE_READER.load(Ordering::Relaxed);
+    if p == 0 {
+        return Err(format!("unable to read input-file <{file}>"));
+    }
+    let f: ResultFileReader = unsafe { core::mem::transmute(p) };
+    f(file, names, t, out)
+}
+
 /// [`SimEngine::take_pending_warnings`] kinds.
 pub const ASSERT_WARNING: i32 = 0;
 pub const ASSERT_SUPPRESSED: i32 = 1;
@@ -1071,27 +1094,41 @@ pub fn row_asserts(e: &mut dyn SimEngine, sim_data: u32, warn: i32) -> i32 {
 fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> String {
     let during = if initial { "during initialization " } else { "" };
     let t = format_f(time);
+    let head = alloc::format!("The following assertion has been violated {during}at time {t}");
+    // A generated `assert()` always names its condition, and C prints it with the
+    // message as one message's second line — including for a backend-generated
+    // variable, whose `FILE_INFO` is empty (`$finalCon$…`'s min/max guard). A
+    // condition-less violation is C's `assertCommonVar` (the math-domain guards).
+    if cond.is_empty() {
+        return head;
+    }
+    let body = alloc::format!("(({cond})) --> \"{}\"", info.msg);
     if info.file.is_empty() {
-        return alloc::format!("The following assertion has been violated {during}at time {t}");
+        return alloc::format!("{head}\n{body}");
     }
     let ro_str = if info.read_only { "readonly" } else { "writable" };
     alloc::format!(
-        "[{}:{}:{}-{}:{}:{ro_str}]\n\
-         The following assertion has been violated {during}at time {t}\n\
-         (({cond})) --> \"{}\"",
-        info.file, info.line_start, info.col_start, info.line_end, info.col_end, info.msg,
+        "[{}:{}:{}-{}:{}:{ro_str}]\n{head}\n{body}",
+        info.file, info.line_start, info.col_start, info.line_end, info.col_end,
     )
 }
 
 fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
-    // C's `assertCommonVar` (the math-domain guards, no source position): the warning
-    // names the time, a debug line carries the message.
-    if info.file.is_empty() {
-        omclog::warning(omclog::ASSERT, false, &assert_block(info, cond, time, initial));
+    let block = assert_block(info, cond, time, initial);
+    // C's `assertCommonVar` (the math-domain guards, no condition and no source
+    // position): the warning names the time, a debug line carries the message.
+    if cond.is_empty() {
+        omclog::warning(omclog::ASSERT, false, &block);
         omclog::message_text(omclog::DEBUG_TYPE, omclog::ASSERT, false, &info.msg);
         return;
     }
-    omclog::error(omclog::ASSERT, false, &assert_block(info, cond, time, initial));
+    // C's generated guard for a backend variable warns (`omc_assert_warning`); one
+    // with a source position is a model `assert()`, which is an error.
+    if info.file.is_empty() {
+        omclog::warning(omclog::ASSERT, false, &block);
+        return;
+    }
+    omclog::error(omclog::ASSERT, false, &block);
 }
 
 /// What the open window has seen: the first assertion suppressed in it, and
@@ -1187,8 +1224,14 @@ pub fn set_abort_slow(v: bool) {
 /// equidistant homotopy continuation (C's `solveWithGlobalHomotopy`), see
 /// `run_initialization_impl`. Leaves lambda = 1, then seeds `relationsPre` for the
 /// continuous phase's held relations.
-pub fn run_initialization(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
-    init_model(e, sim_data, layout, start_time)?;
+pub fn run_initialization(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+    start_time: f64,
+) -> Result<()> {
+    init_model(e, sim_data, layout, inputs, start_time)?;
     signal_init_done();
     Ok(())
 }
@@ -1200,7 +1243,7 @@ pub fn run_initialization_with_clocks(
     sim_data: u32,
     model: &SimMeta,
 ) -> Result<crate::sync::Sync> {
-    init_model(e, sim_data, &model.layout, model.start_time)?;
+    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time)?;
     let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
     // An event clock whose `when` already fired during the initial discrete update
     // is only *scheduled* here (C's `data->simulationInfo->initial` case).
@@ -1209,12 +1252,19 @@ pub fn run_initialization_with_clocks(
     Ok(sync)
 }
 
-fn init_model(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_time: f64) -> Result<()> {
+fn init_model(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+    start_time: f64,
+) -> Result<()> {
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
-    run_initialization_impl(e, sim_data, layout)?;
+    write_i32(e, sim_data + layout.initial_off, 1)?;
+    run_initialization_impl(e, sim_data, layout, inputs)?;
     // C's `storePreValues` after the initial solve (initialization.c:903).
     seed_pre_from_live(e, sim_data, layout)?;
     // Seed the continuous phase's held relations from a full discrete fixed point.
@@ -1231,13 +1281,19 @@ fn init_model(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, start_ti
         e.call1("functionZeroCrossings", sim_data)?;
         save_zc_pre(e, sim_data, layout)?;
     }
+    write_i32(e, sim_data + layout.initial_off, 0)?;
     // C's `initializeModel` ends with `checkForAsserts` — before the
     // initialization-success line.
     check_asserts(e, sim_data, layout, omclog::WARNING)?;
     Ok(())
 }
 
-fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+fn run_initialization_impl(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+) -> Result<()> {
     // C's `updateStaticDataOfNonlinearSystems`.
     omclog::info(omclog::NLS, true, "update static data of non-linear system solvers");
     omclog::close(omclog::NLS);
@@ -1248,7 +1304,14 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     set_no_throw(false);
     term_report::reset();
     steady_report::reset();
-    seed_start_values(e, sim_data, layout)?;
+    seed_start_values(e, sim_data, layout, inputs)?;
+
+    // C's `IIM_NONE`: every variable keeps its start value, the initial system is
+    // never solved. C still marks the systems solved before it picks the method.
+    if crate::simflags::with_flags(|f| f.init_method) == crate::simflags::InitMethod::None {
+        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+        return Ok(());
+    }
 
     // C's `symbolic_initialization`: a model with `homotopy()` goes straight to the
     // global equidistant continuation, unless `-noHomotopyOnFirstTry` asks for the
@@ -1273,7 +1336,7 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
     // C's catch arm resets everything to start before the continuation runs.
     init_report::reset();
     let _ = rethrow_store::take();
-    seed_start_values(e, sim_data, layout)?;
+    seed_start_values(e, sim_data, layout, inputs)?;
     run_homotopy_continuation(e, sim_data, layout)?;
     init_report::set_homotopy_steps(homotopy_steps() as u32);
     Ok(())
@@ -1282,14 +1345,22 @@ fn run_initialization_impl(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLay
 /// C's `setAllParamsToStart` + `setAllVarsToStart` + `updateBoundParameters` +
 /// `updateBoundVariableAttributes`: every variable back at its start value with
 /// the bound parameters recomputed. Run before each attempt at the initial system.
-fn seed_start_values(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+fn seed_start_values(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+) -> Result<()> {
     e.call1("functionParameters", sim_data)?;
-    // Params first (a start expression may read one), then fill start slots, then
-    // start overrides (replacing the just-computed start).
+    // Params first (a start expression may read one), then the start attributes —
+    // the expressions, then the `$START.<var>` equations that bind one to a
+    // parameter — then `-iif`/`-override`, then C's `setAllVarsToStart`.
     apply_param_overrides(e, sim_data)?;
-    e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
     e.call1("functionInitStartValues", sim_data)?;
+    apply_external_input(e, sim_data, inputs)?;
+    e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
     apply_start_overrides(e, sim_data)?;
+    set_all_vars_to_start(e, sim_data, layout)?;
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
     // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
@@ -1574,6 +1645,61 @@ fn seed_pre_from_live(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) 
     Ok(())
 }
 
+/// C's `initializeModel` input step: `input_function_init` seeds `inputVars` from
+/// the inputs' start attributes, `externalInputUpdate` replaces them with
+/// `-csvInput` at `t0`, and `input_function_updateStartValues` writes them back as
+/// the start attributes — so `setAllVarsToStart` puts the file's values on the
+/// inputs. Runs before the attribute equations and `-iif`, both of which C lets
+/// win over the file.
+#[cfg(feature = "std")]
+fn apply_external_input(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    inputs: &[crate::InputVar],
+) -> Result<()> {
+    if inputs.is_empty() {
+        return Ok(());
+    }
+    let Some(file) = crate::simflags::with_flags(|f| f.csv_input.clone()) else { return Ok(()) };
+    let names: Vec<&str> = inputs.iter().map(|v| v.name.as_str()).collect();
+    let Some(mut ext) = crate::extinput::ExternalInput::load(&file, &names) else { return Ok(()) };
+    // C's `input_function_init`; `externalInputUpdate` rewrites every entry (a
+    // column the file lacks becomes 0, from its `calloc`ed rows), so this only
+    // matters for the shape.
+    let mut u = crate::extinput::empty(inputs.len());
+    let t = read_f64(e, sim_data + TIME_OFF)?;
+    ext.update(t, &mut u);
+    for (input, v) in inputs.iter().zip(&u) {
+        match input.wty {
+            crate::WTy::F64 => write_f64(e, sim_data + input.off, *v)?,
+            crate::WTy::I32 => write_i32(e, sim_data + input.off, *v as i32)?,
+        }
+    }
+    Ok(())
+}
+
+/// `-csvInput` needs a filesystem, which the in-wasm runtime has not.
+#[cfg(not(feature = "std"))]
+fn apply_external_input(
+    _e: &mut dyn SimEngine,
+    _sim_data: u32,
+    _inputs: &[crate::InputVar],
+) -> Result<()> {
+    Ok(())
+}
+
+/// C's `setAllVarsToStart` for the reals: every real variable takes its `start`
+/// attribute. Integer/Boolean/String starts are still the emitted equations'.
+fn set_all_vars_to_start(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    let bytes = ((2 * layout.n_states + layout.n_real_alg) * 8) as usize;
+    if bytes == 0 {
+        return Ok(());
+    }
+    let mut buf = vec![0u8; bytes];
+    e.read_bytes(sim_data + layout.start_off, &mut buf)?;
+    e.write_bytes(sim_data + REAL_OFF, &buf)
+}
+
 /// Upper bound on discrete-update iterations at one event: C's `maxEventIterations`
 /// default, which `-mei` replaces.
 const MAX_EVENT_ITER: usize = 20;
@@ -1713,7 +1839,7 @@ fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 /// their pre-event value, so two mutually-triggering crossings never reach a
 /// consistent set and chatter on the integrator instead. Assumes the event time is
 /// already written.
-fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     // Each pass freezes `relationsPre = relations` so the NLS in `functionODE` holds
     // this pass's relations, then re-evaluates the continuous system; the discrete
     // state settles across passes. Comparing the snapshot before and after the
@@ -1971,6 +2097,7 @@ pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
         Some(crate::simflags::Solver::RungeKutta) => "rungekutta",
         Some(crate::simflags::Solver::SymSolver) => "symSolver",
         Some(crate::simflags::Solver::SymSolverSsc) => "symSolverSsc",
+        Some(crate::simflags::Solver::Optimization) => "optimization",
         _ => method,
     }
 }
@@ -1982,7 +2109,10 @@ pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
 fn check_method(method: &str, layout: &SimLayout) -> Result<()> {
     let supported =
         matches!(method, "dassl" | "dasslrt" | "dassljac" | "euler" | "rungekutta" | "gbode" | "")
-            || (matches!(method, "cvode" | "ida") && cfg!(sundials));
+            || (matches!(method, "cvode" | "ida") && cfg!(sundials))
+            // `optimize()`; `drive` handles it before the integrators, and reports
+            // C's "Ipopt is needed but not available." when it was not linked.
+            || method == "optimization";
     if !supported {
         return Err(UNSUPPORTED_METHOD);
     }
@@ -2160,11 +2290,51 @@ pub fn drive(
 
     let mut label = "";
     let outcome = (|| -> Result<Vec<f64>> {
+        // `optimize()`: C's `solver_main` initializes the model, then the loop makes a
+        // single `S_OPTIMIZATION` step and breaks — every result row comes from the
+        // optimizer's own `res2file`, and neither the initial nor the terminal row is
+        // emitted around it.
+        if method == "optimization" {
+            // C's `solver_main_step`: with neither a state nor an input there is
+            // nothing to optimize, and it runs explicit Euler instead.
+            let nothing_to_optimize =
+                layout.n_states == 0 && model.opt.as_ref().is_none_or(|o| o.inputs.is_empty());
+            if nothing_to_optimize {
+                label = "euler-host";
+                let (mut driver, _) = make_driver(e, model, sim_data, "euler")
+                    .map_err(|err| enrich_trap_init(e, err, model.start_time))?;
+                loop {
+                    match driver.advance(e, model, f64::INFINITY).map_err(|err| enrich_trap(e, err))? {
+                        Advance::Done | Advance::Terminated => break,
+                        Advance::Cancelled => return Err("CodegenWasmJit: simulation cancelled"),
+                        Advance::Running => continue,
+                    }
+                }
+                driver.fill_stats(model, &mut stats);
+                let mut rows = driver.take_rows();
+                emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+                return Ok(rows);
+            }
+            label = "optimization";
+            if !crate::optimization::AVAILABLE {
+                omclog::warning(omclog::STDOUT, false, crate::optimization::UNAVAILABLE);
+                return Err(crate::optimization::UNAVAILABLE);
+            }
+            #[cfg(all(ipopt, feature = "std"))]
+            {
+                run_initialization(e, sim_data, layout, &model.inputs, start)
+                    .map_err(|err| enrich_trap_init(e, err, start))?;
+                return crate::optimization::run_optimizer(e, model, sim_data)
+                    .map_err(|err| enrich_trap(e, err));
+            }
+            #[cfg(not(all(ipopt, feature = "std")))]
+            unreachable!("optimization::AVAILABLE is false");
+        }
         if !use_events && method == "euler" && !host_driven {
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
-            let mut rows = run_wasm(e, sim_data, n_reals, n_rows, layout, start, stop, &mut stats)?;
+            let mut rows = run_wasm(e, sim_data, n_reals, n_rows, layout, &model.inputs, start, stop, &mut stats)?;
             emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
             return Ok(rows);
         }
@@ -2224,12 +2394,14 @@ fn run_wasm(
     n_reals: u32,
     n_rows: u32,
     layout: &SimLayout,
+    inputs: &[crate::InputVar],
     start: f64,
     stop: f64,
     stats: &mut SolveStats,
 ) -> Result<Vec<f64>> {
     stats.steps = (n_rows - 1) as u64;
-    run_initialization(e, sim_data, layout, start).map_err(|err| enrich_trap_init(e, err, start))?;
+    run_initialization(e, sim_data, layout, inputs, start)
+        .map_err(|err| enrich_trap_init(e, err, start))?;
     open_assert_window();
     let called = e.call_simulate(sim_data, start, stop, n_rows - 1);
     let settled = close_assert_window(e, sim_data);
@@ -2262,7 +2434,7 @@ impl EulerDriver {
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
         // them internally around its Newton solve.
-        run_initialization(e, sim_data, &model.layout, model.start_time)?;
+        run_initialization(e, sim_data, &model.layout, &model.inputs, model.start_time)?;
         let n_rows = model.n_output_rows();
         let n_reals = model.layout.n_row_total();
         Ok(EulerDriver {
@@ -2392,6 +2564,12 @@ struct ResCtx {
     jac_ypsave: Vec<f64>,
     /// Jacobian evaluations (colors summed over all Jacobian assemblies).
     nje: u64,
+    /// `-csvInput` for the optimizer's initial guess: C's `functionODE_residual`
+    /// re-reads the external input at *every* residual evaluation, so the hook is
+    /// applied here rather than only at the step boundaries. Null when there is none;
+    /// type-erased so the optimization module's types stay out of the driver.
+    ext_input: *mut core::ffi::c_void,
+    ext_apply: Option<unsafe fn(*mut core::ffi::c_void, &mut dyn SimEngine, u32, f64)>,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
     ctx_addr: u32,
     /// The FD step's fallback scale: `n_states` nominals owned by the driver.
@@ -2533,6 +2711,9 @@ unsafe fn dassl_res(
     let run = (|| -> Result<()> {
         write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?; // clear before the solve
         write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
+        if let Some(f) = ctx.ext_apply {
+            unsafe { f(ctx.ext_input, e, ctx.sim_data, *t) };
+        }
         let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ODE);
@@ -2892,7 +3073,7 @@ impl DasslDriver {
         let layout = &model.layout;
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
-        run_initialization(e, sim_data, layout, model.start_time)?;
+        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -3083,6 +3264,8 @@ impl Driver for DasslDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: self.nje,
+            ext_input: core::ptr::null_mut(),
+            ext_apply: None,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
@@ -3604,7 +3787,7 @@ fn fixed_kind(method: &str) -> Option<crate::fixedstep::FixedKind> {
 /// The driver's errors are `&'static str`, but a solver setup error carries the
 /// offending flag value, so the message is built at runtime. Leaking it is fine:
 /// it happens at most once per run, on the path that aborts the run.
-fn leak_error(s: String) -> &'static str {
+pub(crate) fn leak_error(s: String) -> &'static str {
     alloc::boxed::Box::leak(s.into_boxed_str())
 }
 
@@ -3930,6 +4113,8 @@ impl SolverCore {
             jac_ders: Vec::new(),
             jac_ypsave: vec![0.0; self.n_unknowns],
             nje: self.nje,
+            ext_input: core::ptr::null_mut(),
+            ext_apply: None,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
@@ -5017,7 +5202,7 @@ struct CvodeDriver {
 impl CvodeDriver {
     fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
         let layout = &model.layout;
-        run_initialization(e, sim_data, layout, model.start_time)?;
+        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -5137,6 +5322,8 @@ impl Driver for CvodeDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: 0,
+            ext_input: core::ptr::null_mut(),
+            ext_apply: None,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
@@ -5773,7 +5960,7 @@ impl IdaDriver {
     fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
         let layout = &model.layout;
         let setup = IdaSetup::new(model)?;
-        run_initialization(e, sim_data, layout, model.start_time)?;
+        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -5905,6 +6092,8 @@ impl Driver for IdaDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: 0,
+            ext_input: core::ptr::null_mut(),
+            ext_apply: None,
             ctx_addr: e.context_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
@@ -6012,5 +6201,114 @@ impl Driver for IdaDriver {
         if let Some(ida) = self.ida.as_ref() {
             fill_sundials_stats(stats, ida.counters());
         }
+    }
+}
+
+// ───────────────────── optimization: the initial guess's stepper ─────────────────────
+
+/// Publish the time the stepper jumped to (the no-state case).
+#[cfg(ipopt)]
+fn driver_write_time(e: &mut dyn SimEngine, sim_data: u32, t: f64) -> Result<()> {
+    write_f64(e, sim_data + TIME_OFF, t)
+}
+
+/// C's `smallIntSolverStep` (`optimization/DataManagement/InitialGuess.c`): DASSL
+/// stepped to a given time with no event handling and no output rows.
+///
+/// The optimizer's initial guess is a plain simulation over the collocation grid,
+/// so it reuses the integrator the DASSL driver uses without the event/row
+/// machinery around it. Lives here because [`SolverCore`] and its residual context
+/// are private to this module.
+#[cfg(ipopt)]
+pub(crate) struct GuessStepper {
+    core: SolverCore,
+    /// `-csvInput`'s hook, applied at every residual evaluation like C's.
+    ext: Option<*mut core::ffi::c_void>,
+}
+
+#[cfg(ipopt)]
+impl GuessStepper {
+    /// The model is already initialized (the optimizer's caller did that), so this
+    /// only sizes the integrator and latches the current point as `y`/`y'`.
+    pub(crate) fn new(
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        sim_data: u32,
+        t0: f64,
+    ) -> Result<Self> {
+        daskr::auxiliary::xsetf(0); // DASKR's own printing would corrupt the log
+        let mut core = SolverCore::new(e, model, sim_data, t0, "dassl", None)?;
+        core.read_states(e)?;
+        Ok(GuessStepper { core, ext: None })
+    }
+
+    /// Install `-csvInput`'s external-input hook (a `*mut ExtInputHook`, kept alive
+    /// by the caller for as long as this stepper is used).
+    pub(crate) fn set_external_input(&mut self, hook: *mut core::ffi::c_void) {
+        self.ext = Some(hook);
+    }
+
+    pub(crate) fn time(&self) -> f64 {
+        self.core.t
+    }
+
+    /// Integrate to `tstop` and publish the point, ending with C's
+    /// `updateContinuousSystem`. A solver failure is retried from the current time
+    /// with a halved target, as C halves its step size, up to 10 times.
+    pub(crate) fn step_to(
+        &mut self,
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        tstop: f64,
+    ) -> Result<()> {
+        let layout = &model.layout;
+        // C's `smallIntSolverStep` steps the integrator only when there is a state to
+        // integrate: with none it jumps straight to `tstop` and re-evaluates. DASKR
+        // with `NEQ = 0` would `STOP` inside its Fortran, taking omc down with it.
+        if layout.n_states == 0 {
+            self.core.t = tstop;
+            driver_write_time(e, self.core.sim_data, tstop)?;
+            return eval_continuous(e, self.core.sim_data, layout);
+        }
+        let mut ctx = self.core.res_ctx(e, layout);
+        if let Some(hook) = self.ext {
+            ctx.ext_input = hook;
+            ctx.ext_apply = Some(crate::optimization::EXT_INPUT_APPLY);
+        }
+        let _guard = ResCtxGuard;
+        RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
+        let mut did_step = false;
+        let mut iter = 0;
+        let mut frac = 1.0;
+        while self.core.t < tstop {
+            let target = self.core.t + frac * (tstop - self.core.t);
+            match self.core.solve_toward(target, &mut ctx, f64::INFINITY, &mut did_step) {
+                // A root is not an event here: C's initial guess does not locate
+                // events, it just keeps integrating toward `tstop`.
+                Ok(Solved::Reached | Solved::Stepped | Solved::Root | Solved::Yielded) => {
+                    frac = 1.0;
+                }
+                Ok(Solved::Cancelled) => return Err("CodegenWasmJit: simulation cancelled"),
+                Err(err) => {
+                    iter += 1;
+                    if iter > 10 {
+                        omclog::warning(
+                            omclog::STDOUT,
+                            false,
+                            &alloc::format!(
+                                "Initial guess failure at time {}",
+                                format_g(self.core.t, 12)
+                            ),
+                        );
+                        return Err(err);
+                    }
+                    frac *= 0.5;
+                }
+            }
+        }
+        self.core.write_states(e)?;
+        // C's `dassl_step` publishes the accepted time before `updateContinuousSystem`.
+        driver_write_time(e, self.core.sim_data, self.core.t)?;
+        eval_continuous(e, self.core.sim_data, layout)
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
@@ -1,0 +1,153 @@
+//! `-csvInput`: the external input trajectory, C's `simulation/solver/external_input.c`.
+//!
+//! Read at initialization, where C lets the file set the inputs' start values
+//! (`initializeModel`), and by the optimizer's initial guess
+//! (`initial_guess_ipopt_sim`).
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::omclog;
+
+/// C's `simulationInfo->external_input`.
+pub(crate) struct ExternalInput {
+    /// Sample times, ascending.
+    t: Vec<f64>,
+    /// `u[step][input]`, 0 for an input the file has no column for.
+    u: Vec<Vec<f64>>,
+    /// The bracket `[i, i+1]` the last update used; the search continues from it.
+    i: usize,
+}
+
+impl ExternalInput {
+    /// C's `externalInputallocate`: read the csv and map its columns onto the input
+    /// variables by name. `None` when there is no `-csvInput` (C's `active = 0`).
+    pub(crate) fn load(file: &str, input_names: &[&str]) -> Option<Self> {
+        // C prefixes `-inputPath` when it is given; this runtime does not implement
+        // that flag, so the name is used as it stands.
+        let path = String::from(file);
+        let Some(text) = read_file(&path) else {
+            omclog::error(omclog::STDOUT, false, &format!("Failed to read CSV-file {path}"));
+            return None;
+        };
+        // C's `read_csv`: a leading `"sep=<c>"` names the delimiter and the data
+        // starts at byte 8; without it the delimiter is a comma.
+        let b = text.as_bytes();
+        let (sep, body) = match b {
+            [b'"', b's', b'e', b'p', b'=', c, ..] if b.len() > 8 => (*c as char, &text[8..]),
+            _ => (',', &text[..]),
+        };
+        let mut lines = body.lines().filter(|l| !l.trim().is_empty());
+        let header: Vec<&str> = lines.next()?.split(sep).map(str::trim).collect();
+        // Which csv column feeds each input; -1 in C, `None` here.
+        let col: Vec<Option<usize>> =
+            input_names.iter().map(|n| header.iter().position(|h| h == n)).collect();
+        let mut t = Vec::new();
+        let mut u: Vec<Vec<f64>> = Vec::new();
+        for line in lines {
+            let row: Vec<f64> =
+                line.split(sep).map(|v| v.trim().parse::<f64>().unwrap_or(0.0)).collect();
+            let Some(&time) = row.first() else { continue };
+            t.push(time);
+            u.push(col.iter().map(|c| c.and_then(|c| row.get(c).copied()).unwrap_or(0.0)).collect());
+        }
+        if t.is_empty() {
+            return None;
+        }
+        if omclog::active(omclog::SIMULATION) {
+            let mut out = String::from("\nExternal Input");
+            out.push_str("\n========================================================");
+            for (k, time) in t.iter().enumerate() {
+                out.push_str(&format!("\nInput: t={time:.6}   \t"));
+                for (j, v) in u[k].iter().enumerate() {
+                    out.push_str(&format!("u{}(t)= {v:.6} \t", j + 1));
+                }
+            }
+            out.push_str("\n========================================================\n");
+            crate::driver::log_line(&out);
+        }
+        Some(ExternalInput { t, u, i: 0 })
+    }
+
+    /// C's `externalInputUpdate`: the inputs at `time`, linearly interpolated in the
+    /// bracket the sample times give.
+    pub(crate) fn update(&mut self, time: f64, inputs: &mut [f64]) {
+        let n = self.t.len();
+        if n < 2 {
+            inputs.copy_from_slice(&self.u[0][..inputs.len()]);
+            return;
+        }
+        while self.i > 0 && time < self.t[self.i] {
+            self.i -= 1;
+        }
+        while time > self.t[self.i + 1] && self.i + 1 < n - 1 {
+            self.i += 1;
+        }
+        let (t1, t2) = (self.t[self.i], self.t[self.i + 1]);
+        if time == t1 {
+            copy_row(&self.u[self.i], inputs);
+            return;
+        }
+        if time == t2 {
+            copy_row(&self.u[self.i + 1], inputs);
+            return;
+        }
+        let dt = t2 - t1;
+        for (k, out) in inputs.iter_mut().enumerate() {
+            let (u1, u2) = (self.u[self.i][k], self.u[self.i + 1][k]);
+            *out = if u1 == u2 { u1 } else { (u1 * (dt + t1 - time) + (time - t1) * u2) / dt };
+        }
+    }
+}
+
+fn copy_row(row: &[f64], out: &mut [f64]) {
+    for (o, v) in out.iter_mut().zip(row) {
+        *o = *v;
+    }
+}
+
+/// A whole file as text. Host-only: the in-wasm runtime has no `std::fs`, and
+/// [`crate::simflags::check`] rejects the flag there.
+pub(crate) fn read_file(path: &str) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// Zeroed inputs, so a `-csvInput` with fewer columns than inputs behaves like C's
+/// `calloc`ed rows.
+pub(crate) fn empty(n: usize) -> Vec<f64> {
+    vec![0.0; n]
+}
+
+/// The external input as the DASSL residual sees it: C's `functionODE_residual`
+/// calls `externalInputUpdate` + `input_function` at *every* evaluation, so the
+/// guess's integrator must too, not just at the step boundaries.
+pub(crate) struct ExtInputHook {
+    pub(crate) ext: ExternalInput,
+    /// `SimData` offsets of the input variables, in input order.
+    pub(crate) input_offs: Vec<u32>,
+    /// Scratch mirroring C's `simulationInfo->inputVars`.
+    pub(crate) inputs: Vec<f64>,
+}
+
+impl ExtInputHook {
+    /// C's `externalInputUpdate` + `input_function` at time `t`.
+    fn apply(&mut self, e: &mut dyn crate::driver::SimEngine, sim_data: u32, t: f64) {
+        self.ext.update(t, &mut self.inputs);
+        for (k, &off) in self.input_offs.iter().enumerate() {
+            let _ = crate::driver::write_f64(e, sim_data + off, self.inputs[k]);
+        }
+    }
+
+    /// The type-erased entry point [`crate::driver::ResCtx`] holds, so the residual
+    /// can call it without this module's types leaking into the driver.
+    pub(crate) unsafe fn apply_erased(
+        this: *mut core::ffi::c_void,
+        e: &mut dyn crate::driver::SimEngine,
+        sim_data: u32,
+        t: f64,
+    ) {
+        unsafe { (*(this as *mut ExtInputHook)).apply(e, sim_data, t) }
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -29,6 +29,10 @@ pub mod fixedstep;
 pub mod gbode;
 pub mod linearize;
 pub mod omclog;
+/// `-csvInput`, which needs a filesystem: host builds only.
+#[cfg(feature = "std")]
+pub(crate) mod extinput;
+pub mod optimization;
 pub mod simflags;
 pub mod sync;
 #[cfg(sundials)]
@@ -91,8 +95,8 @@ pub struct Layout {
     /// `functionAlgebraics` also runs the discrete update / saves `pre`, so
     /// drivers call it only in the once-per-step order.
     pub has_when: bool,
-    /// The model uses `homotopy()`, so a `functionInitialEquations_lambda0` is
-    /// emitted and the driver may fall back to homotopy continuation.
+    /// A nonlinear system carries the homotopy operator (C's `homotopySupport`), so
+    /// the driver runs the continuation over `functionInitialEquations_lambda0`.
     pub has_homotopy: bool,
     /// `SimData` offset of the homotopy parameter lambda (f64).
     pub lambda_off: u32,
@@ -116,6 +120,9 @@ pub struct Layout {
     /// `terminal()` flag (i32): C's `data->simulationInfo->terminal`, raised by
     /// the driver for the run's final discrete update.
     pub terminal_off: u32,
+    /// `initial()` flag (i32): C's `data->simulationInfo->initial`, raised by the
+    /// driver for the whole initialization phase.
+    pub initial_off: u32,
     /// C's `TermMsg`/`TermInfo`: the fired `terminate(...)`'s message and source
     /// position, as `[msg, file, lineStart, colStart, lineEnd, colEnd, readOnly]`
     /// (i32 each; the first two are String handles).
@@ -159,7 +166,10 @@ pub struct Layout {
     pub mathevents_off: u32,
     /// Zero-crossing hysteresis tolerance slot (f64).
     pub zctol_off: u32,
-    /// Base of the overridable start-value region (one f64 per state).
+    /// C's `realVarsData[i].attribute.start`: one f64 per real variable, in
+    /// real-variable index order (states, derivatives, algebraics).
+    /// `functionInitStartValues` fills it; `-iif`/`-override` may replace entries;
+    /// the driver then copies it over the live region (C's `setAllVarsToStart`).
     pub start_off: u32,
     /// Base of the per-state `nominal` attribute (one f64 per state), written by
     /// `functionUpdateBoundVariableAttributes` once the parameters are computed.
@@ -171,6 +181,18 @@ pub struct Layout {
     /// `linearJac*` fill (column-major), then their seed/`$pDER` slots.
     pub linz_off: u32,
     pub n_linz: u32,
+    /// `method="optimization"`: the attribute arrays C reads out of the `_init.xml`
+    /// (`realVarsData[i].attribute`), one entry per real variable in real-variable
+    /// index order — `min`, `max`, `nominal` as f64 and `useNominal` as i32
+    /// (`start` is [`Layout::start_off`], which every model has). Written by
+    /// `functionUpdateBoundVariableAttributes` once the parameters are known; the
+    /// optimizer also *writes* `nominal` back, as C does.
+    /// `n_opt_attr` is 0 for a model without an optimization problem.
+    pub n_opt_attr: u32,
+    pub opt_min_off: u32,
+    pub opt_max_off: u32,
+    pub opt_nom_off: u32,
+    pub opt_use_nom_off: u32,
     /// C's `simulationInfo->sensitivityMatrix`: `d(state)/d(parameter)`,
     /// parameter-major, written by the IDA driver from `IDAGetSens` and captured
     /// as a result row's last columns.
@@ -233,6 +255,7 @@ impl Layout {
         n_base_clocks: u32,
         n_sub_clocks: u32,
         n_linz: u32,
+        n_opt_attr: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -251,7 +274,8 @@ impl Layout {
         let pre_bool_off = pre_int_off + n_int_alg * 4;
         let terminate_off = pre_bool_off + n_bool_alg * 4;
         let terminal_off = terminate_off + 4;
-        let term_info_off = terminal_off + 4;
+        let initial_off = terminal_off + 4;
+        let term_info_off = initial_off + 4;
         let n_out_off = term_info_off + TERM_INFO_WORDS * 4;
         let nls_fail_off = n_out_off + 4;
         let lambda_off = (nls_fail_off + 4 + 7) & !7;
@@ -269,7 +293,7 @@ impl Layout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let zctol_off = mathevents_off + n_math_slots * 8;
         let start_off = zctol_off + 8;
-        let state_nom_off = start_off + n_states * 8;
+        let state_nom_off = start_off + n_real * 8;
         let state_max_off = state_nom_off + n_states * 8;
         let sens_off = state_max_off + n_states * 8;
         let dae_res_off = sens_off + n_sens * 8;
@@ -279,15 +303,20 @@ impl Layout {
         let subclock_off = clock_off + n_base_clocks * BASECLOCK_BYTES;
         let clock_fire_off = subclock_off + n_sub_clocks * SUBCLOCK_BYTES;
         let linz_off = (clock_fire_off + n_base_clocks * 4 + 7) & !7;
-        let total = linz_off + n_linz * 8;
+        let opt_min_off = linz_off + n_linz * 8;
+        let opt_max_off = opt_min_off + n_opt_attr * 8;
+        let opt_nom_off = opt_max_off + n_opt_attr * 8;
+        let opt_use_nom_off = opt_nom_off + n_opt_attr * 8;
+        let total = opt_use_nom_off + n_opt_attr * 4;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
-            terminate_off, terminal_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
+            terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
             mathevents_off, zctol_off, start_off, state_nom_off, state_max_off, n_sens, sens_off,
             n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
-            n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, linz_off, n_linz, total,
+            n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, linz_off, n_linz,
+            n_opt_attr, opt_min_off, opt_max_off, opt_nom_off, opt_use_nom_off, total,
         }
     }
 
@@ -300,8 +329,8 @@ impl Layout {
         self.subclock_off + k * SUBCLOCK_BYTES
     }
 
-    /// Byte offset of state `i`'s overridable start-value slot.
-    pub fn state_start_off(&self, i: u32) -> u32 {
+    /// Byte offset of real variable `i`'s `start` attribute slot.
+    pub fn real_start_off(&self, i: u32) -> u32 {
         self.start_off + i * 8
     }
 
@@ -521,6 +550,83 @@ pub struct StateSetInfo {
     pub result_offs: Vec<u32>,
 }
 
+/// One symbolic Jacobian the optimizer differentiates through: C's
+/// `analyticJacobians[INDEX_JAC_{B,C,D}]` with the parts `diffSynColoredOptimizerSystem`
+/// reads. Not square (B/C are `nStates+nInputVars` columns by
+/// `nStates + nOptimizeConstraints (+ lagrange, + mayer)` rows), so both dimensions
+/// are carried.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct OptJac {
+    pub n_cols: u32,
+    pub n_rows: u32,
+    /// Each color: the 0-based columns seeded together (C's `sparsePattern->colorCols`
+    /// inverted, as [`JacAInfo::colors`]).
+    pub colors: Vec<Vec<u32>>,
+    /// `rows_by_col[col]` = the 0-based nonzero rows of that column (C's
+    /// `leadindex`/`index` pair).
+    pub rows_by_col: Vec<Vec<u32>>,
+    /// Seed slots in column order (C's `seedVars`): the optimizer writes the
+    /// variable's nominal value into the columns of one color and 0 elsewhere.
+    pub seed_offs: Vec<u32>,
+    /// Result slots in row order (C's `resultVars`).
+    pub result_offs: Vec<u32>,
+    /// Model export evaluating one column, and the seed-independent equations to
+    /// run first (C's `constantEqns`); empty when there are none.
+    pub column_fn: String,
+    pub const_fn: String,
+}
+
+/// C's `$OMC$objectMayerTerm`: the real-variable index holding the term's value
+/// and the Jacobian rows its derivative lands in (C's `index_Dres` / `index_DresB`
+/// / `index_DresC`, its `derIndex`). A row is `None` when the backend did not
+/// differentiate the term into that matrix.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub struct OptTerm {
+    pub index: u32,
+    pub row_b: Option<u32>,
+    pub row_c: Option<u32>,
+}
+
+/// What `method="optimization"` needs from the model beyond the ODE: the
+/// constraint counts, the objective terms, the input variables and the symbolic
+/// Jacobians. `None` ⇒ the model was not translated with
+/// `--generateDynamicJacobian`/Optimica, and C's generated `mayer`/`lagrange`
+/// stubs would report "The model was not compiled with -g=Optimica".
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct OptInfo {
+    /// C's `nOptimizeConstraints` / `nOptimizeFinalConstraints`. Their variables are
+    /// the *last* real variables, so the first constrained index (C's `index_con`)
+    /// is `n_real - (n_con + n_final_con)`.
+    pub n_con: u32,
+    pub n_final_con: u32,
+    /// Real-variable indices of the `input` variables, in C's `inputVars` order —
+    /// the optimizer's `u` (C's `getInputVarIndicesInOptimization`).
+    pub inputs: Vec<u32>,
+    /// C's `OPT_LOOP_INPUT`: an input whose value is taken from another variable's
+    /// slot when the initial guess comes from a file (C's `setInputData(data, 1)`).
+    /// Pairs of (input index into [`inputs`], source real index).
+    pub loop_inputs: Vec<(u32, u32)>,
+    pub mayer: Option<OptTerm>,
+    pub lagrange: Option<OptTerm>,
+    /// Every real variable's name, in real-variable index order. C reads
+    /// `realVarsData[i].info.name`; the result variables are not enough here — an
+    /// input or a constraint variable (`$y`, `$EqCon$y`) is not among them.
+    pub real_names: Vec<String>,
+    /// C's `getTimeGrid`: the `$OPT_TGRID` parameter slots defining a model-supplied
+    /// time grid; empty ⇒ the equidistant grid from `numberOfIntervals`.
+    pub tgrid: Vec<u32>,
+    /// Slot holding the Optimica `startTime` class attribute (C's `startTimeOpt`,
+    /// which starts a pre-simulation phase before `t0`); `None` ⇒ C's default of
+    /// `startTime - 1.0`, i.e. no pre-simulation.
+    pub start_time_opt: Option<u32>,
+    /// C's `INDEX_JAC_B`/`_C`/`_D`. `B` and `C` are required (the constraint
+    /// Jacobian and its final-point variant); `D` exists only with final
+    /// constraints.
+    pub jac_b: Option<OptJac>,
+    pub jac_c: Option<OptJac>,
+    pub jac_d: Option<OptJac>,
+}
+
 /// Solver statistics filled by the driver and rendered into the simulation log by
 /// the host (`LOG_STATS`, mirroring the C runtime's `### STATISTICS ###`).
 #[derive(Default, Clone, Debug)]
@@ -546,9 +652,9 @@ pub struct FmiVr {
     pub wty: WTy,
     /// The variable is a negated alias of the slot at `off`; a read negates it.
     pub negate: bool,
-    /// A state's start-value slot, 0 for everything else. An Initialization Mode
-    /// set must land here: `functionInitStartValues` runs after the parameter
-    /// overrides and would overwrite `off` from `$START`.
+    /// A real variable's `start` attribute slot, 0 for everything else. An
+    /// Initialization Mode set must land here: `setAllVarsToStart` runs after the
+    /// parameter overrides and would overwrite `off` from it.
     pub start_off: u32,
     /// The variable is a String: `off` is its i32 runtime-String-handle slot, so
     /// the adapter reads/writes it through `rt_str_*` rather than as a number.
@@ -599,6 +705,23 @@ pub struct SimMeta {
     pub clocks: Vec<BaseClockMeta>,
     /// What `-l` needs; `None` for a target that emits no linearization support.
     pub lin: Option<LinInfo>,
+    /// What `method="optimization"` needs; `None` for a model without an
+    /// optimization problem.
+    pub opt: Option<OptInfo>,
+    /// C's `modelData->nInputVars` / `inputNames`: each `input` variable in
+    /// declaration order. `-csvInput` matches its columns against the names.
+    pub inputs: Vec<InputVar>,
+}
+
+/// One `input` variable, as `-csvInput` reaches it: `off` is a real input's `start`
+/// attribute slot (published by `setAllVarsToStart`) and any other type's own slot,
+/// which is where C's `input_function` puts it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InputVar {
+    pub off: u32,
+    pub wty: WTy,
+    /// The result name the file's column header has to match.
+    pub name: String,
 }
 
 /// [`SimMeta::nls_vars`] entry.
@@ -793,7 +916,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 11;
+const VERSION: u32 = 12;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -821,13 +944,15 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
     for v in [
         l.n_states, l.n_real_alg, l.lambda_off, l.rparam_off, l.int_off, l.iparam_off, l.bool_off,
         l.bparam_off, l.str_off, l.sparam_off, l.eobj_off, l.pre_real_off, l.pre_int_off, l.pre_bool_off,
-        l.terminate_off, l.terminal_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
+        l.terminate_off, l.terminal_off, l.initial_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
         l.state_nom_off, l.state_max_off, l.n_sens, l.sens_off,
         l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off,
         l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off,
-        l.linz_off, l.n_linz, l.total,
+        l.linz_off, l.n_linz,
+        l.n_opt_attr, l.opt_min_off, l.opt_max_off, l.opt_nom_off, l.opt_use_nom_off,
+        l.total,
     ] {
         put_u32(o, v);
     }
@@ -965,6 +1090,60 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             }
         }
     }
+    match &m.opt {
+        None => o.push(0),
+        Some(t) => {
+            o.push(1);
+            put_u32(&mut o, t.n_con);
+            put_u32(&mut o, t.n_final_con);
+            put_u32s(&mut o, &t.inputs);
+            put_u32(&mut o, t.loop_inputs.len() as u32);
+            for &(i, src) in &t.loop_inputs {
+                put_u32(&mut o, i);
+                put_u32(&mut o, src);
+            }
+            for term in [&t.mayer, &t.lagrange] {
+                match term {
+                    None => o.push(0),
+                    Some(x) => {
+                        o.push(1);
+                        put_u32(&mut o, x.index);
+                        for row in [x.row_b, x.row_c] {
+                            put_u32(&mut o, row.map_or(u32::MAX, |r| r));
+                        }
+                    }
+                }
+            }
+            put_u32(&mut o, t.real_names.len() as u32);
+            for n in &t.real_names {
+                put_str(&mut o, n);
+            }
+            put_u32s(&mut o, &t.tgrid);
+            put_u32(&mut o, t.start_time_opt.unwrap_or(u32::MAX));
+            for j in [&t.jac_b, &t.jac_c, &t.jac_d] {
+                match j {
+                    None => o.push(0),
+                    Some(j) => {
+                        o.push(1);
+                        put_u32(&mut o, j.n_cols);
+                        put_u32(&mut o, j.n_rows);
+                        put_u32s2(&mut o, &j.colors);
+                        put_u32s2(&mut o, &j.rows_by_col);
+                        put_u32s(&mut o, &j.seed_offs);
+                        put_u32s(&mut o, &j.result_offs);
+                        put_str(&mut o, &j.column_fn);
+                        put_str(&mut o, &j.const_fn);
+                    }
+                }
+            }
+        }
+    }
+    put_u32(&mut o, m.inputs.len() as u32);
+    for v in &m.inputs {
+        put_u32(&mut o, v.off);
+        o.push(matches!(v.wty, WTy::F64) as u8);
+        put_str(&mut o, &v.name);
+    }
     o
 }
 
@@ -1036,6 +1215,7 @@ impl<'a> Reader<'a> {
             pre_bool_off: self.u32()?,
             terminate_off: self.u32()?,
             terminal_off: self.u32()?,
+            initial_off: self.u32()?,
             term_info_off: self.u32()?,
             n_out_off: self.u32()?,
             nls_fail_off: self.u32()?,
@@ -1073,6 +1253,11 @@ impl<'a> Reader<'a> {
             clock_fire_off: self.u32()?,
             linz_off: self.u32()?,
             n_linz: self.u32()?,
+            n_opt_attr: self.u32()?,
+            opt_min_off: self.u32()?,
+            opt_max_off: self.u32()?,
+            opt_nom_off: self.u32()?,
+            opt_use_nom_off: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -1231,10 +1416,70 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             })
         }
     };
+    let opt = match r.u8()? {
+        0 => None,
+        _ => {
+            let n_con = r.u32()?;
+            let n_final_con = r.u32()?;
+            let inputs = r.u32s()?;
+            let nloop = r.u32()? as usize;
+            let mut loop_inputs = Vec::with_capacity(nloop);
+            for _ in 0..nloop {
+                loop_inputs.push((r.u32()?, r.u32()?));
+            }
+            let mut term = || -> Result<Option<OptTerm>, &'static str> {
+                Ok(match r.u8()? {
+                    0 => None,
+                    _ => {
+                        let index = r.u32()?;
+                        let mut row = || r.u32().map(|v| (v != u32::MAX).then_some(v));
+                        Some(OptTerm { index, row_b: row()?, row_c: row()? })
+                    }
+                })
+            };
+            let mayer = term()?;
+            let lagrange = term()?;
+            let n_names = r.u32()? as usize;
+            let mut real_names = Vec::with_capacity(n_names);
+            for _ in 0..n_names {
+                real_names.push(r.string()?);
+            }
+            let tgrid = r.u32s()?;
+            let start_time_opt = { let v = r.u32()?; (v != u32::MAX).then_some(v) };
+            let mut jac = || -> Result<Option<OptJac>, &'static str> {
+                Ok(match r.u8()? {
+                    0 => None,
+                    _ => Some(OptJac {
+                        n_cols: r.u32()?,
+                        n_rows: r.u32()?,
+                        colors: r.u32s2()?,
+                        rows_by_col: r.u32s2()?,
+                        seed_offs: r.u32s()?,
+                        result_offs: r.u32s()?,
+                        column_fn: r.string()?,
+                        const_fn: r.string()?,
+                    }),
+                })
+            };
+            let jac_b = jac()?;
+            let jac_c = jac()?;
+            let jac_d = jac()?;
+            Some(OptInfo {
+                n_con, n_final_con, inputs, loop_inputs, mayer, lagrange, real_names, tgrid,
+                start_time_opt, jac_b, jac_c, jac_d,
+            })
+        }
+    };
+    let mut inputs = Vec::new();
+    for _ in 0..r.u32()? {
+        let off = r.u32()?;
+        let wty = if r.u8()? != 0 { WTy::F64 } else { WTy::I32 };
+        inputs.push(InputVar { off, wty, name: r.string()? });
+    }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
-        nls_vars, dae, clocks, lin,
+        nls_vars, dae, clocks, lin, opt, inputs,
     })
 }
 
@@ -1246,7 +1491,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -1317,6 +1562,30 @@ mod tests {
                 jac_rows: [2, 2, 1, 1],
                 jac_cols: [2, 1, 2, 1],
             }),
+            opt: Some(OptInfo {
+                n_con: 1,
+                n_final_con: 1,
+                inputs: vec![4],
+                loop_inputs: vec![(0, 3)],
+                mayer: Some(OptTerm { index: 5, row_b: None, row_c: Some(2) }),
+                lagrange: Some(OptTerm { index: 6, row_b: Some(2), row_c: Some(3) }),
+                real_names: vec!["x".to_string(), "der(x)".to_string()],
+                tgrid: vec![120, 128],
+                start_time_opt: Some(136),
+                jac_b: Some(OptJac {
+                    n_cols: 3,
+                    n_rows: 2,
+                    colors: vec![vec![0], vec![1, 2]],
+                    rows_by_col: vec![vec![0], vec![0, 1], vec![1]],
+                    seed_offs: vec![400, 408, 416],
+                    result_offs: vec![424, 432],
+                    column_fn: "optJacB".to_string(),
+                    const_fn: String::new(),
+                }),
+                jac_c: None,
+                jac_d: None,
+            }),
+            inputs: vec![InputVar { off: 96, wty: WTy::F64, name: "u".to_string() }],
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -8,6 +8,7 @@
 
 use alloc::format;
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 /// Index into [`STREAM_NAME`], i.e. C's `OMC_LOG_*` enumerators.
 pub type Stream = u8;
@@ -88,6 +89,11 @@ pub const EVENTS_V: Stream = 13;
 pub const INIT: Stream = 19;
 pub const INIT_HOMOTOPY: Stream = 20;
 pub const INIT_V: Stream = 21;
+pub const IPOPT: Stream = 22;
+pub const IPOPT_FULL: Stream = 23;
+pub const IPOPT_JAC: Stream = 24;
+pub const IPOPT_HESSE: Stream = 25;
+pub const IPOPT_ERROR: Stream = 26;
 pub const JAC: Stream = 27;
 pub const LS: Stream = 28;
 pub const LS_V: Stream = 29;
@@ -97,6 +103,7 @@ pub const NLS_HOMOTOPY: Stream = 34;
 pub const NLS_JAC: Stream = 35;
 pub const NLS_RES: Stream = 42;
 pub const NLS_EXTRAPOLATE: Stream = 43;
+pub const SIMULATION: Stream = 46;
 pub const SOLVER: Stream = 47;
 pub const SOLVER_V: Stream = 48;
 pub const SOTI: Stream = 50;
@@ -392,6 +399,103 @@ fn exp_str(v: f64, prec: usize) -> String {
     alloc::format!("{s}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
 }
 
+
+/// C's `ryu_hr_tdzp_buf` (`3rdParty/ryu/ryu/om_format.c`): the shortest round-trip
+/// representation, rendered decimal where that is shorter. The optimizer's
+/// `LOG_IPOPT_ERROR` lines are printed with it, so they must match digit for digit.
+///
+/// The same port lives in `metamodelica::real::ryu` for the compiler's `realString`;
+/// this copy keeps the `no_std` simulation runtime independent of it.
+pub fn shortest(d: f64) -> String {
+    if d.is_infinite() {
+        return if d < 0.0 { "-inf".into() } else { "inf".into() };
+    }
+    if d.is_nan() {
+        return "NaN".into();
+    }
+    ryu_to_hr(&format!("{d:e}"), false)
+}
+
+fn ryu_to_hr(d2s_str: &str, real_output: bool) -> String {
+    let Some(epos) = d2s_str.find(['e', 'E']) else {
+        // Not in mantissa-exponent form (e.g. "NaN"); pass through.
+        return d2s_str.replace('E', "e");
+    };
+    let mant_str = &d2s_str[..epos];
+    let mut exp: i32 = d2s_str[epos + 1..].parse().unwrap_or(0);
+    let (neg, mut digits) = match mant_str.strip_prefix('-') {
+        Some(m) => (true, m.to_string()),
+        None => (false, mant_str.to_string()),
+    };
+    // Number of digits after the decimal point in the mantissa.
+    let mut ndec: i32 = if digits.contains('.') { digits.len() as i32 - 2 } else { 0 };
+    // The exponential rendering used when the decimal form is unsuitable.
+    let mut exp_repr: String = d2s_str.replace('E', "e");
+
+    if ndec > 12 && !real_output {
+        // Round the mantissa to 12 decimals; use it only if that removed at
+        // least 4 trailing zeros (i.e. the long tail was an artifact).
+        let mant: f64 = digits.parse().unwrap_or(0.0);
+        let mut rounded = format!("{mant:.12}");
+        // 9.999999999999999 rounds to 10.000000000000: renormalise.
+        if rounded == "10.000000000000" {
+            rounded = "1.000000000000".to_string();
+            exp += 1;
+        }
+        let mut nz = 0;
+        while rounded.ends_with('0') {
+            rounded.pop();
+            nz += 1;
+        }
+        if rounded.ends_with('.') {
+            rounded.pop();
+        }
+        if nz > 3 {
+            digits = rounded;
+            ndec = if digits.contains('.') { digits.len() as i32 - 2 } else { 0 };
+            exp_repr = format!("{}{digits}e{exp}", if neg { "-" } else { "" });
+        }
+    }
+
+    if !(-3..=5).contains(&exp) || (exp > 0 && exp - ndec > 3) {
+        return exp_repr;
+    }
+
+    // Decimal form. `digs` is the mantissa without its decimal point:
+    // one leading digit followed by `ndec` decimals.
+    let digs: Vec<char> = digits.chars().filter(|c| *c != '.').collect();
+    let mut out = String::with_capacity(24);
+    if neg {
+        out.push('-');
+    }
+    if exp == 0 {
+        out.push_str(&digits);
+    } else if exp > 0 {
+        // Move the decimal point `exp` places to the right.
+        out.push(digs[0]);
+        let take = ndec.min(exp) as usize;
+        out.extend(&digs[1..1 + take]);
+        if exp > ndec {
+            for _ in 0..(exp - ndec) {
+                out.push('0');
+            }
+        } else if exp < ndec {
+            out.push('.');
+            out.extend(&digs[1 + take..]);
+        }
+    } else {
+        // exp < 0: the number starts with "0." and some zeros.
+        out.push_str("0.");
+        for _ in 0..(-exp - 1) {
+            out.push('0');
+        }
+        out.extend(&digs);
+    }
+    if exp >= ndec && real_output {
+        out.push_str(".0");
+    }
+    out
+}
 /// C's `debugString`: one plain line.
 pub fn debug_string(stream: Stream, msg: &str) {
     info(stream, false, msg);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/eval.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/eval.rs
@@ -1,0 +1,882 @@
+//! The port of `optimization/eval_all/`: the five Ipopt callbacks.
+//!
+//! Each recovers the [`OptData`] from Ipopt's user-data pointer, the same way the
+//! DASSL residual recovers its context. They report `true` even after a model
+//! error, as the C ones do; the error is surfaced once `IpoptSolve` returns.
+
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ffi::c_void;
+
+use super::ipopt::{Index, Number};
+use super::run::OptData;
+use super::setup;
+use crate::omclog;
+
+/// Recover the problem from Ipopt's user data, moving whatever Ipopt has printed so
+/// far into the log first — that is what keeps its banner ahead of the
+/// `LOG_IPOPT_ERROR` lines these callbacks emit, as in the C target's output.
+unsafe fn opt<'a>(user: *mut c_void) -> &'a mut OptData {
+    let data = unsafe { &mut *(user as *mut OptData) };
+    if let Some(out) = data.out.as_ref() {
+        out.drain();
+    }
+    data
+}
+
+// ───────────────────────────────── EvalF.c ─────────────────────────────────
+
+/// C's `evalfF`: the objective, `∫ lagrange dt + mayer(tf)`.
+pub(crate) unsafe extern "C" fn eval_f(
+    _n: Index,
+    vopt: *mut Number,
+    new_x: bool,
+    obj: *mut Number,
+    user: *mut c_void,
+) -> bool {
+    let data = unsafe { opt(user) };
+    let n = data.dim.nv_total;
+    let v = unsafe { core::slice::from_raw_parts(vopt, n) }.to_vec();
+    if new_x {
+        setup::opt_data2model_data(data, &v, 1);
+    }
+    let mut lagrange = 0.0;
+    let mut mayer = 0.0;
+    if data.s.lagrange {
+        let (nsi, np, il) = (data.dim.nsi, data.dim.np, data.dim.index_lagrange);
+        let mut erg = vec![0.0; np];
+        for j in 0..np {
+            erg[j] = data.time.dt[0] * data.v(0, j)[il];
+        }
+        for i in 1..nsi {
+            for j in 0..np {
+                erg[j] += data.time.dt[i] * data.v(i, j)[il];
+            }
+        }
+        for j in 0..np {
+            lagrange += data.rk.b[j] * erg[j];
+        }
+    }
+    if data.s.mayer {
+        let (nsi, np, im) = (data.dim.nsi, data.dim.np, data.dim.index_mayer);
+        mayer = data.v(nsi - 1, np - 1)[im];
+    }
+    unsafe { *obj = lagrange + mayer };
+    true
+}
+
+/// C's `evalfDiffF`: the objective gradient, which is the Lagrange row of every
+/// point's Jacobian plus the Mayer row at the last one.
+pub(crate) unsafe extern "C" fn eval_grad_f(
+    n: Index,
+    vopt: *mut Number,
+    new_x: bool,
+    grad: *mut Number,
+    user: *mut c_void,
+) -> bool {
+    let data = unsafe { opt(user) };
+    let n = n as usize;
+    let v = unsafe { core::slice::from_raw_parts(vopt, n) }.to_vec();
+    if new_x {
+        setup::opt_data2model_data(data, &v, 1);
+    }
+    let (nv, nsi, np, n_j) = (data.dim.nv, data.dim.nsi, data.dim.np, data.dim.n_j);
+    let out = unsafe { core::slice::from_raw_parts_mut(grad, n) };
+    if data.s.lagrange {
+        let mut ii = 0;
+        for i in 0..nsi {
+            for j in 0..np {
+                out[ii..ii + nv].copy_from_slice(data.jac_row(i, j, n_j));
+                ii += nv;
+            }
+        }
+    } else {
+        out.fill(0.0);
+    }
+    if data.s.mayer {
+        let grad_m = data.jac_row(nsi - 1, np - 1, n_j + 1).to_vec();
+        let base = n - nv;
+        if data.s.lagrange {
+            for i in 0..nv {
+                out[base + i] += grad_m[i];
+            }
+        } else {
+            out[base..base + nv].copy_from_slice(&grad_m);
+        }
+    }
+    true
+}
+
+// ───────────────────────────────── EvalG.c ─────────────────────────────────
+
+/// C's `evalfG`: the collocation constraints and the path/final constraints.
+pub(crate) unsafe extern "C" fn eval_g(
+    _n: Index,
+    vopt: *mut Number,
+    new_x: bool,
+    m: Index,
+    g: *mut Number,
+    user: *mut c_void,
+) -> bool {
+    let data = unsafe { opt(user) };
+    let nv_total = data.dim.nv_total;
+    let v = unsafe { core::slice::from_raw_parts(vopt, nv_total) }.to_vec();
+    if new_x {
+        let index = data.index;
+        setup::opt_data2model_data(data, &v, index);
+    }
+    let (nx, nv, nc, ncf, nsi, np) = (
+        data.dim.nx,
+        data.dim.nv,
+        data.dim.nc,
+        data.dim.ncf,
+        data.dim.nsi,
+        data.dim.np,
+    );
+    let index_con = data.dim.index_con;
+    let index_conf = data.dim.index_conf;
+    let m = m as usize;
+    let out = unsafe { core::slice::from_raw_parts_mut(g, m) };
+    let a = data.rk.a;
+
+    // The previous point's states (`sv0` for the first interval), and this
+    // interval's points, as C's sliding `vv` window.
+    let point = |i: usize, k: usize| -> &[f64] {
+        let base = (i * np + k) * nv;
+        &v[base..base + nv]
+    };
+    let mut shift = 0;
+    if np == 3 {
+        for i in 0..nsi {
+            let sdt = &data.bounds.scaldt[i];
+            let prev: Vec<f64> = if i == 0 {
+                data.sv0.clone()
+            } else {
+                point(i - 1, np - 1).to_vec()
+            };
+            let (p0, p1, p2) =
+                (point(i, 0).to_vec(), point(i, 1).to_vec(), point(i, 2).to_vec());
+            for (j, coeff) in a.iter().enumerate().take(3) {
+                for k in 0..nx {
+                    let der = data.v(i, j)[nx + k];
+                    out[shift] = match j {
+                        0 => {
+                            (coeff[0] * prev[k] + coeff[3] * p2[k] + sdt[k] * der)
+                                - (coeff[1] * p0[k] + coeff[2] * p1[k])
+                        }
+                        1 => {
+                            (coeff[1] * p0[k] + sdt[k] * der)
+                                - (coeff[0] * prev[k] + coeff[2] * p1[k] + coeff[3] * p2[k])
+                        }
+                        _ => {
+                            (coeff[0] * prev[k] + coeff[2] * p1[k] + sdt[k] * der)
+                                - (coeff[1] * p0[k] + coeff[3] * p2[k])
+                        }
+                    };
+                    shift += 1;
+                }
+                out[shift..shift + nc]
+                    .copy_from_slice(&data.v(i, j)[index_con..index_con + nc]);
+                shift += nc;
+            }
+        }
+        // Terminal constraint(s).
+        if ncf > 0 {
+            let last = data.v(nsi - 1, 2)[index_conf..index_conf + ncf].to_vec();
+            out[shift..shift + ncf].copy_from_slice(&last);
+        }
+    } else if np == 1 {
+        for i in 0..nsi {
+            let sdt = &data.bounds.scaldt[i];
+            let prev: Vec<f64> = if i == 0 {
+                data.sv0.clone()
+            } else {
+                point(i - 1, 0).to_vec()
+            };
+            let p0 = point(i, 0).to_vec();
+            for k in 0..nx {
+                let der = data.v(i, 0)[nx + k];
+                out[shift] = prev[k] + (sdt[k] * der - p0[k]);
+                shift += 1;
+            }
+            out[shift..shift + nc].copy_from_slice(&data.v(i, 0)[index_con..index_con + nc]);
+            shift += nc;
+        }
+        if ncf > 0 {
+            let last = data.v(nsi - 1, 0)[index_conf..index_conf + ncf].to_vec();
+            out[m - ncf..].copy_from_slice(&last);
+        }
+    }
+    if omclog::active(omclog::IPOPT_ERROR) {
+        print_max_error(data, out);
+    }
+    true
+}
+
+/// C's `printMaxError`: the largest constraint violation and where it is, logged
+/// once per `evalfG` under `-lv=LOG_IPOPT_ERROR`.
+fn print_max_error(data: &OptData, g: &[f64]) {
+    let (nx, n_j, np, nsi, ncf) = (
+        data.dim.nx,
+        data.dim.n_j,
+        data.dim.np,
+        data.dim.nsi,
+        data.dim.ncf,
+    );
+    let mut gmax = -1.0;
+    let (mut ii, mut jj, mut kk) = (0usize, 0usize, -1i64);
+    let mut l = 0;
+    for i in 0..nsi {
+        for j in 0..np {
+            for k in 0..nx {
+                let tmp = libm::fabs(g[l]);
+                l += 1;
+                if tmp > gmax {
+                    (ii, jj, kk, gmax) = (i, j, k as i64, tmp);
+                }
+            }
+            for k in nx..n_j {
+                let over = g[l] - data.ipop.gmax[l];
+                let under = data.ipop.gmin[l] - g[l];
+                let tmp = over.max(under).max(0.0);
+                l += 1;
+                if tmp > gmax {
+                    (ii, jj, kk, gmax) = (i, j, k as i64, tmp);
+                }
+            }
+        }
+    }
+    for k in n_j..n_j + ncf {
+        let over = g[l] - data.ipop.gmax[l];
+        let under = data.ipop.gmin[l] - g[l];
+        let tmp = over.max(under).max(0.0);
+        l += 1;
+        if tmp > gmax {
+            (ii, jj, kk, gmax) = (nsi - 1, np - 1, k as i64, tmp);
+        }
+    }
+    if kk < 0 {
+        return;
+    }
+    let kk = kk as usize;
+    let t = data.time.t[ii][jj];
+    let name = |i: usize| data.names.get(i).map(alloc::string::String::as_str).unwrap_or("");
+    // C prints these through `ryu_hr_tdzp_buf`, the shortest round-trip form.
+    let (g, tt) = (omclog::shortest(gmax), omclog::shortest(t));
+    let msg = if kk < nx {
+        format!("max error is {g} for the approximation of the state {}(time = {tt})", name(kk))
+    } else if kk < n_j {
+        format!(
+            "max violation is {g} for the constraint {}(time = {tt})",
+            name(kk - nx + data.dim.index_con)
+        )
+    } else {
+        format!(
+            "max violation is {g} for the final constraint {}(time = {tt})",
+            name(kk - nx + data.dim.index_con)
+        )
+    };
+    omclog::info(omclog::IPOPT_ERROR, false, &msg);
+}
+
+/// C's `evalfDiffG`: the constraint Jacobian, as a triplet pattern on the first
+/// call and values afterwards.
+pub(crate) unsafe extern "C" fn eval_jac_g(
+    _n: Index,
+    vopt: *mut Number,
+    new_x: bool,
+    _m: Index,
+    nele: Index,
+    i_row: *mut Index,
+    j_col: *mut Index,
+    values: *mut Number,
+    user: *mut c_void,
+) -> bool {
+    let data = unsafe { opt(user) };
+    let nele = nele as usize;
+    if values.is_null() {
+        let rows = unsafe { core::slice::from_raw_parts_mut(i_row, nele) };
+        let cols = unsafe { core::slice::from_raw_parts_mut(j_col, nele) };
+        generated_jac_struct(data, rows, cols);
+        return true;
+    }
+    let nv_total = data.dim.nv_total;
+    let v = unsafe { core::slice::from_raw_parts(vopt, nv_total) }.to_vec();
+    data.iter_ += 1;
+    if new_x {
+        setup::opt_data2model_data(data, &v, 1);
+    }
+    let (nx, nv, n_j, ncf, nsi, np) = (
+        data.dim.nx,
+        data.dim.nv,
+        data.dim.n_j,
+        data.dim.ncf,
+        data.dim.nsi,
+        data.dim.np,
+    );
+    let out = unsafe { core::slice::from_raw_parts_mut(values, nele) };
+    let mut k = 0;
+    if np == 3 {
+        for i in 0..nsi {
+            for j in 0..np {
+                for l in 0..nx {
+                    let a = data.rk.a[j];
+                    let row = data.jac_row(i, j, l).to_vec();
+                    let pat = &data.s.jder_con[l * nv..l * nv + nv];
+                    // The first interval has no incoming state, so its first block
+                    // lacks the `a[0]` cell.
+                    match (i, j) {
+                        (0, 0) => struct_jac_01(&a, &row, out, &mut k, l, pat),
+                        (0, 1) => struct_jac_02(&a, &row, out, &mut k, l, pat),
+                        (0, 2) => struct_jac_03(&a, &row, out, &mut k, l, pat),
+                        (_, 0) => struct_jac_1(&a, &row, out, &mut k, l, pat),
+                        (_, 1) => struct_jac_2(&a, &row, out, &mut k, l, pat),
+                        (_, _) => struct_jac_3(&a, &row, out, &mut k, l, pat),
+                    }
+                }
+                for l in nx..n_j {
+                    let row = data.jac_row(i, j, l).to_vec();
+                    let pat = &data.s.jder_con[l * nv..l * nv + nv];
+                    struct_jac_c(&row, out, &mut k, pat);
+                }
+            }
+        }
+        for l in 0..ncf {
+            let row = data.jf[l * nv..l * nv + nv].to_vec();
+            let pat = &data.s.j[2][l * nv..l * nv + nv];
+            struct_jac_c(&row, out, &mut k, pat);
+        }
+    } else if np == 1 {
+        for i in 0..nsi {
+            for l in 0..nx {
+                if i > 0 {
+                    out[k] = 1.0;
+                    k += 1;
+                }
+                let row = data.jac_row(i, 0, l).to_vec();
+                for ii in 0..nv {
+                    if data.s.jder_con[l * nv + ii] {
+                        out[k] = if ii == l { row[ii] - 1.0 } else { row[ii] };
+                        k += 1;
+                    }
+                }
+            }
+            for l in nx..n_j {
+                let row = data.jac_row(i, 0, l).to_vec();
+                for ii in 0..nv {
+                    if data.s.jder_con[l * nv + ii] {
+                        out[k] = row[ii];
+                        k += 1;
+                    }
+                }
+            }
+        }
+        for l in 0..ncf {
+            let row = data.jf[l * nv..l * nv + nv].to_vec();
+            let pat = &data.s.j[2][l * nv..l * nv + nv];
+            struct_jac_c(&row, out, &mut k, pat);
+        }
+    }
+    true
+}
+
+/// C's `structJac01`: the first interval's first collocation point.
+fn struct_jac_01(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    for (l, &on) in pat.iter().enumerate() {
+        if on {
+            out[*k] = if j == l { row[l] - a[1] } else { row[l] };
+            *k += 1;
+        }
+    }
+    out[*k] = -a[2];
+    *k += 1;
+    out[*k] = a[3];
+    *k += 1;
+}
+
+fn struct_jac_1(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    out[*k] = a[0];
+    *k += 1;
+    struct_jac_01(a, row, out, k, j, pat);
+}
+
+fn struct_jac_02(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    out[*k] = a[1];
+    *k += 1;
+    for (l, &on) in pat.iter().enumerate() {
+        if on {
+            out[*k] = if j == l { row[l] - a[2] } else { row[l] };
+            *k += 1;
+        }
+    }
+    out[*k] = -a[3];
+    *k += 1;
+}
+
+fn struct_jac_2(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    out[*k] = -a[0];
+    *k += 1;
+    struct_jac_02(a, row, out, k, j, pat);
+}
+
+fn struct_jac_03(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    out[*k] = -a[1];
+    *k += 1;
+    out[*k] = a[2];
+    *k += 1;
+    for (l, &on) in pat.iter().enumerate() {
+        if on {
+            out[*k] = if j == l { row[l] - a[3] } else { row[l] };
+            *k += 1;
+        }
+    }
+}
+
+fn struct_jac_3(a: &[f64; 5], row: &[f64], out: &mut [f64], k: &mut usize, j: usize, pat: &[bool]) {
+    out[*k] = a[0];
+    *k += 1;
+    struct_jac_03(a, row, out, k, j, pat);
+}
+
+/// C's `structJacC`: a constraint row, no collocation cells.
+fn struct_jac_c(row: &[f64], out: &mut [f64], k: &mut usize, pat: &[bool]) {
+    for (l, &on) in pat.iter().enumerate() {
+        if on {
+            out[*k] = row[l];
+            *k += 1;
+        }
+    }
+}
+
+/// C's `generated_jac_struc`: the triplet pattern of the whole constraint Jacobian.
+fn generated_jac_struct(data: &OptData, rows: &mut [Index], cols: &mut [Index]) {
+    let (nv, nx, nsi, n_j, np, ncf) = (
+        data.dim.nv,
+        data.dim.nx,
+        data.dim.nsi,
+        data.dim.n_j,
+        data.dim.np,
+        data.dim.ncf,
+    );
+    let npv = np * nv;
+    // One writer for both triplet arrays, so the pattern helpers below can share it
+    // (two closures cannot each hold `&mut` to the arrays).
+    struct Trip<'a> {
+        rows: &'a mut [Index],
+        cols: &'a mut [Index],
+        k: usize,
+    }
+    impl Trip<'_> {
+        fn cell(&mut self, r: usize, c: usize) {
+            self.rows[self.k] = r as Index;
+            self.cols[self.k] = c as Index;
+            self.k += 1;
+        }
+        fn row(&mut self, pat: &[bool], r: usize, c: usize) {
+            for (i, &on) in pat.iter().enumerate() {
+                if on {
+                    self.cell(r, c + i);
+                }
+            }
+        }
+    }
+    let mut t = Trip { rows, cols, k: 0 };
+    let pat = |l: usize| &data.s.jder_con[l * nv..l * nv + nv];
+    let patf = |l: usize| &data.s.j[2][l * nv..l * nv + nv];
+
+    let mut r = 0;
+    let mut c = 0;
+    if np == 3 {
+        for block in 0..3 {
+            for j in 0..nx {
+                let tmp_r = r + j;
+                let tmp_c = c + j;
+                match block {
+                    0 => {
+                        t.row(pat(j), tmp_r, c);
+                        t.cell(tmp_r, tmp_c + nv);
+                        t.cell(tmp_r, tmp_c + 2 * nv);
+                    }
+                    1 => {
+                        t.cell(tmp_r, tmp_c);
+                        t.row(pat(j), tmp_r, c + nv);
+                        t.cell(tmp_r, tmp_c + 2 * nv);
+                    }
+                    _ => {
+                        t.cell(tmp_r, tmp_c);
+                        t.cell(tmp_r, tmp_c + nv);
+                        t.row(pat(j), tmp_r, c + 2 * nv);
+                    }
+                }
+            }
+            for j in nx..n_j {
+                t.row(pat(j), r + j, c + block * nv);
+            }
+            r += n_j;
+        }
+        c = (np - 1) * nv;
+        for _ in 1..nsi {
+            for block in 0..3 {
+                for j in 0..nx {
+                    let tmp_r = r + j;
+                    let tmp_c = c + j;
+                    for m in 0..4 {
+                        if m == block + 1 {
+                            t.row(pat(j), tmp_r, c + (block + 1) * nv);
+                        } else {
+                            t.cell(tmp_r, tmp_c + m * nv);
+                        }
+                    }
+                }
+                for j in nx..n_j {
+                    t.row(pat(j), r + j, c + (block + 1) * nv);
+                }
+                r += n_j;
+            }
+            c += npv;
+        }
+        for j in 0..ncf {
+            t.row(patf(j), r + j, c);
+        }
+    } else if np == 1 {
+        for j in 0..n_j {
+            t.row(pat(j), r + j, c);
+        }
+        r += n_j;
+        c = (np - 1) * nv;
+        for _ in 1..nsi {
+            for j in 0..nx {
+                t.cell(r + j, c + j);
+                t.row(pat(j), r + j, c + nv);
+            }
+            for j in nx..n_j {
+                t.row(pat(j), r + j, c + nv);
+            }
+            r += n_j;
+            c += npv;
+        }
+        for j in 0..ncf {
+            t.row(patf(j), r + j, c);
+        }
+    }
+}
+
+// ───────────────────────────────── EvalL.c ─────────────────────────────────
+
+/// C's `guess_step_size_for_numerical_differentiation`.
+fn guess_step(v: f64) -> f64 {
+    1e-5 * libm::fabs(v) + 1e-8
+}
+
+/// C's `ipopt_h`: the Lagrangian's Hessian, differenced from the symbolic
+/// Jacobians (C differentiates the Jacobian numerically rather than emitting a
+/// second-order derivative).
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe extern "C" fn eval_h(
+    _n: Index,
+    vopt: *mut Number,
+    _new_x: bool,
+    obj_factor: Number,
+    m: Index,
+    lambda: *mut Number,
+    _new_lambda: bool,
+    nele: Index,
+    i_row: *mut Index,
+    j_col: *mut Index,
+    values: *mut Number,
+    user: *mut c_void,
+) -> bool {
+    let data = unsafe { opt(user) };
+    let nele = nele as usize;
+    let keep = data.dim.update_hessian > data.dim.iter_update_hessian;
+    data.dim.iter_update_hessian += 1;
+    if values.is_null() {
+        let rows = unsafe { core::slice::from_raw_parts_mut(i_row, nele) };
+        let cols = unsafe { core::slice::from_raw_parts_mut(j_col, nele) };
+        init_hessian_structure(data, rows, cols);
+        return true;
+    }
+    let out = unsafe { core::slice::from_raw_parts_mut(values, nele) };
+    if keep {
+        out.copy_from_slice(&data.old_h[..nele]);
+        return true;
+    }
+    let nv_total = data.dim.nv_total;
+    let mut v = unsafe { core::slice::from_raw_parts(vopt, nv_total) }.to_vec();
+    let lam = unsafe { core::slice::from_raw_parts(lambda, m as usize) }.to_vec();
+    fill_hessian_values(data, &mut v, &lam, obj_factor, out);
+    if data.dim.update_hessian > 0 {
+        data.old_h[..nele].copy_from_slice(out);
+    }
+    true
+}
+
+/// C's `init_hessian_structure`: the lower triangle of each point's Hessian block.
+fn init_hessian_structure(data: &OptData, rows: &mut [Index], cols: &mut [Index]) {
+    let (nsi, np, nv) = (data.dim.nsi, data.dim.np, data.dim.nv);
+    let mut k = 0;
+    let (mut r, mut c) = (0usize, 0usize);
+    for _ in 0..nsi.saturating_sub(1) {
+        for _ in 0..np {
+            for j in 0..nv {
+                for l in 0..j + 1 {
+                    if data.s.h0[j * nv + l] {
+                        rows[k] = (r + j) as Index;
+                        cols[k] = (c + l) as Index;
+                        k += 1;
+                    }
+                }
+            }
+            r += nv;
+            c += nv;
+        }
+    }
+    // The last interval: its final point uses `H1` (the Mayer term and the final
+    // constraints contribute only there).
+    for p in 1..=np {
+        for j in 0..nv {
+            for l in 0..j + 1 {
+                let h1 = np == p && data.s.h1[j * nv + l];
+                if h1 || data.s.h0[j * nv + l] {
+                    rows[k] = (r + j) as Index;
+                    cols[k] = (c + l) as Index;
+                    k += 1;
+                }
+            }
+        }
+        r += nv;
+        c += nv;
+    }
+}
+
+/// C's `fill_hessian_values`.
+fn fill_hessian_values(
+    data: &mut OptData,
+    v: &mut [f64],
+    lambda: &[f64],
+    obj_factor: f64,
+    out: &mut [f64],
+) {
+    let (nsi, np, nv, n_j) = (data.dim.nsi, data.dim.np, data.dim.nv, data.dim.n_j);
+    let update_cost = obj_factor != 0.0;
+    let update_mayer = update_cost && data.s.mayer;
+    let update_lagrange = update_cost && data.s.lagrange;
+    data.dim.iter += 1;
+    data.dim.iter_update_hessian = 0;
+    setup::copy_initial_values(data);
+
+    let mut k = 0;
+    let mut voff = 0;
+    let mut loff = 0;
+    for ii in 0..nsi.saturating_sub(1) {
+        for p in 0..np {
+            hessian_numerical(data, v, voff, &lambda[loff..], obj_factor, ii, p, false);
+            for i in 0..nv {
+                for j in 0..i + 1 {
+                    if data.s.h0[i * nv + j] {
+                        out[k] = weighted_sum(data, i, j, update_lagrange);
+                        k += 1;
+                    }
+                }
+            }
+            voff += nv;
+            loff += n_j;
+        }
+    }
+    let ii = nsi - 1;
+    for p in 0..np {
+        hessian_numerical(data, v, voff, &lambda[loff..], obj_factor, ii, p, true);
+        for i in 0..nv {
+            for j in 0..i + 1 {
+                let last = p + 1 == np;
+                if last && data.s.h1[i * nv + j] {
+                    out[k] = weighted_sum_last(data, i, j, update_lagrange, update_mayer);
+                    k += 1;
+                } else if data.s.h0[i * nv + j] {
+                    out[k] = weighted_sum(data, i, j, update_lagrange);
+                    k += 1;
+                }
+            }
+        }
+        voff += nv;
+        loff += n_j;
+    }
+}
+
+/// C's `calculate_hessian_matrix_numerical` and its
+/// `..._last_time_intervall` variant: difference the symbolic Jacobian in each
+/// optimization variable.
+#[allow(clippy::too_many_arguments)]
+fn hessian_numerical(
+    data: &mut OptData,
+    v: &mut [f64],
+    voff: usize,
+    lambda: &[f64],
+    obj_factor: f64,
+    i: usize,
+    j: usize,
+    last_interval: bool,
+) {
+    let (nv, nx, n_j, np, nsi, ncf) = (
+        data.dim.nv,
+        data.dim.nx,
+        data.dim.n_j,
+        data.dim.np,
+        data.dim.nsi,
+        data.dim.ncf,
+    );
+    let n_j1 = n_j + 1;
+    let update_cost = data.s.lagrange && obj_factor != 0.0;
+    let final_point = last_interval && j + 1 == np && i + 1 == nsi;
+    let update_mayer = final_point && data.s.mayer && obj_factor != 0.0;
+    let jac_index = if update_mayer { 3 } else { 2 };
+
+    let t = data.time.t[i][j];
+    data.model.set_time(t);
+    let point = data.v(i, j).to_vec();
+    data.model.write_reals(&point);
+
+    for ii in 0..nv {
+        let v_save = v[voff + ii];
+        let mut h = guess_step(v_save);
+        v[voff + ii] += h;
+        // C flips the difference at the upper bound (`>=` off the last interval).
+        let at_bound = if last_interval {
+            v[voff + ii] > data.bounds.vmax[ii]
+        } else {
+            v[voff + ii] >= data.bounds.vmax[ii]
+        };
+        if at_bound {
+            h = -h;
+            v[voff + ii] = v_save + h;
+        }
+        // The perturbed point through the model, then its Jacobian.
+        let mut perturbed = data.v(i, j).to_vec();
+        for l in 0..nx {
+            perturbed[l] = v[voff + l] * data.bounds.vnom[l];
+        }
+        data.model.write_reals(&perturbed);
+        for l in nx..nv {
+            data.model.inputs[l - nx] = v[voff + l] * data.bounds.vnom[l];
+        }
+        let opt = data.opt.clone();
+        data.model.input_function(&opt);
+        data.model.update_discrete_system();
+        let saved = core::mem::take(&mut data.tmp_j);
+        data.tmp_j = saved;
+        diff_syn_colored_tmp(data, i, j, jac_index);
+        v[voff + ii] = v_save;
+
+        for jj in 0..ii + 1 {
+            if data.s.h0[ii * nv + jj] {
+                for l in 0..n_j {
+                    let use_row = data.s.hg[(l * nv + ii) * nv + jj]
+                        && (last_interval || lambda.get(l).copied().unwrap_or(0.0) != 0.0);
+                    if use_row {
+                        let d = data.tmp_j[l * nv + jj] - data.jac_row(i, j, l)[jj];
+                        data.h[(l * nv + ii) * nv + jj] =
+                            d * lambda.get(l).copied().unwrap_or(0.0) / h;
+                    }
+                }
+            }
+        }
+        if update_cost {
+            let hh = obj_factor / h;
+            for jj in 0..ii + 1 {
+                if data.s.hl[ii * nv + jj] {
+                    let d = data.tmp_j[n_j * nv + jj] - data.jac_row(i, j, n_j)[jj];
+                    data.hl[ii * nv + jj] = d * hh;
+                } else if !last_interval {
+                    data.hl[ii * nv + jj] = 0.0;
+                }
+            }
+        }
+        if update_mayer {
+            let hh = obj_factor / h;
+            for jj in 0..ii + 1 {
+                if data.s.hm[ii * nv + jj] {
+                    let d = data.tmp_j[n_j1 * nv + jj] - data.jac_row(i, j, n_j1)[jj];
+                    data.hm[ii * nv + jj] = d * hh;
+                }
+            }
+        }
+        if final_point && ncf > 0 {
+            diff_syn_colored_f_tmp(data);
+            for jj in 0..ii + 1 {
+                if data.s.h0[ii * nv + jj] {
+                    for l in 0..ncf {
+                        if data.s.hcf[(l * nv + ii) * nv + jj] {
+                            let d = data.tmp_jf[l * nv + jj] - data.jf[l * nv + jj];
+                            data.hcf[(l * nv + ii) * nv + jj] =
+                                d * lambda.get(n_j + l).copied().unwrap_or(0.0) / h;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// [`setup::diff_syn_colored`] into `tmp_j` rather than the point's Jacobian.
+fn diff_syn_colored_tmp(data: &mut OptData, i: usize, j: usize, m: usize) {
+    let saved = data.jac(i, j).to_vec();
+    setup::diff_syn_colored(data, i, j, m);
+    let fresh = data.jac(i, j).to_vec();
+    data.tmp_j.copy_from_slice(&fresh);
+    data.jac_mut(i, j).copy_from_slice(&saved);
+}
+
+/// The same for the final constraints' Jacobian.
+fn diff_syn_colored_f_tmp(data: &mut OptData) {
+    let saved = data.jf.clone();
+    setup::diff_syn_colored_f(data);
+    data.tmp_jf = core::mem::replace(&mut data.jf, saved);
+}
+
+/// C's `calculate_weighted_sum_with_lagrange_multiplicator_from_tensor`.
+fn weighted_sum(data: &OptData, i: usize, j: usize, update_lagrange: bool) -> f64 {
+    let (nv, n_j) = (data.dim.nv, data.dim.n_j);
+    let mut sum = 0.0;
+    for l in 0..n_j {
+        if data.s.hg[(l * nv + i) * nv + j] {
+            sum += data.h[(l * nv + i) * nv + j];
+        }
+    }
+    if update_lagrange && data.s.hl[i * nv + j] {
+        sum += data.hl[i * nv + j];
+    }
+    sum
+}
+
+/// Its `..._last_time_intervall` variant, which adds the final constraints and the
+/// Mayer term.
+fn weighted_sum_last(
+    data: &OptData,
+    i: usize,
+    j: usize,
+    update_lagrange: bool,
+    update_mayer: bool,
+) -> f64 {
+    let (nv, n_j, ncf) = (data.dim.nv, data.dim.n_j, data.dim.ncf);
+    let mut sum = 0.0;
+    if data.s.h0[i * nv + j] {
+        for l in 0..n_j {
+            if data.s.hg[(l * nv + i) * nv + j] {
+                sum += data.h[(l * nv + i) * nv + j];
+            }
+        }
+        if update_lagrange && data.s.hl[i * nv + j] {
+            sum += data.hl[i * nv + j];
+        }
+    }
+    for l in 0..ncf {
+        if data.s.hcf[(l * nv + i) * nv + j] {
+            sum += data.hcf[(l * nv + i) * nv + j];
+        }
+    }
+    if update_mayer && data.s.hm[i * nv + j] {
+        sum += data.hm[i * nv + j];
+    }
+    sum
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/ipopt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/ipopt.rs
@@ -1,0 +1,307 @@
+//! Ipopt's C interface (`IpStdCInterface.h`), as the optimization runtime uses it.
+//!
+//! `ipnumber` is `double` and `ipindex` is `int` for the in-tree build
+//! (`IPOPT_SINGLE=OFF`, `IPOPT_INT64=OFF`); the callbacks return C `bool`, which
+//! is Rust's `bool`. Only the entry points `optimizer_main.c` calls are declared.
+
+use core::ffi::{c_char, c_int, c_void};
+
+pub type Number = f64;
+pub type Index = c_int;
+
+/// Opaque `IpoptProblem`.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Problem(*mut c_void);
+
+impl Problem {
+    pub fn is_null(self) -> bool {
+        self.0.is_null()
+    }
+}
+
+pub type EvalF =
+    unsafe extern "C" fn(Index, *mut Number, bool, *mut Number, *mut c_void) -> bool;
+pub type EvalGradF =
+    unsafe extern "C" fn(Index, *mut Number, bool, *mut Number, *mut c_void) -> bool;
+pub type EvalG =
+    unsafe extern "C" fn(Index, *mut Number, bool, Index, *mut Number, *mut c_void) -> bool;
+#[allow(clippy::type_complexity)]
+pub type EvalJacG = unsafe extern "C" fn(
+    Index,
+    *mut Number,
+    bool,
+    Index,
+    Index,
+    *mut Index,
+    *mut Index,
+    *mut Number,
+    *mut c_void,
+) -> bool;
+#[allow(clippy::type_complexity)]
+pub type EvalH = unsafe extern "C" fn(
+    Index,
+    *mut Number,
+    bool,
+    Number,
+    Index,
+    *mut Number,
+    bool,
+    Index,
+    *mut Index,
+    *mut Index,
+    *mut Number,
+    *mut c_void,
+) -> bool;
+
+unsafe extern "C" {
+    #[allow(clippy::too_many_arguments)]
+    fn CreateIpoptProblem(
+        n: Index,
+        x_l: *mut Number,
+        x_u: *mut Number,
+        m: Index,
+        g_l: *mut Number,
+        g_u: *mut Number,
+        nele_jac: Index,
+        nele_hess: Index,
+        index_style: Index,
+        eval_f: EvalF,
+        eval_g: EvalG,
+        eval_grad_f: EvalGradF,
+        eval_jac_g: EvalJacG,
+        eval_h: EvalH,
+    ) -> Problem;
+    fn FreeIpoptProblem(p: Problem);
+    fn AddIpoptStrOption(p: Problem, keyword: *const c_char, val: *const c_char) -> bool;
+    fn AddIpoptNumOption(p: Problem, keyword: *const c_char, val: Number) -> bool;
+    fn AddIpoptIntOption(p: Problem, keyword: *const c_char, val: Index) -> bool;
+    fn IpoptSolve(
+        p: Problem,
+        x: *mut Number,
+        g: *mut Number,
+        obj_val: *mut Number,
+        mult_g: *mut Number,
+        mult_x_l: *mut Number,
+        mult_x_u: *mut Number,
+        user_data: *mut c_void,
+    ) -> c_int;
+}
+
+/// `ApplicationReturnStatus`, as far as `runOptimizer` distinguishes them.
+pub const SOLVE_SUCCEEDED: c_int = 0;
+pub const SOLVED_TO_ACCEPTABLE_LEVEL: c_int = 1;
+
+/// An `IpoptProblem` that frees itself, so an early return cannot leak it.
+pub struct Nlp {
+    problem: Problem,
+}
+
+impl Drop for Nlp {
+    fn drop(&mut self) {
+        if !self.problem.is_null() {
+            unsafe { FreeIpoptProblem(self.problem) };
+        }
+    }
+}
+
+/// The callback set, in `CreateIpoptProblem` order.
+pub struct Callbacks {
+    pub f: EvalF,
+    pub g: EvalG,
+    pub grad_f: EvalGradF,
+    pub jac_g: EvalJacG,
+    pub h: EvalH,
+}
+
+/// The problem's bounds. Each slice is handed to Ipopt, which copies it.
+pub struct Bounds<'a> {
+    pub x_min: &'a mut [Number],
+    pub x_max: &'a mut [Number],
+    pub g_min: &'a mut [Number],
+    pub g_max: &'a mut [Number],
+    pub nele_jac: usize,
+    pub nele_hess: usize,
+}
+
+impl Nlp {
+    /// C's `CreateIpoptProblem` with 0-based (C-style) triplet indices.
+    pub fn new(b: Bounds<'_>, cb: Callbacks) -> Result<Self, &'static str> {
+        let n = b.x_min.len();
+        let m = b.g_min.len();
+        if b.x_max.len() != n || b.g_max.len() != m {
+            return Err("Ipopt: mismatched bound array lengths");
+        }
+        let problem = unsafe {
+            CreateIpoptProblem(
+                n as Index,
+                b.x_min.as_mut_ptr(),
+                b.x_max.as_mut_ptr(),
+                m as Index,
+                b.g_min.as_mut_ptr(),
+                b.g_max.as_mut_ptr(),
+                b.nele_jac as Index,
+                b.nele_hess as Index,
+                0,
+                cb.f,
+                cb.g,
+                cb.grad_f,
+                cb.jac_g,
+                cb.h,
+            )
+        };
+        if problem.is_null() {
+            return Err("Ipopt: CreateIpoptProblem failed");
+        }
+        Ok(Nlp { problem })
+    }
+
+    /// The option setters. A rejected keyword is a programming error here (the set
+    /// of options is fixed), so it is reported rather than ignored.
+    pub fn str_option(&self, keyword: &str, val: &str) -> bool {
+        let (k, v) = (cstr(keyword), cstr(val));
+        unsafe { AddIpoptStrOption(self.problem, k.as_ptr(), v.as_ptr()) }
+    }
+    pub fn num_option(&self, keyword: &str, val: f64) -> bool {
+        let k = cstr(keyword);
+        unsafe { AddIpoptNumOption(self.problem, k.as_ptr(), val) }
+    }
+    pub fn int_option(&self, keyword: &str, val: i32) -> bool {
+        let k = cstr(keyword);
+        unsafe { AddIpoptIntOption(self.problem, k.as_ptr(), val) }
+    }
+
+    /// C's `IpoptSolve`. `x` is the starting point on entry and the solution on
+    /// exit; the multiplier arrays are read for a warm start and written back.
+    /// `user_data` reaches the callbacks unmodified.
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve(
+        &self,
+        x: &mut [Number],
+        obj: &mut Number,
+        mult_g: &mut [Number],
+        mult_x_l: &mut [Number],
+        mult_x_u: &mut [Number],
+        user_data: *mut c_void,
+    ) -> c_int {
+        unsafe {
+            IpoptSolve(
+                self.problem,
+                x.as_mut_ptr(),
+                core::ptr::null_mut(),
+                obj,
+                mult_g.as_mut_ptr(),
+                mult_x_l.as_mut_ptr(),
+                mult_x_u.as_mut_ptr(),
+                user_data,
+            )
+        }
+    }
+}
+
+/// A NUL-terminated copy for the `char*` options; the C side copies the string.
+fn cstr(s: &str) -> alloc::vec::Vec<c_char> {
+    s.bytes().map(|b| b as c_char).chain(core::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ffi::c_void;
+
+    // HS071 from Ipopt's own C example: min x1*x4*(x1+x2+x3) + x3 subject to
+    // x1*x2*x3*x4 >= 25 and sum(xi^2) == 40, 1 <= xi <= 5. Solving it end to end
+    // is what proves the archive set, the callback ABI and the option setters.
+    unsafe extern "C" fn f(_n: Index, x: *mut Number, _new: bool, obj: *mut Number, _u: *mut c_void) -> bool {
+        let x = unsafe { core::slice::from_raw_parts(x, 4) };
+        unsafe { *obj = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2] };
+        true
+    }
+    unsafe extern "C" fn grad_f(_n: Index, x: *mut Number, _new: bool, g: *mut Number, _u: *mut c_void) -> bool {
+        let x = unsafe { core::slice::from_raw_parts(x, 4) };
+        let g = unsafe { core::slice::from_raw_parts_mut(g, 4) };
+        g[0] = x[3] * (2.0 * x[0] + x[1] + x[2]);
+        g[1] = x[0] * x[3];
+        g[2] = x[0] * x[3] + 1.0;
+        g[3] = x[0] * (x[0] + x[1] + x[2]);
+        true
+    }
+    unsafe extern "C" fn g(_n: Index, x: *mut Number, _new: bool, _m: Index, out: *mut Number, _u: *mut c_void) -> bool {
+        let x = unsafe { core::slice::from_raw_parts(x, 4) };
+        let out = unsafe { core::slice::from_raw_parts_mut(out, 2) };
+        out[0] = x[0] * x[1] * x[2] * x[3];
+        out[1] = x.iter().map(|v| v * v).sum();
+        true
+    }
+    #[allow(clippy::too_many_arguments)]
+    unsafe extern "C" fn jac_g(
+        _n: Index, x: *mut Number, _new: bool, _m: Index, _nele: Index,
+        i_row: *mut Index, j_col: *mut Index, values: *mut Number, _u: *mut c_void,
+    ) -> bool {
+        if values.is_null() {
+            let (r, c) = unsafe {
+                (core::slice::from_raw_parts_mut(i_row, 8), core::slice::from_raw_parts_mut(j_col, 8))
+            };
+            for k in 0..8 {
+                r[k] = (k / 4) as Index;
+                c[k] = (k % 4) as Index;
+            }
+        } else {
+            let x = unsafe { core::slice::from_raw_parts(x, 4) };
+            let v = unsafe { core::slice::from_raw_parts_mut(values, 8) };
+            v[0] = x[1] * x[2] * x[3];
+            v[1] = x[0] * x[2] * x[3];
+            v[2] = x[0] * x[1] * x[3];
+            v[3] = x[0] * x[1] * x[2];
+            for k in 0..4 {
+                v[4 + k] = 2.0 * x[k];
+            }
+        }
+        true
+    }
+    // Exact Hessian is optional for this check; BFGS keeps the test to the ABI.
+    #[allow(clippy::too_many_arguments)]
+    unsafe extern "C" fn h(
+        _n: Index, _x: *mut Number, _new: bool, _of: Number, _m: Index, _l: *mut Number,
+        _nl: bool, _nele: Index, _r: *mut Index, _c: *mut Index, _v: *mut Number, _u: *mut c_void,
+    ) -> bool {
+        false
+    }
+
+    #[test]
+    fn solves_hs071() {
+        let mut x_min = [1.0; 4];
+        let mut x_max = [5.0; 4];
+        let mut g_min = [25.0, 40.0];
+        let mut g_max = [2e19, 40.0];
+        let nlp = Nlp::new(
+            Bounds {
+                x_min: &mut x_min,
+                x_max: &mut x_max,
+                g_min: &mut g_min,
+                g_max: &mut g_max,
+                nele_jac: 8,
+                nele_hess: 10,
+            },
+            Callbacks { f, g, grad_f, jac_g, h },
+        )
+        .expect("CreateIpoptProblem");
+        assert!(nlp.str_option("hessian_approximation", "limited-memory"));
+        assert!(nlp.num_option("tol", 1e-8));
+        assert!(nlp.int_option("print_level", 0));
+        let mut x = [1.0, 5.0, 5.0, 1.0];
+        let mut obj = 0.0;
+        let mut mult_g = [0.0; 2];
+        let mut mult_l = [0.0; 4];
+        let mut mult_u = [0.0; 4];
+        let status =
+            nlp.solve(&mut x, &mut obj, &mut mult_g, &mut mult_l, &mut mult_u, core::ptr::null_mut());
+        assert_eq!(status, SOLVE_SUCCEEDED);
+        // The documented optimum.
+        let expect = [1.0, 4.743, 3.821, 1.379];
+        for (got, want) in x.iter().zip(expect) {
+            assert!((got - want).abs() < 1e-3, "x = {x:?}");
+        }
+        assert!((obj - 17.014).abs() < 1e-3, "obj = {obj}");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/ipopt_out.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/ipopt_out.rs
@@ -1,0 +1,96 @@
+//! Ipopt's own console output, into the run's log.
+//!
+//! Ipopt is C++ and writes its banner and its iteration table straight to `stdout`.
+//! With the C target that is the simulation executable's stdout, which omc captures
+//! whole; a wasm-jit run happens inside omc, so those bytes would bypass the log the
+//! `messages` field is built from and land on the terminal instead.
+//!
+//! So `stdout` is redirected into a pipe for the duration of the solve and drained
+//! into the log sink. The drain also runs at the top of every Ipopt callback, which
+//! is what keeps the order the C target has: the banner (written before the first
+//! callback) precedes the `LOG_IPOPT_ERROR` lines the callbacks emit.
+
+use alloc::string::String;
+use alloc::vec;
+
+/// The redirected `stdout`, restored on drop.
+pub(crate) struct Capture {
+    /// Read end of the pipe.
+    read: i32,
+    /// `dup` of the original `stdout`.
+    saved: i32,
+}
+
+unsafe extern "C" {
+    fn pipe(fds: *mut i32) -> i32;
+    fn dup(fd: i32) -> i32;
+    fn dup2(old: i32, new: i32) -> i32;
+    fn close(fd: i32) -> i32;
+    fn read(fd: i32, buf: *mut u8, n: usize) -> isize;
+    fn fflush(stream: *mut core::ffi::c_void) -> i32;
+    fn fcntl(fd: i32, cmd: i32, ...) -> i32;
+}
+
+/// `F_SETFL` / `O_NONBLOCK` on Linux and macOS; the drain must never block on an
+/// empty pipe.
+const F_SETFL: i32 = 4;
+const O_NONBLOCK: i32 = 0o4000;
+
+impl Capture {
+    /// Redirect `stdout`. `None` if the platform refuses, in which case Ipopt's
+    /// output goes where it always did.
+    pub(crate) fn begin() -> Option<Capture> {
+        let mut fds = [0i32; 2];
+        unsafe {
+            if pipe(fds.as_mut_ptr()) != 0 {
+                return None;
+            }
+            if fcntl(fds[0], F_SETFL, O_NONBLOCK) != 0 {
+                close(fds[0]);
+                close(fds[1]);
+                return None;
+            }
+            let saved = dup(1);
+            if saved < 0 || dup2(fds[1], 1) < 0 {
+                close(fds[0]);
+                close(fds[1]);
+                return None;
+            }
+            close(fds[1]);
+            Some(Capture { read: fds[0], saved })
+        }
+    }
+
+    /// Move whatever Ipopt has written so far into the log.
+    pub(crate) fn drain(&self) {
+        // Ipopt's C++ streams buffer; flush before reading so a partial line is not
+        // held back until the next drain.
+        unsafe { fflush(core::ptr::null_mut()) };
+        let mut buf = vec![0u8; 8192];
+        let mut out = String::new();
+        loop {
+            let n = unsafe { read(self.read, buf.as_mut_ptr(), buf.len()) };
+            if n <= 0 {
+                break;
+            }
+            out.push_str(&String::from_utf8_lossy(&buf[..n as usize]));
+            if (n as usize) < buf.len() {
+                break;
+            }
+        }
+        if !out.is_empty() {
+            crate::driver::log_line(&out);
+        }
+    }
+}
+
+impl Drop for Capture {
+    fn drop(&mut self) {
+        self.drain();
+        unsafe {
+            dup2(self.saved, 1);
+            close(self.saved);
+            close(self.read);
+        }
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/mod.rs
@@ -1,0 +1,517 @@
+//! `method="optimization"`: the collocation NLP `optimize()` solves with Ipopt.
+//!
+//! The port of `SimulationRuntime/c/optimization/`, structured like it:
+//! [`setup`] is `MoveData.c`/`DerStructure.c`/`InitialGuess.c`, [`eval`] is
+//! `eval_all/`, and this module is `optimizer_main.c` plus the shared data.
+//!
+//! Host-only, because Ipopt's only open linear solver (MUMPS) is Fortran and has
+//! no wasm build — an in-wasm runtime reports what a C runtime built without
+//! `OMC_HAVE_IPOPT` reports.
+//!
+//! **Precision.** The C code carries the time grid, the scaling factors and the
+//! Hessian accumulation in `long double` (x87 80-bit). wasm has no such type and
+//! neither does Rust, so those are `f64` here; the difference is in the last few
+//! bits of quantities that are then used to converge an NLP to `tol`.
+
+// Ipopt is linked only into a native (`std`) build; `build.rs` never sets the cfg
+// for wasm32.
+#[cfg(all(ipopt, feature = "std"))]
+pub mod ipopt;
+#[cfg(all(ipopt, feature = "std"))]
+mod ipopt_out;
+#[cfg(all(ipopt, feature = "std"))]
+mod eval;
+#[cfg(all(ipopt, feature = "std"))]
+mod model;
+#[cfg(all(ipopt, feature = "std"))]
+mod setup;
+
+/// C's `solver_main.c` when `OMC_HAVE_IPOPT` is undefined.
+pub const UNAVAILABLE: &str = "Ipopt is needed but not available.";
+
+/// Whether this build can run `method="optimization"`.
+pub const AVAILABLE: bool = cfg!(all(ipopt, feature = "std"));
+
+#[cfg(all(ipopt, feature = "std"))]
+pub use run::run_optimizer;
+
+#[cfg(all(ipopt, feature = "std"))]
+pub(crate) use crate::extinput::ExtInputHook;
+
+/// The driver's type-erased entry point into `-csvInput`'s hook, so the residual can
+/// re-read the external input without this module's types reaching `driver`.
+#[cfg(all(ipopt, feature = "std"))]
+pub(crate) const EXT_INPUT_APPLY: unsafe fn(
+    *mut core::ffi::c_void,
+    &mut dyn crate::driver::SimEngine,
+    u32,
+    f64,
+) = ExtInputHook::apply_erased;
+
+#[cfg(all(ipopt, feature = "std"))]
+mod run {
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::ipopt::{self, Bounds, Callbacks, Nlp};
+    use super::model::Model;
+    use super::{eval, setup};
+    use crate::driver::{self, Result, SimEngine};
+    use crate::{omclog, OptInfo, SimMeta};
+
+    /// C's `OptDataDim`.
+    #[derive(Default)]
+    pub(crate) struct Dim {
+        /// States, inputs and their sum: the variables at one collocation point.
+        pub nx: usize,
+        pub nu: usize,
+        pub nv: usize,
+        /// Path and final constraints.
+        pub nc: usize,
+        pub ncf: usize,
+        /// Rows of the constraint Jacobian per point: states + path constraints.
+        pub n_j: usize,
+        /// `n_j + 2`: the Lagrange and Mayer gradient rows sit above them.
+        pub n_j2: usize,
+        /// Collocation: `nsi` intervals of `np` points each.
+        pub nsi: usize,
+        pub np: usize,
+        pub nt: usize,
+        /// NLP sizes: variables and constraints.
+        pub nv_total: usize,
+        pub n_res: usize,
+        pub n_real: usize,
+        /// First real index of a path / final constraint.
+        pub index_con: usize,
+        pub index_conf: usize,
+        pub index_lagrange: usize,
+        pub index_mayer: usize,
+        /// Nonzeros of one point's constraint Jacobian, and of the final one.
+        pub n_jderx: usize,
+        pub n_jfderx: usize,
+        /// Hessian nonzeros: all of them, and the upper triangle (`_`), for a
+        /// generic point (`0`) and for the last one (`1`).
+        pub nh0: usize,
+        pub nh1: usize,
+        pub nh0_: usize,
+        pub nh1_: usize,
+        /// `-keepHessian`: reuse the Hessian for this many iterations.
+        pub update_hessian: i32,
+        pub iter_update_hessian: i32,
+        /// `-optimizerTimeGrid` supplied a grid.
+        pub ex_time_grid: bool,
+        pub iter: u32,
+    }
+
+    /// C's `OptDataTime`.
+    #[derive(Default)]
+    pub(crate) struct Time {
+        pub t0: f64,
+        pub tf: f64,
+        /// Length of each interval (`nsi + 1` entries, as in C).
+        pub dt: Vec<f64>,
+        /// Collocation times, `nsi × np`.
+        pub t: Vec<Vec<f64>>,
+        /// The model supplied the grid through `$OPT_TGRID`.
+        pub model_grid: bool,
+        pub tt: Vec<f64>,
+    }
+
+    /// C's `OptDataBounds`. `v*` are per-variable (`nv`), `V*` per NLP variable.
+    #[derive(Default)]
+    pub(crate) struct BoundsData {
+        pub vmin: Vec<f64>,
+        pub vmax: Vec<f64>,
+        pub v_min_all: Vec<f64>,
+        pub v_max_all: Vec<f64>,
+        pub vnom: Vec<f64>,
+        pub scal_f: Vec<f64>,
+        /// `scal_f[j] * dt[i]`, `nsi × nx`.
+        pub scaldt: Vec<Vec<f64>>,
+        /// `dt[i] * b[j]`, `nsi × np`.
+        pub scalb: Vec<Vec<f64>>,
+        pub u0: Vec<f64>,
+        /// C's `preSim`: the Optimica `startTime`, before which a pre-simulation runs.
+        pub pre_sim: f64,
+    }
+
+    /// C's `OptDataRK`: the Radau IIA coefficients for `np` collocation points.
+    #[derive(Default)]
+    pub(crate) struct Rk {
+        pub a: [[f64; 5]; 5],
+        pub b: [f64; 5],
+    }
+
+    /// C's `OptDataIpopt`.
+    #[derive(Default)]
+    pub(crate) struct Ipop {
+        pub vopt: Vec<f64>,
+        pub gmin: Vec<f64>,
+        pub gmax: Vec<f64>,
+        pub mult_g: Vec<f64>,
+        pub mult_x_l: Vec<f64>,
+        pub mult_x_u: Vec<f64>,
+        /// `-csvOstep` / `-optDebugJac`: dump each step / compare the Jacobian.
+        pub csv_ostep: Option<String>,
+        pub debug_jac: Option<String>,
+    }
+
+    /// C's `OptDataStructure`: which entries of the Jacobians, gradients and
+    /// Hessians can be nonzero. Flat bit maps with the C shapes.
+    #[derive(Default)]
+    pub(crate) struct Structure {
+        /// C's `matrix[0..4]`, indexed like its `indexABCD`.
+        pub matrix: [bool; 5],
+        /// `J[0]`: `(n_j + 1) × nv` (B), `J[1]`: `n_j2 × nv` (C), `J[2]`: `ncf × nv` (D).
+        pub j: [Vec<bool>; 3],
+        /// `nv × nv` each.
+        pub h0: Vec<bool>,
+        pub h1: Vec<bool>,
+        pub hm: Vec<bool>,
+        pub hl: Vec<bool>,
+        /// `n_j × nv × nv` and `ncf × nv × nv`.
+        pub hg: Vec<bool>,
+        pub hcf: Vec<bool>,
+        pub lagrange: bool,
+        pub mayer: bool,
+        /// C's `derIndex`: the Mayer row in C, the Lagrange rows in B and C.
+        pub der_index: [i32; 3],
+        pub grad_m: Vec<bool>,
+        pub grad_l: Vec<bool>,
+        /// Rows of B / C holding the path constraints (skipping the objective rows).
+        pub index_con2: Vec<usize>,
+        pub index_con3: Vec<usize>,
+        /// Row remapping for B / C: a matrix row -> its slot in `J[i][j]`.
+        pub index_j2: Vec<usize>,
+        pub index_j3: Vec<usize>,
+        /// The constraint Jacobian's own pattern, `n_j × nv`.
+        pub jder_con: Vec<bool>,
+    }
+
+    /// C's `OptData`: everything the callbacks share.
+    pub(crate) struct OptData {
+        pub dim: Dim,
+        pub time: Time,
+        pub bounds: BoundsData,
+        pub rk: Rk,
+        pub s: Structure,
+        pub ipop: Ipop,
+        /// Real variables at each collocation point, `nsi × np × n_real`, flat.
+        pub v: Vec<f64>,
+        /// The initial real variables, and the scaled initial states.
+        pub v0: Vec<f64>,
+        pub sv0: Vec<f64>,
+        /// The discrete state (`pre` values, relations, integers, booleans) as the
+        /// initialization left it; C's `copy_initial_values` restores it per point.
+        pub snapshot: Vec<u8>,
+        /// Constraint Jacobians per point, `nsi × np × n_j2 × nv`, flat.
+        pub j: Vec<f64>,
+        /// Scratch for the perturbed Jacobian the Hessian differences.
+        pub tmp_j: Vec<f64>,
+        /// Final-constraint Jacobian, `ncf × nv`, and its scratch.
+        pub jf: Vec<f64>,
+        pub tmp_jf: Vec<f64>,
+        /// Hessian contributions: constraints (`n_j × nv × nv`), Lagrange and Mayer
+        /// (`nv × nv`), final constraints (`ncf × nv × nv`).
+        pub h: Vec<f64>,
+        pub hl: Vec<f64>,
+        pub hm: Vec<f64>,
+        pub hcf: Vec<f64>,
+        /// `-keepHessian`'s saved values.
+        pub old_h: Vec<f64>,
+        /// C's `iter_`: `evalfDiffG` calls, for `-optDebugJac`.
+        pub iter_: i32,
+        /// C's `index`: whether the Jacobians are evaluated along with the system.
+        pub index: i32,
+        pub model: Model,
+        pub opt: OptInfo,
+        /// Real-variable names, for the log messages.
+        pub names: Vec<String>,
+        /// The rows `res2file` produced, in the driver's result-row layout.
+        pub rows: Vec<f64>,
+        /// `optimizeInput.csv`, which C writes alongside the result file.
+        pub input_csv: String,
+        /// Ipopt's redirected `stdout` while it solves; the callbacks drain it so its
+        /// banner keeps its place in the log.
+        pub out: Option<super::ipopt_out::Capture>,
+        /// The model's metadata, for the initial guess's integrator.
+        pub meta: SimMeta,
+        /// Run scalars the C code reads off `simulationInfo`.
+        pub tol: f64,
+        pub start_time: f64,
+        pub stop_time: f64,
+        pub num_steps: u32,
+    }
+
+    impl OptData {
+        /// `v[i][j]` — one collocation point's real variables.
+        pub fn v(&self, i: usize, j: usize) -> &[f64] {
+            let n = self.dim.n_real;
+            let base = (i * self.dim.np + j) * n;
+            &self.v[base..base + n]
+        }
+        pub fn v_mut(&mut self, i: usize, j: usize) -> &mut [f64] {
+            let n = self.dim.n_real;
+            let base = (i * self.dim.np + j) * n;
+            &mut self.v[base..base + n]
+        }
+        /// `J[i][j]` — one point's constraint Jacobian, `n_j2 × nv` row-major.
+        pub fn jac(&self, i: usize, j: usize) -> &[f64] {
+            let n = self.dim.n_j2 * self.dim.nv;
+            let base = (i * self.dim.np + j) * n;
+            &self.j[base..base + n]
+        }
+        pub fn jac_mut(&mut self, i: usize, j: usize) -> &mut [f64] {
+            let n = self.dim.n_j2 * self.dim.nv;
+            let base = (i * self.dim.np + j) * n;
+            &mut self.j[base..base + n]
+        }
+        pub fn jac_row(&self, i: usize, j: usize, row: usize) -> &[f64] {
+            let nv = self.dim.nv;
+            &self.jac(i, j)[row * nv..row * nv + nv]
+        }
+    }
+
+    /// C's `runOptimizer`. Returns the result rows; the caller writes them out.
+    pub fn run_optimizer(
+        e: &mut (dyn SimEngine + 'static),
+        meta: &SimMeta,
+        sim_data: u32,
+    ) -> Result<Vec<f64>> {
+        let Some(opt) = meta.opt.clone() else {
+            // C's generated stubs when the model was translated without Optimica.
+            return Err("The model was not compiled with -g=Optimica and the corresponding goal \
+                        function. The optimization solver cannot be used.");
+        };
+        // C sets `noThrowDivZero` for the whole optimization: a division by zero at a
+        // trial point must not abort the solve.
+        let mut data = setup::pick_up_model_data(e, meta, sim_data, opt)?;
+        setup::initial_guess(&mut data)?;
+        setup::allocate_der_struct(&mut data)?;
+        let status = solve(&mut data);
+        setup::res2file(&mut data)?;
+        if let Some(err) = data.model.err {
+            return Err(err);
+        }
+        if status != ipopt::SOLVE_SUCCEEDED && status != ipopt::SOLVED_TO_ACCEPTABLE_LEVEL {
+            return Err(OPTIMIZATION_FAILED);
+        }
+        Ok(core::mem::take(&mut data.rows))
+    }
+
+    /// What `performSimulation` reports when the step returns nonzero.
+    pub const OPTIMIZATION_FAILED: &str = "model terminate | optimization failed.";
+
+    /// Ipopt's own banner (`IpoptApplication::PrintCopyrightMessage`), verbatim.
+    const IPOPT_BANNER: &str = "\n\
+        ******************************************************************************\n\
+        This program contains Ipopt, a library for large-scale nonlinear optimization.\n\
+        \u{20}Ipopt is released as open source code under the Eclipse Public License (EPL).\n\
+        \u{20}        For more information visit https://github.com/coin-or/Ipopt\n\
+        ******************************************************************************\n\n";
+
+    /// C's `optimizationWithIpopt`: the options it sets, then `IpoptSolve`.
+    fn solve(data: &mut OptData) -> i32 {
+        let d = &data.dim;
+        let (nsi, np, nx) = (d.nsi, d.np, d.nx);
+        let njac = np * (d.n_jderx * nsi + nx * (np * nsi - 1)) + d.n_jfderx;
+        let nhess = (nsi * np - 1) * d.nh0_ + d.nh1_;
+        let tol = data.tol;
+        let mut max_iter = 5000i32;
+
+        let mut x_min = core::mem::take(&mut data.bounds.v_min_all);
+        let mut x_max = core::mem::take(&mut data.bounds.v_max_all);
+        let mut g_min = core::mem::take(&mut data.ipop.gmin);
+        let mut g_max = core::mem::take(&mut data.ipop.gmax);
+        let nlp = Nlp::new(
+            Bounds {
+                x_min: &mut x_min,
+                x_max: &mut x_max,
+                g_min: &mut g_min,
+                g_max: &mut g_max,
+                nele_jac: njac,
+                nele_hess: nhess,
+            },
+            Callbacks {
+                f: eval::eval_f,
+                g: eval::eval_g,
+                grad_f: eval::eval_grad_f,
+                jac_g: eval::eval_jac_g,
+                h: eval::eval_h,
+            },
+        );
+        let nlp = match nlp {
+            Ok(n) => n,
+            Err(e) => {
+                omclog::error(omclog::STDOUT, false, e);
+                return -1;
+            }
+        };
+        // The bounds are copied by Ipopt; `gmin`/`gmax` are read again by
+        // `printMaxError`, so they go back.
+        data.ipop.gmin = g_min;
+        data.ipop.gmax = g_max;
+
+        nlp.num_option("tol", tol);
+        nlp.str_option("evaluate_orig_obj_at_resto_trial", "yes");
+        // Ipopt prints its banner from a `static` guard, i.e. once per process. The C
+        // target forks a fresh executable per run, so every run shows it; here the
+        // runs share omc's process, so it is suppressed and written by hand where
+        // Ipopt would have printed it -- inside the solve, which `-ipopt_max_iter`
+        // below a zero skips entirely.
+        nlp.str_option("sb", "yes");
+
+        let print_level = if omclog::active(omclog::IPOPT_FULL) {
+            7
+        } else if omclog::active(omclog::IPOPT) {
+            5
+        } else if omclog::active(omclog::STATS) {
+            3
+        } else {
+            2
+        };
+        nlp.int_option("print_level", print_level);
+        nlp.int_option("file_print_level", 0);
+
+        let (jac_test, hesse_test) =
+            (omclog::active(omclog::IPOPT_JAC), omclog::active(omclog::IPOPT_HESSE));
+        match (jac_test, hesse_test) {
+            (true, true) => {
+                nlp.int_option("print_level", 4);
+                nlp.str_option("derivative_test", "second-order");
+            }
+            (true, false) => {
+                nlp.int_option("print_level", 4);
+                nlp.str_option("derivative_test", "first-order");
+            }
+            (false, true) => {
+                nlp.int_option("print_level", 4);
+                nlp.str_option("derivative_test", "only-second-order");
+            }
+            (false, false) => {
+                nlp.str_option("derivative_test", "none");
+            }
+        }
+
+        let flags = crate::simflags::with_flags(|f| f.clone());
+        match flags.ipopt_hesse.as_deref() {
+            Some("BFGS") => {
+                nlp.str_option("hessian_approximation", "limited-memory");
+            }
+            Some("const") | Some("CONST") => {
+                nlp.str_option("hessian_constant", "yes");
+            }
+            Some("num") | Some("NUM") | None => {}
+            Some(other) => omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!("not support ipopt_hesse={other}"),
+            ),
+        }
+
+        if let Some(ls) = flags.ls_ipopt.as_deref() {
+            nlp.str_option("linear_solver", ls);
+        }
+        nlp.num_option("mumps_pivtolmax", 1e-5);
+
+        match flags.ipopt_max_iter.as_deref() {
+            Some(v) => {
+                // C accepts `<digits>e<digits>` as well as a plain integer, and
+                // prints what it parsed.
+                match v.split_once('e') {
+                    None => {
+                        max_iter = v.parse().unwrap_or(0);
+                        if max_iter >= 0 {
+                            nlp.int_option("max_iter", max_iter);
+                        }
+                        driver::log_line(&format!(
+                            "\nmax_iter = {}",
+                            v.parse::<i32>().unwrap_or(0)
+                        ));
+                    }
+                    Some((m, x)) => {
+                        let (m, x): (i32, i32) = (m.parse().unwrap_or(0), x.parse().unwrap_or(0));
+                        let scaled = (m as f64) * libm::pow(10.0, x as f64);
+                        max_iter = scaled as i32;
+                        if max_iter >= 0 {
+                            nlp.int_option("max_iter", max_iter);
+                        }
+                        driver::log_line(&format!(
+                            "\nmax_iter = (int) {} | (double) {}",
+                            max_iter,
+                            crate::driver::format_g(scaled, 6)
+                        ));
+                    }
+                }
+            }
+            None => {
+                nlp.int_option("max_iter", 5000);
+            }
+        }
+
+        // Heuristics: a warm start shifts the barrier parameter and the bound
+        // multipliers toward the given decade.
+        let ws: i32 = flags.ipopt_warm_start.as_deref().and_then(|v| v.parse().ok()).unwrap_or(0);
+        if ws > 0 {
+            let shift = libm::pow(10.0, -(ws as f64));
+            nlp.num_option("mu_init", shift);
+            nlp.num_option("bound_mult_init_val", shift);
+            nlp.str_option("mu_strategy", "monotone");
+            nlp.num_option("bound_push", 1e-5);
+            nlp.num_option("bound_frac", 1e-5);
+            nlp.num_option("slack_bound_push", 1e-5);
+            nlp.num_option("constr_mult_init_max", 1e-5);
+            nlp.str_option("bound_mult_init_method", "mu-based");
+        } else {
+            nlp.str_option("mu_strategy", "adaptive");
+            nlp.str_option("bound_mult_init_method", "constant");
+        }
+        nlp.str_option("fixed_variable_treatment", "make_parameter");
+        nlp.str_option("dependency_detection_with_rhs", "yes");
+        nlp.num_option("nu_init", 1e-9);
+        nlp.num_option("eta_phi", 1e-10);
+
+        let mut res = 0;
+        if max_iter >= 0 {
+            data.iter_ = 0;
+            data.index = 1;
+            driver::log_line(IPOPT_BANNER);
+            data.out = super::ipopt_out::Capture::begin();
+            let mut vopt = core::mem::take(&mut data.ipop.vopt);
+            let mut mult_g = core::mem::take(&mut data.ipop.mult_g);
+            let mut mult_l = core::mem::take(&mut data.ipop.mult_x_l);
+            let mut mult_u = core::mem::take(&mut data.ipop.mult_x_u);
+            let mut obj = 0.0;
+            let user = data as *mut OptData as *mut core::ffi::c_void;
+            res = nlp.solve(&mut vopt, &mut obj, &mut mult_g, &mut mult_l, &mut mult_u, user);
+            data.ipop.vopt = vopt;
+            data.ipop.mult_g = mult_g;
+            data.ipop.mult_x_l = mult_l;
+            data.ipop.mult_x_u = mult_u;
+            // Restores `stdout` and drains the tail (Ipopt's final summary).
+            data.out = None;
+        }
+        if res != 0 && !omclog::active(omclog::IPOPT) {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                "No optimal solution found!\nUse -lv=LOG_IPOPT for more information.",
+            );
+        }
+        // The bounds Ipopt copied are ours again, for a caller that re-solves.
+        data.bounds.v_min_all = x_min;
+        data.bounds.v_max_all = x_max;
+        res
+    }
+
+    /// Zeroed vectors of `n` elements, the C `calloc` idiom.
+    pub(crate) fn zeros(n: usize) -> Vec<f64> {
+        vec![0.0; n]
+    }
+
+    pub(crate) fn flags_bool(n: usize) -> Vec<bool> {
+        vec![false; n]
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/model.rs
@@ -1,0 +1,236 @@
+//! What the C optimizer does to `DATA` directly, done to the model's `SimData`.
+//!
+//! The C code swaps `data->localData[0..2]->realVars` between per-collocation-point
+//! buffers and reads `data->simulationInfo->inputVars`. A wasm model has one live
+//! real region (plus its `pre()` mirror), so a buffer swap becomes a copy in/out of
+//! that region, and `inputVars` is a Vec here whose `input_function` writes the
+//! input variables' slots.
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::driver::{self, SimEngine};
+use crate::{Layout, OptInfo, OptJac, REAL_OFF, TIME_OFF};
+
+/// The model handle the optimizer and its Ipopt callbacks evaluate through. Holds
+/// the engine as a raw pointer because the callbacks reach it through Ipopt's
+/// user-data pointer, exactly as the DASSL residual reaches its `ResCtx`.
+pub struct Model {
+    pub engine: *mut (dyn SimEngine + 'static),
+    pub sim_data: u32,
+    pub layout: Layout,
+    /// Number of real variables (C's `nVariablesReal`): states, derivatives and
+    /// algebraics, in that order — the same index space as C's `realVars`.
+    pub n_real: usize,
+    /// Live `inputVars` (C's `simulationInfo->inputVars`).
+    pub inputs: Vec<f64>,
+    /// Address of the runtime's evaluation-context word, for `setContext`.
+    pub ctx_addr: u32,
+    /// A wasm trap or memory error captured inside a callback, surfaced once Ipopt
+    /// returns (the C-style callbacks cannot propagate a `Result`).
+    pub err: Option<&'static str>,
+}
+
+impl Model {
+    pub fn new(e: &mut (dyn SimEngine + 'static), sim_data: u32, layout: &Layout, n_inputs: usize) -> Self {
+        let ctx_addr = e.context_addr();
+        Model {
+            engine: e as *mut _,
+            sim_data,
+            layout: *layout,
+            n_real: (2 * layout.n_states + layout.n_real_alg) as usize,
+            inputs: vec![0.0; n_inputs],
+            ctx_addr,
+            err: None,
+        }
+    }
+
+    /// Borrow the engine. Sound for the lifetime of the optimizer run: the `&mut`
+    /// it was built from outlives every callback Ipopt makes.
+    #[allow(clippy::mut_from_ref)]
+    fn e(&self) -> &mut (dyn SimEngine + 'static) {
+        unsafe { &mut *self.engine }
+    }
+
+    /// Remember the first error and keep going, like the C callbacks do (they
+    /// return TRUE regardless and let the next model call fail).
+    fn note(&mut self, r: driver::Result<()>) {
+        if let Err(e) = r
+            && self.err.is_none()
+        {
+            self.err = Some(e);
+        }
+    }
+
+    fn real_base(&self) -> u32 {
+        self.sim_data + REAL_OFF
+    }
+
+    /// C's `memcpy(sData->realVars, …)` in both directions.
+    pub fn read_reals(&mut self, out: &mut [f64]) {
+        let base = self.real_base();
+        let mut bytes = vec![0u8; out.len() * 8];
+        let r = self.e().read_bytes(base, &mut bytes);
+        self.note(r);
+        for (v, c) in out.iter_mut().zip(bytes.chunks_exact(8)) {
+            *v = f64::from_le_bytes(c.try_into().unwrap());
+        }
+    }
+
+    pub fn write_reals(&mut self, vals: &[f64]) {
+        let base = self.real_base();
+        let bytes: Vec<u8> = vals.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let r = self.e().write_bytes(base, &bytes);
+        self.note(r);
+    }
+
+    /// The `pre()` mirror of the real region, which `setLocalVars` seeds a
+    /// collocation point's discrete variables from.
+    pub fn read_pre_reals(&mut self, out: &mut [f64]) {
+        let base = self.sim_data + self.layout.pre_real_off;
+        let mut bytes = vec![0u8; out.len() * 8];
+        let r = self.e().read_bytes(base, &mut bytes);
+        self.note(r);
+        for (v, c) in out.iter_mut().zip(bytes.chunks_exact(8)) {
+            *v = f64::from_le_bytes(c.try_into().unwrap());
+        }
+    }
+
+    pub fn read_real(&mut self, index: usize) -> f64 {
+        let addr = self.real_base() + (index as u32) * 8;
+        match driver::read_f64(self.e(), addr) {
+            Ok(v) => v,
+            Err(e) => {
+                self.note(Err(e));
+                0.0
+            }
+        }
+    }
+
+    pub fn write_real(&mut self, index: usize, v: f64) {
+        let addr = self.real_base() + (index as u32) * 8;
+        let r = driver::write_f64(self.e(), addr, v);
+        self.note(r);
+    }
+
+    /// A raw `SimData` region, for the discrete-state snapshot.
+    pub fn read_region(&mut self, off: u32, out: &mut [u8]) {
+        let addr = self.sim_data + off;
+        let r = self.e().read_bytes(addr, out);
+        self.note(r);
+    }
+
+    pub fn write_region(&mut self, off: u32, bytes: &[u8]) {
+        let addr = self.sim_data + off;
+        let r = self.e().write_bytes(addr, bytes);
+        self.note(r);
+    }
+
+    pub fn write_f64_at(&mut self, off: u32, v: f64) {
+        let addr = self.sim_data + off;
+        let r = driver::write_f64(self.e(), addr, v);
+        self.note(r);
+    }
+
+    pub fn read_f64_at(&mut self, off: u32) -> f64 {
+        let addr = self.sim_data + off;
+        match driver::read_f64(self.e(), addr) {
+            Ok(v) => v,
+            Err(e) => {
+                self.note(Err(e));
+                0.0
+            }
+        }
+    }
+
+    pub fn read_i32_at(&mut self, off: u32) -> i32 {
+        let addr = self.sim_data + off;
+        match driver::read_i32(self.e(), addr) {
+            Ok(v) => v,
+            Err(e) => {
+                self.note(Err(e));
+                0
+            }
+        }
+    }
+
+    pub fn set_time(&mut self, t: f64) {
+        let addr = self.sim_data + TIME_OFF;
+        let r = driver::write_f64(self.e(), addr, t);
+        self.note(r);
+    }
+
+    /// C's `input_function`: publish `inputVars` to the input variables' slots.
+    pub fn input_function(&mut self, opt: &OptInfo) {
+        for (k, &index) in opt.inputs.iter().enumerate() {
+            let v = self.inputs[k];
+            self.write_real(index as usize, v);
+        }
+    }
+
+    /// C's generated `setInputData(data, file)`: read the input variables back into
+    /// `inputVars`. With `from_file`, an `OPT_LOOP_INPUT` first takes the value of
+    /// the variable that replaces it.
+    pub fn set_input_data(&mut self, opt: &OptInfo, from_file: bool) {
+        if from_file {
+            for &(k, src) in &opt.loop_inputs {
+                let v = self.read_real(src as usize);
+                let dst = opt.inputs[k as usize] as usize;
+                self.write_real(dst, v);
+            }
+        }
+        for (k, &index) in opt.inputs.iter().enumerate() {
+            self.inputs[k] = self.read_real(index as usize);
+        }
+    }
+
+    /// C's `updateDiscreteSystem`: the discrete update run to a fixed point.
+    pub fn update_discrete_system(&mut self) {
+        let (sim_data, layout) = (self.sim_data, self.layout);
+        let r = driver::iterate_discrete(self.e(), sim_data, &layout);
+        self.note(r);
+    }
+
+    /// One symbolic Jacobian column set, C's `diffSynColoredOptimizerSystem` inner
+    /// loop: seed the columns of one color with their nominal values, run the
+    /// column equations, and read the rows the sparsity pattern lists.
+    ///
+    /// `out` is `n_rows × n_cols` row-major (C's `J[row][col]`), written only where
+    /// the pattern has a nonzero — the caller keeps the rest.
+    pub fn eval_jac_colored(
+        &mut self,
+        jac: &OptJac,
+        vnom: &[f64],
+        mut store: impl FnMut(usize, usize, f64),
+    ) {
+        let (sim_data, ctx) = (self.sim_data, self.ctx_addr);
+        // C's `setContext(CONTEXT_SYM_JACOBIAN)`: a column is evaluated at perturbed
+        // states, so the nonlinear solver must not record it as an initial guess.
+        driver::set_context_jacobian(self.e(), ctx);
+        if !jac.const_fn.is_empty() {
+            let r = self.e().call1_if_present(&jac.const_fn, sim_data);
+            self.note(r);
+        }
+        for color in &jac.colors {
+            // Seeds: this color's columns at their nominal value, everything else 0.
+            for (col, &off) in jac.seed_offs.iter().enumerate() {
+                let v = if color.contains(&(col as u32)) { vnom[col] } else { 0.0 };
+                let r = driver::write_f64(self.e(), sim_data + off, v);
+                self.note(r);
+            }
+            let r = self.e().call1(&jac.column_fn, sim_data);
+            self.note(r);
+            for &col in color {
+                for &row in &jac.rows_by_col[col as usize] {
+                    let off = jac.result_offs[row as usize];
+                    let v = self.read_f64_at(off);
+                    store(row as usize, col as usize, v);
+                }
+            }
+        }
+        // C's `unsetContext` restores what the driver leaves standing between calls.
+        driver::set_context_algebraic(self.e(), ctx);
+    }
+
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/setup.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/setup.rs
@@ -1,0 +1,1483 @@
+//! The port of `optimization/DataManagement/`: picking the problem out of the
+//! model (`MoveData.c`), the derivative/Hessian structure (`DerStructure.c`), the
+//! initial guess (`InitialGuess.c`) and writing the solution back (`res2file`).
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use super::model::Model;
+use super::run::{flags_bool, zeros, BoundsData, Dim, Ipop, OptData, Rk, Structure, Time};
+use crate::driver::{self, format_g, Result, SimEngine};
+use crate::{omclog, OptInfo, OptJac, SimMeta};
+
+/// Radau IIA collocation points for `np = 3` (C's `c[]`), and the trivial one for
+/// `np = 1`.
+const C3: [f64; 3] = [
+    0.155_051_025_721_682_19,
+    0.644_948_974_278_317_8,
+    1.000_00,
+];
+
+/// C's `pickUpModelData`.
+pub(crate) fn pick_up_model_data(
+    e: &mut (dyn SimEngine + 'static),
+    meta: &SimMeta,
+    sim_data: u32,
+    opt: OptInfo,
+) -> Result<OptData> {
+    let mut model = Model::new(e, sim_data, &meta.layout, opt.inputs.len());
+    let names = opt.real_names.clone();
+    let mut data = OptData {
+        dim: Dim::default(),
+        time: Time::default(),
+        bounds: BoundsData::default(),
+        rk: Rk::default(),
+        s: Structure::default(),
+        ipop: Ipop::default(),
+        v: Vec::new(),
+        v0: Vec::new(),
+        sv0: Vec::new(),
+        snapshot: Vec::new(),
+        j: Vec::new(),
+        tmp_j: Vec::new(),
+        jf: Vec::new(),
+        tmp_jf: Vec::new(),
+        h: Vec::new(),
+        hl: Vec::new(),
+        hm: Vec::new(),
+        hcf: Vec::new(),
+        old_h: Vec::new(),
+        iter_: 0,
+        index: 0,
+        model: core::mem::replace(&mut model, Model::new(e, sim_data, &meta.layout, 0)),
+        opt,
+        names,
+        rows: Vec::new(),
+        input_csv: String::new(),
+        out: None,
+        meta: meta.clone(),
+        tol: meta.tolerance,
+        start_time: meta.start_time,
+        stop_time: meta.stop_time,
+        num_steps: meta.n_intervals,
+    };
+    // The model handle above was swapped out to satisfy the borrow checker; use the
+    // real one (same engine and layout, sized for the inputs).
+    data.model = Model::new(e, sim_data, &meta.layout, data.opt.inputs.len());
+
+    pick_up_dim(&mut data);
+    // C's `check_nominal` reads the initialized state (`localData[1]->realVars`) for
+    // its heuristic, so the initial values are latched before the bounds.
+    data.v0 = zeros(data.dim.n_real);
+    data.model.read_reals(&mut data.v0);
+    pick_up_bounds(&mut data);
+    pick_up_time(&mut data);
+    set_rk_coeff(&mut data);
+    calculated_scaling_helper(&mut data);
+    omclog::close(omclog::SOLVER);
+
+    let (nsi, np, n_real) = (data.dim.nsi, data.dim.np, data.dim.n_real);
+    data.v = zeros(nsi * np * n_real);
+    // C copies `localData[0]->realVars` here, after the bounds; `-stateFile` may
+    // still change it.
+    data.model.read_reals(&mut data.v0);
+    pick_up_states(&mut data);
+
+    data.sv0 = (0..data.dim.nx).map(|i| data.v0[i] * data.bounds.scal_f[i]).collect();
+    data.snapshot = read_snapshot(&mut data);
+    print_some_model_infos(&mut data);
+    if let Some(err) = data.model.err {
+        return Err(err);
+    }
+    Ok(data)
+}
+
+/// The discrete state `copy_initial_values` restores at every collocation point:
+/// C's integer/boolean variables, their `pre` values, the real `pre` values and the
+/// three relation arrays.
+fn snapshot_regions(data: &OptData) -> Vec<(u32, usize)> {
+    let l = &data.model.layout;
+    let n_real = data.dim.n_real;
+    vec![
+        (l.int_off, (l.n_int_alg() * 4) as usize),
+        (l.bool_off, (l.n_bool_alg() * 4) as usize),
+        (l.pre_real_off, n_real * 8),
+        (l.pre_int_off, (l.n_int_alg() * 4) as usize),
+        (l.pre_bool_off, (l.n_bool_alg() * 4) as usize),
+        (l.relations_off, (l.n_rel * 4) as usize),
+        (l.relations_pre_off, (l.n_rel * 4) as usize),
+        (l.stored_rel_off, (l.n_rel * 4) as usize),
+    ]
+}
+
+fn read_snapshot(data: &mut OptData) -> Vec<u8> {
+    let regions = snapshot_regions(data);
+    let total: usize = regions.iter().map(|r| r.1).sum();
+    let mut out = vec![0u8; total];
+    let mut p = 0;
+    for (off, len) in regions {
+        let end = p + len;
+        data.model.read_region(off, &mut out[p..end]);
+        p = end;
+    }
+    out
+}
+
+/// C's `copy_initial_values`: the initial real variables and the whole discrete
+/// state back into the model.
+pub(crate) fn copy_initial_values(data: &mut OptData) {
+    let v0 = core::mem::take(&mut data.v0);
+    data.model.write_reals(&v0);
+    data.v0 = v0;
+    let snap = core::mem::take(&mut data.snapshot);
+    let mut p = 0;
+    for (off, len) in snapshot_regions(data) {
+        data.model.write_region(off, &snap[p..p + len]);
+        p += len;
+    }
+    data.snapshot = snap;
+}
+
+/// C's `pickUpDim`.
+fn pick_up_dim(data: &mut OptData) {
+    let np = match crate::simflags::with_flags(|f| f.optimizer_np) {
+        Some(n) if n == 1 || n == 3 => n as usize,
+        Some(n) => {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!(
+                    "FLAG_OPTIZER_NP is {n}. Currently optimizer support only 1 and 3.\n\
+                     FLAG_OPTIZER_NP set of 3"
+                ),
+            );
+            3
+        }
+        None => 3,
+    };
+    let l = data.model.layout;
+    let opt = &data.opt;
+    let d = &mut data.dim;
+    d.np = np;
+    d.nx = l.n_states as usize;
+    d.nu = opt.inputs.len();
+    d.nv = d.nx + d.nu;
+    d.nc = opt.n_con as usize;
+    d.ncf = opt.n_final_con as usize;
+    d.n_j = d.nx + d.nc;
+    d.n_j2 = d.n_j + 2;
+    d.n_real = (2 * l.n_states + l.n_real_alg) as usize;
+    d.index_con = d.n_real - (d.nc + d.ncf);
+    d.index_conf = d.index_con + d.nc;
+
+    // C's `getTimeGrid`: a model-supplied grid wins over `numberOfIntervals`, and
+    // `-optimizerTimeGrid` over both.
+    data.time.model_grid = !opt.tgrid.is_empty();
+    d.nsi = if data.time.model_grid {
+        opt.tgrid.len() - 1
+    } else {
+        data.num_steps as usize
+    };
+    if data.time.model_grid {
+        let offs = data.opt.tgrid.clone();
+        data.time.tt = offs.iter().map(|&off| data.model.read_f64_at(off)).collect();
+    }
+    if let Some(file) = crate::simflags::with_flags(|f| f.optimizer_tgrid.clone()) {
+        let (nsi, ok) = grid_file_rows(&file, data.dim.nsi);
+        data.dim.nsi = nsi;
+        data.dim.ex_time_grid = ok;
+    }
+    let d = &mut data.dim;
+    d.nt = d.nsi * d.np;
+    d.nv_total = d.nt * d.nv;
+    d.n_res = d.nt * d.n_j + d.ncf;
+    assert!(d.nt > 0);
+}
+
+/// C's `getNsi`: one interval per line of the grid file, minus the first (`t0`).
+fn grid_file_rows(file: &str, nsi: usize) -> (usize, bool) {
+    match read_grid_file(file) {
+        Err(e) => {
+            omclog::warning(omclog::STDOUT, false, &e);
+            (nsi, false)
+        }
+        Ok(times) if times.len() < 2 => {
+            omclog::warning(omclog::STDOUT, false, &format!("time grid file: {file} is empty"));
+            (nsi, false)
+        }
+        Ok(times) => (times.len() - 1, true),
+    }
+}
+
+/// The times in a `-optimizerTimeGrid` file, one per line.
+fn read_grid_file(file: &str) -> core::result::Result<Vec<f64>, String> {
+    let text = crate::extinput::read_file(file)
+        .ok_or_else(|| format!("OMC can't find the file {file}."))?;
+    Ok(text.split_whitespace().filter_map(|w| w.parse::<f64>().ok()).collect())
+}
+
+/// C's `pickUpTime`: the collocation grid.
+fn pick_up_time(data: &mut OptData) {
+    let (nsi, np) = (data.dim.nsi, data.dim.np);
+    let np1 = np - 1;
+    let c: Vec<f64> = match np {
+        1 => vec![1.0],
+        3 => C3.to_vec(),
+        n => {
+            omclog::error(omclog::STDOUT, false, &format!("Not support np = {n}"));
+            vec![1.0]
+        }
+    };
+    let t = &mut data.time;
+    t.t0 = data.start_time.max(data.bounds.pre_sim);
+    t.tf = data.stop_time;
+    t.dt = zeros(nsi + 1);
+    t.dt[0] = (t.tf - t.t0) / nsi as f64;
+    t.t = vec![zeros(np); nsi];
+    if nsi < 1 {
+        omclog::error(
+            omclog::STDOUT,
+            false,
+            &format!("Not support numberOfIntervals = {nsi} < 1"),
+        );
+    }
+    let dc: Vec<f64> = c.iter().map(|ck| ck * t.dt[0]).collect();
+    for k in 0..np {
+        t.t[0][k] = t.t0 + dc[k];
+    }
+    for i in 1..nsi {
+        t.dt[i] = t.dt[i - 1];
+        for k in 0..np {
+            t.t[i][k] = t.t[i - 1][np1] + dc[k];
+        }
+    }
+    t.t[nsi - 1][np1] = t.tf;
+    if nsi > 1 {
+        let i = nsi - 1;
+        t.dt[i] = t.t[i][np1] - t.t[i - 1][np1];
+        for k in 0..np {
+            t.t[i][k] = t.t[i - 1][np1] + c[k] * t.dt[i];
+        }
+    } else {
+        t.dt[1] = t.dt[0];
+    }
+
+    if let Some(file) = crate::simflags::with_flags(|f| f.optimizer_tgrid.clone()) {
+        overwrite_time_grid_file(data, &file, &c);
+    }
+    if data.time.model_grid {
+        overwrite_time_grid_model(data, &c);
+    }
+}
+
+/// C's `overwriteTimeGridFile`: the file lists the interval end points.
+fn overwrite_time_grid_file(data: &mut OptData, file: &str, c: &[f64]) {
+    let times = match read_grid_file(file) {
+        Ok(t) if t.len() >= 2 => t,
+        _ => return,
+    };
+    let (nsi, np) = (data.dim.nsi, data.dim.np);
+    let np1 = np - 1;
+    let t = &mut data.time;
+    t.t0 = times[0];
+    t.t[0][np1] = times[1];
+    t.dt[0] = t.t[0][np1] - t.t0;
+    if t.dt[0] <= 0.0 {
+        omclog::warning(omclog::STDOUT, false, "read time grid from file fail!");
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            &format!("line 0: {} <= {}", format_g(t.t[0][np1], 6), format_g(t.t0, 6)),
+        );
+        return;
+    }
+    for k in 0..np {
+        t.t[0][k] = t.t0 + c[k] * t.dt[0];
+    }
+    for i in 1..nsi {
+        let Some(&end) = times.get(i + 1) else { break };
+        t.t[i][np1] = end;
+        t.dt[i] = t.t[i][np1] - t.t[i - 1][np1];
+        for k in 0..np {
+            t.t[i][k] = t.t[i - 1][np1] + c[k] * t.dt[i];
+        }
+        if t.dt[i] <= 0.0 {
+            omclog::warning(omclog::STDOUT, false, "read time grid");
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!(
+                    "line {i}/{nsi}: {} <= {}",
+                    format_g(t.t[i][np1], 6),
+                    format_g(t.t[i - 1][np1], 6)
+                ),
+            );
+            omclog::warning(omclog::STDOUT, false, "failed!");
+            return;
+        }
+    }
+    t.tf = t.t[nsi - 1][np1];
+}
+
+/// C's `overwriteTimeGridModel`: the `$OPT_TGRID` parameters, sorted.
+fn overwrite_time_grid_model(data: &mut OptData, c: &[f64]) {
+    let (nsi, np) = (data.dim.nsi, data.dim.np);
+    let t = &mut data.time;
+    t.t0 = t.tt[0];
+    t.tf = t.tt[nsi];
+    t.tt.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    for i in 0..nsi {
+        t.dt[i] = t.tt[i + 1] - t.tt[i];
+        for k in 0..np {
+            t.t[i][k] = t.tt[i] + c[k] * t.dt[i];
+        }
+    }
+}
+
+/// C's `pickUpBounds`, including `pickUpBoundsForInputsInOptimization`: the
+/// per-variable bounds, the nominal heuristic and the scaled NLP bounds.
+fn pick_up_bounds(data: &mut OptData) {
+    let (nx, nu, nv) = (data.dim.nx, data.dim.nu, data.dim.nv);
+    let attrs = data.model.layout;
+    let inputs = data.opt.inputs.clone();
+
+    data.bounds.vnom = zeros(nv);
+    data.bounds.scal_f = zeros(nv);
+    data.bounds.vmin = zeros(nv);
+    data.bounds.vmax = zeros(nv);
+    data.bounds.u0 = zeros(nu);
+
+    // C's `startTimeOpt`: `startTime - 1` unless the model set the class attribute,
+    // in which case a pre-simulation runs from `startTime` to it.
+    data.bounds.pre_sim = match data.opt.start_time_opt {
+        Some(off) => data.model.read_f64_at(off),
+        None => data.start_time - 1.0,
+    };
+
+    // Inputs first (C fills `umin`/`umax`/`unom`/`u0` through the callback), then the
+    // states, then the input nominals — the order matters because `check_nominal`
+    // reads `u0` clipped to its bounds.
+    let mut use_nominal_input = vec![false; nu];
+    for (k, &idx) in inputs.iter().enumerate() {
+        let i = idx as usize;
+        data.bounds.vmin[nx + k] = data.model.read_f64_at(attrs.opt_min_off + (i as u32) * 8);
+        data.bounds.vmax[nx + k] = data.model.read_f64_at(attrs.opt_max_off + (i as u32) * 8);
+        data.bounds.vnom[nx + k] = data.model.read_f64_at(attrs.opt_nom_off + (i as u32) * 8);
+        data.bounds.u0[k] = data.model.read_f64_at(attrs.real_start_off(i as u32));
+        use_nominal_input[k] = data.model.read_i32_at(attrs.opt_use_nom_off + (i as u32) * 4) != 0;
+    }
+
+    for i in 0..nx {
+        let min = data.model.read_f64_at(attrs.opt_min_off + (i as u32) * 8);
+        let max = data.model.read_f64_at(attrs.opt_max_off + (i as u32) * 8);
+        let nominal = data.model.read_f64_at(attrs.opt_nom_off + (i as u32) * 8);
+        let set = data.model.read_i32_at(attrs.opt_use_nom_off + (i as u32) * 4) != 0;
+        let x0 = data.v0.get(i).copied().unwrap_or(0.0);
+        data.bounds.vnom[i] = check_nominal(min, max, nominal, set, x0);
+        // C writes the heuristic nominal back into the model's attribute, so the
+        // initial guess's DASSL tolerances are scaled by it.
+        let nom = data.bounds.vnom[i];
+        data.model.write_f64_at(attrs.opt_nom_off + (i as u32) * 8, nom);
+        data.model.write_f64_at(data.model.layout.state_nom_off + (i as u32) * 8, nom);
+        data.bounds.scal_f[i] = 1.0 / nom;
+        data.bounds.vmin[i] = min * data.bounds.scal_f[i];
+        data.bounds.vmax[i] = max * data.bounds.scal_f[i];
+    }
+
+    for k in 0..nu {
+        let i = nx + k;
+        let (umin, umax) = (data.bounds.vmin[i], data.bounds.vmax[i]);
+        data.bounds.u0[k] = data.bounds.u0[k].max(umin).min(umax);
+        let nom = check_nominal(
+            umin,
+            umax,
+            data.bounds.vnom[i],
+            use_nominal_input[k],
+            libm::fabs(data.bounds.u0[k]),
+        );
+        data.bounds.vnom[i] = nom;
+        data.bounds.scal_f[i] = 1.0 / nom;
+        data.bounds.vmin[i] *= data.bounds.scal_f[i];
+        data.bounds.vmax[i] *= data.bounds.scal_f[i];
+    }
+
+    let nv_total = data.dim.nv_total;
+    data.bounds.v_min_all = Vec::with_capacity(nv_total);
+    data.bounds.v_max_all = Vec::with_capacity(nv_total);
+    for _ in 0..data.dim.nt {
+        data.bounds.v_min_all.extend_from_slice(&data.bounds.vmin);
+        data.bounds.v_max_all.extend_from_slice(&data.bounds.vmax);
+    }
+}
+
+/// C's `check_nominal`: the heuristic when a variable has no `nominal` of its own.
+fn check_nominal(min: f64, max: f64, nominal: f64, set: bool, x0: f64) -> f64 {
+    if set {
+        return libm::fabs(nominal).max(1e-16);
+    }
+    let (amax, amin) = (libm::fabs(max), libm::fabs(min));
+    let mut nom = amax.max(amin);
+    if nom > 1e12 {
+        let tmp = amax.min(amin);
+        let ax0 = libm::fabs(x0);
+        nom = if tmp < 1e12 { tmp.max(ax0) } else { 1.0 + ax0 };
+    }
+    nom.max(1e-16)
+}
+
+/// C's `calculatedScalingHelper`.
+fn calculated_scaling_helper(data: &mut OptData) {
+    let (nsi, np, nx) = (data.dim.nsi, data.dim.np, data.dim.nx);
+    data.bounds.scaldt = (0..nsi)
+        .map(|i| (0..nx).map(|j| data.bounds.scal_f[j] * data.time.dt[i]).collect())
+        .collect();
+    data.bounds.scalb = (0..nsi)
+        .map(|i| (0..np).map(|j| data.time.dt[i] * data.rk.b[j]).collect())
+        .collect();
+}
+
+/// C's `setRKCoeff`: the inverse Radau IIA coefficients the constraints use.
+fn set_rk_coeff(data: &mut OptData) {
+    let rk = &mut data.rk;
+    if data.dim.np == 3 {
+        rk.a[0] = [
+            4.139_387_691_339_813_7,
+            3.224_744_871_391_589,
+            1.167_840_084_690_405_5,
+            0.253_197_264_742_180_8,
+            0.0,
+        ];
+        rk.a[1] = [
+            1.739_387_691_339_813_8,
+            3.567_840_084_690_405_4,
+            0.775_255_128_608_411,
+            1.053_197_264_742_180_8,
+            0.0,
+        ];
+        rk.a[2] = [
+            3.0,
+            5.531_972_647_421_808,
+            7.531_972_647_421_808,
+            5.0,
+            0.0,
+        ];
+        rk.b[0] = 0.376_403_062_700_467_3;
+        rk.b[1] = 0.512_485_826_188_421_6;
+        rk.b[2] = 1.0 - (rk.b[0] + rk.b[1]);
+    } else if data.dim.np == 1 {
+        rk.a[0][0] = 1.0;
+        rk.b[0] = rk.a[0][0];
+    }
+}
+
+/// C's `printSomeModelInfos`: the "Optimizer Variables" block, which the testsuite
+/// compares verbatim.
+fn print_some_model_infos(data: &mut OptData) {
+    let (nx, nv) = (data.dim.nx, data.dim.nv);
+    let attrs = data.model.layout;
+    let mut out = String::from("\nOptimizer Variables");
+    out.push_str("\n========================================================");
+    for i in 0..nx {
+        let xmin = data.bounds.vmin[i];
+        let xmax = data.bounds.vmax[i];
+        // The unscaled attribute, as C prints `realVarsData[i].attribute.min`.
+        let min = data.model.read_f64_at(attrs.opt_min_off + (i as u32) * 8);
+        let max = data.model.read_f64_at(attrs.opt_max_off + (i as u32) * 8);
+        let start = data.model.read_f64_at(attrs.real_start_off(i as u32));
+        let min_s = if xmin > -1e20 {
+            format!(", min = {}", format_g(min, 6))
+        } else {
+            ", min = -Inf".to_string()
+        };
+        let max_s = if xmax < 1e20 {
+            format!(", max = {}", format_g(max, 6))
+        } else {
+            ", max = +Inf".to_string()
+        };
+        out.push_str(&format!(
+            "\nState[{i}]:{}(start = {}, nominal = {}{min_s}{max_s}, init = {})",
+            data.names.get(i).map(String::as_str).unwrap_or(""),
+            format_g(start, 6),
+            format_g(data.bounds.vnom[i], 6),
+            format_g(data.v0.get(i).copied().unwrap_or(0.0), 6),
+        ));
+    }
+    for (k, i) in (nx..nv).enumerate() {
+        let unom = data.bounds.vnom[i];
+        let umin = data.bounds.vmin[i];
+        let umax = data.bounds.vmax[i];
+        let min_s = if umin > -1e20 {
+            format!(", min = {}", format_g(umin * unom, 6))
+        } else {
+            ", min = -Inf".to_string()
+        };
+        let max_s = if umax < 1e20 {
+            format!(", max = {}", format_g(umax * unom, 6))
+        } else {
+            ", max = +Inf".to_string()
+        };
+        let name = data
+            .opt
+            .inputs
+            .get(k)
+            .and_then(|&idx| data.names.get(idx as usize))
+            .map(String::as_str)
+            .unwrap_or("");
+        out.push_str(&format!(
+            "\nInput[{i}]:{name}(start = {}, nominal = {}{min_s}{max_s})",
+            format_g(data.bounds.u0[k], 6),
+            format_g(unom, 6),
+        ));
+    }
+    out.push_str("\n--------------------------------------------------------");
+    out.push_str(&format!("\nnumber of nonlinear constraints: {}", data.dim.nc));
+    out.push_str("\n========================================================\n");
+    driver::log_line(&out);
+}
+
+/// C's `pickUpStates`: `-csvInput` overrides start values by name.
+fn pick_up_states(data: &mut OptData) {
+    let Some(file) = crate::simflags::with_flags(|f| f.state_file.clone()) else { return };
+    let Some(text) = crate::extinput::read_file(&file) else {
+        omclog::warning(omclog::STDOUT, false, &format!("OMC can't find the file {file}."));
+        return;
+    };
+    if text.lines().next().is_none() {
+        omclog::error(omclog::STDOUT, false, &format!("External input file: {file} is empty!"));
+        return;
+    }
+    let mut out = String::new();
+    for (i, line) in text.lines().enumerate() {
+        let mut it = line.split_whitespace();
+        let (Some(name), Some(value)) = (it.next(), it.next()) else { continue };
+        let Ok(start) = value.parse::<f64>() else { continue };
+        match data.names.iter().position(|n| n == name) {
+            Some(j) => {
+                data.model.write_real(j, start);
+                let slot = i.min(data.v0.len().saturating_sub(1));
+                data.v0[slot] = start;
+                out.push_str(&format!("\n[{i}]set {name}.start {}", format_g(start, 6)));
+            }
+            None => omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!("it was impossible to set {name}.start {}", format_g(start, 6)),
+            ),
+        }
+    }
+    out.push('\n');
+    driver::log_line(&out);
+    data.model.input_function(&data.opt.clone());
+    data.model.update_discrete_system();
+}
+
+// ───────────────────────────── DerStructure.c ─────────────────────────────
+
+/// C's `allocate_der_struct`: the Jacobian and Hessian patterns, and the arrays
+/// sized from them.
+pub(crate) fn allocate_der_struct(data: &mut OptData) -> Result<()> {
+    data.dim.update_hessian = match crate::simflags::with_flags(|f| f.keep_hessian) {
+        Some(n) if n >= 0 => n,
+        Some(n) => {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!("not support {n} for keep hessian-matrix constant."),
+            );
+            0
+        }
+        None => 0,
+    };
+
+    let (nv, nsi, np) = (data.dim.nv, data.dim.nsi, data.dim.np);
+    let (n_j, n_j2, ncf) = (data.dim.n_j, data.dim.n_j2, data.dim.ncf);
+
+    // C's `matrix[1..4]` from `initialAnalyticJacobianX() == 0`; index 0 is unused.
+    data.s.matrix = [
+        false,
+        false, // A is not used by the optimizer
+        data.opt.jac_b.is_some(),
+        data.opt.jac_c.is_some(),
+        data.opt.jac_d.is_some(),
+    ];
+    data.s.j[0] = flags_bool((n_j + 1) * nv);
+    data.s.j[1] = flags_bool(n_j2 * nv);
+    data.s.j[2] = flags_bool(ncf * nv);
+
+    data.s.der_index = [-1, -1, -1];
+    data.s.mayer = data.opt.mayer.is_some();
+    data.s.lagrange = data.opt.lagrange.is_some();
+    if let Some(m) = data.opt.mayer {
+        data.s.der_index[0] = m.row_c.map_or(-1, |r| r as i32);
+        data.dim.index_mayer = m.index as usize;
+    }
+    if let Some(l) = data.opt.lagrange {
+        data.s.der_index[1] = l.row_b.map_or(-1, |r| r as i32);
+        data.s.der_index[2] = l.row_c.map_or(-1, |r| r as i32);
+        data.dim.index_lagrange = l.index as usize;
+    }
+
+    local_jac_struct(data);
+    if omclog::active(omclog::IPOPT_JAC) || omclog::active(omclog::IPOPT_HESSE) {
+        print_local_jac_struct(data);
+    }
+    local_hessian_struct(data);
+    if omclog::active(omclog::IPOPT_JAC) || omclog::active(omclog::IPOPT_HESSE) {
+        print_local_hessian_struct(data);
+    }
+    update_local_jac_struct(data);
+
+    data.j = zeros(nsi * np * n_j2 * nv);
+    data.tmp_j = zeros(n_j2 * nv);
+    data.jf = zeros(ncf * nv);
+    data.tmp_jf = zeros(ncf * nv);
+    data.h = zeros(n_j * nv * nv);
+    data.hcf = zeros(ncf * nv * nv);
+    data.hm = zeros(nv * nv);
+    data.hl = zeros(nv * nv);
+    if data.dim.update_hessian > 0 {
+        let nhess = (nsi * np - 1) * data.dim.nh0_ + data.dim.nh1_;
+        data.old_h = zeros(nhess);
+    }
+    data.dim.iter_update_hessian = data.dim.update_hessian - 1;
+    Ok(())
+}
+
+/// C's `local_jac_struct`: turn each Jacobian's sparsity into the constraint
+/// Jacobian's own pattern, and the row remapping that skips the objective rows.
+fn local_jac_struct(data: &mut OptData) {
+    let (nv, nx, n_j, n_j2, ncf) = (
+        data.dim.nv,
+        data.dim.nx,
+        data.dim.n_j,
+        data.dim.n_j2,
+        data.dim.ncf,
+    );
+    data.s.jder_con = flags_bool(n_j * nv);
+    data.s.grad_m = flags_bool(nv);
+    data.s.grad_l = flags_bool(nv);
+    data.s.index_con2 = vec![0; data.dim.nc];
+    data.s.index_con3 = vec![0; data.dim.nc];
+
+    // C loops `index = 2..4` over B, C and D, filling `J[index-2]`.
+    for index in 2..5usize {
+        let Some(jac) = jac_of(&data.opt, index) else { continue };
+        let tmp = index - 2;
+        for col in 0..jac.n_cols.min(nv as u32) as usize {
+            for &row in &jac.rows_by_col[col] {
+                let stride = match tmp {
+                    0 => nv,
+                    1 => nv,
+                    _ => nv,
+                };
+                let idx = row as usize * stride + col;
+                if let Some(slot) = data.s.j[tmp].get_mut(idx) {
+                    *slot = true;
+                }
+            }
+        }
+        // The rows holding path constraints, skipping the Lagrange / Mayer rows.
+        let mut tmp_nj = n_j;
+        if data.s.lagrange {
+            tmp_nj += 1;
+        }
+        if data.s.mayer && index == 3 {
+            tmp_nj += 1;
+        }
+        let mut j = 0;
+        for ii in nx..tmp_nj {
+            let ii_i = ii as i32;
+            if index == 2 && ii_i != data.s.der_index[1] {
+                if let Some(s) = data.s.index_con2.get_mut(j) {
+                    *s = ii;
+                }
+                j += 1;
+            } else if index == 3 && ii_i != data.s.der_index[2] && ii_i != data.s.der_index[0] {
+                if let Some(s) = data.s.index_con3.get_mut(j) {
+                    *s = ii;
+                }
+                j += 1;
+            }
+        }
+    }
+
+    // C: the constraint Jacobian's pattern is B's, with the constraint rows taken
+    // from `indexCon2`.
+    let mut n_jderx = 0;
+    for i in 0..n_j {
+        for j in 0..nv {
+            let src_row = if i < nx { i } else { data.s.index_con2[i - nx] };
+            if data.s.j[0][src_row * nv + j] {
+                data.s.jder_con[i * nv + j] = true;
+                n_jderx += 1;
+            }
+        }
+    }
+    data.dim.n_jderx = n_jderx;
+    data.dim.n_jfderx = data.s.j[2].iter().filter(|b| **b).count();
+
+    if data.s.lagrange && data.s.der_index[1] >= 0 {
+        let row = data.s.der_index[1] as usize;
+        for j in 0..nv {
+            if data.s.j[0][row * nv + j] {
+                data.s.grad_l[j] = true;
+            }
+        }
+    }
+    if data.s.mayer && data.s.der_index[0] >= 0 {
+        let row = data.s.der_index[0] as usize;
+        for j in 0..nv {
+            if data.s.j[1][row * nv + j] {
+                data.s.grad_m[j] = true;
+            }
+        }
+    }
+
+    // Row remapping: a B row lands at `index_j2[row]`, a C row at `index_j3[row]`;
+    // the objective rows are moved above the constraints (`n_j`, `n_j + 1`).
+    data.s.index_j2 = vec![0; n_j + 1];
+    let mut j = 0;
+    for i in 0..=n_j {
+        if i as i32 == data.s.der_index[1] {
+            data.s.index_j2[i] = n_j;
+        } else {
+            data.s.index_j2[i] = j;
+            j += 1;
+        }
+    }
+    data.s.index_j3 = vec![0; n_j2];
+    let mut j = 0;
+    for i in 0..n_j2 {
+        if i as i32 == data.s.der_index[2] {
+            data.s.index_j3[i] = n_j;
+        } else if i as i32 == data.s.der_index[0] {
+            data.s.index_j3[i] = n_j + 1;
+        } else {
+            data.s.index_j3[i] = j;
+            j += 1;
+        }
+    }
+    let _ = ncf;
+}
+
+/// The Jacobian at C's `indexABCD[index]`.
+fn jac_of(opt: &OptInfo, index: usize) -> Option<&OptJac> {
+    match index {
+        2 => opt.jac_b.as_ref(),
+        3 => opt.jac_c.as_ref(),
+        4 => opt.jac_d.as_ref(),
+        _ => None,
+    }
+}
+
+/// C's `update_local_jac_struct`: the collocation constraint always has a diagonal.
+fn update_local_jac_struct(data: &mut OptData) {
+    let nv = data.dim.nv;
+    for i in 0..data.dim.nx {
+        if !data.s.jder_con[i * nv + i] {
+            data.s.jder_con[i * nv + i] = true;
+            data.dim.n_jderx += 1;
+        }
+    }
+}
+
+/// C's `local_hessian_struct`: the (over-estimated) Hessian pattern, from the outer
+/// products of the Jacobian rows and the objective gradients.
+fn local_hessian_struct(data: &mut OptData) {
+    let (nv, n_j, ncf) = (data.dim.nv, data.dim.n_j, data.dim.ncf);
+    data.s.hg = flags_bool(n_j * nv * nv);
+    data.s.hcf = flags_bool(ncf * nv * nv);
+    data.s.hm = flags_bool(nv * nv);
+    data.s.hl = flags_bool(nv * nv);
+    data.s.h0 = flags_bool(nv * nv);
+    data.s.h1 = flags_bool(nv * nv);
+    data.dim.nh0 = 0;
+    data.dim.nh1 = 0;
+    data.dim.nh0_ = 0;
+    data.dim.nh1_ = 0;
+
+    for l in 0..n_j {
+        for i in 0..nv {
+            for j in 0..nv {
+                if data.s.jder_con[l * nv + i] && data.s.jder_con[l * nv + j] {
+                    data.s.hg[(l * nv + i) * nv + j] = true;
+                }
+            }
+        }
+    }
+    for l in 0..ncf {
+        for i in 0..nv {
+            for j in 0..nv {
+                if data.s.j[2][l * nv + i] && data.s.j[2][l * nv + j] {
+                    data.s.hcf[(l * nv + i) * nv + j] = true;
+                }
+            }
+        }
+    }
+    if data.s.lagrange {
+        for i in 0..nv {
+            for j in 0..nv {
+                if data.s.grad_l[i] && data.s.grad_l[j] {
+                    data.s.hl[i * nv + j] = true;
+                }
+            }
+        }
+    }
+    if data.s.mayer {
+        for i in 0..nv {
+            for j in 0..nv {
+                if data.s.grad_m[i] && data.s.grad_m[j] {
+                    data.s.hm[i * nv + j] = true;
+                }
+            }
+        }
+    }
+
+    for i in 0..nv {
+        for j in 0..nv {
+            let ij = i * nv + j;
+            if n_j > 0 {
+                for l in 0..n_j {
+                    let tmp = data.s.hg[(l * nv + i) * nv + j] || data.s.hl[ij];
+                    if tmp && !data.s.h0[ij] {
+                        data.s.h0[ij] = true;
+                        data.dim.nh0 += 1;
+                        if i <= j {
+                            data.dim.nh0_ += 1;
+                        }
+                    }
+                    if (tmp || data.s.hm[ij]) && !data.s.h1[ij] {
+                        data.s.h1[ij] = true;
+                        data.dim.nh1 += 1;
+                        if i <= j {
+                            data.dim.nh1_ += 1;
+                        }
+                    }
+                    if data.s.h0[ij] && data.s.h1[ij] {
+                        break;
+                    }
+                }
+            } else {
+                if data.s.hl[ij] {
+                    data.s.h0[ij] = true;
+                    data.dim.nh0 += 1;
+                    if i <= j {
+                        data.dim.nh0_ += 1;
+                    }
+                }
+                if data.s.h0[ij] || data.s.hm[ij] {
+                    data.s.h1[ij] = true;
+                    data.dim.nh1 += 1;
+                    if i <= j {
+                        data.dim.nh1_ += 1;
+                    }
+                }
+            }
+        }
+    }
+    if ncf > 0 {
+        for i in 0..nv {
+            for j in 0..nv {
+                let ij = i * nv + j;
+                for l in 0..ncf {
+                    if data.s.hcf[(l * nv + i) * nv + j] && !data.s.h1[ij] {
+                        data.s.h1[ij] = true;
+                        data.dim.nh1 += 1;
+                        if i <= j {
+                            data.dim.nh1_ += 1;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// C's `print_local_jac_struct`.
+fn print_local_jac_struct(data: &OptData) {
+    let (nv, n_j, ncf) = (data.dim.nv, data.dim.n_j, data.dim.ncf);
+    let mut out = format!("\nJacabian Structure {n_j} x {nv}");
+    out.push_str("\n========================================================");
+    for i in 0..n_j {
+        out.push('\n');
+        for j in 0..nv {
+            out.push_str(if data.s.jder_con[i * nv + j] { "* " } else { "0 " });
+        }
+    }
+    if ncf > 0 {
+        out.push_str("\n-------------------------------------------------------");
+        out.push_str("\nfinal constraint(s)");
+        for i in 0..ncf {
+            out.push('\n');
+            for j in 0..nv {
+                out.push_str(if data.s.j[2][i * nv + j] { "* " } else { "0 " });
+            }
+        }
+    }
+    out.push_str("\n========================================================");
+    out.push_str("\nGradient Structure");
+    out.push_str("\n========================================================");
+    if data.s.lagrange {
+        out.push_str("\nlagrange");
+        out.push_str("\n-------------------------------------------------------");
+        out.push('\n');
+        for j in 0..nv {
+            out.push_str(if data.s.grad_l[j] { "* " } else { "0 " });
+        }
+    }
+    if data.s.mayer {
+        out.push_str("\nmayer");
+        out.push_str("\n-------------------------------------------------------");
+        out.push('\n');
+        for j in 0..nv {
+            out.push_str(if data.s.grad_m[j] { "* " } else { "0 " });
+        }
+    }
+    driver::log_line(&out);
+}
+
+/// C's `print_local_hessian_struct`.
+fn print_local_hessian_struct(data: &OptData) {
+    let nv = data.dim.nv;
+    let mut out = String::from("\n========================================================");
+    out.push_str(&format!(
+        "\nHessian Structure {nv} x {nv}\tnz = {}",
+        data.dim.nh0
+    ));
+    out.push_str("\n========================================================");
+    for i in 0..nv {
+        out.push('\n');
+        for j in 0..nv {
+            out.push_str(if data.s.h0[i * nv + j] { "* " } else { "0 " });
+        }
+    }
+    if data.dim.nh1 != data.dim.nh0 {
+        out.push_str("\n========================================================");
+        out.push_str(&format!(
+            "\nHessian Structure {nv} x {nv} for t = stopTime \tnz = {}",
+            data.dim.nh1
+        ));
+        out.push_str("\n========================================================");
+        for i in 0..nv {
+            out.push('\n');
+            for j in 0..nv {
+                out.push_str(if data.s.h1[i * nv + j] { "* " } else { "0 " });
+            }
+        }
+    }
+    driver::log_line(&out);
+}
+
+// ───────────────────────────── InitialGuess.c ─────────────────────────────
+
+/// C's `initial_guess_optimizer`: the trajectory the NLP starts from, and the
+/// derived `vopt`/bound arrays.
+pub(crate) fn initial_guess(data: &mut OptData) -> Result<()> {
+    data.dim.iter = 0;
+    let flags = crate::simflags::with_flags(|f| f.clone());
+    data.ipop.csv_ostep = flags.csv_ostep.clone();
+    data.ipop.debug_jac = flags.opt_debug_jac.clone();
+
+    // C opens `optimizeInput.csv` here and writes the header; the rows follow from
+    // the pre-simulation and `res2file`.
+    let mut header = String::from("time ");
+    for &idx in &data.opt.inputs {
+        header.push_str(data.names.get(idx as usize).map(String::as_str).unwrap_or(""));
+        header.push(' ');
+    }
+    header.push('\n');
+    data.input_csv = header;
+
+    let mut opt = 1;
+    if let Some(cflag) = flags.ipopt_init.as_deref() {
+        opt = initial_guess_cflag(data, cflag);
+    }
+    if opt > 0 {
+        opt = initial_guess_sim(data, opt)?;
+    }
+    init_ipopt_data(data, opt);
+    Ok(())
+}
+
+/// C's `initial_guess_ipopt_cflag`: `-ipopt_init=const|sim|file`.
+fn initial_guess_cflag(data: &mut OptData, cflag: &str) -> i32 {
+    match cflag {
+        "const" | "CONST" => {
+            let u0 = data.bounds.u0.clone();
+            data.model.inputs.copy_from_slice(&u0);
+            let v0 = data.v0.clone();
+            for i in 0..data.dim.nsi {
+                for j in 0..data.dim.np {
+                    data.v_mut(i, j).copy_from_slice(&v0);
+                }
+            }
+            omclog::info(omclog::IPOPT, false, "Using const trajectory as initial guess.");
+            0
+        }
+        "sim" | "SIM" => {
+            omclog::info(omclog::IPOPT, false, "Using simulation as initial guess.");
+            1
+        }
+        "file" | "FILE" => {
+            omclog::info(omclog::STDOUT, false, "Using values from file as initial guess.");
+            2
+        }
+        other => {
+            omclog::warning(omclog::STDOUT, false, &format!("not support ipopt_init={other}"));
+            1
+        }
+    }
+}
+
+/// C's `initial_guess_ipopt_sim`: simulate the model over the collocation grid with
+/// DASSL and take each point's variables as the guess.
+fn initial_guess_sim(data: &mut OptData, o: i32) -> Result<i32> {
+    let (nx, nu, np, nsi, n_real) = (
+        data.dim.nx,
+        data.dim.nu,
+        data.dim.np,
+        data.dim.nsi,
+        data.dim.n_real,
+    );
+    // C clamps the tolerance for the guess: `min(max(tol,1e-8),1e-3)`.
+    let tol = data.tol;
+    let guess_tol = tol.max(1e-8).min(1e-3);
+    omclog::info(omclog::SOLVER, false, "Initial Guess: Initializing DASSL");
+
+    // C's `externalInputallocate`: with `-csvInput` the guess's inputs come from the
+    // file, so `u0` is only used when there is none.
+    let opt = data.opt.clone();
+    let input_names: Vec<&str> = opt
+        .inputs
+        .iter()
+        .map(|&i| data.names.get(i as usize).map(String::as_str).unwrap_or(""))
+        .collect();
+    let mut ext = crate::simflags::with_flags(|f| f.csv_input.clone())
+        .and_then(|file| crate::extinput::ExternalInput::load(&file, &input_names))
+        .map(|ext| {
+            alloc::boxed::Box::new(crate::extinput::ExtInputHook {
+                ext,
+                input_offs: opt.inputs.iter().map(|&i| crate::REAL_OFF + i * 8).collect(),
+                inputs: crate::extinput::empty(nu),
+            })
+        });
+    if ext.is_none() {
+        let u0 = data.bounds.u0.clone();
+        data.model.inputs.copy_from_slice(&u0);
+    }
+    data.model.input_function(&opt);
+
+    let print_guess = omclog::active(omclog::INIT) && !omclog::active(omclog::SOLVER);
+    let meta = data.guess_meta(guess_tol);
+    let engine = data.model.engine;
+    let sim_data = data.model.sim_data;
+    let e = unsafe { &mut *engine };
+    let mut stepper = driver::GuessStepper::new(e, &meta, sim_data, data.start_time)?;
+    // C re-reads the external input at every residual evaluation
+    // (`functionODE_residual`), not just per step.
+    if let Some(hook) = ext.as_mut() {
+        stepper.set_external_input(&mut **hook as *mut _ as *mut core::ffi::c_void);
+    }
+
+    // C's pre-simulation: when the Optimica `startTime` is beyond the experiment's,
+    // simulate up to it first and emit those rows.
+    if data.start_time < data.time.t0 {
+        let mut t = data.start_time;
+        data.csv_row(t);
+        let mut out = String::from("\nPreSim");
+        out.push_str("\n========================================================\n");
+        out.push_str(&format!("\ndone: time[0] = {}", format_g(data.start_time, 6)));
+        driver::log_line(&out);
+        while t < data.time.t0 {
+            if let Some(hook) = ext.as_mut() {
+                hook.ext.update(t, &mut data.model.inputs);
+                data.model.input_function(&opt);
+            }
+            t = (t + data.time.dt[0]).min(data.time.t0);
+            let e = unsafe { &mut *engine };
+            stepper.step_to(e, &meta, t)?;
+            let now = stepper.time();
+            driver::log_line(&format!("\ndone: time[0] = {}", format_g(now, 6)));
+            data.emit_row(now)?;
+            data.csv_row(now);
+        }
+        copy_initial_values(data);
+        let mut out = String::from("\n--------------------------------------------------------");
+        out.push_str("\nfinished: PreSim");
+        out.push_str("\n========================================================\n");
+        driver::log_line(&out);
+    }
+
+    // `-ipopt_init=file` needs `-iif` to name the result file the guess is read from.
+    let iif = crate::simflags::with_flags(|f| f.init_file.clone());
+    let op = if o == 2 && iif.as_deref().is_some_and(|s| !s.is_empty()) { 2 } else { 1 };
+    // C's `importStartValues` writes the start attributes, which carry over from
+    // one collocation point to the next; `start` mirrors that array.
+    let attrs = data.model.layout;
+    let names = data.names.clone();
+    let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let mut start = zeros(n_real);
+    if op == 2 {
+        for (l, s) in start.iter_mut().enumerate() {
+            *s = data.model.read_f64_at(attrs.real_start_off(l as u32));
+        }
+    }
+
+    if print_guess {
+        let mut out = String::from("\nInitial Guess");
+        out.push_str("\n========================================================\n");
+        out.push_str(&format!("\ndone: time[0] = {}", format_g(data.time.t0, 6)));
+        driver::log_line(&out);
+    }
+
+    let mut k = 1;
+    for i in 0..nsi {
+        for j in 0..np {
+            let t = data.time.t[i][j];
+            if let Some(hook) = ext.as_mut() {
+                let now = stepper.time();
+                hook.ext.update(now, &mut data.model.inputs);
+                data.model.input_function(&opt);
+            }
+            if op == 1 {
+                let e = unsafe { &mut *engine };
+                stepper.step_to(e, &meta, t)?;
+            } else {
+                // C's `importStartValues` at this point's time, then every real
+                // variable set to its start (`getStartFromScalarIdx`). A name the
+                // file does not carry keeps the start it already had.
+                driver::read_result_file(iif.as_deref().unwrap_or(""), &name_refs, t, &mut start)
+                    .map_err(driver::leak_error)?;
+                for (l, &v) in start.iter().enumerate() {
+                    data.model.write_f64_at(attrs.real_start_off(l as u32), v);
+                }
+                data.model.write_reals(&start);
+            }
+            if print_guess {
+                driver::log_line(&format!("\ndone: time[{k}] = {}", format_g(t, 6)));
+            }
+            k += 1;
+            let mut buf = zeros(n_real);
+            data.model.read_reals(&mut buf);
+            data.v_mut(i, j).copy_from_slice(&buf);
+            for l in 0..nx {
+                let (lo, hi) = (
+                    data.bounds.vmin[l] * data.bounds.vnom[l],
+                    data.bounds.vmax[l] * data.bounds.vnom[l],
+                );
+                let v = data.v(i, j)[l];
+                if v < lo || v > hi {
+                    driver::log_line("\n********************************************\n");
+                    omclog::warning(
+                        omclog::STDOUT,
+                        false,
+                        &format!("Initial guess failure at time {}", format_g(t, 6)),
+                    );
+                    omclog::warning(
+                        omclog::STDOUT,
+                        false,
+                        &format!(
+                            "{}<= ({}={}) <={}",
+                            format_g(lo, 6),
+                            data.names.get(l).map(String::as_str).unwrap_or(""),
+                            format_g(v, 6),
+                            format_g(hi, 6)
+                        ),
+                    );
+                    driver::log_line("\n********************************************");
+                }
+            }
+        }
+    }
+    if print_guess {
+        let mut out = String::from("\n--------------------------------------------------------");
+        out.push_str("\nfinished: Initial Guess");
+        out.push_str("\n========================================================\n");
+        driver::log_line(&out);
+    }
+    let _ = nu;
+    Ok(op)
+}
+
+/// C's `init_ipopt_data`: `vopt` from the guess, and the constraint bounds.
+fn init_ipopt_data(data: &mut OptData, op: i32) {
+    let d = &data.dim;
+    let (nx, nv, nsi, np, nc, ncf) = (d.nx, d.nv, d.nsi, d.np, d.nc, d.ncf);
+    let (nv_total, n_res, n_j) = (d.nv_total, d.n_res, d.n_j);
+    let (index_con, index_conf) = (d.index_con, d.index_conf);
+    data.ipop.vopt = zeros(nv_total);
+    data.ipop.mult_x_l = zeros(nv_total);
+    data.ipop.mult_x_u = zeros(nv_total);
+    data.ipop.gmin = zeros(n_res);
+    data.ipop.gmax = zeros(n_res);
+    data.ipop.mult_g = zeros(n_res);
+
+    let opt = data.opt.clone();
+    let mut shift = 0;
+    for i in 0..nsi {
+        for j in 0..np {
+            let point = data.v(i, j).to_vec();
+            data.model.write_reals(&point);
+            data.model.set_input_data(&opt, op == 2);
+            for l in 0..nx {
+                data.ipop.vopt[l + shift] = point[l] * data.bounds.scal_f[l];
+            }
+            for l in nx..nv {
+                data.ipop.vopt[l + shift] =
+                    data.model.inputs[l - nx] * data.bounds.scal_f[l];
+            }
+            shift += nv;
+        }
+    }
+
+    // Path-constraint bounds repeat at every collocation point; the final ones sit
+    // at the end of `g`.
+    let attrs = data.model.layout;
+    let l = n_res - ncf;
+    for j in 0..nc {
+        let idx = (j + index_con) as u32;
+        let min = data.model.read_f64_at(attrs.opt_min_off + idx * 8);
+        let max = data.model.read_f64_at(attrs.opt_max_off + idx * 8);
+        let mut i = nx;
+        while i < l {
+            data.ipop.gmin[i + j] = min;
+            data.ipop.gmax[i + j] = max;
+            i += n_j;
+        }
+    }
+    for j in 0..ncf {
+        let idx = (j + index_conf) as u32;
+        data.ipop.gmin[l + j] = data.model.read_f64_at(attrs.opt_min_off + idx * 8);
+        data.ipop.gmax[l + j] = data.model.read_f64_at(attrs.opt_max_off + idx * 8);
+    }
+}
+
+// ───────────────────────── MoveData.c: writing back ─────────────────────────
+
+/// C's `res2file`: the optimal trajectory into the result rows (and the input
+/// values into `optimizeInput.csv`).
+pub(crate) fn res2file(data: &mut OptData) -> Result<()> {
+    let (nx, nu, nv, nsi, np, n_real) = (
+        data.dim.nx,
+        data.dim.nu,
+        data.dim.nv,
+        data.dim.nsi,
+        data.dim.np,
+        data.dim.n_real,
+    );
+    // The Radau extrapolation of the inputs back to `t0` (C's `a[]`).
+    let a: Vec<f64> = match np {
+        3 => vec![
+            1.558_078_204_724_922_4,
+            -0.891_411_538_058_255_7,
+            0.333_333_333_333_333_33,
+        ],
+        1 => vec![1.0],
+        n => {
+            omclog::error(omclog::STDOUT, false, &format!("Not support np = {n}"));
+            return Err("CodegenWasmJit: unsupported number of collocation points");
+        }
+    };
+    let vopt = core::mem::take(&mut data.ipop.vopt);
+    opt_data2model_data(data, &vopt, 0);
+
+    let t0 = data.time.t0;
+    let mut line = format!("{:.6} ", t0);
+    for (i, j) in (nx..nv).enumerate() {
+        let mut tmpv = 0.0;
+        for (k, ak) in a.iter().enumerate() {
+            tmpv += ak * vopt[k * nv + j];
+        }
+        tmpv = tmpv.max(data.bounds.vmin[j]).min(data.bounds.vmax[j]);
+        data.model.inputs[i] = tmpv * data.bounds.vnom[j];
+        line.push_str(&format!("{:.6} ", data.model.inputs[i] as f32));
+    }
+    line.push('\n');
+    data.input_csv.push_str(&line);
+
+    copy_initial_values(data);
+    data.model.set_time(t0);
+    let opt = data.opt.clone();
+    data.model.input_function(&opt);
+    data.model.update_discrete_system();
+    data.emit_row(t0)?;
+
+    for ii in 0..nsi {
+        for jj in 0..np {
+            let point = data.v(ii, jj).to_vec();
+            data.model.write_reals(&point);
+            let t = data.time.t[ii][jj];
+            let mut line = format!("{:.6} ", t);
+            for i in 0..nu {
+                let u = vopt[ii * nv * np + jj * nv + nx + i] * data.bounds.vnom[i + nx];
+                line.push_str(&format!("{:.6} ", u as f32));
+            }
+            line.push('\n');
+            data.input_csv.push_str(&line);
+            data.emit_row(t)?;
+        }
+    }
+    let _ = n_real;
+    data.ipop.vopt = vopt;
+    // C keeps `optimizeInput.csv` open from the initial guess to here; the rows were
+    // collected in `input_csv`.
+    if let Err(e) = std::fs::write("optimizeInput.csv", &data.input_csv) {
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            &format!("optimizeInput.csv could not be written: {e}"),
+        );
+    }
+    Ok(())
+}
+
+/// C's `optData2ModelData`: evaluate the model at every collocation point for the
+/// current `vopt`, and (when `index` is nonzero) the Jacobians there too.
+pub(crate) fn opt_data2model_data(data: &mut OptData, vopt: &[f64], index: i32) {
+    let (nsi, np, nv) = (data.dim.nsi, data.dim.np, data.dim.nv);
+    copy_initial_values(data);
+    let mut shift = 0;
+    for i in 0..nsi - 1 {
+        for j in 0..np {
+            set_local_vars(data, vopt, i, j, shift);
+            update_do_system(data, i, j, index, 2);
+            shift += nv;
+        }
+    }
+    let i = nsi - 1;
+    for j in 0..np - 1 {
+        set_local_vars(data, vopt, i, j, shift);
+        update_do_system(data, i, j, index, 2);
+        shift += nv;
+    }
+    let j = np - 1;
+    set_local_vars(data, vopt, i, j, shift);
+    update_do_system(data, i, j, index, 3);
+
+    // The terminal constraints' Jacobian is evaluated once, at the final point.
+    if index != 0 && data.s.matrix[4] {
+        diff_syn_colored_f(data);
+    }
+}
+
+/// C's `setLocalVars`: this point's states and inputs into the model, starting from
+/// the `pre` values so discrete variables keep them.
+fn set_local_vars(data: &mut OptData, vopt: &[f64], i: usize, j: usize, shift: usize) {
+    let (nx, nv, n_real) = (data.dim.nx, data.dim.nv, data.dim.n_real);
+    let mut point = zeros(n_real);
+    data.model.read_pre_reals(&mut point);
+    let t = data.time.t[i][j];
+    for k in 0..nx {
+        point[k] = vopt[shift + k] * data.bounds.vnom[k];
+    }
+    data.v_mut(i, j).copy_from_slice(&point);
+    data.model.write_reals(&point);
+    data.model.set_time(t);
+    for k in nx..nv {
+        data.model.inputs[k - nx] = vopt[shift + k] * data.bounds.vnom[k];
+    }
+}
+
+/// C's `updateDOSystem`: the discrete update at one point, then its Jacobian.
+fn update_do_system(data: &mut OptData, i: usize, j: usize, index: i32, m: usize) {
+    let opt = data.opt.clone();
+    data.model.input_function(&opt);
+    data.model.update_discrete_system();
+    // The evaluated point is what the callbacks read back.
+    let n_real = data.dim.n_real;
+    let mut buf = zeros(n_real);
+    data.model.read_reals(&mut buf);
+    data.v_mut(i, j).copy_from_slice(&buf);
+    if index != 0 {
+        diff_syn_colored(data, i, j, m);
+    }
+}
+
+/// C's `diffSynColoredOptimizerSystem`: B (`m = 2`) or C (`m = 3`) at one
+/// collocation point, scaled into the constraint Jacobian's rows.
+pub(crate) fn diff_syn_colored(data: &mut OptData, i: usize, j: usize, m: usize) {
+    let Some(jac) = jac_of(&data.opt, m).cloned() else { return };
+    let (nv, nx, n_j) = (data.dim.nv, data.dim.nx, data.dim.n_j);
+    let n_j1 = n_j + 1;
+    let scaldt = data.bounds.scaldt[i].clone();
+    let scalb = data.bounds.scalb[i][j];
+    let index_j: Vec<usize> =
+        if m == 3 { data.s.index_j3.clone() } else { data.s.index_j2.clone() };
+    let vnom = data.bounds.vnom.clone();
+    let (lagrange, mayer) = (data.s.lagrange, data.s.mayer);
+
+    let mut out = vec![(0usize, 0usize, 0.0f64); 0];
+    data.model.eval_jac_colored(&jac, &vnom, |row, col, v| out.push((row, col, v)));
+    let target = data.jac_mut(i, j);
+    for (row, col, v) in out {
+        let l = match index_j.get(row) {
+            Some(&l) => l,
+            None => continue,
+        };
+        let scaled = if l < nx {
+            v * scaldt[l]
+        } else if l < n_j {
+            v
+        } else if l == n_j && lagrange {
+            v * scalb
+        } else if l == n_j1 && mayer {
+            v
+        } else {
+            continue;
+        };
+        if let Some(slot) = target.get_mut(l * nv + col) {
+            *slot = scaled;
+        }
+    }
+}
+
+/// C's `diffSynColoredOptimizerSystemF`: D, the final constraints' Jacobian.
+pub(crate) fn diff_syn_colored_f(data: &mut OptData) {
+    if data.dim.ncf == 0 {
+        return;
+    }
+    let Some(jac) = data.opt.jac_d.clone() else { return };
+    let nv = data.dim.nv;
+    let vnom = data.bounds.vnom.clone();
+    let mut out = vec![(0usize, 0usize, 0.0f64); 0];
+    data.model.eval_jac_colored(&jac, &vnom, |row, col, v| out.push((row, col, v)));
+    for (row, col, v) in out {
+        if let Some(slot) = data.jf.get_mut(row * nv + col) {
+            *slot = v;
+        }
+    }
+}
+
+impl OptData {
+    /// The metadata the guess's DASSL run reads: this model with the guess's
+    /// clamped tolerance.
+    fn guess_meta(&self, tol: f64) -> SimMeta {
+        let mut m = self.meta.clone();
+        m.tolerance = tol;
+        m
+    }
+
+    /// A `optimizeInput.csv` row for the current inputs.
+    fn csv_row(&mut self, t: f64) {
+        let mut line = format!("{:.6} ", t);
+        for i in 0..self.dim.nu {
+            line.push_str(&format!("{:.6} ", self.model.inputs[i] as f32));
+        }
+        line.push('\n');
+        self.input_csv.push_str(&line);
+    }
+
+    /// One result row from `SimData` as it stands, at time `t`. C's `res2file` and
+    /// its pre-simulation both emit an already-evaluated point (the collocation
+    /// point's variables, or `updateContinuousSystem` after a DASSL step), so
+    /// nothing is re-evaluated here.
+    fn emit_row(&mut self, t: f64) -> Result<()> {
+        let (sim_data, layout) = (self.model.sim_data, self.model.layout);
+        let e = unsafe { &mut *self.model.engine };
+        driver::write_f64(e, sim_data + crate::TIME_OFF, t)?;
+        driver::capture_row(e, &mut self.rows, sim_data, &layout)
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -26,6 +26,8 @@ pub enum Solver {
     RungeKutta,
     SymSolver,
     SymSolverSsc,
+    /// `optimize()`'s collocation solver; only selectable where Ipopt is linked.
+    Optimization,
 }
 
 /// `-nls`. The discriminants are the wire codes [`SimFlags::solver_codes`] hands to
@@ -177,6 +179,8 @@ pub struct SimFlags {
     /// `-iif=<file>`: a result file whose values at the start time seed the start
     /// attributes and parameters (C's `importStartValues`).
     pub init_file: Option<String>,
+    /// `-iim=<symbolic|none>`: C's `INIT_INIT_METHOD`.
+    pub init_method: InitMethod,
     /// `-noEquidistantTimeGrid`: emit the integrator's own steps instead of
     /// interpolating onto the output grid.
     pub no_equidistant_grid: bool,
@@ -193,6 +197,31 @@ pub struct SimFlags {
     /// `nonlinearSparseSolverMaxDensity`, the rule that hands a system to kinsol+KLU.
     pub nlss_min_size: Option<u32>,
     pub nlss_max_density: Option<f64>,
+    /// `method="optimization"` (the Ipopt collocation solver): `-optimizerNP=<1|3>`
+    /// collocation points per interval, and `-optimizerTimeGrid=<file>` listing the
+    /// interval end points instead of an equidistant grid.
+    pub optimizer_np: Option<i32>,
+    pub optimizer_tgrid: Option<String>,
+    /// `-ipopt_init=<const|sim|file>`: where the initial trajectory comes from.
+    pub ipopt_init: Option<String>,
+    /// `-ipopt_hesse=<BFGS|const|num>`: how Ipopt approximates the Hessian.
+    pub ipopt_hesse: Option<String>,
+    /// `-ipopt_max_iter=<n>`; C also accepts `<m>e<x>`, so it stays a string.
+    pub ipopt_max_iter: Option<String>,
+    /// `-ipopt_warm_start=<decade>`: shift `mu_init` and the bound multipliers.
+    pub ipopt_warm_start: Option<String>,
+    /// `-ls_ipopt=<solver>`: Ipopt's linear solver (`mumps`, `ma27`, …).
+    pub ls_ipopt: Option<String>,
+    /// `-keepHessian=<n>`: reuse the Hessian for `n` iterations.
+    pub keep_hessian: Option<i32>,
+    /// `-stateFile=<file>`: `name value` lines overriding start values.
+    pub state_file: Option<String>,
+    /// `-csvInput=<file>`: external input `time,u…` rows, interpolated for the
+    /// optimizer's initial guess (C's `external_input.c`).
+    pub csv_input: Option<String>,
+    /// `-csvOstep=<file>` / `-optDebugJac=<iter>`: the optimizer's debug dumps.
+    pub csv_ostep: Option<String>,
+    pub opt_debug_jac: Option<String>,
     /// `-emit_protected`: keep `protected` variables in the result file.
     pub emit_protected: bool,
     /// `-ignoreHideResult`: keep `annotation(HideResult=true)` variables too.
@@ -275,6 +304,8 @@ pub struct Capabilities {
     pub alarm: bool,
     /// This runtime can compile a regex, so `-variableFilter` can be honoured.
     pub variable_filter: bool,
+    /// Ipopt is linked, so `method="optimization"` / `-s=optimization` can run.
+    pub optimization: bool,
 }
 
 /// Reject flag values this runtime cannot honour.
@@ -299,6 +330,7 @@ pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
     let unsupported = match f.solver {
         Some(Solver::Ida) if !cap.ida => "ida",
         Some(Solver::Cvode) if !cap.cvode => "cvode",
+        Some(Solver::Optimization) if !cap.optimization => "optimization",
         _ => return Ok(()),
     };
     let have: Vec<String> = supported(cap)
@@ -319,6 +351,7 @@ pub fn supported(cap: Capabilities) -> Vec<(&'static str, Vec<&'static str>)> {
         ("nlsLS", offered(NLS_LS_VALUES, cap)),
         ("ls", offered(LS_VALUES, cap)),
         ("lss", offered(LSS_VALUES, cap)),
+        ("iim", offered(INIT_METHODS, cap)),
     ];
     if cap.ida {
         menu.push(("idaLS", offered(IDA_LS_VALUES, cap)));
@@ -490,6 +523,19 @@ const C_FLAGS: &[(&str, bool)] = &[
     ("parmodDumpStages", true),
 ];
 
+/// C's `INIT_INIT_METHOD` (`simulation_options.c`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum InitMethod {
+    /// Solve the initial system.
+    #[default]
+    Symbolic,
+    /// Leave every variable at its start value; C's `IIM_NONE`.
+    None,
+}
+
+const INIT_METHODS: &[Value<InitMethod>] =
+    &[("none", InitMethod::None, Offer::Always), ("symbolic", InitMethod::Symbolic, Offer::Always)];
+
 /// C's `JACOBIAN_METHOD_NAME` (`simulation_options.c`).
 const JACOBIAN_METHODS: &[&str] = &[
     "coloredNumerical",
@@ -585,6 +631,23 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "variableFilter" => f.variable_filter = Some(value(name)?),
             "r" => f.result_file = Some(value(name)?),
             "iif" => f.init_file = Some(value(name)?),
+            // The optimizer's flags (`method="optimization"`).
+            "optimizerNP" => f.optimizer_np = Some(int(name, &value(name)?)?),
+            "optimizerTimeGrid" => f.optimizer_tgrid = Some(value(name)?),
+            "ipopt_init" => f.ipopt_init = Some(value(name)?),
+            "ipopt_hesse" => f.ipopt_hesse = Some(value(name)?),
+            "ipopt_max_iter" => f.ipopt_max_iter = Some(value(name)?),
+            "ipopt_warm_start" => f.ipopt_warm_start = Some(value(name)?),
+            "ls_ipopt" => f.ls_ipopt = Some(value(name)?),
+            "keepHessian" => f.keep_hessian = Some(int(name, &value(name)?)?),
+            "stateFile" => f.state_file = Some(value(name)?),
+            "csvInput" => f.csv_input = Some(value(name)?),
+            "csvOstep" => f.csv_ostep = Some(value(name)?),
+            "optDebugJac" => f.opt_debug_jac = Some(value(name)?),
+            // C declares `-ipopt_jac` but never reads it; accept and ignore, as it does.
+            "ipopt_jac" => {
+                let _ = value(name)?;
+            }
             "noEquidistantTimeGrid" => f.no_equidistant_grid = true,
             "noEquidistantOutputFrequency" => {
                 f.no_equidistant_freq = Some(
@@ -613,13 +676,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                         .map_err(|_| "-noEquidistantOutputTime needs a number".to_string())?,
                 )
             }
-            // The only method this runtime has is C's default.
-            "iim" => {
-                let v = value(name)?;
-                if v != "symbolic" {
-                    return Err(format!("-iim={v}: this runtime only has the symbolic method"));
-                }
-            }
+            "iim" => f.init_method = pick("iim", &value(name)?, INIT_METHODS)?,
             "abortSlowSimulation" => f.abort_slow = true,
             "alarm" => {
                 let secs = value(name)?
@@ -854,6 +911,7 @@ enum Offer {
     WithSundials,
     WithIda,
     WithCvode,
+    WithIpopt,
     /// `default`, an alias of a listed value, or one this runtime substitutes for.
     Never,
 }
@@ -865,6 +923,7 @@ impl Offer {
             Offer::WithSundials => cap.klu,
             Offer::WithIda => cap.ida,
             Offer::WithCvode => cap.cvode,
+            Offer::WithIpopt => cap.optimization,
             Offer::Never => false,
         }
     }
@@ -880,6 +939,7 @@ const SOLVERS: &[Value<Solver>] = &[
     ("gbode", Solver::Gbode, Offer::Always),
     ("ida", Solver::Ida, Offer::WithIda),
     ("cvode", Solver::Cvode, Offer::WithCvode),
+    ("optimization", Solver::Optimization, Offer::WithIpopt),
     ("symSolver", Solver::SymSolver, Offer::Never),
     ("symSolverSsc", Solver::SymSolverSsc, Offer::Never),
 ];
@@ -1032,9 +1092,9 @@ mod tests {
     }
 
     const NOTHING: Capabilities =
-        Capabilities { klu: false, ida: false, cvode: false, alarm: false, variable_filter: false };
+        Capabilities { klu: false, ida: false, cvode: false, alarm: false, variable_filter: false, optimization: false };
     const EVERYTHING: Capabilities =
-        Capabilities { klu: true, ida: true, cvode: true, alarm: true, variable_filter: true };
+        Capabilities { klu: true, ida: true, cvode: true, alarm: true, variable_filter: true, optimization: true };
 
     #[test]
     fn defaults_are_all_unset() {
@@ -1178,8 +1238,21 @@ mod tests {
 
     #[test]
     fn a_rejected_options_value_is_not_read_as_a_flag() {
-        let e = parse(&argv(&["-csvInput", "in.csv"])).expect_err("must reject");
-        assert!(e.contains("csvInput"), "{e}");
+        let e = parse(&argv(&["-idaScaling", "-lv=LOG_STATS"])).expect_err("must reject");
+        assert!(e.contains("idaScaling"), "{e}");
+    }
+
+    #[test]
+    fn the_optimizer_flags_parse() {
+        let f = parse(&argv(&[
+            "-optimizerNP=1", "-ipopt_init=const", "-ipopt_max_iter=1e3",
+            "-stateFile", "s.csv", "-ipopt_jac=NUM",
+        ]))
+        .expect("parses");
+        assert_eq!(f.optimizer_np, Some(1));
+        assert_eq!(f.ipopt_init.as_deref(), Some("const"));
+        assert_eq!(f.ipopt_max_iter.as_deref(), Some("1e3"));
+        assert_eq!(f.state_file.as_deref(), Some("s.csv"));
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -42,6 +42,14 @@ pub struct SimModel {
     pub jac_a: Option<JacAInfo>,
     /// User-settable initial conditions (changeable parameters), for `-override`.
     pub editable_params: Vec<EditableParam>,
+    /// C's `realVarsData[i].info.name` and its `attribute.start` slot, in
+    /// real-variable index order. `-iif` imports into these; unlike `-override`
+    /// it reaches every real variable, changeable or not.
+    pub real_starts: Vec<(String, u32)>,
+    /// The rest of what `-iif` imports, likewise by name: the integer and boolean
+    /// variables, and the real, integer and boolean parameters. Their live slot is
+    /// their start here — only reals have a separate attribute array.
+    pub import_slots: Vec<(String, u32, WTy)>,
     /// Result-variable display name -> unit, for a host to label plotted signals.
     pub var_units: HashMap<String, String>,
     /// Driver-facing metadata shared with the in-wasm driver (passed to `sim_driver::drive`).

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1685,7 +1685,15 @@ algorithm
           sim_call := stringAppendList({"\"",exeDir,executableSuffixedExe,"\""," ",simflags});
           System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_SIMULATION);
           SimulationResults.close() "Windows cannot handle reading and writing to the same file from different processes like any real OS :(";
-          resI := System.systemCallRestrictedEnv(sim_call, logFile);
+          // As in the simulate() case: the wasm-jit target runs the JIT-compiled
+          // model in-process instead of spawning an executable.
+          if Config.simCodeTarget() == "wasm-jit" then
+            resI := CodegenWasmJit.runSimulation(executable, result_file, simflags);
+          elseif Config.simCodeTarget() == "wasm" then
+            resI := CodegenWasmJit.runSimulationWasmtime(executable, result_file, simflags);
+          else
+            resI := System.systemCallRestrictedEnv(sim_call, logFile);
+          end if;
           timeSimulation := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMULATE_SIMULATION);
         else
           result_file := "";


### PR DESCRIPTION
Ports `SimulationRuntime/c/optimization/` — the `method="optimization"` collocation NLP — so `optimize()` works under
`--simCodeTarget=wasm-jit`.

| file | C source |
| --- | --- |
| `optimization/mod.rs` | `optimizer_main.c` + `OptData` | | `optimization/setup.rs` | `MoveData.c`, `DerStructure.c`, `InitialGuess.c` | | `optimization/eval.rs` | `eval_all/EvalF.c`, `EvalG.c`, `EvalL.c` | | `optimization/model.rs` | the `DATA` handling, as `SimData` accesses | | `optimization/ipopt.rs` | the `IpStdCInterface.h` subset it calls | | `extinput.rs` | `external_input.c` (`-csvInput`) | | `CodegenWasmJit/optimization.rs` | `optimizationComponents` (`_13opt.c`) |

Ipopt is linked natively (`OMC_IPOPT_NATIVE_DIR`, collected by the new `rust_ipopt_native_collect` target) and drives the model through the wasm engine, so the numerics are the C runtime's — same Ipopt, same MUMPS, same log text. There is no wasm build of it: MUMPS is Fortran 90, so an in-wasm runtime keeps reporting what a C runtime built without `OMC_HAVE_IPOPT` reports.

`optimize()` no longer spawns an executable here. `CevalScriptBackend` takes the in-process branch `simulate()` has, and `driver::drive` sends `method="optimization"` to `run_optimizer` — initializing the model first and emitting only the rows `res2file` produced, as `solver_main` and `perform_simulation` do for `S_OPTIMIZATION`.

| suite | wasm-jit |
| --- | --- |
| `cruntime/optimization/basic` | 50/56 |
| `cruntime/optimization/benchmark` | 2/2 |
| `simulation/modelica/initialization` | 56/90 |
| `simulation/modelica/equations` | 36/38 |

The two `equations` failures are unrelated codegen gaps that predate this work (`SES_IFEQUATION`, `__HOM_LAMBDA`). `diffSimulationResults` against the C target is `(true, {})` on CoupledClutches, Rotational.Friction and Fluid DrumBoiler.

## What the model has to provide

The symbolic B/C/D come from the `-l` linearization's lowering, with `symbolic_jacobians` reporting each matrix's real shape rather than deriving it from `nStates`/`nInputVars`/`nOutputVars` — `DynamicOptimization` reshapes those same matrices, and `LinzPlan::lin_ok` keeps `-l` on its numeric path for a shape it does not recognise. `optJac{B,C,D}{,_const}` are the per-column entry points the optimizer drives them through, seeding the variables' nominal values one colour at a time.

A Jacobian column is not always one assignment: a differentiated algebraic loop arrives as a `SES_LINEAR` and a differentiated external or table call as a `SES_ALGORITHM`. `jac_lowerable` required `SES_SIMPLE_ASSIGN` throughout and dropped the whole matrix otherwise, leaving the NLP with only its collocation diagonal — `TFC8` had 594 equality-Jacobian nonzeros against C's 894, no inequality Jacobian and an empty Hessian. It now mirrors what `lower_equation` accepts, and `lin_jac_systems` scans the Jacobian columns so a torn linear system in one gets its analytic-Jacobian slots registered.

The optimize-constraint variables join the real region (C counts them last in `nVariablesReal`, which is what `index_con` relies on), and `Layout` gains the five attribute arrays C reads out of the `_init.xml`.

## Runtime gaps this had to close

| feature | C |
| --- | --- |
| `initial()` | `data->simulationInfo->initial`, its own `SimData` flag | | `-iim=none` | `IIM_NONE` — seed the starts, skip the solve | | `-iif` | `importStartValues`, over *every* named quantity | | `-ipopt_init=file` | the same, per collocation point | | `-csvInput` | `external_input.c`, re-read at every residual | | `start` attributes | one per real variable, not one per state |

`start` was a per-state region, so `-iif` could only reach the states. C keeps `attribute.start` for every real variable and `setAllVarsToStart` copies the whole array over the live one, which is how an input's start value comes out of a file. `Layout::start_off` now spans the real region and the optimizer's `opt_start_off` is gone — it *was* this array.

`-csvInput`'s reader split on a comma always, while C's `read_csv` takes the delimiter from a leading `"sep=<c>"` and starts the data at byte 8, so every column in the testsuite missed its input and became 0. And C reads the file *before* it initializes, so the file — not the model — gives an input the start value the optimizer reads back as `u0`.

`-iif` imported only what `-override` can reach. C walks `realParameterData` / `integerVarsData` / … by `info.name`, so a quantity marked `isValueChangeable = false` is imported like any other; `testAlgLoop5`'s scalarized `parameter Real tgrid[:]` is one, and without it the optimizer solved over `[0, 0]` instead of `[0.2, 50]`.

## Shared fixes the optimization models exposed

**The nonlinear solver reported SOLVED without solving.** `rt_solve_nls` ran a bare minpack call where `solveHomotopy` hands a failed `newtonAlgorithm` the whole `solveHybrd` retry ladder, and it took minpack's `info == 1` for a root — that is a step test (the trust region collapsed), which `solveHybrd` overrides to "no progress" precisely because it fires away from one. The damped Newton also backed its step length off on any residual above 1e30, where C backs off on a failed assert alone and hands an overflowed but finite residual to the Numerical-Recipes damping.

**Homotopy on first try needs a homotopy *system*.** The continuation ran for any model whose backend emitted a lambda-0 initial system, i.e. for any `homotopy()` anywhere. C's `symbolic_initialization` scans `nonlinearSystemData` for a system that carries the operator; `Modelica.Fluid.Examples.DrumBoiler.DrumBoiler` has three, all `homotopySupport = 0`.

**`T_UNKNOWN` under the new frontend.** `Modelica.Fluid` models failed codegen with `type not supported`, while `-d=-newInst` compiled them. Two sources, both places C's codegen does not consult the DAE type: an operator carrying `T_UNKNOWN` (`daeExpBinary` works off the operands' C types), and `smooth`/`noEvent`/`$getPart`, whose call type *is* the argument's. `sig_ty` also reported into the error buffer from inside, so a caller that merely probed a type and handled the failure still made the run fail; it is split into a quiet probe and a reporting one.

**`compareSimulationResults` panicked** on a result file short enough to reach `cmp_data`'s backward event search, which decrements `j` and tests `j == 0` — C's test, reading `reftime[-1]` on the miss. A failed simulation produces such a file, and the panic took rtest's whole run down rather than the one test.

## Fidelity details, each a silently wrong answer

| symptom | cause |
| --- | --- |
| `nominal = 1` where C says 2 | the heuristic reads the initialized state, so `v0` is latched before the bounds | | Ipopt's banner missing after the first run | it prints once per process; suppressed and written by hand, inside the solve where Ipopt would have | | banner after the `LOG_IPOPT_ERROR` lines | Ipopt's stdout is drained at every callback, not once at the end | | `7.4612842821952796e-06` | C prints `ryu_hr_tdzp_buf`, the shortest round-trip form | | omc exits 0 mid-script | the guess entered DASKR with `NEQ = 0`; C skips the integrator with no states | | `start = 0` where C says 1 | a start-value equation assigns `$START.<var>` | | `$OMC$objectLagrangeTerm` missing | `result_name` dropped every `$` name; C hides `$cse*` by `hideResult` | | assert body line missing | a condition-carrying assert prints it even with an empty `FILE_INFO` | | algebraics wrong at a grid point | the guess published no time before `updateContinuousSystem`, as `dassl_step` does |

## Remaining

`DMwarm`, `DMwarmCsv` and `testAlgLoop5` reproduce C's Ipopt iteration sequence and part company in the last few, which is the `long double` gap: C carries the time grid, the scaling factors and the Hessian accumulation in x87 80-bit, this port uses `f64`. `TFC6` wants `LOG_LS`, `TT` wants C's `OPT_INPUT_WITH_DER` (`der` of an input), and `InputOptIssues` converges to a different optimum with one input column stuck at zero.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
