### PR TITLE
Fix two ScalableTestSuite large-model failures

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -56,7 +56,7 @@ use openmodelica_simcode_types::SimCodeFunction;
 use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
-    ArrayGroup, Attr, AttrTargets, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
+    ArrayGroup, Attr, AttrTargets, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, Literals, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
@@ -3154,7 +3154,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     }
 
     // --- Compile bodies (collecting String literals into the module pool). ---
-    let mut literals: Vec<Vec<u8>> = Vec::new();
+    let mut literals = Literals::default();
     let mut bodies: Vec<we::Function> = Vec::new();
     // Model functions first, in index order; poll for cancellation between them so
     // a long emit is interruptible like the frontend/backend upstream.
@@ -3253,8 +3253,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
-    let meta_seg = literals.len() as u32;
-    literals.push(meta_bytes);
+    let meta_off = literals.intern(&meta_bytes);
     {
         // om_meta_ptr(): rt_alloc(len), memory.init the blob into it, return ptr.
         use we::Instruction as I;
@@ -3262,9 +3261,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         f.instruction(&I::I32Const(meta_len as i32));
         f.instruction(&I::Call(rt_index("rt_alloc")?));
         f.instruction(&I::LocalTee(0));
-        f.instruction(&I::I32Const(0));
+        f.instruction(&I::I32Const(meta_off as i32));
         f.instruction(&I::I32Const(meta_len as i32));
-        f.instruction(&I::MemoryInit { mem: 0, data_index: meta_seg });
+        f.instruction(&I::MemoryInit { mem: 0, data_index: 0 });
         f.instruction(&I::LocalGet(0));
         f.instruction(&I::End);
         bodies.push(f);
@@ -3735,14 +3734,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         }
     }
     if !literals.is_empty() {
-        module.section(&we::DataCountSection { count: literals.len() as u32 });
+        module.section(&we::DataCountSection { count: 1 });
     }
     module.section(&code);
     if !literals.is_empty() {
         let mut data = we::DataSection::new();
-        for lit in &literals {
-            data.passive(lit.iter().copied());
-        }
+        data.passive(literals.blob().iter().copied());
         module.section(&data);
     }
     module.section(&name_section);
@@ -4560,7 +4557,7 @@ fn build_split_fn(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
     bodies: &mut Vec<we::Function>,
     chunks: &mut Vec<we::Function>,
 ) -> Result<SplitFn> {
@@ -4604,7 +4601,7 @@ fn build_eq_fn_single(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
     let mut pending: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
@@ -4631,7 +4628,7 @@ fn build_init_sample_fn(
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -4652,7 +4649,7 @@ fn build_init_synchronous_fn(
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
     let inits: Vec<ClockInit> = clocks
@@ -4689,7 +4686,7 @@ fn build_update_synchronous_fn(
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, literals, 2);
     for (i, c) in clocks.iter().enumerate() {
@@ -4723,7 +4720,7 @@ fn build_equations_synchronous_fn(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, literals, 2);
     for c in clocks {
@@ -4757,7 +4754,7 @@ fn build_init_start_values_fn(
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let sim = SimCtx { start_slots: Arc::default(), ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -4787,7 +4784,7 @@ fn build_update_bound_attrs_fn(
     attr_targets: &HashMap<String, AttrTargets>,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets)> = Vec::new();
     for (attr, eqs) in [
@@ -4828,7 +4825,7 @@ fn build_zero_crossings_fn(
     layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let sim = SimCtx { zc_context: true, ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -4847,7 +4844,7 @@ fn build_update_relations_fn(
     relations: &[Option<Arc<DAE::Exp>>],
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let sim = SimCtx { zc_context: true, ..sim_ctx(var_map) };
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
@@ -4866,7 +4863,7 @@ fn build_store_delayed_fn(
     sim_code: &SimCode::SimCode,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let delayed: Vec<(i32, Arc<DAE::Exp>, Arc<DAE::Exp>, Arc<DAE::Exp>)> =
         lst(&sim_code.delayedExps.delayedExps)
@@ -5153,7 +5150,7 @@ fn build_stateset_jac_fn(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let mut eqs: Vec<Arc<SimCode::SimEqSystem>> = Vec::new();
     for set in lst(state_sets) {
@@ -5741,7 +5738,7 @@ fn build_linz_jac_fn(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     let jm = plan.jacs[k].as_ref().ok_or("CodegenWasmJit: no linearization Jacobian")?;
     let col = lst(&jm.columns).next();
@@ -5946,7 +5943,7 @@ fn build_nls_fns(
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
     jac_info: Option<&NlsJacInfo>,
 ) -> Result<(we::Function, we::Function, Option<we::Function>)> {
     let (inner, residuals, iter_vars) = nls_parts(nlsystem)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -556,7 +556,7 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
     shared_lits::begin(lit_base_global(false));
     let mut functions = we::FunctionSection::new();
     let mut bodies: Vec<we::Function> = Vec::with_capacity(funcs.len());
-    let mut literals: Vec<Vec<u8>> = Vec::new();
+    let mut literals = Literals::default();
     for (id, f) in funcs.iter().enumerate() {
         functions.function(base + id as u32); // type index = base + id
         bodies.push(compile_function(f, &by_name, &mut literals)?);
@@ -644,18 +644,16 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
             module.section(&elements);
         }
     }
-    // String literals become passive data segments materialized at runtime with
+    // String literals live in the constant pool, materialized at runtime with
     // `memory.init` (see SCONST in `compile_exp`). The DataCount section must
     // precede the code section; the Data section follows it.
     if !literals.is_empty() {
-        module.section(&we::DataCountSection { count: literals.len() as u32 });
+        module.section(&we::DataCountSection { count: 1 });
     }
     module.section(&code);
     if !literals.is_empty() {
         let mut data = we::DataSection::new();
-        for lit in &literals {
-            data.passive(lit.iter().copied());
-        }
+        data.passive(literals.blob().iter().copied());
         module.section(&data);
     }
     let bytes = module.finish();
@@ -960,6 +958,45 @@ fn record_decl_fields(path: &str) -> Option<Arc<Vec<(ArcStr, Arc<DAE::Type>)>>> 
     RECORD_DECLS.with(|r| r.borrow().get(path).cloned())
 }
 
+/// The module's constant pool: every literal concatenated into the single
+/// passive data segment 0, since `memory.init` reads its segment at a source
+/// offset. One segment rather than one per literal, which wasm caps at 100000.
+#[derive(Default)]
+pub(crate) struct Literals {
+    blob: Vec<u8>,
+    /// `(hash, len)` -> offsets already placed. Keyed by hash so the pool is not
+    /// held twice; `intern` still compares before reusing one.
+    seen: HashMap<(u64, usize), Vec<u32>>,
+}
+
+impl Literals {
+    /// Offset of `bytes` within segment 0, appending them if not already there.
+    pub(crate) fn intern(&mut self, bytes: &[u8]) -> u32 {
+        use core::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        bytes.hash(&mut h);
+        let key = (h.finish(), bytes.len());
+        let offsets = self.seen.entry(key).or_default();
+        if let Some(&off) = offsets.iter().find(|&&o| self.blob[o as usize..][..bytes.len()] == *bytes) {
+            return off;
+        }
+        let off = self.blob.len() as u32;
+        self.blob.extend_from_slice(bytes);
+        offsets.push(off);
+        off
+    }
+
+    /// Whether nothing was interned. Not "the blob is empty": an empty String
+    /// literal adds no bytes but still emits a `memory.init` naming segment 0.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    pub(crate) fn blob(&self) -> &[u8] {
+        &self.blob
+    }
+}
+
 // -------------------------------------------------------------------------
 // Function-body compilation
 // -------------------------------------------------------------------------
@@ -977,8 +1014,8 @@ pub(crate) struct FnCtx<'a> {
     outputs: Vec<(u32, SigTy)>,
     /// Resolves a `CALL` to another generated function.
     by_name: &'a HashMap<String, FnInfo>,
-    /// Module-wide String-literal pool; index = passive data-segment index.
-    literals: &'a mut Vec<Vec<u8>>,
+    /// Module-wide constant pool; `intern` gives the offset into data segment 0.
+    literals: &'a mut Literals,
     instrs: Vec<we::Instruction<'static>>,
     /// Number of currently-open structured-control frames (`block`/`loop`/`if`),
     /// maintained automatically by [`FnCtx::emit`]. A relative branch index to a
@@ -1294,7 +1331,7 @@ impl<'a> FnCtx<'a> {
     pub(crate) fn new_sim(
         sim: SimCtx,
         by_name: &'a HashMap<String, FnInfo>,
-        literals: &'a mut Vec<Vec<u8>>,
+        literals: &'a mut Literals,
     ) -> Self {
         Self::new_sim_params(sim, by_name, literals, 1)
     }
@@ -1305,7 +1342,7 @@ impl<'a> FnCtx<'a> {
     pub(crate) fn new_sim_params(
         sim: SimCtx,
         by_name: &'a HashMap<String, FnInfo>,
-        literals: &'a mut Vec<Vec<u8>>,
+        literals: &'a mut Literals,
         n_params: u32,
     ) -> Self {
         FnCtx {
@@ -1803,7 +1840,7 @@ impl<'a> FnCtx<'a> {
 pub(crate) fn compile_function(
     f: &SimCodeFunction::Function::Function,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     if matches!(f, SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { .. }) {
         return compile_external_function(f, by_name, literals);
@@ -1915,7 +1952,7 @@ pub(crate) fn compile_function(
 fn compile_external_function(
     f: &SimCodeFunction::Function::Function,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut Literals,
 ) -> Result<we::Function> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
     let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, funArgs, outVars, extName, extArgs, .. } = f else {
@@ -4815,15 +4852,14 @@ pub(crate) fn emit_sim_const_stores(
     if copies.is_empty() {
         return Ok(());
     }
-    let seg = ctx.literals.len() as u32;
-    ctx.literals.push(blob);
+    let base = ctx.literals.intern(&blob);
     for (dest, src, len) in copies {
         ctx.emit(I::LocalGet(data));
         ctx.emit(I::I32Const(dest as i32));
         ctx.emit(I::I32Add);
-        ctx.emit(I::I32Const(src as i32));
+        ctx.emit(I::I32Const((base + src) as i32));
         ctx.emit(I::I32Const(len as i32));
-        ctx.emit(I::MemoryInit { mem: 0, data_index: seg });
+        ctx.emit(I::MemoryInit { mem: 0, data_index: 0 });
     }
     Ok(())
 }
@@ -6751,17 +6787,16 @@ fn emit_string_format(ctx: &mut FnCtx, val: &DAE::Exp, fmt: &DAE::Exp, vty: &Sig
 /// data segment with `memory.init`, leaving the owned handle on the stack.
 fn emit_str_literal(ctx: &mut FnCtx, bytes: &[u8]) -> Result<()> {
     let len = bytes.len() as u32;
-    let seg = ctx.literals.len() as u32;
-    ctx.literals.push(bytes.to_vec());
+    let off = ctx.literals.intern(bytes);
     let obj = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::I32Const(len as i32));
     ctx.emit(we::Instruction::Call(rt_index("rt_str_new")?));
     ctx.emit(we::Instruction::LocalTee(obj));
-    // memory.init dest=rt_str_data(obj), src_offset=0, size=len
+    // memory.init dest=rt_str_data(obj), src_offset=off, size=len
     ctx.emit(we::Instruction::Call(rt_index("rt_str_data")?));
-    ctx.emit(we::Instruction::I32Const(0));
+    ctx.emit(we::Instruction::I32Const(off as i32));
     ctx.emit(we::Instruction::I32Const(len as i32));
-    ctx.emit(we::Instruction::MemoryInit { mem: 0, data_index: seg });
+    ctx.emit(we::Instruction::MemoryInit { mem: 0, data_index: 0 });
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
 }
@@ -7112,22 +7147,15 @@ fn emit_const_run(
         return Ok(());
     }
     let len = bytes.len() as u32;
-    // The same table often appears in more than one equation function (the initial
-    // and the algebraic system evaluate the same `when`); one segment serves both,
-    // and nothing emits `data.drop`.
-    let seg = match ctx.literals.iter().position(|l| l.len() == bytes.len() && *l == bytes) {
-        Some(i) => i as u32,
-        None => {
-            ctx.literals.push(bytes);
-            ctx.literals.len() as u32 - 1
-        }
-    };
+    // Nothing emits `data.drop`, so a table shared by several equation functions
+    // stays readable.
+    let off = ctx.literals.intern(&bytes);
     ctx.emit(I::LocalGet(obj));
     ctx.emit(I::I32Const(dest_off as i32));
     ctx.emit(I::I32Add);
-    ctx.emit(I::I32Const(0));
+    ctx.emit(I::I32Const(off as i32));
     ctx.emit(I::I32Const(len as i32));
-    ctx.emit(I::MemoryInit { mem: 0, data_index: seg });
+    ctx.emit(I::MemoryInit { mem: 0, data_index: 0 });
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/shared_lits.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/shared_lits.rs
@@ -73,7 +73,7 @@ pub(crate) fn build_init_fn(
     exps: &[Arc<DAE::Exp>],
     base_global: u32,
     by_name: &HashMap<String, FnInfo>,
-    literals: &mut Vec<Vec<u8>>,
+    literals: &mut super::Literals,
 ) -> Result<we::Function> {
     HOISTING.with(|h| h.set(false));
     let mut ctx = FnCtx {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
@@ -14,6 +14,9 @@ openmodelica_util_datatypes_basic.workspace=true
 arcstr.workspace=true
 match_deref.workspace=true
 libc.workspace=true
+# Backs System::regex and System::Regex on every target; posix_to_rust
+# translates the POSIX syntax first.
+regex = "1"
 # GraphML reader in the hand-written TaskGraphResults.rs; also the
 # modelDescription.xml parser in the hand-written FMIExt.rs.
 roxmltree.workspace=true
@@ -40,10 +43,6 @@ rayon.workspace = true
 # targets the `lapack-nalgebra` feature opts in (the optional dep above).
 [target.'cfg(any(target_arch = "wasm32", target_os = "windows"))'.dependencies]
 nalgebra = { version = "0.33", default-features = false, features = ["std"] }
-# No POSIX libc regcomp/regexec on wasm or Windows; System::regex is
-# reimplemented over the pure-Rust `regex` crate (POSIX ERE maps directly; BRE
-# is translated first).
-regex = "1"
 
 [features]
 # `zeromq` is NOT a default feature: it pulls native libzmq (no wasm target),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -170,11 +170,10 @@ pub fn stringFindString(r#str: ArcStr, searchStr: ArcStr) -> ArcStr {
     }
 }
 
-/// POSIX `regex(3)` wrapper, a faithful port of `OpenModelica_regexImpl`
-/// (SimulationRuntime/c/util/utility.c): it FFIs straight to the same
-/// `regcomp`/`regexec` the C runtime uses, so BRE/ERE syntax and POSIX
-/// leftmost-longest matching behave identically (rather than reimplementing a
-/// regex engine).
+/// POSIX `regex(3)` wrapper, a port of `OpenModelica_regexImpl`
+/// (SimulationRuntime/c/util/utility.c) over the `regex` crate. The crate is
+/// leftmost-first where POSIX is leftmost-longest; that only shows in which of
+/// several alternatives a *capture* takes, which OMC's patterns do not depend on.
 ///
 /// Returns `(nmatch, matches)` where `matches` always has `maxMatches` elements:
 /// the captured substrings (full match at index 0, then each participating
@@ -183,7 +182,6 @@ pub fn stringFindString(r#str: ArcStr, searchStr: ArcStr) -> ArcStr {
 /// is empty and `nmatch` is 1 on match, 0 otherwise. On a compile error
 /// `nmatch` is 0 and (for `maxMatches > 0`) the error message is the first
 /// element.
-#[cfg(any(target_arch = "wasm32", target_os = "windows"))]
 pub fn regex(
     str: ArcStr,
     re: ArcStr,
@@ -191,11 +189,6 @@ pub fn regex(
     extended: bool,
     ignoreCase: bool,
 ) -> (i32, Arc<List<ArcStr>>) {
-    // POSIX regcomp/regexec are libc-only; on wasm and Windows we run the `regex`
-    // instead. POSIX ERE maps almost directly onto its syntax; POSIX BRE has the
-    // grouping/quantifier metacharacter conventions reversed, so translate first.
-    use regex::RegexBuilder;
-
     fn list_forward(items: Vec<ArcStr>) -> Arc<List<ArcStr>> {
         let mut res = metamodelica::nil();
         for it in items.into_iter().rev() {
@@ -207,12 +200,8 @@ pub fn regex(
     let maxn = maxMatches.max(0) as usize;
     let pattern = posix_to_rust(re.as_str(), extended);
 
-    // The C runtime passes no REG_NEWLINE, so `.` matches newline too and `^`/`$`
-    // anchor the whole subject (multi_line stays off).
-    let compiled = RegexBuilder::new(&pattern)
-        .case_insensitive(ignoreCase)
-        .dot_matches_new_line(true)
-        .build();
+    let mut builder = regex_builder(&pattern);
+    let compiled = builder.case_insensitive(ignoreCase).build();
 
     let re_c = match compiled {
         Ok(c) => c,
@@ -274,7 +263,6 @@ pub fn regex(
 /// Backreferences (`\1`…) aren't supported by the crate and don't occur in OMC's
 /// patterns; a literal backslash inside a bracket expression (POSIX-literal, but
 /// an escape to the crate) likewise doesn't occur and is left as-is.
-#[cfg(any(target_arch = "wasm32", target_os = "windows"))]
 fn posix_to_rust(re: &str, extended: bool) -> String {
     let mut out = String::with_capacity(re.len() + 8);
     let mut chars = re.chars().peekable();
@@ -335,155 +323,36 @@ fn posix_to_rust(re: &str, extended: bool) -> String {
     out
 }
 
+/// The builder every pattern is compiled with, already translated by
+/// [`posix_to_rust`]. The C runtime passes no `REG_NEWLINE`, so `.` matches
+/// newline too and `^`/`$` anchor the whole subject (`multi_line` stays off).
+/// POSIX bounds a pattern only by memory, so the crate's fixed 10 MB/2 MB
+/// budgets scale with it instead — both are too small for a pattern naming every
+/// variable of a large model, the DFA cache disastrously so.
+fn regex_builder(pattern: &str) -> regex::RegexBuilder {
+    let budget = pattern.len().saturating_mul(512);
+    let mut b = regex::RegexBuilder::new(pattern);
+    b.dot_matches_new_line(true).size_limit(budget.max(10 << 20)).dfa_size_limit(budget.max(2 << 20));
+    b
+}
+
 /// A compiled POSIX ERE, so one pattern can be tested against many strings
-/// ([`regex`] compiles per call). Same backends, so a match means what it does in
-/// the C runtime: libc `regcomp`/`regexec`, the `regex` crate on wasm/Windows.
+/// ([`regex`] compiles per call).
 pub struct Regex {
-    #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
     re: regex::Regex,
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-    preg: Box<libc::regex_t>,
 }
 
 impl Regex {
     /// No captures (`REG_NOSUB`); the error is the backend's own message.
     pub fn new(re: &str) -> Result<Self, String> {
-        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
-        {
-            regex::RegexBuilder::new(&posix_to_rust(re, true))
-                .dot_matches_new_line(true)
-                .build()
-                .map(|re| Regex { re })
-                .map_err(|e| e.to_string())
-        }
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-        {
-            let c_re = std::ffi::CString::new(re.as_bytes()).map_err(|e| e.to_string())?;
-            let mut preg: Box<libc::regex_t> = Box::new(unsafe { std::mem::zeroed() });
-            let rc = unsafe {
-                libc::regcomp(&mut *preg, c_re.as_ptr(), libc::REG_EXTENDED | libc::REG_NOSUB)
-            };
-            if rc != 0 {
-                let mut buf = vec![0 as core::ffi::c_char; 2048];
-                unsafe { libc::regerror(rc, &*preg, buf.as_mut_ptr(), buf.len()) };
-                let msg = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }.to_string_lossy().into_owned();
-                unsafe { libc::regfree(&mut *preg) };
-                return Err(msg);
-            }
-            Ok(Regex { preg })
-        }
+        regex_builder(&posix_to_rust(re, true))
+            .build()
+            .map(|re| Regex { re })
+            .map_err(|e| e.to_string())
     }
 
     pub fn is_match(&self, s: &str) -> bool {
-        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
-        {
-            self.re.is_match(s)
-        }
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-        {
-            // regexec takes no NUL; OMC's subjects have none.
-            match std::ffi::CString::new(s.as_bytes()) {
-                Ok(c) => unsafe { libc::regexec(&*self.preg, c.as_ptr(), 0, core::ptr::null_mut(), 0) == 0 },
-                Err(_) => false,
-            }
-        }
-    }
-}
-
-#[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-impl Drop for Regex {
-    fn drop(&mut self) {
-        unsafe { libc::regfree(&mut *self.preg) };
-    }
-}
-
-#[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-pub fn regex(
-    str: ArcStr,
-    re: ArcStr,
-    maxMatches: i32,
-    extended: bool,
-    ignoreCase: bool,
-) -> (i32, Arc<List<ArcStr>>) {
-    use std::ffi::CString;
-
-    fn list_forward(items: Vec<ArcStr>) -> Arc<List<ArcStr>> {
-        let mut res = metamodelica::nil();
-        for it in items.into_iter().rev() {
-            res = metamodelica::cons(it, res);
-        }
-        res
-    }
-
-    let maxn = maxMatches.max(0) as usize;
-    let flags = (if extended { libc::REG_EXTENDED } else { 0 })
-        | (if ignoreCase { libc::REG_ICASE } else { 0 })
-        | (if maxn != 0 { 0 } else { libc::REG_NOSUB });
-
-    // POSIX strings are NUL-terminated; a NUL in the pattern/subject can't be
-    // represented. OMC's patterns and subjects never contain NUL, so treat that
-    // as a non-match (mirrors the C, which would simply see a truncated string).
-    let (c_re, c_str) = match (CString::new(re.as_bytes()), CString::new(str.as_bytes())) {
-        (Ok(a), Ok(b)) => (a, b),
-        _ => {
-            let items = vec![literal!(""); maxn];
-            return (0, list_forward(items));
-        }
-    };
-
-    unsafe {
-        let mut preg: libc::regex_t = std::mem::zeroed();
-        let rc = libc::regcomp(&mut preg, c_re.as_ptr(), flags);
-        if rc != 0 {
-            // Compile failure. With no capture slots there is nothing to report;
-            // otherwise the first slot carries the error message (regerror), the
-            // rest are empty — exactly as OpenModelica_regexImpl does.
-            if maxn == 0 {
-                return (0, metamodelica::nil());
-            }
-            let mut buf = vec![0 as core::ffi::c_char; 2048];
-            libc::regerror(rc, &preg, buf.as_mut_ptr(), buf.len());
-            let msg = std::ffi::CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned();
-            let mut items: Vec<ArcStr> = Vec::with_capacity(maxn);
-            items.push(ArcStr::from(format!("Failed to compile regular expression: {re} with error: {msg}")));
-            for _ in 1..maxn {
-                items.push(literal!(""));
-            }
-            // regcomp leaves nothing to free on failure, but freeing a
-            // zero-initialised regex_t is safe and matches the C path.
-            libc::regfree(&mut preg);
-            return (0, list_forward(items));
-        }
-
-        let mut pmatch: Vec<libc::regmatch_t> = vec![std::mem::zeroed(); maxn.max(1)];
-        let res = libc::regexec(&preg, c_str.as_ptr(), maxn, pmatch.as_mut_ptr(), 0);
-        libc::regfree(&mut preg);
-
-        let bytes = str.as_bytes();
-        let mut nmatch = 0i32;
-        let matches = if maxn == 0 {
-            if res == 0 {
-                nmatch = 1;
-            }
-            metamodelica::nil()
-        } else {
-            let mut items: Vec<ArcStr> = Vec::with_capacity(maxn);
-            for m in pmatch.iter().take(maxn) {
-                // Pack only participating groups (rm_so != -1), like the C.
-                if res == 0 && (m.rm_so as i64) != -1 {
-                    let so = m.rm_so as usize;
-                    let eo = m.rm_eo as usize;
-                    let sub = std::str::from_utf8(&bytes[so..eo]).unwrap_or("");
-                    items.push(ArcStr::from(sub));
-                    nmatch += 1;
-                }
-            }
-            while items.len() < maxn {
-                items.push(literal!(""));
-            }
-            list_forward(items)
-        };
-        (nmatch, matches)
+        self.re.is_match(s)
     }
 }
 


### PR DESCRIPTION
Two unrelated limits, both reached by ScalableTestSuite models under `--simCodeTarget=wasm-jit`.

### One data segment for the literal pool

Every String literal and constant table got a passive data segment of its own, but wasm caps a module at 100000 of them. DistributionSystemModelica_N_56_M_56 emitted 120253, and the engine rejected the whole module with "data count section specifies too many data segments".

`memory.init` already reads its segment at a source offset, so one segment can back every literal — `emit_sim_const_stores` was doing this within a single call. Hoisting that into a module-wide pool also replaces the linear scan `emit_const_run` used for dedup with a hash lookup, and covers strings and the metadata blob rather than only array runs.

| N_56_M_56     | before | after |
| ------------- | ------ | ----- |
| data segments | 120253 |     1 |
| data section  | 13.4MB | 8.5MB |
| module        | 23.7MB |18.8MB |

### The regex crate instead of libc regcomp

glibc's `regcomp` parses a pattern recursively, so a `variableFilter` naming every variable of a large model overflows the 4 MiB `omc-main` stack and aborts omc outright. The library test builds exactly such a filter from the reference file: Table_N_200_M_200 gives 40004 alternations over 470 kB, and omc died with SIGABRT before `apply_variable_filter` could report anything. The C runtime survives it only by accident — under the test's `ulimit` its regcomp returns `REG_ESPACE`, and it falls back to emitting every variable.

The crate builds an automaton with no deep recursion, so the filter is honoured rather than abandoned, and it is much cheaper for a pattern of this shape:

| Table_N_200_M_200 | glibc | regex crate |
| ----------------- | ----- | ----------- |
| compile           | 44.3s |       0.92s |
| match 40k names   | 0.50s |       0.06s |

Both of the crate's fixed budgets are too small here — 10 MB rejects the pattern and a 2 MB lazy-DFA cache thrashes (>280s to match, against 64ms once it fits) — so they scale with the pattern instead.

It was already the backend on wasm and Windows, where there is no POSIX regcomp, so `posix_to_rust` and its BRE/bracket translation already ran in production; this drops the second backend rather than adding one. `System.regex`, the scripting `regex()`/`regexBool()`, is switched over too, since it had the same cliff and no size budget at all. Checked against the C omc over ERE/BRE operator reversal, literal parens in BRE, case sensitivity, `maxMatches = 0`, non-participating group packing, more groups than slots, `.` over newline, whole-subject anchoring, `[]]`/`[[]` members, POSIX character classes and no-match: identical except the message text of a compile failure, which is now the crate's — as it has always been on wasm and Windows.
`interactive-API/regex.mos` matches its recorded output.