### PR TITLE
wasm-jit: external work variables and FORTRAN 77

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -62,7 +62,8 @@ use crate::CodegenWasmJitFunctions::{
     ClockInit, ClockUpdate,
     NlsResidual, emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
-    external_general, function_signature, rt_index, sim_cref_key, sim_const_store,
+    external_general_why, note_declined_external, reset_declined_externals,
+    function_signature, rt_index, sim_cref_key, sim_const_store,
     emit_sim_const_stores,
 };
 
@@ -2924,12 +2925,20 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     }
 
     // --- Collect the model's Modelica functions (callable from equations). ---
+    reset_declined_externals();
     let model_fns: Vec<&SimCodeFunction::Function::Function> = lst(&mi.functions)
         .map(|f| &**f)
         .filter(|f| {
-            matches!(f, SimCodeFunction::Function::Function::FUNCTION { .. })
-                || external_known(f)
-                || external_general(f)
+            if matches!(f, SimCodeFunction::Function::Function::FUNCTION { .. }) || external_known(f) {
+                return true;
+            }
+            match external_general_why(f) {
+                Ok(()) => true,
+                Err(why) => {
+                    note_declined_external(f, why);
+                    false
+                }
+            }
         })
         .collect();
 
@@ -2939,7 +2948,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let mut ext_imports: Vec<ExtCallSig> = Vec::new();
     let mut ext_seen: HashSet<String> = HashSet::new();
     for f in &model_fns {
-        if external_general(f) {
+        if external_general_why(f).is_ok() {
             let sig = external_import_sig(f)?;
             if ext_seen.insert(sig.name.clone()) {
                 ext_imports.push(sig);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -96,7 +96,7 @@ fn unknown_variable(name: &str) -> &'static str {
 // trait rather than an inherent method.
 pub(crate) use openmodelica_sim_meta::WTy;
 use openmodelica_sim_meta::clock_field;
-pub(crate) use openmodelica_wasm_jit::sig::{ExtCallSig, FnSig, SigTy, WTyVal};
+pub(crate) use openmodelica_wasm_jit::sig::{ExtCallSig, ExtLang, FnSig, SigTy, WTyVal};
 
 /// Parse one `.wasm.sig` line into a list of [`SigTy`]s (see [`SigTy::write_code`]
 /// for the encoding). Types are concatenated without separators; an `'['`
@@ -739,62 +739,116 @@ fn supported_external(ext_name: &str, ins: &[SigTy], out: &SigTy) -> bool {
     }
 }
 
-/// A general external function routed to an `ext.<extName>` host import: a
-/// single return (the C return value), all-input args, whose `extName` is NOT a
-/// known builtin ([`external_known`]). Inputs and the output must each be a
-/// marshallable kind — scalar (Real/Integer/Boolean), `String` (→ `char*`), or an
-/// external object (→ `void*`). Arrays and output-pointer args are handled once
-/// [`external_import_sig`]/the trampoline learn `SIMEXTARGSIZE` (see HANDOFF T1).
+/// The declared-output slot an `extArgs` entry writes, 1-based as `SimExtArg`
+/// records it; 0 for an input-side argument. `isInput` does *not* answer this: a
+/// protected `biVars` local is `isInput = false, outputIndex = 0` and passed in.
+fn ext_arg_output_index(a: &SimCodeFunction::SimExtArg::SimExtArg) -> usize {
+    use SimCodeFunction::SimExtArg::SimExtArg as A;
+    match a {
+        A::SIMEXTARG { outputIndex, .. } | A::SIMEXTARGSIZE { outputIndex, .. } => (*outputIndex).max(0) as usize,
+        _ => 0,
+    }
+}
+
+/// The external calling convention of `language`, or `None` for one we do not
+/// lower. `"BUILTIN"` shares C's convention, as in `extFunCall`.
+fn ext_lang(language: &str) -> Option<ExtLang> {
+    match language {
+        "C" | "BUILTIN" => Some(ExtLang::C),
+        "FORTRAN 77" => Some(ExtLang::Fortran77),
+        _ => None,
+    }
+}
+
+thread_local! {
+    /// Externals left out of the module, by Modelica identifier, with why. A call
+    /// to one reports that instead of failing as an unknown builtin — the name
+    /// reaching [`compile_math_builtin`] looks the same either way.
+    static DECLINED_EXTERNALS: std::cell::RefCell<HashMap<String, String>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+pub(crate) fn reset_declined_externals() {
+    DECLINED_EXTERNALS.with(|d| d.borrow_mut().clear());
+}
+
+pub(crate) fn note_declined_external(f: &SimCodeFunction::Function::Function, why: String) {
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, .. } = f else { return };
+    let Ok(ident) = AbsynUtil::pathLastIdent(name.clone()) else { return };
+    DECLINED_EXTERNALS.with(|d| d.borrow_mut().insert(ident.to_string(), why));
+}
+
+fn declined_external_reason(ident: &str) -> Option<String> {
+    DECLINED_EXTERNALS.with(|d| d.borrow().get(ident).cloned())
+}
+
+/// A general external function routed to an `ext.<extName>` host import: one
+/// whose `extName` is not a known builtin ([`external_known`]). Every value
+/// crossing the C boundary must be a marshallable kind — scalar
+/// (Real/Integer/Boolean), `String` (→ `char*`), an external object (→ `void*`),
+/// or an array (→ a pointer to its data); only the return value may not be an
+/// array.
 pub(crate) fn external_general(f: &SimCodeFunction::Function::Function) -> bool {
+    external_general_why(f).is_ok()
+}
+
+/// [`external_general`] with the rejection reason, for the diagnostics the
+/// unlowered call site reports.
+pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> std::result::Result<(), String> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
     if external_known(f) {
-        return false;
+        return Err("lowered as a known math/string builtin".to_string());
     }
-    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { funArgs, outVars, extReturn, extArgs, .. } = f else {
-        return false;
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { funArgs, outVars, biVars, extReturn, extArgs, language, .. } = f else {
+        return Err("not an external function".to_string());
     };
-    // Inputs may be scalars, strings, external objects, or arrays (passed as a
-    // native data pointer). Outputs (the C return value and any `_Out_` pointer
-    // args) must be scalar / string / extObj — an array output would need
-    // copy-back marshalling (not yet).
-    let in_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr | SigTy::Array { .. });
-    // Output args may also be arrays (filled in place / copied back); the C return
-    // value may not (no array returns).
-    let out_arg_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr | SigTy::Array { .. });
-    let out_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr);
-    let mut n_out_args = 0usize;
+    if ext_lang(language).is_none() {
+        return Err(format!("external language \"{language}\" is not supported"));
+    }
+    let arg_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr | SigTy::Array { .. });
+    let ret_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr);
+    let n_out = (&**outVars).into_iter().count();
+    // Each declared output is written by at most one `extArgs` entry (or the
+    // return value); one left unwritten keeps its binding, as in the C target.
+    let mut written = vec![false; n_out];
+    let mut claim = |oi: usize| -> bool {
+        if oi == 0 {
+            return true;
+        }
+        oi <= n_out && !std::mem::replace(&mut written[oi - 1], true)
+    };
     for a in &**extArgs {
-        match &**a {
-            A::SIMEXTARG { isInput: true, type_, .. } => match sig_ty(type_) {
-                Ok(t) if in_ok(&t) => {}
-                _ => return false,
-            },
-            A::SIMEXTARG { isInput: false, type_, .. } => {
-                match sig_ty(type_) {
-                    Ok(t) if out_arg_ok(&t) => {}
-                    _ => return false,
-                }
-                n_out_args += 1;
+        let ty = match &**a {
+            A::SIMEXTARGSIZE { .. } => SigTy::Int,
+            A::SIMEXTARG { type_, .. } | A::SIMEXTARGEXP { type_, .. } => {
+                sig_ty(type_).map_err(|e| e.to_string())?
             }
-            A::SIMEXTARGEXP { .. } | A::SIMEXTARGSIZE { isInput: true, .. } => {}
-            _ => return false,
+            _ => return Err("unsupported external-call argument".to_string()),
+        };
+        if !arg_ok(&ty) {
+            return Err(format!("argument type {ty:?} cannot be marshalled"));
+        }
+        if !claim(ext_arg_output_index(a)) {
+            return Err("an argument writes an output the function does not declare".to_string());
         }
     }
-    let n_ret = match &**extReturn {
-        A::SIMNOEXTARG => 0,
-        A::SIMEXTARG { type_, .. } => match sig_ty(type_) {
-            Ok(t) if out_ok(&t) => 1,
-            _ => return false,
-        },
-        _ => return false,
-    };
-    let Ok(ins) = var_sigtys(funArgs) else { return false };
-    if !ins.iter().all(in_ok) {
-        return false;
+    match &**extReturn {
+        A::SIMNOEXTARG => {}
+        A::SIMEXTARG { type_, outputIndex, .. } => {
+            let t = sig_ty(type_).map_err(|e| e.to_string())?;
+            if !ret_ok(&t) || !claim((*outputIndex).max(0) as usize) {
+                return Err(format!("return type {t:?} cannot be marshalled"));
+            }
+        }
+        _ => return Err("unsupported external return".to_string()),
     }
-    // One wasm result per output (return value + each `_Out_` pointer), matching
-    // the external function's declared outputs.
-    (&**outVars).into_iter().count() == n_ret + n_out_args
+    for (what, vars) in [("input", funArgs), ("output", outVars), ("protected variable", biVars)] {
+        let tys = var_sigtys(vars).map_err(|e| format!("{what}: {e}"))?;
+        if let Some(t) = tys.iter().find(|t| !arg_ok(t)) {
+            return Err(format!("{what} of type {t:?} is not supported"));
+        }
+    }
+    Ok(())
 }
 
 /// The C-call shape ([`ExtCallSig`]) of a general external function, for its
@@ -802,26 +856,31 @@ pub(crate) fn external_general(f: &SimCodeFunction::Function::Function) -> bool 
 /// wrapper's own signature).
 pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Result<ExtCallSig> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
-    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { extName, extArgs, extReturn, .. } = f else {
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { extName, extArgs, extReturn, language, .. } = f else {
         return Err("CodegenWasmJit: external_import_sig on a non-external function");
     };
+    let lang = ext_lang(language).ok_or("CodegenWasmJit: unsupported external language")?;
     let mut args: Vec<(SigTy, bool)> = Vec::new();
     for a in &**extArgs {
-        let (ty, is_out) = match &**a {
+        let ty = match &**a {
             // A `size(array, dim)` argument is a C `int` dimension (input).
-            A::SIMEXTARGSIZE { .. } => (SigTy::Int, false),
-            A::SIMEXTARG { type_, isInput, .. } => (sig_ty(type_)?, !*isInput),
-            A::SIMEXTARGEXP { type_, .. } => (sig_ty(type_)?, false),
+            A::SIMEXTARGSIZE { .. } => SigTy::Int,
+            A::SIMEXTARG { type_, .. } | A::SIMEXTARGEXP { type_, .. } => sig_ty(type_)?,
             other => return Err("CodegenWasmJit: unsupported external-call argument"),
         };
-        args.push((ty, is_out));
+        args.push((ty, ext_arg_output_index(a) != 0));
     }
     let ret = match &**extReturn {
         A::SIMNOEXTARG => None,
         A::SIMEXTARG { type_, .. } => Some(sig_ty(type_)?),
         other => return Err("CodegenWasmJit: unsupported external return"),
     };
-    Ok(ExtCallSig { name: extName.to_string(), args, ret })
+    // Fortran symbols carry a trailing underscore, as `extFunCallF77` emits.
+    let name = match lang {
+        ExtLang::C => extName.to_string(),
+        ExtLang::Fortran77 => format!("{extName}_"),
+    };
+    Ok(ExtCallSig { name, lang, args, ret })
 }
 
 /// The input/output scalar `SigTy`s of the main function, for the sidecar.
@@ -1907,18 +1966,17 @@ pub(crate) fn compile_function(
     Ok(func)
 }
 
-/// Lower a known scalar-math `external "C"`/"builtin" function (see
-/// [`external_known`]) to a wasm function body that calls the corresponding host
-/// builtin: `output := extName(extArgs…)`. The inputs are the wasm parameters;
-/// the external-call arguments (`extArgs`) reference them (or are constant
-/// expressions). Only the return-value form is reached here.
+/// Lower an `external "C"`/`"builtin"`/`"FORTRAN 77"` function to the wasm
+/// equivalent of C's `functionBodyExternalFunction`: allocate and bind the
+/// outputs and the protected `biVars` locals, call `extName` over `extArgs`,
+/// then copy the results into the outputs.
 fn compile_external_function(
     f: &SimCodeFunction::Function::Function,
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Vec<Vec<u8>>,
 ) -> Result<we::Function> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
-    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, funArgs, outVars, extName, extArgs, .. } = f else {
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, funArgs, outVars, biVars, extName, extArgs, extReturn, .. } = f else {
         return Err("CodegenWasmJit: compile_external_function on a non-external function");
     };
     // Only for the mismatch diagnostics below.
@@ -1943,27 +2001,49 @@ fn compile_external_function(
         let slot = intern_local(v, &mut idx, &mut extra_locals, &mut locals, &mut array_allocs)?;
         outputs.push(slot);
     }
+    for v in &**biVars {
+        intern_local(v, &mut idx, &mut extra_locals, &mut locals, &mut array_allocs)?;
+    }
 
     let mut ctx = FnCtx { locals, extra_locals, n_params, outputs, by_name, literals, instrs: Vec::new(), ctrl_depth: 0, loops: Vec::new(), borrowed_locals: Vec::new(), elem_ptr_tmp: None, sim: None };
-    for (slot, elem, dims) in &array_allocs {
-        emit_array_alloc(&mut ctx, *slot, elem, dims)?;
+    // In the order the C body emits them: `extFunCallF77` appends the `biVars` to
+    // the *outputAlloc* buffer, ahead of the outputs (`output Real x[max(nrow,
+    // ncol)] = cat(…nrow…)` reads them); `extFunCallC` appends them behind.
+    let lang = external_import_sig(f).map(|s| s.lang).unwrap_or(ExtLang::C);
+    let ordered: Vec<&Arc<SimCodeFunction::Variable::Variable>> = match lang {
+        ExtLang::Fortran77 => (&**biVars).into_iter().chain(&**outVars).collect(),
+        ExtLang::C => (&**outVars).into_iter().chain(&**biVars).collect(),
+    };
+    for v in ordered {
+        let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, value, bind_from_outside, .. } = &**v else {
+            continue;
+        };
+        let slot = var_name_ty(v).ok().and_then(|(n, _)| ctx.locals.get(&n).cloned());
+        if let Some((slot, SigTy::Array { elem, .. })) = slot
+            && let Some(k) = array_allocs.iter().position(|(i, ..)| *i == slot)
+        {
+            let (_, _, dims) = array_allocs.remove(k);
+            emit_array_alloc(&mut ctx, slot, &elem, &dims)?;
+        }
+        if *bind_from_outside {
+            continue;
+        }
+        let Some(val) = value else { continue };
+        let lhs = DAE::Exp::CREF { componentRef: name.clone(), ty: ty.clone() };
+        compile_assign(&mut ctx, &lhs, val)?;
     }
 
     // Lower an extArg to the argument expression it contributes to the C call.
-    // `_Out_` pointer args (`isInput: false`) contribute no wasm argument — their
-    // value comes back as a call result — so `None` skips them.
+    // A scalar/String `_Out_` arg contributes none — its value comes back as a
+    // call result — so `None` skips it.
     let lower_arg = |a: &A| -> Result<Option<Arc<DAE::Exp>>> {
+        let is_out = ext_arg_output_index(a) != 0;
         Ok(match a {
-            // An output array is pre-allocated and passed by pointer (like an input);
-            // a scalar/string `_Out_` arg contributes no wasm argument (its value
-            // comes back as a call result).
-            A::SIMEXTARG { isInput: false, cref, type_, .. } if matches!(sig_ty(type_), Ok(SigTy::Array { .. })) => {
+            // An output array is pre-allocated and passed by pointer, like an input.
+            A::SIMEXTARG { cref, type_, .. } if !is_out || matches!(sig_ty(type_), Ok(SigTy::Array { .. })) => {
                 Some(Arc::new(DAE::Exp::CREF { componentRef: cref.clone(), ty: type_.clone() }))
             }
-            A::SIMEXTARG { isInput: false, .. } => None,
-            A::SIMEXTARG { cref, type_, .. } => {
-                Some(Arc::new(DAE::Exp::CREF { componentRef: cref.clone(), ty: type_.clone() }))
-            }
+            A::SIMEXTARG { .. } => None,
             A::SIMEXTARGEXP { exp, .. } => Some(exp.clone()),
             // `size(array, dim)`: `cref`+`type_` are the array (full type), `exp`
             // is the 1-based dimension index. Lower as a `size(cref, exp)`
@@ -1996,26 +2076,42 @@ fn compile_external_function(
         // (the C return value first, then each `_Out_` scalar/string pointer's
         // value). Array outputs are filled in place / copied back by the host, so
         // they are not results — their locals are already populated. The results
-        // land on the stack in order; store them into the non-array outputs
-        // back-to-front.
-        // Per-arg SigTy, so the shared-memory path knows which args are String/array.
-        let arg_types = external_import_sig(f)?.wasm_params();
-        let results = emit_general_external_call(&mut ctx, extName, &input_args, &arg_types)?;
-        let scalar_outs: Vec<usize> = (0..ctx.outputs.len())
-            .filter(|&i| !matches!(ctx.outputs[i].1, SigTy::Array { .. }))
-            .collect();
-        if results.len() != scalar_outs.len() {
+        // land on the stack in order, so they are stored back-to-front into the
+        // declared outputs their `outputIndex` names.
+        let sig = external_import_sig(f)?;
+        // No host trampoline there, so nowhere to do the Fortran conversions.
+        if sig.lang == ExtLang::Fortran77 && EXTERNALS_SHARED.with(|c| c.get()) {
             openmodelica_wasm_jit::set_engine_error_detail(format!(
-                "  {}, external `{extName}`: the call returns {} value(s), the function \
-                 declares {} scalar output(s)",
+                "  {}: external \"FORTRAN 77\" is not available in a shared-memory wasm FMU",
+                fn_path(),
+            ));
+            return Err("CodegenWasmJit: external \"FORTRAN 77\" in a shared-memory module");
+        }
+        let results = emit_general_external_call(&mut ctx, &sig.name, &input_args, &sig.wasm_params())?;
+        // The declared output each wasm result feeds, in result order: the C
+        // return value first, then each scalar/String `_Out_` arg.
+        let mut targets: Vec<usize> = Vec::new();
+        if let A::SIMEXTARG { outputIndex, .. } = &**extReturn {
+            targets.push(*outputIndex as usize - 1);
+        }
+        for a in &**extArgs {
+            let oi = ext_arg_output_index(a);
+            let scalar = !matches!(&**a, A::SIMEXTARG { type_, .. } if matches!(sig_ty(type_), Ok(SigTy::Array { .. })));
+            if oi != 0 && scalar {
+                targets.push(oi - 1);
+            }
+        }
+        if results.len() != targets.len() {
+            openmodelica_wasm_jit::set_engine_error_detail(format!(
+                "  {}, external `{extName}`: the call returns {} value(s) for {} scalar output(s)",
                 fn_path(),
                 results.len(),
-                scalar_outs.len(),
+                targets.len(),
             ));
             return Err("CodegenWasmJit: external scalar-return/output count mismatch");
         }
-        for k in (0..scalar_outs.len()).rev() {
-            let (out_idx, out_sty) = ctx.outputs[scalar_outs[k]].clone();
+        for k in (0..targets.len()).rev() {
+            let (out_idx, out_sty) = ctx.outputs[targets[k]].clone();
             if results[k].wty() != out_sty.wty() {
                 openmodelica_wasm_jit::set_engine_error_detail(format!(
                     "  {}, external `{extName}`: output {k} is {:?} in the C call but \
@@ -2519,8 +2615,10 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
     };
     let lhs_v: Vec<&Arc<DAE::Exp>> = (&**lhs).into_iter().collect();
     let results = compile_call(ctx, path, expLst, attr)?;
-    if results.len() != lhs_v.len() {
-        return Err("CodegenWasmJit: tuple assignment arity mismatch");
+    // Trailing outputs the statement does not name are dropped, as in
+    // `algStmtTupleAssign`.
+    if results.len() < lhs_v.len() {
+        return Err("CodegenWasmJit: tuple assignment names more targets than the call returns");
     }
     // Pop the results into temps (the last result is on top of the stack).
     let mut temps = vec![0u32; results.len()];
@@ -2528,6 +2626,12 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
         let vt = ctx.alloc_temp(results[i].wty());
         ctx.emit(we::Instruction::LocalSet(vt));
         temps[i] = vt;
+    }
+    for i in lhs_v.len()..results.len() {
+        if let Some(release_fn) = results[i].release_fn() {
+            ctx.emit(we::Instruction::LocalGet(temps[i]));
+            ctx.emit(we::Instruction::Call(rt_index(release_fn)?));
+        }
     }
     for (i, lhs_exp) in lhs_v.iter().enumerate() {
         let sty = &results[i];
@@ -6594,12 +6698,20 @@ fn compile_math_builtin(
                 None => return Err("CodegenWasmJit: der() is only supported in simulation mode"),
             }
         }
-        other => {
-            crate::CodegenWasmJit::record_error(format!(
-                "CodegenWasmJit: builtin function not yet supported: {other}"
-            ));
-            Err("CodegenWasmJit: builtin function not yet supported")
-        }
+        other => match declined_external_reason(other) {
+            Some(why) => {
+                crate::CodegenWasmJit::record_error(format!(
+                    "CodegenWasmJit: external function not lowered: {other} ({why})"
+                ));
+                Err("CodegenWasmJit: external function not lowered")
+            }
+            None => {
+                crate::CodegenWasmJit::record_error(format!(
+                    "CodegenWasmJit: builtin function not yet supported: {other}"
+                ));
+                Err("CodegenWasmJit: builtin function not yet supported")
+            }
+        },
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtFFT.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtFFT.mo
@@ -1,0 +1,10 @@
+model TestExtFFT "external C with a protected work array, array outputs and several outputs"
+  parameter Real u[6] = {0.0, 0.1, 0.2, 0.4, 0.5, 0.6};
+  Integer info;
+  Real amplitudes[4];
+  Real phases[4];
+  Real x(start = 0, fixed = true);
+equation
+  (info, amplitudes, phases) = Modelica.Math.FastFourierTransform.Internal.rawRealFFT(u);
+  der(x) = amplitudes[2];
+end TestExtFFT;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtLapack.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtLapack.mo
@@ -1,0 +1,16 @@
+model TestExtLapack "external FORTRAN 77 (LAPACK) with protected work variables"
+  // Deliberately not symmetric: a transposed A would still solve, so only an
+  // asymmetric one catches a missing row-major/column-major conversion.
+  parameter Real A[3, 3] = {{2, 1, 5}, {7, 3, 1}, {0, 4, 6}};
+  parameter Real b[3] = {1, 2, 3};
+  Real xs[3];
+  Integer infos;
+  Real LU[3, 3];
+  Integer pivots[3];
+  Integer inff;
+  Real y(start = 0, fixed = true);
+equation
+  (xs, infos) = Modelica.Math.Matrices.LAPACK.dgesv_vec(A, b);
+  (LU, pivots, inff) = Modelica.Math.Matrices.LAPACK.dgetrf(A);
+  der(y) = xs[1] + LU[2, 2];
+end TestExtLapack;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extfft.mos
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extfft.mos
@@ -1,0 +1,9 @@
+// external "C" with protected work arrays / array outputs. Usage: omc run_extfft.mos
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+loadFile("TestExtFFT.mo"); getErrorString();
+simulate(TestExtFFT, stopTime = 1.0, numberOfIntervals = 10); getErrorString();
+val(amplitudes[1], 1.0);
+val(amplitudes[2], 1.0);
+val(phases[2], 1.0);
+val(info, 1.0);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extlapack.mos
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extlapack.mos
@@ -1,0 +1,11 @@
+// external "FORTRAN 77" (LAPACK) calls. Usage: omc run_extlapack.mos
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+loadFile("TestExtLapack.mo"); getErrorString();
+simulate(TestExtLapack, stopTime = 1.0, numberOfIntervals = 10); getErrorString();
+val(xs[1], 1.0);
+val(xs[2], 1.0);
+val(xs[3], 1.0);
+val(infos, 1.0);
+val(LU[2,2], 1.0);
+val(pivots[1], 1.0);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -173,6 +173,55 @@ fn assert_failed(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i
     1
 }
 
+/// The runtime array object as both engines' external-"C" trampolines read it:
+/// header `[refcount][elem kind][ndims][total][dim…]`, then the flat row-major
+/// elements from the next 8-byte boundary on.
+pub mod array_abi {
+    use crate::sig::SigTy;
+
+    /// Every heap handle is a 4-byte `i32`.
+    pub fn elem_size(elem: &SigTy) -> usize {
+        match elem {
+            SigTy::Real => 8,
+            _ => 4,
+        }
+    }
+
+    /// The dimensions and element-area offset of the array object at `obj`.
+    pub fn dims_and_data(mem: &[u8], obj: usize) -> Option<(Vec<usize>, usize)> {
+        let word = |off: usize| -> Option<usize> {
+            Some(u32::from_le_bytes(mem.get(off..off + 4)?.try_into().ok()?) as usize)
+        };
+        let ndims = word(obj + 8)?;
+        let dims = (0..ndims).map(|k| word(obj + 16 + 4 * k)).collect::<Option<Vec<_>>>()?;
+        Some((dims, (16 + ndims * 4 + 7) & !7))
+    }
+
+    /// Copy `src` to `dst` converting between row-major and column-major storage
+    /// (C's `convert_alloc_*_{to,from}_f77`, without its 2-D-only restriction).
+    pub fn reorder(src: &[u8], dst: &mut [u8], dims: &[usize], esz: usize, to_fortran: bool) {
+        let total: usize = dims.iter().product();
+        let mut idx = vec![0usize; dims.len()];
+        for r in 0..total {
+            let mut c = 0usize;
+            let mut stride = 1usize;
+            for k in 0..dims.len() {
+                c += idx[k] * stride;
+                stride *= dims[k];
+            }
+            let (from, to) = if to_fortran { (r, c) } else { (c, r) };
+            dst[to * esz..(to + 1) * esz].copy_from_slice(&src[from * esz..(from + 1) * esz]);
+            for k in (0..dims.len()).rev() {
+                idx[k] += 1;
+                if idx[k] < dims[k] {
+                    break;
+                }
+                idx[k] = 0;
+            }
+        }
+    }
+}
+
 // Native rsparse solve behind the `env.rt_host_lin_solve` import, which the native
 // interactive runtime calls from `rt_solve_lin_sparse_cached`. Symbolic analysis
 // cached per system `handle`; `count()` feeds `stats.lin_solves`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
@@ -151,6 +151,15 @@ pub struct FnSig {
     pub results: Vec<SigTy>,
 }
 
+/// The calling convention of an external function's `extArgs`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ExtLang {
+    /// `external "C"` / `external "builtin"`: scalars by value, arrays row-major.
+    C,
+    /// `external "FORTRAN 77"`: every argument by reference, arrays column-major.
+    Fortran77,
+}
+
 /// The C-call shape of a general external "C" import. `args` is the C argument
 /// list in `extArgs` order, each flagged as an `_Out_` pointer or not; `ret` is
 /// the C return-value type (`None` for a `void` function). The corresponding wasm
@@ -159,10 +168,13 @@ pub struct FnSig {
 /// string outputs — the C return value first (if any), then each `_Out_` scalar/
 /// string pointer's written value — as multi-value results. Array outputs are
 /// filled in place (native) or copied back by the host (web), so they are NOT
-/// results. The host trampoline owns all pointer marshalling.
+/// results. The host trampoline owns all pointer marshalling, including the
+/// by-reference/column-major conversions `lang == Fortran77` asks for.
 #[derive(Clone)]
 pub struct ExtCallSig {
+    /// The linker symbol; already `_`-suffixed for [`ExtLang::Fortran77`].
     pub name: String,
+    pub lang: ExtLang,
     pub args: Vec<(SigTy, bool)>,
     pub ret: Option<SigTy>,
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -441,8 +441,16 @@ fn define_external_imports(
 
     for sig in &model.ext_imports {
         let name = &sig.name;
-        let func = side_inst.exports.get_function(name)
-            .map_err(|e| "CodegenWasmJit: ModelicaExternalC side module has no")?
+        let func = side_inst
+            .exports
+            .get_function(name)
+            .map_err(|e| {
+                crate::set_engine_error_detail(format!(
+                    "  the ModelicaExternalC side module exports no `{name}` — the web \
+                     target only has the libraries built into it"
+                ));
+                "CodegenWasmJit: external \"C\" function not in the side module"
+            })?
             .clone();
         // Nothing to marshal: bind the export straight in, so the engine calls it
         // wasm->wasm instead of through a host trampoline.
@@ -477,13 +485,15 @@ fn define_external_imports(
 /// Whether the wasm import is already the side module's C export. `Ptr` qualifies:
 /// an external object is an opaque handle only the side module dereferences.
 /// `_Out_` args need a scratch cell, and `Str`/`Array`/`Record` bytes live in the
-/// other memory, so both still need the trampoline.
+/// other memory, so both still need the trampoline — as does every Fortran call,
+/// which takes its arguments by reference.
 fn is_passthrough(sig: &crate::sig::ExtCallSig) -> bool {
     use crate::sig::SigTy;
     fn scalar(t: &SigTy) -> bool {
         matches!(t, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Ptr)
     }
-    sig.args.iter().all(|(t, is_out)| !*is_out && scalar(t))
+    sig.lang == crate::sig::ExtLang::C
+        && sig.args.iter().all(|(t, is_out)| !*is_out && scalar(t))
         && sig.ret.as_ref().is_none_or(scalar)
 }
 
@@ -526,8 +536,10 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     // (output SigTy, scratch offset), in output order — matches the import's results.
     let mut out_cells: Vec<(SigTy, u32)> = Vec::new();
     // Output arrays to copy back after the call: (sim array offset, side scratch
-    // offset, byte length, header data offset).
-    let mut out_arrays: Vec<(u32, u32, usize, u32)> = Vec::new();
+    // offset, byte length, header data offset, column-major dims + element size
+    // for a Fortran callee).
+    let mut out_arrays: Vec<(u32, u32, usize, u32, Option<(Vec<usize>, usize)>)> = Vec::new();
+    let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
     let mut in_i = 0usize;
     for (ty, is_out) in &sig.args {
         // Scalar/string outputs get an `_Out_` scratch cell (returned as a result);
@@ -543,6 +555,19 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
         }
         let v = &args[in_i];
         in_i += 1;
+        // Fortran passes scalars by reference; give each one a side-memory cell.
+        if fortran && matches!(ty, SigTy::Real | SigTy::Int | SigTy::Bool) {
+            let mut raw = [0u8; 8];
+            match ty {
+                SigTy::Real => raw.copy_from_slice(&v.f64().ok_or_else(|| "expected f64 arg")?.to_le_bytes()),
+                _ => raw[..4].copy_from_slice(&v.i32().ok_or_else(|| "expected i32 arg")?.to_le_bytes()),
+            }
+            let cell = malloc.call(&mut store, 8).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            side_mem.view(&store).write(cell as u64, &raw).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            temps.push(cell);
+            call_args.push(Value::I32(cell as i32));
+            continue;
+        }
         match ty {
             SigTy::Real => call_args.push(Value::F64(v.f64().ok_or_else(|| "expected f64 arg")?)),
             SigTy::Int | SigTy::Bool | SigTy::Ptr => {
@@ -562,11 +587,24 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                 let off = v.i32().ok_or_else(|| "expected i32 array handle arg")? as u32;
                 let ndims = read_u32_mem(&sim_mem, &store, off + 8)?;
                 let total = read_u32_mem(&sim_mem, &store, off + 12)? as usize;
-                let elem_size = if matches!(**elem, SigTy::Real) { 8 } else { 4 };
+                let elem_size = crate::host::array_abi::elem_size(elem);
                 let data_off = (16 + ndims * 4 + 7) & !7;
                 let bytes = total * elem_size;
                 let mut buf = vec![0u8; bytes];
                 sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                // A Fortran callee reads the array column-major.
+                let f77 = if fortran && ndims > 1 {
+                    let mut dims = Vec::with_capacity(ndims as usize);
+                    for k in 0..ndims {
+                        dims.push(read_u32_mem(&sim_mem, &store, off + 16 + 4 * k)? as usize);
+                    }
+                    let mut col = vec![0u8; bytes];
+                    crate::host::array_abi::reorder(&buf, &mut col, &dims, elem_size, true);
+                    buf = col;
+                    Some((dims, elem_size))
+                } else {
+                    None
+                };
                 let dst = malloc.call(&mut store, bytes as u32).map_err(|_| "CodegenWasmJit: wasm engine error")?;
                 side_mem.view(&store).write(dst as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
                 temps.push(dst);
@@ -574,7 +612,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                 // An output array is filled by the callee in side memory; copy it
                 // back into the pre-allocated wasm array after the call.
                 if *is_out {
-                    out_arrays.push((off, dst, bytes, data_off));
+                    out_arrays.push((off, dst, bytes, data_off, f77));
                 }
             }
             _ => return Err("input argument type not marshalled for the web target"),
@@ -585,9 +623,14 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
 
     // Copy each output array back from the side module's memory into its
     // pre-allocated wasm array (the callee filled the side scratch in place).
-    for (woff, dst, bytes, data_off) in &out_arrays {
+    for (woff, dst, bytes, data_off, f77) in &out_arrays {
         let mut buf = vec![0u8; *bytes];
         side_mem.view(&store).read(*dst as u64, &mut buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+        if let Some((dims, esz)) = f77 {
+            let mut row = vec![0u8; *bytes];
+            crate::host::array_abi::reorder(&buf, &mut row, dims, *esz, false);
+            buf = row;
+        }
         sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -330,8 +330,14 @@ fn define_external_imports(
             sig.wasm_params().iter().map(|s| wty_valtype(s.wty())),
             sig.wasm_results().iter().map(|s| wty_valtype(s.wty())),
         );
-        let addr = openmodelica_util::dynload::external_symbol(&sig.name)
-            .ok_or_else(|| "external \"C\" function not found in any loaded library")?;
+        let addr = openmodelica_util::dynload::external_symbol(&sig.name).ok_or_else(|| {
+            crate::set_engine_error_detail(format!(
+                "  `{}` is in none of the loaded libraries — the wasm-jit target cannot \
+                 build a model's own external C sources",
+                sig.name,
+            ));
+            "external \"C\" function not found in any loaded library"
+        })?;
         let name = sig.name.clone();
         let sig = sig.clone();
         let rt_str_new = rt_str_new.clone();
@@ -417,6 +423,9 @@ fn zero_results(
 /// the registry, and `char*` outputs copied into a fresh in-wasm String
 /// (`rt_str_new`+`rt_str_data`). The whole call is bracketed by
 /// `sim_external_begin/end` so any `ModelicaAllocateString` uses our arena.
+///
+/// A `FORTRAN 77` external takes every argument by reference and its arrays
+/// column-major — the marshalling `extFunCallF77` puts in the generated wrapper.
 unsafe fn call_external(
     addr: usize,
     sig: &crate::sig::ExtCallSig,
@@ -451,12 +460,17 @@ unsafe fn call_external(
         F(f64),
         P(*mut c_void),
     }
+    let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
     let mut slots: Vec<Slot> = Vec::with_capacity(sig.args.len());
     let mut cstrings: Vec<std::ffi::CString> = Vec::new();
     let mut types: Vec<Type> = Vec::with_capacity(sig.args.len());
     // One 8-byte native cell per `_Out_` pointer arg (fits int/double/pointer),
     // in output order; the C call writes through the pointer we pass.
     let mut out_cells: Vec<(SigTy, Box<[u8; 8]>)> = Vec::new();
+    // Fortran by-reference input cells, kept alive for the call.
+    let mut in_cells: Vec<Box<[u8; 8]>> = Vec::new();
+    // (buffer, wasm element-area offset, dims, element size, is output).
+    let mut f77_arrays: Vec<(Vec<u8>, usize, Vec<usize>, usize, bool)> = Vec::new();
     let mut in_i = 0usize;
     // Phase 1: build the C argument list. Reads wasm memory for Str/Array inputs;
     // the borrow ends with this block (only owned copies / raw addresses escape).
@@ -475,6 +489,18 @@ unsafe fn call_external(
             }
             let v = &args[in_i];
             in_i += 1;
+            // Fortran passes scalars by reference; give each one a native cell.
+            if fortran && matches!(ty, SigTy::Real | SigTy::Int | SigTy::Bool) {
+                let mut cell: Box<[u8; 8]> = Box::new([0u8; 8]);
+                match ty {
+                    SigTy::Real => cell[..8].copy_from_slice(&v.unwrap_f64().to_le_bytes()),
+                    _ => cell[..4].copy_from_slice(&v.unwrap_i32().to_le_bytes()),
+                }
+                slots.push(Slot::P(cell.as_mut_ptr() as *mut c_void));
+                types.push(Type::pointer());
+                in_cells.push(cell);
+                continue;
+            }
             match ty {
                 SigTy::Real => {
                     slots.push(Slot::F(v.unwrap_f64()));
@@ -502,12 +528,22 @@ unsafe fn call_external(
                 // Array: a native pointer to the runtime array's contiguous
                 // row-major data (`align8(16 + ndims*4)` past the header). The C
                 // callee reads it in place; the memory can't grow during the call.
-                SigTy::Array { .. } => {
+                // A rank-2-or-higher Fortran array goes as a column-major copy.
+                SigTy::Array { elem, .. } => {
                     let off = v.unwrap_i32() as usize;
-                    let ndims = u32::from_le_bytes(mem[off + 8..off + 12].try_into().unwrap()) as usize;
-                    let data_off = (16 + ndims * 4 + 7) & !7;
-                    let native = mem.as_ptr() as usize + off + data_off;
-                    slots.push(Slot::P(native as *mut c_void));
+                    let (dims, data_off) = crate::host::array_abi::dims_and_data(mem, off)
+                        .ok_or("external \"C\" : malformed array argument")?;
+                    let base = off + data_off;
+                    if fortran && dims.len() > 1 {
+                        let esz = crate::host::array_abi::elem_size(elem);
+                        let n = dims.iter().product::<usize>() * esz;
+                        let mut buf = vec![0u8; n];
+                        crate::host::array_abi::reorder(&mem[base..base + n], &mut buf, &dims, esz, true);
+                        slots.push(Slot::P(buf.as_mut_ptr() as *mut c_void));
+                        f77_arrays.push((buf, base, dims, esz, *is_out));
+                    } else {
+                        slots.push(Slot::P((mem.as_ptr() as usize + base) as *mut c_void));
+                    }
                     types.push(Type::pointer());
                 }
                 other => return Err("CodegenWasmJit: external \"C\" : input argument type not yet marshalled"),
@@ -559,6 +595,16 @@ unsafe fn call_external(
         return Err("CodegenWasmJit: external \"C\" raised a runtime error");
     }
     openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
+
+    // C's `convert_alloc_*_from_f77`.
+    {
+        let mem = memory.data_mut(&mut *caller);
+        for (buf, base, dims, esz, is_out) in &f77_arrays {
+            if *is_out {
+                crate::host::array_abi::reorder(buf, &mut mem[*base..*base + buf.len()], dims, *esz, false);
+            }
+        }
+    }
 
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
     // offset. Re-enters the runtime (`rt_str_new` may grow memory, so `data_mut` is


### PR DESCRIPTION
An `extArgs` entry was classified by `isInput`, but that is not what marks an output: a protected `biVars` local (`Integer n = size(A,1)`, `Real work[...]`, `Real Awork[...] = A`) is `isInput = false` with `outputIndex = 0` and is passed *in*. Counting those as output pointers made `outVars == n_ret + n_out_args` fail, so every external with work variables was dropped from the module — and then reported as a missing *builtin*, since an unresolved name falls through to `compile_math_builtin`.

`compile_external_function` now emits what
`functionBodyExternalFunction` does: allocate and bind the declared outputs and the `biVars` locals, call `extName` over `extArgs`, and store each result into the output its `outputIndex` names. Ordering follows the templates — `extFunCallF77` appends the `biVars` ahead of the outputs, `extFunCallC` behind — which matters for `dgelsy_vec`, whose output binding reads `nrow`/`ncol`.

`external "FORTRAN 77"` is lowered too: the `_`-suffixed symbol with every argument by reference and arrays column-major. The conversion lives in the host trampoline (`ExtLang`, `host::array_abi`) rather than in the emitted wasm — a cell per scalar, a reordered copy per rank-2-or-higher array, written back for outputs. That is `convert_alloc_*_{to,from}_f77` without its 2-D-only restriction. Natively the symbols resolve from the `liblapack` the compiler already links; the web side module has no LAPACK.

Also: a tuple assignment may name fewer targets than the call returns (`(scale, As2, Bs2) := Matrices.balanceABC(A, B)`), as `algStmtTupleAssign` allows; and a declined external now records why, so the call site says so instead of blaming an unknown builtin.

Verified against `/usr/bin/omc`:

| model | result |
| --- | --- |
| `Modelica.Blocks.Examples.Rectifier6pulseFFT` | FFT out to 6e-8 | | `ModelicaTest.Math.TestMatrices` | `diffSimulationResults` true | | `ModelicaTest.Math.TestMatrices2b` | simulates (C target asserts) | | `testmodels/run_ext{fft,lapack}.mos` | bit-identical |

The existing `testmodels/run*.mos` and `dbg_*.mos` are unchanged, and `external_functions/LapackInverse.mos` now passes under rtest.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
