### PR TITLE
wasm-jit: fix five MSL 4.1.0 sweep failures

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5622,7 +5622,9 @@ public
             (outExp, expanded) := ExpandExp.expand(exp);
           end if;
 
-          if expanded then
+          // The ARRAY case above is what consumes the expansion; recursing on
+          // anything else would not terminate.
+          if expanded and isArray(outExp) then
             outExp := promote2(outExp, true, dims, types);
           else
             outExp := CALL(Call.makeTypedCall(

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1059,7 +1059,9 @@ public
 
       case SLICE()
         algorithm
-          exp := ExpandExp.expand(subscript.slice, resize);
+          // A range with constant but non-literal bounds (`3:end-1` becomes
+          // `3:5-1`) does not expand until it is simplified.
+          exp := ExpandExp.expand(SimplifyExp.simplify(subscript.slice), resize);
 
           if Expression.isArray(exp) then
             outSubscript := EXPANDED_SLICE(list(INDEX(e) for e in Expression.arrayElements(exp)));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2895,7 +2895,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     // A model has discrete `when` behaviour through when-equations (SES_WHEN) or
     // when-statements inside an algorithm — both need the per-step pre-value save
     // and the full `allEquations` list as the per-step function.
-    let has_when = dae_eqs.iter().map(|(e, _)| e).chain(all_eqs.iter()).any(|e| match &**e {
+    let when_scan = eqs_with_branches(&all_eqs);
+    let has_when = dae_eqs.iter().map(|(e, _)| e).chain(when_scan.iter()).any(|e| match &**e {
         SimCode::SimEqSystem::SES_WHEN { .. } => true,
         SimCode::SimEqSystem::SES_ALGORITHM { statements, .. } => {
             (&**statements).into_iter().any(|s| matches!(&**s, DAE::Statement::STMT_WHEN { .. }))
@@ -3095,8 +3096,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let nls_nominal_map = build_nls_nominal_map(vars);
     let mut attr_targets: HashMap<String, AttrTargets> = HashMap::new();
     let dae_only_eqs: Vec<Arc<SimCode::SimEqSystem>> = dae_eqs.iter().map(|(e, _)| e.clone()).collect();
+    let nls_scan: Vec<Vec<Arc<SimCode::SimEqSystem>>> =
+        [&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs, &dae_only_eqs]
+            .iter()
+            .map(|l| eqs_with_branches(l.as_slice()))
+            .collect();
     let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) = collect_nls_jobs(
-        &[&param_eqs, &initial_eqs, &lambda0_eqs, &ode_eqs, &algebraic_eqs, &dae_only_eqs],
+        &nls_scan.iter().map(|l| l.as_slice()).collect::<Vec<_>>(),
         &nls_nominal_map,
         &mut attr_targets,
     );
@@ -4475,6 +4481,29 @@ fn flatten_eqs_ll(
     out
 }
 
+/// `eqs` with the equations nested in every `SES_IFEQUATION` branch appended, for
+/// the scans that register nonlinear systems and detect `when` behaviour.
+fn eqs_with_branches(eqs: &[Arc<SimCode::SimEqSystem>]) -> Vec<Arc<SimCode::SimEqSystem>> {
+    fn push(e: &Arc<SimCode::SimEqSystem>, out: &mut Vec<Arc<SimCode::SimEqSystem>>) {
+        out.push(e.clone());
+        if let SimCode::SimEqSystem::SES_IFEQUATION { ifbranches, elsebranch, .. } = &**e {
+            for (_, branch) in lst(ifbranches) {
+                for inner in lst(branch) {
+                    push(inner, out);
+                }
+            }
+            for inner in lst(elsebranch) {
+                push(inner, out);
+            }
+        }
+    }
+    let mut out = Vec::with_capacity(eqs.len());
+    for e in eqs {
+        push(e, &mut out);
+    }
+    out
+}
+
 /// Build one equation function (`SimData* -> ()`), lowering each equation in
 /// order. Unsupported equation kinds (systems, array assigns) fail loudly so a
 /// model that needs them is rejected rather than silently mis-simulated.
@@ -5122,6 +5151,25 @@ fn lower_equation(
         E::SES_ALGORITHM { statements, .. } => ctx.sim_stmts(statements),
         E::SES_WHEN { conditions, whenStmtLst, elseWhen, .. } => {
             ctx.sim_when(conditions, whenStmtLst, elseWhen)
+        }
+        // C's `equationIfEquationAssign`.
+        E::SES_IFEQUATION { ifbranches, elsebranch, .. } => {
+            let mut depth = 0;
+            for (cond, eqs) in lst(ifbranches) {
+                ctx.sim_if_cond(cond)?;
+                for e in lst(eqs) {
+                    lower_equation(ctx, e, eq_index)?;
+                }
+                ctx.sim_else();
+                depth += 1;
+            }
+            for e in lst(elsebranch) {
+                lower_equation(ctx, e, eq_index)?;
+            }
+            for _ in 0..depth {
+                ctx.sim_end_block();
+            }
+            Ok(())
         }
         // An alias equation re-runs another equation (by index): inline it.
         E::SES_ALIAS { aliasOf, .. } => {
@@ -5893,7 +5941,7 @@ fn nls_jac_scratch_f64(sim_code: &SimCode::SimCode) -> u32 {
     let mut seen: HashSet<i32> = HashSet::new();
     let mut total = 0u32;
     let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
-        for e in &eqs {
+        for e in &eqs_with_branches(&eqs) {
             if let E::SES_NONLINEAR { nlSystem, .. } = &**e {
                 if seen.insert(nlSystem.index) && nls_jac_usable(nlSystem) {
                     // seeds + all column variables (results + intermediates) get slots.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1466,6 +1466,18 @@ impl<'a> FnCtx<'a> {
         self.emit(we::Instruction::If(we::BlockType::Empty));
     }
 
+    /// Open `if (cond)`; `sim_else` starts the next branch, `sim_end_block` closes one.
+    pub(crate) fn sim_if_cond(&mut self, cond: &DAE::Exp) -> Result<()> {
+        let w = compile_exp(self, cond)?;
+        coerce(self, w, WTy::I32);
+        self.emit(we::Instruction::If(we::BlockType::Empty));
+        Ok(())
+    }
+
+    pub(crate) fn sim_else(&mut self) {
+        self.emit(we::Instruction::Else);
+    }
+
     pub(crate) fn sim_end_block(&mut self) {
         self.emit(we::Instruction::End);
     }
@@ -2506,7 +2518,15 @@ fn compile_stmts(ctx: &mut FnCtx, stmts: &Arc<List<Arc<DAE::Statement>>>) -> Res
 /// Assign `rhs` to a lhs: a whole-variable (scalar / whole array / string) or a
 /// subscripted array element (`a[i,...] := x`, written in place).
 fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()> {
+    // `(l1, l2, …) = f(...)` in a when-equation (C's `whenOperators` ASSIGN-of-TUPLE).
+    if let DAE::Exp::TUPLE { PR } = lhs {
+        return compile_tuple_assign(ctx, PR, rhs);
+    }
     let DAE::Exp::CREF { componentRef, .. } = lhs else {
+        crate::CodegenWasmJit::record_error(format!(
+            "CodegenWasmJit: assignment to non-cref lhs `{}`",
+            dumped_exp(&Arc::new(lhs.clone()))?
+        ));
         return Err("CodegenWasmJit: assignment to non-cref lhs not supported");
     };
     // Simulation mode: assigning to a model variable writes into the shared
@@ -4645,13 +4665,20 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
     if ctx.sim.is_none() {
         return Ok(None);
     }
-    // `time` is the only built-in scalar; it lives at offset 0 of `SimData`.
+    // `time` lives at offset 0 of `SimData`; `__HOM_LAMBDA` is left behind by
+    // differentiating `homotopy(a, s)` (C maps it to `simulationInfo->lambda`).
     if let DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } = cref {
         if subscriptLst.is_empty() {
             if ident.as_str() == "time" {
                 let data = ctx.sim()?.data_local;
                 ctx.emit(we::Instruction::LocalGet(data));
                 ctx.emit(we::Instruction::F64Load(mem_arg(0, 3)));
+                return Ok(Some(WTy::F64));
+            }
+            if ident.as_str() == openmodelica_backend_types::BackendDAE::homotopyLambda {
+                let (data, lambda_off) = { let s = ctx.sim()?; (s.data_local, s.lambda_off) };
+                ctx.emit(we::Instruction::LocalGet(data));
+                ctx.emit(we::Instruction::F64Load(mem_arg(lambda_off, 3)));
                 return Ok(Some(WTy::F64));
             }
             // A real wasm local (e.g. a `for` iterator) shadows model lookup.
@@ -7377,10 +7404,141 @@ fn emit_const_run(
     Ok(())
 }
 
+/// [`const_dims`] keeping the non-constant dimensions.
+fn type_dims(ty: &DAE::Type) -> Vec<Arc<DAE::Dimension>> {
+    let DAE::Type::T_ARRAY { ty: elem, dims } = ty else {
+        return Vec::new();
+    };
+    let mut out: Vec<Arc<DAE::Dimension>> = (&**dims).into_iter().cloned().collect();
+    out.extend(type_dims(elem));
+    out
+}
+
+/// [`leaf_array_count`] without needing the size.
+fn leaf_is_array(exp: &DAE::Exp) -> bool {
+    matches!(exp_dae_type(exp).as_deref(), Some(DAE::Type::T_ARRAY { .. }))
+}
+
+/// [`compile_array_literal`] for sizes only known at run time (`Real m[2, n]`
+/// with `n` a parameter): allocate from the evaluated dimensions and fill
+/// through a running element index, a sub-array leaf's length being dynamic too.
+fn compile_array_literal_dynamic(
+    ctx: &mut FnCtx,
+    ty: &DAE::Type,
+    elem: &SigTy,
+    rank: u32,
+    whole: &DAE::Exp,
+) -> Result<()> {
+    use we::Instruction as I;
+    let dims = type_dims(ty);
+    if dims.len() as u32 != rank {
+        return Err("CodegenWasmJit: array constructor rank does not match dimensions");
+    }
+    // `emit_dim_value` makes an unknown (`:`) axis 0; fail rather than mis-size.
+    if dims.iter().any(|d| matches!(&**d, DAE::Dimension::DIM_UNKNOWN)) {
+        return Err("CodegenWasmJit: array construction needs constant dimensions");
+    }
+    let mut dim_temps = Vec::with_capacity(dims.len());
+    for d in &dims {
+        let t = ctx.alloc_temp(WTy::I32);
+        emit_dim_value(ctx, d)?;
+        ctx.emit(I::LocalSet(t));
+        dim_temps.push(t);
+    }
+    ctx.emit(I::LocalGet(dim_temps[0]));
+    for t in &dim_temps[1..] {
+        ctx.emit(I::LocalGet(*t));
+        ctx.emit(I::I32Mul);
+    }
+    let total = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalSet(total));
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(elem.elem_kind() as i32));
+    ctx.emit(I::I32Const(rank as i32));
+    ctx.emit(I::LocalGet(total));
+    ctx.emit(I::Call(rt_index("rt_array_new")?));
+    ctx.emit(I::LocalSet(obj));
+    for (axis, t) in dim_temps.iter().enumerate() {
+        ctx.emit(I::LocalGet(obj));
+        ctx.emit(I::I32Const(axis as i32));
+        ctx.emit(I::LocalGet(*t));
+        ctx.emit(I::Call(rt_index("rt_array_set_dim")?));
+    }
+    let mut leaves = Vec::new();
+    flatten_array_exp(whole, &mut leaves);
+    let k = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(k));
+    let data_off = arr_data_off(rank);
+    let stride = elem_stride(elem);
+    for leaf in &leaves {
+        if leaf_is_array(leaf) {
+            let h = ctx.alloc_temp(WTy::I32);
+            compile_exp(ctx, leaf)?;
+            ctx.emit(I::LocalSet(h));
+            ctx.emit(I::LocalGet(obj));
+            ctx.emit(I::LocalGet(k));
+            ctx.emit(I::LocalGet(h));
+            ctx.emit(I::Call(rt_index("rt_array_blit")?));
+            ctx.emit(I::LocalGet(k));
+            ctx.emit(I::LocalGet(h));
+            ctx.emit(I::I32Load(mem_arg(ARR_TOTAL_OFF, 2)));
+            ctx.emit(I::I32Add);
+            ctx.emit(I::LocalSet(k));
+            ctx.emit(I::LocalGet(h));
+            ctx.emit(I::Call(rt_index("rt_array_release")?));
+        } else {
+            ctx.emit(I::LocalGet(obj));
+            ctx.emit(I::LocalGet(k));
+            ctx.emit(I::I32Const(stride as i32));
+            ctx.emit(I::I32Mul);
+            ctx.emit(I::I32Add);
+            let w = compile_exp(ctx, leaf)?;
+            coerce(ctx, w, elem.wty());
+            elem_store_off(ctx, elem, data_off);
+            ctx.emit(I::LocalGet(k));
+            ctx.emit(I::I32Const(1));
+            ctx.emit(I::I32Add);
+            ctx.emit(I::LocalSet(k));
+        }
+    }
+    ctx.emit(I::LocalGet(obj));
+    Ok(())
+}
+
+/// The per-axis sizes of a constructor taken from its own shape, for a declared
+/// type that has none (`Real t[:] = {...}`). Mirrors [`flatten_array_exp`]; the
+/// first element supplies the axes below the node's own.
+fn constructor_dims(exp: &DAE::Exp) -> Result<Vec<u32>> {
+    use DAE::Exp as E;
+    match exp {
+        E::SHARED_LITERAL { exp, .. } => constructor_dims(exp),
+        E::ARRAY { array, .. } => {
+            let mut out = vec![(&**array).into_iter().count() as u32];
+            if let Some(first) = (&**array).into_iter().next() {
+                out.extend(constructor_dims(first)?);
+            }
+            Ok(out)
+        }
+        E::MATRIX { matrix, .. } => {
+            let rows: Vec<_> = (&**matrix).into_iter().collect();
+            let mut out = vec![rows.len() as u32, rows.first().map_or(0, |r| (&***r).into_iter().count()) as u32];
+            if let Some(first) = rows.first().and_then(|r| (&***r).into_iter().next()) {
+                out.extend(constructor_dims(first)?);
+            }
+            Ok(out)
+        }
+        other => match exp_dae_type(other) {
+            Some(ty) => const_dims(&ty),
+            None => Ok(Vec::new()),
+        },
+    }
+}
+
 /// The constant per-axis sizes of an array `DAE.Type`, flattening nested
 /// `T_ARRAY`s (a rectangular array may be one `T_ARRAY` with several `dims` or a
 /// nest of `T_ARRAY`s). Fails on a non-constant dimension (`:` / expression),
-/// which needs the dynamic-allocation path (resize) not yet implemented.
+/// for which the constructor's own shape ([`constructor_dims`]) decides.
 fn const_dims(ty: &DAE::Type) -> Result<Vec<u32>> {
     let DAE::Type::T_ARRAY { ty: elem, dims } = ty else {
         return Ok(Vec::new());
@@ -7427,17 +7585,19 @@ fn compile_array_literal(ctx: &mut FnCtx, ty: &DAE::Type, whole: &DAE::Exp) -> R
     let SigTy::Array { elem, rank } = sig_ty(ty)? else {
         return Err("CodegenWasmJit: array constructor with non-array type");
     };
-    let dims = const_dims(ty)?;
-    if dims.len() as u32 != rank {
-        return Err("CodegenWasmJit: array constructor rank does not match dimensions");
-    }
-    let total: u32 = dims.iter().product();
     // The top-level structure (`ARRAY`/`MATRIX` nodes) is flattened to its
     // outermost element expressions. Each is either a scalar (one element) or an
     // array-valued expression (a sub-array, e.g. `{v, w}` of vectors) whose
     // elements are blitted in. (Scalar leaves remain the common case.)
     let mut leaves = Vec::new();
     flatten_array_exp(whole, &mut leaves);
+    // Static placement needs the axis sizes and every sub-array leaf's length as
+    // constants; a parameter-sized axis is only known once parameters have run.
+    let dims = match const_dims(ty).or_else(|_| constructor_dims(whole)) {
+        Ok(d) if d.len() as u32 == rank && leaves.iter().all(|l| leaf_array_count(l).is_ok()) => d,
+        _ => return compile_array_literal_dynamic(ctx, ty, &elem, rank, whole),
+    };
+    let total: u32 = dims.iter().product();
 
     // obj = rt_array_new(elem_kind, rank, total); set each dimension size.
     let obj = ctx.alloc_temp(WTy::I32);
@@ -7531,6 +7691,9 @@ fn exp_dae_type(exp: &DAE::Exp) -> Option<Arc<DAE::Type>> {
             Some(ty.clone())
         }
         E::CALL { attr, .. } => Some(attr.ty.clone()),
+        // The whole array type for an `array(...)` comprehension, the scalar
+        // accumulator type for a fold (see `compile_reduction`).
+        E::REDUCTION { reductionInfo, .. } => Some(reductionInfo.exprType.clone()),
         E::SHARED_LITERAL { exp, .. } => exp_dae_type(exp),
         E::BINARY { operator, .. } | E::UNARY { operator, .. } => operator_dae_type(operator),
         _ => None,


### PR DESCRIPTION
`SES_IFEQUATION` is now lowered, following `equationIfEquationAssign` in CodegenC.tpl. The scans that register nonlinear systems and detect `when` behaviour walked only the top-level equation lists, so a system nested in an if-branch would have gone unregistered; they now see the branches too.

`__HOM_LAMBDA` reads the homotopy parameter slot. Differentiating `homotopy(a, s)` for an analytic Jacobian leaves this cref behind, and C's `cref` template maps it to `data->simulationInfo->lambda`.

Array constructors no longer require constant dimensions. A declared `[:]` type takes its sizes from the constructor's own shape, and an axis sized by a parameter (`Real m[2, n]`) is allocated and filled at run time through a running element index. `array(...)` comprehension leaves were classified as scalars because `exp_dae_type` did not handle `REDUCTION`, which silently corrupted the result.

A tuple left-hand side in a `when` equation lowers to the multi-output call assignment, as C's `whenOperators` does.

`NFExpression.promote2` recursed forever on `M0[3:end-1, 1]`, taking out the C code generator as well. `Subscript.expandList` dropped the `expanded` flag from `Subscript.expand`, so an unexpandable slice was kept as it was; `expandCref` then reported success while `expandCref4` dropped that dimension and produced an expression of the element type, which `promote2` re-expanded indefinitely. The flag is propagated now, a slice is simplified before expanding so `3:end-1` expands the way `3:4` does, and the recursion only continues on an array.

Verified against the C target: TickBasedPulse, OneSidedDerivative2D, TestWaterPumpVariableSpeed and IMC_withLosses give identical results. Multivibrator builds and simulates but its op-amp switching outputs still differ. ActuatorWithNoise builds and initialises, then hits a separate defect where a variable assigned only inside a `when` keeps its start value.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
