### PR TITLE
Fix four ScalableTestSuite solver defects

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/daskr/src/linpack.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/daskr/src/linpack.rs
@@ -410,11 +410,14 @@ pub fn dgefa(a: &mut [f64], lda: i32, n: i32, ipvt: &mut [i32], info: &mut i32) 
                     a[idx(l, j)] = a[idx(k, j)];
                     a[idx(k, j)] = tj;
                 }
-                // daxpy(n-k, tj, col k, col j) — same array, disjoint columns.
-                let xoff = idx(k + 1, k);
-                let yoff = idx(k + 1, j);
-                for ii in 0..(n - k) as usize {
-                    a[yoff + ii] += tj * a[xoff + ii];
+                // daxpy(n-k, tj, col k, col j) — same array, disjoint columns; its
+                // `da == 0` early-out keeps a banded matrix O(n·b²), not O(n³).
+                if tj != 0.0 {
+                    let xoff = idx(k + 1, k);
+                    let yoff = idx(k + 1, j);
+                    for ii in 0..(n - k) as usize {
+                        a[yoff + ii] += tj * a[xoff + ii];
+                    }
                 }
             }
         }
@@ -547,10 +550,12 @@ pub fn dgbfa(
                         abd[idx(l, j)] = abd[idx(mm, j)];
                         abd[idx(mm, j)] = tj;
                     }
-                    let xoff = idx(m + 1, k);
-                    let yoff = idx(mm + 1, j);
-                    for ii in 0..lm as usize {
-                        abd[yoff + ii] += tj * abd[xoff + ii];
+                    if tj != 0.0 {
+                        let xoff = idx(m + 1, k);
+                        let yoff = idx(mm + 1, j);
+                        for ii in 0..lm as usize {
+                            abd[yoff + ii] += tj * abd[xoff + ii];
+                        }
                     }
                 }
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5623,7 +5623,9 @@ fn real_alg_vars(vars: &SimCodeVar::SimVars) -> Vec<&SimCodeVar::SimVar> {
 /// defaulting to `(1.0, -inf, +inf)` where unset or non-constant.
 fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f64, f64)> {
     let mut map = HashMap::new();
+    // `derivativeVars`: a `$DER.x` iteration variable otherwise scales at nominal 1.
     let all = lst(&vars.stateVars)
+        .chain(lst(&vars.derivativeVars))
         .chain(lst(&vars.algVars))
         .chain(lst(&vars.discreteAlgVars))
         .chain(lst(&vars.paramVars))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -92,6 +92,7 @@ pub(crate) mod klu {
         pub fn klu_refactor(ap: *mut i32, ai: *mut i32, ax: *mut f64, symbolic: *mut c_void, numeric: *mut c_void, common: *mut Common) -> i32;
         pub fn klu_rgrowth(ap: *mut i32, ai: *mut i32, ax: *mut f64, symbolic: *mut c_void, numeric: *mut c_void, common: *mut Common) -> i32;
         pub fn klu_solve(symbolic: *mut c_void, numeric: *mut c_void, ldim: i32, nrhs: i32, b: *mut f64, common: *mut Common) -> i32;
+        pub fn klu_tsolve(symbolic: *mut c_void, numeric: *mut c_void, ldim: i32, nrhs: i32, b: *mut f64, common: *mut Common) -> i32;
         pub fn klu_free_symbolic(symbolic: *mut *mut c_void, common: *mut Common) -> i32;
         pub fn klu_free_numeric(numeric: *mut *mut c_void, common: *mut Common) -> i32;
     }
@@ -117,16 +118,23 @@ pub(crate) mod klu {
         }
     }
 
-    /// C's `DATA_KLU` (`linearSolverKlu.c`): the symbolic analysis is done once per
-    /// system and reused, the numeric factorization refactored per solve. The
-    /// pattern is copied in because the caller's arrays live in a block that is
-    /// freed between solves; the values are only read, so they stay in place.
+    /// C's `DATA_KLU` (`linearSolverKlu.c`): symbolic analysis once per system,
+    /// numeric factorization refactored per solve.
+    ///
+    /// KLU gets `Aᵀ` and a transpose solve, as in C. Factorizing `A` instead holds
+    /// `rgrowth` under the 1e-3 threshold on a MultiBody chain, so the pivots are
+    /// rechosen every solve and `functionODE` stops being a function of the states
+    /// alone — which quietly ruins any finite-difference Jacobian taken through it.
     pub struct Solver {
         common: Common,
         symbolic: *mut c_void,
         numeric: *mut c_void,
+        /// CSC of `Aᵀ` (= CSR of `A`).
         ap: Vec<i32>,
         ai: Vec<i32>,
+        /// Where each `ap`/`ai` entry reads from in the caller's CSC-of-`A` values.
+        perm: Vec<u32>,
+        axt: Vec<f64>,
     }
 
     /// Below this reciprocal pivot growth the reused pivots are no longer good
@@ -134,13 +142,35 @@ pub(crate) mod klu {
     const MIN_RGROWTH: f64 = 1e-3;
 
     impl Solver {
+        /// `colptr`/`rowidx` are the caller's CSC of `A`; the transpose is built here.
         pub fn new(n: usize, colptr: &[i32], rowidx: &[i32]) -> Option<Solver> {
+            let nnz = *colptr.get(n)? as usize;
+            let mut ap = alloc::vec![0i32; n + 1];
+            for &r in &rowidx[..nnz] {
+                ap[r as usize + 1] += 1;
+            }
+            for r in 0..n {
+                ap[r + 1] += ap[r];
+            }
+            let mut fill: Vec<i32> = ap[..n].to_vec();
+            let mut ai = alloc::vec![0i32; nnz];
+            let mut perm = alloc::vec![0u32; nnz];
+            for c in 0..n {
+                for k in colptr[c] as usize..colptr[c + 1] as usize {
+                    let slot = &mut fill[rowidx[k] as usize];
+                    ai[*slot as usize] = c as i32;
+                    perm[*slot as usize] = k as u32;
+                    *slot += 1;
+                }
+            }
             let mut s = Solver {
                 common: Common::defaults()?,
                 symbolic: core::ptr::null_mut(),
                 numeric: core::ptr::null_mut(),
-                ap: colptr.to_vec(),
-                ai: rowidx.to_vec(),
+                ap,
+                ai,
+                perm,
+                axt: alloc::vec![0.0f64; nnz],
             };
             s.symbolic = unsafe {
                 klu_analyze(n as i32, s.ap.as_mut_ptr(), s.ai.as_mut_ptr(), &mut s.common)
@@ -148,10 +178,14 @@ pub(crate) mod klu {
             (!s.symbolic.is_null()).then_some(s)
         }
 
-        /// Factorize with `values` (in the pattern's order) and solve `A x = b` in
-        /// place. `false` if the matrix is singular or a KLU call failed.
+        /// Factorize with `values` (the caller's CSC-of-`A` order) and solve
+        /// `A x = b` in place. `false` if the matrix is singular or a KLU call failed.
         pub fn solve(&mut self, values: *const f64, b: *mut f64, n: usize) -> bool {
-            let ax = values as *mut f64;
+            let src = unsafe { core::slice::from_raw_parts(values, self.perm.len()) };
+            for (dst, &k) in self.axt.iter_mut().zip(&self.perm) {
+                *dst = src[k as usize];
+            }
+            let ax = self.axt.as_mut_ptr();
             let (ap, ai) = (self.ap.as_mut_ptr(), self.ai.as_mut_ptr());
             if !self.numeric.is_null() {
                 let ok = unsafe {
@@ -169,7 +203,7 @@ pub(crate) mod klu {
             if self.numeric.is_null() || self.common.status != 0 {
                 return false;
             }
-            unsafe { klu_solve(self.symbolic, self.numeric, n as i32, 1, b, &mut self.common) != 0 }
+            unsafe { klu_tsolve(self.symbolic, self.numeric, n as i32, 1, b, &mut self.common) != 0 }
         }
     }
 


### PR DESCRIPTION
Each was found by comparing against the C runtime on the same model.

**`daskr`: `dgefa`/`dgbfa` lost `daxpy`'s zero early-out.** Both inline the daxpy of their elimination loop but dropped its `if (da == 0.0) return;`, which C's `dlinpk.c` gets by calling the real `daxpy`. That check is what keeps LINPACK's dense factorization O(n*b^2) on a structurally banded iteration matrix rather than O(n^3): there is no reordering, so a banded matrix keeps its band under LU. Skipping is what C does, so no arithmetic changes and `cargo test -p daskr --features cref` still passes bit-exact.

**Backend: a linear system solved sparsely should not be torn.** `HarmonicOscillatorNetwork_N_40/80/160` hangs, in the C runtime as well as under wasm-jit. Its `xs` system is tridiagonal of size N, and because N stays under `maxSizeLinearTearing` (200) the backend tears it to a single iteration variable. The inner equations are then the shooting recurrence `xs[i+1] = 3*xs[i] - xs[i-1] - xm[i]`, whose characteristic root is (3+sqrt 5)/2 ~ 2.618; over 38 nodes that is 2.6^38 ~ 8e15, so the residual function carries no correct digits. The runtime notices (`Residual norm is 14.0094302893603`) and falls back to total pivoting, which cannot help -- the torn formulation is what is wrong. N_320 escapes only by exceeding the size limit. Tearing is now skipped when the untorn system would go to the sparse solver anyway, by the same test the runtime uses to pick it: density below `--tearingSparseMaxDensity` (new, default 0.2, mirroring `-lssMaxDensity`) or size above 1000. `Tearing12-minimal`, `NPendulum` and `EngineV6_partlintorn` exist to exercise tearing, so they pass `--tearingSparseMaxDensity=0`.

**wasm-jit: no nominal for a `$DER` iteration variable.** `build_nls_nominal_map` did not chain `derivativeVars`, so a nonlinear system iterating on a `$DER.x` fell back to nominal 1. `SteamPipe_N_1280` failed on that at the `time > 1` flow step: system 33284 solves for `der(h[1])`, nominal 1.25e8. C read it via `getNominalFromScalarIdx` and converged in two Newton iterations from an extrapolated 1.69e7; we scaled at 1 and gave up after 831 iterations, the finite-difference step being eight orders too small to see anything.

**wasm-jit: KLU was handed `A` where C hands it `A'`.** `linearSolverKlu.c` builds the CSC of `A'` -- `setAElementKlu` indexes `Ap` by row and stores the column in `Ai`, i.e. CSR of `A` -- and finishes with `klu_tsolve`. Both orientations give the same solution, but they factorize different matrices, and their pivot growth is not comparable on a MultiBody chain. On
`StringModelica_N_32`, factorizing `A` drove `rgrowth` from 7.6e-3 under KLU's 1e-3 re-pivot threshold from the first transient onwards: 56684 of 60000 solves threw the pivots away and did a full `klu_factor`. That costs a factorization every solve, and worse makes `functionODE` depend on the factorization history rather than on the states alone -- so the colored finite-difference Jacobian differenced two different pivot orders and came out meaningless. `rgrowth` now tracks C's: at N_64 ours spans 3.5e-6..1.9231e-3 against C's 1e-6..1.923e-3. The solve was always accurate either way (worst relative residual over ~70000 solves 4.4e-12 against rsparse's 9.2e-13); reproducibility, not accuracy, was the problem.

Simulation time, wasm-jit against the C target:

| model | before | after | C |
| --- | --- | --- | --- |
| ManyEventsManyConditions_N_2000_M_10 | 170 s | 2.9 s | 4.5 s | | HarmonicOscillator_N_1600 | 30 min+ | 2.3 s | 3.1 s | | HarmonicOscillatorNetwork_N_40 | hangs | 0.021 s | hangs | | HarmonicOscillatorNetwork_N_160 | hangs | 0.162 s | hangs | | StringModelica_N_32 | 62 s | 4.5 s | 6.1 s |
| StringModelica_N_64 | 30 min+ | 47.8 s | 38.4 s | | SteamPipe_N_1280 | NLS failure | 259 s | 332 s |

Step, Jacobian and event counts now match the C runtime's, and `StringModelica_N_32` goes from 266 DASSL convergence test failures to none.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
