### PR TITLE
Decide tearing and matrix format in the backend

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -10234,6 +10234,22 @@ algorithm
   end for;
 end warnAboutIterationVariablesWithNoNominal;
 
+public function useSparseSolver
+"Whether a system of this size and sparsity is factorized sparse or dense. The
+ runtime used to decide this itself, which left the backend guessing."
+  input Integer size;
+  input Integer nnz;
+  input Boolean isLinear;
+  output Boolean sparse;
+protected
+  constant Real maxDensityLinear = 0.2, maxDensityNonlinear = 0.1;
+  constant Integer minSize = 1000;
+algorithm
+  sparse := if size <= 0 then false
+            else intReal(nnz) / intReal(size * size) < (if isLinear then maxDensityLinear else maxDensityNonlinear)
+                 or size > minSize;
+end useSparseSolver;
+
 public function getLinearfromJacType "  author: Frenkel TUD 2012-09"
   input BackendDAE.JacobianType jacType;
   output Boolean linear;

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -86,6 +86,8 @@ import ElementSource;
 
 protected constant String BORDER    = "****************************************";
 protected constant String UNDERLINE = "========================================";
+protected constant list<String> withLSS = {"C", "wasm-jit", "wasm"} "targets that provide a linear sparse solver";
+protected constant list<String> withNSS = {"C", "wasm-jit", "wasm"} "targets that provide a nonlinear sparse solver";
 
 uniontype TearingMethod
   record MINIMAL_TEARING "Only tear discrete variables from loops"
@@ -358,6 +360,10 @@ algorithm
         try
           oComp := callTearingMethod(inMethod, isyst, ishared, eindex, vindx, ojac, jacType, mixedSystem, strongComponentIndexOut);
           outRunMatching := true;
+          if not tearingPaysOff(oComp, ishared, eindex, vindx, ojac, jacType, strongComponentIndexOut, isLinear) then
+            oComp := inComp;
+            outRunMatching := false;
+          end if;
         else
           oComp := inComp;
           outRunMatching := false;
@@ -382,8 +388,6 @@ protected function checkTearingSettings
   input Integer numVars;
   output Boolean activateTearing = false;
 protected
-  constant list<String> withLSS = {"C", "wasm-jit", "wasm"} "targets that provide a linear sparse solver";
-  constant list<String> withNSS = {"C", "wasm-jit", "wasm"} "targets that provide a nonlinear sparse solver";
   Boolean debugFlag = Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE);
   Integer maxSize;
   Boolean isDense;
@@ -398,7 +402,7 @@ algorithm
 
   // Check if (component is too big) or (matrix is dense and target has no sparse solver)
   isDense := Flags.getConfigString(Flags.MATRIX_FORMAT) == "dense";
-  hasSparseSolver := listMember(Config.simCodeTarget(), (if isLinear then withLSS else withNSS));
+  hasSparseSolver := targetHasSparseSolver(isLinear);
   forcedTearing := isDense and not hasSparseSolver;
   if numVars > maxSize and not forcedTearing then
     Error.addMessage(Error.MAX_TEARING_SIZE, {intString(strongComponentIndex), intString(numVars),
@@ -418,6 +422,242 @@ algorithm
 
   activateTearing := true;
 end checkTearingSettings;
+
+protected function targetHasSparseSolver
+  input Boolean isLinear;
+  output Boolean hasSparseSolver = listMember(Config.simCodeTarget(), if isLinear then withLSS else withNSS);
+end targetHasSparseSolver;
+
+protected function tearingPaysOff
+"Keeps the torn system unless solving it untorn is clearly cheaper, or unless
+ substituting through the inner equations amplifies an error past what a double
+ carries. The torn matrix does not exist yet, so both its structure and that
+ amplification come from walking the substitution. Costs are in flops."
+  input BackendDAE.StrongComponent tornComp;
+  input BackendDAE.Shared shared;
+  input list<Integer> eindex;
+  input list<Integer> vindx;
+  input Option<list<tuple<Integer, Integer, BackendDAE.Equation>>> ojac;
+  input BackendDAE.JacobianType jacType;
+  input Integer strongComponentIndex;
+  input Boolean isLinear;
+  output Boolean keep = true;
+protected
+  constant Real entryCost = 4.0 "flops one Jacobian entry evaluation is worth";
+  constant Real fillFactor = 14.0 "fill-in a sparse factorization sees, measured";
+  constant Real precisionDigits = 16.0 "digits a double carries";
+  constant Real trustedCoeffs = 0.9 "known coefficients the growth estimate needs";
+  list<tuple<Integer, Integer, BackendDAE.Equation>> jac;
+  list<Integer> tvars, residuals, innerVars;
+  list<tuple<Integer, Real>> stack;
+  tuple<Integer, Real> dep;
+  BackendDAE.Equation dEqn;
+  BackendDAE.InnerEquations innerEquations;
+  BackendDAE.Variables globalKnownVars;
+  array<list<tuple<Integer, Real>>> eqDeps "local equation index -> the local variables it depends on and their coefficients";
+  array<Integer> tvarId, solvedBy, stamp, depth;
+  array<Real> growth "error amplification of the forward substitution, iteration variables being 1";
+  Integer n, nnz, t, m, row, col, v, w, eq, cnt, nnzA, maxRowA, maxDepth, d, valued = 0;
+  Real density, densityA, buildTorn, costDense, costSparse, costTornDense, costTornSparse;
+  Real costTorn, costUntorn, rn, rt, g, coeff, pivot, maxGrowth, digitsLost;
+  Boolean known, isValued;
+algorithm
+  (jac, tvars, residuals, innerEquations, known) := match (ojac, tornComp)
+    case (SOME(jac), BackendDAE.TORNSYSTEM(strictTearingSet = BackendDAE.TEARINGSET(
+            tearingvars = tvars, residualequations = residuals, innerEquations = innerEquations)))
+      then (jac, tvars, residuals, innerEquations, true);
+    else ({}, {}, {}, {}, false);
+  end match;
+  if not known then
+    return;
+  end if;
+
+  n := listLength(vindx);
+  nnz := listLength(jac);
+  t := listLength(tvars);
+  m := listLength(innerEquations);
+
+  globalKnownVars := BackendDAEUtil.getGlobalKnownVarsFromShared(shared);
+  eqDeps := arrayCreate(n, {});
+  for entry in jac loop
+    (row, col, dEqn) := entry;
+    (coeff, isValued) := jacEntryMagnitude(dEqn, globalKnownVars);
+    valued := valued + (if isValued then 1 else 0);
+    arrayUpdate(eqDeps, row, (col, coeff) :: eqDeps[row]);
+  end for;
+
+  // inner equations come in solve order, so one pass gives every depth and growth
+  tvarId := arrayCreate(n, 0);
+  growth := arrayCreate(n, 0.0);
+  cnt := 0;
+  for gv in tvars loop
+    cnt := cnt + 1;
+    v := List.position(gv, vindx);
+    arrayUpdate(tvarId, v, cnt);
+    arrayUpdate(growth, v, 1.0);
+  end for;
+
+  solvedBy := arrayCreate(n, 0);
+  depth := arrayCreate(n, 0);
+  maxDepth := 0;
+  for ie in innerEquations loop
+    (eq, innerVars) := match ie
+      case BackendDAE.INNEREQUATION()
+        then (List.position(ie.eqn, eindex), list(List.position(gv, vindx) for gv in ie.vars));
+      case BackendDAE.INNEREQUATIONCONSTRAINTS()
+        then (List.position(ie.eqn, eindex), list(List.position(gv, vindx) for gv in ie.vars));
+    end match;
+    d := 0;
+    g := 0.0;
+    pivot := 0.0;
+    for dep in eqDeps[eq] loop
+      w := Util.tuple21(dep);
+      coeff := Util.tuple22(dep);
+      if listMember(w, innerVars) then
+        pivot := realMax(pivot, coeff);
+      else
+        d := intMax(d, depth[w]);
+        g := g + coeff * growth[w];
+      end if;
+    end for;
+    g := if pivot > 0.0 then g / pivot else g;
+    for v in innerVars loop
+      arrayUpdate(solvedBy, v, eq);
+      arrayUpdate(depth, v, d + 1);
+      arrayUpdate(growth, v, if g > 1e300 then 1e300 else g);
+    end for;
+    maxDepth := intMax(maxDepth, d + 1);
+  end for;
+
+  stamp := arrayCreate(n, 0);
+  nnzA := 0;
+  maxRowA := 0;
+  maxGrowth := 0.0;
+  row := 0;
+  for ge in residuals loop
+    row := row + 1;
+    cnt := 0;
+    eq := List.position(ge, eindex);
+    g := 0.0;
+    pivot := 0.0;
+    for dep in eqDeps[eq] loop
+      w := Util.tuple21(dep);
+      coeff := Util.tuple22(dep);
+      g := g + coeff * growth[w];
+      pivot := realMax(pivot, coeff);
+    end for;
+    maxGrowth := realMax(maxGrowth, if pivot > 0.0 then g / pivot else g);
+    stack := eqDeps[eq];
+    while not listEmpty(stack) loop
+      v := Util.tuple21(listHead(stack));
+      stack := listRest(stack);
+      if stamp[v] <> row then
+        arrayUpdate(stamp, v, row);
+        if tvarId[v] > 0 then
+          cnt := cnt + 1;
+        elseif solvedBy[v] > 0 then
+          stack := listAppend(eqDeps[solvedBy[v]], stack);
+        end if;
+      end if;
+    end while;
+    nnzA := nnzA + cnt;
+    maxRowA := intMax(maxRowA, cnt);
+  end for;
+
+  rn := intReal(n);
+  rt := intReal(t);
+  density := intReal(nnz) / (rn * rn);
+  densityA := if t > 0 then intReal(nnzA) / (rt * rt) else 1.0;
+  digitsLost := if maxGrowth > 1.0 then log10(maxGrowth) else 0.0;
+
+  buildTorn := entryCost * intReal(maxRowA * nnz);
+  costDense := entryCost * intReal(nnz) + solveCost(rn, intReal(nnz), false);
+  costSparse := entryCost * intReal(nnz) + solveCost(rn, intReal(nnz), true, fillFactor);
+  costTornDense := buildTorn + solveCost(rt, intReal(nnzA), false);
+  costTornSparse := buildTorn + solveCost(rt, intReal(nnzA), true);
+
+  // costed at the format the backend will emit for each
+  costUntorn := if BackendDAEUtil.useSparseSolver(n, nnz, isLinear) then costSparse else costDense;
+  costTorn := if BackendDAEUtil.useSparseSolver(t, nnzA, isLinear) then costTornSparse else costTornDense;
+
+  if Flags.isSet(Flags.TEARING_COST) then
+    print("[tearingCost] component " + intString(strongComponentIndex) + " " + (if isLinear then "LS" else "NLS")
+          + " [" + BackendDump.jacobianTypeStr(jacType) + "]"
+          + " n=" + intString(n) + " nnz=" + intString(nnz) + " density=" + realString(density)
+          + " t=" + intString(t) + " inner=" + intString(m) + " nnzA=" + intString(nnzA)
+          + " densityA=" + realString(densityA) + " colors=" + intString(maxRowA) + " chain=" + intString(maxDepth)
+          + " digitsLost=" + realString(digitsLost) + " valuedCoeffs=" + intString(valued) + "/" + intString(nnz)
+          + " cost dense=" + realString(costDense) + " sparse=" + realString(costSparse)
+          + " tornDense=" + realString(costTornDense) + " tornSparse=" + realString(costTornSparse)
+          + " format=" + (if BackendDAEUtil.useSparseSolver(n, nnz, isLinear) then "sparse" else "dense")
+          + " tornFormat=" + (if BackendDAEUtil.useSparseSolver(t, nnzA, isLinear) then "sparse" else "dense") + "\n");
+  end if;
+
+  // a nonlinear system's cost is its Newton iterations, which this does not model
+  if not isLinear then
+    return;
+  end if;
+
+  if digitsLost >= precisionDigits and intReal(valued) >= trustedCoeffs * intReal(nnz) then
+    Error.addMessage(Error.TEARING_AMPLIFIES_ERROR, {intString(strongComponentIndex), intString(m),
+                                                     intString(realInt(digitsLost))});
+    keep := false;
+  elseif costUntorn * Flags.getConfigReal(Flags.TEARING_COST_MARGIN) < costTorn then
+    Error.addMessage(Error.TEARING_NOT_WORTH_IT, {intString(strongComponentIndex), intString(t),
+                                                  intString(realInt(costTorn)), intString(realInt(costUntorn)),
+                                                  intString(n)});
+    keep := false;
+  end if;
+end tearingPaysOff;
+
+protected function jacEntryMagnitude
+"Magnitude of one Jacobian entry, parameters taken at their bound value. Entries
+ that are not a number at compile time count as 1."
+  input BackendDAE.Equation dEqn;
+  input BackendDAE.Variables globalKnownVars;
+  output Real magnitude;
+  output Boolean known;
+protected
+  DAE.Exp exp;
+algorithm
+  (magnitude, known) := matchcontinue dEqn
+    case BackendDAE.RESIDUAL_EQUATION() algorithm
+      exp := dEqn.exp;
+      for i in 1:3 loop
+        (exp, _) := Expression.traverseExpBottomUp(exp, substituteKnownVar, globalKnownVars);
+        (exp, _) := ExpressionSimplify.simplify(exp);
+      end for;
+    then (abs(Expression.toReal(exp)), true);
+    else (1.0, false);
+  end matchcontinue;
+end jacEntryMagnitude;
+
+protected function substituteKnownVar
+  input output DAE.Exp exp;
+  input output BackendDAE.Variables globalKnownVars;
+algorithm
+  exp := matchcontinue exp
+    local
+      BackendDAE.Var var;
+    case DAE.CREF() algorithm
+      (var, _) := BackendVariable.getVarSingle(exp.componentRef, globalKnownVars);
+    then BackendVariable.varBindExp(var);
+    else exp;
+  end matchcontinue;
+end substituteKnownVar;
+
+protected function solveCost
+"One factorization and back-solve, sparse LU modelled as nnz/size per column."
+  input Real size;
+  input Real nnz;
+  input Boolean sparse;
+  input Real fill = 1.0 "fill-in the factorization sees, 1 for an already dense matrix";
+  output Real cost;
+algorithm
+  cost := if size <= 0.0 then 0.0
+          elseif sparse then fill * nnz * nnz / size + 2.0 * nnz
+          else 2.0 / 3.0 * size * size * size + 2.0 * size * size;
+end solveCost;
 
 protected function getUserTearingSet
   input list<Integer> userTVars;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -978,8 +978,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
     // C prints the sparse-solver announcements (initializeLinear/NonlinearSystems)
     // ahead of the init-success line; prepend our pre-rendered copy to the init output.
-    let head =
-        format!("{experiment_log}{}{}", flag_change_log(&flags), sparse_solver_log(&model, &flags));
+    let head = format!("{experiment_log}{}", flag_change_log(&flags));
     let init_output = if head.is_empty() {
         init_output
     } else {
@@ -1161,9 +1160,8 @@ mod session {
         SPLIT_ARMED.with(|a| a.set(false));
         let flags = simflags::flags();
         let init_log = format!(
-            "{experiment_log}{}{}{}",
+            "{experiment_log}{}{}",
             flag_change_log(&flags),
-            sparse_solver_log(&model, &flags),
             INIT_OUTPUT.with(|c| c.borrow_mut().take()).unwrap_or_default()
         );
         let backend = match built {
@@ -3970,118 +3968,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         import_slots,
         var_units,
         meta,
-        sparse_solver_log: build_sparse_lss_log(sim_code),
-        nls_systems: collect_nls_systems(sim_code),
     })
 }
 
 /// Wrap a `\n`-separated message in the `LOG_STDOUT`/continuation prefixes.
 fn format_log_stdout(msg: &str) -> String {
     openmodelica_modelica_utilities::format_log_stdout(msg, openmodelica_modelica_utilities::LOG_STDOUT_INFO)
-}
-
-/// Reproduce C's `initializeLinearSystems` sparse-solver announcements
-/// (`linearSystem.c`): for each torn linear system chosen as sparse (by
-/// [`lin_use_sparse`]), one message keyed on why (density and/or size), then one
-/// aggregate flag-hint. Systems are taken across the init + simulation equation
-/// lists, deduplicated and ordered by `indexLinearSystem` (C's array order).
-fn build_sparse_lss_log(sim_code: &SimCode::SimCode) -> String {
-    use crate::CodegenWasmJitFunctions::{lin_use_sparse, LSS_MAX_DENSITY, LSS_MIN_SIZE};
-    // (indexLinearSystem, size, nnz), deduped by index, in index order.
-    let mut seen: HashSet<i32> = HashSet::new();
-    let mut systems: Vec<(i32, usize, usize)> = Vec::new();
-    let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
-        for e in &eqs {
-            if let SimCode::SimEqSystem::SES_LINEAR { lSystem, .. } = &**e {
-                let size = count(&lSystem.vars) as usize;
-                let nnz = lin_system_nnz(lSystem);
-                if seen.insert(lSystem.indexLinearSystem) {
-                    systems.push((lSystem.indexLinearSystem, size, nnz));
-                }
-            }
-        }
-    };
-    scan(flatten_eqs(&sim_code.parameterEquations));
-    scan(flatten_eqs(&sim_code.initialEquations));
-    scan(flatten_eqs_ll(&sim_code.odeEquations));
-    scan(flatten_eqs_ll(&sim_code.algebraicEquations));
-    systems.sort_by_key(|&(idx, _, _)| idx);
-
-    let mut out = String::new();
-    let mut some_small_density = false;
-    let mut some_big_size = false;
-    for (idx, size, nnz) in &systems {
-        let (size, nnz) = (*size, *nnz);
-        if size == 0 || !lin_use_sparse(size, nnz) {
-            continue;
-        }
-        let density = nnz as f64 / (size * size) as f64;
-        let small_density = density < LSS_MAX_DENSITY;
-        let big_size = size > LSS_MIN_SIZE;
-        let body = if small_density {
-            some_small_density = true;
-            if big_size {
-                some_big_size = true;
-                format!(
-                    "Using sparse solver for linear system {idx},\nbecause density of {density:.3} remains under threshold of {LSS_MAX_DENSITY:.3}\nand size of {size} exceeds threshold of {LSS_MIN_SIZE}."
-                )
-            } else {
-                format!(
-                    "Using sparse solver for linear system {idx},\nbecause density of {density:.3} remains under threshold of {LSS_MAX_DENSITY:.3}."
-                )
-            }
-        } else {
-            some_big_size = true;
-            format!("Using sparse solver for linear system {idx},\nbecause size of {size} exceeds threshold of {LSS_MIN_SIZE}.")
-        };
-        out.push_str(&format_log_stdout(&body));
-    }
-    let hint = if some_small_density {
-        if some_big_size {
-            Some("The maximum density and the minimal system size for using sparse solvers can be\nspecified using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.")
-        } else {
-            Some("The maximum density for using sparse solvers can be specified\nusing the runtime flag '<-lssMaxDensity=value>'.")
-        }
-    } else if some_big_size {
-        Some("The minimal system size for using sparse solvers can be specified\nusing the runtime flag '<-lssMinSize=value>'.")
-    } else {
-        None
-    };
-    if let Some(h) = hint {
-        out.push_str(&format_log_stdout(h));
-    }
-    out
-}
-
-/// Reproduce C's `initializeNonlinearSystems` sparse-solver announcements
-/// (`nonlinearSystem.c`): one message per system handed to kinsol+KLU, keyed on
-/// why (density and/or size), then one aggregate flag-hint. Systems are in
-/// `indexNonLinearSystem` order (C's array order), matching the `sysNum` printed.
-fn collect_nls_systems(sim_code: &SimCode::SimCode) -> Vec<(i32, i32, u32, u32)> {
-    let mut seen: HashSet<i32> = HashSet::new();
-    // (sysNum, equationIndex, size, nnz), deduped, in system-number order.
-    let mut systems: Vec<(i32, i32, u32, u32)> = Vec::new();
-    let mut scan = |eqs: Vec<Arc<SimCode::SimEqSystem>>| {
-        for e in &eqs {
-            if let SimCode::SimEqSystem::SES_NONLINEAR { nlSystem, .. } = &**e {
-                if seen.insert(nlSystem.indexNonLinearSystem) {
-                    let size = lst(&nlSystem.crefs).count();
-                    systems.push((
-                        nlSystem.indexNonLinearSystem,
-                        nlSystem.index,
-                        size as u32,
-                        nls_system_nnz(nlSystem) as u32,
-                    ));
-                }
-            }
-        }
-    };
-    scan(flatten_eqs(&sim_code.parameterEquations));
-    scan(flatten_eqs(&sim_code.initialEquations));
-    scan(flatten_eqs_ll(&sim_code.odeEquations));
-    scan(flatten_eqs_ll(&sim_code.algebraicEquations));
-    systems.sort_by_key(|&(idx, _, _, _)| idx);
-    systems
 }
 
 /// C's `homotopySupport` loop over `nonlinearSystemData`: whether a nonlinear
@@ -4110,61 +4002,6 @@ fn flag_change_log(flags: &simflags::SimFlags) -> String {
             LOG_STDOUT_INFO
         };
         out.push_str(&openmodelica_modelica_utilities::format_log_stdout(&msg, prefix));
-    }
-    out
-}
-
-/// The linear half is fixed at codegen; the nonlinear half moves with the flags.
-fn sparse_solver_log(model: &SimModel, flags: &simflags::SimFlags) -> String {
-    let (min_size, max_density) = simflags::nlss_thresholds(flags);
-    format!("{}{}", model.sparse_solver_log, sparse_nls_log(&model.nls_systems, min_size, max_density))
-}
-
-/// C's `initializeNonlinearSystems` announcement: `-nlssMinSize`/`-nlssMaxDensity`
-/// move both the choice and the numbers it quotes, so it is rendered per run.
-fn sparse_nls_log(systems: &[(i32, i32, u32, u32)], min_size: u32, max_density: f64) -> String {
-    let mut out = String::new();
-    let mut some_small_density = false;
-    let mut some_big_size = false;
-    for &(idx, eq_index, size, nnz) in systems {
-        let (size, nnz) = (size as usize, nnz as usize);
-        let density = nnz as f64 / (size * size) as f64;
-        let big_size = size > min_size as usize;
-        if size == 0 || nnz == 0 || !(density < max_density || big_size) {
-            continue;
-        }
-        let (nlss_max_density, nlss_min_size) = (max_density, min_size);
-        let body = if density < nlss_max_density {
-            some_small_density = true;
-            if big_size {
-                some_big_size = true;
-                format!(
-                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {nlss_max_density:.2}\nand size of {size} exceeds threshold of {nlss_min_size}."
-                )
-            } else {
-                format!(
-                    "Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause density of {density:.2} remains under threshold of {nlss_max_density:.2}."
-                )
-            }
-        } else {
-            some_big_size = true;
-            format!("Using sparse solver kinsol for nonlinear system {idx} ({eq_index}),\nbecause size of {size} exceeds threshold of {nlss_min_size}.")
-        };
-        out.push_str(&format_log_stdout(&body));
-    }
-    let hint = if some_small_density {
-        if some_big_size {
-            Some("The maximum density and the minimal system size for using sparse solvers can be\nspecified using the runtime flags '<-nlssMaxDensity=value>' and '<-nlssMinSize=value>'.")
-        } else {
-            Some("The maximum density for using sparse solvers can be specified\nusing the runtime flag '<-nlssMaxDensity=value>'.")
-        }
-    } else if some_big_size {
-        Some("The minimal system size for using sparse solvers can be specified\nusing the runtime flag '<-nlssMinSize=value>'.")
-    } else {
-        None
-    };
-    if let Some(h) = hint {
-        out.push_str(&format_log_stdout(h));
     }
     out
 }
@@ -5292,7 +5129,7 @@ fn lower_linear_system(
 }
 
 /// Whether a torn linear system uses the sparse solver (C's density/size
-/// threshold). `nnz` from `lin_system_nnz` so it agrees with the log message.
+/// threshold), an unknown nonzero count counting as dense.
 fn lin_torn_use_sparse(lsystem: &SimCode::LinearSystem, n: usize) -> bool {
     use crate::CodegenWasmJitFunctions::lin_use_sparse;
     if n == 0 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -102,14 +102,7 @@ pub extern "C" fn rt_set_solvers(nls: u32, nls_ls: u32, ls: u32, lss: u32) {
     LSS.store(lss, Ordering::Relaxed);
 }
 
-/// C's `initializeNonlinearSystemData` rule: kinsol+KLU when the density is under
-/// `nlssMaxDensity` or the size over `nlssMinSize`.
-#[unsafe(no_mangle)]
-pub extern "C" fn rt_set_nlss_thresholds(min_size: u32, max_density: f64) {
-    NLSS_MIN_SIZE.store(min_size, Ordering::Relaxed);
-    NLSS_MAX_DENSITY.store(max_density.to_bits(), Ordering::Relaxed);
-}
-
+/// Mirrors `BackendDAEUtil.useSparseSolver`, which chose this system's format.
 pub(crate) fn nls_use_sparse(size: usize, nnz: usize) -> bool {
     let density = nnz as f64 / (size * size) as f64;
     density < f64::from_bits(NLSS_MAX_DENSITY.load(Ordering::Relaxed))
@@ -120,8 +113,6 @@ pub(crate) fn nls_use_sparse(size: usize, nnz: usize) -> bool {
 pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     let (nls, nls_ls, ls, lss) = f.solver_codes();
     rt_set_solvers(nls, nls_ls, ls, lss);
-    let (min_size, max_density) = openmodelica_sim_meta::simflags::nlss_thresholds(f);
-    rt_set_nlss_thresholds(min_size, max_density);
     let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::newton_tuning(f);
     rt_set_newton_tuning(ftol, xtol, msf);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -193,10 +193,8 @@ pub struct SimFlags {
     pub max_step_size: Option<f64>,
     /// `-noEventEmit`: drop the result rows a step that handled an event produces.
     pub no_event_emit: bool,
-    /// `-nlssMinSize=n` / `-nlssMaxDensity=d`: C's `nonlinearSparseSolverMinSize` /
-    /// `nonlinearSparseSolverMaxDensity`, the rule that hands a system to kinsol+KLU.
-    pub nlss_min_size: Option<u32>,
-    pub nlss_max_density: Option<f64>,
+    /// One of the four density/size flags was given. The backend decides now.
+    pub deprecated_density_flag: bool,
     /// `method="optimization"` (the Ipopt collocation solver): `-optimizerNP=<1|3>`
     /// collocation points per interval, and `-optimizerTimeGrid=<file>` listing the
     /// interval end points instead of an equidistant grid.
@@ -666,8 +664,10 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                     return Err(format!("Unknown value `{v}` for flag `-jacobian`"));
                 }
             }
-            "nlssMinSize" => f.nlss_min_size = Some(int(name, &value(name)?)?.max(0) as u32),
-            "nlssMaxDensity" => f.nlss_max_density = Some(real(name, &value(name)?)?),
+            "nlssMinSize" | "nlssMaxDensity" | "lssMinSize" | "lssMaxDensity" => {
+                f.deprecated_density_flag = true;
+                let _ = value(name)?;
+            }
             "maxStepSize" => f.max_step_size = Some(real(name, &value(name)?)?),
             "noEquidistantOutputTime" => {
                 f.no_equidistant_time = Some(
@@ -765,34 +765,12 @@ fn output_format(v: &str) -> Result<String, String> {
 pub fn notices(f: &SimFlags) -> Vec<(crate::omclog::LogType, String)> {
     let g = |v: f64| crate::driver::format_g(v, 6);
     let mut out = Vec::new();
-    if let Some(d) = f.nlss_max_density {
+    if f.deprecated_density_flag {
         out.push((
-            crate::omclog::INFO,
-            format!("Maximum density for using non-linear sparse solver changed to {d:.6}"),
-        ));
-    }
-    if let Some(n) = f.nlss_min_size {
-        out.push((
-            crate::omclog::INFO,
-            format!("Minimum system size for using non-linear sparse solver changed to {n}"),
-        ));
-    }
-    if let Some(v) = f.newton_xtol {
-        out.push((
-            crate::omclog::INFO,
-            format!("Tolerance for updating solution vector in Newton solver changed to {}", g(v)),
-        ));
-    }
-    if let Some(v) = f.newton_ftol {
-        out.push((
-            crate::omclog::INFO,
-            format!("Tolerance for accepting accuracy in Newton solver changed to {}", g(v)),
-        ));
-    }
-    if let Some(v) = f.newton_max_step_factor {
-        out.push((
-            crate::omclog::INFO,
-            format!("Maximum step size factor for a Newton step changed to {}", g(v)),
+            crate::omclog::WARNING,
+            "The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are\n\
+             deprecated and ignored: the compiler chooses dense or sparse per system."
+                .to_string(),
         ));
     }
     if f.dae_mode {
@@ -841,12 +819,6 @@ pub fn print_notices(f: &SimFlags) {
             _ => crate::omclog::info(crate::omclog::STDOUT, false, &msg),
         }
     }
-}
-
-/// C's `nonlinearSparseSolverMinSize` / `nonlinearSparseSolverMaxDensity`, with
-/// C's defaults (`simulation_options.h`) where the flags are absent.
-pub fn nlss_thresholds(f: &SimFlags) -> (u32, f64) {
-    (f.nlss_min_size.unwrap_or(1000), f.nlss_max_density.unwrap_or(0.1))
 }
 
 /// The `-steadyState` bound (C's default without `-steadyStateTol`), `None` when

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -54,13 +54,6 @@ pub struct SimModel {
     pub var_units: HashMap<String, String>,
     /// Driver-facing metadata shared with the in-wasm driver (passed to `sim_driver::drive`).
     pub meta: SimMeta,
-    /// Pre-rendered `LOG_STDOUT` lines announcing which *linear* systems use a
-    /// sparse solver (C's `initializeLinearSystems`), prepended to the sim log.
-    pub sparse_solver_log: String,
-    /// `(sysNum, equationIndex, size, nnz)` per nonlinear system, in C's array
-    /// order. The nonlinear half of that announcement is rendered per run instead,
-    /// because `-nlssMinSize`/`-nlssMaxDensity` move the threshold it reports.
-    pub nls_systems: Vec<(i32, i32, u32, u32)>,
 }
 
 impl SimModel {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -864,12 +864,6 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         let (nls, nls_ls, ls, lss) = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
         wts(set.call(&mut store, nls, nls_ls, ls, lss))?;
     }
-    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, f64), ()>(&store, "rt_set_nlss_thresholds") {
-        let (min_size, max_density) = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::nlss_thresholds(f)
-        });
-        wts(set.call(&mut store, min_size, max_density))?;
-    }
     // See the wasmtime counterpart.
     if let Ok(set) = rt_inst.exports.get_typed_function::<(f64, f64, f64), ()>(&store, "rt_set_newton_tuning") {
         let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::with_flags(|f| {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -797,12 +797,6 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         let codes = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
         wts(set.call(&mut store, codes))?;
     }
-    if let Ok(set) = rt_inst.get_typed_func::<(u32, f64), ()>(&mut store, "rt_set_nlss_thresholds") {
-        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::nlss_thresholds(f)
-        });
-        wts(set.call(&mut store, t))?;
-    }
     // `-newtonFTol`/`-newtonXTol`/`-newtonMaxStepFactor`: the nonlinear solvers that
     // read them run in-wasm whichever driver owns the run.
     if let Ok(set) = rt_inst.get_typed_func::<(f64, f64, f64), ()>(&mut store, "rt_set_newton_tuning") {

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -16783,6 +16783,74 @@ algorithm
   System.removeFile(cmakeVersionLogFile);
 end getCMakeVersion;
 
+protected function matrixFormatC
+  "The SOLVER_MATRIX_FORMAT for a system of this shape. An unknown count, which is
+   any pattern only built at runtime, counts as dense."
+  input Integer size;
+  input Option<Integer> nnz;
+  input Boolean isLinear;
+  output String format;
+protected
+  Integer entries = Util.getOptionOrDefault(nnz, size * size);
+algorithm
+  format := if BackendDAEUtil.useSparseSolver(size, entries, isLinear) then "OMC_MATRIX_SPARSE" else "OMC_MATRIX_DENSE";
+end matrixFormatC;
+
+public function linearSystemMatrixFormat
+  "Format for this linear system, counting nonzeros off the Jacobian's sparsity
+   where there is one, which is what the runtime used to measure itself."
+  input SimCode.LinearSystem ls;
+  output String format;
+protected
+  Option<Integer> nnz;
+algorithm
+  format := match ls
+    case SimCode.LINEARSYSTEM() algorithm
+      nnz := match ls.jacobianMatrix
+        case SOME(SimCode.JAC_MATRIX(sparsity = {})) then simJacNonzeros(ls.simJac);
+        case SOME(SimCode.JAC_MATRIX()) then sparsityNonzeros(ls.jacobianMatrix);
+        else simJacNonzeros(ls.simJac);
+      end match;
+    then matrixFormatC(listLength(ls.vars), nnz, true);
+  end match;
+end linearSystemMatrixFormat;
+
+public function nonlinearSystemMatrixFormat
+  "Format for this nonlinear system."
+  input SimCode.NonlinearSystem nls;
+  output String format;
+algorithm
+  format := match nls
+    case SimCode.NONLINEARSYSTEM()
+      then matrixFormatC(listLength(nls.crefs), sparsityNonzeros(nls.jacobianMatrix), false);
+  end match;
+end nonlinearSystemMatrixFormat;
+
+protected function simJacNonzeros
+  "Entries of A, which a torn system does not give elementwise."
+  input list<tuple<Integer, Integer, SimCode.SimEqSystem>> simJac;
+  output Option<Integer> nnz = if listEmpty(simJac) then NONE() else SOME(listLength(simJac));
+end simJacNonzeros;
+
+protected function sparsityNonzeros
+  "Entries of a Jacobian's sparsity pattern, unknown without one."
+  input Option<SimCode.JacobianMatrix> ojac;
+  output Option<Integer> nnz;
+protected
+  Integer entries = 0;
+algorithm
+  nnz := match ojac
+    local
+      SimCode.SparsityPattern sparsity;
+    case SOME(SimCode.JAC_MATRIX(sparsity = sparsity)) guard not listEmpty(sparsity) algorithm
+      for col in sparsity loop
+        entries := entries + listLength(Util.tuple22(col));
+      end for;
+    then SOME(entries);
+    else NONE();
+  end match;
+end sparsityNonzeros;
+
 public function getExpNominal
   "Returns the nominal value of an expression.
   Used to scale zero-crossings like `a > b`."

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -2392,6 +2392,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%ls.indexLinearSystem%>].equationIndex = <%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].size = <%listLength(ls.vars)%>;
           linearSystemData[<%ls.indexLinearSystem%>].nnz = <%listLength(ls.simJac)%>;
+          linearSystemData[<%ls.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(ls)%>;
           linearSystemData[<%ls.indexLinearSystem%>].method = 0;   /* No symbolic Jacobian available */
           linearSystemData[<%ls.indexLinearSystem%>].strictTearingFunctionCall = NULL;
           linearSystemData[<%ls.indexLinearSystem%>].setA = setLinearMatrixA<%ls.index%>;
@@ -2404,6 +2405,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%ls.indexLinearSystem%>].equationIndex = <%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].size = <%listLength(ls.vars)%>;
           linearSystemData[<%ls.indexLinearSystem%>].nnz = <%listLength(ls.simJac)%>;
+          linearSystemData[<%ls.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(ls)%>;
           linearSystemData[<%ls.indexLinearSystem%>].method = 1;   /* Symbolic Jacobian available */
           linearSystemData[<%ls.indexLinearSystem%>].residualFunc = residualFunc<%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].strictTearingFunctionCall = NULL;
@@ -2428,6 +2430,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%ls.indexLinearSystem%>].equationIndex = <%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].size = <%listLength(ls.vars)%>;
           linearSystemData[<%ls.indexLinearSystem%>].nnz = <%listLength(ls.simJac)%>;
+          linearSystemData[<%ls.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(ls)%>;
           linearSystemData[<%ls.indexLinearSystem%>].method = 0;   /* No symbolic Jacobian available */
           linearSystemData[<%ls.indexLinearSystem%>].strictTearingFunctionCall = NULL;
           linearSystemData[<%ls.indexLinearSystem%>].setA = setLinearMatrixA<%ls.index%>;
@@ -2438,6 +2441,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%at.indexLinearSystem%>].equationIndex = <%at.index%>;
           linearSystemData[<%at.indexLinearSystem%>].size = <%listLength(at.vars)%>;
           linearSystemData[<%at.indexLinearSystem%>].nnz = <%listLength(at.simJac)%>;
+          linearSystemData[<%at.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(at)%>;
           linearSystemData[<%at.indexLinearSystem%>].method = 0;   /* No symbolic Jacobian available */
           linearSystemData[<%at.indexLinearSystem%>].strictTearingFunctionCall = <%symbolName(modelNamePrefix,"eqFunction")%>_<%ls.index%>;
           linearSystemData[<%at.indexLinearSystem%>].setA = setLinearMatrixA<%at.index%>;
@@ -2454,6 +2458,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%ls.indexLinearSystem%>].equationIndex = <%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].size = <%listLength(ls.vars)%>;
           linearSystemData[<%ls.indexLinearSystem%>].nnz = <%listLength(ls.simJac)%>;
+          linearSystemData[<%ls.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(ls)%>;
           linearSystemData[<%ls.indexLinearSystem%>].method = 1;   /* Symbolic Jacobian available */
           linearSystemData[<%ls.indexLinearSystem%>].residualFunc = residualFunc<%ls.index%>;
           linearSystemData[<%ls.indexLinearSystem%>].strictTearingFunctionCall = NULL;
@@ -2468,6 +2473,7 @@ template functionInitialLinearSystemsTemp(list<SimEqSystem> linearSystems, Strin
           linearSystemData[<%at.indexLinearSystem%>].equationIndex = <%at.index%>;
           linearSystemData[<%at.indexLinearSystem%>].size = <%listLength(at.vars)%>;
           linearSystemData[<%at.indexLinearSystem%>].nnz = <%listLength(at.simJac)%>;
+          linearSystemData[<%at.indexLinearSystem%>].matrixFormat = <%linearSystemMatrixFormat(at)%>;
           linearSystemData[<%at.indexLinearSystem%>].method = 1;   /* Symbolic Jacobian available */
           linearSystemData[<%at.indexLinearSystem%>].residualFunc = residualFunc<%at.index%>;
           linearSystemData[<%at.indexLinearSystem%>].strictTearingFunctionCall = <%symbolName(modelNamePrefix,"eqFunction")%>_<%ls.index%>;
@@ -2813,6 +2819,7 @@ template generateNonLinearSystemData(NonlinearSystem system, Integer indexStrict
 
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].equationIndex = <%nls.index%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].size = <%size%>;
+      nonLinearSystemData[<%nls.indexNonLinearSystem%>].matrixFormat = <%nonlinearSystemMatrixFormat(nls)%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].homotopySupport = <%boolStrC(nls.homotopySupport)%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].mixedSystem = <%boolStrC(nls.mixedSystem)%>;
       <%residualCall%>

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1346,6 +1346,16 @@ end SimCodeFunction;
 
 package SimCodeUtil
 
+  function linearSystemMatrixFormat
+    input SimCode.LinearSystem ls;
+    output String format;
+  end linearSystemMatrixFormat;
+
+  function nonlinearSystemMatrixFormat
+    input SimCode.NonlinearSystem nls;
+    output String format;
+  end nonlinearSystemMatrixFormat;
+
   function absoluteClockIdxForBaseClock
     input Integer baseClockIdx;
     input list<SimCode.ClockedPartition> allBaseClockPartitions;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1170,6 +1170,10 @@ public constant ErrorTypes.Message WARNING_DEF_USE_UNPROVEN = ErrorTypes.MESSAGE
   "%s was possibly used before it was defined (given a value): it is not defined on all control flow paths leading to the use. Per the Modelica specification using an uninitialized variable is an error.");
 public constant ErrorTypes.Message UNASSIGNED_FUNCTION_OUTPUT_UNPROVEN = ErrorTypes.MESSAGE(625, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   "Output parameter %s was possibly not assigned a value: it is not assigned on all control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
+public constant ErrorTypes.Message TEARING_NOT_WORTH_IT = ErrorTypes.MESSAGE(626, ErrorTypes.SYMBOLIC(), ErrorTypes.NOTIFICATION(),
+  "Tearing is skipped for linear strong component %s: solving it torn to %s iteration variables is estimated at %s flops against %s for the untorn system of size %s.");
+public constant ErrorTypes.Message TEARING_AMPLIFIES_ERROR = ErrorTypes.MESSAGE(627, ErrorTypes.SYMBOLIC(), ErrorTypes.NOTIFICATION(),
+  "Tearing is skipped for linear strong component %s: substituting through its %s inner equations amplifies an error by 1e%s, which double precision cannot carry.");
 
 public constant ErrorTypes.Message MATCH_SHADOWING = ErrorTypes.MESSAGE(5001, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   "Local variable '%s' shadows another variable.");

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -571,6 +571,8 @@ constant DebugFlag DUMP_CHECK_MODEL = DEBUG_FLAG(199, "dumpCheckModel", false,
   "Dumps the variables and equations found by checkModel.");
 constant DebugFlag CHECK_DEF_USE = DEBUG_FLAG(200, "checkDefUse", false,
   "Warns about variables in functions that cannot statically be proven to be defined (given a value) before they are used, e.g. variables only assigned on some control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
+constant DebugFlag TEARING_COST = DEBUG_FLAG(201, "tearingCost", false,
+  "Dumps the estimated cost of every torn system against solving it untorn.");
 
 public
 // CONFIGURATION FLAGS
@@ -1434,6 +1436,9 @@ constant ConfigFlag FMU_VERSION = CONFIG_FLAG(169, "fmiVersion",
   NONE(), EXTERNAL(), ENUM_FLAG(FMI_VERSION_20, {("1.0", FMI_VERSION_10), ("2.0", FMI_VERSION_20), ("3.0", FMI_VERSION_30)}),
   SOME(STRING_OPTION({"1.0", "2.0", "3.0"})),
   "FMI version for FMU export: 1.0, 2.0, 3.0.");
+constant ConfigFlag TEARING_COST_MARGIN = CONFIG_FLAG(170, "tearingCostMargin",
+  NONE(), EXTERNAL(), REAL_FLAG(2.0), NONE(),
+  "How much cheaper solving a linear system untorn has to be estimated before its\ntearing set is dropped. Raise it to keep tearing systems the estimate would give\nup on, lower it towards 0 to tear less (default 2).");
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -261,7 +261,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DEBUG_ADJOINT,
   Flags.FLOW_ALIAS_ELIMINATION,
   Flags.DUMP_CHECK_MODEL,
-  Flags.CHECK_DEF_USE
+  Flags.CHECK_DEF_USE,
+  Flags.TEARING_COST
 };
 
 protected
@@ -437,7 +438,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.EXPORT_FMU,
   Flags.FMU_TYPE,
   Flags.FMU_PLATFORMS,
-  Flags.FMU_VERSION
+  Flags.FMU_VERSION,
+  Flags.TEARING_COST_MARGIN
 };
 
 public function new

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1175,21 +1175,10 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
     infoStreamPrint(OMC_LOG_STDOUT, 0, "homotopy parameter homTauStart changed to %f", homTauStart);
   }
 
-  if(omc_flag[FLAG_LSS_MAX_DENSITY]) {
-    linearSparseSolverMaxDensity = atof(omc_flagValue[FLAG_LSS_MAX_DENSITY]);
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "Maximum density for using linear sparse solver changed to %f", linearSparseSolverMaxDensity);
-  }
-  if(omc_flag[FLAG_LSS_MIN_SIZE]) {
-    linearSparseSolverMinSize = atoi(omc_flagValue[FLAG_LSS_MIN_SIZE]);
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "Minimum system size for using linear sparse solver changed to %d", linearSparseSolverMinSize);
-  }
-  if(omc_flag[FLAG_NLSS_MAX_DENSITY]) {
-    nonlinearSparseSolverMaxDensity = atof(omc_flagValue[FLAG_NLSS_MAX_DENSITY]);
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "Maximum density for using non-linear sparse solver changed to %f", nonlinearSparseSolverMaxDensity);
-  }
-  if(omc_flag[FLAG_NLSS_MIN_SIZE]) {
-    nonlinearSparseSolverMinSize = atoi(omc_flagValue[FLAG_NLSS_MIN_SIZE]);
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "Minimum system size for using non-linear sparse solver changed to %d", nonlinearSparseSolverMinSize);
+  if(omc_flag[FLAG_LSS_MAX_DENSITY] || omc_flag[FLAG_LSS_MIN_SIZE] ||
+     omc_flag[FLAG_NLSS_MAX_DENSITY] || omc_flag[FLAG_NLSS_MIN_SIZE]) {
+    warningStreamPrint(OMC_LOG_STDOUT, 0, "The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are\n"
+                                          "deprecated and ignored: the compiler chooses dense or sparse per system.");
   }
   if(omc_flag[FLAG_NEWTON_XTOL]) {
     newtonXTol = atof(omc_flagValue[FLAG_NEWTON_XTOL]);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -45,6 +45,7 @@
 #include "linearSolverUmfpack.h"
 #endif
 #include "linearSolverTotalPivot.h"
+#include "../options.h"
 #include "../simulation_info_json.h"
 
 static void setAElement(int row, int col, double value, int nth, LINEAR_SYSTEM_DATA* linearSystemData, threadData_t* threadData);
@@ -69,8 +70,6 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
   int res;
   unsigned int j, maxNumberThreads;
   LINEAR_SYSTEM_DATA *linsys = data->simulationInfo->linearSystemData;
-  modelica_boolean someSmallDensity = 0;  /* pretty dumping of flag info */
-  modelica_boolean someBigSize = 0;       /* analogous to someSmallDensity */
 
   maxNumberThreads = omc_get_max_threads();
 
@@ -129,30 +128,13 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
 #endif
     }
 
-    if (nnz/(double)(size*size) < linearSparseSolverMaxDensity) {
+    /* -ls reaches klu and umfpack too, so naming a solver can override the format. */
+    if (omc_flag[FLAG_LSS]) {
       linsys[i].useSparseSolver = 1;
-      someSmallDensity = 1;
-      if (size > linearSparseSolverMinSize) {
-        someBigSize = 1;
-        infoStreamPrint(OMC_LOG_STDOUT, 0,
-                        "Using sparse solver for linear system %d,\n"
-                        "because density of %.3f remains under threshold of %.3f\n"
-                        "and size of %d exceeds threshold of %d.",
-                        i, nnz/(double)(size*size), linearSparseSolverMaxDensity,
-                        size, linearSparseSolverMinSize);
-      } else {
-        infoStreamPrint(OMC_LOG_STDOUT, 0,
-                        "Using sparse solver for linear system %d,\n"
-                        "because density of %.3f remains under threshold of %.3f.",
-                        i, nnz/(double)(size*size), linearSparseSolverMaxDensity);
-      }
-    } else if (size > linearSparseSolverMinSize) {
+    } else if (omc_flag[FLAG_LS]) {
+      linsys[i].useSparseSolver = 0;
+    } else if (linsys[i].matrixFormat == OMC_MATRIX_SPARSE) {
       linsys[i].useSparseSolver = 1;
-      someBigSize = 1;
-        infoStreamPrint(OMC_LOG_STDOUT, 0,
-                        "Using sparse solver for linear system %d,\n"
-                        "because size of %d exceeds threshold of %d.",
-                        i, size, linearSparseSolverMinSize);
     }
 
     /* Allocate nominal, min and max */
@@ -292,20 +274,6 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
         throwStreamPrint(threadData, "unrecognized dense linear solver (%d)", data->simulationInfo->lsMethod);
       }
     }
-  }
-
-  /* print relevant flag information */
-  if(someSmallDensity) {
-    if(someBigSize) {
-      infoStreamPrint(OMC_LOG_STDOUT, 0, "The maximum density and the minimal system size for using sparse solvers can be\n"
-                                     "specified using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.");
-    } else {
-      infoStreamPrint(OMC_LOG_STDOUT, 0, "The maximum density for using sparse solvers can be specified\n"
-                                     "using the runtime flag '<-lssMaxDensity=value>'.");
-    }
-  } else if(someBigSize) {
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "The minimal system size for using sparse solvers can be specified\n"
-                                   "using the runtime flag '<-lssMinSize=value>'.");
   }
 
   messageClose(OMC_LOG_LS);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -382,16 +382,9 @@ void freeNlsUserData(NLS_USERDATA* userData) {
  * @param threadData        Thread data for error handling.
  * @param nonlinsys         Pointer to non-linear system.
  * @param sysNum            Number of non-linear system.
- * @param isSparseNls       Becomes true when non-linear system density is
- *                          smaller than maximum allowed density for sparse solvers.
- *                          Otherwise value stays unchanged.
- * @param isBigNls          Becomes true when non-linear system size is greater than
- *                          minimum system size for sparse solvers.
- *                          Otherwise value stays unchanged.
  */
-void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *nonlinsys, int sysNum, modelica_boolean* isSparseNls, modelica_boolean* isBigNls) {
+void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *nonlinsys, int sysNum) {
   modelica_integer size;
-  unsigned int nnz;
   struct dataSolver *solverData;
   struct dataMixedSolver *mixedSolverData;
   JACOBIAN* jacobian;
@@ -467,44 +460,14 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
   }
 #endif
 
-  /* Check if the system is sparse enough to use kinsol.
-   * It is considered sparse if
-   * the density (nnz/size^2) is less than a threshold or
-   * the size is bigger than a threshold */
   nonlinsys->nlsMethod = data->simulationInfo->nlsMethod;
   nonlinsys->nlsLinearSolver = data->simulationInfo->nlsLinearSolver;
 #if !defined(OMC_MINIMAL_RUNTIME)
-  if (nonlinsys->sparsePattern && !(data->simulationInfo->nlsMethod == NLS_KINSOL || data->simulationInfo->nlsMethod == NLS_KINSOL_B))
+  if (nonlinsys->matrixFormat == OMC_MATRIX_SPARSE && nonlinsys->sparsePattern
+      && !(data->simulationInfo->nlsMethod == NLS_KINSOL || data->simulationInfo->nlsMethod == NLS_KINSOL_B))
   {
-    nnz = nonlinsys->sparsePattern->nnz;
-
-    if (nnz/(double)(size*size) < nonlinearSparseSolverMaxDensity) {
-      nonlinsys->nlsMethod = NLS_KINSOL;
-      nonlinsys->nlsLinearSolver = NLS_LS_KLU;
-      *isSparseNls = TRUE;
-      if (size > nonlinearSparseSolverMinSize) {
-        *isBigNls = TRUE;
-        infoStreamPrint(OMC_LOG_STDOUT, 0,
-                        "Using sparse solver kinsol for nonlinear system %d (%d),\n"
-                        "because density of %.2f remains under threshold of %.2f\n"
-                        "and size of %d exceeds threshold of %d.",
-                        sysNum, (int)nonlinsys->equationIndex, nnz/(double)(size*size), nonlinearSparseSolverMaxDensity,
-                        (int)size, nonlinearSparseSolverMinSize);
-      } else {
-        infoStreamPrint(OMC_LOG_STDOUT, 0,
-                        "Using sparse solver kinsol for nonlinear system %d (%d),\n"
-                        "because density of %.2f remains under threshold of %.2f.",
-                        sysNum, (int)nonlinsys->equationIndex, nnz/(double)(size*size), nonlinearSparseSolverMaxDensity);
-      }
-    } else if (size > nonlinearSparseSolverMinSize) {
-      nonlinsys->nlsMethod = NLS_KINSOL;
-      nonlinsys->nlsLinearSolver = NLS_LS_KLU;
-      *isBigNls = TRUE;
-      infoStreamPrint(OMC_LOG_STDOUT, 0,
-                      "Using sparse solver kinsol for nonlinear system %d (%d),\n"
-                      "because size of %d exceeds threshold of %d.",
-                      sysNum, (int)nonlinsys->equationIndex, (int)size, nonlinearSparseSolverMinSize);
-    }
+    nonlinsys->nlsMethod = NLS_KINSOL;
+    nonlinsys->nlsLinearSolver = NLS_LS_KLU;
   }
 #endif
 
@@ -609,8 +572,6 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
 int initializeNonlinearSystems(DATA *data, threadData_t *threadData)
 {
   int i;
-  modelica_boolean someSmallDensity = FALSE;  /* pretty dumping of flag info */
-  modelica_boolean someBigSize = FALSE;       /* analogous to someSmallDensity */
   NONLINEAR_SYSTEM_DATA *nonlinsys = data->simulationInfo->nonlinearSystemData;
 
   infoStreamPrint(OMC_LOG_NLS, 1, "initialize non-linear system solvers");
@@ -632,21 +593,7 @@ int initializeNonlinearSystems(DATA *data, threadData_t *threadData)
   }
 
   for (i=0; i<data->modelData->nNonLinearSystems; ++i) {
-    initializeNonlinearSystemData(data, threadData, &nonlinsys[i], i, &someSmallDensity, &someBigSize);
-  }
-
-  /* print relevant flag information */
-  if (someSmallDensity) {
-    if (someBigSize) {
-      infoStreamPrint(OMC_LOG_STDOUT, 0, "The maximum density and the minimal system size for using sparse solvers can be\n"
-                                     "specified using the runtime flags '<-nlssMaxDensity=value>' and '<-nlssMinSize=value>'.");
-    } else {
-      infoStreamPrint(OMC_LOG_STDOUT, 0, "The maximum density for using sparse solvers can be specified\n"
-                                     "using the runtime flag '<-nlssMaxDensity=value>'.");
-    }
-  } else if (someBigSize) {
-    infoStreamPrint(OMC_LOG_STDOUT, 0, "The minimal system size for using sparse solvers can be specified\n"
-                                   "using the runtime flag '<-nlssMinSize=value>'.");
+    initializeNonlinearSystemData(data, threadData, &nonlinsys[i], i);
   }
 
   messageClose(OMC_LOG_NLS);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.h
@@ -79,7 +79,7 @@ int print_csvLineIterStats(void* csvData, int size, int num,
                            int iteration, double* x, double* f, double error_f,
                            double error_fs, double delta_x, double delta_xs,
                            double lambda);
-void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *nonlinsys, int sysNum, modelica_boolean* isSparseNls, modelica_boolean* isBigNls);
+void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *nonlinsys, int sysNum);
 
 NLS_USERDATA* initNlsUserData(DATA* data, threadData_t* threadData, int sysNumber, NONLINEAR_SYSTEM_DATA* nlsData, JACOBIAN* analyticJacobian);
 void freeNlsUserData(NLS_USERDATA* userData);

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -151,6 +151,12 @@ typedef enum
  * CSC uses column coloring and CSR uses row coloring.
  * leadindex: size nCols+1 (CSC) or nRows+1 (CSR)
  */
+typedef enum
+{
+  OMC_MATRIX_DENSE = 0,       /* the backend chose a dense factorization */
+  OMC_MATRIX_SPARSE           /* the backend chose a sparse factorization */
+} SOLVER_MATRIX_FORMAT;
+
 typedef struct SPARSE_PATTERN
 {
   /* Primary CSC/CSR representation */
@@ -415,6 +421,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
   void (*getIterationVars)(DATA* data, double* array);
   int (*checkConstraints)(DATA* data, threadData_t *threadData);
 
+  SOLVER_MATRIX_FORMAT matrixFormat;   /* dense or sparse, chosen by the backend */
   NONLINEAR_SOLVER nlsMethod;          /* nonlinear solver */
   void *solverData;
   NLS_LS nlsLinearSolver;              /* nls linear solver */
@@ -499,7 +506,8 @@ typedef struct LINEAR_SYSTEM_DATA
 
   modelica_integer method;             /* 0: No Jacobain created for linear system
                                         * 1: Symbolic Jacobian available for linear system */
-  modelica_boolean useSparseSolver;    /* true if sparse solver is used */
+  SOLVER_MATRIX_FORMAT matrixFormat;   /* dense or sparse, chosen by the backend */
+  modelica_boolean useSparseSolver;    /* matrixFormat, unless no sparse solver was built in */
 
   LINEAR_SYSTEM_THREAD_DATA* parDynamicData; /* Array of length numMaxThreads for internal write data */
 

--- a/testsuite/openmodelica/cruntime/simoptions/nlssMaxDensity.mos
+++ b/testsuite/openmodelica/cruntime/simoptions/nlssMaxDensity.mos
@@ -18,7 +18,8 @@ simulate(M, simflags="-nlssMaxDensity=0.1"); getErrorString();
 // record SimulationResult
 //     resultFile = "M_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nlssMaxDensity=0.1'",
-//     messages = "LOG_STDOUT        | info    | Maximum density for using non-linear sparse solver changed to 0.100000
+//     messages = "LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
+++ b/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
@@ -17,14 +17,9 @@ simulate(M, simflags="-nlssMinSize=0"); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "M_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nlssMinSize=0'",
-//     messages = "LOG_STDOUT        | info    | Minimum system size for using non-linear sparse solver changed to 0
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (5),
-// |                 | |       | because size of 1 exceeds threshold of 0.
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 1 (10),
-// |                 | |       | because size of 1 exceeds threshold of 0.
-// LOG_STDOUT        | info    | The minimal system size for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMinSize=value>'.
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nlssMinSize=0'",
+//     messages = "LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos
@@ -25,16 +25,10 @@ runScript(modelTesting);getErrorString();
 // ""
 // OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench
-// {"source.plug_p.reference.gamma","source.voltageSource[2].pin_p.reference.gamma","source.voltageSource[3].pin_p.reference.gamma"}
-// Simulation options: startTime = 0.0, stopTime = 0.1, numberOfIntervals = 100, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench', options = '', outputFormat = 'mat', variableFilter = 'time|source.plug_p.reference.gamma|source.voltageSource.2..pin_p.reference.gamma|source.voltageSource.3..pin_p.reference.gamma', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
+// {"source.plug_p.reference.gamma", "source.voltageSource[2].pin_p.reference.gamma", "source.voltageSource[3].pin_p.reference.gamma"}
+// Simulation options: startTime = 0.0, stopTime = 0.1, numberOfIntervals = 100, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench', options = '', outputFormat = 'mat', variableFilter = 'time|source.plug_p.reference.gamma|source.voltageSource.2..pin_p.reference.gamma|source.voltageSource.3..pin_p.reference.gamma', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench_res.mat
-// Messages: LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 2 (603),
-// |                 | |       | because density of 0.04 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 10 (1566),
-// |                 | |       | because density of 0.04 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
@@ -79,29 +79,14 @@ runScript(modelTesting);getErrorString();
 // {"X1.X1.X1.X1.Q1.vbe", "X1.X1.X1.X1.Q2.vbc", "X1.X1.X1.X1.Q2.vbe", "X1.X1.X1.X1.Q3.vbc", "X1.X1.X1.X1.Q3.vbe", "X1.X1.X1.X1.Q4.vbc", "X1.X1.X1.X1.Q4.vbe", "X1.X1.X1.X1.Q5.vbc", "X1.X1.X1.X1.Q5.vbe", "X1.X1.X1.X2.Q1.vbc", "X1.X1.X1.X2.Q1.vbe", "X1.X1.X1.X2.Q2.vbe", "X1.X1.X1.X2.Q3.vbc", "X1.X1.X1.X2.Q3.vbe", "X1.X1.X1.X2.Q4.vbc", "X1.X1.X1.X2.Q4.vbe", "X1.X1.X1.X2.Q5.vbc", "X1.X1.X1.X2.Q5.vbe", "X1.X1.X2.X3.Q1.vbc", "X1.X1.X2.X3.Q1.vbe", "X1.X1.X2.X3.Q2.vbe", "X1.X1.X2.X3.Q3.vbc", "X1.X1.X2.X3.Q3.vbe", "X1.X1.X2.X3.Q4.vbc", "X1.X1.X2.X3.Q4.vbe", "X1.X1.X2.X3.Q5.vbe", "X1.X1.X2.X4.Q1.vbc", "X1.X1.X2.X4.Q1.vbe", "X1.X1.X2.X4.Q2.vbc", "X1.X1.X2.X4.Q2.vbe", "X1.X1.X2.X4.Q3.vbc", "X1.X1.X2.X4.Q3.vbe", "X1.X1.X2.X4.Q4.vbc", "X1.X1.X2.X4.Q4.vbe", "X1.X1.X2.X4.Q5.vbc", "X1.X1.X2.X4.Q5.vbe", "X1.X2.X2.X9.Q1.vbc", "X1.X2.X2.X9.Q1.vbe", "X1.X2.X2.X9.Q2.vbc", "X1.X2.X2.X9.Q2.vbe", "X1.X2.X2.X9.Q3.vbc", "X1.X2.X2.X9.Q3.vbe", "X1.X2.X2.X9.Q4.vbc", "X1.X2.X2.X9.Q4.vbe", "X1.X2.X2.X9.Q5.vbc", "X1.X2.X2.X9.Q5.vbe"}
 // Simulation options: startTime = 0.0, stopTime = 1e-9, numberOfIntervals = 1000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder', options = '', outputFormat = 'mat', variableFilter = 'time|X1.X1.X1.X1.Q1.vbe|X1.X1.X1.X1.Q2.vbc|X1.X1.X1.X1.Q2.vbe|X1.X1.X1.X1.Q3.vbc|X1.X1.X1.X1.Q3.vbe|X1.X1.X1.X1.Q4.vbc|X1.X1.X1.X1.Q4.vbe|X1.X1.X1.X1.Q5.vbc|X1.X1.X1.X1.Q5.vbe|X1.X1.X1.X2.Q1.vbc|X1.X1.X1.X2.Q1.vbe|X1.X1.X1.X2.Q2.vbe|X1.X1.X1.X2.Q3.vbc|X1.X1.X1.X2.Q3.vbe|X1.X1.X1.X2.Q4.vbc|X1.X1.X1.X2.Q4.vbe|X1.X1.X1.X2.Q5.vbc|X1.X1.X1.X2.Q5.vbe|X1.X1.X2.X3.Q1.vbc|X1.X1.X2.X3.Q1.vbe|X1.X1.X2.X3.Q2.vbe|X1.X1.X2.X3.Q3.vbc|X1.X1.X2.X3.Q3.vbe|X1.X1.X2.X3.Q4.vbc|X1.X1.X2.X3.Q4.vbe|X1.X1.X2.X3.Q5.vbe|X1.X1.X2.X4.Q1.vbc|X1.X1.X2.X4.Q1.vbe|X1.X1.X2.X4.Q2.vbc|X1.X1.X2.X4.Q2.vbe|X1.X1.X2.X4.Q3.vbc|X1.X1.X2.X4.Q3.vbe|X1.X1.X2.X4.Q4.vbc|X1.X1.X2.X4.Q4.vbe|X1.X1.X2.X4.Q5.vbc|X1.X1.X2.X4.Q5.vbe|X1.X2.X2.X9.Q1.vbc|X1.X2.X2.X9.Q1.vbe|X1.X2.X2.X9.Q2.vbc|X1.X2.X2.X9.Q2.vbe|X1.X2.X2.X9.Q3.vbc|X1.X2.X2.X9.Q3.vbe|X1.X2.X2.X9.Q4.vbc|X1.X2.X2.X9.Q4.vbe|X1.X2.X2.X9.Q5.vbc|X1.X2.X2.X9.Q5.vbe', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder_res.mat
-// Messages: LOG_STDOUT        | info    | Using sparse solver for linear system 12,
-// |                 | |       | because density of 0.184 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 25,
-// |                 | |       | because density of 0.189 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 38,
-// |                 | |       | because density of 0.167 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 51,
-// |                 | |       | because density of 0.167 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 75,
-// |                 | |       | because density of 0.178 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 87,
-// |                 | |       | because density of 0.169 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 97,
-// |                 | |       | because density of 0.153 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 102,
-// |                 | |       | because density of 0.168 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions("-d=initialization").
+// Notification: Tearing is skipped for linear strong component 128: solving it torn to 30 iteration variables is estimated at 22757 flops against 10665 for the untorn system of size 126.
+// Notification: Tearing is skipped for linear strong component 149: solving it torn to 30 iteration variables is estimated at 23794 flops against 10665 for the untorn system of size 126.
+// Notification: Tearing is skipped for linear strong component 175: solving it torn to 28 iteration variables is estimated at 20190 flops against 9517 for the untorn system of size 113.
 //
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos
@@ -32,13 +32,7 @@ runScript(modelTesting);getErrorString();
 // {"load.phi", "load.w", "filter.x[1]", "filter.x[2]"}
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6', options = '', outputFormat = 'mat', variableFilter = 'time|load.phi|load.w|filter.x.1.|filter.x.2.', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_res.mat
-// Messages: LOG_STDOUT        | info    | Using sparse solver for linear system 6,
-// |                 | |       | because density of 0.154 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 13,
-// |                 | |       | because density of 0.155 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividual.mos
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividual.mos
@@ -18,11 +18,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ScalableTestSuite.Electr
 // record SimulationResult
 //     resultFile = "ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (1461),
-// |                 | |       | because density of 0.00 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/daemode/testDAEScaling.mos
+++ b/testsuite/simulation/modelica/daemode/testDAEScaling.mos
@@ -52,12 +52,8 @@ simulate(Test3, stopTime = 2, simflags="-noEquidistantTimeGrid");getErrorString(
 // true
 // record SimulationResult
 //     resultFile = "Test3_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'ida', fileNamePrefix = 'Test3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-noEquidistantTimeGrid'",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (500),
-// |                 | |       | because density of 0.01 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'ida', fileNamePrefix = 'Test3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-noEquidistantTimeGrid'",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/linear_system/EngineV6_partlintorn.mos
+++ b/testsuite/simulation/modelica/linear_system/EngineV6_partlintorn.mos
@@ -22,14 +22,8 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Mechanics.Multi
 // ""
 // record SimulationResult
 //     resultFile = "Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver for linear system 6,
-// |                 | |       | because density of 0.176 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 7,
-// |                 | |       | because density of 0.155 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/linear_system/NPendulum.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum.mos
@@ -57,21 +57,21 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 setCommandLineOptions("--maxSizeLinearTearing=0"); getErrorString();
 buildModel(NPendulum.pendulum); getErrorString();
 
-system(realpath(".") + "/NPendulum.pendulum -ls totalpivot -lssMinSize=4000", "simcall_totalpivot.log");
+system(realpath(".") + "/NPendulum.pendulum -ls totalpivot ", "simcall_totalpivot.log");
 readFile("simcall_totalpivot.log"); remove("simcall_totalpivot.log");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls lapack -lssMinSize=4000", "simcall_lapack.log");
+system(realpath(".") + "/NPendulum.pendulum -ls lapack ", "simcall_lapack.log");
 readFile("simcall_lapack.log"); remove("simcall_lapack.log");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls umfpack -lssMinSize=4000", "simcall_umfpack.log");
+system(realpath(".") + "/NPendulum.pendulum -ls umfpack ", "simcall_umfpack.log");
 readFile("simcall_umfpack.log"); remove("simcall_umfpack.log");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
@@ -88,7 +88,7 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
   {"phi[10]"});
 */
 
-system(realpath(".") + "/NPendulum.pendulum -ls klu -lssMinSize=4000", "simcall_klu.log");
+system(realpath(".") + "/NPendulum.pendulum -ls klu ", "simcall_klu.log");
 readFile("simcall_klu.log"); remove("simcall_klu.log");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
@@ -136,53 +136,25 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 // {"NPendulum.pendulum", "NPendulum.pendulum_init.xml"}
 // ""
 // 0
-// "LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.012 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.013 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.012 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.013 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.012 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.013 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.012 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.013 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true

--- a/testsuite/simulation/modelica/linear_system/NPendulum40.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum40.mos
@@ -31,28 +31,14 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res
 // true
 // {"NPendulum.pendulum40", "NPendulum.pendulum40_init.xml"}
 // ""
-// LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 2,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
+// LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // 0
 // {"Files Equal!"}
-// LOG_STDOUT        | info    | Minimum system size for using linear sparse solver changed to 4000
-// LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 2,
-// |                 | |       | because density of 0.003 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
+// LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // 0

--- a/testsuite/simulation/modelica/linear_system/linSymSolConstA.mos
+++ b/testsuite/simulation/modelica/linear_system/linSymSolConstA.mos
@@ -32,12 +32,13 @@ val(max_res,1);
 //     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 5000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_system.problem4', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_LS -s euler'",
 //     messages = "LOG_LS            | info    | initialize linear system solvers
 // |                 | |       | | 1 linear systems
-// LOG_LS            | info    | Start solving Linear System 42 (size 19) at time 0 with Lapack Solver
+// LOG_LS            | info    | Start solving Linear System 2 (size 20) at time 0 with Lapack Solver
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// ""
+// "Notification: Tearing is skipped for linear strong component 1: solving it torn to 19 iteration variables is estimated at 35694 flops against 7733 for the untorn system of size 20.
+// "
 // 1.0
 // 1.000000000000518
 // true
@@ -51,7 +52,9 @@ val(max_res,1);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// ""
+// "Notification: Tearing is skipped for linear strong component 1: solving it torn to 19 iteration variables is estimated at 35694 flops against 7733 for the untorn system of size 20.
+// Notification: Tearing is skipped for linear strong component 2: solving it torn to 19 iteration variables is estimated at 35694 flops against 7733 for the untorn system of size 20.
+// "
 // 1.0
 // 1.000000000000248
 // endResult

--- a/testsuite/simulation/modelica/nonlinear_system/problem6_symjac.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/problem6_symjac.mos
@@ -28,26 +28,20 @@ val(x[100],{0.0});
 // ""
 // record SimulationResult
 //     resultFile = "nonlinear_system.problem6_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'nonlinear_system.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (198),
-// |                 | |       | because density of 0.03 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 1 (395),
-// |                 | |       | because density of 0.03 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'nonlinear_system.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""
 // {0.0}
-// {-0.06532729491620363}
-// {-0.09089404927173822}
-// {-0.1093185611137726}
-// {-0.1196136958219066}
-// {-0.1206187352141816}
-// {-0.110961216371588}
-// {-0.08900861786245826}
-// {-0.05280668518725216}
+// {-0.06532729491620391}
+// {-0.09089404927173926}
+// {-0.10931856111377469}
+// {-0.1196136958219094}
+// {-0.12061873521418404}
+// {-0.11096121637158994}
+// {-0.08900861786245985}
+// {-0.05280668518725322}
 // {0.0}
 // endResult

--- a/testsuite/simulation/modelica/others/EngineV6_output.mos
+++ b/testsuite/simulation/modelica/others/EngineV6_output.mos
@@ -21,13 +21,7 @@ val(crankshaftSpeed,1.0); getErrorString();
 // record SimulationResult
 //     resultFile = "EngineV6_output_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'EngineV6_output', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver for linear system 6,
-// |                 | |       | because density of 0.176 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 13,
-// |                 | |       | because density of 0.155 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/solver/problem1-symSolverImp.mos
+++ b/testsuite/simulation/modelica/solver/problem1-symSolverImp.mos
@@ -51,12 +51,8 @@ getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "testSolver.problem1_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 2e-06, numberOfIntervals = 1000, tolerance = 1e-06, method = 'symSolver', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (1216),
-// |                 | |       | because density of 0.04 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_STDOUT        | warning | Integration method 'symSolver' is deprecated and will be removed in a future version of OpenModelica.
+//     simulationOptions = "startTime = 0.0, stopTime = 2e-6, numberOfIntervals = 1000, tolerance = 1e-6, method = 'symSolver', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Integration method 'symSolver' is deprecated and will be removed in a future version of OpenModelica.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/solver/problem1-symSolverImpSsc.mos
+++ b/testsuite/simulation/modelica/solver/problem1-symSolverImpSsc.mos
@@ -51,12 +51,8 @@ getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "testSolver.problem1_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 2e-06, numberOfIntervals = 1000, tolerance = 1e-06, method = 'symSolverSsc', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 0 (1216),
-// |                 | |       | because density of 0.04 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_STDOUT        | warning | Integration method 'symSolverSsc' is deprecated and will be removed in a future version of OpenModelica.
+//     simulationOptions = "startTime = 0.0, stopTime = 2e-6, numberOfIntervals = 1000, tolerance = 1e-6, method = 'symSolverSsc', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Integration method 'symSolverSsc' is deprecated and will be removed in a future version of OpenModelica.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/tearing/Tearing12-cel.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-cel.mos
@@ -25,7 +25,7 @@ simulate(Tearing12); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing12_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -33,6 +33,7 @@ simulate(Tearing12); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 9901
 //  * Number of variables: 9901
+// Notification: Tearing is skipped for linear strong component 1: solving it torn to 59 iteration variables is estimated at 896957 flops against 176144 for the untorn system of size 908.
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1968
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -47,13 +48,16 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(59,849,78.3%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(908,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
+// Notification: Tearing is skipped for linear strong component 2: solving it torn to 60 iteration variables is estimated at 915600 flops against 176037 for the untorn system of size 905.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 4
 //  * Number of states: 62 ('-d=stateselection' for list of states)
@@ -68,12 +72,14 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(60,845,77.4%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(905,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
 // "
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing12-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-celMC3.mos
@@ -26,7 +26,7 @@ simulate(Tearing12); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing12_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -34,6 +34,7 @@ simulate(Tearing12); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 9901
 //  * Number of variables: 9901
+// Notification: Tearing is skipped for linear strong component 1: solving it torn to 48 iteration variables is estimated at 691008 flops against 176144 for the untorn system of size 908.
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1968
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -48,13 +49,16 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(48,860,82.6%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(908,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
+// Notification: Tearing is skipped for linear strong component 2: solving it torn to 79 iteration variables is estimated at 1131054 flops against 176037 for the untorn system of size 905.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 4
 //  * Number of states: 62 ('-d=stateselection' for list of states)
@@ -69,12 +73,14 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(79,826,45.4%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(905,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
 // "
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing12-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-minimal.mos
@@ -26,14 +26,8 @@ simulate(Tearing12); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing12_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.004 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.004 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/tearing/Tearing12-omc.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-omc.mos
@@ -24,7 +24,7 @@ simulate(Tearing12); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing12_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -32,6 +32,7 @@ simulate(Tearing12); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 9901
 //  * Number of variables: 9901
+// Notification: Tearing is skipped for linear strong component 1: solving it torn to 125 iteration variables is estimated at 2762901 flops against 176144 for the untorn system of size 908.
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1968
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -46,13 +47,16 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(125,783,36.0%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(908,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
+// Notification: Tearing is skipped for linear strong component 2: solving it torn to 77 iteration variables is estimated at 1297193 flops against 176037 for the untorn system of size 905.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 4
 //  * Number of states: 62 ('-d=stateselection' for list of states)
@@ -67,12 +71,14 @@ simulate(Tearing12); getErrorString();
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
-//  * Equation systems (not torn): 0
-//  * Torn equation systems: 1
+//  * Equation systems (not torn): 1
+//  * Torn equation systems: 0
 //  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems (#iteration vars, #inner vars, density): 1 system
-//    {(77,828,70.4%)}
-//  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
+// Notification: Equation system details (not torn):
+//  * Constant Jacobian (size): 0 systems
+//  * Linear Jacobian (size,density): 1 system
+//    {(905,0.4%)}
+//  * Non-linear Jacobian (size): 0 systems
+//  * Without analytic Jacobian (size): 0 systems
 // "
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing7-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing7-minimal.mos
@@ -28,14 +28,8 @@ val(R1.v,0.2); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing7_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing7', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.136 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.136 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing7', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -95,8 +89,8 @@ val(R1.v,0.2); getErrorString();
 //    {(18,0,13.6%)}
 //  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
 // "
-// 0.3170188387650512
+// 0.31701883876505116
 // ""
-// 0.3170188387650512
+// 0.31701883876505116
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing8-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing8-minimal.mos
@@ -26,14 +26,8 @@ val(R1.v,0.2); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "Tearing8_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.087 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.087 remains under threshold of 0.200.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-lssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -98,8 +92,8 @@ val(R1.v,0.2); getErrorString();
 //    {(29,0,8.7%)}
 //  * Non-linear torn systems (#iteration vars, #inner vars): 0 systems
 // "
-// 0.3170188387650512
+// 0.31701883876505116
 // ""
-// 0.3170188387650512
+// 0.31701883876505116
 // ""
 // endResult


### PR DESCRIPTION
`HarmonicOscillatorNetwork_N_40/80/160` hangs, in the C runtime as well as under wasm-jit. Its `xs` system is tridiagonal of size N, and because N stays under `maxSizeLinearTearing` (200) the backend tears it to a single iteration variable. The inner equations are then the shooting recurrence `xs[i+1] = 3*xs[i] - xs[i-1] - xm[i]`, whose characteristic root is (3+sqrt 5)/2 ~ 2.618; over 38 nodes that is 8e15, so the residual carries no correct digits. The runtime notices (`Residual norm is 14.0094302893603`) and falls back to total pivoting, which cannot help -- the torn formulation is what is wrong. N_320 escapes only by exceeding the size limit.

Two decisions were being made on system size and density alone, and neither knew what the other would do. Both now rest on an estimate.

**Tearing runs first and its result is judged.** The torn matrix A does not exist yet, so `tearingPaysOff` derives it: A[i][j] is filled iff residual i reaches iteration variable j through the forward substitution of the inner equations. Walking that substitution gives both the structure of A and, taking each Jacobian entry at its value where the parameter bindings give one, how far an error in an iteration variable has grown by the time it reaches a residual. The tearing set is dropped when that growth exceeds what a double carries, or when the untorn system is estimated at less than half the cost. `--tearingCostMargin` scales that factor, so a model needing one system torn can ask for it without forcing every small system.

**The backend picks each system's matrix format and emits it.** The generated code sets nothing but the verdict:

    typedef enum {
      OMC_MATRIX_DENSE, OMC_MATRIX_SPARSE
    } SOLVER_MATRIX_FORMAT;

`BackendDAEUtil.useSparseSolver` is the one rule, keeping the thresholds the runtime applied (0.2/1000 linear, 0.1/1000 nonlinear), so the same systems go sparse as before. It sits in the backend because both `SimCodeUtil` and `Tearing` need it and the dependency may only point that way. `initializeLinearSystems` and `initializeNonlinearSystemData` read the field instead of computing a density, and `-lssMaxDensity`, `-lssMinSize`, `-nlssMaxDensity` and `-nlssMinSize` warn once that they are ignored. wasm-jit loses its `nlss_thresholds` plumbing for the same reason. Naming a solver still overrides the format: `-ls` takes the dense path, which reaches klu and umfpack too, and `-lss` the sparse one. `NPendulum` had been relying on `-lssMinSize=4000` for that, and had in fact been ignoring its own `-ls` argument, because the runtime picked sparse by density regardless.

Both constants in the estimate were measured against the C runtime with `-lv LOG_STATS_V`, forcing each configuration in turn, and each is confirmed by two independent models: evaluating one Jacobian entry is worth about four flops, and a sparse factorization sees about 14 times the fill a flat nnz/size per column would give.

Predicted against measured, per solve of the same system:

| system | predicted | measured |
| --- | --- | --- |
| EngineV6 n=9 -> t=2 | torn, 3.5x | torn, 1.4x |
| EngineV6 n=683 -> t=25 | torn, 1.01x | tie |
| NPendulum n=275 -> t=27 | untorn, 1.7x | untorn, 1.4x | | Tearing12 n=905 -> t=79 | untorn, 5.1x | untorn, 4.1x | | dense 60x60 -> t=59 | untorn, 6.0x | untorn, 1.6x |

The margin of 2 is what those error bars buy: the model ranks every measured case correctly but overstates by up to 4x. Untorn and dense is the one configuration that must not be reached by accident -- it did not finish in 900 s on either `EngineV6` (n=683) or `Tearing12` (n=905).

`HarmonicOscillatorNetwork_N_40` now reports 1e19 of growth over its 39 inner equations, is left untorn, goes to the sparse solver and simulates. All 33 strong components of the tearing testsuite stay torn, as do `NPendulum` and `EngineV6_partlintorn`. `linSymSolConstA` tears 20 equations to 19 iteration variables, which the estimate rejects at 35694 flops against 7733; it solves to the same residual, so only its log moved. The remaining test updates are the reworded solver messages.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
