### PR TITLE
wasm-jit: event logging and event-driver defects

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -3401,7 +3401,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     }
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
-        fmi_vrs, zc_descriptions(&zero_crossings), sens_params, nls_vars, dae,
+        fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&relations),
+        samples.iter().map(|s| s.index).collect(), soti_vars(vars)?, sens_params, nls_vars, dae,
         clocks.iter().map(|c| c.meta.clone()).collect(),
         build_lin_info(&linz, vars, &var_map)?,
         opt_info, input_vars,
@@ -4227,6 +4228,9 @@ fn build_sim_meta(
     state_sets: &[StateSetInfo],
     fmi_vrs: Vec<FmiVr>,
     zc_desc: Vec<String>,
+    rel_desc: Vec<String>,
+    sample_index: Vec<i32>,
+    soti: openmodelica_sim_meta::SotiVars,
     sens_params: Vec<u32>,
     nls_vars: Vec<openmodelica_sim_meta::NlsVars>,
     dae: Option<openmodelica_sim_meta::DaeInfo>,
@@ -4250,6 +4254,9 @@ fn build_sim_meta(
         state_sets: state_sets.to_vec(),
         fmi_vrs,
         zc_desc,
+        rel_desc,
+        sample_index,
+        soti,
         sens_params,
         nls_vars,
         dae,
@@ -4263,13 +4270,75 @@ fn build_sim_meta(
 /// The Modelica source of each zero-crossing relation (via
 /// `ExpressionBasics::printExpStr`), so the driver can name the crossing that
 /// triggered chattering. A math-event crossing has no relation string.
+/// C's `modelData` variable arrays: the same lists, in the same order, as the
+/// `SimData` variable regions.
+fn soti_vars(vars: &SimCodeVar::SimVars) -> Result<openmodelica_sim_meta::SotiVars> {
+    // C's `info.name`: a derivative reads `der(x)`, other `$` names stay raw.
+    let named = |sv: &SimCodeVar::SimVar| -> Result<String> {
+        let raw = cref_display(&sv.name)?.to_string();
+        Ok(match raw.strip_prefix("$DER.") {
+            Some(rest) => format!("der({rest})"),
+            None => raw,
+        })
+    };
+    let mut reals = Vec::new();
+    for sv in lst(&vars.stateVars).chain(lst(&vars.derivativeVars)).chain(real_alg_vars(vars)) {
+        reals.push((named(sv)?, const_real(&sv.nominalValue).unwrap_or(1.0)));
+    }
+    let mut ints = Vec::new();
+    for sv in lst(&vars.intAlgVars) {
+        ints.push((named(sv)?, const_int(&sv.initialValue).unwrap_or(0)));
+    }
+    let mut bools = Vec::new();
+    for sv in lst(&vars.boolAlgVars) {
+        bools.push((named(sv)?, const_int(&sv.initialValue).unwrap_or(0)));
+    }
+    let mut strings = Vec::new();
+    for sv in lst(&vars.stringAlgVars) {
+        strings.push((named(sv)?, const_str(&sv.initialValue).unwrap_or_default()));
+    }
+    Ok(openmodelica_sim_meta::SotiVars { reals, ints, bools, strings })
+}
+
+fn const_real(e: &Option<Arc<DAE::Exp>>) -> Option<f64> {
+    match e.as_deref()? {
+        DAE::Exp::RCONST { real } => Some(real.into_inner()),
+        DAE::Exp::ICONST { integer } => Some(*integer as f64),
+        _ => None,
+    }
+}
+
+fn const_int(e: &Option<Arc<DAE::Exp>>) -> Option<i32> {
+    match e.as_deref()? {
+        DAE::Exp::ICONST { integer } => Some(*integer),
+        DAE::Exp::BCONST { bool } => Some(*bool as i32),
+        DAE::Exp::ENUM_LITERAL { index, .. } => Some(*index),
+        _ => None,
+    }
+}
+
+fn const_str(e: &Option<Arc<DAE::Exp>>) -> Option<String> {
+    match e.as_deref()? {
+        DAE::Exp::SCONST { string } => Some(string.to_string()),
+        _ => None,
+    }
+}
+
+fn rel_descriptions(relations: &[Option<Arc<DAE::Exp>>]) -> Vec<String> {
+    relations.iter().map(|r| r.as_ref().map(|e| dump_exp(e)).unwrap_or_default()).collect()
+}
+
+fn dump_exp(e: &Arc<DAE::Exp>) -> String {
+    openmodelica_frontend_dump::ExpressionBasics::printExpStr(e.clone())
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
 fn zc_descriptions(crossings: &[ZcInfo]) -> Vec<String> {
     crossings
         .iter()
         .map(|zc| match zc {
-            ZcInfo::Bool { expr } => openmodelica_frontend_dump::ExpressionBasics::printExpStr(expr.clone())
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
+            ZcInfo::Bool { expr } => dump_exp(expr),
             ZcInfo::Math { .. } => String::new(),
         })
         .collect()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -245,6 +245,10 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// output row the emitted `simulate` loop just stored — the driver's per-row
 /// `LOG_ASSERT` step, which that loop cannot reach from wasm. `warn` selects the
 /// level; a nonzero result means a suppressed `assert()` ends the run.
+///
+/// `rt_reinit_note(state_off, value)` records an executed `reinit` for the driver's
+/// `LOG_EVENTS` block; C prints that line from the model itself, but the block's
+/// indentation belongs to whichever driver owns the run.
 pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     (
         "rt_assert",
@@ -258,6 +262,7 @@ pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     ),
     ("rt_print", &[WTy::I32], &[]),
     ("rt_row_asserts", &[WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_reinit_note", &[WTy::I32, WTy::F64], &[]),
 ];
 
 /// Absolute wasm function index of an `ENV_EXTRA` import (after the `BUILTINS`
@@ -1893,7 +1898,8 @@ impl<'a> FnCtx<'a> {
             W::ASSIGN { left, right, .. } => compile_assign(self, left, right),
             W::REINIT { stateVar, value, .. } => {
                 let lhs = DAE::Exp::CREF { componentRef: stateVar.clone(), ty: crate::CodegenWasmJit::t_real() };
-                compile_assign(self, &lhs, value)
+                compile_assign(self, &lhs, value)?;
+                emit_reinit_note(self, stateVar)
             }
             // `terminate(msg)`: request a clean early end of the simulation by
             // raising the `SimData` terminate flag; the drivers poll it after each
@@ -5407,10 +5413,8 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
                 };
                 return compile_array_ew(ctx, exp1, exp2, op_code, ty);
             }
-            let a = compile_exp(ctx, exp1)?;
-            coerce(ctx, a, WTy::I32);
-            let b = compile_exp(ctx, exp2)?;
-            coerce(ctx, b, WTy::I32);
+            compile_bool_operand(ctx, exp1)?;
+            compile_bool_operand(ctx, exp2)?;
             match operator {
                 DAE::Operator::AND { .. } => ctx.emit(we::Instruction::I32And),
                 DAE::Operator::OR { .. } => ctx.emit(we::Instruction::I32Or),
@@ -5908,10 +5912,13 @@ fn compile_relation_indexed(
     // The slot address `data + eff_index*4`. A relation inside a `for`-loop shares
     // one AST node across iterations, so its effective index is
     // `index + (iterator - i)/j` (C's `daeExpRelationSim`); otherwise it is `index`.
+    // The crossing function evaluates the scalarized copies outside that loop, so
+    // the iterator does not exist there and it keeps the base `index`, as C does.
+    let zc_context = ctx.sim()?.zc_context;
     let slot = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::LocalGet(data));
     ctx.emit(we::Instruction::I32Const(index));
-    if let Some((iter, i, j)) = asub {
+    if let Some((iter, i, j)) = asub.as_ref().filter(|_| !zc_context) {
         let w = compile_exp(ctx, iter)?;
         coerce(ctx, w, WTy::I32);
         ctx.emit(we::Instruction::I32Const(*i));
@@ -5924,7 +5931,7 @@ fn compile_relation_indexed(
     ctx.emit(we::Instruction::I32Mul);
     ctx.emit(we::Instruction::I32Add); // data + eff_index*4
     ctx.emit(we::Instruction::LocalSet(slot));
-    if ctx.sim()?.zc_context {
+    if zc_context {
         if real_ineq {
             compile_relation_hyst(ctx, e1, op, e2, slot, dir_off)?;
         } else {
@@ -6063,10 +6070,17 @@ fn nominal_const(e: &DAE::Exp) -> f64 {
 fn compile_relation_fresh(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2: &DAE::Exp) -> Result<WTy> {
     use DAE::Operator as O;
     let operand_wty = operand_type_of_relation(op)?;
-    let a = compile_exp(ctx, e1)?;
-    coerce(ctx, a, operand_wty);
-    let b = compile_exp(ctx, e2)?;
-    coerce(ctx, b, operand_wty);
+    if matches!(relation_operand_sigty(op), Ok(SigTy::Bool)) {
+        // C compares Booleans through `!`, so a value outside {0,1} still compares
+        // by truth value.
+        compile_bool_operand(ctx, e1)?;
+        compile_bool_operand(ctx, e2)?;
+    } else {
+        let a = compile_exp(ctx, e1)?;
+        coerce(ctx, a, operand_wty);
+        let b = compile_exp(ctx, e2)?;
+        coerce(ctx, b, operand_wty);
+    }
     let instr = match (op, operand_wty) {
         (O::LESS { .. }, WTy::F64) => we::Instruction::F64Lt,
         (O::LESS { .. }, WTy::I32) => we::Instruction::I32LtS,
@@ -6088,6 +6102,20 @@ fn compile_relation_fresh(ctx: &mut FnCtx, e1: &DAE::Exp, op: &DAE::Operator, e2
 
 fn operand_type_of_relation(op: &DAE::Operator) -> Result<WTy> {
     Ok(relation_operand_sigty(op)?.wty())
+}
+
+/// Compile a Boolean operand of `and`/`or`/a Boolean relation as a 0/1 i32. C's
+/// `!e`/`e && f` take any nonzero as true and an `external "C"` output can be such
+/// a value, so the truth value is materialized unless the form already gives it.
+fn compile_bool_operand(ctx: &mut FnCtx, e: &DAE::Exp) -> Result<()> {
+    use DAE::Exp as E;
+    let w = compile_exp(ctx, e)?;
+    coerce(ctx, w, WTy::I32);
+    if !matches!(e, E::BCONST { .. } | E::RELATION { .. } | E::LBINARY { .. } | E::LUNARY { .. }) {
+        ctx.emit(we::Instruction::I32Const(0));
+        ctx.emit(we::Instruction::I32Ne);
+    }
+    Ok(())
 }
 
 /// The `SigTy` of a relational operator's operands (distinguishes String, whose
@@ -7054,6 +7082,22 @@ fn emit_str_literal(ctx: &mut FnCtx, bytes: &[u8]) -> Result<()> {
     ctx.emit(we::Instruction::I32Const(len as i32));
     ctx.emit(we::Instruction::MemoryInit { mem: 0, data_index: 0 });
     ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// Hand the executed `reinit` to the driver for C's `reinit <var> = <value>` line.
+/// The state's `SimData` offset names it; the value is re-read from the slot.
+fn emit_reinit_note(ctx: &mut FnCtx, stateVar: &DAE::ComponentRef) -> Result<()> {
+    let key = sim_cref_key(stateVar)?;
+    let Some(slot) = ctx.sim()?.vars.get(&key).copied() else { return Ok(()) };
+    if slot.wty != WTy::F64 {
+        return Ok(());
+    }
+    let data = ctx.sim()?.data_local;
+    ctx.emit(we::Instruction::I32Const(slot.off as i32));
+    ctx.emit(we::Instruction::LocalGet(data));
+    ctx.emit(we::Instruction::F64Load(mem_arg(slot.off, 3)));
+    ctx.emit(we::Instruction::Call(env_extra_index("rt_reinit_note")?));
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -2571,141 +2571,140 @@ pub extern "C" fn rt_solve_nls(
     // Last residual eval was at the returned `x`, so the epilogue need not repeat
     // it to leave the slots and torn variables set.
     let mut settled = false;
-    // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
-    // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
-    // O(n^3) per step, which is what the sparse choice exists to avoid.
-    let converged = if sparse {
-        kinsol_sparse_solve(
-            n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
-            pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
-        )
-    } else if pick == Nls::Newton {
-        solve_newton_c(
-            n, &mut x, &warm, &nominal, &mut res_scaling, discrete_call, &mut eval, &mut jaceval,
-            has_jac,
-        )
-    } else if pick == Nls::Homotopy {
-        // Both start directions, as C's runHomotopy.
-        let mut ok = false;
-        for &dir in &[1.0f64, -1.0] {
-            let mut hx = guess.clone();
-            if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
-                x.copy_from_slice(&hx);
-                ok = true;
-                break;
-            }
-        }
-        ok
-    } else {
-        // C's default `NLS_MIXED` runs `solveHomotopy`, whose primary solver is
-        // `newtonAlgorithm`; minpack `hybrd` is only its fallback, restarted from the
-        // same start point. `-nls=hybrid` selects `solveHybrd` alone and skips ahead.
-        // Both share the retry/homotopy tail below.
-        let start = x.clone();
-        // C's `nlsx`, which `solveHomotopy` overwrites with the start point its entry
-        // phase settled on. `solveHybrd` restarts from that, not from the raw guess.
-        let mut nlsx = start.clone();
-        let mut converged = false;
-        if matches!(pick, Nls::Default | Nls::Mixed) {
-            (converged, settled) = newton_c(
-                n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
-                has_jac,
-            );
-            if !converged {
-                stat_inc(STAT_NLS_NEWTON_FAIL);
-                x.copy_from_slice(&start);
-            }
-        }
-        settled &= converged;
-        // C's `solveHomotopy` on `newtonAlgorithm`'s `info == -1`.
-        if !converged {
-            stat_inc(STAT_NLS_RETRY);
-            // C's `discreteCall` is set for an initial system too; only an event call
-            // has relations to hold, so only there does the continuity flag move.
-            let mut set_cont = |c: bool| {
-                if saved_rel_fresh == 1 {
-                    unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
-                }
-            };
-            converged = hybrd_c(
-                n, &mut x, &nlsx, &warm, &nominal, &bounds, saved_rel_fresh != 0, &mut eval,
-                &mut set_cont,
-            );
-        }
-        // The rungs below are not `solveHomotopy`'s; they catch what C gives up on.
-        // `nls_accept` takes only a point at tolerance, so none can report a non-root.
-        if !converged {
-            stat_inc(STAT_NLS_RETRY);
-            x.copy_from_slice(&warm);
-            converged = newton_solve(n, &mut x, &mut eval);
-        }
-        // An initial system gets a second `newtonAlgorithm`, from `x0`.
-        if !converged && saved_rel_fresh == 2 {
-            x.copy_from_slice(&guess);
-            converged = newton_c(
-                n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
+    // C's `alreadyTested`: the mixed re-check below fires at most once.
+    let mut retried = false;
+    // C's `x0`, which the mixed retry restarts from.
+    let start_point = x.clone();
+    let converged = loop {
+        // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
+        // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
+        // O(n^3) per step, which is what the sparse choice exists to avoid.
+        let converged = if sparse {
+            kinsol_sparse_solve(
+                n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
+                pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
+            )
+        } else if pick == Nls::Newton {
+            solve_newton_c(
+                n, &mut x, &warm, &nominal, &mut res_scaling, discrete_call, &mut eval, &mut jaceval,
                 has_jac,
             )
-            .0;
-        }
-        if !converged {
-            stat_inc(STAT_NLS_RETRY);
-            converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-        }
-        if !converged {
-            x.copy_from_slice(&guess);
-            converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-        }
-        if !converged {
-            x.copy_from_slice(&guess);
-            converged = lm_solve(n, &mut x, &mut eval);
-        }
-        if !converged {
-            x.copy_from_slice(&warm);
-            converged = lm_solve(n, &mut x, &mut eval);
-        }
-        // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
-        if !converged && saved_rel_fresh == 2 {
-            // Forward then reversed start direction, as C's runHomotopy.
-            for &dir in &[1.0f64, -1.0f64] {
+        } else if pick == Nls::Homotopy {
+            // Both start directions, as C's runHomotopy.
+            let mut ok = false;
+            for &dir in &[1.0f64, -1.0] {
                 let mut hx = guess.clone();
                 if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
                     x.copy_from_slice(&hx);
-                    converged = true;
+                    ok = true;
                     break;
                 }
             }
-        }
-        converged
-    };
-    if converged {
-        // Leave the slots + torn variables at the solution. C's `solveHomotopy`: a
-        // mixed system at an event re-checks the relations live at the solution and,
-        // if the branch moved, re-solves once from the start point with them live.
-        if mixed {
-            unsafe { store_u32(rel_fresh_addr, 1) };
-            eval(&x, &mut scratch);
-            if (0..n_rel).any(|i| unsafe { load_u32(rel_addr + i * 4) } != rel_backup[i as usize]) {
-                let held = core::mem::replace(&mut x, warm.clone());
-                let ok = if sparse {
-                    kinsol_sparse_solve(
-                        n, &mut x, &warm, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
-                        pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
-                    )
-                } else if has_jac {
-                    hybrj_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval, &mut jaceval)
-                } else {
-                    hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval)
-                };
-                if !ok {
-                    x = held;
+            ok
+        } else {
+            // C's default `NLS_MIXED` runs `solveHomotopy`, whose primary solver is
+            // `newtonAlgorithm`; minpack `hybrd` is only its fallback, restarted from the
+            // same start point. `-nls=hybrid` selects `solveHybrd` alone and skips ahead.
+            // Both share the retry/homotopy tail below.
+            let start = x.clone();
+            // C's `nlsx`, which `solveHomotopy` overwrites with the start point its entry
+            // phase settled on. `solveHybrd` restarts from that, not from the raw guess.
+            let mut nlsx = start.clone();
+            let mut converged = false;
+            if matches!(pick, Nls::Default | Nls::Mixed) {
+                (converged, settled) = newton_c(
+                    n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
+                    has_jac,
+                );
+                if !converged {
+                    stat_inc(STAT_NLS_NEWTON_FAIL);
+                    x.copy_from_slice(&start);
                 }
-                eval(&x, &mut scratch);
             }
-            unsafe { store_u32(rel_fresh_addr, 0) };
-        } else if !settled {
-            eval(&x, &mut scratch);
+            settled &= converged;
+            // C's `solveHomotopy` on `newtonAlgorithm`'s `info == -1`.
+            if !converged {
+                stat_inc(STAT_NLS_RETRY);
+                // C's `discreteCall` is set for an initial system too; only an event call
+                // has relations to hold, so only there does the continuity flag move.
+                let mut set_cont = |c: bool| {
+                    if saved_rel_fresh == 1 {
+                        unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
+                    }
+                };
+                converged = hybrd_c(
+                    n, &mut x, &nlsx, &warm, &nominal, &bounds, saved_rel_fresh != 0, &mut eval,
+                    &mut set_cont,
+                );
+            }
+            // The rungs below are not `solveHomotopy`'s; they catch what C gives up on.
+            // `nls_accept` takes only a point at tolerance, so none can report a non-root.
+            if !converged {
+                stat_inc(STAT_NLS_RETRY);
+                x.copy_from_slice(&warm);
+                converged = newton_solve(n, &mut x, &mut eval);
+            }
+            // An initial system gets a second `newtonAlgorithm`, from `x0`.
+            if !converged && saved_rel_fresh == 2 {
+                x.copy_from_slice(&guess);
+                converged = newton_c(
+                    n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
+                    has_jac,
+                )
+                .0;
+            }
+            if !converged {
+                stat_inc(STAT_NLS_RETRY);
+                converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+            }
+            if !converged {
+                x.copy_from_slice(&guess);
+                converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+            }
+            if !converged {
+                x.copy_from_slice(&guess);
+                converged = lm_solve(n, &mut x, &mut eval);
+            }
+            if !converged {
+                x.copy_from_slice(&warm);
+                converged = lm_solve(n, &mut x, &mut eval);
+            }
+            // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
+            if !converged && saved_rel_fresh == 2 {
+                // Forward then reversed start direction, as C's runHomotopy.
+                for &dir in &[1.0f64, -1.0f64] {
+                    let mut hx = guess.clone();
+                    if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
+                        x.copy_from_slice(&hx);
+                        converged = true;
+                        break;
+                    }
+                }
+            }
+            converged
+        };
+        // C's `solveHomotopy` mixed tail: relations live at the solution, and if the
+        // branch moved, the *same* ladder again from the start point with them live.
+        if !converged || !mixed || retried {
+            break converged;
         }
+        unsafe { store_u32(rel_fresh_addr, 1) };
+        eval(&x, &mut scratch);
+        settled = true;
+        if (0..n_rel).all(|i| unsafe { load_u32(rel_addr + i * 4) } == rel_backup[i as usize]) {
+            break converged;
+        }
+        retried = true;
+        settled = false;
+        x.copy_from_slice(&start_point);
+    };
+    if retried {
+        // `hybrd_c`'s rung may have left the flag held.
+        unsafe { store_u32(rel_fresh_addr, 1) };
+    }
+    // Leave the slots + torn variables at the solution.
+    if converged && !settled {
+        eval(&x, &mut scratch);
     }
     for i in 0..n {
         unsafe { store_f64(scale_addr + (i * 8) as u32, res_scaling[i]) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -31,6 +31,8 @@ unsafe extern "C" {
     /// Copy up to `max` of the violations the model left with the host's
     /// `rt_assert`/`rt_assert_warning` (which it imports either way) to `ptr`.
     fn rt_host_take_warnings(ptr: u32, max: u32) -> u32;
+    /// Same for the `reinit`s the model recorded with `rt_reinit_note`.
+    fn rt_host_take_reinits(ptr: u32, max: u32) -> u32;
     /// Open/close C's `noThrowAsserts` phase, on the host: that is where
     /// `rt_assert` lives, whichever driver runs.
     fn rt_host_set_no_throw(v: i32);
@@ -131,6 +133,17 @@ impl SimEngine for InWasmEngine {
         loop {
             let mut buf = [[0i32; 9]; 8];
             let n = unsafe { rt_host_take_warnings(buf.as_mut_ptr() as u32, buf.len() as u32) } as usize;
+            out.extend_from_slice(&buf[..n.min(buf.len())]);
+            if n < buf.len() {
+                return out;
+            }
+        }
+    }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        let mut out = Vec::new();
+        loop {
+            let mut buf = [(0u32, 0.0f64); 8];
+            let n = unsafe { rt_host_take_reinits(buf.as_mut_ptr() as u32, buf.len() as u32) } as usize;
             out.extend_from_slice(&buf[..n.min(buf.len())]);
             if n < buf.len() {
                 return out;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -140,6 +140,9 @@ impl SimEngine for StandaloneEngine {
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> driver::Result<u32> {
         Ok(unsafe { simulate(sim_data, start, stop, n_steps) })
     }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        core::mem::take(unsafe { &mut *REINITS.0.get() })
+    }
     fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
         // No host to record it; a failed model assert traps (see `rt_assert`).
         None
@@ -309,6 +312,19 @@ pub extern "C" fn rt_print(handle: i32) {
         let mut out = std::io::stdout();
         let _ = out.write_all(bytes);
         let _ = out.flush();
+    }
+}
+
+/// Executed `reinit`s awaiting the driver's `LOG_EVENTS` block; single-threaded.
+struct Reinits(core::cell::UnsafeCell<Vec<(u32, f64)>>);
+unsafe impl Sync for Reinits {}
+static REINITS: Reinits = Reinits(core::cell::UnsafeCell::new(Vec::new()));
+
+/// In-wasm `rt_reinit_note`, the standalone counterpart of the host import.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_reinit_note(off: i32, value: f64) {
+    if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::EVENTS) {
+        unsafe { &mut *REINITS.0.get() }.push((off as u32, value));
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -263,6 +263,11 @@ pub trait SimEngine {
     fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         Vec::new()
     }
+    /// Take the `reinit`s the model executed since the last call, as `(state
+    /// SimData offset, value)`, for the event's `LOG_EVENTS` block. Default: none.
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        Vec::new()
+    }
     /// Linear-system solves the runtime performed in-wasm, which the host driver
     /// never sees. Default: none (backends whose solver runs host-side).
     fn lin_solves(&mut self) -> u64 {
@@ -684,7 +689,7 @@ fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
         omclog::DEBUG_TYPE,
         omclog::ASSERT,
         false,
-        &alloc::format!(
+        &format!(
             "Solving non-linear system {} failed at time={}.\nFor more information please use -lv LOG_NLS.",
             failed - 1,
             format_g15(time),
@@ -998,7 +1003,7 @@ mod steady_report {
 
 /// Format `%f`-style (C's `%f`: 6 fractional digits), for the assertion time value.
 pub(crate) fn format_f(v: f64) -> String {
-    alloc::format!("{v:.6}")
+    format!("{v:.6}")
 }
 
 fn format_g15(v: f64) -> String {
@@ -1009,7 +1014,7 @@ fn format_g15(v: f64) -> String {
 /// zeros and a bare decimal point trimmed.
 pub fn format_g(v: f64, p: i32) -> String {
     if !v.is_finite() || v == 0.0 {
-        return alloc::format!("{v}");
+        return format!("{v}");
     }
     let exp = libm::floor(libm::log10(libm::fabs(v))) as i32;
     let trim = |s: String| -> String {
@@ -1019,10 +1024,10 @@ pub fn format_g(v: f64, p: i32) -> String {
         s.trim_end_matches('0').trim_end_matches('.').to_string()
     };
     if exp < -4 || exp >= p {
-        let m = trim(alloc::format!("{:.*}", (p - 1) as usize, v / libm::pow(10.0, exp as f64)));
-        return alloc::format!("{m}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs());
+        let m = trim(format!("{:.*}", (p - 1) as usize, v / libm::pow(10.0, exp as f64)));
+        return format!("{m}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs());
     }
-    trim(alloc::format!("{:.*}", (p - 1 - exp).max(0) as usize, v))
+    trim(format!("{:.*}", (p - 1 - exp).max(0) as usize, v))
 }
 
 /// Evaluate `functionCheckAsserts` (C's `checkForAsserts`) at the current point and
@@ -1070,7 +1075,7 @@ fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: omclog::LogType) -
             rethrow_store::arm(info);
             armed = true;
         } else {
-            let key = alloc::format!("{}:{sl}:{sc}-{el}:{ec}|{cond}", info.file);
+            let key = format!("{}:{sl}:{sc}-{el}:{ec}|{cond}", info.file);
             if assert_warn_store::first_time(key) {
                 omclog::message_text(ty, omclog::ASSERT, false, &line);
             }
@@ -1094,7 +1099,7 @@ pub fn row_asserts(e: &mut dyn SimEngine, sim_data: u32, warn: i32) -> i32 {
 fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> String {
     let during = if initial { "during initialization " } else { "" };
     let t = format_f(time);
-    let head = alloc::format!("The following assertion has been violated {during}at time {t}");
+    let head = format!("The following assertion has been violated {during}at time {t}");
     // A generated `assert()` always names its condition, and C prints it with the
     // message as one message's second line — including for a backend-generated
     // variable, whose `FILE_INFO` is empty (`$finalCon$…`'s min/max guard). A
@@ -1102,12 +1107,12 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> Stri
     if cond.is_empty() {
         return head;
     }
-    let body = alloc::format!("(({cond})) --> \"{}\"", info.msg);
+    let body = format!("(({cond})) --> \"{}\"", info.msg);
     if info.file.is_empty() {
-        return alloc::format!("{head}\n{body}");
+        return format!("{head}\n{body}");
     }
     let ro_str = if info.read_only { "readonly" } else { "writable" };
-    alloc::format!(
+    format!(
         "[{}:{}:{}-{}:{}:{ro_str}]\n{head}\n{body}",
         info.file, info.line_start, info.col_start, info.line_end, info.col_end,
     )
@@ -1231,7 +1236,15 @@ pub fn run_initialization(
     inputs: &[crate::InputVar],
     start_time: f64,
 ) -> Result<()> {
-    init_model(e, sim_data, layout, inputs, start_time)?;
+    init_model(e, sim_data, layout, inputs, start_time, None)?;
+    signal_init_done();
+    Ok(())
+}
+
+/// [`run_initialization`] where the caller has the metadata the `LOG_SOTI` dump
+/// and the discrete start attributes need.
+pub fn run_initialization_model(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) -> Result<()> {
+    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model))?;
     signal_init_done();
     Ok(())
 }
@@ -1243,11 +1256,12 @@ pub fn run_initialization_with_clocks(
     sim_data: u32,
     model: &SimMeta,
 ) -> Result<crate::sync::Sync> {
-    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time)?;
+    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model))?;
     let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
     // An event clock whose `when` already fired during the initial discrete update
     // is only *scheduled* here (C's `data->simulationInfo->initial` case).
     sync.take_fired(e, model.start_time)?;
+    log_event_status(e, sim_data, model, omclog::EVENTS)?;
     signal_init_done();
     Ok(sync)
 }
@@ -1258,13 +1272,17 @@ fn init_model(
     layout: &SimLayout,
     inputs: &[crate::InputVar],
     start_time: f64,
+    model: Option<&SimMeta>,
 ) -> Result<()> {
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
     write_i32(e, sim_data + layout.initial_off, 1)?;
-    run_initialization_impl(e, sim_data, layout, inputs)?;
+    run_initialization_impl(e, sim_data, layout, inputs, model)?;
+    if let Some(m) = model {
+        dump_initial_solution(e, sim_data, m);
+    }
     // C's `storePreValues` after the initial solve (initialization.c:903).
     seed_pre_from_live(e, sim_data, layout)?;
     // Seed the continuous phase's held relations from a full discrete fixed point.
@@ -1278,8 +1296,8 @@ fn init_model(
     e.call1_if_present("functionStoreDelayed", sim_data)?;
     if layout.n_zc > 0 {
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-        e.call1("functionZeroCrossings", sim_data)?;
         save_zc_pre(e, sim_data, layout)?;
+        e.call1("functionZeroCrossings", sim_data)?;
     }
     write_i32(e, sim_data + layout.initial_off, 0)?;
     // C's `initializeModel` ends with `checkForAsserts` — before the
@@ -1293,6 +1311,7 @@ fn run_initialization_impl(
     sim_data: u32,
     layout: &SimLayout,
     inputs: &[crate::InputVar],
+    model: Option<&SimMeta>,
 ) -> Result<()> {
     // C's `updateStaticDataOfNonlinearSystems`.
     omclog::info(omclog::NLS, true, "update static data of non-linear system solvers");
@@ -1304,7 +1323,7 @@ fn run_initialization_impl(
     set_no_throw(false);
     term_report::reset();
     steady_report::reset();
-    seed_start_values(e, sim_data, layout, inputs)?;
+    seed_start_values(e, sim_data, layout, inputs, model)?;
 
     // C's `IIM_NONE`: every variable keeps its start value, the initial system is
     // never solved. C still marks the systems solved before it picks the method.
@@ -1336,7 +1355,7 @@ fn run_initialization_impl(
     // C's catch arm resets everything to start before the continuation runs.
     init_report::reset();
     let _ = rethrow_store::take();
-    seed_start_values(e, sim_data, layout, inputs)?;
+    seed_start_values(e, sim_data, layout, inputs, model)?;
     run_homotopy_continuation(e, sim_data, layout)?;
     init_report::set_homotopy_steps(homotopy_steps() as u32);
     Ok(())
@@ -1350,6 +1369,7 @@ fn seed_start_values(
     sim_data: u32,
     layout: &SimLayout,
     inputs: &[crate::InputVar],
+    model: Option<&SimMeta>,
 ) -> Result<()> {
     e.call1("functionParameters", sim_data)?;
     // Params first (a start expression may read one), then the start attributes —
@@ -1360,7 +1380,7 @@ fn seed_start_values(
     apply_external_input(e, sim_data, inputs)?;
     e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
     apply_start_overrides(e, sim_data)?;
-    set_all_vars_to_start(e, sim_data, layout)?;
+    set_all_vars_to_start(e, sim_data, layout, model)?;
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
     // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
@@ -1448,12 +1468,12 @@ fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bo
         // C prints the source position raw (`printInfo`), outside the message system.
         if !file.is_empty() {
             let ro = if w(6)? != 0 { "readonly" } else { "writable" };
-            log_line(&alloc::format!("[{file}:{}:{}-{}:{}:{ro}]\n", w(2)?, w(3)?, w(4)?, w(5)?));
+            log_line(&format!("[{file}:{}:{}-{}:{}:{ro}]\n", w(2)?, w(3)?, w(4)?, w(5)?));
         }
         omclog::info(
             omclog::STDOUT,
             false,
-            &alloc::format!(
+            &format!(
                 "Simulation call terminate() at time {}\nMessage : {msg}",
                 format_f(read_f64(e, sim_data + TIME_OFF)?),
             ),
@@ -1487,7 +1507,7 @@ fn steady_state_reached(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
     omclog::info(
         omclog::STDOUT,
         false,
-        &alloc::format!(
+        &format!(
             "steady state reached at time = {}\n  * max(|d(x_i)/dt|/nominal(x_i)) = {}\n  * \
              relative tolerance = {}",
             format_g(read_f64(e, sim_data + TIME_OFF)?, 6),
@@ -1690,7 +1710,17 @@ fn apply_external_input(
 
 /// C's `setAllVarsToStart` for the reals: every real variable takes its `start`
 /// attribute. Integer/Boolean/String starts are still the emitted equations'.
-fn set_all_vars_to_start(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+fn set_all_vars_to_start(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, model: Option<&SimMeta>) -> Result<()> {
+    // The discrete `start` attributes are constants, so they are metadata rather
+    // than a `SimData` region; C reads them out of the `_init.xml`.
+    if let Some(m) = model {
+        for (i, (_, start)) in m.soti.ints.iter().enumerate() {
+            write_i32(e, sim_data + layout.int_off + i as u32 * 4, *start)?;
+        }
+        for (i, (_, start)) in m.soti.bools.iter().enumerate() {
+            write_i32(e, sim_data + layout.bool_off + i as u32 * 4, *start)?;
+        }
+    }
     let bytes = ((2 * layout.n_states + layout.n_real_alg) * 8) as usize;
     if bytes == 0 {
         return Ok(());
@@ -1752,6 +1782,168 @@ fn refresh_relations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -
     store_relations(e, sim_data, layout)
 }
 
+/// C's `dumpInitialSolution` (`initialization.c`): the `LOG_SOTI` block, printed
+/// after the initial system is solved and *before* the pre-values are stored — so
+/// a derivative still reads `(pre: 0)`.
+fn dump_initial_solution(e: &dyn SimEngine, sim_data: u32, model: &SimMeta) {
+    if !omclog::active(omclog::SOTI) {
+        return;
+    }
+    let layout = &model.layout;
+    let soti = &model.soti;
+    let n = layout.n_states as usize;
+    let real = |off: u32| read_f64(e, sim_data + off).unwrap_or(0.0);
+    let pre_real = |off: u32| layout.pre_slot_off(off).map_or(0.0, |p| real(p));
+    let g = |v: f64| format_g(v, 6);
+    omclog::info(omclog::SOTI, true, "### SOLUTION OF THE INITIALIZATION ###");
+    let real_line = |i: usize| {
+        let off = REAL_OFF + i as u32 * 8;
+        let (name, nom) = &soti.reals[i];
+        let nom = if i < n { real(layout.state_nom_off + i as u32 * 8) } else { *nom };
+        format!(
+            "[{}] Real {name}(start={}, nominal={}) = {} (pre: {})",
+            i + 1,
+            g(real(layout.real_start_off(i as u32))),
+            g(nom),
+            g(real(off)),
+            g(pre_real(off))
+        )
+    };
+    if n > 0 && soti.reals.len() >= 2 * n {
+        omclog::info(omclog::SOTI, true, "states variables");
+        for i in 0..n {
+            omclog::info(omclog::SOTI, false, &real_line(i));
+        }
+        omclog::close(omclog::SOTI);
+        omclog::info(omclog::SOTI, true, "derivatives variables");
+        for i in n..2 * n {
+            let off = REAL_OFF + i as u32 * 8;
+            let name = &soti.reals[i].0;
+            let line = format!("[{}] Real {name} = {} (pre: {})", i + 1, g(real(off)), g(pre_real(off)));
+            omclog::info(omclog::SOTI, false, &line);
+        }
+        omclog::close(omclog::SOTI);
+    }
+    if soti.reals.len() > 2 * n {
+        omclog::info(omclog::SOTI, true, "other real variables");
+        for i in 2 * n..soti.reals.len() {
+            omclog::info(omclog::SOTI, false, &real_line(i));
+        }
+        omclog::close(omclog::SOTI);
+    }
+    let i32_at = |off: u32| read_i32(e, sim_data + off).unwrap_or(0);
+    let pre_i32 = |off: u32| layout.pre_slot_off(off).map_or(0, |p| i32_at(p));
+    if !soti.ints.is_empty() {
+        omclog::info(omclog::SOTI, true, "integer variables");
+        for (i, (name, start)) in soti.ints.iter().enumerate() {
+            let off = layout.int_off + i as u32 * 4;
+            let line =
+                format!("[{}] Integer {name}(start={start}) = {} (pre: {})", i + 1, i32_at(off), pre_i32(off));
+            omclog::info(omclog::SOTI, false, &line);
+        }
+        omclog::close(omclog::SOTI);
+    }
+    if !soti.bools.is_empty() {
+        omclog::info(omclog::SOTI, true, "boolean variables");
+        let b = |v: i32| if v != 0 { "true" } else { "false" };
+        for (i, (name, start)) in soti.bools.iter().enumerate() {
+            let off = layout.bool_off + i as u32 * 4;
+            let line = format!(
+                "[{}] Boolean {name}(start={}) = {} (pre: {})",
+                i + 1,
+                b(*start),
+                b(i32_at(off)),
+                b(pre_i32(off))
+            );
+            omclog::info(omclog::SOTI, false, &line);
+        }
+        omclog::close(omclog::SOTI);
+    }
+    if !soti.strings.is_empty() {
+        omclog::info(omclog::SOTI, true, "string variables");
+        for (i, (name, start)) in soti.strings.iter().enumerate() {
+            let cur = read_rt_string(e, i32_at(layout.str_off + i as u32 * 4)).unwrap_or_default();
+            let line = format!("[{}] String {name}(start=\"{start}\") = \"{cur}\" (pre: \"{cur}\")", i + 1);
+            omclog::info(omclog::SOTI, false, &line);
+        }
+        omclog::close(omclog::SOTI);
+    }
+    omclog::close(omclog::SOTI);
+}
+
+/// C's `perform_simulation` event header plus `handleEvents`' crossing list. Left
+/// open until the discrete update has run, so the model's `reinit` lines land in it.
+fn log_state_event(time: f64, roots: &[usize], model: &SimMeta) {
+    if !omclog::active(omclog::EVENTS) {
+        return;
+    }
+    omclog::info(omclog::EVENTS, true, &format!("state event at time={}", format_g(time, 12)));
+    for &i in roots {
+        let desc = model.zc_desc.get(i).map(String::as_str).unwrap_or_default();
+        omclog::info(omclog::EVENTS, false, &format!("[{}] {desc}", i + 1));
+    }
+}
+
+/// C's `algStmtReinit` message, from what the model recorded during the update.
+fn log_reinits(e: &mut dyn SimEngine, model: &SimMeta) {
+    for (off, value) in e.take_pending_reinits() {
+        if !omclog::active(omclog::EVENTS) {
+            continue;
+        }
+        let col = 1 + off.saturating_sub(REAL_OFF) / 8; // column 0 is `time`
+        let name = model
+            .vars
+            .iter()
+            .find(|v| matches!(v.kind, ResultKind::Column { col: c, negate: false } if c == col))
+            .map(|v| v.name.as_str())
+            .unwrap_or_default();
+        omclog::info(omclog::EVENTS, false, &format!("reinit {name} = {}", format_g(value, 6)));
+    }
+}
+
+/// [`log_state_event`] for a time event: C names the samples that fired.
+fn log_time_event(time: f64, samples: &Samples, model: &SimMeta) {
+    if !omclog::active(omclog::EVENTS) {
+        return;
+    }
+    omclog::info(omclog::EVENTS, true, &format!("time event at time={}", format_g(time, 12)));
+    for (k, start, interval) in samples.due(time) {
+        let index = model.sample_index.get(k).copied().unwrap_or(k as i32 + 1);
+        omclog::info(
+            omclog::EVENTS,
+            false,
+            &format!("[{index}] sample({}, {})", format_g(start, 6), format_g(interval, 6)),
+        );
+    }
+}
+
+/// C's `printRelations` + `printZeroCrossings` (`model_help.c`), which
+/// `initializeModel` ends with on `LOG_EVENTS`.
+pub fn log_event_status(e: &dyn SimEngine, sim_data: u32, model: &SimMeta, stream: omclog::Stream) -> Result<()> {
+    if !omclog::active(stream) {
+        return Ok(());
+    }
+    let layout = &model.layout;
+    let time = format_g(read_f64(e, sim_data + TIME_OFF)?, 12);
+    omclog::info(stream, true, &format!("status of relations at time={time}"));
+    for i in 0..layout.n_rel {
+        let flag = |off: u32| if read_i32(e, sim_data + off + i * 4).unwrap_or(0) != 0 { " true" } else { "false" };
+        let desc = model.rel_desc.get(i as usize).map(String::as_str).unwrap_or_default();
+        let (pre, cur) = (flag(layout.relations_pre_off), flag(layout.relations_off));
+        omclog::info(stream, false, &format!("[{}] (pre: {pre}) {cur} = {desc}", i + 1));
+    }
+    omclog::close(stream);
+    omclog::info(stream, true, &format!("status of zero crossings at time={time}"));
+    for i in 0..layout.n_zc {
+        let g = |off: u32| omclog::g(read_f64(e, sim_data + off + i * 8).unwrap_or(0.0), 2, 1);
+        let desc = model.zc_desc.get(i as usize).map(String::as_str).unwrap_or_default();
+        let (pre, cur) = (g(layout.zc_pre_off), g(layout.zc_off));
+        omclog::info(stream, false, &format!("[{}] (pre: {pre}) {cur} = {desc}", i + 1));
+    }
+    omclog::close(stream);
+    Ok(())
+}
+
 /// Copy `relations[]` into `relationsPre`. Freezing it before an event-iteration
 /// pass keeps held relations fixed while that pass's NLS solve runs.
 fn update_relations_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
@@ -1787,6 +1979,11 @@ fn eval_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout,
 /// event lies in the bracketed interval.
 fn zc_crossed(a: &[f64], b: &[f64]) -> bool {
     a.iter().zip(b).any(|(&x, &y)| (x < 0.0) != (y < 0.0))
+}
+
+/// Which crossings changed sign — C's `eventLst`.
+fn zc_crossed_idx(a: &[f64], b: &[f64]) -> Vec<usize> {
+    a.iter().zip(b).enumerate().filter(|(_, (x, y))| (**x < 0.0) != (**y < 0.0)).map(|(i, _)| i).collect()
 }
 
 /// Bisect `(t0, t1]` for the earliest zero-crossing, given the values `zc0` at `t0`
@@ -1844,7 +2041,9 @@ pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &Si
     // this pass's relations, then re-evaluates the continuous system; the discrete
     // state settles across passes. Comparing the snapshot before and after the
     // evaluation lets an already-settled system stop after a single evaluation.
-    for iter in 0..max_event_iter() {
+    let max = max_event_iter();
+    let mut iter = 0usize;
+    loop {
         let prev = discrete_snapshot(e, sim_data, layout)?;
         // C's `updateDiscreteSystem` `storePreValues`: make this pass's discrete
         // values visible as `pre()` to the next (e.g. a clutch's `pre(mode)`).
@@ -1854,10 +2053,21 @@ pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &Si
         update_relations_pre(e, sim_data, layout)?;
         eval_discrete(e, sim_data, layout)?;
         if discrete_snapshot(e, sim_data, layout)? == prev {
-            break;
+            return Ok(());
+        }
+        iter += 1;
+        if iter > max {
+            omclog::message_text(
+                omclog::DEBUG_TYPE,
+                omclog::ASSERT,
+                false,
+                &format!(
+                    "Simulation terminated due to too many, i.e. {max}, event iterations.\n                     This could either indicate an inconsistent system or an undersized limit of                      event iterations.\nThe limit of event iterations can be specified using the                      runtime flag '\u{2013}mei=<value>'."
+                ),
+            );
+            return Err(ASSERT_ERR);
         }
     }
-    Ok(())
 }
 
 /// Per-sample time-event state: each sample's next firing time and its interval,
@@ -1868,6 +2078,8 @@ pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &Si
 pub struct Samples {
     /// Next firing time per sample (starts at the sample's `start`).
     next: Vec<f64>,
+    /// C's `samplesInfo[i].start`, kept for the `LOG_EVENTS` time-event line.
+    start: Vec<f64>,
     interval: Vec<f64>,
     /// Absolute address of the `active` flag array (`sim_data + sample_active_off`).
     active_off: u32,
@@ -1887,11 +2099,21 @@ impl Samples {
             interval.push(read_f64(e, base + 8)?);
         }
         Ok(Samples {
+            start: next.clone(),
             next,
             interval,
             active_off: sim_data + layout.sample_active_off,
             dae: layout.dae_mode(),
         })
+    }
+
+    /// The samples due at `t` as `(k, start, interval)`, C's `handleEvents`
+    /// `LOG_EVENTS` line.
+    pub fn due(&self, t: f64) -> impl Iterator<Item = (usize, f64, f64)> + '_ {
+        let eps = t.abs().max(1.0) * 1e-10;
+        (0..self.next.len())
+            .filter(move |&k| self.next[k] <= t + eps)
+            .map(move |k| (k, self.start[k], self.interval[k]))
     }
 
     /// Time of the next sample event (min of `next`), or +inf if there are none.
@@ -2169,7 +2391,7 @@ pub fn make_driver(
     omclog::info(
         omclog::NLS,
         false,
-        &alloc::format!("{} non-linear systems", model.nls_vars.len()),
+        &format!("{} non-linear systems", model.nls_vars.len()),
     );
     omclog::close(omclog::NLS);
     let layout = &model.layout;
@@ -2242,7 +2464,7 @@ pub fn finalize_run(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> R
         omclog::warning(
             omclog::STDOUT,
             false,
-            &alloc::format!(
+            &format!(
                 "Steady state has not been reached.\nThis may be due to too restrictive relative \
                  tolerance ({}) or short stopTime ({}).",
                 format_g(tol, 6),
@@ -2322,7 +2544,7 @@ pub fn drive(
             }
             #[cfg(all(ipopt, feature = "std"))]
             {
-                run_initialization(e, sim_data, layout, &model.inputs, start)
+                run_initialization_model(e, sim_data, model)
                     .map_err(|err| enrich_trap_init(e, err, start))?;
                 return crate::optimization::run_optimizer(e, model, sim_data)
                     .map_err(|err| enrich_trap(e, err));
@@ -2334,7 +2556,7 @@ pub fn drive(
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
-            let mut rows = run_wasm(e, sim_data, n_reals, n_rows, layout, &model.inputs, start, stop, &mut stats)?;
+            let mut rows = run_wasm(e, sim_data, n_reals, n_rows, model, start, stop, &mut stats)?;
             emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
             return Ok(rows);
         }
@@ -2393,14 +2615,14 @@ fn run_wasm(
     sim_data: u32,
     n_reals: u32,
     n_rows: u32,
-    layout: &SimLayout,
-    inputs: &[crate::InputVar],
+    model: &SimModel,
     start: f64,
     stop: f64,
     stats: &mut SolveStats,
 ) -> Result<Vec<f64>> {
+    let layout = &model.layout;
     stats.steps = (n_rows - 1) as u64;
-    run_initialization(e, sim_data, layout, inputs, start)
+    run_initialization_model(e, sim_data, model)
         .map_err(|err| enrich_trap_init(e, err, start))?;
     open_assert_window();
     let called = e.call_simulate(sim_data, start, stop, n_rows - 1);
@@ -2434,7 +2656,7 @@ impl EulerDriver {
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2, set by run_initialization); `rt_solve_nls` still holds
         // them internally around its Newton solve.
-        run_initialization(e, sim_data, &model.layout, &model.inputs, model.start_time)?;
+        run_initialization_model(e, sim_data, model)?;
         let n_rows = model.n_output_rows();
         let n_reals = model.layout.n_row_total();
         Ok(EulerDriver {
@@ -2941,7 +3163,7 @@ fn log_dassl() -> bool {
 }
 
 fn log_dassl_step(t: f64) {
-    omclog::info(omclog::DASSL, false, &alloc::format!("new step at time = {}", format_g(t, 15)));
+    omclog::info(omclog::DASSL, false, &format!("new step at time = {}", format_g(t, 15)));
 }
 
 /// The `dassl call statistics:` block, from the work-array indices `dassl.c` reads.
@@ -2952,18 +3174,18 @@ fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
     let i = |k: usize| iwork.get(k).copied().unwrap_or(0);
     omclog::info(omclog::DASSL, true, "dassl call statistics: ");
     for l in [
-        alloc::format!("value of idid: {idid}"),
-        alloc::format!("current time value: {}", g(t)),
-        alloc::format!("current integration time value: {}", g(r(3))),
-        alloc::format!("step size H to be attempted on next step: {}", g(r(2))),
-        alloc::format!("step size used on last successful step: {}", g(r(6))),
-        alloc::format!("the order of the method used on the last step: {}", i(7)),
-        alloc::format!("the order of the method to be attempted on the next step: {}", i(8)),
-        alloc::format!("number of steps taken so far: {}", i(10)),
-        alloc::format!("number of calls of functionODE() : {}", i(11)),
-        alloc::format!("number of calculation of jacobian : {}", i(12)),
-        alloc::format!("total number of convergence test failures: {}", i(14)),
-        alloc::format!("total number of error test failures: {}", i(13)),
+        format!("value of idid: {idid}"),
+        format!("current time value: {}", g(t)),
+        format!("current integration time value: {}", g(r(3))),
+        format!("step size H to be attempted on next step: {}", g(r(2))),
+        format!("step size used on last successful step: {}", g(r(6))),
+        format!("the order of the method used on the last step: {}", i(7)),
+        format!("the order of the method to be attempted on the next step: {}", i(8)),
+        format!("number of steps taken so far: {}", i(10)),
+        format!("number of calls of functionODE() : {}", i(11)),
+        format!("number of calculation of jacobian : {}", i(12)),
+        format!("total number of convergence test failures: {}", i(14)),
+        format!("total number of error test failures: {}", i(13)),
     ] {
         omclog::info(omclog::DASSL, false, &l);
     }
@@ -3073,7 +3295,7 @@ impl DasslDriver {
         let layout = &model.layout;
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
-        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
+        run_initialization_model(e, sim_data, model)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -4031,11 +4253,23 @@ impl SolverCore {
     }
 
     /// A time event changes discrete state the derivative may depend on, so a
-    /// solver that carries its own step history has to re-initialize. DASKR only
-    /// needs it when the model has zero-crossings (the existing rule); gbode always
+    /// solver that carries its own step history has to re-initialize. gbode always
     /// does, as C's `didEventStep` is set for time events too.
     fn restart_after_time_event(&self) -> bool {
         matches!(self.solver, Solver::Gbode(_))
+    }
+
+    /// Recompute `yp` after an event, as C's `updateContinuousSystem` does: a
+    /// `reinit` otherwise leaves the next step on the pre-event derivative.
+    fn refresh_yp(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+        if self.dae {
+            return Ok(());
+        }
+        e.call1("functionODE", self.sim_data)?;
+        for i in 0..self.n_states {
+            self.yp[i] = read_f64(e, self.ders_base + (i as u32) * 8)?;
+        }
+        Ok(())
     }
 
     /// Latch `(y, yp)` from `SimData` — after initialization, or after anything
@@ -4259,6 +4493,19 @@ impl SolverCore {
     }
 
     /// The first root function that fired, for the chattering message.
+    /// Every crossing whose indicator flipped at the located root — C's `eventLst`.
+    fn roots_nonzero(&self) -> Vec<usize> {
+        let pos = |r: &[i32]| r.iter().enumerate().filter(|(_, v)| **v != 0).map(|(i, _)| i).collect();
+        match &self.solver {
+            Solver::Daskr(d) => pos(&d.jroot),
+            #[cfg(sundials)]
+            Solver::Cvode(c) => c.cv.as_ref().map(|cv| pos(cv.roots())).unwrap_or_default(),
+            #[cfg(sundials)]
+            Solver::Ida(s) => s.ida.as_ref().map(|ida| pos(ida.roots())).unwrap_or_default(),
+            Solver::Gbode(_) | Solver::Fixed(_) => vec![self.root_index()],
+        }
+    }
+
     fn root_index(&self) -> usize {
         match &self.solver {
             Solver::Daskr(d) => d.jroot.iter().position(|&r| r != 0).unwrap_or(0),
@@ -4366,6 +4613,7 @@ impl SolverCore {
                         return Ok(Step::Event { time: troot });
                     }
                     self.state_events += 1;
+                    log_state_event(troot, &self.roots_nonzero(), model);
                     let step_size = model.step_size();
                     if let Some((t0, t1)) = self.note_chatter_event(troot, step_size) {
                         let zc = self.root_index();
@@ -4409,18 +4657,15 @@ impl SolverCore {
                         return Ok(Step::Terminated);
                     }
                     fire_clocks(e, sync, model, sim_data, troot, eps, rows.as_deref_mut())?;
+                    log_reinits(e, model);
+                    omclog::close(omclog::EVENTS);
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
                     }
                     // Re-read states (a reinit may have jumped one), recompute the
                     // consistent derivative, and restart DASKR at troot (INFO(1)=0).
                     self.read_states(e)?;
-                    if !self.dae {
-                        e.call1("functionODE", sim_data)?;
-                        for i in 0..n_states {
-                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-                        }
-                    }
+                    self.refresh_yp(e)?;
                     self.restart()?;
                     self.dae_restart(e, ctx)?;
                     continue;
@@ -4440,6 +4685,7 @@ impl SolverCore {
                     write_f64(e, sim_data + TIME_OFF, te)?;
                     return Ok(Step::Event { time: te });
                 }
+                log_time_event(te, samp, model);
                 if let Some(r) = rows.as_deref_mut()
                     && !no_event_emit()
                 {
@@ -4455,19 +4701,16 @@ impl SolverCore {
                 {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?;
                 }
+                log_reinits(e, model);
+                omclog::close(omclog::EVENTS);
                 if terminated(e, sim_data, layout)? {
                     return Ok(Step::Terminated);
                 }
                 self.read_y(e)?;
                 // A sample may change discrete state the derivative depends on;
                 // recompute yp and restart so the integrator continues consistently.
+                self.refresh_yp(e)?;
                 if layout.n_zc > 0 || self.dae || self.restart_after_time_event() {
-                    if !self.dae {
-                        e.call1("functionODE", sim_data)?;
-                        for i in 0..n_states {
-                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-                        }
-                    }
                     self.restart()?;
                     self.dae_restart(e, ctx)?;
                 }
@@ -4489,12 +4732,7 @@ impl SolverCore {
                         return Ok(Step::Terminated);
                     }
                     self.read_y(e)?;
-                    if !self.dae {
-                        e.call1("functionODE", sim_data)?;
-                        for i in 0..n_states {
-                            self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
-                        }
-                    }
+                    self.refresh_yp(e)?;
                     self.restart()?;
                     self.dae_restart(e, ctx)?;
                     if target >= tout - eps {
@@ -4895,6 +5133,10 @@ impl Driver for EventsDriver {
                         }
                     }
                     if let Some(tr) = troot {
+                        // The bisection left `SimData` at its last probe; C's
+                        // integrators hand the event handler the system at the root.
+                        eval_zero_crossings(e, sim_data, layout, tr, &mut scratch)?;
+                        log_state_event(tr, &zc_crossed_idx(&zc0, &scratch), model);
                         if !no_event_emit() {
                             capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
                         }
@@ -4919,6 +5161,8 @@ impl Driver for EventsDriver {
                         e.call1_if_present("functionStoreDelayed", sim_data)?;
                         eval_zero_crossings(e, sim_data, layout, tr, &mut zc0)?;
                         save_zc_pre(e, sim_data, layout)?;
+                        log_reinits(e, model);
+                        omclog::close(omclog::EVENTS);
                         continue;
                     }
                     // No state event before the next sample time. Fire the sample if
@@ -4926,6 +5170,7 @@ impl Driver for EventsDriver {
                     // is clean up to `tout`.
                     if te <= subtarget + eps {
                         let te = if (te - tout).abs() <= eps { tout } else { te };
+                        log_time_event(te, &self.samp, model);
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?; // held pre row
                         if !no_event_emit() {
                             emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?;
@@ -4948,6 +5193,8 @@ impl Driver for EventsDriver {
                             eval_zero_crossings(e, sim_data, layout, te, &mut zc0)?;
                             save_zc_pre(e, sim_data, layout)?;
                         }
+                        log_reinits(e, model);
+                        omclog::close(omclog::EVENTS);
                         if te >= tout - eps {
                             grid_covered = true;
                         }
@@ -5202,7 +5449,7 @@ struct CvodeDriver {
 impl CvodeDriver {
     fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
         let layout = &model.layout;
-        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
+        run_initialization_model(e, sim_data, model)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -5960,7 +6207,7 @@ impl IdaDriver {
     fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32) -> Result<Self> {
         let layout = &model.layout;
         let setup = IdaSetup::new(model)?;
-        run_initialization(e, sim_data, layout, &model.inputs, model.start_time)?;
+        run_initialization_model(e, sim_data, model)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
@@ -6295,7 +6542,7 @@ impl GuessStepper {
                         omclog::warning(
                             omclog::STDOUT,
                             false,
-                            &alloc::format!(
+                            &format!(
                                 "Initial guess failure at time {}",
                                 format_g(self.core.t, 12)
                             ),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -406,6 +406,22 @@ pub struct MetaVar {
     pub filter: u8,
 }
 
+/// The `modelData` variable arrays C's `dumpInitialSolution` walks, in print order.
+/// Values, `pre`-values and real `start`s live in `SimData`; only the names and the
+/// constant attributes it quotes are metadata.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct SotiVars {
+    /// Real variables in real-variable index order (states, derivatives, then the
+    /// other reals) with the `nominal` attribute; a state's runtime nominal comes
+    /// from [`Layout::state_nom_off`] instead.
+    pub reals: Vec<(String, f64)>,
+    /// Integer/Boolean variables with their `start` attribute.
+    pub ints: Vec<(String, i32)>,
+    pub bools: Vec<(String, i32)>,
+    /// String variables with their `start` attribute.
+    pub strings: Vec<(String, String)>,
+}
+
 /// [`MetaVar::filter`] bits: what keeps a variable out of the result file, and
 /// which flag lets it back in (C's `shouldFilterOutput` +
 /// `initializeOutputFilter`).
@@ -691,6 +707,14 @@ pub struct SimMeta {
     /// `x > 0.0`), 1:1 with the layout's zero-crossings — the driver names the
     /// culprit crossing in the chattering message. Empty ⇒ descriptions absent.
     pub zc_desc: Vec<String>,
+    /// Per-relation description, 1:1 with the layout's relations — C's
+    /// `relationDescription`, dumped in the `LOG_EVENTS` relation status block.
+    pub rel_desc: Vec<String>,
+    /// C's `samplesInfo[i].index`, 1:1 with the layout's samples; named in the
+    /// `LOG_EVENTS` time-event line.
+    pub sample_index: Vec<i32>,
+    /// C's `modelData` variable arrays, for the `LOG_SOTI` initialization dump.
+    pub soti: SotiVars,
     /// C's `simulationInfo->sensitivityParList`: the `SimData` offsets of the
     /// parameters `--calculateSensitivities` selected, in block order.
     pub sens_params: Vec<u32>,
@@ -1037,6 +1061,31 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     for d in &m.zc_desc {
         put_str(&mut o, d);
     }
+    put_u32(&mut o, m.rel_desc.len() as u32);
+    for d in &m.rel_desc {
+        put_str(&mut o, d);
+    }
+    put_u32(&mut o, m.sample_index.len() as u32);
+    for i in &m.sample_index {
+        put_u32(&mut o, *i as u32);
+    }
+    put_u32(&mut o, m.soti.reals.len() as u32);
+    for (n, v) in &m.soti.reals {
+        put_str(&mut o, n);
+        put_f64(&mut o, *v);
+    }
+    for list in [&m.soti.ints, &m.soti.bools] {
+        put_u32(&mut o, list.len() as u32);
+        for (n, v) in list {
+            put_str(&mut o, n);
+            put_u32(&mut o, *v as u32);
+        }
+    }
+    put_u32(&mut o, m.soti.strings.len() as u32);
+    for (n, v) in &m.soti.strings {
+        put_str(&mut o, n);
+        put_str(&mut o, v);
+    }
     put_u32s(&mut o, &m.sens_params);
     put_u32(&mut o, m.nls_vars.len() as u32);
     for v in &m.nls_vars {
@@ -1336,6 +1385,25 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     for _ in 0..ndesc {
         zc_desc.push(r.string()?);
     }
+    let nrdesc = r.u32()? as usize;
+    let mut rel_desc = Vec::with_capacity(nrdesc);
+    for _ in 0..nrdesc {
+        rel_desc.push(r.string()?);
+    }
+    let sample_index = r.u32s()?.into_iter().map(|v| v as i32).collect();
+    let mut soti = SotiVars::default();
+    for _ in 0..r.u32()? {
+        soti.reals.push((r.string()?, r.f64()?));
+    }
+    for _ in 0..r.u32()? {
+        soti.ints.push((r.string()?, r.u32()? as i32));
+    }
+    for _ in 0..r.u32()? {
+        soti.bools.push((r.string()?, r.u32()? as i32));
+    }
+    for _ in 0..r.u32()? {
+        soti.strings.push((r.string()?, r.string()?));
+    }
     let sens_params = r.u32s()?;
     let nsys = r.u32()? as usize;
     let mut nls_vars = Vec::with_capacity(nsys);
@@ -1478,7 +1546,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
-        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, sens_params,
+        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, sample_index, soti, sens_params,
         nls_vars, dae, clocks, lin, opt, inputs,
     })
 }
@@ -1528,6 +1596,9 @@ mod tests {
                 FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true },
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
+            rel_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
+            sample_index: vec![1],
+            soti: SotiVars::default(),
             sens_params: vec![88],
             nls_vars: vec![NlsVars {
                 eq_index: 1074,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -25,6 +25,38 @@ thread_local! {
     /// C's `noThrowAsserts`: the driver has the model on a provisional state, so
     /// `rt_assert` records instead of telling the caller to trap.
     static NO_THROW: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Executed `reinit`s, `(state SimData offset, value)`, for the driver's
+    /// `LOG_EVENTS` block. Only filled while that stream is on.
+    static PENDING_REINITS: std::cell::RefCell<Vec<(u32, f64)>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// `rt_reinit_note`: record an executed `reinit` while `LOG_EVENTS` is on.
+pub fn record_reinit(off: u32, value: f64) {
+    if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::EVENTS) {
+        PENDING_REINITS.with(|p| p.borrow_mut().push((off, value)));
+    }
+}
+
+/// Take (and clear) the `reinit`s recorded since the last call.
+pub fn take_pending_reinits() -> Vec<(u32, f64)> {
+    PENDING_REINITS.with(|p| core::mem::take(&mut *p.borrow_mut()))
+}
+
+/// Serialise them for the in-wasm driver: `[off: u32][value: f64]` per record.
+const REINIT_BYTES: usize = 16;
+
+fn take_reinits_into(dst: &mut [u8], max: usize) -> u32 {
+    let recs = PENDING_REINITS.with(|p| {
+        let mut p = p.borrow_mut();
+        let n = max.min(p.len()).min(dst.len() / REINIT_BYTES);
+        p.drain(..n).collect::<Vec<_>>()
+    });
+    for (i, (off, v)) in recs.iter().enumerate() {
+        let b = i * REINIT_BYTES;
+        dst[b..b + 4].copy_from_slice(&off.to_le_bytes());
+        dst[b + 8..b + 16].copy_from_slice(&v.to_le_bytes());
+    }
+    recs.len() as u32
 }
 
 /// Driver hook (`driver::set_no_throw_hook`). Opening drops the assertion a
@@ -314,6 +346,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     wt(linker.func_wrap("rt", "rt_assert_warning", |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
         record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
     }))?;
+    wt(linker.func_wrap("rt", "rt_reinit_note", |off: i32, value: f64| record_reinit(off as u32, value)))?;
     wt(linker.func_wrap(
         "rt",
         "rt_row_asserts",
@@ -369,6 +402,20 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
             }
         },
     ))?;
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_take_reinits",
+        |mut caller: wasmtime::Caller<'_, T>, ptr: u32, max: u32| -> u32 {
+            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 0 };
+            let off = ptr as usize;
+            let end = off + max as usize * REINIT_BYTES;
+            let data = mem.data_mut(&mut caller);
+            match data.get_mut(off..end) {
+                Some(dst) => take_reinits_into(dst, max as usize),
+                None => 0,
+            }
+        },
+    ))?;
     // Solve the CSC system in the caller's (the runtime's) shared memory; the
     // interactive runtime imports this. Returns 0 (solved, `b` overwritten) or 1.
     wt(linker.func_wrap(
@@ -416,6 +463,8 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
             record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
         }));
+    imports.define("rt", "rt_reinit_note", Function::new_typed(store,
+        |off: i32, value: f64| record_reinit(off as u32, value)));
     // Both memory-reading imports share one env, filled in by `HostMem::set`.
     let mem_env = wasmer::FunctionEnv::new(store, None);
     imports.define(
@@ -465,6 +514,24 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
                 let mut buf = vec![0u8; recs.len() * REC_BYTES];
                 let n = write_warnings(&recs, &mut buf);
                 match memory.view(&store).write(ptr as u64, &buf) {
+                    Ok(()) => n,
+                    Err(_) => 0,
+                }
+            },
+        ),
+    );
+    imports.define(
+        "env",
+        "rt_host_take_reinits",
+        Function::new_typed_with_env(
+            store,
+            &mem_env,
+            |mut env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, max: u32| -> u32 {
+                let (data, store) = env.data_and_store_mut();
+                let Some(memory) = data.clone() else { return 0 };
+                let mut buf = vec![0u8; max as usize * REINIT_BYTES];
+                let n = take_reinits_into(&mut buf, max as usize);
+                match memory.view(&store).write(ptr as u64, &buf[..n as usize * REINIT_BYTES]) {
                     Ok(()) => n,
                     Err(_) => 0,
                 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -982,6 +982,9 @@ impl sim_driver::SimEngine for WasmerEngine {
     fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        crate::host::take_pending_reinits()
+    }
     fn lin_solves(&mut self) -> u64 {
         match self.rt_inst.exports.get_typed_function::<(), u64>(&self.store, "rt_lin_solves") {
             Ok(f) => f.call(&mut self.store).unwrap_or(0),
@@ -1130,6 +1133,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
+    }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        crate::host::take_pending_reinits()
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -980,6 +980,9 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
     }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        crate::host::take_pending_reinits()
+    }
     fn lin_solves(&mut self) -> u64 {
         match self.rt_inst.get_typed_func::<(), u64>(&mut self.store, "rt_lin_solves") {
             Ok(f) => f.call(&mut self.store, ()).unwrap_or(0),
@@ -1135,6 +1138,9 @@ impl sim_driver::SimEngine for InWasmSession {
     }
     fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
         crate::host::take_pending_warnings()
+    }
+    fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
+        crate::host::take_pending_reinits()
     }
 }
 


### PR DESCRIPTION
Eight of the eleven `simulation/modelica/events` tests failing under `--simCodeTarget=wasm-jit`.

| test | gap |
| --- | --- |
| `ZeroCrossing`, `bug2752` | relation iterator in the crossing fn | | `bug2808` | `and` over a non-0/1 `external "C"` Boolean | | `EventTests2`, `EventTests3` | no `-lv=LOG_EVENTS` output | | `EventLoop` | event iteration never hit its limit | | `EventTests` | no `-lv=LOG_SOTI` output |
| `TestNoEventsFlags` | stale `der()` after a time event (values) |

`SimCode.zeroCrossings` is scalarized (`not a[1] > x or ...`), but the inner `RELATION` nodes keep the `optionExpisASUB` iterator of the `for`-loop they came from. C's `daeExpRelationSim` ignores it in `ZEROCROSSINGS_CONTEXT` and indexes `storedRelations` by the loop base for every copy; we compiled the iterator expression before branching on the context, so lowering died on the unbound `i`/`j`.

C writes `&&`, `||` and Boolean `==` through `!`, so an operand outside {0,1} still compares by truth value. `ModelicaStrings_compare` returns 1/2/3 into a Boolean output and `2 & 1` is 0 — `bug2808` exactly.

`printRelations`/`printZeroCrossings` end initialization, and each event opens a `"%s event at time=%.12g"` block naming the crossings or samples that fired. The `reinit` line C prints *from the model* goes through a new `rt_reinit_note` import instead: the block's indentation lives in whichever `omclog` the driver owns, and the host-driven and in-wasm drivers have different ones, so the model records and the driver formats — the `rt_assert_warning` pattern. `SimMeta` gained the relation descriptions and `samplesInfo[i].index`.

`updateDiscreteSystem` throws past `-mei` iterations; we gave up in silence. `saveZeroCrossings` copies into `zeroCrossingsPre` *before* evaluating, which is what makes the init dump read `(pre: 0)`.

`dumpInitialSolution` walks C's `modelData` arrays, which we have no counterpart of — the result-variable list is a different set (aliases in, `$whenCondition*` out) in a different order. `SimMeta.soti` carries the four arrays; values, `pre`-values and real `start`s come out of `SimData`. It runs before `storePreValues`, as C does, hence `der(x) ... (pre: 0)`. That exposed `setAllVarsToStart` covering the Integer, Boolean and String variables too, where we only copied the real start region: their `pre` values began at 0 instead of `start`, readable by any initial equation taking `pre()` of a discrete variable.

Last, the `yp` refresh after a sample event was gated on the model having zero-crossings, so a `reinit` inside `when sample(...)` in a model whose relations are all `noEvent` left the integrator on the pre-`reinit` derivative. C re-runs `functionODE` in `updateContinuousSystem` anyway.

`noEventEmit`, `TestNoEventsFlags`' `t=0.6` point and `CheckEvents` stay red; they need C's `perform_simulation` step arithmetic and its `IRES = -1` residual retry, written up in
`HANDOFF-wasm-jit-simulation-correctness.md`.

Verified on the `TESTFILES` of `simulation/modelica/{events,equations, initialization,when_equation}` (161 tests, 44 -> 34 failures, none new; `initialization` `bug_2830`, `bug_3014` and `bug_3536` also flip to ok).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
