### PR TITLE
external "C" for the wasm-jit target

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -922,6 +922,17 @@ function(omc_rust_setup_codegen)
             DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT omc)
   endif()
 
+  # The PIC wasi-libc sysroot an external "C" library for wasm-jit is compiled
+  # against. Under the wasm triple with an `omc` subdirectory so it cannot be
+  # confused with a distribution's /usr/lib/wasm32-wasi, and with the compiler-rt
+  # builtins so it matches the libc.so omc resolves imports against.
+  install(DIRECTORY ${RUST_WASI_PIC_SYSROOT}/
+          DESTINATION lib/wasm32-wasi/omc COMPONENT omc)
+  if(_wasi_builtins)
+    install(FILES ${_wasi_builtins}
+            DESTINATION lib/wasm32-wasi/omc/lib/wasm32-wasip1 COMPONENT omc)
+  endif()
+
   # The native egui OMShell client (omshell_egui), built when the GUI clients are
   # enabled (OM_ENABLE_GUI_CLIENTS, the same flag that drives OMEdit). It links the
   # compiler in-process as an ordinary cargo dependency (omshell_omc ->

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -317,6 +317,8 @@ openmodelica_wasi_libc/external_c_callbacks.c
 openmodelica_wasm_jit/Cargo.toml
 openmodelica_wasm_jit/build.rs
 openmodelica_wasm_jit/external_c_stubs.c
+openmodelica_wasm_jit/src/dylink.rs
+openmodelica_wasm_jit/src/dylink_wasmtime.rs
 openmodelica_wasm_jit/src/engine_config.rs
 openmodelica_wasm_jit/src/host.rs
 openmodelica_wasm_jit/src/lib.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6919,6 +6919,7 @@ dependencies = [
  "openmodelica_sim_meta",
  "openmodelica_util",
  "openmodelica_wasi",
+ "openmodelica_wasi_libc",
  "rsparse",
  "wasm-encoder 0.252.0",
  "wasmer",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -85,7 +85,7 @@ use openmodelica_sim_meta::{
 use openmodelica_wasm_jit::{sim_driver, sim_runtime};
 #[cfg(feature = "jit")]
 use openmodelica_wasm_jit::wasi_shim;
-pub(crate) use openmodelica_wasm_jit::model::{EditableParam, ModelCompileJob, SimModel};
+pub(crate) use openmodelica_wasm_jit::model::{EditableParam, ExtLibrary, ModelCompileJob, SimModel};
 #[cfg(feature = "jit")]
 pub use openmodelica_wasm_jit::model::{set_inwasm_driver_override, set_sim_bench};
 #[cfg(feature = "jit")]
@@ -862,6 +862,9 @@ thread_local! {
     /// callers (the interactive session) share the hook but must not split. Armed
     /// for one firing.
     static SPLIT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Taken when the teardown hook fires, so destructor output follows the
+    /// success line.
+    static SIM_OUTPUT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 
 /// Init-done hook: take the initialization phase's output, then restart the
@@ -871,6 +874,13 @@ fn on_init_done() {
         return;
     }
     INIT_OUTPUT.with(|c| *c.borrow_mut() = Some(openmodelica_wasi::wasi::take_stdout_capture()));
+    openmodelica_wasi::wasi::start_stdout_capture();
+}
+
+/// The same split for what the external objects' destructors print: C runs them
+/// after "The simulation finished successfully.".
+fn on_teardown() {
+    SIM_OUTPUT.with(|c| *c.borrow_mut() = Some(openmodelica_wasi::wasi::take_stdout_capture()));
     openmodelica_wasi::wasi::start_stdout_capture();
 }
 
@@ -939,6 +949,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     }
     INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
     sim_driver::set_init_done_hook(on_init_done);
+    SIM_OUTPUT.with(|c| *c.borrow_mut() = None);
+    sim_driver::set_teardown_hook(on_teardown);
     SPLIT_ARMED.with(|a| a.set(true));
     sim_driver::init_host_hooks();
     sim_driver::set_result_file_reader(read_result_values);
@@ -974,7 +986,15 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     SPLIT_ARMED.with(|a| a.set(false));
     // Everything captured after the split is the simulation phase (plus `extra`:
     // LOG_STATS / chattering lines). `INIT_OUTPUT` is `None` when init failed.
-    let sim_output = format!("{}{extra}", openmodelica_wasi::wasi::take_stdout_capture());
+    // With the hook fired, the capture holds the destructors' output instead.
+    let teardown_output = SIM_OUTPUT.with(|c| c.borrow_mut().take());
+    let tail = openmodelica_wasi::wasi::take_stdout_capture();
+    let (sim_capture, post_capture) = match teardown_output {
+        Some(sim) => (sim, tail),
+        None => (tail, String::new()),
+    };
+    let post = format!("{post_capture}{post}");
+    let sim_output = format!("{sim_capture}{extra}");
     let init_output = INIT_OUTPUT.with(|c| c.borrow_mut().take());
     // C prints the sparse-solver announcements (initializeLinear/NonlinearSystems)
     // ahead of the init-success line; prepend our pre-rendered copy to the init output.
@@ -1126,6 +1146,8 @@ mod session {
         LAST_SIM_LOG.with(|c| c.borrow_mut().clear());
         INIT_OUTPUT.with(|c| *c.borrow_mut() = None);
         sim_driver::set_init_done_hook(on_init_done);
+    SIM_OUTPUT.with(|c| *c.borrow_mut() = None);
+    sim_driver::set_teardown_hook(on_teardown);
         SPLIT_ARMED.with(|a| a.set(true));
         sim_driver::init_host_hooks();
         sim_driver::set_result_file_reader(read_result_values);
@@ -1432,6 +1454,167 @@ use openmodelica_wasi_libc::{
     SUNDIALS_DYLINK, WASI_P1_ADAPTER,
 };
 
+// ===========================================================================
+// The model's own `external "C"` libraries
+// ===========================================================================
+
+/// Resolve the `Library` annotations (already wasm module names, from
+/// `SimCodeFunctionUtil`) against the library directories. A name that resolves to
+/// nothing is reported here, not later as an unresolvable `ext.<fn>` import.
+pub(crate) fn resolve_ext_libraries(
+    mp: &SimCodeFunction::MakefileParams,
+    notes: &mut Vec<String>,
+) -> Result<Vec<ExtLibrary>> {
+    let mut dirs: Vec<String> = vec![String::new()]; // relative to the working directory
+    for d in lst(&mp.libPaths) {
+        dirs.push(format!("{d}/"));
+    }
+    let mut out: Vec<ExtLibrary> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for lib in lst(&mp.libs) {
+        let lib = lib.to_string();
+        // The library list is shared with the other code generators.
+        if lib.starts_with('-') || !seen.insert(lib.clone()) {
+            continue;
+        }
+        let Some((path, bytes)) = find_ext_library(&lib, &dirs) else {
+            notes.push(format!(
+                "`{lib}` was not found (looked in {}); a wasm target loads a prebuilt shared \
+                 library, built with `clang --target=wasm32-wasip1 -fPIC -shared`",
+                dirs.iter().map(|d| if d.is_empty() { "." } else { d.trim_end_matches('/') })
+                    .collect::<Vec<_>>().join(", ")
+            ));
+            continue;
+        };
+        out.push(ExtLibrary { name: path, bytes });
+    }
+    Ok(out)
+}
+
+/// Compile the model's `Include` annotations into a wasm library: C *source* has no
+/// `Library` to load. Native only; the browser omc has no compiler. A failure is a
+/// note, not an error: only a symbol nothing defines is fatal.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn compile_include_library(
+    prefix: &str,
+    includes: &[String],
+    include_dirs: &[String],
+    notes: &mut Vec<String>,
+) -> Result<Option<ExtLibrary>> {
+    use std::process::Command;
+    if includes.is_empty() {
+        return Ok(None);
+    }
+    let sysroot = wasi_sysroot();
+    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
+    let dir = std::env::temp_dir().join(format!("om-wasm-include-{}-{prefix}", std::process::id()));
+    std::fs::create_dir_all(&dir).map_err(|_| "CodegenWasmJit: cannot create a temporary directory")?;
+    let tu = dir.join(format!("{prefix}_includes.c"));
+    let out = dir.join(format!("{prefix}_includes.wasm"));
+    std::fs::write(&tu, includes.join("\n") + "\n")
+        .map_err(|_| "CodegenWasmJit: cannot write the external \"C\" translation unit")?;
+
+    let mut cmd = Command::new(&clang);
+    cmd.args(["--target=wasm32-wasip1", "-O1", "-fPIC", "-shared", "-nodefaultlibs"])
+        .arg(format!("--sysroot={}", sysroot.display()))
+        .args(["-Wl,--export-all", "-Wl,--allow-undefined"]);
+    // Compiled in a temporary directory, so `#include "x.h"` needs the model's own.
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.arg("-I").arg(cwd);
+    }
+    // `IncludeDirectory` annotations, already `-I"..."` strings.
+    for inc in include_dirs {
+        cmd.arg(inc.trim_matches('"'));
+    }
+    cmd.arg("-o").arg(&out).arg(&tu);
+    if let Some(builtins) = wasm_builtins(&sysroot) {
+        cmd.arg(builtins);
+    }
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(e) => {
+            notes.push(format!("`{clang}` could not be run to compile the `Include` C sources: {e}"));
+            return Ok(None);
+        }
+    };
+    if !output.status.success() {
+        notes.push(format!(
+            "the `Include` C sources did not compile for the wasm target:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&out).map_err(|_| "CodegenWasmJit: cannot read the compiled include library")?;
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(Some(ExtLibrary { name: format!("{prefix}_includes.wasm"), bytes }))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn compile_include_library(
+    _prefix: &str,
+    includes: &[String],
+    _include_dirs: &[String],
+    notes: &mut Vec<String>,
+) -> Result<Option<ExtLibrary>> {
+    if includes.is_empty() {
+        return Ok(None);
+    }
+    notes.push(
+        "the implementation comes from an `Include` annotation with C source, which has to be \
+         compiled — the browser omc has no compiler. Provide it as a `Library` built with \
+         `clang --target=wasm32-wasip1 -fPIC -shared`"
+            .to_string(),
+    );
+    Ok(None)
+}
+
+/// The sysroot omc ships, unless pointed elsewhere.
+#[cfg(not(target_arch = "wasm32"))]
+fn wasi_sysroot() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("OMC_WASI_SYSROOT") {
+        return std::path::PathBuf::from(p);
+    }
+    let home = openmodelica_util::Settings::getInstallationDirectoryPath()
+        .map(|p| p.to_string())
+        .unwrap_or_default();
+    std::path::PathBuf::from(home).join("lib/wasm32-wasi/omc")
+}
+
+/// The shipped sysroot carries a copy; otherwise probe clang, whose 21 driver
+/// looks under a per-triple directory while Debian still uses `lib/wasi`.
+#[cfg(not(target_arch = "wasm32"))]
+fn wasm_builtins(sysroot: &std::path::Path) -> Option<std::path::PathBuf> {
+    let shipped = sysroot.join("lib/wasm32-wasip1/libclang_rt.builtins-wasm32.a");
+    if shipped.exists() {
+        return Some(shipped);
+    }
+    let out = std::process::Command::new(std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned()))
+        .arg("-print-resource-dir")
+        .output()
+        .ok()?;
+    let res = std::path::PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    [
+        res.join("lib/wasm32-unknown-wasip1/libclang_rt.builtins.a"),
+        res.join("lib/wasi/libclang_rt.builtins-wasm32.a"),
+    ]
+    .into_iter()
+    .find(|p| p.exists())
+}
+
+/// `<dir><name>` or `<dir>lib<name>`, the two spellings a `Library="foo"`
+/// annotation is written with.
+fn find_ext_library(name: &str, dirs: &[String]) -> Option<(String, Vec<u8>)> {
+    let stem = name.strip_suffix(".wasm").unwrap_or(name);
+    for dir in dirs {
+        for candidate in [format!("{dir}{stem}.wasm"), format!("{dir}lib{stem}.wasm")] {
+            if let Ok(bytes) = openmodelica_wasi::fs::read(&candidate) {
+                return Some((candidate, bytes));
+            }
+        }
+    }
+    None
+}
+
 /// Renames the model's `rt`/`ext` import modules → `env`, the dylink convention
 /// `wit_component::Linker` resolves against (so `ext.<fn>` binds to the
 /// ModelicaExternalC side module's export `<fn>`).
@@ -1546,7 +1729,12 @@ fn first_external_import(model_wasm: &[u8]) -> Option<String> {
 /// the browser omc too). When the model uses `external "C"`, ModelicaExternalC +
 /// PIC `libc.so` are added as shared-everything libraries and libc's preview1
 /// imports bridged to the component's preview2 WASI by the reactor adapter.
-fn link_fmu_component(model_wasm: &[u8], adapter: &[u8], sundials: bool) -> Result<Vec<u8>> {
+fn link_fmu_component(
+    model_wasm: &[u8],
+    adapter: &[u8],
+    sundials: bool,
+    ext_libs: &[ExtLibrary],
+) -> Result<Vec<u8>> {
     if adapter.is_empty() {
         return Err("CodegenWasmJit: FMI3 adapter unavailable (build wasm32-unknown-unknown + -Z build-std)");
     }
@@ -1565,6 +1753,10 @@ fn link_fmu_component(model_wasm: &[u8], adapter: &[u8], sundials: bool) -> Resu
         // runtime rt_alloc over one shared heap) is intentional. SUNDIALS needs libc
         // too, so it brings the same libraries along.
         if has_ext {
+            // First, so a symbol they define wins over ModelicaExternalC's.
+            for lib in ext_libs {
+                l = l.library(&lib.name, &lib.bytes, false).map_err(link_err)?;
+            }
             l = l.library("modelicaexternalc", EXTERNAL_C_DYLINK, false).map_err(link_err)?;
         }
         l = l.library("libc", LIBC_PIC, false).map_err(link_err)?;
@@ -1829,7 +2021,7 @@ fn emit_fmu(
         }
         let sundials = cs && fmu_needs_sundials(&model.method);
         let component =
-            link_fmu_component(&model.wasm, if sundials { adapter.1 } else { adapter.0 }, sundials)?;
+            link_fmu_component(&model.wasm, if sundials { adapter.1 } else { adapter.0 }, sundials, &model.ext_libs)?;
         let model_id = sanitize_identifier(&model.model_name);
         let mut entries = vec![
             ("modelDescription.xml".to_string(), model_description.as_bytes().to_vec()),
@@ -3030,6 +3222,21 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             }
         }
     }
+    // A `Library` on a function the model never reaches must not fail the build.
+    let mut ext_lib_notes: Vec<String> = Vec::new();
+    let ext_libs = if ext_imports.is_empty() {
+        Vec::new()
+    } else {
+        let mut libs = resolve_ext_libraries(&sim_code.makefileParams, &mut ext_lib_notes)?;
+        // What the `Library` annotations did not provide may come from an
+        // `Include` carrying the C source.
+        let includes: Vec<String> = lst(&sim_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
+        let dirs: Vec<String> = lst(&sim_code.makefileParams.includes).map(|s| s.to_string()).collect();
+        if let Some(l) = compile_include_library(&sim_code.fileNamePrefix, &includes, &dirs, &mut ext_lib_notes)? {
+            libs.push(l);
+        }
+        libs
+    };
 
     // Function index space: imports (env builtins, rt runtime, env-extra, then
     // the `ext.*` externals), then the model's Modelica functions, then the
@@ -3954,6 +4161,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         prepared: Mutex::new(None),
         layout,
         result_vars,
+        ext_libs,
+        ext_lib_notes,
         ext_imports,
         model_name,
         start_time: settings.startTime.into_inner(),
@@ -7143,7 +7352,7 @@ mod link_tests {
                 continue; // omc built without the wasm32 toolchain or without sundials
             }
             assert!(
-                link_fmu_component(&build_stub_model(), adapter, sundials).is_ok(),
+                link_fmu_component(&build_stub_model(), adapter, sundials, &[]).is_ok(),
                 "{label} adapter does not link into a component: {}",
                 openmodelica_util::Error::printMessagesStr(false)
             );

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -42,7 +42,9 @@
 // `CevalScript` caller resolves them; the rest of the module is idiomatic Rust.
 #![allow(non_snake_case)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+// The record layout is shared with the host, which reads records this code built.
+use openmodelica_wasm_jit::sig::{record_layout, RecordLayout};
 use std::sync::Arc;
 
 use metamodelica::Result;
@@ -484,7 +486,55 @@ pub(crate) struct FnInfo {
 
 /// Build the wasm module for `fnCode`. Returns the encoded module bytes and the
 /// input/output `SigTy`s of the main function (for the sidecar).
-fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec<SigTy>, Vec<SigTy>)> {
+/// Read back what [`write_ext_sig`] wrote.
+pub(crate) fn parse_ext_sig(line: &str) -> Result<ExtCallSig> {
+    let mut f = line.split('\t');
+    let (Some(name), Some(lang), Some(ret), Some(args), Some(outs)) =
+        (f.next(), f.next(), f.next(), f.next(), f.next())
+    else {
+        return Err("CodegenWasmJit: malformed external \"C\" signature in the .wasm.sig sidecar");
+    };
+    let tys = parse_sig_types(args)?;
+    if tys.len() != outs.chars().count() {
+        return Err("CodegenWasmJit: external \"C\" signature has a stale output mask");
+    }
+    Ok(ExtCallSig {
+        name: name.to_string(),
+        lang: if lang == "F" { ExtLang::Fortran77 } else { ExtLang::C },
+        args: tys.into_iter().zip(outs.chars()).map(|(t, o)| (t, o == '1')).collect(),
+        ret: if ret == "-" { None } else { parse_sig_types(ret)?.into_iter().next() },
+    })
+}
+
+/// `<symbol>\t<C|F>\t<return code or ->\t<argument codes>\t<one 0/1 per argument>`,
+/// a `1` marking an `_Out_`. The flags are separate because an argument code is
+/// variable-length.
+fn write_ext_sig(e: &ExtCallSig) -> String {
+    let mut args = String::new();
+    let mut outs = String::new();
+    for (ty, is_out) in &e.args {
+        ty.write_code(&mut args);
+        outs.push(if *is_out { '1' } else { '0' });
+    }
+    let mut ret = String::new();
+    match &e.ret {
+        Some(t) => t.write_code(&mut ret),
+        None => ret.push('-'),
+    }
+    let lang = if e.lang == ExtLang::Fortran77 { 'F' } else { 'C' };
+    format!("{}\t{lang}\t{ret}\t{args}\t{outs}", e.name)
+}
+
+/// A lowered function module and what its sidecar has to record: the main
+/// function's signature, and the `external "C"` functions the module calls out to.
+struct BuiltModule {
+    bytes: Vec<u8>,
+    in_sig: Vec<SigTy>,
+    out_sig: Vec<SigTy>,
+    ext_imports: Vec<ExtCallSig>,
+}
+
+fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<BuiltModule> {
     set_record_decls(&fn_code.extraRecordDecls)?;
     // Collect the functions: the main function first (wasm index BUILTINS.len()),
     // then the dependencies.
@@ -499,18 +549,36 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
         // `RECORD_CONSTRUCTOR` but are lowered inline (`E::RECORD`), and unknown
         // external / function-pointer dependencies cannot be JITed and, if
         // actually called, fail loudly at that call site instead.
-        if matches!(&**f, SimCodeFunction::Function::Function::FUNCTION { .. }) || external_known(f) {
+        if matches!(&**f, SimCodeFunction::Function::Function::FUNCTION { .. })
+            || external_known(f)
+            || external_general(f)
+        {
             funcs.push(&**f);
         }
     }
 
+    // The `external "C"` functions reached from here, as `ext.<extName>` imports.
+    let mut ext_imports: Vec<ExtCallSig> = Vec::new();
+    let mut ext_seen: HashSet<String> = HashSet::new();
+    for f in &funcs {
+        if external_general_why(f).is_ok() {
+            let sig = external_import_sig(f)?;
+            if ext_seen.insert(sig.name.clone()) {
+                ext_imports.push(sig);
+            }
+        }
+    }
+
     // Imported functions occupy the low function indices: the `env` math
-    // builtins, then the `rt` heap-runtime functions; generated functions
-    // follow. (The imported `memory` has its own index space and does not
-    // shift function indices.)
-    let base = (BUILTINS.len() + RT_BUILTINS.len() + ENV_EXTRA.len()) as u32;
+    // builtins, the `rt` heap-runtime functions, then the `ext` externals;
+    // generated functions follow.
+    let ext_base = (BUILTINS.len() + RT_BUILTINS.len() + ENV_EXTRA.len()) as u32;
+    let base = ext_base + ext_imports.len() as u32;
     // Map mangled function name -> (local id, signature) so CALLs can resolve.
     let mut by_name: HashMap<String, FnInfo> = HashMap::new();
+    for (i, sig) in ext_imports.iter().enumerate() {
+        by_name.insert(format!("ext.{}", sig.name), FnInfo { index: ext_base + i as u32, sig: sig.wasm_sig() });
+    }
     let mut sigs: Vec<FnSig> = Vec::with_capacity(funcs.len());
     for (id, f) in funcs.iter().enumerate() {
         let (name, sig) = function_signature(f)?;
@@ -530,6 +598,12 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
     for (_, params, results) in ENV_EXTRA {
         types.ty().function(params.iter().map(|w| w.val()), results.iter().map(|w| w.val()));
     }
+    for sig in &ext_imports {
+        types.ty().function(
+            sig.wasm_params().iter().map(|s| s.wty().val()),
+            sig.wasm_results().iter().map(|s| s.wty().val()),
+        );
+    }
     for sig in &sigs {
         types.ty().function(sig.params.iter().map(|s| s.wty().val()), sig.results.iter().map(|s| s.wty().val()));
     }
@@ -543,14 +617,19 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
         "memory",
         we::MemoryType { minimum: 0, maximum: None, memory64: false, shared: false, page_size_log2: None },
     );
+    // All three come from the runtime instance the host registers as `rt`: the math
+    // builtins are in-wasm (libm), not host functions.
     for (i, (name, _, _)) in BUILTINS.iter().enumerate() {
-        imports.import("env", *name, we::EntityType::Function(i as u32));
+        imports.import("rt", *name, we::EntityType::Function(i as u32));
     }
     for (j, (name, _, _)) in RT_BUILTINS.iter().enumerate() {
         imports.import("rt", *name, we::EntityType::Function((BUILTINS.len() + j) as u32));
     }
     for (k, (name, _, _)) in ENV_EXTRA.iter().enumerate() {
-        imports.import("env", *name, we::EntityType::Function((BUILTINS.len() + RT_BUILTINS.len() + k) as u32));
+        imports.import("rt", *name, we::EntityType::Function((BUILTINS.len() + RT_BUILTINS.len() + k) as u32));
+    }
+    for (i, sig) in ext_imports.iter().enumerate() {
+        imports.import("ext", &sig.name, we::EntityType::Function(ext_base + i as u32));
     }
 
     // Compile the function bodies first (collecting any String literals into a
@@ -665,7 +744,7 @@ fn build_module(fn_code: &SimCodeFunction::FunctionCode) -> Result<(Vec<u8>, Vec
 
     // Signature types of the main function for the sidecar.
     let (in_sig, out_sig) = main_sig_types(main)?;
-    Ok((bytes, in_sig, out_sig))
+    Ok(BuiltModule { bytes, in_sig, out_sig, ext_imports })
 }
 
 /// The mangled name and wasm signature of a generated function.
@@ -808,17 +887,33 @@ pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> s
     if ext_lang(language).is_none() {
         return Err(format!("external language \"{language}\" is not supported"));
     }
-    let arg_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr | SigTy::Array { .. });
-    let ret_ok = |s: &SigTy| matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr);
+    // The host converts a record field by field, so each field must marshal too.
+    fn record_ok(s: &SigTy) -> bool {
+        match s {
+            SigTy::Record { fields, .. } => fields.iter().all(|(_, t)| {
+                matches!(t, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Array { .. }) || record_ok(t)
+            }),
+            _ => false,
+        }
+    }
+    let arg_ok = |s: &SigTy| {
+        matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr | SigTy::Array { .. })
+            || record_ok(s)
+    };
+    let ret_ok = |s: &SigTy| {
+        matches!(s, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Str | SigTy::Ptr) || record_ok(s)
+    };
     let n_out = (&**outVars).into_iter().count();
     // Each declared output is written by at most one `extArgs` entry (or the
     // return value); one left unwritten keeps its binding, as in the C target.
     let mut written = vec![false; n_out];
-    let mut claim = |oi: usize| -> bool {
+    // Written once — except that a record output may be filled through its pointer
+    // *and* have one field assigned from the return value, different lvalues.
+    let mut claim = |oi: usize, field: bool| -> bool {
         if oi == 0 {
             return true;
         }
-        oi <= n_out && !std::mem::replace(&mut written[oi - 1], true)
+        oi <= n_out && (field || !std::mem::replace(&mut written[oi - 1], true))
     };
     for a in &**extArgs {
         let ty = match &**a {
@@ -831,15 +926,15 @@ pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> s
         if !arg_ok(&ty) {
             return Err(format!("argument type {ty:?} cannot be marshalled"));
         }
-        if !claim(ext_arg_output_index(a)) {
+        if !claim(ext_arg_output_index(a), false) {
             return Err("an argument writes an output the function does not declare".to_string());
         }
     }
     match &**extReturn {
         A::SIMNOEXTARG => {}
-        A::SIMEXTARG { type_, outputIndex, .. } => {
+        A::SIMEXTARG { type_, outputIndex, cref, .. } => {
             let t = sig_ty_quiet(type_).map_err(|e| e.to_string())?;
-            if !ret_ok(&t) || !claim((*outputIndex).max(0) as usize) {
+            if !ret_ok(&t) || !claim((*outputIndex).max(0) as usize, cref_field(cref).is_some()) {
                 return Err(format!("return type {t:?} cannot be marshalled"));
             }
         }
@@ -2144,15 +2239,20 @@ fn compile_external_function(
         let results = emit_general_external_call(&mut ctx, &sig.name, &input_args, &sig.wasm_params())?;
         // The declared output each wasm result feeds, in result order: the C
         // return value first, then each scalar/String `_Out_` arg.
-        let mut targets: Vec<usize> = Vec::new();
-        if let A::SIMEXTARG { outputIndex, .. } = &**extReturn {
-            targets.push(*outputIndex as usize - 1);
+        // `(declared output, the field of it this value assigns)`.
+        let mut targets: Vec<(usize, Option<String>)> = Vec::new();
+        if let A::SIMEXTARG { outputIndex, cref, .. } = &**extReturn {
+            targets.push((*outputIndex as usize - 1, cref_field(cref)));
         }
         for a in &**extArgs {
             let oi = ext_arg_output_index(a);
             let scalar = !matches!(&**a, A::SIMEXTARG { type_, .. } if matches!(sig_ty_quiet(type_), Ok(SigTy::Array { .. })));
             if oi != 0 && scalar {
-                targets.push(oi - 1);
+                let field = match &**a {
+                    A::SIMEXTARG { cref, .. } => cref_field(cref),
+                    _ => None,
+                };
+                targets.push((oi - 1, field));
             }
         }
         if results.len() != targets.len() {
@@ -2165,7 +2265,23 @@ fn compile_external_function(
             return Err("CodegenWasmJit: external scalar-return/output count mismatch");
         }
         for k in (0..targets.len()).rev() {
-            let (out_idx, out_sty) = ctx.outputs[targets[k]].clone();
+            let (target, field) = targets[k].clone();
+            let (out_idx, out_sty) = ctx.outputs[target].clone();
+            // Must follow the whole-record store through the pointer argument, which
+            // it does: results go back-to-front.
+            if let Some(field) = field {
+                let SigTy::Record { fields, .. } = &out_sty else {
+                    openmodelica_wasm_jit::set_engine_error_detail(format!(
+                        "  {}, external `{extName}`: `{field}` is a field of an output that is not a record",
+                        fn_path(),
+                    ));
+                    return Err("CodegenWasmJit: external output field on a non-record");
+                };
+                let vt = ctx.alloc_temp(results[k].wty());
+                ctx.emit(we::Instruction::LocalSet(vt));
+                store_fresh_into_field(&mut ctx, out_idx, fields, &field, vt)?;
+                continue;
+            }
             if results[k].wty() != out_sty.wty() {
                 openmodelica_wasm_jit::set_engine_error_detail(format!(
                     "  {}, external `{extName}`: output {k} is {:?} in the C call but \
@@ -2512,6 +2628,18 @@ fn var_name_ty(v: &SimCodeFunction::Variable::Variable) -> Result<(String, SigTy
 
 /// The identifier of a scalar `CREF_IDENT` component reference (no subscripts /
 /// qualification, which only arise for arrays / records).
+/// The field when a reference is `<var>.<field>` — an external call assigning one
+/// member of a record output (`external "C" r.y = f(…)`).
+fn cref_field(cr: &DAE::ComponentRef) -> Option<String> {
+    match cr {
+        DAE::ComponentRef::CREF_QUAL { componentRef, .. } => match &**componentRef {
+            DAE::ComponentRef::CREF_IDENT { ident, .. } => Some(ident.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn cref_ident(cr: &DAE::ComponentRef) -> Result<String> {
     match cr {
         DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. } => {
@@ -2797,49 +2925,8 @@ const ARR_TOTAL_OFF: u32 = 12;
 const ARR_DIMS_OFF: u32 = 16;
 
 // -------------------------------------------------------------------------
-// Record object layout (mirrors the runtime's record object)
+// Record object layout (`openmodelica_wasm_jit::sig`, shared with the hosts)
 // -------------------------------------------------------------------------
-
-/// Byte size of one record field: Real is 8, everything else (Integer/Boolean
-/// and every heap handle) is 4.
-fn field_size(t: &SigTy) -> u32 {
-    if matches!(t, SigTy::Real) { 8 } else { 4 }
-}
-
-fn align_up(n: u32, a: u32) -> u32 {
-    (n + a - 1) & !(a - 1)
-}
-
-/// The byte layout of a record object's payload. `data_off` is the offset from
-/// the object base to the first field (after the refcount, `nheap`, and the
-/// inline heap-field table); `field_off[i]` is field `i`'s offset within the
-/// field-data area; `heap` lists `(elem_kind, field_off)` for the heap fields
-/// (the inline release table); `size` is the total payload to allocate. Must
-/// agree with `rec_data_off` / the field layout in the runtime.
-struct RecordLayout {
-    data_off: u32,
-    size: u32,
-    field_off: Vec<u32>,
-    heap: Vec<(u32, u32)>,
-}
-
-fn record_layout(fields: &[(ArcStr, SigTy)]) -> RecordLayout {
-    let nheap = fields.iter().filter(|(_, t)| t.is_heap()).count() as u32;
-    let data_off = align_up(8 + nheap * 8, 8);
-    let mut off = 0u32;
-    let mut field_off = Vec::with_capacity(fields.len());
-    let mut heap = Vec::new();
-    for (_, t) in fields {
-        let sz = field_size(t);
-        off = align_up(off, sz);
-        field_off.push(off);
-        if t.is_heap() {
-            heap.push((t.elem_kind(), off));
-        }
-        off += sz;
-    }
-    RecordLayout { data_off, size: data_off + align_up(off, 8), field_off, heap }
-}
 
 /// Resolve a record field by name to `(absolute offset from the object base,
 /// field type)`.
@@ -3914,16 +4001,14 @@ fn compile_for_int_range(
     let pw = compile_exp(ctx, stop)?;
     coerce(ctx, pw, WTy::I32);
     ctx.emit(we::Instruction::LocalSet(stop_l));
+    emit_step_check(ctx, step, step_l)?;
 
-    // block { loop { (it>stop) -> br 1; block { body }; it+=step; br 0 } }
-    // Assumes a positive step (the common case for generated loops). The inner
-    // block is the `continue` target — falling through runs the increment.
+    // block { loop { past stop -> br 1; block { body }; it+=step; br 0 } }
+    // The inner block is the `continue` target — falling through runs the increment.
     ctx.emit(we::Instruction::Block(we::BlockType::Empty));
     let break_level = ctx.ctrl_depth;
     ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
-    ctx.emit(we::Instruction::LocalGet(it));
-    ctx.emit(we::Instruction::LocalGet(stop_l));
-    ctx.emit(we::Instruction::I32GtS);
+    emit_range_done(ctx, step, it, step_l, stop_l);
     ctx.emit(we::Instruction::BrIf(1));
     compile_loop_body(ctx, break_level, body)?;
     ctx.emit(we::Instruction::LocalGet(it));
@@ -4053,7 +4138,57 @@ fn emit_range_iter(
     let pw = compile_exp(ctx, stop)?;
     coerce(ctx, pw, WTy::I32);
     ctx.emit(we::Instruction::LocalSet(stop_l));
+    emit_step_check(ctx, step, step_l)?;
     Ok((it, step_l, stop_l))
+}
+
+fn const_step(step: &Option<Arc<DAE::Exp>>) -> Option<i32> {
+    match step {
+        None => Some(1),
+        Some(e) => match &**e {
+            DAE::Exp::ICONST { integer } => Some(*integer),
+            _ => None,
+        },
+    }
+}
+
+/// Leave `it` has passed `stop` on the stack — which way, per C's
+/// `in_range_integer`, is the step's sign.
+fn emit_range_done(ctx: &mut FnCtx, step: &Option<Arc<DAE::Exp>>, it: u32, step_l: u32, stop_l: u32) {
+    ctx.emit(we::Instruction::LocalGet(it));
+    ctx.emit(we::Instruction::LocalGet(stop_l));
+    match const_step(step) {
+        Some(k) if k < 0 => ctx.emit(we::Instruction::I32LtS),
+        Some(_) => ctx.emit(we::Instruction::I32GtS),
+        None => {
+            ctx.emit(we::Instruction::I32GtS);
+            ctx.emit(we::Instruction::LocalGet(it));
+            ctx.emit(we::Instruction::LocalGet(stop_l));
+            ctx.emit(we::Instruction::I32LtS);
+            ctx.emit(we::Instruction::LocalGet(step_l));
+            ctx.emit(we::Instruction::I32Const(0));
+            ctx.emit(we::Instruction::I32GtS);
+            ctx.emit(we::Instruction::Select);
+        }
+    }
+}
+
+const ZERO_STEP: &str = "assertion range step != 0 failed";
+
+/// A zero step never reaches `stop`; C's generated code asserts on it.
+fn emit_step_check(ctx: &mut FnCtx, step: &Option<Arc<DAE::Exp>>, step_l: u32) -> Result<()> {
+    match const_step(step) {
+        Some(0) => emit_runtime_error(ctx, ZERO_STEP),
+        Some(_) => Ok(()),
+        None => {
+            ctx.emit(we::Instruction::LocalGet(step_l));
+            ctx.emit(we::Instruction::I32Eqz);
+            ctx.emit(we::Instruction::If(we::BlockType::Empty));
+            emit_runtime_error(ctx, ZERO_STEP)?;
+            ctx.emit(we::Instruction::End);
+            Ok(())
+        }
+    }
 }
 
 /// Evaluate an Integer range into a fresh local holding its element count,
@@ -4065,17 +4200,34 @@ fn emit_range_count(
     stop: &DAE::Exp,
 ) -> Result<u32> {
     let cnt = ctx.alloc_temp(WTy::I32);
+    // A zero step would divide by zero below, before any loop asserts on it.
+    let step_l = match (const_step(step), step) {
+        (Some(0), _) => {
+            emit_runtime_error(ctx, ZERO_STEP)?;
+            None
+        }
+        (None, Some(e)) => {
+            let l = ctx.alloc_temp(WTy::I32);
+            let w = compile_exp(ctx, e)?;
+            coerce(ctx, w, WTy::I32);
+            ctx.emit(we::Instruction::LocalSet(l));
+            emit_step_check(ctx, step, l)?;
+            Some(l)
+        }
+        _ => None,
+    };
     let pw = compile_exp(ctx, stop)?;
     coerce(ctx, pw, WTy::I32);
     let sw = compile_exp(ctx, start)?;
     coerce(ctx, sw, WTy::I32);
     ctx.emit(we::Instruction::I32Sub);
-    match step {
-        Some(e) => {
+    match (step_l, step) {
+        (Some(l), _) => ctx.emit(we::Instruction::LocalGet(l)),
+        (None, Some(e)) => {
             let w = compile_exp(ctx, e)?;
             coerce(ctx, w, WTy::I32);
         }
-        None => ctx.emit(we::Instruction::I32Const(1)),
+        (None, None) => ctx.emit(we::Instruction::I32Const(1)),
     }
     ctx.emit(we::Instruction::I32DivS);
     ctx.emit(we::Instruction::I32Const(1));
@@ -4110,9 +4262,7 @@ fn emit_red_nest(
     let (it, step_l, stop_l) = emit_range_iter(ctx, &iter.id, start, step, stop)?;
     ctx.emit(we::Instruction::Block(we::BlockType::Empty));
     ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
-    ctx.emit(we::Instruction::LocalGet(it));
-    ctx.emit(we::Instruction::LocalGet(stop_l));
-    ctx.emit(we::Instruction::I32GtS);
+    emit_range_done(ctx, step, it, step_l, stop_l);
     ctx.emit(we::Instruction::BrIf(1));
     match &iter.guardExp {
         Some(guard) => {
@@ -8759,14 +8909,36 @@ pub fn translateFunctions(fnCode: SimCodeFunction::FunctionCode) {
 }
 
 fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<()> {
-    let (bytes, in_sig, out_sig) = build_module(fn_code)?;
+    let BuiltModule { bytes, in_sig, out_sig, ext_imports } = build_module(fn_code)?;
     let base = fn_code.name.to_string();
-    // Sidecar: line 1 = input type codes, line 2 = output type codes.
+    // Sidecar: input type codes, output type codes, then a `lib`/`ext` line per
+    // external "C" library and per function called in one.
     let mut in_codes = String::new();
     in_sig.iter().for_each(|s| s.write_code(&mut in_codes));
     let mut out_codes = String::new();
     out_sig.iter().for_each(|s| s.write_code(&mut out_codes));
-    let sig = format!("{in_codes}\n{out_codes}\n");
+    let mut sig = format!("{in_codes}\n{out_codes}\n");
+    if !ext_imports.is_empty() {
+        let mut notes: Vec<String> = Vec::new();
+        for lib in crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)? {
+            sig.push_str(&format!("lib\t{}\n", lib.name));
+        }
+        // An implementation given as C source in an `Include`.
+        let includes: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
+        let dirs: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.makefileParams.includes).map(|s| s.to_string()).collect();
+        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &mut notes)? {
+            let path = format!("{base}_includes.wasm");
+            openmodelica_wasi::fs::write(&path, &l.bytes)
+                .map_err(|_| "CodegenWasmJitFunctions: cannot stage the compiled include library")?;
+            sig.push_str(&format!("lib\t{path}\n"));
+        }
+        for e in &ext_imports {
+            sig.push_str(&format!("ext\t{}\n", write_ext_sig(e)));
+        }
+        for n in &notes {
+            sig.push_str(&format!("note\t{}\n", n.replace('\n', " ")));
+        }
+    }
     // Native writes the module + sidecar to disk; wasm has no OS filesystem, so
     // the facade stages them in the VFS where `load_and_execute` reads them back.
     openmodelica_wasi::fs::write(&format!("{base}.wasm"), &bytes).map_err(|_| "CodegenWasmJitFunctions: cannot write wasm")?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -452,9 +452,10 @@ fn record_to_value(store: &mut Store, rt: &RtFns, path: &ArcStr, fields: &[(ArcS
     })
 }
 
-/// Rebuild an `Absyn.Path` from a dotted record name (`"A.B.C"`).
+/// Rebuild an `Absyn.Path` from a dotted record name. A record declaration's name
+/// is fully qualified (`".A.B"`): the leading `.` is a marker, not an identifier.
 fn path_from_dotted(s: &str) -> Arc<Absyn::Path> {
-    let parts: Vec<&str> = s.split('.').collect();
+    let parts: Vec<&str> = s.trim_start_matches('.').split('.').collect();
     let mut it = parts.iter().rev();
     let last = it.next().copied().unwrap_or("");
     let mut p = Absyn::Path::IDENT { name: ArcStr::from(last) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -16,6 +16,8 @@ use openmodelica_ast::Absyn;
 use openmodelica_frontend_types::Values;
 
 use super::SigTy;
+use openmodelica_wasm_jit::sig::ExtCallSig;
+use openmodelica_wasi::wasi::WasiCtx;
 
 /// wasmtime errors carry their own (re-exported) `anyhow`, which does not unify
 /// with ours under the feature set we build with; flatten via the message.
@@ -47,7 +49,7 @@ struct JitCache {
     engine: wasmtime::Engine,
     /// Host-imported math builtins (module `"env"`); identical for every module,
     /// so built once and reused for every instantiation.
-    env_linker: wasmtime::Linker<()>,
+    env_linker: wasmtime::Linker<WasiCtx>,
     /// The static linear-memory runtime ([`RUNTIME_WASM`]), compiled once. A
     /// fresh instance is created per call to give each evaluation its own heap.
     runtime_module: wasmtime::Module,
@@ -89,11 +91,106 @@ fn get_or_compile_module(cache: &JitCache, bytes: &[u8]) -> Result<wasmtime::Mod
         .clone())
 }
 
-/// Parsed `.wasm.sig` sidecar: scalar types of the main function's inputs and
-/// outputs.
+/// The runtime does not export this one; it is the host's.
+fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: wasmtime::Memory) -> Result<()> {
+    wt(linker.func_wrap("rt", "rt_print", move |caller: wasmtime::Caller<'_, WasiCtx>, handle: i32| {
+        if handle == 0 {
+            return;
+        }
+        // [refcount:u32][len:u32][utf8]
+        let data = memory.data(&caller);
+        let h = handle as usize;
+        let Some(lenb) = data.get(h + 4..h + 8) else { return };
+        let len = u32::from_le_bytes(lenb.try_into().unwrap()) as usize;
+        if let Some(bytes) = data.get(h + 8..h + 8 + len) {
+            openmodelica_wasi::wasi::stdout_write(bytes);
+        }
+    }))?;
+    Ok(())
+}
+
+/// Load the `external "C"` libraries the sidecar names and bind the module's
+/// `ext.<name>` imports to them, with the loader a simulation uses.
+fn define_external_imports(
+    store: &mut wasmtime::Store<WasiCtx>,
+    linker: &mut wasmtime::Linker<WasiCtx>,
+    rt_inst: wasmtime::Instance,
+    memory: wasmtime::Memory,
+    sig: &Sig,
+) -> Result<()> {
+    use openmodelica_wasm_jit::dylink_engine as dl;
+    if sig.ext_imports.is_empty() {
+        return Ok(());
+    }
+    openmodelica_wasm_jit::host::set_sim_memory(memory);
+    let ext_rt = dl::ExtRt {
+        str_new: wt(rt_inst.get_typed_func(&mut *store, "rt_str_new"))?,
+        str_data: wt(rt_inst.get_typed_func(&mut *store, "rt_str_data"))?,
+        alloc: wt(rt_inst.get_typed_func(&mut *store, "rt_alloc"))?,
+        free: wt(rt_inst.get_typed_func(&mut *store, "rt_free"))?,
+        record_new: wt(rt_inst.get_typed_func(&mut *store, "rt_record_new"))?,
+    };
+    let mut libs = Vec::with_capacity(sig.libs.len() + 1);
+    let libc = openmodelica_wasi_libc::LIBC_PIC;
+    if libc.is_empty() {
+        return Err("CodegenWasmJit: this omc was built without the PIC wasi-libc, so it cannot \
+                    load an external \"C\" library");
+    }
+    libs.push(dl::Library { name: "libc.so".to_string(), bytes: libc.to_vec() });
+    for path in &sig.libs {
+        let bytes = openmodelica_wasi::fs::read(path)
+            .map_err(|_| "CodegenWasmJit: cannot read an external \"C\" library")?;
+        libs.push(dl::Library { name: path.clone(), bytes });
+    }
+    let table = rt_inst
+        .get_table(&mut *store, "__indirect_function_table")
+        .ok_or_else(|| "CodegenWasmJit: runtime has no __indirect_function_table export")?;
+    let host = dl::modelica_utilities_imports(&mut *store, &ext_rt);
+    let engine = linker.engine().clone();
+    let loaded = dl::load(&mut *store, &engine, memory, table, &ext_rt.alloc, &libs, &host)
+        .map_err(|e| record_dylink_error(e))?;
+    for s in &sig.ext_imports {
+        let functype = wasmtime::FuncType::new(
+            &engine,
+            s.wasm_params().iter().map(|t| valtype(t.wty())),
+            s.wasm_results().iter().map(|t| valtype(t.wty())),
+        );
+        let target = loaded.func(&s.name).cloned().ok_or_else(|| {
+            record_dylink_error(format!(
+                "external \"C\" function `{}` is in none of the model's libraries{}",
+                s.name,
+                sig.notes.iter().map(|n| format!("\n  {n}")).collect::<String>()
+            ))
+        })?;
+        let f = dl::bind_in_wasm_external(&mut *store, s, &functype, target, &ext_rt)
+            .map_err(record_dylink_error)?
+            .ok_or("CodegenWasmJit: external \"C\" function has the wrong signature in the library")?;
+        wt(linker.define(&mut *store, "ext", &s.name, f))?;
+    }
+    Ok(())
+}
+
+/// The reason (a missing symbol, a library built without `-shared`) is specific
+/// and useless if swallowed.
+fn record_dylink_error(e: String) -> &'static str {
+    crate::CodegenWasmJit::record_error(format!("CodegenWasmJit: {e}"));
+    "CodegenWasmJit: cannot load the model's external \"C\" libraries"
+}
+
+fn valtype(w: openmodelica_wasm_jit::sig::WTy) -> wasmtime::ValType {
+    match w {
+        openmodelica_wasm_jit::sig::WTy::I32 => wasmtime::ValType::I32,
+        openmodelica_wasm_jit::sig::WTy::F64 => wasmtime::ValType::F64,
+    }
+}
+
+/// Parsed `.wasm.sig` sidecar.
 struct Sig {
     inputs: Vec<SigTy>,
     outputs: Vec<SigTy>,
+    libs: Vec<String>,
+    ext_imports: Vec<ExtCallSig>,
+    notes: Vec<String>,
 }
 
 fn read_sig(path: &str) -> Result<Sig> {
@@ -104,7 +201,18 @@ fn read_sig(path: &str) -> Result<Sig> {
     };
     let inputs = parse(lines.next())?;
     let outputs = parse(lines.next())?;
-    Ok(Sig { inputs, outputs })
+    let mut libs = Vec::new();
+    let mut ext_imports = Vec::new();
+    let mut notes = Vec::new();
+    for line in lines {
+        match line.split_once('\t') {
+            Some(("lib", rest)) => libs.push(rest.to_string()),
+            Some(("ext", rest)) => ext_imports.push(super::parse_ext_sig(rest)?),
+            Some(("note", rest)) => notes.push(rest.to_string()),
+            _ => {}
+        }
+    }
+    Ok(Sig { inputs, outputs, libs, ext_imports, notes })
 }
 
 
@@ -145,17 +253,29 @@ pub(super) fn load_and_execute(
     // module name "rt", plus the `env` math builtins.
     let cache = jit_cache();
     let module = get_or_compile_module(cache, &bytes)?;
-    let mut store = wasmtime::Store::new(&cache.engine, ());
+    let mut store = wasmtime::Store::new(&cache.engine, WasiCtx::new(".", Vec::new()));
     let rt_inst = wt(cache.env_linker.instantiate(&mut store, &cache.runtime_module))?;
     let mut linker = cache.env_linker.clone();
     wt(linker.instance(&mut store, "rt", rt_inst))?;
-    let instance = wt(linker.instantiate(&mut store, &module))?;
 
     // Runtime entry points needed to marshal heap values (strings, arrays) in
     // and out of the shared heap.
     let memory = rt_inst
         .get_memory(&mut store, "memory")
         .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;
+    // `print(s)` in an evaluated function, onto the same stdout a simulation uses.
+    define_print_import(&mut linker, memory)?;
+    define_external_imports(&mut store, &mut linker, rt_inst, memory, &sig).inspect_err(|e| {
+        crate::CodegenWasmJit::record_error(format!(
+            "CodegenWasmJit: cannot bind the external \"C\" functions of `{file_name}`: {e}"
+        ))
+    })?;
+    let instance = linker.instantiate(&mut store, &module).map_err(|e| {
+        crate::CodegenWasmJit::record_error(format!(
+            "CodegenWasmJit: cannot instantiate the JIT module for `{file_name}`: {e}"
+        ));
+        "CodegenWasmJit: wasm engine error"
+    })?;
     let rt = RtFns {
         mem: memory,
         str_new: wt(rt_inst.get_typed_func(&mut store, "rt_str_new"))?,
@@ -270,7 +390,8 @@ struct RtFns {
     rec_new: wasmtime::TypedFunc<(i32, i32), i32>,
 }
 
-type Store = wasmtime::Store<()>;
+// A WASI context so a loaded library (and its libc) has real file I/O.
+type Store = wasmtime::Store<WasiCtx>;
 
 /// Build a `wasmtime::Val` (scalar, or an `i32` handle into the heap) for the
 /// argument value `v` of the given Modelica type. Heap values (strings, arrays)
@@ -451,9 +572,10 @@ fn record_to_value(store: &mut Store, rt: &RtFns, path: &ArcStr, fields: &[(ArcS
     })
 }
 
-/// Rebuild an `Absyn.Path` from a dotted record name (`"A.B.C"`).
+/// Rebuild an `Absyn.Path` from a dotted record name. A record declaration's name
+/// is fully qualified (`".A.B"`): the leading `.` is a marker, not an identifier.
 fn path_from_dotted(s: &str) -> Arc<Absyn::Path> {
-    let parts: Vec<&str> = s.split('.').collect();
+    let parts: Vec<&str> = s.trim_start_matches('.').split('.').collect();
     let mut it = parts.iter().rev();
     let last = it.next().copied().unwrap_or("");
     let mut p = Absyn::Path::IDENT { name: ArcStr::from(last) };
@@ -550,10 +672,10 @@ mod tests {
 
     /// The precompiled runtime, instantiated over the same host imports the
     /// production linker provides.
-    fn runtime_instance() -> (wasmtime::Store<()>, wasmtime::Instance) {
+    fn runtime_instance() -> (Store, wasmtime::Instance) {
         let engine = wasmtime::Engine::default();
         let module = wasmtime::Module::new(&engine, RUNTIME_WASM).unwrap();
-        let mut store = wasmtime::Store::new(&engine, ());
+        let mut store = wasmtime::Store::new(&engine, WasiCtx::new(".", Vec::new()));
         let mut linker = wasmtime::Linker::new(&engine);
         openmodelica_wasm_jit::host::add_host_builtins(&mut linker).unwrap();
         let inst = linker.instantiate(&mut store, &module).unwrap();
@@ -562,7 +684,7 @@ mod tests {
 
     /// Read the bytes of a runtime string handle out of an instance's memory.
     fn read_rt_string(
-        store: &mut wasmtime::Store<()>,
+        store: &mut Store,
         inst: &wasmtime::Instance,
         mem: wasmtime::Memory,
         handle: i32,
@@ -771,7 +893,7 @@ mod tests {
         }
 
         // rt_str_pad: write a string into a fresh runtime object, then pad.
-        let make = |store: &mut wasmtime::Store<()>, s: &str| -> i32 {
+        let make = |store: &mut Store, s: &str| -> i32 {
             let h = str_new.call(&mut *store, s.len() as i32).unwrap();
             let d = str_data.call(&mut *store, h).unwrap() as usize;
             mem.write(&mut *store, d, s.as_bytes()).unwrap();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -570,6 +570,21 @@ static INIT_DONE_HOOK: AtomicUsize = AtomicUsize::new(0);
 pub fn set_init_done_hook(f: fn()) {
     INIT_DONE_HOOK.store(f as usize, Ordering::Relaxed);
 }
+// Fires before the external objects are destroyed. C prints "The simulation
+// finished successfully." before destroying them, so the host keeps their output
+// apart from the simulation's.
+static TEARDOWN_HOOK: AtomicUsize = AtomicUsize::new(0);
+pub fn set_teardown_hook(f: fn()) {
+    TEARDOWN_HOOK.store(f as usize, Ordering::Relaxed);
+}
+fn signal_teardown() {
+    let p = TEARDOWN_HOOK.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn() = unsafe { core::mem::transmute(p) };
+        f();
+    }
+}
+
 /// Public because the in-wasm driver's hook cannot reach the host's capture: it
 /// relays the boundary over `env.rt_host_init_done`, which calls this.
 pub fn signal_init_done() {
@@ -2472,6 +2487,7 @@ pub fn finalize_run(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> R
             ),
         );
     }
+    signal_teardown();
     e.call1_if_present("callExternalObjectDestructors", sim_data)?;
     let mut params = Vec::new();
     for v in &model.vars {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
@@ -14,6 +14,8 @@ metamodelica.workspace = true
 openmodelica_util.workspace = true
 openmodelica_error.workspace = true
 openmodelica_wasi.workspace = true
+# The PIC wasi-libc a model's own external "C" library is loaded on top of.
+openmodelica_wasi_libc.workspace = true
 # Native DAE solver for the DASSL driver; only with the engine (jit).
 daskr = { path = "../daskr", optional = true }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink.rs
@@ -1,0 +1,192 @@
+//! The `dylink.0` metadata of a shared-everything wasm library.
+//!
+//! An `external "C"` library for a wasm target is a PIC dylink module: it
+//! addresses data through `env.__memory_base` and the table through
+//! `env.__table_base`, so the loader may place it anywhere in the simulation's
+//! memory. Engine-independent — both hosts drive it.
+
+/// The `WASM_DYLINK_MEM_INFO` subsection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MemInfo {
+    pub mem_size: u32,
+    /// Power-of-two exponent, as stored (4 means 16-byte alignment).
+    pub mem_p2align: u32,
+    pub table_size: u32,
+    pub table_p2align: u32,
+}
+
+impl MemInfo {
+    pub fn mem_align(&self) -> u32 {
+        1u32 << self.mem_p2align.min(16)
+    }
+}
+
+/// A parsed `dylink.0` custom section.
+#[derive(Debug, Clone, Default)]
+pub struct Dylink {
+    pub mem: MemInfo,
+    pub needed: Vec<String>,
+    /// Weakly bound imports: one that nothing defines is a null address rather
+    /// than a link failure, which is how `libc.so` references things only a main
+    /// module would have.
+    pub weak_imports: Vec<String>,
+}
+
+const SUB_MEM_INFO: u8 = 1;
+const SUB_NEEDED: u8 = 2;
+const SUB_IMPORT_INFO: u8 = 4;
+const SYM_WEAK: u32 = 0x01;
+
+fn uleb(bytes: &[u8], pos: &mut usize) -> Option<u32> {
+    let mut result: u64 = 0;
+    let mut shift = 0;
+    loop {
+        let b = *bytes.get(*pos)?;
+        *pos += 1;
+        result |= ((b & 0x7f) as u64) << shift;
+        if b & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift > 35 {
+            return None;
+        }
+    }
+    u32::try_from(result).ok()
+}
+
+fn name<'a>(bytes: &'a [u8], pos: &mut usize) -> Option<&'a str> {
+    let len = uleb(bytes, pos)? as usize;
+    let s = bytes.get(*pos..*pos + len)?;
+    *pos += len;
+    core::str::from_utf8(s).ok()
+}
+
+/// The `dylink.0` section, or `None` when the module is not a shared library —
+/// which the caller reports, `-c` instead of `-shared` being an easy mistake.
+pub fn parse(module: &[u8]) -> Option<Dylink> {
+    // Magic + version, then (id, size, payload) sections.
+    if module.len() < 8 || &module[..4] != b"\0asm" {
+        return None;
+    }
+    let mut pos = 8;
+    while pos < module.len() {
+        let id = *module.get(pos)?;
+        pos += 1;
+        let size = uleb(module, &mut pos)? as usize;
+        let end = pos.checked_add(size)?;
+        if id != 0 {
+            // dylink.0 precedes every non-custom section.
+            return None;
+        }
+        let mut p = pos;
+        let sec_name = name(module, &mut p)?;
+        if sec_name == "dylink.0" {
+            return parse_dylink0(module.get(p..end)?);
+        }
+        pos = end;
+    }
+    None
+}
+
+fn parse_dylink0(body: &[u8]) -> Option<Dylink> {
+    let mut out = Dylink::default();
+    let mut pos = 0usize;
+    while pos < body.len() {
+        let id = *body.get(pos)?;
+        pos += 1;
+        let size = uleb(body, &mut pos)? as usize;
+        let end = pos.checked_add(size)?;
+        match id {
+            SUB_MEM_INFO => {
+                let mut p = pos;
+                out.mem = MemInfo {
+                    mem_size: uleb(body, &mut p)?,
+                    mem_p2align: uleb(body, &mut p)?,
+                    table_size: uleb(body, &mut p)?,
+                    table_p2align: uleb(body, &mut p)?,
+                };
+            }
+            SUB_NEEDED => {
+                let mut p = pos;
+                let count = uleb(body, &mut p)?;
+                for _ in 0..count {
+                    out.needed.push(name(body, &mut p)?.to_string());
+                }
+            }
+            SUB_IMPORT_INFO => {
+                let mut p = pos;
+                let count = uleb(body, &mut p)?;
+                for _ in 0..count {
+                    let _module = name(body, &mut p)?;
+                    let field = name(body, &mut p)?;
+                    if uleb(body, &mut p)? & SYM_WEAK != 0 {
+                        out.weak_imports.push(field.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+        pos = end;
+    }
+    Some(out)
+}
+
+/// Round `addr` up to `align` (a power of two).
+pub fn align_up(addr: u32, align: u32) -> u32 {
+    let align = align.max(1);
+    addr.wrapping_add(align - 1) & !(align - 1)
+}
+
+/// The stack a loaded library runs on, shared by every side library (they share
+/// one `env.__stack_pointer`) and separate from the runtime's own.
+pub const SIDE_STACK_SIZE: u32 = 512 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mem_info_and_needed() {
+        let mut body = Vec::new();
+        body.push(SUB_MEM_INFO);
+        body.push(4);
+        body.extend_from_slice(&[52, 2, 0, 0]);
+        body.push(SUB_NEEDED);
+        let needed = b"libc.so";
+        body.push((1 + 1 + needed.len()) as u8);
+        body.push(1);
+        body.push(needed.len() as u8);
+        body.extend_from_slice(needed);
+
+        let mut sec = Vec::new();
+        sec.push(8u8);
+        sec.extend_from_slice(b"dylink.0");
+        sec.extend_from_slice(&body);
+
+        let mut module = Vec::new();
+        module.extend_from_slice(b"\0asm\x01\0\0\0");
+        module.push(0); // custom section
+        module.push(sec.len() as u8);
+        module.extend_from_slice(&sec);
+
+        let d = parse(&module).expect("dylink.0 parses");
+        assert_eq!(d.mem.mem_size, 52);
+        assert_eq!(d.mem.mem_align(), 4);
+        assert_eq!(d.needed, vec!["libc.so".to_string()]);
+    }
+
+    #[test]
+    fn a_module_without_dylink0_is_not_a_library() {
+        let module = b"\0asm\x01\0\0\0";
+        assert!(parse(module).is_none());
+    }
+
+    #[test]
+    fn align_up_rounds_to_power_of_two() {
+        assert_eq!(align_up(0, 16), 0);
+        assert_eq!(align_up(1, 16), 16);
+        assert_eq!(align_up(16, 16), 16);
+        assert_eq!(align_up(17, 16), 32);
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -1,0 +1,1293 @@
+//! Loading shared-everything wasm libraries into a running simulation (wasmtime).
+//!
+//! The libraries share the runtime's memory and `__indirect_function_table`, so an
+//! `external "C"` function takes pointers straight from the model. Placing one
+//! means giving it a slice of the runtime heap (`env.__memory_base`), a run of
+//! table slots (`env.__table_base`) and a stack; its own start function then
+//! initialises its data relative to that base.
+
+use std::collections::HashMap;
+
+use wasmtime::{Caller, Extern, Func, FuncType, Global, GlobalType, Memory, Mutability, Ref, Table, Val, ValType};
+
+use crate::dylink::{self, Dylink, SIDE_STACK_SIZE};
+use openmodelica_wasi::wasi::WasiCtx;
+use crate::model::SimModel;
+
+type Result<T> = std::result::Result<T, String>;
+
+pub struct Library {
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+pub struct Loaded {
+    /// First library to define a symbol wins.
+    funcs: HashMap<String, Func>,
+    /// Data symbols as absolute addresses in the shared memory.
+    data: HashMap<String, u32>,
+    func_slots: HashMap<String, u32>,
+    table: Table,
+}
+
+impl Loaded {
+    pub fn func(&self, name: &str) -> Option<&Func> {
+        self.funcs.get(name)
+    }
+}
+
+/// `rt_alloc` guarantees only 8-byte alignment, so over-allocate and round up.
+fn alloc_aligned(
+    store: &mut wasmtime::Store<WasiCtx>,
+    rt_alloc: &wasmtime::TypedFunc<u32, u32>,
+    size: u32,
+    align: u32,
+) -> Result<u32> {
+    if size == 0 {
+        // A distinct base even so: a zero-size library must not alias another.
+        return rt_alloc.call(&mut *store, 8).map_err(|e| format!("rt_alloc: {e}"));
+    }
+    let raw = rt_alloc
+        .call(&mut *store, size + align)
+        .map_err(|e| format!("rt_alloc: {e}"))?;
+    Ok(dylink::align_up(raw, align))
+}
+
+/// Load `libs` in order — a library may use anything an earlier one exports, so
+/// `libc.so` goes first. `memory`, `table` and `rt_alloc` are the runtime's.
+pub fn load(
+    store: &mut wasmtime::Store<WasiCtx>,
+    engine: &wasmtime::Engine,
+    memory: Memory,
+    table: Table,
+    rt_alloc: &wasmtime::TypedFunc<u32, u32>,
+    libs: &[Library],
+    host_imports: &HashMap<String, Func>,
+) -> Result<Loaded> {
+    let mut loaded = Loaded {
+        funcs: HashMap::new(),
+        data: HashMap::new(),
+        func_slots: HashMap::new(),
+        table,
+    };
+    if libs.is_empty() {
+        return Ok(loaded);
+    }
+    // A library imports the memory rather than exporting one, so the WASI shim
+    // cannot find it through the caller.
+    crate::host::set_sim_memory(memory);
+
+    // `libc.so` asks for the stack bounds by name (weak `GOT.mem` imports a main
+    // module would define), so they are seeded as data symbols.
+    let stack = alloc_aligned(store, rt_alloc, SIDE_STACK_SIZE, 16)?;
+    let stack_pointer = Global::new(
+        &mut *store,
+        GlobalType::new(ValType::I32, Mutability::Var),
+        Val::I32((stack + SIDE_STACK_SIZE) as i32),
+    )
+    .map_err(|e| format!("dylink: cannot create __stack_pointer: {e}"))?;
+    loaded.data.insert("__stack_low".to_string(), stack);
+    loaded.data.insert("__stack_high".to_string(), stack + SIDE_STACK_SIZE);
+    // An empty initial dlmalloc segment: every allocation then comes from `sbrk`,
+    // i.e. freshly grown pages, so libc cannot hand out `rt_alloc`'s bytes.
+    loaded.data.insert("__heap_base".to_string(), stack + SIDE_STACK_SIZE);
+    loaded.data.insert("__heap_end".to_string(), stack + SIDE_STACK_SIZE);
+
+    // A GOT entry may name a symbol only a later library defines, so these are
+    // mutable and patched once everything is placed.
+    let mut got_mem: HashMap<String, Global> = HashMap::new();
+    let mut got_func: HashMap<String, Global> = HashMap::new();
+
+    // libc's file I/O goes through the same VFS omc uses.
+    let mut wasi = wasmtime::Linker::new(engine);
+    crate::wasi_shim::add_to_linker(&mut wasi).map_err(|e| format!("dylink: {e}"))?;
+
+    let mut weak: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for lib in libs {
+        let dl = dylink::parse(&lib.bytes).ok_or_else(|| {
+            format!(
+                "external \"C\" library `{}` is not a shared library (no dylink.0 section) \
+                 — build it with `clang -fPIC -shared`, not `-c`",
+                lib.name
+            )
+        })?;
+        weak.extend(dl.weak_imports.iter().cloned());
+        place(
+            store,
+            engine,
+            &lib.name,
+            &lib.bytes,
+            &dl,
+            memory,
+            table,
+            rt_alloc,
+            &stack_pointer,
+            &wasi,
+            host_imports,
+            &mut got_mem,
+            &mut got_func,
+            &mut loaded,
+        )?;
+    }
+
+    for (sym, g) in &got_mem {
+        let addr = match loaded.data.get(sym).copied() {
+            Some(a) => a,
+            None if weak.contains(sym) => 0,
+            None => {
+                return Err(format!("external \"C\" library references undefined data symbol `{sym}`"))
+            }
+        };
+        g.set(&mut *store, Val::I32(addr as i32))
+            .map_err(|e| format!("dylink: cannot set GOT.mem.{sym}: {e}"))?;
+    }
+    for (sym, g) in &got_func {
+        let idx = match func_slot(store, &mut loaded, sym) {
+            Ok(i) => i,
+            Err(_) if weak.contains(sym) => 0,
+            Err(e) => return Err(e),
+        };
+        g.set(&mut *store, Val::I32(idx as i32))
+            .map_err(|e| format!("dylink: cannot set GOT.func.{sym}: {e}"))?;
+    }
+
+    // Data relocations read the GOT, so they wait for its final values.
+    for lib in libs {
+        if let Some(f) = loaded.funcs.get(&reloc_key(&lib.name)).cloned() {
+            f.call(&mut *store, &[], &mut [])
+                .map_err(|e| format!("external \"C\" library `{}` failed to relocate: {e}", lib.name))?;
+        }
+    }
+
+    // Last, so a constructor may call into any library.
+    for lib in libs {
+        if let Some(init) = loaded.funcs.get(&init_key(&lib.name)).cloned() {
+            init.call(&mut *store, &[], &mut [])
+                .map_err(|e| format!("external \"C\" library `{}` failed to initialise: {e}", lib.name))?;
+        }
+    }
+    unbuffer_stdout(store, &loaded)?;
+    Ok(loaded)
+}
+
+/// Nothing flushes libc's buffer — the module is torn down, not exited — so a
+/// library's `printf` would come out interleaved, or not at all.
+fn unbuffer_stdout(store: &mut wasmtime::Store<WasiCtx>, loaded: &Loaded) -> Result<()> {
+    const IONBF: i32 = 2;
+    let (Some(setvbuf), Some(&stdout)) = (loaded.funcs.get("setvbuf").cloned(), loaded.data.get("stdout"))
+    else {
+        return Ok(());
+    };
+    // `stdout` is a `FILE **`, so the stream is one load away.
+    let handle = crate::host::get_sim_memory()
+        .and_then(|m| {
+            let d = m.data(&*store);
+            d.get(stdout as usize..stdout as usize + 4)
+                .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+        })
+        .unwrap_or(0);
+    if handle == 0 {
+        return Ok(());
+    }
+    let mut ret = [Val::I32(0)];
+    setvbuf
+        .call(
+            &mut *store,
+            &[Val::I32(handle as i32), Val::I32(0), Val::I32(IONBF), Val::I32(0)],
+            &mut ret,
+        )
+        .map_err(|e| format!("dylink: cannot make the external library's stdout unbuffered: {e}"))?;
+    Ok(())
+}
+
+fn init_key(lib: &str) -> String {
+    format!("\0init\0{lib}")
+}
+
+fn reloc_key(lib: &str) -> String {
+    format!("\0reloc\0{lib}")
+}
+
+/// The table index of `sym`, appending it the first time it is taken by address.
+fn func_slot(store: &mut wasmtime::Store<WasiCtx>, loaded: &mut Loaded, sym: &str) -> Result<u32> {
+    if let Some(idx) = loaded.func_slots.get(sym) {
+        return Ok(*idx);
+    }
+    let f = loaded
+        .funcs
+        .get(sym)
+        .cloned()
+        .ok_or_else(|| format!("external \"C\" library takes the address of undefined function `{sym}`"))?;
+    let idx = loaded
+        .table
+        .grow(&mut *store, 1, Ref::Func(Some(f)))
+        .map_err(|e| format!("dylink: cannot grow the indirect function table: {e}"))? as u32;
+    loaded.func_slots.insert(sym.to_string(), idx);
+    Ok(idx)
+}
+
+/// Give one library its addresses, bind its imports and instantiate it.
+#[allow(clippy::too_many_arguments)]
+fn place(
+    store: &mut wasmtime::Store<WasiCtx>,
+    engine: &wasmtime::Engine,
+    lib_name: &str,
+    bytes: &[u8],
+    dl: &Dylink,
+    memory: Memory,
+    table: Table,
+    rt_alloc: &wasmtime::TypedFunc<u32, u32>,
+    stack_pointer: &Global,
+    wasi: &wasmtime::Linker<WasiCtx>,
+    host_imports: &HashMap<String, Func>,
+    got_mem: &mut HashMap<String, Global>,
+    got_func: &mut HashMap<String, Global>,
+    loaded: &mut Loaded,
+) -> Result<()> {
+    let module = wasmtime::Module::new(engine, bytes)
+        .map_err(|e| format!("external \"C\" library `{lib_name}` is not valid wasm: {e}"))?;
+
+    let memory_base = alloc_aligned(store, rt_alloc, dl.mem.mem_size, dl.mem.mem_align())?;
+    let table_base = if dl.mem.table_size == 0 {
+        table.size(&*store)
+    } else {
+        table
+            .grow(&mut *store, dl.mem.table_size as u64, Ref::Func(None))
+            .map_err(|e| format!("dylink: cannot grow the indirect function table for `{lib_name}`: {e}"))?
+    } as u32;
+
+    let mut imports: Vec<Extern> = Vec::new();
+    for imp in module.imports() {
+        let ext = match (imp.module(), imp.name()) {
+            ("env", "memory") => Extern::Memory(memory),
+            ("env", "__indirect_function_table") => Extern::Table(table),
+            ("env", "__stack_pointer") => Extern::Global(*stack_pointer),
+            ("env", "__memory_base") => Extern::Global(const_i32(store, memory_base)?),
+            ("env", "__table_base") => Extern::Global(const_i32(store, table_base)?),
+            // The 64-bit variant's spelling; same value.
+            ("env", "__table_base32") => Extern::Global(const_i32(store, table_base)?),
+            ("GOT.mem", sym) => Extern::Global(got_entry(store, got_mem, sym)?),
+            ("GOT.func", sym) => Extern::Global(got_entry(store, got_func, sym)?),
+            ("env", sym) => {
+                // Another library's export, else a host import, else undefined.
+                let ty = imp
+                    .ty()
+                    .func()
+                    .cloned()
+                    .ok_or_else(|| format!("external \"C\" library `{lib_name}` imports env.{sym}, which is not a function"))?;
+                match loaded.funcs.get(sym).or_else(|| host_imports.get(sym)) {
+                    Some(f) => Extern::Func(*f),
+                    None => Extern::Func(missing_symbol_stub(store, &ty, lib_name, sym)),
+                }
+            }
+            ("wasi_snapshot_preview1", sym) => {
+                // Real file I/O over omc's VFS.
+                let ty = imp.ty().func().cloned().ok_or_else(|| {
+                    format!("external \"C\" library `{lib_name}` imports a non-function from wasi_snapshot_preview1")
+                })?;
+                match wasi.get(&mut *store, "wasi_snapshot_preview1", sym) {
+                    Ok(e) => e,
+                    Err(_) => Extern::Func(missing_symbol_stub(store, &ty, lib_name, sym)),
+                }
+            }
+            (module, name) => {
+                return Err(format!(
+                    "external \"C\" library `{lib_name}` imports {module}.{name}, which no wasm-jit host provides"
+                ))
+            }
+        };
+        imports.push(ext);
+    }
+
+    let instance = wasmtime::Instance::new(&mut *store, &module, &imports)
+        .map_err(|e| format!("external \"C\" library `{lib_name}` failed to load: {e}"))?;
+
+    // Before running anything, so a constructor can reach the rest of the library.
+    let mut apply_relocs = None;
+    let mut initialize = None;
+    for exp in module.exports() {
+        let name = exp.name().to_string();
+        match instance.get_export(&mut *store, &name) {
+            Some(Extern::Func(f)) => {
+                match name.as_str() {
+                    "__wasm_apply_data_relocs" => apply_relocs = Some(f),
+                    // A reactor's `_initialize` runs `__wasm_call_ctors` itself.
+                    "_initialize" => initialize = Some(f),
+                    "__wasm_call_ctors" if initialize.is_none() => initialize = Some(f),
+                    _ => {}
+                }
+                loaded.funcs.entry(name).or_insert(f);
+            }
+            Some(Extern::Global(g)) => {
+                // A data symbol's global holds an offset within the library's data.
+                if let Val::I32(off) = g.get(&mut *store) {
+                    loaded.data.entry(name).or_insert(memory_base.wrapping_add(off as u32));
+                }
+            }
+            _ => {}
+        }
+    }
+    // Deferred to `load`: the GOT is not final until every library is placed.
+    if let Some(f) = apply_relocs {
+        loaded.funcs.insert(reloc_key(lib_name), f);
+    }
+    if let Some(f) = initialize {
+        loaded.funcs.insert(init_key(lib_name), f);
+    }
+    Ok(())
+}
+
+fn const_i32(store: &mut wasmtime::Store<WasiCtx>, value: u32) -> Result<Global> {
+    Global::new(
+        &mut *store,
+        GlobalType::new(ValType::I32, Mutability::Const),
+        Val::I32(value as i32),
+    )
+    .map_err(|e| format!("dylink: cannot create a base global: {e}"))
+}
+
+/// The mutable global backing one GOT entry, created on first reference.
+fn got_entry(
+    store: &mut wasmtime::Store<WasiCtx>,
+    map: &mut HashMap<String, Global>,
+    sym: &str,
+) -> Result<Global> {
+    if let Some(g) = map.get(sym) {
+        return Ok(*g);
+    }
+    let g = Global::new(
+        &mut *store,
+        GlobalType::new(ValType::I32, Mutability::Var),
+        Val::I32(0),
+    )
+    .map_err(|e| format!("dylink: cannot create GOT entry for {sym}: {e}"))?;
+    map.insert(sym.to_string(), g);
+    Ok(g)
+}
+
+/// Traps naming the symbol, rather than returning a plausible zero.
+fn missing_symbol_stub(
+    store: &mut wasmtime::Store<WasiCtx>,
+    ty: &FuncType,
+    lib_name: &str,
+    sym: &str,
+) -> Func {
+    let msg = format!("external \"C\" library `{lib_name}` called `{sym}`, which is not available in wasm");
+    Func::new(&mut *store, ty.clone(), move |_: Caller<'_, WasiCtx>, _, _| {
+        Err(wasmtime::Error::msg(msg.clone()))
+    })
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile `src` the way a user (and the testsuite's `setup_command`) does.
+    fn build_library(name: &str, src: &str) -> Option<Vec<u8>> {
+        let sysroot = option_env!("OMC_WASI_PIC_SYSROOT")?;
+        let dir = std::env::temp_dir().join(format!("om-dylink-test-{}-{name}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok()?;
+        let c = dir.join(format!("{name}.c"));
+        let wasm = dir.join(format!("{name}.wasm"));
+        std::fs::write(&c, src).ok()?;
+        let status = std::process::Command::new("clang")
+            .args(["--target=wasm32-wasip1", "-fPIC", "-shared", "-nodefaultlibs", "-O1"])
+            .arg(format!("--sysroot={sysroot}"))
+            .args(["-Wl,--export-all", "-Wl,--allow-undefined"])
+            .arg("-o")
+            .arg(&wasm)
+            .arg(&c)
+            .status()
+            .ok()?;
+        status.success().then(|| std::fs::read(&wasm).ok())?
+    }
+
+    /// `libc.so` under the library: a library's `_initialize` calls its
+    /// `__wasi_init_tp`, so it is never absent.
+    fn with_libc(name: &str, bytes: Vec<u8>) -> Option<[Library; 2]> {
+        if openmodelica_wasi_libc::LIBC_PIC.is_empty() {
+            eprintln!("no PIC libc; skipping");
+            return None;
+        }
+        Some([
+            Library { name: "libc.so".into(), bytes: openmodelica_wasi_libc::LIBC_PIC.to_vec() },
+            Library { name: name.into(), bytes },
+        ])
+    }
+
+    /// The runtime owns the memory, table and allocator the libraries go in.
+    fn runtime() -> (wasmtime::Store<WasiCtx>, wasmtime::Engine, wasmtime::Instance) {
+        let engine = wasmtime::Engine::default();
+        let module = wasmtime::Module::new(&engine, crate::RUNTIME_WASM).unwrap();
+        let mut store = wasmtime::Store::new(&engine, WasiCtx::new(".", Vec::new()));
+        let mut linker = wasmtime::Linker::new(&engine);
+        crate::host::add_host_builtins(&mut linker).unwrap();
+        let inst = linker.instantiate(&mut store, &module).unwrap();
+        (store, engine, inst)
+    }
+
+    /// Placement, data-segment init against `__memory_base`, and the call.
+    #[test]
+    fn loads_a_library_and_calls_it() {
+        let Some(bytes) = build_library("scalar", "double triple(double x) { return 3*x; }") else {
+            eprintln!("no wasi sysroot; skipping");
+            return;
+        };
+        let (mut store, engine, rt_inst) = runtime();
+        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
+        let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
+
+        let Some(libs) = with_libc("scalar.wasm", bytes) else { return };
+        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let f = loaded.func("triple").expect("the library exports `triple`").clone();
+        let f = f.typed::<f64, f64>(&store).unwrap();
+        assert_eq!(f.call(&mut store, 5.0).unwrap(), 15.0);
+    }
+
+    /// Static data is reachable, and inside the region the loader allocated.
+    #[test]
+    fn static_data_is_relocated_into_the_shared_memory() {
+        let Some(bytes) = build_library(
+            "data",
+            "static const double table[3] = {1.5, 2.5, 3.5};\n\
+             double pick(int i) { return table[i]; }\n\
+             const double *addr(void) { return table; }",
+        ) else {
+            eprintln!("no wasi sysroot; skipping");
+            return;
+        };
+        let (mut store, engine, rt_inst) = runtime();
+        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
+        let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
+
+        let Some(libs) = with_libc("data.wasm", bytes) else { return };
+        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let pick = loaded.func("pick").unwrap().clone().typed::<i32, f64>(&store).unwrap();
+        assert_eq!(pick.call(&mut store, 1).unwrap(), 2.5);
+
+        // It really is in the simulation's memory, so the host can read it.
+        let addr = loaded.func("addr").unwrap().clone().typed::<(), i32>(&store).unwrap();
+        let at = addr.call(&mut store, ()).unwrap() as usize;
+        let raw = &memory.data(&store)[at..at + 8];
+        assert_eq!(f64::from_le_bytes(raw.try_into().unwrap()), 1.5);
+    }
+
+    /// A library calling libc is served by the `libc.so` beneath it.
+    #[test]
+    fn a_library_can_use_libc() {
+        let Some(bytes) = build_library(
+            "uselibc",
+            "#include <string.h>\n#include <stdlib.h>\n\
+             int len_of_copy(const char *s) { char *d = strdup(s); int n = strlen(d); free(d); return n; }",
+        ) else {
+            eprintln!("no wasi sysroot; skipping");
+            return;
+        };
+        let (mut store, engine, rt_inst) = runtime();
+        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
+        let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
+
+        let Some(libs) = with_libc("uselibc.wasm", bytes) else { return };
+        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+
+        // A NUL-terminated string in the shared memory, as `Str` marshalling does.
+        let cell = alloc.call(&mut store, 6).unwrap();
+        memory.data_mut(&mut store)[cell as usize..cell as usize + 6].copy_from_slice(b"hello\0");
+        let f = loaded.func("len_of_copy").unwrap().clone().typed::<i32, i32>(&store).unwrap();
+        assert_eq!(f.call(&mut store, cell as i32).unwrap(), 5);
+    }
+
+    /// A scalar external is called wasm→wasm, so the types must agree.
+    #[test]
+    fn a_scalar_external_binds_directly() {
+        use crate::sig::{ExtCallSig, ExtLang, SigTy};
+        let Some(bytes) = build_library("bind", "double triple(double x) { return 3*x; }") else {
+            return;
+        };
+        let Some(libs) = with_libc("bind.wasm", bytes) else { return };
+        let (mut store, engine, rt_inst) = runtime();
+        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
+        let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
+        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+
+        let rt = ExtRt {
+            str_new: rt_inst.get_typed_func(&mut store, "rt_str_new").unwrap(),
+            str_data: rt_inst.get_typed_func(&mut store, "rt_str_data").unwrap(),
+            alloc: alloc.clone(),
+            free: rt_inst.get_typed_func(&mut store, "rt_free").unwrap(),
+            record_new: rt_inst.get_typed_func(&mut store, "rt_record_new").unwrap(),
+        };
+        let sig = ExtCallSig {
+            name: "triple".into(),
+            lang: ExtLang::C,
+            args: vec![(SigTy::Real, false)],
+            ret: Some(SigTy::Real),
+        };
+        let functype = wasmtime::FuncType::new(
+            &engine,
+            sig.wasm_params().iter().map(|t| match t.wty() {
+                crate::sig::WTy::I32 => wasmtime::ValType::I32,
+                crate::sig::WTy::F64 => wasmtime::ValType::F64,
+            }),
+            sig.wasm_results().iter().map(|t| match t.wty() {
+                crate::sig::WTy::I32 => wasmtime::ValType::I32,
+                crate::sig::WTy::F64 => wasmtime::ValType::F64,
+            }),
+        );
+        let target = loaded.func("triple").unwrap().clone();
+        let bound = bind_in_wasm_external(&mut store, &sig, &functype, target, &rt)
+            .unwrap()
+            .expect("a matching scalar external binds");
+        let f = bound.into_func().unwrap().typed::<f64, f64>(&store).unwrap();
+        assert_eq!(f.call(&mut store, 5.0).unwrap(), 15.0);
+    }
+
+    /// The mistake to expect, reported as such rather than as unresolved imports.
+    #[test]
+    fn an_object_file_is_rejected_with_a_useful_message() {
+        let Some(sysroot) = option_env!("OMC_WASI_PIC_SYSROOT") else { return };
+        let dir = std::env::temp_dir().join(format!("om-dylink-test-{}-obj", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let c = dir.join("obj.c");
+        let o = dir.join("obj.o");
+        std::fs::write(&c, "double twice(double x) { return 2*x; }").unwrap();
+        let ok = std::process::Command::new("clang")
+            .args(["--target=wasm32-wasip1", "-fPIC", "-c"])
+            .arg(format!("--sysroot={sysroot}"))
+            .arg("-o")
+            .arg(&o)
+            .arg(&c)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+        let (mut store, engine, rt_inst) = runtime();
+        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
+        let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
+        let libs = [Library { name: "obj.o".into(), bytes: std::fs::read(&o).unwrap() }];
+        let err = match load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()) {
+            Err(e) => e,
+            Ok(_) => panic!("an object file was accepted as a library"),
+        };
+        assert!(err.contains("not a shared library"), "{err}");
+    }
+}
+
+// ─────────────────── calling into a loaded library ───────────────────
+
+/// The model's own `external "C"` libraries, with the PIC `libc.so` under them.
+pub fn load_ext_libraries(
+    store: &mut wasmtime::Store<WasiCtx>,
+    engine: &wasmtime::Engine,
+    rt_inst: wasmtime::Instance,
+    memory: wasmtime::Memory,
+    model: &SimModel,
+    rt: &ExtRt,
+) -> std::result::Result<Loaded, String> {
+    use Library;
+    let table = rt_inst
+        .get_table(&mut *store, "__indirect_function_table")
+        .ok_or_else(|| "CodegenWasmJit: runtime has no __indirect_function_table export".to_string())?;
+    if model.ext_libs.is_empty() {
+        return load(store, engine, memory, table, &rt.alloc, &[], &HashMap::new());
+    }
+    let libc = openmodelica_wasi_libc::LIBC_PIC;
+    if libc.is_empty() {
+        return Err("CodegenWasmJit: this omc was built without the PIC wasi-libc, so it cannot \
+                    load an external \"C\" library"
+            .to_string());
+    }
+    let mut libs = Vec::with_capacity(model.ext_libs.len() + 1);
+    libs.push(Library { name: "libc.so".to_string(), bytes: libc.to_vec() });
+    for l in &model.ext_libs {
+        libs.push(Library { name: l.name.clone(), bytes: l.bytes.clone() });
+    }
+    let host = modelica_utilities_imports(store, rt);
+    load(store, engine, memory, table, &rt.alloc, &libs, &host)
+}
+
+fn shared_cstr(caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: i32) -> String {
+    let Some(memory) = crate::host::get_sim_memory() else { return String::new() };
+    let data = memory.data(&*caller);
+    let p = ptr as usize;
+    let Some(rest) = data.get(p..) else { return String::new() };
+    let len = rest.iter().position(|&b| b == 0).unwrap_or(0);
+    String::from_utf8_lossy(&rest[..len]).into_owned()
+}
+
+/// The ModelicaUtilities a library may call: host imports, because the messages
+/// belong in omc's error buffer. A formatted variant gets `(format, va_list)` and
+/// is not interpolated, as on the web target.
+pub fn modelica_utilities_imports(
+    store: &mut wasmtime::Store<WasiCtx>,
+    rt: &ExtRt,
+) -> HashMap<String, wasmtime::Func> {
+    use wasmtime::{Caller, Func};
+    let mut m: HashMap<String, Func> = HashMap::new();
+
+    let error = |mut caller: Caller<'_, WasiCtx>, ptr: i32| -> std::result::Result<(), wasmtime::Error> {
+        let msg = shared_cstr(&mut caller, ptr);
+        openmodelica_error::ErrorExt::runtime_error(&msg);
+        Err(wasmtime::Error::msg(format!("ModelicaError: {msg}")))
+    };
+    let error_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| -> std::result::Result<(), wasmtime::Error> {
+        let msg = shared_cstr(&mut caller, fmt);
+        openmodelica_error::ErrorExt::runtime_error(&msg);
+        Err(wasmtime::Error::msg(format!("ModelicaError: {msg}")))
+    };
+    let warning = |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
+        let msg = shared_cstr(&mut caller, ptr);
+        openmodelica_error::ErrorExt::runtime_warning(&msg);
+    };
+    let warning_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
+        let msg = shared_cstr(&mut caller, fmt);
+        openmodelica_error::ErrorExt::runtime_warning(&msg);
+    };
+
+    let message = |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
+        let msg = shared_cstr(&mut caller, ptr);
+        openmodelica_wasi::wasi::stdout_write(msg.as_bytes());
+    };
+    let message_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
+        let msg = shared_cstr(&mut caller, fmt);
+        openmodelica_wasi::wasi::stdout_write(msg.as_bytes());
+    };
+
+    m.insert("ModelicaError".into(), Func::wrap(&mut *store, error));
+    m.insert("ModelicaFormatError".into(), Func::wrap(&mut *store, error_fmt));
+    m.insert("ModelicaVFormatError".into(), Func::wrap(&mut *store, error_fmt));
+    m.insert("ModelicaWarning".into(), Func::wrap(&mut *store, warning));
+    m.insert("ModelicaFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
+    m.insert("ModelicaVFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
+    m.insert("ModelicaMessage".into(), Func::wrap(&mut *store, message));
+    m.insert("ModelicaFormatMessage".into(), Func::wrap(&mut *store, message_fmt));
+    m.insert("ModelicaVFormatMessage".into(), Func::wrap(&mut *store, message_fmt));
+
+    // The simulation's allocator, so a string the callee builds is readable from
+    // the model's memory.
+    let alloc = rt.alloc.clone();
+    let allocate = move |mut caller: Caller<'_, WasiCtx>, len: i32| -> std::result::Result<i32, wasmtime::Error> {
+        let n = len.max(0) as u32 + 1;
+        let p = alloc.call(&mut caller, n)?;
+        if let Some(memory) = crate::host::get_sim_memory() {
+            memory.data_mut(&mut caller)[p as usize..(p + n) as usize].fill(0);
+        }
+        Ok(p as i32)
+    };
+    let allocate2 = allocate.clone();
+    m.insert("ModelicaAllocateString".into(), Func::wrap(&mut *store, allocate));
+    m.insert("ModelicaAllocateStringWithErrorReturn".into(), Func::wrap(&mut *store, allocate2));
+    m
+}
+
+/// The runtime entry points an external "C" call needs.
+#[derive(Clone)]
+pub struct ExtRt {
+    pub str_new: wasmtime::TypedFunc<u32, u32>,
+    pub str_data: wasmtime::TypedFunc<u32, u32>,
+    pub alloc: wasmtime::TypedFunc<u32, u32>,
+    pub free: wasmtime::TypedFunc<u32, ()>,
+    pub record_new: wasmtime::TypedFunc<(u32, u32), u32>,
+}
+
+/// Whether the import is already exactly the C function, so the engine can call it
+/// wasm→wasm. `Ptr` qualifies: with shared memory it is a real address.
+fn is_direct_call(sig: &crate::sig::ExtCallSig) -> bool {
+    use crate::sig::SigTy;
+    fn scalar(t: &SigTy) -> bool {
+        matches!(t, SigTy::Int | SigTy::Real | SigTy::Bool | SigTy::Ptr)
+    }
+    sig.lang == crate::sig::ExtLang::C
+        && sig.args.iter().all(|(t, is_out)| !*is_out && scalar(t))
+        && sig.ret.as_ref().is_none_or(scalar)
+}
+
+/// Bind `ext.<name>` to a library export. An array argument is passed as the
+/// address of the model's own elements — no copy either way; only a String
+/// (length-prefixed, not NUL-terminated) and an `_Out_` cell need scratch.
+///
+/// `None` when the library's function has the wrong wasm type.
+pub fn bind_in_wasm_external(
+    store: &mut wasmtime::Store<WasiCtx>,
+    sig: &crate::sig::ExtCallSig,
+    functype: &wasmtime::FuncType,
+    target: wasmtime::Func,
+    rt: &ExtRt,
+) -> Result<Option<wasmtime::Extern>> {
+    if is_direct_call(sig) {
+        let same = {
+            let ty = target.ty(&*store);
+            ty.params().len() == functype.params().len()
+                && ty.results().len() == functype.results().len()
+                && ty.params().zip(functype.params()).all(|(a, b)| a.matches(&b))
+                && ty.results().zip(functype.results()).all(|(a, b)| a.matches(&b))
+        };
+        return Ok(same.then_some(wasmtime::Extern::Func(target)));
+    }
+    let sig = sig.clone();
+    let rt = rt.clone();
+    let f = wasmtime::Func::new(&mut *store, functype.clone(), move |mut caller, args, rets| {
+        call_external_in_wasm(&sig, &rt, &target, &mut caller, args, rets)
+            .map_err(|e| wasmtime::Error::msg(format!("external \"C\" `{}`: {e}", sig.name)))
+    });
+    Ok(Some(wasmtime::Extern::Func(f)))
+}
+
+/// Call `target` with the C argument list its prototype expects, then hand the
+/// results back as the import's wasm results.
+fn call_external_in_wasm(
+    sig: &crate::sig::ExtCallSig,
+    rt: &ExtRt,
+    target: &wasmtime::Func,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    args: &[wasmtime::Val],
+    rets: &mut [wasmtime::Val],
+) -> Result<()> {
+    use crate::sig::SigTy;
+    use wasmtime::Val;
+
+    let memory = crate::host::get_sim_memory().ok_or_else(|| "external \"C\": the run has no shared memory".to_string())?;
+    let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
+    let mut call_args: Vec<Val> = Vec::with_capacity(sig.args.len());
+    let mut temps: Vec<u32> = Vec::new();
+    // (output type, scratch address), in the order the import returns them.
+    let mut out_cells: Vec<(SigTy, u32)> = Vec::new();
+    // Column-major copies a FORTRAN 77 callee gets instead of the array itself:
+    // (scratch, element area, dims, element size, is output).
+    let mut f77_arrays: Vec<(u32, u32, Vec<usize>, usize, bool)> = Vec::new();
+
+    let alloc = |caller: &mut wasmtime::Caller<'_, WasiCtx>, n: u32| -> Result<u32> {
+        rt.alloc.call(&mut *caller, n).map_err(|e| format!("rt_alloc: {e}"))
+    };
+
+    // A returned struct comes back through an `sret` pointer ahead of every declared
+    // argument (`struct ADD f(double)` → `(i32, f64) -> ()`).
+    let sret = match sig.ret.as_ref().map(|t| (t, abi_of(t))) {
+        Some((SigTy::Record { fields, .. }, Abi::Indirect)) => {
+            let cell = alloc(caller, c_record_layout(fields).size.max(1))?;
+            memory.data_mut(&mut *caller)[cell as usize..cell as usize + c_record_layout(fields).size as usize].fill(0);
+            temps.push(cell);
+            call_args.push(Val::I32(cell as i32));
+            Some(cell)
+        }
+        _ => None,
+    };
+
+    let mut in_i = 0usize;
+    for (ty, is_out) in &sig.args {
+        // A struct: by pointer, or as its member's scalar when it has one member.
+        if let SigTy::Record { fields, .. } = ty {
+            // An output record is a wasm *result*, so it consumes no parameter.
+            let v = if *is_out {
+                None
+            } else {
+                let v = args.get(in_i).ok_or_else(|| {
+                    "external \"C\": the call passes fewer arguments than the signature declares".to_string()
+                })?;
+                in_i += 1;
+                Some(v)
+            };
+            match abi_of(ty) {
+                // No members: no argument at all.
+                Abi::Dropped => {
+                    if *is_out {
+                        out_cells.push((ty.clone(), 0));
+                    }
+                }
+                Abi::Scalar(s) => {
+                    if *is_out {
+                        return Err("external \"C\": a single-member record cannot be an output".to_string());
+                    }
+                    let handle = v.map(|v| v.unwrap_i32()).unwrap_or(0) as u32;
+                    let (off, leaf) = record_leaf(fields);
+                    call_args.push(match leaf {
+                        SigTy::Real => Val::F64(read_u64(memory, caller, handle + off)),
+                        _ => Val::I32(read_u32(memory, caller, handle + off) as i32),
+                    });
+                    let _ = s;
+                }
+                Abi::Indirect => {
+                    let c = c_record_layout(fields);
+                    let cell = alloc(caller, c.size.max(1))?;
+                    memory.data_mut(&mut *caller)[cell as usize..cell as usize + c.size as usize].fill(0);
+                    if let Some(v) = v {
+                        record_to_c(caller, memory, rt, fields, v.unwrap_i32() as u32, cell, &mut temps)?;
+                    }
+                    temps.push(cell);
+                    if *is_out {
+                        out_cells.push((ty.clone(), cell));
+                    }
+                    call_args.push(Val::I32(cell as i32));
+                }
+            }
+            continue;
+        }
+        // An `_Out_` scalar/string is written through a pointer; an output array is
+        // filled in place, so it goes through the `Array` arm like an input.
+        if *is_out && !matches!(ty, SigTy::Array { .. }) {
+            let cell = alloc(caller, 8)?;
+            memory.data_mut(&mut *caller)[cell as usize..cell as usize + 8].fill(0);
+            temps.push(cell);
+            out_cells.push((ty.clone(), cell));
+            call_args.push(Val::I32(cell as i32));
+            continue;
+        }
+        let v = args.get(in_i).ok_or_else(|| {
+            "external \"C\": the call passes fewer arguments than the signature declares".to_string()
+        })?;
+        in_i += 1;
+        if fortran && matches!(ty, SigTy::Real | SigTy::Int | SigTy::Bool) {
+            let cell = alloc(caller, 8)?;
+            let raw = match ty {
+                SigTy::Real => v.unwrap_f64().to_le_bytes(),
+                _ => {
+                    let mut b = [0u8; 8];
+                    b[..4].copy_from_slice(&v.unwrap_i32().to_le_bytes());
+                    b
+                }
+            };
+            memory.data_mut(&mut *caller)[cell as usize..cell as usize + 8].copy_from_slice(&raw);
+            temps.push(cell);
+            call_args.push(Val::I32(cell as i32));
+            continue;
+        }
+        match ty {
+            SigTy::Real => call_args.push(Val::F64(v.unwrap_f64().to_bits())),
+            SigTy::Int | SigTy::Bool | SigTy::Ptr => call_args.push(Val::I32(v.unwrap_i32())),
+            SigTy::Str => {
+                // `char*`: the same bytes, NUL-terminated.
+                let off = v.unwrap_i32() as usize;
+                let data = memory.data(&*caller);
+                let len = u32::from_le_bytes(
+                    data.get(off + 4..off + 8).ok_or_else(|| "external \"C\": malformed String argument".to_string())?.try_into().unwrap(),
+                ) as usize;
+                let cell = alloc(caller, (len + 1) as u32)?;
+                let mem = memory.data_mut(&mut *caller);
+                mem.copy_within(off + 8..off + 8 + len, cell as usize);
+                mem[cell as usize + len] = 0;
+                temps.push(cell);
+                call_args.push(Val::I32(cell as i32));
+            }
+            SigTy::Array { elem, .. } => {
+                let off = v.unwrap_i32() as usize;
+                let (dims, data_off) = crate::host::array_abi::dims_and_data(memory.data(&*caller), off)
+                    .ok_or_else(|| "external \"C\": malformed array argument".to_string())?;
+                let base = (off + data_off) as u32;
+                if fortran && dims.len() > 1 {
+                    // C's `convert_alloc_*_to_f77`.
+                    let esz = crate::host::array_abi::elem_size(elem);
+                    let n = dims.iter().product::<usize>() * esz;
+                    let cell = alloc(caller, n as u32)?;
+                    let mut buf = vec![0u8; n];
+                    let mem = memory.data_mut(&mut *caller);
+                    crate::host::array_abi::reorder(&mem[base as usize..base as usize + n], &mut buf, &dims, esz, true);
+                    mem[cell as usize..cell as usize + n].copy_from_slice(&buf);
+                    temps.push(cell);
+                    call_args.push(Val::I32(cell as i32));
+                    f77_arrays.push((cell, base, dims, esz, *is_out));
+                } else {
+                    call_args.push(Val::I32(base as i32));
+                }
+            }
+            _ => return Err("external \"C\": input argument type not marshalled".to_string()),
+        }
+    }
+
+    // A struct return goes through `sret`, so the call itself yields nothing.
+    let returns_value = match sig.ret.as_ref().map(abi_of) {
+        None | Some(Abi::Dropped) | Some(Abi::Indirect) => false,
+        Some(Abi::Scalar(_)) => true,
+    };
+    let mut raw_ret = [Val::I32(0)];
+    let ret_slice = if returns_value { &mut raw_ret[..] } else { &mut raw_ret[..0] };
+    target.call(&mut *caller, &call_args, ret_slice).map_err(|e| format!("{e}"))?;
+
+    // C's `convert_alloc_*_from_f77`.
+    for (cell, base, dims, esz, is_out) in &f77_arrays {
+        if !*is_out {
+            continue;
+        }
+        let n = dims.iter().product::<usize>() * esz;
+        let mem = memory.data_mut(&mut *caller);
+        let mut buf = vec![0u8; n];
+        crate::host::array_abi::reorder(&mem[*cell as usize..*cell as usize + n], &mut buf, dims, *esz, false);
+        mem[*base as usize..*base as usize + n].copy_from_slice(&buf);
+    }
+
+    let mut result = Vec::with_capacity(rets.len());
+    if let Some(ret_ty) = &sig.ret {
+        match (ret_ty, abi_of(ret_ty)) {
+
+            (SigTy::Record { fields, .. }, Abi::Indirect | Abi::Dropped) => {
+                let handle = record_from_c(caller, memory, rt, fields, sret.unwrap_or(0))?;
+                result.push(Val::I32(handle as i32));
+            }
+
+            (SigTy::Record { fields, .. }, Abi::Scalar(leaf)) => {
+                let (off, _) = record_leaf(fields);
+                let handle = record_from_scalar(caller, memory, rt, fields, off, &leaf, &raw_ret[0])?;
+                result.push(Val::I32(handle as i32));
+            }
+            _ => {
+                let raw = match ret_ty {
+                    SigTy::Real => raw_ret[0].unwrap_f64().to_le_bytes(),
+                    _ => {
+                        let mut b = [0u8; 8];
+                        b[..4].copy_from_slice(&raw_ret[0].unwrap_i32().to_le_bytes());
+                        b
+                    }
+                };
+                result.push(ext_result(ret_ty, raw, rt, caller, memory)?);
+            }
+        }
+    }
+    for (ty, cell) in &out_cells {
+        if let SigTy::Record { fields, .. } = ty {
+            let handle = record_from_c(caller, memory, rt, fields, *cell)?;
+            result.push(Val::I32(handle as i32));
+            continue;
+        }
+        let mut raw = [0u8; 8];
+        raw.copy_from_slice(&memory.data(&*caller)[*cell as usize..*cell as usize + 8]);
+        result.push(ext_result(ty, raw, rt, caller, memory)?);
+    }
+    for (slot, v) in rets.iter_mut().zip(result) {
+        *slot = v;
+    }
+    for t in temps {
+        let _ = rt.free.call(&mut *caller, t);
+    }
+    Ok(())
+}
+
+/// The 8 raw bytes the C side produced, as the wasm value the import declares. A
+/// `char*` becomes a fresh String: the callee's buffer is its own to reuse.
+
+fn ext_result(
+    ty: &crate::sig::SigTy,
+    raw: [u8; 8],
+    rt: &ExtRt,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+) -> Result<wasmtime::Val> {
+    use crate::sig::SigTy;
+    use wasmtime::Val;
+    Ok(match ty {
+        SigTy::Real => Val::F64(f64::from_le_bytes(raw).to_bits()),
+        SigTy::Int | SigTy::Bool | SigTy::Ptr => Val::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
+        SigTy::Str => {
+            let ptr = u32::from_le_bytes(raw[..4].try_into().unwrap()) as usize;
+            let data = memory.data(&*caller);
+            let len = if ptr == 0 {
+                0
+            } else {
+                data[ptr..].iter().position(|&b| b == 0).ok_or_else(|| "external \"C\": unterminated `char*` result".to_string())?
+            };
+            let handle = rt.str_new.call(&mut *caller, len as u32).map_err(|e| format!("{e}"))?;
+            let dst = rt.str_data.call(&mut *caller, handle).map_err(|e| format!("{e}"))? as usize;
+            memory.data_mut(&mut *caller).copy_within(ptr..ptr + len, dst);
+            Val::I32(handle as i32)
+        }
+        _ => return Err("external \"C\": result type not marshalled".to_string()),
+    })
+}
+
+
+// ─────────────────── records across the C boundary ───────────────────
+
+/// The C type an `external "C"` prototype gives a value.
+fn c_size_align(t: &crate::sig::SigTy) -> (u32, u32) {
+    use crate::sig::SigTy;
+    match t {
+        SigTy::Real => (8, 8),
+        SigTy::Record { fields, .. } => {
+            let l = c_record_layout(fields);
+            (l.size, l.align)
+        }
+        _ => (4, 4),
+    }
+}
+
+/// The C struct the callee declares. Not the record object's own layout: a
+/// `String` member is a `char*` and a nested record is inlined, not referenced.
+struct CRecord {
+    size: u32,
+    align: u32,
+    offsets: Vec<u32>,
+}
+
+fn c_record_layout(fields: &[(arcstr::ArcStr, crate::sig::SigTy)]) -> CRecord {
+    let mut off = 0u32;
+    let mut align = 1u32;
+    let mut offsets = Vec::with_capacity(fields.len());
+    for (_, t) in fields {
+        let (sz, a) = c_size_align(t);
+        off = dylink::align_up(off, a);
+        offsets.push(off);
+        off += sz;
+        align = align.max(a);
+    }
+    CRecord { size: dylink::align_up(off, align), align, offsets }
+}
+
+/// How the wasm C ABI passes a value.
+enum Abi {
+    /// No members: no argument, no result.
+    Dropped,
+    /// A struct with exactly one member passes and returns as that member,
+    /// recursively: clang lowers `struct One { double x; } f(double)` to
+    /// `(f64) -> f64`.
+    Scalar(crate::sig::SigTy),
+    /// By pointer; a return value gets a prepended `sret` pointer.
+    Indirect,
+}
+
+fn abi_of(t: &crate::sig::SigTy) -> Abi {
+    use crate::sig::SigTy;
+    match t {
+        SigTy::Record { fields, .. } => match fields.len() {
+            0 => Abi::Dropped,
+            1 => abi_of(&fields[0].1),
+            _ => Abi::Indirect,
+        },
+        other => Abi::Scalar(other.clone()),
+    }
+}
+
+/// The member a single-member struct collapses to, as `(offset from the record
+/// object's base, type)`. Descends nested single-member records.
+fn record_leaf(fields: &[(arcstr::ArcStr, crate::sig::SigTy)]) -> (u32, crate::sig::SigTy) {
+    use crate::sig::SigTy;
+    let layout = crate::sig::record_layout(fields);
+    let off = layout.data_off + layout.field_off.first().copied().unwrap_or(0);
+    match fields.first().map(|(_, t)| t) {
+        Some(SigTy::Record { fields: inner, .. }) if inner.len() == 1 => {
+            // The member is itself a record *object*, so its own base is stored here.
+            let (inner_off, ty) = record_leaf(inner);
+            (off + inner_off, ty)
+        }
+        Some(t) => (off, t.clone()),
+        None => (off, SigTy::Int),
+    }
+}
+
+/// Rebuild a single-member record from the scalar the ABI returned in place of it.
+fn record_from_scalar(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &ExtRt,
+    fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
+    leaf_off: u32,
+    leaf: &crate::sig::SigTy,
+    value: &wasmtime::Val,
+) -> Result<u32> {
+    use crate::sig::SigTy;
+    let layout = crate::sig::record_layout(fields);
+    let handle = rt
+        .record_new
+        .call(&mut *caller, (layout.heap.len() as u32, layout.size))
+        .map_err(|e| format!("rt_record_new: {e}"))?;
+    for (k, (kind, off)) in layout.heap.iter().enumerate() {
+        write_u32(memory, caller, handle + 8 + k as u32 * 8, *kind);
+        write_u32(memory, caller, handle + 8 + k as u32 * 8 + 4, *off);
+    }
+    // A nested one needs its own object before the value can go in.
+    if let Some((_, SigTy::Record { fields: inner, .. })) = fields.first()
+        && inner.len() == 1
+    {
+        let nested = record_from_scalar(caller, memory, rt, inner, leaf_off, leaf, value)?;
+        write_u32(memory, caller, handle + layout.data_off + layout.field_off[0], nested);
+        return Ok(handle);
+    }
+    let at = handle + layout.data_off + layout.field_off.first().copied().unwrap_or(0);
+    match leaf {
+        SigTy::Real => write_u64(memory, caller, at, value.unwrap_f64().to_bits()),
+        SigTy::Str => {
+            let s = wasm_string(caller, memory, rt, value.unwrap_i32() as u32)?;
+            write_u32(memory, caller, at, s);
+        }
+        _ => write_u32(memory, caller, at, value.unwrap_i32() as u32),
+    }
+    Ok(handle)
+}
+
+/// Write the record object `handle` into the C struct at `dst`; `temps` collects
+/// scratch to release after.
+fn record_to_c(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &ExtRt,
+    fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
+    handle: u32,
+    dst: u32,
+    temps: &mut Vec<u32>,
+) -> Result<()> {
+    use crate::sig::SigTy;
+    let layout = crate::sig::record_layout(fields);
+    let c = c_record_layout(fields);
+    for (i, (_, ty)) in fields.iter().enumerate() {
+        let src = handle + layout.data_off + layout.field_off[i];
+        let at = dst + c.offsets[i];
+        match ty {
+            SigTy::Real => {
+                let v = read_u64(memory, caller, src);
+                write_u64(memory, caller, at, v);
+            }
+            SigTy::Int | SigTy::Bool | SigTy::Ptr => {
+                let v = read_u32(memory, caller, src);
+                write_u32(memory, caller, at, v);
+            }
+            SigTy::Str => {
+                let s = read_u32(memory, caller, src);
+                let p = c_string(caller, memory, rt, s, temps)?;
+                write_u32(memory, caller, at, p);
+            }
+            SigTy::Array { .. } => {
+                // The elements themselves, so the callee writes the model's array.
+                let h = read_u32(memory, caller, src) as usize;
+                let (_, data_off) = crate::host::array_abi::dims_and_data(memory.data(&*caller), h)
+                    .ok_or_else(|| "external \"C\": malformed array field".to_string())?;
+                write_u32(memory, caller, at, h as u32 + data_off as u32);
+            }
+            SigTy::Record { fields: inner, .. } => {
+                let h = read_u32(memory, caller, src);
+                record_to_c(caller, memory, rt, inner, h, at, temps)?;
+            }
+            _ => return Err("external \"C\": record field type not marshalled".to_string()),
+        }
+    }
+    Ok(())
+}
+
+/// The inverse of [`record_to_c`], for an `_Out_` record or a returned struct.
+fn record_from_c(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &ExtRt,
+    fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
+    src: u32,
+) -> Result<u32> {
+    use crate::sig::SigTy;
+    let layout = crate::sig::record_layout(fields);
+    let c = c_record_layout(fields);
+    let handle = rt
+        .record_new
+        .call(&mut *caller, (layout.heap.len() as u32, layout.size))
+        .map_err(|e| format!("rt_record_new: {e}"))?;
+    // The inline table the runtime releases the record's heap fields by.
+    for (k, (kind, off)) in layout.heap.iter().enumerate() {
+        write_u32(memory, caller, handle + 8 + k as u32 * 8, *kind);
+        write_u32(memory, caller, handle + 8 + k as u32 * 8 + 4, *off);
+    }
+    for (i, (_, ty)) in fields.iter().enumerate() {
+        let at = src + c.offsets[i];
+        let dst = handle + layout.data_off + layout.field_off[i];
+        match ty {
+            SigTy::Real => {
+                let v = read_u64(memory, caller, at);
+                write_u64(memory, caller, dst, v);
+            }
+            SigTy::Int | SigTy::Bool | SigTy::Ptr => {
+                let v = read_u32(memory, caller, at);
+                write_u32(memory, caller, dst, v);
+            }
+            SigTy::Str => {
+                let p = read_u32(memory, caller, at);
+                let s = wasm_string(caller, memory, rt, p)?;
+                write_u32(memory, caller, dst, s);
+            }
+            SigTy::Record { fields: inner, .. } => {
+                let h = record_from_c(caller, memory, rt, inner, at)?;
+                write_u32(memory, caller, dst, h);
+            }
+            _ => return Err("external \"C\": record field type not marshalled".to_string()),
+        }
+    }
+    Ok(handle)
+}
+
+/// A NUL-terminated copy of `handle`, as a `char*`.
+fn c_string(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &ExtRt,
+    handle: u32,
+    temps: &mut Vec<u32>,
+) -> Result<u32> {
+    if handle == 0 {
+        return Ok(0);
+    }
+    let len = read_u32(memory, caller, handle + 4) as usize;
+    let cell = rt
+        .alloc
+        .call(&mut *caller, (len + 1) as u32)
+        .map_err(|e| format!("rt_alloc: {e}"))?;
+    let mem = memory.data_mut(&mut *caller);
+    mem.copy_within(handle as usize + 8..handle as usize + 8 + len, cell as usize);
+    mem[cell as usize + len] = 0;
+    temps.push(cell);
+    Ok(cell)
+}
+
+/// A fresh String with the bytes of the `char*` at `ptr`.
+fn wasm_string(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &ExtRt,
+    ptr: u32,
+) -> Result<u32> {
+    let len = if ptr == 0 {
+        0
+    } else {
+        let data = memory.data(&*caller);
+        data.get(ptr as usize..)
+            .and_then(|r| r.iter().position(|&b| b == 0))
+            .ok_or_else(|| "external \"C\": unterminated `char*`".to_string())?
+    };
+    let handle = rt
+        .str_new
+        .call(&mut *caller, len as u32)
+        .map_err(|e| format!("rt_str_new: {e}"))?;
+    let dst = rt
+        .str_data
+        .call(&mut *caller, handle)
+        .map_err(|e| format!("rt_str_data: {e}"))? as usize;
+    if len > 0 {
+        memory.data_mut(&mut *caller).copy_within(ptr as usize..ptr as usize + len, dst);
+    }
+    Ok(handle)
+}
+
+fn read_u32(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u32 {
+    let d = memory.data(&*caller);
+    d.get(at as usize..at as usize + 4)
+        .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+        .unwrap_or(0)
+}
+
+fn read_u64(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u64 {
+    let d = memory.data(&*caller);
+    d.get(at as usize..at as usize + 8)
+        .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
+        .unwrap_or(0)
+}
+
+fn write_u32(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u32) {
+    let d = memory.data_mut(&mut *caller);
+    if let Some(s) = d.get_mut(at as usize..at as usize + 4) {
+        s.copy_from_slice(&v.to_le_bytes());
+    }
+}
+
+fn write_u64(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u64) {
+    let d = memory.data_mut(&mut *caller);
+    if let Some(s) = d.get_mut(at as usize..at as usize + 8) {
+        s.copy_from_slice(&v.to_le_bytes());
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -176,6 +176,8 @@ mod sim_memory {
 
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub use sim_memory::set as set_sim_memory;
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub use sim_memory::get as get_sim_memory;
 
 fn record_assert(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) {
     PENDING_ASSERT.with(|p| {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -29,6 +29,7 @@ pub const SUNDIALS: bool = cfg!(sundials);
 
 pub mod sig;
 pub mod model;
+pub mod dylink;
 
 // A wasm trap collapses to the crate's `&'static str` error on the way out of the
 // engine, losing the trap kind and the backtrace. The engine parks its message
@@ -78,3 +79,6 @@ pub mod sim_runtime;
 #[cfg(feature = "jit")]
 #[path = "wasi_shim.rs"]
 pub mod wasi_shim;
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+#[path = "dylink_wasmtime.rs"]
+pub mod dylink_engine;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -23,6 +23,12 @@ pub struct SimModel {
     /// The `ext.<extName>` host imports (external "C" functions) with the full
     /// C-call shape, so the host trampoline can marshal strings/arrays/pointers.
     pub ext_imports: Vec<ExtCallSig>,
+    /// The model's own `external "C"` libraries, loaded into the simulation's
+    /// memory, where they define the `ext_imports` the runtime cannot resolve.
+    pub ext_libs: Vec<ExtLibrary>,
+    /// Why a `Library` or an `Include` yielded no wasm library; reported only if a
+    /// symbol then turns out to be missing.
+    pub ext_lib_notes: Vec<String>,
     pub model_name: String,
     pub start_time: f64,
     pub stop_time: f64,
@@ -63,6 +69,14 @@ impl SimModel {
     pub fn run_meta(&self) -> SimMeta {
         openmodelica_sim_meta::simflags::with_flags(|f| self.meta.with_flags(f))
     }
+}
+
+/// One resolved `external "C"` library, read at codegen time so a run needs no
+/// filesystem.
+#[derive(Clone)]
+pub struct ExtLibrary {
+    pub name: String,
+    pub bytes: Vec<u8>,
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
@@ -201,3 +201,45 @@ impl ExtCallSig {
         FnSig { params: self.wasm_params(), results: self.wasm_results() }
     }
 }
+
+// ─────────────────────────── record objects ───────────────────────────
+
+/// 8 bytes for a `Real`, 4 for everything else (an `Integer`/`Boolean`, a handle).
+pub fn field_size(t: &SigTy) -> u32 {
+    if matches!(t, SigTy::Real) { 8 } else { 4 }
+}
+
+fn align_up(n: u32, a: u32) -> u32 {
+    (n + a - 1) & !(a - 1)
+}
+
+/// The byte layout of a record object's payload, which must agree with
+/// `rec_data_off` in the runtime. `data_off` is the offset from the object base to
+/// the first field (after the refcount, `nheap` and the inline release table),
+/// `field_off[i]` field `i`'s offset within the field data, `heap` the
+/// `(elem_kind, field_off)` of each heap field.
+pub struct RecordLayout {
+    pub data_off: u32,
+    pub size: u32,
+    pub field_off: Vec<u32>,
+    pub heap: Vec<(u32, u32)>,
+}
+
+pub fn record_layout(fields: &[(ArcStr, SigTy)]) -> RecordLayout {
+    let nheap = fields.iter().filter(|(_, t)| t.is_heap()).count() as u32;
+    let data_off = align_up(8 + nheap * 8, 8);
+    let mut off = 0u32;
+    let mut field_off = Vec::with_capacity(fields.len());
+    let mut heap = Vec::new();
+    for (_, t) in fields {
+        let sz = field_size(t);
+        off = align_up(off, sz);
+        field_off.push(off);
+        if t.is_heap() {
+            heap.push((t.elem_kind(), off));
+        }
+        off += sz;
+    }
+    RecordLayout { data_off, size: data_off + align_up(off, 8), field_off, heap }
+}
+

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -304,6 +304,30 @@ fn wty_valtype(w: crate::sig::WTy) -> wasmtime::ValType {
     }
 }
 
+/// Why an `external "C"` function could not be found, and what to do about it. The
+/// codegen's notes come out here, where a library that yielded nothing has become a
+/// missing symbol.
+fn unresolved_external_detail(name: &str, model: &SimModel) -> String {
+    let mut s = if model.ext_libs.is_empty() {
+        format!(
+            "  `{name}` is in none of the model's libraries — the model declares no `Library` \
+             annotation that resolves to a wasm library. Build the implementation with \
+             `clang --target=wasm32-wasip1 -fPIC -shared` and name it in `Library`."
+        )
+    } else {
+        format!(
+            "  `{name}` is in none of the model's libraries ({}). Check that the library exports it \
+             (`-Wl,--export-all`, or `-Wl,--export={name}`).",
+            model.ext_libs.iter().map(|l| l.name.as_str()).collect::<Vec<_>>().join(", "),
+        )
+    };
+    for note in &model.ext_lib_notes {
+        s.push_str("\n  ");
+        s.push_str(note);
+    }
+    s
+}
+
 /// Define the model's external "C" function imports (wasm module `ext`) from the
 /// host. Uses the model's `ext_imports` (the C-call `SigTy` signature) rather than
 /// the wasm `FuncType`, because the latter can't distinguish an `i32` that is a
@@ -312,12 +336,15 @@ fn wty_valtype(w: crate::sig::WTy) -> wasmtime::ValType {
 /// memory (`memory`).
 fn define_external_imports(
     linker: &mut wasmtime::Linker<WasiCtx>,
+    store: &mut wasmtime::Store<WasiCtx>,
     model: &SimModel,
     memory: wasmtime::Memory,
-    rt_str_new: wasmtime::TypedFunc<u32, u32>,
-    rt_str_data: wasmtime::TypedFunc<u32, u32>,
+    rt: &crate::dylink_engine::ExtRt,
+    libs: &crate::dylink_engine::Loaded,
     nls: NlsHooks,
 ) -> Result<()> {
+    let rt_str_new = rt.str_new.clone();
+    let rt_str_data = rt.str_data.clone();
     registry_reset();
     openmodelica_util::dynload::install_modelica_message_interception(
         openmodelica_modelica_utilities::modelica_message_hook,
@@ -330,12 +357,17 @@ fn define_external_imports(
             sig.wasm_params().iter().map(|s| wty_valtype(s.wty())),
             sig.wasm_results().iter().map(|s| wty_valtype(s.wty())),
         );
+        // The model's own libraries shadow a same-named symbol in the process.
+        if let Some(target) = libs.func(&sig.name).cloned() {
+            if let Some(f) = crate::dylink_engine::bind_in_wasm_external(store, sig, &functype, target, rt)
+                .map_err(|_| "external \"C\": cannot bind a library function")?
+            {
+                wt(linker.define(&mut *store, "ext", &sig.name, f))?;
+                continue;
+            }
+        }
         let addr = openmodelica_util::dynload::external_symbol(&sig.name).ok_or_else(|| {
-            crate::set_engine_error_detail(format!(
-                "  `{}` is in none of the loaded libraries — the wasm-jit target cannot \
-                 build a model's own external C sources",
-                sig.name,
-            ));
+            crate::set_engine_error_detail(unresolved_external_detail(&sig.name, model));
             "external \"C\" function not found in any loaded library"
         })?;
         let name = sig.name.clone();
@@ -783,10 +815,18 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         recovering: wts(rt_inst.get_typed_func::<(), i32>(&mut store, "rt_nls_recovering"))?,
         note: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_nls_note_assert"))?,
     };
-    define_external_imports(&mut linker, model, memory, rt_str_new, rt_str_data, nls)?;
-    define_print_import(&mut linker, memory)?;
     // `rt_row_asserts` is called by the model, which only imports `memory`.
     crate::host::set_sim_memory(memory);
+    let ext_rt = crate::dylink_engine::ExtRt {
+        str_new: rt_str_new,
+        str_data: rt_str_data,
+        alloc: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?,
+        free: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free"))?,
+        record_new: wts(rt_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
+    };
+    let ext_libs = crate::dylink_engine::load_ext_libraries(&mut store, engine, rt_inst, memory, model, &ext_rt)?;
+    define_external_imports(&mut linker, &mut store, model, memory, &ext_rt, &ext_libs, nls)?;
+    define_print_import(&mut linker, memory)?;
     let instance = wts(linker.instantiate(&mut store, &model_module))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
@@ -26,11 +26,16 @@ mod wasmtime_impl {
 
     type Linker = wasmtime::Linker<WasiCtx>;
 
-    /// Borrow `(SliceMem, ctx)` from the caller, or return ERRNO_FAULT if the
-    /// guest exports no `memory`.
+    /// Borrow `(SliceMem, ctx)` from the caller, or ERRNO_FAULT if there is no
+    /// memory. A shared library imports the memory rather than exporting one, so
+    /// fall back to the one the engine registered for the run.
     macro_rules! mem_ctx {
         ($caller:expr) => {{
-            match $caller.get_export("memory").and_then(|e| e.into_memory()) {
+            let mem = $caller
+                .get_export("memory")
+                .and_then(|e| e.into_memory())
+                .or_else(crate::host::get_sim_memory);
+            match mem {
                 Some(m) => {
                     let (data, ctx) = m.data_and_store_mut(&mut $caller);
                     (SliceMem(data), ctx)

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -70,6 +70,7 @@ import Mod;
 import Patternm;
 import SCode;
 import SCodeUtil;
+import StringUtil;
 import Testsuite;
 import UnorderedMap;
 import Config;
@@ -2090,6 +2091,11 @@ protected function generateExtFunctionLibraryDirectoryFlags2
   input list<String> inLibs;
   output list<String> libs;
 algorithm
+  // A wasm target loads modules by path (libPaths) instead of linking.
+  if isWasmSimCodeTarget() then
+    libs := inLibs;
+    return;
+  end if;
   libs := if isLinux then "-Wl,-rpath=\"" + dir + "\""::inLibs else inLibs;
   libs := (if getGerneralTarget(target)=="msvc" then "/LIBPATH:\"" + dir + "\"" else "\"-L" + dir + "\"")::libs;
 end generateExtFunctionLibraryDirectoryFlags2;
@@ -2133,6 +2139,7 @@ algorithm
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform3,""), str + "/" + platform3, isLinux, libs);
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform2,""), str + "/" + platform2, isLinux, libs);
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform1,""), str + "/" + platform1, isLinux, libs);
+        libs := generateExtFunctionLibraryDirectoryPaths2(isWasmSimCodeTarget(), str + "/wasm32-wasip1", isLinux, libs);
       then libs;
     case _
       algorithm
@@ -2147,6 +2154,7 @@ algorithm
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform3,""), str + "/" + platform3, isLinux, libs);
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform2,""), str + "/" + platform2, isLinux, libs);
         libs := generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform1,""), str + "/" + platform1, isLinux, libs);
+        libs := generateExtFunctionLibraryDirectoryPaths2(isWasmSimCodeTarget(), str + "/wasm32-wasip1", isLinux, libs);
       then libs;
     else {};
   end matchcontinue;
@@ -2334,18 +2342,96 @@ algorithm
   end matchcontinue;
 end getLibraryStringInGccFormat;
 
+protected function isWasmSimCodeTarget
+"An FMU export falls back to C in the testsuite (SimCodeMain.callTargetTemplatesFMU)."
+  output Boolean isWasm = StringUtil.startsWith(Config.simCodeTarget(), "wasm")
+                          and not (Flags.getConfigBool(Flags.BUILDING_FMU) and Testsuite.isRunning());
+end isWasmSimCodeTarget;
+
+protected function stripLibraryExtension
+"The base name of a library written for any target, so an annotation naming a host
+ object file or shared library still identifies the wasm module."
+  input String str;
+  output String base = str;
+algorithm
+  for ext in {".wasm", ".dylib", ".obj", ".dll", ".lib", ".so", ".a", ".o"} loop
+    if StringUtil.endsWith(str, ext) then
+      base := Util.removeLastNChar(str, stringLength(ext));
+      return;
+    end if;
+  end for;
+end stripLibraryExtension;
+
+protected function getLibraryStringInWasmFormat
+"The name of the wasm module implementing the library the Absyn.STRING describes.
+ A wasm target has no linker: the annotation resolves to a PIC dylink module omc
+ loads as-is, rather than to linker flags."
+  input Absyn.Exp exp;
+  output list<String> strs;
+  output list<String> names;
+algorithm
+  (strs, names) := match exp
+    local
+      String str;
+
+    // In the runtime already: LAPACK/BLAS are in-wasm, and ModelicaExternalC is
+    // the side module omc carries.
+    case Absyn.STRING("lapack") then ({},{});
+    case Absyn.STRING("Lapack") then ({},{});
+    case Absyn.STRING("blas") then ({},{});
+    case Absyn.STRING("ModelicaExternalC") then ({},{});
+    case Absyn.STRING("ModelicaStandardTables") then ({},{});
+    case Absyn.STRING("ModelicaIO") then ({},{});
+    case Absyn.STRING("ModelicaMatIO") then ({},{});
+    case Absyn.STRING("zlib") then ({},{});
+
+    case Absyn.STRING(str)
+      algorithm
+        // Linker flags mean nothing here; only a library name can be resolved.
+        if "-" == stringGetStringChar(str, 1) then
+          strs := {};
+          names := {};
+        else
+          // No name for the generic existence check: it looks for host libraries,
+          // while the wasm code generator resolves the module itself.
+          strs := {stripLibraryExtension(str) + ".wasm"};
+          names := {};
+        end if;
+      then (strs, names);
+
+    else
+      algorithm
+        Error.addInternalError("Failed to process Library annotation for external function", sourceInfo());
+      then fail();
+  end match;
+end getLibraryStringInWasmFormat;
+
 protected function generateExtFunctionIncludesLibstr
   input String target;
   input SCode.Mod inMod;
   output list<String> outStringLst;
   output list<String> names;
 algorithm
-  (outStringLst, names) := matchcontinue getGerneralTarget(target)
+  (outStringLst, names) := matchcontinue (if isWasmSimCodeTarget() then "wasm" else getGerneralTarget(target))
     local
       list<Absyn.Exp> arr;
       list<String> libs;
       list<list<String>> libsList, namesList;
       Absyn.Exp exp;
+    case "wasm"
+      algorithm
+        SCode.MOD(binding = SOME(Absyn.ARRAY(arr))) :=
+          Mod.getUnelabedSubMod(inMod, "Library");
+        (libsList, namesList) := List.map_2(arr, getLibraryStringInWasmFormat);
+      then
+        (List.flatten(libsList), List.flatten(namesList));
+    case "wasm"
+      algorithm
+        SCode.MOD(binding = SOME(exp)) :=
+          Mod.getUnelabedSubMod(inMod, "Library");
+        (libs,names) := getLibraryStringInWasmFormat(exp);
+      then
+        (libs,names);
     case "msvc"
       algorithm
         SCode.MOD(binding = SOME(Absyn.ARRAY(arr))) :=

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -16,7 +16,27 @@ rtest special directives added to help creating testcases:
   Useful if you e.g. want to disable compiling functions with gcc while you flatten code.  
   You can also set the environment variable RTEST_OMCFLAGS if you want to insert these flags for all commands you run.
 * setup_command: gcc ...  
-  Will execute the provided command before running omc.
+  Will execute the provided command before running omc.  
+  A command that builds an external "C" library should not name a compiler
+  directly; use the variables rtest exports so the test also works for the
+  wasm-jit target, which needs the library as a PIC dylink `.wasm` module
+  rather than a host object file:
+
+      // setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o foo$OMC_EXTLIB_EXT foo.c $OMC_EXTLIB_LIBS
+
+  | Variable | Default | wasm-jit |
+  | --- | --- | --- |
+  | `OMC_CC` | `gcc` | `clang --target=wasm32-wasip1 --sysroot=$OPENMODELICAHOME/lib/wasm32-wasi/omc` |
+  | `OMC_CFLAGS` | `-fPIC` | `-fPIC` |
+  | `OMC_EXTLIB_FLAGS` | `-c` | `-shared -nodefaultlibs -Wl,--export-all -Wl,--allow-undefined` |
+  | `OMC_EXTLIB_LIBS` | (empty) | the wasm32 compiler-rt builtins archive |
+  | `OMC_EXTLIB_EXT` | `.o` | `.wasm` |
+  | `OMC_AR` | `ar` | `true` (a dylink module is already linked) |
+
+  Each is taken from the environment when already set, so a run can point them
+  at another toolchain. The wasm values are used when the target under test is
+  wasm-jit (`OPENMODELICA_TEST_SIMCODETARGET` or `--simCodeTarget=` in
+  `RTEST_OMCFLAGS`).
 * teardown_command: rm -f ...  
   Will execute the provided command after running omc.
 * suite: metamodelica, 63bit  

--- a/testsuite/flattening/modelica/external-functions/ExternalFunction1.mo
+++ b/testsuite/flattening/modelica/external-functions/ExternalFunction1.mo
@@ -1,8 +1,8 @@
 // name:     ExternalFunction1
 // keywords: external function,code generation,constant propagation
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o ExternalFunction1_f.o ExternalFunction1_f.c
-// teardown_command: rm -f ExternalFunction1_f.o
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ExternalFunction1_f$OMC_EXTLIB_EXT ExternalFunction1_f.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f ExternalFunction1_f$OMC_EXTLIB_EXT
 //
 // Constant evaluation of function calls. Result of a function call with
 // constant arguments is inserted into flat modelica.

--- a/testsuite/flattening/modelica/external-functions/ExternalFunction2.mo
+++ b/testsuite/flattening/modelica/external-functions/ExternalFunction2.mo
@@ -1,8 +1,8 @@
 // name:     ExternalFunction2
 // keywords: external function,code generation,constant propagation
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o ExternalFunction2_f.o ExternalFunction2_f.c
-// teardown_command: rm -f ExternalFunction2_f.o ext__f*
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ExternalFunction2_f$OMC_EXTLIB_EXT ExternalFunction2_f.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f ExternalFunction2_f$OMC_EXTLIB_EXT ext__f*
 //
 // Constant evaluation of function calls. Result of a function call with
 // constant arguments is inserted into flat modelica.

--- a/testsuite/flattening/modelica/external-functions/ExternalFunction3.mo
+++ b/testsuite/flattening/modelica/external-functions/ExternalFunction3.mo
@@ -1,8 +1,8 @@
 // name:     ExternalFunction3
 // keywords: external function,code generation,constant propagation
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o ExternalFunction3-addmatrices.o ExternalFunction3-addmatrices.c
-// teardown_command: rm -f ExternalFunction3-addmatrices.o ExternalFunction3_*
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ExternalFunction3-addmatrices$OMC_EXTLIB_EXT ExternalFunction3-addmatrices.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f ExternalFunction3-addmatrices$OMC_EXTLIB_EXT ExternalFunction3_*
 //
 // Constant evaluation of function calls. Result of a function call with
 // constant arguments is inserted into flat modelica.

--- a/testsuite/flattening/modelica/mosfiles/ExternalLibraryFunction.mos
+++ b/testsuite/flattening/modelica/mosfiles/ExternalLibraryFunction.mos
@@ -1,7 +1,7 @@
 // name: ExternalLibraryFunction
 // status: correct
-// setup_command: gcc -o ./TestLibrary/Resources/Library/ext1.o -c ./TestLibrary/Resources/Library/ext1.c && ar -cr ./TestLibrary/Resources/Library/libext1.a ./TestLibrary/Resources/Library/ext1.o && gcc -o ./TestLibrary/Resources/SpecialLib/ext2.o -c ./TestLibrary/Resources/SpecialLib/ext2.c && ar -cr ./TestLibrary/Resources/SpecialLib/libext2.a ./TestLibrary/Resources/SpecialLib/ext2.o
-// teardown_command: rm -f ./TestLibrary/Resources/Library/ext1.o ./TestLibrary/Resources/Library/libext1.a ./TestLibrary/Resources/SpecialLib/ext2.o ./TestLibrary/Resources/SpecialLib/libext2.a Test_ext*
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ./TestLibrary/Resources/Library/libext1$OMC_EXTLIB_EXT ./TestLibrary/Resources/Library/ext1.c $OMC_EXTLIB_LIBS && $OMC_AR -cr ./TestLibrary/Resources/Library/libext1.a ./TestLibrary/Resources/Library/libext1.o && $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ./TestLibrary/Resources/SpecialLib/libext2$OMC_EXTLIB_EXT ./TestLibrary/Resources/SpecialLib/ext2.c $OMC_EXTLIB_LIBS && $OMC_AR -cr ./TestLibrary/Resources/SpecialLib/libext2.a ./TestLibrary/Resources/SpecialLib/libext2.o
+// teardown_command: rm -f ./TestLibrary/Resources/Library/libext1$OMC_EXTLIB_EXT ./TestLibrary/Resources/Library/libext1.a ./TestLibrary/Resources/SpecialLib/libext2$OMC_EXTLIB_EXT ./TestLibrary/Resources/SpecialLib/libext2.a Test_ext*
 // depends: TestLibrary
 // cflags: -d=-newInst
 

--- a/testsuite/flattening/modelica/records/EmptyRecordTestConstructor.mos
+++ b/testsuite/flattening/modelica/records/EmptyRecordTestConstructor.mos
@@ -1,8 +1,8 @@
 // name:     Empty Record Constructor
 // keywords: algorithm
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o External_C_RecordTest.o External_C_RecordTest.c
-// teardown_command: rm -f External_C_RecordTest.o
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o External_C_RecordTest$OMC_EXTLIB_EXT External_C_RecordTest.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f External_C_RecordTest$OMC_EXTLIB_EXT
 // cflags: -d=-newInst
 
 loadFile("RecordTest.mo");

--- a/testsuite/flattening/modelica/records/NestedRecordTestConstructor.mos
+++ b/testsuite/flattening/modelica/records/NestedRecordTestConstructor.mos
@@ -1,8 +1,8 @@
 // name:     Record-in-Record Constructor
 // keywords: algorithm
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o External_C_RecordTest.o External_C_RecordTest.c
-// teardown_command: rm -f External_C_RecordTest.o
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o External_C_RecordTest$OMC_EXTLIB_EXT External_C_RecordTest.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f External_C_RecordTest$OMC_EXTLIB_EXT
 // cflags: -d=-newInst
 
 loadFile("RecordTest.mo");

--- a/testsuite/flattening/modelica/records/SimpleRecordTestConstructor.mos
+++ b/testsuite/flattening/modelica/records/SimpleRecordTestConstructor.mos
@@ -1,8 +1,8 @@
 // name:     Simple Record Constructor
 // keywords: algorithm
 // status:   correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o External_C_RecordTest.o External_C_RecordTest.c
-// teardown_command: rm -f External_C_RecordTest.o
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o External_C_RecordTest$OMC_EXTLIB_EXT External_C_RecordTest.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f External_C_RecordTest$OMC_EXTLIB_EXT
 // cflags: -d=-newInst
 
 loadFile("RecordTest.mo");

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -60,6 +60,8 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   exit 0;
 }
 
+setup_command_toolchain();
+
 system "$OPENMODELICAHOME/bin/omc-diff -v1.4";
 if ($?) {
   print "$OPENMODELICAHOME/bin/omc-diff seems to be missing or of an incompatible version.";
@@ -106,6 +108,68 @@ $eps_mo = 1.0e-7;
 $eps_mos = 5e-3;
 $set_modelica_lib = 1;
 $nodelete = 0;
+
+# The simulation code generator under test.
+sub sim_code_target
+{
+  return $ENV{'OPENMODELICA_TEST_SIMCODETARGET'} if $ENV{'OPENMODELICA_TEST_SIMCODETARGET'};
+  return $1 if $omcflags =~ /--simCodeTarget=(\S+)/;
+  return "";
+}
+
+# The wasm32 compiler-rt builtins. The shipped sysroot carries a copy; otherwise
+# probe clang, whose 21 driver looks under a per-triple directory while the Debian
+# libclang-rt-*-dev-wasm32 packages still use the old lib/wasi layout.
+sub wasm_builtins
+{
+  my $sysroot = shift;
+  return $ENV{'OMC_WASM_BUILTINS'} if $ENV{'OMC_WASM_BUILTINS'};
+  my $shipped = "$sysroot/lib/wasm32-wasip1/libclang_rt.builtins-wasm32.a";
+  return $shipped if -e $shipped;
+  my $res = `clang -print-resource-dir 2>/dev/null`;
+  chomp $res;
+  return "" if !$res;
+  for my $p ("$res/lib/wasm32-unknown-wasip1/libclang_rt.builtins.a",
+             "$res/lib/wasi/libclang_rt.builtins-wasm32.a") {
+    return $p if -e $p;
+  }
+  return "";
+}
+
+# The toolchain a `setup_command` builds an external "C" library with, so a test
+# spells it $OMC_CC/$OMC_CFLAGS/... instead of hardcoding gcc. Anything already set
+# in the environment wins.
+#
+# wasm-jit needs a PIC dylink module rather than a host object file: omc has no
+# linker, so the Library annotation must name the finished, loadable artifact.
+sub setup_command_toolchain
+{
+  my $wasm = sim_code_target() =~ /^wasm/;
+  my $sysroot = $ENV{'OMC_WASI_SYSROOT'} || "$OPENMODELICAHOME/lib/wasm32-wasi/omc";
+  my %tc = $wasm ? (
+    OMC_CC           => "clang --target=wasm32-wasip1 --sysroot=$sysroot",
+    OMC_CFLAGS       => "-fPIC",
+    # --allow-undefined: ModelicaUtilities and libc are bound when omc loads it.
+    OMC_EXTLIB_FLAGS => "-shared -nodefaultlibs -Wl,--export-all -Wl,--allow-undefined",
+    OMC_EXTLIB_LIBS  => wasm_builtins($sysroot),
+    OMC_EXTLIB_EXT   => ".wasm",
+    # A dylink module is already linked.
+    OMC_AR           => "true",
+  ) : (
+    OMC_CC           => "gcc",
+    OMC_CFLAGS       => "-fPIC",
+    OMC_EXTLIB_FLAGS => "-c",
+    OMC_EXTLIB_LIBS  => "",
+    OMC_EXTLIB_EXT   => ".o",
+    OMC_AR           => "ar",
+  );
+  for my $k (keys %tc) {
+    $ENV{$k} = $tc{$k} unless defined $ENV{$k};
+  }
+  if ($wasm && !$ENV{'OMC_EXTLIB_LIBS'}) {
+    print "Warning: no libclang_rt.builtins-wasm32.a found; external \"C\" setup_commands may fail to link.\n";
+  }
+}
 
 sub isMinGW_UCRT {
   my $temp = $ENV{'MSYSTEM'};
@@ -308,6 +372,8 @@ sub runone
         # Ignore; sometimes comes from libhwloc when running docker
       } elsif ($str =~ /^GC Warning:/) {
         # Ignore; comes from libgc
+      } elsif ($str =~ /^wasm-ld[\d.-]*: warning: creating shared libraries, with -shared, is not yet stable/) {
+        # Ignore; comes from a setup_command building a wasm external "C" library
       } else {
         print RES $str;
       }

--- a/testsuite/simulation/modelica/external_functions/ExtObjStringParam.mos
+++ b/testsuite/simulation/modelica/external_functions/ExtObjStringParam.mos
@@ -1,8 +1,8 @@
 // name:     External Object with String parameter input
 // keywords: initialization
 // status:   correct
-// setup_command: gcc -c -o ExtObjStringParam.ext.o ExtObjStringParam.ext.c
-// teardown_command: rm -rf ExtObjStringParam_* ExtObjStringParam ExtObjStringParam.exe ExtObjStringParam.ext.o ExtObjStringParam.cpp ExtObjStringParam.conv.cpp ExtObjStringParam.makefile ExtObjStringParam.libs ExtObjStringParam.log ExtObjStringParam2_* ExtObjStringParam2 ExtObjStringParam2.exe ExtObjStringParam2.cpp ExtObjStringParam2.conv.cpp ExtObjStringParam2.makefile ExtObjStringParam2.libs ExtObjStringParam2.log output.log
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ExtObjStringParam.ext$OMC_EXTLIB_EXT ExtObjStringParam.ext.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -rf ExtObjStringParam_* ExtObjStringParam ExtObjStringParam.exe ExtObjStringParam.ext$OMC_EXTLIB_EXT ExtObjStringParam.cpp ExtObjStringParam.conv.cpp ExtObjStringParam.makefile ExtObjStringParam.libs ExtObjStringParam.log ExtObjStringParam2_* ExtObjStringParam2 ExtObjStringParam2.exe ExtObjStringParam2.cpp ExtObjStringParam2.conv.cpp ExtObjStringParam2.makefile ExtObjStringParam2.libs ExtObjStringParam2.log output.log
 // depends: sampledata.xml
 // depends: ExtObjStringParam.ext.c
 // depends: ExtObjStringParam.ext.h

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mos
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mos
@@ -2,8 +2,8 @@
 // keywords: ExternalObject
 // status:   correct
 // cflags: -d=newInst
-// setup_command: gcc -c -o ExternalCFuncInputOnly.o ExternalCFuncInputOnly.c
-// teardown_command: rm -rf ExternalCFuncInputOnly_*
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o ExternalCFuncInputOnly$OMC_EXTLIB_EXT ExternalCFuncInputOnly.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -rf ExternalCFuncInputOnly_* ExternalCFuncInputOnly$OMC_EXTLIB_EXT
 // depends: ExternalCFuncInputOnly.c
 // depends: ExternalCFuncInputOnly.h
 //

--- a/testsuite/simulation/modelica/external_functions/QualifiedCrefArg.mos
+++ b/testsuite/simulation/modelica/external_functions/QualifiedCrefArg.mos
@@ -1,8 +1,8 @@
 // name: QualifiedCrefArg
 // keyword: external function, qualified cref
 // status: correct
-// setup_command: gcc `if test "x86_64" = \`uname -m\`; then echo -fPIC; fi` -c -o QualifiedCrefArg-f.o QualifiedCrefArg-f.c
-// teardown_command: rm -f QualifiedCrefArg-f.o QualifiedCrefArg_*
+// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o QualifiedCrefArg-f$OMC_EXTLIB_EXT QualifiedCrefArg-f.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -f QualifiedCrefArg-f$OMC_EXTLIB_EXT QualifiedCrefArg_*
 // cflags: -d=-newInst
 //
 //


### PR DESCRIPTION
A model's own external "C" now works under --simCodeTarget=wasm-jit. A `Library` annotation names a PIC dylink `.wasm`, which omc loads into the simulation's own linear memory; omc itself neither compiles nor links it, so the browser omc can use the very same artifact, and so can an exported wasm FMU (`wit_component::Linker` consumes exactly this shape).

Sharing the memory is the point: an array argument is the address of the model's own elements, with no copy in either direction. Only a String (length-prefixed here, NUL-terminated in C) and an `_Out_` cell need scratch, and an all-scalar call binds wasm->wasm with no host frame.

The loader places each library in the runtime heap (`__memory_base`), in the shared table (`__table_base`) and on a side stack, resolves GOT.mem / GOT.func once every library is placed, then runs the data relocations and the constructors. `libc.so` wants its stack and heap bounds by name; `__heap_base == __heap_end` is deliberate, because dlmalloc then takes only freshly grown pages and cannot hand out `rt_alloc`'s bytes.

Records cross as the C struct the callee declares, following the wasm C ABI as clang implements it: a single-member struct passes and returns as that member, others go by pointer, a struct return prepends an sret pointer, and an empty struct is dropped. An output record may also be filled through its pointer *and* have one field assigned from the return value, which are different lvalues -- rejecting that made the call look like a constructor for the record it returns.

An implementation given as C source in an `Include` annotation has no library to load, so omc compiles it against the sysroot now installed under lib/wasm32-wasi/omc. That needs a compiler and is therefore native only; the browser omc reports it instead.

Two ordering rules the C runtime sets: a library's `printf` must not sit in libc's buffer, since nothing flushes it (the module is torn down, not exited) and an external object destructor's output would be lost; and C prints "The simulation finished successfully." before destroying the external objects, so `set_teardown_hook` splits the captured output there the way `set_init_done_hook` already splits initialization from simulation.

Five defects fixed on the way were pre-existing and unrelated: the -d=gen function JIT had never run end to end (Ceval interprets ordinary functions without codegen), so its module imported the math builtins and `rt_assert` from `env` where the runtime supplies them as `rt`, nothing defined `rt_print` for it, `path_from_dotted` kept the empty leading segment of a fully-qualified record name, `callExternalObjectDestructors` was exported and never called, and `loadAndExecute` collapsed every failure into META_FAIL -- which is why the original symptom was a silent `y = ()`.

testsuite: a `setup_command` that builds an external "C" library now spells the toolchain `$OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o foo$OMC_EXTLIB_EXT foo.c $OMC_EXTLIB_LIBS` instead of hardcoding gcc, so the same test serves both targets. rtest exports those (wasm values when the target under test is wasm-jit) and each honours the environment.

Every testsuite case with a `setup_command` passes under wasm-jit, and they all still pass natively.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
