### PR TITLE
[CG/Runtime] More fixes to garbage collect memory in FMI context

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -810,7 +810,7 @@ match var
 case var as VARIABLE(__) then
 
   match var.ty
-  case ty as T_ARRAY(__) then arrayVarAllocInit(var.name, var.ty, ty.dims, var.value, var.bind_from_outside, context, &varDecls, &auxFunction)
+  case ty as T_ARRAY(__) then arrayVarAllocInit(var.name, var.ty, ty.dims, var.value, var.bind_from_outside, var.kind, context, &varDecls, &auxFunction)
 
   case ty as T_COMPLEX(complexClassType=RECORD(__)) then recordVarAllocInit(var.value, var.name, var.bind_from_outside, var.ty, context, &varDecls, &auxFunction)
 
@@ -888,11 +888,33 @@ match subvar
 end match
 end recordInitOutsideBindings;
 
-template arrayVarAllocInit(ComponentRef var_cref, Type var_type, list<DAE.Dimension> var_dims, Option<DAE.Exp> value, Boolean bind_outside, Context context, Text &varDecls, Text &auxFunction)
+template arrayVarConstLiteralAlias(DAE.VarKind var_kind, Option<DAE.Exp> value, Boolean bind_outside, Text var_name, Context context, Text &varDecls, Text &auxFunction)
+ "A Modelica `constant` array bound to a shared literal can never be assigned, so it can point
+  straight at the literal instead of allocating a fresh copy of it on every call. Restricted to
+  CONST on purpose: any other variability may be written to, and writing through a shared literal
+  would hit read-only memory."
+::=
+  match var_kind
+  case CONST(__) then
+    if bind_outside then
+      ""
+    else
+      (match value
+       case SOME(lit as SHARED_LITERAL(__)) then
+         let &preExp = buffer ""
+         let litExp = daeExp(lit, context, &preExp, &varDecls, &auxFunction)
+         '<%var_name%> = <%litExp%>; /* constant: alias the shared literal, no copy needed */<%\n%>'
+       else "")
+  else ""
+end arrayVarConstLiteralAlias;
+
+template arrayVarAllocInit(ComponentRef var_cref, Type var_type, list<DAE.Dimension> var_dims, Option<DAE.Exp> value, Boolean bind_outside, DAE.VarKind var_kind, Context context, Text &varDecls, Text &auxFunction)
 ::=
   let type_name = expTypeShort(var_type)
   let var_name = contextCrefNoPrevExp(var_cref, context, &auxFunction)
+  let constAlias = arrayVarConstLiteralAlias(var_kind, value, bind_outside, var_name, context, &varDecls, &auxFunction)
 
+  if constAlias then constAlias else
   match value
     case SOME(rhs_exp) then
       let &preExpBind = buffer ""
@@ -2280,7 +2302,7 @@ case var as VARIABLE(parallelism = NON_PARALLEL(__)) then
   let &varDecls += if not outStruct then '<%typeNameFull%> <%varName%><%initVar%>;<%\n%>' //else ""
 
   if instDims then
-    let &varInits += arrayVarAllocInit(var.name, var.ty, instDims, var.value, var.bind_from_outside, contextFunction, &varDecls, &auxFunction)
+    let &varInits += arrayVarAllocInit(var.name, var.ty, instDims, var.value, var.bind_from_outside, var.kind, contextFunction, &varDecls, &auxFunction)
     ""
   else if isRecordType(var.ty) then
     let &varInits += recordVarAllocInit(var.value, var.name, var.bind_from_outside, var.ty, contextFunction, &varDecls, &auxFunction)

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -1506,12 +1506,33 @@ case FUNCTION(__) then
   let boxedFn = if not funcHasParallelInOutArrays(fn) then functionBodyBoxed(fn, isSimulation) else ""
   let &afterBody = buffer ""
   let prototype = functionPrototype(fname, functionArguments, outVars, false, visibility, isSimulation, false, afterBody)
+  /* If nothing this function returns can hold pool-allocated data, everything it allocates
+     is dead once it returns, so the pool can be rolled back to the state it had on entry.
+     Only the pooled allocator (FMI/minimal runtime) can do this; the GC build has no pool. */
+  /* variableDeclarations holds the locals and the outputs but never the inputs (isVarQ filters
+     those out), so the arguments have to be checked separately for external objects. */
+  let poolExtObj = '<%functionHasExternalObject(variableDeclarations)%><%functionHasExternalObject(functionArguments)%>'
+  let poolScoped = (if outVarsHoldNoHeapData(outVars) then
+                      (if poolExtObj then "" else "x"))
+  let poolSave = if poolScoped then
+    <<
+    #if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    MemPoolState omc_pool_state = omc_util_get_pool_state();
+    #endif<%\n%>
+    >>
+  let poolRestore = if poolScoped then
+    <<
+    #if defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME)
+    omc_util_restore_pool_state(omc_pool_state);
+    #endif<%\n%>
+    >>
   <<
   <%auxFunction%>
   <% match visibility case PUBLIC(__) then "DLLDirection" %>
   <%prototype%>
   {
     <%varDecls%>
+    <%poolSave%>
     <% if boolNot(isSimulation) then 'MMC_SO();<%\n%>'%>_tailrecursive: OMC_LABEL_UNUSED
     <%varInits%>
     <%bodyPart%>
@@ -1520,6 +1541,7 @@ case FUNCTION(__) then
     <%if acceptParModelicaGrammar() then
     '/* Free GPU/OpenCL CPU memory */<%\n%><%varFrees%>'%>
     <%freeConstructedExternalObjects%>
+    <%poolRestore%>
     <%match outVars
        case v::_ then 'return <%funArgName(v)%>;'
        else 'return;'
@@ -1530,6 +1552,43 @@ case FUNCTION(__) then
   <%boxedFn%>
   >>
 end functionBodyRegularFunction;
+
+template outVarsHoldNoHeapData(list<Variable> outVars)
+ "Returns non-empty if none of the outputs can carry heap allocated data, i.e. every output is a
+  scalar Real/Integer/Boolean. Arrays, records, strings, metatypes and function pointers can all
+  reference memory the caller keeps using, so they rule the function out."
+::=
+  let heapOut = (outVars |> var => outVarHoldsHeapData(var))
+  if heapOut then "" else "x"
+end outVarsHoldNoHeapData;
+
+template outVarHoldsHeapData(Variable var)
+ "Returns non-empty if this output may carry heap allocated data."
+::=
+  match var
+  case var as VARIABLE(__) then
+    if instDims then
+      "x"
+    else
+      match varType(var)
+      case "modelica_real"
+      case "modelica_integer"
+      case "modelica_boolean" then ""
+      else "x"
+  else "x"
+end outVarHoldsHeapData;
+
+template functionHasExternalObject(list<Variable> vars)
+ "Returns non-empty if the list holds an external object. Such an object can own memory across
+  calls, and external code reached through it could keep a pointer to something the function
+  allocated, so those functions are left alone. Call it for the arguments as well as the
+  declarations: variableDeclarations never contains the inputs."
+::=
+  (vars |> var =>
+    match var
+    case VARIABLE(ty=T_COMPLEX(complexClassType=EXTERNAL_OBJ(__))) then "x"
+    else "")
+end functionHasExternalObject;
 
 template generateInFunc(Text fname, list<Variable> functionArguments, list<Variable> outVars)
 ::=

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -87,15 +87,24 @@ static inline void pool_expand(size_t len)
 {
   OMCMemPoolBlock *newBlock = NULL;
 
-  // The new block will be 1.5x the current block's size. More if we request a very large array.
+  // The new block will be 1.5x the current block's size.
   size_t new_size = 3*memory_pools->size / 2;
   // Align the new size to the initial block size (2MB right now) for easier debugging.
   new_size = round_up(new_size, OMC_INITIAL_BLOCK_SIZE);
 
   // Report an error if the size is too big. This will error out before the size request is
-  // able to overflow the the size_t size (at 4GB)
+  // able to overflow the the size_t size (at 4GB).
+  // Only the geometric growth is checked here: a single allocation that is legitimately larger
+  // than the limit is not a sign of broken memory management and is served below.
   if (new_size >= OMC_ERROR_AT_EXPAND_REQUEST) {
     omc_assert_macro(0 && "Attempt to allocate an unusually large memory. The memory management does not seem to be working as intended. Please create an issue on https://github.com/OpenModelica/OpenModelica/issues.");
+  }
+
+  // The caller writes len bytes into this block unconditionally and never checks again, so the
+  // block has to be able to hold the request that triggered the expansion. Growing by 1.5x alone
+  // does not guarantee that for a single large allocation.
+  if (new_size < len) {
+    new_size = round_up(len, OMC_INITIAL_BLOCK_SIZE);
   }
 
   newBlock = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905.mos
@@ -1,0 +1,99 @@
+// name: Issue13905
+// keywords: FMI 2.0 export memory pool function scope
+// status: correct
+// teardown_command: rm -rf Issue13905.fmu Issue13905.fmutmp/ Issue13905.scoped Issue13905.notscoped Issue13905.log Issue13905_info.json Issue13905_me_FMU* Issue13905_res.mat index.html
+//
+// Regression test for #13905. FMU functions allocate from the memory pool, which is only rolled
+// back at the FMI entry points, so a function that allocates in a loop accumulates for the whole
+// solver step until pool_expand asserts. When every output of a function is a scalar, nothing it
+// returns can point into the pool, so the generated body is bracketed with
+// omc_util_get_pool_state()/omc_util_restore_pool_state().
+//
+// scalarFun returns a Real and must be pool scoped; arrayFun returns an array, whose data pointer
+// is returned by value to the caller, and must NOT be scoped. Old backend, C runtime.
+
+setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
+
+loadString("
+model Issue13905
+  function scalarFun
+    input Real x;
+    output Real y;
+  protected
+    Real[3] t;
+  algorithm
+    y := 0.0;
+    for i in 1:3 loop
+      t := {x*i, x, x};
+      y := y + t[1];
+    end for;
+  end scalarFun;
+
+  function arrayFun
+    input Real x;
+    output Real[3] y;
+  algorithm
+    y := {x, 2*x, 3*x};
+  end arrayFun;
+
+  Real z(start = 1.0, fixed = true);
+  output Real s = scalarFun(z);
+  output Real a = sum(arrayFun(z));
+equation
+  der(z) = -z;
+end Issue13905;
+"); getErrorString();
+
+buildModelFMU(Issue13905, version="2.0", fmuType="me"); getErrorString();
+
+// A scalar-output function gets the pool save/restore pair.
+system("unzip -cqq Issue13905.fmu sources/Issue13905_functions.c | awk '/^modelica_real omc_Issue13905_scalarFun\\(/,/^}/' | grep -c 'omc_util_.*_pool_state' > Issue13905.scoped"); getErrorString();
+readFile("Issue13905.scoped"); getErrorString();
+
+// An array-output function must not be touched.
+system("unzip -cqq Issue13905.fmu sources/Issue13905_functions.c | awk '/^real_array omc_Issue13905_arrayFun\\(/,/^}/' | grep -c 'omc_util_.*_pool_state' > Issue13905.notscoped"); getErrorString();
+readFile("Issue13905.notscoped"); getErrorString();
+
+// The exported FMU must still initialize and simulate to the same values.
+importFMU("Issue13905.fmu"); getErrorString();
+loadFile("Issue13905_me_FMU.mo"); getErrorString();
+simulate(Issue13905_me_FMU, stopTime=1.0); getErrorString();
+val(s, 0.0); getErrorString();
+val(a, 0.0); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// "Issue13905.fmu"
+// ""
+// 0
+// ""
+// "2
+// "
+// ""
+// 1
+// ""
+// "0
+// "
+// ""
+// "Issue13905_me_FMU.mo"
+// ""
+// true
+// ""
+// record SimulationResult
+// resultFile = "Issue13905_me_FMU_res.mat",
+// simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue13905_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+// messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Notification: Automatically loaded package Complex 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.1.0 due to usage.
+// "
+// 6.0
+// ""
+// 6.0
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905_pool_expand.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905_pool_expand.mos
@@ -1,0 +1,65 @@
+// name: Issue13905_pool_expand
+// keywords: FMI 2.0 export memory pool
+// status: correct
+// teardown_command: rm -rf Issue13905_pool_expand.fmu Issue13905_pool_expand.fmutmp/ Issue13905_pool_expand.log Issue13905_pool_expand_info.json Issue13905_pool_expand_me_FMU* Issue13905_pool_expand_res.mat index.html
+//
+// Regression test for #13905. pool_expand() ignored its `len` argument and always made the new
+// block 1.5x the previous one, while pool_malloc() documents that "the new block should, at
+// least, be as big as the requested size" and then memsets `len` bytes into it without checking.
+// A single allocation bigger than that overflowed the block: with the 2 MB initial block a 16 MB
+// request got a 4 MB block and wrote 12 MB past the end of it.
+//
+// The function local below is 16 MB, so building and running this FMU segfaults without the fix.
+
+setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
+
+loadString("
+model Issue13905_pool_expand
+  function bigLocal
+    input Real x;
+    output Real y;
+  protected
+    Real[2000000] t \"16 MB, far more than the 4 MB a 1.5x growth would hand back\";
+  algorithm
+    t[1] := x;
+    t[2000000] := 2*x;
+    y := t[1] + t[2000000];
+  end bigLocal;
+
+  Real z;
+initial equation
+  z = bigLocal(time);
+equation
+  der(z) = -z;
+end Issue13905_pool_expand;
+"); getErrorString();
+
+buildModelFMU(Issue13905_pool_expand, version="2.0", fmuType="me"); getErrorString();
+
+// Must initialize and simulate instead of overflowing the pool block.
+importFMU("Issue13905_pool_expand.fmu"); getErrorString();
+loadFile("Issue13905_pool_expand_me_FMU.mo"); getErrorString();
+simulate(Issue13905_pool_expand_me_FMU, stopTime=1.0); getErrorString();
+val(z, 0.0); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// "Issue13905_pool_expand.fmu"
+// ""
+// "Issue13905_pool_expand_me_FMU.mo"
+// ""
+// true
+// ""
+// record SimulationResult
+// resultFile = "Issue13905_pool_expand_me_FMU_res.mat",
+// simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue13905_pool_expand_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+// messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -31,6 +31,7 @@ fmi_attributes_24.mos \
 fmi_attributes_25.mos \
 fmi2_array_attributes_nb.mos \
 fmi2_array_attributes.mos \
+Issue13905.mos \
 fmi2_array_nonscalarized.mos \
 fmi2_arrays_initial_unknowns.mos \
 fmi_export_derivative_annotation.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -32,6 +32,7 @@ fmi_attributes_25.mos \
 fmi2_array_attributes_nb.mos \
 fmi2_array_attributes.mos \
 Issue13905.mos \
+Issue13905_pool_expand.mos \
 fmi2_array_nonscalarized.mos \
 fmi2_arrays_initial_unknowns.mos \
 fmi_export_derivative_annotation.mos \


### PR DESCRIPTION
Closes #13905. Related to the FMI memory growth umbrella issue #13991.

`Buildings.Fluid.Geothermal.Borefields.Examples.RectangularBorefield` exported as an ME 2.0 FMU
dies in `fmi2ExitInitializationMode`:

```
memory_pool.c:98: pool_expand: Assertion `0 && "Attempt to allocate an unusually large memory.
The memory management does not seem to be working as intended. ..."' failed.
```

The assertion text is misleading: there is no large allocation. Every request that triggered a
pool expansion was **8–120 bytes**. Raising the ceiling shows what initialization actually costs
on master: **344 million allocations, 9.6 GB of pool, 10.4 GB RSS**, averaging 29 bytes each. The
defect is allocation *volume* that is never reclaimed.

Backtraces taken at every pool expansion all land in one place — a straight-line initial equation,
never a solver:

```
RectangularBorefield_eqFunction_625            (an initial equation)
└ LoadAggregation.temperatureResponseMatrix
  └ ThermalResponseFactors.gFunction / finiteLineSource_Equivalent
    └ Modelica.Math.Nonlinear.quadratureLobatto   (recursive adaptive quadStep)
      └ finiteLineSource_Integrand_Equivalent
        ├ Modelica.Math.Special.erf → Special.Internal.erfcUtil → alloc_real_array
        ├ mul_alloc_real_array_scalar / mul_alloc_real_array / usub_alloc_real_array
        └ cast_integer_array_to_real
also: Buildings.Utilities.Math.Functions.besselJ0, Buildings.Utilities.Clustering.KMeans
```

## 1. `[CG/C]` Roll the memory pool back when a function returns

FMU functions allocate from the memory pool, which is only rolled back at the FMI entry points in
`fmu2_model_interface.c`. Everything a function allocates therefore survives until the end of the
solver step.

Every hot function above returns a **scalar** — `erfcUtil`, `erf`, `besselJ0`, `quadratureLobatto`,
`finiteLineSource_Erfint` and the integrand are all `modelica_real omc_...(...)`. Nothing they
allocate can escape the call, so the pool can be restored to its entry state on return. The
generated body is bracketed with the existing
`omc_util_get_pool_state()`/`omc_util_restore_pool_state()`, guarded by
`OMC_MINIMAL_RUNTIME`/`OMC_FMI_RUNTIME` so only the pooled allocator is affected and the GC build
is byte-for-byte unchanged.

What is excluded, and why:

| output / declaration | codegen | verdict |
|---|---|---|
| first output | the whole `base_array_t` descriptor is returned by value, `data`/`dim_size` point at callee memory, and `boxptr_*` wraps it without copying | non-scalar outputs excluded |
| outputs 2..n | `varOutput` → `copy_*_array` → `real_array_alloc_copy`, which allocates **inside the callee** | non-scalar outputs excluded |
| array inputs | descriptor passed by value, but `data`/`dim_size` point at *caller* memory allocated before the save point; inputs are read-only and local↔local assignment deep-copies | safe |
| external objects | may own memory across calls | excluded, in `functionArguments` as well as `variableDeclarations`, because `isVarQ` keeps inputs out of the latter |
| `external "C"` functions | generated by `functionBodyExternalFunction` | never scoped, different template |

The restore sits after the output assignments and the external-object destructors, so every
`return` path is covered; throwing `longjmp`s past it, which merely means no reclamation.

## 2. `[CG/C]` Do not copy constant array literals on every call

A function-local `constant` array bound to a literal was heap-allocated and then filled from the
shared literal on **every call**:

```c
alloc_real_array(&(_P1), 1, (_index_t)6);
real_array_copy_data(_OMC_LIT2, _P1);
```

while `_OMC_LIT2` is a `static real_array const` over `static const modelica_real[]` that already
holds exactly those values. `Modelica.Math.Special.Internal.erfcUtil` does this for 8 coefficient
arrays per call and `Buildings.Utilities.Math.Functions.besselJ0` for 4 — measured at **46% of all
allocations** during this initialization.

The variable now points at the literal instead. This is restricted to `DAE.CONST`: the existing
comment on `varAllocDefaultValue` already records that aliasing a shared literal segfaults if the
variable is later assigned, and a Modelica `constant` never is. Unlike the pool scoping, this also
helps the GC runtime, which has no pool to roll back.

## 3. `[Runtime]` Make `pool_expand` honour the size that triggered it

Independent latent bug found while investigating, not what fails for this model. `pool_expand(size_t len)`
never read `len` — it always made the new block 1.5x the previous one, while `pool_malloc`
documents the opposite and then writes `len` bytes in with no further check:

```c
if (memory_pools->size - memory_pools->used < requested_size) pool_expand(requested_size);
res  = (char*)memory_pools->memory + memory_pools->used;
memory_pools->used += requested_size;   /* can now exceed ->size */
memset(res, 0, requested_size);         /* writes past the block */
```

Any single allocation larger than 1.5x the current block overflowed it. With the 2 MB initial
block a 16 MB request got a 4 MB block and memset **12 MB past the end**, which AddressSanitizer
reports as a heap-buffer-overflow. It also leaves `used > size`, after which `size - used`
underflows and the pool never expands again, handing out ever more out-of-bounds pointers.

The new block is now sized to the request when the geometric growth is not enough. The
runaway-growth assertion still triggers at exactly the same point, because it is checked against
the 1.5x size before the request is taken into account; a single allocation that is legitimately
larger than the limit is not evidence of broken memory management and is now served.

## Results

RectangularBorefield, cold cache, stock 1 GB ceiling:

| build | initialization | RSS after init |
|---|---|---|
| master | **assertion, fails** | — |
| master, ceiling raised to 60 GB | succeeds | 10403.5 MiB |
| this PR | **succeeds** | **74 MiB** |

All **3626** initialized `Real` variables are unchanged against the master reference (<1e-9
relative).

## Tests

Both in `testsuite/openmodelica/fmi/ModelExchange/2.0`:

- `Issue13905.mos` — checks the codegen decision on the exported FMU sources: a `Real`-returning
  function gets the save/restore pair, an array-returning one does not; then re-imports and
  simulates the FMU. On master the scalar function reports 0 pool calls instead of 2.
- `Issue13905_pool_expand.mos` — an FMU whose function has a 16 MB local array:

```mo
function bigLocal
  input Real x;
  output Real y;
protected
  Real[2000000] t "16 MB, far more than the 4 MB a 1.5x growth would hand back";
algorithm
  t[1] := x;
  t[2000000] := 2*x;
  y := t[1] + t[2000000];
end bigLocal;
```

  This segfaults on master and simulates here.

Regressions: `openmodelica/fmi/ModelExchange/2.0` 67/67 pass, `simulation/modelica/algorithms_functions`
36/36 pass.

## Relationship to #16082

PR #16082 adds the same save/restore around **nonlinear solver** residual and Jacobian evaluations.
**This PR does not supersede it and both should land** — the coverage is disjoint in both
directions.

What #16082 covers and this PR does not: anything a residual allocates outside a scalar-output
function. A residual calling a function that returns an array is the common case — the array output
is excluded here by design, because its descriptor is returned to the caller by value:

```mo
function vecFun
  input Real x;
  output Real[3] y;
algorithm
  y := {x, x^2, x^3};
end vecFun;
```

In the generated residual that becomes three `omc_..._vecFun` calls per evaluation, each
allocating two arrays that this PR leaves in the pool and #16082 reclaims. The same applies to
array temporaries emitted directly into the residual body, which are not a function body at all.

What this PR covers and #16082 does not: every function call outside a nonlinear solver —
initialization, event handling, output computation — and models with no nonlinear systems.
Issue #13905 is exactly that case, which is why #16082 does not close it: `SimCodeMain.mo` copies
the nonlinear solver sources into an FMU only `if varInfo.numNonLinearSystems > 0`, and this model
has `OMC_NUM_NONLINEAR_SYSTEMS 0` (with 63 linear systems), so those files are not even compiled
into its FMU. Confirmed by exporting a model that does have nonlinear systems, where they are
bundled as expected.

The two compose safely: nested save/restore only rolls back to the inner saved point.

## Known limitation

A regular function that calls `external "C"` code and passes it a temporary it allocated itself,
where the C side retains that pointer past the call, is not caught by any output-type test.
Retaining pool memory beyond the allocating scope is already unsupported in FMI builds — the
restore at the FMI entry point frees it regardless — so this change only narrows the window from
"FMI entry point" to "function return". Closing it properly would require SimCode to tell the
template whether a function transitively calls external code.

---
generated by Claude Code
