### PR TITLE
Keep loggingOn from enabling the solver dumps

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -130,15 +130,17 @@ fn fmi_log(status: Status, cat: u32, msg: &str) {
     }
 }
 
-/// The runtime's and driver's log lines. They exist only because [`stream_mask`]
-/// switched their stream on, so the category is `logAll` rather than a per-line one.
+/// The runtime's and driver's log lines: whatever stream they came from is lost
+/// by here, so the category is `logAll` rather than a per-line one.
 fn log_sink(s: &str) {
     if logger().on {
         log_raw(Status::Ok, CAT_ALL, s);
     }
 }
 
-/// The `-lv` streams the model-diagnostics categories stand for.
+/// The `-lv` streams the model-diagnostics categories stand for. Only
+/// `set-debug-logging` reaches this: C's FMU leaves every stream but stdout and
+/// assert off.
 fn stream_mask(cats: u32) -> omclog::Mask {
     let mut streams: Vec<&str> = Vec::new();
     for (cat, stream) in [
@@ -162,7 +164,7 @@ fn init_logging(name: String, logging_on: bool) {
     l.on = logging_on;
     l.cats = if logging_on { !0 } else { 0 };
     driver::set_log_sink(log_sink);
-    omclog::set_mask(stream_mask(l.cats));
+    omclog::set_mask(omclog::ALWAYS_ON);
 }
 
 /// The runtime `String` behind a handle, empty for the null handle.

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
@@ -201,7 +201,11 @@ export function parseModelDescription(xml) {
   for (const e of mv ? Array.from(mv.children) : []) {
     const type = TYPES[e.tagName];
     if (!type) continue;
-    const start = attr(e, 'start');
+    // String and Binary carry their start in a <Start value="…"/> child.
+    const startEl = e.querySelector(':scope > Start');
+    const startAttr = attr(e, 'start');
+    const start = startEl ? attr(startEl, 'value')
+      : startAttr == null ? null : startAttr.trim().split(/\s+/)[0];
     const name = attr(e, 'name') || '';
     variables.push({
       name,
@@ -211,7 +215,7 @@ export function parseModelDescription(xml) {
       numeric: NUMERIC.has(e.tagName),
       causality: attr(e, 'causality') || 'local',
       variability: attr(e, 'variability') || (e.tagName.startsWith('Float') ? 'continuous' : 'discrete'),
-      start: start == null ? null : start.trim().split(/\s+/)[0],
+      start,
       initial: attr(e, 'initial'),
       unit: attr(e, 'unit') || attr(e, 'displayUnit') || '',
       description: attr(e, 'description') || '',

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -48,6 +48,7 @@
     border-top:1px solid var(--border); background:var(--panel); }
   .log-head { display:flex; align-items:center; gap:8px; }
   .log-head .section-label { flex:1 1 auto; }
+  .log-head .dropped { color:var(--muted); font-size:12px; }
   .log-body { flex:1 1 auto; overflow-y:auto; padding:2px 12px 8px;
     font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace; white-space:pre-wrap; }
   .log-body .warning, .log-body .stderr { color:var(--warn); }
@@ -134,6 +135,7 @@
     <div class="log-pane">
       <div class="log-head">
         <div class="section-label">FMU log</div>
+        <span class="dropped" id="logDropped"></span>
         <button class="icon-btn" id="logClear" title="Clear the log">✕</button>
       </div>
       <div class="log-body" id="log"><span class="empty">No messages.</span></div>
@@ -169,16 +171,40 @@ let animView = null;    // shared 3D animation panel, if the FMU carries a <Visu
 const setStatus = (text, cls = '') => { statusEl.textContent = text; statusEl.className = 'status ' + cls; };
 const num = (v, d) => { const n = parseFloat(v); return isFinite(n) ? n : d; };
 
+// A node plus a forced layout per message takes the tab down when an FMU logs
+// thousands of lines per step: bounded scrollback, flushed once per frame.
+const LOG_MAX = 2000;
+let logPending = [], logFrame = 0, logDropped = 0;
+
 function log(cls, text) {
   if (!logCount++) logEl.replaceChildren();
-  const line = document.createElement('div');
-  line.className = cls;
-  line.textContent = text;
+  logPending.push([cls, text]);
+  if (logPending.length > LOG_MAX) { logPending.shift(); logDropped++; }
+  if (!logFrame) logFrame = requestAnimationFrame(flushLog);
+}
+
+function flushLog() {
+  logFrame = 0;
   const atBottom = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 4;
-  logEl.appendChild(line);
+  const frag = document.createDocumentFragment();
+  for (const [cls, text] of logPending) {
+    const line = document.createElement('div');
+    line.className = cls;
+    line.textContent = text;
+    frag.appendChild(line);
+  }
+  logPending = [];
+  logEl.appendChild(frag);
+  while (logEl.childElementCount > LOG_MAX) { logEl.firstElementChild.remove(); logDropped++; }
+  el('logDropped').textContent = logDropped ? `${logDropped} earlier messages dropped` : '';
   if (atBottom) logEl.scrollTop = logEl.scrollHeight;
 }
-el('logClear').onclick = () => { logEl.innerHTML = '<span class="empty">No messages.</span>'; logCount = 0; };
+
+el('logClear').onclick = () => {
+  logEl.innerHTML = '<span class="empty">No messages.</span>';
+  logCount = 0; logPending = []; logDropped = 0;
+  el('logDropped').textContent = '';
+};
 
 // --- loading ----------------------------------------------------------------
 openBtn.onclick = () => fileEl.click();
@@ -280,7 +306,9 @@ function renderFields() {
     nm.innerHTML = escapeHtml(v.name)
       + (isInput ? '<span class="in">f(t)</span>' : isStart(v) ? '<span class="in">start</span>' : '');
     const input = document.createElement('input');
-    input.value = v.start != null ? v.start : (v.tag === 'Boolean' ? 'false' : '0');
+    // An input must be driven; a parameter with no declared start is left unset.
+    input.value = v.start != null ? v.start : isInput ? (v.tag === 'Boolean' ? 'false' : '0') : '';
+    input.placeholder = input.value === '' ? 'unset' : '';
     input.spellcheck = false;
     const unit = document.createElement('span');
     unit.className = 'unit';
@@ -321,11 +349,12 @@ function collectFields() {
   const inputs = [], parameters = [];
   for (const f of fields) {
     f.input.classList.remove('bad');
-    const src = f.input.value.trim() || '0';
+    const src = f.input.value.trim();
+    if (f.kind === 'parameter' && f.v.start == null && src === '') continue;
     const target = f.kind === 'input' ? inputs : parameters;
     try {
       if (f.v.tag === 'String') { target.push({ vr: f.v.vr, type: 'String', value: () => f.input.value }); continue; }
-      const fn = compileExpr(src, f.v.name);
+      const fn = compileExpr(src || '0', f.v.name);
       target.push({ vr: f.v.vr, type: f.v.type, value: fn });
     } catch (e) { f.input.classList.add('bad'); throw e; }
   }


### PR DESCRIPTION
`fmi3InstantiateCoSimulation(loggingOn=true)` turned on every FMI log category, and the adapter mapped those categories onto OpenModelica's `-lv` streams, so `LOG_NLS`/`LOG_EVENTS`/`LOG_LS`/`LOG_DSS` all went live. C's FMU does no such thing: `fmu3_model_interface.c` leaves `omc_useStream[]` at stdout and assert, and `omcSetDebugLogging` touches `logCategories` alone. Only `set-debug-logging` reaches `stream_mask` now.

FullRobot exported for Co-Simulation, driven to its stop time:

| | log messages | wall time |
| --- | --- | --- |
| before | 1 329 417 | 60 s |
| after | 2 | 1.8 s |

Every message is a DOM node plus a forced layout in the browser master, so the page did not survive the flood at all — the renderer reached 4.3 GB and stopped answering. It now runs the model in 2.0 s.

Two defects the same run exposed in that page:

* FMI 3.0 gives String and Binary variables their start value in a `<Start value="…"/>` child rather than the attribute, so `terminationText` and friends parsed as unset.
* A parameter with no start was then sent to the FMU as `0`, which is how `terminate()` came to report `Message : 0` instead of the model's text. Such a parameter is now left as the FMU set it.

The log pane is a bounded scrollback flushed once per frame, so no FMU's log volume can take the tab down.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
