### PR TITLE
wasm-jit: C's initialization logging and checks

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -477,9 +477,11 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
         // Chattering abort (`-abortSlowSimulation`): the driver's output carries the
         // chattering + aborting lines.
         Err(e) if *e == sim_driver::CHATTER_ABORT_ERR => format!("{init_seg}{sim_output}"),
-        // A failed assertion has already logged C's `LOG_ASSERT` block; any other
-        // failure needs its reason spelled out.
-        Err(e) if *e == sim_driver::ASSERT_ERR => format!("{init_seg}{sim_output}"),
+        // A failed assertion has already logged C's `LOG_ASSERT` block, and a failed
+        // initialization its `LOG_INIT` reason; anything else needs spelling out.
+        Err(e) if *e == sim_driver::ASSERT_ERR || *e == sim_driver::INIT_FAILED_ERR => {
+            format!("{init_seg}{sim_output}")
+        }
         Err(e) => format!(
             "{init_seg}{sim_output}LOG_ERROR         | error   | wasm-jit simulation failed: {}\n",
             with_engine_detail(e)
@@ -3339,6 +3341,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         // The optimizer's attribute arrays: one entry per real variable, only for a
         // model that carries an optimization problem.
         if optimization::is_optimization(sim_code) { 2 * n_states + n_real_alg } else { 0 },
+        bound_attr_equations(sim_code).len() as u32,
+        removed_init_residuals(sim_code).len() as u32,
         has_when,
         has_homotopy,
     );
@@ -3817,6 +3821,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&relations),
+        param_vars(vars)?, attr_log_entries(sim_code)?,
+        removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
         samples.iter().map(|s| s.index).collect(), soti_vars(vars)?, sens_params, nls_vars, dae,
         clocks.iter().map(|c| c.meta.clone()).collect(),
         build_lin_info(&linz, vars, &var_map)?,
@@ -4016,7 +4022,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             .copied()
             .collect();
         bodies.push(build_update_bound_attrs_fn(
-            sim_code, &defaults, &opt_attrs.ints, &attr_targets, &var_map, &by_name, &mut literals,
+            sim_code, &layout, &defaults, &opt_attrs.ints, &attr_targets, &var_map, &by_name,
+            &mut literals,
         )?);
         idx
     };
@@ -4043,6 +4050,16 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
             &clocks, &layout, &var_map, &eq_index, &by_name, &mut literals,
         )?);
         (init, init + 1, init + 2)
+    };
+    // C's over-determined check; a stub when nothing was removed.
+    let removed_init_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if count(&sim_code.removedInitialEquations) == 0 {
+            empty_eqfn()
+        } else {
+            build_removed_init_eqs_fn(sim_code, &layout, &var_map, &eq_index, &by_name, &mut literals)?
+        });
+        idx
     };
     // Emitted only for a DAE-mode model: its absence is how the standalone export and
     // the FMU adapters know the model is an explicit ODE.
@@ -4110,6 +4127,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     functions.function(eqfn_type); // functionInitSynchronous: (i32) -> ()
     functions.function(sync_fn_type); // functionUpdateSynchronous: (i32, i32) -> ()
     functions.function(sync_fn_type); // functionEquationsSynchronous: (i32, i32) -> ()
+    functions.function(eqfn_type); // functionRemovedInitialEquations: (i32) -> ()
     if let Some(ti) = dae_fn_type {
         functions.function(ti); // evaluateDAEResiduals: (i32, i32) -> ()
     }
@@ -4215,6 +4233,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         exports.export(*name, we::ExportKind::Func, opt_jac_idx + k as u32);
     }
     let (sync_init, sync_update, sync_eqs) = sync_idx;
+    exports.export("functionRemovedInitialEquations", we::ExportKind::Func, removed_init_idx);
     exports.export("functionInitSynchronous", we::ExportKind::Func, sync_init);
     exports.export("functionUpdateSynchronous", we::ExportKind::Func, sync_update);
     exports.export("functionEquationsSynchronous", we::ExportKind::Func, sync_eqs);
@@ -4273,6 +4292,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     ] {
         names.push((idx, name.to_string()));
     }
+    names.push((removed_init_idx, "functionRemovedInitialEquations".to_string()));
     names.push((sync_init, "functionInitSynchronous".to_string()));
     names.push((sync_update, "functionUpdateSynchronous".to_string()));
     names.push((sync_eqs, "functionEquationsSynchronous".to_string()));
@@ -4639,6 +4659,9 @@ fn build_sim_meta(
     fmi_vrs: Vec<FmiVr>,
     zc_desc: Vec<String>,
     rel_desc: Vec<String>,
+    params: openmodelica_sim_meta::ParamVars,
+    attr_log: Vec<openmodelica_sim_meta::AttrLog>,
+    removed_init_desc: Vec<String>,
     sample_index: Vec<i32>,
     soti: openmodelica_sim_meta::SotiVars,
     sens_params: Vec<u32>,
@@ -4665,6 +4688,9 @@ fn build_sim_meta(
         fmi_vrs,
         zc_desc,
         rel_desc,
+        params,
+        attr_log,
+        removed_init_desc,
         sample_index,
         soti,
         sens_params,
@@ -4708,6 +4734,45 @@ fn soti_vars(vars: &SimCodeVar::SimVars) -> Result<openmodelica_sim_meta::SotiVa
         strings.push((named(sv)?, const_str(&sv.initialValue).unwrap_or_default()));
     }
     Ok(openmodelica_sim_meta::SotiVars { reals, ints, bools, strings })
+}
+
+/// C's `modelData` parameter arrays: the same lists, in the same order, as the
+/// `SimData` parameter regions.
+fn param_vars(vars: &SimCodeVar::SimVars) -> Result<openmodelica_sim_meta::ParamVars> {
+    let mut reals = Vec::new();
+    for sv in lst(&vars.paramVars) {
+        reals.push((cref_display(&sv.name)?.to_string(), const_real(&sv.initialValue).unwrap_or(0.0), sv.isFixed));
+    }
+    let mut ints = Vec::new();
+    for sv in lst(&vars.intParamVars) {
+        ints.push((cref_display(&sv.name)?.to_string(), const_int(&sv.initialValue).unwrap_or(0), sv.isFixed));
+    }
+    let mut bools = Vec::new();
+    for sv in lst(&vars.boolParamVars) {
+        bools.push((cref_display(&sv.name)?.to_string(), const_int(&sv.initialValue).unwrap_or(0), sv.isFixed));
+    }
+    let mut strings = Vec::new();
+    for sv in lst(&vars.stringParamVars) {
+        strings.push((cref_display(&sv.name)?.to_string(), const_str(&sv.initialValue).unwrap_or_default()));
+    }
+    Ok(openmodelica_sim_meta::ParamVars { reals, ints, bools, strings })
+}
+
+/// Name and attribute kind of every attribute-log slot.
+fn attr_log_entries(sim_code: &SimCode::SimCode) -> Result<Vec<openmodelica_sim_meta::AttrLog>> {
+    let mut out = Vec::new();
+    for (attr, cref, _) in bound_attr_equations(sim_code) {
+        let raw = cref_display(cref)?.to_string();
+        let name = raw.strip_prefix("$START.").unwrap_or(&raw).to_string();
+        let kind = match attr {
+            Attr::Min => 0,
+            Attr::Max => 1,
+            Attr::Nominal => 2,
+            Attr::Start => 3,
+        };
+        out.push(openmodelica_sim_meta::AttrLog { kind, name });
+    }
+    Ok(out)
 }
 
 fn const_real(e: &Option<Arc<DAE::Exp>>) -> Option<f64> {
@@ -4837,16 +4902,28 @@ fn collect_param_bindings(
     {
         // A parameter an equation computes must not also be assigned from its binding
         // here: the prelude runs before both equation lists, so the binding would see
-        // dependencies that are still 0 (or a null handle). C leaves such a parameter
-        // at the 0 of a `_init.xml` entry with no `start`.
+        // dependencies that are still 0 (or a null handle). A *constant* binding reads
+        // nothing, so it is stored regardless — C's `setAllParamsToStart`.
         if let Some(v) = &p.initialValue {
-            if sim_cref_key(&p.name).map(|k| computed.contains(&k)).unwrap_or(false) {
+            if !is_const_exp(v) && sim_cref_key(&p.name).map(|k| computed.contains(&k)).unwrap_or(false) {
                 continue;
             }
             out.push((p.name.clone(), v.clone()));
         }
     }
     out
+}
+
+/// A literal the `_init.xml` would carry verbatim as a `start` attribute.
+fn is_const_exp(e: &DAE::Exp) -> bool {
+    matches!(
+        e,
+        DAE::Exp::ICONST { .. }
+            | DAE::Exp::RCONST { .. }
+            | DAE::Exp::BCONST { .. }
+            | DAE::Exp::SCONST { .. }
+            | DAE::Exp::ENUM_LITERAL { .. }
+    )
 }
 
 /// Keys of the crefs assigned by a `SimEqSystem` list (scalar/array assigns).
@@ -5187,6 +5264,54 @@ fn build_init_sample_fn(
     Ok(func)
 }
 
+/// The initial equations the backend removed as redundant, kept as `0 = <exp>`
+/// checks. A `SCONST` residual is C's `res = 0`, never inconsistent.
+fn removed_init_residuals(sim_code: &SimCode::SimCode) -> Vec<&Arc<DAE::Exp>> {
+    lst(&sim_code.removedInitialEquations)
+        .filter_map(|eq| match &**eq {
+            SimCode::SimEqSystem::SES_RESIDUAL { exp, .. } => Some(exp),
+            _ => None,
+        })
+        .filter(|exp| !matches!(&***exp, DAE::Exp::SCONST { .. }))
+        .collect()
+}
+
+/// Build `functionRemovedInitialEquations(SimData*)`. The first residual off zero
+/// stops the function; a non-residual entry is an ordinary equation.
+fn build_removed_init_eqs_fn(
+    sim_code: &SimCode::SimCode,
+    layout: &SimLayout,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
+    ctx.emit_removed_init_reset(layout.removed_init_idx_off)?;
+    let mut pending: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+    let mut index = 0u32;
+    for eq in lst(&sim_code.removedInitialEquations) {
+        match &**eq {
+            SimCode::SimEqSystem::SES_RESIDUAL { exp, .. } => {
+                if matches!(&**exp, DAE::Exp::SCONST { .. }) {
+                    continue;
+                }
+                emit_sim_const_stores(&mut ctx, &core::mem::take(&mut pending))?;
+                ctx.emit_removed_init_residual(
+                    index,
+                    exp,
+                    layout.removed_init_res_off,
+                    layout.removed_init_idx_off,
+                )?;
+                index += 1;
+            }
+            _ => lower_unit(&mut ctx, &EqUnit::Eq(eq, None), eq_index, &mut pending)?,
+        }
+    }
+    emit_sim_const_stores(&mut ctx, &pending)?;
+    Ok(finish_fn(ctx))
+}
+
 /// Build `functionInitSynchronous(SimData*)` — C's `function_initSynchronous`.
 fn build_init_synchronous_fn(
     clocks: &[ClockInfo],
@@ -5316,20 +5441,12 @@ fn build_init_start_values_fn(
     Ok(func)
 }
 
-/// Build `functionUpdateBoundVariableAttributes(SimData*)`. An attribute bound to a
-/// parameter is not a constant, so the backend hands it over as an equation; only
-/// here, after `functionParameters`, does it have a value. Attributes nothing reads
-/// back are skipped.
-fn build_update_bound_attrs_fn(
+/// The attribute equations in C's `min`, `max`, `nominal`, `start` group order.
+/// A start equation assigns `$START.<var>`, i.e. that variable's `start` attribute.
+fn bound_attr_equations(
     sim_code: &SimCode::SimCode,
-    defaults: &[(u32, f64)],
-    int_defaults: &[(u32, i32)],
-    attr_targets: &HashMap<String, AttrTargets>,
-    var_map: &SimVarMap,
-    by_name: &HashMap<String, FnInfo>,
-    literals: &mut Literals,
-) -> Result<we::Function> {
-    let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets)> = Vec::new();
+) -> Vec<(Attr, &Arc<DAE::ComponentRef>, &Arc<DAE::Exp>)> {
+    let mut out = Vec::new();
     for (attr, eqs) in [
         (Attr::Min, &sim_code.minValueEquations),
         (Attr::Max, &sim_code.maxValueEquations),
@@ -5337,27 +5454,37 @@ fn build_update_bound_attrs_fn(
         (Attr::Start, &sim_code.startValueEquations),
     ] {
         for eq in lst(eqs) {
-            let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq else { continue };
-            // A start-value equation assigns `$START.<var>` (C writes it into the
-            // variable's `start` attribute); the others name the variable itself.
-            let Some(t) = sim_cref_key(cref)
-                .ok()
-                .map(|k| k.strip_prefix("$START.").unwrap_or(&k).to_string())
-                .and_then(|k| attr_targets.get(&k))
-            else {
-                continue;
-            };
-            let wanted = match attr {
-                Attr::Nominal => !t.nom_offs.is_empty() || !t.opt_nom_offs.is_empty(),
-                Attr::Max => !t.max_offs.is_empty() || !t.opt_max_offs.is_empty(),
-                Attr::Min => !t.opt_min_offs.is_empty(),
-                Attr::Start => !t.start_offs.is_empty(),
-            };
-            if t.nls.is_empty() && !wanted {
-                continue;
+            if let SimCode::SimEqSystem::SES_SIMPLE_ASSIGN { cref, exp, .. } = &**eq {
+                out.push((attr, cref, exp));
             }
-            attrs.push((attr, exp.clone(), t.clone()));
         }
+    }
+    out
+}
+
+/// Build `functionUpdateBoundVariableAttributes(SimData*)`. An attribute bound to a
+/// parameter is not a constant, so the backend hands it over as an equation; only
+/// here, after `functionParameters`, does it have a value. Every attribute is
+/// evaluated (as C does) and left in the log region, whatever else it feeds.
+fn build_update_bound_attrs_fn(
+    sim_code: &SimCode::SimCode,
+    layout: &SimLayout,
+    defaults: &[(u32, f64)],
+    int_defaults: &[(u32, i32)],
+    attr_targets: &HashMap<String, AttrTargets>,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
+    let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets, u32)> = Vec::new();
+    for (i, (attr, cref, exp)) in bound_attr_equations(sim_code).into_iter().enumerate() {
+        let targets = sim_cref_key(cref)
+            .ok()
+            .map(|k| k.strip_prefix("$START.").unwrap_or(&k).to_string())
+            .and_then(|k| attr_targets.get(&k))
+            .cloned()
+            .unwrap_or_default();
+        attrs.push((attr, exp.clone(), targets, layout.attr_log_off + i as u32 * 8));
     }
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1747,7 +1747,7 @@ impl<'a> FnCtx<'a> {
         &mut self,
         defaults: &[(u32, f64)],
         int_defaults: &[(u32, i32)],
-        attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets)],
+        attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets, u32)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
         for (off, value) in defaults {
@@ -1764,10 +1764,14 @@ impl<'a> FnCtx<'a> {
             return Ok(());
         }
         let (raw, val) = (self.alloc_temp(WTy::F64), self.alloc_temp(WTy::F64));
-        for (attr, exp, targets) in attrs {
+        for (attr, exp, targets, log_off) in attrs {
             let w = compile_exp(self, exp)?;
             coerce(self, w, WTy::F64);
             self.emit(we::Instruction::LocalSet(raw));
+            // C prints the value from inside this function; the driver reads it here.
+            self.emit(we::Instruction::LocalGet(data));
+            self.emit(we::Instruction::LocalGet(raw));
+            self.emit(we::Instruction::F64Store(mem_arg(*log_off, 3)));
             if matches!(attr, Attr::Nominal) {
                 for off in &targets.nom_offs {
                     // C's `dassl.c`: `atol[i] = tol * fmax(fabs(nominal), 1e-32)`.
@@ -1937,6 +1941,46 @@ impl<'a> FnCtx<'a> {
             }
             self.emit(we::Instruction::Call(rt_index("rt_delay_store")?));
         }
+        Ok(())
+    }
+
+    /// Clear the rejected-residual index, so a re-run never reports a stale verdict.
+    pub(crate) fn emit_removed_init_reset(&mut self, idx_off: u32) -> Result<()> {
+        let data = self.sim()?.data_local;
+        self.emit(we::Instruction::LocalGet(data));
+        self.emit(we::Instruction::I32Const(0));
+        self.emit(we::Instruction::I32Store(mem_arg(idx_off, 2)));
+        Ok(())
+    }
+
+    /// C's `functionRemovedInitialEquationsBody`: missing zero by more than `1e-5`
+    /// leaves the residual and its 1-based index behind for the driver and ends the
+    /// function, as C's `return 1` does.
+    pub(crate) fn emit_removed_init_residual(
+        &mut self,
+        index: u32,
+        exp: &DAE::Exp,
+        res_off: u32,
+        idx_off: u32,
+    ) -> Result<()> {
+        use we::Instruction as I;
+        let data = self.sim()?.data_local;
+        let res = self.alloc_temp(WTy::F64);
+        let w = compile_exp(self, exp)?;
+        coerce(self, w, WTy::F64);
+        self.emit(I::LocalTee(res));
+        self.emit(I::F64Abs);
+        self.emit(I::F64Const(1e-5f64.into()));
+        self.emit(I::F64Gt);
+        self.emit(I::If(we::BlockType::Empty));
+        self.emit(I::LocalGet(data));
+        self.emit(I::LocalGet(res));
+        self.emit(I::F64Store(mem_arg(res_off, 3)));
+        self.emit(I::LocalGet(data));
+        self.emit(I::I32Const(index as i32 + 1));
+        self.emit(I::I32Store(mem_arg(idx_off, 2)));
+        self.emit(I::Return);
+        self.emit(I::End);
         Ok(())
     }
 
@@ -3602,6 +3646,8 @@ fn emit_assert(
     source: &DAE::ElementSource,
 ) -> Result<()> {
     let is_warning = matches!(level, DAE::Exp::ENUM_LITERAL { index: 1, .. });
+    // C's `FUNCTION_CONTEXT` arm reports the message alone, with no dumped condition.
+    let in_function = ctx.sim().is_err();
     let c = compile_exp(ctx, cond)?;
     coerce(ctx, c, WTy::I32);
     ctx.emit(we::Instruction::I32Eqz);
@@ -3612,7 +3658,8 @@ fn emit_assert(
         // The dumped condition (C's `assert_cond`), then the message, then the
         // source position — all consumed by `rt_assert_warning`; execution
         // continues afterwards (no trap).
-        emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition
+        let dumped = if in_function { String::new() } else { dumped_exp(cond)? };
+        emit_str_literal(ctx, dumped.as_bytes())?; // dumped condition
         let mw = compile_exp(ctx, msg)?; // owned message String handle
         if mw != WTy::I32 {
             return Err("CodegenWasmJit: assert message is not a String");
@@ -3638,7 +3685,11 @@ fn emit_assert(
     ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
     ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
-    emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
+    if in_function {
+        ctx.emit(we::Instruction::I32Const(0));
+    } else {
+        emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
+    }
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     // Trap unless the driver took it (suppressed during the event search).
     ctx.emit(we::Instruction::If(we::BlockType::Empty));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -49,6 +49,7 @@ unsafe extern "C" {
     fn functionInitDelay(sim_data: u32);
     fn functionUpdateBoundParameters(sim_data: u32);
     fn functionUpdateBoundVariableAttributes(sim_data: u32);
+    fn functionRemovedInitialEquations(sim_data: u32);
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn linearJacA(sim_data: u32);
@@ -109,6 +110,7 @@ impl SimEngine for StandaloneEngine {
                 "functionInitDelay" => functionInitDelay(arg),
                 "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
+                "functionRemovedInitialEquations" => functionRemovedInitialEquations(arg),
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 "linearJacA" => linearJacA(arg),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -53,6 +53,7 @@ unsafe extern "C" {
     fn functionInitDelay(sim_data: u32);
     fn functionUpdateBoundParameters(sim_data: u32);
     fn functionUpdateBoundVariableAttributes(sim_data: u32);
+    fn functionRemovedInitialEquations(sim_data: u32);
     fn initSample(sim_data: u32);
     fn functionInitSynchronous(sim_data: u32);
     fn functionUpdateSynchronous(sim_data: u32, base_idx: u32);
@@ -264,6 +265,7 @@ impl SimEngine for Engine {
                 "functionInitDelay" => functionInitDelay(arg),
                 "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
+                "functionRemovedInitialEquations" => functionRemovedInitialEquations(arg),
                 "initSample" => initSample(arg),
                 "functionInitSynchronous" => functionInitSynchronous(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -213,6 +213,7 @@ pub const MODEL_FNS: &[&str] = &[
     "linearJacB",
     "linearJacC",
     "linearJacD",
+    "functionRemovedInitialEquations",
 ];
 
 /// The model entry points that are not `fn(SimData*)`: `--daeMode`'s residual
@@ -809,6 +810,8 @@ pub const CHATTER_ABORT_ERR: &str = "CodegenWasmJit: aborting simulation due to 
 pub const ALARM_ABORT_ERR: &str = "CodegenWasmJit: simulation aborted (-alarm)";
 /// What [`enrich_trap`] returns for a trap that was a failed model `assert()`.
 pub const ASSERT_ERR: &str = "assertion failed";
+/// C's `initialization()` returning nonzero: the reason is already logged.
+pub const INIT_FAILED_ERR: &str = "initialization failed";
 
 /// `-abortSlowSimulation` flag + the driver's chattering log lines, set on the host
 /// before a run (the driver can only return a `&'static str`).
@@ -1125,29 +1128,31 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> Stri
     let during = if initial { "during initialization " } else { "" };
     let t = format_f(time);
     let head = format!("The following assertion has been violated {during}at time {t}");
-    // A generated `assert()` always names its condition, and C prints it with the
+    let ro_str = if info.read_only { "readonly" } else { "writable" };
+    let pos = format!(
+        "[{}:{}:{}-{}:{}:{ro_str}]",
+        info.file, info.line_start, info.col_start, info.line_end, info.col_end,
+    );
+    // An equation `assert()` always names its condition, and C prints it with the
     // message as one message's second line — including for a backend-generated
-    // variable, whose `FILE_INFO` is empty (`$finalCon$…`'s min/max guard). A
-    // condition-less violation is C's `assertCommonVar` (the math-domain guards).
+    // variable, whose `FILE_INFO` is empty (`$finalCon$…`'s min/max guard). Without
+    // a condition it is C's `FUNCTION_CONTEXT` `omc_assert` (position and message
+    // only) or `assertCommonVar` (the math-domain guards, neither).
     if cond.is_empty() {
-        return head;
+        return if info.file.is_empty() { head } else { format!("{pos}\n{}", info.msg) };
     }
     let body = format!("(({cond})) --> \"{}\"", info.msg);
     if info.file.is_empty() {
         return format!("{head}\n{body}");
     }
-    let ro_str = if info.read_only { "readonly" } else { "writable" };
-    format!(
-        "[{}:{}:{}-{}:{}:{ro_str}]\n{head}\n{body}",
-        info.file, info.line_start, info.col_start, info.line_end, info.col_end,
-    )
+    format!("{pos}\n{head}\n{body}")
 }
 
 fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
     let block = assert_block(info, cond, time, initial);
     // C's `assertCommonVar` (the math-domain guards, no condition and no source
     // position): the warning names the time, a debug line carries the message.
-    if cond.is_empty() {
+    if cond.is_empty() && info.file.is_empty() {
         omclog::warning(omclog::ASSERT, false, &block);
         omclog::message_text(omclog::DEBUG_TYPE, omclog::ASSERT, false, &info.msg);
         return;
@@ -1319,6 +1324,7 @@ fn init_model(
     if let Some(m) = model {
         dump_initial_solution(e, sim_data, m);
     }
+    omclog::info(omclog::INIT, false, "### END INITIALIZATION ###");
     // C's `storePreValues` after the initial solve (initialization.c:903).
     seed_pre_from_live(e, sim_data, layout)?;
     // Seed the continuous phase's held relations from a full discrete fixed point.
@@ -1349,6 +1355,7 @@ fn run_initialization_impl(
     inputs: &[crate::InputVar],
     model: Option<&SimMeta>,
 ) -> Result<()> {
+    omclog::info(omclog::INIT, false, "### START INITIALIZATION ###");
     // C's `updateStaticDataOfNonlinearSystems`.
     omclog::info(omclog::NLS, true, "update static data of non-linear system solvers");
     omclog::close(omclog::NLS);
@@ -1364,13 +1371,43 @@ fn run_initialization_impl(
     // C's `IIM_NONE`: every variable keeps its start value, the initial system is
     // never solved. C still marks the systems solved before it picks the method.
     if crate::simflags::with_flags(|f| f.init_method) == crate::simflags::InitMethod::None {
+        log_init_method("none", "sets all variables to their start values and skips the initialization process");
         write_i32(e, sim_data + layout.nls_fail_off, 0)?;
         return Ok(());
     }
+    log_init_method("symbolic", "solves the initialization problem symbolically - default");
 
-    // C's `symbolic_initialization`: a model with `homotopy()` goes straight to the
-    // global equidistant continuation, unless `-noHomotopyOnFirstTry` asks for the
-    // direct solve first with the continuation as the fallback.
+    symbolic_initialization(e, sim_data, layout, inputs, model)
+}
+
+/// C's `INIT_METHOD_NAME`/`INIT_METHOD_DESC` line.
+fn log_init_method(name: &str, desc: &str) {
+    omclog::info(omclog::INIT, false, &format!("initialization method: {name:<15} [{desc}]"));
+}
+
+/// C's `symbolic_initialization`: solve, then check the equations the backend
+/// removed as redundant.
+fn symbolic_initialization(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+    model: Option<&SimMeta>,
+) -> Result<()> {
+    solve_initial_system(e, sim_data, layout, inputs, model)?;
+    check_removed_initial_equations(e, sim_data, layout, model)
+}
+
+/// A model with `homotopy()` goes straight to the global equidistant continuation,
+/// unless `-noHomotopyOnFirstTry` asks for the direct solve first with the
+/// continuation as the fallback.
+fn solve_initial_system(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    inputs: &[crate::InputVar],
+    model: Option<&SimMeta>,
+) -> Result<()> {
     if !layout.has_homotopy {
         return direct_initial_solve(e, sim_data, layout);
     }
@@ -1395,6 +1432,48 @@ fn run_initialization_impl(
     run_homotopy_continuation(e, sim_data, layout)?;
     init_report::set_homotopy_steps(homotopy_steps() as u32);
     Ok(())
+}
+
+/// C's over-determined check: the removed initial equations are residuals of the
+/// solution just found, and one off zero means the problem has none.
+fn check_removed_initial_equations(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    model: Option<&SimMeta>,
+) -> Result<()> {
+    if layout.n_removed_init == 0 {
+        return Ok(());
+    }
+    e.call1("functionRemovedInitialEquations", sim_data)?;
+    let idx = read_i32(e, sim_data + layout.removed_init_idx_off)?;
+    if idx == 0 {
+        return Ok(());
+    }
+    let res = read_f64(e, sim_data + layout.removed_init_res_off)?;
+    let desc = model
+        .and_then(|m| m.removed_init_desc.get(idx as usize - 1))
+        .map(String::as_str)
+        .unwrap_or_default();
+    omclog::error(
+        omclog::INIT,
+        false,
+        &format!(
+            "The initialization problem is inconsistent due to the following equation: 0 != {} = {desc}",
+            format_g(res, 6)
+        ),
+    );
+    Err(report_init_failure())
+}
+
+/// C's `solver_main` reaction to a failed `initialization()`.
+fn report_init_failure() -> &'static str {
+    omclog::warning(
+        omclog::STDOUT,
+        false,
+        "Error in initialization. Storing results and exiting.\nUse -lv=LOG_INIT -w for more information.",
+    );
+    INIT_FAILED_ERR
 }
 
 /// C's `setAllParamsToStart` + `setAllVarsToStart` + `updateBoundParameters` +
@@ -1426,8 +1505,12 @@ fn seed_start_values(
     e.call1("functionInitStartValues", sim_data)?;
     apply_external_input(e, sim_data, inputs)?;
     e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
+    log_bound_attr_updates(e, sim_data, layout, model);
     apply_start_overrides(e, sim_data)?;
     set_all_vars_to_start(e, sim_data, layout, model)?;
+    // C runs `updateBoundParameters` *after* `setAllVarsToStart`: those equations
+    // also assign the constant-bound variables, which the copy would undo.
+    e.call1("functionUpdateBoundParameters", sim_data)?;
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
     // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
@@ -1436,6 +1519,121 @@ fn seed_start_values(
         e.call1("initSample", sim_data)?;
     }
     Ok(())
+}
+
+/// C's `updateBoundVariableAttributes` log, over the values the model left in the
+/// attribute-log region. A group's header appears even when it is empty, as C's
+/// unconditional `infoStreamPrint` in that function gives.
+fn log_bound_attr_updates(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, model: Option<&SimMeta>) {
+    if !omclog::active(omclog::INIT) {
+        return;
+    }
+    let entries: &[crate::AttrLog] = model.map_or(&[], |m| &m.attr_log);
+    for (kind, name) in crate::ATTR_NAME.iter().enumerate() {
+        let header = match *name {
+            "start" => "primary start-values".to_string(),
+            _ => format!("{name}-values"),
+        };
+        omclog::info(omclog::INIT, true, &format!("updating {header}"));
+        if omclog::active(omclog::INIT_V) {
+            for (i, a) in entries.iter().enumerate().filter(|(_, a)| a.kind as usize == kind) {
+                let v = read_f64(e, sim_data + layout.attr_log_off + i as u32 * 8).unwrap_or(0.0);
+                let line = match *name {
+                    "start" => format!("updated start value: {}(start={})", a.name, format_g(v, 6)),
+                    _ => format!("{}({name}={})", a.name, format_g(v, 6)),
+                };
+                omclog::info(omclog::INIT_V, false, &line);
+            }
+        }
+        omclog::close(omclog::INIT);
+    }
+}
+
+/// C's `printParameters` (`model_help.c`), which `dumpInitialSolution` opens with.
+fn print_parameters(e: &dyn SimEngine, sim_data: u32, model: &SimMeta) {
+    if !omclog::active(omclog::INIT_V) {
+        return;
+    }
+    let p = &model.params;
+    let layout = &model.layout;
+    // C's `-override` rewrites the `_init.xml` entry, `start` included.
+    let ov = overrides_store::params();
+    let start_of = |off: u32, v: f64| ov.iter().find(|o| o.0 == off).map_or(v, |o| o.2);
+    omclog::info(omclog::INIT_V, true, "parameter values");
+    let mut group = |header: &str, lines: alloc::vec::Vec<String>| {
+        if lines.is_empty() {
+            return;
+        }
+        omclog::info(omclog::INIT_V, true, header);
+        for l in &lines {
+            omclog::info(omclog::INIT_V, false, l);
+        }
+        omclog::close(omclog::INIT_V);
+    };
+    let fixed = |f: bool| if f { "true" } else { "false" };
+    group(
+        "real parameters",
+        p.reals
+            .iter()
+            .enumerate()
+            .map(|(i, (n, start, f))| {
+                let off = layout.rparam_off + i as u32 * 8;
+                let v = read_f64(e, sim_data + off).unwrap_or(0.0);
+                format!(
+                    "[{}] parameter Real {n}(start={}, fixed={}) = {}",
+                    i + 1,
+                    format_g(start_of(off, *start), 6),
+                    fixed(*f),
+                    format_g(v, 6)
+                )
+            })
+            .collect(),
+    );
+    group(
+        "integer parameters",
+        p.ints
+            .iter()
+            .enumerate()
+            .map(|(i, (n, start, f))| {
+                let off = layout.iparam_off + i as u32 * 4;
+                let v = read_i32(e, sim_data + off).unwrap_or(0);
+                let start = start_of(off, *start as f64) as i32;
+                format!("[{}] parameter Integer {n}(start={start}, fixed={}) = {v}", i + 1, fixed(*f))
+            })
+            .collect(),
+    );
+    let b = |v: i32| if v != 0 { "true" } else { "false" };
+    group(
+        "boolean parameters",
+        p.bools
+            .iter()
+            .enumerate()
+            .map(|(i, (n, start, f))| {
+                let off = layout.bparam_off + i as u32 * 4;
+                let v = read_i32(e, sim_data + off).unwrap_or(0);
+                format!(
+                    "[{}] parameter Boolean {n}(start={}, fixed={}) = {}",
+                    i + 1,
+                    b(start_of(off, *start as f64) as i32),
+                    fixed(*f),
+                    b(v)
+                )
+            })
+            .collect(),
+    );
+    group(
+        "string parameters",
+        p.strings
+            .iter()
+            .enumerate()
+            .map(|(i, (n, start))| {
+                let h = read_i32(e, sim_data + layout.sparam_off + i as u32 * 4).unwrap_or(0);
+                let v = read_rt_string(e, h).unwrap_or_default();
+                format!("[{}] parameter String {n}(start=\"{start}\") = \"{v}\"", i + 1)
+            })
+            .collect(),
+    );
+    omclog::close(omclog::INIT_V);
 }
 
 /// Solve the initial system at lambda = 1, where `homotopy(a, s)` is `a`.
@@ -1839,6 +2037,7 @@ fn refresh_relations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -
 /// after the initial system is solved and *before* the pre-values are stored — so
 /// a derivative still reads `(pre: 0)`.
 fn dump_initial_solution(e: &dyn SimEngine, sim_data: u32, model: &SimMeta) {
+    print_parameters(e, sim_data, model);
     if !omclog::active(omclog::SOTI) {
         return;
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -223,6 +223,15 @@ pub struct Layout {
     /// Base of the per-base-clock `$_clkfire` flags (one i32 each): an event
     /// clock's `when`-body raises its flag, the driver fires and clears it.
     pub clock_fire_off: u32,
+    /// One f64 per attribute `functionUpdateBoundVariableAttributes` computes; C
+    /// prints those values from inside that function, which the driver cannot.
+    pub n_attr_log: u32,
+    pub attr_log_off: u32,
+    /// Residuals `functionRemovedInitialEquations` checks; 0 ⇒ it is a stub.
+    pub n_removed_init: u32,
+    /// The rejected residual (f64) and its 1-based index (i32); index 0 ⇒ consistent.
+    pub removed_init_res_off: u32,
+    pub removed_init_idx_off: u32,
     pub total: u32,
 }
 
@@ -256,6 +265,8 @@ impl Layout {
         n_sub_clocks: u32,
         n_linz: u32,
         n_opt_attr: u32,
+        n_attr_log: u32,
+        n_removed_init: u32,
         has_when: bool,
         has_homotopy: bool,
     ) -> Self {
@@ -307,7 +318,10 @@ impl Layout {
         let opt_max_off = opt_min_off + n_opt_attr * 8;
         let opt_nom_off = opt_max_off + n_opt_attr * 8;
         let opt_use_nom_off = opt_nom_off + n_opt_attr * 8;
-        let total = opt_use_nom_off + n_opt_attr * 4;
+        let attr_log_off = (opt_use_nom_off + n_opt_attr * 4 + 7) & !7;
+        let removed_init_res_off = attr_log_off + n_attr_log * 8;
+        let removed_init_idx_off = removed_init_res_off + 8;
+        let total = removed_init_idx_off + 4;
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
@@ -316,7 +330,9 @@ impl Layout {
             mathevents_off, zctol_off, start_off, state_nom_off, state_max_off, n_sens, sens_off,
             n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
             n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, linz_off, n_linz,
-            n_opt_attr, opt_min_off, opt_max_off, opt_nom_off, opt_use_nom_off, total,
+            n_opt_attr, opt_min_off, opt_max_off, opt_nom_off, opt_use_nom_off,
+            n_attr_log, attr_log_off,
+            n_removed_init, removed_init_res_off, removed_init_idx_off, total,
         }
     }
 
@@ -421,6 +437,28 @@ pub struct SotiVars {
     /// String variables with their `start` attribute.
     pub strings: Vec<(String, String)>,
 }
+
+/// C's `modelData` parameter arrays (name, `start`, `fixed`) in the order of the
+/// `SimData` parameter regions, which hold the values `printParameters` reports.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ParamVars {
+    pub reals: Vec<(String, f64, bool)>,
+    pub ints: Vec<(String, i32, bool)>,
+    pub bools: Vec<(String, i32, bool)>,
+    /// C prints no `fixed` for a String parameter.
+    pub strings: Vec<(String, String)>,
+}
+
+/// The variable (C's `info.name`) an [`Layout::attr_log_off`] slot belongs to, and
+/// which attribute of it — an index into [`ATTR_NAME`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct AttrLog {
+    pub kind: u8,
+    pub name: String,
+}
+
+/// [`AttrLog::kind`], in the group order C prints.
+pub const ATTR_NAME: [&str; 4] = ["min", "max", "nominal", "start"];
 
 /// [`MetaVar::filter`] bits: what keeps a variable out of the result file, and
 /// which flag lets it back in (C's `shouldFilterOutput` +
@@ -715,6 +753,13 @@ pub struct SimMeta {
     pub sample_index: Vec<i32>,
     /// C's `modelData` variable arrays, for the `LOG_SOTI` initialization dump.
     pub soti: SotiVars,
+    /// C's `modelData` parameter arrays, for the `LOG_INIT_V` parameter dump.
+    pub params: ParamVars,
+    /// 1:1 with the [`Layout::attr_log_off`] slots.
+    pub attr_log: Vec<AttrLog>,
+    /// Modelica source of each residual `functionRemovedInitialEquations` checks;
+    /// C bakes the same text into the generated `errorStreamPrint`.
+    pub removed_init_desc: Vec<String>,
     /// C's `simulationInfo->sensitivityParList`: the `SimData` offsets of the
     /// parameters `--calculateSensitivities` selected, in block order.
     pub sens_params: Vec<u32>,
@@ -976,6 +1021,8 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off,
         l.linz_off, l.n_linz,
         l.n_opt_attr, l.opt_min_off, l.opt_max_off, l.opt_nom_off, l.opt_use_nom_off,
+        l.n_attr_log, l.attr_log_off,
+        l.n_removed_init, l.removed_init_res_off, l.removed_init_idx_off,
         l.total,
     ] {
         put_u32(o, v);
@@ -1063,6 +1110,34 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     }
     put_u32(&mut o, m.rel_desc.len() as u32);
     for d in &m.rel_desc {
+        put_str(&mut o, d);
+    }
+    put_u32(&mut o, m.params.reals.len() as u32);
+    for (n, v, f) in &m.params.reals {
+        put_str(&mut o, n);
+        put_f64(&mut o, *v);
+        o.push(*f as u8);
+    }
+    for list in [&m.params.ints, &m.params.bools] {
+        put_u32(&mut o, list.len() as u32);
+        for (n, v, f) in list {
+            put_str(&mut o, n);
+            put_u32(&mut o, *v as u32);
+            o.push(*f as u8);
+        }
+    }
+    put_u32(&mut o, m.params.strings.len() as u32);
+    for (n, v) in &m.params.strings {
+        put_str(&mut o, n);
+        put_str(&mut o, v);
+    }
+    put_u32(&mut o, m.attr_log.len() as u32);
+    for a in &m.attr_log {
+        o.push(a.kind);
+        put_str(&mut o, &a.name);
+    }
+    put_u32(&mut o, m.removed_init_desc.len() as u32);
+    for d in &m.removed_init_desc {
         put_str(&mut o, d);
     }
     put_u32(&mut o, m.sample_index.len() as u32);
@@ -1307,6 +1382,11 @@ impl<'a> Reader<'a> {
             opt_max_off: self.u32()?,
             opt_nom_off: self.u32()?,
             opt_use_nom_off: self.u32()?,
+            n_attr_log: self.u32()?,
+            attr_log_off: self.u32()?,
+            n_removed_init: self.u32()?,
+            removed_init_res_off: self.u32()?,
+            removed_init_idx_off: self.u32()?,
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
@@ -1389,6 +1469,27 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let mut rel_desc = Vec::with_capacity(nrdesc);
     for _ in 0..nrdesc {
         rel_desc.push(r.string()?);
+    }
+    let mut params = ParamVars::default();
+    for _ in 0..r.u32()? {
+        params.reals.push((r.string()?, r.f64()?, r.u8()? != 0));
+    }
+    for list in [&mut params.ints, &mut params.bools] {
+        for _ in 0..r.u32()? {
+            list.push((r.string()?, r.u32()? as i32, r.u8()? != 0));
+        }
+    }
+    for _ in 0..r.u32()? {
+        params.strings.push((r.string()?, r.string()?));
+    }
+    let mut attr_log = Vec::new();
+    for _ in 0..r.u32()? {
+        attr_log.push(AttrLog { kind: r.u8()?, name: r.string()? });
+    }
+    let nridesc = r.u32()? as usize;
+    let mut removed_init_desc = Vec::with_capacity(nridesc);
+    for _ in 0..nridesc {
+        removed_init_desc.push(r.string()?);
     }
     let sample_index = r.u32s()?.into_iter().map(|v| v as i32).collect();
     let mut soti = SotiVars::default();
@@ -1546,8 +1647,8 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
-        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, sample_index, soti, sens_params,
-        nls_vars, dae, clocks, lin, opt, inputs,
+        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
+        removed_init_desc, sample_index, soti, sens_params, nls_vars, dae, clocks, lin, opt, inputs,
     })
 }
 
@@ -1559,7 +1660,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, 2, 1, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -1597,6 +1698,17 @@ mod tests {
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             rel_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
+            params: ParamVars {
+                reals: vec![("a".to_string(), 1.5, true)],
+                ints: vec![("i".to_string(), 3, false)],
+                bools: vec![("b".to_string(), 1, true)],
+                strings: vec![("s".to_string(), "two".to_string())],
+            },
+            attr_log: vec![
+                AttrLog { kind: 0, name: "x".to_string() },
+                AttrLog { kind: 3, name: "y".to_string() },
+            ],
+            removed_init_desc: vec!["4.0 - z".to_string()],
             sample_index: vec![1],
             soti: SotiVars::default(),
             sens_params: vec![88],


### PR DESCRIPTION
Port the parts of `simulation/solver/initialization/initialization.c` the wasm-jit target was missing.

**Over-determined initial systems.** `functionRemovedInitialEquations` is a new model export: it evaluates the initial equations the backend removed as redundant and, for the first residual off zero by more than `1e-5`, leaves the value and its 1-based index in `SimData`. The driver formats C's `LOG_INIT` error from `SimMeta::removed_init_desc` and ends the run through a new `INIT_FAILED_ERR`, which suppresses the generic `LOG_ERROR` line since the reason is already logged.

**The `LOG_INIT` block.** `### START/END INITIALIZATION ###`, the `initialization method: …` line, the four `updating <attr>-values` groups and `printParameters` on `LOG_INIT_V`. C prints the attribute values from inside the generated function, so
`functionUpdateBoundVariableAttributes` now evaluates *every* attribute equation (as C does) and stores each into a new `Layout::attr_log_off` region that `SimMeta::attr_log` names. `SimMeta::params` carries name/`start`/`fixed` per parameter region; `-override` replaces the reported `start`, as C's `_init.xml` rewrite does.

**Two ordering fixes against C.** A *constant* parameter binding is emitted even when an equation also computes the parameter — that is `setAllParamsToStart`, without which the parameter min/max asserts in `parameterEquations` ran against 0. And `functionUpdateBoundParameters` runs after `setAllVarsToStart`, C's order: those equations also assign the constant-bound variables, which the start-value copy was undoing.

**Function-body `assert()`** reports position and message only, C's `FUNCTION_CONTEXT` arm, rather than the equation form's `(cond) --> "msg"`.

Fixes 12 `simulation/modelica/initialization` tests under `--simCodeTarget=wasm-jit`:

* over-determined check: SingularInitial, bug_2263, bug_2566, bug_2583 and both OverdeterminedInitialization *FullInitialInconsistent tests
* LOG_INIT block: bug_2207, bug_2990, bug_2994, parameters
* bound-parameter ordering: bug_3052
* function-body assert: bug_4718

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
