### PR TITLE
[CI] Fix the nightly release and make Jenkins abort the remaining stages on failure (#16239)

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -10,6 +10,8 @@ jobs:
   build:
     if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       OMVERSION : ''
     steps:
@@ -26,15 +28,24 @@ jobs:
           echo "$OMVERSION" > OMVERSION.txt
           cd ..
           ln -s ${{ github.event.repository.name }} ${{ github.event.repository.name }}-$OMVERSION
-          zip ${{ github.event.repository.name }}/${{ github.event.repository.name }}-$OMVERSION-nightly.zip ${{ github.event.repository.name }}-$OMVERSION -r -x '*/.git/*'
+          zip -q ${{ github.event.repository.name }}/${{ github.event.repository.name }}-$OMVERSION-nightly.zip ${{ github.event.repository.name }}-$OMVERSION -r -x '*/.git/*'
           rm -f ${{ github.event.repository.name }}-$OMVERSION
+          ls -l ${{ github.event.repository.name }}/${{ github.event.repository.name }}-$OMVERSION-nightly.zip
 
       - name: Delete old release assets
-        uses: mknejp/delete-release-assets@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: nightly
-          assets: '*nightly.zip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          assets=$(gh release view nightly --json assets --jq '.assets[].name' 2>/dev/null | grep 'nightly\.zip$' || true)
+          if [ -z "$assets" ]; then
+            echo "No old nightly assets to delete."
+            exit 0
+          fi
+          echo "$assets" | while read -r asset; do
+            echo "Deleting $asset"
+            gh release delete-asset nightly "$asset" --yes
+          done
 
       - name: Upload the new assets
         uses: pyTooling/Actions/releaser@r0
@@ -42,3 +53,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: nightly
           files: ${{ github.event.repository.name }}-*nightly.zip
+
+      - name: Check that the release has the new assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          assets=$(gh release view nightly --json assets --jq '.assets[] | "\(.name) \(.size) \(.state)"')
+          echo "$assets"
+          echo "$assets" | grep -q 'nightly\.zip .* uploaded'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,10 @@ pipeline {
   agent none
   options {
     newContainerPerStage()
+    // Abort the sibling branches as soon as one of them fails: the build is
+    // going to be red anyway and the stages that are still running would keep
+    // the nodes busy for hours.
+    parallelsAlwaysFailFast()
     buildDiscarder(logRotator(daysToKeepStr: "14", artifactNumToKeepStr: "2"))
   }
   environment {


### PR DESCRIPTION
Fixes #16239.

Two CI changes: the `nightly-release` GitHub Actions workflow, and fail-fast for the Jenkins pipeline.

## 1. nightly-release no longer dies when there is nothing to delete

The job has failed on **every** push to `master` since 2026-08-11 ([latest run](https://github.com/OpenModelica/OpenModelica/actions/runs/31577123703)):

```
##[error]No assets in the release match the provided patterns.
```

`mknejp/delete-release-assets@v1` fails hard when nothing matches its pattern, and the `nightly` release is currently empty (`gh api repos/OpenModelica/OpenModelica/releases/tags/nightly --jq '.assets'` → `[]`). Because that step runs *before* the upload, the freshly built zip never gets uploaded, so the release stays empty and the next run fails identically — the failure keeps itself alive.

* **Delete step** — replaced the third-party action with a plain `gh` CLI step that does nothing when there is no matching asset. This also drops an unmaintained action that GitHub already warns about (Node.js 20 deprecation).
* **Permissions** — the job now declares `contents: write` instead of relying on the repository's default token permissions.
* **Build step** — `zip -q` plus an `ls -l` on the result: the log currently carries ~55000 `adding:` lines and never tells you how big the asset actually is.
* **New verification step** — after the upload, check that the release really carries an `uploaded` `*nightly.zip`. The last green run reported a successful upload yet left the release with no assets at all, and its logs have since aged out. With this check, a silently failing upload becomes a red job instead of an empty nightly release.

The build itself was never the problem: `git describe` yields `v1.28.0-dev-299-g80c430c362` and the zip is created normally, well below the 2 GB release-asset limit.

## 2. Jenkins aborts the remaining stages once one fails

A red stage means the build is red, but today every other branch of the parallel blocks runs to completion — testsuite shards, web and GUI builds, the cross-build — holding nodes for hours on work that cannot change the outcome.

`parallelsAlwaysFailFast()` in the pipeline `options` turns fail-fast on for every `parallel` block in the file (`setup`, `tests + extras`, `fmuchecker + FMPy + OMEdit testsuite`, `check-and-upload`, `publish`), including any added later. Branches already running are interrupted; branches not yet started never allocate a node. The `try`/`finally` blocks in `.CI/common.groovy` (sccache stats, partest cleanup, the nextest junit publish) still run while unwinding, and nothing in the pipeline swallows the interrupt, so the abort is real and the cleanup still happens.

Worth being aware of: an infrastructure flake now aborts the whole build. The first Jenkins run of this PR hit exactly that — stage `10 web target` died with `ERROR: Timeout after 180 seconds` while `docker run` was starting `build-deps:ubuntu-26.04-rust`, i.e. the docker-workflow plugin's `DockerClient.CLIENT_TIMEOUT` (default 180 s) expiring on container startup under load. That is a controller-side setting (`-Dorg.jenkinsci.plugins.docker.workflow.client.DockerClient.CLIENT_TIMEOUT=…` in the Jenkins JVM options) and is not addressed here.

## Testing

CI-configuration only, so it can only really be exercised on the CI itself. Locally verified for the workflow change:

* both `run:` scripts pass `bash -n`;
* the delete step exits 0 with `No old nightly assets to delete.` when `gh release view` returns nothing — the exact situation that is currently breaking the job.

After merge, the first push to `master` should delete nothing, upload the zip, and pass the new verification step; the `nightly` release then has its asset back.

---
generated by Claude Code
