### PR TITLE
do not pass removed equations for data Reconciliation problem

### DIFF
--- a/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
+++ b/OMCompiler/Compiler/BackEnd/DataReconciliation.mo
@@ -302,6 +302,11 @@ algorithm
   // Prepare the final DAE System with Set-C equations as residual equations
   currentSystem := BackendDAEUtil.setEqSystVars(currentSystem, BackendVariable.mergeVariables(outResidualVars, outOtherVars));
   currentSystem := BackendDAEUtil.setEqSystEqs(currentSystem, BackendEquation.merge(outResidualEqns, outOtherEqns));
+  /* fix issue https://github.com/OpenModelica/OpenModelica/issues/12277
+   * the removed equations should be set to empty, otherwise the removed equations
+   * will be added to the final DAE system and cause the assertion failure in the data reconciliation problem which should not be the case
+  */
+  currentSystem.removedEqs :=  BackendEquation.emptyEqns();
 
   inputVars := BackendVariable.listVar(List.map1(BackendVariable.varList(outDiffVars), BackendVariable.setVarDirection, DAE.INPUT()));
   shared := BackendDAEUtil.setSharedGlobalKnownVars(shared, BackendVariable.mergeVariables(shared.globalKnownVars, inputVars));
@@ -716,6 +721,11 @@ algorithm
   // Prepare the final DAE System with Set-B and Set-S' equations
   currentSystem := BackendDAEUtil.setEqSystEqs(currentSystem, BackendEquation.merge(outBoundaryConditionEquations, outOtherEqns));
   currentSystem := BackendDAEUtil.setEqSystVars(currentSystem, BackendVariable.mergeVariables(outBoundaryConditionVars, outOtherVars));
+  /* fix issue https://github.com/OpenModelica/OpenModelica/issues/12277
+   * the removed equations should be set to empty, otherwise the removed equations
+   * will be added to the final DAE system and cause the assertion failure in the data reconciliation problem which should not be the case
+  */
+  currentSystem.removedEqs :=  BackendEquation.emptyEqns();
 
   inputVars := BackendVariable.listVar(List.map1(BackendVariable.varList(outDiffVars), BackendVariable.setVarDirection, DAE.INPUT()));
   shared := BackendDAEUtil.setSharedGlobalKnownVars(shared, BackendVariable.mergeVariables(shared.globalKnownVars, inputVars));
@@ -1103,6 +1113,11 @@ algorithm
 
   currentSystem := BackendDAEUtil.setEqSystEqs(currentSystem, BackendEquation.listEquation(allDaeEqs));
   currentSystem := BackendDAEUtil.setEqSystVars(currentSystem, BackendVariable.listVar(listAppend(setSVars, residualVars)));
+  /* fix issue https://github.com/OpenModelica/OpenModelica/issues/12277
+   * the removed equations should be set to empty, otherwise the removed equations
+   * will be added to the final DAE system and cause the assertion failure in the data reconciliation problem which should not be the case
+  */
+  currentSystem.removedEqs :=  BackendEquation.emptyEqns();
 
   inputVars := BackendVariable.listVar(List.map1(BackendVariable.varList(outDiffVars), BackendVariable.setVarDirection, DAE.INPUT()));
   shared := BackendDAEUtil.setSharedGlobalKnownVars(shared, BackendVariable.mergeVariables(shared.globalKnownVars, inputVars));

--- a/testsuite/openmodelica/dataReconciliation/Makefile
+++ b/testsuite/openmodelica/dataReconciliation/Makefile
@@ -2,6 +2,7 @@ TEST = ../../rtest -v
 BASELINE = ../../rtest -b
 
 TESTFILES = \
+assert.mos\
 DistillationTower.mos\
 VDI2048Exple.mos\
 Pipe1.mos\

--- a/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/assert.mo
+++ b/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/assert.mo
@@ -1,0 +1,11 @@
+within NewDataReconciliationSimpleTests;
+model assert
+  Real a(uncertain = Uncertainty.refine);
+  Real b(uncertain = Uncertainty.refine);
+  parameter Real c=5 annotation(__OpenModelica_BoundaryCondition = true);
+  Real table_real[2]={1.0,2.0};
+equation
+  a=b;
+  a=c;
+  assert(table_real[1]==1.0,"Assert");
+end assert;

--- a/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/package.order
+++ b/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/package.order
@@ -1,3 +1,4 @@
+assert
 VDI2048Example
 VDI2048Example_Corrected
 DistillationTower

--- a/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/resources/model_assert_DR.csv
+++ b/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/resources/model_assert_DR.csv
@@ -1,0 +1,3 @@
+Variable name;Measured value;Weight
+a;12;2
+b;11;2

--- a/testsuite/openmodelica/dataReconciliation/assert.mos
+++ b/testsuite/openmodelica/dataReconciliation/assert.mos
@@ -1,0 +1,240 @@
+// name:     assert
+// keywords: extraction algorithm
+// status:   correct
+// depends: ./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv
+
+setCommandLineOptions("--preOptModules+=dataReconciliation");
+getErrorString();
+
+loadString("
+  model model_assert_DR
+    Real a(uncertain = Uncertainty.refine);
+    Real b(uncertain = Uncertainty.refine);
+    parameter Real c=5 annotation(__OpenModelica_BoundaryCondition = true);
+    Real table_real[2]={1.0,2.0};
+  equation
+    a=b;
+    a=c;
+    assert(table_real[1]==1.0,\"Assert\");
+  end model_assert_DR;
+  ");
+getErrorString();
+
+simulate(model_assert_DR, simflags="-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC");
+getErrorString();
+
+
+// Result:
+// true
+// ""
+// true
+// ""
+//
+// ModelInfo: model_assert_DR
+// ==========================================================================
+//
+//
+// OrderedVariables (5)
+// ========================================
+// 1: table_real[2]:VARIABLE()  type: Real [2]
+// 2: table_real[1]:VARIABLE()  type: Real [2]
+// 3: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 4: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 5: c:VARIABLE()  type: Real
+//
+//
+// OrderedEquation (4, 5)
+// ========================================
+// 1/1 (1): c = 5.0   [binding |0|0|0|0|]
+// 2/2 (2): table_real = {1.0, 2.0}   [dynamic |0|0|0|0|]
+// 3/4 (1): a = b   [dynamic |0|0|0|0|]
+// 4/5 (1): a = c   [dynamic |0|0|0|0|]
+//
+// Matching
+// ========================================
+// 5 variables and equations
+// var 1 is solved in eqn 3
+// var 2 is solved in eqn 2
+// var 3 is solved in eqn 4
+// var 4 is solved in eqn 5
+// var 5 is solved in eqn 1
+//
+// Standard BLT of the original model:(5)
+// ============================================================
+//
+// 5: c: (1/1): (1): c = 5.0
+// 4: a: (4/5): (1): a = c
+// 3: b: (3/4): (1): a = b
+// 2: table_real[1]: (2/2): (2): table_real = {1.0, 2.0}
+// 1: table_real[2]: (2/3): (2): table_real = {1.0, 2.0}
+//
+//
+// Variables of interest (2)
+// ========================================
+// 1: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 2: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+//
+//
+// Boundary conditions (1)
+// ========================================
+// 1: c:VARIABLE()  type: Real
+//
+//
+// Binding equations:(1)
+// ============================================================
+//
+// 5: c: (1/1): (1): c = 5.0
+//
+//
+// E-BLT: equations that compute the variables of interest:(2)
+// ============================================================
+//
+// 3: b: (3/4): (1): a = b
+// 4: a: (4/5): (1): a = c
+//
+//
+// Extracting SET-C and SET-S from E-BLT
+// Procedure is applied on each equation in the E-BLT
+// ==========================================================================
+// >>>3: b: (3/4): (1): a = b
+// Procedure success
+//
+// >>>4: a: (4/5): (1): a = c
+// c is a boundary condition ---> exit procedure
+// Procedure failed
+//
+// Extraction procedure failed for iteration count: 1, re-running with modified model
+// ==========================================================================
+//
+// OrderedVariables (5)
+// ========================================
+// 1: table_real[2]:VARIABLE()  type: Real [2]
+// 2: table_real[1]:VARIABLE()  type: Real [2]
+// 3: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 4: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 5: c:VARIABLE()  type: Real
+//
+//
+// OrderedEquation (4, 5)
+// ========================================
+// 1/1 (1): a = 0.0   [binding |0|0|0|0|]
+// 2/2 (1): c = 5.0   [binding |0|0|0|0|]
+// 3/3 (2): table_real = {1.0, 2.0}   [dynamic |0|0|0|0|]
+// 4/5 (1): a = b   [dynamic |0|0|0|0|]
+//
+// Matching
+// ========================================
+// 5 variables and equations
+// var 1 is solved in eqn 4
+// var 2 is solved in eqn 3
+// var 3 is solved in eqn 5
+// var 4 is solved in eqn 1
+// var 5 is solved in eqn 2
+//
+// Standard BLT of the original model:(5)
+// ============================================================
+//
+// 5: c: (2/2): (1): c = 5.0
+// 4: a: (1/1): (1): a = 0.0
+// 3: b: (4/5): (1): a = b
+// 2: table_real[1]: (3/3): (2): table_real = {1.0, 2.0}
+// 1: table_real[2]: (3/4): (2): table_real = {1.0, 2.0}
+//
+//
+// Variables of interest (2)
+// ========================================
+// 1: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 2: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+//
+//
+// Boundary conditions (1)
+// ========================================
+// 1: c:VARIABLE()  type: Real
+//
+//
+// Binding equations:(2)
+// ============================================================
+//
+// 5: c: (2/2): (1): c = 5.0
+// 4: a: (1/1): (1): a = 0.0
+//
+//
+// E-BLT: equations that compute the variables of interest:(1)
+// ============================================================
+//
+// 3: b: (4/5): (1): a = b
+//
+//
+// Extracting SET-C and SET-S from E-BLT
+// Procedure is applied on each equation in the E-BLT
+// ==========================================================================
+// >>>3: b: (4/5): (1): a = b
+// Procedure success
+//
+// Extraction procedure is successfully completed in iteration count: 2
+// ==========================================================================
+//
+// Final set of equations after extraction algorithm
+// ==========================================================================
+// SET_C: {4}
+// SET_S: {}
+//
+//
+// SET_C (1, 1)
+// ========================================
+// 1/1 (1): a = b   [dynamic |0|0|0|0|]
+//
+//
+// Unknown variables in SET_S (0)
+// ========================================
+//
+//
+//
+//
+// Automatic Verification Steps of DataReconciliation Algorithm
+// ==========================================================================
+//
+// knownVariables:{3, 4} (2)
+// ========================================
+// 1: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 2: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+//
+// -SET_C:{4}
+// -SET_S:{}
+//
+// Condition-1 "SET_C and SET_S must not have no equations in common"
+// ==========================================================================
+// -Passed
+//
+// Condition-2 "All variables of interest must be involved in SET_C or SET_S"
+// ==========================================================================
+// -Passed
+//
+// -SET_C has all known variables:{3, 4} (2)
+// ========================================
+// 1: b:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+// 2: a:VARIABLE(uncertain=Uncertainty.refine)  type: Real
+//
+// Condition-3 "SET_C equations must be strictly less than Variable of Interest"
+// ==========================================================================
+// -Passed
+// -SET_C contains:1 equations < 2 known variables
+//
+// Condition-4 "SET_S should contain all intermediate variables involved in SET_C"
+// ==========================================================================
+// -Passed
+// -SET_C contains No Intermediate Variables
+//
+// record SimulationResult
+//     resultFile = "econcile",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'model_assert_DR', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// LOG_STDOUT        | info    | DataReconciliation Starting!
+// LOG_STDOUT        | info    | model_assert_DR
+// LOG_STDOUT        | info    | DataReconciliation Completed!
+// "
+// end SimulationResult;
+// "[<interactive>:10:5-10:40:writable] Warning: In relation table_real[1] == 1.0, == on Real operands is deprecated in non-function contexts.
+// "
+// endResult

--- a/testsuite/openmodelica/dataReconciliation/assert.mos
+++ b/testsuite/openmodelica/dataReconciliation/assert.mos
@@ -6,21 +6,10 @@
 setCommandLineOptions("--preOptModules+=dataReconciliation");
 getErrorString();
 
-loadString("
-  model model_assert_DR
-    Real a(uncertain = Uncertainty.refine);
-    Real b(uncertain = Uncertainty.refine);
-    parameter Real c=5 annotation(__OpenModelica_BoundaryCondition = true);
-    Real table_real[2]={1.0,2.0};
-  equation
-    a=b;
-    a=c;
-    assert(table_real[1]==1.0,\"Assert\");
-  end model_assert_DR;
-  ");
+loadFile("NewDataReconciliationSimpleTests/package.mo");
 getErrorString();
 
-simulate(model_assert_DR, simflags="-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC");
+simulate(NewDataReconciliationSimpleTests.assert, simflags="-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC");
 getErrorString();
 
 
@@ -28,9 +17,13 @@ getErrorString();
 // true
 // ""
 // true
-// ""
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
+// "
 //
-// ModelInfo: model_assert_DR
+// ModelInfo: NewDataReconciliationSimpleTests.assert
 // ==========================================================================
 //
 //
@@ -227,14 +220,14 @@ getErrorString();
 //
 // record SimulationResult
 //     resultFile = "econcile",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'model_assert_DR', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NewDataReconciliationSimpleTests.assert', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-reconcile -sx=./NewDataReconciliationSimpleTests/resources/model_assert_DR.csv -eps=0.0023 -lv=LOG_JAC'",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // LOG_STDOUT        | info    | DataReconciliation Starting!
-// LOG_STDOUT        | info    | model_assert_DR
+// LOG_STDOUT        | info    | NewDataReconciliationSimpleTests.assert
 // LOG_STDOUT        | info    | DataReconciliation Completed!
 // "
 // end SimulationResult;
-// "[<interactive>:10:5-10:40:writable] Warning: In relation table_real[1] == 1.0, == on Real operands is deprecated in non-function contexts.
+// "[openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/assert.mo:10:3-10:38:writable] Warning: In relation table_real[1] == 1.0, == on Real operands is deprecated in non-function contexts.
 // "
 // endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12277

### Purpose

Do not pass removed equations to data Reconciliation problem as code generation generates equations for those removed equations which are not part of the extraction aglorithm and causes assertion error which is not related to Data Reconciliation problem.

