### PR TITLE
wasm-jit: native external "C" on the native host

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -85,7 +85,7 @@ use openmodelica_sim_meta::{
 use openmodelica_wasm_jit::{sim_driver, sim_runtime};
 #[cfg(feature = "jit")]
 use openmodelica_wasm_jit::wasi_shim;
-pub(crate) use openmodelica_wasm_jit::model::{EditableParam, ExtLibrary, ModelCompileJob, SimModel};
+pub(crate) use openmodelica_wasm_jit::model::{EditableParam, ExtIncludes, ExtLibrary, ModelCompileJob, SimModel};
 #[cfg(feature = "jit")]
 pub use openmodelica_wasm_jit::model::{set_inwasm_driver_override, set_sim_bench};
 #[cfg(feature = "jit")]
@@ -421,7 +421,7 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
     let prefix = simCode.fileNamePrefix.to_string();
     let _ = std::fs::remove_file(format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
-    let outcome = build_sim_model(&simCode, false).and_then(|model| {
+    let outcome = build_sim_model(&simCode, false, ExtHost::SIM).and_then(|model| {
         write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), Arc::new(model));
         Ok(())
@@ -963,6 +963,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     SIM_OUTPUT.with(|c| *c.borrow_mut() = None);
     sim_driver::set_teardown_hook(on_teardown);
     SPLIT_ARMED.with(|a| a.set(true));
+    openmodelica_wasm_jit::host::native_stdout::install();
     sim_driver::init_host_hooks();
     sim_driver::set_result_file_reader(read_result_values);
     let (meta, experiment_log) = run_experiment(&model, &flags);
@@ -1178,6 +1179,7 @@ mod session {
     SIM_OUTPUT.with(|c| *c.borrow_mut() = None);
     sim_driver::set_teardown_hook(on_teardown);
         SPLIT_ARMED.with(|a| a.set(true));
+        openmodelica_wasm_jit::host::native_stdout::install();
         sim_driver::init_host_hooks();
         sim_driver::set_result_file_reader(read_result_values);
         let (meta, experiment_log) = run_experiment(&model, &flags);
@@ -1413,7 +1415,7 @@ use openmodelica_wasm_jit::RUNTIME_WASIP1;
 /// `wasm-merge` is an external tool, absent in the omc wasm build.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn emit_standalone_module(sim_code: &SimCode::SimCode) -> Result<Vec<u8>> {
-    let model = build_sim_model(sim_code, false)?;
+    let model = build_sim_model(sim_code, false, ExtHost::Wasm)?;
     merge_standalone(&model.wasm)
 }
 
@@ -1487,23 +1489,47 @@ use openmodelica_wasi_libc::{
 // The model's own `external "C"` libraries
 // ===========================================================================
 
-/// Resolve the `Library` annotations (already wasm module names, from
-/// `SimCodeFunctionUtil`) against the library directories. A name that resolves to
-/// nothing is reported here, not later as an unresolvable `ext.<fn>` import.
+/// What the `Library` annotations resolved to. `SimCodeFunctionUtil` emits each
+/// one twice: the wasm module name, then the host linker spec.
+#[derive(Default)]
+pub(crate) struct ExtLibraries {
+    pub wasm: Vec<ExtLibrary>,
+    /// In link order, for a native host to fall back to.
+    pub native: Vec<String>,
+    /// `#include` lines for the C sources a `Library` named, which the C target
+    /// hands to the compiler rather than the linker.
+    pub sources: Vec<String>,
+}
+
+/// Resolve the `Library` annotations against the library directories. A name that
+/// resolves to nothing is reported here, not later as an unresolvable `ext.<fn>`
+/// import.
 pub(crate) fn resolve_ext_libraries(
     mp: &SimCodeFunction::MakefileParams,
     notes: &mut Vec<String>,
-) -> Result<Vec<ExtLibrary>> {
+) -> Result<ExtLibraries> {
     let mut dirs: Vec<String> = vec![String::new()]; // relative to the working directory
     for d in lst(&mp.libPaths) {
         dirs.push(format!("{d}/"));
     }
-    let mut out: Vec<ExtLibrary> = Vec::new();
+    for lib in lst(&mp.libs) {
+        if let Some(d) = lib.strip_prefix("-L") {
+            dirs.push(format!("{}/", d.trim_matches('"')));
+        }
+    }
+    let mut out = ExtLibraries::default();
     let mut seen: HashSet<String> = HashSet::new();
     for lib in lst(&mp.libs) {
         let lib = lib.to_string();
-        // The library list is shared with the other code generators.
-        if lib.starts_with('-') || !seen.insert(lib.clone()) {
+        if !seen.insert(lib.clone()) {
+            continue;
+        }
+        if !lib.ends_with(".wasm") {
+            if let Some(path) = find_source_library(&lib, &dirs) {
+                out.sources.push(format!("#include \"{}\"", path.replace('\\', "/")));
+            } else if let Some(path) = find_native_library(&lib, &dirs) {
+                out.native.push(path);
+            }
             continue;
         }
         let Some((path, bytes)) = find_ext_library(&lib, &dirs) else {
@@ -1515,7 +1541,7 @@ pub(crate) fn resolve_ext_libraries(
             ));
             continue;
         };
-        out.push(ExtLibrary { name: path, bytes });
+        out.wasm.push(ExtLibrary { name: path, bytes });
     }
     Ok(out)
 }
@@ -1540,7 +1566,8 @@ pub(crate) fn compile_include_library(
     std::fs::create_dir_all(&dir).map_err(|_| "CodegenWasmJit: cannot create a temporary directory")?;
     let tu = dir.join(format!("{prefix}_includes.c"));
     let out = dir.join(format!("{prefix}_includes.wasm"));
-    std::fs::write(&tu, includes.join("\n") + "\n")
+    let prologue = openmodelica_wasm_jit::model::INCLUDE_TU_PROLOGUE_WASM;
+    std::fs::write(&tu, prologue.to_owned() + &includes.join("\n") + "\n")
         .map_err(|_| "CodegenWasmJit: cannot write the external \"C\" translation unit")?;
 
     let mut cmd = Command::new(&clang);
@@ -1550,6 +1577,9 @@ pub(crate) fn compile_include_library(
     // Compiled in a temporary directory, so `#include "x.h"` needs the model's own.
     if let Ok(cwd) = std::env::current_dir() {
         cmd.arg("-I").arg(cwd);
+    }
+    for dir in openmodelica_wasm_jit::model::omc_c_include_dirs() {
+        cmd.arg("-I").arg(dir);
     }
     // `IncludeDirectory` annotations, already `-I"..."` strings.
     for inc in include_dirs {
@@ -1628,6 +1658,58 @@ fn wasm_builtins(sysroot: &std::path::Path) -> Option<std::path::PathBuf> {
     ]
     .into_iter()
     .find(|p| p.exists())
+}
+
+/// The `external "C"` functions none of `libs` exports — what an `Include` still
+/// has to provide.
+fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<String> {
+    let mut defined: HashSet<&str> = HashSet::new();
+    for lib in libs {
+        for payload in wasmparser::Parser::new(0).parse_all(&lib.bytes).flatten() {
+            if let wasmparser::Payload::ExportSection(exports) = payload {
+                defined.extend(exports.into_iter().flatten().map(|e| e.name));
+            }
+        }
+    }
+    ext_imports.iter().map(|s| s.name.as_str()).filter(|n| !defined.contains(n)).map(String::from).collect()
+}
+
+/// A `Library` naming a C source file, which gcc compiles rather than links.
+fn find_source_library(spec: &str, dirs: &[String]) -> Option<String> {
+    if !spec.ends_with(".c") && !spec.ends_with(".cc") && !spec.ends_with(".cpp") && !spec.ends_with(".cxx") {
+        return None;
+    }
+    dirs.iter().map(|d| format!("{d}{spec}")).find(|p| openmodelica_wasi::fs::exists(p))
+}
+
+/// The platform shared library a host linker spec names. A `-lfoo` nothing under
+/// `dirs` provides stays a plain soname, for the system loader to find the way the
+/// linker would; static archives and object files have no loadable form at all.
+fn find_native_library(spec: &str, dirs: &[String]) -> Option<String> {
+    if cfg!(target_arch = "wasm32") {
+        return None; // no dynamic loader to fall back to
+    }
+    let (prefix, suffix) = (std::env::consts::DLL_PREFIX, std::env::consts::DLL_SUFFIX);
+    let name = match spec.strip_prefix("-l") {
+        Some(n) => n,
+        // Any other linker flag (`-L`, `-Wl,…`, `-pthread`) names no library.
+        None if spec.starts_with('-') => return None,
+        None => spec,
+    };
+    if name.ends_with(".a") || name.ends_with(".o") || name.ends_with(".obj") || name.ends_with(".lib") {
+        return None;
+    }
+    if name.contains(suffix) || name.contains(std::path::MAIN_SEPARATOR) {
+        return dirs.iter().map(|d| format!("{d}{name}")).find(|p| std::path::Path::new(p).exists());
+    }
+    for dir in dirs {
+        for candidate in [format!("{dir}{prefix}{name}{suffix}"), format!("{dir}{name}{suffix}")] {
+            if std::path::Path::new(&candidate).exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    (spec != name).then(|| format!("{prefix}{name}{suffix}"))
 }
 
 /// `<dir><name>` or `<dir>lib<name>`, the two spellings a `Library="foo"`
@@ -2175,7 +2257,7 @@ fn emit_fmu(
     let outcome = (|| -> Result<()> {
         // Shared linear memory across model + runtime + ModelicaExternalC, so
         // `external "C"` calls pass real pointers, not handles.
-        let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| build_sim_model(&sim_code, true))?;
+        let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| build_sim_model(&sim_code, true, ExtHost::Wasm))?;
         if let Some(func) = first_external_import(&model.wasm) {
             if !external_c_available() {
                 record_error(format!(
@@ -3259,8 +3341,22 @@ fn collect_clocks(partitions: &Arc<List<SimCode::ClockedPartition>>) -> Result<V
     Ok(out)
 }
 
+/// Where the model will run, which decides how an `Include` C source is built: for
+/// the host, or for an artifact that is itself wasm (an FMU, the standalone module).
+#[derive(Clone, Copy, PartialEq)]
+enum ExtHost {
+    Native,
+    Wasm,
+}
+
+impl ExtHost {
+    /// A simulation run. The browser omc has neither a host compiler nor a dynamic
+    /// loader, so there a run is as wasm as an exported FMU.
+    const SIM: ExtHost = if cfg!(target_arch = "wasm32") { ExtHost::Wasm } else { ExtHost::Native };
+}
+
 /// `fmi_vrs`: also record the FMI value-reference table (FMU export only).
-fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimModel> {
+fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost) -> Result<SimModel> {
     crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
     let mi = &sim_code.modelInfo;
     let vi = &mi.varInfo;
@@ -3436,19 +3532,44 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
     }
     // A `Library` on a function the model never reaches must not fail the build.
     let mut ext_lib_notes: Vec<String> = Vec::new();
-    let ext_libs = if ext_imports.is_empty() {
-        Vec::new()
-    } else {
-        let mut libs = resolve_ext_libraries(&sim_code.makefileParams, &mut ext_lib_notes)?;
-        // What the `Library` annotations did not provide may come from an
-        // `Include` carrying the C source.
-        let includes: Vec<String> = lst(&sim_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
-        let dirs: Vec<String> = lst(&sim_code.makefileParams.includes).map(|s| s.to_string()).collect();
-        if let Some(l) = compile_include_library(&sim_code.fileNamePrefix, &includes, &dirs, &mut ext_lib_notes)? {
-            libs.push(l);
+    let mut ext_libs = ExtLibraries::default();
+    let mut ext_includes = None;
+    if !ext_imports.is_empty() {
+        ext_libs = resolve_ext_libraries(&sim_code.makefileParams, &mut ext_lib_notes)?;
+        // What the `Library` annotations did not provide may come from an `Include`
+        // carrying the C source, though most carry only the declarations.
+        let mp = &sim_code.makefileParams;
+        let sources: Vec<String> = lst(&sim_code.externalFunctionIncludes)
+            .map(|s| s.to_string())
+            .chain(std::mem::take(&mut ext_libs.sources))
+            .collect();
+        let dirs: Vec<String> = lst(&mp.includes).map(|s| s.to_string()).collect();
+        let prefix = sim_code.fileNamePrefix.to_string();
+        if !sources.is_empty() {
+            match ext_host {
+                // Built on demand, for a symbol the loaded libraries turn out not
+                // to define.
+                ExtHost::Native => {
+                    ext_includes = Some(ExtIncludes {
+                        sources,
+                        include_dirs: dirs,
+                        ccompiler: mp.ccompiler.to_string(),
+                        cflags: mp.cflags.to_string(),
+                        dllext: mp.dllext.to_string(),
+                        prefix,
+                    })
+                }
+                // A wasm artifact carries every implementation, so the same
+                // decision has to be made here, off the libraries' exports.
+                ExtHost::Wasm if !missing_ext_symbols(&ext_imports, &ext_libs.wasm).is_empty() => {
+                    if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &mut ext_lib_notes)? {
+                        ext_libs.wasm.push(l);
+                    }
+                }
+                ExtHost::Wasm => {}
+            }
         }
-        libs
-    };
+    }
 
     // Function index space: imports (env builtins, rt runtime, env-extra, then
     // the `ext.*` externals), then the model's Modelica functions, then the
@@ -3670,17 +3791,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         metamodelica::cancel::bail_if_cancelled()?;
         bodies.push(compile_function(f, &by_name, &mut literals)?);
     }
-    // Every parameter is initialized from its binding expression in declaration
+    // C's `setAllParamsToStart`: every parameter from its binding, in declaration
     // order (the backend sorts dependent parameters so a binding only references
-    // earlier ones), then `parameterEquations` runs for the computed ones.
+    // earlier ones). `parameterEquations` belongs to `functionUpdateBoundParameters`
+    // alone — evaluated in both, an external object's constructor runs twice.
     let stateset_diag = stateset_diag_offsets(&sim_code.stateSets, &var_map)?;
     let mut chunks: Vec<we::Function> = Vec::new();
     let mut splits: Vec<SplitFn> = Vec::new();
-    let param_units: Vec<EqUnit> = param_bindings
-        .iter()
-        .map(|(cref, exp)| EqUnit::Binding(cref, exp))
-        .chain(param_eqs.iter().map(|e| EqUnit::Eq(e, None)))
-        .collect();
+    let param_units: Vec<EqUnit> =
+        param_bindings.iter().map(|(cref, exp)| EqUnit::Binding(cref, exp)).collect();
     splits.push(build_split_fn("functionParameters", &param_units, 1, eqfn_type, &stateset_diag, &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
     // Seed `relationsPre := relations` at the end of init (the in-wasm `simulate`
     // path skips the host `run_initialization`).
@@ -4382,7 +4501,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool) -> Result<SimMode
         prepared: Mutex::new(None),
         layout,
         result_vars,
-        ext_libs,
+        ext_libs: ext_libs.wasm,
+        ext_native_libs: ext_libs.native,
+        ext_includes,
         ext_lib_notes,
         ext_imports,
         model_name,
@@ -4905,7 +5026,7 @@ fn collect_param_bindings(
         // dependencies that are still 0 (or a null handle). A *constant* binding reads
         // nothing, so it is stored regardless — C's `setAllParamsToStart`.
         if let Some(v) = &p.initialValue {
-            if !is_const_exp(v) && sim_cref_key(&p.name).map(|k| computed.contains(&k)).unwrap_or(false) {
+            if !is_const_exp(v) && sim_cref_key(&p.name).map(|k| is_computed(&k, computed)).unwrap_or(false) {
                 continue;
             }
             out.push((p.name.clone(), v.clone()));
@@ -4924,6 +5045,16 @@ fn is_const_exp(e: &DAE::Exp) -> bool {
             | DAE::Exp::SCONST { .. }
             | DAE::Exp::ENUM_LITERAL { .. }
     )
+}
+
+/// Whether an equation list assigns `key`, directly or as one element of its array:
+/// the `SimVar`s are scalarized (`ts[1]`), an array assign names the whole `ts`.
+fn is_computed(key: &str, computed: &std::collections::HashSet<String>) -> bool {
+    computed.contains(key)
+        || key
+            .strip_suffix(']')
+            .and_then(|k| k.rfind('['))
+            .is_some_and(|i| computed.contains(&key[..i]))
 }
 
 /// Keys of the crefs assigned by a `SimEqSystem` list (scalar/array assigns).
@@ -5476,15 +5607,15 @@ fn build_update_bound_attrs_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Literals,
 ) -> Result<we::Function> {
-    let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets, u32)> = Vec::new();
+    let mut attrs: Vec<(Attr, Arc<DAE::Exp>, AttrTargets, u32, Option<SimSlot>)> = Vec::new();
     for (i, (attr, cref, exp)) in bound_attr_equations(sim_code).into_iter().enumerate() {
-        let targets = sim_cref_key(cref)
-            .ok()
-            .map(|k| k.strip_prefix("$START.").unwrap_or(&k).to_string())
-            .and_then(|k| attr_targets.get(&k))
-            .cloned()
-            .unwrap_or_default();
-        attrs.push((attr, exp.clone(), targets, layout.attr_log_off + i as u32 * 8));
+        let key = sim_cref_key(cref).ok().map(|k| k.strip_prefix("$START.").unwrap_or(&k).to_string());
+        let targets = key.as_deref().and_then(|k| attr_targets.get(k)).cloned().unwrap_or_default();
+        let var = match attr {
+            Attr::Start => key.as_deref().and_then(|k| var_map.vars.get(k)).copied(),
+            _ => None,
+        };
+        attrs.push((attr, exp.clone(), targets, layout.attr_log_off + i as u32 * 8, var));
     }
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1747,7 +1747,7 @@ impl<'a> FnCtx<'a> {
         &mut self,
         defaults: &[(u32, f64)],
         int_defaults: &[(u32, i32)],
-        attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets, u32)],
+        attrs: &[(Attr, Arc<DAE::Exp>, AttrTargets, u32, Option<SimSlot>)],
     ) -> Result<()> {
         let data = self.sim()?.data_local;
         for (off, value) in defaults {
@@ -1764,7 +1764,7 @@ impl<'a> FnCtx<'a> {
             return Ok(());
         }
         let (raw, val) = (self.alloc_temp(WTy::F64), self.alloc_temp(WTy::F64));
-        for (attr, exp, targets, log_off) in attrs {
+        for (attr, exp, targets, log_off, var) in attrs {
             let w = compile_exp(self, exp)?;
             coerce(self, w, WTy::F64);
             self.emit(we::Instruction::LocalSet(raw));
@@ -1801,6 +1801,19 @@ impl<'a> FnCtx<'a> {
                 self.emit(we::Instruction::LocalGet(data));
                 self.emit(we::Instruction::LocalGet(raw));
                 self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
+            }
+            // C's `postExp`: `<var> = $START.<var>`, but not for a String, whose slot
+            // holds a reference-counted handle.
+            if let Some(slot) = var.filter(|s| !s.negate && !s.heap) {
+                self.emit(we::Instruction::LocalGet(data));
+                self.emit(we::Instruction::LocalGet(raw));
+                match slot.wty {
+                    WTy::F64 => self.emit(we::Instruction::F64Store(mem_arg(slot.off, 3))),
+                    _ => {
+                        self.emit(we::Instruction::I32TruncSatF64S);
+                        self.emit(we::Instruction::I32Store(mem_arg(slot.off, 2)));
+                    }
+                }
             }
             if targets.nls.is_empty() {
                 continue;
@@ -9300,7 +9313,9 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
     let mut sig = format!("{in_codes}\n{out_codes}\n");
     if !ext_imports.is_empty() {
         let mut notes: Vec<String> = Vec::new();
-        for lib in crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)? {
+        // Only the wasm modules: the function JIT calls them wasm->wasm, with no
+        // libffi trampoline to reach a platform library through.
+        for lib in &crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?.wasm {
             sig.push_str(&format!("lib\t{}\n", lib.name));
         }
         // An implementation given as C source in an `Include`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
@@ -456,6 +456,17 @@ pub fn initAssertionFunctions() {
     ASSERT_FUNCTIONS_REGISTERED.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
+std::thread_local! {
+    static LAST_RUNTIME_ERROR: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+/// The most recent `ModelicaError`/`omc_assert` from an external function, as the
+/// function wrote it. A simulation host reports it the way C's `throwStreamPrint`
+/// does — on the run's log, not through the error buffer the run rolls back.
+pub fn take_last_runtime_error() -> Option<String> {
+    LAST_RUNTIME_ERROR.with(|c| c.borrow_mut().take())
+}
+
 /// Append a positionless `RUNTIME`/`Error` message to the buffer — the analogue
 /// of `c_add_message(NULL, 0, ErrorType_runtime, ErrorLevel_error, str, ...)`.
 /// With no source location it renders as `Error: <msg>`, matching the C
@@ -463,6 +474,7 @@ pub fn initAssertionFunctions() {
 /// `ModelicaError`/`ModelicaFormatError` interception (see
 /// [`registerModelicaFormatError`]).
 fn add_runtime_error_message(msg: &str) {
+    LAST_RUNTIME_ERROR.with(|c| *c.borrow_mut() = Some(msg.to_owned()));
     addSourceMessage(
         0,
         MessageType::SIMULATION, // C `ErrorType_runtime` → prints as RUNTIME

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -375,7 +375,32 @@ pub fn enrich_trap_init(e: &mut dyn SimEngine, err: &'static str, start_time: f6
     enrich_trap_impl(e, err, Some(start_time))
 }
 
+/// Set by [`note_runtime_error`]; consumed by the trap it precedes.
+static RUNTIME_ERROR: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// C's `va_throwStreamPrint(NULL, …)`, which an external function's `ModelicaError`
+/// reaches: log the message on `LOG_ASSERT` and unwind. It has no condition and no
+/// source position, so the trap that follows must not go looking for the assertion
+/// block a model `assert()` would have left.
+pub fn note_runtime_error(msg: &str) {
+    // The whole `vsnprintf` buffer is one message, so a format ending in a
+    // newline must not turn into a blank line.
+    omclog::message_text(omclog::DEBUG_TYPE, omclog::ASSERT, false, msg.trim_end());
+    RUNTIME_ERROR.store(true, Ordering::Relaxed);
+}
+
+/// Drop one a previous run left behind (only a trap consumes it).
+pub fn clear_runtime_error() {
+    RUNTIME_ERROR.store(false, Ordering::Relaxed);
+}
+
 fn enrich_trap_impl(e: &mut dyn SimEngine, err: &'static str, init_time: Option<f64>) -> &'static str {
+    if RUNTIME_ERROR.swap(false, Ordering::Relaxed) {
+        if init_time.is_some() {
+            omclog::info(omclog::ASSERT, false, "simulation terminated by an assertion at initialization");
+        }
+        return ASSERT_ERR;
+    }
     let Some(pa) = e.take_pending_assert() else { return err };
     let cond = read_rt_string(e, pa[7]).unwrap_or_default();
     let info = AssertInfo {
@@ -1497,20 +1522,23 @@ fn seed_start_values(
     inputs: &[crate::InputVar],
     model: Option<&SimMeta>,
 ) -> Result<()> {
+    // C's `initialization` order: `setAllParamsToStart`, the start values (here the
+    // start expressions, then `-iif`/`-override`), `setAllVarsToStart`.
     e.call1("functionParameters", sim_data)?;
-    // Params first (a start expression may read one), then the start attributes —
-    // the expressions, then the `$START.<var>` equations that bind one to a
-    // parameter — then `-iif`/`-override`, then C's `setAllVarsToStart`.
     apply_param_overrides(e, sim_data)?;
     e.call1("functionInitStartValues", sim_data)?;
     apply_external_input(e, sim_data, inputs)?;
-    e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
-    log_bound_attr_updates(e, sim_data, layout, model);
+    // C's `read_init_from_file` branch runs them *before* `importStartValues`, giving
+    // the file the last word on a start value.
+    let from_file = crate::simflags::with_flags(|f| f.init_file.is_some());
+    if from_file {
+        update_bound_values(e, sim_data, layout, model)?;
+    }
     apply_start_overrides(e, sim_data)?;
     set_all_vars_to_start(e, sim_data, layout, model)?;
-    // C runs `updateBoundParameters` *after* `setAllVarsToStart`: those equations
-    // also assign the constant-bound variables, which the copy would undo.
-    e.call1("functionUpdateBoundParameters", sim_data)?;
+    if !from_file {
+        update_bound_values(e, sim_data, layout, model)?;
+    }
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
     // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
@@ -1518,6 +1546,20 @@ fn seed_start_values(
     if layout.n_samples > 0 {
         e.call1("initSample", sim_data)?;
     }
+    Ok(())
+}
+
+/// C's `updateBoundParameters` + `updateBoundVariableAttributes`, always a pair and
+/// after `setAllVarsToStart`, whose copy would undo the variables they assign.
+fn update_bound_values(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    model: Option<&SimMeta>,
+) -> Result<()> {
+    e.call1("functionUpdateBoundParameters", sim_data)?;
+    e.call1("functionUpdateBoundVariableAttributes", sim_data)?;
+    log_bound_attr_updates(e, sim_data, layout, model);
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -97,6 +97,15 @@ pub(crate) mod dl {
         !unsafe { libc::dlopen(c.as_ptr(), libc::RTLD_GLOBAL | libc::RTLD_NOW) }.is_null()
     }
 
+    /// Global scope, deferred binding: for libraries that reference each other, so
+    /// the order they are loaded in need not be a topological one.
+    pub fn open_global_deferred(name: &str) -> std::result::Result<usize, String> {
+        let c = CString::new(name).map_err(|_| "NUL byte in path".to_owned())?;
+        unsafe { libc::dlerror() };
+        let h = unsafe { libc::dlopen(c.as_ptr(), libc::RTLD_GLOBAL | libc::RTLD_LAZY) };
+        if h.is_null() { Err(last_error()) } else { Ok(h as usize) }
+    }
+
     pub fn sym(handle: usize, name: &str) -> Option<usize> {
         let c = CString::new(name).ok()?;
         let p = unsafe { libc::dlsym(handle as *mut c_void, c.as_ptr()) };
@@ -178,6 +187,14 @@ pub(crate) mod dl {
             GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN, c.as_ptr(), &mut module);
         }
         true
+    }
+
+    /// The Windows loader always binds lazily and has no global scope; a plain
+    /// `LoadLibrary` is what [`open_global_deferred`] means here.
+    pub fn open_global_deferred(name: &str) -> std::result::Result<usize, String> {
+        let c = CString::new(name).map_err(|_| "NUL byte in path".to_owned())?;
+        let h = unsafe { LoadLibraryA(c.as_ptr()) };
+        if h.is_null() { Err(last_error()) } else { Ok(h as usize) }
     }
 
     pub fn sym(handle: usize, name: &str) -> Option<usize> {
@@ -429,11 +446,42 @@ pub fn runtime_symbol(name: &str) -> Option<usize> {
 /// process image (self + globally-loaded libraries, incl. libm). Returns the
 /// function address, or `None` if no loaded library provides it.
 pub fn external_symbol(name: &str) -> Option<usize> {
+    ensure_sim_libs();
+    let me = dl::open_self().ok()?;
+    dl::sym(me, name)
+}
+
+fn ensure_sim_libs() {
     ensure_runtime_solibs();
     ensure_ffi_solibs();
     ensure_sim_error_interception();
-    let me = dl::open_self().ok()?;
-    dl::sym(me, name)
+}
+
+/// The platform shared libraries a model's `Library` annotations name, which the C
+/// target would have linked into the simulation executable. Loaded once per path (a
+/// model may be resimulated), into the global scope so they resolve against the C
+/// runtime's `ModelicaError` and each other. Returns why any that would not load did
+/// not, alongside the handles.
+pub fn load_external_libraries(paths: &[String]) -> (Vec<usize>, Vec<String>) {
+    static LOADED: LazyLock<Mutex<HashMap<String, std::result::Result<usize, String>>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+    ensure_sim_libs();
+    let mut loaded = LOADED.lock().unwrap();
+    let mut handles = Vec::new();
+    let mut errors = Vec::new();
+    for path in paths {
+        match loaded.entry(path.clone()).or_insert_with(|| dl::open_global_deferred(path)) {
+            Ok(h) => handles.push(*h),
+            Err(e) => errors.push(format!("`{path}` could not be loaded: {e}")),
+        }
+    }
+    (handles, errors)
+}
+
+/// Resolve against `handles` — the model's own libraries, which shadow a same-named
+/// symbol elsewhere — then against the process image.
+pub fn external_symbol_in(handles: &[usize], name: &str) -> Option<usize> {
+    handles.iter().find_map(|&h| dl::sym(h, name)).or_else(|| external_symbol(name))
 }
 
 /// Install the panic-mode `ModelicaError`/`omc_assert` interception for the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
@@ -22,14 +22,31 @@ thread_local! {
 /// console on the web target.
 pub fn start_stdout_capture() {
     STDOUT_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+    NATIVE_CAPTURE.with(|h| h.get().map(|(begin, _)| begin()));
 }
 
 /// End capture and return the accumulated bytes as a lossy-UTF-8 string.
 pub fn take_stdout_capture() -> String {
+    let native = NATIVE_CAPTURE.with(|h| h.get().map(|(_, end)| end())).unwrap_or_default();
     STDOUT_CAPTURE
         .with(|c| c.borrow_mut().take())
-        .map(|v| String::from_utf8_lossy(&v).into_owned())
+        .map(|mut v| {
+            v.extend_from_slice(&native);
+            String::from_utf8_lossy(&v).into_owned()
+        })
         .unwrap_or_default()
+}
+
+thread_local! {
+    static NATIVE_CAPTURE: std::cell::Cell<Option<(fn(), fn() -> Vec<u8>)>> = const { std::cell::Cell::new(None) };
+}
+
+/// Extend the capture over the *process's* stdout, which a `dlopen`ed external "C"
+/// library's `printf` reaches directly — past the WASI shim, past `ModelicaMessage`.
+/// C's simulation executable has a stdout of its own, so that output belongs in the
+/// run's log too.
+pub fn set_native_capture(begin: fn(), end: fn() -> Vec<u8>) {
+    NATIVE_CAPTURE.with(|h| h.set(Some((begin, end))));
 }
 
 /// Write to stdout (fd 1) through the same capture/host routing as a guest

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -542,3 +542,108 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
     );
     Ok(HostMem(mem_env))
 }
+
+/// Redirect the process's stdout/stderr into the run's log for one capture phase
+/// (`openmodelica_wasi::wasi::set_native_capture`). A temp file, not a pipe, which
+/// would deadlock on its buffer with nothing draining it; `fflush(NULL)` empties
+/// libc's own buffers into it before each read.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod native_stdout {
+    use std::cell::RefCell;
+
+    /// Raw CRT fds throughout: a `File` must not own the same one, or both close it.
+    struct Redirect {
+        fd: i32,
+        saved_out: i32,
+        saved_err: i32,
+    }
+
+    thread_local! {
+        static ACTIVE: RefCell<Option<Redirect>> = const { RefCell::new(None) };
+    }
+
+    pub fn install() {
+        openmodelica_wasi::wasi::set_native_capture(begin, end);
+    }
+
+    fn begin() {
+        ACTIVE.with(|a| {
+            let mut a = a.borrow_mut();
+            if a.is_some() {
+                return;
+            }
+            let Some(fd) = scratch_fd() else { return };
+            unsafe {
+                let (saved_out, saved_err) = (libc::dup(1), libc::dup(2));
+                if saved_out < 0 || saved_err < 0 {
+                    libc::close(fd);
+                    return;
+                }
+                libc::fflush(std::ptr::null_mut());
+                libc::dup2(fd, 1);
+                libc::dup2(fd, 2);
+                *a = Some(Redirect { fd, saved_out, saved_err });
+            }
+        });
+    }
+
+    fn end() -> Vec<u8> {
+        ACTIVE.with(|a| {
+            let Some(r) = a.borrow_mut().take() else { return Vec::new() };
+            let mut out = Vec::new();
+            unsafe {
+                libc::fflush(std::ptr::null_mut());
+                libc::dup2(r.saved_out, 1);
+                libc::dup2(r.saved_err, 2);
+                libc::close(r.saved_out);
+                libc::close(r.saved_err);
+                libc::lseek(r.fd, 0, libc::SEEK_SET);
+                let mut buf = [0u8; 8192];
+                loop {
+                    let n = libc::read(r.fd, buf.as_mut_ptr() as *mut _, buf.len() as _);
+                    if n <= 0 {
+                        break;
+                    }
+                    out.extend_from_slice(&buf[..n as usize]);
+                }
+                libc::close(r.fd);
+            }
+            out
+        })
+    }
+
+    /// A file only this redirect can reach: unlinked at once on unix, delete-on-close
+    /// on Windows, where an open file cannot be unlinked.
+    fn scratch_fd() -> Option<i32> {
+        let path = std::env::temp_dir().join(format!("om-simout-{}", std::process::id()));
+        let mut opts = std::fs::File::options();
+        opts.read(true).write(true).create(true).truncate(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
+            opts.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
+        }
+        let file = opts.open(&path).ok()?;
+        #[cfg(unix)]
+        {
+            let _ = std::fs::remove_file(&path);
+            Some(std::os::fd::IntoRawFd::into_raw_fd(file))
+        }
+        // `_open_osfhandle` takes the handle over, so `File` must give it up first.
+        #[cfg(windows)]
+        {
+            let h = std::os::windows::io::IntoRawHandle::into_raw_handle(file);
+            match unsafe { libc::open_osfhandle(h as isize, 0) } {
+                fd if fd >= 0 => Some(fd),
+                _ => None,
+            }
+        }
+    }
+}
+
+/// The browser has no process stdout to redirect.
+#[cfg(target_arch = "wasm32")]
+pub mod native_stdout {
+    pub fn install() {}
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -26,6 +26,11 @@ pub struct SimModel {
     /// The model's own `external "C"` libraries, loaded into the simulation's
     /// memory, where they define the `ext_imports` the runtime cannot resolve.
     pub ext_libs: Vec<ExtLibrary>,
+    /// The same implementations as platform shared libraries, for a symbol no wasm
+    /// library defines: a native host dlopens them and calls in through libffi.
+    /// Empty in the browser.
+    pub ext_native_libs: Vec<String>,
+    pub ext_includes: Option<ExtIncludes>,
     /// Why a `Library` or an `Include` yielded no wasm library; reported only if a
     /// symbol then turns out to be missing.
     pub ext_lib_notes: Vec<String>,
@@ -77,6 +82,97 @@ impl SimModel {
 pub struct ExtLibrary {
     pub name: String,
     pub bytes: Vec<u8>,
+}
+
+/// The model's `Include` annotations, and what it takes to build them: host C source
+/// the C target compiles into the simulation executable. Built only once a symbol
+/// turns out to be missing from every library — an `Include` most often just declares
+/// what a `Library` defines, and a header-only unit would produce nothing to load.
+#[derive(Clone, Default)]
+pub struct ExtIncludes {
+    pub sources: Vec<String>,
+    /// `IncludeDirectory` annotations, already `-I"…"` strings.
+    pub include_dirs: Vec<String>,
+    pub ccompiler: String,
+    pub cflags: String,
+    pub dllext: String,
+    /// Names the object after the model, as the C target does.
+    pub prefix: String,
+}
+
+impl ExtIncludes {
+    /// Build the sources into a host shared library and return its path. Per-process
+    /// temp directory: it stays mapped as long as the model can be resimulated.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn compile(&self) -> std::result::Result<String, String> {
+        use std::process::Command;
+        let dir = std::env::temp_dir().join(format!("om-extc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+        let tu = dir.join(format!("{}_includes.c", self.prefix));
+        let out = dir.join(format!("{}_includes{}", self.prefix, self.dllext));
+        std::fs::write(&tu, INCLUDE_TU_PROLOGUE.to_owned() + &self.sources.join("\n") + "\n")
+            .map_err(|e| format!("cannot write {}: {e}", tu.display()))?;
+
+        let mut cmd = Command::new(&self.ccompiler);
+        cmd.args(["-shared", "-fPIC", "-O1"]);
+        // `--cflags`, minus the make variables it is written to be expanded with.
+        cmd.args(self.cflags.split_whitespace().filter(|f| !f.starts_with("${") && !f.starts_with("$(")));
+        // Compiled in a temporary directory, so `#include "x.h"` needs the model's own.
+        if let Ok(cwd) = std::env::current_dir() {
+            cmd.arg("-I").arg(cwd);
+        }
+        for dir in omc_c_include_dirs() {
+            cmd.arg("-I").arg(dir);
+        }
+        for inc in &self.include_dirs {
+            cmd.arg(inc.trim_matches('"'));
+        }
+        cmd.arg("-o").arg(&out).arg(&tu);
+        let output = cmd
+            .output()
+            .map_err(|e| format!("`{}` could not be run to compile the `Include` C sources: {e}", self.ccompiler))?;
+        if !output.status.success() {
+            return Err(format!(
+                "the `Include` C sources did not compile:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        let _ = std::fs::remove_file(&tu);
+        Ok(out.to_string_lossy().into_owned())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn compile(&self) -> std::result::Result<String, String> {
+        Err("the implementation comes from an `Include` annotation with C source, which has to be \
+             compiled — the browser omc has no compiler. Provide it as a `Library` built with \
+             `clang --target=wasm32-wasip1 -fPIC -shared`"
+            .to_string())
+    }
+}
+
+/// What the C target's generated `<prefix>_includes.h` opens with, so external C
+/// source sees the same declarations wherever it is built.
+pub const INCLUDE_TU_PROLOGUE: &str = "\
+#include \"openmodelica.h\"       /* Defines OPENMODELICA_H_ for libraries to test if called from OpenModelica. */\n\
+#include \"ModelicaUtilities.h\"  /* Make Modelica C util functions available for external includes. */\n";
+
+/// The same for a wasm unit, where `openmodelica.h` cannot be opened — it reaches the
+/// Boehm GC and `setjmp`. Name what external source uses it for instead.
+pub const INCLUDE_TU_PROLOGUE_WASM: &str = "\
+#include <stddef.h>\n\
+#include <stdio.h>\n\
+#include <stdlib.h>\n\
+#include <string.h>\n\
+#include <math.h>\n\
+#include \"ModelicaUtilities.h\"\n";
+
+/// omc's own C headers, plus the bundled `gc.h` that `openmodelica.h` reaches —
+/// the `-I` set the C target's makefile compiles the same source with.
+pub fn omc_c_include_dirs() -> [String; 2] {
+    let home = openmodelica_util::Settings::getInstallationDirectoryPath()
+        .map(|p| p.to_string())
+        .unwrap_or_default();
+    [format!("{home}/include/omc/c"), format!("{home}/include/omc")]
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -307,25 +307,73 @@ fn wty_valtype(w: crate::sig::WTy) -> wasmtime::ValType {
 /// Why an `external "C"` function could not be found, and what to do about it. The
 /// codegen's notes come out here, where a library that yielded nothing has become a
 /// missing symbol.
-fn unresolved_external_detail(name: &str, model: &SimModel) -> String {
-    let mut s = if model.ext_libs.is_empty() {
+fn unresolved_external_detail(name: &str, model: &SimModel, load_errors: &[String]) -> String {
+    let searched: Vec<&str> = model
+        .ext_libs
+        .iter()
+        .map(|l| l.name.as_str())
+        .chain(model.ext_native_libs.iter().map(|s| s.as_str()))
+        .collect();
+    let mut s = if searched.is_empty() {
         format!(
             "  `{name}` is in none of the model's libraries — the model declares no `Library` \
-             annotation that resolves to a wasm library. Build the implementation with \
-             `clang --target=wasm32-wasip1 -fPIC -shared` and name it in `Library`."
+             annotation that resolves to one. Name a wasm module built with \
+             `clang --target=wasm32-wasip1 -fPIC -shared`, or, for a native run, the platform \
+             shared library the C target would link."
         )
     } else {
         format!(
             "  `{name}` is in none of the model's libraries ({}). Check that the library exports it \
              (`-Wl,--export-all`, or `-Wl,--export={name}`).",
-            model.ext_libs.iter().map(|l| l.name.as_str()).collect::<Vec<_>>().join(", "),
+            searched.join(", "),
         )
     };
-    for note in &model.ext_lib_notes {
+    for note in model.ext_lib_notes.iter().chain(load_errors) {
         s.push_str("\n  ");
         s.push_str(note);
     }
     s
+}
+
+/// The model's `external "C"` implementations outside wasm, resolved on demand: the
+/// platform libraries its `Library` annotations name, then — only once those and the
+/// process image have come up short — its `Include` C source.
+#[derive(Default)]
+struct NativeExternals {
+    handles: Vec<usize>,
+    loaded: bool,
+    built_includes: bool,
+    errors: Vec<String>,
+}
+
+impl NativeExternals {
+    fn resolve(&mut self, name: &str, model: &SimModel) -> Option<usize> {
+        if !self.loaded {
+            self.loaded = true;
+            let (handles, errors) = openmodelica_util::dynload::load_external_libraries(&model.ext_native_libs);
+            self.handles = handles;
+            self.errors = errors;
+        }
+        if let Some(addr) = openmodelica_util::dynload::external_symbol_in(&self.handles, name) {
+            return Some(addr);
+        }
+        if !self.built_includes {
+            self.built_includes = true;
+            if let Some(inc) = &model.ext_includes {
+                match inc.compile() {
+                    Ok(path) => {
+                        let (h, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
+                        // Searched first: it is the model's own source.
+                        self.handles.splice(0..0, h);
+                        self.errors.extend(errors);
+                    }
+                    Err(e) => self.errors.push(e),
+                }
+                return openmodelica_util::dynload::external_symbol_in(&self.handles, name);
+            }
+        }
+        None
+    }
 }
 
 /// Define the model's external "C" function imports (wasm module `ext`) from the
@@ -346,11 +394,13 @@ fn define_external_imports(
     let rt_str_new = rt.str_new.clone();
     let rt_str_data = rt.str_data.clone();
     registry_reset();
+    sim_driver::clear_runtime_error();
     openmodelica_util::dynload::install_modelica_message_interception(
         openmodelica_modelica_utilities::modelica_message_hook,
         openmodelica_modelica_utilities::modelica_warning_hook,
     );
     let engine = linker.engine().clone();
+    let mut native = NativeExternals::default();
     for sig in &model.ext_imports {
         let functype = wasmtime::FuncType::new(
             &engine,
@@ -366,8 +416,8 @@ fn define_external_imports(
                 continue;
             }
         }
-        let addr = openmodelica_util::dynload::external_symbol(&sig.name).ok_or_else(|| {
-            crate::set_engine_error_detail(unresolved_external_detail(&sig.name, model));
+        let addr = native.resolve(&sig.name, model).ok_or_else(|| {
+            crate::set_engine_error_detail(unresolved_external_detail(&sig.name, model, &native.errors));
             "external \"C\" function not found in any loaded library"
         })?;
         let name = sig.name.clone();
@@ -495,6 +545,8 @@ unsafe fn call_external(
     let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
     let mut slots: Vec<Slot> = Vec::with_capacity(sig.args.len());
     let mut cstrings: Vec<std::ffi::CString> = Vec::new();
+    // `const char**` argument vectors, kept alive alongside the strings they point at.
+    let mut str_arrays: Vec<Vec<*const std::os::raw::c_char>> = Vec::new();
     let mut types: Vec<Type> = Vec::with_capacity(sig.args.len());
     // One 8-byte native cell per `_Out_` pointer arg (fits int/double/pointer),
     // in output order; the C call writes through the pointer we pass.
@@ -513,6 +565,11 @@ unsafe fn call_external(
             // pre-allocated on the wasm side and passed by pointer (filled in place,
             // like an input array — handled by the `Array` arm below).
             if *is_out && !matches!(ty, SigTy::Array { .. }) {
+                // The cell is one C value wide, and a record output is a struct
+                // whose layout only its own C declaration fixes.
+                if !matches!(ty, SigTy::Real | SigTy::Int | SigTy::Bool | SigTy::Str | SigTy::Ptr) {
+                    return Err("CodegenWasmJit: external \"C\" : output argument type not marshalled");
+                }
                 let mut cell: Box<[u8; 8]> = Box::new([0u8; 8]);
                 slots.push(Slot::P(cell.as_mut_ptr() as *mut c_void));
                 types.push(Type::pointer());
@@ -566,6 +623,31 @@ unsafe fn call_external(
                     let (dims, data_off) = crate::host::array_abi::dims_and_data(mem, off)
                         .ok_or("external \"C\" : malformed array argument")?;
                     let base = off + data_off;
+                    // Only scalar elements are already a native array. A `String[:]`
+                    // is in-wasm handles, not the `const char**` C declares, so it
+                    // is rebuilt; anything else has no C form at all.
+                    if let SigTy::Str = &**elem {
+                        if *is_out {
+                            return Err("CodegenWasmJit: external \"C\" : a String output array is not marshalled");
+                        }
+                        let n = dims.iter().product::<usize>();
+                        let mut ptrs: Vec<*const std::os::raw::c_char> = Vec::with_capacity(n);
+                        for k in 0..n {
+                            let h = u32::from_le_bytes(mem[base + k * 4..base + k * 4 + 4].try_into().unwrap()) as usize;
+                            let len = u32::from_le_bytes(mem[h + 4..h + 8].try_into().unwrap()) as usize;
+                            let cs = std::ffi::CString::new(&mem[h + 8..h + 8 + len])
+                                .map_err(|_| "external \"C\" : string argument has an interior NUL")?;
+                            ptrs.push(cs.as_ptr());
+                            cstrings.push(cs);
+                        }
+                        slots.push(Slot::P(ptrs.as_mut_ptr() as *mut c_void));
+                        str_arrays.push(ptrs);
+                        types.push(Type::pointer());
+                        continue;
+                    }
+                    if !matches!(&**elem, SigTy::Real | SigTy::Int | SigTy::Bool) {
+                        return Err("CodegenWasmJit: external \"C\" : array element type not marshalled");
+                    }
                     if fortran && dims.len() > 1 {
                         let esz = crate::host::array_abi::elem_size(elem);
                         let n = dims.iter().product::<usize>() * esz;
@@ -623,7 +705,11 @@ unsafe fn call_external(
             nls.note(caller)?;
             return zero_results(sig, caller, rt_str_new, rets);
         }
-        openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
+        // The run reports itself through its log alone, as C's separate executable
+        // does, so the buffer the message also went to is rolled back.
+        let msg = openmodelica_error::ErrorExt::take_last_runtime_error();
+        openmodelica_error::ErrorExt::rollBack(EXT_CHECKPOINT);
+        sim_driver::note_runtime_error(&msg.unwrap_or_else(|| format!("external \"C\" `{}` failed", sig.name)));
         return Err("CodegenWasmJit: external \"C\" raised a runtime error");
     }
     openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2365,7 +2365,10 @@ end stripLibraryExtension;
 protected function getLibraryStringInWasmFormat
 "The name of the wasm module implementing the library the Absyn.STRING describes.
  A wasm target has no linker: the annotation resolves to a PIC dylink module omc
- loads as-is, rather than to linker flags."
+ loads as-is, rather than to linker flags.
+
+ The gcc-format string follows it, so a native host running the wasm can fall back
+ to the platform shared library for a function no wasm module implements."
   input Absyn.Exp exp;
   output list<String> strs;
   output list<String> names;
@@ -2373,6 +2376,7 @@ algorithm
   (strs, names) := match exp
     local
       String str;
+      list<String> host;
 
     // In the runtime already: LAPACK/BLAS are in-wasm, and ModelicaExternalC is
     // the side module omc carries.
@@ -2390,13 +2394,13 @@ algorithm
         // Linker flags mean nothing here; only a library name can be resolved.
         if "-" == stringGetStringChar(str, 1) then
           strs := {};
-          names := {};
         else
-          // No name for the generic existence check: it looks for host libraries,
-          // while the wasm code generator resolves the module itself.
-          strs := {stripLibraryExtension(str) + ".wasm"};
-          names := {};
+          (host, _) := getLibraryStringInGccFormat(exp);
+          strs := (stripLibraryExtension(str) + ".wasm") :: host;
         end if;
+        // No name for the generic existence check: it looks for host libraries,
+        // while the wasm code generator resolves the module itself.
+        names := {};
       then (strs, names);
 
     else


### PR DESCRIPTION
A wasm target has no linker, so `external "C"` has so far meant a PIC dylink module and nothing else. That leaves out every library which cannot be built for wasm at all -- Buildings shells out to Python and EnergyPlus -- and every `Include` whose C source assumes a real filesystem. On a native host there is no reason to stop at wasm: the platform shared library the C target would have linked is right there, and libffi already reaches it (that is how ModelicaStandardTables is called today).

Resolve an `ext.<fn>` import in this order, lazily, so a model whose externals are all in wasm never touches the loader:

| | |
| --- | --- |
| 1 | a `.wasm` dylink module a `Library` names |
| 2 | the platform `.so` for that same `Library`, dlopen'd + libffi | | 3 | the process image, as before |
| 4 | the `Include` C source, compiled to a host `.so` |

`getLibraryStringInWasmFormat` now emits each `Library` twice, the wasm module name and the gcc-format spec, which is how `mp.libs` carries both forms. A `Library` may also name a `.c` file; that joins the `Include` translation unit, as gcc would have compiled it.

Step 4 is last because an `Include` most often only declares what a `Library` defines, and building a header-only translation unit produces nothing to load. The wasm path makes the same decision statically, off the resolved libraries' exports.

Both translation units were missing omc's own headers, which is why `ModelicaUtilities.h` was not found: they now get
`-I$(OMHOME)/include/omc/c -I$(OMHOME)/include/omc` and C's `<prefix>_includes.h` prologue. `openmodelica.h` cannot be opened for wasm32 (Boehm GC, setjmp), so that unit names libc and `ModelicaUtilities.h` directly instead.

Five defects this uncovered:

* A `ModelicaError` from an external function was swallowed, because the run rolls the Error buffer back the way C's separate executable leaves it empty. Report it on the run's log through `LOG_ASSERT`, which is what C's `va_throwStreamPrint` does.
* `collect_param_bindings` compared the scalarized key `ts[1]` against the array-assign key `ts`, so an array parameter bound to a function call was evaluated twice in the binding prelude -- before the String parameters it read were assigned.
* `functionParameters` carried `parameterEquations` as well, which #16237 also gave to `functionUpdateBoundParameters`; the driver calls both, so an external object's constructor ran twice over.
* A dlopen'd library's `printf` reaches fd 1 directly, past the WASI shim and past `ModelicaMessage`, while C's executable would have had it in the log. Redirect fd 1/2 into the capture for each phase.
* An `_Out_` record argument was given an 8-byte cell and the callee filled a struct into it. Reject what has no C form, and rebuild a `String[:]` input as the `const char**` C declares.

Buildings' weather-data models and ModelicaByExample's external vector interpolation now run under --simCodeTarget=wasm-jit with results identical to the C target. In testsuite/simulation/modelica, external_functions goes from 9 failures to 7 (RecordMemberArguments and ExtObjStringParam) and initialization is unchanged at 15.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
