### PR TITLE
wasm-jit: constant variables and record defaults

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -56,7 +56,7 @@ use openmodelica_simcode_types::SimCodeFunction;
 use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
-    ArrayGroup, Attr, AttrTargets, BUILTINS, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, Literals, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
+    ArrayGroup, Attr, AttrTargets, BUILTINS, ConstGroup, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, Literals, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
@@ -2284,6 +2284,12 @@ pub(crate) struct SimVarMap {
     start_slots: Arc<HashMap<String, u32>>,
     /// Finalized array-variable groups (base cref key -> contiguous slot range).
     array_groups: Arc<HashMap<String, ArrayGroup>>,
+    /// `varKind = CONST` variables own no `SimData` slot: a reference is the
+    /// binding literal, as in C's `varArrayNameValues`. `const_groups` is the
+    /// `array_groups` counterpart, `const_acc` its transient accumulator.
+    consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
+    const_groups: Arc<HashMap<String, ConstGroup>>,
+    const_acc: HashMap<String, Vec<(Vec<i32>, Arc<DAE::Exp>, WTy)>>,
     /// Transient accumulator: base cref key -> the scalarized elements seen
     /// (subscripts, byte offset, value type). Finalized into `array_groups` at the
     /// end of [`build_var_map`].
@@ -2668,6 +2674,9 @@ fn build_var_map(
         starts: Arc::default(),
         start_slots: Arc::default(),
         array_groups: Arc::default(),
+        consts: Arc::default(),
+        const_groups: Arc::default(),
+        const_acc: HashMap::new(),
         array_acc: HashMap::new(),
         terminate_off: layout.terminate_off,
         terminal_off: layout.terminal_off,
@@ -2840,9 +2849,23 @@ fn build_var_map(
     // in the result too, e.g. visualization colors). Record their values so a
     // constant's aliases resolve below.
     let mut const_of: HashMap<String, f64> = HashMap::new();
-    for sv in lst(&vars.constVars).chain(lst(&vars.intConstVars)).chain(lst(&vars.boolConstVars)) {
+    let const_lists = [
+        (&vars.constVars, Some(WTy::F64)),
+        (&vars.intConstVars, Some(WTy::I32)),
+        (&vars.boolConstVars, Some(WTy::I32)),
+        (&vars.stringConstVars, None),
+    ];
+    for sv in const_lists.iter().flat_map(|(l, wty)| lst(l).map(move |sv| (sv, *wty))) {
+        let (sv, wty) = sv;
+        let key = sim_cref_key(&sv.name)?;
+        if let Some(exp) = sv.initialValue.clone() {
+            Arc::make_mut(&mut map.consts).insert(key.clone(), exp.clone());
+            if let (Some(wty), Some((base, subs))) = (wty, array_element_of(&sv.name)?) {
+                map.const_acc.entry(base).or_default().push((subs, exp, wty));
+            }
+        }
         let Some(value) = const_value(&sv.initialValue) else { continue };
-        const_of.insert(sim_cref_key(&sv.name)?, value);
+        const_of.insert(key, value);
         if let Some(name) = result_name(&cref_display(&sv.name)?) {
             result_vars.push(ResultVar {
                 name,
@@ -3035,6 +3058,41 @@ fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
             continue;
         }
         Arc::make_mut(&mut map.array_groups).insert(base, ArrayGroup { base_off, wty, dims, total });
+    }
+    finalize_const_groups(map)
+}
+
+/// [`finalize_array_groups`] for constants, which own no slots: the group is the
+/// row-major list of its elements' literals.
+fn finalize_const_groups(map: &mut SimVarMap) -> Result<()> {
+    let acc = std::mem::take(&mut map.const_acc);
+    for (base, mut elems) in acc {
+        let Some(rank) = elems.first().map(|(s, _, _)| s.len()) else { continue };
+        if elems.iter().any(|(s, _, _)| s.len() != rank) {
+            continue; // ragged rank
+        }
+        if elems.iter().any(|(subs, _, _)| subs.iter().any(|&ix| ix < 1)) {
+            continue;
+        }
+        let mut dims = vec![0u32; rank];
+        for (subs, _, _) in &elems {
+            for (axis, &ix) in subs.iter().enumerate() {
+                dims[axis] = dims[axis].max(ix as u32);
+            }
+        }
+        let total: u32 = dims.iter().product();
+        if total as usize != elems.len() {
+            continue; // not every element is its own constant
+        }
+        let wty = elems[0].2;
+        if elems.iter().any(|(_, _, w)| *w != wty) {
+            continue;
+        }
+        elems.sort_by_key(|(subs, _, _)| {
+            subs.iter().enumerate().fold(0u32, |lin, (axis, &ix)| lin * dims[axis] + (ix as u32 - 1))
+        });
+        let values = elems.into_iter().map(|(_, e, _)| e).collect();
+        Arc::make_mut(&mut map.const_groups).insert(base, ConstGroup { wty, dims, values });
     }
     Ok(())
 }
@@ -4957,6 +5015,8 @@ fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         starts: var_map.starts.clone(),
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
+        consts: var_map.consts.clone(),
+        const_groups: var_map.const_groups.clone(),
         terminate_off: var_map.terminate_off,
         terminal_off: var_map.terminal_off,
         initial_off: var_map.initial_off,
@@ -6939,6 +6999,8 @@ fn build_nls_fns(
         starts: var_map.starts.clone(),
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
+        consts: var_map.consts.clone(),
+        const_groups: var_map.const_groups.clone(),
         terminate_off: var_map.terminate_off,
         terminal_off: var_map.terminal_off,
         initial_off: var_map.initial_off,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -80,11 +80,43 @@ pub(crate) mod runtime;
 #[path = "CodegenWasmJitFunctions/runtime_stub.rs"]
 pub(crate) mod runtime;
 
+thread_local! {
+    /// What is being lowered, for the diagnostics below.
+    static CURRENT_FN: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+    static CURRENT_PART: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+}
+
+fn fn_context() -> String {
+    let part = CURRENT_PART.with(|p| p.borrow().clone());
+    CURRENT_FN.with(|f| match (f.borrow().as_str(), part.as_str()) {
+        ("", "") => String::new(),
+        ("", p) => format!(" in {p}"),
+        (name, "") => format!(" in function `{name}`"),
+        (name, p) => format!(" in {p} in function `{name}`"),
+    })
+}
+
+/// Sets `CURRENT_PART` until it drops, restoring the previous value.
+struct PartGuard(String);
+
+impl PartGuard {
+    fn new(part: String) -> Self {
+        PartGuard(CURRENT_PART.with(|p| p.replace(part)))
+    }
+}
+
+impl Drop for PartGuard {
+    fn drop(&mut self) {
+        CURRENT_PART.with(|p| *p.borrow_mut() = std::mem::take(&mut self.0));
+    }
+}
+
 /// Record a message naming the unresolved variable (the `Result` error is a
 /// `&'static str`; `translateModel` surfaces the recorded message).
 fn unknown_variable(name: &str) -> &'static str {
     crate::CodegenWasmJit::record_error(format!(
-        "CodegenWasmJit: reference to unknown variable `{name}`"
+        "CodegenWasmJit: reference to unknown variable `{name}`{}",
+        fn_context()
     ));
     "CodegenWasmJit: reference to unknown variable"
 }
@@ -1060,8 +1092,8 @@ pub(crate) fn sig_ty_quiet(ty: &DAE::Type) -> Result<SigTy> {
             let mut fields = Vec::new();
             match record_decl_fields(&path_str) {
                 Some(decl) => {
-                    for (name, ty) in decl.iter() {
-                        fields.push((name.clone(), sig_ty_quiet(ty)?));
+                    for f in decl.iter() {
+                        fields.push((f.name.clone(), sig_ty_quiet(&f.ty)?));
                     }
                 }
                 None => {
@@ -1096,12 +1128,24 @@ pub(crate) fn sig_ty(ty: &DAE::Type) -> Result<SigTy> {
     })
 }
 
+/// One field of a record *declaration* (C's `RECORD_DECL_FULL` variables), which
+/// is what [`emit_record_default`] builds the default constructor from.
+pub(crate) struct RecDeclField {
+    name: ArcStr,
+    ty: Arc<DAE::Type>,
+    /// The declared binding, evaluated in the record's own scope.
+    value: Option<Arc<DAE::Exp>>,
+    /// The binding came from a derived record (`record A = B(k=exp)`) and is
+    /// evaluated in the using scope instead.
+    bind_outside: bool,
+}
+
 std::thread_local! {
     /// One field list per record class (the C target's one `<Rec>` struct), keyed
     /// by definition path. A record *expression*'s `T_COMPLEX` can disagree with
     /// its consumer's about a field type, which would give the two ends different
     /// field offsets; the declaration decides for both.
-    static RECORD_DECLS: std::cell::RefCell<HashMap<String, Arc<Vec<(ArcStr, Arc<DAE::Type>)>>>> =
+    static RECORD_DECLS: std::cell::RefCell<HashMap<String, Arc<Vec<RecDeclField>>>> =
         std::cell::RefCell::new(HashMap::new());
 }
 
@@ -1118,8 +1162,16 @@ pub(crate) fn set_record_decls(
         let path = AbsynUtil::pathString(defPath.clone(), arcstr::literal!("."), true, false)?;
         let mut fields = Vec::new();
         for v in &**variables {
-            let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, .. } = &**v else { continue };
-            fields.push((ArcStr::from(cref_ident(name)?), ty.clone()));
+            let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, value, bind_from_outside, .. } = &**v
+            else {
+                continue;
+            };
+            fields.push(RecDeclField {
+                name: ArcStr::from(cref_ident(name)?),
+                ty: ty.clone(),
+                value: value.clone(),
+                bind_outside: *bind_from_outside,
+            });
         }
         map.insert(path.to_string(), Arc::new(fields));
     }
@@ -1127,8 +1179,17 @@ pub(crate) fn set_record_decls(
     Ok(())
 }
 
-fn record_decl_fields(path: &str) -> Option<Arc<Vec<(ArcStr, Arc<DAE::Type>)>>> {
+fn record_decl_fields(path: &str) -> Option<Arc<Vec<RecDeclField>>> {
     RECORD_DECLS.with(|r| r.borrow().get(path).cloned())
+}
+
+/// The declaration of record type `ty`, if the module declares one.
+fn record_decl_of(ty: &DAE::Type) -> Result<Option<Arc<Vec<RecDeclField>>>> {
+    let DAE::Type::T_COMPLEX { complexClassType: ClassInf::State::RECORD { path }, .. } = ty else {
+        return Ok(None);
+    };
+    let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
+    Ok(record_decl_fields(&path_str))
 }
 
 /// The module's constant pool: every literal concatenated into the single
@@ -1239,6 +1300,10 @@ pub(crate) struct SimCtx {
     /// as one runtime array object (gather on read, scatter on assign). See
     /// `compile_sim_cref_read`/`compile_sim_cref_assign`.
     pub(crate) array_groups: Arc<HashMap<String, ArrayGroup>>,
+    /// `varKind = CONST` variables own no slot: a reference is the binding
+    /// literal, as in C's `varArrayNameValues`.
+    pub(crate) consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
+    pub(crate) const_groups: Arc<HashMap<String, ConstGroup>>,
     /// `SimData` byte offset of the `terminate` flag, written by a fired
     /// `terminate(...)` when-operator (see `lower_when_op`).
     pub(crate) terminate_off: u32,
@@ -1422,6 +1487,14 @@ pub(crate) struct ArrayGroup {
     pub(crate) dims: Vec<u32>,
     /// Product of `dims` (number of scalar elements).
     pub(crate) total: u32,
+}
+
+/// A constant array's elements, row-major; it owns no `SimData` slots.
+#[derive(Clone)]
+pub(crate) struct ConstGroup {
+    pub(crate) wty: WTy,
+    pub(crate) dims: Vec<u32>,
+    pub(crate) values: Vec<Arc<DAE::Exp>>,
 }
 
 /// A scalar model variable's location within the `SimData` block.
@@ -2061,6 +2134,31 @@ pub(crate) fn compile_function(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Literals,
 ) -> Result<we::Function> {
+    CURRENT_FN.with(|c| *c.borrow_mut() = function_path(f));
+    let out = compile_function_body(f, by_name, literals);
+    CURRENT_FN.with(|c| c.borrow_mut().clear());
+    out
+}
+
+fn function_path(f: &SimCodeFunction::Function::Function) -> String {
+    use SimCodeFunction::Function::Function as F;
+    let path = match f {
+        F::FUNCTION { name, .. }
+        | F::PARALLEL_FUNCTION { name, .. }
+        | F::KERNEL_FUNCTION { name, .. }
+        | F::EXTERNAL_FUNCTION { name, .. }
+        | F::RECORD_CONSTRUCTOR { name, .. } => name,
+    };
+    AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
+fn compile_function_body(
+    f: &SimCodeFunction::Function::Function,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
     if matches!(f, SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { .. }) {
         return compile_external_function(f, by_name, literals);
     }
@@ -2483,12 +2581,13 @@ fn init_var(
     let SimCodeFunction::Variable::Variable::VARIABLE { name, ty, value, bind_from_outside, .. } = v else {
         return Ok(());
     };
-    let (_, sty) = var_name_ty(v)?;
+    let (vname, sty) = var_name_ty(v)?;
     let Some(slot) = var_slot(ctx, v) else { return Ok(()) };
     if done.contains(&slot) {
         return Ok(());
     }
     done.push(slot);
+    let _g = PartGuard::new(format!("the declaration of `{vname}`"));
     if let Some(k) = array_allocs.iter().position(|(i, ..)| *i == slot) {
         let (_, elem, dims) = array_allocs.remove(k);
         emit_array_alloc(ctx, slot, &elem, &dims)?;
@@ -2700,7 +2799,13 @@ fn compile_assign(ctx: &mut FnCtx, lhs: &DAE::Exp, rhs: &DAE::Exp) -> Result<()>
     let (idx, dst_sty) = ctx
         .locals
         .get(&name)
-        .ok_or_else(|| "CodegenWasmJit: assignment to unknown variable")?
+        .ok_or_else(|| {
+            crate::CodegenWasmJit::record_error(format!(
+                "CodegenWasmJit: assignment to unknown variable `{name}`{}",
+                fn_context()
+            ));
+            "CodegenWasmJit: assignment to unknown variable"
+        })?
         .clone();
 
     if !subscriptLst.is_empty() {
@@ -3043,6 +3148,9 @@ struct RecField {
     sig: SigTy,
     ty: Arc<DAE::Type>,
     default: Option<Arc<DAE::Exp>>,
+    /// This use site binds the field from outside, so `default` belongs to the
+    /// using scope (see [`RecDeclField::bind_outside`]).
+    bind_outside: bool,
 }
 
 /// The canonical fields of record type `ty`, or `None` if `ty` is not a record.
@@ -3054,7 +3162,7 @@ fn record_fields(ty: &DAE::Type) -> Result<Option<Vec<RecField>>> {
     let path_str = AbsynUtil::pathString(path.clone(), arcstr::literal!("."), true, false)?;
     let vars: Vec<&Arc<DAE::Var>> = (&**varLst).into_iter().collect();
     let declared: Vec<(ArcStr, Arc<DAE::Type>)> = match record_decl_fields(&path_str) {
-        Some(d) => d.iter().cloned().collect(),
+        Some(d) => d.iter().map(|f| (f.name.clone(), f.ty.clone())).collect(),
         None => vars.iter().map(|v| (v.name.clone(), v.ty.clone())).collect(),
     };
     let mut out = Vec::with_capacity(declared.len());
@@ -3063,6 +3171,7 @@ fn record_fields(ty: &DAE::Type) -> Result<Option<Vec<RecField>>> {
         out.push(RecField {
             sig: sig_ty(&fty)?,
             default: var.and_then(|v| record_field_default(v)),
+            bind_outside: var.is_some_and(|v| v.bind_from_outside),
             ty: fty,
             name,
         });
@@ -3075,39 +3184,84 @@ fn rec_layout(fields: &[RecField]) -> RecordLayout {
 }
 
 /// Default-construct a record value of type `ty` (the C target's
-/// `<Rec>_construct`), leaving the owned handle on the stack.
+/// `<Rec>_construct`), leaving the owned handle on the stack. A declared field
+/// binding is evaluated in the record's own scope (C's `ths->_x`), a
+/// `bind_from_outside` one in this scope; the constructor is inlined here, so
+/// the first scope is made by binding each finished field under its own name.
 fn emit_record_default(ctx: &mut FnCtx, ty: &DAE::Type) -> Result<()> {
     let Some(fields) = record_fields(ty)? else {
         return Err("CodegenWasmJit: default construction of a non-record type");
     };
+    let decl = record_decl_of(ty)?;
+    let decl_of = |name: &ArcStr| decl.as_ref().and_then(|d| d.iter().find(|f| &f.name == name));
     let layout = rec_layout(&fields);
-    let obj = emit_record_alloc(ctx, &layout)?;
-    for (i, f) in fields.iter().enumerate() {
-        let fty = f.sig.clone();
-        match &f.default {
-            Some(exp) => {
-                let w = compile_exp(ctx, exp)?;
-                coerce(ctx, w, fty.wty());
-                if let Some((copy_fn, rel_fn)) = value_copy_fns(&fty) {
-                    if !value_rhs_is_fresh(exp) {
-                        let t = ctx.alloc_temp(WTy::I32);
-                        ctx.emit(we::Instruction::LocalSet(t));
-                        ctx.emit(we::Instruction::LocalGet(t));
-                        ctx.emit(we::Instruction::Call(rt_index(copy_fn)?));
-                        ctx.emit(we::Instruction::LocalGet(t));
-                        ctx.emit(we::Instruction::Call(rt_index(rel_fn)?));
-                    }
-                }
+    // Evaluated before any field name is shadowed below.
+    let mut outside: Vec<Option<u32>> = Vec::with_capacity(fields.len());
+    for f in &fields {
+        outside.push(match (f.bind_outside, &f.default) {
+            (true, Some(exp)) => {
+                emit_field_value(ctx, &f.sig, exp)?;
+                let t = ctx.alloc_temp(f.sig.wty());
+                ctx.emit(we::Instruction::LocalSet(t));
+                Some(t)
             }
-            None => emit_type_default(ctx, &f.ty)?,
-        }
-        let vt = ctx.alloc_temp(fty.wty());
-        ctx.emit(we::Instruction::LocalSet(vt));
-        ctx.emit(we::Instruction::LocalGet(obj));
-        ctx.emit(we::Instruction::LocalGet(vt));
-        field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+            _ => None,
+        });
     }
+    let obj = emit_record_alloc(ctx, &layout)?;
+    let mut shadowed: Vec<(String, Option<(u32, SigTy)>)> = Vec::new();
+    let result = (|ctx: &mut FnCtx| -> Result<()> {
+        for (i, f) in fields.iter().enumerate() {
+            let fty = f.sig.clone();
+            // A record with no declaration has only the use site's binding.
+            let bound = match decl_of(&f.name) {
+                Some(d) if !d.bind_outside => d.value.clone().or_else(|| f.default.clone()),
+                _ => f.default.clone(),
+            };
+            match (outside[i], &bound) {
+                (Some(t), _) => ctx.emit(we::Instruction::LocalGet(t)),
+                (None, Some(exp)) => {
+                    let _g = PartGuard::new(format!("the default of record field `{}`", f.name));
+                    emit_field_value(ctx, &fty, exp)?;
+                }
+                (None, None) => emit_type_default(ctx, &f.ty)?,
+            }
+            let vt = ctx.alloc_temp(fty.wty());
+            ctx.emit(we::Instruction::LocalSet(vt));
+            ctx.emit(we::Instruction::LocalGet(obj));
+            ctx.emit(we::Instruction::LocalGet(vt));
+            field_store(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+            let name = f.name.to_string();
+            let prev = ctx.locals.insert(name.clone(), (vt, fty));
+            shadowed.push((name, prev));
+        }
+        Ok(())
+    })(ctx);
+    for (name, prev) in shadowed {
+        match prev {
+            Some(v) => ctx.locals.insert(name, v),
+            None => ctx.locals.remove(&name),
+        };
+    }
+    result?;
     ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// One record-field binding, copied if it came from an alias (value semantics).
+fn emit_field_value(ctx: &mut FnCtx, fty: &SigTy, exp: &DAE::Exp) -> Result<()> {
+    let w = compile_exp(ctx, exp)?;
+    coerce(ctx, w, fty.wty());
+    if let Some((copy_fn, rel_fn)) = value_copy_fns(fty) {
+        if !value_rhs_is_fresh(exp) {
+            let t = ctx.alloc_temp(WTy::I32);
+            ctx.emit(we::Instruction::LocalSet(t));
+            ctx.emit(we::Instruction::LocalGet(t));
+            ctx.emit(we::Instruction::Call(rt_index(copy_fn)?));
+            ctx.emit(we::Instruction::LocalGet(t));
+            ctx.emit(we::Instruction::Call(rt_index(rel_fn)?));
+        }
+    }
     Ok(())
 }
 
@@ -3204,8 +3358,8 @@ fn metarecord_sigty(path: &Arc<Absyn::Path>) -> Result<SigTy> {
         return Err("CodegenWasmJit: boxed record constructor for an undeclared record");
     };
     let mut fields = Vec::with_capacity(declared.len());
-    for (name, ty) in declared.iter() {
-        fields.push((name.clone(), sig_ty(ty)?));
+    for f in declared.iter() {
+        fields.push((f.name.clone(), sig_ty(&f.ty)?));
     }
     Ok(SigTy::Record { path: path_str, fields: Arc::new(fields) })
 }
@@ -5223,6 +5377,13 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 emit_sim_array_gather(ctx, &group)?;
                 return Ok(Some(WTy::I32));
             }
+            if let Some(exp) = ctx.sim()?.consts.get(&key).cloned() {
+                return compile_exp(ctx, &exp).map(Some);
+            }
+            if ctx.sim()?.const_groups.contains_key(&key) {
+                emit_const_array(ctx, &key)?;
+                return Ok(Some(WTy::I32));
+            }
             // A whole record model variable: gather its scalar field slots into a
             // fresh runtime record object.
             if try_emit_sim_record_gather(ctx, cref)? {
@@ -5559,6 +5720,43 @@ fn emit_sim_array_gather(ctx: &mut FnCtx, group: &ArrayGroup) -> Result<()> {
     ctx.emit(we::Instruction::I32Add);
     ctx.emit(we::Instruction::I32Const((group.total * stride) as i32));
     ctx.emit(we::Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+/// [`emit_sim_array_gather`] for a constant array: nothing to copy from, each
+/// element is its own literal.
+fn emit_const_array(ctx: &mut FnCtx, key: &str) -> Result<()> {
+    let group = ctx.sim()?.const_groups.get(key).ok_or("CodegenWasmJit: not a constant array")?;
+    let (wty, dims, values) = (group.wty, group.dims.clone(), group.values.clone());
+    let (ek, stride) = sim_array_elem_kind_stride(wty);
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(ek as i32));
+    ctx.emit(we::Instruction::I32Const(dims.len() as i32));
+    ctx.emit(we::Instruction::I32Const(values.len() as i32));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_new")?));
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (axis, d) in dims.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(axis as i32));
+        ctx.emit(we::Instruction::I32Const(*d as i32));
+        ctx.emit(we::Instruction::Call(rt_index("rt_array_set_dim")?));
+    }
+    let data = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    ctx.emit(we::Instruction::LocalSet(data));
+    for (i, exp) in values.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(data));
+        let w = compile_exp(ctx, exp)?;
+        coerce(ctx, w, wty);
+        let off = i as u32 * stride;
+        match wty {
+            WTy::F64 => ctx.emit(we::Instruction::F64Store(mem_arg(off, 3))),
+            WTy::I32 => ctx.emit(we::Instruction::I32Store(mem_arg(off, 2))),
+        }
+    }
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(())
 }
@@ -5994,8 +6192,9 @@ fn unsupported_exp(exp: &DAE::Exp) -> &'static str {
         .map(|s| s.to_string())
         .unwrap_or_default();
     crate::CodegenWasmJit::record_error(format!(
-        "CodegenWasmJit: expression not yet supported: `{shown}` ({})",
-        exp_variant_name(exp)
+        "CodegenWasmJit: expression not yet supported: `{shown}` ({}){}",
+        exp_variant_name(exp),
+        fn_context()
     ));
     "CodegenWasmJit: expression not yet supported"
 }


### PR DESCRIPTION
Two lowering gaps found by the library sweep, both cases where the C target does something the wasm-jit backend did not.

## Constant model variables

A `SimVar` with `varKind = CONST` owns no `SimData` slot; C inlines its binding literal (`varArrayNameValues`, the
`SIMVAR(varKind=CONST(), initialValue=SOME(value))` case). The wasm-jit backend collected constants only to resolve their aliases, so an equation referring to one failed with

    simulation reference to unknown variable `x.gas.condensingIndex`

`SimVarMap`/`SimCtx` now carry the constants and `compile_sim_cref_read` lowers a reference to the literal. Scalarized elements of a constant array are also collected into `const_groups`, the `array_groups` counterpart, so a whole-array reference builds the array from them.

Fixes `ClaRa.StaticCycles.Fittings.Check.TestMixSplitGas` and the testsuite's `records/constVar1.mos`, `constVar2.mos`, `constVar4.mos`.

## Record default construction

C generates `<Rec>_construct` as a separate function whose body is emitted with a `ths->` prefix (`recordConstructorDef`), so a declared field binding referring to a sibling becomes `ths->_MM`. Bindings a derived record takes from outside (`record A = B(k=exp)`) are instead evaluated at the call site and passed in (`recordVarAllocInit`).

`emit_record_default` inlines the constructor and lowered every binding in the caller's scope, so a record like HelmholtzMedia's

    record HelmholtzDerivs
      constant MolarMass MM = fluidConstants[1].molarMass;
      constant SpecificHeatCapacity R_s = Modelica.Constants.R/MM;

failed on `R_s` with ``reference to unknown variable `MM` ``. It now mirrors C's split: `bind_from_outside` bindings are evaluated first, in this scope, and the rest afterwards with each finished field bound under its own name so a sibling reference resolves. The declaration's bindings are the ones used, so `RECORD_DECLS` keeps `value` and `bind_from_outside` per field.

`HelmholtzMedia.Examples.MediaTestModels.ButaneTestModel_ph` now simulates and `compareSimulationResults` reports the run equal to the C target's.

## Diagnostics

A lowering error named neither the function nor what inside it failed, which is why both of these were hard to place. `unknown_variable`, `unsupported_exp` and the assignment error now name both, as in ``in the default of record field `R_s` in function `X` ``.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
