### PR TITLE
Implement spatialDistribution for wasm-jit

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -168,6 +168,7 @@ openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls_c_trace.rs
 openmodelica_codegen_wasm_jit_runtime/src/session.rs
 openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
 openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
 openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
 openmodelica_fmi3_wasm/Cargo.lock

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -958,6 +958,17 @@ algorithm
   (eres, ((outZeroCrossings, outrelationsinZC, outSamplesLst, outCountMathFunctions), _, _)) := Expression.traverseExpTopDown(e, collectZC, ((inZeroCrossings, inrelationsinZC, inSamplesLst, incountMathFunctions), (counteq, vars, globalKnownVars), NONE()));
 end findZeroCrossings3;
 
+protected function operatorEventsSupported
+  "Whether the selected target's runtime implements the event handling of the
+   stateful operators, i.e. delayZeroCrossing() and
+   spatialDistributionZeroCrossing(). Only the C and WebAssembly runtimes do."
+  output Boolean supported;
+protected
+  String target = Config.simCodeTarget();
+algorithm
+  supported := target == "C" or target == "wasm-jit" or target == "wasm";
+end operatorEventsSupported;
+
 protected function collectZC
   "Collects zero crossings in equations"
   input DAE.Exp inExp;
@@ -966,7 +977,7 @@ protected function collectZC
   output Boolean cont;
   output ZCArgType outTpl;
 algorithm
-  (outExp,cont,outTpl) := match (inExp, inTpl, Config.simCodeTarget())
+  (outExp,cont,outTpl) := match (inExp, inTpl, operatorEventsSupported())
     local
       DAE.Exp e, e1, e2, e_1, e_2, eres, eres1;
       DAE.Exp index, delay, delayMax, in0, in1, x, dir, initPnts, initVals;
@@ -1009,8 +1020,7 @@ algorithm
     then (outExp, false, ((zeroCrossings, relations, samples, numMathFunctions), tp1, NONE()));
 
     // delay() can trigger events which are are handled individually via the function delayZeroCrossing() > 0
-    // But of course the C and C++ runtimes are different and only C supports this...
-    case (DAE.CALL(path=Absyn.IDENT(name="delay"), expLst={index, e, delay, delayMax}, attr = attr), ((zeroCrossings, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters), "C")
+    case (DAE.CALL(path=Absyn.IDENT(name="delay"), expLst={index, e, delay, delayMax}, attr = attr), ((zeroCrossings, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters), true)
       algorithm
         // traverse relevant arguments
         (e, ((_, relations, samples, numMathFunctions), tp1, iters))                     := Expression.traverseExpTopDown(e, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));
@@ -1031,8 +1041,7 @@ algorithm
     then (DAE.CALL(Absyn.IDENT(name="delay"), {index, e, delay, delayMax}, attr), true, ((zeroCrossings, relations, samples, numMathFunctions), tp1, iters));
 
     // spatialDistribution() can trigger events which are handled individually via the function spatialDistributionZeroCrossing() > 0
-    // But of course the C and C++ runtimes are different and only C supports this...
-    case (DAE.CALL(path=Absyn.IDENT(name="spatialDistribution"), expLst = {index, in0, in1, x, dir, initPnts, initVals}, attr = attr), ((zeroCrossings, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters), "C")
+    case (DAE.CALL(path=Absyn.IDENT(name="spatialDistribution"), expLst = {index, in0, in1, x, dir, initPnts, initVals}, attr = attr), ((zeroCrossings, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters), true)
       algorithm
         // traverse relevant arguments
         (in0, ((_, relations, samples, numMathFunctions), tp1, iters))                     := Expression.traverseExpTopDown(in0, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2416,6 +2416,8 @@ pub(crate) struct SimVarMap {
     clock_fire_off: u32,
     /// Number of `delay(...)` expression buffers (`delayedExps.maxDelayedIndex + 1`).
     n_delays: u32,
+    /// Number of `spatialDistribution(...)` operators (`spatialInfo.maxIndex + 1`).
+    n_spatial: u32,
 }
 
 /// Display name of a model variable's component reference (OMC `.`-separated
@@ -2780,6 +2782,7 @@ fn build_var_map(
         zc_pre_off: layout.zc_pre_off,
         clock_fire_off: layout.clock_fire_off,
         n_delays: 0,
+        n_spatial: 0,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
     // User-settable parameters (isValueChangeable), collected as they are laid out.
@@ -3215,7 +3218,8 @@ pub(crate) enum ZcInfo {
     /// A math-event builtin (`integer`/`floor`/`ceil`/`div`/`mod`): `g =
     /// (test(fresh arg) != test(pre[idx])) ? 1 : -1`, C's `zeroCrossingTpl`. `ops`
     /// are the operands (1 for integer/floor/ceil, 2 for div/mod).
-    Math { kind: MathEventKind, ops: Vec<Arc<DAE::Exp>>, idx: u32 },
+    /// `expr` is the original call, only for the `LOG_EVENTS` description.
+    Math { kind: MathEventKind, ops: Vec<Arc<DAE::Exp>>, idx: u32, expr: Arc<DAE::Exp> },
 }
 
 /// A math-event builtin's discretizing test (what `mathEventsValuePre` compares).
@@ -3298,7 +3302,7 @@ fn collect_zero_crossings(
                 let argv: Vec<Arc<DAE::Exp>> = lst(expLst).cloned().collect();
                 let idx = math_event_index(argv.last().unwrap())?;
                 let ops = argv[..argv.len() - 1].to_vec();
-                out.push(ZcInfo::Math { kind, ops, idx });
+                out.push(ZcInfo::Math { kind, ops, idx, expr: zc.relation_.clone() });
             }
             other => return Err("CodegenWasmJit: unsupported zero-crossing form"),
         }
@@ -3499,6 +3503,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         removed_init_residuals(sim_code).len() as u32,
         has_when,
         has_homotopy,
+        // `delay(...)` / `spatialDistribution(...)`: the driver has to store their
+        // accepted points, which costs an extra evaluation, so it asks first.
+        sim_code.delayedExps.maxDelayedIndex >= 0 || sim_code.spatialInfo.maxIndex >= 0,
     );
 
     let (mut var_map, mut result_vars, editable_params, real_starts, import_slots) =
@@ -3526,6 +3533,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     var_map.sample_active_off = layout.sample_active_off;
     // Delay-buffer count (0 when the model has no `delay(...)`).
     var_map.n_delays = (sim_code.delayedExps.maxDelayedIndex + 1).max(0) as u32;
+    // Transported-profile count (`maxIndex` is -1 when the model has none).
+    var_map.n_spatial = (sim_code.spatialInfo.maxIndex + 1).max(0) as u32;
 
     // State sets: register the Jacobian seed/result crefs at the scratch region
     // and collect the driver-side selection metadata (candidate/state/A offsets).
@@ -3997,7 +4006,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     }
     let meta = build_sim_meta(
         &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
-        fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&relations),
+        fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
         param_vars(vars)?, attr_log_entries(sim_code)?,
         removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
         samples.iter().map(|s| s.index).collect(), soti_vars(vars)?, sens_params, nls_vars, dae,
@@ -4168,6 +4177,27 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         });
         idx
     };
+    // `functionStoreSpatialDistribution` / `functionInitSpatialDistribution` (C's
+    // `function_storeSpatialDistribution` + `function_initSpatialDistribution`);
+    // empty stubs when the model has no `spatialDistribution(...)`.
+    let store_spatial_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if var_map.n_spatial == 0 {
+            empty_eqfn()
+        } else {
+            build_store_spatial_fn(sim_code, &var_map, &by_name, &mut literals)?
+        });
+        idx
+    };
+    let init_spatial_idx = {
+        let idx = import_base + bodies.len() as u32;
+        bodies.push(if var_map.n_spatial == 0 {
+            empty_eqfn()
+        } else {
+            build_init_spatial_fn(sim_code, &var_map, &by_name, &mut literals)?
+        });
+        idx
+    };
     // C's `updateBoundParameters`: `parameterEquations` *without* the constant
     // bindings, so re-evaluating the dependent parameters does not undo a
     // perturbation IDAS made to a sensitivity parameter.
@@ -4293,6 +4323,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
     functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
+    functions.function(eqfn_type); // functionStoreSpatialDistribution: (i32) -> ()
+    functions.function(eqfn_type); // functionInitSpatialDistribution: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
     for _ in 0..4 {
@@ -4401,6 +4433,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     exports.export("functionUpdateRelations", we::ExportKind::Func, update_relations_idx);
     exports.export("functionStoreDelayed", we::ExportKind::Func, store_delayed_idx);
     exports.export("functionInitDelay", we::ExportKind::Func, init_delay_idx);
+    exports.export("functionStoreSpatialDistribution", we::ExportKind::Func, store_spatial_idx);
+    exports.export("functionInitSpatialDistribution", we::ExportKind::Func, init_spatial_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
     exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
     for (k, name) in ["linearJacA", "linearJacB", "linearJacC", "linearJacD"].iter().enumerate() {
@@ -4454,6 +4488,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         ("functionUpdateRelations", update_relations_idx),
         ("functionStoreDelayed", store_delayed_idx),
         ("functionInitDelay", init_delay_idx),
+        ("functionStoreSpatialDistribution", store_spatial_idx),
+        ("functionInitSpatialDistribution", init_spatial_idx),
         ("functionUpdateBoundParameters", update_bound_params_idx),
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
         ("linearJacA", linz_jac_idx),
@@ -4978,8 +5014,14 @@ fn const_str(e: &Option<Arc<DAE::Exp>>) -> Option<String> {
     }
 }
 
-fn rel_descriptions(relations: &[Option<Arc<DAE::Exp>>]) -> Vec<String> {
-    relations.iter().map(|r| r.as_ref().map(|e| dump_exp(e)).unwrap_or_default()).collect()
+/// One description per relation, from the backend's list rather than from the
+/// subset [`collect_relations`] can evaluate: `delayZeroCrossing` /
+/// `spatialDistributionZeroCrossing` are stored as the bare call, which no target
+/// assigns to `relations[]`, but C's `relationDescription` still names them.
+fn rel_descriptions(
+    rels: &Arc<List<openmodelica_backend_types::BackendDAE::ZeroCrossing>>,
+) -> Vec<String> {
+    lst(rels).map(|zc| dump_exp(&zc.relation_)).collect()
 }
 
 fn dump_exp(e: &Arc<DAE::Exp>) -> String {
@@ -4993,7 +5035,7 @@ fn zc_descriptions(crossings: &[ZcInfo]) -> Vec<String> {
         .iter()
         .map(|zc| match zc {
             ZcInfo::Bool { expr } => dump_exp(expr),
-            ZcInfo::Math { .. } => String::new(),
+            ZcInfo::Math { expr, .. } => dump_exp(expr),
         })
         .collect()
 }
@@ -5762,6 +5804,51 @@ fn build_init_delay_fn(n_delays: u32) -> we::Function {
     f.instruction(&I::Call(rt_index("rt_delay_init").expect("rt_delay_init is a runtime builtin")));
     f.instruction(&I::End);
     f
+}
+
+/// The model's `spatialDistribution(...)` operators, lowest index first (the
+/// backend collects them in reverse).
+fn spatial_ops(sim_code: &SimCode::SimCode) -> Vec<SimCode::SpatialDistribution> {
+    let mut ops: Vec<SimCode::SpatialDistribution> =
+        lst(&sim_code.spatialInfo.spatialDistributions).cloned().collect();
+    ops.sort_by_key(|sd| sd.index);
+    ops
+}
+
+/// Build `functionStoreSpatialDistribution(SimData*)`; see [`FnCtx::emit_store_spatial`].
+fn build_store_spatial_fn(
+    sim_code: &SimCode::SimCode,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
+    let sim = sim_ctx(var_map);
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    ctx.emit_store_spatial(&spatial_ops(sim_code))?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionInitSpatialDistribution(SimData*)`; see [`FnCtx::emit_init_spatial`].
+fn build_init_spatial_fn(
+    sim_code: &SimCode::SimCode,
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
+    let sim = sim_ctx(var_map);
+    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
+    ctx.emit_init_spatial(var_map.n_spatial, &spatial_ops(sim_code))?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
 }
 
 /// Lower a single `SimEqSystem` into the current equation function.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -58,6 +58,7 @@ use openmodelica_frontend_dump::AbsynUtil;
 use openmodelica_frontend_dump::ExpressionDumpTpl;
 use openmodelica_tpl::Tpl;
 use openmodelica_frontend_types::{ClassInf, DAE, Values};
+use openmodelica_simcode_types::SimCode;
 use openmodelica_simcode_types::SimCodeFunction;
 
 use wasm_encoder as we;
@@ -458,6 +459,16 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
     ("rt_delay_eval", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
     ("rt_delay_zc", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64], &[WTy::F64]),
+    // `spatialDistribution(...)` transported profiles (runtime `spatial.rs`).
+    // `rt_spatial_eval` returns `out0`; `rt_spatial_out1` hands back the `out1` of
+    // that same call, which is C's `double* out1` out-parameter without a
+    // scratch address.
+    ("rt_spatial_init", &[WTy::I32], &[]),
+    ("rt_spatial_init_profile", &[WTy::I32, WTy::I32, WTy::I32], &[]),
+    ("rt_spatial_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64, WTy::I32], &[]),
+    ("rt_spatial_eval", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64, WTy::I32, WTy::I32], &[WTy::F64]),
+    ("rt_spatial_out1", &[WTy::I32], &[WTy::F64]),
+    ("rt_spatial_zc", &[WTy::I32, WTy::F64, WTy::I32, WTy::F64], &[WTy::F64]),
     // Recoverable-assert hooks for a nonlinear-solver residual (see `nls.rs`).
     ("rt_nls_recovering", &[], &[WTy::I32]),
     ("rt_nls_note_assert", &[], &[]),
@@ -1969,7 +1980,7 @@ impl<'a> FnCtx<'a> {
                     coerce(self, w, WTy::I32);
                     self.emit(we::Instruction::Select);
                 }
-                ZcInfo::Math { kind, ops, idx } => {
+                ZcInfo::Math { kind, ops, idx, .. } => {
                     // gout = (test(fresh arg) != test(held pre)) ? 1 : -1.
                     self.emit(we::Instruction::F64Const(1.0f64.into()));
                     self.emit(we::Instruction::F64Const((-1.0f64).into()));
@@ -2026,6 +2037,75 @@ impl<'a> FnCtx<'a> {
                 coerce(self, w, WTy::F64);
             }
             self.emit(we::Instruction::Call(rt_index("rt_delay_store")?));
+        }
+        Ok(())
+    }
+
+    /// Emit `functionStoreSpatialDistribution`: `rt_spatial_store(idx, time, in0,
+    /// in1, x, positiveVelocity)` per `spatialDistribution(...)` operator (C's
+    /// `function_storeSpatialDistribution`).
+    ///
+    /// An operator inside an `if`-branch is guarded by the same condition as the
+    /// branch: storing while it is inactive would advance a profile the model is not
+    /// reading (#16099).
+    pub(crate) fn emit_store_spatial(
+        &mut self,
+        spatial: &[SimCode::SpatialDistribution],
+    ) -> Result<()> {
+        let data = self.sim()?.data_local;
+        for sd in spatial {
+            if let Some(cond) = &sd.condition {
+                compile_bool_operand(self, cond)?;
+                self.emit(we::Instruction::If(we::BlockType::Empty));
+            }
+            self.emit(we::Instruction::I32Const(sd.index));
+            self.emit(we::Instruction::LocalGet(data)); // time (TIME_OFF = 0)
+            self.emit(we::Instruction::F64Load(mem_arg(0, 3)));
+            for exp in [&sd.in0, &sd.in1, &sd.pos] {
+                let w = compile_exp(self, exp)?;
+                coerce(self, w, WTy::F64);
+            }
+            let w = compile_exp(self, &sd.dir)?;
+            coerce(self, w, WTy::I32);
+            self.emit(we::Instruction::Call(rt_index("rt_spatial_store")?));
+            if sd.condition.is_some() {
+                self.emit(we::Instruction::End);
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit `functionInitSpatialDistribution`: allocate the operators for this run
+    /// and fill each from its `initialPoints`/`initialValues` parameter arrays (C's
+    /// `allocSpatialDistribution` + `function_initSpatialDistribution`).
+    pub(crate) fn emit_init_spatial(
+        &mut self,
+        n_spatial: u32,
+        spatial: &[SimCode::SpatialDistribution],
+    ) -> Result<()> {
+        self.emit(we::Instruction::I32Const(n_spatial as i32));
+        self.emit(we::Instruction::Call(rt_index("rt_spatial_init")?));
+        for sd in spatial {
+            // The two array handles are owned here and only borrowed by the runtime,
+            // so they go through temps and are released after the call.
+            let mut temps = Vec::new();
+            for exp in [&sd.initPnts, &sd.initVals] {
+                let w = compile_exp(self, exp)?;
+                if w != WTy::I32 {
+                    return Err("CodegenWasmJit: spatialDistribution initialPoints/initialValues is not an array");
+                }
+                let t = self.alloc_temp(WTy::I32);
+                self.emit(we::Instruction::LocalSet(t));
+                temps.push(t);
+            }
+            self.emit(we::Instruction::I32Const(sd.index));
+            for t in &temps {
+                self.emit(we::Instruction::LocalGet(*t));
+            }
+            self.emit(we::Instruction::Call(rt_index("rt_spatial_init_profile")?));
+            for t in &temps {
+                release_temp_array(self, *t)?;
+            }
         }
         Ok(())
     }
@@ -6123,6 +6203,12 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             match results.len() {
                 1 => Ok(results[0].wty()),
                 0 => return Err("CodegenWasmJit: call to used in expression position returns no value"),
+                // Only `spatialDistribution` gets here: used as a scalar it is its
+                // first output, as any multi-output function call is.
+                2 if matches!(&**path, Absyn::Path::IDENT { name } if &**name == "spatialDistribution") => {
+                    ctx.emit(we::Instruction::Drop);
+                    Ok(results[0].wty())
+                }
                 _ => return Err("CodegenWasmJit: call to returns multiple values; not usable in expression position"),
             }
         }
@@ -6935,7 +7021,46 @@ fn compile_call(
         release_temp(ctx, t)?;
         return Ok(Vec::new());
     }
+    // The only two-output builtin: the transported profile lives in the runtime, so
+    // the tuple is one call for `out0` plus a read-back of that call's `out1`.
+    if name == "spatialDistribution" {
+        return compile_spatial_distribution(ctx, args).map(|_| vec![SigTy::Real, SigTy::Real]);
+    }
     compile_math_builtin(ctx, &name, args, attr).map(|s| vec![s])
+}
+
+/// `(out0, out1) = spatialDistribution(index, in0, in1, x, positiveVelocity,
+/// initialPoints, initialValues)` — the backend's form, with the operator index
+/// prepended — leaving both outputs on the stack, first result deepest.
+/// `initialPoints`/`initialValues` are only used during initialization
+/// (`functionInitSpatialDistribution`), as in C.
+fn compile_spatial_distribution(ctx: &mut FnCtx, args: &Arc<List<Arc<DAE::Exp>>>) -> Result<()> {
+    use we::Instruction as I;
+    let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
+    if argv.len() != 7 {
+        return Err("CodegenWasmJit: `spatialDistribution` expects the backend's 7-argument form");
+    }
+    let DAE::Exp::ICONST { integer: index } = &**argv[0] else {
+        return Err("CodegenWasmJit: `spatialDistribution` index must be an integer literal");
+    };
+    let (data, rel_fresh_off) = { let s = ctx.sim()?; (s.data_local, s.rel_fresh_off) };
+    ctx.emit(I::I32Const(*index));
+    ctx.emit(I::LocalGet(data)); // time (TIME_OFF = 0)
+    ctx.emit(I::F64Load(mem_arg(0, 3)));
+    for a in &argv[1..4] {
+        let w = compile_exp(ctx, a)?; // in0, in1, x
+        coerce(ctx, w, WTy::F64);
+    }
+    let w = compile_exp(ctx, argv[4])?; // positiveVelocity
+    coerce(ctx, w, WTy::I32);
+    // C's `simulationInfo->discreteCall`: the relation mode is nonzero for an event
+    // update and for the initial system, zero during continuous integration.
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Load(mem_arg(rel_fresh_off, 2)));
+    ctx.emit(I::Call(rt_index("rt_spatial_eval")?));
+    ctx.emit(I::I32Const(*index));
+    ctx.emit(I::Call(rt_index("rt_spatial_out1")?));
+    Ok(())
 }
 
 /// Like [`compile_call`] but for statement position; returns the result types
@@ -7546,6 +7671,31 @@ fn compile_math_builtin(
             ctx.emit(we::Instruction::LocalGet(data)); // zeroCrossingsPre[rindex]
             ctx.emit(we::Instruction::F64Load(mem_arg(zc_pre_off + *rindex as u32 * 8, 3)));
             ctx.emit(we::Instruction::Call(rt_index("rt_delay_zc")?));
+            Ok(SigTy::Real)
+        }
+        // spatialDistributionZeroCrossing(index, rindex, x, positiveVelocity): flips
+        // sign each time a stored discontinuity passes the operator's output edge,
+        // holding `zeroCrossingsPre[rindex]` while there is none.
+        "spatialDistributionZeroCrossing" => {
+            need_args(&argv, 4, name)?;
+            if !ctx.sim()?.zc_context {
+                return Err("CodegenWasmJit: spatialDistributionZeroCrossing outside a zero-crossing context");
+            }
+            let DAE::Exp::ICONST { integer: index } = &**argv[0] else {
+                return Err("CodegenWasmJit: `spatialDistributionZeroCrossing` index must be an integer literal");
+            };
+            let DAE::Exp::ICONST { integer: rindex } = &**argv[1] else {
+                return Err("CodegenWasmJit: `spatialDistributionZeroCrossing` relation index must be an integer literal");
+            };
+            let (data, zc_pre_off) = { let s = ctx.sim()?; (s.data_local, s.zc_pre_off) };
+            ctx.emit(we::Instruction::I32Const(*index));
+            let w = compile_exp(ctx, argv[2])?; // x
+            coerce(ctx, w, WTy::F64);
+            let w = compile_exp(ctx, argv[3])?; // positiveVelocity
+            coerce(ctx, w, WTy::I32);
+            ctx.emit(we::Instruction::LocalGet(data)); // zeroCrossingsPre[rindex]
+            ctx.emit(we::Instruction::F64Load(mem_arg(zc_pre_off + *rindex as u32 * 8, 3)));
+            ctx.emit(we::Instruction::Call(rt_index("rt_spatial_zc")?));
             Ok(SigTy::Real)
         }
         // `terminal()` — C's `simulationInfo->terminal`, true only during the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub use nls::{rt_nls_clean_history, rt_set_step_size};
 #[cfg(test)]
 mod nls_c_trace;
 mod solvers;
+mod spatial;
 // SUNDIALS/KLU. The archives are wasip1-only (they need a libc) and only linked
 // when the build script found them, so `cfg(sundials)` gates the calls; the module
 // itself compiles everywhere for its capability report.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
@@ -1,0 +1,1063 @@
+//! Port of `SimulationRuntime/c/simulation/solver/spatialDistribution.c`: the
+//! transported profile `z(xi, t)` behind each `spatialDistribution(...)` operator.
+//!
+//! The profile is the list of `(position, value)` nodes describing `z` in the
+//! *material* coordinate `position = xi - x(t)`, so a node keeps its position for
+//! as long as it stays in the domain and only the read/write edges move with `x`.
+//! For a positive velocity the input edge is the front (`-x`) and the output edge
+//! the back (`-x + 1`); for a negative velocity the two swap. Two adjacent nodes
+//! at the same position are a discontinuity, tracked separately in `events` so the
+//! zero-crossing function can announce it as it reaches an output.
+//!
+//! Where C uses two malloc-per-node doubly-linked lists, this keeps both in
+//! `VecDeque`s: the operator only ever pushes at one end and pops at the other, so
+//! a ring buffer fits it exactly, and the contiguous storage makes the
+//! zero-crossing lookup a binary search instead of a walk (see [`Spatial::zc`]).
+//! State is a module global (single-threaded wasm), reset by `rt_spatial_init`.
+
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+use crate::omclog;
+
+/// The relation evaluation modes `rt_spatial_eval` is handed (`SimLayout`'s
+/// `rel_fresh`): continuous integration, an event update, the initial system.
+const MODE_CONTINUOUS: u32 = 0;
+const MODE_EVENT: u32 = 1;
+
+/// C `SPATIAL_EPS` (`epsilon.h`).
+const SPATIAL_EPS: f64 = f64::EPSILON;
+/// C `SPATIAL_ZERO_DELTA_X`: the `x` progress below which a step is standing still.
+const SPATIAL_ZERO_DELTA_X: f64 = 1e-12;
+/// C's `SPATIAL_EPS_ULPS`: positions and values are not absolute, so the epsilons
+/// below scale with them (clamped at 1 so nothing gets tighter than unscaled).
+const EPS_ULPS: f64 = 8.0;
+
+fn scale(a: f64, b: f64) -> f64 {
+    let s = if a.abs() > b.abs() { a.abs() } else { b.abs() };
+    if s > 1.0 { s } else { 1.0 }
+}
+
+fn pos_eps(a: f64, b: f64) -> f64 {
+    EPS_ULPS * SPATIAL_EPS * scale(a, b)
+}
+
+fn val_eps(a: f64, b: f64) -> f64 {
+    EPS_ULPS * SPATIAL_EPS * scale(a, b)
+}
+
+/// Never below the resolution of the position coordinate.
+fn zero_delta_x(a: f64, b: f64) -> f64 {
+    let e = pos_eps(a, b);
+    if SPATIAL_ZERO_DELTA_X > e { SPATIAL_ZERO_DELTA_X } else { e }
+}
+
+#[derive(Clone, Copy)]
+struct Node {
+    pos: f64,
+    val: f64,
+}
+
+/// A discontinuity of `z`: two profile nodes sharing a position. `sign` alternates
+/// along the list, so the zero-crossing value flips at every one it passes.
+#[derive(Clone, Copy)]
+struct Event {
+    pos: f64,
+    sign: f64,
+}
+
+fn f(v: f64) -> alloc::string::String {
+    format!("{v:.6}")
+}
+
+fn e(v: f64) -> alloc::string::String {
+    omclog::e(v, 0, 6)
+}
+
+/// C's `errorStreamPrint(OMC_LOG_STDOUT, ...)` + `omc_throw_function`.
+fn fatal(msg: &str) -> ! {
+    omclog::error(omclog::STDOUT, false, msg);
+    crate::trap()
+}
+
+fn interpolate(left: Node, right: Node, at: f64) -> f64 {
+    let d = right.pos - left.pos;
+    if !(d > 0.0) {
+        fatal("interpolateTransportedQuantity: wrong order or same position!");
+    }
+    left.val * ((right.pos - at) / d) + right.val * ((at - left.pos) / d)
+}
+
+fn extrapolate(left: Node, right: Node, at: f64) -> f64 {
+    let d = right.pos - left.pos;
+    if !(d > 0.0) {
+        fatal("extrapolateTransportedQuantity: wrong order or same position!");
+    }
+    left.val + (right.val - left.val) / d * (at - left.pos)
+}
+
+/// What [`Spatial::read_output`] found at the output edge.
+struct Read {
+    out: f64,
+    /// Value in front of the last discontinuity walked over.
+    event_pre: Option<f64>,
+    /// Number of discontinuities between the stored output edge and the new one.
+    events: i32,
+}
+
+/// One `spatialDistribution(...)` operator's state.
+struct Spatial {
+    profile: VecDeque<Node>,
+    events: VecDeque<Event>,
+    initialized: bool,
+    /// `x` at the operator's first call. The operator only depends on the *change*
+    /// of `x`, and the initial profile is stored assuming `x(t0) = 0`, so this is
+    /// subtracted from every `x` (C's `startPosX`). Captured lazily: an operator
+    /// inside an inactive `if`-branch must not start before the branch is taken.
+    start_pos_x: Option<f64>,
+    /// `x` at the last accepted step (C's `oldPosX`), shifted.
+    old_pos_x: f64,
+    /// `sign` of the last discontinuity that left the domain, so the alternation
+    /// survives an event list that ran empty.
+    last_event_sign: f64,
+    /// Second output of the last [`Spatial::eval`], for [`rt_spatial_out1`].
+    out1: f64,
+}
+
+impl Spatial {
+    fn new() -> Self {
+        Spatial {
+            profile: VecDeque::new(),
+            events: VecDeque::new(),
+            initialized: false,
+            start_pos_x: None,
+            old_pos_x: 0.0,
+            last_event_sign: 0.0,
+            out1: 0.0,
+        }
+    }
+
+    /// C's `doubleEndedListPrint`, minus the node addresses.
+    fn log_lists(&self) {
+        if !omclog::active(omclog::SPATIALDISTR) {
+            return;
+        }
+        for n in &self.profile {
+            omclog::info(omclog::SPATIALDISTR, false, &format!("({},{})", e(n.pos), e(n.val)));
+        }
+        omclog::info(omclog::SPATIALDISTR, false, "List of events");
+        for ev in &self.events {
+            omclog::info(omclog::SPATIALDISTR, false, &format!("({},{})", e(ev.pos), e(ev.sign)));
+        }
+    }
+
+    /// C `initSpatialDistribution`: the parameter profile becomes the initial one,
+    /// with an event for every pair of `initialPoints` sharing a position.
+    fn init_profile(&mut self, index: u32, points: &[f64], values: &[f64]) {
+        omclog::info(
+            omclog::SPATIALDISTR,
+            true,
+            &format!("Initializing spatial distributions (index={index})"),
+        );
+        let n = points.len();
+        if n < 2 || values.len() != n {
+            fatal("Initialization of spatial distribution failed: initialPoints and initialValues must have the same size >= 2.");
+        }
+        if points[0].abs() > SPATIAL_EPS {
+            omclog::error(
+                omclog::STDOUT,
+                true,
+                &format!("Initialization of spatial distribution with index {index} failed."),
+            );
+            fatal(&format!("initialPoints[0] = {} is not zero.", e(points[0])));
+        }
+        if (points[n - 1] - 1.0).abs() > SPATIAL_EPS {
+            omclog::error(
+                omclog::STDOUT,
+                true,
+                &format!("Initialization of spatial distribution with index {index} failed."),
+            );
+            fatal(&format!("initialPoints[end] = {} is not one.", e(points[n - 1])));
+        }
+        if self.initialized {
+            fatal("SpatialDistribution was allready allocated!");
+        }
+        let mut num_same = 0;
+        let mut sign = -1.0;
+        for i in 0..n - 1 {
+            if points[i] > points[i + 1] {
+                omclog::error(
+                    omclog::STDOUT,
+                    true,
+                    &format!("Initialization of spatial distribution with index {index} failed."),
+                );
+                omclog::error(
+                    omclog::STDOUT,
+                    false,
+                    &format!("initialPoints[{i}] > initialPoints[{}]", i + 1),
+                );
+                fatal(&format!("{} > {}", f(points[i]), f(points[i + 1])));
+            }
+            self.profile.push_back(Node { pos: points[i], val: values[i] });
+            if points[i] == points[i + 1] {
+                num_same += 1;
+                if num_same > 1 {
+                    omclog::error(
+                        omclog::STDOUT,
+                        true,
+                        &format!("Initialization of spatial distribution with index {index} failed."),
+                    );
+                    omclog::error(
+                        omclog::STDOUT,
+                        false,
+                        &format!(
+                            "initialPoints[{}] = initialPoints[{i}] = initialPoints[{}]",
+                            i - 1,
+                            i + 1
+                        ),
+                    );
+                    fatal("Only events with one pre-value and one value are allowed.");
+                }
+                sign = -sign;
+                self.events.push_back(Event { pos: points[i], sign });
+            } else {
+                num_same = 0;
+            }
+        }
+        self.profile.push_back(Node { pos: points[n - 1], val: values[n - 1] });
+        self.initialized = true;
+        self.log_lists();
+        omclog::close(omclog::SPATIALDISTR);
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!("Finished initializing spatial distribution (index={index})"),
+        );
+    }
+
+    fn shift(&mut self, pos_x: f64) -> f64 {
+        pos_x - *self.start_pos_x.get_or_insert(pos_x)
+    }
+
+    fn front(&self) -> Node {
+        self.profile[0]
+    }
+
+    fn back(&self) -> Node {
+        self.profile[self.profile.len() - 1]
+    }
+
+    /// Material position the operator reads `z` at (`xi = 1` / `xi = 0`).
+    fn out_pos(pos_x: f64, positive: bool) -> f64 {
+        if positive { 1.0 - pos_x } else { -pos_x }
+    }
+
+    /// Material position the boundary condition enters at.
+    fn in_pos(pos_x: f64, positive: bool) -> f64 {
+        if positive { -pos_x } else { 1.0 - pos_x }
+    }
+
+    /// Direction `x` moved in since the last accepted step, and `|dx|`.
+    fn progress(&self, pos_x: f64) -> (Option<bool>, f64) {
+        let d = pos_x - self.old_pos_x;
+        if d > 0.0 {
+            (Some(true), d)
+        } else if d < 0.0 {
+            (Some(false), -d)
+        } else {
+            (None, 0.0)
+        }
+    }
+
+    /// C `storeSpatialDistribution`: an accepted step, so the boundary condition
+    /// becomes a new node at the input edge and whatever left the domain is dropped.
+    fn store(&mut self, index: u32, time: f64, in0: f64, in1: f64, pos_x: f64, positive: bool) {
+        let pos_x = self.shift(pos_x);
+        omclog::info(
+            omclog::SPATIALDISTR,
+            true,
+            &format!("Calling storeSpatialDistribution (index={index}, time={})", e(time)),
+        );
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!(
+                "spatialDistribution({}, {}, {}, {})",
+                f(in0),
+                f(in1),
+                f(pos_x),
+                if positive { "true" } else { "false" }
+            ),
+        );
+        self.log_lists();
+
+        // The sign of the actual progress outranks the operator's argument: with
+        // `positiveVelocity` inside a `noEvent` the argument can lag a reversal.
+        let (moved, _) = self.progress(pos_x);
+        let positive = moved.unwrap_or(positive);
+
+        // A node at the input edge, or -- when the edge did not move -- a
+        // discontinuity on top of the node already sitting there. Event nodes go
+        // exactly onto the existing position: `prune` computes edge positions as
+        // `edge +/- 1`, so the freshly computed edge can be an ulp off it.
+        let edge = Self::in_pos(pos_x, positive);
+        let old = if positive { self.front() } else { self.back() };
+        let in_val = if positive { in0 } else { in1 };
+        if (edge - old.pos).abs() < pos_eps(edge, old.pos) {
+            if (old.val - in_val).abs() > val_eps(old.val, in_val) {
+                self.add_node(positive, old.pos, in_val, true);
+            }
+        } else {
+            self.add_node(positive, edge, in_val, false);
+        }
+
+        let walked = self.prune(positive);
+        if walked > 1 {
+            omclog::warning(
+                omclog::STDOUT,
+                true,
+                "Removed more then one event from spatialDistribution. Step size to big!",
+            );
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!(
+                    "time: {}, spatialDistribution index: {index}, number of events: {walked}",
+                    f(time)
+                ),
+            );
+            omclog::close_warning(omclog::STDOUT);
+        }
+        self.old_pos_x = pos_x;
+        omclog::close(omclog::SPATIALDISTR);
+    }
+
+    /// C `addNewNodeSpatialDistribution`: a new node at the front (positive
+    /// velocity) or the back, plus its event when it is a discontinuity.
+    fn add_node(&mut self, front: bool, pos: f64, val: f64, is_event: bool) {
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!(
+                "Adding ({},{}) at {}.",
+                e(pos),
+                e(val),
+                if front { "front" } else { "back" }
+            ),
+        );
+        if front {
+            if pos > self.front().pos {
+                fatal("New front position is not smaller then previous first node.");
+            }
+            self.profile.push_front(Node { pos, val });
+        } else {
+            if pos < self.back().pos {
+                fatal("New end position is not bigger then previous last node.");
+            }
+            self.profile.push_back(Node { pos, val });
+        }
+        if !is_event {
+            self.log_lists();
+            return;
+        }
+        // The alternation is along the position axis, so the sign comes from the
+        // neighbour at the end the node is added to.
+        let sign = if front {
+            match self.events.front() {
+                None if self.last_event_sign == 0.0 => 1.0,
+                None => -self.last_event_sign,
+                Some(ev) => {
+                    if pos > ev.pos {
+                        fatal("New front position is not smaller then previous first event node.");
+                    }
+                    -ev.sign
+                }
+            }
+        } else {
+            match self.events.back() {
+                None => 1.0,
+                Some(ev) => {
+                    if pos < ev.pos {
+                        fatal("New end position is not bigger then previous last event node.");
+                    }
+                    -ev.sign
+                }
+            }
+        };
+        let ev = Event { pos, sign };
+        if front {
+            self.events.push_front(ev);
+        } else {
+            self.events.push_back(ev);
+        }
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!(
+                "Adding event ({},{}) at {}.",
+                e(ev.pos),
+                e(ev.sign),
+                if front { "front" } else { "back" }
+            ),
+        );
+        self.log_lists();
+    }
+
+    /// C `pruneSpatialDistribution`: cut the profile back to length 1, moving the
+    /// node that straddles the output edge onto it, and drop the events that left
+    /// with it. Returns how many discontinuities were dropped.
+    fn prune(&mut self, positive: bool) -> i32 {
+        let n = self.profile.len();
+        let edge = if positive { self.front() } else { self.back() };
+        let mut i = if positive { n - 1 } else { 0 };
+        if (self.profile[i].pos - edge.pos).abs() + pos_eps(self.profile[i].pos, edge.pos) < 1.0 {
+            fatal(
+                "Error for spatialDistribution in function pruneSpatialDistribution.\n\
+                 This case should not be possible. Please open a bug report about it.",
+            );
+        }
+        let mut prev = i;
+        let mut walked = 0;
+        let mut inside = false;
+        while i != if positive { 0 } else { n - 1 } {
+            i = if positive { i - 1 } else { i + 1 };
+            if (self.profile[prev].pos - self.profile[i].pos).abs()
+                < pos_eps(self.profile[prev].pos, self.profile[i].pos)
+            {
+                walked += 1;
+            }
+            let d = (self.profile[i].pos - edge.pos).abs();
+            if d + pos_eps(self.profile[i].pos, edge.pos) < 1.0 {
+                inside = true;
+                break;
+            }
+            prev = i;
+        }
+        // `prev` is the first node still outside the domain: interpolate it onto
+        // the output edge and drop everything past it.
+        if inside {
+            let target = if positive { edge.pos + 1.0 } else { edge.pos - 1.0 };
+            let (left, right) = if positive {
+                (self.profile[i], self.profile[prev])
+            } else {
+                (self.profile[prev], self.profile[i])
+            };
+            self.profile[prev] = Node { pos: target, val: interpolate(left, right, target) };
+            omclog::info(
+                omclog::SPATIALDISTR,
+                false,
+                &format!("Interpolate at {}", if positive { "end" } else { "front" }),
+            );
+        }
+        if positive {
+            self.profile.truncate(prev + 1);
+        } else {
+            self.profile.drain(..prev);
+        }
+
+        // Events outside [leftEdge - SPATIAL_ZERO_DELTA_X, rightEdge + SPATIAL_ZERO_DELTA_X].
+        if positive {
+            while let Some(ev) = self.events.back().copied() {
+                if edge.pos + 1.0 + zero_delta_x(edge.pos, ev.pos) >= ev.pos {
+                    break;
+                }
+                self.last_event_sign = ev.sign;
+                self.events.pop_back();
+            }
+        } else {
+            while let Some(ev) = self.events.front().copied() {
+                if edge.pos - 1.0 - zero_delta_x(edge.pos, ev.pos) <= ev.pos {
+                    break;
+                }
+                self.last_event_sign = ev.sign;
+                self.events.pop_front();
+            }
+        }
+        self.log_lists();
+        walked
+    }
+
+    /// C `findOppositeEndSpatialDistribution`: `z` at the output edge for the `x`
+    /// of this call, walking in from the stored output edge.
+    fn read_output(&self, in0: f64, in1: f64, pos_x: f64, positive: bool) -> Read {
+        let n = self.profile.len();
+        let first = self.front();
+        let last = self.back();
+        let read = Self::out_pos(pos_x, positive);
+
+        // More than one domain length since the last accepted step: the material at
+        // the output edge entered after it, so only the boundary condition describes it.
+        if positive && read < first.pos {
+            let inject = Node { pos: -pos_x, val: in0 };
+            let out = interpolate(inject, first, read);
+            return Read { out, event_pre: Some(out), events: self.events.len() as i32 };
+        }
+        if !positive && read > last.pos {
+            let inject = Node { pos: 1.0 - pos_x, val: in1 };
+            let out = interpolate(last, inject, read);
+            return Read { out, event_pre: Some(out), events: self.events.len() as i32 };
+        }
+
+        // Clamped: `x` may have moved backwards since the last accepted step.
+        let read = if positive { read.min(last.pos) } else { read.max(first.pos) };
+        let edge_pos = if positive { first.pos } else { last.pos };
+        let mut i = if positive { n - 1 } else { 0 };
+        if (self.profile[i].pos - edge_pos).abs() + pos_eps(self.profile[i].pos, edge_pos) < 1.0 {
+            fatal(
+                "Error for spatialDistribution in function findOppositeEndSpatialDistribution.\n\
+                 This case should not be possible. Please open a bug report about it.",
+            );
+        }
+        let mut prev = i;
+        let mut walked = 0;
+        let mut event_pre = None;
+        let mut passed = false;
+        loop {
+            if positive {
+                if i == 0 {
+                    break;
+                }
+                i -= 1;
+            } else {
+                if i + 1 == n {
+                    break;
+                }
+                i += 1;
+            }
+            if (self.profile[prev].pos - self.profile[i].pos).abs()
+                < pos_eps(self.profile[prev].pos, self.profile[i].pos)
+            {
+                event_pre = Some(self.profile[prev].val);
+                walked += 1;
+            }
+            let beyond = if positive {
+                self.profile[i].pos < read
+            } else {
+                self.profile[i].pos > read
+            };
+            if beyond && (self.profile[i].pos - read).abs() > pos_eps(self.profile[i].pos, read) {
+                passed = true;
+                break;
+            }
+            prev = i;
+        }
+        let out = if !passed {
+            // The read position is at or beyond the far end of the stored profile.
+            if positive { first.val } else { last.val }
+        } else if positive {
+            interpolate(self.profile[i], self.profile[prev], read)
+        } else {
+            interpolate(self.profile[prev], self.profile[i], read)
+        };
+        Read { out, event_pre, events: walked }
+    }
+
+    /// C `spatialDistribution`: `(out0, out1)` for the `x` of this call, without
+    /// storing anything — the step may still be rejected.
+    fn eval(
+        &mut self,
+        index: u32,
+        time: f64,
+        in0: f64,
+        in1: f64,
+        pos_x: f64,
+        positive: bool,
+        // `mode` is the relation evaluation mode; C's `discreteCall` is
+        // `mode != MODE_CONTINUOUS`, but only a genuine event update announces a
+        // discontinuity.
+        mode: u32,
+    ) -> (f64, f64) {
+        let pos_x = self.shift(pos_x);
+        omclog::info(
+            omclog::SPATIALDISTR,
+            true,
+            &format!("Calling spatialDistribution (index={index}, time={})", e(time)),
+        );
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!(
+                "(out0,out1) = spatialDistribution(in0={}, in1={}, x={}, isPositiveVelocity={})",
+                f(in0),
+                f(in1),
+                f(pos_x),
+                if positive { "true" } else { "false" }
+            ),
+        );
+        self.log_lists();
+
+        let discrete = mode != MODE_CONTINUOUS;
+        let (moved, delta) = self.progress(pos_x);
+        let zdx = zero_delta_x(self.old_pos_x, pos_x);
+        // The argument disagrees with the direction `x` actually moved in. Trust
+        // the movement, but remember that the velocity sign is in doubt.
+        let jumped = delta > zdx && moved == Some(!positive);
+        let positive = if jumped { !positive } else { positive };
+        if delta > zdx && discrete {
+            fatal(&format!(
+                "x got reinitialized during an event at time {}. OpenModelica can't handle that.",
+                f(time)
+            ));
+        }
+
+        // This event update is announcing the discontinuities at the output edge.
+        if mode == MODE_EVENT {
+            self.consume_events(pos_x, positive);
+        }
+
+        let (out0, out1) = if delta < pos_eps(self.old_pos_x, pos_x) {
+            (self.front().val, self.back().val)
+        } else {
+            let read = self.read_output(in0, in1, pos_x, positive);
+            if read.events > 1 {
+                omclog::warning(
+                    omclog::STDOUT,
+                    true,
+                    "Need to output more then one event from spatialDistribution. Step size to big!",
+                );
+                omclog::warning(
+                    omclog::STDOUT,
+                    false,
+                    &format!(
+                        "time: {}, spatialDistribution index: {index}, number of events: {}",
+                        f(time),
+                        read.events
+                    ),
+                );
+                omclog::close_warning(omclog::STDOUT);
+            }
+            // A discontinuity reached the output edge: a continuous call reports the
+            // value in front of it so the zero crossing has something to bracket; the
+            // event call that follows reports the value behind it.
+            let mut out = read.out;
+            if read.events > 0 && !discrete {
+                if let Some(pre) = read.event_pre {
+                    omclog::info(
+                        omclog::SPATIALDISTR,
+                        false,
+                        &format!("Found event in spatial distribution at time {}", f(time)),
+                    );
+                    out = pre;
+                }
+            }
+            // The input-side output is extrapolated rather than taken straight from
+            // `in0`/`in1`, which would close an algebraic loop through the operator.
+            // Suppressed after a `jumped` step: which input feeds which end is
+            // exactly what is in doubt there.
+            let n = self.profile.len();
+            let extrapolate_ok = !jumped && delta > pos_eps(self.old_pos_x, pos_x);
+            if positive {
+                let (a, b) = (self.profile[0], self.profile[1]);
+                let out0 = if extrapolate_ok && (a.pos - b.pos).abs() > pos_eps(a.pos, b.pos) {
+                    extrapolate(a, b, -pos_x)
+                } else {
+                    a.val
+                };
+                (out0, out)
+            } else {
+                let (a, b) = (self.profile[n - 2], self.profile[n - 1]);
+                let out1 = if extrapolate_ok && (a.pos - b.pos).abs() > pos_eps(a.pos, b.pos) {
+                    extrapolate(a, b, 1.0 - pos_x)
+                } else {
+                    b.val
+                };
+                (out, out1)
+            }
+        };
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!("(out0,out1) = ({}, {})", f(out0), f(out1)),
+        );
+        omclog::close(omclog::SPATIALDISTR);
+        self.out1 = out1;
+        (out0, out1)
+    }
+
+    /// Drop the discontinuities that have reached the output edge: the event call
+    /// this is made from is announcing them, and the accepted step's
+    /// [`Spatial::store`] has already cut their jump into the output. Keeping them
+    /// would leave [`Spatial::zc`] reporting the pre-event value at the located root,
+    /// and an integrator that re-primes its root finder from the value *at* that root
+    /// reports the same crossing again a step later.
+    fn consume_events(&mut self, pos_x: f64, positive: bool) {
+        let read = Self::out_pos(pos_x, positive);
+        loop {
+            let ev = match if positive { self.events.back() } else { self.events.front() } {
+                Some(ev) => *ev,
+                None => return,
+            };
+            let reached = if positive {
+                ev.pos > read - pos_eps(ev.pos, read)
+            } else {
+                ev.pos < read + pos_eps(ev.pos, read)
+            };
+            if !reached {
+                return;
+            }
+            self.last_event_sign = ev.sign;
+            if positive {
+                self.events.pop_back();
+            } else {
+                self.events.pop_front();
+            }
+            omclog::info(
+                omclog::SPATIALDISTR,
+                false,
+                &format!("Announced event ({},{}) leaves the event list.", e(ev.pos), e(ev.sign)),
+            );
+        }
+    }
+
+    /// C `spatialDistributionZeroCrossing`: flips sign every time a stored
+    /// discontinuity passes the output edge, so the root finder can place the event.
+    ///
+    /// C spells this out as two mirrored walks over the event list; both come down to
+    /// the negated sign of the nearest discontinuity at or below the read position
+    /// (the signs alternate, so "the one above, not negated" is the same value).
+    fn zc(&self, pos_x: f64, positive: bool, zc_pre: f64) -> f64 {
+        if self.events.is_empty() {
+            omclog::info(
+                omclog::SPATIALDISTR,
+                false,
+                &format!(
+                    "spatialDistributionZeroCrossing({}) = {} (no stored events, returning previous value)",
+                    e(pos_x),
+                    e(zc_pre)
+                ),
+            );
+            return zc_pre;
+        }
+        // Deliberately *not* `shift`: the solver evaluates this unconditionally, also
+        // while the operator is frozen inside an inactive `if`-branch, and capturing
+        // the start position here would start it too early (#16099). Not started means
+        // its zero point is still open, so report the value it will have at x = 0 —
+        // else activating the branch flips the crossing for a discontinuity that has
+        // not moved.
+        let pos_x = match self.start_pos_x {
+            Some(start) => pos_x - start,
+            None => 0.0,
+        };
+        let read = Self::out_pos(pos_x, positive);
+        // Rightmost discontinuity at or below the read position. The tolerance is the
+        // absolute `SPATIAL_EPS`: a wider one flips the value before the discontinuity
+        // is reached, leaving no sign change to find.
+        let below = self.events.partition_point(|ev| ev.pos <= read + SPATIAL_EPS);
+        let value = if below == 0 { self.events[0].sign } else { -self.events[below - 1].sign };
+        omclog::info(
+            omclog::SPATIALDISTR,
+            false,
+            &format!(
+                "List of events for spatialDistributionZeroCrossing({}) = {}",
+                e(pos_x),
+                e(value)
+            ),
+        );
+        self.log_lists();
+        value
+    }
+}
+
+struct SpatialCell(UnsafeCell<Vec<Spatial>>);
+// Single-threaded wasm: no concurrent access to the operator state.
+unsafe impl Sync for SpatialCell {}
+static SPATIAL: SpatialCell = SpatialCell(UnsafeCell::new(Vec::new()));
+
+fn at(index: u32) -> &'static mut Spatial {
+    let all = unsafe { &mut *SPATIAL.0.get() };
+    match all.get_mut(index as usize) {
+        Some(s) => s,
+        None => fatal("spatialDistribution: operator index out of range (rt_spatial_init not called?)"),
+    }
+}
+
+/// [`at`] for the calls that read the profile: an index the backend allocated but
+/// never handed an initial profile to would otherwise index an empty deque.
+fn at_ready(index: u32) -> &'static mut Spatial {
+    let s = at(index);
+    if !s.initialized {
+        fatal("spatialDistribution was evaluated before its initial profile was set.");
+    }
+    s
+}
+
+/// (Re)allocate `n` uninitialized operators for a fresh run.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_init(n: u32) {
+    omclog::info(
+        omclog::SPATIALDISTR,
+        false,
+        &format!("Allocating memory for {n} spatial distribution(s)."),
+    );
+    let all = unsafe { &mut *SPATIAL.0.get() };
+    all.clear();
+    all.reserve(n as usize);
+    for _ in 0..n {
+        all.push(Spatial::new());
+    }
+}
+
+/// Fill operator `index` from its `initialPoints` / `initialValues` arrays (Real
+/// array handles, borrowed).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_init_profile(index: u32, points: u32, values: u32) {
+    let read = |handle: u32| -> Vec<f64> {
+        let n = crate::rt_array_total(handle);
+        (1..=n as i32)
+            .map(|k| unsafe { crate::load_f64(crate::rt_array_elem_ptr(handle, k)) })
+            .collect()
+    };
+    let (p, v) = (read(points), read(values));
+    at(index).init_profile(index, &p, &v);
+}
+
+/// C `storeSpatialDistribution`: commit the boundary condition of an accepted step.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_store(
+    index: u32,
+    time: f64,
+    in0: f64,
+    in1: f64,
+    pos_x: f64,
+    positive: u32,
+) {
+    at_ready(index).store(index, time, in0, in1, pos_x, positive != 0);
+}
+
+/// C `spatialDistribution`: returns `out0`; `out1` follows from
+/// [`rt_spatial_out1`]. `mode` is the relation evaluation mode, of which C's
+/// `simulationInfo->discreteCall` is `mode != 0`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_eval(
+    index: u32,
+    time: f64,
+    in0: f64,
+    in1: f64,
+    pos_x: f64,
+    positive: u32,
+    mode: u32,
+) -> f64 {
+    at_ready(index).eval(index, time, in0, in1, pos_x, positive != 0, mode).0
+}
+
+/// The second output of the preceding [`rt_spatial_eval`] of the same operator.
+/// The codegen emits the two back to back for one `spatialDistribution(...)` call,
+/// which is C's `double* out1` out-parameter without the scratch address.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_out1(index: u32) -> f64 {
+    at(index).out1
+}
+
+/// C `spatialDistributionZeroCrossing`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_spatial_zc(index: u32, pos_x: f64, positive: u32, zc_pre: f64) -> f64 {
+    at(index).zc(pos_x, positive != 0, zc_pre)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A belt initialized as `functionInitSpatialDistribution` does, then called
+    /// once at `x = 0` as the driver's initialization does (that first call is what
+    /// fixes the operator's zero point).
+    fn belt(points: &[f64], values: &[f64]) -> Spatial {
+        let mut s = Spatial::new();
+        s.init_profile(0, points, values);
+        s.eval(0, 0.0, values[0], values[values.len() - 1], 0.0, true, MODE_CONTINUOUS);
+        s.store(0, 0.0, values[0], values[values.len() - 1], 0.0, true);
+        s
+    }
+
+    /// Transport at unit velocity in `n` steps of `h`: `(time, out0, out1)` per step,
+    /// evaluated then stored as an accepted step, like the driver does.
+    fn run(
+        s: &mut Spatial,
+        in0: impl Fn(f64) -> f64,
+        in1: impl Fn(f64) -> f64,
+        positive: bool,
+        h: f64,
+        n: usize,
+    ) -> Vec<(f64, f64, f64)> {
+        let mut out = Vec::new();
+        for k in 1..=n {
+            let t = k as f64 * h;
+            let x = if positive { t } else { -t };
+            let (o0, o1) = s.eval(0, t, in0(t), in1(t), x, positive, MODE_CONTINUOUS);
+            out.push((t, o0, o1));
+            s.store(0, t, in0(t), in1(t), x, positive);
+        }
+        out
+    }
+
+    #[test]
+    fn flat_profile_is_a_pure_delay() {
+        let mut s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        // Velocity 1 over a domain of length 1: out1(t) = in0(t - 1).
+        for (t, _, o1) in run(&mut s, |t| t, |_| 0.0, true, 0.01, 200) {
+            let want = if t < 1.0 { 0.0 } else { t - 1.0 };
+            assert!((o1 - want).abs() < 1e-9, "t={t}: out1={o1}, want {want}");
+        }
+    }
+
+    #[test]
+    fn initial_profile_leaves_in_order() {
+        // A ramp 1 -> 0 over the domain: the right edge sees 0, 0.05, 0.1, ...
+        let mut s = belt(&[0.0, 1.0], &[1.0, 0.0]);
+        for (t, _, o1) in run(&mut s, |_| 0.0, |_| 0.0, true, 0.05, 20) {
+            assert!((o1 - t).abs() < 1e-9, "t={t}: out1={o1}");
+        }
+    }
+
+    #[test]
+    fn negative_velocity_transports_in1_to_out0() {
+        let mut s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        for (t, o0, _) in run(&mut s, |_| 0.0, |t| t, false, 0.01, 200) {
+            let want = if t < 1.0 { 0.0 } else { t - 1.0 };
+            assert!((o0 - want).abs() < 1e-9, "t={t}: out0={o0}, want {want}");
+        }
+    }
+
+    #[test]
+    fn zero_crossing_flips_when_a_discontinuity_reaches_the_output() {
+        // Discontinuity at the middle of the domain: it reaches xi = 1 at x = 0.5.
+        let s = belt(&[0.0, 0.5, 0.5, 1.0], &[2.0, 2.0, 1.0, 1.0]);
+        let before = s.zc(0.0, true, 0.0);
+        assert_eq!(s.zc(0.49, true, 0.0), before, "no flip before the event");
+        assert_eq!(s.zc(0.51, true, 0.0), -before, "flip after the event");
+        // And it stays flipped further along.
+        assert_eq!(s.zc(0.9, true, 0.0), -before);
+    }
+
+    #[test]
+    fn an_announced_crossing_is_not_reported_twice() {
+        // The discontinuity at 0.5 reaches the output edge at x = 0.5. Reproduce what
+        // a root-finding integrator does: locate it, store the accepted point, run the
+        // event update — after which the crossing function must already read the
+        // post-event value, or the next step reports the same crossing again.
+        // Two of them, so the list is not left empty (which would hold the previous
+        // value for a different reason).
+        let mut s = belt(&[0.0, 0.3, 0.3, 0.5, 0.5, 1.0], &[3.0, 3.0, 2.0, 2.0, 1.0, 1.0]);
+        let before = s.zc(0.0, true, 0.0);
+        assert_eq!(s.zc(0.5, true, 0.0), before, "not flipped yet at the root");
+        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_CONTINUOUS);
+        s.store(0, 0.5, 0.0, 0.0, 0.5, true);
+        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_EVENT);
+        // No sign change is left for the integrator to find at or past the root, so
+        // the crossing is reported once instead of again a step later.
+        let after = s.zc(0.5, true, before);
+        assert_eq!(after, -before, "announced: the value has moved on");
+        assert_eq!(s.zc(0.5001, true, after), after, "and stays there");
+        assert_eq!(s.zc(0.55, true, after), after);
+    }
+
+    #[test]
+    fn the_last_announced_crossing_holds_its_value() {
+        // With nothing left in the list the crossing function holds the previous
+        // value, which is again no sign change for the integrator to re-find.
+        let mut s = belt(&[0.0, 0.5, 0.5, 1.0], &[2.0, 2.0, 1.0, 1.0]);
+        let before = s.zc(0.0, true, 0.0);
+        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_CONTINUOUS);
+        s.store(0, 0.5, 0.0, 0.0, 0.5, true);
+        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_EVENT);
+        assert_eq!(s.zc(0.5, true, before), before);
+        assert_eq!(s.zc(0.6, true, before), before);
+    }
+
+    #[test]
+    fn zero_crossing_holds_its_previous_value_without_events() {
+        let s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        assert_eq!(s.zc(0.3, true, 1.0), 1.0);
+        assert_eq!(s.zc(0.3, true, -1.0), -1.0);
+    }
+
+    #[test]
+    fn continuous_call_reports_the_value_in_front_of_a_discontinuity() {
+        let mut s = belt(&[0.0, 0.5, 0.5, 1.0], &[2.0, 2.0, 1.0, 1.0]);
+        // A step that walks the discontinuity past the output edge: the continuous
+        // call still reports the value in front of it, so the zero crossing has a
+        // sign change to bracket; the event call that follows reports the one behind.
+        let (_, pre) = s.eval(0, 0.6, 0.0, 0.0, 0.6, true, MODE_CONTINUOUS);
+        assert_eq!(pre, 1.0);
+        // The driver stores the accepted point before running the discrete update,
+        // so the event call sees the same `x` (a moved `x` there is an error).
+        s.store(0, 0.6, 0.0, 0.0, 0.6, true);
+        let (_, post) = s.eval(0, 0.6, 0.0, 0.0, 0.6, true, MODE_EVENT);
+        assert_eq!(post, 2.0);
+    }
+
+    #[test]
+    fn discontinuity_count_survives_pruning() {
+        // Two discontinuities inside one step: both are reported as walked over.
+        let s = belt(&[0.0, 0.3, 0.3, 0.6, 0.6, 1.0], &[3.0, 3.0, 2.0, 2.0, 1.0, 1.0]);
+        assert_eq!(s.read_output(0.0, 0.0, 0.75, true).events, 2);
+    }
+
+    #[test]
+    fn standing_still_reports_the_stored_edges() {
+        let mut s = belt(&[0.0, 1.0], &[7.0, 9.0]);
+        let (o0, o1) = s.eval(0, 0.0, 1.0, 2.0, 0.0, true, MODE_CONTINUOUS);
+        assert_eq!((o0, o1), (7.0, 9.0));
+    }
+
+    #[test]
+    fn nonzero_start_position_behaves_like_zero() {
+        let mut a = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        let mut b = Spatial::new();
+        b.init_profile(0, &[0.0, 1.0], &[0.0, 0.0]);
+        // Same run, but x starts at 5 instead of 0.
+        b.eval(0, 0.0, 0.0, 0.0, 5.0, true, MODE_CONTINUOUS);
+        b.store(0, 0.0, 0.0, 0.0, 5.0, true);
+        for k in 1..=150 {
+            let t = k as f64 * 0.01;
+            let (_, ra) = a.eval(0, t, t, 0.0, t, true, MODE_CONTINUOUS);
+            a.store(0, t, t, 0.0, t, true);
+            let (_, rb) = b.eval(0, t, t, 0.0, 5.0 + t, true, MODE_CONTINUOUS);
+            b.store(0, t, t, 0.0, 5.0 + t, true);
+            assert!((ra - rb).abs() < 1e-12, "t={t}: {ra} vs {rb}");
+        }
+    }
+
+    #[test]
+    fn a_step_longer_than_the_domain_reads_the_boundary_condition() {
+        // x advances 2.5 domain lengths in one step: the material at the output edge
+        // entered after the last accepted step, so the only description of it is the
+        // line from the profile's front (0, 0) to the boundary condition (-2.5, 42).
+        let mut s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        let (_, o1) = s.eval(0, 0.5, 42.0, 0.0, 2.5, true, MODE_CONTINUOUS);
+        assert!((o1 - 42.0 * 1.5 / 2.5).abs() < 1e-12, "out1={o1}");
+    }
+
+    #[test]
+    fn profile_length_stays_bounded() {
+        let mut s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        run(&mut s, |t| t, |_| 0.0, true, 0.001, 5000);
+        // One domain length of material at a 0.001 step is ~1000 nodes plus the
+        // edges, not one per step.
+        assert!(s.profile.len() < 1100, "profile grew to {}", s.profile.len());
+    }
+
+    #[test]
+    fn reversal_transports_the_material_back_out() {
+        let mut s = belt(&[0.0, 1.0], &[0.0, 0.0]);
+        // Fill half the domain with 1.0 from the left, then reverse.
+        for k in 1..=50 {
+            let t = k as f64 * 0.01;
+            s.eval(0, t, 1.0, 0.0, t, true, MODE_CONTINUOUS);
+            s.store(0, t, 1.0, 0.0, t, true);
+        }
+        let mut seen = 0.0f64;
+        for k in 1..=40 {
+            let t = 0.5 + k as f64 * 0.01;
+            let x = 0.5 - k as f64 * 0.01;
+            let (o0, _) = s.eval(0, t, 1.0, 0.0, x, false, MODE_CONTINUOUS);
+            s.store(0, t, 1.0, 0.0, x, false);
+            seen = seen.max(o0);
+        }
+        // What went in on the left comes back out of the left.
+        assert!((seen - 1.0).abs() < 1e-9, "out0 peaked at {seen}");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -47,6 +47,8 @@ unsafe extern "C" {
     fn functionCheckAsserts(sim_data: u32);
     fn functionStoreDelayed(sim_data: u32);
     fn functionInitDelay(sim_data: u32);
+    fn functionStoreSpatialDistribution(sim_data: u32);
+    fn functionInitSpatialDistribution(sim_data: u32);
     fn functionUpdateBoundParameters(sim_data: u32);
     fn functionUpdateBoundVariableAttributes(sim_data: u32);
     fn functionRemovedInitialEquations(sim_data: u32);
@@ -108,6 +110,8 @@ impl SimEngine for StandaloneEngine {
                 "functionCheckAsserts" => functionCheckAsserts(arg),
                 "functionStoreDelayed" => functionStoreDelayed(arg),
                 "functionInitDelay" => functionInitDelay(arg),
+                "functionStoreSpatialDistribution" => functionStoreSpatialDistribution(arg),
+                "functionInitSpatialDistribution" => functionInitSpatialDistribution(arg),
                 "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "functionRemovedInitialEquations" => functionRemovedInitialEquations(arg),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -51,6 +51,8 @@ unsafe extern "C" {
     fn functionCheckAsserts(sim_data: u32);
     fn functionStoreDelayed(sim_data: u32);
     fn functionInitDelay(sim_data: u32);
+    fn functionStoreSpatialDistribution(sim_data: u32);
+    fn functionInitSpatialDistribution(sim_data: u32);
     fn functionUpdateBoundParameters(sim_data: u32);
     fn functionUpdateBoundVariableAttributes(sim_data: u32);
     fn functionRemovedInitialEquations(sim_data: u32);
@@ -265,6 +267,8 @@ impl SimEngine for Engine {
                 "functionCheckAsserts" => functionCheckAsserts(arg),
                 "functionStoreDelayed" => functionStoreDelayed(arg),
                 "functionInitDelay" => functionInitDelay(arg),
+                "functionStoreSpatialDistribution" => functionStoreSpatialDistribution(arg),
+                "functionInitSpatialDistribution" => functionInitSpatialDistribution(arg),
                 "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
                 "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
                 "functionRemovedInitialEquations" => functionRemovedInitialEquations(arg),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -203,6 +203,8 @@ pub const MODEL_FNS: &[&str] = &[
     "functionCheckAsserts",
     "functionStoreDelayed",
     "functionInitDelay",
+    "functionStoreSpatialDistribution",
+    "functionInitSpatialDistribution",
     "functionUpdateBoundParameters",
     "functionUpdateBoundVariableAttributes",
     "evaluateDAEResiduals",
@@ -1356,11 +1358,16 @@ fn init_model(
     // The initial system does not necessarily touch every relation guarding the
     // continuous equations, so a straight snapshot of `relations[]` here would
     // freeze those at their stale (zero) value and pick the wrong equation branch.
+    // `refresh_relations` first, as C's `updateDiscreteSystem` does: a relation
+    // sitting in a branch no evaluation takes (`if a then .. else if b then ..`,
+    // entered on the `a` side) is reached by nothing but the exact sweep.
+    refresh_relations(e, sim_data, layout)?;
     iterate_discrete(e, sim_data, layout)?;
     store_relations(e, sim_data, layout)?;
     update_relations_pre(e, sim_data, layout)?;
-    // Seed the delay buffers and snapshot `zeroCrossingsPre` for step 1.
-    e.call1_if_present("functionStoreDelayed", sim_data)?;
+    // Seed the delay buffers / transported profiles and snapshot `zeroCrossingsPre`
+    // for step 1.
+    store_operators(e, sim_data, layout)?;
     if layout.n_zc > 0 {
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
         save_zc_pre(e, sim_data, layout)?;
@@ -1539,6 +1546,10 @@ fn seed_start_values(
     if !from_file {
         update_bound_values(e, sim_data, layout, model)?;
     }
+    // The initial profiles come from parameter arrays, so this follows the bound
+    // parameters and precedes the initial system (C's `initializeModel`). Idempotent:
+    // it reallocates, so a retried initialization starts from a clean profile.
+    e.call1_if_present("functionInitSpatialDistribution", sim_data)?;
     // C's `storePreValues` before the initial solve: a `$PRE.<discrete>` read in
     // an initial equation sees `start`, not 0.
     seed_pre_from_live(e, sim_data, layout)?;
@@ -1810,6 +1821,35 @@ fn steady_state_reached(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
 
 /// C's `updateContinuousSystem`: recompute everything an output row reads. A
 /// `--daeMode` model has no explicit ODE, so that is one algebraic-stage residual.
+/// C's `function_storeDelayed` + `function_storeSpatialDistribution`, the tail of
+/// `updateContinuousSystem`: the operators with an internal history record the point
+/// the model was last evaluated at. A model without any skips it entirely.
+fn store_operators(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if !layout.has_history_ops {
+        return Ok(());
+    }
+    e.call1_if_present("functionStoreDelayed", sim_data)?;
+    e.call1_if_present("functionStoreSpatialDistribution", sim_data)
+}
+
+/// [`store_operators`] at an accepted point the model has not been evaluated at yet:
+/// the whole of C's `updateContinuousSystem`. `spatialDistribution` reads its
+/// boundary conditions out of `SimData`, and its own `x` must not have moved by the
+/// time the discrete update calls it, so the store belongs *before* the event.
+fn store_operators_at(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    time: f64,
+) -> Result<()> {
+    if !layout.has_history_ops {
+        return Ok(());
+    }
+    write_f64(e, sim_data + TIME_OFF, time)?;
+    eval_continuous(e, sim_data, layout)?;
+    store_operators(e, sim_data, layout)
+}
+
 fn eval_continuous(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ALGEBRAIC);
@@ -2172,7 +2212,9 @@ fn log_state_event(time: f64, roots: &[usize], model: &SimMeta) {
         return;
     }
     omclog::info(omclog::EVENTS, true, &format!("state event at time={}", format_g(time, 12)));
-    for &i in roots {
+    // Highest index first: C's `checkForStateEvent` pushes each crossing onto the
+    // front of the event list it then walks, so simultaneous ones come out reversed.
+    for &i in roots.iter().rev() {
         let desc = model.zc_desc.get(i).map(String::as_str).unwrap_or_default();
         omclog::info(omclog::EVENTS, false, &format!("[{}] {desc}", i + 1));
     }
@@ -3006,6 +3048,7 @@ impl Driver for EulerDriver {
                 emit_row(e, &mut self.rows, sim_data, layout, time, stop)
             };
             close_assert_window(e, sim_data).and(emitted)?;
+            store_operators(e, sim_data, layout)?;
             check_nls(e, sim_data, layout)?; // Euler cannot back off — non-convergence is fatal
             // terminate() fired in functionAlgebraics: keep this row, stop the run.
             if terminated(e, sim_data, layout)? {
@@ -3747,6 +3790,7 @@ impl Driver for DasslDriver {
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
+                store_operators(e, sim_data, layout)?;
                 if terminated(e, sim_data, layout)? {
                     self.finished = true;
                     return Ok(Advance::Terminated);
@@ -3879,6 +3923,7 @@ impl Driver for DasslDriver {
                     let emitted =
                         emit_row(e, &mut self.rows, sim_data, layout, self.t, model.stop_time);
                     close_assert_window(e, sim_data).and(emitted)?;
+                    store_operators(e, sim_data, layout)?;
                     if terminated(e, sim_data, layout)? {
                         break Advance::Terminated;
                     }
@@ -3895,6 +3940,7 @@ impl Driver for DasslDriver {
             open_assert_window();
             let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
             close_assert_window(e, sim_data).and(emitted)?;
+            store_operators(e, sim_data, layout)?;
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated; // terminate() fired: keep this row, stop
             }
@@ -4935,6 +4981,7 @@ impl SolverCore {
                             return Ok(Step::Terminated);
                         }
                     }
+                    store_operators_at(e, sim_data, layout, self.t)?;
                     continue;
                 }
                 // A zero-crossing root at `t` (< target). Handle the state event
@@ -4979,6 +5026,7 @@ impl SolverCore {
                     {
                         capture_pre(e, r, sim_data, layout, troot)?;
                     }
+                    store_operators_at(e, sim_data, layout, troot)?;
                     event_update(e, sim_data, layout, None, troot)?;
                     if let Some(r) = rows.as_deref_mut() {
                         if emit_post_event_row(model, troot) {
@@ -4990,6 +5038,9 @@ impl SolverCore {
                         return Ok(Step::Terminated);
                     }
                     fire_clocks(e, sync, model, sim_data, troot, eps, rows.as_deref_mut())?;
+                    // C's "add event to spatialDistribution": the post-event input
+                    // jump becomes a discontinuity in the transported profile.
+                    store_operators(e, sim_data, layout)?;
                     log_reinits(e, model);
                     omclog::close(omclog::EVENTS);
                     if terminated(e, sim_data, layout)? {
@@ -5024,6 +5075,7 @@ impl SolverCore {
                 {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?; // pre-event row (held)
                 }
+                store_operators_at(e, sim_data, layout, te)?;
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
                 refresh_relations(e, sim_data, layout)?;
@@ -5034,6 +5086,7 @@ impl SolverCore {
                 {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?;
                 }
+                store_operators(e, sim_data, layout)?;
                 log_reinits(e, model);
                 omclog::close(omclog::EVENTS);
                 if terminated(e, sim_data, layout)? {
@@ -5064,6 +5117,7 @@ impl SolverCore {
                     if terminated(e, sim_data, layout)? {
                         return Ok(Step::Terminated);
                     }
+                    store_operators(e, sim_data, layout)?;
                     self.read_y(e)?;
                     self.refresh_yp(e)?;
                     self.restart()?;
@@ -5074,6 +5128,14 @@ impl SolverCore {
                 }
             }
             if target >= tout - eps {
+                // C stores after the accepted point's evaluation and before the row is
+                // written, so the row reports the operator's pre-store outputs — an
+                // input-side output extrapolated from the just-stored value would close
+                // the algebraic loop the extrapolation exists to avoid. `rows` is Some
+                // exactly when the caller writes that row and stores after it.
+                if rows.is_none() {
+                    store_operators_at(e, sim_data, layout, self.t)?;
+                }
                 return Ok(Step::Reached { grid_covered });
             }
         }
@@ -5472,6 +5534,7 @@ impl Driver for EventsDriver {
                         if !no_event_emit() {
                             capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
                         }
+                        store_operators_at(e, sim_data, layout, tr)?;
                         event_update(e, sim_data, layout, None, tr)?;
                         self.core.state_events += 1;
                         if emit_post_event_row(model, tr) {
@@ -5490,7 +5553,9 @@ impl Driver for EventsDriver {
                             self.finished = true;
                             return Ok(Advance::Terminated);
                         }
-                        e.call1_if_present("functionStoreDelayed", sim_data)?;
+                        // C's "add event to spatialDistribution": the post-event
+                        // input jump becomes a discontinuity in the profile.
+                        store_operators(e, sim_data, layout)?;
                         eval_zero_crossings(e, sim_data, layout, tr, &mut zc0)?;
                         save_zc_pre(e, sim_data, layout)?;
                         log_reinits(e, model);
@@ -5507,6 +5572,7 @@ impl Driver for EventsDriver {
                         if !no_event_emit() {
                             emit_row(e, &mut self.rows, sim_data, layout, te, model.stop_time)?;
                         }
+                        store_operators_at(e, sim_data, layout, te)?;
                         write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh
                         self.samp.fire(e, sim_data, te)?;
                         refresh_relations(e, sim_data, layout)?;
@@ -5520,7 +5586,7 @@ impl Driver for EventsDriver {
                             return Ok(Advance::Terminated);
                         }
                         self.core.t = te;
-                        e.call1_if_present("functionStoreDelayed", sim_data)?;
+                        store_operators(e, sim_data, layout)?;
                         if layout.n_zc > 0 {
                             eval_zero_crossings(e, sim_data, layout, te, &mut zc0)?;
                             save_zc_pre(e, sim_data, layout)?;
@@ -5544,7 +5610,7 @@ impl Driver for EventsDriver {
                                 self.finished = true;
                                 return Ok(Advance::Terminated);
                             }
-                            e.call1_if_present("functionStoreDelayed", sim_data)?;
+                            store_operators(e, sim_data, layout)?;
                             if layout.n_zc > 0 {
                                 eval_zero_crossings(e, sim_data, layout, subtarget, &mut zc0)?;
                                 save_zc_pre(e, sim_data, layout)?;
@@ -5565,7 +5631,7 @@ impl Driver for EventsDriver {
                         self.finished = true;
                         return Ok(Advance::Terminated);
                     }
-                    e.call1_if_present("functionStoreDelayed", sim_data)?;
+                    store_operators(e, sim_data, layout)?;
                     if layout.n_zc > 0 {
                         eval_zero_crossings(e, sim_data, layout, tout, &mut zc0)?;
                         save_zc_pre(e, sim_data, layout)?;
@@ -5625,6 +5691,8 @@ impl Driver for EventsDriver {
                 did_step = true;
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
+                // The row's evaluation is this point's `updateContinuousSystem`.
+                store_operators(e, sim_data, layout)?;
                 if terminated(e, sim_data, layout)? {
                     break Advance::Terminated;
                 }
@@ -5871,6 +5939,7 @@ impl Driver for CvodeDriver {
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
+                store_operators(e, sim_data, layout)?;
                 if terminated(e, sim_data, layout)? {
                     self.finished = true;
                     return Ok(Advance::Terminated);
@@ -5960,6 +6029,7 @@ impl Driver for CvodeDriver {
             open_assert_window();
             let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
             close_assert_window(e, sim_data).and(emitted)?;
+            store_operators(e, sim_data, layout)?;
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated;
             }
@@ -6641,6 +6711,7 @@ impl Driver for IdaDriver {
                 open_assert_window();
                 let emitted = emit_row(e, &mut self.rows, sim_data, layout, time, model.stop_time);
                 close_assert_window(e, sim_data).and(emitted)?;
+                store_operators(e, sim_data, layout)?;
                 if terminated(e, sim_data, layout)? {
                     self.finished = true;
                     return Ok(Advance::Terminated);
@@ -6736,6 +6807,7 @@ impl Driver for IdaDriver {
                     let emitted =
                         emit_row(e, &mut self.rows, sim_data, layout, self.t, model.stop_time);
                     close_assert_window(e, sim_data).and(emitted)?;
+                    store_operators(e, sim_data, layout)?;
                     if terminated(e, sim_data, layout)? {
                         break Advance::Terminated;
                     }
@@ -6749,6 +6821,7 @@ impl Driver for IdaDriver {
             open_assert_window();
             let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
             close_assert_window(e, sim_data).and(emitted)?;
+            store_operators(e, sim_data, layout)?;
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated;
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -98,6 +98,10 @@ pub struct Layout {
     /// A nonlinear system carries the homotopy operator (C's `homotopySupport`), so
     /// the driver runs the continuation over `functionInitialEquations_lambda0`.
     pub has_homotopy: bool,
+    /// The model has `delay(...)` or `spatialDistribution(...)`, i.e. an operator
+    /// with an internal history that `functionStoreDelayed` /
+    /// `functionStoreSpatialDistribution` must be fed at every accepted point.
+    pub has_history_ops: bool,
     /// `SimData` offset of the homotopy parameter lambda (f64).
     pub lambda_off: u32,
     pub rparam_off: u32,
@@ -269,6 +273,7 @@ impl Layout {
         n_removed_init: u32,
         has_when: bool,
         has_homotopy: bool,
+        has_history_ops: bool,
     ) -> Self {
         let n_real = 2 * n_states + n_real_alg; // states | ders | algs
         let rparam_off = REAL_OFF + n_real * 8;
@@ -323,7 +328,7 @@ impl Layout {
         let removed_init_idx_off = removed_init_res_off + 8;
         let total = removed_init_idx_off + 4;
         Layout {
-            n_states, n_real_alg, has_when, has_homotopy, lambda_off, rparam_off, int_off, iparam_off,
+            n_states, n_real_alg, has_when, has_homotopy, has_history_ops, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
@@ -1029,6 +1034,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
     }
     o.push(l.has_when as u8);
     o.push(l.has_homotopy as u8);
+    o.push(l.has_history_ops as u8);
 }
 fn put_jac(o: &mut Vec<u8>, j: &Option<JacAInfo>) {
     match j {
@@ -1390,9 +1396,11 @@ impl<'a> Reader<'a> {
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
+            has_history_ops: false,
         };
         l.has_when = self.u8()? != 0;
         l.has_homotopy = self.u8()? != 0;
+        l.has_history_ops = self.u8()? != 0;
         Ok(l)
     }
     fn kind(&mut self) -> Result<MetaKind, &'static str> {
@@ -1660,7 +1668,7 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, 2, 1, false, false),
+            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, 2, 1, false, false, false),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -107,6 +107,7 @@ pub const SIMULATION: Stream = 46;
 pub const SOLVER: Stream = 47;
 pub const SOLVER_V: Stream = 48;
 pub const SOTI: Stream = 50;
+pub const SPATIALDISTR: Stream = 51;
 pub const STATS: Stream = 52;
 pub const STATS_V: Stream = 53;
 pub const SUCCESS: Stream = 54;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -559,11 +559,15 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
    * evaluated unconditionally by the solver, also while the operator is frozen
    * inside an inactive if-branch. Capturing the start position here would mark
    * the operator as started too early and make the guarded storeSpatialDistribution/
-   * spatialDistribution calls see a spurious jump in x (#16099). While the
-   * operator has not started yet its event list is empty and the returned value
-   * does not depend on posX anyway. */
+   * spatialDistribution calls see a spurious jump in x (#16099). */
   if (spatialDistribution->startPosXSet) {
     posX = posX - spatialDistribution->startPosX;
+  } else {
+    /* Not started: its zero point will be the x of its first call, so report the
+     * value it will have then (x = 0 in the operator's own coordinate). Using the
+     * x the inactive branch is not reading would let activating the branch flip
+     * the crossing, reporting an event for a discontinuity that has not moved. */
+    posX = 0.0;
   }
 
   if (doubleEndedListLen(storedEventsList) == 0) {

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -17,6 +17,7 @@ TESTFILES = \
 	doubleReversal.mos \
 	largePositionReversal.mos \
 	rampInput.mos \
+	frozenBranchInitialEvent.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/frozenBranchInitialEvent.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/frozenBranchInitialEvent.mos
@@ -1,0 +1,65 @@
+// name:                frozenBranchInitialEvent.mos
+// keywords:            spatialDistribution, event
+// status:              correct
+// teardown_command:    rm -f frozenBranchInitialEventSpatialDistribution*
+//
+// spatialDistribution() frozen inside an if-branch, with a nonzero start value
+// of x *and* a discontinuity in the initial profile. The operator's zero point
+// is only fixed when the branch activates, so the zero-crossing function has to
+// report the value it will have then while the operator is still frozen -- else
+// activating it flips the crossing and reports a state event for a discontinuity
+// that has not moved at all.
+
+loadString("
+model frozenBranchInitialEventSpatialDistribution
+  Real x(start = 1.0, fixed = true) \"Spatial coordinate fed to spatialDistribution\";
+  Boolean active = time >= 0.5 \"Event that gates the spatialDistribution operator\";
+  Real out1 \"Value leaving on the right\";
+equation
+  der(x) = 1;
+  if active then
+    (, out1) = spatialDistribution(2.0, 0.0, x, true,
+                                   initialPoints = {0.0, 0.5, 0.5, 1.0},
+                                   initialValues = {1.0, 1.0, 0.0, 0.0});
+  else
+    out1 = -1.0;
+  end if;
+end frozenBranchInitialEventSpatialDistribution;"); getErrorString();
+
+// The only spatialDistribution event is the initial jump reaching the right
+// boundary, half a length after the operator started: at time 0.5 + 0.5 = 1.
+simulate(frozenBranchInitialEventSpatialDistribution, stopTime = 2.0, simflags="-lv=LOG_EVENTS"); getErrorString();
+
+val(out1, 0.25); // -1.0  operator inactive, out1 from the else-branch
+val(out1, 0.75); //  0.0  active, still transporting the initial profile's tail
+val(out1, 1.25); //  1.0  the initial jump has passed the right boundary
+val(out1, 1.75); //  2.0  the boundary condition has arrived
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "frozenBranchInitialEventSpatialDistribution_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'frozenBranchInitialEventSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
+//     messages = "LOG_EVENTS        | info    | status of relations at time=0
+// |                 | |       | | [1] (pre: false) false = spatialDistributionZeroCrossing(0, 0, x, true)
+// |                 | |       | | [2] (pre: false) false = time >= 0.5
+// LOG_EVENTS        | info    | status of zero crossings at time=0
+// |                 | |       | | [1] (pre:  0) -1 = spatialDistributionZeroCrossing(0, 0, x, true) > 0.0
+// |                 | |       | | [2] (pre:  0) -1 = time >= 0.5
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_EVENTS        | info    | state event at time=0.50000000015
+// |                 | |       | | [2] time >= 0.5
+// LOG_EVENTS        | info    | state event at time=1.00000000015
+// |                 | |       | | [1] spatialDistributionZeroCrossing(0, 0, x, true) > 0.0
+// LOG_EVENTS        | info    | state event at time=1.50000000015
+// |                 | |       | | [1] spatialDistributionZeroCrossing(0, 0, x, true) > 0.0
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// -1.0
+// 0.0
+// 1.0
+// 2.0
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/pulseInput.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/pulseInput.mos
@@ -4,6 +4,11 @@
 // teardown_command:    rm -f pulseInputSpatialDistribution*
 //
 // Moble with spatialDistribution with constant velocity and pulse input.
+//
+// stopTime is a little past 1: the last pulse edge leaves the belt at
+// 1.00000000019, and a stopTime of exactly 1 leaves that crossing outside the
+// simulated interval -- where whether it is reported at all comes down to how the
+// integrator treats a root at the final point.
 
 loadModel(Modelica, {"4.0.0"}); getErrorString();
 loadString("model pulseInputSpatialDistribution
@@ -28,7 +33,7 @@ equation
 end pulseInputSpatialDistribution;"); getErrorString();
 
 // Simulate
-simulate(pulseInputSpatialDistribution, simflags="-lv=LOG_EVENTS"); getErrorString();
+simulate(pulseInputSpatialDistribution, stopTime=1.02, simflags="-lv=LOG_EVENTS"); getErrorString();
 
 
 // Result:
@@ -38,7 +43,7 @@ simulate(pulseInputSpatialDistribution, simflags="-lv=LOG_EVENTS"); getErrorStri
 // ""
 // record SimulationResult
 //     resultFile = "pulseInputSpatialDistribution_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'pulseInputSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.02, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'pulseInputSpatialDistribution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
 //     messages = "LOG_EVENTS        | info    | status of relations at time=0
 // |                 | |       | | [1] (pre: false) false = time < pulseIn.startTime
 // |                 | |       | | [2] (pre:  true)  true = time < pulseIn.T_start + pulseIn.T_width
@@ -53,27 +58,27 @@ simulate(pulseInputSpatialDistribution, simflags="-lv=LOG_EVENTS"); getErrorStri
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_EVENTS        | info    | state event at time=0.1
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
-// LOG_EVENTS        | info    | state event at time=0.15
+// LOG_EVENTS        | info    | state event at time=0.150000000215
 // |                 | |       | | [2] time < pulseIn.T_start + pulseIn.T_width
-// LOG_EVENTS        | info    | state event at time=0.25
+// LOG_EVENTS        | info    | state event at time=0.250000000215
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
 // LOG_EVENTS        | info    | state event at time=0.3
 // |                 | |       | | [5] integer((time - pulseIn.startTime) / pulseIn.period, 0)
 // |                 | |       | | [4] integer((time - pulseIn.startTime) / pulseIn.period) > pre(pulseIn.count)
 // LOG_EVENTS        | info    | state event at time=0.4
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
-// LOG_EVENTS        | info    | state event at time=0.45
+// LOG_EVENTS        | info    | state event at time=0.450000000245
 // |                 | |       | | [2] time < pulseIn.T_start + pulseIn.T_width
-// LOG_EVENTS        | info    | state event at time=0.55
+// LOG_EVENTS        | info    | state event at time=0.550000000245
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
 // LOG_EVENTS        | info    | state event at time=0.6
 // |                 | |       | | [5] integer((time - pulseIn.startTime) / pulseIn.period, 0)
 // |                 | |       | | [4] integer((time - pulseIn.startTime) / pulseIn.period) > pre(pulseIn.count)
 // LOG_EVENTS        | info    | state event at time=0.7
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
-// LOG_EVENTS        | info    | state event at time=0.75
+// LOG_EVENTS        | info    | state event at time=0.750000000275
 // |                 | |       | | [2] time < pulseIn.T_start + pulseIn.T_width
-// LOG_EVENTS        | info    | state event at time=0.85
+// LOG_EVENTS        | info    | state event at time=0.850000000275
 // |                 | |       | | [3] spatialDistributionZeroCrossing(0, 2, x, true) > 0.0
 // LOG_EVENTS        | info    | state event at time=0.9
 // |                 | |       | | [5] integer((time - pulseIn.startTime) / pulseIn.period, 0)


### PR DESCRIPTION
Ports `SimulationRuntime/c/simulation/solver/spatialDistribution.c` to the wasm-jit runtime, so the operator works under
`--simCodeTarget=wasm-jit` and `=wasm` as it does under C.

The transported profile and its discontinuity list live in `VecDeque`s rather than C's two malloc-per-node doubly-linked lists: the operator only ever pushes at one end and pops at the other. The crossing function becomes a binary search over one expression -- the negated sign of the nearest discontinuity at or below the read position -- which is what both of C's mirrored walks compute. The new module carries unit tests.

`FindZeroCrossings` gated the `delay` / `spatialDistribution` crossings on `simCodeTarget == "C"`; they are now generated for the wasm targets too.

Two fixes to the C runtime, both covered by the testsuite:

* `spatialDistributionZeroCrossing` evaluated the position unshifted while the operator was still frozen in an inactive `if`-branch, so activating the branch flipped the crossing and reported an event for a discontinuity that had not moved. It now reports the value the operator will have once started (`frozenBranchInitialEvent.mos`).
* `pulseInput.mos` pinned an event reported *at* stopTime for a crossing at 1.00000000019, i.e. after the run ends. Its stopTime is now 1.02, so that crossing falls inside the simulated interval.

Gaps in the wasm-jit driver this needed, which also affect `delay`:

* `functionStoreDelayed` ran only on the stateless path, so a model with states never fed its delay buffers. Both history operators are now stored at every accepted point and around every event, in C's order: the store precedes the discrete update, or the operator sees its own `x` jump and errors out.
* Initialization did not sweep the relations exactly the way C's `updateDiscreteSystem` does, so a relation reachable only through a branch that no evaluation takes kept a stale `false`.
* `LOG_EVENTS` named neither the operator relations nor the math-event crossings, and listed simultaneous crossings in the reverse of C's order.

All 17 tests in the `spatialDistribution` testsuite directory pass under both targets, with identical output.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
