### PR TITLE
wasm-jit: String output arrays and uriToFilename

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -171,6 +171,7 @@ openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
 openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
 openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
 openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+openmodelica_codegen_wasm_jit_runtime/src/uri.rs
 openmodelica_fmi3_wasm/Cargo.lock
 openmodelica_fmi3_wasm/Cargo.toml
 openmodelica_fmi3_wasm/src/lib.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2011,6 +2011,27 @@ fn deflate(data: &[u8]) -> Option<Vec<u8>> {
     Some(miniz_oxide::deflate::compress_to_vec(data, 6))
 }
 
+/// Add `path` (a file, or a directory copied whole) under `resources/<path>`,
+/// keeping the absolute path so `rt_uri_to_filename` names it again at run time.
+fn add_resource(entries: &mut Vec<(String, Vec<u8>)>, path: &str) {
+    if openmodelica_wasi::fs::is_dir(path) {
+        let Ok(dir) = openmodelica_wasi::fs::read_dir(path) else { return };
+        for e in dir {
+            add_resource(entries, &format!("{}/{}", path.trim_end_matches('/'), e.name));
+        }
+        return;
+    }
+    // A drive letter cannot be a directory name.
+    let drive = path.len() > 2
+        && path.as_bytes()[0].is_ascii_alphabetic()
+        && path.as_bytes()[1] == b':'
+        && matches!(path.as_bytes()[2], b'/' | b'\\');
+    let name = if drive { path.replace(':', "").replace('\\', "/") } else { path.trim_start_matches('/').to_string() };
+    if let Ok(bytes) = openmodelica_wasi::fs::read(path) {
+        entries.push((format!("resources/{name}"), bytes));
+    }
+}
+
 /// A ZIP assembled in-process rather than by an external `zip`, deflated unless
 /// that would grow the entry.
 fn zip_archive(entries: &[(String, Vec<u8>)]) -> Vec<u8> {
@@ -2318,6 +2339,11 @@ fn emit_fmu(
             entries.push((format!("resources/{model_id}.wasm"), component));
         } else {
             entries.push((format!("binaries/wasm32-wasip2/{model_id}.wasm"), component));
+        }
+        // What `Modelica.Utilities.Files.loadResource` named; C's `SimCodeMain`
+        // copies the same set.
+        for path in lst(&sim_code.modelInfo.resourcePaths) {
+            add_resource(&mut entries, path);
         }
         // Ship the -d=visxml scene as a resource (the <Visualization> annotation
         // points at it), plus the CAD files it references so the scene is

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -284,6 +284,10 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_reinit_note(state_off, value)` records an executed `reinit` for the driver's
 /// `LOG_EVENTS` block; C prints that line from the model itself, but the block's
 /// indentation belongs to whichever driver owns the run.
+///
+/// `rt_uri_to_filename(uri, fmu) -> filename` is C's `OpenModelica_uriToFilename_impl`,
+/// which needs a filesystem and the loaded program's class directories. `fmu` picks
+/// the FMU resources directory (`OpenModelica_fmuLoadResource`). Borrows `uri`.
 pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     (
         "rt_assert",
@@ -298,6 +302,7 @@ pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_print", &[WTy::I32], &[]),
     ("rt_row_asserts", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_reinit_note", &[WTy::I32, WTy::F64], &[]),
+    ("rt_uri_to_filename", &[WTy::I32, WTy::I32], &[WTy::I32]),
 ];
 
 /// Absolute wasm function index of an `ENV_EXTRA` import (after the `BUILTINS`
@@ -7784,6 +7789,18 @@ fn compile_math_builtin(
             let w = compile_exp(ctx, argv[0])?;
             Ok(exp_sigty(argv[0])
                 .unwrap_or(if w == WTy::F64 { SigTy::Real } else { SigTy::Int }))
+        }
+        // The frontend folds a literal URI, so the argument here is computed.
+        "OpenModelica_uriToFilename" | "OpenModelica_fmuLoadResource" => {
+            need_args(&argv, 1, name)?;
+            compile_exp(ctx, argv[0])?;
+            let t = ctx.alloc_temp(WTy::I32);
+            ctx.emit(we::Instruction::LocalSet(t));
+            ctx.emit(we::Instruction::LocalGet(t));
+            ctx.emit(we::Instruction::I32Const(i32::from(name == "OpenModelica_fmuLoadResource")));
+            ctx.emit(we::Instruction::Call(env_extra_index("rt_uri_to_filename")?));
+            release_temp(ctx, t)?;
+            Ok(SigTy::Str)
         }
         // der(cref): an explicit derivative left in an equation. Read the
         // derivative variable's slot ($DER.<cref>), as the C target does.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -145,7 +145,6 @@ pub(super) fn load_and_execute(
     openmodelica_wasm_jit::host::add_host_builtins(&mut store, &mut imports)?;
     let rt_inst = wt(wasmer::Instance::new(&mut store, &cache.runtime_module, &imports))?;
     imports.register_namespace("rt", rt_inst.exports.iter().map(|(k, v)| (k.clone(), v.clone())));
-    let instance = wt(wasmer::Instance::new(&mut store, &module, &imports))?;
 
     // Runtime entry points needed to marshal heap values (strings, arrays) in
     // and out of the shared heap.
@@ -154,6 +153,15 @@ pub(super) fn load_and_execute(
         .get_memory("memory")
         .map_err(|e| "CodegenWasmJit: runtime has no `memory` export")?
         .clone();
+    // The host's, not the runtime's, so it goes after the namespace registration
+    // that would shadow it.
+    {
+        let str_new = wt(rt_inst.exports.get_typed_function(&store, "rt_str_new"))?;
+        let str_data = wt(rt_inst.exports.get_typed_function(&store, "rt_str_data"))?;
+        openmodelica_wasm_jit::host::define_uri_import(&mut store, &mut imports, &memory, &str_new, &str_data);
+    }
+    let instance = wt(wasmer::Instance::new(&mut store, &module, &imports))?;
+
     let rt = RtFns {
         mem: memory,
         str_new: wt(rt_inst.exports.get_typed_function(&store, "rt_str_new"))?,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -126,6 +126,7 @@ fn define_external_imports(
     let ext_rt = dl::ExtRt {
         str_new: wt(rt_inst.get_typed_func(&mut *store, "rt_str_new"))?,
         str_data: wt(rt_inst.get_typed_func(&mut *store, "rt_str_data"))?,
+        release: wt(rt_inst.get_typed_func(&mut *store, "rt_release"))?,
         alloc: wt(rt_inst.get_typed_func(&mut *store, "rt_alloc"))?,
         free: wt(rt_inst.get_typed_func(&mut *store, "rt_free"))?,
         record_new: wt(rt_inst.get_typed_func(&mut *store, "rt_record_new"))?,
@@ -265,6 +266,12 @@ pub(super) fn load_and_execute(
         .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;
     // `print(s)` in an evaluated function, onto the same stdout a simulation uses.
     define_print_import(&mut linker, memory)?;
+    openmodelica_wasm_jit::host::define_uri_import(
+        &mut linker,
+        memory,
+        wt(rt_inst.get_typed_func(&mut store, "rt_str_new"))?,
+        wt(rt_inst.get_typed_func(&mut store, "rt_str_data"))?,
+    )?;
     define_external_imports(&mut store, &mut linker, rt_inst, memory, &sig).inspect_err(|e| {
         crate::CodegenWasmJit::record_error(format!(
             "CodegenWasmJit: cannot bind the external \"C\" functions of `{file_name}`: {e}"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -114,6 +114,13 @@ mod reinit_notes {
 #[cfg(not(feature = "host_log"))]
 pub use reinit_notes::take_reinit_notes;
 
+// `rt_uri_to_filename`: same rule as `rt_reinit_note` — a host binds its own
+// resolver (which has the class directories); a host-free module resolves it here.
+#[cfg(not(feature = "host_log"))]
+mod uri;
+#[cfg(not(feature = "host_log"))]
+pub use uri::set_resources_dir;
+
 /// With a host present the notes live host-side (`rt_host_take_reinits`).
 #[cfg(feature = "host_log")]
 pub fn take_reinit_notes() -> alloc::vec::Vec<(u32, f64)> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/uri.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/uri.rs
@@ -1,0 +1,144 @@
+//! `rt_uri_to_filename` for the runtimes with no host to ask: C's
+//! `OpenModelica_uriToFilename_impl` (`SimulationRuntime/c/util/utility.c`).
+//!
+//! The wasip1 standalone command has a filesystem; the FMI adapter has none and
+//! needs none, since a literal URI is already folded to a path by the time it
+//! exports. The `modelica://Pkg/rest` class lookup needs the table
+//! `OpenModelica_updateUriMapping` installs, which only a host has.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+
+/// The importer's resources directory, C's `data->modelData->resourcesDir`.
+struct ResourcesDir(core::cell::UnsafeCell<Option<String>>);
+unsafe impl Sync for ResourcesDir {}
+static RESOURCES_DIR: ResourcesDir = ResourcesDir(core::cell::UnsafeCell::new(None));
+
+/// Set the resources directory `OpenModelica_fmuLoadResource` resolves against.
+/// Called once per instantiate by the FMI adapter; single-threaded by the ABI.
+pub fn set_resources_dir(dir: &str) {
+    *unsafe { &mut *RESOURCES_DIR.0.get() } = (!dir.is_empty()).then(|| dir.to_string());
+}
+
+fn resources_dir() -> Option<&'static str> {
+    unsafe { &*RESOURCES_DIR.0.get() }.as_deref()
+}
+
+/// The `uri` String handle resolved to a filename, as a fresh String handle.
+/// `fmu` resolves relative to the resources directory (`OpenModelica_fmuLoadResource`).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_uri_to_filename(uri: u32, fmu: i32) -> u32 {
+    let bytes = unsafe { crate::str_bytes(uri) };
+    let uri = core::str::from_utf8(bytes).unwrap_or("");
+    match resolve(uri, fmu != 0) {
+        Ok(path) => crate::new_str_from(&path),
+        Err(msg) => {
+            // C's `omc_assert` + `MMC_THROW`: report and abort the run.
+            openmodelica_sim_meta::driver::note_runtime_error(&msg);
+            crate::trap()
+        }
+    }
+}
+
+/// C's `hasDriveLetter`.
+fn has_drive_letter(p: &str) -> bool {
+    let b = p.as_bytes();
+    b.len() > 2 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'/' || b[2] == b'\\')
+}
+
+fn starts_ci(s: &str, prefix: &str) -> bool {
+    s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix)
+}
+
+fn resolve(uri: &str, fmu: bool) -> Result<String, String> {
+    if uri.is_empty() {
+        return Err("Malformed URI (got an empty string)".to_string());
+    }
+    let resources = if fmu { resources_dir() } else { None };
+    if starts_ci(uri, "modelica://") {
+        return Err(format!(
+            "Failed to lookup URI (this module carries no class directories) {uri}"
+        ));
+    }
+    if starts_ci(uri, "file://") {
+        return Ok(regular_paths(&uri[7..], uri, resources));
+    }
+    if uri.contains("://") {
+        return Err(format!("Unknown URI schema: {uri}"));
+    }
+    Ok(regular_paths(uri, uri, resources))
+}
+
+/// C's `uriToFilenameRegularPaths`, minus the `PATH_MAX` bookkeeping (no fixed
+/// buffer here): try the resources directory first, then the path itself.
+fn regular_paths(path: &str, orig: &str, resources: Option<&str>) -> String {
+    let exists = fs::exists(path);
+    if let Some(res) = resources {
+        // `res` is `/` when the resources directory is the whole filesystem, so
+        // the separator is not doubled onto an absolute path.
+        let res = res.trim_end_matches('/');
+        let rooted = if has_drive_letter(path) {
+            format!("{res}/{}", path.replace(':', "").replace('\\', "/"))
+        } else {
+            format!("{res}/{}", path.trim_start_matches('/'))
+        };
+        if !exists || fs::exists(&rooted) {
+            return regular_paths(&rooted, orig, None);
+        }
+    }
+    if exists {
+        let mut real = fs::realpath(path);
+        // A directory keeps a trailing '/' when the original URI had one.
+        if orig.ends_with('/') && !real.ends_with('/') && fs::is_dir(path) {
+            real.push('/');
+        }
+        return real;
+    }
+    if path.starts_with('/') || has_drive_letter(path) {
+        return path.to_string();
+    }
+    match fs::cwd() {
+        Some(cwd) => format!("{}/{path}", cwd.trim_end_matches('/')),
+        None => path.to_string(),
+    }
+}
+
+/// The filesystem the standalone command has and the FMI adapter does not.
+#[cfg(target_os = "wasi")]
+mod fs {
+    use alloc::string::{String, ToString};
+
+    pub fn exists(p: &str) -> bool {
+        std::fs::metadata(p).is_ok()
+    }
+    pub fn is_dir(p: &str) -> bool {
+        std::fs::metadata(p).map(|m| m.is_dir()).unwrap_or(false)
+    }
+    pub fn realpath(p: &str) -> String {
+        match std::fs::canonicalize(p) {
+            Ok(c) => c.to_string_lossy().into_owned(),
+            Err(_) => p.to_string(),
+        }
+    }
+    pub fn cwd() -> Option<String> {
+        std::env::current_dir().ok().map(|d| d.to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(not(target_os = "wasi"))]
+mod fs {
+    use alloc::string::{String, ToString};
+
+    pub fn exists(_p: &str) -> bool {
+        false
+    }
+    pub fn is_dir(_p: &str) -> bool {
+        false
+    }
+    pub fn realpath(p: &str) -> String {
+        p.to_string()
+    }
+    pub fn cwd() -> Option<String> {
+        None
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -1023,6 +1023,9 @@ impl GuestModelExchangeInstance for Instance {
         logging_on: bool,
     ) -> Option<ModelExchangeInstance> {
         init_logging(instance_name, logging_on);
+        // What `OpenModelica_fmuLoadResource` resolves against: the loader preopens
+        // the FMU's `resources/` as this component's root, not the host path.
+        openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
         let st = new_state()?;
         Some(ModelExchangeInstance::new(Instance { st: RefCell::new(st) }))
     }
@@ -1129,6 +1132,9 @@ impl GuestCoSimulationInstance for Instance {
         _required_intermediate_variables: Vec<u32>,
     ) -> Option<CoSimulationInstance> {
         init_logging(instance_name, logging_on);
+        // What `OpenModelica_fmuLoadResource` resolves against: the loader preopens
+        // the FMU's `resources/` as this component's root, not the host path.
+        openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
         let mut st = new_state()?;
         st.event_mode = event_mode_used;
         Some(CoSimulationInstance::new(Instance { st: RefCell::new(st) }))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -516,6 +516,7 @@ mod tests {
         let rt = ExtRt {
             str_new: rt_inst.get_typed_func(&mut store, "rt_str_new").unwrap(),
             str_data: rt_inst.get_typed_func(&mut store, "rt_str_data").unwrap(),
+            release: rt_inst.get_typed_func(&mut store, "rt_release").unwrap(),
             alloc: alloc.clone(),
             free: rt_inst.get_typed_func(&mut store, "rt_free").unwrap(),
             record_new: rt_inst.get_typed_func(&mut store, "rt_record_new").unwrap(),
@@ -691,6 +692,7 @@ pub fn modelica_utilities_imports(
 pub struct ExtRt {
     pub str_new: wasmtime::TypedFunc<u32, u32>,
     pub str_data: wasmtime::TypedFunc<u32, u32>,
+    pub release: wasmtime::TypedFunc<u32, ()>,
     pub alloc: wasmtime::TypedFunc<u32, u32>,
     pub free: wasmtime::TypedFunc<u32, ()>,
     pub record_new: wasmtime::TypedFunc<(u32, u32), u32>,
@@ -761,6 +763,8 @@ fn call_external_in_wasm(
     // Column-major copies a FORTRAN 77 callee gets instead of the array itself:
     // (scratch, element area, dims, element size, is output).
     let mut f77_arrays: Vec<(u32, u32, Vec<usize>, usize, bool)> = Vec::new();
+    // Output `String[…]`: (`char**` scratch, element area, element count).
+    let mut str_out_arrays: Vec<(u32, u32, usize)> = Vec::new();
 
     let alloc = |caller: &mut wasmtime::Caller<'_, WasiCtx>, n: u32| -> Result<u32> {
         rt.alloc.call(&mut *caller, n).map_err(|e| format!("rt_alloc: {e}"))
@@ -879,6 +883,29 @@ fn call_external_in_wasm(
                 let (dims, data_off) = crate::host::array_abi::dims_and_data(memory.data(&*caller), off)
                     .ok_or_else(|| "external \"C\": malformed array argument".to_string())?;
                 let base = (off + data_off) as u32;
+                // Handles, not the `const char**` C declares: rebuilt as a vector of
+                // NUL-terminated copies (C's `data_of_string_c89_array`).
+                if let SigTy::Str = &**elem {
+                    let n = dims.iter().product::<usize>();
+                    let vec_cell = alloc(caller, (n * 4).max(1) as u32)?;
+                    temps.push(vec_cell);
+                    for k in 0..n {
+                        let h = read_u32(memory, caller, base + (k * 4) as u32);
+                        let len = if h == 0 { 0 } else { read_u32(memory, caller, h + 4) as usize };
+                        let cell = alloc(caller, (len + 1) as u32)?;
+                        temps.push(cell);
+                        let mem = memory.data_mut(&mut *caller);
+                        mem.copy_within(h as usize + 8..h as usize + 8 + len, cell as usize);
+                        mem[cell as usize + len] = 0;
+                        let slot = vec_cell as usize + k * 4;
+                        mem[slot..slot + 4].copy_from_slice(&cell.to_le_bytes());
+                    }
+                    call_args.push(Val::I32(vec_cell as i32));
+                    if *is_out {
+                        str_out_arrays.push((vec_cell, base, n));
+                    }
+                    continue;
+                }
                 if fortran && dims.len() > 1 {
                     // C's `convert_alloc_*_to_f77`.
                     let esz = crate::host::array_abi::elem_size(elem);
@@ -918,6 +945,28 @@ fn call_external_in_wasm(
         let mut buf = vec![0u8; n];
         crate::host::array_abi::reorder(&mem[*cell as usize..*cell as usize + n], &mut buf, dims, *esz, false);
         mem[*base as usize..*base as usize + n].copy_from_slice(&buf);
+    }
+
+    // C's `unpack_string_array`; an element the callee did not write still points
+    // at our own input copy.
+    for (vec_cell, base, n) in &str_out_arrays {
+        for k in 0..*n {
+            let ptr = read_u32(memory, caller, vec_cell + (k * 4) as u32) as usize;
+            let len = str_len(memory, caller, ptr)?;
+            let handle = rt.str_new.call(&mut *caller, len as u32).map_err(|e| format!("{e}"))?;
+            let dst = rt.str_data.call(&mut *caller, handle).map_err(|e| format!("{e}"))? as usize;
+            let slot = *base as usize + k * 4;
+            let old = {
+                let mem = memory.data_mut(&mut *caller);
+                mem.copy_within(ptr..ptr + len, dst);
+                let old = u32::from_le_bytes(mem[slot..slot + 4].try_into().unwrap());
+                mem[slot..slot + 4].copy_from_slice(&handle.to_le_bytes());
+                old
+            };
+            if old != 0 {
+                rt.release.call(&mut *caller, old).map_err(|e| format!("{e}"))?;
+            }
+        }
     }
 
     let mut result = Vec::with_capacity(rets.len());
@@ -983,12 +1032,7 @@ fn ext_result(
         SigTy::Int | SigTy::Bool | SigTy::Ptr => Val::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
         SigTy::Str => {
             let ptr = u32::from_le_bytes(raw[..4].try_into().unwrap()) as usize;
-            let data = memory.data(&*caller);
-            let len = if ptr == 0 {
-                0
-            } else {
-                data[ptr..].iter().position(|&b| b == 0).ok_or_else(|| "external \"C\": unterminated `char*` result".to_string())?
-            };
+            let len = str_len(memory, caller, ptr)?;
             let handle = rt.str_new.call(&mut *caller, len as u32).map_err(|e| format!("{e}"))?;
             let dst = rt.str_data.call(&mut *caller, handle).map_err(|e| format!("{e}"))? as usize;
             memory.data_mut(&mut *caller).copy_within(ptr..ptr + len, dst);
@@ -1262,6 +1306,17 @@ fn wasm_string(
         memory.data_mut(&mut *caller).copy_within(ptr as usize..ptr as usize + len, dst);
     }
     Ok(handle)
+}
+
+/// `strlen` of the NUL-terminated `char*` at `ptr` in the shared memory.
+fn str_len(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: usize) -> Result<usize> {
+    if ptr == 0 {
+        return Ok(0);
+    }
+    memory.data(&*caller)[ptr..]
+        .iter()
+        .position(|&b| b == 0)
+        .ok_or_else(|| "external \"C\": unterminated `char*`".to_string())
 }
 
 fn read_u32(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u32 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -115,6 +115,32 @@ fn write_warnings(recs: &[[i32; 9]], dst: &mut [u8]) -> u32 {
 /// Wire size of one record, shared with the in-wasm reader.
 const REC_BYTES: usize = 9 * 4;
 
+/// `rt_uri_to_filename` on a host: `metamodelica`'s port of
+/// `OpenModelica_uriToFilename_impl`, resolving `modelica://` against the class
+/// directories `System.updateUriMapping` installed. A host run has no FMU
+/// resources directory, so the `fmu` selector only matters inside an FMU.
+///
+/// Like the external "C" path, the run reports itself through its log alone, so
+/// the message the `omc_assert` hook buffered is rolled back and returned.
+#[cfg(feature = "jit")]
+fn uri_to_filename(uri: &str) -> std::result::Result<String, String> {
+    const CP: arcstr::ArcStr = arcstr::literal!("wasm-jit uriToFilename");
+    openmodelica_error::ErrorExt::setCheckpoint(CP);
+    match metamodelica::uriToFilename(arcstr::ArcStr::from(uri)) {
+        Ok(path) => {
+            openmodelica_error::ErrorExt::delCheckpoint(CP);
+            Ok(path.to_string())
+        }
+        Err(_) => {
+            let msg = openmodelica_error::ErrorExt::take_last_runtime_error();
+            openmodelica_error::ErrorExt::rollBack(CP);
+            let msg = msg.unwrap_or_else(|| format!("uriToFilename: cannot resolve {uri}"));
+            crate::sim_driver::note_runtime_error(&msg);
+            Err(msg)
+        }
+    }
+}
+
 /// A [`SimEngine`] over nothing but a read window into the shared linear memory:
 /// formatting a `LOG_ASSERT` block reads the time and the String handles and never
 /// calls back into the model. The reader is a closure so each engine can serve it
@@ -442,6 +468,45 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     Ok(())
 }
 
+/// `rt.rt_uri_to_filename`: the model's URI resolved into a fresh in-wasm String.
+/// Per instance, not in [`add_host_builtins`]: it re-enters the string constructors.
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub fn define_uri_import<T: 'static>(
+    linker: &mut wasmtime::Linker<T>,
+    memory: wasmtime::Memory,
+    str_new: wasmtime::TypedFunc<u32, u32>,
+    str_data: wasmtime::TypedFunc<u32, u32>,
+) -> Result<()> {
+    linker
+        .func_wrap(
+            "rt",
+            "rt_uri_to_filename",
+            move |mut caller: wasmtime::Caller<'_, T>, handle: u32, _fmu: i32| -> std::result::Result<u32, wasmtime::Error> {
+                let uri = read_wasm_string(memory, &caller, handle);
+                let path = uri_to_filename(&uri).map_err(wasmtime::Error::msg)?;
+                let out = str_new.call(&mut caller, path.len() as u32)?;
+                let at = str_data.call(&mut caller, out)? as usize;
+                memory.data_mut(&mut caller)[at..at + path.len()].copy_from_slice(path.as_bytes());
+                Ok(out)
+            },
+        )
+        .map(|_| ())
+        .map_err(|_| "CodegenWasmJit: wasm engine error")
+}
+
+/// The bytes of the String at `handle` (`[refcount:u32][len:u32][utf8…]`).
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+fn read_wasm_string<T>(memory: wasmtime::Memory, caller: &wasmtime::Caller<'_, T>, handle: u32) -> String {
+    if handle == 0 {
+        return String::new();
+    }
+    let data = memory.data(caller);
+    let h = handle as usize;
+    let Some(lenb) = data.get(h + 4..h + 8) else { return String::new() };
+    let len = u32::from_le_bytes(lenb.try_into().unwrap()) as usize;
+    data.get(h + 8..h + 8 + len).map(|b| String::from_utf8_lossy(b).into_owned()).unwrap_or_default()
+}
+
 /// The runtime's memory, handed to the wasmer host builtins by [`HostMem::set`]
 /// once the instance exists; the imports have to be defined before it.
 #[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
@@ -541,6 +606,52 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         ),
     );
     Ok(HostMem(mem_env))
+}
+
+/// The wasmer counterpart of [`define_uri_import`] (wasmtime): see there.
+#[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
+pub fn define_uri_import(
+    store: &mut wasmer::Store,
+    imports: &mut wasmer::Imports,
+    memory: &wasmer::Memory,
+    str_new: &wasmer::TypedFunction<u32, u32>,
+    str_data: &wasmer::TypedFunction<u32, u32>,
+) {
+    use wasmer::{Function, FunctionEnv, FunctionEnvMut, RuntimeError};
+    struct Env {
+        memory: wasmer::Memory,
+        str_new: wasmer::TypedFunction<u32, u32>,
+        str_data: wasmer::TypedFunction<u32, u32>,
+    }
+    let env = FunctionEnv::new(
+        &mut *store,
+        Env { memory: memory.clone(), str_new: str_new.clone(), str_data: str_data.clone() },
+    );
+    let f = Function::new_typed_with_env(
+        &mut *store,
+        &env,
+        |mut env: FunctionEnvMut<Env>, handle: u32, _fmu: i32| -> std::result::Result<u32, RuntimeError> {
+            let (data, mut store) = env.data_and_store_mut();
+            let (memory, str_new, str_data) = (data.memory.clone(), data.str_new.clone(), data.str_data.clone());
+            // String layout: [refcount:u32][len:u32][utf8].
+            let view = memory.view(&store);
+            let mut lenb = [0u8; 4];
+            let mut uri = Vec::new();
+            if handle != 0 && view.read(handle as u64 + 4, &mut lenb).is_ok() {
+                uri = vec![0u8; u32::from_le_bytes(lenb) as usize];
+                view.read(handle as u64 + 8, &mut uri).map_err(|e| RuntimeError::new(e.to_string()))?;
+            }
+            let path = uri_to_filename(&String::from_utf8_lossy(&uri)).map_err(RuntimeError::new)?;
+            let out = str_new.call(&mut store, path.len() as u32)?;
+            let at = str_data.call(&mut store, out)?;
+            memory
+                .view(&store)
+                .write(at as u64, path.as_bytes())
+                .map_err(|e| RuntimeError::new(e.to_string()))?;
+            Ok(out)
+        },
+    );
+    imports.define("rt", "rt_uri_to_filename", f);
 }
 
 /// Redirect the process's stdout/stderr into the run's log for one capture phase

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -303,6 +303,7 @@ struct ExtEnv {
     free: wasmer::TypedFunction<u32, ()>,
     rt_str_new: wasmer::TypedFunction<u32, u32>,
     rt_str_data: wasmer::TypedFunction<u32, u32>,
+    rt_release: wasmer::TypedFunction<u32, ()>,
     func: wasmer::Function,
     sig: crate::sig::ExtCallSig,
 }
@@ -325,6 +326,7 @@ fn define_external_imports(
     sim_mem: &wasmer::Memory,
     rt_str_new: &wasmer::TypedFunction<u32, u32>,
     rt_str_data: &wasmer::TypedFunction<u32, u32>,
+    rt_release: &wasmer::TypedFunction<u32, ()>,
 ) -> Result<()> {
     use wasmer::{AsStoreRef, Function, FunctionEnv, FunctionEnvMut, FunctionType, RuntimeError, Value};
 
@@ -469,6 +471,7 @@ fn define_external_imports(
             free: free.clone(),
             rt_str_new: rt_str_new.clone(),
             rt_str_data: rt_str_data.clone(),
+            rt_release: rt_release.clone(),
             func,
             sig: sig.clone(),
         });
@@ -523,6 +526,7 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     let free = data.free.clone();
     let rt_str_new = data.rt_str_new.clone();
     let rt_str_data = data.rt_str_data.clone();
+    let rt_release = data.rt_release.clone();
     let func = data.func.clone();
     let sig = data.sig.clone();
 
@@ -539,6 +543,8 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
     // offset, byte length, header data offset, column-major dims + element size
     // for a Fortran callee).
     let mut out_arrays: Vec<(u32, u32, usize, u32, Option<(Vec<usize>, usize)>)> = Vec::new();
+    // Output `String[…]`: (`char**` side scratch, sim element area, element count).
+    let mut str_out_arrays: Vec<(u32, u32, usize)> = Vec::new();
     let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
     let mut in_i = 0usize;
     for (ty, is_out) in &sig.args {
@@ -589,6 +595,33 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
                 let total = read_u32_mem(&sim_mem, &store, off + 12)? as usize;
                 let elem_size = crate::host::array_abi::elem_size(elem);
                 let data_off = (16 + ndims * 4 + 7) & !7;
+                // Handles, not the `const char**` C declares: rebuilt in side memory
+                // as NUL-terminated copies (C's `data_of_string_c89_array`).
+                if let SigTy::Str = &**elem {
+                    let base = off + data_off;
+                    let vec_cell = malloc.call(&mut store, (total * 4).max(1) as u32)
+                        .map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                    temps.push(vec_cell);
+                    for k in 0..total {
+                        let h = read_u32_mem(&sim_mem, &store, base + (k * 4) as u32)?;
+                        let len = if h == 0 { 0 } else { read_u32_mem(&sim_mem, &store, h + 4)? as usize };
+                        let mut buf = vec![0u8; len + 1]; // + NUL
+                        sim_mem.view(&store).read((h + 8) as u64, &mut buf[..len])
+                            .map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                        let cell = malloc.call(&mut store, (len + 1) as u32)
+                            .map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                        side_mem.view(&store).write(cell as u64, &buf)
+                            .map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                        temps.push(cell);
+                        side_mem.view(&store).write((vec_cell + (k * 4) as u32) as u64, &cell.to_le_bytes())
+                            .map_err(|_| "CodegenWasmJit: wasm engine error")?;
+                    }
+                    call_args.push(Value::I32(vec_cell as i32));
+                    if *is_out {
+                        str_out_arrays.push((vec_cell, base, total));
+                    }
+                    continue;
+                }
                 let bytes = total * elem_size;
                 let mut buf = vec![0u8; bytes];
                 sim_mem.view(&store).read((off + data_off) as u64, &mut buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
@@ -632,6 +665,24 @@ fn call_external_side(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>, args: &[wasmer:
             buf = row;
         }
         sim_mem.view(&store).write((*woff + *data_off) as u64, &buf).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+    }
+
+    // C's `unpack_string_array`; an element the callee did not write still points
+    // at our own input copy.
+    for (vec_cell, base, n) in &str_out_arrays {
+        for k in 0..*n {
+            let ptr = read_u32_mem(&side_mem, &store, vec_cell + (k * 4) as u32)?;
+            let bytes = read_side_cstr(&side_mem, &store, ptr)?;
+            let handle = rt_str_new.call(&mut store, bytes.len() as u32).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            let doff = rt_str_data.call(&mut store, handle).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            sim_mem.view(&store).write(doff as u64, &bytes).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            let slot = base + (k * 4) as u32;
+            let old = read_u32_mem(&sim_mem, &store, slot)?;
+            sim_mem.view(&store).write(slot as u64, &handle.to_le_bytes()).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            if old != 0 {
+                rt_release.call(&mut store, old).map_err(|_| "CodegenWasmJit: wasm engine error")?;
+            }
+        }
     }
 
     // Build an in-wasm String (in the sim memory) from a NUL-terminated `char*` at
@@ -852,9 +903,15 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     if !model.ext_imports.is_empty() {
         let rt_str_new: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_new"))?;
         let rt_str_data: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_data"))?;
-        define_external_imports(&mut store, &mut imports, model, &memory, &rt_str_new, &rt_str_data)?;
+        let rt_release: wasmer::TypedFunction<u32, ()> = wts(rt_inst.exports.get_typed_function(&store, "rt_release"))?;
+        define_external_imports(&mut store, &mut imports, model, &memory, &rt_str_new, &rt_str_data, &rt_release)?;
     }
     define_print_import(&mut store, &mut imports, &memory);
+    {
+        let str_new: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_new"))?;
+        let str_data: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_data"))?;
+        crate::host::define_uri_import(&mut store, &mut imports, &memory, &str_new, &str_data);
+    }
 
     let instance = wts(wasmer::Instance::new(&mut store, &model_module, &imports))?;
     let inst_time = t_inst.elapsed();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -393,6 +393,7 @@ fn define_external_imports(
 ) -> Result<()> {
     let rt_str_new = rt.str_new.clone();
     let rt_str_data = rt.str_data.clone();
+    let rt_release = rt.release.clone();
     registry_reset();
     sim_driver::clear_runtime_error();
     openmodelica_util::dynload::install_modelica_message_interception(
@@ -424,11 +425,14 @@ fn define_external_imports(
         let sig = sig.clone();
         let rt_str_new = rt_str_new.clone();
         let rt_str_data = rt_str_data.clone();
+        let rt_release = rt_release.clone();
         let nls = nls.clone();
         wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
             // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-            unsafe { call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &nls, args, rets) }
-                .map_err(|e| wasmtime::Error::msg(format!("{e}")))
+            unsafe {
+                call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &rt_release, &nls, args, rets)
+            }
+            .map_err(|e| wasmtime::Error::msg(format!("{e}")))
         }))?;
     }
     Ok(())
@@ -503,7 +507,8 @@ fn zero_results(
 /// passed to C. The wasm results are the C return value (if any) then each output
 /// cell's written value, in order — scalars directly, external-object pointers via
 /// the registry, and `char*` outputs copied into a fresh in-wasm String
-/// (`rt_str_new`+`rt_str_data`). The whole call is bracketed by
+/// (`rt_str_new`+`rt_str_data`). A `String[…]` output array is written back
+/// element by element (C's `unpack_string_array`). The whole call is bracketed by
 /// `sim_external_begin/end` so any `ModelicaAllocateString` uses our arena.
 ///
 /// A `FORTRAN 77` external takes every argument by reference and its arrays
@@ -515,6 +520,7 @@ unsafe fn call_external(
     memory: wasmtime::Memory,
     rt_str_new: &wasmtime::TypedFunc<u32, u32>,
     rt_str_data: &wasmtime::TypedFunc<u32, u32>,
+    rt_release: &wasmtime::TypedFunc<u32, ()>,
     nls: &NlsHooks,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
@@ -547,6 +553,8 @@ unsafe fn call_external(
     let mut cstrings: Vec<std::ffi::CString> = Vec::new();
     // `const char**` argument vectors, kept alive alongside the strings they point at.
     let mut str_arrays: Vec<Vec<*const std::os::raw::c_char>> = Vec::new();
+    // Output `String[…]`: (index into `str_arrays`, wasm element-area offset).
+    let mut str_out_arrays: Vec<(usize, usize)> = Vec::new();
     let mut types: Vec<Type> = Vec::with_capacity(sig.args.len());
     // One 8-byte native cell per `_Out_` pointer arg (fits int/double/pointer),
     // in output order; the C call writes through the pointer we pass.
@@ -625,22 +633,29 @@ unsafe fn call_external(
                     let base = off + data_off;
                     // Only scalar elements are already a native array. A `String[:]`
                     // is in-wasm handles, not the `const char**` C declares, so it
-                    // is rebuilt; anything else has no C form at all.
+                    // is rebuilt (C's `data_of_string_c89_array`); anything else has
+                    // no C form at all.
                     if let SigTy::Str = &**elem {
-                        if *is_out {
-                            return Err("CodegenWasmJit: external \"C\" : a String output array is not marshalled");
-                        }
                         let n = dims.iter().product::<usize>();
                         let mut ptrs: Vec<*const std::os::raw::c_char> = Vec::with_capacity(n);
                         for k in 0..n {
                             let h = u32::from_le_bytes(mem[base + k * 4..base + k * 4 + 4].try_into().unwrap()) as usize;
-                            let len = u32::from_le_bytes(mem[h + 4..h + 8].try_into().unwrap()) as usize;
-                            let cs = std::ffi::CString::new(&mem[h + 8..h + 8 + len])
+                            // Never filled (a fresh output array): C sees "".
+                            let bytes: &[u8] = if h == 0 {
+                                &[]
+                            } else {
+                                let len = u32::from_le_bytes(mem[h + 4..h + 8].try_into().unwrap()) as usize;
+                                &mem[h + 8..h + 8 + len]
+                            };
+                            let cs = std::ffi::CString::new(bytes)
                                 .map_err(|_| "external \"C\" : string argument has an interior NUL")?;
                             ptrs.push(cs.as_ptr());
                             cstrings.push(cs);
                         }
                         slots.push(Slot::P(ptrs.as_mut_ptr() as *mut c_void));
+                        if *is_out {
+                            str_out_arrays.push((str_arrays.len(), base));
+                        }
                         str_arrays.push(ptrs);
                         types.push(Type::pointer());
                         continue;
@@ -694,7 +709,6 @@ unsafe fn call_external(
     let ok = openmodelica_error::ErrorExt::catch_runtime_error(|| unsafe {
         ffi_call(cif_ptr, Some(target), rvalue_ptr, avalue_ptr);
     });
-    drop(cstrings); // char* input copies stay alive across the call
     if ok.is_err() {
         openmodelica_modelica_utilities::sim_external_end();
         // A `ModelicaError` recorded its message in the Error buffer and unwound
@@ -723,6 +737,29 @@ unsafe fn call_external(
             }
         }
     }
+
+    // C's `unpack_string_array`. An element the callee did not write still points
+    // at our own input copy, so `cstrings` outlives this.
+    for (k, base) in &str_out_arrays {
+        for (i, cptr) in str_arrays[*k].iter().enumerate() {
+            let bytes: &[u8] =
+                if cptr.is_null() { &[] } else { unsafe { std::ffi::CStr::from_ptr(*cptr) }.to_bytes() };
+            let soff = wt(rt_str_new.call(&mut *caller, bytes.len() as u32))?;
+            let doff = wt(rt_str_data.call(&mut *caller, soff))? as usize;
+            let slot = base + i * 4;
+            let old = {
+                let mem = memory.data_mut(&mut *caller);
+                mem[doff..doff + bytes.len()].copy_from_slice(bytes);
+                let old = u32::from_le_bytes(mem[slot..slot + 4].try_into().unwrap());
+                mem[slot..slot + 4].copy_from_slice(&soff.to_le_bytes());
+                old
+            };
+            if old != 0 {
+                wt(rt_release.call(&mut *caller, old))?;
+            }
+        }
+    }
+    drop(cstrings);
 
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
     // offset. Re-enters the runtime (`rt_str_new` may grow memory, so `data_mut` is
@@ -906,6 +943,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     let ext_rt = crate::dylink_engine::ExtRt {
         str_new: rt_str_new,
         str_data: rt_str_data,
+        release: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_release"))?,
         alloc: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?,
         free: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free"))?,
         record_new: wts(rt_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
@@ -913,6 +951,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     let ext_libs = crate::dylink_engine::load_ext_libraries(&mut store, engine, rt_inst, memory, model, &ext_rt)?;
     define_external_imports(&mut linker, &mut store, model, memory, &ext_rt, &ext_libs, nls)?;
     define_print_import(&mut linker, memory)?;
+    crate::host::define_uri_import(&mut linker, memory, ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
     let instance = wts(linker.instantiate(&mut store, &model_module))?;
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;


### PR DESCRIPTION
`Modelica.Utilities.Streams.readFile` declares `output String stringVector[countLines(fileName)]`, which C passes as the `const char**` that `data_of_string_c89_array` builds and reads back with `unpack_string_array`. The wasm-jit runtime built that vector for input arrays only and refused the output, so
`ModelicaTest.Utilities.TestReadFile` could not run.

All three marshalling paths now do both halves. `sim_runtime_wasmtime` (native libffi) had the input half; `dylink_wasmtime` (wasm side module, shared memory) and `sim_runtime_wasmer` (web) passed the array's handle words where the callee expected `char*`s, so a `String[:]` was wrong in either direction there.

An element the callee did not write still points at our own input copy, so those copies outlive the write-back. A null handle (a freshly allocated output array) is an empty string rather than a read at offset 4. An overwritten element handle is released, which an in/out array needs; `ExtRt` carries `rt_release` for it.

`OpenModelica_uriToFilename` and `OpenModelica_fmuLoadResource` were not lowered at all. They become `rt_uri_to_filename(uri, fmu)`, with the two implementations the other host-effect builtins already split into:

* the host binds `metamodelica::uriToFilename`, so `modelica://` resolves against the class directories `System.updateUriMapping` installed;
* a host-free module (the wasip1 standalone command, the FMI adapter) resolves it itself in the runtime crate's new `uri.rs`, a port of `uriToFilenameRegularPaths` including the `resourcesDir` re-rooting.

That completes the FMI side too: `emit_fmu` ships
`modelInfo.resourcePaths` under their own absolute path, the layout `SimCodeMain` produces for C, and the FMI3 adapter sets the resources root at instantiate. It sets `/`, not the host path `fmi3Instantiate*` reports, because the loader preopens the FMU's `resources/` as the component's root.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
