### PR TITLE
wasm-jit: C-faithful start/nominal attributes

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2369,8 +2369,7 @@ pub(crate) struct SimVarMap {
     pub(crate) vars: Arc<HashMap<String, SimSlot>>,
     starts: Arc<HashMap<String, Option<Arc<DAE::Exp>>>>,
     /// State cref key -> its start-value slot; when present, `$START.<key>` reads the
-    /// slot instead of the inline expression. Empty when building
-    /// `functionInitStartValues` (it fills the slots, so must not read them).
+    /// slot instead of the inline expression.
     start_slots: Arc<HashMap<String, u32>>,
     /// Finalized array-variable groups (base cref key -> contiguous slot range).
     array_groups: Arc<HashMap<String, ArrayGroup>>,
@@ -3729,7 +3728,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     let mut max_defaults: Vec<(u32, f64)> = Vec::new();
     for (i, sv) in lst(&vars.stateVars).take(n_states as usize).enumerate() {
         let off = layout.state_max_off + (i as u32) * 8;
-        max_defaults.push((off, const_value(&sv.maxValue).unwrap_or(f64::INFINITY)));
+        max_defaults.push((off, const_value(&sv.maxValue).unwrap_or(f64::MAX)));
         if let Ok(k) = sim_cref_key(&sv.name) {
             attr_targets.entry(k).or_default().max_offs.push(off);
         }
@@ -3885,12 +3884,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         .chain(real_alg_vars(vars))
         .collect();
     bodies.push(build_init_start_values_fn(&all_reals, &layout, &var_map, &by_name, &mut literals)?);
-    // A start bound to a parameter arrives as a `$START.<var>` equation instead of
-    // an expression on the variable; `functionUpdateBoundVariableAttributes` runs
-    // it after the pass above and overwrites the slot, as C's does.
+    // A start or nominal bound to a parameter arrives as an attribute equation;
+    // `functionUpdateBoundVariableAttributes` fills these slots from those.
     for (i, sv) in all_reals.iter().enumerate() {
+        let nom_off = layout.real_nominal_off(i as u32);
+        nominal_defaults.push((nom_off, literal_value(&sv.nominalValue).unwrap_or(1.0)));
         if let Ok(k) = sim_cref_key(&sv.name) {
-            attr_targets.entry(k).or_default().start_offs.push(layout.real_start_off(i as u32));
+            let t = attr_targets.entry(k).or_default();
+            t.start_offs.push(layout.real_start_off(i as u32));
+            t.raw_nom_offs.push(nom_off);
         }
     }
     // The integrator loop calls `functionCheckAsserts`, whose index is only known
@@ -4931,7 +4933,7 @@ fn soti_vars(vars: &SimCodeVar::SimVars) -> Result<openmodelica_sim_meta::SotiVa
     };
     let mut reals = Vec::new();
     for sv in lst(&vars.stateVars).chain(lst(&vars.derivativeVars)).chain(real_alg_vars(vars)) {
-        reals.push((named(sv)?, const_real(&sv.nominalValue).unwrap_or(1.0)));
+        reals.push(named(sv)?);
     }
     let mut ints = Vec::new();
     for sv in lst(&vars.intAlgVars) {
@@ -5643,11 +5645,11 @@ fn build_equations_synchronous_fn(
 }
 
 /// Build `functionInitStartValues(SimData*)`: every real variable's `start`
-/// attribute slot from its start expression, in real-variable index order — C's
-/// `_init.xml` values plus the `updateBoundVariableAttributes` ones in one pass.
-/// The driver copies the slots over the live region afterwards (C's
-/// `setAllVarsToStart`), so `-iif`/`-override` land in between.
-/// Empty `start_slots` so start expressions compile inline.
+/// attribute slot, in real-variable index order — the values C's `_init.xml`
+/// carries. The driver copies the slots over the live region afterwards (C's
+/// `setAllVarsToStart`), so `-iif`/`-override` land in between. Literals only, as
+/// in C's `SerializeInitXML.expString`: evaluating a parameter-bound start here
+/// would put it on the wrong side of the `pre`-value snapshot.
 fn build_init_start_values_fn(
     reals: &[&SimCodeVar::SimVar],
     layout: &SimLayout,
@@ -5655,14 +5657,13 @@ fn build_init_start_values_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Literals,
 ) -> Result<we::Function> {
-    let sim = SimCtx { start_slots: Arc::default(), ..sim_ctx(var_map) };
-    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    let pairs: Vec<(Option<Arc<DAE::Exp>>, u32)> = reals
+    let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
+    let starts: Vec<(f64, u32)> = reals
         .iter()
         .enumerate()
-        .map(|(i, sv)| (sv.initialValue.clone(), layout.real_start_off(i as u32)))
+        .map(|(i, sv)| (literal_value(&sv.initialValue).unwrap_or(0.0), layout.real_start_off(i as u32)))
         .collect();
-    ctx.emit_init_start_values(&pairs)?;
+    ctx.emit_init_start_values(&starts)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -5690,6 +5691,23 @@ fn bound_attr_equations(
         }
     }
     out
+}
+
+/// What C's `_init.xml` records for an attribute, i.e. what
+/// `SerializeInitXML.expString` serializes: a literal, and nothing else.
+fn literal_value(exp: &Option<Arc<DAE::Exp>>) -> Option<f64> {
+    fn eval(e: &DAE::Exp) -> Option<f64> {
+        use DAE::Exp as E;
+        match e {
+            E::ICONST { integer } => Some(*integer as f64),
+            E::RCONST { real } => Some(real.into_inner()),
+            E::BCONST { bool } => Some(*bool as u8 as f64),
+            E::ENUM_LITERAL { index, .. } => Some(*index as f64),
+            E::REDUCTION { expr, .. } => eval(expr),
+            _ => None,
+        }
+    }
+    exp.as_deref().and_then(eval)
 }
 
 /// Build `functionUpdateBoundVariableAttributes(SimData*)`. An attribute bound to a
@@ -6302,7 +6320,7 @@ fn collect_nls_jobs(
                     let (nom, lo, hi) = key
                         .as_ref()
                         .and_then(|k| nominal_of.get(k).copied())
-                        .unwrap_or((1.0, f64::NEG_INFINITY, f64::INFINITY));
+                        .unwrap_or((1.0, -f64::MAX, f64::MAX));
                     if let Some(k) = key {
                         attr_targets.entry(k).or_default().nls.push(nominals.len() as u32);
                     }
@@ -6351,8 +6369,8 @@ fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f6
     for sv in all {
         if let Ok(key) = sim_cref_key(&sv.name) {
             let nom = const_value(&sv.nominalValue).map(|v| v.abs()).filter(|v| *v > 0.0).unwrap_or(1.0);
-            let lo = const_value(&sv.minValue).unwrap_or(f64::NEG_INFINITY);
-            let hi = const_value(&sv.maxValue).unwrap_or(f64::INFINITY);
+            let lo = const_value(&sv.minValue).unwrap_or(-f64::MAX);
+            let hi = const_value(&sv.maxValue).unwrap_or(f64::MAX);
             map.entry(key).or_insert((nom, lo, hi));
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
@@ -70,11 +70,11 @@ pub(crate) fn attr_defaults(
             if let Ok(k) = crate::CodegenWasmJit::sim_cref_key(&sv.name) {
                 let t = attr_targets.entry(k).or_default();
                 if base == layout.opt_min_off {
-                    t.opt_min_offs.push(off);
+                    t.raw_min_offs.push(off);
                 } else if base == layout.opt_max_off {
-                    t.opt_max_offs.push(off);
+                    t.raw_max_offs.push(off);
                 } else {
-                    t.opt_nom_offs.push(off);
+                    t.raw_nom_offs.push(off);
                 }
             }
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1459,7 +1459,7 @@ pub(crate) const NLS_PAT_GLOBAL: u32 = 3;
 pub(crate) const NLS_BOUNDS_GLOBAL: u32 = 4;
 
 /// A variable attribute the solvers read back at run time.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Attr {
     Nominal,
     Min,
@@ -1478,14 +1478,11 @@ pub(crate) struct AttrTargets {
     pub(crate) nom_offs: Vec<u32>,
     /// A state's `SimData` `max` slot, which the numeric linearization reads.
     pub(crate) max_offs: Vec<u32>,
-    /// The optimizer's per-real-variable attribute slots (C's
-    /// `realVarsData[i].attribute`, which it reads for every state, input and
-    /// constrained variable). Unlike the two above these take the value as it is:
-    /// no `fmax(|nominal|, 1e-32)` clamp, since the optimizer applies its own
-    /// heuristic.
-    pub(crate) opt_min_offs: Vec<u32>,
-    pub(crate) opt_max_offs: Vec<u32>,
-    pub(crate) opt_nom_offs: Vec<u32>,
+    /// C's `realVarsData[i].attribute` as declared (`Layout::real_nom_off` and the
+    /// optimizer's arrays): verbatim, without the `fmax(|nominal|, 1e-32)` clamp.
+    pub(crate) raw_min_offs: Vec<u32>,
+    pub(crate) raw_max_offs: Vec<u32>,
+    pub(crate) raw_nom_offs: Vec<u32>,
     pub(crate) start_offs: Vec<u32>,
 }
 
@@ -1879,14 +1876,13 @@ impl<'a> FnCtx<'a> {
                     self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
                 }
             }
-            // The optimizer's attribute arrays take the value verbatim.
-            let opt_offs: &[u32] = match attr {
-                Attr::Min => &targets.opt_min_offs,
-                Attr::Max => &targets.opt_max_offs,
-                Attr::Nominal => &targets.opt_nom_offs,
+            let raw_offs: &[u32] = match attr {
+                Attr::Min => &targets.raw_min_offs,
+                Attr::Max => &targets.raw_max_offs,
+                Attr::Nominal => &targets.raw_nom_offs,
                 Attr::Start => &targets.start_offs,
             };
-            for off in opt_offs {
+            for off in raw_offs {
                 self.emit(we::Instruction::LocalGet(data));
                 self.emit(we::Instruction::LocalGet(raw));
                 self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
@@ -1940,22 +1936,13 @@ impl<'a> FnCtx<'a> {
         Ok(())
     }
 
-    /// Store each real variable's `start` expression (`0.0` when it has none) in
-    /// its start attribute slot at `off`.
-    pub(crate) fn emit_init_start_values(
-        &mut self,
-        starts: &[(Option<Arc<DAE::Exp>>, u32)],
-    ) -> Result<()> {
+    /// Store each real variable's declared `start` value in its start attribute
+    /// slot at `off`.
+    pub(crate) fn emit_init_start_values(&mut self, starts: &[(f64, u32)]) -> Result<()> {
         let data = self.sim()?.data_local;
-        for (exp, off) in starts {
+        for (value, off) in starts {
             self.emit(we::Instruction::LocalGet(data));
-            match exp {
-                Some(e) => {
-                    let w = compile_exp(self, e)?;
-                    coerce(self, w, WTy::F64);
-                }
-                None => self.emit(we::Instruction::F64Const(0.0f64.into())),
-            }
+            self.emit(we::Instruction::F64Const((*value).into()));
             self.emit(we::Instruction::F64Store(mem_arg(*off, 3)));
         }
         Ok(())
@@ -5552,13 +5539,25 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
     }
     // `$START.x := expr` in the initial system: the C target sets `x`'s start
     // attribute *and* the live value `realVars[x] = start` (see the
-    // `$START.<cref>`-LHS pattern in `_06inz`). The numeric effect is `x := expr`,
-    // so redirect the assignment to the underlying variable's live slot. (Reads of
-    // `$START.x` still resolve to the start attribute via `compile_sim_cref_read`,
-    // which is consistent — the start expression equals the assigned value.)
+    // `$START.<cref>`-LHS pattern in `_06inz`), so write both: the slot is what a
+    // solver reads for its initial guess and what `LOG_SOTI` prints.
     if let DAE::ComponentRef::CREF_QUAL { ident, componentRef, .. } = cref {
         if ident.as_str() == "$START" {
-            return compile_sim_cref_assign(ctx, componentRef, rhs);
+            let start_off = sim_cref_key(componentRef)
+                .ok()
+                .and_then(|k| ctx.sim().ok()?.start_slots.get(&k).copied());
+            let Some(off) = start_off else {
+                return compile_sim_cref_assign(ctx, componentRef, rhs);
+            };
+            let data = ctx.sim()?.data_local;
+            let w = rhs.push(ctx)?;
+            coerce(ctx, w, WTy::F64);
+            let tmp = ctx.alloc_temp(WTy::F64);
+            ctx.emit(we::Instruction::LocalSet(tmp));
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::LocalGet(tmp));
+            ctx.emit(we::Instruction::F64Store(mem_arg(off, 3)));
+            return compile_sim_cref_assign(ctx, componentRef, RhsSource::Temp { local: tmp, wty: WTy::F64 });
         }
         // `$PRE.x := e` targets x's pre-slot when one is registered; otherwise
         // (no pre-slot, e.g. a parameter) fall back to the live slot.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -325,6 +325,8 @@ fn total_pivot_augmented(n: usize, x: &mut [f64], a: &mut [f64], pos: &mut i32) 
         }
         if abs_max < f64::EPSILON {
             rank = i;
+            crate::omclog::debug_int(crate::omclog::NLS_V, "rank = ", rank as i32);
+            crate::omclog::debug_int(crate::omclog::NLS_V, "position = ", *pos);
             break;
         }
         ind_row.swap(i, p_row);
@@ -360,8 +362,15 @@ fn total_pivot_augmented(n: usize, x: &mut [f64], a: &mut [f64], pos: &mut i32) 
         }
     }
     x[ind_col[n]] = 1.0;
+    if crate::omclog::active(crate::omclog::NLS_V) {
+        let as_i32 = |v: &[usize]| v.iter().map(|i| *i as i32).collect::<alloc::vec::Vec<i32>>();
+        crate::omclog::debug_vector_int(crate::omclog::NLS_V, "indRow:", &as_i32(&ind_row));
+        crate::omclog::debug_vector_int(crate::omclog::NLS_V, "indCol:", &as_i32(&ind_col));
+        crate::omclog::debug_vector_double(crate::omclog::NLS_V, "vector x (solution):", x);
+    }
     if *pos < 0 {
         *pos = ind_col[n] as i32;
+        crate::omclog::debug_int(crate::omclog::NLS_V, "position of largest value = ", *pos);
     }
     0
 }
@@ -1048,7 +1057,7 @@ fn hybrd_c(
             hybrd_res_scaling(n, &fjacobian, &mut res_scaling);
             let mut scaled = vec![0.0f64; n];
             for i in 0..n {
-                scaled[i] = fvec[i] / res_scaling[i];
+                scaled[i] = fvec[i] * (1.0 / res_scaling[i]);
             }
             (enorm(&fvec), enorm(&scaled))
         };
@@ -1559,6 +1568,8 @@ struct HomotopyTrace {
     time: f64,
     /// C's `discreteCall`: "System values" rather than "System extrapolation".
     discrete: bool,
+    /// C's `simulationInfo->initial`, which its warnings name instead of a time.
+    initial: bool,
 }
 
 /// C's `solveHomotopy` header block, which opens the `LOG_NLS_V` block
@@ -1584,6 +1595,62 @@ fn log_homotopy_enter(t: &HomotopyTrace, n: usize, x: &[f64], nominal: &[f64], x
     let mut scaling = xscaling.to_vec();
     scaling.push(1.0);
     omclog::debug_vector_double(omclog::NLS_V, "Scaling values", &scaling);
+}
+
+/// `newtonAlgorithm`'s block rule and its two verdicts, verbatim.
+const BAR: &str = "******************************************************";
+const NO_CONVERGE: &str = "NEWTON SOLVER DID ---NOT--- CONVERGE TO A SOLUTION!!!";
+const UPS: &str = "UPS! MUST HANDLE A PROBLEM (Newton method), time : ";
+
+/// C's `printUnknowns`. Its `nom` column is `xScaling`, not the `nominal` attribute.
+fn log_nls_status(t: &HomotopyTrace, x: &[f64], xscaling: &[f64], bounds: &[f64]) {
+    use crate::omclog;
+    if !omclog::active(omclog::NLS_V) {
+        return;
+    }
+    let names = var_names(t.eq_index);
+    omclog::info(omclog::NLS_V, true, "nls status");
+    omclog::info(omclog::NLS_V, false, "variables");
+    for i in 0..x.len() {
+        omclog::info(
+            omclog::NLS_V,
+            false,
+            &alloc::format!(
+                "{}{}\t\t nom = {}\t\t min = {}\t\t max = {}",
+                var_label(names, i),
+                omclog::g(x[i], 16, 8),
+                omclog::g(xscaling[i], 16, 8),
+                omclog::g(bounds[2 * i], 16, 8),
+                omclog::g(bounds[2 * i + 1], 16, 8)
+            ),
+        );
+    }
+    omclog::close(omclog::NLS_V);
+}
+
+/// C's `printNewtonStep`: the full Newton step and the iterate it leads to.
+fn log_newton_step(t: &HomotopyTrace, x1: &[f64], step: &[f64], x: &[f64]) {
+    use crate::omclog;
+    if !omclog::active(omclog::NLS_V) {
+        return;
+    }
+    let names = var_names(t.eq_index);
+    omclog::info(omclog::NLS_V, true, "newton step");
+    omclog::info(omclog::NLS_V, false, "variables");
+    for i in 0..x.len() {
+        omclog::info(
+            omclog::NLS_V,
+            false,
+            &alloc::format!(
+                "{}{}\t\t step = {}\t\t old = {}",
+                var_label(names, i),
+                omclog::g(x1[i], 16, 8),
+                omclog::g(step[i], 16, 8),
+                omclog::g(x[i], 16, 8)
+            ),
+        );
+    }
+    omclog::close(omclog::NLS_V);
 }
 
 /// C's `solveHomotopy` entry phase and its `newtonAlgorithm`
@@ -1669,7 +1736,9 @@ fn newton_c(
                 }
                 x[col] = saved + h;
                 eval(x, rp);
-                let inv = xscaling[col] / h;
+                // C's `1./delta_hh * xScaling[i]`: `xScaling[i]/delta_hh` rounds
+                // differently, and `1/h` magnifies that into the quotient.
+                let inv = 1.0 / h * xscaling[col];
                 for i in 0..n {
                     jac[col * n + i] = (rp[i] - fvec[i]) * inv;
                 }
@@ -1736,11 +1805,25 @@ fn newton_c(
     let mut error_f_sqrd = nsq(&fvec);
     let mut error_f_sqrd_scaled = scaled_sq(n, &fvec, res_scaling);
 
+    let max_iter = 100 * n as i32;
+    if let Some(t) = trace {
+        crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+        crate::omclog::debug_int(crate::omclog::NLS_V, "NEWTON SOLVER STARTED! equation number: ", t.eq_index as i32);
+        crate::omclog::debug_int(crate::omclog::NLS_V, "maximum number of function evaluation: ", max_iter);
+        log_nls_status(t, &x[..n], &xscaling, bounds);
+    }
     let mut iter = 0i32;
     let mut neg_steps = 0i32;
     let mut small_steps = 0i32;
     loop {
         stat_inc(STAT_NLS_ITER);
+        if let Some(t) = trace {
+            crate::omclog::debug_int(crate::omclog::NLS_V, "Iteration:", iter + 1);
+            for i in 0..n {
+                x1[i] = x[i] + step[i];
+            }
+            log_newton_step(t, &x1, &step, x);
+        }
         let grad_f = -2.0 * error_f_sqrd;
         let grad_f_scaled = -2.0 * error_f_sqrd_scaled;
 
@@ -1755,6 +1838,9 @@ fn newton_c(
             if !assert_hit() {
                 break;
             }
+            if trace.is_some() {
+                crate::omclog::debug_double(crate::omclog::NLS_V, "Assert of Newton step: lambda1 =", lambda1);
+            }
             lambda1 *= 0.655;
             if lambda1 <= LAMBDA_MIN_C {
                 break;
@@ -1762,10 +1848,21 @@ fn newton_c(
         }
         if lambda1 < LAMBDA_MIN_C {
             stat_inc(STAT_NEWTON_LAMBDA);
+            if let Some(t) = trace {
+                crate::omclog::debug_double(crate::omclog::NLS_V, UPS, t.time);
+            }
             return (false, false);
         }
         let error_f1_sqrd = nsq(&fvec);
         let error_f1_sqrd_scaled = scaled_sq(n, &fvec, res_scaling);
+        if trace.is_some() {
+            let d = |m: &str, v: f64| crate::omclog::debug_double(crate::omclog::NLS_V, m, v);
+            d("Need to damp, grad_f = ", grad_f);
+            d("Need to damp, error_f = ", libm::sqrt(error_f_sqrd));
+            d("Need to damp this!! lambda1 = ", lambda1);
+            d("Need to damp, error_f1 = ", libm::sqrt(error_f1_sqrd));
+            d("Need to damp, forced error = ", error_f_sqrd + ALPHA * lambda1 * grad_f);
+        }
 
         // Numerical-Recipes damping: quadratic then cubic model of ‖f‖².
         if error_f1_sqrd > error_f_sqrd + ALPHA * lambda1 * grad_f
@@ -1776,11 +1873,17 @@ fn newton_c(
             let lambda2 = (-lambda1 * lambda1 * grad_f
                 / (2.0 * (error_f1_sqrd - error_f_sqrd - lambda1 * grad_f)))
                 .max(LAMBDA_MIN_C);
+            if trace.is_some() {
+                crate::omclog::debug_double(crate::omclog::NLS_V, "Need to damp this!! lambda2 = ", lambda2);
+            }
             for i in 0..n {
                 x1[i] = x[i] + lambda2 * step[i];
             }
             eval(&x1, &mut fvec);
             let error_f2_sqrd = nsq(&fvec);
+            if trace.is_some() {
+                crate::omclog::debug_double(crate::omclog::NLS_V, "Need to damp, error_f2 = ", libm::sqrt(error_f2_sqrd));
+            }
             if error_f1_sqrd > error_f_sqrd + ALPHA * lambda2 * grad_f
                 && error_f_sqrd > 1e-12
                 && error_f_sqrd_scaled > 1e-12
@@ -1804,11 +1907,27 @@ fn newton_c(
                     }
                 }
                 lam = lam.max(LAMBDA_MIN_C);
+                if trace.is_some() {
+                    crate::omclog::debug_double(crate::omclog::NLS_V, "Need to damp this!! lambda = ", lam);
+                }
                 for i in 0..n {
                     x1[i] = x[i] + lam * step[i];
                 }
                 eval(&x1, &mut fvec);
+                if trace.is_some() {
+                    crate::omclog::debug_double(crate::omclog::NLS_V, "Need to damp, error_f1 = ", libm::sqrt(nsq(&fvec)));
+                }
             }
+        }
+
+        if trace.is_some() {
+            crate::omclog::debug_vector_double(crate::omclog::NLS_V, "function values:", &fvec);
+            let mut scaled = vec![0.0f64; n];
+            for i in 0..n {
+                let d = res_scaling[i].abs();
+                scaled[i] = if d > 0.0 { fvec[i] / d } else { fvec[i] };
+            }
+            crate::omclog::debug_vector_double(crate::omclog::NLS_V, "scaled function values:", &scaled);
         }
 
         // Error measures (C uses the FULL Newton step ‖dy0‖ for delta_x).
@@ -1823,8 +1942,21 @@ fn newton_c(
         error_f_sqrd = nsq(&fvec);
         error_f_sqrd_scaled = scaled_sq(n, &fvec, res_scaling);
         neg_steps += (error_f_sqrd > 10.0 * error_f_old) as i32;
+        if trace.is_some() {
+            let d = |m: &str, v: f64| crate::omclog::debug_double(crate::omclog::NLS_V, m, v);
+            crate::omclog::debug_string(crate::omclog::NLS_V, "error measurements:");
+            d("delta_x        =", libm::sqrt(delta_x_sqrd));
+            d("delta_x_scaled =", libm::sqrt(delta_x_sqrd_scaled));
+            d("newtonXTol          =", libm::sqrt(xtol_sq));
+            d("error_f        =", libm::sqrt(error_f_sqrd));
+            d("error_f_scaled =", libm::sqrt(error_f_sqrd_scaled));
+            d("newtonFTol          =", libm::sqrt(ftol_sq));
+        }
         if neg_steps > 20 {
             stat_inc(STAT_NEWTON_NEGSTEP);
+            if trace.is_some() {
+                crate::omclog::debug_int(crate::omclog::NLS_V, "UPS! Something happened, NegativeSteps = ", neg_steps);
+            }
             return (false, false);
         }
         // C's issue #6419: on success keep the previous `x` when the new residual is no
@@ -1834,15 +1966,38 @@ fn newton_c(
         let f_ok = error_f_sqrd < ftol_sq || error_f_sqrd_scaled < ftol_sq;
         let x_ok = delta_x_sqrd_scaled < xtol_sq || delta_x_sqrd < xtol_sq;
         if f_ok && x_ok {
-            if !last_was_good {
+            if last_was_good {
+                if trace.is_some() {
+                    crate::omclog::debug_string(
+                        crate::omclog::NLS_V,
+                        "Note: newton solver rejected last x because previous was as good",
+                    );
+                }
+            } else {
                 x.copy_from_slice(&x1);
             }
             return (true, !last_was_good);
         }
         iter += 1;
         // C's `maxNumberOfIterations = size*100`.
-        if iter > 100 * n as i32 {
+        if iter > max_iter {
             stat_inc(STAT_NEWTON_MAXITER);
+            if let Some(t) = trace {
+                let when = if t.initial {
+                    alloc::string::String::from("at initialization")
+                } else {
+                    alloc::format!("at time {:.6}", t.time)
+                };
+                crate::omclog::warning(
+                    crate::omclog::NLS_V,
+                    false,
+                    &alloc::format!(
+                        "Homotopy solver Newton iteration: Maximum number of iterations reached {when}, but no root found."
+                    ),
+                );
+                crate::omclog::debug_string(crate::omclog::NLS_V, NO_CONVERGE);
+                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+            }
             return (false, false);
         }
         small_steps += (delta_x_sqrd < xtol_sq * 1e4 || delta_x_sqrd_scaled < xtol_sq * 1e4) as i32;
@@ -1851,12 +2006,28 @@ fn newton_c(
             if !less_accurate {
                 stat_inc(STAT_NEWTON_STUCK);
             }
+            if let Some(t) = trace {
+                if less_accurate {
+                    crate::omclog::debug_string(
+                        crate::omclog::NLS_V,
+                        "NEWTON SOLVER DID CONVERGE TO A SOLUTION WITH LESS ACCURACY!!!",
+                    );
+                    log_nls_status(t, &x[..n], &xscaling, bounds);
+                } else {
+                    crate::omclog::debug_string(crate::omclog::NLS_V, "Warning: newton solver gets stuck!!!");
+                    crate::omclog::debug_string(crate::omclog::NLS_V, NO_CONVERGE);
+                }
+                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+            }
             return (less_accurate, false);
         }
 
         x.copy_from_slice(&x1);
         if !form_jac(x, &fvec, &mut jac, &mut rp, &xscaling, eval, jaceval) {
             stat_inc(STAT_NEWTON_JAC);
+            if trace.is_some() {
+                crate::omclog::debug_string(crate::omclog::NLS_V, "UPS! assert when calculating Jacobian!!!");
+            }
             return (false, false);
         }
         row_scaling(n, &jac, res_scaling);
@@ -1865,6 +2036,12 @@ fn newton_c(
         step.copy_from_slice(&fvec);
         if !lu_solve(&jac, &mut step, n) {
             stat_inc(STAT_NEWTON_SINGULAR);
+            if trace.is_some() {
+                crate::omclog::debug_string(crate::omclog::NLS_V, "Linear lapack solver failed!!!");
+                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+                crate::omclog::debug_string(crate::omclog::NLS_V, NO_CONVERGE);
+                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+            }
             return (false, false);
         }
         for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
@@ -1874,18 +2051,11 @@ fn newton_c(
 }
 
 /// The Newton step at the start point; failing it is what makes the point
-/// "irregular". C always runs `solveSystemWithTotalPivotSearch`, but an LU decides
-/// the same way wherever it succeeds (a nonsingular system has one solution) and
-/// skips the O(n²)-per-column pivot search, so the total pivot is kept only for the
-/// rank-deficient-but-consistent case it exists for. Step comes back unscaled.
+/// "irregular". C's `solveHomotopy` entry phase reaches for
+/// `solveSystemWithTotalPivotSearch` rather than the LAPACK solve its iterations
+/// use: a rank-deficient-but-consistent start point is regular there. Step comes
+/// back unscaled.
 fn total_pivot_step(n: usize, jac: &[f64], fvec: &[f64], xscaling: &[f64], step: &mut [f64]) -> bool {
-    step.copy_from_slice(fvec);
-    if lu_solve(jac, step, n) {
-        for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
-            *s = -*s * sc;
-        }
-        return true;
-    }
     let mut aug = vec![0.0f64; n * (n + 1)];
     aug[..n * n].copy_from_slice(jac);
     aug[n * n..].copy_from_slice(fvec);
@@ -2675,7 +2845,8 @@ pub extern "C" fn rt_solve_nls(
             if homotopy_solver {
                 // C's `discreteCall` covers the initial system too, so it is not
                 // `discrete_call` (which is only about holding relations).
-                let t = HomotopyTrace { eq_index, time, discrete: saved_rel_fresh != 0 };
+                let t =
+                    HomotopyTrace { eq_index, time, discrete: saved_rel_fresh != 0, initial: saved_rel_fresh == 2 };
                 (converged, settled) = newton_c(
                     n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
                     has_jac, Some(&t),
@@ -2759,7 +2930,9 @@ pub extern "C" fn rt_solve_nls(
             break converged;
         }
         unsafe { store_u32(rel_fresh_addr, 1) };
+        let uncounted = n_feval.get();
         eval(&x, &mut scratch);
+        n_feval.set(uncounted);
         settled = true;
         if (0..n_rel).all(|i| unsafe { load_u32(rel_addr + i * 4) } == rel_backup[i as usize]) {
             break converged;
@@ -2772,9 +2945,12 @@ pub extern "C" fn rt_solve_nls(
         // `hybrd_c`'s rung may have left the flag held.
         unsafe { store_u32(rel_fresh_addr, 1) };
     }
-    // Leave the slots + torn variables at the solution.
+    // Leave the slots + torn variables at the solution. C leaves them wherever its
+    // last trial step put them, so this has no counterpart in its feval count.
     if converged && !settled {
+        let uncounted = n_feval.get();
         eval(&x, &mut scratch);
+        n_feval.set(uncounted);
     }
     for i in 0..n {
         unsafe { store_f64(scale_addr + (i * 8) as u32, res_scaling[i]) };
@@ -2796,7 +2972,9 @@ pub extern "C" fn rt_solve_nls(
         if saved_rel_fresh != 2 {
             unsafe { store_u32(rel_fresh_addr, 0) };
         }
+        let uncounted = n_feval.get();
         eval(&warm, &mut scratch);
+        n_feval.set(uncounted);
         // C's equation index, +1 so nonzero still means "failed". First-writer-wins:
         // C throws out of the equation list at the first failure, never reporting a
         // later one.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2348,13 +2348,12 @@ fn dump_initial_solution(e: &dyn SimEngine, sim_data: u32, model: &SimMeta) {
     omclog::info(omclog::SOTI, true, "### SOLUTION OF THE INITIALIZATION ###");
     let real_line = |i: usize| {
         let off = REAL_OFF + i as u32 * 8;
-        let (name, nom) = &soti.reals[i];
-        let nom = if i < n { real(layout.state_nom_off + i as u32 * 8) } else { *nom };
+        let name = &soti.reals[i];
         format!(
             "[{}] Real {name}(start={}, nominal={}) = {} (pre: {})",
             i + 1,
             g(real(layout.real_start_off(i as u32))),
-            g(nom),
+            g(real(layout.real_nominal_off(i as u32))),
             g(real(off)),
             g(pre_real(off))
         )
@@ -2368,7 +2367,7 @@ fn dump_initial_solution(e: &dyn SimEngine, sim_data: u32, model: &SimMeta) {
         omclog::info(omclog::SOTI, true, "derivatives variables");
         for i in n..2 * n {
             let off = REAL_OFF + i as u32 * 8;
-            let name = &soti.reals[i].0;
+            let name = &soti.reals[i];
             let line = format!("[{}] Real {name} = {} (pre: {})", i + 1, g(real(off)), g(pre_real(off)));
             omclog::info(omclog::SOTI, false, &line);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -175,8 +175,14 @@ pub struct Layout {
     /// `functionInitStartValues` fills it; `-iif`/`-override` may replace entries;
     /// the driver then copies it over the live region (C's `setAllVarsToStart`).
     pub start_off: u32,
+    /// C's `realVarsData[i].attribute.nominal` as declared, one f64 per real
+    /// variable in [`Layout::start_off`] order. [`Layout::state_nom_off`] is the
+    /// integrator's clamped copy.
+    pub real_nom_off: u32,
     /// Base of the per-state `nominal` attribute (one f64 per state), written by
     /// `functionUpdateBoundVariableAttributes` once the parameters are computed.
+    /// `fmax(|nominal|, 1e-32)` rather than the attribute itself: it is the
+    /// integrator's `atol` scale and the Jacobian's FD step floor.
     pub state_nom_off: u32,
     /// Base of the per-state `max` attribute, written the same way; C's
     /// `functionJacAC_num` flips its difference quotient at the bound.
@@ -309,7 +315,8 @@ impl Layout {
         let n_math_slots = if n_math > 0 { n_math + 2 } else { 0 };
         let zctol_off = mathevents_off + n_math_slots * 8;
         let start_off = zctol_off + 8;
-        let state_nom_off = start_off + n_real * 8;
+        let real_nom_off = start_off + n_real * 8;
+        let state_nom_off = real_nom_off + n_real * 8;
         let state_max_off = state_nom_off + n_states * 8;
         let sens_off = state_max_off + n_states * 8;
         let dae_res_off = sens_off + n_sens * 8;
@@ -332,7 +339,7 @@ impl Layout {
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
-            mathevents_off, zctol_off, start_off, state_nom_off, state_max_off, n_sens, sens_off,
+            mathevents_off, zctol_off, start_off, real_nom_off, state_nom_off, state_max_off, n_sens, sens_off,
             n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
             n_base_clocks, clock_off, n_sub_clocks, subclock_off, clock_fire_off, linz_off, n_linz,
             n_opt_attr, opt_min_off, opt_max_off, opt_nom_off, opt_use_nom_off,
@@ -353,6 +360,11 @@ impl Layout {
     /// Byte offset of real variable `i`'s `start` attribute slot.
     pub fn real_start_off(&self, i: u32) -> u32 {
         self.start_off + i * 8
+    }
+
+    /// Byte offset of real variable `i`'s `nominal` attribute slot.
+    pub fn real_nominal_off(&self, i: u32) -> u32 {
+        self.real_nom_off + i * 8
     }
 
     /// C's `compiledInDAEMode`: the integrator solves `F(t, y, y') = 0` over states
@@ -433,9 +445,8 @@ pub struct MetaVar {
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct SotiVars {
     /// Real variables in real-variable index order (states, derivatives, then the
-    /// other reals) with the `nominal` attribute; a state's runtime nominal comes
-    /// from [`Layout::state_nom_off`] instead.
-    pub reals: Vec<(String, f64)>,
+    /// other reals). Their `start` and `nominal` attributes are `SimData` slots.
+    pub reals: Vec<String>,
     /// Integer/Boolean variables with their `start` attribute.
     pub ints: Vec<(String, i32)>,
     pub bools: Vec<(String, i32)>,
@@ -830,7 +841,7 @@ impl SimMeta {
         }
         [
             group(
-                self.soti.reals.iter().map(|(n, _)| n.as_str()).collect(),
+                self.soti.reals.iter().map(|n| n.as_str()).collect(),
                 &|i| l.real_start_off(i as u32),
                 WTy::F64,
             ),
@@ -1077,7 +1088,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.terminate_off, l.terminal_off, l.initial_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
         l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
-        l.state_nom_off, l.state_max_off, l.n_sens, l.sens_off,
+        l.real_nom_off, l.state_nom_off, l.state_max_off, l.n_sens, l.sens_off,
         l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off,
         l.n_base_clocks, l.clock_off, l.n_sub_clocks, l.subclock_off, l.clock_fire_off,
         l.linz_off, l.n_linz,
@@ -1207,9 +1218,8 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_u32(&mut o, *i as u32);
     }
     put_u32(&mut o, m.soti.reals.len() as u32);
-    for (n, v) in &m.soti.reals {
+    for n in &m.soti.reals {
         put_str(&mut o, n);
-        put_f64(&mut o, *v);
     }
     for list in [&m.soti.ints, &m.soti.bools] {
         put_u32(&mut o, list.len() as u32);
@@ -1422,6 +1432,7 @@ impl<'a> Reader<'a> {
             mathevents_off: self.u32()?,
             zctol_off: self.u32()?,
             start_off: self.u32()?,
+            real_nom_off: self.u32()?,
             state_nom_off: self.u32()?,
             state_max_off: self.u32()?,
             n_sens: self.u32()?,
@@ -1558,7 +1569,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let sample_index = r.u32s()?.into_iter().map(|v| v as i32).collect();
     let mut soti = SotiVars::default();
     for _ in 0..r.u32()? {
-        soti.reals.push((r.string()?, r.f64()?));
+        soti.reals.push(r.string()?);
     }
     for _ in 0..r.u32()? {
         soti.ints.push((r.string()?, r.u32()? as i32));

--- a/testsuite/simulation/modelica/initialization/Makefile
+++ b/testsuite/simulation/modelica/initialization/Makefile
@@ -54,6 +54,7 @@ scaling1.mos \
 scaling2.mos \
 SingularInitial.mos \
 singularJacobian.mos \
+solveTupleFunction.mos \
 startValue.mos \
 startValue1.mos \
 startValue2.mos \

--- a/testsuite/simulation/modelica/initialization/solveTupleFunction.mos
+++ b/testsuite/simulation/modelica/initialization/solveTupleFunction.mos
@@ -29,7 +29,7 @@ package initializationTests
 end initializationTests;
 "); getErrorString();
 
-simulate(initializationTests.solveTuple, simflags="-lv=LOG_INIT"); getErrorString();
+simulate(initializationTests.solveTuple, simflags="-lv=LOG_INIT,LOG_SOTI"); getErrorString();
 
 
 // Result:
@@ -37,23 +37,24 @@ simulate(initializationTests.solveTuple, simflags="-lv=LOG_INIT"); getErrorStrin
 // ""
 // record SimulationResult
 //     resultFile = "initializationTests.solveTuple_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'initializationTests.solveTuple', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.solveTuple', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT,LOG_SOTI'",
 //     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating start-values
+// LOG_INIT          | info    | updating primary start-values
 // LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT          | info    | parameter values
 // LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
 // |                 | |       | | states variables
 // |                 | |       | | | [1] Real x(start=0, nominal=1) = 1.5708 (pre: 0)
 // |                 | |       | | derivatives variables
 // |                 | |       | | | [2] Real der(x) = 1 (pre: 0)
 // |                 | |       | | other real variables
-// |                 | |       | | | [3] Real y(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [4] Real $TMP__initializationTests_solveTuple_f3.y(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real $TMP_initializationTests_solveTuple_f3.y(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [4] Real y(start=0, nominal=1) = 1 (pre: 0)
 // LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""


### PR DESCRIPTION
`functionInitStartValues` evaluated every start expression, including the parameter-dependent ones. C's `_init.xml` carries only literals (see `SerializeInitXML.expString`) and leaves the rest to `functionUpdateBoundVariableAttributes`, or to a `$START.<var>` equation in the initial system. `copyStartValuestoInitValues` snapshots the `pre` values between the two, so evaluating them early is observable: bug_2673 reported `pre: 5` where C reports `pre: 0`.

Two things follow from that:

* `$START.<var> := e` writes the start attribute slot, not just the live variable, as C's `_06inz` does. That slot is what a solver reads for its initial guess and what `LOG_SOTI` prints.
* `nominal` gets a per-real slot, `Layout::real_nom_off`. `state_nom_off` holds `fmax(|nominal|, 1e-32)` for the integrator, so `LOG_SOTI` reported `nominal=1` for every variable whose nominal is bound to a parameter.

`min`/`max` also default to +-DBL_MAX rather than infinity, as C's `_init.xml` reader does.

The homotopy solver's damped Newton gained its `LOG_NLS_V` trace: the `NEWTON SOLVER STARTED` header, `printUnknowns`/`printNewtonStep`, the damping lambdas, the function values and the error measurements, plus `indRow`/`indCol`/`vector x` from `solveSystemWithTotalPivotSearch`, which now runs at the start point instead of an LU shortcut. Two numeric details came with it: the finite-difference Jacobian scales by `1./h * xScaling`, whose rounding `1/h` magnifies into the quotient, and the post-solve residual evaluations that leave the slots at the solution no longer count towards `numberOfFEval`, which C has no counterpart for.

Fixes bug_2673 and bug_2841 under wasm-jit.

`solveTupleFunction` was in neither `TESTFILES` nor `FAILINGTESTFILES`; enable it, with `LOG_SOTI` added to its simflags (`LOG_INIT` no longer implies it) and its stale baseline refreshed. Its output is now identical on the C and wasm-jit targets.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
