### PR TITLE
wasm-jit: external "C" in an FMI 2.0 wasm FMU

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -85,7 +85,9 @@ use openmodelica_sim_meta::{
 use openmodelica_wasm_jit::{sim_driver, sim_runtime};
 #[cfg(feature = "jit")]
 use openmodelica_wasm_jit::wasi_shim;
-pub(crate) use openmodelica_wasm_jit::model::{EditableParam, ExtIncludes, ExtLibrary, ModelCompileJob, SimModel};
+pub(crate) use openmodelica_wasm_jit::model::{
+    EditableParam, ExtArchives, ExtIncludes, ExtLibrary, ModelCompileJob, SimModel,
+};
 #[cfg(feature = "jit")]
 pub use openmodelica_wasm_jit::model::{set_inwasm_driver_override, set_sim_bench};
 #[cfg(feature = "jit")]
@@ -1478,6 +1480,8 @@ pub(crate) struct ExtLibraries {
     pub wasm: Vec<ExtLibrary>,
     /// In link order, for a native host to fall back to.
     pub native: Vec<String>,
+    /// The static archives and object files among them, likewise in link order.
+    pub archives: Vec<String>,
     /// `#include` lines for the C sources a `Library` named, which the C target
     /// hands to the compiler rather than the linker.
     pub sources: Vec<String>,
@@ -1499,6 +1503,14 @@ pub(crate) fn resolve_ext_libraries(
             dirs.push(format!("{}/", d.trim_matches('"')));
         }
     }
+    // The rest of the `LDFLAGS=` line CodegenC.tpl writes. `ffi/` comes first: it
+    // holds the shared build of libraries the lib dir ships only as archives.
+    dirs.push(format!("{}/lib/{}/omc/ffi/", mp.omhome, openmodelica_util::Autoconf::triple));
+    dirs.push(format!("{}/lib/{}/omc/", mp.omhome, openmodelica_util::Autoconf::triple));
+    dirs.push(format!("{}/lib/", mp.omhome));
+    for d in ld_search_dirs(&mp.ldflags) {
+        dirs.push(format!("{d}/"));
+    }
     let mut out = ExtLibraries::default();
     let mut seen: HashSet<String> = HashSet::new();
     for lib in lst(&mp.libs) {
@@ -1509,8 +1521,12 @@ pub(crate) fn resolve_ext_libraries(
         if !lib.ends_with(".wasm") {
             if let Some(path) = find_source_library(&lib, &dirs) {
                 out.sources.push(format!("#include \"{}\"", path.replace('\\', "/")));
-            } else if let Some(path) = find_native_library(&lib, &dirs) {
-                out.native.push(path);
+            } else {
+                match find_native_library(&lib, &dirs) {
+                    Some(NativeLib::Shared(path)) => out.native.push(path),
+                    Some(NativeLib::Archive(path)) => out.archives.push(path),
+                    None => (),
+                }
             }
             continue;
         }
@@ -1656,6 +1672,40 @@ fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<S
     ext_imports.iter().map(|s| s.name.as_str()).filter(|n| !defined.contains(n)).map(String::from).collect()
 }
 
+/// The `-L` directories of a linker flag string (`-Ldir`, `-L"dir"`, `-L dir`).
+/// It is a shell command line, so quotes group rather than belong to the path.
+fn ld_search_dirs(flags: &str) -> Vec<String> {
+    let mut words: Vec<String> = Vec::new();
+    let mut word = String::new();
+    let mut quote: Option<char> = None;
+    for c in flags.chars() {
+        match (quote, c) {
+            (Some(q), c) if c == q => quote = None,
+            (Some(_), c) => word.push(c),
+            (None, '"' | '\'') => quote = Some(c),
+            (None, c) if c.is_whitespace() => {
+                if !word.is_empty() {
+                    words.push(std::mem::take(&mut word));
+                }
+            }
+            (None, c) => word.push(c),
+        }
+    }
+    if !word.is_empty() {
+        words.push(word);
+    }
+    let mut dirs = Vec::new();
+    let mut words = words.into_iter();
+    while let Some(w) = words.next() {
+        if w == "-L" {
+            dirs.extend(words.next());
+        } else if let Some(d) = w.strip_prefix("-L") {
+            dirs.push(d.to_owned());
+        }
+    }
+    dirs
+}
+
 /// A `Library` naming a C source file, which gcc compiles rather than links.
 fn find_source_library(spec: &str, dirs: &[String]) -> Option<String> {
     if !spec.ends_with(".c") && !spec.ends_with(".cc") && !spec.ends_with(".cpp") && !spec.ends_with(".cxx") {
@@ -1664,10 +1714,22 @@ fn find_source_library(spec: &str, dirs: &[String]) -> Option<String> {
     dirs.iter().map(|d| format!("{d}{spec}")).find(|p| openmodelica_wasi::fs::exists(p))
 }
 
-/// The platform shared library a host linker spec names. A `-lfoo` nothing under
-/// `dirs` provides stays a plain soname, for the system loader to find the way the
-/// linker would; static archives and object files have no loadable form at all.
-fn find_native_library(spec: &str, dirs: &[String]) -> Option<String> {
+/// What a host linker spec resolves to.
+enum NativeLib {
+    /// A shared object, which the loader opens as it is.
+    Shared(String),
+    /// A static archive or an object file, which [`ExtArchives`] has to link first.
+    Archive(String),
+}
+
+fn is_link_input(name: &str) -> bool {
+    name.ends_with(".a") || name.ends_with(".o")
+}
+
+/// The platform library a host linker spec names. A `-lfoo` nothing under `dirs`
+/// provides stays a plain soname, for the system loader to find the way the linker
+/// would.
+fn find_native_library(spec: &str, dirs: &[String]) -> Option<NativeLib> {
     if cfg!(target_arch = "wasm32") {
         return None; // no dynamic loader to fall back to
     }
@@ -1678,20 +1740,23 @@ fn find_native_library(spec: &str, dirs: &[String]) -> Option<String> {
         None if spec.starts_with('-') => return None,
         None => spec,
     };
-    if name.ends_with(".a") || name.ends_with(".o") || name.ends_with(".obj") || name.ends_with(".lib") {
+    // `.lib` is both spellings on Windows, with no `cc -shared` to sort them out.
+    if name.ends_with(".obj") || name.ends_with(".lib") {
         return None;
     }
-    if name.contains(suffix) || name.contains(std::path::MAIN_SEPARATOR) {
-        return dirs.iter().map(|d| format!("{d}{name}")).find(|p| std::path::Path::new(p).exists());
+    let found = |p: String| Some(if is_link_input(&p) { NativeLib::Archive(p) } else { NativeLib::Shared(p) });
+    if is_link_input(name) || name.contains(suffix) || name.contains(std::path::MAIN_SEPARATOR) {
+        return dirs.iter().map(|d| format!("{d}{name}")).find(|p| std::path::Path::new(p).exists()).and_then(found);
     }
+    // As ld searches: a directory at a time, the shared object before the archive.
     for dir in dirs {
-        for candidate in [format!("{dir}{prefix}{name}{suffix}"), format!("{dir}{name}{suffix}")] {
-            if std::path::Path::new(&candidate).exists() {
-                return Some(candidate);
-            }
+        let candidates =
+            [format!("{dir}{prefix}{name}{suffix}"), format!("{dir}{name}{suffix}"), format!("{dir}{prefix}{name}.a")];
+        if let Some(p) = candidates.into_iter().find(|p| std::path::Path::new(p).exists()) {
+            return found(p);
         }
     }
-    (spec != name).then(|| format!("{prefix}{name}{suffix}"))
+    (spec != name).then(|| NativeLib::Shared(format!("{prefix}{name}{suffix}")))
 }
 
 /// `<dir><name>` or `<dir>lib<name>`, the two spellings a `Library="foo"`
@@ -3600,6 +3665,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     let mut ext_lib_notes: Vec<String> = Vec::new();
     let mut ext_libs = ExtLibraries::default();
     let mut ext_includes = None;
+    let mut ext_archives = None;
     if !ext_imports.is_empty() {
         ext_libs = resolve_ext_libraries(&sim_code.makefileParams, &mut ext_lib_notes)?;
         // What the `Library` annotations did not provide may come from an `Include`
@@ -3611,6 +3677,15 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
             .collect();
         let dirs: Vec<String> = lst(&mp.includes).map(|s| s.to_string()).collect();
         let prefix = sim_code.fileNamePrefix.to_string();
+        if !ext_libs.archives.is_empty() && ext_host == ExtHost::Native {
+            ext_archives = Some(ExtArchives {
+                archives: std::mem::take(&mut ext_libs.archives),
+                symbols: ext_imports.iter().map(|s| s.name.clone()).collect(),
+                ccompiler: mp.ccompiler.to_string(),
+                dllext: mp.dllext.to_string(),
+                prefix: prefix.clone(),
+            });
+        }
         if !sources.is_empty() {
             match ext_host {
                 // Built on demand, for a symbol the loaded libraries turn out not
@@ -4596,6 +4671,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         result_vars,
         ext_libs: ext_libs.wasm,
         ext_native_libs: ext_libs.native,
+        ext_archives,
         ext_includes,
         ext_lib_notes,
         ext_imports,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -349,6 +349,8 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_array_total", &[WTy::I32], &[WTy::I32]),
     ("rt_array_dim", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_array_elem_ptr", &[WTy::I32, WTy::I32], &[WTy::I32]),
+    // The element area itself, for an `external "C"` array argument.
+    ("rt_array_data", &[WTy::I32], &[WTy::I32]),
     // The out-of-range arm of the inlined element-address computation.
     ("rt_elem_ptr_oob", &[], &[WTy::I32]),
     ("rt_array_release", &[WTy::I32], &[]),
@@ -2585,7 +2587,7 @@ fn emit_known_external_call(
 /// pointer's value) are left on the stack in order; their `SigTy`s are returned.
 thread_local! {
     /// When set, `external "C"` calls pass real shared-memory pointers for String/
-    /// array args (`rt_str_data`/`rt_array_elem_ptr`) instead of runtime handles —
+    /// array args (`rt_str_data`/`rt_array_data`) instead of runtime handles —
     /// for a host-free wasm FMU, where model + runtime + ModelicaExternalC share one
     /// memory so no host trampoline marshals. The interactive wasmer path leaves it
     /// off (two memories, host-marshalled).
@@ -2618,9 +2620,7 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
             match sty {
                 SigTy::Str => ctx.emit(we::Instruction::Call(rt_index("rt_str_data")?)),
                 SigTy::Array { .. } => {
-                    // `rt_array_elem_ptr` is 1-based; element 1 is the data start.
-                    ctx.emit(we::Instruction::I32Const(1));
-                    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+                    ctx.emit(we::Instruction::Call(rt_index("rt_array_data")?));
                 }
                 _ => {}
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -121,6 +121,40 @@ mod uri;
 #[cfg(not(feature = "host_log"))]
 pub use uri::set_resources_dir;
 
+// `rt_ext_*`: where an external "C" function's `ModelicaError`/`Message`/`Warning`
+// goes when the module carries the implementations itself
+// (`openmodelica_wasi_libc/external_c_callbacks.c`), which C's
+// `ModelicaUtilities.c` sends to the simulation log — in an FMU the FMI logger,
+// and the only way out. Same rule as `rt_reinit_note`: with a host present, the
+// host binds `env.Modelica*` instead.
+#[cfg(not(feature = "host_log"))]
+mod ext_report {
+    use openmodelica_sim_meta::{driver, omclog};
+
+    fn cstr<'a>(p: u32) -> &'a str {
+        unsafe { core::ffi::CStr::from_ptr(p as *const core::ffi::c_char) }.to_str().unwrap_or("")
+    }
+
+    /// C's `throwStreamPrint(NULL, …)`, then `MMC_THROW`'s end of the run.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn rt_ext_error(msg: u32) {
+        driver::note_runtime_error(cstr(msg));
+        crate::trap()
+    }
+
+    /// C's `infoStreamPrint(OMC_LOG_STDOUT, 0, …)`.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn rt_ext_message(msg: u32) {
+        omclog::info(omclog::STDOUT, false, cstr(msg).trim_end());
+    }
+
+    /// C's `warningStreamPrint(OMC_LOG_STDOUT, 0, …)`.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn rt_ext_warning(msg: u32) {
+        omclog::warning(omclog::STDOUT, false, cstr(msg).trim_end());
+    }
+}
+
 /// With a host present the notes live host-side (`rt_host_take_reinits`).
 #[cfg(feature = "host_log")]
 pub fn take_reinit_notes() -> alloc::vec::Vec<(u32, f64)> {
@@ -485,6 +519,14 @@ pub extern "C" fn rt_array_elem_ptr(obj: u32, index: i32) -> u32 {
     }
     let kind = unsafe { load_u32(obj + ARR_KIND_OFF) };
     arr_data(obj) + (index as u32 - 1) * elem_stride(kind)
+}
+
+/// Byte address of the element area, whatever the array's size: C's `arr.data`,
+/// which is what an `external "C"` array argument is. An empty one has no element
+/// to bounds-check, and the callee is told the sizes separately.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_array_data(obj: u32) -> u32 {
+    arr_data(obj)
 }
 
 /// The out-of-range arm of [`rt_array_elem_ptr`], also used by the inlined
@@ -1682,13 +1724,18 @@ const STR_DATA_OFF: u32 = 8;
 
 /// Allocate an uninitialized `String` object of `len` bytes (refcount 1, length
 /// set). The caller fills `rt_str_data(obj)..+len` with the bytes.
+///
+/// The byte after them is a NUL, so `rt_str_data` is also a C string, as C's
+/// `modelica_string` always is — an `external "C"` call sharing the memory is
+/// handed it directly.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_str_new(len: u32) -> u32 {
     stat_inc(STAT_STR_NEW);
-    let obj = rt_alloc(STR_DATA_OFF + len);
+    let obj = rt_alloc(STR_DATA_OFF + len + 1);
     unsafe {
         store_u32(obj, 1); // refcount
         store_u32(obj + STR_LEN_OFF, len);
+        *((obj + STR_DATA_OFF + len) as *mut u8) = 0;
     }
     obj
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/external_c_callbacks.c
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/external_c_callbacks.c
@@ -30,11 +30,21 @@
  * from the runtime; in a host-free wasm FMU there is no host, so the PIC
  * dylink side module carries them itself. Because the FMU is one shared linear
  * memory, an allocated string is a plain pointer the model reads directly — no
- * marshalling. Errors abort (fatal); the FMI master sees the resulting trap. */
+ * marshalling. They report through the runtime, as
+ * `SimulationRuntime/c/util/ModelicaUtilities.c` does: an FMU has no stdout, and
+ * its simulation log is the FMI logger. An error ends the run (C's MMC_THROW). */
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+
+/* openmodelica_codegen_wasm_jit_runtime. */
+void rt_ext_error(const char* msg) __attribute__((noreturn));
+void rt_ext_message(const char* msg);
+void rt_ext_warning(const char* msg);
+
+/* C's SIZE_LOG_BUFFER, and the same truncation. */
+#define LOG_BUFFER 2048
 
 char* ModelicaAllocateString(size_t len) {
     char* p = (char*) malloc(len + 1);
@@ -46,15 +56,20 @@ char* ModelicaAllocateStringWithErrorReturn(size_t len) {
     return ModelicaAllocateString(len);
 }
 
+static void report(void (*to)(const char*), const char* fmt, va_list ap) {
+    char buf[LOG_BUFFER];
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    to(buf);
+}
+
 void ModelicaError(const char* string) {
-    fputs(string, stderr);
-    fputc('\n', stderr);
-    abort();
+    rt_ext_error(string);
 }
 
 void ModelicaVFormatError(const char* fmt, va_list ap) {
-    vfprintf(stderr, fmt, ap);
-    abort();
+    char buf[LOG_BUFFER];
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    rt_ext_error(buf);
 }
 
 void ModelicaFormatError(const char* fmt, ...) {
@@ -65,11 +80,11 @@ void ModelicaFormatError(const char* fmt, ...) {
 }
 
 void ModelicaMessage(const char* string) {
-    fputs(string, stderr);
+    rt_ext_message(string);
 }
 
 void ModelicaVFormatMessage(const char* fmt, va_list ap) {
-    vfprintf(stderr, fmt, ap);
+    report(rt_ext_message, fmt, ap);
 }
 
 void ModelicaFormatMessage(const char* fmt, ...) {
@@ -80,11 +95,11 @@ void ModelicaFormatMessage(const char* fmt, ...) {
 }
 
 void ModelicaWarning(const char* string) {
-    fputs(string, stderr);
+    rt_ext_warning(string);
 }
 
 void ModelicaVFormatWarning(const char* fmt, va_list ap) {
-    vfprintf(stderr, fmt, ap);
+    report(rt_ext_warning, fmt, ap);
 }
 
 void ModelicaFormatWarning(const char* fmt, ...) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -30,6 +30,8 @@ pub struct SimModel {
     /// library defines: a native host dlopens them and calls in through libffi.
     /// Empty in the browser.
     pub ext_native_libs: Vec<String>,
+    /// The archives and object files among them ([`ExtArchives`]).
+    pub ext_archives: Option<ExtArchives>,
     pub ext_includes: Option<ExtIncludes>,
     /// Why a `Library` or an `Include` yielded no wasm library; reported only if a
     /// symbol then turns out to be missing.
@@ -74,6 +76,69 @@ impl SimModel {
 pub struct ExtLibrary {
     pub name: String,
     pub bytes: Vec<u8>,
+}
+
+/// The static archives and object files a `Library` annotation resolved to
+/// (`libfmilib.a` and friends). No loader can open one, so they are linked into a
+/// shared object with the model's `external "C"` functions as the undefined
+/// symbols that pull the archive members in — the members the C target's own link
+/// pulls in. What is left undefined (`ModelicaFormatError`, libc) resolves in the
+/// global scope, as it would there.
+#[derive(Clone, Default)]
+pub struct ExtArchives {
+    /// In link order.
+    pub archives: Vec<String>,
+    /// The `external "C"` functions to pull out of them.
+    pub symbols: Vec<String>,
+    pub ccompiler: String,
+    pub dllext: String,
+    pub prefix: String,
+}
+
+impl ExtArchives {
+    /// Link them and return the shared object's path, once per process: the model
+    /// can be resimulated, and the link is a compiler run.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn link(&self) -> std::result::Result<String, String> {
+        use std::sync::{LazyLock, Mutex};
+        static LINKED: LazyLock<Mutex<HashMap<String, std::result::Result<String, String>>>> =
+            LazyLock::new(|| Mutex::new(HashMap::new()));
+        let key = format!("{}\n{}", self.archives.join("\n"), self.symbols.join(" "));
+        LINKED.lock().unwrap().entry(key).or_insert_with(|| self.link_uncached()).clone()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn link_uncached(&self) -> std::result::Result<String, String> {
+        use std::process::Command;
+        let dir = std::env::temp_dir().join(format!("om-extc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+        let out = dir.join(format!("{}_libs{}", self.prefix, self.dllext));
+        let mut cmd = Command::new(&self.ccompiler);
+        cmd.arg("-shared").arg("-o").arg(&out);
+        for sym in &self.symbols {
+            cmd.arg(format!("-Wl,-u,{sym}"));
+        }
+        cmd.args(&self.archives);
+        let output = cmd
+            .output()
+            .map_err(|e| format!("`{}` could not be run to link the static libraries: {e}", self.ccompiler))?;
+        if !output.status.success() {
+            return Err(format!(
+                "the static libraries ({}) did not link into a loadable one:\n{}",
+                self.archives.join(", "),
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        Ok(out.to_string_lossy().into_owned())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn link(&self) -> std::result::Result<String, String> {
+        Err("the implementation comes from a static library, which has to be linked — the browser \
+             omc has no linker. Provide it as a `Library` built with \
+             `clang --target=wasm32-wasip1 -fPIC -shared`"
+            .to_string())
+    }
 }
 
 /// The model's `Include` annotations, and what it takes to build them: host C source

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -313,6 +313,7 @@ fn unresolved_external_detail(name: &str, model: &SimModel, load_errors: &[Strin
         .iter()
         .map(|l| l.name.as_str())
         .chain(model.ext_native_libs.iter().map(|s| s.as_str()))
+        .chain(model.ext_archives.iter().flat_map(|a| a.archives.iter().map(|s| s.as_str())))
         .collect();
     let mut s = if searched.is_empty() {
         format!(
@@ -336,8 +337,9 @@ fn unresolved_external_detail(name: &str, model: &SimModel, load_errors: &[Strin
 }
 
 /// The model's `external "C"` implementations outside wasm, resolved on demand: the
-/// platform libraries its `Library` annotations name, then — only once those and the
-/// process image have come up short — its `Include` C source.
+/// platform libraries its `Library` annotations name (its archives linked into
+/// one), then — only once those and the process image have come up short — its
+/// `Include` C source.
 #[derive(Default)]
 struct NativeExternals {
     handles: Vec<usize>,
@@ -353,6 +355,16 @@ impl NativeExternals {
             let (handles, errors) = openmodelica_util::dynload::load_external_libraries(&model.ext_native_libs);
             self.handles = handles;
             self.errors = errors;
+            if let Some(archives) = &model.ext_archives {
+                match archives.link() {
+                    Ok(path) => {
+                        let (h, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
+                        self.handles.extend(h);
+                        self.errors.extend(errors);
+                    }
+                    Err(e) => self.errors.push(e),
+                }
+            }
         }
         if let Some(addr) = openmodelica_util::dynload::external_symbol_in(&self.handles, name) {
             return Some(addr);


### PR DESCRIPTION
`FMUResourceTest` under `--simCodeTarget=wasm-jit` exports an FMU, imports it and simulates the wrapper. Four things stood between that and a result file.

**The wrapper's libraries were never found.** `resolve_ext_libraries` searched `libPaths` and the `-L`s inside `makefileParams.libs`, but not the `-L"$OMHOME/lib/<triple>/omc"` that `CodegenC.tpl` writes into `LDFLAGS=`, so `-lOpenModelicaFMIRuntimeC -lfmilib` resolved to bare sonames the loader cannot find. Both ship only as `.a`, which `find_native_library` dropped outright. They go into `ExtArchives` now, linked on demand into one shared object with the model's `external "C"` names as `-Wl,-u` seeds — the members the C target's own link pulls in. `ffi/` is searched before the lib dir so a library with a shared build there is opened rather than relinked. An object file (`Library="libFoo.o"`) is a linker input too.

**An array argument was bounds-checked.** The shared-memory path lowered it as `rt_array_elem_ptr(arr, 1)`, which traps on the `0x2` `table` a `tableOnFile` CombiTable passes. `rt_array_data` is C's `arr.data`.

**Runtime strings were not NUL-terminated**, so the `tableName` handed to `strcmp` was `"a"` plus whatever followed it on the heap — the table matrix was "not found". `rt_str_new` terminates now, as C's `modelica_string` always is.

**And none of it was visible**: `ModelicaError` and friends in the host-free side module wrote to a stderr the component discards and then `abort()`ed, so every diagnostic looked like a bare wasm trap. They go through the new `rt_ext_*` to the simulation log — in an FMU, the FMI logger — the way `SimulationRuntime/c/util/ModelicaUtilities.c` routes them.

Measured against the same tree with the change stashed:

| suite (wasm-jit) | before | after |
| --- | --- | --- |
| `openmodelica/fmi/ModelExchange/2.0` | 24/66 | 14/66 | | `simulation/modelica/external_functions` | 7/16 | 5/16 | | `simulation/modelica/built_in_functions` | 6/22 | 6/22 |

The remaining failures are a strict subset of the before-sets.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
