### PR TITLE
[FMI] Import an FMI 3.0 FMU and simulate it

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1963,6 +1963,10 @@ case FMIIMPORT(__) then
       importFMU1CoSimulationStandAlone(fmi, name)
     case (INFO(fmiVersion = "2.0", fmiType = 1)) then
       importFMU2ModelExchange(fmi, name)
+    /* FMI 3.0 numbers its interface types as flags, so Model Exchange is 2 here and
+       not the 1 of FMI 2.0; see fmi3_fmu_kind_enu_t. */
+    case (INFO(fmiVersion = "3.0", fmiType = 2)) then
+      importFMU3ModelExchange(fmi, name)
 end importFMUModelica;
 
 template importFMU1ModelExchange(FmiImport fmi, String name)
@@ -2742,6 +2746,423 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
   >>
 end importFMU2ModelExchange;
 
+template importFMU3ModelExchange(FmiImport fmi, String name)
+ "Generates Modelica code for FMI Model Exchange version 3.0"
+::=
+match fmi
+case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)) then
+  /* Get Real parameters and their value references */
+  let realParametersVRs = dumpVariables(fmiModelVariablesList, "real", "parameter", false, 1, "3.0")
+  let realParametersNames = dumpVariables(fmiModelVariablesList, "real", "parameter", false, 2, "3.0")
+  /* Get Integer parameters and their value references */
+  let integerParametersVRs = dumpVariables(fmiModelVariablesList, "integer", "parameter", false, 1, "3.0")
+  let integerParametersNames = dumpVariables(fmiModelVariablesList, "integer", "parameter", false, 2, "3.0")
+  /* Get Boolean parameters and their value references */
+  let booleanParametersVRs = dumpVariables(fmiModelVariablesList, "boolean", "parameter", false, 1, "3.0")
+  let booleanParametersNames = dumpVariables(fmiModelVariablesList, "boolean", "parameter", false, 2, "3.0")
+  /* Get String parameters and their value references */
+  let stringParametersVRs = dumpVariables(fmiModelVariablesList, "string", "parameter", false, 1, "3.0")
+  let stringParametersNames = dumpVariables(fmiModelVariablesList, "string", "parameter", false, 2, "3.0")
+  /* Get dependent Real parameters and their value references */
+  let realDependentParametersVRs = dumpVariables(fmiModelVariablesList, "real", "parameter", true, 1, "3.0")
+  let realDependentParametersNames = dumpVariables(fmiModelVariablesList, "real", "parameter", true, 2, "3.0")
+  /* Get dependent Integer parameters and their value references */
+  let integerDependentParametersVRs = dumpVariables(fmiModelVariablesList, "integer", "parameter", true, 1, "3.0")
+  let integerDependentParametersNames = dumpVariables(fmiModelVariablesList, "integer", "parameter", true, 2, "3.0")
+  /* Get dependent Boolean parameters and their value references */
+  let booleanDependentParametersVRs = dumpVariables(fmiModelVariablesList, "boolean", "parameter", true, 1, "3.0")
+  let booleanDependentParametersNames = dumpVariables(fmiModelVariablesList, "boolean", "parameter", true, 2, "3.0")
+  /* Get dependent String parameters and their value references */
+  let stringDependentParametersVRs = dumpVariables(fmiModelVariablesList, "string", "parameter", true, 1, "3.0")
+  let stringDependentParametersNames = dumpVariables(fmiModelVariablesList, "string", "parameter", true, 2, "3.0")
+  /* Get input Real varibales and their value references */
+  let nRealInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "real", "input"))
+  let realInputVariablesVRs = dumpVariables(fmiModelVariablesList, "real", "input", false, 1, "3.0")
+  let realInputVariablesNames = dumpVariables(fmiModelVariablesList, "real", "input", false, 2, "3.0")
+  let realInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "real", "input", false, 3, "3.0")
+  /* Get input Integer varibales and their value references */
+  let nIntegerInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "integer", "input"))
+  let integerInputVariablesVRs = dumpVariables(fmiModelVariablesList, "integer", "input", false, 1, "3.0")
+  let integerInputVariablesNames = dumpVariables(fmiModelVariablesList, "integer", "input", false, 2, "3.0")
+  let integerInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "integer", "input", false, 3, "3.0")
+  /* Get input Boolean varibales and their value references */
+  let nBooleanInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "boolean", "input"))
+  let booleanInputVariablesVRs = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 1, "3.0")
+  let booleanInputVariablesNames = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 2, "3.0")
+  let booleanInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 3, "3.0")
+  /* Get input String varibales and their value references */
+  let nStringInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "string", "input"))
+  let stringInputVariablesVRs = dumpVariables(fmiModelVariablesList, "string", "input", false, 1, "3.0")
+  let stringStartVariablesNames = dumpVariables(fmiModelVariablesList, "string", "input", false, 2, "3.0")
+  let stringInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "string", "input", false, 3, "3.0")
+  /* Get event input Real varibales and their value references */
+  let nRealEventInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "real", "input"))
+  let realEventInputVariablesVRs = dumpVariables(fmiModelVariablesList, "real", "input", false, 1, "3.0")
+  let realEventInputVariablesNames = dumpVariables(fmiModelVariablesList, "real", "input", false, 2, "3.0")
+  let realEventInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "real", "input", false, 3, "3.0")
+  /* Get event input Integer varibales and their value references */
+  let nIntegerEventInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "integer", "input"))
+  let integerEventInputVariablesVRs = dumpVariables(fmiModelVariablesList, "integer", "input", false, 1, "3.0")
+  let integerEventInputVariablesNames = dumpVariables(fmiModelVariablesList, "integer", "input", false, 2, "3.0")
+  let integerEventInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "integer", "input", false, 3, "3.0")
+  /* Get event input Boolean varibales and their value references */
+  let nBooleanEventInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "boolean", "input"))
+  let booleanEventInputVariablesVRs = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 1, "3.0")
+  let booleanEventInputVariablesNames = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 2, "3.0")
+  let booleanEventInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "boolean", "input", false, 3, "3.0")
+  /* Get event input String varibales and their value references */
+  let nStringEventInputVariables = listLength(filterModelVariables(fmiModelVariablesList, "string", "input"))
+  let stringEventInputVariablesVRs = dumpVariables(fmiModelVariablesList, "string", "input", false, 1, "3.0")
+  let stringEventStartVariablesNames = dumpVariables(fmiModelVariablesList, "string", "input", false, 2, "3.0")
+  let stringEventInputVariablesReturnNames = dumpVariables(fmiModelVariablesList, "string", "input", false, 3, "3.0")
+  /* Get output Real varibales and their value references */
+  let realOutputVariablesVRs = dumpVariables(fmiModelVariablesList, "real", "output", false, 1, "3.0")
+  let realOutputVariablesNames = dumpVariables(fmiModelVariablesList, "real", "output", false, 2, "3.0")
+  /* Get output Integer varibales and their value references */
+  let integerOutputVariablesVRs = dumpVariables(fmiModelVariablesList, "integer", "output", false, 1, "3.0")
+  let integerOutputVariablesNames = dumpVariables(fmiModelVariablesList, "integer", "output", false, 2, "3.0")
+  /* Get output Boolean varibales and their value references */
+  let booleanOutputVariablesVRs = dumpVariables(fmiModelVariablesList, "boolean", "output", false, 1, "3.0")
+  let booleanOutputVariablesNames = dumpVariables(fmiModelVariablesList, "boolean", "output", false, 2, "3.0")
+  /* Get output String varibales and their value references */
+  let stringOutputVariablesVRs = dumpVariables(fmiModelVariablesList, "string", "output", false, 1, "3.0")
+  let stringOutputVariablesNames = dumpVariables(fmiModelVariablesList, "string", "output", false, 2, "3.0")
+  <<
+  model <%if stringEq(name, "") then fmiInfo.fmiModelIdentifier+"_"+getFMIType(fmiInfo)+"_FMU" else name%><%if stringEq(fmiInfo.fmiDescription, "") then "" else " \""+fmiInfo.fmiDescription+"\""%>
+    <%dumpFMITypeDefinitions(fmiTypeDefinitionsList)%>
+    constant String fmuWorkingDir = "<%fmuWorkingDirectory%>";
+    parameter Integer logLevel = <%fmiLogLevel%> "log level used during the loading of FMU" annotation (Dialog(tab="FMI", group="Enable logging"));
+    parameter Boolean debugLogging = <%fmiDebugOutput%> "enables the FMU simulation logging" annotation (Dialog(tab="FMI", group="Enable logging"));
+    <%dumpFMIModelVariablesList("3.0", fmiModelVariablesList, fmiTypeDefinitionsList, generateInputConnectors, generateOutputConnectors)%>
+  protected
+    FMI3ModelExchange fmi3me = FMI3ModelExchange(logLevel, fmuWorkingDir, "<%fmiInfo.fmiModelIdentifier%>", debugLogging);
+    constant Integer numberOfContinuousStates = <%listLength(fmiInfo.fmiNumberOfContinuousStates)%>;
+    Real fmi_x[numberOfContinuousStates] "States";
+    Real fmi_x_new[numberOfContinuousStates](each fixed=true) "New States";
+    constant Integer numberOfEventIndicators = <%listLength(fmiInfo.fmiNumberOfEventIndicators)%>;
+    Real fmi_z[numberOfEventIndicators] "Events Indicators";
+    Boolean fmi_z_positive[numberOfEventIndicators](each fixed=true);
+    parameter Real flowStartTime(fixed=false);
+    Real flowTime;
+    parameter Real flowEnterInitialization(fixed=false);
+    parameter Real flowInitialized(fixed=false);
+    parameter Real flowParamsStart(fixed=false);
+    parameter Real flowInitInputs(fixed=false);
+    Real flowStatesInputs;
+    <%if not stringEq(realInputVariablesVRs, "") then "Real realInputVariables["+nRealInputVariables+"];"%>
+    <%if not stringEq(realInputVariablesVRs, "") then "Real "+realInputVariablesReturnNames+";"%>
+    <%if not stringEq(integerInputVariablesVRs, "") then "Integer integerInputVariables["+nIntegerInputVariables+"];"%>
+    <%if not stringEq(integerInputVariablesVRs, "") then "Integer "+integerInputVariablesReturnNames+";"%>
+    <%if not stringEq(booleanInputVariablesVRs, "") then "Boolean booleanInputVariables["+nBooleanInputVariables+"];"%>
+    <%if not stringEq(booleanInputVariablesVRs, "") then "Boolean "+booleanInputVariablesReturnNames+";"%>
+    <%if not stringEq(stringInputVariablesVRs, "") then "String stringInputVariables["+nStringInputVariables+"];"%>
+    <%if not stringEq(stringInputVariablesVRs, "") then "String "+stringInputVariablesReturnNames+";"%>
+    <%if not stringEq(realEventInputVariablesVRs, "") then "Real realEventInputVariables["+nRealEventInputVariables+"](each fixed=true);"%>
+    <%if not stringEq(integerEventInputVariablesVRs, "") then "Integer integerEventInputVariables["+nIntegerEventInputVariables+"](each fixed=true);"%>
+    <%if not stringEq(booleanEventInputVariablesVRs, "") then "Boolean booleanEventInputVariables["+nBooleanEventInputVariables+"](each fixed=true);"%>
+    <%if not stringEq(stringEventInputVariablesVRs, "") then "String stringEventInputVariables["+nStringEventInputVariables+"](each fixed=true);"%>
+    Boolean callEventUpdate;
+    Boolean newStatesAvailable(fixed = true);
+    Real triggerDSSEvent;
+    Real nextEventTime(fixed = true);
+  initial equation
+    <%if intGt(listLength(fmiInfo.fmiNumberOfContinuousStates), 0) then
+    <<
+    fmi_x = fmi3Functions.fmi3GetContinuousStates(fmi3me, numberOfContinuousStates, flowParamsStart+flowInitialized);
+    >>
+    %>
+  initial algorithm
+    flowParamsStart := 1;
+    flowInitInputs := 1;
+    flowStartTime := flowParamsStart+flowInitInputs;
+    flowEnterInitialization := fmi3Functions.fmi3EnterInitialization(fmi3me, false, 0.0, time, false, 0.0, flowParamsStart+flowInitInputs);
+    flowInitialized := fmi3Functions.fmi3ExitInitialization(fmi3me, flowParamsStart+flowInitInputs+flowStartTime+flowEnterInitialization);
+    <%if not stringEq(realParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetRealParameter(fmi3me, {"+realParametersVRs+"}, {"+realParametersNames+"});"%>
+    <%if not stringEq(integerParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetIntegerParameter(fmi3me, {"+integerParametersVRs+"}, {"+integerParametersNames+"});"%>
+    <%if not stringEq(booleanParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetBooleanParameter(fmi3me, {"+booleanParametersVRs+"}, {"+booleanParametersNames+"});"%>
+    <%if not stringEq(stringParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetStringParameter(fmi3me, {"+stringParametersVRs+"}, {"+stringParametersNames+"});"%>
+  initial equation
+    <%if not stringEq(realDependentParametersVRs, "") then "{"+realDependentParametersNames+"} = fmi3Functions.fmi3GetReal(fmi3me, {"+realDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(integerDependentParametersVRs, "") then "{"+integerDependentParametersNames+"} = fmi3Functions.fmi3GetInteger(fmi3me, {"+integerDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(booleanDependentParametersVRs, "") then "{"+booleanDependentParametersNames+"} = fmi3Functions.fmi3GetBoolean(fmi3me, {"+booleanDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(stringDependentParametersVRs, "") then "{"+stringDependentParametersNames+"} = fmi3Functions.fmi3GetString(fmi3me, {"+stringDependentParametersVRs+"}, flowInitialized);"%>
+  algorithm
+    flowTime := if not initial() then fmi3Functions.fmi3SetTime(fmi3me, time, flowInitialized) else time;
+    /* algorithm section ensures that inputs to fmi (if any) are set directly after the new time is set */
+    <%if not stringEq(realInputVariablesVRs, "") then "realInputVariables := fmi3Functions.fmi3SetReal(fmi3me, {"+realInputVariablesVRs+"}, {"+realInputVariablesNames+"});"%>
+    <%if not stringEq(integerInputVariablesVRs, "") then "integerInputVariables := fmi3Functions.fmi3SetInteger(fmi3me, {"+integerInputVariablesVRs+"}, {"+integerInputVariablesNames+"});"%>
+    <%if not stringEq(booleanInputVariablesVRs, "") then "booleanInputVariables := fmi3Functions.fmi3SetBoolean(fmi3me, {"+booleanInputVariablesVRs+"}, {"+booleanInputVariablesNames+"});"%>
+    <%if not stringEq(stringInputVariablesVRs, "") then "stringInputVariables := fmi3Functions.fmi3SetString(fmi3me, {"+stringInputVariablesVRs+"}, {"+stringStartVariablesNames+"});"%>
+  equation
+    <%if not stringEq(realInputVariablesVRs, "") then "{"+realInputVariablesReturnNames+"} = realInputVariables;"%>
+    <%if not stringEq(integerInputVariablesVRs, "") then "{"+integerInputVariablesReturnNames+"} = integerInputVariables;"%>
+    <%if not stringEq(booleanInputVariablesVRs, "") then "{"+booleanInputVariablesReturnNames+"} = booleanInputVariables;"%>
+    <%if not stringEq(stringInputVariablesVRs, "") then "{"+stringInputVariablesReturnNames+"} = stringInputVariables;"%>
+    flowStatesInputs = fmi3Functions.fmi3SetContinuousStates(fmi3me, fmi_x, flowParamsStart + flowTime);
+    der(fmi_x) = fmi3Functions.fmi3GetDerivatives(fmi3me, numberOfContinuousStates, flowStatesInputs);
+    fmi_z  = fmi3Functions.fmi3GetEventIndicators(fmi3me, numberOfEventIndicators, flowStatesInputs);
+    for i in 1:size(fmi_z,1) loop
+      fmi_z_positive[i] = if not terminal() then fmi_z[i] > 0 else pre(fmi_z_positive[i]);
+    end for;
+
+    triggerDSSEvent = noEvent(if callEventUpdate then flowStatesInputs+1.0 else flowStatesInputs-1.0);
+
+    <%if not boolAnd(stringEq(realOutputVariablesNames, ""), stringEq(realOutputVariablesVRs, "")) then "{"+realOutputVariablesNames+"} = fmi3Functions.fmi3GetReal(fmi3me, {"+realOutputVariablesVRs+"}, flowStatesInputs);"%>
+    <%if not boolAnd(stringEq(integerOutputVariablesNames, ""), stringEq(integerOutputVariablesVRs, "")) then "{"+integerOutputVariablesNames+"} = fmi3Functions.fmi3GetInteger(fmi3me, {"+integerOutputVariablesVRs+"}, flowStatesInputs);"%>
+    <%if not boolAnd(stringEq(booleanOutputVariablesNames, ""), stringEq(booleanOutputVariablesVRs, "")) then "{"+booleanOutputVariablesNames+"} = fmi3Functions.fmi3GetBoolean(fmi3me, {"+booleanOutputVariablesVRs+"}, flowStatesInputs);"%>
+    <%if not boolAnd(stringEq(stringOutputVariablesNames, ""), stringEq(stringOutputVariablesVRs, "")) then "{"+stringOutputVariablesNames+"} = fmi3Functions.fmi3GetString(fmi3me, {"+stringOutputVariablesVRs+"}, flowStatesInputs);"%>
+    <%dumpOutputGetEnumerationVariables(fmiModelVariablesList, fmiTypeDefinitionsList, "fmi3Functions.fmi3GetInteger", "fmi3me")%>
+    callEventUpdate = fmi3Functions.fmi3CompletedIntegratorStep(fmi3me, flowStatesInputs+flowTime);
+  algorithm
+  <%if intGt(listLength(fmiInfo.fmiNumberOfEventIndicators), 0) then
+  <<
+    when {<%fmiInfo.fmiNumberOfEventIndicators |> eventIndicator =>  "change(fmi_z_positive["+eventIndicator+"])" ;separator=" or "%>, triggerDSSEvent > flowStatesInputs, pre(nextEventTime) < time, terminal()} then
+  >>
+  else
+  <<
+    when {triggerDSSEvent > flowStatesInputs, pre(nextEventTime) < time, terminal()} then
+  >>
+  %>
+      fmi3Functions.fmi3StartEventUpdate(fmi3me);
+      <%if not stringEq(realEventInputVariablesVRs, "") then "realEventInputVariables := fmi3Functions.fmi3SetReal(fmi3me, {"+realEventInputVariablesVRs+"}, {"+realEventInputVariablesNames+"});"%>
+      <%if not stringEq(integerEventInputVariablesVRs, "") then "integerEventInputVariables := fmi3Functions.fmi3SetInteger(fmi3me, {"+integerEventInputVariablesVRs+"}, {"+integerEventInputVariablesNames+"});"%>
+      <%if not stringEq(booleanEventInputVariablesVRs, "") then "booleanEventInputVariables := fmi3Functions.fmi3SetBoolean(fmi3me, {"+booleanEventInputVariablesVRs+"}, {"+booleanEventInputVariablesNames+"});"%>
+      <%if not stringEq(stringEventInputVariablesVRs, "") then "stringEventInputVariables := fmi3Functions.fmi3SetString(fmi3me, {"+stringEventInputVariablesVRs+"}, {"+stringEventStartVariablesNames+"});"%>
+      newStatesAvailable := fmi3Functions.fmi3EndEventUpdate(fmi3me);
+      nextEventTime := fmi3Functions.fmi3nextEventTime(fmi3me, flowStatesInputs);
+  <%if intGt(listLength(fmiInfo.fmiNumberOfContinuousStates), 0) then
+  <<
+      if newStatesAvailable then
+        fmi_x_new := fmi3Functions.fmi3GetContinuousStates(fmi3me, numberOfContinuousStates, flowStatesInputs);
+        <%fmiInfo.fmiNumberOfContinuousStates |> continuousStates =>  "reinit(fmi_x["+continuousStates+"], fmi_x_new["+continuousStates+"]);" ;separator="\n"%>
+      end if;
+  >>
+  %>
+    end when;
+    annotation(experiment(StartTime=<%fmiExperimentAnnotation.fmiExperimentStartTime%>, StopTime=<%fmiExperimentAnnotation.fmiExperimentStopTime%>, Tolerance=<%fmiExperimentAnnotation.fmiExperimentTolerance%>));
+    annotation (Icon(graphics={
+        Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,0},
+          fillColor={240,240,240},
+          fillPattern=FillPattern.Solid,
+          lineThickness=0.5),
+        Text(
+          extent={{-100,40},{100,0}},
+          lineColor={0,0,0},
+          textString="%name"),
+        Text(
+          extent={{-100,-50},{100,-90}},
+          lineColor={0,0,0},
+          textString="V3.0")}));
+  protected
+    class FMI3ModelExchange
+      extends ExternalObject;
+        function constructor
+          input Integer logLevel;
+          input String workingDirectory;
+          input String instanceName;
+          input Boolean debugLogging;
+          output FMI3ModelExchange fmi3me;
+          external "C" fmi3me = FMI3ModelExchangeConstructor_OMC(logLevel, workingDirectory, instanceName, debugLogging) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        end constructor;
+
+        function destructor
+          input FMI3ModelExchange fmi3me;
+          external "C" FMI3ModelExchangeDestructor_OMC(fmi3me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        end destructor;
+    end FMI3ModelExchange;
+
+    <%dumpFMITypeDefinitionsMappingFunctions(fmiTypeDefinitionsList)%>
+
+    <%dumpFMITypeDefinitionsArrayMappingFunctions(fmiTypeDefinitionsList)%>
+
+    package fmi3Functions
+      function fmi3SetTime
+        input FMI3ModelExchange fmi3me;
+        input Real inTime;
+        input Real inFlow;
+        output Real outFlow = inFlow;
+        external "C" fmi3SetTime_OMC(fmi3me, inTime) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetTime;
+
+      function fmi3EnterInitialization
+        "FMI 3.0 folded what fmi2SetupExperiment carried into fmi3EnterInitializationMode."
+        input FMI3ModelExchange fmi3me;
+        input Boolean inToleranceDefined;
+        input Real inTolerance;
+        input Real inStartTime;
+        input Boolean inStopTimeDefined;
+        input Real inStopTime;
+        input Real inFlowVariable;
+        output Real outFlowVariable = inFlowVariable;
+        external "C" fmi3EnterInitializationModel_OMC(fmi3me, inToleranceDefined, inTolerance, inStartTime, inStopTimeDefined, inStopTime) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3EnterInitialization;
+
+      function fmi3ExitInitialization
+        input FMI3ModelExchange fmi3me;
+        input Real inFlowVariable;
+        output Real outFlowVariable = inFlowVariable;
+        external "C" fmi3ExitInitializationModel_OMC(fmi3me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3ExitInitialization;
+
+      function fmi3GetContinuousStates
+        input FMI3ModelExchange fmi3me;
+        input Integer numberOfContinuousStates;
+        input Real inFlowParams;
+        output Real fmi_x[numberOfContinuousStates];
+        external "C" fmi3GetContinuousStates_OMC(fmi3me, numberOfContinuousStates, inFlowParams, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetContinuousStates;
+
+      function fmi3SetContinuousStates
+        input FMI3ModelExchange fmi3me;
+        input Real fmi_x[:];
+        input Real inFlowParams;
+        output Real outFlowStates;
+        external "C" outFlowStates = fmi3SetContinuousStates_OMC(fmi3me, size(fmi_x, 1), inFlowParams, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetContinuousStates;
+
+      function fmi3GetDerivatives
+        input FMI3ModelExchange fmi3me;
+        input Integer numberOfContinuousStates;
+        input Real inFlowStates;
+        output Real fmi_x[numberOfContinuousStates];
+        external "C" fmi3GetDerivatives_OMC(fmi3me, numberOfContinuousStates, inFlowStates, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetDerivatives;
+
+      function fmi3GetEventIndicators
+        input FMI3ModelExchange fmi3me;
+        input Integer numberOfEventIndicators;
+        input Real inFlowStates;
+        output Real fmi_z[numberOfEventIndicators];
+        external "C" fmi3GetEventIndicators_OMC(fmi3me, numberOfEventIndicators, inFlowStates, fmi_z) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetEventIndicators;
+
+      function fmi3GetReal
+        input FMI3ModelExchange fmi3me;
+        input Real realValuesReferences[:];
+        input Real inFlowStatesInput;
+        output Real realValues[size(realValuesReferences, 1)];
+        external "C" fmi3GetReal_OMC(fmi3me, size(realValuesReferences, 1), realValuesReferences, inFlowStatesInput, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetReal;
+
+      function fmi3SetReal
+        input FMI3ModelExchange fmi3me;
+        input Real realValueReferences[:];
+        input Real realValues[size(realValueReferences, 1)];
+        output Real outValues[size(realValueReferences, 1)] = realValues;
+        external "C" fmi3SetReal_OMC(fmi3me, size(realValueReferences, 1), realValueReferences, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetReal;
+
+      function fmi3SetRealParameter
+        input FMI3ModelExchange fmi3me;
+        input Real realValueReferences[:];
+        input Real realValues[size(realValueReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi3SetReal_OMC(fmi3me, size(realValueReferences, 1), realValueReferences, realValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetRealParameter;
+
+      function fmi3GetInteger
+        input FMI3ModelExchange fmi3me;
+        input Real integerValueReferences[:];
+        input Real inFlowStatesInput;
+        output Integer integerValues[size(integerValueReferences, 1)];
+        external "C" fmi3GetInteger_OMC(fmi3me, size(integerValueReferences, 1), integerValueReferences, inFlowStatesInput, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetInteger;
+
+      function fmi3SetInteger
+        input FMI3ModelExchange fmi3me;
+        input Real integerValuesReferences[:];
+        input Integer integerValues[size(integerValuesReferences, 1)];
+        output Integer outValues[size(integerValuesReferences, 1)] = integerValues;
+        external "C" fmi3SetInteger_OMC(fmi3me, size(integerValuesReferences, 1), integerValuesReferences, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetInteger;
+
+      function fmi3SetIntegerParameter
+        input FMI3ModelExchange fmi3me;
+        input Real integerValuesReferences[:];
+        input Integer integerValues[size(integerValuesReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi3SetInteger_OMC(fmi3me, size(integerValuesReferences, 1), integerValuesReferences, integerValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetIntegerParameter;
+
+      function fmi3GetBoolean
+        input FMI3ModelExchange fmi3me;
+        input Real booleanValuesReferences[:];
+        input Real inFlowStatesInput;
+        output Boolean booleanValues[size(booleanValuesReferences, 1)];
+        external "C" fmi3GetBoolean_OMC(fmi3me, size(booleanValuesReferences, 1), booleanValuesReferences, inFlowStatesInput, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetBoolean;
+
+      function fmi3SetBoolean
+        input FMI3ModelExchange fmi3me;
+        input Real booleanValueReferences[:];
+        input Boolean booleanValues[size(booleanValueReferences, 1)];
+        output Boolean outValues[size(booleanValueReferences, 1)] = booleanValues;
+        external "C" fmi3SetBoolean_OMC(fmi3me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetBoolean;
+
+      function fmi3SetBooleanParameter
+        input FMI3ModelExchange fmi3me;
+        input Real booleanValueReferences[:];
+        input Boolean booleanValues[size(booleanValueReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi3SetBoolean_OMC(fmi3me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetBooleanParameter;
+
+      function fmi3GetString
+        input FMI3ModelExchange fmi3me;
+        input Real stringValuesReferences[:];
+        input Real inFlowStatesInput;
+        output String stringValues[size(stringValuesReferences, 1)];
+        external "C" fmi3GetString_OMC(fmi3me, size(stringValuesReferences, 1), stringValuesReferences, inFlowStatesInput, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3GetString;
+
+      function fmi3SetString
+        input FMI3ModelExchange fmi3me;
+        input Real stringValueReferences[:];
+        input String stringValues[size(stringValueReferences, 1)];
+        output String outValues[size(stringValueReferences, 1)] = stringValues;
+        external "C" fmi3SetString_OMC(fmi3me, size(stringValueReferences, 1), stringValueReferences, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetString;
+
+      function fmi3SetStringParameter
+        input FMI3ModelExchange fmi3me;
+        input Real stringValueReferences[:];
+        input String stringValues[size(stringValueReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi3SetString_OMC(fmi3me, size(stringValueReferences, 1), stringValueReferences, stringValues) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3SetStringParameter;
+
+      function fmi3StartEventUpdate
+        input FMI3ModelExchange fmi3me;
+        external "C" fmi3StartEventUpdate_OMC(fmi3me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3StartEventUpdate;
+
+      function fmi3EndEventUpdate
+        input FMI3ModelExchange fmi3me;
+        output Boolean outNewStatesAvailable;
+        external "C" outNewStatesAvailable = fmi3EndEventUpdate_OMC(fmi3me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3EndEventUpdate;
+
+      function fmi3nextEventTime
+        input FMI3ModelExchange fmi3me;
+        input Real inFlowStates;
+        output Real outNewnextTime;
+        external "C" outNewnextTime = fmi3nextEventTime_OMC(fmi3me, inFlowStates) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3nextEventTime;
+
+      function fmi3CompletedIntegratorStep
+        input FMI3ModelExchange fmi3me;
+        input Real inFlowStates;
+        output Boolean outCallEventUpdate;
+        external "C" outCallEventUpdate = fmi3CompletedIntegratorStep_OMC(fmi3me, inFlowStates) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi3CompletedIntegratorStep;
+    end fmi3Functions;
+  end <%if stringEq(name, "") then fmiInfo.fmiModelIdentifier+"_"+getFMIType(fmiInfo)+"_FMU" else name%>;
+  >>
+end importFMU3ModelExchange;
+
 template importFMU1CoSimulationStandAlone(FmiImport fmi, String name)
  "Generates Modelica code for FMI Co-simulation stand alone version 1.0"
 ::=
@@ -3128,6 +3549,32 @@ case "2.0" then
     <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMIEnumerationModelVariableStartValue(fmiTypeDefinitionsList, baseType, hasStartValue, startValue, isFixed)%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
     >>
   end match
+case "3.0" then
+  /* Arrays, Binary and Clock are skipped: no Modelica declaration fits them yet, and
+     so is the independent variable, which is Modelica's own time. */
+  match fmiModelVariable
+  case FMI3REALVARIABLE(causality="independent") then ""
+  case FMI3REALVARIABLE(__) then
+    <<
+    <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMI3RealModelVariableStartValue(causality, startValue, isFixed)%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3INTEGERVARIABLE(__) then
+    <<
+    <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMI3IntegerModelVariableStartValue(causality, startValue, isFixed)%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3BOOLEANVARIABLE(__) then
+    <<
+    <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMI3BooleanModelVariableStartValue(causality, startValue, isFixed)%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3STRINGVARIABLE(__) then
+    <<
+    <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMI3StringModelVariableStartValue(causality, startValue, isFixed)%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3ENUMERATIONVARIABLE(__) then
+    <<
+    <%dumpFMIModelVariableVariability(variability)%><%dumpFMIModelVariableCausalityAndBaseType(causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%name%><%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  end match
 end dumpFMIModelVariable;
 
 template dumpFMIModelVariableVariability(String variability)
@@ -3154,6 +3601,94 @@ template dumpFMIModelVariableCausality(String causality)
   <%if stringEq(causality, "") then "" else causality+" "%>
   >>
 end dumpFMIModelVariableCausality;
+
+template dumpFMI3RealModelVariableStartValue(String causality, list<Real> startValue, Boolean isFixed)
+ "The start value part of an FMI 3.0 Real variable declaration.
+
+  The record holds a list because an FMI 3.0 variable can be an array; only scalars
+  are imported, so the list has at most one element and an empty one means the FMU
+  gave no start value."
+::=
+match startValue
+case {} then
+  match causality
+  case "parameter" then
+    if isFixed then "(fixed=true)" else "(fixed=false)"
+  else ""
+case startVal :: _ then
+  match causality
+  case "parameter" then
+    if isFixed then " = "+startVal
+    else "(start="+startVal+",fixed=false)"
+  else
+    if boolNot(isFixed) then "(start="+startVal+",fixed=false)"
+end dumpFMI3RealModelVariableStartValue;
+
+template dumpFMI3IntegerModelVariableStartValue(String causality, list<Integer> startValue, Boolean isFixed)
+ "The start value part of an FMI 3.0 Integer variable declaration.
+
+  The record holds a list because an FMI 3.0 variable can be an array; only scalars
+  are imported, so the list has at most one element and an empty one means the FMU
+  gave no start value."
+::=
+match startValue
+case {} then
+  match causality
+  case "parameter" then
+    if isFixed then "(fixed=true)" else "(fixed=false)"
+  else ""
+case startVal :: _ then
+  match causality
+  case "parameter" then
+    if isFixed then " = "+startVal
+    else "(start="+startVal+",fixed=false)"
+  else
+    if boolNot(isFixed) then "(start="+startVal+",fixed=false)"
+end dumpFMI3IntegerModelVariableStartValue;
+
+template dumpFMI3BooleanModelVariableStartValue(String causality, list<Boolean> startValue, Boolean isFixed)
+ "The start value part of an FMI 3.0 Boolean variable declaration.
+
+  The record holds a list because an FMI 3.0 variable can be an array; only scalars
+  are imported, so the list has at most one element and an empty one means the FMU
+  gave no start value."
+::=
+match startValue
+case {} then
+  match causality
+  case "parameter" then
+    if isFixed then "(fixed=true)" else "(fixed=false)"
+  else ""
+case startVal :: _ then
+  match causality
+  case "parameter" then
+    if isFixed then " = "+startVal
+    else "(start="+startVal+",fixed=false)"
+  else
+    if boolNot(isFixed) then "(start="+startVal+",fixed=false)"
+end dumpFMI3BooleanModelVariableStartValue;
+
+template dumpFMI3StringModelVariableStartValue(String causality, list<String> startValue, Boolean isFixed)
+ "The start value part of an FMI 3.0 String variable declaration.
+
+  The record holds a list because an FMI 3.0 variable can be an array; only scalars
+  are imported, so the list has at most one element and an empty one means the FMU
+  gave no start value."
+::=
+match startValue
+case {} then
+  match causality
+  case "parameter" then
+    if isFixed then "(fixed=true)" else "(fixed=false)"
+  else ""
+case startVal :: _ then
+  match causality
+  case "parameter" then
+    if isFixed then " = \""+startVal+"\""
+    else "(start=\""+startVal+"\",fixed=false)"
+  else
+    if boolNot(isFixed) then "(start=\""+startVal+"\",fixed=false)"
+end dumpFMI3StringModelVariableStartValue;
 
 template dumpFMIRealModelVariableStartValue(String FMUVersion, String variabilityCausality, Boolean hasStartValue, Real startValue, Boolean isFixed)
 ::=
@@ -3293,6 +3828,11 @@ else if stringEq(fmiVersion,"2.0") then
   match fmiModelVariable
   case REALVARIABLE(causality="parameter", hasStartValue=true) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
+  end match
+else if stringEq(fmiVersion,"3.0") then
+  match fmiModelVariable
+  case FMI3REALVARIABLE(causality="parameter", hasStartValue=true) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
 else if boolAnd(stringEq(type, "integer"), (boolAnd(stringEq(variabilityCausality, "parameter"), boolNot(dependent)))) then
@@ -3305,7 +3845,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case INTEGERVARIABLE(causality="parameter", hasStartValue=true) then
+case INTEGERVARIABLE(causality="parameter", hasStartValue=true) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3INTEGERVARIABLE(causality="parameter", hasStartValue=true) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3319,7 +3864,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case BOOLEANVARIABLE(causality="parameter", hasStartValue=true) then
+case BOOLEANVARIABLE(causality="parameter", hasStartValue=true) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3BOOLEANVARIABLE(causality="parameter", hasStartValue=true) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3333,7 +3883,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case STRINGVARIABLE(causality="parameter", hasStartValue=true) then
+case STRINGVARIABLE(causality="parameter", hasStartValue=true) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3STRINGVARIABLE(causality="parameter", hasStartValue=true) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3347,7 +3902,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case REALVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+case REALVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3REALVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3361,7 +3921,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case INTEGERVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+case INTEGERVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3INTEGERVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3375,7 +3940,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case BOOLEANVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+case BOOLEANVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3BOOLEANVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3389,7 +3959,12 @@ match fmiModelVariable
 end match
 else if stringEq(fmiVersion,"2.0") then
 match fmiModelVariable
-  case STRINGVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+case STRINGVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+end match
+else if stringEq(fmiVersion,"3.0") then
+match fmiModelVariable
+case FMI3STRINGVARIABLE(causality="parameter", hasStartValue=false, isFixed=false) then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3399,6 +3974,8 @@ else if boolAnd(stringEq(type, "real"), stringEq(variabilityCausality, "input"))
 match fmiModelVariable
   case REALVARIABLE(causality="input") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
+  case FMI3REALVARIABLE(causality="input") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
 %>
 >>
 else if boolAnd(stringEq(type, "integer"), stringEq(variabilityCausality, "input")) then
@@ -3406,6 +3983,8 @@ else if boolAnd(stringEq(type, "integer"), stringEq(variabilityCausality, "input
 <%
 match fmiModelVariable
   case INTEGERVARIABLE(causality="input") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
+  case FMI3INTEGERVARIABLE(causality="input") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
 %>
 >>
@@ -3415,6 +3994,8 @@ else if boolAnd(stringEq(type, "boolean"), stringEq(variabilityCausality, "input
 match fmiModelVariable
   case BOOLEANVARIABLE(causality="input") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
+  case FMI3BOOLEANVARIABLE(causality="input") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
 %>
 >>
 else if boolAnd(stringEq(type, "string"), stringEq(variabilityCausality, "input")) then
@@ -3422,6 +4003,8 @@ else if boolAnd(stringEq(type, "string"), stringEq(variabilityCausality, "input"
 <%
 match fmiModelVariable
   case STRINGVARIABLE(causality="input") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
+  case FMI3STRINGVARIABLE(causality="input") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name else if intEq(what,3) then "fmi_input_"+name
 %>
 >>
@@ -3431,7 +4014,11 @@ else if boolAnd(stringEq(type, "real"), stringEq(variabilityCausality, "output")
 match fmiModelVariable
   case REALVARIABLE(variability = "",causality="") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3REALVARIABLE(variability = "",causality="") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
   case REALVARIABLE(variability = "",causality="output") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3REALVARIABLE(variability = "",causality="output") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3441,7 +4028,11 @@ else if boolAnd(stringEq(type, "integer"), stringEq(variabilityCausality, "outpu
 match fmiModelVariable
   case INTEGERVARIABLE(variability = "",causality="") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3INTEGERVARIABLE(variability = "",causality="") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
   case INTEGERVARIABLE(variability = "",causality="output") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3INTEGERVARIABLE(variability = "",causality="output") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3451,7 +4042,11 @@ else if boolAnd(stringEq(type, "boolean"), stringEq(variabilityCausality, "outpu
 match fmiModelVariable
   case BOOLEANVARIABLE(variability = "",causality="") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3BOOLEANVARIABLE(variability = "",causality="") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
   case BOOLEANVARIABLE(variability = "",causality="output") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3BOOLEANVARIABLE(variability = "",causality="output") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
@@ -3461,29 +4056,41 @@ else if boolAnd(stringEq(type, "string"), stringEq(variabilityCausality, "output
 match fmiModelVariable
   case STRINGVARIABLE(variability = "",causality="") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3STRINGVARIABLE(variability = "",causality="") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
   case STRINGVARIABLE(variability = "",causality="output") then
+    if intEq(what,1) then valueReference else if intEq(what,2) then name
+  case FMI3STRINGVARIABLE(variability = "",causality="output") then
     if intEq(what,1) then valueReference else if intEq(what,2) then name
 %>
 >>
 end dumpVariable;
 
-template dumpOutputGetEnumerationVariables(list<ModelVariables> fmiModelVariablesList, list<TypeDefinitions> fmiTypeDefinitionsList, String fmiGetFunction, String fmiType)
+template dumpOutputGetEnumerationVariables(list<ModelVariables> fmiModelVariablesList, list<TypeDefinitions> fmiTypeDefinitionsList, String fmiGetFunction, String fmiInstance)
 ::=
   <<
-  <%fmiModelVariablesList |> fmiModelVariable => dumpOutputGetEnumerationVariable(fmiModelVariable, fmiTypeDefinitionsList, fmiGetFunction, fmiType)%>
+  <%fmiModelVariablesList |> fmiModelVariable => dumpOutputGetEnumerationVariable(fmiModelVariable, fmiTypeDefinitionsList, fmiGetFunction, fmiInstance)%>
   >>
 end dumpOutputGetEnumerationVariables;
 
-template dumpOutputGetEnumerationVariable(ModelVariables fmiModelVariable, list<TypeDefinitions> fmiTypeDefinitionsList, String fmiGetFunction, String fmiType)
+template dumpOutputGetEnumerationVariable(ModelVariables fmiModelVariable, list<TypeDefinitions> fmiTypeDefinitionsList, String fmiGetFunction, String fmiInstance)
 ::=
 match fmiModelVariable
 case ENUMERATIONVARIABLE(variability = "",causality="") then
   <<
-  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiType%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
+  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiInstance%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
   >>
 case ENUMERATIONVARIABLE(variability = "",causality="output") then
   <<
-  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiType%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
+  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiInstance%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
+  >>
+case FMI3ENUMERATIONVARIABLE(variability = "",causality="") then
+  <<
+  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiInstance%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
+  >>
+case FMI3ENUMERATIONVARIABLE(variability = "",causality="output") then
+  <<
+  {<%name%>} = map_<%getEnumerationTypeFromTypes(fmiTypeDefinitionsList, baseType)%>_from_integers(<%fmiGetFunction%>(<%fmiInstance%>, {<%valueReference%>}, flowStatesInputs));<%\n%>
   >>
 end dumpOutputGetEnumerationVariable;
 

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1847,10 +1847,13 @@ template importFMUModelDescription(FmiImport fmi)
 ::=
 match fmi
 case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)) then
+  /* FMI 1.0 and 2.0 share the records and are both dumped by the "1.0" case; FMI 3.0
+     has records of its own. */
+  let mdVersion = if isFMIVersion30(fmiInfo.fmiVersion) then "3.0" else "1.0"
   <<
   model <%fmiInfo.fmiModelIdentifier%>_Input_Output_FMU<%if stringEq(fmiInfo.fmiDescription, "") then "" else " \""+fmiInfo.fmiDescription+"\""%>
     <%dumpFMITypeDefinitions(fmiTypeDefinitionsList)%>
-    <%dumpFMUModelDescriptionVariablesList("1.0", fmiModelVariablesList, fmiTypeDefinitionsList, generateInputConnectors, generateOutputConnectors)%>
+    <%dumpFMUModelDescriptionVariablesList(mdVersion, fmiModelVariablesList, fmiTypeDefinitionsList, generateInputConnectors, generateOutputConnectors)%>
   end <%fmiInfo.fmiModelIdentifier%>_Input_Output_FMU;
   >>
 end importFMUModelDescription;
@@ -1895,6 +1898,43 @@ case "1.0" then
   case ENUMERATIONVARIABLE(__) then
     let isInputOrOutput = if boolOr(stringEq(causality, "input"), stringEq(causality, "output")) then true
     if isInputOrOutput then
+    <<
+    <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  end match
+case "3.0" then
+  /* The FMI 3.0 records, which carry the same baseType as the older ones -- Real for
+     both float types, Integer for all eight integer types -- so the connector a
+     variable becomes is chosen exactly as above. Binary and Clock have no Modelica
+     type and are left out, as are arrays, which a connector cannot carry. */
+  match fmiModelVariable
+  case FMI3REALVARIABLE(__) then
+    let emitConnector = if boolAnd(boolOr(stringEq(causality, "input"), stringEq(causality, "output")), listEmpty(dimensions)) then true
+    if emitConnector then
+    <<
+    <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3INTEGERVARIABLE(__) then
+    let emitConnector = if boolAnd(boolOr(stringEq(causality, "input"), stringEq(causality, "output")), listEmpty(dimensions)) then true
+    if emitConnector then
+    <<
+    <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3BOOLEANVARIABLE(__) then
+    let emitConnector = if boolAnd(boolOr(stringEq(causality, "input"), stringEq(causality, "output")), listEmpty(dimensions)) then true
+    if emitConnector then
+    <<
+    <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3STRINGVARIABLE(__) then
+    let emitConnector = if boolAnd(boolOr(stringEq(causality, "input"), stringEq(causality, "output")), listEmpty(dimensions)) then true
+    if emitConnector then
+    <<
+    <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
+    >>
+  case FMI3ENUMERATIONVARIABLE(__) then
+    let emitConnector = if boolAnd(boolOr(stringEq(causality, "input"), stringEq(causality, "output")), listEmpty(dimensions)) then true
+    if emitConnector then
     <<
     <%dumpFMUModelDescriptionInputOutputVariable(name, causality, baseType, generateInputConnectors, generateOutputConnectors)%> <%dumpFMIModelVariableDescription(description)%><%dumpFMIModelVariablePlacementAnnotation(x1Placement, x2Placement, y1Placement, y2Placement, generateInputConnectors, generateOutputConnectors, causality)%>;
     >>

--- a/OMCompiler/Compiler/Util/FMI.mo
+++ b/OMCompiler/Compiler/Util/FMI.mo
@@ -364,6 +364,13 @@ algorithm
     case INFO(fmiVersion = "2.0", fmiType = 1) then "me";
     case INFO(fmiVersion = "2.0", fmiType = 2) then "cs";
     case INFO(fmiVersion = "2.0", fmiType = 3) then "me_cs";
+    /* FMI 3.0 numbers its interface types as flags, so 2, 4 and 8 rather than the
+       1, 2, 3 of FMI 2.0; see fmi3_fmu_kind_enu_t. FMIImpl.c stores the one the
+       import picked, not the set the FMU offers. */
+    case INFO(fmiVersion = "3.0", fmiType = 2) then "me";
+    case INFO(fmiVersion = "3.0", fmiType = 4) then "cs";
+    case INFO(fmiVersion = "3.0", fmiType = 8) then "se";
+    else "";
   end match;
 end getFMIType;
 

--- a/OMCompiler/Compiler/runtime/FMIImpl.c
+++ b/OMCompiler/Compiler/runtime/FMIImpl.c
@@ -292,8 +292,12 @@ const char* getFMI3ModelVariableCausality(fmi3_import_variable_t* variable)
     case fmi3_causality_enu_parameter:
     case fmi3_causality_enu_structural_parameter:
       return "parameter";
-    case fmi3_causality_enu_calculated_parameter:
+    /* FMI 3.0 requires the independent variable to be declared, which FMI 2.0 did not.
+       It is named so that the wrapper can leave it out: it is Modelica's own time, and
+       declaring it would clash with the built-in. */
     case fmi3_causality_enu_independent:
+      return "independent";
+    case fmi3_causality_enu_calculated_parameter:
     case fmi3_causality_enu_local:
     case fmi3_causality_enu_unknown:
     default:

--- a/OMCompiler/SimulationRuntime/c/Makefile.objs
+++ b/OMCompiler/SimulationRuntime/c/Makefile.objs
@@ -284,7 +284,7 @@ SIM_HFILES = ../dataReconciliation/dataReconciliation.h \
              socket.h
 
 FMIPATH = fmi/
-FMI_OBJS = FMICommon$(OBJ_EXT) FMI1Common$(OBJ_EXT) FMI1ModelExchange$(OBJ_EXT) FMI1CoSimulation$(OBJ_EXT) FMI2Common$(OBJ_EXT) FMI2ModelExchange$(OBJ_EXT)
+FMI_OBJS = FMICommon$(OBJ_EXT) FMI1Common$(OBJ_EXT) FMI1ModelExchange$(OBJ_EXT) FMI1CoSimulation$(OBJ_EXT) FMI2Common$(OBJ_EXT) FMI2ModelExchange$(OBJ_EXT) FMI3Common$(OBJ_EXT) FMI3ModelExchange$(OBJ_EXT)
 FMIOBJSPATH = $(FMI_OBJS:%=$(BUILDPATH)/$(FMIPATH)%)
 
 GCPATH = gc/

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.c
@@ -1,0 +1,226 @@
+/*
+ * This file belongs to the OpenModelica Run-Time System
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC), c/o Linköpings
+ * universitet, Department of Computer and Information Science, SE-58183 Linköping, Sweden. All rights
+ * reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * AGPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8. ANY
+ * USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE BSD NEW LICENSE OR THE OSMC PUBLIC LICENSE OR THE AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium) Public License
+ * (OSMC-PL) are obtained from OSMC, either from the above address, from the URLs:
+ * http://www.openmodelica.org or https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica distribution. GNU
+ * AGPL version 3 is obtained from: https://www.gnu.org/licenses/licenses.html#GPL. The BSD NEW
+ * License is obtained from: http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY
+ * SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF
+ * OSMC-PL.
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "FMI3Common.h"
+
+/**
+ * @brief FMU 3.0 internal logger callback.
+ *
+ * FMI 3.0 hands the callback an instance environment rather than a component and an
+ * instance name, and the message is already formatted, so there is no va_list to
+ * forward as there was in FMI 2.0.
+ *
+ * @param instanceEnvironment  What was given to fmi3_import_create_dllfmu.
+ * @param status               Severity status of the message.
+ * @param category             Log category string.
+ * @param message              The message.
+ */
+void fmi3logger(fmi3_instance_environment_t instanceEnvironment, fmi3_status_t status, fmi3_string_t category, fmi3_string_t message)
+{
+  fmi3_log_forwarding(instanceEnvironment, status, category, message);
+  fflush(NULL);
+}
+
+/**
+ * @brief Convert an array of double-encoded value references to fmi3_value_reference_t.
+ *
+ * The generated Modelica code carries value references as Real, as it does for FMI 1.0
+ * and 2.0, so that it does not have to model an unsigned integer.
+ *
+ * @param numberOfValueReferences Number of value references to convert.
+ * @param valuesReferences        Input array of value references encoded as doubles.
+ * @return Newly allocated array of fmi3_value_reference_t; caller must free().
+ */
+fmi3_value_reference_t* real_to_fmi3_value_reference(int numberOfValueReferences, double* valuesReferences)
+{
+  fmi3_value_reference_t* valuesReferences_int = malloc(sizeof(fmi3_value_reference_t)*numberOfValueReferences);
+  int i;
+  for (i = 0 ; i < numberOfValueReferences ; i++) {
+    valuesReferences_int[i] = (fmi3_value_reference_t)valuesReferences[i];
+  }
+  return valuesReferences_int;
+}
+
+/*
+ * The get and set wrappers below all take nValues as well as nvr, which FMI 3.0 needs
+ * because a variable can be an array. Only scalars are imported so far, so the two are
+ * the same; when arrays arrive nValues becomes the sum of their sizes.
+ */
+
+/**
+ * @brief Wrapper for fmi3GetFloat64.
+ */
+void fmi3GetReal_OMC(void* in_fmi3, int numberOfValueReferences, double* realValuesReferences, double flowStatesInput, double* realValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, realValuesReferences);
+  fmi3_status_t status = fmi3_import_get_float64(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                 (fmi3_float64_t*)realValues, numberOfValueReferences);
+  free(valuesReferences_int);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetFloat64 failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3SetFloat64.
+ *
+ * Only sets values in instantiated, initialization, event, or continuous-time mode.
+ */
+void fmi3SetReal_OMC(void* in_fmi3, int numberOfValueReferences, double* realValuesReferences, double* realValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  if (FMI3ME->FMISolvingMode == fmi3_instantiated_mode || FMI3ME->FMISolvingMode == fmi3_initialization_mode || FMI3ME->FMISolvingMode == fmi3_event_mode || FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, realValuesReferences);
+    fmi3_status_t status = fmi3_import_set_float64(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                   (const fmi3_float64_t*)realValues, numberOfValueReferences);
+    free(valuesReferences_int);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetFloat64 failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3GetInt32.
+ */
+void fmi3GetInteger_OMC(void* in_fmi3, int numberOfValueReferences, double* integerValuesReferences, double flowStatesInput, int* integerValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, integerValuesReferences);
+  fmi3_status_t status = fmi3_import_get_int32(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                               (fmi3_int32_t*)integerValues, numberOfValueReferences);
+  free(valuesReferences_int);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetInt32 failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3SetInt32.
+ */
+void fmi3SetInteger_OMC(void* in_fmi3, int numberOfValueReferences, double* integerValuesReferences, int* integerValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  if (FMI3ME->FMISolvingMode == fmi3_instantiated_mode || FMI3ME->FMISolvingMode == fmi3_initialization_mode || FMI3ME->FMISolvingMode == fmi3_event_mode || FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, integerValuesReferences);
+    fmi3_status_t status = fmi3_import_set_int32(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                 (const fmi3_int32_t*)integerValues, numberOfValueReferences);
+    free(valuesReferences_int);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetInt32 failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3GetBoolean.
+ *
+ * Modelica booleans are signed char and FMI 3.0 ones are fmi3_boolean_t, so the values
+ * are read into a buffer of the FMI type and copied over.
+ */
+void fmi3GetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, signed char* booleanValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, booleanValuesReferences);
+  fmi3_boolean_t* fmiBooleans = malloc(sizeof(fmi3_boolean_t)*numberOfValueReferences);
+  fmi3_status_t status = fmi3_import_get_boolean(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                 fmiBooleans, numberOfValueReferences);
+  int i;
+  for (i = 0; i < numberOfValueReferences; i++) {
+    booleanValues[i] = (signed char)fmiBooleans[i];
+  }
+  free(fmiBooleans);
+  free(valuesReferences_int);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetBoolean failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3SetBoolean.
+ */
+void fmi3SetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, signed char* booleanValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  if (FMI3ME->FMISolvingMode == fmi3_instantiated_mode || FMI3ME->FMISolvingMode == fmi3_initialization_mode || FMI3ME->FMISolvingMode == fmi3_event_mode || FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, booleanValuesReferences);
+    fmi3_boolean_t* fmiBooleans = malloc(sizeof(fmi3_boolean_t)*numberOfValueReferences);
+    fmi3_status_t status;
+    int i;
+    for (i = 0; i < numberOfValueReferences; i++) {
+      fmiBooleans[i] = (fmi3_boolean_t)booleanValues[i];
+    }
+    status = fmi3_import_set_boolean(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                     fmiBooleans, numberOfValueReferences);
+    free(fmiBooleans);
+    free(valuesReferences_int);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetBoolean failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3GetString.
+ */
+void fmi3GetString_OMC(void* in_fmi3, int numberOfValueReferences, double* stringValuesReferences, double flowStatesInput, char** stringValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, stringValuesReferences);
+  fmi3_status_t status = fmi3_import_get_string(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                (fmi3_string_t*)stringValues, numberOfValueReferences);
+  free(valuesReferences_int);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetString failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/**
+ * @brief Wrapper for fmi3SetString.
+ */
+void fmi3SetString_OMC(void* in_fmi3, int numberOfValueReferences, double* stringValuesReferences, char** stringValues)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
+  if (FMI3ME->FMISolvingMode == fmi3_instantiated_mode || FMI3ME->FMISolvingMode == fmi3_initialization_mode || FMI3ME->FMISolvingMode == fmi3_event_mode || FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, stringValuesReferences);
+    fmi3_status_t status = fmi3_import_set_string(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
+                                                  (const fmi3_string_t*)stringValues, numberOfValueReferences);
+    free(valuesReferences_int);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetString failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.h
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.h
@@ -1,0 +1,84 @@
+/*
+ * This file belongs to the OpenModelica Run-Time System
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC), c/o Linköpings
+ * universitet, Department of Computer and Information Science, SE-58183 Linköping, Sweden. All rights
+ * reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * AGPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8. ANY
+ * USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE BSD NEW LICENSE OR THE OSMC PUBLIC LICENSE OR THE AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium) Public License
+ * (OSMC-PL) are obtained from OSMC, either from the above address, from the URLs:
+ * http://www.openmodelica.org or https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica distribution. GNU
+ * AGPL version 3 is obtained from: https://www.gnu.org/licenses/licenses.html#GPL. The BSD NEW
+ * License is obtained from: http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY
+ * SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF
+ * OSMC-PL.
+ *
+ */
+
+#ifndef FMI3COMMON__H_
+#define FMI3COMMON__H_
+
+#include "FMICommon.h"
+
+/*
+ * type to separate the different solving stages.
+ */
+typedef enum {
+  fmi3_instantiated_mode,
+  fmi3_initialization_mode,
+  fmi3_continuousTime_mode,
+  fmi3_event_mode,
+  fmi3_none_mode
+} fmi3_solving_mode_t;
+
+/*
+ * What fmi3UpdateDiscreteStates reports.
+ *
+ * FMI 2.0 had an fmi2_event_info_t that fmi2NewDiscreteStates filled in; FMI 3.0
+ * returns the same information through out parameters instead, so the event state
+ * of the run is kept here between the calls that produce it and the ones that read
+ * it.
+ */
+typedef struct {
+  fmi3_boolean_t discreteStatesNeedUpdate;
+  fmi3_boolean_t terminateSimulation;
+  fmi3_boolean_t nominalsOfContinuousStatesChanged;
+  fmi3_boolean_t valuesOfContinuousStatesChanged;
+  fmi3_boolean_t nextEventTimeDefined;
+  fmi3_float64_t nextEventTime;
+} fmi3_event_info_omc_t;
+
+/*
+ * Structure used as an External Object in the generated Modelica code of the imported FMU.
+ * Used for FMI 3.0 Model Exchange.
+ *
+ * There is no fmi3_callback_functions_t to hold: FMI 3.0 passes an instance
+ * environment and a single log callback to fmi3_import_create_dllfmu instead.
+ */
+typedef struct {
+  int FMILogLevel;
+  jm_callbacks JMCallbacks;
+  fmi_import_context_t* FMIImportContext;
+  char* FMIWorkingDirectory;
+  fmi3_import_t* FMIImportInstance;
+  char* FMIInstanceName;
+  int FMIDebugLogging;
+  int FMIToleranceControlled;
+  double FMIRelativeTolerance;
+  fmi3_event_info_omc_t FMIEventInfo;
+  fmi3_solving_mode_t FMISolvingMode;
+} FMI3ModelExchange;
+
+void fmi3logger(fmi3_instance_environment_t instanceEnvironment, fmi3_status_t status, fmi3_string_t category, fmi3_string_t message);
+
+#endif

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI3ModelExchange.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI3ModelExchange.c
@@ -1,0 +1,325 @@
+/*
+ * This file belongs to the OpenModelica Run-Time System
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC), c/o Linköpings
+ * universitet, Department of Computer and Information Science, SE-58183 Linköping, Sweden. All rights
+ * reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * AGPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8. ANY
+ * USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE BSD NEW LICENSE OR THE OSMC PUBLIC LICENSE OR THE AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium) Public License
+ * (OSMC-PL) are obtained from OSMC, either from the above address, from the URLs:
+ * http://www.openmodelica.org or https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica distribution. GNU
+ * AGPL version 3 is obtained from: https://www.gnu.org/licenses/licenses.html#GPL. The BSD NEW
+ * License is obtained from: http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY
+ * SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF
+ * OSMC-PL.
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <float.h>
+
+#include "FMICommon.h"
+#include "FMI3Common.h"
+
+/*
+ * FMI version 3.0 ModelExchange functions
+ *
+ * These follow the FMI 2.0 ones next door, with the differences FMI 3.0 introduced:
+ *
+ *   - there is no fmi3SetupExperiment. What it did is now arguments of
+ *     fmi3EnterInitializationMode.
+ *   - fmi3UpdateDiscreteStates replaces fmi2NewDiscreteStates and reports through out
+ *     parameters rather than filling in an event info structure.
+ *   - the instance is created with an instance environment and one log callback
+ *     instead of a table of callback functions.
+ *   - fmi3GetContinuousStateDerivatives replaces fmi2GetDerivatives.
+ */
+
+void* FMI3ModelExchangeConstructor_OMC(int fmi_log_level, char* working_directory, char* instanceName, int debugLogging)
+{
+  FMI3ModelExchange* FMI3ME = malloc(sizeof(FMI3ModelExchange));
+  jm_status_enu_t status, instantiateModelStatus;
+  FMI3ME->FMILogLevel = fmi_log_level;
+  /* JM callbacks */
+  FMI3ME->JMCallbacks.malloc = malloc;
+  FMI3ME->JMCallbacks.calloc = calloc;
+  FMI3ME->JMCallbacks.realloc = realloc;
+  FMI3ME->JMCallbacks.free = free;
+  FMI3ME->JMCallbacks.logger = importlogger;
+  FMI3ME->JMCallbacks.log_level = FMI3ME->FMILogLevel;
+  FMI3ME->JMCallbacks.context = 0;
+  FMI3ME->FMIImportContext = fmi_import_allocate_context(&FMI3ME->JMCallbacks);
+  /* parse the xml file */
+  FMI3ME->FMIWorkingDirectory = (char*) malloc(strlen(working_directory)+1);
+  strcpy(FMI3ME->FMIWorkingDirectory, working_directory);
+  FMI3ME->FMIImportInstance = fmi3_import_parse_xml(FMI3ME->FMIImportContext, FMI3ME->FMIWorkingDirectory, NULL);
+  if (!FMI3ME->FMIImportInstance) {
+    FMI3ME->FMISolvingMode = fmi3_none_mode;
+    ModelicaFormatError("Error parsing the XML file contained in %s\n", FMI3ME->FMIWorkingDirectory);
+    return 0;
+  }
+  /* Load the binary (dll/so) */
+  status = fmi3_import_create_dllfmu(FMI3ME->FMIImportInstance, fmi3_fmu_kind_me, FMI3ME->FMIImportInstance, fmi3logger);
+  if (status == jm_status_error) {
+    FMI3ME->FMISolvingMode = fmi3_none_mode;
+    ModelicaFormatError("Loading of FMU dynamic link library failed");
+    return 0;
+  }
+  FMI3ME->FMIInstanceName = (char*) malloc(strlen(instanceName)+1);
+  strcpy(FMI3ME->FMIInstanceName, instanceName);
+  FMI3ME->FMIDebugLogging = debugLogging;
+  instantiateModelStatus = fmi3_import_instantiate_model_exchange(FMI3ME->FMIImportInstance, FMI3ME->FMIInstanceName, NULL, fmi3_false, FMI3ME->FMIDebugLogging ? fmi3_true : fmi3_false);
+  if (instantiateModelStatus == jm_status_error) {
+    FMI3ME->FMISolvingMode = fmi3_none_mode;
+    ModelicaFormatError("fmi3InstantiateModelExchange failed");
+    return 0;
+  }
+  /* Only call fmi3SetDebugLogging if debugLogging is true */
+  if (FMI3ME->FMIDebugLogging) {
+    size_t i;
+    size_t categoriesSize = fmi3_import_get_log_categories_num(FMI3ME->FMIImportInstance);
+    fmi3_string_t* categories = (fmi3_string_t*)malloc(categoriesSize*sizeof(fmi3_string_t));
+    fmi3_status_t debugLoggingStatus;
+    for (i = 0 ; i < categoriesSize ; i++) {
+      categories[i] = fmi3_import_get_log_category(FMI3ME->FMIImportInstance, i);
+    }
+    debugLoggingStatus = fmi3_import_set_debug_logging(FMI3ME->FMIImportInstance, fmi3_true, categoriesSize, categories);
+    free(categories);
+    if (debugLoggingStatus != fmi3_status_ok && debugLoggingStatus != fmi3_status_warning) {
+      ModelicaFormatMessage("fmi3SetDebugLogging failed with status : %s\n", fmi3_status_to_string(debugLoggingStatus));
+    }
+  }
+  FMI3ME->FMIToleranceControlled = fmi3_true;
+  FMI3ME->FMIRelativeTolerance = 0.001;
+  memset(&FMI3ME->FMIEventInfo, 0, sizeof(fmi3_event_info_omc_t));
+  FMI3ME->FMISolvingMode = fmi3_instantiated_mode;
+  return FMI3ME;
+}
+
+void FMI3ModelExchangeDestructor_OMC(void* in_fmi3me)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_import_terminate(FMI3ME->FMIImportInstance);
+  fmi3_import_free_instance(FMI3ME->FMIImportInstance);
+  fmi3_import_destroy_dllfmu(FMI3ME->FMIImportInstance);
+  fmi3_import_free(FMI3ME->FMIImportInstance);
+  fmi_import_free_context(FMI3ME->FMIImportContext);
+  free(FMI3ME->FMIWorkingDirectory);
+  free(FMI3ME->FMIInstanceName);
+}
+
+/*
+ * Wrapper for the FMI function fmi3EnterInitializationMode.
+ *
+ * FMI 3.0 has no fmi3SetupExperiment; what it carried is passed here instead, so the
+ * generated code calls this where it called fmi2SetupExperiment and
+ * fmi2EnterInitializationMode in turn.
+ */
+void fmi3EnterInitializationModel_OMC(void* in_fmi3me, int toleranceDefined, double tolerance, double startTime, int stopTimeDefined, double stopTime)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_status_t status = fmi3_import_enter_initialization_mode(FMI3ME->FMIImportInstance,
+      toleranceDefined ? fmi3_true : fmi3_false, tolerance,
+      startTime,
+      stopTimeDefined ? fmi3_true : fmi3_false, stopTime);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3EnterInitializationMode failed with status : %s\n", fmi3_status_to_string(status));
+  }
+  FMI3ME->FMISolvingMode = fmi3_initialization_mode;
+}
+
+/*
+ * Wrapper for the FMI function fmi3ExitInitializationMode.
+ *
+ * An FMI 3.0 Model Exchange FMU is in Event Mode when initialization ends, which is
+ * where FMI 2.0 needed an explicit fmi2EnterEventMode.
+ */
+void fmi3ExitInitializationModel_OMC(void* in_fmi3me)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_status_t status = fmi3_import_exit_initialization_mode(FMI3ME->FMIImportInstance);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3ExitInitializationMode failed with status : %s\n", fmi3_status_to_string(status));
+  }
+  FMI3ME->FMISolvingMode = fmi3_event_mode;
+}
+
+/*
+ * Wrapper for the FMI function fmi3SetTime.
+ */
+void fmi3SetTime_OMC(void* in_fmi3me, double time)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  if (FMI3ME->FMISolvingMode == fmi3_continuousTime_mode || FMI3ME->FMISolvingMode == fmi3_event_mode) {
+    fmi3_status_t status = fmi3_import_set_time(FMI3ME->FMIImportInstance, time);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetTime failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+}
+
+/*
+ * Wrapper for the FMI function fmi3GetContinuousStates.
+ * parameter flowParams is dummy and is only used to run the equations in sequence.
+ */
+void fmi3GetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates, double flowParams, double* states)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_status_t status = fmi3_import_get_continuous_states(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetContinuousStates failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/*
+ * Wrapper for the FMI function fmi3SetContinuousStates.
+ * parameter flowParams is dummy and is only used to run the equations in sequence.
+ */
+double fmi3SetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates, double flowParams, double* states)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  if (FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_status_t status = fmi3_import_set_continuous_states(FMI3ME->FMIImportInstance, (const fmi3_float64_t*)states, numberOfContinuousStates);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3SetContinuousStates failed with status : %s\n", fmi3_status_to_string(status));
+    }
+  }
+  return flowParams;
+}
+
+/*
+ * Wrapper for the FMI function fmi3GetEventIndicators.
+ * parameter flowStates is dummy and is only used to run the equations in sequence.
+ */
+void fmi3GetEventIndicators_OMC(void* in_fmi3me, int numberOfEventIndicators, double flowStates, double* events)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_status_t status = fmi3_import_get_event_indicators(FMI3ME->FMIImportInstance, (fmi3_float64_t*)events, numberOfEventIndicators);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetEventIndicators failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/*
+ * Wrapper for the FMI function fmi3GetContinuousStateDerivatives, which is what FMI 2.0
+ * called fmi2GetDerivatives.
+ * parameter flowStates is dummy and is only used to run the equations in sequence.
+ */
+void fmi3GetDerivatives_OMC(void* in_fmi3me, int numberOfContinuousStates, double flowStates, double* states)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  /* FMI Library still calls this fmi3_import_get_derivatives, though FMI 3.0 renamed
+     the function it wraps to fmi3GetContinuousStateDerivatives. */
+  fmi3_status_t status = fmi3_import_get_derivatives(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3GetContinuousStateDerivatives failed with status : %s\n", fmi3_status_to_string(status));
+  }
+}
+
+/*
+ * Wrapper for the FMI function fmi3EnterEventMode.
+ */
+void fmi3StartEventUpdate_OMC(void* in_fmi3me)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_status_t status = fmi3_import_enter_event_mode(FMI3ME->FMIImportInstance);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3EnterEventMode failed with status : %s\n", fmi3_status_to_string(status));
+  }
+  FMI3ME->FMISolvingMode = fmi3_event_mode;
+  FMI3ME->FMIEventInfo.discreteStatesNeedUpdate = fmi3_true;
+  FMI3ME->FMIEventInfo.terminateSimulation = fmi3_false;
+}
+
+/*
+ * Wrapper for the FMI function fmi3UpdateDiscreteStates, which is what FMI 2.0 called
+ * fmi2NewDiscreteStates. It reports through out parameters, which are kept in the
+ * external object so that fmi3nextEventTime_OMC can read them afterwards.
+ *
+ * The FMU may need more than one pass before the discrete states settle, which is what
+ * discreteStatesNeedUpdate says; iterate until it does.
+ *
+ * Returns valuesOfContinuousStatesChanged.
+ */
+int fmi3EndEventUpdate_OMC(void* in_fmi3me)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  fmi3_event_info_omc_t* eventInfo = &FMI3ME->FMIEventInfo;
+  fmi3_boolean_t valuesOfContinuousStatesChanged = fmi3_false;
+  fmi3_status_t status;
+
+  eventInfo->discreteStatesNeedUpdate = fmi3_true;
+  eventInfo->terminateSimulation = fmi3_false;
+  while (eventInfo->discreteStatesNeedUpdate && !eventInfo->terminateSimulation) {
+    status = fmi3_import_update_discrete_states(FMI3ME->FMIImportInstance,
+        &eventInfo->discreteStatesNeedUpdate,
+        &eventInfo->terminateSimulation,
+        &eventInfo->nominalsOfContinuousStatesChanged,
+        &eventInfo->valuesOfContinuousStatesChanged,
+        &eventInfo->nextEventTimeDefined,
+        &eventInfo->nextEventTime);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3UpdateDiscreteStates failed with status : %s\n", fmi3_status_to_string(status));
+    }
+    /* any pass that moved the states counts, not only the last one */
+    if (eventInfo->valuesOfContinuousStatesChanged) {
+      valuesOfContinuousStatesChanged = fmi3_true;
+    }
+  }
+
+  status = fmi3_import_enter_continuous_time_mode(FMI3ME->FMIImportInstance);
+  if (status != fmi3_status_ok && status != fmi3_status_warning) {
+    ModelicaFormatError("fmi3EnterContinuousTimeMode failed with status : %s\n", fmi3_status_to_string(status));
+  }
+  FMI3ME->FMISolvingMode = fmi3_continuousTime_mode;
+  return valuesOfContinuousStatesChanged;
+}
+
+/*
+ * parameter flowStates is dummy and is only used to run the equations in sequence.
+ * Returns the next event time, or infinity when the FMU did not give one, which is
+ * what the generated code expects for "no event scheduled".
+ */
+double fmi3nextEventTime_OMC(void* in_fmi3me, double flowStates)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  if (FMI3ME->FMIEventInfo.nextEventTimeDefined) {
+    return FMI3ME->FMIEventInfo.nextEventTime;
+  }
+  return DBL_MAX;
+}
+
+/*
+ * Wrapper for the FMI function fmi3CompletedIntegratorStep.
+ */
+int fmi3CompletedIntegratorStep_OMC(void* in_fmi3me, double flowStates)
+{
+  FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
+  if (FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+    fmi3_boolean_t callEventUpdate = fmi3_false;
+    fmi3_boolean_t terminateSimulation = fmi3_false;
+    fmi3_status_t status = fmi3_import_completed_integrator_step(FMI3ME->FMIImportInstance, fmi3_true, &callEventUpdate, &terminateSimulation);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3CompletedIntegratorStep failed with status : %s\n", fmi3_status_to_string(status));
+    }
+    return callEventUpdate;
+  }
+  return fmi3_false;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -5,6 +5,7 @@ fmi3_array_attributes.mos \
 fmi3_array_attributes_nb.mos \
 fmi3_array_nonscalarized.mos \
 fmi3_arrays.mos \
+fmi3_import_me.mos \
 fmi3_arrays_approx.mos \
 fmi3_arrays_start_vector.mos \
 fmi3_attributes_01.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
@@ -1,0 +1,74 @@
+// name: fmi3_import_me
+// keywords: FMI 3.0 import ModelExchange
+// status: correct
+//
+// Exports a model as an FMI 3.0 Model Exchange FMU, imports it again and simulates
+// the wrapper. The result is cos(t), which is what der(x) = v, der(v) = -x with
+// x(0) = 1 and v(0) = 0 has to give. See OpenModelica/OpenModelica#16173.
+//
+// teardown_command: rm -rf Osc3.fmu Osc3_me_FMU.mo Osc3_me_FMU* Osc3.log Osc3_info.json Osc3.fmutmp/ binaries sources documentation modelDescription.xml
+
+setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
+
+loadString("
+model Osc
+  Real x(start = 1, fixed = true);
+  Real v(start = 0, fixed = true);
+  output Real y;
+equation
+  der(x) = v;
+  der(v) = -x;
+  y = x;
+end Osc;
+"); getErrorString();
+
+buildModelFMU(Osc, version = "3.0", fmuType = "me", fileNamePrefix = "Osc3"); getErrorString();
+
+importFMU("Osc3.fmu"); getErrorString();
+loadFile("Osc3_me_FMU.mo"); getErrorString();
+
+simulate(Osc3_me_FMU, stopTime = 6.283185307, numberOfIntervals = 500); getErrorString();
+
+// cos(t) at 0, pi and 2*pi
+val(x, 0.0);
+val(x, 3.141592653);
+val(x, 6.283185307);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "Osc3.fmu"
+// ""
+// "Osc3_me_FMU.mo"
+// "Warning: module = Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3ModelDescription.xsd' is ignored. Using standard fmiModelDescription.xsd., log level = WARNING: FMI3XML
+// Warning: module = Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/v3.0.2/schema/fmi3TerminalsAndIcons.xsd' is ignored. Using standard fmiModelDescription.xsd., log level = WARNING: FMI3XML
+// Error: module = Unknown attribute 'matchingRule=plug' in XML, log level = ERROR: FMI3XML
+// Error: module = Unknown attribute 'variableName=y' in XML, log level = ERROR: FMI3XML
+// Error: module = Unknown attribute 'memberName=y' in XML, log level = ERROR: FMI3XML
+// Error: module = Unknown attribute 'variableKind=signal' in XML, log level = ERROR: FMI3XML
+// "
+// true
+// ""
+// record SimulationResult
+// resultFile = "Osc3_me_FMU_res.mat",
+// simulationOptions = "startTime = 0.0, stopTime = 6.283185307, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Osc3_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+// messages = "module = FMI3XML, log level = WARNING: Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3ModelDescription.xsd' is ignored. Using standard fmiModelDescription.xsd.
+// module = FMI3XML, log level = WARNING: Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/v3.0.2/schema/fmi3TerminalsAndIcons.xsd' is ignored. Using standard fmiModelDescription.xsd.
+// module = FMI3XML, log level = ERROR: Unknown attribute 'matchingRule=plug' in XML
+// module = FMI3XML, log level = ERROR: Unknown attribute 'variableName=y' in XML
+// module = FMI3XML, log level = ERROR: Unknown attribute 'memberName=y' in XML
+// module = FMI3XML, log level = ERROR: Unknown attribute 'variableKind=signal' in XML
+// LOG_SUCCESS | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Notification: Automatically loaded package Complex 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.1.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.1.0 due to usage.
+// "
+// 1.0
+// -1.0000005624560047
+// 0.9999980742648854
+// endResult


### PR DESCRIPTION
`importFMU` now writes a Modelica wrapper for an FMI 3.0 Model Exchange FMU, and the wrapper
simulates. This is the other half of #16173, whose library half landed in #16251 and whose
data model landed in #16257.

## What it does

```mo
buildModelFMU(Osc, version = "3.0", fmuType = "me", fileNamePrefix = "Osc3");
importFMU("Osc3.fmu");        // -> Osc3_me_FMU.mo
loadFile("Osc3_me_FMU.mo");
simulate(Osc3_me_FMU, stopTime = 6.283185307);
```

Before this, `importFMU` returned nothing for an FMI 3.0 FMU.

## The three commits

1. **Model description import** — `importFMUModelDescription` for FMI 3.0. It used to write an
   empty model, the template asking for the FMI 1.0 records whatever the version.
2. **The runtime** — `FMI3Common.{c,h}` and `FMI3ModelExchange.c`, 21 entry points, the C the
   generated wrapper calls.
3. **The wrapper** — `importFMU3ModelExchange` and the templates that collect and declare the
   variables.

## FMI 3.0 differences that are not renames

| FMI 2.0 | FMI 3.0 |
| --- | --- |
| `fmi2SetupExperiment` then `fmi2EnterInitializationMode` | one `fmi3EnterInitializationMode`, carrying the arguments |
| `fmi2NewDiscreteStates(eventInfo)` | `fmi3UpdateDiscreteStates` with six out parameters, **iterated** while it asks for another pass |
| a table of callback functions | an instance environment and one log callback |
| `fmi2GetDerivatives` | `fmi3GetContinuousStateDerivatives` — though FMI Library still names its wrapper `fmi3_import_get_derivatives` |
| the independent variable is implicit | it **must** be declared, and it is Modelica's own `time` |

The last one is worth calling out: the FMI 3.0 independent variable is now reported with
causality `"independent"` so the wrapper can leave it out. Declaring it made the generated model
clash with the built-in `time`.

Also fixed while getting there: an enumeration read back through a template whose parameter was
called `fmiType`, which the FMI 3.0 records also have as a **field**. Inside a `case` the field
shadowed the parameter and the FMU instance argument came out as the base type name. The
parameter is now `fmiInstance`.

## Testing

The FMU exported from `der(x) = v, der(v) = -x` with `x(0) = 1, v(0) = 0`, whose solution is
`cos(t)`:

| t | FMI 3.0 import | FMI 2.0 import of the same model |
| --- | --- | --- |
| 0 | `1.0` | |
| π | `-1.0000005624560047` | `-1.0000005624560033` |
| 2π | `0.9999980742648854` | `0.9999980742648846` |

The two import paths agree to fourteen significant figures, so the FMI 3.0 wrapper is doing
equivalent work and not merely producing plausible numbers. New test `fmi3_import_me.mos` does
the export, the import and the simulation.

`testsuite/openmodelica/fmi` on Linux/clang, **101/101**:

| suite | |
| --- | --- |
| `ModelExchange/1.0` | 3/3 |
| `ModelExchange/2.0` | 66/66 |
| `ModelExchange/3.0` | 20/20 (19 + the new test) |
| `CoSimulation/2.0` | 9/9 |
| `CoSimulation/3.0` | 2/2 |
| `ScheduledExecution/3.0` | 1/1 |

An imported wrapper uses `reinit` in an algorithm section, so it needs
`--allowNonStandardModelica=reinitInAlgorithms`, exactly as the FMI 2.0 imports do.

## Not in this PR

Arrays, `Binary` and `Clock`, which have no Modelica declaration here and are skipped, and
Co-Simulation and Scheduled Execution. Windows, macOS and the Cpp runtime were not tested.

---
generated by Claude Code
