### PR TITLE
wasm-jit: FMI fixes for the OMSimulator tests

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1993,6 +1993,14 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
         .chain(lst(&vars.boolAlgVars))
         .chain(lst(&vars.boolParamVars))
         .chain(lst(&vars.boolAliasVars));
+    // C's `mapOutputReference2RealOutputDerivatives`.
+    let mut out_der: HashMap<String, u32> = HashMap::new();
+    for sv in lst(&vars.outputVars) {
+        let key = sim_cref_key(&sv.name)?;
+        if let Some(slot) = map.vars.get(&format!("${key}_der")) {
+            out_der.insert(key, slot.off);
+        }
+    }
     let mut out = Vec::new();
     for sv in all {
         let key = sim_cref_key(&sv.name)?;
@@ -2003,7 +2011,16 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
         // A real variable's start slot: an init-mode set must go to the `start`
         // attribute, not to the live slot `setAllVarsToStart` is about to rewrite.
         let start_off = map.start_slots.get(&key).copied().unwrap_or(0);
-        out.push(FmiVr { vr, off: slot.off, wty: slot.wty, negate: slot.negate, start_off, is_string: false });
+        let der_off = out_der.get(&key).copied().unwrap_or(0);
+        out.push(FmiVr {
+            vr,
+            off: slot.off,
+            wty: slot.wty,
+            negate: slot.negate,
+            start_off,
+            is_string: false,
+            der_off,
+        });
     }
     // String variables: `is_string` marks the slot as an i32 runtime-String
     // handle, so the adapter reads/writes it via `rt_str_*`, not as a number.
@@ -2016,13 +2033,29 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
         let vr: u32 = SimCodeUtil::getFMI3ValueReference(sv.clone(), sim_code.clone())?
             .parse()
             .map_err(|_| "CodegenWasmJit: FMI3 value reference is not a number")?;
-        out.push(FmiVr { vr, off: slot.off, wty: slot.wty, negate: slot.negate, start_off: 0, is_string: true });
+        out.push(FmiVr {
+            vr,
+            off: slot.off,
+            wty: slot.wty,
+            negate: slot.negate,
+            start_off: 0,
+            is_string: true,
+            der_off: 0,
+        });
     }
     // time, then the event indicators after it (`EventIndicatorVariables3`).
     let time_vr: u32 = SimCodeUtil::getFMI3TimeValueReference(sim_code.clone())?
         .parse()
         .map_err(|_| "CodegenWasmJit: FMI3 time value reference is not a number")?;
-    out.push(FmiVr { vr: time_vr, off: TIME_OFF, wty: WTy::F64, negate: false, start_off: 0, is_string: false });
+    out.push(FmiVr {
+        vr: time_vr,
+        off: TIME_OFF,
+        wty: WTy::F64,
+        negate: false,
+        start_off: 0,
+        is_string: false,
+        der_off: 0,
+    });
     for k in 0..layout.n_zc {
         out.push(FmiVr {
             vr: time_vr + 1 + k,
@@ -2031,6 +2064,7 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
             negate: false,
             start_off: 0,
             is_string: false,
+            der_off: 0,
         });
     }
     out.sort_by_key(|e| e.vr);
@@ -2311,10 +2345,14 @@ fn emit_fmu(
     // one solver, so the flag has to reach the export. On the settings it reaches
     // both the adapter choice and the metadata the driver reads.
     let mut sim_code = sim_code;
-    if let (Some(s), Some(settings)) =
-        (fmi_flag(&simulation_flags_json, "s"), sim_code.simulationSettingsOpt.as_mut())
-    {
-        settings.method = ArcStr::from(s.as_str());
+    if let Some(settings) = sim_code.simulationSettingsOpt.as_mut() {
+        match fmi_flag(&simulation_flags_json, "s") {
+            Some(s) => settings.method = ArcStr::from(s.as_str()),
+            // C's `FMI2CS_initializeSolverData` default. The method the model was
+            // translated with is the standalone simulation's, not the FMU's.
+            None if kind != "ME" => settings.method = ArcStr::from("euler"),
+            None => {}
+        }
     }
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -338,6 +338,14 @@ impl Vrs {
 }
 
 // ── Instance state ───────────────────────────────────────────────────────────
+/// C's `ModelState`, as far as the component acts on it.
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    Instantiated,
+    Init,
+    Ready,
+}
+
 struct MeState {
     sim_data: u32,
     layout: Layout,
@@ -352,16 +360,23 @@ struct MeState {
     #[cfg(feature = "cs")]
     event_mode: bool,
     vrs: Vrs,
-    in_init: bool,
-    /// Set during Initialization Mode, applied by `run_initialization`: states as
-    /// start overrides (see `FmiVr::start_off`), everything else as parameters.
+    mode: Mode,
+    /// C's `_need_update`, consumed by `update_if_needed`.
+    need_update: bool,
+    /// Every set made before Initialization Mode is left, applied by
+    /// `run_initialization`: states as start overrides (see `FmiVr::start_off`),
+    /// everything else as parameters. C's `setReal` writes the `start` attribute
+    /// in both states, and `fmi2EnterInitializationMode` snapshots the live values
+    /// into it, so a set made before Initialization Mode counts too.
     init_overrides: Vec<(u32, WTy, f64)>,
     init_start_overrides: Vec<(u32, WTy, f64)>,
-    /// String parameter sets from Initialization Mode, applied after
-    /// `run_initialization` so init equations don't clobber them (cf `init_overrides`).
+    /// String parameter sets, applied after `run_initialization` so init equations
+    /// don't clobber them (cf `init_overrides`).
     init_string_overrides: Vec<(u32, String)>,
     /// Sample schedule, loaded once the model's `initSample` has run.
     samples: Option<Samples>,
+    /// Synchronous clocks (C's `initSynchronous`), for a model that has any.
+    sync: Option<openmodelica_sim_meta::sync::Sync>,
 }
 
 impl MeState {
@@ -410,6 +425,52 @@ impl MeState {
         let _ = e.call1("functionODE", self.sim_data);
         if !self.layout.has_when {
             let _ = e.call1("functionAlgebraics", self.sim_data);
+        }
+    }
+
+    /// C's `updateIfNeeded`. In Initialization Mode the update is the initial
+    /// solve, with the sets made so far as start values.
+    fn update_if_needed(&mut self) -> driver::Result<()> {
+        if !self.need_update {
+            return Ok(());
+        }
+        if self.mode == Mode::Init {
+            self.run_init()?;
+        } else {
+            self.eval();
+        }
+        self.need_update = false;
+        Ok(())
+    }
+
+    /// C's `initialization()`, repeatable: the overrides stay, so the importer can
+    /// keep setting and get a fresh solve each time.
+    fn run_init(&mut self) -> driver::Result<()> {
+        set_param_overrides(self.init_overrides.clone(), self.init_start_overrides.clone());
+        let mut e = Engine;
+        let start_time = self.read_f64(TIME_OFF);
+        // No `-csvInput` on the FMI path: the importer drives the inputs.
+        run_initialization(&mut e, self.sim_data, &self.layout, &[], start_time)?;
+        // C's `initializeModel` runs `initSynchronous` too.
+        if !self.meta.clocks.is_empty() {
+            let mut sync = openmodelica_sim_meta::sync::Sync::new(&mut e, &self.meta, self.sim_data)?;
+            sync.take_fired(&mut e, start_time)?;
+            self.sync = Some(sync);
+        }
+        // After the init equations, so they land in the slots last.
+        for (off, val) in core::mem::take(&mut self.init_string_overrides) {
+            self.write_string(off, &val);
+        }
+        Ok(())
+    }
+
+    /// C's `setReal` writing the `start` attribute. Last write per slot wins, so a
+    /// master iterating an algebraic loop does not grow the list.
+    fn record_override(&mut self, off: u32, wty: WTy, val: f64, is_start: bool) {
+        let list = if is_start { &mut self.init_start_overrides } else { &mut self.init_overrides };
+        match list.iter_mut().find(|(o, _, _)| *o == off) {
+            Some(e) => e.2 = val,
+            None => list.push((off, wty, val)),
         }
     }
 }
@@ -486,11 +547,13 @@ fn new_state() -> Option<MeState> {
         cs: None,
         #[cfg(feature = "cs")]
         event_mode: false,
-        in_init: false,
+        mode: Mode::Instantiated,
+        need_update: true,
         init_overrides: Vec::new(),
         init_start_overrides: Vec::new(),
         init_string_overrides: Vec::new(),
         samples: None,
+        sync: None,
     };
     st.seed_start_state();
     Some(st)
@@ -546,9 +609,10 @@ macro_rules! shared_instance_methods {
         _stop_time: Option<f64>,
     ) -> Status {
         let mut st = self.st.borrow_mut();
-        st.in_init = true;
-        st.init_overrides.clear();
-        st.init_start_overrides.clear();
+        // The sets made while Instantiated stay: C's `setStartValues` here turns
+        // the live values into the `start` attributes the initial solve reads.
+        st.mode = Mode::Init;
+        st.need_update = true;
         st.write_f64(TIME_OFF, start_time);
         let (sim_data, layout) = (st.sim_data, st.layout);
         let mut e = Engine;
@@ -560,21 +624,12 @@ macro_rules! shared_instance_methods {
 
     fn exit_initialization_mode(&self) -> Status {
         let mut st = self.st.borrow_mut();
-        st.in_init = false;
-        let params = core::mem::take(&mut st.init_overrides);
-        let starts = core::mem::take(&mut st.init_start_overrides);
-        set_param_overrides(params, starts);
-        let mut e = Engine;
-        let start_time = st.read_f64(TIME_OFF);
-        // No `-csvInput` on the FMI path: the importer drives the inputs.
-        if let Err(err) = run_initialization(&mut e, st.sim_data, &st.layout, &[], start_time) {
+        // Only when something was set since the last solve: a get in Initialization
+        // Mode has already run it otherwise.
+        if let Err(err) = st.update_if_needed() {
             return err_status(err);
         }
-        // Apply deferred String parameter sets now that init equations have run, so
-        // they land in the slots last (mirrors the numeric init_overrides above).
-        for (off, val) in core::mem::take(&mut st.init_string_overrides) {
-            st.write_string(off, &val);
-        }
+        st.mode = Mode::Ready;
         // `run_initialization` has run `initSample`, so the schedule is readable.
         if st.layout.n_samples > 0 {
             match Samples::load(&Engine, st.sim_data, &st.layout) {
@@ -591,7 +646,7 @@ macro_rules! shared_instance_methods {
         if st.event_mode {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
             let meta = st.meta.clone();
-            match CsDriver::new(&mut e, &meta, sim_data, t) {
+            match CsDriver::new(&mut Engine, &meta, sim_data, t) {
                 Ok(d) => st.cs = Some(d),
                 Err(_) => return Status::Error,
             }
@@ -636,13 +691,30 @@ macro_rules! shared_instance_methods {
             Err(err) => return Err(err_status(err)),
         };
 
+        // C's `internalEventUpdate`: the timers, then the earliest of the next
+        // sample and the next activation.
+        let mut next = up.next_event_time;
+        let mut ticked = false;
+        if let Some(mut sync) = st.sync.take() {
+            let r = driver::fmi_handle_timers(&mut e, &mut sync, &st.meta, sim_data, time);
+            let tc = sync.next_time();
+            st.sync = Some(sync);
+            match r {
+                Ok(fired) => ticked = fired,
+                Err(err) => return Err(err_status(err)),
+            }
+            if tc.is_finite() {
+                next = Some(next.map_or(tc, |n: f64| n.min(tc)));
+            }
+        }
+
         Ok(DiscreteStatesInfo {
             new_discrete_states_needed: false,
             terminate_simulation: up.terminate,
             nominals_of_continuous_states_changed: false,
-            values_of_continuous_states_changed: up.states_changed,
-            next_event_time_defined: up.next_event_time.is_some(),
-            next_event_time: up.next_event_time.unwrap_or(0.0),
+            values_of_continuous_states_changed: up.states_changed || ticked,
+            next_event_time_defined: next.is_some(),
+            next_event_time: next.unwrap_or(0.0),
         })
     }
 
@@ -661,11 +733,13 @@ macro_rules! shared_instance_methods {
         unsafe {
             core::ptr::write_bytes(st.sim_data as *mut u8, 0, st.layout.total as usize);
         }
-        st.in_init = false;
+        st.mode = Mode::Instantiated;
+        st.need_update = true;
         st.init_overrides.clear();
         st.init_start_overrides.clear();
         st.init_string_overrides.clear();
         st.samples = None;
+        st.sync = None;
         #[cfg(feature = "cs")]
         {
             st.cs = None;
@@ -686,8 +760,10 @@ macro_rules! shared_instance_methods {
         Err(Status::Error)
     }
     fn get_float64(&self, vrs: Vec<u32>) -> Result<Vec<f64>, Status> {
-        let st = self.st.borrow();
-        st.eval();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -707,8 +783,10 @@ macro_rules! shared_instance_methods {
         Err(Status::Error)
     }
     fn get_int32(&self, vrs: Vec<u32>) -> Result<Vec<i32>, Status> {
-        let st = self.st.borrow();
-        st.eval();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -724,8 +802,10 @@ macro_rules! shared_instance_methods {
     // fmi3 accesses `<Enumeration>` vars via Int64; they are `WTy::I32` slots here,
     // so widen/narrow around the i32.
     fn get_int64(&self, vrs: Vec<u32>) -> Result<Vec<i64>, Status> {
-        let st = self.st.borrow();
-        st.eval();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -748,8 +828,10 @@ macro_rules! shared_instance_methods {
         Err(Status::Error)
     }
     fn get_uint64(&self, vrs: Vec<u32>) -> Result<Vec<u64>, Status> {
-        let st = self.st.borrow();
-        st.eval();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -760,8 +842,10 @@ macro_rules! shared_instance_methods {
         Ok(out)
     }
     fn get_boolean(&self, vrs: Vec<u32>) -> Result<Vec<bool>, Status> {
-        let st = self.st.borrow();
-        st.eval();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -772,7 +856,10 @@ macro_rules! shared_instance_methods {
         Ok(out)
     }
     fn get_string(&self, vrs: Vec<u32>) -> Result<Vec<String>, Status> {
-        let st = self.st.borrow();
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
@@ -801,17 +888,16 @@ macro_rules! shared_instance_methods {
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::F64 && !e.negate => {
-                    if st.in_init && e.start_off != 0 {
-                        st.init_start_overrides.push((e.start_off, WTy::F64, v));
-                    } else if st.in_init {
-                        st.init_overrides.push((e.off, WTy::F64, v));
-                    } else {
-                        st.write_f64(e.off, v);
+                    st.write_f64(e.off, v);
+                    if st.mode != Mode::Ready {
+                        let start = e.start_off != 0;
+                        st.record_override(if start { e.start_off } else { e.off }, WTy::F64, v, start);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_int8(&self, _: Vec<u32>, _: Vec<i8>) -> Status {
@@ -828,15 +914,15 @@ macro_rules! shared_instance_methods {
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
-                    if st.in_init {
-                        st.init_overrides.push((e.off, WTy::I32, v as f64));
-                    } else {
-                        st.write_i32(e.off, v);
+                    st.write_i32(e.off, v);
+                    if st.mode != Mode::Ready {
+                        st.record_override(e.off, WTy::I32, v as f64, false);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_int64(&self, vrs: Vec<u32>, values: Vec<i64>) -> Status {
@@ -847,15 +933,15 @@ macro_rules! shared_instance_methods {
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
-                    if st.in_init {
-                        st.init_overrides.push((e.off, WTy::I32, v as f64));
-                    } else {
-                        st.write_i32(e.off, v as i32);
+                    st.write_i32(e.off, v as i32);
+                    if st.mode != Mode::Ready {
+                        st.record_override(e.off, WTy::I32, v as f64, false);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_uint8(&self, _: Vec<u32>, _: Vec<u8>) -> Status {
@@ -875,15 +961,15 @@ macro_rules! shared_instance_methods {
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
-                    if st.in_init {
-                        st.init_overrides.push((e.off, WTy::I32, v as f64));
-                    } else {
-                        st.write_i32(e.off, v as i32);
+                    st.write_i32(e.off, v as i32);
+                    if st.mode != Mode::Ready {
+                        st.record_override(e.off, WTy::I32, v as f64, false);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_boolean(&self, vrs: Vec<u32>, values: Vec<bool>) -> Status {
@@ -895,15 +981,15 @@ macro_rules! shared_instance_methods {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
                     let iv = if v { 1 } else { 0 };
-                    if st.in_init {
-                        st.init_overrides.push((e.off, WTy::I32, iv as f64));
-                    } else {
-                        st.write_i32(e.off, iv);
+                    st.write_i32(e.off, iv);
+                    if st.mode != Mode::Ready {
+                        st.record_override(e.off, WTy::I32, iv as f64, false);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_string(&self, vrs: Vec<u32>, values: Vec<String>) -> Status {
@@ -914,15 +1000,16 @@ macro_rules! shared_instance_methods {
         for (vr, val) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
                 Some(e) if e.is_string => {
-                    if st.in_init {
+                    st.write_string(e.off, &val);
+                    if st.mode != Mode::Ready {
+                        st.init_string_overrides.retain(|(o, _)| *o != e.off);
                         st.init_string_overrides.push((e.off, val)); // see the field
-                    } else {
-                        st.write_string(e.off, &val);
                     }
                 }
                 _ => return Status::Error,
             }
         }
+        st.need_update = true;
         Status::Ok
     }
     fn set_binary(&self, _: Vec<u32>, _: Vec<Vec<u8>>) -> Status {
@@ -1006,8 +1093,25 @@ macro_rules! shared_instance_methods {
         Status::Ok
     }
 
-    fn get_output_derivatives(&self, _: Vec<(u32, u32)>) -> Result<Vec<f64>, Status> {
-        Err(Status::Error)
+    /// C's `fmi2GetRealOutputDerivatives`: `$<name>_der`. C reports the first
+    /// derivative whatever order is asked for.
+    fn get_output_derivatives(&self, requests: Vec<(u32, u32)>) -> Result<Vec<f64>, Status> {
+        let mut st = self.st.borrow_mut();
+        if let Err(err) = st.update_if_needed() {
+            return Err(err_status(err));
+        }
+        let mut out = Vec::with_capacity(requests.len());
+        for (vr, _order) in requests {
+            match st.vrs.resolve(vr) {
+                Some(e) if e.der_off != 0 => out.push(st.read_f64(e.der_off)),
+                _ => {
+                    return Err(err_status(
+                        "the model has no output derivative for this variable                          (an FMU exported with -d=fmuExperimental has them)",
+                    ))
+                }
+            }
+        }
+        Ok(out)
     }
     };
 }
@@ -1035,25 +1139,29 @@ impl GuestModelExchangeInstance for Instance {
     }
 
     fn set_time(&self, time: f64) -> Status {
-        let st = self.st.borrow();
+        let mut st = self.st.borrow_mut();
         st.write_f64(TIME_OFF, time);
+        st.need_update = true;
         Status::Ok
     }
     fn set_continuous_states(&self, states: Vec<f64>) -> Status {
-        let st = self.st.borrow();
+        let mut st = self.st.borrow_mut();
         if states.len() != st.layout.n_states as usize {
             return Status::Error;
         }
         for (i, v) in states.into_iter().enumerate() {
             st.write_f64(REAL_OFF + (i as u32) * 8, v);
         }
+        st.need_update = true;
         Status::Ok
     }
 
+    /// C's `internalGetDerivatives`, which leaves `_need_update` set for the next
+    /// getter.
     fn get_continuous_state_derivatives(&self) -> Result<Vec<f64>, Status> {
         let st = self.st.borrow();
         let mut e = Engine;
-        if e.call1("functionODE", st.sim_data).is_err() {
+        if st.need_update && e.call1("functionODE", st.sim_data).is_err() {
             return Err(Status::Error);
         }
         let n = st.layout.n_states;
@@ -1061,9 +1169,12 @@ impl GuestModelExchangeInstance for Instance {
         Ok((0..n).map(|i| st.read_f64(base + i * 8)).collect())
     }
     fn get_event_indicators(&self) -> Result<Vec<f64>, Status> {
-        let st = self.st.borrow();
+        let mut st = self.st.borrow_mut();
         let mut e = Engine;
-        let _ = e.call1("functionODE", st.sim_data);
+        if st.need_update {
+            let _ = e.call1("functionODE", st.sim_data);
+            st.need_update = false;
+        }
         if st.layout.n_zc == 0 {
             return Ok(Vec::new());
         }
@@ -1172,6 +1283,8 @@ impl GuestCoSimulationInstance for Instance {
         };
         let last = driver.time();
         st.cs = Some(driver);
+        // C's `fmi2DoStep`: the getters now report the new time's values.
+        st.need_update = true;
         let eps = target.abs().max(1.0) * 1e-10;
         match outcome {
             Ok(CsStep::Reached) => Ok(DoStepResult {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
@@ -689,13 +689,34 @@ pub unsafe extern "C" fn fmi2SetRealInputDerivatives(
     ERROR
 }
 
+/// The derivative of each named output.
 #[no_mangle]
 pub unsafe extern "C" fn fmi2GetRealOutputDerivatives(
-    _c: *mut c_void,
-    _value_references: *const u32,
-    _n_value_references: usize,
-    _orders: *const i32,
-    _values: *mut f64,
+    c: *mut c_void,
+    value_references: *const u32,
+    n_value_references: usize,
+    orders: *const i32,
+    values: *mut f64,
 ) -> i32 {
-    ERROR
+    let Some(inst) = inst_mut(c) else { return ERROR };
+    let Some(refs) = shift(inst, value_references, n_value_references, Base::Real) else { return ERROR };
+    if (values.is_null() || orders.is_null()) && n_value_references != 0 {
+        return ERROR;
+    }
+    // The order reaches the component unused, as in C.
+    let requests: Vec<(u32, u32)> =
+        refs.iter().enumerate().map(|(i, vr)| (*vr, (*orders.add(i)).max(0) as u32)).collect();
+    on_instance!(Some(inst), |store, g, h, st| match g.call_get_output_derivatives(store, h, &requests) {
+        Ok(Ok(v)) => {
+            if v.len() != n_value_references {
+                return ERROR;
+            }
+            for (i, x) in v.into_iter().enumerate() {
+                *values.add(i) = x;
+            }
+            OK
+        }
+        Ok(Err(s)) => st(s),
+        Err(_) => ERROR,
+    })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2775,6 +2775,19 @@ fn fire_clocks(
     Ok(any)
 }
 
+/// C's `handleTimersFMI`: the clock half of the event update for a host that owns
+/// the integration (`fmi2NewDiscreteStates`), so no output rows. Reports whether
+/// any clock ticked.
+pub fn fmi_handle_timers(
+    e: &mut dyn SimEngine,
+    sync: &mut crate::sync::Sync,
+    model: &SimMeta,
+    sim_data: u32,
+    time: f64,
+) -> Result<bool> {
+    fire_clocks(e, sync, model, sim_data, time, time.abs().max(1.0) * 1e-10, None)
+}
+
 /// Output point `row` of the equidistant grid, as C's `perform_simulation`
 /// computes it: `row*(stop-start)/numSteps + start`, *not* `start + row*h` —
 /// the two round differently and the result files must agree bit for bit.
@@ -4615,6 +4628,12 @@ pub(crate) fn leak_error(s: String) -> &'static str {
     alloc::boxed::Box::leak(s.into_boxed_str())
 }
 
+/// How close to a target counts as reached, and so the smallest step the chunked
+/// fixed-step loop may ask for.
+fn reached_eps(t: f64) -> f64 {
+    t.abs().max(1.0) * 1e-10
+}
+
 /// How far one [`SolverCore::solve_toward`] got.
 enum Solved {
     Reached,
@@ -5150,7 +5169,7 @@ impl SolverCore {
         let sim_data = self.sim_data;
         let n_states = self.n_states;
         let ders_base = self.ders_base;
-        let eps = tout.abs().max(1.0) * 1e-10;
+        let eps = reached_eps(tout);
         let mut grid_covered = false;
 
         loop {
@@ -5454,6 +5473,7 @@ impl CsDriver {
             return Ok(CsStep::Reached);
         }
 
+        self.refresh_ders(e)?;
         let outcome = self.integrate_chunked(e, model, t_target, false)?;
         match outcome {
             Step::Terminated => return Ok(CsStep::Terminated),
@@ -5518,6 +5538,7 @@ impl CsDriver {
             return Ok(CsStep::Reached);
         }
 
+        self.refresh_ders(e)?;
         let outcome = self.integrate_chunked(e, model, t_target, true)?;
         match outcome {
             Step::Terminated => return Ok(CsStep::Terminated),
@@ -5563,6 +5584,18 @@ impl CsDriver {
         Ok(up)
     }
 
+    /// C's `fmi2DoStep` reads the derivatives at the start of every step, after the
+    /// master has set that point's inputs; a fixed-step method takes its first
+    /// stage from them. The variable-step solvers evaluate the model themselves and
+    /// must keep their own history, so this is for the fixed-step ones.
+    fn refresh_ders(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+        if self.fixed_h.is_none() || self.core.n_states == 0 {
+            return Ok(());
+        }
+        e.call1("functionODE", self.core.sim_data)?;
+        self.core.read_states(e)
+    }
+
     /// Integrate to `t_target`: in one go for a variable-step method, or one step per
     /// call for a fixed-step one. Those steps land on the model's own output grid — the
     /// sequence the standalone driver produces — so a communication point only cuts the
@@ -5583,21 +5616,34 @@ impl CsDriver {
         let mut did_step = false;
         loop {
             let target = match self.fixed_h {
-                // The next grid point after `t`; the nudge stops drift just short of
-                // one from producing a step of nearly zero length.
+                // The next grid point past `t` by more than `integrate_to` calls
+                // reached, or it refuses the step and this asks forever. Communication
+                // points drift off the grid further than a nudge on the quotient.
                 Some(h) => {
-                    let k = libm::floor((self.core.t - model.start_time) / h + 1e-10) + 1.0;
-                    (model.start_time + k * h).min(t_target)
+                    let mut g = model.start_time + (libm::floor((self.core.t - model.start_time) / h) + 1.0) * h;
+                    if g - self.core.t <= reached_eps(self.core.t) {
+                        g += h;
+                    }
+                    g.min(t_target)
                 }
                 None => t_target,
             };
+            let t_before = self.core.t;
             let outcome = self.core.integrate_to(
                 e, model, &mut ctx, &mut self.samp, &mut self.sync, target, f64::INFINITY, None,
                 &mut did_step, stop_at_event,
             )?;
-            if !matches!(outcome, Step::Reached { .. }) || self.core.t >= t_target - eps {
+            // On the chunk that asked for the caller's target, wherever rounding left
+            // `t`: a tighter test on `t` asks for the same chunk forever.
+            if !matches!(outcome, Step::Reached { .. }) || target >= t_target - eps {
                 self.core.nfe = ctx.nfe;
                 return Ok(outcome);
+            }
+            if self.core.t <= t_before {
+                return Err(leak_error(alloc::format!(
+                    "CodegenWasmJit: the integrator made no progress at t={} toward {t_target}",
+                    self.core.t
+                )));
             }
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -744,6 +744,10 @@ pub struct FmiVr {
     /// The variable is a String: `off` is its i32 runtime-String-handle slot, so
     /// the adapter reads/writes it through `rt_str_*` rather than as a number.
     pub is_string: bool,
+    /// The slot of this output's derivative (`$<name>_der`, which
+    /// `-d=fmuExperimental` adds), 0 for everything else. What
+    /// `fmi2GetRealOutputDerivatives` reports.
+    pub der_off: u32,
 }
 
 /// Everything the driver and the `.mat` writer need about one model: its layout,
@@ -1057,7 +1061,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 12;
+const VERSION: u32 = 13;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -1176,6 +1180,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         o.push(v.negate as u8);
         put_u32(&mut o, v.start_off);
         o.push(v.is_string as u8);
+        put_u32(&mut o, v.der_off);
     }
     put_u32(&mut o, m.zc_desc.len() as u32);
     for d in &m.zc_desc {
@@ -1533,7 +1538,8 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         let negate = r.u8()? != 0;
         let start_off = r.u32()?;
         let is_string = r.u8()? != 0;
-        fmi_vrs.push(FmiVr { vr, off, wty, negate, start_off, is_string });
+        let der_off = r.u32()?;
+        fmi_vrs.push(FmiVr { vr, off, wty, negate, start_off, is_string, der_off });
     }
     let ndesc = r.u32()? as usize;
     let mut zc_desc = Vec::with_capacity(ndesc);
@@ -1768,8 +1774,8 @@ mod tests {
                 result_offs: vec![224],
             }],
             fmi_vrs: vec![
-                FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: false, start_off: 96, is_string: false },
-                FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true },
+                FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: false, start_off: 96, is_string: false, der_off: 0 },
+                FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true, der_off: 0 },
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             rel_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],

--- a/testsuite/omsimulator/recompileFMU.mos
+++ b/testsuite/omsimulator/recompileFMU.mos
@@ -1,4 +1,5 @@
 // name : recompileFMU.mos
+// suite: fmuCSources
 // status: correct
 // teardown_command: rm -rf simpleLoop* model_res.mat build_simpleLoop.log
 //


### PR DESCRIPTION
Seventeen of the eighteen `testsuite/omsimulator` tests failed under `--simCodeTarget=wasm-jit`. Five distinct causes, each a place where the wasm FMU did something the C FMU does not.

**`_need_update` / `updateIfNeeded`.** C's FMU answers a getter from a model it re-evaluates on demand: a setter raises `_need_update`, and `fmi2Get*` either re-runs the whole initialization (Initialization Mode) or the continuous equations. The component deferred every set to `fmi2ExitInitializationMode` and evaluated on every get, so a get between
set and exit reported the seeded start state. A set made while merely *instantiated* now counts as a start value too, as C's `fmi2EnterInitializationMode` `setStartValues` makes it. `testLoopsOverFMUs`
is the sharp case: the master solves an algebraic loop across FMUs by setting inputs and reading outputs in Initialization Mode, and against constant outputs it walked into `sqrt` of a negative number.

**The Co-Simulation solver.** `FMI2CS_initializeSolverData` defaults a CS
FMU to explicit Euler over the communication step; only `--fmiFlags=s:` in
`resources/<prefix>_flags.json` changes it. The export carried the method
the model was *translated* with instead. C also reads the derivatives at the top of every `fmi2DoStep`, after the master has set that point's inputs — a fixed-step method takes its first stage from them, so without it the FMU integrated one communication step behind on every input change.

**Synchronous clocks in Model Exchange.** The component had `Samples` but
no `Sync` on the ME path, so a clocked partition never activated under an
external master. `update_discrete_states` now fires the timers (C's `handleTimersFMI`) and folds the next activation into `nextEventTime`.

**`fmi2GetRealOutputDerivatives`.** Served from `$<name>_der`, the derivative `-d=fmuExperimental` emits per real output, resolved to a slot
at export as `FmiVr::der_off`.

**A chunked fixed step that asked for a step it would not take.** `integrate_to` calls a target within `1e-10*|t|` reached and returns without stepping; `integrate_chunked` used `1e-12` to decide it was done,
so a grid point inside that gap made it ask for the same chunk forever.

| test | was |
| --- | --- |
| `DualMassOscillator_cs` | CS integrated with dassl, not Euler | | `fmi_interpolate_cs` | no output derivatives, then a hang | | `Issue_FMU_update_vars`, `outputState` | get before exit-init | | `testLoopsOverFMUs` | loop solved against constant outputs | | `testSynchronousFMU_01`, `_02` | clocks never fired | | `recompileFMU` | recompiles `sources/`: `suite: fmuCSources` |

`omsimulator/terminateTest` still differs by the one line `omc_terminate_fmi` writes to the importer's stderr, which a component has
no channel for; see the handoff for the WASI route.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
