### PR TITLE
Fix delay/spatialDistribution zero crossings

### DIFF
--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -1917,6 +1917,46 @@ algorithm
   end match;
 end traverseStmtsForExps;
 
+public function setOperatorZeroCrossingIndices
+  "`delayZeroCrossing` and `spatialDistributionZeroCrossing` read `zeroCrossingsPre` at
+   the index passed as their second argument, so it has to be the crossing's own index.
+   `collectZC` cannot know it yet -- the call must exist before the crossing can be
+   registered -- so it fills in the relation index; overwrite it once the list is final.
+   A model has at least as many relations as crossings, so leaving it there reads
+   another crossing's held value, or past the end of the array."
+  input list<BackendDAE.ZeroCrossing> inZeroCrossings;
+  output list<BackendDAE.ZeroCrossing> outZeroCrossings = {};
+protected
+  DAE.Exp relation_;
+algorithm
+  for zc in inZeroCrossings loop
+    (relation_, _) := Expression.traverseExpBottomUp(zc.relation_, setOperatorIndex, zc.index);
+    zc.relation_ := relation_;
+    outZeroCrossings := zc :: outZeroCrossings;
+  end for;
+  outZeroCrossings := listReverse(outZeroCrossings);
+end setOperatorZeroCrossingIndices;
+
+protected function setOperatorIndex
+  input DAE.Exp inExp;
+  input Integer inIndex;
+  output DAE.Exp outExp;
+  output Integer outIndex = inIndex;
+algorithm
+  outExp := match inExp
+    local
+      DAE.Exp expr, delay, x, dir;
+      DAE.CallAttributes attr;
+    case DAE.CALL(path = Absyn.IDENT("delayZeroCrossing"), expLst = {expr, _, delay}, attr = attr)
+    then DAE.CALL(Absyn.IDENT("delayZeroCrossing"), {expr, DAE.ICONST(inIndex), delay}, attr);
+
+    case DAE.CALL(path = Absyn.IDENT("spatialDistributionZeroCrossing"), expLst = {expr, _, x, dir}, attr = attr)
+    then DAE.CALL(Absyn.IDENT("spatialDistributionZeroCrossing"), {expr, DAE.ICONST(inIndex), x, dir}, attr);
+
+    else inExp;
+  end match;
+end setOperatorIndex;
+
 protected function createZeroCrossings "
   Constructs a list of zero crossings from a list of relations. Each zero
   crossing gets the same equation indices and when clause indices."

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6793,6 +6793,7 @@ version = "0.1.0"
 dependencies = [
  "daskr",
  "libm",
+ "openmodelica_mat_writer",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -74,7 +74,7 @@ use crate::CodegenWasmJitFunctions::{
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{
     var_filter, BaseClockMeta, FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind,
-    MetaVar as ResultVar, SimMeta, StateSetInfo, SubClockMeta,
+    MetaVar as ResultVar, Neg, SimMeta, StateSetInfo, SubClockMeta,
 };
 
 // Engine selected at compile time; same module interface across all three
@@ -220,8 +220,7 @@ fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[Str
             let hit = v.name == *name;
             match &v.kind {
                 ResultKind::Column { col, negate } if hit => {
-                    let raw = run.rows[last + *col as usize];
-                    let raw = if *negate { -raw } else { raw };
+                    let raw = negate.apply_f64(run.rows[last + *col as usize]);
                     if *col < n_real_cols {
                         out.push_str(&format!(",{name}={}", g20(raw)));
                     } else {
@@ -232,7 +231,7 @@ fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[Str
                     let raw = run.params.get(param_idx).copied().unwrap_or(0.0);
                     param_idx += 1;
                     if hit {
-                        let raw = if *negate { -raw } else { raw };
+                        let raw = negate.apply_f64(raw);
                         match wty {
                             WTy::F64 => out.push_str(&format!(",{name}={}", g20(raw))),
                             _ => out.push_str(&format!(",{name}={}", raw as i64)),
@@ -254,13 +253,8 @@ fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[Str
 fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]) {
     let n_reals = run.n_reals as usize;
     let n_rows = if n_reals == 0 { 0 } else { run.rows.len() / n_reals };
-    let column = |col: usize, negate: bool| -> Vec<f64> {
-        (0..n_rows)
-            .map(|r| {
-                let v = run.rows[r * n_reals + col];
-                if negate { -v } else { v }
-            })
-            .collect()
+    let column = |col: usize, negate: Neg| -> Vec<f64> {
+        (0..n_rows).map(|r| negate.apply_f64(run.rows[r * n_reals + col])).collect()
     };
     let is_const_col = |vals: &[f64]| vals.iter().all(|&v| v == vals.first().copied().unwrap_or(0.0));
 
@@ -284,7 +278,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]
             series_keep.push(keep);
         }
         match &v.kind {
-            ResultKind::Time => time = column(0, false),
+            ResultKind::Time => time = column(0, Neg::None),
             ResultKind::Column { col, negate } => {
                 let values = column(*col as usize, *negate);
                 let constant = is_const_col(&values);
@@ -295,7 +289,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]
                 let raw = run.params.get(param_idx).copied().unwrap_or(0.0);
                 param_idx += 1;
                 param_value_by_off.entry(*off).or_insert(raw);
-                let value = if *negate { -raw } else { raw };
+                let value = negate.apply_f64(raw);
                 let alias = !seen_param_offs.insert(*off);
                 series.push(SimSeries {
                     name: v.name.clone(),
@@ -2051,7 +2045,7 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
         vr: time_vr,
         off: TIME_OFF,
         wty: WTy::F64,
-        negate: false,
+        negate: Neg::None,
         start_off: 0,
         is_string: false,
         der_off: 0,
@@ -2061,7 +2055,7 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
             vr: time_vr + 1 + k,
             off: layout.zc_off + k * 8,
             wty: WTy::F64,
-            negate: false,
+            negate: Neg::None,
             start_off: 0,
             is_string: false,
             der_off: 0,
@@ -2632,7 +2626,7 @@ pub(crate) fn const_value(exp: &Option<Arc<DAE::Exp>>) -> Option<f64> {
 /// file: a time-variant real reads a result-buffer column; a real/integer/
 /// boolean parameter reads `data_1`. Integer/boolean *algebraic* variables (not
 /// captured per row) and string variables have no numeric result column.
-fn kind_from_slot(off: u32, wty: WTy, negate: bool, heap: bool, layout: &SimLayout) -> Option<ResultKind> {
+fn kind_from_slot(off: u32, wty: WTy, negate: Neg, heap: bool, layout: &SimLayout) -> Option<ResultKind> {
     if heap {
         return None; // strings are not stored as numeric result data
     }
@@ -2848,7 +2842,7 @@ fn push_sensitivity_vars(
         result_vars.push(ResultVar {
             name: cref_display(&sv.name)?,
             comment: sv.comment.to_string(),
-            kind: ResultKind::Column { col: layout.sens_col0() + i as u32, negate: false },
+            kind: ResultKind::Column { col: layout.sens_col0() + i as u32, negate: Neg::None },
             filter: filter_bits(sv),
         });
     }
@@ -2934,7 +2928,7 @@ fn build_var_map(
          sv: &SimCodeVar::SimVar, off: u32, wty: WTy, heap: bool, raw_name: String| -> Result<()> {
             insert_var(map, sv, off, wty, heap)?;
             if let Some(name) = result_name(&raw_name) {
-                if let Some(kind) = kind_from_slot(off, wty, false, heap, layout) {
+                if let Some(kind) = kind_from_slot(off, wty, Neg::None, heap, layout) {
                     result_vars.push(ResultVar {
                         name,
                         comment: sv.comment.to_string(),
@@ -3067,7 +3061,12 @@ fn build_var_map(
     // and `$START` of an alias read the aliased value, AND emit the alias as a
     // result signal pointing at the target's data column / parameter (with sign)
     // — the C runtime's `dataInfo` aliasing, so the data is stored once.
-    for av in lst(&vars.aliasVars).chain(lst(&vars.intAliasVars)).chain(lst(&vars.boolAliasVars)) {
+    // A Boolean negation is logical, any other arithmetic (C's `crefToCStr`).
+    let alias_lists = lst(&vars.aliasVars)
+        .map(|v| (v, false))
+        .chain(lst(&vars.intAliasVars).map(|v| (v, false)))
+        .chain(lst(&vars.boolAliasVars).map(|v| (v, true)));
+    for (av, is_bool) in alias_lists {
         let (target, negate) = match &av.aliasvar {
             SimCodeVar::AliasVariable::ALIAS { varName } => (varName.clone(), false),
             SimCodeVar::AliasVariable::NEGATEDALIAS { varName } => (varName.clone(), true),
@@ -3078,7 +3077,8 @@ fn build_var_map(
             // Target has no slot: it may be a compile-time constant.
             if let Some(&cval) = const_of.get(&tkey) {
                 if let Some(name) = result_name(&cref_display(&av.name)?) {
-                    let value = if negate { -cval } else { cval };
+                    let value =
+                        if negate { Neg::None.toggle(is_bool).apply_f64(cval) } else { cval };
                     result_vars.push(ResultVar {
                         name,
                         comment: av.comment.to_string(),
@@ -3092,7 +3092,7 @@ fn build_var_map(
         let slot = SimSlot {
             off: tslot.off,
             wty: tslot.wty,
-            negate: tslot.negate ^ negate,
+            negate: if negate { tslot.negate.toggle(is_bool) } else { tslot.negate },
             heap: tslot.heap,
         };
         Arc::make_mut(&mut map.vars).insert(sim_cref_key(&av.name)?, slot);
@@ -3136,7 +3136,7 @@ fn build_var_map(
 /// under its array base name so a whole-array reference can later be marshalled.
 fn insert_var(map: &mut SimVarMap, sv: &SimCodeVar::SimVar, off: u32, wty: WTy, heap: bool) -> Result<()> {
     let key = sim_cref_key(&sv.name)?;
-    Arc::make_mut(&mut map.vars).insert(key.clone(), SimSlot { off, wty, negate: false, heap });
+    Arc::make_mut(&mut map.vars).insert(key.clone(), SimSlot { off, wty, negate: Neg::None, heap });
     Arc::make_mut(&mut map.starts).insert(key, sv.initialValue.clone());
     if let Some((base, subs)) = array_element_of(&sv.name)? {
         map.array_acc.entry(base).or_default().push((subs, off, wty));
@@ -6201,7 +6201,7 @@ fn build_state_set_infos(
         for sv in lst(&set.jacobianMatrix.seedVars) {
             let off = cursor;
             cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
             seed_offs.push(off);
         }
         // Result slots (row order) — register the column result var crefs.
@@ -6209,7 +6209,7 @@ fn build_state_set_infos(
         for sv in lst(&col.columnVars) {
             let off = cursor;
             cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
             result_offs.push(off);
         }
 
@@ -6832,7 +6832,7 @@ fn build_nls_jac_infos(
         for sv in lst(&jm.seedVars) {
             let off = cursor;
             cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
             listed_offs.push(off);
         }
         // Every column variable (results + intermediates) needs a slot so the
@@ -6847,7 +6847,7 @@ fn build_nls_jac_infos(
         for sv in &jac_column_vars(jm) {
             let off = cursor;
             cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: false, heap: false });
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
             if matches!(sv.varKind, VarKind::JAC_VAR) {
                 let row = jac_result_row(sv)
                     .filter(|&r| r < n)
@@ -6968,7 +6968,7 @@ fn build_linz_jac_infos(
         let mut listed = Vec::new();
         for sv in lst(&jm.seedVars) {
             Arc::make_mut(&mut var_map.vars)
-                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: Neg::None, heap: false });
             listed.push(cursor);
             cursor += 8;
         }
@@ -6976,7 +6976,7 @@ fn build_linz_jac_infos(
         let mut result_offs = vec![None; rows];
         for sv in &jac_column_vars(jm) {
             Arc::make_mut(&mut var_map.vars)
-                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+                .insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: Neg::None, heap: false });
             if matches!(sv.varKind, VarKind::JAC_VAR)
                 && let Some(row) = jac_result_row(sv).filter(|&r| r < rows)
             {
@@ -7204,7 +7204,7 @@ fn build_lin_jac_infos(
     for sys in lin_jac_systems(sim_code) {
         let jm = sys.jacobianMatrix.as_ref().unwrap();
         for sv in lst(&jm.seedVars).chain(jac_column_vars(jm).iter()) {
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: false, heap: false });
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: Neg::None, heap: false });
             cursor += 8;
         }
     }
@@ -7883,7 +7883,7 @@ fn write_csv(
     let bool_col0 = int_col0 + layout.n_int_alg();
     let sens_col0 = layout.sens_col0();
     // Integers and booleans are captured as f64 but printed as integers.
-    let cols: Vec<(&str, u32, bool, bool)> = model
+    let cols: Vec<(&str, u32, Neg, bool)> = model
         .result_vars
         .iter()
         .zip(keep)
@@ -7903,8 +7903,7 @@ fn write_csv(
     for row in rows.chunks_exact(n_reals.max(1)) {
         out.push_str(&sim_driver::format_g(row[0], 16));
         for &(_, col, negate, is_int) in &cols {
-            let v = row.get(col as usize).copied().unwrap_or(0.0);
-            let v = if negate { -v } else { v };
+            let v = negate.apply_f64(row.get(col as usize).copied().unwrap_or(0.0));
             out.push(',');
             if is_int {
                 out.push_str(&format!("{}", v as i64));
@@ -7927,7 +7926,7 @@ fn write_mat4(
     params: &[f64],
     keep: &[bool],
 ) -> Result<()> {
-    use openmodelica_mat_writer::{MatKind, MatVar};
+    use openmodelica_mat_writer::MatVar;
     // `params` is positional over the unfiltered `Param` signals.
     let mut kept_params: Vec<f64> = Vec::new();
     let mut param_idx = 0usize;
@@ -7941,16 +7940,7 @@ fn write_mat4(
         if !keep {
             continue;
         }
-        vars.push(MatVar {
-            name: &v.name,
-            comment: &v.comment,
-            kind: match &v.kind {
-                ResultKind::Time => MatKind::Time,
-                ResultKind::Column { col, negate } => MatKind::Column { col: *col, negate: *negate },
-                ResultKind::Param { negate, .. } => MatKind::Param { negate: *negate },
-                ResultKind::Const { value } => MatKind::Const { value: *value },
-            },
-        });
+        vars.push(MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() });
     }
     let bytes =
         openmodelica_mat_writer::write_mat4(&vars, meta.start_time, meta.stop_time, rows, n_reals, &kept_params);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -129,7 +129,7 @@ fn unknown_variable(name: &str) -> &'static str {
 // driver so the emitted layout and the driver's readback cannot drift). Its
 // wasm-encoder `ValType` mapping is host-only, so it lives here as an extension
 // trait rather than an inherent method.
-pub(crate) use openmodelica_sim_meta::WTy;
+pub(crate) use openmodelica_sim_meta::{Neg, WTy};
 use openmodelica_sim_meta::clock_field;
 pub(crate) use openmodelica_wasm_jit::sig::{ExtCallSig, ExtLang, FnSig, SigTy, WTyVal};
 
@@ -1522,7 +1522,7 @@ pub(crate) struct SimSlot {
     pub(crate) wty: WTy,
     /// Alias negation: the cref is a negated alias of the variable at `off`, so
     /// a read negates and a write is rejected (aliases are never assigned).
-    pub(crate) negate: bool,
+    pub(crate) negate: Neg,
     /// The slot holds a reference-counted heap handle (a String). A read retains;
     /// an assignment releases the previous handle before storing the new (owned)
     /// one. Scalar Real/Integer/Boolean slots are not heap.
@@ -1892,7 +1892,7 @@ impl<'a> FnCtx<'a> {
             }
             // C's `postExp`: `<var> = $START.<var>`, but not for a String, whose slot
             // holds a reference-counted handle.
-            if let Some(slot) = var.filter(|s| !s.negate && !s.heap) {
+            if let Some(slot) = var.filter(|s| s.negate == Neg::None && !s.heap) {
                 self.emit(we::Instruction::LocalGet(data));
                 self.emit(we::Instruction::LocalGet(raw));
                 match slot.wty {
@@ -5500,17 +5500,20 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
     match slot.wty {
         WTy::F64 => {
             ctx.emit(we::Instruction::F64Load(mem_arg(slot.off, 3)));
-            if slot.negate {
+            if slot.negate != Neg::None {
                 ctx.emit(we::Instruction::F64Neg);
             }
         }
         WTy::I32 => {
             ctx.emit(we::Instruction::I32Load(mem_arg(slot.off, 2)));
-            if slot.negate {
-                // Integer negate; a Boolean negated alias uses `!` but is stored
-                // as 0/1 — handled when Boolean aliases are added.
-                ctx.emit(we::Instruction::I32Const(0));
-                ctx.emit(we::Instruction::I32Sub);
+            match slot.negate {
+                Neg::None => {}
+                Neg::Arith => {
+                    ctx.emit(we::Instruction::I32Const(0));
+                    ctx.emit(we::Instruction::I32Sub);
+                }
+                // A Boolean is stored as 0/1, so `!v` is `v == 0`.
+                Neg::Not => ctx.emit(we::Instruction::I32Eqz),
             }
         }
     }
@@ -5646,7 +5649,7 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
             return Err("CodegenWasmJit: simulation assignment to unknown variable")
         }
     };
-    if slot.negate {
+    if slot.negate != Neg::None {
         return Err("CodegenWasmJit: assignment to negated alias");
     }
     let data = ctx.sim()?.data_local;
@@ -5711,7 +5714,7 @@ pub(crate) fn sim_const_store(
         }
     }
     let Some(slot) = sim.vars.get(&sim_cref_key(cref)?) else { return Ok(None) };
-    if slot.negate || slot.heap {
+    if slot.negate != Neg::None || slot.heap {
         return Ok(None);
     }
     let bytes = match (const_num(exp), slot.wty) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
@@ -193,6 +193,7 @@ version = "0.1.0"
 dependencies = [
  "daskr",
  "libm",
+ "openmodelica_mat_writer",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/delay.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/delay.rs
@@ -2,12 +2,26 @@
 //! ring buffer per `delay(...)` expression. State is a module global (single-
 //! threaded wasm), reset by `rt_delay_init` each run.
 
+use crate::omclog;
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
+use openmodelica_sim_meta::driver::{format_e, format_g};
 
 /// C `DBL_EPSILON`.
 const DBL_EPSILON: f64 = f64::EPSILON;
+
+/// C `printRingBuffer` with `printDelayBuffer`, minus the element addresses.
+fn print_buffer(stream: omclog::Stream, buf: &VecDeque<Row>) {
+    if !omclog::active(stream) {
+        return;
+    }
+    omclog::info(stream, true, "Printing ring buffer:");
+    for &(t, v) in buf {
+        omclog::info(stream, false, &alloc::format!("({},{})", format_e(t), format_e(v)));
+    }
+    omclog::close(stream);
+}
 
 /// One `(time, value)` ring-buffer row.
 type Row = (f64, f64);
@@ -61,6 +75,9 @@ fn search_event(time: f64, buf: &VecDeque<Row>) -> bool {
             break;
         }
     }
+    if found {
+        print_buffer(omclog::DEBUG, buf);
+    }
     found
 }
 
@@ -100,6 +117,17 @@ impl DelayState {
                 buf.pop_front();
             }
         }
+        omclog::info(
+            omclog::DELAY,
+            false,
+            &alloc::format!(
+                "storeDelayed[{idx}] ({},{}) position={}",
+                format_g(time, 6),
+                format_g(value, 6),
+                buf.len()
+            ),
+        );
+        print_buffer(omclog::DELAY, buf);
     }
 
     /// C `delayImpl`: `expr(time - delay_time)` by linear interpolation, with the
@@ -107,10 +135,28 @@ impl DelayState {
     fn eval(&self, idx: usize, time: f64, value: f64, delay_time: f64) -> f64 {
         let buf = &self.buffers[idx];
         let length = buf.len();
+        omclog::info(
+            omclog::DELAY,
+            false,
+            &alloc::format!(
+                "delayImpl: exprNumber = {idx}, exprValue = {}, time = {}, delayTime = {}",
+                format_g(value, 6),
+                format_g(time, 6),
+                format_g(delay_time, 6)
+            ),
+        );
         if time <= self.start_time {
             return value;
         }
         if length == 0 {
+            omclog::info(
+                omclog::EVENTS,
+                false,
+                &alloc::format!(
+                    "delayImpl: Missing initial value, using argument value {} instead.",
+                    format_g(value, 6)
+                ),
+            );
             return value;
         }
         if time <= self.start_time + delay_time {
@@ -141,9 +187,8 @@ impl DelayState {
             return value1;
         }
         let timedif = time1 - time0;
-        let dt0 = time1 - time_stamp;
         let dt1 = time_stamp - time0;
-        (value0 * dt0 + value1 * dt1) / timedif
+        value0 + (value1 - value0) * (dt1 / timedif)
     }
 
     /// C `delayZeroCrossing`: the wrapped relation's pre g-value, sign-flipped when

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -24,7 +24,7 @@
 //! - `wasm-merge runtime.wasm rt model.wasm model` connects both directions,
 //!   leaving only the WASI imports (satisfied by `wasmtime`/the worker shim).
 
-use openmodelica_mat_writer::{MatKind, MatVar};
+use openmodelica_mat_writer::MatVar;
 use openmodelica_sim_meta::driver::{self, SimEngine};
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{self as meta, MetaKind, SimMeta};
@@ -220,16 +220,7 @@ fn run() {
         if !keep {
             continue;
         }
-        matvars.push(MatVar {
-            name: &v.name,
-            comment: &v.comment,
-            kind: match &v.kind {
-                MetaKind::Time => MatKind::Time,
-                MetaKind::Column { col, negate } => MatKind::Column { col: *col, negate: *negate },
-                MetaKind::Param { negate, .. } => MatKind::Param { negate: *negate },
-                MetaKind::Const { value } => MatKind::Const { value: *value },
-            },
-        });
+        matvars.push(MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() });
     }
 
     let bytes = openmodelica_mat_writer::write_mat4(

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -32,7 +32,7 @@ use openmodelica_sim_meta::driver::{
 };
 #[cfg(feature = "cs")]
 use openmodelica_sim_meta::driver::{CsDriver, CsStep};
-use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, WTy, REAL_OFF, TIME_OFF};
+use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, Neg, WTy, REAL_OFF, TIME_OFF};
 
 // ── Model kernel imports ─────────────────────────────────────────────────────
 // `env` is the dylink convention: the Linker resolves these against the model
@@ -769,10 +769,7 @@ macro_rules! shared_instance_methods {
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::F64 => {
-                    let v = st.read_f64(e.off);
-                    out.push(if e.negate { -v } else { v });
-                }
+                Some(e) if e.wty == WTy::F64 => out.push(e.negate.apply_f64(st.read_f64(e.off))),
                 _ => return Err(Status::Error),
             }
         }
@@ -793,8 +790,7 @@ macro_rules! shared_instance_methods {
         for vr in vrs {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.is_string => {
-                    let v = st.read_i32(e.off);
-                    out.push(if e.negate { -v } else { v });
+                    out.push(e.negate.apply_i32(st.read_i32(e.off)))
                 }
                 _ => return Err(Status::Error),
             }
@@ -812,8 +808,7 @@ macro_rules! shared_instance_methods {
         for vr in vrs {
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.is_string => {
-                    let v = st.read_i32(e.off);
-                    out.push((if e.negate { -v } else { v }) as i64);
+                    out.push(e.negate.apply_i32(st.read_i32(e.off)) as i64)
                 }
                 _ => return Err(Status::Error),
             }
@@ -851,7 +846,9 @@ macro_rules! shared_instance_methods {
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::I32 && !e.is_string => out.push(st.read_i32(e.off) != 0),
+                Some(e) if e.wty == WTy::I32 && !e.is_string => {
+                    out.push(e.negate.apply_i32(st.read_i32(e.off)) != 0)
+                }
                 _ => return Err(Status::Error),
             }
         }
@@ -889,7 +886,7 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::F64 && !e.negate => {
+                Some(e) if e.wty == WTy::F64 && e.negate == Neg::None => {
                     st.write_f64(e.off, v);
                     if st.mode != Mode::Ready {
                         let start = e.start_off != 0;
@@ -915,7 +912,7 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
+                Some(e) if e.wty == WTy::I32 && e.negate == Neg::None && !e.is_string => {
                     st.write_i32(e.off, v);
                     if st.mode != Mode::Ready {
                         st.record_override(e.off, WTy::I32, v as f64, false);
@@ -934,7 +931,7 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
+                Some(e) if e.wty == WTy::I32 && e.negate == Neg::None && !e.is_string => {
                     st.write_i32(e.off, v as i32);
                     if st.mode != Mode::Ready {
                         st.record_override(e.off, WTy::I32, v as f64, false);
@@ -962,7 +959,7 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
+                Some(e) if e.wty == WTy::I32 && e.negate == Neg::None && !e.is_string => {
                     st.write_i32(e.off, v as i32);
                     if st.mode != Mode::Ready {
                         st.record_override(e.off, WTy::I32, v as f64, false);
@@ -981,7 +978,7 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
             match st.vrs.resolve(vr) {
-                Some(e) if e.wty == WTy::I32 && !e.negate && !e.is_string => {
+                Some(e) if e.wty == WTy::I32 && e.negate == Neg::None && !e.is_string => {
                     let iv = if v { 1 } else { 0 };
                     st.write_i32(e.off, iv);
                     if st.mode != Mode::Ready {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_mat_writer/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_mat_writer/src/lib.rs
@@ -21,6 +21,16 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 /// How a result signal sources its value in the `.mat`.
+/// Mirrors `openmodelica_sim_meta::Neg`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Neg {
+    None,
+    /// `-v`: shares the aliased row through a negative `dataInfo` index.
+    Arith,
+    /// `!v` = `1 - v`: not a sign, so it needs a row of its own.
+    Not,
+}
+
 #[derive(Clone, Copy)]
 pub enum MatKind {
     /// The independent variable (`time`): data_2 row 1.
@@ -28,10 +38,10 @@ pub enum MatKind {
     /// A time-variant real signal reading result-buffer column `col` (0-based
     /// into the `[time | realVars]` row layout, so `col >= 1`). Several signals
     /// may share one column (aliases); `negate` flags a negated alias.
-    Column { col: u32, negate: bool },
+    Column { col: u32, negate: Neg },
     /// A time-invariant parameter; its value comes from the `params` slice in
     /// `Param` order. `negate` flags a negated alias of a parameter.
-    Param { negate: bool },
+    Param { negate: Neg },
     /// A compile-time constant written directly to `data_1`.
     Const { value: f64 },
 }
@@ -71,27 +81,27 @@ pub fn write_mat4(
     write_char_matrix_cols(&mut out, "name", &names);
     write_char_matrix_cols(&mut out, "description", &descs);
 
-    // Build data_2 / data_1 like the C runtime: each `Column` signal references
-    // a result-buffer column; several names can share one column (alias dedup).
-    // A referenced column that is constant over the whole run is stored once in
-    // data_1; varying ones go to data_2. Parameters (and constant aliases of
-    // them) go to data_1. Negated aliases get a negative dataInfo index.
+    // Names can share a column, an arithmetic negation reading it through a negative
+    // dataInfo index; a Boolean one needs the `1 - v` row C's `mat4_emit4` adds.
     let demote = n_rows >= 2;
 
-    // Which buffer columns does any signal reference, and is each constant?
     let mut referenced = vec![false; n_reals];
+    let mut referenced_not = vec![false; n_reals];
     for v in signals {
-        if let MatKind::Column { col, .. } = &v.kind {
+        if let MatKind::Column { col, negate } = &v.kind {
             let c = *col as usize;
             if c < n_reals {
-                referenced[c] = true;
+                match negate {
+                    Neg::Not => referenced_not[c] = true,
+                    _ => referenced[c] = true,
+                }
             }
         }
     }
     let mut col_is_const = vec![false; n_reals];
     if demote {
         for c in 1..n_reals {
-            if referenced[c] {
+            if referenced[c] || referenced_not[c] {
                 let first = rows[c];
                 col_is_const[c] = (1..n_rows).all(|r| rows[r * n_reals + c] == first);
             }
@@ -109,20 +119,29 @@ pub fn write_mat4(
     // referenced columns (after [start,stop] and the scalar signals).
     let mut col_data2_row = vec![0i32; n_reals];
     let mut col_data1_row = vec![0i32; n_reals];
-    let mut varying_cols: Vec<usize> = Vec::new();
-    let mut const_cols: Vec<usize> = Vec::new();
+    let mut not_data2_row = vec![0i32; n_reals];
+    let mut not_data1_row = vec![0i32; n_reals];
+    let mut varying_cols: Vec<(usize, Neg)> = Vec::new();
+    let mut const_cols: Vec<(usize, Neg)> = Vec::new();
     let mut next_const_row: i32 = 2 + n_scalars as i32;
     for c in 1..n_reals {
-        if !referenced[c] {
-            continue; // column belongs to a filtered-out variable — drop it
-        }
-        if col_is_const[c] {
-            const_cols.push(c);
-            col_data1_row[c] = next_const_row;
-            next_const_row += 1;
-        } else {
-            varying_cols.push(c);
-            col_data2_row[c] = 1 + varying_cols.len() as i32;
+        for neg in [Neg::None, Neg::Not] {
+            let (wanted, d1, d2) = if neg == Neg::Not {
+                (referenced_not[c], &mut not_data1_row, &mut not_data2_row)
+            } else {
+                (referenced[c], &mut col_data1_row, &mut col_data2_row)
+            };
+            if !wanted {
+                continue; // filtered-out variable
+            }
+            if col_is_const[c] {
+                const_cols.push((c, neg));
+                d1[c] = next_const_row;
+                next_const_row += 1;
+            } else {
+                varying_cols.push((c, neg));
+                d2[c] = 1 + varying_cols.len() as i32;
+            }
         }
     }
 
@@ -134,11 +153,15 @@ pub fn write_mat4(
             MatKind::Time => [0, 1, 0, -1],
             MatKind::Column { col, negate } => {
                 let c = *col as usize;
-                let sgn = if *negate { -1 } else { 1 };
-                if c < n_reals && col_data1_row[c] != 0 {
-                    [1, sgn * col_data1_row[c], 0, 0]
-                } else if c < n_reals && col_data2_row[c] != 0 {
-                    [2, sgn * col_data2_row[c], 0, 0]
+                let (d1, d2, sgn) = match negate {
+                    Neg::Not => (&not_data1_row, &not_data2_row, 1),
+                    Neg::Arith => (&col_data1_row, &col_data2_row, -1),
+                    Neg::None => (&col_data1_row, &col_data2_row, 1),
+                };
+                if c < n_reals && d1[c] != 0 {
+                    [1, sgn * d1[c], 0, 0]
+                } else if c < n_reals && d2[c] != 0 {
+                    [2, sgn * d2[c], 0, 0]
                 } else {
                     [0, 1, 0, -1] // unreachable (every Column is referenced); alias time
                 }
@@ -146,7 +169,7 @@ pub fn write_mat4(
             MatKind::Param { negate } => {
                 let r = next_scalar_row;
                 next_scalar_row += 1;
-                [1, if *negate { -r } else { r }, 0, 0]
+                [1, if *negate == Neg::Arith { -r } else { r }, 0, 0]
             }
             MatKind::Const { .. } => {
                 let r = next_scalar_row;
@@ -169,10 +192,10 @@ pub fn write_mat4(
     let mut param_idx = 0usize;
     for v in signals {
         let val = match &v.kind {
-            MatKind::Param { .. } => {
+            MatKind::Param { negate } => {
                 let v = params.get(param_idx).copied().unwrap_or(0.0);
                 param_idx += 1;
-                v
+                if *negate == Neg::Not { 1.0 - v } else { v }
             }
             MatKind::Const { value } => *value,
             _ => continue,
@@ -181,10 +204,12 @@ pub fn write_mat4(
         data_1[n_data1 + row_idx] = val;
         row_idx += 1;
     }
-    for &c in &const_cols {
-        let idx = (col_data1_row[c] - 1) as usize; // 1-based row -> 0-based index
-        data_1[idx] = rows[c];
-        data_1[n_data1 + idx] = rows[c];
+    for &(c, neg) in &const_cols {
+        let row = if neg == Neg::Not { not_data1_row[c] } else { col_data1_row[c] };
+        let idx = (row - 1) as usize;
+        let v = if neg == Neg::Not { 1.0 - rows[c] } else { rows[c] };
+        data_1[idx] = v;
+        data_1[n_data1 + idx] = v;
     }
     write_double_matrix(&mut out, "data_1", n_data1, 2, &data_1);
 
@@ -193,8 +218,9 @@ pub fn write_mat4(
     let mut data_2: Vec<f64> = Vec::with_capacity(n_rows * n_reals2);
     for r in 0..n_rows {
         data_2.push(rows[r * n_reals]); // time
-        for &c in &varying_cols {
-            data_2.push(rows[r * n_reals + c]);
+        for &(c, neg) in &varying_cols {
+            let v = rows[r * n_reals + c];
+            data_2.push(if neg == Neg::Not { 1.0 - v } else { v });
         }
     }
     write_double_matrix(&mut out, "data_2", n_reals2, n_rows, &data_2);
@@ -303,8 +329,8 @@ mod tests {
     fn writes_expected_matrices() {
         let vars = [
             MatVar { name: "time", comment: "Time in s", kind: MatKind::Time },
-            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: false } },
-            MatVar { name: "p", comment: "a param", kind: MatKind::Param { negate: false } },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+            MatVar { name: "p", comment: "a param", kind: MatKind::Param { negate: Neg::None } },
             MatVar { name: "k", comment: "", kind: MatKind::Const { value: 9.0 } },
         ];
         // 3 communication points; x ramps 0,1,2.
@@ -340,5 +366,37 @@ mod tests {
         assert_eq!((m2, n2), (2, 3));
         let d2 = f64s(d2);
         assert_eq!(d2, vec![0.0, 0.0, 0.5, 1.0, 1.0, 2.0]);
+    }
+
+    /// Arithmetic negation shares the target's row; a Boolean one gets its own.
+    #[test]
+    fn negated_aliases() {
+        let vars = [
+            MatVar { name: "time", comment: "", kind: MatKind::Time },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+            MatVar { name: "mx", comment: "", kind: MatKind::Column { col: 1, negate: Neg::Arith } },
+            MatVar { name: "b", comment: "", kind: MatKind::Column { col: 2, negate: Neg::None } },
+            MatVar { name: "nb", comment: "", kind: MatKind::Column { col: 2, negate: Neg::Not } },
+            MatVar { name: "np", comment: "", kind: MatKind::Param { negate: Neg::Not } },
+        ];
+        // n_reals = 3: [time, x, b]; b toggles, so its column stays time-variant.
+        let rows = [0.0, 1.0, 0.0, /*r1*/ 0.5, 2.0, 1.0];
+        let buf = write_mat4(&vars, 0.0, 0.5, &rows, 3, &[1.0]);
+
+        let (_r, _c, di) = find_matrix(&buf, "dataInfo");
+        let di = i32s(di);
+        assert_eq!(&di[4..8], &[2, 2, 0, 0]); // x -> data_2 row 2
+        assert_eq!(&di[8..12], &[2, -2, 0, 0]); // mx -> same row, negated
+        assert_eq!(&di[12..16], &[2, 3, 0, 0]); // b -> data_2 row 3
+        assert_eq!(&di[16..20], &[2, 4, 0, 0]); // nb -> its own derived row
+        assert_eq!(&di[20..24], &[1, 2, 0, 0]); // np -> data_1 row 2, not negated
+
+        let (m1, _n1, d1) = find_matrix(&buf, "data_1");
+        assert_eq!(f64s(d1)[1], 0.0);
+        assert_eq!(m1, 2);
+
+        let (m2, n2, d2) = find_matrix(&buf, "data_2");
+        assert_eq!((m2, n2), (4, 2));
+        assert_eq!(f64s(d2), vec![0.0, 1.0, 0.0, 1.0, 0.5, 2.0, 1.0, 0.0]);
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/Cargo.toml
@@ -25,5 +25,7 @@ sundials_extern = []
 daskr = { path = "../daskr", default-features = false }
 # no_std `sqrt` for the colored-FD Jacobian; unused under `std` (inherent method).
 libm = "0.2"
+# The `.mat` serializer `MetaKind` projects onto (`MetaKind::mat`).
+openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
 
 [lib]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -18,7 +18,8 @@ use core::cell::RefCell;
 
 use crate::omclog;
 use crate::{
-    JacAInfo, Layout as SimLayout, MetaKind as ResultKind, REAL_OFF, SimMeta, SolveStats, StateSetInfo, TIME_OFF,
+    JacAInfo, Layout as SimLayout, MetaKind as ResultKind, Neg, REAL_OFF, SimMeta, SolveStats, StateSetInfo,
+    TIME_OFF,
     WTy,
 };
 
@@ -2298,8 +2299,7 @@ pub(crate) fn bisection_iterations(width: f64, ttol: f64) -> i64 {
     }
 }
 
-/// Snapshot the zero-crossing g-values into `zeroCrossingsPre` (C's
-/// `saveZeroCrossings`); `delayZeroCrossing` reads it as the held g-value.
+/// Hold the zero-crossing g-values as `pre(zeroCrossing)`.
 fn save_zc_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.n_zc == 0 {
         return Ok(());
@@ -2307,6 +2307,60 @@ fn save_zc_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Resu
     let mut buf = vec![0u8; (layout.n_zc * 8) as usize];
     e.read_bytes(sim_data + layout.zc_off, &mut buf)?;
     e.write_bytes(sim_data + layout.zc_pre_off, &buf)
+}
+
+/// C's `sign()` (`omc_math.h`).
+fn zsign(v: f64) -> i32 {
+    if v > 0.0 {
+        1
+    } else if v < 0.0 {
+        -1
+    } else {
+        0
+    }
+}
+
+/// C's `checkForStateEvent` (`events.c`): the crossings whose g-value changed sign
+/// against the held one. The root finding only supplies the time.
+fn zc_sign_changed(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<usize>> {
+    let mut out = Vec::new();
+    for i in 0..layout.n_zc {
+        let cur = read_f64(e, sim_data + layout.zc_off + i * 8)?;
+        let pre = read_f64(e, sim_data + layout.zc_pre_off + i * 8)?;
+        if zsign(cur) != zsign(pre) {
+            out.push(i as usize);
+        }
+    }
+    Ok(out)
+}
+
+/// C's `saveZeroCrossings` (`model_help.c`), the tail of every `simulationUpdate`:
+/// hold, then recompute at the accepted point.
+fn save_zero_crossings(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+) -> Result<Vec<usize>> {
+    if layout.n_zc == 0 {
+        return Ok(Vec::new());
+    }
+    save_zc_pre(e, sim_data, layout)?;
+    e.call1("functionZeroCrossings", sim_data)?;
+    zc_sign_changed(e, sim_data, layout)
+}
+
+/// C's `saveZeroCrossingsAfterEvent` (`events.c`): recompute first, *then* hold, so
+/// the discrete update's own jump is not read as a crossing.
+fn save_zero_crossings_after_event(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+) -> Result<()> {
+    if layout.n_zc == 0 {
+        return Ok(());
+    }
+    e.call1("functionZeroCrossings", sim_data)?;
+    save_zc_pre(e, sim_data, layout)
 }
 
 /// Copy `relations[]` into the held relation snapshot at `stored_rel_off`. The
@@ -2455,7 +2509,7 @@ fn log_reinits(e: &mut dyn SimEngine, model: &SimMeta) {
         let name = model
             .vars
             .iter()
-            .find(|v| matches!(v.kind, ResultKind::Column { col: c, negate: false } if c == col))
+            .find(|v| matches!(v.kind, ResultKind::Column { col: c, negate: Neg::None } if c == col))
             .map(|v| v.name.as_str())
             .unwrap_or_default();
         omclog::info(omclog::EVENTS, false, &format!("reinit {name} = {}", format_g(value, 6)));
@@ -5147,6 +5201,54 @@ impl SolverCore {
         }
     }
 
+    /// C's `handleEvents` for the crossings [`save_zero_crossings`] reported at an
+    /// accepted point; there is no root to localize. `Ok(true)` = terminated.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_zc_flips(
+        &mut self,
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        ctx: &mut ResCtx,
+        sync: &mut crate::sync::Sync,
+        mut rows: Option<&mut Vec<f64>>,
+        flips: &[usize],
+    ) -> Result<bool> {
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        let t = self.t;
+        let eps = t.abs().max(1.0) * 1e-10;
+        self.state_events += 1;
+        log_state_event(t, flips, model);
+        if let Some(r) = rows.as_deref_mut()
+            && !no_event_emit()
+        {
+            capture_pre(e, r, sim_data, layout, t)?;
+        }
+        event_update(e, sim_data, layout, None, t)?;
+        save_zero_crossings_after_event(e, sim_data, layout)?;
+        if let Some(r) = rows.as_deref_mut() {
+            if emit_post_event_row(model, t) {
+                capture_row(e, r, sim_data, layout)?;
+            }
+            check_asserts(e, sim_data, layout, omclog::INFO)?;
+        }
+        if terminated(e, sim_data, layout)? {
+            return Ok(true);
+        }
+        fire_clocks(e, sync, model, sim_data, t, eps, rows.as_deref_mut())?;
+        store_operators(e, sim_data, layout)?;
+        log_reinits(e, model);
+        omclog::close(omclog::EVENTS);
+        if terminated(e, sim_data, layout)? {
+            return Ok(true);
+        }
+        self.read_states(e)?;
+        self.refresh_yp(e)?;
+        self.restart()?;
+        self.dae_restart(e, ctx)?;
+        Ok(false)
+    }
+
     /// Integrate to `tout`, handling the state events the solver roots out and the
     /// samples due on the way. `rows` collects the pre/post-event rows when the
     /// caller wants them; CS passes `None`. A `Yielded` return resumes on the same
@@ -5226,6 +5328,13 @@ impl SolverCore {
                         }
                     }
                     store_operators_at(e, sim_data, layout, self.t)?;
+                    let flips = save_zero_crossings(e, sim_data, layout)?;
+                    if !flips.is_empty() {
+                        *did_step = true;
+                        if self.handle_zc_flips(e, model, ctx, sync, rows.as_deref_mut(), &flips)? {
+                            return Ok(Step::Terminated);
+                        }
+                    }
                     continue;
                 }
                 // A zero-crossing root at `t` (< target). Handle the state event
@@ -5271,7 +5380,9 @@ impl SolverCore {
                         capture_pre(e, r, sim_data, layout, troot)?;
                     }
                     store_operators_at(e, sim_data, layout, troot)?;
+                    let _ = save_zero_crossings(e, sim_data, layout)?;
                     event_update(e, sim_data, layout, None, troot)?;
+                    save_zero_crossings_after_event(e, sim_data, layout)?;
                     if let Some(r) = rows.as_deref_mut() {
                         if emit_post_event_row(model, troot) {
                             capture_row(e, r, sim_data, layout)?;
@@ -5320,6 +5431,7 @@ impl SolverCore {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?; // pre-event row (held)
                 }
                 store_operators_at(e, sim_data, layout, te)?;
+                let _ = save_zero_crossings(e, sim_data, layout)?;
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?; // event: refresh relations
                 samp.fire(e, sim_data, te)?;
                 refresh_relations(e, sim_data, layout)?;
@@ -5330,6 +5442,7 @@ impl SolverCore {
                 {
                     emit_row(e, r, sim_data, layout, te, model.stop_time)?;
                 }
+                save_zero_crossings_after_event(e, sim_data, layout)?;
                 store_operators(e, sim_data, layout)?;
                 log_reinits(e, model);
                 omclog::close(omclog::EVENTS);
@@ -5379,6 +5492,10 @@ impl SolverCore {
                 // exactly when the caller writes that row and stores after it.
                 if rows.is_none() {
                     store_operators_at(e, sim_data, layout, self.t)?;
+                    let flips = save_zero_crossings(e, sim_data, layout)?;
+                    if !flips.is_empty() && self.handle_zc_flips(e, model, ctx, sync, None, &flips)? {
+                        return Ok(Step::Terminated);
+                    }
                 }
                 return Ok(Step::Reached { grid_covered });
             }
@@ -5964,6 +6081,12 @@ impl Driver for EventsDriver {
                 close_assert_window(e, sim_data).and(emitted)?;
                 // The row's evaluation is this point's `updateContinuousSystem`.
                 store_operators(e, sim_data, layout)?;
+                let flips = save_zero_crossings(e, sim_data, layout)?;
+                if !flips.is_empty()
+                    && self.core.handle_zc_flips(e, model, &mut ctx, &mut self.sync, Some(&mut self.rows), &flips)?
+                {
+                    break Advance::Terminated;
+                }
                 if terminated(e, sim_data, layout)? {
                     break Advance::Terminated;
                 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -411,6 +411,57 @@ impl Layout {
     }
 }
 
+/// How a negated alias derives its value. C's `crefToCStr` negates a Boolean
+/// logically, everything else arithmetically.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Neg {
+    #[default]
+    None,
+    /// `-v`
+    Arith,
+    /// `!v`, i.e. `1 - v` over the 0/1 encoding.
+    Not,
+}
+
+impl Neg {
+    pub fn apply_f64(self, v: f64) -> f64 {
+        match self {
+            Neg::None => v,
+            Neg::Arith => -v,
+            Neg::Not => 1.0 - v,
+        }
+    }
+    pub fn apply_i32(self, v: i32) -> i32 {
+        match self {
+            Neg::None => v,
+            Neg::Arith => -v,
+            Neg::Not => (v == 0) as i32,
+        }
+    }
+    /// Compose one more negation step (an alias of an alias).
+    pub fn toggle(self, is_bool: bool) -> Neg {
+        match self {
+            Neg::None if is_bool => Neg::Not,
+            Neg::None => Neg::Arith,
+            _ => Neg::None,
+        }
+    }
+    fn code(self) -> u8 {
+        match self {
+            Neg::None => 0,
+            Neg::Arith => 1,
+            Neg::Not => 2,
+        }
+    }
+    fn from_code(c: u8) -> Neg {
+        match c {
+            1 => Neg::Arith,
+            2 => Neg::Not,
+            _ => Neg::None,
+        }
+    }
+}
+
 /// How a result signal sources its value (the run-time superset of
 /// `openmodelica_mat_writer::MatKind`: `Param` additionally carries the `SimData`
 /// offset/type so the driver can read the parameter's value back after the run).
@@ -420,12 +471,30 @@ pub enum MetaKind {
     Time,
     /// A time-variant real signal at result-buffer column `col` (`negate` for a
     /// negated alias).
-    Column { col: u32, negate: bool },
+    Column { col: u32, negate: Neg },
     /// A time-invariant parameter read from `SimData` at byte offset `off` as
     /// `wty` (`negate` for a negated alias).
-    Param { off: u32, wty: WTy, negate: bool },
+    Param { off: u32, wty: WTy, negate: Neg },
     /// A compile-time constant.
     Const { value: f64 },
+}
+
+impl MetaKind {
+    /// Project onto the `.mat` writer's kind.
+    pub fn mat(&self) -> openmodelica_mat_writer::MatKind {
+        use openmodelica_mat_writer::{MatKind, Neg as MatNeg};
+        let neg = |n: &Neg| match n {
+            Neg::None => MatNeg::None,
+            Neg::Arith => MatNeg::Arith,
+            Neg::Not => MatNeg::Not,
+        };
+        match self {
+            MetaKind::Time => MatKind::Time,
+            MetaKind::Column { col, negate } => MatKind::Column { col: *col, negate: neg(negate) },
+            MetaKind::Param { negate, .. } => MatKind::Param { negate: neg(negate) },
+            MetaKind::Const { value } => MatKind::Const { value: *value },
+        }
+    }
 }
 
 /// One result signal (C-compatible order: time, states, derivatives, algebraics,
@@ -557,7 +626,7 @@ impl LinLanguage {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct LinVar {
     pub off: u32,
-    pub negate: bool,
+    pub negate: Neg,
 }
 
 /// What `-l` needs beyond the ODE: C's `nInputVars`/`nOutputVars` as `SimData`
@@ -736,7 +805,7 @@ pub struct FmiVr {
     pub off: u32,
     pub wty: WTy,
     /// The variable is a negated alias of the slot at `off`; a read negates it.
-    pub negate: bool,
+    pub negate: Neg,
     /// A real variable's `start` attribute slot, 0 for everything else. An
     /// Initialization Mode set must land here: `setAllVarsToStart` runs after the
     /// parameter overrides and would overwrite `off` from it.
@@ -1124,13 +1193,13 @@ fn put_kind(o: &mut Vec<u8>, k: &MetaKind) {
         MetaKind::Column { col, negate } => {
             o.push(1);
             put_u32(o, *col);
-            o.push(*negate as u8);
+            o.push(negate.code());
         }
         MetaKind::Param { off, wty, negate } => {
             o.push(2);
             put_u32(o, *off);
             o.push(matches!(wty, WTy::F64) as u8);
-            o.push(*negate as u8);
+            o.push(negate.code());
         }
         MetaKind::Const { value } => {
             o.push(3);
@@ -1177,7 +1246,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_u32(&mut o, v.vr);
         put_u32(&mut o, v.off);
         o.push(matches!(v.wty, WTy::F64) as u8);
-        o.push(v.negate as u8);
+        o.push(v.negate.code());
         put_u32(&mut o, v.start_off);
         o.push(v.is_string as u8);
         put_u32(&mut o, v.der_off);
@@ -1277,7 +1346,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
                 put_u32(&mut o, g.len() as u32);
                 for v in g {
                     put_u32(&mut o, v.off);
-                    o.push(v.negate as u8);
+                    o.push(v.negate.code());
                 }
             }
             o.push(l.language as u8);
@@ -1478,11 +1547,11 @@ impl<'a> Reader<'a> {
     fn kind(&mut self) -> Result<MetaKind, &'static str> {
         Ok(match self.u8()? {
             0 => MetaKind::Time,
-            1 => MetaKind::Column { col: self.u32()?, negate: self.u8()? != 0 },
+            1 => MetaKind::Column { col: self.u32()?, negate: Neg::from_code(self.u8()?) },
             2 => MetaKind::Param {
                 off: self.u32()?,
                 wty: if self.u8()? != 0 { WTy::F64 } else { WTy::I32 },
-                negate: self.u8()? != 0,
+                negate: Neg::from_code(self.u8()?),
             },
             3 => MetaKind::Const { value: self.f64()? },
             _ => return Err("sim_meta: bad MetaKind tag"),
@@ -1535,7 +1604,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         let vr = r.u32()?;
         let off = r.u32()?;
         let wty = if r.u8()? != 0 { WTy::F64 } else { WTy::I32 };
-        let negate = r.u8()? != 0;
+        let negate = Neg::from_code(r.u8()?);
         let start_off = r.u32()?;
         let is_string = r.u8()? != 0;
         let der_off = r.u32()?;
@@ -1629,7 +1698,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
                 let n = r.u32()? as usize;
                 let mut out = Vec::with_capacity(n);
                 for _ in 0..n {
-                    out.push(LinVar { off: r.u32()?, negate: r.u8()? != 0 });
+                    out.push(LinVar { off: r.u32()?, negate: Neg::from_code(r.u8()?) });
                 }
                 Ok(out)
             };
@@ -1752,10 +1821,10 @@ mod tests {
             model_name: "MyModel".to_string(),
             vars: vec![
                 MetaVar { name: "time".to_string(), comment: "Time in s".to_string(), kind: MetaKind::Time, filter: 0 },
-                MetaVar { name: "x".to_string(), comment: "".to_string(), kind: MetaKind::Column { col: 1, negate: false }, filter: var_filter::PROTECTED },
-                MetaVar { name: "y".to_string(), comment: "neg alias".to_string(), kind: MetaKind::Column { col: 1, negate: true }, filter: var_filter::ALIAS },
-                MetaVar { name: "p".to_string(), comment: "a param".to_string(), kind: MetaKind::Param { off: 88, wty: WTy::F64, negate: false }, filter: 0 },
-                MetaVar { name: "n".to_string(), comment: "".to_string(), kind: MetaKind::Param { off: 92, wty: WTy::I32, negate: false }, filter: var_filter::HIDE_RESULT },
+                MetaVar { name: "x".to_string(), comment: "".to_string(), kind: MetaKind::Column { col: 1, negate: Neg::None }, filter: var_filter::PROTECTED },
+                MetaVar { name: "y".to_string(), comment: "neg alias".to_string(), kind: MetaKind::Column { col: 1, negate: Neg::Not }, filter: var_filter::ALIAS },
+                MetaVar { name: "p".to_string(), comment: "a param".to_string(), kind: MetaKind::Param { off: 88, wty: WTy::F64, negate: Neg::Arith }, filter: 0 },
+                MetaVar { name: "n".to_string(), comment: "".to_string(), kind: MetaKind::Param { off: 92, wty: WTy::I32, negate: Neg::None }, filter: var_filter::HIDE_RESULT },
                 MetaVar { name: "k".to_string(), comment: "".to_string(), kind: MetaKind::Const { value: 9.5 }, filter: var_filter::FILTERED },
             ],
             jac_a: Some(JacAInfo {
@@ -1774,8 +1843,8 @@ mod tests {
                 result_offs: vec![224],
             }],
             fmi_vrs: vec![
-                FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: false, start_off: 96, is_string: false, der_off: 0 },
-                FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: true, start_off: 0, is_string: true, der_off: 0 },
+                FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: Neg::None, start_off: 96, is_string: false, der_off: 0 },
+                FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: Neg::Arith, start_off: 0, is_string: true, der_off: 0 },
             ],
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             rel_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
@@ -1815,8 +1884,8 @@ mod tests {
                 ],
             }],
             lin: Some(LinInfo {
-                input_vars: vec![LinVar { off: 40, negate: false }],
-                output_vars: vec![LinVar { off: 48, negate: true }],
+                input_vars: vec![LinVar { off: 40, negate: Neg::None }],
+                output_vars: vec![LinVar { off: 48, negate: Neg::Arith }],
                 language: LinLanguage::Julia,
                 frame: "function linearized_model()\n%s%s%s%s%s%s\nend".to_string(),
                 frame_datarec: String::new(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
@@ -43,11 +43,11 @@ fn jac_off(lin: &LinInfo, layout: &crate::Layout, k: usize) -> u32 {
 
 fn read_lin_var(e: &dyn SimEngine, sim_data: u32, v: &LinVar) -> Result<f64> {
     let raw = read_f64(e, sim_data + v.off)?;
-    Ok(if v.negate { -raw } else { raw })
+    Ok(v.negate.apply_f64(raw))
 }
 
 fn write_lin_var(e: &mut dyn SimEngine, sim_data: u32, v: &LinVar, value: f64) -> Result<()> {
-    write_f64(e, sim_data + v.off, if v.negate { -value } else { value })
+    write_f64(e, sim_data + v.off, v.negate.apply_f64(value))
 }
 
 /// C's `functionODE_residual`.

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -93,6 +93,7 @@ import FGraph;
 import Flags;
 import FlagsUtil;
 import FlatModel = NFFlatModel;
+import FindZeroCrossings;
 import NFFunction;
 import NFFlatten.{FunctionTree, FunctionTreeImpl};
 import NFApi;
@@ -2099,7 +2100,7 @@ algorithm
       stateSets                   = {},
       constraints                 = {},
       classAttributes             = {},
-      zeroCrossings               = ZeroCrossings.updateIndices(zeroCrossings),
+      zeroCrossings               = FindZeroCrossings.setOperatorZeroCrossingIndices(ZeroCrossings.updateIndices(zeroCrossings)),
       relations                   = ZeroCrossings.updateIndices(relations),
       timeEvents                  = timeEvents,
       discreteModelVars           = discreteModelVars,

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -134,6 +134,7 @@ import TypesDump;
 import Util;
 import ValuesUtil;
 import VisualXML;
+import FindZeroCrossings;
 import ZeroCrossings;
 import ReduceDAE;
 import Settings;
@@ -799,7 +800,7 @@ algorithm
       stateSets                   = stateSets,
       constraints                 = constraints,
       classAttributes             = classAttributes,
-      zeroCrossings               = ZeroCrossings.updateIndices(zeroCrossings),
+      zeroCrossings               = FindZeroCrossings.setOperatorZeroCrossingIndices(ZeroCrossings.updateIndices(zeroCrossings)),
       relations                   = ZeroCrossings.updateIndices(relations),
       timeEvents                  = timeEvents,
       discreteModelVars           = discreteModelVars,

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
@@ -217,7 +217,6 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
   double timeStamp;
   double time0, time1, value0, value1;
   double timedif;
-  double dt0;
   double dt1;
   double retVal;
   int i;
@@ -285,9 +284,9 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
     /* FIXME instead of linear, do the same interpolation order as the integrator */
     else {
       timedif = time1 - time0;
-      dt0 = time1 - timeStamp;
       dt1 = timeStamp - time0;
-      retVal = (value0 * dt0 + value1 * dt1) / timedif;
+      /* Exact when value0 == value1, unlike (value0*dt0 + value1*dt1)/timedif */
+      retVal = value0 + (value1 - value0) * (dt1 / timedif);
       return retVal;
     }
   }

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Digital.Examples.Counter.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Digital.Examples.Counter.mos
@@ -8,7 +8,7 @@
 
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.SimpleSimulation;
+modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Electrical.Digital.Examples.Counter);
 compareVars :=
 {
@@ -30,7 +30,7 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.SimpleSimulation
+// OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Electrical.Digital.Examples.Counter
 // {"Enable.y", "Clock.y", "Counter.q[1]", "Counter.q[2]", "Counter.q[3]", "Counter.q[4]", "Q0.y[1]", "Q1.y[1]", "Q2.y[1]", "Q3.y[1]"}
 // Simulation options: startTime = 0.0, stopTime = 100.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Digital.Examples.Counter', options = '', outputFormat = 'mat', variableFilter = 'time|Enable.y|Clock.y|Counter.q.1.|Counter.q.2.|Counter.q.3.|Counter.q.4.|Q0.y.1.|Q1.y.1.|Q2.y.1.|Q3.y.1.', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
@@ -38,6 +38,7 @@ runScript(modelTesting);getErrorString();
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
+// Files Equal!
 // "true
 // "
 // ""

--- a/testsuite/simulation/modelica/built_in_functions/delay/Delay.mos
+++ b/testsuite/simulation/modelica/built_in_functions/delay/Delay.mos
@@ -6,7 +6,7 @@
 //
 // Test builtin function delay
 // Expected values are sin(2.5)-1, cos(5), sin(4.99) and sin(3)
-// There must be events at time 5.0 and time 7.5
+// There must be events at time 5.0, 5.01 (delay 0.01), 5.5 (delay 0.5) and 7.5 (delay 2.5)
 //
 
 loadFile("Delay.mo");
@@ -32,13 +32,15 @@ val(w, 5);      // sin(3)
 // |                 | |       | | [1] (pre:  0) -1 = delayZeroCrossing(0, 0, 2.5) > 0.0
 // |                 | |       | | [2] (pre:  0)  1 = time < 5.0
 // |                 | |       | | [3] (pre:  0) -1 = delayZeroCrossing(1, 2, 0.01) > 0.0
-// |                 | |       | | [4] (pre:  0) -1 = delayZeroCrossing(3, 4, 1.5) > 0.0
-// |                 | |       | | [5] (pre:  0) -1 = delayZeroCrossing(2, 5, 0.5) > 0.0
+// |                 | |       | | [4] (pre:  0) -1 = delayZeroCrossing(3, 3, 1.5) > 0.0
+// |                 | |       | | [5] (pre:  0) -1 = delayZeroCrossing(2, 4, 0.5) > 0.0
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_EVENTS        | info    | state event at time=5.0
 // |                 | |       | | [2] time < 5.0
 // LOG_EVENTS        | info    | state event at time=5.01
 // |                 | |       | | [3] delayZeroCrossing(1, 2, 0.01) > 0.0
+// LOG_EVENTS        | info    | state event at time=5.5
+// |                 | |       | | [5] delayZeroCrossing(2, 4, 0.5) > 0.0
 // LOG_EVENTS        | info    | state event at time=7.5
 // |                 | |       | | [1] delayZeroCrossing(0, 0, 2.5) > 0.0
 // LOG_SUCCESS       | info    | The simulation finished successfully.

--- a/testsuite/simulation/modelica/events/DelayZeroCrossing.mos
+++ b/testsuite/simulation/modelica/events/DelayZeroCrossing.mos
@@ -1,0 +1,45 @@
+// name:     DelayZeroCrossing
+// keywords: events, delay
+// status: correct
+// teardown_command: rm -rf delayTests.DelayZeroCrossing* output.log
+//
+// A discontinuity in a delay()'s input has to re-trigger an event delayTime later
+// (delayZeroCrossing). The state makes the run take the integrator's root-finding
+// path, where that crossing is held in pre(zeroCrossing) between steps.
+//
+loadString("
+package delayTests
+  model DelayZeroCrossing
+    Real x(start = 0, fixed = true);
+    Real u = if time < 0.5 then 0.0 else 1.0;
+    Real y = delay(u, 0.1, 0.1);
+  equation
+    der(x) = 1 - x;
+  end DelayZeroCrossing;
+end delayTests;
+"); getErrorString();
+
+simulate(delayTests.DelayZeroCrossing, stopTime = 1.0, simflags = "-lv=LOG_EVENTS"); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "delayTests.DelayZeroCrossing_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'delayTests.DelayZeroCrossing', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
+//     messages = "LOG_EVENTS        | info    | status of relations at time=0
+// |                 | |       | | [1] (pre:  true)  true = time < 0.5
+// |                 | |       | | [2] (pre: false) false = delayZeroCrossing(0, 1, 0.1)
+// LOG_EVENTS        | info    | status of zero crossings at time=0
+// |                 | |       | | [1] (pre:  0)  1 = time < 0.5
+// |                 | |       | | [2] (pre:  0) -1 = delayZeroCrossing(0, 1, 0.1) > 0.0
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_EVENTS        | info    | state event at time=0.50000000015
+// |                 | |       | | [1] time < 0.5
+// LOG_EVENTS        | info    | state event at time=0.60000000015
+// |                 | |       | | [2] delayZeroCrossing(0, 1, 0.1) > 0.0
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/events/Makefile
+++ b/testsuite/simulation/modelica/events/Makefile
@@ -13,6 +13,7 @@ ChatteringEventsTest1.mos \
 ChatteringEventsTest2.mos \
 CheckEvents.mos \
 cseOutsideNoEvent.mos \
+DelayZeroCrossing.mos \
 discreteRelations.mos \
 EventDelay.mos \
 EventIteration.mos \

--- a/testsuite/simulation/modelica/others/Makefile
+++ b/testsuite/simulation/modelica/others/Makefile
@@ -28,6 +28,7 @@ ExtendsBasic.mos  \
 FrameTest.mos \
 IdealDiode.mos  \
 impureTest.mos \
+NegatedBooleanAlias.mos \
 NoLoadModel.mos \
 nonConstantIndex.mos \
 nonConstantParam.mos \

--- a/testsuite/simulation/modelica/others/NegatedBooleanAlias.mo
+++ b/testsuite/simulation/modelica/others/NegatedBooleanAlias.mo
@@ -1,0 +1,12 @@
+model NegatedBooleanAlias "Boolean negated alias: `!v`, not `-v`"
+  Boolean u = time > 0.5;
+  Boolean nu;
+  Integer k(start = 0, fixed = true);
+  Real y;
+equation
+  nu = not u;
+  y = if nu then 1.0 else 2.0;
+  when sample(0.1, 0.1) then
+    k = pre(k) + (if pre(nu) then 1 else 0);
+  end when;
+end NegatedBooleanAlias;

--- a/testsuite/simulation/modelica/others/NegatedBooleanAlias.mos
+++ b/testsuite/simulation/modelica/others/NegatedBooleanAlias.mos
@@ -1,0 +1,33 @@
+// name:     NegatedBooleanAlias
+// keywords: alias
+// status: correct
+// teardown_command: rm -rf NegatedBooleanAlias_* NegatedBooleanAlias.exe NegatedBooleanAlias NegatedBooleanAlias.log NegatedBooleanAlias.wasm output.log
+//
+// A Boolean negated alias reads `!v`, not the `-v` a Real/Integer one reads:
+// both in the equations (`pre(nu)` below) and in the result file.
+//
+loadFile("NegatedBooleanAlias.mo"); getErrorString();
+simulate(NegatedBooleanAlias, stopTime = 1.0, numberOfIntervals = 10); getErrorString();
+val(nu, 0.0);
+val(nu, 1.0);
+val(y, 0.0);
+val(y, 1.0);
+val(k, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "NegatedBooleanAlias_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NegatedBooleanAlias', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 0.0
+// 1.0
+// 2.0
+// 5.0
+// endResult


### PR DESCRIPTION
`FindZeroCrossings` passed `DoubleEnded.length(relations)` -- a *relation* index -- as the second argument of `delayZeroCrossing` and `spatialDistributionZeroCrossing`, and both runtimes use that argument to index `zeroCrossingsPre`, which is sized by the number of *zero crossings*. A model has at least as many relations as crossings, so the operator read another crossing's held value, or past the array:

| model | relations | crossings | read |
| ----- | --------- | --------- | ---- |
| `delay/Delay.mo` | 6 | 5 | `zeroCrossingsPre[5]` | | `Dynawo…WT4ACurrentSource2020FOCB` | 41 | 41 | 19 reads slot 20 |

`setOperatorZeroCrossingIndices` stamps the crossing's own index once the list is final. It cannot be done in `collectZC` -- the call has to exist before the crossing can be registered, and `updateIndices` renumbers afterwards anyway -- so it runs at both `SIMCODE` constructions. Only the `zeroCrossings` list is rewritten; the `relations` copy of the call is never evaluated.

`Delay.mos` gains a correct event at t=5.5, the 0.5 s delay of its t=5 discontinuity, which the stale index had swallowed.

## wasm-jit: delay-induced events never fired

`delayZeroCrossing` returns `pre(zeroCrossing)`, sign-flipped once the buffered discontinuity reaches the delay's output edge, so the held value is the whole mechanism. Only `EventsDriver`'s grid-walk branch refreshed it, which is why a stateless `delay()` model worked and anything with a state did not. `SolverCore::integrate_to` now does C's `saveZeroCrossings` at each accepted point and
`saveZeroCrossingsAfterEvent` after the discrete update, in C's orderings -- the post-event operator store has to come after the snapshot or the new discontinuity is absorbed into it.

C also identifies *every* state event with `checkForStateEvent` (`sign(zc) != sign(zcPre)`), the root finding only supplying the time; this had no counterpart here, so a crossing whose g steps between accepted points was invisible. Added as `zc_sign_changed` and `handle_zc_flips`.

`LOG_DELAY` is implemented too, and is now byte-comparable with C's.

On the Dynawo model the two runtimes went from 41 vs 33 state events to 29 vs 29, with identical event times and crossing sets.

## wasm-jit: Boolean negated alias read `-v` instead of `!v`

C's `crefToCStr` splits on type: a Boolean `NEGATEDALIAS` reads `!(v)`, everything else `-(v)`. A single `negate: bool` was threaded through `SimSlot` / `MetaKind` / `FmiVr` / `LinVar` and lowered as `0 - v` for both, so a Boolean alias came out as `-0.0` / `-1.0`. Replaced by `Neg { None, Arith, Not }`; the flavour is decided from which alias list the variable came from, and `Neg::Not` lowers to `i32.eqz`.

The `.mat` writer needed more than a sign: `writeDataInfo` gives a negated Boolean alias its own time-variant column and `mat4_emit4` writes `1 - v` into it, so the writer now allocates a derived row per such column. FMI3 `get_boolean`, which ignored `negate` entirely, is fixed as well.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
