### PR TITLE
Install libexpat so a CMake omc can export an OMSU

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSI/base/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSI/base/CMakeLists.txt
@@ -47,9 +47,12 @@ install(TARGETS ${OSUBaseName}
   LIBRARY DESTINATION ${LIBINSTALLEXT}
   ARCHIVE DESTINATION ${LIBINSTALLEXT})
 
-# Fallback for "standalone" makefile build
-# TODO: Remove when switching to CMake build
-if(NOT TARGET omc::3rd::FMIL::expat)
+# The generated OMSU makefile copies and links libexpat from $OMHOME/lib/<triple>/omc.
+if(TARGET omc::3rd::FMIL::expat)
+  install(FILES $<TARGET_FILE:omc::3rd::FMIL::expat> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+else()
+  # Fallback for "standalone" makefile build
+  # TODO: Remove when switching to CMake build
   install(FILES ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/libexpat.a DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 


### PR DESCRIPTION
The makefile generated for an OMSU copies `libexpat.*` out of `$OMHOME/lib/<triple>/omc` and links `-lexpat` from there, but the CMake build never installed it: FMIL builds the bundled Expat with `EXPAT_ENABLE_INSTALL=OFF`, and the only install rule was guarded by `if(NOT TARGET omc::3rd::FMIL::expat)`, so it fired only for the standalone makefile build. `buildModelFMU` therefore died in `copyFiles` with

    cp: cannot stat '.../omc/libexpat.*': No such file or directory

and returned `""`, failing all four `openmodelica/omsi/omsic` tests.

The autotools build does install the archive, and the gcc/clang testsuite stages run an autotools omc, which is why this only showed up in the Rust partest -- the one testsuite run against a CMake-installed omc. It has nothing to do with `--simCodeTarget=wasm-jit`; those tests force `omsic`.

Verified with a pristine `cmake --install` of the Rust build into a scratch prefix: buildSimpleOMSU, simulateSimpleOMSU, problem2 and simpleLoop all pass under `RTEST_OMCFLAGS=--simCodeTarget=wasm-jit`, where they failed before. The omsicpp makefile copies libexpat from the same directory, so that target is covered as well.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
