### PR TITLE
wasm-jit: initial() in the assertion header

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -260,13 +260,14 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_*` indices are unaffected), just before the generated functions. The host
 /// closures live in `runtime::add_host_builtins`.
 ///
-/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly, cond) -> shouldTrap`
+/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly, cond, initial) -> shouldTrap`
 /// records the failed assertion and answers whether the generated code must trap:
 /// it need not while the driver has asserts suppressed (C's `noThrowAsserts`).
 /// `cond` is the dumped condition, or 0 for a model/runtime error, which is never
 /// suppressed; it comes last so callers that already pushed the message append.
+/// `initial` is C's `initial()` at the assert site, for the message header.
 ///
-/// `rt_assert_warning(cond, msg, file, sline, scol, eline, ecol, isReadOnly)`
+/// `rt_assert_warning(cond, msg, file, sline, scol, eline, ecol, isReadOnly, initial)`
 /// records a *non-fatal* (AssertionLevel.warning) violation — the string handles
 /// (dumped condition, message, file) plus source position — for the driver to
 /// format as a `LOG_ASSERT` warning after the step. The generated code continues
@@ -291,12 +292,12 @@ fn builtin_index(name: &str) -> Option<u32> {
 pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     (
         "rt_assert",
-        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
         &[WTy::I32],
     ),
     (
         "rt_assert_warning",
-        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
         &[],
     ),
     ("rt_print", &[WTy::I32], &[]),
@@ -3909,6 +3910,7 @@ fn emit_assert(
         ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
         ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
         ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
+        emit_initial_flag(ctx);
         ctx.emit(we::Instruction::Call(env_extra_index("rt_assert_warning")?));
         ctx.emit(we::Instruction::End);
         return Ok(());
@@ -3929,6 +3931,7 @@ fn emit_assert(
     } else {
         emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
     }
+    emit_initial_flag(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     // Trap unless the driver took it (suppressed during the event search).
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
@@ -3960,10 +3963,22 @@ fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
         ctx.emit(we::Instruction::I32Const(0)); // line/col start+end, isReadOnly
     }
     ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
+    emit_initial_flag(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     ctx.emit(we::Instruction::Drop);
     ctx.emit(we::Instruction::Unreachable);
     Ok(())
+}
+
+/// 0 outside a simulation: C's `FUNCTION_CONTEXT` arm prints no header at all.
+fn emit_initial_flag(ctx: &mut FnCtx) {
+    match ctx.sim.as_ref().map(|s| (s.data_local, s.initial_off)) {
+        Some((data, off)) => {
+            ctx.emit(we::Instruction::LocalGet(data));
+            ctx.emit(we::Instruction::I32Load(mem_arg(off, 2)));
+        }
+        None => ctx.emit(we::Instruction::I32Const(0)),
+    }
 }
 
 /// The dumped source form of `e`, for embedding in an assertion message.
@@ -8023,6 +8038,7 @@ fn emit_runtime_error(ctx: &mut FnCtx, msg: &str) -> Result<()> {
         ctx.emit(we::Instruction::I32Const(0)); // file handle (null) + zeroed line/col
     }
     ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
+    emit_initial_flag(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     ctx.emit(we::Instruction::Drop);
     ctx.emit(we::Instruction::Unreachable);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -128,10 +128,10 @@ impl SimEngine for InWasmEngine {
         let f: extern "C" fn(u32, f64, f64, u32) -> u32 = unsafe { core::mem::transmute(idx as usize) };
         Ok(f(sim_data, start, stop, n_steps))
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         let mut out = Vec::new();
         loop {
-            let mut buf = [[0i32; 9]; 8];
+            let mut buf = [[0i32; 10]; 8];
             let n = unsafe { rt_host_take_warnings(buf.as_mut_ptr() as u32, buf.len() as u32) } as usize;
             out.extend_from_slice(&buf[..n.min(buf.len())]);
             if n < buf.len() {
@@ -150,7 +150,7 @@ impl SimEngine for InWasmEngine {
             }
         }
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         // The model imports `rt_assert` from the host; a failed assert traps and
         // unwinds out of `rt_sim_advance` to the host, which reports it. Nothing
         // to take in-wasm.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -149,7 +149,7 @@ impl SimEngine for StandaloneEngine {
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
         crate::take_reinit_notes()
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         // No host to record it; a failed model assert traps (see `rt_assert`).
         None
     }
@@ -294,7 +294,7 @@ pub extern "C" fn _start() {
 /// assertion, so print the message (`msg` is an `rt` String handle:
 /// `[refcount:u32][len:u32][utf8…]`) and trap, which aborts the command.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32, _cond: i32) -> i32 {
+pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32, _cond: i32, _initial: i32) -> i32 {
     if msg != 0 {
         let h = msg as u32;
         let len = unsafe { crate::load_u32(h + 4) } as usize;
@@ -341,6 +341,7 @@ pub extern "C" fn rt_assert_warning(
     _eline: i32,
     _ecol: i32,
     _read_only: i32,
+    _initial: i32,
 ) {
     if msg != 0 {
         let h = msg as u32;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -205,6 +205,7 @@ pub extern "C" fn rt_assert(
     _ecol: i32,
     _read_only: i32,
     _cond: i32,
+    _initial: i32,
 ) -> i32 {
     fmi_log(Status::Error, CAT_ERROR, &assert_message(msg, file, sline));
     core::arch::wasm32::unreachable()
@@ -221,6 +222,7 @@ pub extern "C" fn rt_assert_warning(
     _eline: i32,
     _ecol: i32,
     _read_only: i32,
+    _initial: i32,
 ) {
     fmi_log(Status::Warning, CAT_WARNING, &assert_message(msg, file, sline));
 }
@@ -302,7 +304,7 @@ impl SimEngine for Engine {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> driver::Result<u32> {
         Err("fmi3-me: simulate not used")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         None
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -256,14 +256,14 @@ pub trait SimEngine {
     /// in-wasm Euler driver; returns the result-buffer pointer.
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32>;
     /// If the last wasm call trapped on a failed `assert()`, take the recorded
-    /// assertion as `[msg, file, sline, scol, eline, ecol, read_only, cond]` (handles
-    /// into shared memory), else `None`. Backed by the engine's `rt_assert` host
-    /// import; lets [`drive`] report a model assertion instead of a bare trap.
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]>;
+    /// assertion as `[msg, file, sline, scol, eline, ecol, read_only, cond, initial]`
+    /// (handles into shared memory), else `None`. Backed by the engine's `rt_assert`
+    /// host import; lets [`drive`] report a model assertion instead of a bare trap.
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]>;
     /// Take the violations that did not throw, each as `[kind, cond, msg, file,
-    /// sline, scol, eline, ecol, read_only]` (`kind` per `ASSERT_*`). Drained by
-    /// the drivers to emit C's `LOG_ASSERT` blocks. Default: none.
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    /// sline, scol, eline, ecol, read_only, initial]` (`kind` per `ASSERT_*`). Drained
+    /// by the drivers to emit C's `LOG_ASSERT` blocks. Default: none.
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         Vec::new()
     }
     /// Take the `reinit`s the model executed since the last call, as `(state
@@ -415,7 +415,7 @@ fn enrich_trap_impl(e: &mut dyn SimEngine, err: &'static str, init_time: Option<
         col_end: pa[5],
     };
     if let Some(t) = init_time {
-        log_assert_block(&info, &cond, t, true);
+        log_assert_block(&info, &cond, t, pa[8] != 0);
         omclog::info(omclog::ASSERT, false, "simulation terminated by an assertion at initialization");
     }
     let p = ASSERT_REPORTER.load(Ordering::Relaxed);
@@ -1291,7 +1291,7 @@ fn drain_asserts(e: &mut dyn SimEngine, sim_data: u32, level: omclog::LogType) -
             line_end: el,
             col_end: ec,
         };
-        let line = assert_block(&info, &cond, time, false);
+        let line = assert_block(&info, &cond, time, w[9] != 0);
         let ty = if suppressed { omclog::INFO } else { level };
         if suppressed {
             omclog::message_text(ty, omclog::ASSERT, false, &line);
@@ -1514,7 +1514,6 @@ fn init_model(
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
-    write_i32(e, sim_data + layout.initial_off, 1)?;
     run_initialization_impl(e, sim_data, layout, inputs, model)?;
     if let Some(m) = model {
         dump_initial_solution(e, sim_data, m);
@@ -1565,6 +1564,9 @@ fn run_initialization_impl(
     steady_report::reset();
     seed_start_values(e, sim_data, layout, inputs, model)?;
     log_static_data_update();
+    // C sets `initial()` here: the start values and bound parameters above are
+    // evaluated with it still clear.
+    write_i32(e, sim_data + layout.initial_off, 1)?;
 
     // C's `IIM_NONE`: every variable keeps its start value, the initial system is
     // never solved. C still marks the systems solved before it picks the method.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
@@ -765,7 +765,7 @@ mod tests {
         fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
             Err("unused")
         }
-        fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+        fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
             None
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -15,13 +15,14 @@ pub struct PendingAssert {
     pub eline: i32,
     pub ecol: i32,
     pub read_only: bool,
+    pub initial: bool,
 }
 
 thread_local! {
     static PENDING_ASSERT: std::cell::RefCell<Option<PendingAssert>> = const { std::cell::RefCell::new(None) };
     /// Violations that did not throw: `[kind, cond, msg, file, sline, scol, eline,
-    /// ecol, read_only]`, `kind` per `driver::ASSERT_*`.
-    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 9]>> = const { std::cell::RefCell::new(Vec::new()) };
+    /// ecol, read_only, initial]`, `kind` per `driver::ASSERT_*`.
+    static PENDING_WARNINGS: std::cell::RefCell<Vec<[i32; 10]>> = const { std::cell::RefCell::new(Vec::new()) };
     /// C's `noThrowAsserts`: the driver has the model on a provisional state, so
     /// `rt_assert` records instead of telling the caller to trap.
     static NO_THROW: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -79,20 +80,22 @@ pub fn take_pending_assert_raw() -> Option<PendingAssert> {
 }
 
 /// Take the pending assertion as `[msg, file, sline, scol, eline, ecol, read_only,
-/// cond]` (for the simulation drivers surfacing a failed `assert()` after a trap).
-pub fn take_pending_assert() -> Option<[i32; 8]> {
-    take_pending_assert_raw()
-        .map(|pa| [pa.msg, pa.file, pa.sline, pa.scol, pa.eline, pa.ecol, pa.read_only as i32, pa.cond])
+/// cond, initial]` (for the simulation drivers surfacing a failed `assert()` after
+/// a trap).
+pub fn take_pending_assert() -> Option<[i32; 9]> {
+    take_pending_assert_raw().map(|pa| {
+        [pa.msg, pa.file, pa.sline, pa.scol, pa.eline, pa.ecol, pa.read_only as i32, pa.cond, pa.initial as i32]
+    })
 }
 
 /// Take (and clear) the warning-level assertion violations recorded since the last call.
-pub fn take_pending_warnings() -> Vec<[i32; 9]> {
+pub fn take_pending_warnings() -> Vec<[i32; 10]> {
     PENDING_WARNINGS.with(|p| core::mem::take(&mut *p.borrow_mut()))
 }
 
 /// Take at most `max` of them, oldest first: `rt_host_take_warnings` hands them
 /// to the in-wasm driver a bufferful at a time.
-fn take_pending_warnings_upto(max: usize) -> Vec<[i32; 9]> {
+fn take_pending_warnings_upto(max: usize) -> Vec<[i32; 10]> {
     PENDING_WARNINGS.with(|p| {
         let mut p = p.borrow_mut();
         let n = max.min(p.len());
@@ -100,8 +103,8 @@ fn take_pending_warnings_upto(max: usize) -> Vec<[i32; 9]> {
     })
 }
 
-/// Serialise the records into `dst` (little-endian `[i32; 9]` each).
-fn write_warnings(recs: &[[i32; 9]], dst: &mut [u8]) -> u32 {
+/// Serialise the records into `dst` (little-endian `[i32; 10]` each).
+fn write_warnings(recs: &[[i32; 10]], dst: &mut [u8]) -> u32 {
     let n = recs.len().min(dst.len() / REC_BYTES);
     for (i, rec) in recs[..n].iter().enumerate() {
         for (k, v) in rec.iter().enumerate() {
@@ -113,7 +116,7 @@ fn write_warnings(recs: &[[i32; 9]], dst: &mut [u8]) -> u32 {
 }
 
 /// Wire size of one record, shared with the in-wasm reader.
-const REC_BYTES: usize = 9 * 4;
+const REC_BYTES: usize = 10 * 4;
 
 /// `rt_uri_to_filename` on a host: `metamodelica`'s port of
 /// `OpenModelica_uriToFilename_impl`, resolving `modelica://` against the class
@@ -170,10 +173,10 @@ impl openmodelica_sim_meta::driver::SimEngine for MemEngine<'_> {
     }
     /// Left to the engine that owns the run: taking it here would consume what
     /// `enrich_trap` reports if the loop goes on to trap.
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         None
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         take_pending_warnings()
     }
 }
@@ -205,31 +208,35 @@ pub use sim_memory::set as set_sim_memory;
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub use sim_memory::get as get_sim_memory;
 
-fn record_assert(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) {
+fn record_assert(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, initial: i32) {
     PENDING_ASSERT.with(|p| {
-        *p.borrow_mut() = Some(PendingAssert { cond, msg, file, sline, scol, eline, ecol, read_only: read_only != 0 });
+        *p.borrow_mut() = Some(PendingAssert {
+            cond, msg, file, sline, scol, eline, ecol,
+            read_only: read_only != 0,
+            initial: initial != 0,
+        });
     });
 }
 
-fn record_warning(rec: [i32; 9]) {
+fn record_warning(rec: [i32; 10]) {
     PENDING_WARNINGS.with(|p| p.borrow_mut().push(rec));
 }
 
 /// `rt_assert`: a failed `assert()`. Returns 1 when the caller must trap — a model
 /// or runtime error (`cond == 0`) always does, a user assertion is recorded
 /// instead while the driver has asserts suppressed.
-fn assert_failed(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32) -> i32 {
+fn assert_failed(cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, initial: i32) -> i32 {
     if cond != 0 && NO_THROW.with(|n| n.get()) {
         record_warning([
             openmodelica_sim_meta::driver::ASSERT_SUPPRESSED,
-            cond, msg, file, sline, scol, eline, ecol, read_only,
+            cond, msg, file, sline, scol, eline, ecol, read_only, initial,
         ]);
         // Also as a pending assertion: if the phase throws, this reports it — the
         // in-wasm driver's own reporter cannot reach the host's error buffer.
-        record_assert(cond, msg, file, sline, scol, eline, ecol, read_only);
+        record_assert(cond, msg, file, sline, scol, eline, ecol, read_only, initial);
         return 0;
     }
-    record_assert(cond, msg, file, sline, scol, eline, ecol, read_only);
+    record_assert(cond, msg, file, sline, scol, eline, ecol, read_only, initial);
     1
 }
 
@@ -368,11 +375,11 @@ pub mod lin_solve {
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result<()> {
     let wt = |r: std::result::Result<&mut wasmtime::Linker<T>, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
-    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32| -> i32 {
-        assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only)
+    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32| -> i32 {
+        assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only, initial)
     }))?;
-    wt(linker.func_wrap("rt", "rt_assert_warning", |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-        record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
+    wt(linker.func_wrap("rt", "rt_assert_warning", |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, initial: i32| {
+        record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only, initial]);
     }))?;
     wt(linker.func_wrap("rt", "rt_reinit_note", |off: i32, value: f64| record_reinit(off as u32, value)))?;
     wt(linker.func_wrap(
@@ -523,12 +530,12 @@ impl HostMem {
 pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Imports) -> Result<HostMem> {
     use wasmer::Function;
     imports.define("rt", "rt_assert", Function::new_typed(store,
-        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32| -> i32 {
-            assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only)
+        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32| -> i32 {
+            assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only, initial)
         }));
     imports.define("rt", "rt_assert_warning", Function::new_typed(store,
-        |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32| {
-            record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only]);
+        |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, initial: i32| {
+            record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only, initial]);
         }));
     imports.define("rt", "rt_reinit_note", Function::new_typed(store,
         |off: i32, value: f64| record_reinit(off as u32, value)));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1033,10 +1033,10 @@ impl sim_driver::SimEngine for WasmerEngine {
             wt(self.instance.exports.get_typed_function(&self.store, "simulate"))?;
         wt(f.call(&mut self.store, sim_data, start, stop, n_steps))
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         crate::host::take_pending_warnings()
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
@@ -1185,10 +1185,10 @@ impl sim_driver::SimEngine for InWasmSession {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         crate::host::take_pending_warnings()
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1151,10 +1151,10 @@ impl sim_driver::SimEngine for WasmtimeEngine {
         let f = wt(self.instance.get_typed_func::<(u32, f64, f64, u32), u32>(&mut self.store, "simulate"))?;
         wt(f.call(&mut self.store, (sim_data, start, stop, n_steps)))
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         crate::host::take_pending_warnings()
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
@@ -1310,10 +1310,10 @@ impl sim_driver::SimEngine for InWasmSession {
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
         Err("CodegenWasmJit: call_simulate on in-wasm session (unreachable)")
     }
-    fn take_pending_assert(&mut self) -> Option<[i32; 8]> {
+    fn take_pending_assert(&mut self) -> Option<[i32; 9]> {
         crate::host::take_pending_assert()
     }
-    fn take_pending_warnings(&mut self) -> Vec<[i32; 9]> {
+    fn take_pending_warnings(&mut self) -> Vec<[i32; 10]> {
         crate::host::take_pending_warnings()
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {


### PR DESCRIPTION
C's generated assertion header is

    "The following assertion has been violated %sat time %f",
    initial() ? "during initialization " : ""

evaluated in the model, at the assert site. wasm-jit got this wrong in two independent ways, both of which surfaced as a spurious "during initialization " on `NthRoot2`/`NthRoot3`:

| # | Divergence | C |
| - | ---------- | - |
| 1 | the driver set `SimData.initial` before `seed_start_values` | `initialization()` sets it *after* the start values and bound parameters, once the init method is picked (`initialization.c:846`) | | 2 | `enrich_trap_impl` passed a hardcoded `true` for any assert raised during initialization, `drain_asserts` a hardcoded `false` for warnings | the model evaluates `initial()` itself |

The `nthRoot` equations of those two models are bound-parameter equations (`NthRoot2_08bnd.c`), so C reports them with `initial()` clear.

`rt_assert`/`rt_assert_warning` now take `initial` as a trailing argument, loaded from `SimData` by the emitted code — 0 in function context, where C's `FUNCTION_CONTEXT` arm prints no header at all. `PendingAssert` and the warning records carry it to the formatter.

`nthRoot` itself needed nothing: `emit_nth_root` already matches C's `copysign(pow(fabs(v), 1.0/n), v)` and both `assertCommonVar` guards.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
