### PR TITLE
[GBODE] fix MR FIRK with internal, unify sparsity pattern and coloring utils

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_internal_nls.c
@@ -29,6 +29,7 @@
 
 #include "gbode_main.h"
 #include "gbode_util.h"
+#include "gbode_sparse.h"
 #include "gbode_internal_nls.h"
 
 #include "../options.h"
@@ -88,18 +89,18 @@ extern void dcopy_(const int *n,
 
 typedef struct KLUInternals
 {
-  klu_common common;
-  klu_symbolic *symbolic;
-  klu_numeric *numeric;
+  klu_common common;       // shared KLU configuration for all transformed systems
+  klu_symbolic *symbolic;  // shared symbolic factorization of the NLS sparse pattern
+  klu_numeric **num_real;  // real numerical factorizations
+  klu_numeric **num_cmplx; // complex numerical factorizations
+  int n_real;
+  int n_cmplx;
 } KLUInternals;
 
 typedef struct GB_INTERNAL_NLS_DATA
 {
   NLS_USERDATA *nls_user_data;       // pointer to data, gbode data, etc.
-  KLUInternals *klu_internals_real;  // internal data structures for real systems with klu linear solver (might change for ptr + enum, e.g. to have LAPACK)
-  KLUInternals *klu_internals_cmplx; // internal data structures for complex systems with klu linear solver (might change for ptr + enum, e.g. to have LAPACK)
-  SPARSE_PATTERN *nlsPattern;        // sparse pattern struct(I + J) (for DIRK == NLS sparse pattern, else created)
-  modelica_boolean ownsNlsPattern;   // true if sparse pattern was created or false if taken from the NLS
+  KLUInternals klu;                  // KLU data
   double *jacobian_callback;         // buffer for continuous ODE Jacobian (size = nnz(J_f))
   int *ode_to_nls;                   // mapping ODE Jacobian nnz -> NLS Jacobian nnz
   int *nls_diag_indices;             // all diagonal nz indices of NLS Jacobian (size = cols)
@@ -124,151 +125,18 @@ typedef struct GB_INTERNAL_NLS_DATA
   double *work;                      // some work memory for the T transformation (size: transform->size * x.size) or other stuff, at least 32 * N_STATES bytes
 
   // stuff for multirate
-  modelica_boolean multirate;         // multirate or singlerate system?
-  modelica_boolean new_fast_states;   // if the selection changed and we need to update sparse pattern and symbolic factorization - set from NLS routine
-  SPARSE_PATTERN *odePatternMR;         // pattern of the ODE / fast states ODE
-  modelica_boolean ownsODEPatternMR; // true if sparse pattern was created or false if taken from the NLS
-  unsigned int* colorCols_stub;       // contains the coloring for evalJacobian
-  unsigned int maxColors_stub;        // Number of colors
+  modelica_boolean multirate;        // multirate or singlerate system?
+  modelica_boolean new_fast_states;  // if the selection changed and we need to update sparse pattern and symbolic factorization - set from NLS routine
 } GB_INTERNAL_NLS_DATA;
 
-/**
- * @brief Map ODE sparsity pattern indices into the enlarged (I+J) pattern.
- *
- * Locates diagonal entries of (I + J) and records their positions in `nls_diag_indices`.
- * Builds a mapping `ode_to_nls` from ODE Jacobian nonzero positions to the corresponding
- * positions in the (I + J) pattern column-wise.
- *
- * @param I_plus_J_pat  Sparse pattern of (I + J)
- * @param J_pat         ODE Jacobian structure
- * @param nls           Internal NLS data (nls_diag_indices and ode_to_nls members are filled)
- * @param size          Number of States
- *
- */
-static void updateSparsePatternMappings(SPARSE_PATTERN *I_plus_J_pat,
-                              SPARSE_PATTERN *J_pat,
-                              GB_INTERNAL_NLS_DATA *nls,
-                              int size)
+static inline SPARSE_PATTERN *getODEPattern(DATA *data, DATA_GBODE *gbData, GB_INTERNAL_NLS_DATA *nls)
 {
-  for (int col = 0; col < size; col++)
-  {
-    for (int nz = I_plus_J_pat->leadindex[col]; nz < I_plus_J_pat->leadindex[col + 1]; nz++)
-    {
-      int row = I_plus_J_pat->index[nz];
-      if (row == col)
-      {
-        nls->nls_diag_indices[col] = nz;
-        break;
-      }
-    }
-  }
-
-  for (int col = 0; col < size; col++)
-  {
-    int ode_start = J_pat->leadindex[col];
-    int ode_end   = J_pat->leadindex[col + 1];
-    int nls_start = I_plus_J_pat->leadindex[col];
-    int nls_end   = I_plus_J_pat->leadindex[col + 1];
-
-    int ptr_ode = ode_start;
-    int ptr_nls = nls_start;
-
-    while (ptr_ode < ode_end && ptr_nls < nls_end)
-    {
-      int row_ode = J_pat->index[ptr_ode];
-      int row_nls = I_plus_J_pat->index[ptr_nls];
-
-      if (row_ode == row_nls)
-      {
-        nls->ode_to_nls[ptr_ode++] = ptr_nls++;
-      }
-      else
-      {
-        ptr_nls++;
-      }
-    }
-  }
+  return nls->multirate ? gbData->gbfData->sparsePattern_ODE : data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern;
 }
 
-/**
- * @brief Build a new CSC sparsity pattern containing base_pat plus identity: struct(I + J).
- *
- * @param base_pat  Input CSC pattern
- * @param size      Matrix dimension (cols / rows)
- * @param blueprint Potential Input / Output CSC pattern. Must be allocated with sufficient size. If != NULL it is filled, else new allocation.
- *
- * @note This should be somewhere in GBODE already!!
- */
-static SPARSE_PATTERN* buildSparsePatternWithDiagonal(const SPARSE_PATTERN *base_pat, int size, SPARSE_PATTERN *blueprint)
+static inline SPARSE_PATTERN *getNLSPattern(DATA_GBODE *gbData, GB_INTERNAL_NLS_DATA *nls)
 {
-  SPARSE_PATTERN *acc_pat;
-  int diag_cnt = 0;
-
-  /* Count existing diagonal entries */
-  for (int col = 0; col < size; col++)
-  {
-    for (int nz = base_pat->leadindex[col]; nz < base_pat->leadindex[col + 1]; nz++)
-    {
-      if (base_pat->index[nz] == col)
-      {
-        diag_cnt++;
-      }
-    }
-  }
-
-  int missing_diags = size - diag_cnt;
-  int total_nnz = base_pat->nnz + missing_diags;
-
-  // accumulate pattern = struct(I + J), where J is base_pat
-  if (blueprint != NULL)
-  {
-    // if we have a blueprint, then simply override the entries of the blueprint, we sure that it is allocated with sufficient size though!
-    acc_pat = blueprint;
-    acc_pat->nnz = total_nnz;
-    acc_pat->maxColors = size;
-  }
-  else
-  {
-    // if we dont have a blueprint we allocate a new sparse pattern from scratch
-    acc_pat = allocSparsePattern(size, total_nnz, size);
-  }
-
-  int acc_nz = 0;
-  acc_pat->leadindex[0] = 0;
-
-  for (int col = 0; col < size; col++) {
-
-    modelica_boolean diag_present = FALSE;
-
-    for (int ode_nz = base_pat->leadindex[col]; ode_nz < base_pat->leadindex[col + 1]; ode_nz++)
-    {
-      int row = base_pat->index[ode_nz];
-
-      if (!diag_present && row > col)
-      {
-        acc_pat->index[acc_nz++] = col;
-        diag_present = TRUE;
-      }
-
-      if (row == col)
-      {
-        diag_present = TRUE;
-      }
-
-      acc_pat->index[acc_nz++] = row;
-    }
-
-    if (!diag_present)
-    {
-      acc_pat->index[acc_nz++] = col;
-    }
-
-    acc_pat->leadindex[col + 1] = acc_nz;
-  }
-
-  acc_pat->nnz = acc_nz;
-
-  return acc_pat;
+  return nls->multirate ? gbData->gbfData->sparsePattern_NLS : gbData->sparsePattern_NLS;
 }
 
 static void gbInternal_evalJacobianMR(DATA* data,
@@ -278,23 +146,23 @@ static void gbInternal_evalJacobianMR(DATA* data,
                                       GB_INTERNAL_NLS_DATA *nls,
                                       double* smallJac)
 {
-  const SPARSE_PATTERN* fullSp  = fullJac->sparsePattern;
-  const SPARSE_PATTERN* smallSp = nls->odePatternMR;
+  const SPARSE_PATTERN* smallSp = gbData->gbfData->sparsePattern_ODE;
 
   int* fast_idx = gbData->fastStatesIdx;
   unsigned int  size_fast = gbData->nFastStates;
 
-  fullJac->evalSelection = NULL; // TODO: set evalSelection for Jacobian gbData->gbfData->jacobian->evalSelection;
+  fullJac->evalSelection = NULL;
+  memset(fullJac->seedVars, 0, fullJac->sizeCols * sizeof(modelica_real));
 
   int color, col, nz;
 
-  for (color = 0; color < nls->maxColors_stub; color++)
+  for (color = 0; color < smallSp->maxColors; color++)
   {
     for (col = 0; col < size_fast; col++)
     {
       unsigned int big_col = fast_idx[col];
 
-      if (nls->colorCols_stub[big_col] - 1 == color)
+      if (smallSp->colorCols[col] - 1 == color)
       {
         fullJac->seedVars[big_col] = 1.0;
       }
@@ -306,7 +174,7 @@ static void gbInternal_evalJacobianMR(DATA* data,
     {
       unsigned int big_col = fast_idx[col];
 
-      if (nls->colorCols_stub[big_col] - 1 == color)
+      if (smallSp->colorCols[col] - 1 == color)
       {
         for (nz = smallSp->leadindex[col]; nz < smallSp->leadindex[col + 1]; nz++)
         {
@@ -327,35 +195,21 @@ static void gbInternal_evalJacobianMR(DATA* data,
 static void gbInternal_evalNumericalJacobian(DATA *data,
                                              threadData_t *threadData,
                                              DATA_GBODE *gbData,
-                                             GB_INTERNAL_NLS_DATA *nls,
-                                             JACOBIAN *jacobian_ODE)
+                                             GB_INTERNAL_NLS_DATA *nls)
 {
   const double delta_h = numericalDifferentiationDeltaXsolver;
 
-  const SPARSE_PATTERN *sparsity;
+  const SPARSE_PATTERN *sparsity = getODEPattern(data, gbData, nls);
   EVAL_SELECTION *selection = NULL;
   int *state_map = NULL;
-
-  int size;
-  unsigned int max_colors;
-  unsigned int *color_cols;
+  int size = gbData->nStates;
   int full_size = gbData->nStates;
 
   if (nls->multirate)
   {
-    sparsity = nls->odePatternMR;
     state_map = gbData->fastStatesIdx;
     size = gbData->nFastStates;
     selection = gbData->gbfData->evalSelectionFast;
-    max_colors = nls->maxColors_stub;
-    color_cols = nls->colorCols_stub;
-  }
-  else
-  {
-    sparsity = jacobian_ODE->sparsePattern;
-    size = gbData->nStates;
-    max_colors = sparsity->maxColors;
-    color_cols = sparsity->colorCols;
   }
 
   double *x = data->localData[0]->realVars;
@@ -371,14 +225,14 @@ static void gbInternal_evalNumericalJacobian(DATA *data,
 
   memcpy(der_x_ref, der_x, full_size * sizeof(double));
 
-  for (unsigned int color = 0; color < max_colors; color++)
+  for (unsigned int color = 0; color < sparsity->maxColors; color++)
   {
     // careful perturbation of the variables (a la DASSL interface)
     for (unsigned int col = 0; col < size; col++)
     {
       unsigned int big_col = state_map ? state_map[col] : col;
 
-      if (color_cols[big_col] - 1 == color)
+      if (sparsity->colorCols[col] - 1 == color)
       {
         // we follow the procedure of the DASSL interface for the selection of perturbation h_i
 
@@ -411,7 +265,7 @@ static void gbInternal_evalNumericalJacobian(DATA *data,
     {
       unsigned int big_col = state_map ? state_map[col] : col;
 
-      if (color_cols[big_col] - 1 == color)
+      if (sparsity->colorCols[col] - 1 == color)
       {
         for (unsigned int nz = sparsity->leadindex[col]; nz < sparsity->leadindex[col + 1]; nz++)
         {
@@ -462,7 +316,7 @@ static int gbInternal_evalJacobian(DATA *data, threadData_t *threadData, DATA_GB
   }
   else
   {
-    gbInternal_evalNumericalJacobian(data, threadData, gbData, nls, jacobian_ODE);
+    gbInternal_evalNumericalJacobian(data, threadData, gbData, nls);
   }
 
   ret = 0;
@@ -508,7 +362,7 @@ static int jacobian_DIRK_assemble(DATA *data,
                                   double *jac_buf_ode,
                                   double *jac_buf_nls)
 {
-  memset(jac_buf_nls, 0, nls->nlsPattern->nnz * sizeof(double));
+  memset(jac_buf_nls, 0, getNLSPattern(gbData, nls)->nnz * sizeof(double));
 
   DATA_GBODEF *gbfData = gbData->gbfData;
 
@@ -552,7 +406,7 @@ static int jacobian_real_assemble(DATA *data,
                                   double *jac_buf_ode,
                                   double *jac_buf_nls)
 {
-  memset(jac_buf_nls, 0, nls->nlsPattern->nnz * sizeof(double));
+  memset(jac_buf_nls, 0, getNLSPattern(gbData, nls)->nnz * sizeof(double));
 
   const double inv_step = 1.0 / (nls->multirate ? gbData->gbfData->stepSize : gbData->stepSize);
   const double weight = inv_step * gamma;
@@ -597,7 +451,7 @@ static int jacobian_cmplx_assemble(DATA *data,
                                    double *jac_buf_ode,
                                    double *jac_buf_nls)
 {
-  memset(jac_buf_nls, 0, 2 * nls->nlsPattern->nnz * sizeof(double));
+  memset(jac_buf_nls, 0, 2 * getNLSPattern(gbData, nls)->nnz * sizeof(double));
 
   const double inv_step = 1.0 / (nls->multirate ? gbData->gbfData->stepSize : gbData->stepSize);
   const double weight_real = inv_step * alpha;
@@ -618,57 +472,112 @@ static int jacobian_cmplx_assemble(DATA *data,
   return 0;
 }
 
-/** @brief Run symbolic analysis for a CSC matrix using KLU. */
-static int gbInternal_KLU_analyze(KLUInternals *internals, int size, int *Ap, int *Ai)
+static void gbInternal_KLU_initialize(KLUInternals *klu, int n_real, int n_cmplx)
 {
-  klu_defaults(&internals->common);
-  internals->symbolic = klu_analyze(size, Ap, Ai, &internals->common);
-  if (internals->common.status < 0) throwStreamPrint(NULL, "Error in gbInternal_KLU_analyze. Symbolic analysis with KLU failed.");
-  return internals->common.status;
+  assertStreamPrint(NULL, n_real >= 0 && n_cmplx >= 0, "Invalid number of KLU systems: %d real and %d complex.", n_real, n_cmplx);
+  klu_defaults(&klu->common);
+  klu->symbolic = NULL;
+  klu->n_real = n_real;
+  klu->n_cmplx = n_cmplx;
+  klu->num_real = n_real ? (klu_numeric **) calloc(n_real, sizeof(klu_numeric *)) : NULL;
+  klu->num_cmplx = n_cmplx ? (klu_numeric **) calloc(n_cmplx, sizeof(klu_numeric *)) : NULL;
+}
+
+static void gbInternal_KLU_freeNumerics(KLUInternals *klu)
+{
+  for (int sys = 0; sys < klu->n_real; sys++)
+  {
+    if (klu->num_real[sys])
+    {
+      klu_free_numeric(&klu->num_real[sys], &klu->common);
+    }
+  }
+  for (int sys = 0; sys < klu->n_cmplx; sys++)
+  {
+    if (klu->num_cmplx[sys])
+    {
+      klu_free_numeric(&klu->num_cmplx[sys], &klu->common);
+    }
+  }
+}
+
+/** @brief Run one shared symbolic analysis for all KLU systems. */
+static int gbInternal_KLU_analyze(KLUInternals *klu, int size, int *Ap, int *Ai)
+{
+  klu_defaults(&klu->common);
+  klu->symbolic = klu_analyze(size, Ap, Ai, &klu->common);
+  if (klu->common.status < 0)
+  {
+    throwStreamPrint(NULL, "Error in gbInternal_KLU_analyze. Symbolic analysis with KLU failed.");
+  }
+  return klu->common.status;
+}
+
+static int gbInternal_KLU_reanalyze(KLUInternals *klu, int size, int *Ap, int *Ai)
+{
+  gbInternal_KLU_freeNumerics(klu);
+  if (klu->symbolic)
+  {
+    klu_free_symbolic(&klu->symbolic, &klu->common);
+  }
+  return gbInternal_KLU_analyze(klu, size, Ap, Ai);
+}
+
+static void gbInternal_KLU_free(KLUInternals *klu)
+{
+  gbInternal_KLU_freeNumerics(klu);
+  if (klu->symbolic)
+  {
+    klu_free_symbolic(&klu->symbolic, &klu->common);
+  }
+  free(klu->num_real);
+  free(klu->num_cmplx);
 }
 
 /** @brief Perform or update real-valued KLU numeric factorization. */
-static int gbInternal_dKLU_factorize(KLUInternals *internals, int size, int *Ap, int *Ai, double *values)
+static int gbInternal_dKLU_factorize(KLUInternals *klu, int system, int *Ap, int *Ai, double *values)
 {
-  if (internals->numeric)
+  assertStreamPrint(NULL, system >= 0 && system < klu->n_real, "Invalid real KLU system index %d.", system);
+  klu_numeric **numeric = &klu->num_real[system];
+  if (*numeric)
   {
-    klu_refactor(Ap, Ai, values, internals->symbolic, internals->numeric, &internals->common);
+    klu_refactor(Ap, Ai, values, klu->symbolic, *numeric, &klu->common);
   }
   else
   {
-    internals->numeric = klu_factor(Ap, Ai, values, internals->symbolic, &internals->common);
+    *numeric = klu_factor(Ap, Ai, values, klu->symbolic, &klu->common);
   }
-  return internals->common.status;
+  return klu->common.status;
 }
 
 /** @brief Solve a real linear system using KLU. */
-static int gbInternal_dKLU_solve(KLUInternals *internals, int size, double *rhs)
+static int gbInternal_dKLU_solve(KLUInternals *klu, int system, int size, double *rhs)
 {
-  int nrhs = 1; /* we could solve all of ESDIRK at once this way */
-  int ok = klu_solve(internals->symbolic, internals->numeric, size, nrhs, rhs, &internals->common);
-  return ok;
+  assertStreamPrint(NULL, system >= 0 && system < klu->n_real, "Invalid real KLU system index %d.", system);
+  return klu_solve(klu->symbolic, klu->num_real[system], size, 1, rhs, &klu->common);
 }
 
 /** @brief Perform or update complex-valued KLU numeric factorization (values packed as struct {double real, double imag}). */
-static int gbInternal_zKLU_factorize(KLUInternals *internals, int size, int *Ap, int *Ai, double *values)
+static int gbInternal_zKLU_factorize(KLUInternals *klu, int system, int *Ap, int *Ai, double *values)
 {
-  if (internals->numeric)
+  assertStreamPrint(NULL, system >= 0 && system < klu->n_cmplx, "Invalid complex KLU system index %d.", system);
+  klu_numeric **numeric = &klu->num_cmplx[system];
+  if (*numeric)
   {
-    klu_z_refactor(Ap, Ai, values, internals->symbolic, internals->numeric, &internals->common);
+    klu_z_refactor(Ap, Ai, values, klu->symbolic, *numeric, &klu->common);
   }
   else
   {
-    internals->numeric = klu_z_factor(Ap, Ai, values, internals->symbolic, &internals->common);
+    *numeric = klu_z_factor(Ap, Ai, values, klu->symbolic, &klu->common);
   }
-  return internals->common.status;
+  return klu->common.status;
 }
 
 /** @brief Solve a complex linear system using KLU (values packed as struct {double real, double imag}). */
-static int gbInternal_zKLU_solve(KLUInternals *internals, int size, double *rhs)
+static int gbInternal_zKLU_solve(KLUInternals *klu, int system, int size, double *rhs)
 {
-  int nrhs = 1;
-  int ok = klu_z_solve(internals->symbolic, internals->numeric, size, nrhs, rhs, &internals->common);
-  return ok;
+  assertStreamPrint(NULL, system >= 0 && system < klu->n_cmplx, "Invalid complex KLU system index %d.", system);
+  return klu_z_solve(klu->symbolic, klu->num_cmplx[system], size, 1, rhs, &klu->common);
 }
 
 /** @brief Create scalings for scaled 2-norms: used for Newton convergence and integration acceptance criteria. */
@@ -795,7 +704,8 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_DIRK(DATA *data,
   double *scal = nls->scal;
 
   RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=(nls->multirate ? (void *) gbData->gbfData : (void *) gbData)};
-  SPARSE_PATTERN *ode_pattern = (nls->multirate ? nls->odePatternMR : data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern);
+  SPARSE_PATTERN *ode_pattern = getODEPattern(data, gbData, nls);
+  SPARSE_PATTERN *nls_pattern = getNLSPattern(gbData, nls);
 
   const int flag = 1;
   modelica_boolean jac_called = FALSE;
@@ -818,7 +728,7 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_DIRK(DATA *data,
       jacobian_DIRK_assemble(data, threadData, gbData, nls, ode_pattern, nls->jacobian_callback, nls->real_nls_jacs[0]);
 
       /* perform factorization */
-      ret = gbInternal_dKLU_factorize(nls->klu_internals_real, size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index, nls->real_nls_jacs[0]);
+      ret = gbInternal_dKLU_factorize(&nls->klu, 0, (int *) nls_pattern->leadindex, (int *) nls_pattern->index, nls->real_nls_jacs[0]);
       if (ret < 0) return NLS_FAILED;
     }
   }
@@ -839,7 +749,7 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_DIRK(DATA *data,
   {
     nonlinsys->residualFunc(&resUserData, x, res, &flag);
 
-    ret = gbInternal_dKLU_solve(nls->klu_internals_real, size, res);
+    ret = gbInternal_dKLU_solve(&nls->klu, 0, size, res);
     if (ret < 0) return NLS_FAILED;
     daxpy_(&size, &DBL_MINUS_ONE, res, &INT_ONE, x, &INT_ONE);
 
@@ -1197,7 +1107,8 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
   createGbScales(nls, gbData, x, x_start);
   double *scal = nls->scal;
 
-  SPARSE_PATTERN *ode_pattern = (nls->multirate ? nls->odePatternMR : data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern);
+  SPARSE_PATTERN *ode_pattern = getODEPattern(data, gbData, nls);
+  SPARSE_PATTERN *nls_pattern = getNLSPattern(gbData, nls);
   T_TRANSFORM *transform = nls->tabl->t_transform;
 
   modelica_boolean jac_called = FALSE;
@@ -1235,10 +1146,9 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
       /* create Jacobian real: gamma/h * I - J_f */
       jacobian_real_assemble(data, threadData, gbData, nls, transform->gamma[sys_real],
                              ode_pattern, nls->jacobian_callback, nls->real_nls_jacs[sys_real]);
-      ret = gbInternal_dKLU_factorize(&nls->klu_internals_real[sys_real],
-                                      size,
-                                      (int *) nls->nlsPattern->leadindex,
-                                      (int *) nls->nlsPattern->index,
+      ret = gbInternal_dKLU_factorize(&nls->klu, sys_real,
+                                      (int *) nls_pattern->leadindex,
+                                      (int *) nls_pattern->index,
                                       nls->real_nls_jacs[sys_real]);
       if (ret < 0) return NLS_FAILED;
     }
@@ -1247,10 +1157,9 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
       /* create Jacobian complex: (alpha + i * beta)/h * I - J_f */
       jacobian_cmplx_assemble(data, threadData, gbData, nls, transform->alpha[sys_cmplx], transform->beta[sys_cmplx],
                               ode_pattern, nls->jacobian_callback, nls->cmplx_nls_jacs[sys_cmplx]);
-      ret = gbInternal_zKLU_factorize(&nls->klu_internals_cmplx[sys_cmplx],
-                                      size,
-                                      (int *) nls->nlsPattern->leadindex,
-                                      (int *) nls->nlsPattern->index,
+      ret = gbInternal_zKLU_factorize(&nls->klu, sys_cmplx,
+                                      (int *) nls_pattern->leadindex,
+                                      (int *) nls_pattern->index,
                                       nls->cmplx_nls_jacs[sys_cmplx]);
       if (ret < 0) return NLS_FAILED;
     }
@@ -1324,7 +1233,7 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
       }
 
       int sys = transform->realEigenvalueIndex[real_row];
-      ret = gbInternal_dKLU_solve(&nls->klu_internals_real[sys], size, res_row);
+      ret = gbInternal_dKLU_solve(&nls->klu, sys, size, res_row);
       if (ret < 0) return NLS_FAILED;
     }
 
@@ -1358,7 +1267,7 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
       dcopy_(&size, res0, &INT_ONE, &nls->cmplx_nls_res[sys][0], &INT_TWO); // .real
       dcopy_(&size, res1, &INT_ONE, &nls->cmplx_nls_res[sys][1], &INT_TWO); // .imag
 
-      ret = gbInternal_zKLU_solve(&nls->klu_internals_cmplx[sys], size, &nls->cmplx_nls_res[sys][0]);
+      ret = gbInternal_zKLU_solve(&nls->klu, sys, size, &nls->cmplx_nls_res[sys][0]);
       if (ret < 0) return NLS_FAILED;
 
       dcopy_(&size, &nls->cmplx_nls_res[sys][0], &INT_TWO, res0, &INT_ONE); // r1
@@ -1427,8 +1336,7 @@ static NLS_SOLVER_STATUS gbInternalSolveNls_T_Transform(DATA *data,
 
       // recompute weights K from Z via K = 1 / h * (A_part^{-1} otimes I) * Z + rho * k_1 if k_1 explicit else 0 (rho := -A_part^{-1} * A_{r, 1})
       // where r are all rows that belong to A_part
-      dense_kron_id_vec(transform->size, size, transform->A_part_inv, nls->Z,
-                        &kPacked[offset]);
+      dense_kron_id_vec(transform->size, size, transform->A_part_inv, nls->Z, &kPacked[offset]);
       dscal_(&w_size, &invh, &kPacked[offset], &INT_ONE);
 
       if (transform->firstRowZero)
@@ -1488,12 +1396,14 @@ void *gbInternalNlsAllocate(int size,
                             modelica_boolean attemptRetry,
                             modelica_boolean isFast)
 {
-  BUTCHER_TABLEAU *tabl = (isFast ? ((DATA_GBODEF *) userData->solverData)->tableau
-                                  : ((DATA_GBODE *) userData->solverData)->tableau);
+  DATA_GBODE *gbData = isFast ? NULL : (DATA_GBODE *) userData->solverData;
+  DATA_GBODEF *gbfData = isFast ? (DATA_GBODEF *) userData->solverData : NULL;
+  BUTCHER_TABLEAU *tabl = isFast ? gbfData->tableau : gbData->tableau;
   T_TRANSFORM *transform = tabl->t_transform;
   JACOBIAN* jacobian_ODE = &(userData->data->simulationInfo->analyticJacobians[userData->data->callback->INDEX_JAC_A]);
 
   GB_INTERNAL_NLS_DATA *nls = (GB_INTERNAL_NLS_DATA *) malloc(sizeof(GB_INTERNAL_NLS_DATA));
+  gbInternal_KLU_initialize(&nls->klu, transform ? transform->nRealEigenvalues : 1, transform ? transform->nComplexEigenpairs : 0);
 
   // multirate stuff
   nls->multirate = isFast;
@@ -1511,46 +1421,15 @@ void *gbInternalNlsAllocate(int size,
   nls->tabl = tabl;
   nls->use_t_transform = (transform != NULL);
 
-  // we have to delay setting the sparse pattern and the symbolic analysis of KLU
-  // until we know the structure of the fast state system, in case of singlerate everything is known at allocation time
-  if (nls->multirate)
-  {
-    // overestimate the nnz for the buffer sizes and allocate enough memory for the pattern I + J
-    nls_nnz_estimate = jacobian_ODE->sparsePattern->nnz + jacobian_ODE->sizeRows;
-
-    nls->nlsPattern = allocSparsePattern(jacobian_ODE->sizeRows, nls_nnz_estimate, jacobian_ODE->sizeRows);
-    nls->ownsNlsPattern = TRUE;
-
-    nls->odePatternMR = allocSparsePattern(jacobian_ODE->sizeRows, nls_nnz_estimate, jacobian_ODE->sizeRows);
-    nls->ownsODEPatternMR = TRUE;
-
-    // we also need to allocate the stub data
-    nls->colorCols_stub = (unsigned int *) malloc(jacobian_ODE->sizeRows * sizeof(unsigned int));
-    nls->maxColors_stub = 0;
-  }
-  else if (nls->use_t_transform)
-  {
-    // allocate the correct sparse pattern directly
-    nls->nlsPattern = buildSparsePatternWithDiagonal(jacobian_ODE->sparsePattern, jacobian_ODE->sizeRows, NULL);
-    nls->ownsNlsPattern = TRUE;
-  }
-  else
-  {
-    // use the sparse pattern from the user data
-    nls->nlsPattern = userData->nlsData->sparsePattern;
-    nls->ownsNlsPattern = FALSE;
-  }
+  SPARSE_PATTERN *odePattern = isFast ? gbfData->sparsePattern_ODE : jacobian_ODE->sparsePattern;
+  SPARSE_PATTERN *nlsPattern = isFast ? gbfData->sparsePattern_NLS : gbData->sparsePattern_NLS;
+  assertStreamPrint(NULL, odePattern != NULL && nlsPattern != NULL, "GBODE internal NLS requires sparse patterns.");
+  nls_nnz_estimate = nlsPattern->nnz;
 
   if (!nls->multirate)
   {
     // create ODE Jac -> NLS Jacobian mapping
-    updateSparsePatternMappings(nls->nlsPattern, jacobian_ODE->sparsePattern, nls, jacobian_ODE->sizeRows);
-
-    nls->odePatternMR = NULL;
-    nls->ownsODEPatternMR = FALSE;
-
-    // set exact value
-    nls_nnz_estimate = nls->nlsPattern->nnz;
+    gbodeMapSparsePattern(odePattern, nlsPattern, jacobian_ODE->sizeRows, nls->ode_to_nls, nls->nls_diag_indices);
   }
 
   nls->scal = (double *) malloc(jacobian_ODE->sizeRows * sizeof(double));
@@ -1615,7 +1494,7 @@ void *gbInternalNlsAllocate(int size,
     // heuristic that takes sparsity into account
     if (nls->size > 8)
     {
-      nls->theta_keep = pow(10.0, -3.0 + 1.75 * log(1.0 + (double)jacobian_ODE->sparsePattern->maxColors) / log(1.0 + (double)nls->size));
+      nls->theta_keep = pow(10.0, -3.0 + 1.75 * log(1.0 + (double)odePattern->maxColors) / log(1.0 + (double)nls->size));
     }
     else
     {
@@ -1630,9 +1509,6 @@ void *gbInternalNlsAllocate(int size,
 
   if (!transform)
   {
-    nls->klu_internals_real = (KLUInternals *) calloc(1, sizeof(KLUInternals));
-    nls->klu_internals_real->numeric = NULL;
-    nls->klu_internals_cmplx = NULL;
     nls->real_nls_jacs = (double **) malloc(sizeof(double *));
     nls->real_nls_jacs[0] = (double *) malloc(nls_nnz_estimate * sizeof(double));
 
@@ -1641,43 +1517,30 @@ void *gbInternalNlsAllocate(int size,
 
     if (!nls->multirate)
     {
-      gbInternal_KLU_analyze(nls->klu_internals_real, nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
+      gbInternal_KLU_analyze(&nls->klu, nls->size, (int *) nlsPattern->leadindex, (int *) nlsPattern->index);
     }
   }
   else
   {
-    nls->klu_internals_real = (KLUInternals *) calloc(transform->nRealEigenvalues, sizeof(KLUInternals));
-    nls->klu_internals_cmplx = (KLUInternals *) calloc(transform->nComplexEigenpairs, sizeof(KLUInternals));
-
     nls->real_nls_jacs = (double **) malloc(transform->nRealEigenvalues * sizeof(double *));
     nls->real_nls_res = (double **) malloc(transform->nRealEigenvalues * sizeof(double *));
     nls->cmplx_nls_jacs = (double **) malloc(transform->nComplexEigenpairs * sizeof(double *));
     nls->cmplx_nls_res = (double **) malloc(transform->nComplexEigenpairs * sizeof(double *));
 
-    // TODO: We are able to remove these redundant analysis parts, as we can use 1 analysis (symbolic) and compute different factorizations.
     for (int sys_real = 0; sys_real < transform->nRealEigenvalues; sys_real++)
     {
       nls->real_nls_res[sys_real] = (double *) malloc(nls->size * sizeof(double));
       nls->real_nls_jacs[sys_real] = (double *) malloc(nls_nnz_estimate * sizeof(double));
-
-      if (!nls->multirate)
-      {
-        gbInternal_KLU_analyze(&nls->klu_internals_real[sys_real], nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
-      }
-
-      nls->klu_internals_real[sys_real].numeric = NULL;
     }
     for (int sys_cmplx = 0; sys_cmplx < transform->nComplexEigenpairs; sys_cmplx++)
     {
       nls->cmplx_nls_res[sys_cmplx] = (double *) malloc(2 * nls->size * sizeof(double));
       nls->cmplx_nls_jacs[sys_cmplx] = (double *) malloc(2 * nls_nnz_estimate * sizeof(double));
+    }
 
-      if (!nls->multirate)
-      {
-        gbInternal_KLU_analyze(&nls->klu_internals_cmplx[sys_cmplx], nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
-      }
-
-      nls->klu_internals_cmplx[sys_cmplx].numeric = NULL;
+    if (!nls->multirate)
+    {
+      gbInternal_KLU_analyze(&nls->klu, nls->size, (int *) nlsPattern->leadindex, (int *) nlsPattern->index);
     }
 
     // iterate
@@ -1695,6 +1558,7 @@ void *gbInternalNlsAllocate(int size,
 void gbInternalNlsFree(void *nls_ptr)
 {
   GB_INTERNAL_NLS_DATA *nls = (GB_INTERNAL_NLS_DATA *) nls_ptr;
+  gbInternal_KLU_free(&nls->klu);
   free(nls->jacobian_callback);
   free(nls->ode_to_nls);
   free(nls->nls_diag_indices);
@@ -1702,21 +1566,8 @@ void gbInternalNlsFree(void *nls_ptr)
   free(nls->etas);
   free(nls->work);
 
-  if (nls->ownsNlsPattern)
-  {
-    freeSparsePattern(nls->nlsPattern);
-  }
-
-  if (nls->ownsODEPatternMR)
-  {
-    freeSparsePattern(nls->odePatternMR);
-  }
-
   if (!nls->tabl->t_transform)
   {
-    if (nls->klu_internals_real->numeric) klu_free_numeric(&nls->klu_internals_real->numeric, &nls->klu_internals_real->common);
-    if (nls->klu_internals_real->symbolic) klu_free_symbolic(&nls->klu_internals_real->symbolic, &nls->klu_internals_real->common);
-    free(nls->klu_internals_real);
     free(nls->real_nls_jacs[0]);
     free(nls->real_nls_jacs);
   }
@@ -1726,15 +1577,11 @@ void gbInternalNlsFree(void *nls_ptr)
     {
       free(nls->real_nls_jacs[sys_real]);
       free(nls->real_nls_res[sys_real]);
-      if (nls->klu_internals_real[sys_real].numeric) klu_free_numeric(&nls->klu_internals_real[sys_real].numeric, &nls->klu_internals_real[sys_real].common);
-      if (nls->klu_internals_real[sys_real].symbolic) klu_free_symbolic(&nls->klu_internals_real[sys_real].symbolic, &nls->klu_internals_real[sys_real].common);
     }
     for (int sys_cmplx = 0; sys_cmplx < nls->tabl->t_transform->nComplexEigenpairs; sys_cmplx++)
     {
       free(nls->cmplx_nls_jacs[sys_cmplx]);
       free(nls->cmplx_nls_res[sys_cmplx]);
-      if (nls->klu_internals_cmplx[sys_cmplx].numeric) klu_free_numeric(&nls->klu_internals_cmplx[sys_cmplx].numeric, &nls->klu_internals_cmplx[sys_cmplx].common);
-      if (nls->klu_internals_cmplx[sys_cmplx].symbolic) klu_free_symbolic(&nls->klu_internals_cmplx[sys_cmplx].symbolic, &nls->klu_internals_cmplx[sys_cmplx].common);
     }
 
     free(nls->real_nls_jacs);
@@ -1742,16 +1589,8 @@ void gbInternalNlsFree(void *nls_ptr)
     free(nls->cmplx_nls_jacs);
     free(nls->cmplx_nls_res);
 
-    if (nls->klu_internals_real) free(nls->klu_internals_real);
-    if (nls->klu_internals_cmplx) free(nls->klu_internals_cmplx);
-
     free(nls->Z);
     free(nls->W);
-  }
-
-  if (nls->multirate)
-  {
-    free(nls->colorCols_stub);
   }
 
   freeNlsUserData(nls->nls_user_data);
@@ -1764,134 +1603,15 @@ void gbInternalScheduleFastStatesUpdate(void *nls_ptr)
   ((GB_INTERNAL_NLS_DATA *) nls_ptr)->new_fast_states = TRUE;
 }
 
-static void transferFastColoring(GB_INTERNAL_NLS_DATA *nls,
-                                 DATA_GBODE *gbData,
-                                 SPARSE_PATTERN *fast_ode_pattern)
-{
-  nls->maxColors_stub = fast_ode_pattern->maxColors;
-  memset(nls->colorCols_stub, 0, gbData->nStates * sizeof(unsigned int));
-
-  for (unsigned int i = 0; i < nls->size; i++)
-  {
-    unsigned int fast_idx = gbData->fastStatesIdx[i];
-    nls->colorCols_stub[fast_idx] = fast_ode_pattern->colorCols[i];
-  }
-}
-
-/**
- * @brief Reduces a full sparse CSC pattern to a smaller subpattern.
- *
- * Extracts only the rows and columns specified in the `indices` array.
- * The output pattern `out` must be preallocated with sufficient size.
- * Coloring is not handled in this function.
- *
- * @param[in]  full         Pointer to the full sparse pattern (CSC format).
- * @param[in]  size_full    Total number of columns/rows in the full matrix.
- * @param[out] out          Pointer to the preallocated sparse pattern to fill.
- * @param[in]  indices      Array of indices to keep (both rows and columns).
- * @param[in]  size_indices Number of indices in the `indices` array.
- * @param[in,out] work      Temporary workspace of size `size_full` (mutated).
- */
-static void reduceFullToFastPattern(const SPARSE_PATTERN *full,
-                                    int size_full,
-                                    SPARSE_PATTERN *out,
-                                    const int *indices,
-                                    int size_indices,
-                                    unsigned int *work)
-{
-  unsigned int nnz = 0;
-
-  for (int i = 0; i < size_full; i++)
-  {
-    work[i] = UINT_MAX;
-  }
-
-  for (int i = 0; i < size_indices; i++)
-  {
-    work[indices[i]] = i;
-  }
-
-  out->leadindex[0] = 0;
-
-  for (int small_col = 0; small_col < size_indices; small_col++)
-  {
-    unsigned int full_col = indices[small_col];
-
-    for (unsigned int nz_full = full->leadindex[full_col]; nz_full < full->leadindex[full_col + 1]; nz_full++)
-    {
-      unsigned int full_row = full->index[nz_full];
-      unsigned int small_row = work[full_row];
-
-      if (small_row != UINT_MAX)
-      {
-        out->index[nnz++] = small_row;
-      }
-    }
-
-    out->leadindex[small_col + 1] = nnz;
-  }
-
-  out->nnz = nnz;
-}
-
-static void createGreedyColoring(SPARSE_PATTERN *pattern,
-                                 unsigned int size,
-                                 unsigned int *work)
-{
-  unsigned int *rowUsed = work;
-  unsigned int remaining = size;
-  unsigned int color = 1;
-
-  for (unsigned int i = 0; i < size; i++)
-    pattern->colorCols[i] = 0;
-
-  while (remaining > 0)
-  {
-    memset(rowUsed, 0, size * sizeof(unsigned int));
-
-    for (unsigned int col = 0; col < size; col++)
-    {
-      if (pattern->colorCols[col] != 0) continue;
-
-      int conflict = 0;
-
-      for (unsigned int nz = pattern->leadindex[col]; nz < pattern->leadindex[col+1]; nz++)
-      {
-        unsigned int row = pattern->index[nz];
-        if (rowUsed[row])
-        {
-          conflict = 1;
-          break;
-        }
-      }
-
-      if (!conflict)
-      {
-        pattern->colorCols[col] = color;
-        remaining--;
-
-        for (unsigned int nz = pattern->leadindex[col]; nz < pattern->leadindex[col+1]; nz++)
-        {
-          unsigned int row = pattern->index[nz];
-          rowUsed[row] = 1;
-        }
-      }
-    }
-
-    color++;
-  }
-
-  pattern->maxColors = color - 1;
-}
-
 modelica_boolean updateFastStates(DATA *data,
                                   threadData_t *threadData,
                                   NONLINEAR_SYSTEM_DATA* nonlinsys,
                                   DATA_GBODE* gbData,
                                   GB_INTERNAL_NLS_DATA *nls)
 {
-  SPARSE_PATTERN *full_ode_pattern = data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern;
   DATA_GBODEF *gbfData = gbData->gbfData;
+  SPARSE_PATTERN *odePattern = gbfData->sparsePattern_ODE;
+  SPARSE_PATTERN *nlsPattern = gbfData->sparsePattern_NLS;
 
   // update size
   nls->size = gbData->nFastStates;
@@ -1902,47 +1622,11 @@ modelica_boolean updateFastStates(DATA *data,
     nls->etas[stage] = DBL_MAX;
   }
 
-  // fill preallocated nls->odePatternMR with struct(J)_fast
-  reduceFullToFastPattern(full_ode_pattern, gbData->nStates, nls->odePatternMR, gbData->fastStatesIdx, gbData->nFastStates, (unsigned int *) nls->work);
-
-  // create the coloring for struct(J)_fast
-  createGreedyColoring(nls->odePatternMR, gbData->nFastStates, (unsigned int *) nls->work);
-
-  // transfer the coloring of struct(J)_fast -> struct(J)_fast embedded into J itself for selective evaluation
-  transferFastColoring(nls, gbData, nls->odePatternMR);
-
-  // fill preallocated nls->nlsPattern with struct(I + J)_fast
-  buildSparsePatternWithDiagonal(nls->odePatternMR, gbfData->nFastStates, nls->nlsPattern);
-
   // update mappings: ode_to_nls and nls_diag_indices
-  updateSparsePatternMappings(nls->nlsPattern, nls->odePatternMR, nls, nls->size);
+  gbodeMapSparsePattern(odePattern, nlsPattern, nls->size, nls->ode_to_nls, nls->nls_diag_indices);
 
-  // create new symbolic factorization
-  if (gbfData->tableau->t_transform == NULL)
-  {
-    if (nls->klu_internals_real->numeric) klu_free_numeric(&nls->klu_internals_real->numeric, &nls->klu_internals_real->common);
-    if (nls->klu_internals_real->symbolic) klu_free_symbolic(&nls->klu_internals_real->symbolic, &nls->klu_internals_real->common);
-    gbInternal_KLU_analyze(nls->klu_internals_real, nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
-    nls->klu_internals_real->numeric = NULL;
-  }
-  else
-  {
-    // TODO: same as in allocation: we are able to remove these redundant analysis parts, as we can use 1 analysis (symbolic) and compute different factorizations.
-    for (int sys_real = 0; sys_real < gbfData->tableau->t_transform->nRealEigenvalues; sys_real++)
-    {
-      if (nls->klu_internals_real[sys_real].numeric) klu_free_numeric(&nls->klu_internals_real[sys_real].numeric, &nls->klu_internals_real[sys_real].common);
-      if (nls->klu_internals_real[sys_real].symbolic) klu_free_symbolic(&nls->klu_internals_real[sys_real].symbolic, &nls->klu_internals_real[sys_real].common);
-      gbInternal_KLU_analyze(&nls->klu_internals_real[sys_real], nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
-      nls->klu_internals_real[sys_real].numeric = NULL;
-    }
-    for (int sys_cmplx = 0; sys_cmplx < gbfData->tableau->t_transform->nComplexEigenpairs; sys_cmplx++)
-    {
-      if (nls->klu_internals_cmplx[sys_cmplx].numeric) klu_free_numeric(&nls->klu_internals_cmplx[sys_cmplx].numeric, &nls->klu_internals_cmplx[sys_cmplx].common);
-      if (nls->klu_internals_cmplx[sys_cmplx].symbolic) klu_free_symbolic(&nls->klu_internals_cmplx[sys_cmplx].symbolic, &nls->klu_internals_cmplx[sys_cmplx].common);
-      gbInternal_KLU_analyze(&nls->klu_internals_cmplx[sys_cmplx], nls->size, (int *) nls->nlsPattern->leadindex, (int *) nls->nlsPattern->index);
-      nls->klu_internals_cmplx[sys_cmplx].numeric = NULL;
-    }
-  }
+  // all transformed systems have the same sparsity pattern and share one symbolic analysis
+  gbInternal_KLU_reanalyze(&nls->klu, nls->size, (int *) nlsPattern->leadindex, (int *) nlsPattern->index);
 
   return TRUE;
 }
@@ -2039,7 +1723,7 @@ void gbInternalContractiveDefect(DATA *data,
   }
 
   // ERR := (gamma / h * I - J)^{-1} * yt = (gamma / h * I - J)^{-1} * (f(t_n, y(t_n)) - d(0)^T * A * k) (exact error measure)
-  gbInternal_dKLU_solve(&nls->klu_internals_real[0], size, err);
+  gbInternal_dKLU_solve(&nls->klu, 0, size, err);
 }
 
 static void gbInternalContractiveFilterPacked(GB_INTERNAL_NLS_DATA *nls,
@@ -2057,7 +1741,7 @@ static void gbInternalContractiveFilterPacked(GB_INTERNAL_NLS_DATA *nls,
 
   // DIRK systems use h*gamma*J - I, so the solve already applies the filter up to sign.
   // FIRK/T systems use gamma/h*I - J = gamma/h * (I - h/gamma*J), so scale by gamma/h after the solve.
-  gbInternal_dKLU_solve(&nls->klu_internals_real[0], size, err);
+  gbInternal_dKLU_solve(&nls->klu, 0, size, err);
   if (filter_scale != 1.0) dscal_(&size, &filter_scale, err, &INT_ONE);
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -267,13 +267,19 @@ int gbodef_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solve
     if (jacobian->availability == JACOBIAN_AVAILABLE) {
       data->callback->getDAG_JacA(data, threadData, jacobian);
     }
+    if (!jacobian->dag) {
+      throwStreamPrint(threadData,
+                       "Cannot create multirate data structures without a valid Jacobian DAG. Use a symbolic Jacobian "
+                       "(--generateDynamicJacobian=symbolic), an explicit integrator, or switch to single-rate integration.");
+    }
+
+    initializeSparsePattern_GBODEF(data, gbfData);
 
     /* Initialize data for the nonlinear solver */
     gbfData->nlsData = initRK_NLS_DATA_MR(data, threadData, gbfData);
     if (!gbfData->nlsData) {
       return -1;
     }
-    gbfData->sparsePattern_DIRK = initializeSparsePattern_SR(data, gbfData->nlsData);
   } else {
     gbfData->symJacAvailable = FALSE;
     gbfData->nlsSolverMethod = GB_NLS_UNKNOWN;
@@ -514,6 +520,8 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
       gbData->symJacAvailable = FALSE;
     }
 
+    initializeSparsePattern_GBODE(data, gbData);
+
     /* Initialize data for the nonlinear solver */
     gbData->nlsData = initRK_NLS_DATA(data, threadData, gbData);
     if (!gbData->nlsData) {
@@ -617,8 +625,10 @@ void gbodef_freeData(DATA_GBODEF *gbfData)
   /* Free Jacobian */
   freeJacobianCopy(gbfData->jacobian);
 
-  /* Free sparsity pattern */
-  freeSparsePattern(gbfData->sparsePattern_DIRK);
+  /* Free sparsity data. */
+  freeSparsePattern(gbfData->sparsePattern_ODE);
+  freeSparsePattern(gbfData->sparsePattern_NLS);
+  free(gbfData->sparseWork);
 
   /* Free Butcher tableau */
   freeButcherTableau(gbfData->tableau);
@@ -672,6 +682,9 @@ void gbode_freeData(DATA* data, DATA_GBODE *gbData)
 
   /* Free Jacobian */
   freeJacobianCopy(gbData->jacobian);
+
+  /* Free sparsity data. */
+  freeSparsePattern(gbData->sparsePattern_NLS);
 
   /* Free Butcher tableau */
   freeButcherTableau(gbData->tableau);
@@ -945,11 +958,10 @@ int gbodef_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, d
     }
     messageClose(OMC_LOG_GBODE);
 
-    if (gbfData->nlsData->sparsePattern) {
+    if (gbfData->sparsePattern_NLS) {
+      updateSparsePattern_GBODEF(data, gbData);
       if (gbfData->nlsSolverMethod != GB_NLS_INTERNAL)
       {
-        // internal does it by itself
-        updateSparsePattern_MR(gbData, gbfData->jacobian->sparsePattern);
         gbfData->jacobian->sizeCols = nFastStates;
         gbfData->jacobian->sizeRows = nFastStates;
       }
@@ -982,8 +994,10 @@ int gbodef_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, d
         throwStreamPrint(NULL, "NLS method %s not yet implemented.", GB_NLS_METHOD_NAME[gbfData->nlsSolverMethod]);
       }
     }
-    if (gbfData->jacobian->availability == JACOBIAN_AVAILABLE)
+    // TODO: -gbnls=internal currently does not use the Jacobian eval selection
+    if (gbfData->nlsSolverMethod != GB_NLS_INTERNAL && gbfData->symJacAvailable) {
       updateEvalSelectionJacobian(data, gbData);
+    }
   }
 
   // print informations on the calling details

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
@@ -72,7 +72,9 @@ typedef struct DATA_GBODEF{
                                                      *  0 = yold-x + h*(sum(A[i,j]*k[j], j=1..i-1) + A[i,i]*f(t + c[i]*h, x))
                                                      * */
   JACOBIAN* jacobian;                               /* Jacobian of non-linear system of implicit Runge-Kutta method */
-  SPARSE_PATTERN* sparsePattern_DIRK;               /* Sparsity pattern for the DIRK methd, will be reduced based on the fast states selection */
+  SPARSE_PATTERN* sparsePattern_ODE;                /* Owned reduced J */
+  SPARSE_PATTERN* sparsePattern_NLS;                /* Owned reduced I + J */
+  unsigned int* sparseWork;                         /* Sparse reduction and coloring workspace */
   SLOW_STATE_CACHE *slowStateCache;                 /* Reusable cache data of full step, slow state interpolations */
 
   double *y;                                        /* State vector of the current Runge-Kutta step */
@@ -138,6 +140,7 @@ typedef struct DATA_GBODE{
                                                      *  0 = yold-x + h*(sum(A[i,j]*k[j], j=1..i-1) + A[i,i]*f(t + c[i]*h, x))
                                                      * */
   JACOBIAN* jacobian;                               /* Jacobian of non-linear system of implicit Runge-Kutta method */
+  SPARSE_PATTERN* sparsePattern_NLS;                /* Owned NLS pattern */
   double *y;                                        /* State vector of the current Runge-Kutta step */
   double *yt, *y1, *y2;                             /* Legacy signed error estimate for MS/Richardson and temporary state vectors */
   double *yLeft, *kLeft, *yRight, *kRight;          /* Needed for interpolation of the slow states and emitting to the result files */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
@@ -86,9 +86,8 @@ void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_
   memcpy(nonlinsys->min, gbData->mins, nonlinsys->size * sizeof(double));
   memcpy(nonlinsys->max, gbData->maxs, nonlinsys->size * sizeof(double));
 
-  /* Initialize sparsity pattern */
   if (initSparsePattern) {
-    nonlinsys->sparsePattern = initializeSparsePattern_SR(data, nonlinsys);
+    nonlinsys->sparsePattern = gbData->sparsePattern_NLS;
   }
 }
 
@@ -113,9 +112,8 @@ void initializeStaticNLSData_MR(DATA* data, threadData_t *threadData, NONLINEAR_
   memcpy(nonlinsys->min, gbData->mins, nonlinsys->size * sizeof(double));
   memcpy(nonlinsys->max, gbData->maxs, nonlinsys->size * sizeof(double));
 
-  /* Initialize sparsity pattern, First guess (all states are fast states) */
   if (initSparsePattern) {
-    nonlinsys->sparsePattern = initializeSparsePattern_SR(data, nonlinsys);
+    nonlinsys->sparsePattern = gbData->gbfData->sparsePattern_NLS;
   }
 }
 
@@ -143,9 +141,8 @@ void initializeStaticNLSData_IRK(DATA* data, threadData_t *threadData, NONLINEAR
     nonlinsys->max[i]     = gbData->maxs[ii];
   }
 
-  /* Initialize sparsity pattern */
   if (initSparsePattern) {
-    nonlinsys->sparsePattern = initializeSparsePattern_IRK(data, nonlinsys);
+    nonlinsys->sparsePattern = gbData->sparsePattern_NLS;
   }
 }
 
@@ -191,6 +188,7 @@ void freeNlsDataGB(NONLINEAR_SYSTEM_DATA* nlsData)
   free(nlsData->nominal);
   free(nlsData->min);
   free(nlsData->max);
+  /* sparsePattern is a view of DATA_GBODE / DATA_GBODEF. */
   free(nlsData);
 }
 
@@ -216,7 +214,6 @@ NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA(DATA* data, threadData_t* threadData, DAT
   nlsData->equationIndex = -1;
 
   modelica_boolean useInternal = gbData->nlsSolverMethod == GB_NLS_INTERNAL;
-  modelica_boolean useInternalTransform = useInternal && gbData->tableau->t_transform != NULL;
 
   switch (gbData->type)
   {
@@ -257,7 +254,7 @@ NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA(DATA* data, threadData_t* threadData, DAT
     throwStreamPrint(NULL, "Residual function for NLS type %i not yet implemented.", gbData->type);
   }
 
-  nlsData->initializeStaticNLSData(data, threadData, nlsData, !useInternalTransform, TRUE);
+  nlsData->initializeStaticNLSData(data, threadData, nlsData, !useInternal, TRUE);
 
   if (!useInternal)
   {
@@ -340,7 +337,7 @@ NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA_MR(DATA* data, threadData_t* threadData, 
 
   NONLINEAR_SYSTEM_DATA* nlsData;
 
-  nlsData = allocNlsDataGB(threadData, gbfData->nStates);
+  nlsData = allocNlsDataGB(threadData, gbfData->nlSystemSize);
   nlsData->equationIndex = -1;
 
   switch (gbfData->type)
@@ -368,17 +365,16 @@ NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA_MR(DATA* data, threadData_t* threadData, 
 
     break;
   case GM_TYPE_IMPLICIT:
-    // Only works for -gbnls=internal (error should be caught beforehand, if we are not in -gbnls=internal)
-    // As -gbnls=internal does all the stuff from scratch and only really requires the nlsxOld, nlsxExtrapolation and nlsx fields
-    // we must do nothing here except check that pattern is available
-    assertStreamPrint(threadData, nlsData->sparsePattern, "Sparsity pattern not available.");
+    /* Fully implicit MR uses the internal method and the GBODEF I + J pattern. */
     nlsData->initializeStaticNLSData = NULL;
     break;
   default:
     throwStreamPrint(NULL, "Residual function for NLS type %i not yet implemented.", gbfData->type);
   }
 
-  if (nlsData->initializeStaticNLSData) nlsData->initializeStaticNLSData(data, threadData, nlsData, TRUE, TRUE);
+  if (nlsData->initializeStaticNLSData) {
+    nlsData->initializeStaticNLSData(data, threadData, nlsData, gbfData->nlsSolverMethod != GB_NLS_INTERNAL, TRUE);
+  }
 
   JACOBIAN* jacobian_ODE = &(data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A]);
   gbfData->jacobian = (JACOBIAN*) malloc(sizeof(JACOBIAN));

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_sparse.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_sparse.c
@@ -35,269 +35,276 @@
 #include "simulation_data.h"
 #include "solver_main.h"
 
-// TODO: Describe me
-// TODO: Don't allocate memory for leadindex at each call but give it a work array
-void sparsePatternTranspose(int sizeRows, int sizeCols, SPARSE_PATTERN* sparsePattern, SPARSE_PATTERN* sparsePatternT)
-{
-  unsigned int i, j, loc;
-  int* leadindex = calloc(sizeCols, sizeof(int));
-
-  for (i=0; i < sparsePattern->nnz; i++)
-  {
-    leadindex[sparsePattern->index[i]]++;
-  }
-  sparsePatternT->leadindex[0] = 0;
-  for(i=1;i<sizeCols+1;i++)
-  {
-    sparsePatternT->leadindex[i] = sparsePatternT->leadindex[i-1] + leadindex[i-1];
-  }
-  memcpy(leadindex, sparsePatternT->leadindex, sizeof(unsigned int)*sizeCols);
-  for (i=0,j=0;i<sizeRows;i++)
-  {
-    for(; j < sparsePattern->leadindex[i+1];) {
-      loc = leadindex[sparsePattern->index[j]];
-      sparsePatternT->index[loc] = i;
-      leadindex[sparsePattern->index[j]]++;
-      j++;
-    }
-  }
-  printSparseStructure(sparsePattern,
-                       sizeRows,
-                       sizeCols,
-                       OMC_LOG_GBODE_V,
-                       "sparsePattern");
-  printSparseStructure(sparsePatternT,
-                       sizeRows,
-                       sizeCols,
-                       OMC_LOG_GBODE_V,
-                       "sparsePatternT");
-
-  free(leadindex);
-}
+#include <limits.h>
 
 /**
- * @brief Simple sparse matrix coloring.
+ * Greedily pack structurally independent columns into colors.
  *
- * Determine column by column the next possible color,
- * by looking at columns with values in corresponding rows (transpose matrix necessary)
- *
- * @param sparsePattern Sparse pattern of the matirx
- * @param sizeRows      Number or rows
- * @param sizeCols      Number of columns
- * @param nStages       Number of stages (different stages will get different color for full
- *                      implicit RK methods)
+ * This works directly on CSC data in O(colors * (nnz + columns)) time and
+ * O(rows) workspace.
  */
-void ColoringAlg(SPARSE_PATTERN* sparsePattern, int sizeRows, int sizeCols, int nStages)
+static void colorSparsePattern(SPARSE_PATTERN *pattern, int sizeRows, int sizeCols, int nStages, unsigned int *work)
 {
-  SPARSE_PATTERN* sparsePatternT;
-  int row, col, nCols, leadIdx;
-  int i, j, maxColors = 0;
-
-  // initialize array to zeros
-  int* tabu;
-  tabu = (int*) calloc(sizeCols*sizeCols, sizeof(int));
-
-  // Allocate memory for new sparsity pattern
-  sparsePatternT = allocSparsePattern(sizeCols, sparsePattern->nnz, sizeCols);
-
-  // Determine the sparse pattern of the transposed matrix
-  sparsePatternTranspose(sizeRows, sizeCols, sparsePattern, sparsePatternT);
-
-  // Projection of the stages on the ODE jacobian
-  int sizeCols_ODE = sizeCols/nStages;
-  int act_stage;
-
-  for (col=0; col<sizeCols; col++)
+  assertStreamPrint(NULL, sizeRows >= 0 && sizeCols >= 0 && nStages > 0 && sizeCols % nStages == 0,
+                    "Invalid GBODE sparse coloring dimensions %d x %d with %d stages.", sizeRows, sizeCols, nStages);
+  if (sizeCols == 0)
   {
-    // Look for the next free color, based on the tabu list
-    for (i=0; i<sizeCols ; i++)
-    {
-      if (tabu[col*sizeCols + i] == 0)
-      {
-        sparsePattern->colorCols[col] = i+1;
-        maxColors = fmax(maxColors, i+1);
+    pattern->maxColors = 0;
+    return;
+  }
+  modelica_boolean ownsWork = work == NULL;
+  if (ownsWork)
+  {
+    work = malloc(sizeRows * sizeof(unsigned int));
+  }
 
-        // set tabu for columns that have entries in the same row!
-        for (row=sparsePattern->leadindex[col]; row<sparsePattern->leadindex[col+1]; row++)
+  unsigned int color = 0;
+  const int stageSize = sizeCols / nStages;
+  memset(pattern->colorCols, 0, sizeCols * sizeof(unsigned int));
+  memset(work, 0, sizeRows * sizeof(unsigned int));
+  for (int stage = 0; stage < nStages; stage++)
+  {
+    const int firstCol = stage * stageSize;
+    const int endCol = firstCol + stageSize;
+    int remaining = stageSize;
+    while (remaining > 0)
+    {
+      color++;
+
+      for (int col = firstCol; col < endCol; col++)
+      {
+        if (pattern->colorCols[col])
         {
-          int rowIdx = sparsePattern->index[row];
-          for (j=sparsePatternT->leadindex[rowIdx]; j<sparsePatternT->leadindex[rowIdx+1]; j++)
+          continue;
+        }
+
+        modelica_boolean conflict = FALSE;
+        for (unsigned int nz = pattern->leadindex[col]; nz < pattern->leadindex[col + 1]; nz++)
+        {
+          if (work[pattern->index[nz]] == color)
           {
-            tabu[sparsePatternT->index[j]*sizeCols + i]=1;
+            conflict = TRUE;
+            break;
           }
         }
-
-        // each stage has different colors, due to the columnwise jacobian calculation
-        // only important and utilized, if a fully implicit RK-method is used
-        act_stage = col/sizeCols_ODE;
-        for (j=(act_stage+1)*sizeCols_ODE; j<sizeCols; j++)
+        if (conflict)
         {
-          tabu[j*sizeCols + i]=1;
+          continue;
         }
 
-        break;
+        pattern->colorCols[col] = color;
+        remaining--;
+        for (unsigned int nz = pattern->leadindex[col]; nz < pattern->leadindex[col + 1]; nz++)
+        {
+          work[pattern->index[nz]] = color;
+        }
       }
     }
   }
-  sparsePattern->maxColors = maxColors;
 
-  // free memory allocation for the transposed sprasity pattern
-  freeSparsePattern(sparsePatternT);
-  free(tabu);
-}
-
-
-/**
- * @brief Initialize sparsity pattern for non-linear system of diagonal implicit Runge-Kutta methods.
- *
- * Get sparsity pattern of ODE Jacobian and edit to be non-zero on diagonal elements.
- * Coloring of ODE Jacobian will be used, if it had non-zero elements on all diagonal entries.
- * Calculate coloring otherwise.
- *
- * @param data                Runtime data struct.
- * @param sysData             Non-linear system.
- * @return SPARSE_PATTERN*    Pointer to sparsity pattern of non-linear system.
- */
-SPARSE_PATTERN* initializeSparsePattern_SR(DATA* data, NONLINEAR_SYSTEM_DATA* sysData)
-{
-  unsigned int i,j;
-  unsigned int row, col;
-  unsigned int missingZeros = 0;
-  unsigned int nDiags = 0;
-  unsigned int shift = 0;
-  modelica_boolean diagElemNonZero;
-  SPARSE_PATTERN* sparsePattern_DIRK;
-
-  /* Get Sparsity of ODE Jacobian */
-  JACOBIAN* jacobian = &(data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A]);
-  SPARSE_PATTERN* sparsePattern_ODE = jacobian->sparsePattern;
-
-  int sizeRows = jacobian->sizeRows;
-  int sizeCols = jacobian->sizeCols;
-
-  /* Compute size of new sparsitiy pattern
-   * Increase the size to contain non-zero elements on diagonal. */
-  i = 0;
-  for(row=0; row < sizeRows; row++) {
-    for(; i < sparsePattern_ODE->leadindex[row+1]; i++) {
-      if(sparsePattern_ODE->index[i] == row) {
-        nDiags++;
-      }
-    }
-  }
-  int missingDiags = jacobian->sizeRows - nDiags;
-  int length_index = jacobian->sparsePattern->nnz + missingDiags;
-
-  // Allocate memory for new sparsity pattern
-  sparsePattern_DIRK = allocSparsePattern(sizeRows, length_index, sizeCols);
-
-  /* Set diagonal elements of sparsitiy pattern to non-zero */
-  i = 0;
-  j = 0;
-  sparsePattern_DIRK->leadindex[0] = sparsePattern_ODE->leadindex[0];
-  for(row=0; row < sizeRows; row++) {
-    diagElemNonZero = FALSE;
-    int leadIdx = sparsePattern_ODE->leadindex[row+1];
-    for(; j < leadIdx;) {
-      if(sparsePattern_ODE->index[j] == row) {
-        diagElemNonZero = TRUE;
-        sparsePattern_DIRK->leadindex[row+1] = sparsePattern_ODE->leadindex[row+1] + shift;
-      }
-      if(sparsePattern_ODE->index[j] > row && !diagElemNonZero) {
-        sparsePattern_DIRK->index[i] = row;
-        shift++;
-        sparsePattern_DIRK->leadindex[row+1] = sparsePattern_ODE->leadindex[row+1] + shift;
-        i++;
-        diagElemNonZero = TRUE;
-      }
-      sparsePattern_DIRK->index[i] = sparsePattern_ODE->index[j];
-      i++;
-      j++;
-    }
-    if (!diagElemNonZero) {
-      sparsePattern_DIRK->index[i] = row;
-      shift++;
-      sparsePattern_DIRK->leadindex[row+1] = sparsePattern_ODE->leadindex[row+1] + shift;
-      i++;
-    }
-  }
-
-  if (missingDiags == 0) {
-    // If missingDiags=0 we can re-use coloring (and everything else)
-    sparsePattern_DIRK->maxColors = sparsePattern_ODE->maxColors;
-    memcpy(sparsePattern_DIRK->colorCols, sparsePattern_ODE->colorCols, jacobian->sizeCols*sizeof(unsigned int));
-  } else {
-    // Calculate new coloring, because of additional nonZeroDiagonals
-    ColoringAlg(sparsePattern_DIRK, sizeRows, sizeCols, 1);
-  }
-
-  return sparsePattern_DIRK;
-}
-
-
-/**
- * @brief Update sparsity pattern for non-linear system of diagonal implicit Runge-Kutta methods.
- *
- * Get sparsity pattern of ODE Jacobian and edit to be non-zero on diagonal elements.
- * Coloring of ODE Jacobian will be used, if it had non-zero elements on all diagonal entries.
- * Calculate coloring otherwise.
- *
- * @param data                Runtime data struct.
- * @param sysData             Non-linear system.
- * @return SPARSE_PATTERN*    Pointer to sparsity pattern of non-linear system.
- */
-void updateSparsePattern_MR(DATA_GBODE* gbData, SPARSE_PATTERN *sparsePattern_MR)
-{
-  DATA_GBODEF* gbfData = gbData->gbfData;
-  int nFastStates = gbData->nFastStates;
-  int i, j, l, r, ii, jj, ll, rr;
-
-  // The following assumes that the fastStates are sorted (i.e. [0, 2, 6, 7, ...])
-  SPARSE_PATTERN *sparsePattern_DIRK = gbfData->sparsePattern_DIRK;
-
-  /* Set sparsity pattern for the fast states */
-  ii = 0;
-  jj = 0;
-  ll = 0;
-
-  sparsePattern_MR->leadindex[0] = sparsePattern_DIRK->leadindex[0];
-  for (rr = 0; rr < nFastStates; rr++)
+  pattern->maxColors = color;
+  if (ownsWork)
   {
-    r = gbData->fastStatesIdx[rr];
-    ii = 0;
-    for (jj = sparsePattern_DIRK->leadindex[r]; jj < sparsePattern_DIRK->leadindex[r + 1];)
+    free(work);
+  }
+}
+
+static SPARSE_PATTERN *copySparsePattern(const SPARSE_PATTERN *source, int size, modelica_boolean copyColoring)
+{
+  SPARSE_PATTERN *copy = allocSparsePattern(size, source->nnz, size);
+  memcpy(copy->leadindex, source->leadindex, (size + 1) * sizeof(unsigned int));
+  memcpy(copy->index, source->index, source->nnz * sizeof(unsigned int));
+  if (copyColoring)
+  {
+    memcpy(copy->colorCols, source->colorCols, size * sizeof(unsigned int));
+    copy->maxColors = source->maxColors;
+  }
+  else
+  {
+    memset(copy->colorCols, 0, size * sizeof(unsigned int));
+    copy->maxColors = 0;
+  }
+  return copy;
+}
+
+// Build struct(I + J), optionally coloring it, allocating a pattern when target is NULL
+static SPARSE_PATTERN *sparsePatternWithDiagonal(const SPARSE_PATTERN *source, int size, SPARSE_PATTERN *target, unsigned int *work,
+                                                 modelica_boolean colorPattern, modelica_boolean reuseSourceColoring)
+{
+  int diagonalCount = 0;
+
+  if (target == NULL)
+  {
+    for (int col = 0; col < size; col++)
     {
-      i = gbData->fastStatesIdx[ii];
-      j = sparsePattern_DIRK->index[jj];
-      if (i == j)
+      for (unsigned int nz = source->leadindex[col]; nz < source->leadindex[col + 1]; nz++)
       {
-        sparsePattern_MR->index[ll] = ii;
-        ll++;
-      }
-      if (j > i)
-      {
-        ii++;
-        if (ii >= nFastStates)
+        if (source->index[nz] == col)
+        {
+          diagonalCount++;
           break;
+        }
       }
-      else
-        jj++;
     }
-    sparsePattern_MR->leadindex[rr + 1] = ll;
+    target = allocSparsePattern(size, source->nnz + size - diagonalCount, size);
   }
 
-  sparsePattern_MR->nnz = ll;
+  unsigned int targetNz = 0;
+  diagonalCount = 0;
+  target->leadindex[0] = 0;
+  for (int col = 0; col < size; col++)
+  {
+    modelica_boolean diagonalPresent = FALSE;
+    for (unsigned int nz = source->leadindex[col]; nz < source->leadindex[col + 1]; nz++)
+    {
+      unsigned int row = source->index[nz];
+      if (!diagonalPresent && row > col)
+      {
+        target->index[targetNz++] = col;
+        diagonalPresent = TRUE;
+      }
+      if (row == col)
+      {
+        diagonalPresent = TRUE;
+        diagonalCount++;
+      }
+      target->index[targetNz++] = row;
+    }
+    if (!diagonalPresent)
+    {
+      target->index[targetNz++] = col;
+    }
+    target->leadindex[col + 1] = targetNz;
+  }
+  target->nnz = targetNz;
 
-  ColoringAlg(sparsePattern_MR, nFastStates, nFastStates, 1);
+  if (!colorPattern)
+  {
+    memset(target->colorCols, 0, size * sizeof(unsigned int));
+    target->maxColors = 0;
+  }
+  else if (reuseSourceColoring && diagonalCount == size && source->maxColors > 0)
+  {
+    memcpy(target->colorCols, source->colorCols, size * sizeof(unsigned int));
+    target->maxColors = source->maxColors;
+  }
+  else
+  {
+    colorSparsePattern(target, size, size, 1, work);
+  }
 
-  printSparseStructure(sparsePattern_MR,
-                       nFastStates,
-                       nFastStates,
-                       OMC_LOG_GBODE_V,
-                       "sparsePattern_MR");
+  return target;
+}
 
+// Reduce a square CSC pattern to the principal submatrix selected by indices
+static void reduceSparsePattern(const SPARSE_PATTERN *source, int sourceSize, SPARSE_PATTERN *target,
+                                const int *indices, int targetSize, unsigned int *work)
+{
+  for (int i = 0; i < sourceSize; i++)
+  {
+    work[i] = UINT_MAX;
+  }
+  for (int i = 0; i < targetSize; i++)
+  {
+    work[indices[i]] = i;
+  }
 
-  return;
+  unsigned int targetNz = 0;
+  target->leadindex[0] = 0;
+  for (int col = 0; col < targetSize; col++)
+  {
+    int sourceCol = indices[col];
+    for (unsigned int nz = source->leadindex[sourceCol]; nz < source->leadindex[sourceCol + 1]; nz++)
+    {
+      unsigned int row = work[source->index[nz]];
+      if (row != UINT_MAX)
+      {
+        target->index[targetNz++] = row;
+      }
+    }
+    target->leadindex[col + 1] = targetNz;
+  }
+  target->nnz = targetNz;
+  memset(target->colorCols, 0, targetSize * sizeof(unsigned int));
+  target->maxColors = 0;
+}
+
+void gbodeMapSparsePattern(const SPARSE_PATTERN *source, const SPARSE_PATTERN *target,
+                           int size, int *sourceToTarget, int *targetDiagonal)
+{
+  for (int col = 0; col < size; col++)
+  {
+    unsigned int sourceNz = source->leadindex[col];
+    unsigned int sourceEnd = source->leadindex[col + 1];
+    targetDiagonal[col] = -1;
+
+    for (unsigned int targetNz = target->leadindex[col]; targetNz < target->leadindex[col + 1]; targetNz++)
+    {
+      unsigned int targetRow = target->index[targetNz];
+      if (targetRow == col)
+      {
+        targetDiagonal[col] = targetNz;
+      }
+      if (sourceNz < sourceEnd && source->index[sourceNz] == targetRow)
+      {
+        sourceToTarget[sourceNz++] = targetNz;
+      }
+    }
+
+    assertStreamPrint(NULL, targetDiagonal[col] >= 0 && sourceNz == sourceEnd, "GBODE sparse pattern mapping failed in column %d.", col);
+  }
+}
+
+// Create the struct(I + J) pattern used by block solves
+static SPARSE_PATTERN* initializeSparsePatternBlock(DATA* data, modelica_boolean colorPattern)
+{
+  JACOBIAN *jacobian = &data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A];
+  return sparsePatternWithDiagonal(jacobian->sparsePattern, jacobian->sizeRows, NULL, NULL, colorPattern, TRUE);
+}
+
+static SPARSE_PATTERN* initializeSparsePattern_IRK(DATA* data);
+
+void initializeSparsePattern_GBODE(DATA* data, DATA_GBODE* gbData)
+{
+  assertStreamPrint(NULL, !gbData->isExplicit,
+                    "Cannot initialize GBODE sparsity for an explicit method.");
+  if (gbData->type == GM_TYPE_IMPLICIT && gbData->nlsSolverMethod != GB_NLS_INTERNAL)
+  {
+    gbData->sparsePattern_NLS = initializeSparsePattern_IRK(data);
+  }
+  else
+  {
+    gbData->sparsePattern_NLS = initializeSparsePatternBlock(data, gbData->nlsSolverMethod != GB_NLS_INTERNAL);
+  }
+}
+
+void initializeSparsePattern_GBODEF(DATA* data, DATA_GBODEF* gbfData)
+{
+  assertStreamPrint(NULL, !gbfData->isExplicit,
+                    "Cannot initialize GBODEF sparsity for an explicit method.");
+  JACOBIAN *jacobian = &data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A];
+  const modelica_boolean useInternal = gbfData->nlsSolverMethod == GB_NLS_INTERNAL;
+  gbfData->sparseWork = malloc(jacobian->sizeRows * sizeof(unsigned int));
+  gbfData->sparsePattern_ODE = copySparsePattern(jacobian->sparsePattern, jacobian->sizeRows, useInternal);
+  gbfData->sparsePattern_NLS = sparsePatternWithDiagonal(jacobian->sparsePattern, jacobian->sizeRows,
+                                                         NULL, gbfData->sparseWork, !useInternal, TRUE);
+}
+
+void updateSparsePattern_GBODEF(DATA* data, DATA_GBODE* gbData)
+{
+  DATA_GBODEF *gbfData = gbData->gbfData;
+  SPARSE_PATTERN *fullPattern = data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern;
+
+  reduceSparsePattern(fullPattern, gbData->nStates, gbfData->sparsePattern_ODE, gbData->fastStatesIdx, gbData->nFastStates, gbfData->sparseWork);
+  if (gbfData->nlsSolverMethod == GB_NLS_INTERNAL)
+  {
+    colorSparsePattern(gbfData->sparsePattern_ODE, gbData->nFastStates, gbData->nFastStates, 1, gbfData->sparseWork);
+  }
+
+  sparsePatternWithDiagonal(gbfData->sparsePattern_ODE, gbData->nFastStates, gbfData->sparsePattern_NLS,
+                            gbfData->sparseWork, gbfData->nlsSolverMethod != GB_NLS_INTERNAL, FALSE);
+
+  printSparseStructure(gbfData->sparsePattern_NLS, gbData->nFastStates, gbData->nFastStates, OMC_LOG_GBODE_V, "sparsePattern_MR");
 }
 
 /**
@@ -309,10 +316,9 @@ void updateSparsePattern_MR(DATA_GBODE* gbData, SPARSE_PATTERN *sparsePattern_MR
  * column-wise calculation of the Jacobian
  *
  * @param data                Runtime data struct.
- * @param sysData             Non-linear system.
  * @return SPARSE_PATTERN*    Pointer to sparsity pattern of non-linear system.
  */
-SPARSE_PATTERN* initializeSparsePattern_IRK(DATA* data, NONLINEAR_SYSTEM_DATA* sysData)
+static SPARSE_PATTERN* initializeSparsePattern_IRK(DATA* data)
 {
   unsigned int i,j,k,l;
   unsigned int row, col;
@@ -430,10 +436,7 @@ SPARSE_PATTERN* initializeSparsePattern_IRK(DATA* data, NONLINEAR_SYSTEM_DATA* s
   free(coo_col);
   free(coo_row);
 
-  ColoringAlg(sparsePattern_IRK, sizeRows*nStages, sizeCols*nStages, nStages);
-
-  // for (int k=0; k<nStages; k++)
-  //   printIntVector_gb("colorCols: ", &sparsePattern_IRK->colorCols[k*nStates], sizeCols, 0);
+  colorSparsePattern(sparsePattern_IRK, sizeRows*nStages, sizeCols*nStages, nStages, NULL);
 
   return sparsePattern_IRK;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_sparse.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_sparse.h
@@ -35,12 +35,10 @@
 extern "C" {
 #endif
 
-void ColoringAlg(SPARSE_PATTERN* sparsePattern, int sizeRows, int sizeCols, int nStages);
-
-SPARSE_PATTERN* initializeSparsePattern_SR(DATA* data, NONLINEAR_SYSTEM_DATA* sysData);
-SPARSE_PATTERN* initializeSparsePattern_IRK(DATA* data, NONLINEAR_SYSTEM_DATA* sysData);
-
-void updateSparsePattern_MR(DATA_GBODE* gbData, SPARSE_PATTERN *sparsePattern_MR);
+void initializeSparsePattern_GBODE(DATA* data, DATA_GBODE* gbData);
+void initializeSparsePattern_GBODEF(DATA* data, DATA_GBODEF* gbfData);
+void updateSparsePattern_GBODEF(DATA* data, DATA_GBODE* gbData);
+void gbodeMapSparsePattern(const SPARSE_PATTERN *source, const SPARSE_PATTERN *target, int size, int *sourceToTarget, int *targetDiagonal);
 
 #ifdef __cplusplus
 };

--- a/testsuite/simulation/modelica/solver/gbode/Makefile
+++ b/testsuite/simulation/modelica/solver/gbode/Makefile
@@ -5,6 +5,7 @@ Burger_01.mos \
 HeatingSystem.mos \
 IRK_01.mos \
 multiRate_01.mos \
+multiRateInternal_01.mos \
 RK_01.mos \
 
 FAILINGTESTFILES = \

--- a/testsuite/simulation/modelica/solver/gbode/multiRateInternal_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/multiRateInternal_01.mos
@@ -1,0 +1,41 @@
+// name: multiRateInternal_01
+// status: correct
+// teardown_command: rm -rf SlowFastDynamics_* *.log SlowFastDynamics.bat
+//
+// Fully implicit multirate integration uses the internal solver's decoupled
+// I + J pattern rather than the I otimes I + A otimes J generic NLS pattern.
+
+loadString("
+model SlowFastDynamics
+  parameter Real epsilon = 3;
+  parameter Real corr = 0.01;
+  parameter Real fast = 7;
+  parameter Real slow = 0.1;
+  Real y[2](start = {1,1}, each fixed=true);
+equation
+  der(y) = {-y[1] - corr*y[2] + fast*sin(fast*time), corr*y[1] - epsilon*y[2] - cos(slow*time)};
+  annotation(experiment(StopTime=20));
+end SlowFastDynamics;");
+getErrorString();
+
+setCommandLineOptions("--generateDynamicJacobian=symbolic");
+getErrorString();
+
+buildModel(SlowFastDynamics);
+getErrorString();
+
+system(realpath(".") + "/SlowFastDynamics -s=gbode -gbratio=0.5 -gbm=radauIIA3 -gbfm=radauIIA3 -gbnls=internal -gberr=embedded -gbferr=embedded", "multirateInternal.log");
+print(readFile("multirateInternal.log"));
+
+// Result:
+// true
+// ""
+// true
+// ""
+// {"SlowFastDynamics", "SlowFastDynamics_init.xml"}
+// ""
+// 0
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+//
+// endResult


### PR DESCRIPTION
I noticed that MR did not work anymore with FIRK integrators, as the sparsity pattern was delayed for internal, and this was required for DAG (selective evaluation).

This PR unifies sparsity pattern creation + coloring for all GBODE NLS routines, i.e. moves internal utitilies to `gbode_sparse.c`, and adds a test to check if internal Radau IIA works with MR.

Also exploit reuse of symbolic factorizations in `gbode_internal_nls.c`