### PR TITLE
wasm-jit: the deprecated QSS solver

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -264,6 +264,7 @@ openmodelica_sim_meta/src/optimization/ipopt_out.rs
 openmodelica_sim_meta/src/optimization/mod.rs
 openmodelica_sim_meta/src/optimization/model.rs
 openmodelica_sim_meta/src/optimization/setup.rs
+openmodelica_sim_meta/src/qss.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs
 openmodelica_sim_meta/src/sync.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -640,6 +640,8 @@ const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     variable_filter: true,
     // `optimize()`'s solver: the host-driven driver's Ipopt.
     optimization: openmodelica_sim_meta::optimization::AVAILABLE,
+    // A `simulate()` run drives the whole trajectory, which is all QSS can do.
+    qss: true,
 };
 
 /// The solver values a caller may offer for this build, so a menu built from it
@@ -662,6 +664,8 @@ fn fmu_capabilities() -> simflags::Capabilities {
         variable_filter: false,
         // An FMU has no notion of an optimization problem.
         optimization: false,
+        // A Co-Simulation FMU steps to communication points; QSS cannot be stepped.
+        qss: false,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -366,12 +366,14 @@ fn finish(s: &mut Session) {
     s.stats = SolveStats::default();
     s.driver.fill_stats(&s.model, &mut s.stats);
     s.rows = s.driver.take_rows();
+    let at = s.driver.terminal_time();
     let _ = driver::emit_terminal_row(
         &mut s.engine,
         &mut s.rows,
         s.sim_data,
         &s.model.layout,
         s.n_reals,
+        at,
     );
     if let Ok(Some(f)) = openmodelica_sim_meta::linearize::linearize(&mut s.engine, &s.model, s.sim_data) {
         s.lin.extend_from_slice(f.name.as_bytes());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -24,6 +24,8 @@ pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
         // Ipopt has no wasm build (MUMPS is Fortran), so `method="optimization"`
         // reports "Ipopt is needed but not available." here.
         optimization: false,
+        // Both runtimes drive a whole trajectory, which is all QSS can do.
+        qss: true,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -463,6 +463,12 @@ pub trait Driver {
     fn advance(&mut self, e: &mut (dyn SimEngine + 'static), model: &SimModel, budget_ms: f64) -> Result<Advance>;
     fn take_rows(&mut self) -> Vec<f64>;
     fn fill_stats(&mut self, model: &SimModel, stats: &mut SolveStats);
+    /// The time C's `finishSimulation` emits its terminal row at
+    /// (`localData[0]->timeValue`). `None` ⇒ the last emitted row's time, where
+    /// every driver that follows the output grid leaves it.
+    fn terminal_time(&self) -> Option<f64> {
+        None
+    }
 }
 
 // Wall-clock (ms) for the chunk budget. wasm has no `Instant`, so the host injects
@@ -514,10 +520,10 @@ fn env_var(_name: &str) -> Option<String> {
 }
 
 /// `+inf` (one-shot) keeps `now_ms` off the hot path via `is_finite` short-circuit.
-fn deadline_from(budget_ms: f64) -> f64 {
+pub(crate) fn deadline_from(budget_ms: f64) -> f64 {
     if budget_ms.is_finite() { now_ms() + budget_ms } else { f64::INFINITY }
 }
-fn past_deadline(deadline: f64) -> bool {
+pub(crate) fn past_deadline(deadline: f64) -> bool {
     deadline.is_finite() && now_ms() >= deadline
 }
 
@@ -565,7 +571,7 @@ fn arm_alarm() {
     });
 }
 
-fn check_alarm() -> Result<()> {
+pub(crate) fn check_alarm() -> Result<()> {
     match past_deadline(alarm_store::get()) {
         true => Err(ALARM_ABORT_ERR),
         false => Ok(()),
@@ -581,7 +587,7 @@ static CANCEL_HOOK: AtomicUsize = AtomicUsize::new(0);
 pub fn set_cancel_hook(f: fn() -> bool) {
     CANCEL_HOOK.store(f as usize, Ordering::Relaxed);
 }
-fn cancel_requested() -> bool {
+pub(crate) fn cancel_requested() -> bool {
     let p = CANCEL_HOOK.load(Ordering::Relaxed);
     if p == 0 {
         return false;
@@ -705,7 +711,7 @@ pub(crate) fn write_i32(e: &mut dyn SimEngine, addr: u32, v: i32) -> Result<()> 
 /// Error out if a nonlinear system raised the `nls_fail` flag during the last
 /// equation call in a context that cannot back off (initialisation, an output
 /// point, the Euler loop). The DASSL residual handles this recoverably instead.
-fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub(crate) fn check_nls(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     let failed = read_i32(e, sim_data + layout.nls_fail_off)?;
     if failed != 0 {
         init_report::set_failed_system(failed - 1);
@@ -1959,7 +1965,7 @@ pub(crate) fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32,
 /// `SimData` flag during the last step (C's `checkSimulationTerminated`), or
 /// `-steadyState` is satisfied. Every driver asks after each output row, so both
 /// C stop conditions are served in one place. The first observation reports it.
-fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bool> {
+pub(crate) fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<bool> {
     if read_i32(e, sim_data + layout.terminate_off)? == 0 {
         return steady_state_reached(e, sim_data, layout);
     }
@@ -2028,7 +2034,7 @@ fn steady_state_reached(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
 /// C's `function_storeDelayed` + `function_storeSpatialDistribution`, the tail of
 /// `updateContinuousSystem`: the operators with an internal history record the point
 /// the model was last evaluated at. A model without any skips it entirely.
-fn store_operators(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub(crate) fn store_operators(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if !layout.has_history_ops {
         return Ok(());
     }
@@ -2054,7 +2060,7 @@ fn store_operators_at(
     store_operators(e, sim_data, layout)
 }
 
-fn eval_continuous(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub(crate) fn eval_continuous(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ALGEBRAIC);
     }
@@ -2110,15 +2116,18 @@ fn emit_row(
 }
 
 /// C's `finishSimulation`: a discrete update with `terminal()` true and one more
-/// row at the same time, so a `when terminal()` body reaches the result file.
+/// row at the same time, so a `when terminal()` body reaches the result file. `at`
+/// overrides that time for a driver whose last row is older than `stopTime`
+/// ([`Driver::terminal_time`]).
 pub fn emit_terminal_row(
     e: &mut dyn SimEngine,
     rows: &mut Vec<f64>,
     sim_data: u32,
     layout: &SimLayout,
     n_reals: u32,
+    at: Option<f64>,
 ) -> Result<()> {
-    let Some(time) = rows.len().checked_sub(n_reals as usize).map(|i| rows[i]) else {
+    let Some(time) = rows.len().checked_sub(n_reals as usize).map(|i| at.unwrap_or(rows[i])) else {
         return Ok(());
     };
     if no_event_emit() {
@@ -2141,7 +2150,7 @@ pub fn emit_terminal_row(
 /// The initial result row. C emits it straight after `initializeModel` with no
 /// re-evaluation: `SimData` is already consistent, and re-running the equations
 /// would repeat any side effect they have (`Streams.print`).
-fn emit_initial_row(
+pub(crate) fn emit_initial_row(
     e: &mut dyn SimEngine,
     rows: &mut Vec<f64>,
     sim_data: u32,
@@ -2893,6 +2902,7 @@ pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
         Some(crate::simflags::Solver::RungeKutta) => "rungekutta",
         Some(crate::simflags::Solver::SymSolver) => "symSolver",
         Some(crate::simflags::Solver::SymSolverSsc) => "symSolverSsc",
+        Some(crate::simflags::Solver::Qss) => "qss",
         Some(crate::simflags::Solver::Optimization) => "optimization",
         _ => method,
     }
@@ -2901,7 +2911,7 @@ pub(crate) fn effective_method<'a>(method: &'a str) -> &'a str {
 /// Whether this build's `SolverCore` can serve `method`. `dassljac` is dassl
 /// with a symbolic Jacobian and `""` the dassl default.
 fn check_method(method: &str) -> bool {
-    matches!(method, "dassl" | "dasslrt" | "dassljac" | "euler" | "rungekutta" | "gbode" | "")
+    matches!(method, "dassl" | "dasslrt" | "dassljac" | "euler" | "rungekutta" | "gbode" | "qss" | "")
         || (matches!(method, "cvode" | "ida") && cfg!(sundials))
         // `optimize()`; `drive` handles it before the integrators, and reports
         // C's "Ipopt is needed but not available." when it was not linked.
@@ -2997,6 +3007,18 @@ pub fn make_driver(
              Colored numerical Jacobian will be used.",
         );
     }
+    // C's `solver_main` runs QSS from its own branch: it has no event handling and
+    // no output grid, so it never reaches the standard solver interface. With no
+    // states there is nothing to quantize, and C's `simulation_runtime.cpp` has
+    // already swapped in euler ("since it does nothing").
+    let mut method = method;
+    if method == "qss" {
+        if layout.n_states > 0 {
+            return Ok((Box::new(crate::qss::Qss::new(e, model, sim_data)?), "qss"));
+        }
+        omclog::info(omclog::SOLVER, false, "No states present, continuing without ODE solver.");
+        method = "euler";
+    }
     // DAE mode always takes the `SolverCore` path: the consistent-restart its
     // discrete update needs lives there.
     // A clocked partition is an event source too, and only `EventsDriver` has the
@@ -3031,10 +3053,10 @@ pub fn make_driver(
 /// so this is only reached by a `method=` the model was compiled with.
 const UNSUPPORTED_METHOD: &str = if cfg!(sundials) {
     "CodegenWasmJit: unsupported integration method (supported: `dassl`, `cvode`, `ida`, `gbode`, \
-     `euler`, `rungekutta`)"
+     `euler`, `rungekutta`, `qss`)"
 } else {
     "CodegenWasmJit: unsupported integration method (supported: `dassl`, `gbode`, `euler`, \
-     `rungekutta`)"
+     `rungekutta`, `qss`)"
 };
 
 /// Free external objects (so repeated runs don't leak) and read back parameter
@@ -3117,7 +3139,7 @@ pub fn drive(
                 }
                 driver.fill_stats(model, &mut stats);
                 let mut rows = driver.take_rows();
-                emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+                emit_terminal_row(e, &mut rows, sim_data, layout, n_reals, driver.terminal_time())?;
                 return Ok(rows);
             }
             label = "optimization";
@@ -3140,7 +3162,7 @@ pub fn drive(
             label = "euler-wasm";
             set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
             let mut rows = run_wasm(e, sim_data, n_reals, n_rows, model, start, stop, &mut stats)?;
-            emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+            emit_terminal_row(e, &mut rows, sim_data, layout, n_reals, None)?;
             return Ok(rows);
         }
         // enrich_trap: a trap in init/integration is usually a failed model assert().
@@ -3162,7 +3184,7 @@ pub fn drive(
         }
         driver.fill_stats(model, &mut stats);
         let mut rows = driver.take_rows();
-        emit_terminal_row(e, &mut rows, sim_data, layout, n_reals)?;
+        emit_terminal_row(e, &mut rows, sim_data, layout, n_reals, driver.terminal_time())?;
         Ok(rows)
     })();
     let _ = bench;
@@ -5424,6 +5446,11 @@ impl CsDriver {
         daskr::auxiliary::xsetf(0);
         let layout = &model.layout;
         let method = resolve_solver_method(&model.method, layout.dae_mode())?;
+        // QSS runs a whole simulation of its own; C's `solver_main_step` throws
+        // "Unhandled case" for it rather than stepping it.
+        if method == "qss" {
+            return Err("CodegenWasmJit: method=\"qss\" cannot step to a communication point");
+        }
         store_relations(e, sim_data, layout)?;
         let samp = Samples::load(e, sim_data, layout)?;
         let mut sync = crate::sync::Sync::new(e, model, sim_data)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -33,6 +33,7 @@ pub mod omclog;
 #[cfg(feature = "std")]
 pub(crate) mod extinput;
 pub mod optimization;
+pub(crate) mod qss;
 pub mod simflags;
 pub mod sync;
 #[cfg(sundials)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/qss.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/qss.rs
@@ -1,0 +1,378 @@
+//! QSS1, the Quantized State System solver of C's
+//! `simulation/solver/perform_qss_simulation.c.inc`.
+//!
+//! Every state carries its own quantum `dQ` (nominal·10⁻⁴), its own timestamp and
+//! its own time of next change; the solver repeatedly advances the state that
+//! changes first by one quantum and re-evaluates only the derivatives the ODE
+//! Jacobian's sparsity says depend on it. There is no output grid: one result row
+//! is emitted per accepted quantum change, at that change's own time.
+
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::driver::{
+    Advance, Driver, Result, SimEngine, cancel_requested, capture_row, check_alarm, check_nls,
+    deadline_from, emit_initial_row, eval_continuous, format_f, past_deadline, read_f64,
+    store_operators, terminated, write_f64, write_i32,
+};
+use crate::omclog;
+use crate::{JacAInfo, Layout as SimLayout, REAL_OFF, SimMeta as SimModel, SolveStats, TIME_OFF};
+
+/// C's `enum error_msg` as this runtime's error strings. `OO_MEMORY` has no
+/// counterpart: allocation failure aborts here.
+const ISNAN: &str = "CodegenWasmJit: qss: the time of next change is NaN";
+const UNKNOWN: &str = "CodegenWasmJit: qss: no ODE Jacobian sparse pattern";
+
+const EPS: f64 = 1e-15;
+
+/// C's `performQSSSimulation` locals, held across `advance` calls so a resumed
+/// chunk continues the exact same continuation.
+pub(crate) struct Qss {
+    sim_data: u32,
+    /// C's `solverInfo->currentTime`.
+    current_time: f64,
+    /// C's `simInfo->stopTime`, which `terminate()` moves to the current time.
+    stop_time: f64,
+    /// Approximation of states
+    qik: Vec<f64>,
+    /// states
+    xik: Vec<f64>,
+    /// Derivative of states
+    der_xik: Vec<f64>,
+    /// Time of approximation, because not all approximations are calculated at a
+    /// specific time, each approx. has its own timestamp
+    tq: Vec<f64>,
+    /// Time of the states, because not all states are calculated at a specific
+    /// time, each state has its own timestamp
+    tx: Vec<f64>,
+    /// Time of the next change in state
+    tqp: Vec<f64>,
+    /// next value of the state
+    nqh: Vec<f64>,
+    /// change in quantity of every state, default = nominal*10^-4
+    dq: Vec<f64>,
+    /// Derivatives which are influenced by the state being advanced, and how many
+    /// of them there are (C's `der`/`numDer`).
+    der: Vec<usize>,
+    num_der: usize,
+    /// `leadindex`/`index` of the ODE Jacobian's sparse pattern: the derivatives
+    /// each state occurs in.
+    rows_by_col: Vec<Vec<u32>>,
+    curr_step_no: u64,
+    rows: Vec<f64>,
+}
+
+impl Qss {
+    pub(crate) fn new(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Result<Self> {
+        let layout = &model.layout;
+        let states = layout.n_states as usize;
+
+        crate::driver::run_initialization_model(e, sim_data, model)?;
+        // C emits the initial row from `solver_main` before it enters the loop.
+        let mut rows = Vec::new();
+        emit_initial_row(e, &mut rows, sim_data, layout, model.start_time)?;
+
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            "This QSS method is under development and should not be used yet.",
+        );
+
+        // C's `initialAnalyticJacobianA`: without the pattern there is nothing to
+        // tell which derivatives a state occurs in.
+        let Some(jac) = model.jac_a.as_ref() else {
+            omclog::info(
+                omclog::STDOUT,
+                false,
+                "Jacobian or sparse pattern is not generated or failed to initialize.",
+            );
+            return Err(UNKNOWN);
+        };
+        print_sparse_structure(jac, omclog::SOLVER, "ODE sparse pattern");
+
+        let mut qss = Qss {
+            sim_data,
+            current_time: model.start_time,
+            stop_time: model.stop_time,
+            qik: vec![0.0; states],
+            xik: vec![0.0; states],
+            der_xik: vec![0.0; states],
+            tq: vec![0.0; states],
+            tx: vec![0.0; states],
+            tqp: vec![0.0; states],
+            nqh: vec![0.0; states],
+            dq: vec![0.0; states],
+            // Transform the sparsity pattern into a data structure for an index
+            // based access. (QSS2 or higher would also need the reverse map: which
+            // states occur in each derivative.)
+            der: vec![0; jac.rows_by_col.len()],
+            num_der: 0,
+            rows_by_col: jac.rows_by_col.clone(),
+            curr_step_no: 0,
+            rows,
+        };
+
+        // further initialization of local variables
+        for i in 0..states {
+            let nominal = read_f64(e, sim_data + layout.real_nominal_off(i as u32))?;
+            qss.dq[i] = 0.0001 * nominal;
+            qss.tx[i] = model.start_time;
+            qss.tq[i] = model.start_time;
+            qss.qik[i] = read_f64(e, state_addr(sim_data, i))?;
+            qss.xik[i] = qss.qik[i];
+            qss.der_xik[i] = read_f64(e, der_addr(sim_data, layout, i))?;
+            let (d_tnext_q, next_q, _) = delta_q(e, sim_data, layout, qss.dq[i], i)?;
+            qss.tqp[i] = qss.tq[i] + d_tnext_q;
+            qss.nqh[i] = next_q;
+        }
+        Ok(qss)
+    }
+
+    /// Returns the indices of all derivatives with state k inside.
+    fn get_der_with_state_k(&mut self, k: usize) {
+        let mut j = 0;
+        for &row in &self.rows_by_col[k] {
+            self.der[j] = row as usize;
+            j += 1;
+        }
+        self.num_der = j;
+    }
+}
+
+impl Driver for Qss {
+    fn advance(
+        &mut self,
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        budget_ms: f64,
+    ) -> Result<Advance> {
+        let layout = &model.layout;
+        let sim_data = self.sim_data;
+        let states = layout.n_states as usize;
+        let deadline = deadline_from(budget_ms);
+        let mut did_step = false;
+
+        // Start main simulation loop
+        while self.current_time < self.stop_time {
+            if did_step && past_deadline(deadline) {
+                return Ok(Advance::Running);
+            }
+            check_alarm()?;
+            if cancel_requested() {
+                return Ok(Advance::Cancelled);
+            }
+            did_step = true;
+            self.curr_step_no += 1;
+
+            let ind = min_step(&self.tqp);
+
+            if self.tqp[ind].is_nan() {
+                return Err(ISNAN);
+            }
+            if self.tqp[ind].is_infinite() {
+                // If all derivatives are zero, the states stay constant and only
+                // the time propagates till stop->time.
+                omclog::warning(
+                    omclog::STDOUT,
+                    false,
+                    &format!(
+                        "All derivatives are zero at time {}!.",
+                        format_f(read_f64(e, sim_data + TIME_OFF)?)
+                    ),
+                );
+                self.current_time = self.stop_time;
+                write_f64(e, sim_data + TIME_OFF, self.current_time)?;
+
+                continue;
+            }
+
+            self.qik[ind] = self.nqh[ind];
+
+            self.xik[ind] = self.qik[ind];
+            write_f64(e, state_addr(sim_data, ind), self.qik[ind])?;
+
+            self.tx[ind] = self.tqp[ind];
+            self.tq[ind] = self.tqp[ind];
+
+            self.current_time = self.tqp[ind];
+
+            // the state[ind] will change again in dTnextQ
+            let (d_tnext_q, next_q, _) = delta_q(e, sim_data, layout, self.dq[ind], ind)?;
+            self.tqp[ind] = self.tq[ind] + d_tnext_q;
+            self.nqh[ind] = next_q;
+
+            // get the derivatives depending on state[ind]
+            self.get_der_with_state_k(ind);
+
+            for k in 0..self.num_der {
+                let j = self.der[k];
+                if j != ind {
+                    self.xik[j] += self.der_xik[j] * (self.current_time - self.tx[j]);
+                    write_f64(e, state_addr(sim_data, j), self.xik[j])?;
+                    self.tx[j] = self.current_time;
+                }
+            }
+
+            // Recalculate all equations which are affected by state[ind].
+            // Unfortunately all equations will be calculated up to now. And we need
+            // to evaluate the equations as f(t,q) and not f(t,x). So all states were
+            // saved onto a local stack and overwritten by q. After evaluating the
+            // equations the states are written back.
+            for i in 0..states {
+                self.xik[i] = read_f64(e, state_addr(sim_data, i))?; // save current state
+                // overwrite current state for dx/dt = f(t,q)
+                write_f64(e, state_addr(sim_data, i), self.qik[i])?;
+            }
+
+            // update continous system. The QSS loop does not open C's
+            // `noThrowAsserts` window, so a violated assert ends the run here.
+            // `nls_fail` is C's per-solve `solved` flag: only this point's solve
+            // may fail the step.
+            write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+            write_f64(e, sim_data + TIME_OFF, self.current_time)?;
+            eval_continuous(e, sim_data, layout)?;
+            store_operators(e, sim_data, layout)?;
+
+            for i in 0..states {
+                write_f64(e, state_addr(sim_data, i), self.xik[i])?; // restore current state
+            }
+
+            // Get derivatives affected by state[ind] and write back ALL
+            // derivatives. After that we have states and derivatives for different
+            // times tx.
+            for k in 0..self.num_der {
+                let j = self.der[k];
+                self.der_xik[j] = read_f64(e, der_addr(sim_data, layout, j))?;
+            }
+            // not in every case part of the above derivatives
+            self.der_xik[ind] = read_f64(e, der_addr(sim_data, layout, ind))?;
+
+            for i in 0..states {
+                // write back all derivatives
+                write_f64(e, der_addr(sim_data, layout, i), self.der_xik[i])?;
+            }
+
+            // recalculate the time of next change only for the affected states
+            for k in 0..self.num_der {
+                let j = self.der[k];
+                let (d_tnext_q, next_q, _) = delta_q(e, sim_data, layout, self.dq[j], j)?;
+                self.tqp[j] = self.current_time + d_tnext_q;
+                self.nqh[j] = next_q;
+            }
+
+            capture_row(e, &mut self.rows, sim_data, layout)?;
+
+            // check if terminate()=true
+            if terminated(e, sim_data, layout)? {
+                self.stop_time = self.current_time;
+                return Ok(Advance::Terminated);
+            }
+
+            // terminate for some cases:
+            // - non-linear system failed to solve
+            // - assert was called
+            check_nls(e, sim_data, layout)?;
+        }
+        // End of main loop
+        Ok(Advance::Done)
+    }
+
+    fn take_rows(&mut self) -> Vec<f64> {
+        core::mem::take(&mut self.rows)
+    }
+
+    fn fill_stats(&mut self, _model: &SimModel, stats: &mut SolveStats) {
+        stats.steps = self.curr_step_no;
+    }
+
+    /// `timeValue` at the end of the loop, which the all-derivatives-are-zero
+    /// shortcut leaves at `stopTime` while the last emitted row is older.
+    fn terminal_time(&self) -> Option<f64> {
+        Some(self.current_time)
+    }
+}
+
+/// `SimData` address of state `i`.
+fn state_addr(sim_data: u32, i: usize) -> u32 {
+    sim_data + REAL_OFF + i as u32 * 8
+}
+
+/// `SimData` address of `der(state i)`.
+fn der_addr(sim_data: u32, layout: &SimLayout, i: usize) -> u32 {
+    sim_data + REAL_OFF + (layout.n_states + i as u32) * 8
+}
+
+/// Computes the next step in time and quantity for `state[index]`.
+///
+/// `dq` is the change of quantity for `state[index]`, (nominal value) * 10^-4.
+/// Returns `dTnextQ` (the state will change after that many seconds), `nextQ` (the
+/// next quantity reached by the state) and `diffQ` (the difference between the
+/// state's current and future value).
+fn delta_q(
+    e: &dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    dq: f64,
+    index: usize,
+) -> Result<(f64, f64, f64)> {
+    let x = read_f64(e, state_addr(sim_data, index))?;
+    let state_der = read_f64(e, der_addr(sim_data, layout, index))?;
+
+    let mut next_q;
+    if state_der >= 0.0 {
+        // quantity of the state will increase
+        next_q = (libm::floor(x / dq) + 1.0) * dq;
+        if next_q <= x + EPS {
+            next_q += dq;
+        }
+    } else {
+        next_q = libm::floor(x / dq) * dq;
+        if next_q >= x - EPS {
+            next_q -= dq;
+        }
+    }
+
+    let diff_q = libm::fabs(next_q - x);
+    let d_tnext_q = libm::fabs(diff_q / state_der);
+
+    Ok((d_tnext_q, next_q, diff_q))
+}
+
+/// Finds the index of the state which will change first: `state[i]` will change in
+/// time `tqp[i]`.
+fn min_step(tqp: &[f64]) -> usize {
+    let mut ind = 0;
+    // We can have a QNAN at any index and tqp[i] < QNAN will fail in every case.
+    let mut tmin = f64::INFINITY;
+
+    for (i, &t) in tqp.iter().enumerate() {
+        if t < tmin && !t.is_nan() {
+            ind = i;
+            tmin = t;
+        }
+    }
+    ind
+}
+
+/// C's `printSparseStructure` (`model_help.c`) for a square Jacobian pattern.
+fn print_sparse_structure(jac: &JacAInfo, stream: omclog::Stream, name: &str) {
+    if !omclog::active(stream) {
+        return;
+    }
+    let nnz: usize = jac.rows_by_col.iter().map(|r| r.len()).sum();
+    omclog::info(stream, true, &format!("Sparse structure of {name} [size: {0}x{0}]", jac.n));
+    omclog::info(stream, false, &format!("{nnz} non-zero elements"));
+
+    omclog::info(stream, true, "Transposed sparse structure (rows: states)");
+    for rows in &jac.rows_by_col {
+        let mut buffer = alloc::string::String::new();
+        for col in 0..rows.last().map_or(0, |&r| r + 1) {
+            buffer.push(if rows.contains(&col) { '*' } else { ' ' });
+            buffer.push(' ');
+        }
+        omclog::info(stream, false, &buffer);
+    }
+    omclog::close(stream);
+    omclog::close(stream);
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -26,6 +26,8 @@ pub enum Solver {
     RungeKutta,
     SymSolver,
     SymSolverSsc,
+    /// C's deprecated experimental QSS1 (`perform_qss_simulation.c.inc`).
+    Qss,
     /// `optimize()`'s collocation solver; only selectable where Ipopt is linked.
     Optimization,
 }
@@ -304,6 +306,10 @@ pub struct Capabilities {
     pub variable_filter: bool,
     /// Ipopt is linked, so `method="optimization"` / `-s=optimization` can run.
     pub optimization: bool,
+    /// This runtime runs a whole simulation of its own, so `-s=qss` — which has no
+    /// output grid and no stepping interface — can drive it. C throws "Unhandled
+    /// case in solver_main_step" where it cannot.
+    pub qss: bool,
 }
 
 /// Reject flag values this runtime cannot honour.
@@ -329,6 +335,7 @@ pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
         Some(Solver::Ida) if !cap.ida => "ida",
         Some(Solver::Cvode) if !cap.cvode => "cvode",
         Some(Solver::Optimization) if !cap.optimization => "optimization",
+        Some(Solver::Qss) if !cap.qss => "qss",
         _ => return Ok(()),
     };
     let have: Vec<String> = supported(cap)
@@ -884,6 +891,7 @@ enum Offer {
     WithIda,
     WithCvode,
     WithIpopt,
+    WithQss,
     /// `default`, an alias of a listed value, or one this runtime substitutes for.
     Never,
 }
@@ -896,6 +904,7 @@ impl Offer {
             Offer::WithIda => cap.ida,
             Offer::WithCvode => cap.cvode,
             Offer::WithIpopt => cap.optimization,
+            Offer::WithQss => cap.qss,
             Offer::Never => false,
         }
     }
@@ -914,6 +923,7 @@ const SOLVERS: &[Value<Solver>] = &[
     ("optimization", Solver::Optimization, Offer::WithIpopt),
     ("symSolver", Solver::SymSolver, Offer::Never),
     ("symSolverSsc", Solver::SymSolverSsc, Offer::Never),
+    ("qss", Solver::Qss, Offer::WithQss),
 ];
 
 /// `-nls`. Without the archives `kinsol` runs the runtime's own sparse Newton.
@@ -1063,10 +1073,24 @@ mod tests {
         core::iter::once("model".to_string()).chain(s.iter().map(|x| x.to_string())).collect()
     }
 
-    const NOTHING: Capabilities =
-        Capabilities { klu: false, ida: false, cvode: false, alarm: false, variable_filter: false, optimization: false };
-    const EVERYTHING: Capabilities =
-        Capabilities { klu: true, ida: true, cvode: true, alarm: true, variable_filter: true, optimization: true };
+    const NOTHING: Capabilities = Capabilities {
+        klu: false,
+        ida: false,
+        cvode: false,
+        alarm: false,
+        variable_filter: false,
+        optimization: false,
+        qss: false,
+    };
+    const EVERYTHING: Capabilities = Capabilities {
+        klu: true,
+        ida: true,
+        cvode: true,
+        alarm: true,
+        variable_filter: true,
+        optimization: true,
+        qss: true,
+    };
 
     #[test]
     fn defaults_are_all_unset() {


### PR DESCRIPTION
Port `simulation/solver/perform_qss_simulation.c.inc` to the wasm-jit runtime as `openmodelica_sim_meta/src/qss.rs`, so `method="qss"` / `-s=qss` runs there instead of being rejected with "unsupported integration method". `performQSSSimulation`, `deltaQ`, `getDerWithStateK` and `minStep` keep C's structure and comments, plus `model_help.c`'s `printSparseStructure` for `LOG_SOLVER`.

Three details the C code makes easy to get wrong:

* `dQ[i] = 1e-4 * nominal` uses the *declared* nominal (`Layout::real_nom_off`, C's `realVarsData[i].attribute.nominal`), not the integrator's clamped `state_nom_off`.
* `pattern->leadindex`/`index` of JAC_A is CSC over states, i.e. exactly `JacAInfo::rows_by_col[k]` — the derivatives state `k` occurs in.
* "All derivatives are zero" moves `timeValue` to `stopTime` and leaves the loop *without* emitting, so `finishSimulation`'s terminal row is newer than the last one. Hence `Driver::terminal_time()`, which `emit_terminal_row` now takes; it is `None` for every driver that follows the output grid, so their behaviour is unchanged.

C's QSS has no event handling and opens no `noThrowAsserts` window, so neither does this: `make_driver` returns the QSS driver before the `EventsDriver` branch, a violated assert ends the run where it is raised, and with no states euler is substituted as `simulation_runtime.cpp` already does. A new `Capabilities::qss` gates the method — true for `simulate()` (host JIT and the in-wasm session/standalone runtimes), false for a Co-Simulation FMU, whose `CsDriver` steps to communication points where C throws "Unhandled case in solver_main_step".

All nine `simulation/modelica/qss/qss_example*` pass under `--simCodeTarget=wasm-jit` and match the C runtime to 14-16 significant digits.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
