### PR TITLE
Expand der() in removed when-equations

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -3801,14 +3801,18 @@ algorithm
   (syst, shared) := match (syst, shared)
     local
       BackendDAE.Variables vars;
-      BackendDAE.EquationArray eqns, inieqns;
+      BackendDAE.EquationArray eqns, inieqns, remeqns;
       Mutable<BackendDAE.Shared> shared_arr;
 
-    case (syst as BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), BackendDAE.SHARED(initialEqs=inieqns))
+    case (syst as BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns, removedEqs=remeqns), BackendDAE.SHARED(initialEqs=inieqns))
       algorithm
         shared_arr := Mutable.create(shared);
         (_, vars) := BackendEquation.traverseEquationArray_WithUpdate(eqns, function traverserexpandDerEquation(shared=shared_arr), vars);
         (_, vars) := BackendEquation.traverseEquationArray_WithUpdate(inieqns, function traverserexpandDerEquation(shared=shared_arr), vars);
+        // A side-effect-only when-equation is a removed equation, but its
+        // condition is still evaluated.
+        (remeqns, vars) := BackendEquation.traverseEquationArray_WithUpdate(remeqns, function traverserexpandDerEquation(shared=shared_arr), vars);
+        syst.removedEqs := remeqns;
         syst.orderedVars := vars;
       then (syst, Mutable.access(shared_arr));
   end match;

--- a/testsuite/simulation/modelica/events/Makefile
+++ b/testsuite/simulation/modelica/events/Makefile
@@ -14,6 +14,7 @@ ChatteringEventsTest2.mos \
 CheckEvents.mos \
 cseOutsideNoEvent.mos \
 DelayZeroCrossing.mos \
+derInWhenCondition.mos \
 discreteRelations.mos \
 EventDelay.mos \
 EventIteration.mos \

--- a/testsuite/simulation/modelica/events/derInWhenCondition.mos
+++ b/testsuite/simulation/modelica/events/derInWhenCondition.mos
@@ -1,0 +1,50 @@
+// name: derInWhenCondition
+// keywords: when, der, zero crossing, index reduction
+// status: correct
+// teardown_command: rm -rf DerInWhenCondition* output.log
+//
+//  der() of an algebraic variable in the condition of a when-equation whose body
+//  only has side effects. Such a when-equation is a removed equation, but its
+//  condition is still evaluated, so the variable has to become a state and get a
+//  differentiated equation just as in any other equation.
+//
+
+loadString("
+model DerInWhenCondition
+  Real x(start = 0, fixed = true);
+  Real y;
+equation
+  der(x) = 1;
+  y = 2 * sin(x);
+  when der(y) < 0 then
+    assert(y < 100.0, \"y stays bounded\");
+  end when;
+end DerInWhenCondition;
+"); getErrorString();
+
+simulate(DerInWhenCondition, stopTime = 2.0, numberOfIntervals = 2, simflags = "-lv=LOG_EVENTS"); getErrorString();
+readSimulationResultVars("DerInWhenCondition_res.mat"); getErrorString();
+val(y, 2.0); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "DerInWhenCondition_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DerInWhenCondition', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
+//     messages = "LOG_EVENTS        | info    | status of relations at time=0
+// |                 | |       | | [1] (pre: false) false = $DER.y < 0.0
+// LOG_EVENTS        | info    | status of zero crossings at time=0
+// |                 | |       | | [1] (pre:  0) -1 = $DER.y < 0.0
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_EVENTS        | info    | state event at time=1.57079632684
+// |                 | |       | | [1] $DER.y < 0.0
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// {"der(x)", "der(y)", "time", "x", "y"}
+// ""
+// 1.8185948536513634
+// ""
+// endResult


### PR DESCRIPTION
A when-equation whose body only has side effects -- `assert`, `terminate`, `reinit` or a function call -- defines no variable, so `lowerWhenEqn2` puts it in the equation system's `removedEqs`. `expandDerOperator`, the pre-optimization module that expands `der(expr)` and marks the variables it finds as states, traversed only `orderedEqs` and `initialEqs`. A `der(x)` appearing solely in such a condition therefore left `x` an algebraic variable with no `$DER.x` anywhere.

The condition is still evaluated at run time, so code generation emitted a reference to a variable that does not exist. The C target produced C that does not compile,

    error: use of undeclared identifier '_omcQ_24DER'

and wasm-jit, which resolves every simulation reference to a slot,

    Internal error CodegenWasmJit: simulation reference to unknown
    variable `$DER.y`

`expandDerOperator` now traverses `removedEqs` as well, so the variable becomes a state and index reduction differentiates its equation, exactly as it already did when the same when-equation had a body that defines a variable.

Found on Dynawo master's `Examples.IEEE14.TestCases.IEEE14CLA`, whose current limit automaton has

    when tThresholdReached <> inf and tOrder == inf and der(IMonitored) < 0 then
      Constraint.logConstraintBeginData(...);
    end when;

That model gets past this error but not yet through the backend: making `IMonitored` a state pulls the network equations into index reduction and dynamic state selection then leaves one equation unmatched (`analyseStrongComponentBlock failed`), on both targets.

| test | before | after |
| --- | --- | --- |
| `events/derInWhenCondition` (new) | fail (both targets) | pass | | `simulation/modelica/daemode` | 13/13 | 13/13 |

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
