### PR TITLE
Clear the phase clocks when a translation starts

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1366,6 +1366,8 @@ protected
   String flatString = "", NFFlatString = "";
 
 algorithm
+  List.map_0({ClockIndexes.RT_CLOCK_FRONTEND,ClockIndexes.RT_CLOCK_BACKEND,
+              ClockIndexes.RT_CLOCK_SIMCODE,ClockIndexes.RT_CLOCK_TEMPLATES},System.realtimeClear);
   FlagsUtil.setConfigBool(Flags.BUILDING_MODEL, true);
 
   outLibs := {};


### PR DESCRIPTION
The RT_CLOCK_FRONTEND/BACKEND/SIMCODE/TEMPLATES clocks belong to the omc session, not to the command, and timerTock only reports -1 for a clock that was never ticked. A translation that failed in the frontend left BACKEND and the ones after it holding the tick of an earlier translation in the same session, so a caller that reads the clocks afterwards saw a phase that never ran as having run.

OpenModelicaLibraryTesting computes the phase durations as differences between these clocks, and reported

    Frontend  Backend  SimCode  Templates
       -0.02     0.01     0.01       0.01

for a model that failed in the frontend: the negative time is the gap between the two ticks, and everything after it is charged to a phase the model never reached.

buildModel already cleared the clocks it starts. Do the same in SimCodeMain.translateModel, which translateModel, simulate, translateModelFMU and buildModelFMU all go through.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
