### PR TITLE
wasm-jit: recover from an external ModelicaError

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -883,6 +883,13 @@ function(omc_rust_setup_codegen)
   if(RUST_OMC_LAPACK_NALGEBRA)
     list(APPEND _rust_omc_features openmodelica_util/lapack-nalgebra)
   endif()
+  # Run the wasm-jit simulations on wasmer rather than wasmtime: the web target's
+  # own host code (`sim_runtime_wasmer.rs`, the ModelicaExternalC side module),
+  # which is otherwise reachable only from a browser.
+  option(RUST_OMC_ENGINE_WASMER "Build the native omc with the wasmer wasm-jit host (the web target's) instead of wasmtime." OFF)
+  if(RUST_OMC_ENGINE_WASMER)
+    list(APPEND _rust_omc_features engine-wasmer)
+  endif()
   # --no-default-features makes sundials off by default; enable it only when
   # the wasm cross-compile is enabled.
   if(RUST_OMC_ENABLE_SUNDIALS)

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.toml
@@ -66,7 +66,7 @@ wasm-encoder = "0.252"
 # or wasmer — whose `js` backend is the only one that can JIT inside a
 # browser-wasm build of omc, and which can also be selected natively
 # (`--features engine-wasmer`) to benchmark against wasmtime.
-wasmtime = { version = "45", default-features = false, features = ["std", "cranelift", "runtime", "parallel-compilation"] }
+wasmtime = { version = "45", default-features = false, features = ["std", "cranelift", "runtime", "parallel-compilation", "gc", "gc-null"] }
 wasmer = { version = "7.2.0-alpha.3", default-features = false, features = ["std", "wat"] }
 openmodelica_wasm_jit = {path = "openmodelica_wasm_jit"}
 openmodelica_codegen_wasm_jit = {path = "openmodelica_codegen_wasm_jit"}

--- a/OMCompiler/Compiler/OpenModelica.rs/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/README.md
@@ -115,6 +115,11 @@ The nalgebra LAPACK fallback can also be exercised on a native Linux build with
 `openmodelica_util`/the cdylib with `--features lapack-nalgebra` (or run the
 testsuite against such a build) to validate it against system LAPACK.
 
+`-DRUST_OMC_ENGINE_WASMER=ON` runs the wasm-jit simulations on wasmer instead of
+wasmtime — the *web* target's host code (`sim_runtime_wasmer.rs`, external "C"
+through the ModelicaExternalC side module rather than a dynamic library), which
+is otherwise only reachable from a browser.
+
 ### Cross-compiling the C/C++ runtime too (`.cmake/xwin-toolchain.cmake`)
 
 The command above cross-compiles only the Rust omc; the C/C++ parts (3rdParty +

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -3896,6 +3896,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         );
         ext_type.push(ti);
     }
+    // `om_throw_model_error`'s type, shared with the `model_error` tag: a
+    // library's `ModelicaError` throws it and the `ext` call site catches it,
+    // C's `longjmp` out of a residual. Only a model with external "C" carries a
+    // tag — a module with one needs an engine that takes the exception-handling
+    // proposal.
+    let throw_fn_type = types.len();
+    types.ty().function([], []);
+    let error_tag_type = (!ext_imports.is_empty()).then_some(throw_fn_type);
     let mut model_fn_type: Vec<u32> = Vec::with_capacity(model_fns.len());
     for f in &model_fns {
         let (_, sig) = function_signature(f)?;
@@ -3981,6 +3989,9 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     // --- Compile bodies (collecting String literals into the module pool). ---
     let mut literals = Literals::default();
     let mut bodies: Vec<we::Function> = Vec::new();
+    // With a tag in the module, every `ext` call is lowered under a `try_table`
+    // (tag index 0: the module imports none).
+    crate::CodegenWasmJitFunctions::set_ext_error_catch(error_tag_type.map(|_| 0));
     // Model functions first, in index order; poll for cancellation between them so
     // a long emit is interruptible like the frontend/backend upstream.
     for f in &model_fns {
@@ -4420,6 +4431,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     }
 
     // --- Function section (type index per body, in body order). ---
+    crate::CodegenWasmJitFunctions::set_ext_error_catch(None);
+
     let mut functions = we::FunctionSection::new();
     for ti in &model_fn_type {
         functions.function(*ti);
@@ -4529,6 +4542,20 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     } else {
         None
     };
+    // The throw a host-free `rt_ext_error` reaches for, rustc emitting none for a
+    // wasm target. Always exported, whatever the model does: the runtime module is
+    // prebuilt and its import cannot be conditional.
+    let throw_fn = import_base + bodies.len() as u32;
+    {
+        let mut f = we::Function::new([]);
+        f.instruction(&match error_tag_type {
+            Some(_) => we::Instruction::Throw(0),
+            None => we::Instruction::Unreachable,
+        });
+        f.instruction(&we::Instruction::End);
+        functions.function(throw_fn_type);
+        bodies.push(f);
+    }
     if nls_wiring.is_some() || !thunk_indices.is_empty() {
         imports.import("rt", "__indirect_function_table", we::EntityType::Table(we::TableType {
             element_type: we::RefType::FUNCREF,
@@ -4548,6 +4575,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     // --- Exports: the equation functions (for the host-driven driver) and
     // `simulate` (for the in-wasm driver). ---
     let mut exports = we::ExportSection::new();
+    if error_tag_type.is_some() {
+        // Exported for the host to throw with; caught here whoever throws, so the
+        // tag itself never crosses a module boundary.
+        exports.export("model_error", we::ExportKind::Tag, 0);
+    }
+    exports.export("om_throw_model_error", we::ExportKind::Func, throw_fn);
     exports.export("functionParameters", we::ExportKind::Func, eqfn.parameters);
     exports.export("functionInitialEquations", we::ExportKind::Func, eqfn.initial);
     exports.export("functionInitStartValues", we::ExportKind::Func, eqfn.init_start_values);
@@ -4661,6 +4694,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     module.section(&types);
     module.section(&imports);
     module.section(&functions);
+    if let Some(ti) = error_tag_type {
+        let mut tags = we::TagSection::new();
+        tags.tag(we::TagType { kind: we::TagKind::Exception, func_type_idx: ti });
+        module.section(&tags);
+    }
     // Global + Start + Element sections (in the canonical order) carry the
     // shared-table wiring (NLS callbacks and/or closure thunks) and the
     // shared-literal objects.
@@ -8012,6 +8050,7 @@ mod link_tests {
         );
         // 4: (i32,i32)->()  (functionUpdateSynchronous / functionEquationsSynchronous)
         types.ty().function([we::ValType::I32, we::ValType::I32], []);
+        types.ty().function([], []); // 5: ()->()      (om_throw_model_error)
         m.section(&types);
 
         let mut imports = we::ImportSection::new();
@@ -8051,6 +8090,7 @@ mod link_tests {
         funcs.function(3); // simulate
         funcs.function(4); // functionUpdateSynchronous
         funcs.function(4); // functionEquationsSynchronous
+        funcs.function(5); // om_throw_model_error
         m.section(&funcs);
 
         // Defined-func indices start at 1 (rt_alloc is import 0).
@@ -8072,6 +8112,7 @@ mod link_tests {
             we::ExportKind::Func,
             meta_ptr_idx + 4,
         );
+        exports.export("om_throw_model_error", we::ExportKind::Func, meta_ptr_idx + 5);
         m.section(&exports);
 
         let mut code = we::CodeSection::new();
@@ -8104,6 +8145,11 @@ mod link_tests {
         let mut sync_eqs = we::Function::new([]);
         sync_eqs.instruction(&I::End);
         code.function(&sync_eqs);
+        // om_throw_model_error(): the emitter's no-external-"C" body.
+        let mut throw = we::Function::new([]);
+        throw.instruction(&I::Unreachable);
+        throw.instruction(&I::End);
+        code.function(&throw);
         m.section(&code);
 
         m.finish()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/native_fmu.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/native_fmu.rs
@@ -97,12 +97,15 @@ pub fn available() -> Vec<String> {
 pub fn precompile(component: &[u8], p: &Platform) -> Result<Vec<u8>> {
     let mut cfg = wasmtime::Config::new();
     cfg.wasm_component_model(true);
+    // A model with external "C" carries the `model_error` tag its call sites catch.
+    cfg.wasm_exceptions(true);
     cfg.target(p.triple).map_err(|_| "CodegenWasmJit: unknown target for the FMU platform")?;
     let engine = wasmtime::Engine::new(&cfg)
         .map_err(|_| "CodegenWasmJit: cannot configure the FMU cross-compiler")?;
-    engine
-        .precompile_component(component)
-        .map_err(|_| "CodegenWasmJit: cannot compile the component for the FMU platform")
+    engine.precompile_component(component).map_err(|e| {
+        super::record_error(format!("CodegenWasmJit: compiling the FMU for {}: {e:#}", p.fmi));
+        "CodegenWasmJit: cannot compile the component for the FMU platform"
+    })
 }
 
 /// Nothing to announce: this omc compiles in process.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -304,6 +304,10 @@ pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_row_asserts", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_reinit_note", &[WTy::I32, WTy::F64], &[]),
     ("rt_uri_to_filename", &[WTy::I32, WTy::I32], &[WTy::I32]),
+    // Give the external "C" libraries their shadow stack back after a throw
+    // abandoned their frames — the epilogues that would have done it never ran.
+    ("rt_ext_stack_save", &[], &[WTy::I32]),
+    ("rt_ext_stack_restore", &[WTy::I32], &[]),
 ];
 
 /// Absolute wasm function index of an `ENV_EXTRA` import (after the `BUILTINS`
@@ -1564,7 +1568,10 @@ impl<'a> FnCtx<'a> {
         // Track structured-control nesting so `break`/`continue` can compute their
         // relative branch depth. `Else` keeps the same frame; `End` closes one.
         match i {
-            we::Instruction::Block(_) | we::Instruction::Loop(_) | we::Instruction::If(_) => {
+            we::Instruction::Block(_)
+            | we::Instruction::Loop(_)
+            | we::Instruction::If(_)
+            | we::Instruction::TryTable(..) => {
                 self.ctrl_depth += 1;
             }
             we::Instruction::End => {
@@ -2590,6 +2597,18 @@ pub(crate) fn with_shared_externals<T>(f: impl FnOnce() -> T) -> T {
     r
 }
 
+thread_local! {
+    /// The `model_error` tag, while lowering a module that catches an external
+    /// `ModelicaError` rather than letting it trap. Unset for the `-d=gen`
+    /// function JIT, which has no solver to recover into.
+    static EXT_ERROR_CATCH: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
+}
+
+/// Lower `ext` calls under a `try_table` for `tag` until unset again.
+pub(crate) fn set_ext_error_catch(tag: Option<u32>) {
+    EXT_ERROR_CATCH.with(|c| c.set(tag));
+}
+
 fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Exp>], arg_types: &[SigTy]) -> Result<Vec<SigTy>> {
     let key = format!("ext.{ext_name}");
     let (index, params, results) = match ctx.by_name.get(&key) {
@@ -2599,6 +2618,22 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
     if args.len() != params.len() {
         return Err("CodegenWasmJit: external input argument count mismatch");
     }
+    let catch = EXT_ERROR_CATCH.with(|c| c.get());
+    let mut temps: Vec<u32> = Vec::new();
+    let mut saved_stack = 0;
+    if let Some(tag) = catch {
+        temps = results.iter().map(|r| ctx.alloc_temp(r.wty())).collect();
+        saved_stack = ctx.alloc_temp(WTy::I32);
+        ctx.emit(we::Instruction::Call(env_extra_index("rt_ext_stack_save")?));
+        ctx.emit(we::Instruction::LocalSet(saved_stack));
+        ctx.emit(we::Instruction::Block(we::BlockType::Empty)); // done
+        ctx.emit(we::Instruction::Block(we::BlockType::Result(we::ValType::EXNREF))); // handler
+        ctx.emit(we::Instruction::TryTable(
+            we::BlockType::Empty,
+            vec![we::Catch::OneRef { tag, label: 0 }].into(),
+        ));
+    }
+
     let shared = EXTERNALS_SHARED.with(|c| c.get());
     for ((a, p), sty) in args.iter().zip(params.iter()).zip(arg_types.iter()) {
         let w = compile_exp(ctx, a)?;
@@ -2615,6 +2650,31 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
         }
     }
     ctx.emit(we::Instruction::Call(index));
+    if catch.is_some() {
+        // Out of the `try_table` region: the results travel through locals so every
+        // block here is empty-typed but the one the caught `exnref` lands in.
+        for t in temps.iter().rev() {
+            ctx.emit(we::Instruction::LocalSet(*t));
+        }
+        ctx.emit(we::Instruction::End); // try_table
+        ctx.emit(we::Instruction::Br(1)); // done
+        ctx.emit(we::Instruction::End); // handler: the exception is on the stack
+        ctx.emit(we::Instruction::Call(rt_index("rt_nls_recovering")?));
+        ctx.emit(we::Instruction::If(we::BlockType::Empty));
+        ctx.emit(we::Instruction::LocalGet(saved_stack));
+        ctx.emit(we::Instruction::Call(env_extra_index("rt_ext_stack_restore")?));
+        ctx.emit(we::Instruction::Call(rt_index("rt_nls_note_assert")?));
+        release_heap_locals(ctx)?;
+        push_outputs(ctx);
+        ctx.emit(we::Instruction::Return);
+        ctx.emit(we::Instruction::End); // if
+        // Not inside a residual: a `ModelicaError` ends the run, as in C.
+        ctx.emit(we::Instruction::ThrowRef);
+        ctx.emit(we::Instruction::End); // done
+        for t in &temps {
+            ctx.emit(we::Instruction::LocalGet(*t));
+        }
+    }
     Ok(results)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -130,6 +130,7 @@ fn define_external_imports(
         alloc: wt(rt_inst.get_typed_func(&mut *store, "rt_alloc"))?,
         free: wt(rt_inst.get_typed_func(&mut *store, "rt_free"))?,
         record_new: wt(rt_inst.get_typed_func(&mut *store, "rt_record_new"))?,
+        nls: None,
     };
     let mut libs = Vec::with_capacity(sig.libs.len() + 1);
     let libc = openmodelica_wasi_libc::LIBC_PIC;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtNlsRecovery.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtNlsRecovery.mo
@@ -1,0 +1,50 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// A ModelicaError inside a nonlinear-solver residual is a rejected trial, not the
+// end of the run. The raising function is ModelicaExternalC's, unlike testsuite
+// ExternalNlsRecovery's, so this is the web target's error path: the side module.
+// The first Newton step overshoots far past u_max = 2 (the slope at the start
+// point is 1/1000 of the one at the root), where NoExtrapolation refuses.
+// Root: y = 0.001 + 0.999*(u - 1) = 0.5 + 0.4*time, i.e. u = 1.4995 .. 1.8999.
+model TestExtNlsRecovery
+  Modelica.Blocks.Tables.CombiTable1Ds tab(
+    table = [0, 0; 1, 0.001; 2, 1],
+    extrapolation = Modelica.Blocks.Types.Extrapolation.NoExtrapolation);
+  Real x(start = 0.5);
+equation
+  tab.u = x;
+  tab.y[1] = 0.5 + 0.4 * time;
+end TestExtNlsRecovery;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtTableError.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestExtTableError.mo
@@ -1,0 +1,45 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// The same error outside a residual: fatal. u = time leaves the table at t > 2,
+// and the message is a ModelicaFormatError, `%lf`-interpolated in the side module.
+model TestExtTableError
+  Modelica.Blocks.Tables.CombiTable1Ds tab(
+    table = [0, 0; 1, 1; 2, 4],
+    extrapolation = Modelica.Blocks.Types.Extrapolation.NoExtrapolation);
+  Real y = tab.y[1];
+equation
+  tab.u = time;
+end TestExtTableError;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extnlsrecovery.mos
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_extnlsrecovery.mos
@@ -1,0 +1,12 @@
+// Recovering from an external "C" ModelicaError under wasm-jit: rejected trial
+// inside the solver, fatal outside it.
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadModel(Modelica); getErrorString();
+
+loadFile("TestExtNlsRecovery.mo"); getErrorString();
+simulate(TestExtNlsRecovery, stopTime = 1.0, numberOfIntervals = 2); getErrorString();
+val(x, 0.0); // 1.4995
+val(x, 1.0); // 1.8999
+
+loadFile("TestExtTableError.mo"); getErrorString();
+simulate(TestExtTableError, stopTime = 3.0, numberOfIntervals = 3); getErrorString();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -37,6 +37,8 @@
 // driver / `write_mat4` / `_start` to do file I/O over WASI — so std is left
 // enabled there, and the custom panic handler (std provides one) is dropped.
 #![cfg_attr(all(not(target_os = "wasi"), not(test)), no_std)]
+// `global_asm!` on wasm32, for the two shadow-stack accessors below.
+#![feature(asm_experimental_arch)]
 
 extern crate alloc;
 
@@ -114,6 +116,29 @@ mod reinit_notes {
 #[cfg(not(feature = "host_log"))]
 pub use reinit_notes::take_reinit_notes;
 
+// `rt_ext_stack_save` / `rt_ext_stack_restore`: an external "C" call site saves
+// the shadow stack before the call and hands it back if a `ModelicaError` threw
+// out of it — the abandoned frames' epilogues never ran. `__stack_pointer` is
+// the linker's own global, which no Rust expression reaches. Same rule as
+// `rt_reinit_note`: with a host present the host binds both instead.
+#[cfg(all(target_arch = "wasm32", not(feature = "host_log")))]
+core::arch::global_asm!(
+    ".globaltype __stack_pointer, i32",
+    ".globl rt_ext_stack_save",
+    ".export_name rt_ext_stack_save, rt_ext_stack_save",
+    "rt_ext_stack_save:",
+    ".functype rt_ext_stack_save () -> (i32)",
+    "global.get __stack_pointer",
+    "end_function",
+    ".globl rt_ext_stack_restore",
+    ".export_name rt_ext_stack_restore, rt_ext_stack_restore",
+    "rt_ext_stack_restore:",
+    ".functype rt_ext_stack_restore (i32) -> ()",
+    "local.get 0",
+    "global.set __stack_pointer",
+    "end_function",
+);
+
 // `rt_uri_to_filename`: same rule as `rt_reinit_note` — a host binds its own
 // resolver (which has the class directories); a host-free module resolves it here.
 #[cfg(not(feature = "host_log"))]
@@ -135,10 +160,24 @@ mod ext_report {
         unsafe { core::ffi::CStr::from_ptr(p as *const core::ffi::c_char) }.to_str().unwrap_or("")
     }
 
-    /// C's `throwStreamPrint(NULL, …)`, then `MMC_THROW`'s end of the run.
+    // The model module's `throw`, which rustc emits for no wasm target: merged
+    // as `model` into the standalone module, resolved through `env` by the FMU's
+    // shared-everything linker. Always exported by the emitter — with an
+    // `unreachable` body when the model has no external "C" to throw for.
+    #[cfg_attr(target_os = "wasi", link(wasm_import_module = "model"))]
+    #[cfg_attr(not(target_os = "wasi"), link(wasm_import_module = "env"))]
+    unsafe extern "C" {
+        fn om_throw_model_error();
+    }
+
+    /// C's `throwStreamPrint(NULL, …)`, then `MMC_THROW` — which a nonlinear
+    /// solver catches, so a trial it will reject leaves no message behind.
     #[unsafe(no_mangle)]
     pub extern "C" fn rt_ext_error(msg: u32) {
-        driver::note_runtime_error(cstr(msg));
+        if crate::nls::rt_nls_recovering() == 0 {
+            driver::note_runtime_error(cstr(msg));
+        }
+        unsafe { om_throw_model_error() };
         crate::trap()
     }
 
@@ -159,6 +198,43 @@ mod ext_report {
 #[cfg(feature = "host_log")]
 pub fn take_reinit_notes() -> alloc::vec::Vec<(u32, f64)> {
     alloc::vec::Vec::new()
+}
+
+// `rt_ext_error` with a host present: the message lives in the side module's own
+// memory, so the host reports it, but the throw must stay in wasm (an unwind
+// through a host frame loses the exception) and reaches the model's
+// `om_throw_model_error` through the shared table.
+#[cfg(all(target_arch = "wasm32", feature = "host_log"))]
+mod ext_report_hosted {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    #[link(wasm_import_module = "env")]
+    unsafe extern "C" {
+        fn rt_host_ext_error(msg: u32);
+    }
+
+    /// The model's thrower; 0 (wasm-lld's null slot) is unset, as in the `-d=gen`
+    /// function JIT, which instantiates no model.
+    static THROW_SLOT: AtomicU32 = AtomicU32::new(0);
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn rt_set_ext_throw(slot: u32) {
+        THROW_SLOT.store(slot, Ordering::Relaxed);
+    }
+
+    /// C's `throwStreamPrint(NULL, …)` then `MMC_THROW`; see `ext_report`'s.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn rt_ext_error(msg: u32) {
+        if crate::nls::rt_nls_recovering() == 0 {
+            unsafe { rt_host_ext_error(msg) };
+        }
+        let slot = THROW_SLOT.load(Ordering::Relaxed);
+        if slot != 0 {
+            let throw: extern "C" fn() = unsafe { core::mem::transmute(slot as usize) };
+            throw();
+        }
+        crate::trap()
+    }
 }
 
 // The standalone-export entry point (`_start` + the in-wasm driver), only on the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -277,11 +277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "openmodelica_mat_writer"
+version = "0.1.0"
+
+[[package]]
 name = "openmodelica_sim_meta"
 version = "0.1.0"
 dependencies = [
  "daskr",
  "libm",
+ "openmodelica_mat_writer",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_aot/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_aot/src/lib.rs
@@ -64,6 +64,8 @@ pub extern "C" fn aot_result_len() -> usize {
 fn compile(component: &[u8], triple: &str) -> Result<Vec<u8>, String> {
     let mut cfg = wasmtime::Config::new();
     cfg.wasm_component_model(true);
+    // Must match the loader's engine (see openmodelica_fmi_ls_wasm_to_native).
+    cfg.wasm_exceptions(true);
     cfg.target(triple).map_err(|e| format!("unknown target `{triple}`: {e}"))?;
     let engine = wasmtime::Engine::new(&cfg).map_err(|e| format!("engine: {e}"))?;
     engine.precompile_component(component).map_err(|e| format!("compiling for {triple}: {e}"))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
@@ -285,6 +285,9 @@ const PLATFORM: &str = {
 fn engine() -> wasmtime::Result<Engine> {
     let mut cfg = Config::new();
     cfg.wasm_component_model(true);
+    // A model with external "C" carries the `model_error` tag its call sites catch.
+    // The exporter's engine must agree, or the `.cwasm` it precompiled is rejected.
+    cfg.wasm_exceptions(true);
     Engine::new(&cfg)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/external_c_callbacks.c
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/external_c_callbacks.c
@@ -32,7 +32,11 @@
  * memory, an allocated string is a plain pointer the model reads directly — no
  * marshalling. They report through the runtime, as
  * `SimulationRuntime/c/util/ModelicaUtilities.c` does: an FMU has no stdout, and
- * its simulation log is the FMI logger. An error ends the run (C's MMC_THROW). */
+ * its simulation log is the FMI logger. An error ends the run (C's MMC_THROW).
+ *
+ * `OM_EXT_HOST_ALLOC`: the web build's side module has a memory of its own, so
+ * the host allocates the returned strings and records the offsets it frees after
+ * copying them out. Everything else here is the same on both. */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -46,6 +50,7 @@ void rt_ext_warning(const char* msg);
 /* C's SIZE_LOG_BUFFER, and the same truncation. */
 #define LOG_BUFFER 2048
 
+#ifndef OM_EXT_HOST_ALLOC
 char* ModelicaAllocateString(size_t len) {
     char* p = (char*) malloc(len + 1);
     if (p) p[len] = '\0';
@@ -55,6 +60,7 @@ char* ModelicaAllocateString(size_t len) {
 char* ModelicaAllocateStringWithErrorReturn(size_t len) {
     return ModelicaAllocateString(len);
 }
+#endif
 
 static void report(void (*to)(const char*), const char* fmt, va_list ap) {
     char buf[LOG_BUFFER];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -559,19 +559,26 @@ fn build_dylink_adapter(adapter_dir: &Path, out_dir: &Path, v: &AdapterVariant) 
 
 /// The `env` imports `sim_runtime_wasmer::define_external_imports` binds. Any other
 /// undefined symbol is a link error, see `build_external_c_wasm`.
+///
+/// The `Modelica*` entry points are not among them: the side module carries
+/// `external_c_callbacks.c`, the same one an FMU links, so a `%g` is interpolated
+/// by `vsnprintf` before the host ever sees the message. Only allocation stays
+/// host-side (`OM_EXT_HOST_ALLOC`) — the buffer lives in the side module's own
+/// memory and the trampoline frees it after copying it out.
 const HOST_PROVIDED: &[&str] = &[
-    "ModelicaError",
-    "ModelicaFormatError",
-    "ModelicaFormatMessage",
-    "ModelicaFormatWarning",
-    "ModelicaVFormatError",
-    "ModelicaVFormatWarning",
+    "rt_ext_error",
+    "rt_ext_message",
+    "rt_ext_warning",
     "ModelicaAllocateString",
     "ModelicaAllocateStringWithErrorReturn",
     "ModelicaInternal_getTime",
     "ModelicaInternal_getpid",
     "usertab",
 ];
+
+/// `--export-all` keeps older MSL compatibility entry points present, but exports
+/// functions only — hence `__stack_pointer`, which the recovery path restores.
+const EXTRA_LINK_ARGS: &[&str] = &["-Wl,--export-all", "-Wl,--export=__stack_pointer"];
 
 /// Build + embed the ModelicaExternalC WASI side module (`modelicaexternalc.wasm`)
 /// for the web (wasmer) simulation host. Provides `ext.Modelica*_*` external functions
@@ -598,6 +605,7 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
         .expect("OMC_EXTERNAL_C_SOURCES not set (CMake provides it)");
 
     let stubs = crate_dir.join("external_c_stubs.c");
+    let callbacks = crate_dir.join("../openmodelica_wasi_libc/external_c_callbacks.c");
     let sources = [
         "ModelicaStandardTables.c", "ModelicaStrings.c", "ModelicaRandom.c",
         "ModelicaIO.c", "ModelicaMatIO.c", "snprintf.c",
@@ -606,6 +614,7 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     let src_paths: Vec<PathBuf> = sources.iter().map(|s| c_sources.join(s)).collect();
 
     println!("cargo:rerun-if-changed={}", stubs.display());
+    println!("cargo:rerun-if-changed={}", callbacks.display());
     for src in &src_paths {
         println!("cargo:rerun-if-changed={}", src.display());
     }
@@ -634,12 +643,13 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     let hash = {
         let mut h: u64 = 0xcbf29ce484222325;
         let mut mix = |bytes: &[u8]| for &byte in bytes { h ^= byte as u64; h = h.wrapping_mul(0x100000001b3); };
-        for f in all_srcs.iter().copied().chain(std::iter::once(&stubs)) {
+        for f in all_srcs.iter().copied().chain([&stubs, &callbacks]) {
             if let Ok(b) = std::fs::read(f) { mix(&b); }
         }
         mix(clang.as_bytes());
         mix(sysroot.as_bytes());
         for s in HOST_PROVIDED { mix(s.as_bytes()); }
+        for s in EXTRA_LINK_ARGS { mix(s.as_bytes()); }
         format!("{h:016x}")
     };
     if dest.exists() && std::fs::metadata(&dest).map(|m| m.len() > 0).unwrap_or(false)
@@ -647,9 +657,8 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
         return;
     }
 
-    // `--export-all`: export every symbol so older MSL compatibility entry points
-    // are always present. `-mexec-model=reactor`: exports `_initialize` (runs ctors),
-    // no `_start`. `-nodefaultlibs` means `-lc` has to be explicit.
+    // `-mexec-model=reactor`: exports `_initialize` (runs ctors), no `_start`.
+    // `-nodefaultlibs` means `-lc` has to be explicit.
     //
     // `--allow-undefined-file` rather than blanket `--allow-undefined`: a sysroot that
     // fails to provide libc must be a link error, not a module whose `malloc`/`strlen`/
@@ -661,15 +670,15 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
     }).unwrap_or_else(|e| panic!("{e}"));
     let mut cmd = Command::new(&clang);
     cmd.args(["--target=wasm32-wasip1", "-O2", "-mexec-model=reactor",
-               "-nodefaultlibs", "-DNO_MUTEX", "-DHAVE_ZLIB",
+               "-nodefaultlibs", "-DNO_MUTEX", "-DHAVE_ZLIB", "-DOM_EXT_HOST_ALLOC",
                "-Wno-error=implicit-function-declaration"])
         .arg(format!("--sysroot={sysroot}"))
         .arg("-I").arg(&c_sources)
         .arg("-I").arg(&zlib_dir)
-        .args(&all_srcs).arg(&stubs)
+        .args(&all_srcs).arg(&stubs).arg(&callbacks)
         .arg("-lc")
         .arg(&builtins)
-        .arg("-Wl,--export-all")
+        .args(EXTRA_LINK_ARGS)
         .arg(format!("-Wl,--allow-undefined-file={}", permit.display()))
         .arg("-o").arg(&dest);
     let what = format!("{clang} (modelicaexternalc.wasm, --target=wasm32-wasip1, sysroot {sysroot})");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -28,11 +28,18 @@ pub struct Loaded {
     data: HashMap<String, u32>,
     func_slots: HashMap<String, u32>,
     table: Table,
+    /// The libraries' shared shadow stack: after a `ModelicaError` unwound their
+    /// frames the epilogues that would have handed it back never ran, so the
+    /// model's recovery path restores what it saved (`rt_ext_stack_restore`).
+    stack_pointer: Option<Global>,
 }
 
 impl Loaded {
     pub fn func(&self, name: &str) -> Option<&Func> {
         self.funcs.get(name)
+    }
+    pub fn shadow_stack(&self) -> Option<Global> {
+        self.stack_pointer
     }
 }
 
@@ -69,6 +76,7 @@ pub fn load(
         data: HashMap::new(),
         func_slots: HashMap::new(),
         table,
+        stack_pointer: None,
     };
     if libs.is_empty() {
         return Ok(loaded);
@@ -86,6 +94,7 @@ pub fn load(
         Val::I32((stack + SIDE_STACK_SIZE) as i32),
     )
     .map_err(|e| format!("dylink: cannot create __stack_pointer: {e}"))?;
+    loaded.stack_pointer = Some(stack_pointer);
     loaded.data.insert("__stack_low".to_string(), stack);
     loaded.data.insert("__stack_high".to_string(), stack + SIDE_STACK_SIZE);
     // An empty initial dlmalloc segment: every allocation then comes from `sbrk`,
@@ -520,6 +529,7 @@ mod tests {
             alloc: alloc.clone(),
             free: rt_inst.get_typed_func(&mut store, "rt_free").unwrap(),
             record_new: rt_inst.get_typed_func(&mut store, "rt_record_new").unwrap(),
+            nls: None,
         };
         let sig = ExtCallSig {
             name: "triple".into(),
@@ -632,16 +642,19 @@ pub fn modelica_utilities_imports(
     use wasmtime::{Caller, Func};
     let mut m: HashMap<String, Func> = HashMap::new();
 
-    let error = |mut caller: Caller<'_, WasiCtx>, ptr: i32| -> std::result::Result<(), wasmtime::Error> {
-        let msg = shared_cstr(&mut caller, ptr);
-        openmodelica_error::ErrorExt::runtime_error(&msg);
-        Err(wasmtime::Error::msg(format!("ModelicaError: {msg}")))
-    };
-    let error_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| -> std::result::Result<(), wasmtime::Error> {
-        let msg = shared_cstr(&mut caller, fmt);
-        openmodelica_error::ErrorExt::runtime_error(&msg);
-        Err(wasmtime::Error::msg(format!("ModelicaError: {msg}")))
-    };
+    let nls = rt.nls.clone();
+    let err_fn = |store: &mut wasmtime::Store<WasiCtx>, nls: Option<NlsHooks>| Func::wrap(
+        store,
+        move |mut caller: Caller<'_, WasiCtx>, ptr: i32| -> std::result::Result<(), wasmtime::Error> {
+            raise_model_error(&nls, &mut caller, ptr)
+        },
+    );
+    let err_fmt_fn = |store: &mut wasmtime::Store<WasiCtx>, nls: Option<NlsHooks>| Func::wrap(
+        store,
+        move |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| -> std::result::Result<(), wasmtime::Error> {
+            raise_model_error(&nls, &mut caller, fmt)
+        },
+    );
     let warning = |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
         let msg = shared_cstr(&mut caller, ptr);
         openmodelica_error::ErrorExt::runtime_warning(&msg);
@@ -660,9 +673,9 @@ pub fn modelica_utilities_imports(
         openmodelica_wasi::wasi::stdout_write(msg.as_bytes());
     };
 
-    m.insert("ModelicaError".into(), Func::wrap(&mut *store, error));
-    m.insert("ModelicaFormatError".into(), Func::wrap(&mut *store, error_fmt));
-    m.insert("ModelicaVFormatError".into(), Func::wrap(&mut *store, error_fmt));
+    m.insert("ModelicaError".into(), err_fn(&mut *store, nls.clone()));
+    m.insert("ModelicaFormatError".into(), err_fmt_fn(&mut *store, nls.clone()));
+    m.insert("ModelicaVFormatError".into(), err_fmt_fn(&mut *store, nls));
     m.insert("ModelicaWarning".into(), Func::wrap(&mut *store, warning));
     m.insert("ModelicaFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
     m.insert("ModelicaVFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
@@ -696,6 +709,76 @@ pub struct ExtRt {
     pub alloc: wasmtime::TypedFunc<u32, u32>,
     pub free: wasmtime::TypedFunc<u32, ()>,
     pub record_new: wasmtime::TypedFunc<(u32, u32), u32>,
+    /// A run's solver state; the `-d=gen` function JIT has no solver.
+    pub nls: Option<NlsHooks>,
+}
+
+/// The runtime's recoverable-model-error state, reached from the host so an
+/// external "C" `ModelicaError` inside a residual backs the trial off.
+#[derive(Clone)]
+pub struct NlsHooks {
+    pub recovering: wasmtime::TypedFunc<(), i32>,
+    pub note: wasmtime::TypedFunc<(), ()>,
+}
+
+impl NlsHooks {
+    pub fn recovering(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> std::result::Result<bool, wasmtime::Error> {
+        Ok(self.recovering.call(&mut *caller, ())? != 0)
+    }
+    pub fn note(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> std::result::Result<(), wasmtime::Error> {
+        self.note.call(&mut *caller, ())
+    }
+}
+
+/// End the call the way C's `throwStreamPrint` does: with the model's
+/// `model_error` tag, which the `ext` call site catches — inside a residual to
+/// reject the trial, outside one to end the run (so only then is the message
+/// worth reporting). With no tag registered (the `-d=gen` function JIT, whose
+/// module has no solver to recover into) it stays a trap.
+fn raise_model_error(
+    nls: &Option<NlsHooks>,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    ptr: i32,
+) -> std::result::Result<(), wasmtime::Error> {
+    let recovering = match nls {
+        Some(nls) => nls.recovering(caller)?,
+        None => false,
+    };
+    if !recovering {
+        let msg = shared_cstr(caller, ptr);
+        // A run reports itself through its log alone, as C's separate executable
+        // does; the function JIT has no log and answers through the Error buffer.
+        match nls {
+            Some(_) => crate::sim_driver::note_runtime_error(&msg),
+            None => openmodelica_error::ErrorExt::runtime_error(&msg),
+        }
+    }
+    match crate::host::model_error_exception(caller)? {
+        Some(exn) => {
+            use wasmtime::AsContextMut;
+            caller.as_context_mut().throw::<()>(exn).map_err(wasmtime::Error::new)
+        }
+        None => Err(wasmtime::Error::msg(format!("ModelicaError: {}", shared_cstr(caller, ptr)))),
+    }
+}
+
+/// Zeroed results (an empty String for `char*`) after a recovered `ModelicaError`.
+/// The solver discards the residual they feed, but they must be valid handles.
+pub fn zero_results(
+    sig: &crate::sig::ExtCallSig,
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    rt_str_new: &wasmtime::TypedFunc<u32, u32>,
+    rets: &mut [wasmtime::Val],
+) -> std::result::Result<(), wasmtime::Error> {
+    use crate::sig::SigTy;
+    for (slot, ty) in rets.iter_mut().zip(sig.wasm_results()) {
+        *slot = match ty {
+            SigTy::Real => wasmtime::Val::F64(0.0f64.to_bits()),
+            SigTy::Str => wasmtime::Val::I32(rt_str_new.call(&mut *caller, 0)? as i32),
+            _ => wasmtime::Val::I32(0),
+        };
+    }
+    Ok(())
 }
 
 /// Whether the import is already exactly the C function, so the engine can call it
@@ -735,8 +818,12 @@ pub fn bind_in_wasm_external(
     let sig = sig.clone();
     let rt = rt.clone();
     let f = wasmtime::Func::new(&mut *store, functype.clone(), move |mut caller, args, rets| {
-        call_external_in_wasm(&sig, &rt, &target, &mut caller, args, rets)
-            .map_err(|e| wasmtime::Error::msg(format!("external \"C\" `{}`: {e}", sig.name)))
+        let mut thrown = None;
+        let r = call_external_in_wasm(&sig, &rt, &target, &mut caller, args, rets, &mut thrown);
+        match thrown {
+            Some(e) => Err(e),
+            None => r.map_err(|e| wasmtime::Error::msg(format!("external \"C\" `{}`: {e}", sig.name))),
+        }
     });
     Ok(Some(wasmtime::Extern::Func(f)))
 }
@@ -750,6 +837,7 @@ fn call_external_in_wasm(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
+    thrown: &mut Option<wasmtime::Error>,
 ) -> Result<()> {
     use crate::sig::SigTy;
     use wasmtime::Val;
@@ -933,7 +1021,16 @@ fn call_external_in_wasm(
     };
     let mut raw_ret = [Val::I32(0)];
     let ret_slice = if returns_value { &mut raw_ret[..] } else { &mut raw_ret[..0] };
-    target.call(&mut *caller, &call_args, ret_slice).map_err(|e| format!("{e}"))?;
+    if let Err(e) = target.call(&mut *caller, &call_args, ret_slice) {
+        // A `model_error` on its way to the model's `try_table` passes straight
+        // through: rewritten, the store's pending exception would never land.
+        if e.downcast_ref::<wasmtime::ThrownException>().is_some() {
+            *thrown = Some(e);
+            return Ok(());
+        }
+        // `{e:?}`: whatever ended the call is the trap's cause.
+        return Err(format!("{e:?}"));
+    }
 
     // C's `convert_alloc_*_from_f77`.
     for (cell, base, dims, esz, is_out) in &f77_arrays {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -203,6 +203,70 @@ mod sim_memory {
     }
 }
 
+/// The run's `model_error` tag, and the libraries' shadow stack that a caught
+/// throw leaves claimed. Both belong to the run's store, so they are registered
+/// after the model module is instantiated and cleared when the next run starts.
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+mod model_error {
+    use std::cell::RefCell;
+    use wasmtime::{AsContextMut, ExnRef, ExnRefPre, ExnType, Global, Rooted, Tag, Val};
+
+    thread_local! {
+        static TAG: RefCell<Option<(Tag, ExnRefPre)>> = const { RefCell::new(None) };
+        static STACK: RefCell<Option<Global>> = const { RefCell::new(None) };
+    }
+
+    /// `None` clears it — a store outlives neither the run nor its tag.
+    pub fn set_tag(mut store: impl AsContextMut, tag: Option<Tag>) -> Result<(), wasmtime::Error> {
+        let entry = match tag {
+            Some(tag) => {
+                let ty = ExnType::from_tag_type(&tag.ty(&store.as_context_mut()))?;
+                Some((tag, ExnRefPre::new(&mut store, ty)))
+            }
+            None => None,
+        };
+        TAG.with(|t| *t.borrow_mut() = entry);
+        Ok(())
+    }
+
+    pub fn set_shadow_stack(s: Option<Global>) {
+        STACK.with(|c| *c.borrow_mut() = s);
+    }
+
+    /// A fresh exception object to throw, when this run catches them at all.
+    pub fn exception(
+        store: &mut impl AsContextMut,
+    ) -> Result<Option<Rooted<ExnRef>>, wasmtime::Error> {
+        TAG.with(|t| match t.borrow().as_ref() {
+            Some((tag, pre)) => ExnRef::new(&mut *store, pre, tag, &[]).map(Some),
+            None => Ok(None),
+        })
+    }
+
+    /// `rt.rt_ext_stack_save`: the libraries' shadow stack, which the module's own
+    /// (`__stack_pointer` in the runtime) is not — they are separate instances here.
+    pub fn save_shadow_stack(mut store: impl AsContextMut) -> Result<i32, wasmtime::Error> {
+        match STACK.with(|c| *c.borrow()) {
+            Some(g) => Ok(g.get(&mut store).i32().unwrap_or(0)),
+            None => Ok(0),
+        }
+    }
+
+    /// `rt.rt_ext_stack_restore`.
+    pub fn restore_shadow_stack(mut store: impl AsContextMut, sp: i32) -> Result<(), wasmtime::Error> {
+        if let Some(g) = STACK.with(|c| *c.borrow()) {
+            g.set(&mut store, Val::I32(sp))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub use model_error::{
+    exception as model_error_exception, restore_shadow_stack, save_shadow_stack, set_shadow_stack,
+    set_tag as set_model_error_tag,
+};
+
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub use sim_memory::set as set_sim_memory;
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
@@ -378,8 +442,23 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32| -> i32 {
         assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only, initial)
     }))?;
+    wt(linker.func_wrap("rt", "rt_ext_stack_save", |mut caller: wasmtime::Caller<'_, T>| -> std::result::Result<i32, wasmtime::Error> {
+        save_shadow_stack(&mut caller)
+    }))?;
+    wt(linker.func_wrap("rt", "rt_ext_stack_restore", |mut caller: wasmtime::Caller<'_, T>, sp: i32| -> std::result::Result<(), wasmtime::Error> {
+        restore_shadow_stack(&mut caller, sp)
+    }))?;
     wt(linker.func_wrap("rt", "rt_assert_warning", |cond: i32, msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, initial: i32| {
         record_warning([openmodelica_sim_meta::driver::ASSERT_WARNING, cond, msg, file, sline, scol, eline, ecol, read_only, initial]);
+    }))?;
+    // Where the runtime's `rt_ext_error` reports. Unused on this engine, whose
+    // libraries import `ModelicaError` from the host, which throws for itself.
+    wt(linker.func_wrap("env", "rt_host_ext_error", |caller: wasmtime::Caller<'_, T>, msg: u32| {
+        let Some(memory) = sim_memory::get() else { return };
+        let data = memory.data(&caller);
+        let Some(rest) = data.get(msg as usize..) else { return };
+        let len = rest.iter().position(|&b| b == 0).unwrap_or(0);
+        openmodelica_sim_meta::driver::note_runtime_error(&String::from_utf8_lossy(&rest[..len]));
     }))?;
     wt(linker.func_wrap("rt", "rt_reinit_note", |off: i32, value: f64| record_reinit(off as u32, value)))?;
     wt(linker.func_wrap(
@@ -514,15 +593,30 @@ fn read_wasm_string<T>(memory: wasmtime::Memory, caller: &wasmtime::Caller<'_, T
     data.get(h + 8..h + 8 + len).map(|b| String::from_utf8_lossy(b).into_owned()).unwrap_or_default()
 }
 
-/// The runtime's memory, handed to the wasmer host builtins by [`HostMem::set`]
-/// once the instance exists; the imports have to be defined before it.
+/// What the wasmer host builtins read, filled in once the instances exist (the
+/// imports have to be defined before them).
 #[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
-pub struct HostMem(wasmer::FunctionEnv<Option<wasmer::Memory>>);
+#[derive(Default)]
+pub struct HostEnv {
+    mem: Option<wasmer::Memory>,
+    /// The external "C" side module's own memory and shadow stack.
+    side_mem: Option<wasmer::Memory>,
+    side_sp: Option<wasmer::Global>,
+}
+
+#[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
+pub struct HostMem(wasmer::FunctionEnv<HostEnv>);
 
 #[cfg(all(feature = "jit", any(feature = "engine-wasmer", target_arch = "wasm32")))]
 impl HostMem {
     pub fn set(&self, store: &mut wasmer::Store, memory: &wasmer::Memory) {
-        *self.0.as_mut(store) = Some(memory.clone());
+        self.0.as_mut(store).mem = Some(memory.clone());
+    }
+    /// The ModelicaExternalC side module, once instantiated.
+    pub fn set_side(&self, store: &mut wasmer::Store, memory: &wasmer::Memory, sp: Option<wasmer::Global>) {
+        let env = self.0.as_mut(store);
+        env.side_mem = Some(memory.clone());
+        env.side_sp = sp;
     }
 }
 
@@ -539,16 +633,48 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         }));
     imports.define("rt", "rt_reinit_note", Function::new_typed(store,
         |off: i32, value: f64| record_reinit(off as u32, value)));
-    // Both memory-reading imports share one env, filled in by `HostMem::set`.
-    let mem_env = wasmer::FunctionEnv::new(store, None);
+    // The imports reading an instance share one env, filled in by `HostMem`.
+    let mem_env = wasmer::FunctionEnv::new(store, HostEnv::default());
+    // The side module's shadow stack, which the frames a throw abandoned never
+    // handed back.
+    imports.define(
+        "rt",
+        "rt_ext_stack_save",
+        Function::new_typed_with_env(store, &mem_env, |mut env: wasmer::FunctionEnvMut<HostEnv>| -> i32 {
+            match env.data().side_sp.clone() {
+                Some(g) => g.get(&mut env).i32().unwrap_or(0),
+                None => 0,
+            }
+        }),
+    );
+    imports.define(
+        "rt",
+        "rt_ext_stack_restore",
+        Function::new_typed_with_env(store, &mem_env, |mut env: wasmer::FunctionEnvMut<HostEnv>, sp: i32| {
+            if let Some(g) = env.data().side_sp.clone() {
+                let _ = g.set(&mut env, wasmer::Value::I32(sp));
+            }
+        }),
+    );
+    // A side-module `ModelicaError`: the runtime cannot read the message (other
+    // memory), so it reports through here before throwing — C's
+    // `throwStreamPrint`, into the run's log.
+    imports.define(
+        "env",
+        "rt_host_ext_error",
+        Function::new_typed_with_env(store, &mem_env, |env: wasmer::FunctionEnvMut<HostEnv>, msg: u32| {
+            let Some(memory) = env.data().side_mem.clone() else { return };
+            openmodelica_sim_meta::driver::note_runtime_error(&crate::sim_runtime::read_cstr(&memory, &env, msg));
+        }),
+    );
     imports.define(
         "rt",
         "rt_row_asserts",
         Function::new_typed_with_env(
             store,
             &mem_env,
-            |env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, sim_data: u32, warn: i32| -> i32 {
-                let Some(memory) = env.data().clone() else { return 1 };
+            |env: wasmer::FunctionEnvMut<HostEnv>, sim_data: u32, warn: i32| -> i32 {
+                let Some(memory) = env.data().mem.clone() else { return 1 };
                 let view = memory.view(&env);
                 row_asserts(&|addr: u32, buf: &mut [u8]| view.read(addr as u64, buf).is_ok(), sim_data, warn)
             },
@@ -561,8 +687,8 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         Function::new_typed_with_env(
             store,
             &mem_env,
-            |env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, len: u32| {
-                let Some(memory) = env.data().clone() else { return };
+            |env: wasmer::FunctionEnvMut<HostEnv>, ptr: u32, len: u32| {
+                let Some(memory) = env.data().mem.clone() else { return };
                 let mut buf = vec![0u8; len as usize];
                 if memory.view(&env).read(ptr as u64, &mut buf).is_ok() {
                     openmodelica_wasi::wasi::stdout_write(&buf);
@@ -581,9 +707,9 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         Function::new_typed_with_env(
             store,
             &mem_env,
-            |mut env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, max: u32| -> u32 {
+            |mut env: wasmer::FunctionEnvMut<HostEnv>, ptr: u32, max: u32| -> u32 {
                 let (data, store) = env.data_and_store_mut();
-                let Some(memory) = data.clone() else { return 0 };
+                let Some(memory) = data.mem.clone() else { return 0 };
                 let recs = take_pending_warnings_upto(max as usize);
                 let mut buf = vec![0u8; recs.len() * REC_BYTES];
                 let n = write_warnings(&recs, &mut buf);
@@ -600,9 +726,9 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         Function::new_typed_with_env(
             store,
             &mem_env,
-            |mut env: wasmer::FunctionEnvMut<Option<wasmer::Memory>>, ptr: u32, max: u32| -> u32 {
+            |mut env: wasmer::FunctionEnvMut<HostEnv>, ptr: u32, max: u32| -> u32 {
                 let (data, store) = env.data_and_store_mut();
-                let Some(memory) = data.clone() else { return 0 };
+                let Some(memory) = data.mem.clone() else { return 0 };
                 let mut buf = vec![0u8; max as usize * REINIT_BYTES];
                 let n = take_reinits_into(&mut buf, max as usize);
                 match memory.view(&store).write(ptr as u64, &buf[..n as usize * REINIT_BYTES]) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -261,7 +261,7 @@ fn wts<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> std::result::Resu
 }
 
 /// Read a NUL-terminated C string from wasm memory at `ptr` (bounded).
-fn read_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, ptr: u32) -> String {
+pub(crate) fn read_cstr(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, ptr: u32) -> String {
     let view = mem.view(store);
     let mut bytes = Vec::new();
     let mut a = ptr as u64;
@@ -279,8 +279,8 @@ fn read_u32_mem(mem: &wasmer::Memory, store: &impl wasmer::AsStoreRef, addr: u32
     Ok(u32::from_le_bytes(b))
 }
 
-/// Host state for the side module's `env.Modelica*Error` imports: its memory
-/// (filled in after instantiation) to read the message from.
+/// Host state for the side module's `env.rt_ext_message`/`rt_ext_warning` imports:
+/// its memory (filled in after instantiation) to read the message from.
 struct SideErrEnv {
     mem: Option<wasmer::Memory>,
 }
@@ -304,6 +304,10 @@ struct ExtEnv {
     rt_str_new: wasmer::TypedFunction<u32, u32>,
     rt_str_data: wasmer::TypedFunction<u32, u32>,
     rt_release: wasmer::TypedFunction<u32, ()>,
+    /// What [`recover_trial`] judges a failed call by, and the stack it restores.
+    nls_recovering: wasmer::TypedFunction<(), i32>,
+    nls_note: wasmer::TypedFunction<(), ()>,
+    side_sp: Option<wasmer::Global>,
     func: wasmer::Function,
     sig: crate::sig::ExtCallSig,
 }
@@ -316,14 +320,17 @@ struct ExtEnv {
 /// pointer outputs (scalars, and `char*`/`char**` strings) back — the latter into
 /// fresh in-wasm strings (`rt_str_new`/`rt_str_data`). External-object handles
 /// (`tableID`) are the side module's own pointers, passed straight through as `i32`.
-/// A `ModelicaError` inside the side module records to the Error buffer and traps
-/// (surfaced like the native path). Mirrors
+/// A `ModelicaError` goes to the runtime's `rt_ext_error`, bound wasm→wasm so the
+/// throw it ends in reaches the model's `try_table`; a marshalled call has a host
+/// frame in the way and recovers by [`recover_trial`] instead. Mirrors
 /// `sim_runtime_wasmtime::define_external_imports`.
 fn define_external_imports(
     store: &mut Store,
     imports: &mut wasmer::Imports,
     model: &SimModel,
     sim_mem: &wasmer::Memory,
+    rt_inst: &wasmer::Instance,
+    host_mem: &crate::host::HostMem,
     rt_str_new: &wasmer::TypedFunction<u32, u32>,
     rt_str_data: &wasmer::TypedFunction<u32, u32>,
     rt_release: &wasmer::TypedFunction<u32, ()>,
@@ -334,26 +341,34 @@ fn define_external_imports(
         return Err("error");
     }
 
-    // Instantiate the side module with its `env.Modelica*Error`/`usertab`/
-    // `ModelicaAllocateString` imports.
+    // Instantiate the side module with its `env.rt_ext_*`/`usertab`/
+    // `ModelicaAllocateString` imports. The `Modelica*` entry points themselves
+    // are inside it (`external_c_callbacks.c`), so what arrives here has already
+    // been through `vsnprintf`.
     let side_module = wasmer::Module::from_binary(store.engine(), EXTERNAL_C_WASM).map_err(|_| "CodegenWasmJit: wasm engine error")?;
     let err_env = FunctionEnv::new(&mut *store, SideErrEnv { mem: None });
-    let modelica_error = Function::new_typed_with_env(
+    let side_msg = |env: &FunctionEnvMut<SideErrEnv>, ptr: i32| -> String {
+        let mem = env.data().mem.clone();
+        mem.map(|m| read_cstr(&m, &env.as_store_ref(), ptr as u32)).unwrap_or_default()
+    };
+    // The runtime's own export, so no host frame sits under the throw; it reports
+    // through `env.rt_host_ext_error` first. Message and warning return, so they
+    // stay host closures.
+    let rt_ext_error = rt_inst
+        .exports
+        .get_function("rt_ext_error")
+        .map_err(|_| "CodegenWasmJit: the runtime module exports no `rt_ext_error`")?
+        .clone();
+    let rt_ext_warning = Function::new_typed_with_env(
         &mut *store, &err_env,
-        |env: FunctionEnvMut<SideErrEnv>, ptr: i32| -> std::result::Result<(), RuntimeError> {
-            let mem = env.data().mem.clone();
-            let msg = mem.map(|m| read_cstr(&m, &env.as_store_ref(), ptr as u32)).unwrap_or_default();
-            openmodelica_error::ErrorExt::runtime_error(&msg);
-            Err(RuntimeError::new(format!("ModelicaError: {msg}")))
+        move |env: FunctionEnvMut<SideErrEnv>, ptr: i32| {
+            openmodelica_error::ErrorExt::runtime_warning(&side_msg(&env, ptr));
         },
     );
-    let modelica_format_error = Function::new_typed_with_env(
+    let rt_ext_message = Function::new_typed_with_env(
         &mut *store, &err_env,
-        |env: FunctionEnvMut<SideErrEnv>, fmt: i32, _args: i32| -> std::result::Result<(), RuntimeError> {
-            let mem = env.data().mem.clone();
-            let msg = mem.map(|m| read_cstr(&m, &env.as_store_ref(), fmt as u32)).unwrap_or_default();
-            openmodelica_error::ErrorExt::runtime_error(&msg);
-            Err(RuntimeError::new(format!("ModelicaError: {msg}")))
+        move |env: FunctionEnvMut<SideErrEnv>, ptr: i32| {
+            openmodelica_wasi::wasi::stdout_write(side_msg(&env, ptr).as_bytes());
         },
     );
     // `usertab` (user-defined table callback) is never used by the standard table
@@ -374,30 +389,6 @@ fn define_external_imports(
         },
     );
 
-    // `ModelicaFormatWarning`/`ModelicaVFormatWarning`/`ModelicaFormatMessage` (fmt,
-    // args) — non-fatal; record the (unformatted) format string. `ModelicaVFormatError`
-    // is the noreturn va_list error: trap like `ModelicaError`. All are `(i32,i32)->()`;
-    // ModelicaIO/MatIO pull the extra three (the base three come from tables/strings).
-    let warn_fn = |store: &mut wasmer::Store, err_env: &FunctionEnv<SideErrEnv>| Function::new_typed_with_env(
-        store, err_env,
-        |env: FunctionEnvMut<SideErrEnv>, fmt: i32, _args: i32| {
-            let mem = env.data().mem.clone();
-            let msg = mem.map(|m| read_cstr(&m, &env.as_store_ref(), fmt as u32)).unwrap_or_default();
-            openmodelica_error::ErrorExt::runtime_warning(&msg);
-        },
-    );
-    let modelica_format_warning = warn_fn(&mut *store, &err_env);
-    let modelica_vformat_warning = warn_fn(&mut *store, &err_env);
-    let modelica_format_message = warn_fn(&mut *store, &err_env);
-    let modelica_vformat_error = Function::new_typed_with_env(
-        &mut *store, &err_env,
-        |env: FunctionEnvMut<SideErrEnv>, fmt: i32, _args: i32| -> std::result::Result<(), RuntimeError> {
-            let mem = env.data().mem.clone();
-            let msg = mem.map(|m| read_cstr(&m, &env.as_store_ref(), fmt as u32)).unwrap_or_default();
-            openmodelica_error::ErrorExt::runtime_error(&msg);
-            Err(RuntimeError::new(format!("ModelicaError: {msg}")))
-        },
-    );
     // `ModelicaInternal_get*`: seeding helpers ModelicaRandom pulls in. `getTime`
     // writes nothing (7 int* outs left as-is); `getpid` returns a constant. (Only
     // ModelicaRandom's automatic global seed uses them; explicit-seed RNG does not.)
@@ -406,12 +397,9 @@ fn define_external_imports(
     let modelica_getpid = Function::new_typed(&mut *store, || -> i32 { 1 });
 
     let mut side_imports = wasmer::Imports::new();
-    side_imports.define("env", "ModelicaError", modelica_error);
-    side_imports.define("env", "ModelicaFormatError", modelica_format_error);
-    side_imports.define("env", "ModelicaFormatWarning", modelica_format_warning);
-    side_imports.define("env", "ModelicaVFormatWarning", modelica_vformat_warning);
-    side_imports.define("env", "ModelicaFormatMessage", modelica_format_message);
-    side_imports.define("env", "ModelicaVFormatError", modelica_vformat_error);
+    side_imports.define("env", "rt_ext_error", rt_ext_error);
+    side_imports.define("env", "rt_ext_warning", rt_ext_warning);
+    side_imports.define("env", "rt_ext_message", rt_ext_message);
     side_imports.define("env", "usertab", usertab);
     side_imports.define("env", "ModelicaAllocateString", modelica_alloc_string.clone());
     // ModelicaInternal uses the error-returning variant; same malloc-backed impl
@@ -429,9 +417,12 @@ fn define_external_imports(
 
     let side_mem = side_inst.exports.get_memory("memory")
         .map_err(|e| "CodegenWasmJit: modelicaexternalc.wasm has no `memory")?.clone();
-    // Let the error hooks + WASI calls read/write the side module's memory.
+    // Let the error hooks, the WASI calls and the `rt_ext_stack_*` builtins reach
+    // the side module.
     err_env.as_mut(&mut *store).mem = Some(side_mem.clone());
     wasi_env.as_mut(&mut *store).set_memory(side_mem.clone());
+    let side_sp = side_inst.exports.get_global("__stack_pointer").ok().cloned();
+    host_mem.set_side(&mut *store, &side_mem, side_sp.clone());
     // WASI reactor initialization (sets up the C runtime state).
     if let Ok(init) = side_inst.exports.get_typed_function::<(), ()>(&*store, "_initialize") {
         wt(init.call(&mut *store))?;
@@ -440,6 +431,8 @@ fn define_external_imports(
     let free: wasmer::TypedFunction<u32, ()> = wt(side_inst.exports.get_typed_function(&*store, "free"))?;
     // Now the allocator import can reach the side module's `malloc`.
     alloc_env.as_mut(&mut *store).malloc = Some(malloc.clone());
+    let nls_recovering: wasmer::TypedFunction<(), i32> = wt(rt_inst.exports.get_typed_function(&*store, "rt_nls_recovering"))?;
+    let nls_note: wasmer::TypedFunction<(), ()> = wt(rt_inst.exports.get_typed_function(&*store, "rt_nls_note_assert"))?;
 
     for sig in &model.ext_imports {
         let name = &sig.name;
@@ -472,13 +465,23 @@ fn define_external_imports(
             rt_str_new: rt_str_new.clone(),
             rt_str_data: rt_str_data.clone(),
             rt_release: rt_release.clone(),
+            nls_recovering: nls_recovering.clone(),
+            nls_note: nls_note.clone(),
+            side_sp: side_sp.clone(),
             func,
             sig: sig.clone(),
         });
         let nm = name.clone();
         let host = Function::new_with_env(&mut *store, &env, functype,
             move |mut fenv: FunctionEnvMut<ExtEnv>, args: &[Value]| -> std::result::Result<Vec<Value>, RuntimeError> {
-                call_external_side(&mut fenv, args).map_err(|e| RuntimeError::new(format!("external \"C\" `{nm}`: {e}")))
+                let sp = side_stack(&mut fenv);
+                match call_external_side(&mut fenv, args) {
+                    Ok(v) => Ok(v),
+                    Err(e) => match recover_trial(&mut fenv, sp)? {
+                        Some(zeroed) => Ok(zeroed),
+                        None => Err(RuntimeError::new(format!("external \"C\" `{nm}`: {e}"))),
+                    },
+                }
             });
         imports.define("ext", name, host);
     }
@@ -505,6 +508,44 @@ fn valtype(w: WTy) -> wasmer::Type {
         WTy::F64 => wasmer::Type::F64,
         WTy::I32 => wasmer::Type::I32,
     }
+}
+
+/// The side module's `__stack_pointer`, before a call that may abandon frames.
+fn side_stack(fenv: &mut wasmer::FunctionEnvMut<ExtEnv>) -> Option<i32> {
+    let g = fenv.data().side_sp.clone()?;
+    g.get(fenv).i32()
+}
+
+/// What the model's `try_table` would have done, for a call whose throw could not
+/// cross this host trampoline: inside a residual, note the trial and hand back
+/// zeroed results; outside one, `None` — the call really failed. The shadow stack
+/// goes back to `saved_stack` either way.
+fn recover_trial(
+    fenv: &mut wasmer::FunctionEnvMut<ExtEnv>,
+    saved_stack: Option<i32>,
+) -> std::result::Result<Option<Vec<wasmer::Value>>, wasmer::RuntimeError> {
+    use crate::sig::SigTy;
+    use wasmer::Value;
+    let (data, mut store) = fenv.data_and_store_mut();
+    let (recovering, note, str_new, sig, sp) =
+        (data.nls_recovering.clone(), data.nls_note.clone(), data.rt_str_new.clone(), data.sig.clone(), data.side_sp.clone());
+    if let (Some(g), Some(v)) = (sp, saved_stack) {
+        g.set(&mut store, Value::I32(v))?;
+    }
+    if recovering.call(&mut store)? == 0 {
+        return Ok(None);
+    }
+    note.call(&mut store)?;
+    let results = sig.wasm_results();
+    let mut out = Vec::with_capacity(results.len());
+    for ty in results {
+        out.push(match ty {
+            SigTy::Real => Value::F64(0.0),
+            SigTy::Str => Value::I32(str_new.call(&mut store, 0)? as i32),
+            _ => Value::I32(0),
+        });
+    }
+    Ok(Some(out))
 }
 
 /// Marshal `args` (the import's input params) into the side module's memory per the
@@ -904,7 +945,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         let rt_str_new: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_new"))?;
         let rt_str_data: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_str_data"))?;
         let rt_release: wasmer::TypedFunction<u32, ()> = wts(rt_inst.exports.get_typed_function(&store, "rt_release"))?;
-        define_external_imports(&mut store, &mut imports, model, &memory, &rt_str_new, &rt_str_data, &rt_release)?;
+        define_external_imports(&mut store, &mut imports, model, &memory, &rt_inst, &host_mem, &rt_str_new, &rt_str_data, &rt_release)?;
     }
     define_print_import(&mut store, &mut imports, &memory);
     {
@@ -915,6 +956,16 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
 
     let instance = wts(wasmer::Instance::new(&mut store, &model_module, &imports))?;
     let inst_time = t_inst.elapsed();
+    // The runtime is instantiated first, so `rt_ext_error` reaches the model's
+    // thrower only through the table.
+    if !model.ext_imports.is_empty() {
+        let throw = wts(instance.exports.get_function("om_throw_model_error"))?.clone();
+        let table = wts(rt_inst.exports.get_table("__indirect_function_table"))?.clone();
+        let slot = wts(table.grow(&mut store, 1, wasmer::Value::FuncRef(None)))?;
+        wts(table.set(&mut store, slot, wasmer::Value::FuncRef(Some(throw))))?;
+        let set: wasmer::TypedFunction<u32, ()> = wts(rt_inst.exports.get_typed_function(&store, "rt_set_ext_throw"))?;
+        wts(set.call(&mut store, slot))?;
+    }
     let rt_alloc: wasmer::TypedFunction<u32, u32> = wts(rt_inst.exports.get_typed_function(&store, "rt_alloc"))?;
     // Solver selectors; see the wasmtime runtime.
     if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32, u32), ()>(&store, "rt_set_solvers") {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -24,6 +24,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 use crate::sim_driver;
+use crate::dylink_engine::{NlsHooks, zero_results};
 use crate::model::SimModel;
 use openmodelica_sim_meta::SimMeta;
 use crate::host::add_host_builtins;
@@ -116,6 +117,9 @@ fn plain_engine() -> &'static wasmtime::Engine {
 fn build_engine_cfg(extra: impl FnOnce(&mut wasmtime::Config)) -> wasmtime::Engine {
     let mut cfg = wasmtime::Config::new();
     crate::tune_memory(&mut cfg);
+    // A model with external "C" carries the `model_error` tag its `ext` call sites
+    // catch, so the module does not validate without this.
+    cfg.wasm_exceptions(true);
     // Compile module functions across threads (off by default with
     // default-features=false) — ~4x faster module compilation here.
     cfg.parallel_compilation(!crate::model::single_threaded());
@@ -401,11 +405,11 @@ fn define_external_imports(
     memory: wasmtime::Memory,
     rt: &crate::dylink_engine::ExtRt,
     libs: &crate::dylink_engine::Loaded,
-    nls: NlsHooks,
 ) -> Result<()> {
     let rt_str_new = rt.str_new.clone();
     let rt_str_data = rt.str_data.clone();
     let rt_release = rt.release.clone();
+    let nls = rt.nls.clone();
     registry_reset();
     sim_driver::clear_runtime_error();
     openmodelica_util::dynload::install_modelica_message_interception(
@@ -474,42 +478,6 @@ fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: wasmtime:
 /// nonlinear solver recovers from leaves no message behind.
 const EXT_CHECKPOINT: arcstr::ArcStr = arcstr::literal!("wasm-jit external \"C\"");
 
-/// The runtime's recoverable-model-error state, reached from the host so an
-/// external "C" `ModelicaError` inside a residual backs the trial off.
-#[derive(Clone)]
-struct NlsHooks {
-    recovering: wasmtime::TypedFunc<(), i32>,
-    note: wasmtime::TypedFunc<(), ()>,
-}
-
-impl NlsHooks {
-    fn recovering(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> Result<bool> {
-        Ok(wt(self.recovering.call(&mut *caller, ()))? != 0)
-    }
-    fn note(&self, caller: &mut wasmtime::Caller<'_, WasiCtx>) -> Result<()> {
-        wt(self.note.call(&mut *caller, ()))
-    }
-}
-
-/// Zeroed results (an empty String for `char*`) after a recovered `ModelicaError`.
-/// The solver discards the residual they feed, but they must be valid handles.
-fn zero_results(
-    sig: &crate::sig::ExtCallSig,
-    caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    rt_str_new: &wasmtime::TypedFunc<u32, u32>,
-    rets: &mut [wasmtime::Val],
-) -> Result<()> {
-    use crate::sig::SigTy;
-    for (slot, ty) in rets.iter_mut().zip(sig.wasm_results()) {
-        *slot = match ty {
-            SigTy::Real => wasmtime::Val::F64(0.0f64.to_bits()),
-            SigTy::Str => wasmtime::Val::I32(wt(rt_str_new.call(&mut *caller, 0))? as i32),
-            _ => wasmtime::Val::I32(0),
-        };
-    }
-    Ok(())
-}
-
 /// Call native external `addr` through libffi, marshalling by the C-call
 /// [`ExtCallSig`]. Input args (in `extArgs` order) come from the wasm parameters:
 /// scalars (Real→f64, Integer/Boolean→i64) by value; `Str` as a NUL-terminated
@@ -533,7 +501,7 @@ unsafe fn call_external(
     rt_str_new: &wasmtime::TypedFunc<u32, u32>,
     rt_str_data: &wasmtime::TypedFunc<u32, u32>,
     rt_release: &wasmtime::TypedFunc<u32, ()>,
-    nls: &NlsHooks,
+    nls: &Option<NlsHooks>,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
 ) -> Result<()> {
@@ -726,10 +694,12 @@ unsafe fn call_external(
         // A `ModelicaError` recorded its message in the Error buffer and unwound
         // here as a panic. C's `throwStreamPrint` is caught by a nonlinear solver,
         // so back the trial off first, dropping the message it will not fail on.
-        if nls.recovering(caller)? {
+        if let Some(nls) = nls
+            && wt(nls.recovering(caller))?
+        {
             openmodelica_error::ErrorExt::rollBack(EXT_CHECKPOINT);
-            nls.note(caller)?;
-            return zero_results(sig, caller, rt_str_new, rets);
+            wt(nls.note(caller))?;
+            return wt(zero_results(sig, caller, rt_str_new, rets));
         }
         // The run reports itself through its log alone, as C's separate executable
         // does, so the buffer the message also went to is rolled back.
@@ -959,12 +929,20 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         alloc: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?,
         free: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free"))?,
         record_new: wts(rt_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
+        nls: Some(nls),
     };
     let ext_libs = crate::dylink_engine::load_ext_libraries(&mut store, engine, rt_inst, memory, model, &ext_rt)?;
-    define_external_imports(&mut linker, &mut store, model, memory, &ext_rt, &ext_libs, nls)?;
+    crate::host::set_shadow_stack(ext_libs.shadow_stack());
+    wts(crate::host::set_model_error_tag(&mut store, None))?;
+    define_external_imports(&mut linker, &mut store, model, memory, &ext_rt, &ext_libs)?;
     define_print_import(&mut linker, memory)?;
     crate::host::define_uri_import(&mut linker, memory, ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
     let instance = wts(linker.instantiate(&mut store, &model_module))?;
+    // What a library's `ModelicaError` throws, now that the module defining the
+    // tag exists. Only a model with external "C" carries one.
+    if let Some(wasmtime::Extern::Tag(tag)) = instance.get_export(&mut store, "model_error") {
+        wts(crate::host::set_model_error_tag(&mut store, Some(tag)))?;
+    }
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
     // `-nls`/`-nlsLS`/`-ls`/`-lss`: the host-driven runtime links no flag store of

--- a/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery-f.c
+++ b/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery-f.c
@@ -1,0 +1,10 @@
+#include <ModelicaUtilities.h>
+
+/* 1/x, defined on (0, 10]; a trial outside that is an error, not a value. */
+double ExternalNlsRecovery_f(double x)
+{
+  if (x <= 0.0 || x > 10.0) {
+    ModelicaError("ExternalNlsRecovery_f: x is out of range");
+  }
+  return 1.0 / x;
+}

--- a/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery.mo
+++ b/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery.mo
@@ -1,0 +1,10 @@
+model ExternalNlsRecovery
+  function f
+    input Real x;
+    output Real y;
+    external "C" y = ExternalNlsRecovery_f(x) annotation(Library = "ExternalNlsRecovery-f.o");
+  end f;
+  Real x(start = 5.0);
+equation
+  f(x) = 1.0 + time;
+end ExternalNlsRecovery;

--- a/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery.mos
+++ b/testsuite/simulation/modelica/external_functions/ExternalNlsRecovery.mos
@@ -1,0 +1,37 @@
+// name:     ExternalNlsRecovery
+// keywords: external, nonlinear
+// status:   correct
+// setup_command: $OMC_CC $OMC_CFLAGS -I"$OPENMODELICAHOME/include/omc/c" $OMC_EXTLIB_FLAGS -o ExternalNlsRecovery-f$OMC_EXTLIB_EXT ExternalNlsRecovery-f.c $OMC_EXTLIB_LIBS
+// teardown_command: rm -rf ExternalNlsRecovery_* ExternalNlsRecovery ExternalNlsRecovery.exe ExternalNlsRecovery-f.c.o ExternalNlsRecovery-f.o ExternalNlsRecovery-f.wasm ExternalNlsRecovery.makefile ExternalNlsRecovery.libs ExternalNlsRecovery.log output.log
+// depends: ExternalNlsRecovery-f.c
+//
+// A ModelicaError inside a nonlinear-solver residual is a rejected trial, not the
+// end of the run: the Newton step from x=5 overshoots to x=-15, where the external
+// function refuses, and the solver backs off onto the root x = 1/(1+time).
+// -lv=-LOG_ASSERT drops the per-trial message, which the wasm-jit target (whose
+// recovery does not evaluate it) does not print.
+//
+
+loadFile("ExternalNlsRecovery.mo");
+getErrorString();
+
+simulate(ExternalNlsRecovery, stopTime=1.0, numberOfIntervals=2, simflags="-lv=-LOG_ASSERT");
+getErrorString();
+
+val(x, 0.0);
+val(x, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ExternalNlsRecovery_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ExternalNlsRecovery', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=-LOG_ASSERT'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 0.5
+// endResult

--- a/testsuite/simulation/modelica/external_functions/Makefile
+++ b/testsuite/simulation/modelica/external_functions/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 CevalModelicaStrings.mos \
 ExternalCFuncInputOnly.mos \
 ExternalLibraries.mos \
+ExternalNlsRecovery.mos \
 ExternalRHSFlag.mos \
 extObj_ticket3446.mos \
 ExtObj.mos \
@@ -37,6 +38,7 @@ ExternalFunc1_ext.h \
 ExternalFunc1.c \
 ExternalFunc2.c \
 ExternalFunc2.h \
+ExternalNlsRecovery-f.c \
 ExternalRHSFlag.c \
 ExtObj.c \
 ExtObj.h \


### PR DESCRIPTION
A `ModelicaError` raised inside a nonlinear-solver residual is a rejected trial in the C runtime: `throwStreamPrint` longjmps into the solver's `MMC_TRY_INTERNAL`, which scores the trial as a huge residual and lets the solver back off. wasm-jit had no way to unwind out of an external "C" frame, so the same model ended the run instead.

Use the wasm exception-handling proposal in place of the longjmp. A model with `external "C"` carries a `model_error` tag and every `ext` call site is lowered under a `try_table`; the handler is `emit_assert`'s — inside a residual note the trial and return `ASSERT_RESIDUAL`, outside one rethrow the caught `exnref` so the run still ends the way C's does.

Who throws depends on the artifact:

| artifact | what raises it |
| --- | --- |
| JIT run (wasmtime) | the host's `env.Modelica*Error` builds an `ExnRef` and `Store::throw`s it | | JIT run (web) | the side module's `ModelicaError` calls the runtime's `rt_ext_error`, which throws | | FMU, standalone | the library's own `ModelicaError` reaches the same `rt_ext_error` |

`rt_ext_error` throws by calling `om_throw_model_error`, a helper every model exports because rustc emits no `throw` for a wasm target. It reaches it by link name where the runtime is linked with the model, and through the shared table where the host instantiates them separately: the host appends the export to `rt.__indirect_function_table` and hands the runtime the slot with `rt_set_ext_throw`.

The last two rows are the case the C runtime gives up on (its recovery is `#ifndef OMC_EMCC`): the throw crosses the library's frames with no host anywhere in the chain. On the web that is not an optimisation but the only way — wasmer's glue catches a JS exception raised through a host import and stringifies it, so nothing can rethrow the original. Hence the message, which lives in the side module's own memory, is reported through a host import (`env.rt_host_ext_error`) *before* the throw, and `env.rt_ext_error` binds straight to the runtime's export.

Those abandoned frames never run the epilogue that hands the shadow stack back, so the call site saves `__stack_pointer` and the handler restores it. The runtime reaches that global through `global_asm!`, no Rust expression being able to; the web's side module has one of its own, which `--export-all` does not export (functions only).

A marshalled external is called through a host trampoline the throw cannot cross, so that one keeps the older mechanism: on a failure, ask the runtime whether a solver is recovering and, if it is, note the trial and return zeroed results. A scalar external needs no host frame between the model and the library at all — `is_direct_call` is unconditional again — and takes the exception.

The engine has to agree — a module with a tag does not validate without `wasm_exceptions`, and an FMU's `.cwasm` is rejected at load unless the exporter and the importer configured it the same way.

Two things came along the way. `modelicaexternalc.wasm` now links `external_c_callbacks.c`, the file an FMU already used, so the nine `Modelica*` entry points live inside the side module: a `ModelicaFormatError("x is %g", x)` reached the web host as its format string before, `(format, va_list)` being something no host can expand. And `-DRUST_OMC_ENGINE_WASMER=ON` builds the native omc on the wasmer host, which is the web target's — the `engine-wasmer` feature was there all along with no way to ask cmake for it, leaving the one host that cannot be run under a debugger the one nothing could exercise.

Verified on both engines with the two models added under `testmodels`: `TestExtNlsRecovery` interpolates an MSL table whose first Newton trial lands at u=500, far outside it, and still converges to the exact root as the solver damps the step; `TestExtTableError` raises the same error outside a residual and ends the run with the message. Also an FMU export whose *first* residual evaluation is out of range, and a standalone `--simCodeTarget=wasm` module, which still merges to WASI imports only.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
