### PR TITLE
wasm-jit: pre(x[i]) with a non-constant index

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -3129,6 +3129,20 @@ fn build_var_map(
     for (key, slot) in pre_entries {
         Arc::make_mut(&mut map.vars).insert(key, slot);
     }
+    // Same for the array accumulator, so `pre(x[i])` with a non-constant subscript
+    // resolves through a `$PRE.<base>` group.
+    let pre_groups: Vec<(String, Vec<(Vec<i32>, u32, WTy)>)> = map
+        .array_acc
+        .iter()
+        .filter_map(|(base, elems)| {
+            let pre: Option<Vec<_>> = elems
+                .iter()
+                .map(|(subs, off, wty)| layout.pre_slot_off(*off).map(|p| (subs.clone(), p, *wty)))
+                .collect();
+            Some((format!("$PRE.{base}"), pre?))
+        })
+        .collect();
+    map.array_acc.extend(pre_groups);
 
     finalize_array_groups(&mut map)?;
     editable.extend(start_editable);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -4971,6 +4971,23 @@ fn pre_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
     })
 }
 
+/// Does `$PRE.<x>` have pre-storage — its own scalar slot, or a subscripted
+/// element of a `$PRE` array group? A whole-array `pre(x)` deliberately does not
+/// count: C's `daeExpCrefRhsSimContext` wraps the live `<type>Vars` region for it,
+/// never `<type>VarsPre`.
+fn sim_pre_is_stored(ctx: &FnCtx, cref: &DAE::ComponentRef) -> Result<bool> {
+    let sim = ctx.sim()?;
+    if let Ok(key) = sim_cref_key(cref) {
+        if sim.vars.contains_key(&key) {
+            return Ok(true);
+        }
+    }
+    match sim_array_base_subs(cref)? {
+        Some((base, _)) => Ok(sim.array_groups.contains_key(&base)),
+        None => Ok(false),
+    }
+}
+
 /// The `previous(cr)` component reference: `cr` wrapped in `DAE.previousNamePrefix`,
 /// the variable the backend introduced for it (key `$CLKPRE.<cr>`).
 fn clkpre_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
@@ -5405,13 +5422,12 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
         }
     }
     // `$START.<cref>`: read the variable's start-attribute expression (used by
-    // the initial-equation system). `$PRE.<cref>`: the value at the last event;
-    // for the continuous models handled so far it equals the current value, so
-    // we read the live slot (discrete/event handling is future work).
+    // the initial-equation system). `$PRE.<cref>`: the value at the last event,
+    // read from the mirrored pre-slot the driver refreshes at every event.
     if let DAE::ComponentRef::CREF_QUAL { ident, componentRef, .. } = cref {
         match ident.as_str() {
             "$START" => {
-                let key = sim_cref_key(componentRef)?;
+                let key = sim_cref_key_fatal(componentRef)?;
                 if let Some(wty) = emit_sim_start_scalar(ctx, &key)? {
                     return Ok(Some(wty));
                 }
@@ -5423,11 +5439,8 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 return Err("CodegenWasmJit: $START for unknown variable");
             }
             "$PRE" => {
-                // A registered `$PRE.<var>` slot resolves via the normal path
-                // below. Otherwise (e.g. `pre()` of a parameter, whose value is
-                // event-invariant) read the live value.
-                let key = sim_cref_key(cref)?;
-                if !ctx.sim()?.vars.contains_key(&key) {
+                // No pre-storage (e.g. `pre()` of a parameter): read the live value.
+                if !sim_pre_is_stored(ctx, cref)? {
                     return compile_sim_cref_read(ctx, componentRef);
                 }
             }
@@ -5579,11 +5592,8 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
         }
         // `$PRE.x := e` targets x's pre-slot when one is registered; otherwise
         // (no pre-slot, e.g. a parameter) fall back to the live slot.
-        if ident.as_str() == "$PRE" {
-            let key = sim_cref_key(cref)?;
-            if !ctx.sim()?.vars.contains_key(&key) {
-                return compile_sim_cref_assign(ctx, componentRef, rhs);
-            }
+        if ident.as_str() == "$PRE" && !sim_pre_is_stored(ctx, cref)? {
+            return compile_sim_cref_assign(ctx, componentRef, rhs);
         }
     }
     // Plain idents that are wasm locals are handled by the normal path.
@@ -5689,7 +5699,7 @@ pub(crate) fn sim_const_store(
         if ident.as_str() == "$START" {
             return sim_const_store(ctx, componentRef, exp);
         }
-        if ident.as_str() == "$PRE" && !sim.vars.contains_key(&sim_cref_key(cref)?) {
+        if ident.as_str() == "$PRE" && !sim_pre_is_stored(ctx, cref)? {
             return sim_const_store(ctx, componentRef, exp);
         }
     }
@@ -8012,9 +8022,11 @@ fn emit_str_literal(ctx: &mut FnCtx, bytes: &[u8]) -> Result<()> {
 }
 
 /// Hand the executed `reinit` to the driver for C's `reinit <var> = <value>` line.
-/// The state's `SimData` offset names it; the value is re-read from the slot.
+/// The state's `SimData` offset names it; the value is re-read from the slot. A
+/// state with no static offset (`reinit(x[i], …)`) still reinitializes, just
+/// without the log line.
 fn emit_reinit_note(ctx: &mut FnCtx, stateVar: &DAE::ComponentRef) -> Result<()> {
-    let key = sim_cref_key(stateVar)?;
+    let Ok(key) = sim_cref_key(stateVar) else { return Ok(()) };
     let Some(slot) = ctx.sim()?.vars.get(&key).copied() else { return Ok(()) };
     if slot.wty != WTy::F64 {
         return Ok(());


### PR DESCRIPTION
`compile_sim_cref_read`/`_assign` and `sim_const_store` resolved the `$PRE` prefix by building a static cref key before reaching the dynamic array-element path, so a `pre()` of an array element subscripted by a `for`-loop iterator aborted the build:

    Internal error CodegenWasmJit: cannot build simulation module for
    `PNlib.Examples.DisTest.ConflictBeneBaB`: CodegenWasmJit:
    non-constant subscript in simulation cref

Register `$PRE.<base>` array groups next to the `$PRE.<key>` scalar slots, mirroring offsets through `Layout::pre_slot_off`, and gate the three call sites on `sim_pre_is_stored` so a cref with no static key still resolves through its group.

A whole-array `pre(x)` keeps reading the live array on purpose: the `T_ARRAY` case of C's `daeExpCrefRhsSimContext` wraps `<type>Vars` and never `<type>VarsPre`, and reading the pre-slots there moved four PNlib models away from the C results.

Also stop `reinit(x[i], ...)` from failing the build over its log line, and name the cref when a `$START` reference cannot be resolved.

All 92 PNlib examples now translate and simulate under wasm-jit, the 13 PNlib rtest tests pass with `--simCodeTarget=wasm-jit`, and every result file is byte-identical to the previous compiler's.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
