### PR TITLE
wasm-jit: two Buildings simulation failures

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5317,13 +5317,18 @@ fn is_const_exp(e: &DAE::Exp) -> bool {
 }
 
 /// Whether an equation list assigns `key`, directly or as one element of its array:
-/// the `SimVar`s are scalarized (`ts[1]`), an array assign names the whole `ts`.
+/// the `SimVar`s are scalarized (`ts[1]`, `layer[1][1][1][1]`), an array assign names
+/// the whole `ts`. `sim_cref_key` spells one bracket pair per subscript, so strip
+/// every rank, not just the last.
 fn is_computed(key: &str, computed: &std::collections::HashSet<String>) -> bool {
-    computed.contains(key)
-        || key
-            .strip_suffix(']')
-            .and_then(|k| k.rfind('['))
-            .is_some_and(|i| computed.contains(&key[..i]))
+    let mut key = key;
+    loop {
+        if computed.contains(key) {
+            return true;
+        }
+        let Some(i) = key.strip_suffix(']').and_then(|k| k.rfind('[')) else { return false };
+        key = &key[..i];
+    }
 }
 
 /// Keys of the crefs assigned by a `SimEqSystem` list (scalar/array assigns).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -5722,6 +5722,19 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
     if slot.negate != Neg::None {
         return Err("CodegenWasmJit: assignment to negated alias");
     }
+    // An array-valued rhs would `coerce` its handle into the slot: a pointer stored
+    // as a Real. Reject only a type `exp_sigty` names: it is best-effort, and an
+    // expression it cannot type is still one `compile_exp` lowers.
+    if !slot.heap {
+        if let RhsSource::Exp(e) = rhs {
+            if matches!(exp_sigty(e), Ok(SigTy::Array { .. })) {
+                crate::CodegenWasmJit::record_error(format!(
+                    "CodegenWasmJit: array-valued expression assigned to the scalar slot `{key}`"
+                ));
+                return Err("CodegenWasmJit: array-valued expression assigned to a scalar slot");
+            }
+        }
+    }
     let data = ctx.sim()?.data_local;
     if slot.heap {
         // Release the handle the slot currently holds before overwriting it with
@@ -6570,7 +6583,16 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
             },
         },
         E::CAST { ty, .. } => sig_ty_quiet(ty)?,
-        E::BINARY { operator, .. } | E::UNARY { operator, .. } => operator_sigty(operator)?,
+        // The new frontend leaves some operators `T_UNKNOWN`; read the operands
+        // instead, as `compile_binary` does.
+        E::BINARY { exp1, operator, exp2 } => match operator_sigty(operator) {
+            Ok(s) => s,
+            Err(_) => operand_sigty(exp1, exp2)?,
+        },
+        E::UNARY { operator, exp } => match operator_sigty(operator) {
+            Ok(s) => s,
+            Err(_) => exp_sigty(exp)?,
+        },
         E::RELATION { .. } | E::LBINARY { .. } | E::LUNARY { .. } => SigTy::Bool,
         E::IFEXP { expThen, .. } => exp_sigty(expThen)?,
         E::SHARED_LITERAL { exp, .. } => exp_sigty(exp)?,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestArrayParamBinding.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestArrayParamBinding.mo
@@ -1,0 +1,20 @@
+model TestArrayParamBinding
+  "A rank-3 parameter array bound to a function of parameters an equation computes"
+  function prop
+    input Integer n;
+    input Real a[3, n];
+    output Real o[3, n, 2];
+  algorithm
+    assert(a[1, 1] > 0, "prop ran before its inputs were computed");
+    for i in 1:3 loop
+      for j in 1:n loop
+        o[i, j, 1] := a[i, j];
+        o[i, j, 2] := 2*a[i, j];
+      end for;
+    end for;
+  end prop;
+  parameter Real s = 0.5;
+  parameter Real a[3, 2] = {{s, 2*s}, {3*s, 4*s}, {5*s, 6*s}};
+  parameter Real o[3, 2, 2] = prop(2, a);
+  Real y = o[1, 1, 1] + o[3, 2, 2] + time;
+end TestArrayParamBinding;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestOdeErrorRecovery.mo
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/TestOdeErrorRecovery.mo
@@ -1,0 +1,13 @@
+model TestOdeErrorRecovery
+  "A model error at a DASSL trial point: recoverable, as C's IRES = -1"
+  function bad
+    input Real u;
+    output Real y;
+  algorithm
+    assert(u < 0.5, "u out of range");
+    y := u;
+  end bad;
+  Real x(start = 0.4, fixed = true);
+equation
+  der(x) = -bad(x + time);
+end TestOdeErrorRecovery;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_arrayparam.mos
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/testmodels/run_arrayparam.mos
@@ -1,0 +1,7 @@
+// A parameter array of rank >= 2 is computed by `functionUpdateBoundParameters`;
+// its binding must not also run in `functionParameters`, where the parameters it
+// reads are still 0.
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("TestArrayParamBinding.mo"); getErrorString();
+simulate(TestArrayParamBinding, stopTime = 1.0, numberOfIntervals = 1); getErrorString();
+val(y, 0.0); // 0.5 + 6.0 = 6.5

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -56,6 +56,20 @@ fn step_size() -> f64 {
     f64::from_bits(STEP_SIZE.load(Ordering::Relaxed))
 }
 
+/// C's `threadData->currentErrorStage`, as two words the driver stores into: `[0]`
+/// the stage, `[1]` set when a model error was absorbed there.
+/// `ERROR_NONLINEARSOLVER` is [`NLS_DEPTH`], the runtime's own nesting, instead.
+pub const ERROR_SIMULATION: u32 = 0;
+pub const ERROR_INTEGRATOR: u32 = 1;
+static ERROR_STAGE: [AtomicU32; 2] = [AtomicU32::new(ERROR_SIMULATION), AtomicU32::new(0)];
+
+/// Address of [`ERROR_STAGE`], so the driver marks a region with a store rather than
+/// a wasm call per evaluation (as for [`rt_context_addr`]).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_error_stage_addr() -> u32 {
+    ERROR_STAGE.as_ptr() as u32
+}
+
 /// Recoverable-assert state (C's `ERROR_NONLINEARSOLVER`). While `NLS_DEPTH` > 0 a
 /// failed model `assert()` records itself in `NLS_ASSERT_HIT` and returns instead of
 /// trapping; `eval` then turns that trial into a huge residual so the solver backs off.
@@ -107,26 +121,31 @@ fn attempt_aborted() -> bool {
     NLS_ASSERT_SEEN.load(Ordering::Relaxed) != 0
 }
 
-/// Model side (emitted by `emit_assert`): is a failed assert currently recoverable
-/// (i.e. inside a nonlinear-solver residual)? Non-zero → the model records the
-/// assert via [`rt_nls_note_assert`] and bails out instead of trapping.
+/// Model side (emitted by `emit_assert`): is a failed assert currently recoverable —
+/// inside a nonlinear-solver residual, or the integrator's? Non-zero → the model
+/// records the assert via [`rt_nls_note_assert`] and bails out instead of trapping.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_recovering() -> i32 {
-    (NLS_DEPTH.load(Ordering::Relaxed) > 0) as i32
+    (NLS_DEPTH.load(Ordering::Relaxed) > 0
+        || ERROR_STAGE[0].load(Ordering::Relaxed) == ERROR_INTEGRATOR) as i32
 }
 
 /// Model side: flag that a recoverable assert fired at the current trial point.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_note_assert() {
-    NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
+    if NLS_DEPTH.load(Ordering::Relaxed) > 0 {
+        NLS_ASSERT_HIT.store(1, Ordering::Relaxed);
+    } else {
+        ERROR_STAGE[1].store(1, Ordering::Relaxed);
+    }
 }
 
 /// A model error where C's generated code calls `throwStreamPrint` — an invalid
-/// root, a zero divisor, an index out of range. C's `longjmp` lands in the solver's
+/// root, a zero divisor, an index out of range. C's `longjmp` lands in the innermost
 /// `MMC_TRY_INTERNAL`, so inside a residual note the trial and let the caller return
-/// a dummy `eval` discards. Outside one the error is fatal.
+/// a dummy the solver discards. With neither stage open the error is fatal.
 pub(crate) fn model_error() {
-    if NLS_DEPTH.load(Ordering::Relaxed) > 0 {
+    if rt_nls_recovering() != 0 {
         rt_nls_note_assert();
         return;
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -166,6 +166,9 @@ impl SimEngine for InWasmEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn error_stage_addr(&mut self) -> u32 {
+        crate::nls::rt_error_stage_addr()
+    }
     fn clean_nls_history(&mut self, time: f64) {
         crate::nls::rt_nls_clean_history(time);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -156,6 +156,9 @@ impl SimEngine for StandaloneEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn error_stage_addr(&mut self) -> u32 {
+        crate::nls::rt_error_stage_addr()
+    }
     fn clean_nls_history(&mut self, time: f64) {
         crate::nls::rt_nls_clean_history(time);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -286,6 +286,11 @@ pub trait SimEngine {
     fn context_addr(&mut self) -> u32 {
         0
     }
+    /// Address of the runtime's error stage / absorbed-error pair, or 0 when the
+    /// backend has no such export.
+    fn error_stage_addr(&mut self) -> u32 {
+        0
+    }
     /// C's `cleanUpOldValueListAfterEvent`. Default: none (an engine that never
     /// integrates).
     fn clean_nls_history(&mut self, _time: f64) {}
@@ -317,6 +322,33 @@ fn set_context(e: &mut dyn SimEngine, addr: u32, ctx: i32) {
     if addr != 0 {
         let _ = write_i32(e, addr, ctx);
     }
+}
+
+/// C's `threadData->currentErrorStage`, mirrored from the runtime's `nls.rs`.
+pub const ERROR_SIMULATION: i32 = 0;
+pub const ERROR_INTEGRATOR: i32 = 1;
+
+/// Open C's `MMC_TRY_INTERNAL(simulationJumpBuffer)` around an integrator callback: a
+/// model error inside it is absorbed rather than trapping, and [`took_error_stage`]
+/// reports it. A no-op without the runtime slot, where such an error stays fatal.
+fn set_error_stage(e: &mut dyn SimEngine, addr: u32, stage: i32) {
+    if addr != 0 {
+        let _ = write_i32(e, addr, stage);
+        if stage != ERROR_SIMULATION {
+            let _ = write_i32(e, addr + 4, 0);
+        }
+    }
+}
+
+/// Close the region [`set_error_stage`] opened: back to `ERROR_SIMULATION`, and
+/// whether a model error was absorbed while it was open (C's `success == 0`).
+fn took_error_stage(e: &mut dyn SimEngine, addr: u32) -> bool {
+    if addr == 0 {
+        return false;
+    }
+    let hit = read_i32(e, addr + 4).unwrap_or(0) != 0;
+    let _ = write_i32(e, addr, ERROR_SIMULATION);
+    hit
 }
 
 /// Must match the runtime's `N_STATS`.
@@ -3454,6 +3486,8 @@ struct ResCtx {
     ext_apply: Option<unsafe fn(*mut core::ffi::c_void, &mut dyn SimEngine, u32, f64)>,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
     ctx_addr: u32,
+    /// Linear-memory address of the runtime's error stage (0 = unsupported).
+    err_stage_addr: u32,
     /// The FD step's fallback scale: `n_states` nominals owned by the driver.
     nominals: *const f64,
     nominal_factor: f64,
@@ -3599,6 +3633,7 @@ unsafe fn dassl_res(
         let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ODE);
+        set_error_stage(e, ctx.err_stage_addr, ERROR_INTEGRATOR);
         e.call1("functionODE", ctx.sim_data)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
         // delta := yprime - f
@@ -3609,6 +3644,7 @@ unsafe fn dassl_res(
         }
         Ok(())
     })();
+    let model_error = took_error_stage(e, ctx.err_stage_addr);
     ctx.nfe += 1;
     match run {
         Err(err) => {
@@ -3616,10 +3652,13 @@ unsafe fn dassl_res(
             unsafe { *ires = -2 };
         }
         Ok(()) => {
-            // A nonlinear system did not converge: recoverable — ask DASKR to
-            // retry at a smaller step (the guess was restored by the codegen).
+            // A model error, or a nonlinear system that did not converge: both
+            // recoverable — ask DASKR to retry at a smaller step (the guess was
+            // restored by the codegen).
             if read_i32(e, ctx.sim_data + ctx.nls_fail_off).unwrap_or(0) != 0 {
                 report_nls_failure_at(e, ctx.sim_data, ctx.nls_fail_off);
+                unsafe { *ires = -1 };
+            } else if model_error {
                 unsafe { *ires = -1 };
             }
         }
@@ -3662,6 +3701,9 @@ unsafe fn dassl_jac(
     // One assembly, however many colours it takes, as C's DASSL counts it.
     ctx.nje += 1;
     set_context(e, ctx.ctx_addr, CONTEXT_JACOBIAN);
+    // C holds `ERROR_INTEGRATOR` over the whole DDASKR call, and there is no `IRES`
+    // here: a model error at a perturbed point leaves the assembly as it stands.
+    set_error_stage(e, ctx.err_stage_addr, ERROR_INTEGRATOR);
     let run = (|| -> Result<()> {
         write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
         for color in &jac.colors {
@@ -3712,6 +3754,7 @@ unsafe fn dassl_jac(
         Ok(())
     })();
     set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
+    took_error_stage(e, ctx.err_stage_addr);
     if let Err(err) = run {
         ctx.err = Some(err);
     }
@@ -3828,6 +3871,28 @@ fn log_dassl_step(t: f64) {
 
 /// The `dassl call statistics:` block, from the work-array indices `dassl.c` reads.
 /// A restart zeroes the counters, as in C.
+/// C's `continue_DASSL`: name the negative `IDID` DASKR stopped on, then
+/// `can't continue`. `-10` is the one [`dassl_res`]'s `IRES = -1` leads to.
+fn report_dassl_failure(idid: i32, t: f64) -> &'static str {
+    let msg = match idid {
+        -2 => "The error tolerances are too stringent",
+        -6 => "DDASSL had repeated error test failures on the last attempted step.",
+        -7 => "The corrector could not converge.",
+        -8 => "The matrix of partial derivatives is singular.",
+        -9 => "The corrector could not converge. There were repeated error test failures in this step.",
+        -10 => "A Modelica assert prevents the integrator to continue. For more information use -lv LOG_SOLVER",
+        -11 => "IRES equal to -2 was encountered and control is being returned to the calling program.",
+        -12 => "DDASSL failed to compute the initial YPRIME.",
+        -33 => "The code has encountered trouble from which it cannot recover.",
+        _ => "",
+    };
+    if !msg.is_empty() {
+        omclog::warning(omclog::STDOUT, false, msg);
+    }
+    omclog::warning(omclog::STDOUT, false, &format!("can't continue. time = {t:.6}"));
+    "CodegenWasmJit: DASSL (daskr) failed"
+}
+
 fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
     let g = |v: f64| format_g(v, 4);
     let r = |k: usize| rwork.get(k).copied().unwrap_or(0.0);
@@ -4150,6 +4215,7 @@ impl Driver for DasslDriver {
             ext_input: core::ptr::null_mut(),
             ext_apply: None,
             ctx_addr: e.context_addr(),
+            err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
             tol: self.tol,
@@ -4223,7 +4289,7 @@ impl Driver for DasslDriver {
                 continue;
             }
             if self.idid < 0 {
-                return Err("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
+                return Err(report_dassl_failure(self.idid, self.t));
             }
             // IDID=1 (INFO(3)=1): one internal step, TOUT still ahead.
             if self.idid == 1 {
@@ -4429,7 +4495,7 @@ impl DaskrState {
         }
         self.ev_retries = 0; // this target's integration is done (or failing)
         if self.idid < 0 {
-            return Progress::Failed("CodegenWasmJit: DASSL (daskr) failed at t=, IDID=");
+            return Progress::Failed(report_dassl_failure(self.idid, *t));
         }
         // IDID=5: stopped at a zero-crossing root; IDID=1: intermediate-output step.
         match self.idid {
@@ -5049,6 +5115,7 @@ impl SolverCore {
             ext_input: core::ptr::null_mut(),
             ext_apply: None,
             ctx_addr: e.context_addr(),
+            err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
             tol: self.tol,
@@ -6394,6 +6461,7 @@ impl Driver for CvodeDriver {
             ext_input: core::ptr::null_mut(),
             ext_apply: None,
             ctx_addr: e.context_addr(),
+            err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
             tol: self.tol,
@@ -7166,6 +7234,7 @@ impl Driver for IdaDriver {
             ext_input: core::ptr::null_mut(),
             ext_apply: None,
             ctx_addr: e.context_addr(),
+            err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
             nominal_factor: nominal_factor(),
             tol: self.tol,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1105,6 +1105,12 @@ impl sim_driver::SimEngine for WasmerEngine {
             Err(_) => 0,
         }
     }
+    fn error_stage_addr(&mut self) -> u32 {
+        match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_error_stage_addr") {
+            Ok(f) => f.call(&mut self.store).unwrap_or(0),
+            Err(_) => 0,
+        }
+    }
     fn clean_nls_history(&mut self, time: f64) {
         if let Ok(f) = self.rt_inst.exports.get_typed_function::<f64, ()>(&self.store, "rt_nls_clean_history") {
             let _ = f.call(&mut self.store, time);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1160,6 +1160,13 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             .and_then(|f| f.call(&mut self.store, ()).ok())
             .unwrap_or(0)
     }
+    fn error_stage_addr(&mut self) -> u32 {
+        self.rt_inst
+            .get_typed_func::<(), u32>(&mut self.store, "rt_error_stage_addr")
+            .ok()
+            .and_then(|f| f.call(&mut self.store, ()).ok())
+            .unwrap_or(0)
+    }
     fn clean_nls_history(&mut self, time: f64) {
         if let Ok(f) = self.rt_inst.get_typed_func::<f64, ()>(&mut self.store, "rt_nls_clean_history") {
             let _ = f.call(&mut self.store, time);


### PR DESCRIPTION
`ChillerDXHeatingEconomizer` ended at initialization on an assert inside `glassPropertyUncoated`, and `CouplingSpawnZ6` trapped in `functionODE`.

## A parameter binding evaluated before its dependencies

`functionParameters` is C's `setAllParamsToStart`, so a binding whose variable `parameterEquations` also computes must not run there — it would read dependencies that are still 0. `is_computed` stripped only the last subscript group, while `sim_cref_key` spells one bracket pair per subscript, so for `layer[1][1][1][1]` it asked for `layer[1][1][1]` and missed `layer`. Rank-1 arrays and element-wise assigned ones matched; only a rank >= 2 array behind one `SES_ARRAY_CALL_ASSIGN` got through. `Buildings.HeatTransfer.Windows.BaseClasses.RadiationData` is made of those, and `glassProperty` ran with `glass = {0,0,0}, x = 0`, where `(glass[Ra] - rho0)/(rho0*glass[TRA])` is NaN and the extinction coefficient assert is the first one to notice.

That binding was also lowered per scalarized element: the function ran once per element of the result and each store was
`f64.convert_i32_s` of the returned array handle. An array-valued rhs into a scalar slot is now a codegen error instead.

## A model error in the integrator's residual

`rt_real_pow` rejects a nan/inf result exactly as `CodegenCFunctions` does, but C's `throwStreamPrint` unwinds into `functionODE_residual`'s `MMC_TRY_INTERNAL`, which reports `IRES = -1` and lets DASSL shorten the step; `sublimationPressureIce` overflowing at a trial point is routine. wasm-jit had only C's `ERROR_NONLINEARSOLVER`, so the same error trapped and ended the run.

Mirror `threadData->currentErrorStage` as two runtime words the driver stores into, as it already does for the evaluation context. `dassl_res` opens `ERROR_INTEGRATOR` around `functionODE` and turns an absorbed error into `IRES = -1`; `dassl_jac` opens it too, C holding that stage over the whole DDASKR call. The `try_table` handler for an external `ModelicaError` shares the predicate, so a library called from the equations recovers the same way.

## `continue_DASSL`

Every negative `IDID` reported `DASSL (daskr) failed at t=, IDID=` — placeholders in a `&'static str` that nothing filled. `IDID = -10` is now reachable, so port C's switch and its `can't continue` line.

Verified: `ChillerDXHeatingEconomizer` at stopTime=86400 finishes; `TestOdeErrorRecovery` matches the C runtime down to the time it gives up at. `simulation/modelica/{parameters,arrays,initialization}` under `--simCodeTarget=wasm-jit` are unchanged (139 ok, 18 equation mismatch, all pre-existing), as are `nonlinear_system` and `ExternalNlsRecovery`. `CouplingSpawnZ6` itself was not run: no Spawn binaries on this image.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
