### PR TITLE
Fix middle click closing two tabs in tabbed view

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -90,6 +90,41 @@
 #include <QOpenGLWidget>
 #include <QNetworkProxyFactory>
 
+namespace {
+/*!
+ * \brief MdiAreaTabBarMiddleClickEventFilter
+ * Consumes the middle mouse button release event on the QMdiArea tab bar.
+ *
+ * Since Qt 6.11, QTabBar::mouseReleaseEvent() emits tabCloseRequested() on a middle
+ * mouse button release (see commit 571c55dbcd6). The QMdiAreaTabBar already closes
+ * the tab under the cursor on the middle mouse button press, so a single middle
+ * click used to close two tabs (issue #16264): the clicked tab and, because the tab
+ * bar is re-laid out after the press, the tab that shifts into the released position.
+ *
+ * This filter swallows the middle mouse button release so that only the clicked tab
+ * is closed.
+ */
+class MdiAreaTabBarMiddleClickEventFilter : public QObject
+{
+public:
+  explicit MdiAreaTabBarMiddleClickEventFilter(QObject *pParent = 0)
+    : QObject(pParent)
+  {
+  }
+
+  virtual bool eventFilter(QObject *pObject, QEvent *pEvent)
+  {
+    if (pEvent->type() == QEvent::MouseButtonRelease) {
+      QMouseEvent *pMouseEvent = static_cast<QMouseEvent*>(pEvent);
+      if (pMouseEvent && pMouseEvent->button() == Qt::MiddleButton) {
+        return true;
+      }
+    }
+    return QObject::eventFilter(pObject, pEvent);
+  }
+};
+}
+
 namespace ToolBars {
   QString welcomePerspective = "welcomePerspective";
   QString modelingModelicaPerspective = "modelingModelicaPerspective";
@@ -2037,15 +2072,26 @@ void MainWindow::switchToWindowMode(QMdiArea *pMdiArea)
 void MainWindow::switchToTabbedMode(QMdiArea *pMdiArea)
 {
   pMdiArea->setViewMode(QMdiArea::TabbedView);
-#ifdef Q_OS_WIN
-  /* See #15239
-   * When switching to tabbed mode, the order of subwindows is not updated until a tab is moved.
-   * To fix this, we connect to the tabMoved signal and set the active subwindow to the moved window.
-   * This way, the order of subwindows is updated immediately after switching to tabbed mode.
-   * This issue is not seen in Linux.
-   */
   QTabBar* tabBar = pMdiArea->findChild<QTabBar*>();
   if (tabBar) {
+    /* See #16264
+     * Since Qt 6.11 the QTabBar emits tabCloseRequested() on a middle mouse button release.
+     * The QMdiAreaTabBar also closes the tab under the cursor on the middle mouse button press.
+     * Since the tab bar is re-laid out after the press, a single middle click closes two tabs.
+     * Install a filter that swallows the middle mouse button release so that only the clicked tab is closed.
+     */
+    if (!tabBar->property("omeditMdiAreaTabBarMiddleClickFilter").toBool()) {
+      tabBar->setProperty("omeditMdiAreaTabBarMiddleClickFilter", true);
+      MdiAreaTabBarMiddleClickEventFilter *pFilter = new MdiAreaTabBarMiddleClickEventFilter(tabBar);
+      tabBar->installEventFilter(pFilter);
+    }
+#ifdef Q_OS_WIN
+    /* See #15239
+     * When switching to tabbed mode, the order of subwindows is not updated until a tab is moved.
+     * To fix this, we connect to the tabMoved signal and set the active subwindow to the moved window.
+     * This way, the order of subwindows is updated immediately after switching to tabbed mode.
+     * This issue is not seen in Linux.
+     */
     connect(tabBar, &QTabBar::tabMoved, MainWindow::instance(), [pMdiArea](int from, int to) {
       Q_UNUSED(from)
       QMdiSubWindow* movedWindow = pMdiArea->subWindowList().at(to);
@@ -2053,8 +2099,8 @@ void MainWindow::switchToTabbedMode(QMdiArea *pMdiArea)
         pMdiArea->setActiveSubWindow(movedWindow);
       }
     });
-  }
 #endif // #ifdef Q_OS_WIN
+  }
 }
 
 /*!

--- a/OMEdit/Testsuite/CMakeLists.txt
+++ b/OMEdit/Testsuite/CMakeLists.txt
@@ -73,6 +73,10 @@ set(OMEDIT_TEST_STRINGHANDLER_SOURCES StringHandler/StringHandlerTest.cpp
                                        StringHandler/StringHandlerTest.h)
 add_omedit_test(StringHandler "${OMEDIT_TEST_STRINGHANDLER_SOURCES}")
 
+set(OMEDIT_TEST_TABBEDVIEW_SOURCES TabbedView/TabbedViewTest.cpp
+                                   TabbedView/TabbedViewTest.h)
+add_omedit_test(TabbedView "${OMEDIT_TEST_TABBEDVIEW_SOURCES}")
+
 set(OMEDIT_TEST_TRANSFORMATION_SOURCES Transformation/TransformationTest.cpp
                                        Transformation/TransformationTest.h)
 add_omedit_test(Transformation "${OMEDIT_TEST_TRANSFORMATION_SOURCES}")

--- a/OMEdit/Testsuite/RunOMEditTestsuite.sh
+++ b/OMEdit/Testsuite/RunOMEditTestsuite.sh
@@ -2,7 +2,7 @@
 set -e
 
 testcases=( "BrowseMSL" "Diagram" "Transformation" "Homotopy" "Expression"
-            "ModelInstance" "VariableValue" "Utilities" "StringHandler" "DynamicAnnotation"
+            "ModelInstance" "TabbedView" "VariableValue" "Utilities" "StringHandler" "DynamicAnnotation"
             "AutoCompletion" "MergeExtendsModifiers" )
 OMEditTestResults="$PWD/OMEditTestResult"
 

--- a/OMEdit/Testsuite/TabbedView/TabbedView.pro
+++ b/OMEdit/Testsuite/TabbedView/TabbedView.pro
@@ -30,33 +30,11 @@
 #
 # See the full OSMC Public License conditions for more details.
 
-TEMPLATE = subdirs
+include(../Common/Testsuite.pri)
+include(../Common/Util.pri)
 
-SUBDIRS = Util \
-  BrowseMSL \
-  Diagram \
-  Transformation \
-  Homotopy \
-  Expression \
-  ModelInstance \
-  TabbedView \
-  VariableValue \
-  Utilities \
-  StringHandler \
-  DynamicAnnotation \
-  AutoCompletion \
-  MergeExtendsModifiers
+TARGET = TabbedView
 
-BrowseMSL.depends = Util
-Diagram.depends = Util
-Transformation.depends = Util
-Homotopy.depends = Util
-Expression.depends = Util
-ModelInstance.depends = Util
-TabbedView.depends = Util
-VariableValue.depends = Util
-Utilities.depends = Util
-StringHandler.depends = Util
-DynamicAnnotation.depends = Util
-AutoCompletion.depends = Util
-MergeExtendsModifiers.depends = Util
+SOURCES += TabbedViewTest.cpp
+
+HEADERS += TabbedViewTest.h

--- a/OMEdit/Testsuite/TabbedView/TabbedViewTest.cpp
+++ b/OMEdit/Testsuite/TabbedView/TabbedViewTest.cpp
@@ -1,0 +1,114 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#include "TabbedViewTest.h"
+#include "Util.h"
+#include "MainWindow.h"
+#include "Modeling/LibraryTreeWidget.h"
+#include "Modeling/ModelWidgetContainer.h"
+#include <QApplication>
+#include <QMouseEvent>
+
+OMEDITTEST_MAIN(TabbedViewTest)
+
+void TabbedViewTest::initTestCase()
+{
+  // load TabbedViewTest.mo
+  const QString tabbedViewTestFileName = QFINDTESTDATA("TabbedViewTest.mo");
+  MainWindow::instance()->getLibraryWidget()->openFile(tabbedViewTestFileName);
+  if (!MainWindow::instance()->getOMCProxy()->existClass("TabbedViewTest")) {
+    QFAIL(QString("Failed to load file %1").arg(tabbedViewTestFileName).toStdString().c_str());
+  }
+  // Make sure the modeling view is in tabbed mode.
+  MainWindow::switchToTabbedMode(MainWindow::instance()->getModelWidgetContainer());
+  QApplication::processEvents();
+}
+
+void TabbedViewTest::middleClickClosesOnlyClickedTab()
+{
+  LibraryTreeModel *pLibraryTreeModel = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel();
+  LibraryTreeItem *pLibraryTreeItem1 = pLibraryTreeModel->findLibraryTreeItem("TabbedViewTest.Model1");
+  LibraryTreeItem *pLibraryTreeItem2 = pLibraryTreeModel->findLibraryTreeItem("TabbedViewTest.Model2");
+  if (!pLibraryTreeItem1 || !pLibraryTreeItem2) {
+    QFAIL("Failed to find the test models.");
+  }
+  pLibraryTreeModel->showModelWidget(pLibraryTreeItem1);
+  pLibraryTreeModel->showModelWidget(pLibraryTreeItem2);
+  QApplication::processEvents();
+
+  ModelWidgetContainer *pModelWidgetContainer = MainWindow::instance()->getModelWidgetContainer();
+  if (pModelWidgetContainer->subWindowList().size() != 2) {
+    QFAIL("Expected two open model widgets.");
+  }
+
+  QTabBar *pTabBar = pModelWidgetContainer->findChild<QTabBar*>(QString(), Qt::FindDirectChildrenOnly);
+  if (!pTabBar) {
+    QFAIL("Failed to find the tab bar.");
+  }
+  if (pTabBar->count() != 2) {
+    QFAIL("Expected two tabs.");
+  }
+  QRect firstTabRect = pTabBar->tabRect(0);
+  if (firstTabRect.isEmpty()) {
+    QFAIL("The tab bar is not laid out.");
+  }
+
+  // Simulate a middle click (press and release) on the first tab.
+  QPoint clickPos = firstTabRect.center();
+  QMouseEvent pressEvent(QEvent::MouseButtonPress, QPointF(clickPos), QPointF(clickPos), QPointF(pTabBar->mapToGlobal(clickPos)), Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+  QApplication::sendEvent(pTabBar, &pressEvent);
+  QApplication::processEvents();
+  QMouseEvent releaseEvent(QEvent::MouseButtonRelease, QPointF(clickPos), QPointF(clickPos), QPointF(pTabBar->mapToGlobal(clickPos)), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
+  QApplication::sendEvent(pTabBar, &releaseEvent);
+  QApplication::processEvents();
+
+  // Only the clicked tab should have been closed (issue #16264).
+  if (pModelWidgetContainer->subWindowList().size() != 1) {
+    QFAIL("Middle click should have closed only the clicked tab.");
+  }
+  QMdiSubWindow *pMdiSubWindow = pModelWidgetContainer->subWindowList().at(0);
+  if (!pMdiSubWindow || pMdiSubWindow->widget() != pLibraryTreeItem2->getModelWidget()) {
+    QFAIL("The remaining tab should be the second model.");
+  }
+}
+
+void TabbedViewTest::cleanupTestCase()
+{
+  MainWindow::instance()->close();
+}

--- a/OMEdit/Testsuite/TabbedView/TabbedViewTest.h
+++ b/OMEdit/Testsuite/TabbedView/TabbedViewTest.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+
+#ifndef TABBEDVIEWTEST_H
+#define TABBEDVIEWTEST_H
+
+#include <QObject>
+
+/*!
+ * \brief The TabbedViewTest class
+ * Tests the tabbed view of the ModelWidgetContainer.
+ */
+class TabbedViewTest: public QObject
+{
+  Q_OBJECT
+private slots:
+  void initTestCase();
+  /*!
+   * \brief middleClickClosesOnlyClickedTab
+   * Tests that a middle click on a tab closes only the clicked tab (issue #16264).
+   */
+  void middleClickClosesOnlyClickedTab();
+  void cleanupTestCase();
+};
+
+#endif // TABBEDVIEWTEST_H

--- a/OMEdit/Testsuite/TabbedView/TabbedViewTest.mo
+++ b/OMEdit/Testsuite/TabbedView/TabbedViewTest.mo
@@ -1,0 +1,13 @@
+package TabbedViewTest
+  model Model1
+    Real x;
+  equation
+    x = 1;
+  end Model1;
+
+  model Model2
+    Real y;
+  equation
+    y = 2;
+  end Model2;
+end TabbedViewTest;


### PR DESCRIPTION
### Related Issues

#16264

### Purpose

Avoid closing two tabs on middle click.

### Approach

Since Qt 6.11, QTabBar::mouseReleaseEvent() emits tabCloseRequested() on a middle mouse button release. The QMdiAreaTabBar already closes the tab under the cursor on the middle mouse button press, so a single middle click closed the clicked tab plus the one that shifted into the released position after the relayout. Install an event filter that swallows the middle mouse button release so only the clicked tab is closed. Added a TabbedView test to check the middle click behavior.
