### PR TITLE
wasm: Disable FMU tests that rely on C sources

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -672,10 +672,10 @@ void partestRust(partition) {
   """
   String simCodeTargetArg = params.RUST_PARTEST_SIMCODETARGET ? " -simCodeTarget=${params.RUST_PARTEST_SIMCODETARGET}" : ''
   // cpp/hpcom: the Rust omc is built without the C++ runtime. metamodelica:
-  // MetaModelica code generation only works against the C runtime. 63bit/antlr:
-  // the port's Integer is i32 and its parser is winnow, not ANTLR; see
-  // testsuite/rust-ignore-tests.txt.
-  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr'
+  // MetaModelica code generation only works against the C runtime.
+  // fmuCSources checks the generated C files or the list in the XML - wasm-jit does not use C
+  // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
+  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-fmuCSources'
   try {
     sh """#!/bin/bash
       set -o pipefail

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
@@ -1,5 +1,6 @@
 // name:  testBug2764
 // keywords: FMI 2.0 export
+// suite: fmuCSources
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_Bug2764* output.log
 // cflags: -d=-newInst

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -1,5 +1,6 @@
 // name:  testBug3049
 // keywords: FMI 2.0 export
+// suite: fmuCSources
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_Bug3049* output.log
 // cflags: -d=-newInst

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
@@ -1,5 +1,6 @@
 // name:  testDisableDependency
 // keywords: FMI 2.0 export
+// suite: fmuCSources
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml testDID* output.log
 // cflags: -d=-newInst

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
@@ -1,5 +1,6 @@
 // name:  testDiscreteStruct
 // keywords: FMI 2.0 export
+// suite: fmuCSources
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml testDID* output.log
 // cflags: -d=-newInst


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
