### PR TITLE
Add junit xml as downloadable artifact for Rust partest

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -703,6 +703,8 @@ void partestRust(partition) {
     if (params.RUST_PARTEST_JUNIT) {
       junit testResults: 'testsuite/partest/result.xml', allowEmptyResults: true, skipPublishingChecks: true
     }
+    sh "cp testsuite/partest/result.xml partest-rust-partest-junit-${partition}.xml"
+    archiveArtifacts artifacts: 'partest-rust-partest-junit-${partition}.xml', allowEmptyArchive: true, fingerprint: true
   }
 }
 


### PR DESCRIPTION
In partestRust, copy result.xml to a partitioned name and stash it. This file is always archived regardless of RUST_PARTEST_JUNIT.

In assembleWeb, unstash and archive the partition junit files as downloadable artifacts. The junit step itself remains gated.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
