### PR TITLE
Open modelica:// links with target="_blank"

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -1408,6 +1408,9 @@ DocumentationViewer::DocumentationViewer(DocumentationWidget *pDocumentationWidg
    */
   connect(page(), SIGNAL(linkClicked(QUrl)), SLOT(processLinkClick(QUrl)));
   connect(page(), SIGNAL(linkHovered(QString)), SLOT(processLinkHover(QString)));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+  connect(page(), SIGNAL(newWindowRequested(QWebEngineNewWindowRequest&)), SLOT(newWindowRequested(QWebEngineNewWindowRequest&)));
+#endif
   createActions();
   connect(this, SIGNAL(loadFinished(bool)), SLOT(pageLoaded(bool)));
 }
@@ -1561,21 +1564,21 @@ void DocumentationViewer::pageLoaded(bool ok)
   }
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 /*!
- * \brief DocumentationViewer::createWindow
- * \param type
- * \return
+ * \brief DocumentationViewer::newWindowRequested
+ * Slot activated when the newWindowRequested signal is raised.\n
+ * target="_blank" links and window.open() requests arrive here with the requested URL.
+ * Route the URL through processLinkClick and do not create a new window (do not call
+ * openIn()), so the current documentation remains untouched.
+ * See #16234
+ * \param request
  */
-QWebEngineView* DocumentationViewer::createWindow(QWebEnginePage::WebWindowType type)
+void DocumentationViewer::newWindowRequested(QWebEngineNewWindowRequest &request)
 {
-  Q_UNUSED(type);
-  QWebEngineView *webView = new QWebEngineView;
-  QWebEnginePage *newWeb = new QWebEnginePage(webView);
-  webView->setAttribute(Qt::WA_DeleteOnClose, true);
-  webView->setPage(newWeb);
-  webView->show();
-  return webView;
+  processLinkClick(request.requestedUrl());
 }
+#endif
 
 /*!
  * \brief DocumentationViewer::keyPressEvent

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.h
@@ -49,6 +49,9 @@
 #else
 #include <QWebEngineView>
 #include <QWebEnginePage>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+#include <QWebEngineNewWindowRequest>
+#endif
 #endif
 #include <QToolBar>
 #include <QComboBox>
@@ -222,8 +225,10 @@ public slots:
   void processLinkHover(QString link, QString title, QString textContent);
   void showContextMenu(QPoint point);
   void pageLoaded(bool ok);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+  void newWindowRequested(QWebEngineNewWindowRequest &request);
+#endif
 protected:
-  virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type) override;
   virtual void keyPressEvent(QKeyEvent *event) override;
   virtual void wheelEvent(QWheelEvent *event) override;
   virtual void mouseDoubleClickEvent(QMouseEvent *event) override;

--- a/OMEdit/OMEditLIB/Modeling/WasmDocViewer.h
+++ b/OMEdit/OMEditLIB/Modeling/WasmDocViewer.h
@@ -67,6 +67,12 @@ public:
   void setDefaultTextEncoding(const char *) {}
 };
 
+class QWebEngineNewWindowRequest
+{
+public:
+  QUrl requestedUrl() const { return QUrl(); }
+};
+
 class QWebEnginePage : public QObject
 {
   Q_OBJECT
@@ -74,9 +80,6 @@ public:
   enum WebAction {
     SelectAll, Copy, Cut, Paste, ToggleBold, ToggleItalic, ToggleUnderline,
     ToggleStrikethrough, Indent, Outdent
-  };
-  enum WebWindowType {
-    WebBrowserWindow, WebBrowserTab, WebDialog, WebBrowserBackgroundTab
   };
   enum NavigationType {
     NavigationTypeLinkClicked, NavigationTypeTyped, NavigationTypeFormSubmitted,
@@ -103,6 +106,7 @@ signals:
   void linkClicked(const QUrl &);
   void linkHovered(const QString &);
   void selectionChanged();
+  void newWindowRequested(QWebEngineNewWindowRequest &request);
 private:
   QTextBrowser *mpBrowser = nullptr;
 };
@@ -123,8 +127,6 @@ public:
   qreal zoomFactor() const { return mZoom; }
 signals:
   void loadFinished(bool ok);
-protected:
-  virtual QWebEngineView *createWindow(QWebEnginePage::WebWindowType) { return nullptr; }
 private slots:
   void onAnchorClicked(const QUrl &url);
   void onHighlighted(const QUrl &url);

--- a/OMEdit/OMEditLIB/Modeling/qtwebengine_compat.h
+++ b/OMEdit/OMEditLIB/Modeling/qtwebengine_compat.h
@@ -77,6 +77,12 @@ public:
   void setDefaultTextEncoding(const char *) {}
 };
 
+class QWebEngineNewWindowRequest
+{
+public:
+  QUrl requestedUrl() const { return QUrl(); }
+};
+
 class QWebEnginePage : public QObject
 {
   Q_OBJECT
@@ -84,9 +90,6 @@ public:
   enum WebAction {
     SelectAll, Copy, Cut, Paste, ToggleBold, ToggleItalic, ToggleUnderline,
     ToggleStrikethrough, Indent, Outdent
-  };
-  enum WebWindowType {
-    WebBrowserWindow, WebBrowserTab, WebDialog, WebBrowserBackgroundTab
   };
   enum NavigationType {
     NavigationTypeLinkClicked, NavigationTypeTyped, NavigationTypeFormSubmitted,
@@ -106,6 +109,8 @@ public:
   QPointF scrollPosition() const { return QPointF(); }
   void setHtml(const QString &) {}
   void setUrl(const QUrl &) {}
+signals:
+  void newWindowRequested(QWebEngineNewWindowRequest &request);
 protected:
   virtual bool acceptNavigationRequest(const QUrl &, NavigationType, bool) { return true; }
 };
@@ -124,8 +129,6 @@ public:
   void load(const QUrl &) {}
   void setZoomFactor(qreal) {}
   qreal zoomFactor() const { return 1.0; }
-protected:
-  virtual QWebEngineView *createWindow(QWebEnginePage::WebWindowType) { return nullptr; }
 private:
   QWebEnginePage *mpPage = nullptr;
 };


### PR DESCRIPTION
### Related Issues

#16234

### Purpose

Open links that has `target="_blank"` attribute.

### Approach

Open links that use target="_blank" in the documentation viewer through processLinkClick. Do not override QWebEngineView::createWindow() the default implmentation returns nullptr, a newWindowRequested handler routes the requested URL through the existing link handling. The createWindow override is removed and newWindowRequested/QWebEngineNewWindowRequest are added to the wasm stubs.