### PR TITLE
CI: limit test memory with cgroups, not ulimit -v

### DIFF
--- a/.CI/Jenkinsfile.cpp
+++ b/.CI/Jenkinsfile.cpp
@@ -31,13 +31,7 @@ pipeline {
     }
     stage('cpp-test') {
       agent {
-        docker {
-          image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-          alwaysPull true
-          label 'linux'
-          args "--mount type=volume,source=runtest-cpp-test-cache,target=/cache/runtest " +
-               "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
-        }
+        label 'linux'
       }
       environment {
         RUNTESTDB = "/cache/runtest/"
@@ -48,9 +42,13 @@ pipeline {
       }
       steps {
         script {
-          common.buildOMC('clang', 'clang++', '--without-hwloc')
-          common.makeLibsAndCache()
-          common.partest(true, '-cppruntime')
+          common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                 "--mount type=volume,source=runtest-cpp-test-cache,target=/cache/runtest " +
+                                 "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary") {
+            common.buildOMC('clang', 'clang++', '--without-hwloc')
+            common.makeLibsAndCache()
+            common.partest(true, '-cppruntime')
+          }
         }
       }
     }

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -71,6 +71,43 @@ def numLogicalCPU() {
   return env.JENKINS_NUM_LOGICAL_CPU
 }
 
+// 6 GB per parallel test job, at most 80% of the node's RAM. Override 6 and 80
+// with OM_PARTEST_MEM_PER_JOB_GB / OM_PARTEST_MEM_PERCENT when a machine hosts
+// more than one Jenkins instance. The arithmetic is awk's because the Groovy
+// sandbox rejects most of the numeric conversions this would otherwise need.
+String testMemoryLimitMB() {
+  String vars = "-v jobs=${numPhysicalCPU()}" +
+                " -v per_job=\"\${OM_PARTEST_MEM_PER_JOB_GB:-6}\"" +
+                " -v percent=\"\${OM_PARTEST_MEM_PERCENT:-80}\""
+  String prog = '/^MemTotal:/ { cap = int($2/1024*percent/100); want = per_job*1024*jobs; print (want < cap ? want : cap) }'
+  return sh(script: "awk ${vars} '${prog}' /proc/meminfo", returnStdout: true).trim()
+}
+
+// The container's cgroup memory.max: covers every process the run spawns and
+// charges memory in use, not address space. --memory-swap must equal --memory to
+// forbid swapping; docker reads 0 as "unset" and then allows swap up to --memory.
+String memoryLimitArgs() {
+  String mb = testMemoryLimitMB()
+  echo "Test container memory limit: ${mb} MB, no swap"
+  return "--memory=${mb}m --memory-swap=${mb}m"
+}
+
+String testCacheMounts(String runtestCache) {
+  return "--mount type=volume,source=${runtestCache},target=/cache/runtest " +
+         "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+         "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+}
+
+// Not an `agent { docker { args } }`: those args are evaluated before a node is
+// allocated, so the limit could not depend on the node's RAM or CPU count.
+void insideTestImage(String image, String extraArgs, Closure body) {
+  def img = docker.image(image)
+  img.pull()
+  img.inside("${memoryLimitArgs()} ${extraArgs}") {
+    body()
+  }
+}
+
 void partest(partition=1,partitionmodulo=1,cache=true,extraArgs='') {
   if (isWindows()) {
 
@@ -106,11 +143,14 @@ void partest(partition=1,partitionmodulo=1,cache=true,extraArgs='') {
 
   sh ("""#!/bin/bash -x
   ulimit -t 1500
+  # On top of the cgroup limit, to catch a single runaway process early
   ulimit -v 6291456 # Max 6GB per process
 
+  .CI/scripts/cgroup-memory.sh check
   cd testsuite/partest
   ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/${partitionmodulo} -nocolour -with-xml ${extraArgs}
   CODE=\$?
+  ../../.CI/scripts/cgroup-memory.sh report
   test \$CODE = 0 -o \$CODE = 7 || exit 1
   """
   + (cache ?
@@ -676,17 +716,24 @@ void partestRust(partition) {
   // fmuCSources checks the generated C files or the list in the XML - wasm-jit does not use C
   // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
   String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-fmuCSources'
+  // wasmtime reserves ~4 GiB of address space per wasm memory, and shrinking that
+  // reservation to fit an RLIMIT_AS costs the bounds-check-free fast path.
+  String asLimit = params.RUST_PARTEST_SIMCODETARGET == 'wasm-jit'
+                   ? '# wasm-jit: address space is not limited, only the cgroup is'
+                   : 'ulimit -v 6291456 # Max 6GB per process'
   try {
     sh """#!/bin/bash
       set -o pipefail
       ulimit -t 1500
-      ulimit -v 6291456
+      ${asLimit}
+      .CI/scripts/cgroup-memory.sh check
       rm -f testsuite/partest-failed-${partition}.txt
       cd testsuite/partest
       set -x
       ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/2 -nocolour -with-xml${suitesArg}${simCodeTargetArg} 2>&1 | tee runtests-${partition}.log
       CODE=\${PIPESTATUS[0]}
       set +x
+      ../../.CI/scripts/cgroup-memory.sh report
       # 0/7 == the run completed (7 means some tests failed); only fail the step on
       # anything else, so junit below still publishes the per-test results.
       test \$CODE = 0 -o \$CODE = 7 || exit 1

--- a/.CI/scripts/cgroup-memory.sh
+++ b/.CI/scripts/cgroup-memory.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Report the cgroup memory limit a test run is under (check) and what it used
+# (report). The limit comes from `docker run --memory`; see .CI/common.groovy.
+
+set -u
+
+cg=/sys/fs/cgroup
+rel=$(sed -n 's/^0:://p' /proc/self/cgroup 2>/dev/null | head -n1)
+if [ -n "${rel:-}" ] && [ "$rel" != / ] && [ -d "${cg}${rel}" ]; then
+  cg="${cg}${rel}"
+fi
+
+if [ -r "$cg/memory.max" ]; then
+  f_max=$cg/memory.max
+  f_swap=$cg/memory.swap.max
+  f_peak=$cg/memory.peak
+  f_events=$cg/memory.events
+  oom_field=oom_kill
+else
+  # cgroup v1 host
+  cg=/sys/fs/cgroup/memory
+  f_max=$cg/memory.limit_in_bytes
+  f_swap=$cg/memory.memsw.limit_in_bytes
+  f_peak=$cg/memory.max_usage_in_bytes
+  f_events=
+  oom_field=
+fi
+
+show() {
+  if [ -r "$1" ]; then cat "$1"; else echo '?'; fi
+}
+
+case "${1:-check}" in
+check)
+  max=$(show "$f_max")
+  swap=$(show "$f_swap")
+  echo "cgroup $cg: memory limit $max, swap limit $swap"
+  case "$max" in
+    max|'?'|9223372036854771712)
+      echo "WARNING: no cgroup memory limit - a runaway test can take the machine down" >&2
+      ;;
+  esac
+  if [ "$swap" != 0 ] && [ "$swap" != "$max" ]; then
+    echo "WARNING: swapping is allowed ($swap); a test should be killed, not swapped" >&2
+  fi
+  # memory.oom.group would kill the whole run, not just the greediest process.
+  if [ "$(show "$cg/memory.oom.group")" = 1 ]; then
+    echo "WARNING: memory.oom.group is set; one runaway test takes down runtests.pl" >&2
+  fi
+  ;;
+report)
+  echo "cgroup $cg: peak memory $(show "$f_peak") of $(show "$f_max")"
+  if [ -n "$f_events" ] && [ -r "$f_events" ]; then
+    kills=$(awk -v k="$oom_field" '$1 == k { print $2 }' "$f_events")
+    echo "OOM kills: ${kills:-0}"
+    if [ "${kills:-0}" != 0 ]; then
+      echo "WARNING: ${kills} process(es) hit the memory limit and were killed" >&2
+    fi
+  fi
+  ;;
+*)
+  echo "usage: $0 [check|report]" >&2
+  exit 2
+  ;;
+esac

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,16 +362,7 @@ pipeline {
         // common.partestRust().
         stage('01 testsuite-rust 1/2') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-26.04-rust'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-rust-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -383,22 +374,16 @@ pipeline {
           }
           steps {
             script {
-              common.partestRust(1)
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
+                                     common.testCacheMounts('runtest-rust-cache')) {
+                common.partestRust(1)
+              }
             }
           }
         }
         stage('02 testsuite-rust 2/2') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-26.04-rust'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-rust-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -410,23 +395,17 @@ pipeline {
           }
           steps {
             script {
-              common.partestRust(2)
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
+                                     common.testCacheMounts('runtest-rust-cache')) {
+                common.partestRust(2)
+              }
             }
           }
         }
 
         stage('04 testsuite-gcc 1/3') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-gcc-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -440,22 +419,18 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-gcc', 1, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-gcc-cache')) {
+                common.partestStashed('omc-gcc', 1, 3)
+              }
+            }
           }
         }
 
         stage('05 testsuite-gcc 2/3') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-gcc-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -469,22 +444,18 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-gcc', 2, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-gcc-cache')) {
+                common.partestStashed('omc-gcc', 2, 3)
+              }
+            }
           }
         }
 
         stage('06 testsuite-gcc 3/3') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-gcc-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -498,22 +469,18 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-gcc', 3, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-gcc-cache')) {
+                common.partestStashed('omc-gcc', 3, 3)
+              }
+            }
           }
         }
 
         stage('07 testsuite-clang 1/3') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-clang-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -527,22 +494,18 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-clang', 1, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-clang-cache')) {
+                common.partestStashed('omc-clang', 1, 3)
+              }
+            }
           }
         }
 
         stage('08 testsuite-clang 2/3') {
           agent {
-           docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-clang-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -556,22 +519,18 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-clang', 2, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-clang-cache')) {
+                common.partestStashed('omc-clang', 2, 3)
+              }
+            }
           }
         }
 
         stage('09 testsuite-clang 3/3') {
           agent {
-            docker {
-              alwaysPull true
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux'
-              args '''
-                --mount type=volume,source=runtest-clang-cache,target=/cache/runtest \
-                --mount type=volume,source=omlibrary-cache,target=/cache/omlibrary \
-                -v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache
-              '''
-            }
+            label 'linux'
           }
           environment {
             RUNTESTDB = "/cache/runtest/"
@@ -585,7 +544,12 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestStashed('omc-clang', 3, 3) }
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04',
+                                     common.testCacheMounts('runtest-clang-cache')) {
+                common.partestStashed('omc-clang', 3, 3)
+              }
+            }
           }
         }
 
@@ -805,12 +769,7 @@ pipeline {
 
         stage('18 testsuite-clang-parmod') {
           agent {
-            docker {
-              image 'docker.openmodelica.org/build-deps:ubuntu-22.04'
-              label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
-              alwaysPull true
-              // No runtest.db cache necessary; the tests run in serial and do not load libraries!
-            }
+            label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
           }
           when {
             beforeAgent true
@@ -820,7 +779,12 @@ pipeline {
             retry(count: 2, conditions: [nonresumable()])
           }
           steps {
-            script { common.partestParmod() }
+            script {
+              // No runtest.db cache necessary; the tests run in serial and do not load libraries!
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-22.04', '') {
+                common.partestParmod()
+              }
+            }
           }
         }
 


### PR DESCRIPTION
`ulimit -v` caps address space, which a wasm-jit run cannot live with: wasmtime reserves ~4 GiB per wasm memory, so even a bouncing ball peaks at 3.6 GB of address space for 71 MB of RSS. Under the 6 GB cap the runtime fell back to a 256 MiB reservation, i.e. CI has been measuring wasm-jit on the slow bounds-checked path rather than the fast one.

Cap the memory a testsuite container may use with its own cgroup instead: `docker run --memory=N --memory-swap=N`, with N = min(6 GB * jobs, 80% of the node's RAM). It covers every process the run spawns, charges memory in use rather than address space, and on a breach the kernel kills the greediest process in the container - the runaway test, not runtests.pl or the Jenkins agent, which runs outside the container. --memory-swap has to repeat N: docker reads 0 as "unset" and then allows swapping up to --memory.

- The testsuite stages trade `agent { docker { } }` for `agent { label }` plus common.insideTestImage(), which is docker.image().inside() with the limit. Declarative agent args are evaluated before a node is allocated, so the limit could not be derived from the node's RAM and CPU count there.
- `ulimit -v 6291456` stays for the C runtime, on top of the cgroup, to catch a single runaway process early; partestRust drops it only when the target is wasm-jit.
- .CI/scripts/cgroup-memory.sh logs the limit in force before the run and the peak usage plus OOM kill count after it, so a failing shard can be recognised as one that ran out of memory.
- OM_PARTEST_MEM_PER_JOB_GB and OM_PARTEST_MEM_PERCENT override the 6 and the 80, for a machine hosting more than one Jenkins instance: per-container limits do not compose.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
