### PR TITLE
SimRT/C: Mismatching c/c++ flags

### DIFF
--- a/OMCompiler/SimulationRuntime/c/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/c/CMakeLists.txt
@@ -14,9 +14,14 @@ if(NOT MSVC)
   # Clang puts designated-initializer warnings under -Werror=c23-extensions and
   # -Wc++20-extensions / -Wc++23-extensions (warning-level, not
   # extension-level), so -pedantic-errors alone does not promote them to errors.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Werror=c23-extensions>")
+  endif ()
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Werror=c++20-extensions)
-    add_compile_options(-Werror=c23-extensions -Werror=c++23-extensions)
+    add_compile_options(
+      "$<$<COMPILE_LANGUAGE:CXX>:-Werror=c++20-extensions>"
+      "$<$<COMPILE_LANGUAGE:CXX>:-Werror=c++23-extensions>"
+    )
   endif()
 endif()
 


### PR DESCRIPTION
Fixes compilation with clang for C++ and gcc as C compiler:
2026-08-14T15:03:41.7944730Z  │ │ cc1: warning: '-Werror=' argument '-Werror=c++20-extensions' is not valid for C
2026-08-14T15:03:41.7948730Z  │ │ cc1: error: '-Werror=c23-extensions': no option '-Wc23-extensions'; did you mean '-Wc++23-extensions'?
2026-08-14T15:03:41.7952880Z  │ │ cc1: warning: '-Werror=' argument '-Werror=c++23-extensions' is not valid for C