### PR TITLE
wasm-jit: C's dynamic state selection semantics

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -6397,28 +6397,25 @@ fn lin_torn_use_sparse(lsystem: &SimCode::LinearSystem, n: usize) -> bool {
 }
 
 
-/// Total f64 count of the state-set Jacobian scratch region: each set contributes
-/// its seed inputs (`n_candidates`) and its column result outputs (`n_dummy`).
+/// Total f64 count of the state-set Jacobian scratch region: the seeds plus every
+/// variable the column equations write.
 fn stateset_scratch_f64(state_sets: &Arc<List<SimCode::StateSet>>) -> Result<u32> {
     let mut n = 0u32;
     for set in lst(state_sets) {
-        let col = lst(&set.jacobianMatrix.columns)
-            .next()
-            .ok_or_else(|| "CodegenWasmJit: state set has no Jacobian column")?;
-        n += count(&set.jacobianMatrix.seedVars) as u32 + count(&col.columnVars) as u32;
+        n += count(&set.jacobianMatrix.seedVars) as u32 + jac_column_vars(&set.jacobianMatrix).len() as u32;
     }
     Ok(n)
 }
 
-/// Register each state set's Jacobian seed/result crefs at the scratch region and
-/// collect the driver-side [`StateSetInfo`]. The seed vars (one per candidate) and
-/// the column result vars get f64 scratch slots so the emitted
-/// `functionStateSetJacobians` (which lowers the `columnEqns`) reads/writes them.
+/// Register each state set's Jacobian seed/column crefs at the scratch region and
+/// collect the driver-side [`StateSetInfo`], so the emitted
+/// `functionStateSetJacobians` works on the Jacobian's own storage.
 fn build_state_set_infos(
     state_sets: &Arc<List<SimCode::StateSet>>,
     layout: &SimLayout,
     var_map: &mut SimVarMap,
 ) -> Result<Vec<StateSetInfo>> {
+    use openmodelica_backend_types::BackendDAE::VarKind;
     let mut infos = Vec::new();
     let mut cursor = layout.stateset_off;
     let real_slot = |var_map: &SimVarMap, cr: &Arc<DAE::ComponentRef>| -> Result<u32> {
@@ -6436,30 +6433,40 @@ fn build_state_set_infos(
         let n_candidates = set.nCandidates.max(0) as u32;
         let n_states = set.nStates.max(0) as u32;
         let n_dummy = n_candidates - n_states;
-        let col = lst(&set.jacobianMatrix.columns)
-            .next()
-            .ok_or_else(|| "CodegenWasmJit: state set has no Jacobian column")?;
+        let jm = &set.jacobianMatrix;
+        let register = |var_map: &mut SimVarMap, sv: &SimCodeVar::SimVar, cursor: &mut u32| -> Result<u32> {
+            let off = *cursor;
+            *cursor += 8;
+            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
+            Ok(off)
+        };
 
-        // Seed slots (candidate order) — register the seed var crefs.
-        let mut seed_offs = Vec::new();
-        for sv in lst(&set.jacobianMatrix.seedVars) {
-            let off = cursor;
-            cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
-            seed_offs.push(off);
+        // Seeds are listed in their own order; the driver wants Jacobian-column order.
+        let listed: Vec<u32> = lst(&jm.seedVars)
+            .map(|sv| register(var_map, &sv, &mut cursor))
+            .collect::<Result<_>>()?;
+        let seed_offs = jac_seed_offs_by_column(jm, &listed, n_candidates as usize)
+            .ok_or("CodegenWasmJit: state-set Jacobian seed columns are not a permutation")?;
+
+        let mut result_offs = vec![u32::MAX; n_dummy as usize];
+        for sv in &jac_column_vars(jm) {
+            let off = register(var_map, sv, &mut cursor)?;
+            if matches!(sv.varKind, VarKind::JAC_VAR) {
+                let row = jac_result_row(sv)
+                    .filter(|&r| r < n_dummy as usize)
+                    .ok_or("CodegenWasmJit: state-set Jacobian result var has no row index")?;
+                result_offs[row] = off;
+            }
         }
-        // Result slots (row order) — register the column result var crefs.
-        let mut result_offs = Vec::new();
-        for sv in lst(&col.columnVars) {
-            let off = cursor;
-            cursor += 8;
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
-            result_offs.push(off);
+        if result_offs.contains(&u32::MAX) {
+            return Err("CodegenWasmJit: state-set Jacobian has no result var for every row");
         }
 
         let candidate_offs: Vec<u32> = lst(&set.statescandidates)
             .map(|cr| real_slot(var_map, cr))
             .collect::<Result<_>>()?;
+        let candidate_names: Vec<String> =
+            lst(&set.statescandidates).map(|cr| cref_display(cr)).collect::<Result<_>>()?;
         let state_offs: Vec<u32> = lst(&set.states)
             .map(|cr| real_slot(var_map, cr))
             .collect::<Result<_>>()?;
@@ -6486,15 +6493,16 @@ fn build_state_set_infos(
             a_offs,
             seed_offs,
             result_offs,
+            candidate_names,
         });
     }
     Ok(infos)
 }
 
 /// Build `functionStateSetJacobians(SimData*)`: run every state set's Jacobian
-/// `columnEqns`, reading the seed slots and writing the result slots (both in the
-/// scratch region). The driver seeds one candidate at a time and reads back one
-/// Jacobian column (`getAnalyticalJacobianSet` in C's `stateset.c`).
+/// `constantEqns` and `columnEqns` over the scratch slots. The driver seeds one
+/// candidate at a time and reads back one Jacobian column
+/// (`getAnalyticalJacobianSet` in C's `stateset.c`).
 fn build_stateset_jac_fn(
     state_sets: &Arc<List<SimCode::StateSet>>,
     var_map: &SimVarMap,
@@ -6505,6 +6513,7 @@ fn build_stateset_jac_fn(
     let mut eqs: Vec<Arc<SimCode::SimEqSystem>> = Vec::new();
     for set in lst(state_sets) {
         for col in lst(&set.jacobianMatrix.columns) {
+            eqs.extend(lst(&col.constantEqns).cloned());
             eqs.extend(lst(&col.columnEqns).cloned());
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -111,6 +111,8 @@ fn state_selection_set(
     sim_data: u32,
     info: &StateSetInfo,
     st: &mut StateSetPivot,
+    set_index: usize,
+    report_error: bool,
 ) -> Result<bool> {
     let nc = info.n_candidates as usize;
     let nd = info.n_dummy as usize;
@@ -135,8 +137,21 @@ fn state_selection_set(
         write_f64(e, sim_data + soff, 0.0)?;
     }
 
+    if omclog::active(omclog::DSS_JAC) {
+        log_state_set_jacobian(omclog::INFO, omclog::DSS_JAC, info, &jac, set_index);
+    }
+
     let old_col = st.col_pivot.clone();
-    if !pivot(&mut jac, nd, nc, &mut st.row_pivot, &mut st.col_pivot) {
+    if !pivot(&mut jac, nd, nc, &mut st.row_pivot, &mut st.col_pivot) && report_error {
+        log_state_set_jacobian(omclog::WARNING, omclog::DSS, info, &jac, set_index);
+        let t = read_f64(e, sim_data + TIME_OFF)?;
+        omclog::error(
+            omclog::STDOUT,
+            false,
+            &format!(
+                "Error, singular Jacobian for dynamic state selection at time {t:.6}\nUse -lv LOG_DSS_JAC to get the Jacobian"
+            ),
+        );
         return Err("CodegenWasmJit: singular Jacobian for dynamic state selection");
     }
 
@@ -165,21 +180,107 @@ fn state_selection_set(
                 row += 1;
             }
         }
+        if omclog::active(omclog::DSS) {
+            let t = read_f64(e, sim_data + TIME_OFF)?;
+            omclog::info(omclog::DSS, true, &format!("StateSelection Set {set_index} at time = {t:.6}"));
+            print_state_selection_info(e, sim_data, info)?;
+            omclog::close(omclog::DSS);
+        }
     }
     Ok(changed)
 }
 
-/// Run state selection over every `$STATESET` (C's `stateSelection`). Returns
-/// whether any set switched its selection.
+/// C's `printStateSelectionInfo`.
+fn print_state_selection_info(e: &mut dyn SimEngine, sim_data: u32, info: &StateSetInfo) -> Result<()> {
+    let nc = info.n_candidates as usize;
+    let ns = info.n_states as usize;
+    let name = |i: usize| info.candidate_names.get(i).map(String::as_str).unwrap_or("?");
+    let plural = if ns == 1 { "" } else { "s" };
+    omclog::info(omclog::DSS, false, &format!("Select {ns} state{plural} from {nc} candidates."));
+    omclog::info(omclog::DSS, true, "State candidates:");
+    for k in 0..nc {
+        omclog::info(omclog::DSS, false, &format!("[{}] {}", k + 1, name(k)));
+    }
+    omclog::close(omclog::DSS);
+    omclog::info(omclog::DSS, true, &format!("Selected state{plural}"));
+    for row in 0..ns {
+        for col in 0..nc {
+            if read_i32(e, sim_data + info.a_offs[row * nc + col])? == 1 {
+                omclog::info(omclog::DSS, false, &format!("[{}] {}", col + 1, name(col)));
+                break;
+            }
+        }
+    }
+    omclog::close(omclog::DSS);
+    Ok(())
+}
+
+/// C's `LOG_DSS_JAC` dump, and the block it warns with before throwing on a
+/// singular Jacobian (which adds the candidate names).
+fn log_state_set_jacobian(ty: omclog::LogType, stream: omclog::Stream, info: &StateSetInfo, jac: &[f64], set_index: usize) {
+    let nc = info.n_candidates as usize;
+    let nd = info.n_dummy as usize;
+    let mut block = format!("jacobian {nd}x{nc} [id: {set_index}]");
+    for row in 0..nd {
+        block.push('\n');
+        for col in 0..nc {
+            block.push_str(&omclog::e(jac[row + nd * col], 0, 5));
+            block.push(' ');
+        }
+    }
+    if ty == omclog::WARNING {
+        for n in &info.candidate_names {
+            block.push('\n');
+            block.push_str(n);
+        }
+        omclog::warning(stream, false, &block);
+    } else {
+        omclog::info(stream, false, &block);
+    }
+}
+
+/// Run state selection over every `$STATESET` (C's `stateSelection` with
+/// `reportError=1`). Returns whether any set switched its selection.
 fn run_state_selection(
     e: &mut dyn SimEngine,
     sim_data: u32,
     state_sets: &[StateSetInfo],
     pivots: &mut [StateSetPivot],
 ) -> Result<bool> {
+    state_selection(e, sim_data, state_sets, pivots, true)
+}
+
+/// The selection C runs at the end of `initialization()`: the first pass does not
+/// report a singular Jacobian, and only a second switch in a row warns.
+fn run_state_selection_initial(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    state_sets: &[StateSetInfo],
+    pivots: &mut [StateSetPivot],
+) -> Result<bool> {
+    if !state_selection(e, sim_data, state_sets, pivots, false)? {
+        return Ok(false);
+    }
+    if state_selection(e, sim_data, state_sets, pivots, true)? {
+        omclog::warning(
+            omclog::STDOUT,
+            false,
+            "Cannot initialize the dynamic state selection in an unique way. Use -lv LOG_DSS to see the switching state set.",
+        );
+    }
+    Ok(true)
+}
+
+fn state_selection(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    state_sets: &[StateSetInfo],
+    pivots: &mut [StateSetPivot],
+    report_error: bool,
+) -> Result<bool> {
     let mut changed = false;
-    for (info, st) in state_sets.iter().zip(pivots.iter_mut()) {
-        changed |= state_selection_set(e, sim_data, info, st)?;
+    for (i, (info, st)) in state_sets.iter().zip(pivots.iter_mut()).enumerate() {
+        changed |= state_selection_set(e, sim_data, info, st, i, report_error)?;
     }
     Ok(changed)
 }
@@ -3407,10 +3508,16 @@ impl Driver for EulerDriver {
             }
             // Re-select states before the Euler update; a switch reinits the states,
             // so refresh the derivatives it uses (see `DasslDriver`).
-            if !model.state_sets.is_empty()
-                && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)?
-            {
-                e.call1("functionODE", sim_data)?;
+            if !model.state_sets.is_empty() {
+                let sets = &model.state_sets;
+                let changed = if self.row == 0 {
+                    run_state_selection_initial(e, sim_data, sets, &mut self.pivots)?
+                } else {
+                    run_state_selection(e, sim_data, sets, &mut self.pivots)?
+                };
+                if changed {
+                    e.call1("functionODE", sim_data)?;
+                }
             }
             // Forward-Euler update of the states, over this row's own step.
             let h = grid(self.row + 1) - grid(self.row);
@@ -4044,7 +4151,7 @@ impl DasslDriver {
         let mut pivots = init_state_pivots(&model.state_sets);
         let (mut y, mut yp) = (Vec::new(), Vec::new());
         if n_states > 0 && !pending_terminate {
-            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+            if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
                 e.call1("functionODE", sim_data)?;
             }
             y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;
@@ -5642,7 +5749,7 @@ impl CsDriver {
         let mut core = SolverCore::new(&*e, model, sim_data, t, method, alloc_gbode(model, method)?)?;
         let mut pivots = init_state_pivots(&model.state_sets);
         if core.n_states > 0 {
-            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+            if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
                 e.call1("functionODE", sim_data)?;
             }
             core.read_states(e)?;
@@ -5907,7 +6014,7 @@ impl EventsDriver {
         // point (see `DasslDriver`). A switch reinits states, so refresh derivatives.
         let mut pivots = init_state_pivots(&model.state_sets);
         if n_states > 0 && !pending_terminate {
-            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+            if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
                 e.call1("functionODE", sim_data)?;
             }
             core.read_states(e)?;
@@ -6353,7 +6460,7 @@ impl CvodeDriver {
         let mut pivots = init_state_pivots(&model.state_sets);
         let mut y = Vec::new();
         if n_states > 0 && !pending_terminate {
-            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+            if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
                 e.call1("functionODE", sim_data)?;
             }
             y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;
@@ -7117,7 +7224,7 @@ impl IdaDriver {
         let mut pivots = init_state_pivots(&model.state_sets);
         let (mut y, mut yp) = (Vec::new(), Vec::new());
         if n_states > 0 && !pending_terminate {
-            if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut pivots)? {
+            if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
                 e.call1("functionODE", sim_data)?;
             }
             y = (0..n_states).map(|i| read_f64(e, states_base + (i as u32) * 8)).collect::<Result<_>>()?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -703,6 +703,8 @@ pub struct StateSetInfo {
     pub seed_offs: Vec<u32>,
     /// Jacobian result slots (f64), row order (`n_dummy` of them) — column output.
     pub result_offs: Vec<u32>,
+    /// Candidate names, candidate order (C's `statescandidates[i]->name`).
+    pub candidate_names: Vec<String>,
 }
 
 /// One symbolic Jacobian the optimizer differentiates through: C's
@@ -1241,6 +1243,10 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         put_u32s(&mut o, &s.a_offs);
         put_u32s(&mut o, &s.seed_offs);
         put_u32s(&mut o, &s.result_offs);
+        put_u32(&mut o, s.candidate_names.len() as u32);
+        for n in &s.candidate_names {
+            put_str(&mut o, n);
+        }
     }
     put_u32(&mut o, m.fmi_vrs.len() as u32);
     for v in &m.fmi_vrs {
@@ -1588,7 +1594,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let nsets = r.u32()? as usize;
     let mut state_sets = Vec::with_capacity(nsets);
     for _ in 0..nsets {
-        state_sets.push(StateSetInfo {
+        let mut s = StateSetInfo {
             n_candidates: r.u32()?,
             n_states: r.u32()?,
             n_dummy: r.u32()?,
@@ -1597,7 +1603,11 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             a_offs: r.u32s()?,
             seed_offs: r.u32s()?,
             result_offs: r.u32s()?,
-        });
+            candidate_names: Vec::new(),
+        };
+        let nn = r.u32()? as usize;
+        s.candidate_names = (0..nn).map(|_| r.string()).collect::<core::result::Result<_, _>>()?;
+        state_sets.push(s);
     }
     let nvr = r.u32()? as usize;
     let mut fmi_vrs = Vec::with_capacity(nvr);
@@ -1842,6 +1852,7 @@ mod tests {
                 a_offs: vec![100, 104, 108, 112, 116, 120],
                 seed_offs: vec![200, 208, 216],
                 result_offs: vec![224],
+                candidate_names: vec!["a.w".to_string(), "b.w".to_string(), "c.w".to_string()],
             }],
             fmi_vrs: vec![
                 FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: Neg::None, start_off: 96, is_string: false, der_off: 0 },

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -84,6 +84,7 @@ pub const DEBUG: Stream = 5;
 pub const DELAY: Stream = 6;
 pub const DIVISION: Stream = 7;
 pub const DSS: Stream = 8;
+pub const DSS_JAC: Stream = 9;
 pub const EVENTS: Stream = 12;
 pub const EVENTS_V: Stream = 13;
 pub const INIT: Stream = 19;
@@ -176,7 +177,6 @@ fn finish(mut m: Mask) -> Mask {
     const GBODE_V: Stream = 15;
     const GBODE_NLS: Stream = 16;
     const GBODE_NLS_V: Stream = 17;
-    const DSS_JAC: Stream = 9;
     for (from, to) in [
         (GBODE_V, GBODE),
         (GBODE_NLS_V, GBODE_NLS),


### PR DESCRIPTION
Three PlanarMechanics testcases aborted under `--simCodeTarget=wasm-jit` with "singular Jacobian for dynamic state selection" right after initialization, where the C runtime runs them to completion.

C's `stateSelection()` takes a `reportError` flag, and `initialization()` calls it with `reportError=0` first: a singular Jacobian at the initial point is not fatal there, only the per-step calls from `perform_simulation` report it. The driver had no such flag and treated every call as reporting, so it threw where C continues.

Also ported from `stateset.c` while here:

| what | why it was missing |
| --- | --- |
| `LOG_DSS` / `LOG_DSS_JAC` | never implemented; no way to see a switch | | column `constantEqns` | `evalJacobian` runs them; the state-set path did not | | seeds by Jacobian column | were taken in `seedVars` list order | | results by `JAC_VAR` row | were taken in `columnVars` list order | | `crefsHT` column temporaries | got no scratch slot |

The last three follow what the torn-linear and NLS Jacobians already do. `StateSetInfo` carries the candidate names so the `LOG_DSS` report can name them as C's `printStateSelectionInfo` does.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
