### PR TITLE
wasm-jit: header-only external "C" Include

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1551,12 +1551,32 @@ pub(crate) fn compile_include_library(
     prefix: &str,
     includes: &[String],
     include_dirs: &[String],
+    symbols: &[String],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
-    use std::process::Command;
     if includes.is_empty() {
         return Ok(None);
     }
+    let wrappers = openmodelica_wasm_jit::model::ext_addr_wrappers(symbols);
+    let n = notes.len();
+    match compile_include_tu(prefix, includes, include_dirs, &wrappers, notes)? {
+        None if !wrappers.is_empty() => {
+            notes.truncate(n);
+            compile_include_tu(prefix, includes, include_dirs, "", notes)
+        }
+        r => Ok(r),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn compile_include_tu(
+    prefix: &str,
+    includes: &[String],
+    include_dirs: &[String],
+    wrappers: &str,
+    notes: &mut Vec<String>,
+) -> Result<Option<ExtLibrary>> {
+    use std::process::Command;
     let sysroot = wasi_sysroot();
     let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
     let dir = std::env::temp_dir().join(format!("om-wasm-include-{}-{prefix}", std::process::id()));
@@ -1564,7 +1584,7 @@ pub(crate) fn compile_include_library(
     let tu = dir.join(format!("{prefix}_includes.c"));
     let out = dir.join(format!("{prefix}_includes.wasm"));
     let prologue = openmodelica_wasm_jit::model::INCLUDE_TU_PROLOGUE_WASM;
-    std::fs::write(&tu, prologue.to_owned() + &includes.join("\n") + "\n")
+    std::fs::write(&tu, prologue.to_owned() + &includes.join("\n") + "\n" + wrappers)
         .map_err(|_| "CodegenWasmJit: cannot write the external \"C\" translation unit")?;
 
     let mut cmd = Command::new(&clang);
@@ -1610,6 +1630,7 @@ pub(crate) fn compile_include_library(
     _prefix: &str,
     includes: &[String],
     _include_dirs: &[String],
+    _symbols: &[String],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
     if includes.is_empty() {
@@ -1657,12 +1678,12 @@ fn wasm_builtins(sysroot: &std::path::Path) -> Option<std::path::PathBuf> {
     .find(|p| p.exists())
 }
 
-/// The `external "C"` functions none of `libs` exports — what an `Include` still
-/// has to provide.
-fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<String> {
+/// The `external "C"` functions neither `libs` nor the libraries every run loads
+/// (libc, ModelicaExternalC) export — what an `Include` still has to provide.
+pub(crate) fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<String> {
     let mut defined: HashSet<&str> = HashSet::new();
-    for lib in libs {
-        for payload in wasmparser::Parser::new(0).parse_all(&lib.bytes).flatten() {
+    for bytes in libs.iter().map(|l| &l.bytes[..]).chain([LIBC_PIC, EXTERNAL_C_DYLINK]) {
+        for payload in wasmparser::Parser::new(0).parse_all(bytes).flatten() {
             if let wasmparser::Payload::ExportSection(exports) = payload {
                 defined.extend(exports.into_iter().flatten().map(|e| e.name));
             }
@@ -3926,12 +3947,14 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
                 }
                 // A wasm artifact carries every implementation, so the same
                 // decision has to be made here, off the libraries' exports.
-                ExtHost::Wasm if !missing_ext_symbols(&ext_imports, &ext_libs.wasm).is_empty() => {
-                    if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &mut ext_lib_notes)? {
-                        ext_libs.wasm.push(l);
+                ExtHost::Wasm => {
+                    let missing = missing_ext_symbols(&ext_imports, &ext_libs.wasm);
+                    if !missing.is_empty() {
+                        if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &missing, &mut ext_lib_notes)? {
+                            ext_libs.wasm.push(l);
+                        }
                     }
                 }
-                ExtHost::Wasm => {}
             }
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -9950,13 +9950,15 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
         let mut notes: Vec<String> = Vec::new();
         // Only the wasm modules: the function JIT calls them wasm->wasm, with no
         // libffi trampoline to reach a platform library through.
-        for lib in &crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?.wasm {
+        let libs = crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?.wasm;
+        for lib in &libs {
             sig.push_str(&format!("lib\t{}\n", lib.name));
         }
         // An implementation given as C source in an `Include`.
         let includes: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
         let dirs: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.makefileParams.includes).map(|s| s.to_string()).collect();
-        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &mut notes)? {
+        let missing = crate::CodegenWasmJit::missing_ext_symbols(&ext_imports, &libs);
+        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &missing, &mut notes)? {
             let path = format!("{base}_includes.wasm");
             openmodelica_wasi::fs::write(&path, &l.bytes)
                 .map_err(|_| "CodegenWasmJitFunctions: cannot stage the compiled include library")?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -157,7 +157,7 @@ fn define_external_imports(
             s.wasm_params().iter().map(|t| valtype(t.wty())),
             s.wasm_results().iter().map(|t| valtype(t.wty())),
         );
-        let target = loaded.func(&s.name).cloned().ok_or_else(|| {
+        let target = loaded.func_or_addr(&mut *store, &s.name).ok_or_else(|| {
             record_dylink_error(format!(
                 "external \"C\" function `{}` is in none of the model's libraries{}",
                 s.name,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -38,6 +38,18 @@ impl Loaded {
     pub fn func(&self, name: &str) -> Option<&Func> {
         self.funcs.get(name)
     }
+    /// `name`, else what its `Include` address wrapper points at.
+    pub fn func_or_addr(&self, store: &mut wasmtime::Store<WasiCtx>, name: &str) -> Option<Func> {
+        if let Some(f) = self.funcs.get(name) {
+            return Some(f.clone());
+        }
+        let w = self.funcs.get(&format!("{}{name}", crate::model::EXT_ADDR_PREFIX))?;
+        // Slot 0 is the null function pointer: the sources only declared it.
+        match w.typed::<(), i32>(&*store).ok()?.call(&mut *store, ()).ok()? {
+            0 => None,
+            idx => self.table.get(store, idx as u64)?.as_func().flatten().cloned(),
+        }
+    }
     pub fn shadow_stack(&self) -> Option<Global> {
         self.stack_pointer
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -161,13 +161,24 @@ impl ExtIncludes {
     /// Build the sources into a host shared library and return its path. Per-process
     /// temp directory: it stays mapped as long as the model can be resimulated.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn compile(&self) -> std::result::Result<String, String> {
+    pub fn compile(&self, symbols: &[String]) -> std::result::Result<String, String> {
+        let wrappers = ext_addr_wrappers(symbols);
+        match self.compile_tu(&wrappers) {
+            Err(e) if !wrappers.is_empty() => self.compile_tu("").map_err(|_| e),
+            r => r,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn compile_tu(&self, wrappers: &str) -> std::result::Result<String, String> {
         use std::process::Command;
         let dir = std::env::temp_dir().join(format!("om-extc-{}", std::process::id()));
         std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
-        let tu = dir.join(format!("{}_includes.c", self.prefix));
-        let out = dir.join(format!("{}_includes{}", self.prefix, self.dllext));
-        std::fs::write(&tu, INCLUDE_TU_PROLOGUE.to_owned() + &self.sources.join("\n") + "\n")
+        // The fallback build must not be handed the path it just failed to load.
+        let stem = if wrappers.is_empty() { "includes_exports" } else { "includes" };
+        let tu = dir.join(format!("{}_{stem}.c", self.prefix));
+        let out = dir.join(format!("{}_{stem}{}", self.prefix, self.dllext));
+        std::fs::write(&tu, INCLUDE_TU_PROLOGUE.to_owned() + &self.sources.join("\n") + "\n" + wrappers)
             .map_err(|e| format!("cannot write {}: {e}", tu.display()))?;
 
         let mut cmd = Command::new(&self.ccompiler);
@@ -199,12 +210,25 @@ impl ExtIncludes {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn compile(&self) -> std::result::Result<String, String> {
+    pub fn compile(&self, _symbols: &[String]) -> std::result::Result<String, String> {
         Err("the implementation comes from an `Include` annotation with C source, which has to be \
              compiled — the browser omc has no compiler. Provide it as a `Library` built with \
              `clang --target=wasm32-wasip1 -fPIC -shared`"
             .to_string())
     }
+}
+
+/// A header-only `Include` may declare every function `static`, exporting nothing;
+/// a wrapper handing back the address needs no prototype and reaches it anyway.
+pub const EXT_ADDR_PREFIX: &str = "omc_ext_addr_";
+
+/// Taking the address of a function the sources never declare does not compile,
+/// so the caller falls back to the unit without these.
+pub fn ext_addr_wrappers(symbols: &[String]) -> String {
+    symbols
+        .iter()
+        .map(|s| format!("void (*{EXT_ADDR_PREFIX}{s}(void))(void) {{ return (void (*)(void)) {s}; }}\n"))
+        .collect()
 }
 
 /// What the C target's generated `<prefix>_includes.h` opens with, so external C

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 
 use crate::sim_driver;
 use crate::dylink_engine::{NlsHooks, zero_results};
-use crate::model::SimModel;
+use crate::model::{self, SimModel};
 use openmodelica_sim_meta::SimMeta;
 use crate::host::add_host_builtins;
 
@@ -370,25 +370,58 @@ impl NativeExternals {
                 }
             }
         }
-        if let Some(addr) = openmodelica_util::dynload::external_symbol_in(&self.handles, name) {
+        if let Some(addr) = self.symbol(name) {
             return Some(addr);
         }
         if !self.built_includes {
             self.built_includes = true;
             if let Some(inc) = &model.ext_includes {
-                match inc.compile() {
-                    Ok(path) => {
-                        let (h, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
-                        // Searched first: it is the model's own source.
-                        self.handles.splice(0..0, h);
-                        self.errors.extend(errors);
-                    }
-                    Err(e) => self.errors.push(e),
+                let missing: Vec<String> = model
+                    .ext_imports
+                    .iter()
+                    .map(|s| s.name.clone())
+                    .filter(|n| self.symbol(n).is_none())
+                    .collect();
+                let errors = self.errors.len();
+                // A wrapper for a function the sources only declare leaves an
+                // address the loader cannot resolve.
+                if !self.load_includes(inc, &missing) && !missing.is_empty() {
+                    self.errors.truncate(errors);
+                    self.load_includes(inc, &[]);
                 }
-                return openmodelica_util::dynload::external_symbol_in(&self.handles, name);
+                return self.symbol(name);
             }
         }
         None
+    }
+
+    /// Build the `Include` sources with `symbols` reachable by address, and load
+    /// the result. Searched first: it is the model's own source.
+    fn load_includes(&mut self, inc: &model::ExtIncludes, symbols: &[String]) -> bool {
+        let path = match inc.compile(symbols) {
+            Ok(p) => p,
+            Err(e) => {
+                self.errors.push(e);
+                return false;
+            }
+        };
+        let (handles, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
+        let loaded = !handles.is_empty();
+        self.handles.splice(0..0, handles);
+        self.errors.extend(errors);
+        loaded
+    }
+
+    /// The symbol itself, else the address its `Include` wrapper hands back.
+    fn symbol(&self, name: &str) -> Option<usize> {
+        use openmodelica_util::dynload::external_symbol_in;
+        if let Some(addr) = external_symbol_in(&self.handles, name) {
+            return Some(addr);
+        }
+        let wrapper = external_symbol_in(&self.handles, &format!("{}{name}", model::EXT_ADDR_PREFIX))?;
+        // Safety: the generated wrapper is `void (*w(void))(void)`.
+        let w: extern "C" fn() -> usize = unsafe { std::mem::transmute(wrapper) };
+        Some(w()).filter(|a| *a != 0)
     }
 }
 
@@ -425,7 +458,7 @@ fn define_external_imports(
             sig.wasm_results().iter().map(|s| wty_valtype(s.wty())),
         );
         // The model's own libraries shadow a same-named symbol in the process.
-        if let Some(target) = libs.func(&sig.name).cloned() {
+        if let Some(target) = libs.func_or_addr(&mut *store, &sig.name) {
             if let Some(f) = crate::dylink_engine::bind_in_wasm_external(store, sig, &functype, target, rt)
                 .map_err(|_| "external \"C\": cannot bind a library function")?
             {


### PR DESCRIPTION
An `Include` annotation is C *source*, which the C target compiles into the translation unit that calls it. A header-only library therefore never needs external linkage, and Modelica_DeviceDrivers has none: its `DllExport` expands to `static` unless `MDDSHAREDLIBRARY` is defined. Compiling that unit into a shared object exported nothing, so every `MDD_SerialPackager*` came out of wasm-jit as an unresolved `ext.*` import.

The unit now carries one address wrapper per function still to be found:

    void (*omc_ext_addr_MDD_SerialPackagerConstructor(void))(void)
    { return (void (*)(void)) MDD_SerialPackagerConstructor; }

It needs no prototype, so it fits any signature, and hands back what the call site wants: an address for the native libffi trampoline, a table index for a wasm artifact, which `Loaded::func_or_addr` reads back out of the shared `__indirect_function_table` for the `-d=gen` function JIT and FMU export too.

Only what nothing else defines is wrapped, which is both the set an `Include` is left to provide and the set that compiles — `&f` for a function the sources never declare is an error. Natively that set is taken at load time; for a wasm artifact `missing_ext_symbols` computes it, now also discounting libc and ModelicaExternalC. A function the sources only *declare* still compiles but leaves an address the loader cannot resolve, so a library that fails to load is rebuilt without the wrappers, under its own name so the loader's path cache does not hand back the failure.

Fixes, under `--simCodeTarget=wasm-jit`, the three `Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager` tests (plain, `_String`, `_ExternalTrigger`).

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
