### PR TITLE
wasm-jit: all four --homotopyApproach values

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -444,7 +444,8 @@ fn init_success_line() -> String {
     if steps == 0 {
         "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.".to_string()
     } else {
-        format!("LOG_SUCCESS       | info    | The initialization finished successfully with {steps} homotopy steps.")
+        let local = if sim_driver::init_homotopy_local() { "local " } else { "" };
+        format!("LOG_SUCCESS       | info    | The initialization finished successfully with {steps} {local}homotopy steps.")
     }
 }
 
@@ -2539,6 +2540,8 @@ pub(crate) struct SimVarMap {
     n_mathevents: u32,
     /// `SimData` byte offset of the homotopy parameter lambda (`SimLayout`).
     lambda_off: u32,
+    /// C's `homotopyMethod` code (`SimLayout::homotopy_method`).
+    homotopy_method: u8,
     /// `SimData` byte offset of the zero-crossing hysteresis tolerance (`SimCtx::zctol_off`).
     zctol_off: u32,
     /// `SimData` byte offset of `zeroCrossingsPre` (`SimLayout::zc_pre_off`).
@@ -2914,6 +2917,7 @@ fn build_var_map(
         mathevents_off: layout.mathevents_off,
         n_mathevents: layout.n_math,
         lambda_off: layout.lambda_off,
+        homotopy_method: layout.homotopy_method.code(),
         zctol_off: layout.zctol_off,
         zc_pre_off: layout.zc_pre_off,
         clock_fire_off: layout.clock_fire_off,
@@ -3817,6 +3821,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         removed_init_residuals(sim_code).len() as u32,
         has_when,
         has_homotopy,
+        homotopy_method()?,
+        lst(&sim_code.initialEquations_lambda0).next().is_some(),
         // `delay(...)` / `spatialDistribution(...)`: the driver has to store their
         // accepted points, which costs an extra evaluation, so it asks first.
         sim_code.delayedExps.maxDelayedIndex >= 0 || sim_code.spatialInfo.maxIndex >= 0,
@@ -4027,7 +4033,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
             .iter()
             .map(|l| eqs_with_branches(l.as_slice()))
             .collect();
-    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns) = collect_nls_jobs(
+    let (nls_systems, nls_jobs, nls_hist_bytes, nls_nominals, nls_bounds, nls_patterns, nls_warnings) = collect_nls_jobs(
         &nls_scan.iter().map(|l| l.as_slice()).collect::<Vec<_>>(),
         &nls_nominal_map,
         &mut attr_targets,
@@ -4347,6 +4353,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
         param_vars(vars)?, attr_log_entries(sim_code)?,
         removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
+        nls_warnings.clone(),
         samples.iter().map(|s| s.index).collect(), soti_vars(vars)?, sens_params, nls_vars, dae,
         clocks.iter().map(|c| c.meta.clone()).collect(),
         build_lin_info(&linz, vars, &var_map)?,
@@ -5001,6 +5008,21 @@ fn nls_homotopy_support(sim_code: &SimCode::SimCode) -> bool {
         || has(flatten_eqs_ll(&sim_code.algebraicEquations))
 }
 
+/// C's `homotopyMethod` model-callback entry, from the same `Config` predicates.
+fn homotopy_method() -> Result<openmodelica_sim_meta::HomotopyMethod> {
+    use openmodelica_sim_meta::HomotopyMethod as H;
+    use openmodelica_util::Config;
+    Ok(if Config::replacedHomotopy()? {
+        H::None
+    } else if Config::adaptiveHomotopy()? {
+        if Config::globalHomotopy()? { H::GlobalAdaptive } else { H::LocalAdaptive }
+    } else if Config::globalHomotopy()? {
+        H::GlobalEquidistant
+    } else {
+        H::LocalEquidistant
+    })
+}
+
 /// C's `LOG_STDOUT` "… changed to …" lines, ahead of everything the run prints.
 fn flag_change_log(flags: &simflags::SimFlags) -> String {
     use openmodelica_modelica_utilities::{LOG_STDOUT_INFO, LOG_STDOUT_WARNING};
@@ -5041,12 +5063,36 @@ struct NlsJacPattern {
 }
 
 /// The two patterns C can carry, in the order `functionNonLinearResiduals` picks
-/// them.
+/// them, minus what C's `sparsitySanityCheck` rejects.
 fn nls_jac_pattern(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
+    let pat = nls_jac_pattern_raw(jm, n)?;
+    sparsity_sanity_check(&pat.colptr, &pat.rowidx, n).then_some(pat)
+}
+
+/// The pattern as the backend emitted it, before C's sanity check.
+fn nls_jac_pattern_raw(jm: &SimCode::JacobianMatrix, n: usize) -> Option<NlsJacPattern> {
     match &jm.sparsityMatrix {
         SimCode::Sparsity::SPARSITY { .. } => nls_jac_pattern_resizable(jm, n),
         _ => nls_jac_pattern_static(jm, n),
     }
+}
+
+/// C's `sparsitySanityCheck` over the CSC pattern (its `leadindex`/`index`). A
+/// homotopy system always fails it: `__HOM_LAMBDA` has no residual row.
+fn sparsity_sanity_check(colptr: &[i32], rowidx: &[i32], n: usize) -> bool {
+    if n == 0 || rowidx.len() < n {
+        return false;
+    }
+    if (1..n).any(|i| colptr[i] == colptr[i - 1]) {
+        return false;
+    }
+    let mut seen = vec![false; n];
+    for &r in &rowidx[..colptr[n] as usize] {
+        if let Some(s) = seen.get_mut(r as usize) {
+            *s = true;
+        }
+    }
+    seen.iter().all(|&s| s)
 }
 
 /// C's `generateStaticSparseData`: one `sparsity` entry per column holding its
@@ -5241,6 +5287,7 @@ fn build_sim_meta(
     params: openmodelica_sim_meta::ParamVars,
     attr_log: Vec<openmodelica_sim_meta::AttrLog>,
     removed_init_desc: Vec<String>,
+    nls_warnings: Vec<String>,
     sample_index: Vec<i32>,
     soti: openmodelica_sim_meta::SotiVars,
     sens_params: Vec<u32>,
@@ -5270,6 +5317,7 @@ fn build_sim_meta(
         params,
         attr_log,
         removed_init_desc,
+        nls_warnings,
         sample_index,
         soti,
         sens_params,
@@ -5576,6 +5624,7 @@ fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         mathevents_off: var_map.mathevents_off,
         n_mathevents: var_map.n_mathevents,
         lambda_off: var_map.lambda_off,
+        homotopy_method: var_map.homotopy_method,
         zctol_off: var_map.zctol_off,
         zc_pre_off: var_map.zc_pre_off,
         zc_context: false,
@@ -6638,12 +6687,23 @@ fn nls_parts(
     }
     let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
     // A for-residual's count is only known at run time, so validate the unknown
-    // count only for scalar-only systems.
+    // count only for scalar-only systems. An adaptive approach appends
+    // `__HOM_LAMBDA` without a residual: the arc-length condition closes it.
     let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
-    if all_scalar && iter_vars.len() != residuals.len() {
+    let extra = usize::from(is_homotopy_lambda(iter_vars.last()));
+    if all_scalar && iter_vars.len() != residuals.len() + extra {
         return Err("CodegenWasmJit: SES_NONLINEAR unknown/residual count mismatch");
     }
     Ok((inner, residuals, iter_vars))
+}
+
+/// The `__HOM_LAMBDA` unknown `generateHomotopyComponents` appends under an
+/// adaptive approach. C maps the cref to `simulationInfo->lambda`.
+fn is_homotopy_lambda(cr: Option<&Arc<DAE::ComponentRef>>) -> bool {
+    matches!(cr.map(|c| &**c),
+        Some(DAE::ComponentRef::CREF_IDENT { ident, subscriptLst, .. })
+            if subscriptLst.is_empty()
+                && ident.as_str() == openmodelica_backend_types::BackendDAE::homotopyLambda)
 }
 
 /// Scan the compiled equation lists for `SES_NONLINEAR` systems (deduplicated by
@@ -6654,9 +6714,12 @@ fn collect_nls_jobs(
     eq_lists: &[&[Arc<SimCode::SimEqSystem>]],
     nominal_of: &HashMap<String, (f64, f64, f64)>,
     attr_targets: &mut HashMap<String, AttrTargets>,
-) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<f64>, Vec<i32>) {
+) -> (Vec<Arc<SimCode::NonlinearSystem>>, HashMap<i32, NlsJob>, u32, Vec<f64>, Vec<f64>, Vec<i32>, Vec<String>) {
     use SimCode::SimEqSystem as E;
     let mut systems: Vec<Arc<SimCode::NonlinearSystem>> = Vec::new();
+    // C's `initializeNonlinearSystems` warning for a rejected pattern, indexed by
+    // the system ordinal as C's `sysNum` is.
+    let mut warnings: Vec<String> = Vec::new();
     let mut jobs: HashMap<i32, NlsJob> = HashMap::new();
     let mut hist_off = 0u32;
     let mut nominal_off = 0u32;
@@ -6681,9 +6744,24 @@ fn collect_nls_jobs(
                 // The pattern goes in whenever it exists: C's density/size rule only
                 // picks the *default* solver (kinsol+KLU vs the dense ladder), while
                 // `-nls=kinsol` hands every patterned system to KINSOL.
-                let pat = has_jac
-                    .then(|| nls_jac_pattern(nlSystem.jacobianMatrix.as_ref().unwrap(), n as usize))
-                    .flatten();
+                // C builds the pattern from the `JAC_MATRIX` alone — an empty column
+                // list still carries one — then checks it.
+                let raw_pat = nlSystem
+                    .jacobianMatrix
+                    .as_ref()
+                    .and_then(|jm| nls_jac_pattern_raw(jm, n as usize));
+                let pat = raw_pat.filter(|p| {
+                    sparsity_sanity_check(&p.colptr, &p.rowidx, n as usize) || {
+                        warnings.push(format!(
+                            "Sparsity pattern for non-linear system {} is not regular. This indicates \
+                             that something went wrong during sparsity pattern generation. Removing \
+                             sparsity pattern and disabling NLS scaling.",
+                            systems.len()
+                        ));
+                        false
+                    }
+                });
+                let pat = if has_jac { pat } else { None };
                 let nnz = pat.as_ref().map_or(0, |p| p.rowidx.len() as u32);
                 let sparse_default = nnz != 0 && nls_use_sparse(n as usize, nnz as usize);
                 if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
@@ -6699,7 +6777,7 @@ fn collect_nls_jobs(
                     patterns.extend_from_slice(&p.colptr);
                     patterns.extend_from_slice(&p.rowidx);
                 }
-                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, eq_index: nlSystem.index as u32, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default });
+                jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, eq_index: nlSystem.index as u32, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default, homotopy_support: nlSystem.homotopySupport });
                 if nnz != 0 {
                     pat_off += 4 * (n + 1 + nnz);
                 }
@@ -6722,7 +6800,7 @@ fn collect_nls_jobs(
             }
         }
     }
-    (systems, jobs, hist_off, nominals, bounds, patterns)
+    (systems, jobs, hist_off, nominals, bounds, patterns, warnings)
 }
 
 /// The optimizer's Jacobian entry points, in emission order: for B, C and D the
@@ -7046,7 +7124,14 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
         return false;
     }
     let n = lst(&nlsystem.crefs).count();
-    n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(jm, n).is_some()
+    let rows = n - nls_lambda_extra(nlsystem) as usize;
+    n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(jm, rows).is_some()
+}
+
+/// 1 when the last unknown is `__HOM_LAMBDA`, which has no residual row: C's
+/// `size` is then one more than the solver's `n`.
+fn nls_lambda_extra(nlsystem: &SimCode::NonlinearSystem) -> u32 {
+    u32::from(is_homotopy_lambda(lst(&nlsystem.crefs).last()))
 }
 
 /// Torn linear system usable for analytic assembly: square Jacobian with one seed
@@ -7116,17 +7201,19 @@ fn build_nls_jac_infos(
         // residual row (`SimVar.index`), since the listing order need not be row
         // order. Seeds are likewise placed at their column index.
         use openmodelica_backend_types::BackendDAE::VarKind;
-        let n = listed_offs.len();
-        let seed_offs = jac_seed_offs_by_column(jm, &listed_offs, n)
+        let n_cols = listed_offs.len();
+        // A homotopy system's Jacobian is `n×(n+1)`: a `__HOM_LAMBDA` column, no row.
+        let n_rows = n_cols - nls_lambda_extra(sys) as usize;
+        let seed_offs = jac_seed_offs_by_column(jm, &listed_offs, n_cols)
             .ok_or_else(|| "CodegenWasmJit: nonlinear-system Jacobian seed columns are not a permutation")?;
-        let mut result_offs = vec![u32::MAX; n];
+        let mut result_offs = vec![u32::MAX; n_rows];
         for sv in &jac_column_vars(jm) {
             let off = cursor;
             cursor += 8;
             Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
             if matches!(sv.varKind, VarKind::JAC_VAR) {
                 let row = jac_result_row(sv)
-                    .filter(|&r| r < n)
+                    .filter(|&r| r < n_rows)
                     .ok_or_else(|| "CodegenWasmJit: nonlinear-system Jacobian result var has no row index")?;
                 result_offs[row] = off;
             }
@@ -7605,6 +7692,10 @@ fn build_nls_fns(
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(iter_vars.len());
     for cr in &iter_vars {
+        if is_homotopy_lambda(Some(cr)) {
+            slots.push(var_map.lambda_off);
+            continue;
+        }
         let key = sim_cref_key(cr)?;
         let slot = var_map
             .vars

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -465,7 +465,7 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // index, load-table index, n unknowns, nls_fail flag address) -> 0 ok / 1
     // recoverable failure. The Newton driver lives in the runtime; the model
     // supplies `residual`/`load` funcs reached by `call_indirect` (see `nls.rs`).
-    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_solve_nls", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     // `delay(...)` / `delayZeroCrossing(...)` ring buffers (runtime `delay.rs`).
     ("rt_delay_init", &[WTy::I32, WTy::F64], &[]),
     ("rt_delay_store", &[WTy::I32, WTy::F64, WTy::F64, WTy::F64, WTy::F64], &[]),
@@ -1373,6 +1373,8 @@ pub(crate) struct SimCtx {
     /// `SimData` byte offset of the homotopy parameter lambda (`homotopy(a, s)` =
     /// `s + lambda*(a-s)`).
     pub(crate) lambda_off: u32,
+    /// C's `homotopyMethod` code, handed to `rt_solve_nls`.
+    pub(crate) homotopy_method: u8,
     /// True while lowering the `functionZeroCrossings` body: an indexed relation is
     /// then evaluated *fresh* (so a sign change is detectable) rather than held.
     pub(crate) zc_context: bool,
@@ -1444,6 +1446,8 @@ pub(crate) struct NlsJob {
     /// (sparse) rather than the dense `NLS_MIXED` ladder. `-nls=` overrides it, and
     /// it also picks the format `nls_jac` writes (CSC vs dense `n×n`).
     pub(crate) sparse_default: bool,
+    /// C's `NONLINEAR_SYSTEM_DATA::homotopySupport`.
+    pub(crate) homotopy_support: bool,
 }
 
 /// Per-system solver state for `n` unknowns: a count (padded to 8), C's

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -188,7 +188,10 @@ pub(crate) fn emit_nls_jac_body(
     lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
-    let n = iter_slots.len();
+    // Equal but for a homotopy system, whose `__HOM_LAMBDA` column has no row
+    // (C's `n × (n+1)` `fJac`).
+    let n_cols = iter_slots.len();
+    let n_rows = result_offs.len();
     for (j, &off) in iter_slots.iter().enumerate() {
         ctx.emit(I::LocalGet(0));
         ctx.emit(I::LocalGet(1));
@@ -202,7 +205,7 @@ pub(crate) fn emit_nls_jac_body(
         ctx.emit(I::F64Const(val.into()));
         ctx.emit(I::F64Store(mem_arg(off, 3)));
     };
-    for j in 0..n {
+    for j in 0..n_cols {
         for (k, &soff) in seed_offs.iter().enumerate() {
             store_const(ctx, soff, if k == j { 1.0 } else { 0.0 });
         }
@@ -214,7 +217,7 @@ pub(crate) fn emit_nls_jac_body(
             ctx.emit(I::LocalGet(2));
             ctx.emit(I::LocalGet(0));
             ctx.emit(I::F64Load(mem_arg(roff, 3)));
-            ctx.emit(I::F64Store(mem_arg(((j * n + i) as u32) * 8, 3)));
+            ctx.emit(I::F64Store(mem_arg(((j * n_rows + i) as u32) * 8, 3)));
         }
     }
     Ok(())
@@ -1434,6 +1437,7 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     let data = ctx.sim()?.data_local;
     let nls_fail_off = ctx.sim()?.nls_fail_off;
     let rel_fresh_off = ctx.sim()?.rel_fresh_off;
+    let lambda_off = ctx.sim()?.lambda_off;
     ctx.emit(I::LocalGet(data));
     ctx.emit(I::GlobalGet(NLS_BASE_GLOBAL));
     ctx.emit(I::I32Const((3 * job.k) as i32));
@@ -1494,6 +1498,12 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
     ctx.emit(I::I32Const(job.sparse_default as i32));
     ctx.emit(I::I32Const(nls_lss_handle(job.k) as i32));
     ctx.emit(I::I32Const(job.eq_index as i32));
+    // C's `homotopySupport`/`homotopyMethod` and the `lambda` slot they drive.
+    ctx.emit(I::I32Const(job.homotopy_support as i32));
+    ctx.emit(I::I32Const(ctx.sim()?.homotopy_method as i32));
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Const(lambda_off as i32));
+    ctx.emit(I::I32Add);
     ctx.emit(I::Call(rt_index("rt_solve_nls")?));
     ctx.emit(I::Drop);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -313,7 +313,10 @@ pub const STAT_NEWTON_MAXITER: u32 = 20;
 pub const STAT_NEWTON_STUCK: u32 = 21;
 pub const STAT_NEWTON_JAC: u32 = 22;
 pub const STAT_NEWTON_SINGULAR: u32 = 23;
-pub const N_STATS: usize = 24;
+/// Not a diagnostic: C's `homotopySteps`, which the driver folds into the
+/// initialization success line.
+pub const STAT_HOMOTOPY_STEPS: u32 = 24;
+pub const N_STATS: usize = 25;
 
 static STATS: [core::sync::atomic::AtomicU64; N_STATS] =
     [const { core::sync::atomic::AtomicU64::new(0) }; N_STATS];
@@ -321,6 +324,10 @@ static STATS: [core::sync::atomic::AtomicU64; N_STATS] =
 #[inline]
 pub(crate) fn stat_inc(kind: u32) {
     STATS[kind as usize].fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+
+pub(crate) fn stat_add(kind: u32, n: u64) {
+    STATS[kind as usize].fetch_add(n, core::sync::atomic::Ordering::Relaxed);
 }
 
 #[unsafe(no_mangle)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -523,83 +523,203 @@ fn scale_matrix_rows_aug(n: usize, a: &mut [f64]) {
     }
 }
 
-/// Arc-length homotopy continuation, a port of C's `homotopyAlgorithm`
-/// (`nonlinearSolverHomotopy.c`): Newton homotopy `H(y) = F(x) − (1−λ)·F(x0)` tracked
-/// λ: 0→1 by a tangent predictor + fixed-coordinate Newton corrector with adaptive
-/// step `tau`. Follows folds a fixed-λ homotopy can't. `x` = guess in / λ=1 root out.
-fn homotopy_solve(
+/// Why a homotopy run stopped, so the init arm can print the message C prints.
+enum HomFail {
+    /// C's `iter >= maxTries` with tau already at `tauMin`.
+    TauStuck,
+    /// C's `iter >= maxTries` with tries left to shrink tau.
+    MaxTries(i32),
+    /// C's `y0[n] < -1`: the path turned away from lambda = 1.
+    LambdaNegative(f64),
+    /// C's `numSteps >= maxLambdaSteps`.
+    MaxLambdaSteps(usize),
+    /// C's singular `solveSystemWithTotalPivotSearch` on the tangent.
+    Singular,
+    /// C's "increment zero": the corrector step vanished against the predictor.
+    IncrementZero,
+    /// C's predictor `assert` with tau no longer shrinkable.
+    PredictorTau(f64),
+}
+
+impl HomFail {
+    /// The `LOG_ASSERT` text C's `initHomotopy` arm prints.
+    fn message(&self) -> alloc::string::String {
+        const MORE: &str = "You can use -lv=LOG_INIT_HOMOTOPY,LOG_NLS_HOMOTOPY to get more information.";
+        const NEWTON_TAIL: &str = "You can also try to allow more newton steps in the corrector step with:\n\t\
+             -homMaxNewtonSteps=<value>\nor change the tolerance for the solution with:\n\t\
+             -homHEps=<value>\nYou can also try to use another backtrace stategy in the corrector step \
+             with:\n\t-homBacktraceStrategy=<fix|orthogonal>\n";
+        const TAU_TAIL: &str = "\t-homTauDecFac=<value>\n\t-homTauDecFacPredictor=<value>\n\t\
+             -homTauIncFac=<value>\n\t-homTauIncThreshold=<value>\n\t-homTauMax=<value>\n\t\
+             -homTauMin=<value>\n\t-homTauStart=<value>\n";
+        let head = "Homotopy algorithm did not converge.\n";
+        match self {
+            HomFail::TauStuck => alloc::format!(
+                "{head}No solution for current step size tau found and tau cannot be decreased any \
+                 further.\nYou can set the minimum step size tau with:\n\t-homTauMin=<value>\n\
+                 {NEWTON_TAIL}{MORE}"
+            ),
+            HomFail::MaxTries(iter) => alloc::format!(
+                "{head}The maximum number of tries for one lambda is reached ({iter}).\nYou can \
+                 change the number of tries with:\n\t-homMaxTries=<value>\n{NEWTON_TAIL}{MORE}"
+            ),
+            HomFail::LambdaNegative(l) => {
+                alloc::format!("{head}lambda is smaller than -1: lambda={}\n{MORE}", fmt_g6(*l))
+            }
+            HomFail::MaxLambdaSteps(n) => alloc::format!(
+                "{head}The maximum number of lambda steps is reached ({n}).\nYou can change the \
+                 maximum number of lambda steps with:\n\t-homMaxLambdaSteps=<value>\nYou can also \
+                 try to influence the step size tau with the following flags:\n{TAU_TAIL}or you can \
+                 also set the threshold for accepting the current bending with:\n\t\
+                 -homAdaptBend=<value>\nYou can also try to use another backtrace stategy in the \
+                 corrector step with:\n\t-homBacktraceStrategy=<fix|orthogonal>\n{MORE}"
+            ),
+            HomFail::Singular => alloc::format!("{head}The system is singular and not solvable.\n{MORE}"),
+            HomFail::IncrementZero => alloc::format!(
+                "{head}The value specifying the bending of the homotopy curve is smaller than \
+                 DBL_EPSILON (increment zero).\n{MORE}"
+            ),
+            HomFail::PredictorTau(tau) => alloc::format!(
+                "{head}The step size tau cannot be decreased anymore and current tau={} already \
+                 failed.\nYou can influence the calculation of tau with the following flags:\n\
+                 {TAU_TAIL}You can also set the threshold for accepting the current bending with:\n\t\
+                 -homAdaptBend=<value>\n{MORE}",
+                fmt_g6(*tau)
+            ),
+        }
+    }
+}
+
+/// The homotopy `H(y)` a continuation tracks, `y = [x, λ]` with `m = n+1` entries:
+/// C's `h_function` / `hJac_dh` pair, in its two variants.
+trait Homotopy {
+    /// `H(y)` into `hvec` (`n` residuals).
+    fn h(&mut self, y: &[f64], hvec: &mut [f64]);
+    /// The `n×m` Jacobian at `y`, column-scaled by `xScaling`, given `H(y)` as the
+    /// finite-difference base.
+    fn jac(&mut self, y: &[f64], hbase: &[f64], out: &mut [f64]);
+}
+
+/// C's `getNumericalJacobianHomotopy`: forward differences over the first `n_cols`
+/// coordinates of `y`, scaled by `xScaling[j]`; `max_value` flips the step's sign.
+fn fd_homotopy_jacobian(
+    hom: &mut impl Homotopy,
     n: usize,
-    x: &mut [f64],
-    nominal: &[f64],
+    n_cols: usize,
+    y: &[f64],
+    hbase: &[f64],
+    xscaling: &[f64],
+    max_value: Option<&[f64]>,
+    out: &mut [f64],
+) {
+    let delta_h = libm::sqrt(f64::EPSILON * 20.0);
+    let mut yp = y.to_vec();
+    let mut f2 = vec![0.0f64; n];
+    for j in 0..n_cols {
+        let ysave = yp[j];
+        let mut hh = delta_h * (libm::fabs(ysave) + 1.0);
+        if max_value.is_some_and(|mx| ysave + hh >= mx[j]) {
+            hh = -hh;
+        }
+        yp[j] = ysave + hh;
+        let inv = xscaling[j] / hh;
+        hom.h(&yp, &mut f2);
+        for i in 0..n {
+            out[i + j * n] = (f2[i] - hbase[i]) * inv;
+        }
+        yp[j] = ysave;
+    }
+}
+
+/// C's `wrapper_fvec_homotopy_newton`: `H(y) = F(x) − (1−λ)·F(x0)`, whose λ column
+/// is the constant `F(x0)`.
+struct NewtonHom<'a, 'b> {
+    n: usize,
+    fx0: alloc::vec::Vec<f64>,
+    fx: alloc::vec::Vec<f64>,
+    xscaling: &'a [f64],
+    eval: &'a mut (dyn FnMut(&[f64], &mut [f64]) + 'b),
+}
+
+impl Homotopy for NewtonHom<'_, '_> {
+    fn h(&mut self, y: &[f64], hvec: &mut [f64]) {
+        (self.eval)(&y[..self.n], &mut self.fx);
+        let lam = y[self.n];
+        for i in 0..self.n {
+            hvec[i] = self.fx[i] - (1.0 - lam) * self.fx0[i];
+        }
+    }
+    fn jac(&mut self, y: &[f64], hbase: &[f64], out: &mut [f64]) {
+        let (n, xs) = (self.n, self.xscaling);
+        let xs: alloc::vec::Vec<f64> = xs.to_vec();
+        fd_homotopy_jacobian(self, n, n, y, hbase, &xs, None, out);
+        out[n * n..].copy_from_slice(&self.fx0);
+    }
+}
+
+/// C's `initHomotopy`: `H(y)` is the model's own residual with `λ = y[n]` driving
+/// its `homotopy()` calls, so the λ column is one more Jacobian column.
+struct InitHom<'a, 'b> {
+    n: usize,
+    xscaling: &'a [f64],
+    max_value: Option<&'a [f64]>,
+    /// `y` (`m` entries) -> residual (`n` entries), the model's `residualFunc`.
+    eval: &'a mut (dyn FnMut(&[f64], &mut [f64]) + 'b),
+    /// The symbolic `n×m` Jacobian, unscaled, or `None` for finite differences.
+    jac: Option<&'a mut (dyn FnMut(&[f64], &mut [f64]) + 'b)>,
+}
+
+impl Homotopy for InitHom<'_, '_> {
+    fn h(&mut self, y: &[f64], hvec: &mut [f64]) {
+        (self.eval)(y, hvec);
+    }
+    fn jac(&mut self, y: &[f64], hbase: &[f64], out: &mut [f64]) {
+        let (n, m) = (self.n, self.n + 1);
+        if let Some(j) = self.jac.as_mut() {
+            j(y, out);
+            // C's `getAnalyticalJacobianHomotopy` scales each column by `xScaling[j]`.
+            for c in 0..m {
+                for r in 0..n {
+                    out[r + c * n] *= self.xscaling[c];
+                }
+            }
+            return;
+        }
+        let xs: alloc::vec::Vec<f64> = self.xscaling.to_vec();
+        let mx: Option<alloc::vec::Vec<f64>> = self.max_value.map(|v| v.to_vec());
+        fd_homotopy_jacobian(self, n, m, y, hbase, &xs, mx.as_deref(), out);
+    }
+}
+
+/// Arc-length homotopy continuation, a port of C's `homotopyAlgorithm`
+/// (`nonlinearSolverHomotopy.c`): `H(y)`, `y = [x, λ]`, tracked λ: 0→1 by a tangent
+/// predictor + fixed-coordinate Newton corrector with adaptive step `tau`. Follows
+/// folds a fixed-λ homotopy can't. `y` carries the start `x` in and the λ=1 root
+/// out; `Ok(steps)` is C's `numSteps`.
+fn homotopy_algorithm(
+    n: usize,
+    y: &mut [f64],
+    xscaling: &[f64],
     start_dir: f64,
-    eval: &mut dyn FnMut(&[f64], &mut [f64]),
-) -> bool {
-    const TAU_START: f64 = 0.2;
-    const TAU_MAX: f64 = 10.0;
-    const TAU_MIN: f64 = 1.0e-4;
-    const H_EPS: f64 = 1.0e-5;
-    const ADAPT_BEND: f64 = 0.5;
-    const TAU_DEC: f64 = 10.0;
-    const TAU_DEC_PRED: f64 = 2.0;
-    const TAU_INC: f64 = 2.0;
-    const TAU_INC_THRESH: f64 = 10.0;
-    const MAX_NEWTON: usize = 20;
-    const MAX_TRIES: i32 = 10;
-    const MAX_LAMBDA_STEPS: usize = 1000;
+    log: crate::omclog::Stream,
+    hom: &mut impl Homotopy,
+) -> core::result::Result<usize, HomFail> {
+    let t = crate::solvers::hom_tuning();
     let m = n + 1;
-
-    // xScaling[i] = max(nominal[i], |xStart[i]|) from the original start values.
-    let mut xscaling = vec![0.0f64; m];
-    for i in 0..n {
-        xscaling[i] = nominal[i].abs().max(x[i].abs());
-        if xscaling[i] <= 0.0 {
-            xscaling[i] = 1.0;
-        }
-    }
-    xscaling[m - 1] = 1.0;
-
-    // Regular-initial-point search (C solveHomotopy): the raw start may sit on a
-    // singularity (a spring loop seeds s_rel=0, where the residual and Jacobian
-    // blow up and the homotopy path becomes pathological). Perturb x0 by
-    // xScaling·(i/n)·{0, 1%, 10%} until f(x0) is finite and moderate.
-    let xstart = x[..n].to_vec();
-    let mut x0v = xstart.clone();
-    let mut fx0 = vec![0.0f64; n];
-    for tries in 0..=2 {
-        let pert = match tries {
-            1 => 0.01,
-            2 => 0.10,
-            _ => 0.0,
-        };
-        for i in 0..n {
-            x0v[i] = xstart[i] + xscaling[i] * (i as f64 / n as f64) * pert;
-        }
-        eval(&x0v, &mut fx0);
-        if fx0.iter().all(|v| v.is_finite() && v.abs() < 1e6) {
-            break;
-        }
-    }
-
-    // Homotopy function H and its FD Jacobian, both over the augmented y = [x, λ].
-    let fx0_ref = &fx0;
-    let h_function = |y: &[f64], hvec: &mut [f64], fx: &mut [f64], eval: &mut dyn FnMut(&[f64], &mut [f64])| {
-        eval(&y[..n], fx);
-        let lam = y[n];
-        for i in 0..n {
-            hvec[i] = fx[i] - (1.0 - lam) * fx0_ref[i];
-        }
-    };
+    let max_newton = t.max_newton_steps as usize;
+    let max_tries = t.max_tries as i32;
+    // C's `homMaxLambdaSteps ? … : maxNumberOfIterations` (the solver's `size*100`).
+    let max_lambda_steps = if t.max_lambda_steps > 0 { t.max_lambda_steps as usize } else { n * 100 };
+    let mut tau = t.tau_start;
 
     let mut y0 = vec![0.0f64; m];
-    y0[..n].copy_from_slice(&x0v);
+    y0[..n].copy_from_slice(&y[..n]);
     let mut prev_tangent = vec![0.0f64; m];
     prev_tangent[m - 1] = start_dir;
 
     let mut hvec = vec![0.0f64; n];
-    let mut fx = vec![0.0f64; n];
-    h_function(&y0, &mut hvec, &mut fx, eval);
+    hom.h(&y0, &mut hvec);
 
-    let mut tau = TAU_START;
     let mut iter: i32 = 0;
     let mut num_steps = 0usize;
     let mut initial_step = true;
@@ -608,50 +728,30 @@ fn homotopy_solve(
     let mut y1 = vec![0.0f64; m];
     let mut yt = vec![0.0f64; m];
     let mut dy1 = vec![0.0f64; m];
-    let mut f2 = vec![0.0f64; n];
     let mut res_scaling = vec![1.0f64; n];
     let mut hvec_scaled = vec![0.0f64; n];
-
+    let mut pre_tau = tau;
     let mut tangent_pos: i32 = -1;
 
-    let delta_h = libm::sqrt(f64::EPSILON * 20.0);
-    // Build the scaled n×(n+1) homotopy Jacobian at `y` (FD, fx = F(x) base).
-    let build_jac = |y: &[f64],
-                     fbase: &[f64],
-                     hjac: &mut [f64],
-                     f2: &mut [f64],
-                     xscaling: &[f64],
-                     eval: &mut dyn FnMut(&[f64], &mut [f64])| {
-        let mut xp = y[..n].to_vec();
-        for j in 0..n {
-            let xsave = xp[j];
-            let hh = delta_h * (xsave.abs() + 1.0);
-            xp[j] = xsave + hh;
-            let inv = xscaling[j] / hh;
-            eval(&xp, f2);
-            for i in 0..n {
-                hjac[i + j * n] = (f2[i] - fbase[i]) * inv;
-            }
-            xp[j] = xsave;
-        }
-        // The λ column (∂H/∂λ = F(x0)) is filled in by the caller.
-    };
-
     while y0[n] < 1.0 {
-        if iter >= MAX_TRIES || y0[n] < -1.0 || num_steps >= MAX_LAMBDA_STEPS {
-            return false;
+        crate::omclog::info(log, false, &alloc::format!("homotopy parameter lambda = {}", fmt_g6(y0[n])));
+        if iter >= max_tries {
+            return Err(if pre_tau == tau { HomFail::TauStuck } else { HomFail::MaxTries(iter) });
+        }
+        if y0[n] < -1.0 {
+            return Err(HomFail::LambdaNegative(y0[n]));
+        }
+        if num_steps >= max_lambda_steps {
+            return Err(HomFail::MaxLambdaSteps(max_lambda_steps));
         }
 
         // ---- Predictor: tangent vector (only after an accepted step) ----
         if iter == 0 {
-            build_jac(&y0, &fx, &mut hjac, &mut f2, &xscaling, eval);
-            for i in 0..n {
-                hjac[i + n * n] = fx0[i]; // ∂H/∂λ = F(x0)
-            }
+            hom.jac(&y0, &hvec, &mut hjac);
             scale_matrix_rows_aug(n, &mut hjac);
             tangent_pos = -1;
             if total_pivot_augmented(n, &mut tangent, &mut hjac, &mut tangent_pos) == -1 {
-                return false;
+                return Err(HomFail::Singular);
             }
             for i in 0..m {
                 tangent[i] *= xscaling[i];
@@ -661,14 +761,14 @@ fn homotopy_solve(
             for i in 0..m {
                 dot += tangent[i] * prev_tangent[i];
             }
-            if dot < 0.0 || (dot.abs() < f64::EPSILON && start_dir == -1.0 && initial_step) {
-                for t in tangent.iter_mut() {
-                    *t = -*t;
+            if dot < 0.0 || (libm::fabs(dot) < f64::EPSILON && start_dir == -1.0 && initial_step) {
+                for v in tangent.iter_mut() {
+                    *v = -*v;
                 }
             }
             // Cap tau so λ + tau·dλ ≤ 1.
-            if tangent[n].abs() > 1e-8 {
-                tau = tau.min((1.0 - y0[n]) / tangent[n].abs());
+            if libm::fabs(tangent[n]) > 1e-8 {
+                tau = tau.min((1.0 - y0[n]) / libm::fabs(tangent[n]));
             }
         }
 
@@ -678,42 +778,39 @@ fn homotopy_solve(
             for i in 0..m {
                 y1[i] = y0[i] + tau * tangent[i];
             }
-            h_function(&y1, &mut hvec, &mut fx, eval);
-            if hvec.iter().all(|v| v.abs() < 1e30) {
+            hom.h(&y1, &mut hvec);
+            if hvec.iter().all(|v| libm::fabs(*v) < ASSERT_RESIDUAL) {
                 assert_ok = true;
                 break;
             }
-            tau /= TAU_DEC_PRED;
-            if tau <= TAU_MIN {
+            tau /= t.tau_dec_pred;
+            if tau <= t.tau_min {
                 break;
             }
         }
         if !assert_ok {
-            return false;
+            return Err(HomFail::PredictorTau(tau));
         }
         yt.copy_from_slice(&y1);
 
         // ---- Corrector: Newton with coordinate `pos` fixed ----
         let last_step = y1[n] >= 1.0;
-        let h_eps = if last_step { newton_ftol() } else { H_EPS };
+        let h_eps = if last_step { newton_ftol() } else { t.h_eps };
         let mut pos = if last_step { n as i32 } else { tangent_pos };
         let mut step_accept = false;
         let mut corrector_ok = true;
         hvec_scaled.copy_from_slice(&hvec); // C: hvecScaled starts as hvec (unscaled)
-        for _ in 0..MAX_NEWTON {
+        for _ in 0..max_newton {
             if enorm(&hvec) < h_eps || enorm(&hvec_scaled) < h_eps {
                 step_accept = true;
                 break;
             }
-            build_jac(&y1, &fx, &mut hjac, &mut f2, &xscaling, eval);
-            for i in 0..n {
-                hjac[i + n * n] = fx0[i];
-            }
+            hom.jac(&y1, &hvec, &mut hjac);
             // resScaling[i] = row abs-sum of the homotopy Jacobian (before fixing pos).
             for i in 0..n {
                 let mut s = 0.0;
                 for j in 0..m {
-                    s += hjac[i + j * n].abs();
+                    s += libm::fabs(hjac[i + j * n]);
                 }
                 res_scaling[i] = if s > 0.0 { s } else { 1.0 };
             }
@@ -732,8 +829,8 @@ fn homotopy_solve(
                 dy1[i] *= xscaling[i];
                 y1[i] += dy1[i];
             }
-            h_function(&y1, &mut hvec, &mut fx, eval);
-            if hvec.iter().any(|v| v.abs() >= 1e30) {
+            hom.h(&y1, &mut hvec);
+            if hvec.iter().any(|v| libm::fabs(*v) >= ASSERT_RESIDUAL) {
                 corrector_ok = false;
                 break;
             }
@@ -757,14 +854,14 @@ fn homotopy_solve(
             bend = if pred > 0.0 { libm::sqrt(corr) / pred } else { f64::INFINITY };
         }
 
-        if bend > ADAPT_BEND || !step_accept {
+        if bend > t.adapt_bend || !step_accept {
             if corrector_ok && bend < f64::EPSILON {
-                return false;
+                return Err(HomFail::IncrementZero);
             }
-            let pre_tau = tau;
-            tau = TAU_MIN.max(tau / TAU_DEC);
+            pre_tau = tau;
+            tau = t.tau_min.max(tau / t.tau_dec);
             if tau == pre_tau {
-                iter = MAX_TRIES;
+                iter = max_tries;
             } else {
                 iter += 1;
             }
@@ -772,15 +869,135 @@ fn homotopy_solve(
             initial_step = false;
             iter = 0;
             num_steps += 1;
-            if bend < ADAPT_BEND / TAU_INC_THRESH {
-                tau = TAU_MAX.min(tau * TAU_INC);
+            if bend < t.adapt_bend / t.tau_inc_threshold {
+                tau = t.tau_max.min(tau * t.tau_inc);
             }
             y0.copy_from_slice(&y1);
             prev_tangent.copy_from_slice(&tangent);
         }
     }
-    x[..n].copy_from_slice(&y1[..n]);
-    true
+    crate::omclog::info(log, false, &alloc::format!("homotopy parameter lambda = {}", fmt_g6(y0[n])));
+    y.copy_from_slice(&y1);
+    Ok(num_steps)
+}
+
+/// C's `!initHomotopy` runs: the Newton homotopy over `F`, from the regular start
+/// point the perturbation search below finds. `x` = guess in / λ=1 root out.
+fn homotopy_solve(
+    n: usize,
+    x: &mut [f64],
+    nominal: &[f64],
+    start_dir: f64,
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) -> bool {
+    let m = n + 1;
+    // xScaling[i] = max(nominal[i], |xStart[i]|) from the original start values.
+    let mut xscaling = vec![0.0f64; m];
+    for i in 0..n {
+        xscaling[i] = libm::fabs(nominal[i]).max(libm::fabs(x[i]));
+        if xscaling[i] <= 0.0 {
+            xscaling[i] = 1.0;
+        }
+    }
+    xscaling[m - 1] = 1.0;
+
+    // Regular-initial-point search (C solveHomotopy): the raw start may sit on a
+    // singularity, where the path is pathological. Perturb x0 by
+    // xScaling·(i/n)·{0, 1%, 10%} until f(x0) is finite and moderate.
+    let xstart = x[..n].to_vec();
+    let mut x0v = xstart.clone();
+    let mut fx0 = vec![0.0f64; n];
+    for tries in 0..=2 {
+        let pert = match tries {
+            1 => 0.01,
+            2 => 0.10,
+            _ => 0.0,
+        };
+        for i in 0..n {
+            x0v[i] = xstart[i] + xscaling[i] * (i as f64 / n as f64) * pert;
+        }
+        eval(&x0v, &mut fx0);
+        if fx0.iter().all(|v| v.is_finite() && libm::fabs(*v) < 1e6) {
+            break;
+        }
+    }
+
+    let mut y = vec![0.0f64; m];
+    y[..n].copy_from_slice(&x0v);
+    let mut hom = NewtonHom { n, fx0, fx: vec![0.0f64; n], xscaling: &xscaling, eval };
+    let ok = homotopy_algorithm(n, &mut y, &xscaling, start_dir, crate::omclog::NLS_HOMOTOPY, &mut hom).is_ok();
+    if ok {
+        x[..n].copy_from_slice(&y[..n]);
+    }
+    ok
+}
+
+/// C's `solveHomotopy` with `initHomotopy`: continue the component along its own
+/// lambda from 0, the opposing start direction being the second and last try. `x`
+/// holds `n` unknowns plus the lambda slot. Returns C's `homotopySteps` share.
+fn init_homotopy_solve<'e>(
+    n: usize,
+    x: &mut [f64],
+    nominal: &[f64],
+    bounds: &[f64],
+    eval: &mut (dyn FnMut(&[f64], &mut [f64]) + 'e),
+    mut jac: Option<&mut (dyn FnMut(&[f64], &mut [f64]) + 'e)>,
+) -> Option<usize> {
+    let m = n + 1;
+    let mut xscaling = vec![0.0f64; m];
+    for i in 0..n {
+        xscaling[i] = libm::fabs(nominal[i]).max(libm::fabs(x[i]));
+    }
+    xscaling[m - 1] = 1.0;
+    // C's `nlsData->max`, the FD sign-flip bound; lambda's own is unbounded.
+    let mut max_value = vec![f64::MAX; m];
+    for i in 0..n {
+        max_value[i] = bounds[2 * i + 1];
+    }
+    let x0 = x[..n].to_vec();
+    let neg = crate::solvers::hom_tuning().neg_start_dir;
+    // C's `runHomotopy` 1 and 2: the second try reverses the start direction.
+    for run in 1..=2 {
+        let dir = if (run == 1) != neg { 1.0 } else { -1.0 };
+        if run == 2 {
+            crate::omclog::info(
+                crate::omclog::ASSERT,
+                false,
+                "The homotopy algorithm is started again with opposing start direction.",
+            );
+        }
+        crate::omclog::debug_int(crate::omclog::INIT_HOMOTOPY, "Homotopy run: ", run);
+        crate::omclog::debug_double(
+            crate::omclog::INIT_HOMOTOPY,
+            if run == 1 { "startDirection = " } else { "Try again with startDirection = " },
+            dir,
+        );
+        let mut y = vec![0.0f64; m];
+        y[..n].copy_from_slice(&x0);
+        let r = {
+            let mut hom = InitHom {
+                n,
+                xscaling: &xscaling,
+                max_value: Some(&max_value),
+                eval,
+                jac: jac.as_deref_mut(),
+            };
+            homotopy_algorithm(n, &mut y, &xscaling, dir, crate::omclog::INIT_HOMOTOPY, &mut hom)
+        };
+        match r {
+            Ok(steps) => {
+                x[..m].copy_from_slice(&y);
+                crate::omclog::debug_int(
+                    crate::omclog::INIT_HOMOTOPY,
+                    "Total number of lambda steps for this homotopy loop:",
+                    steps as i32,
+                );
+                return Some(steps);
+            }
+            Err(e) => crate::omclog::warning(crate::omclog::ASSERT, false, &e.message()),
+        }
+    }
+    None
 }
 
 /// Newton's method with a forward-difference Jacobian and a damped (line-search)
@@ -1430,6 +1647,46 @@ pub(crate) const HIST_DEPTH: usize = 10;
 /// C's `MINIMAL_STEP_SIZE` (`epsilon.h`): times within this count as the same time.
 const MINIMAL_STEP_SIZE: f64 = 1.0e-12;
 
+/// C's `LOCAL_EQUIDISTANT_HOMOTOPY`, the one method the sweep below serves.
+const HOM_LOCAL_EQUIDISTANT: u32 = 0;
+/// The two `HOMOTOPY_METHOD` values C hands to `solveWithInitHomotopy`.
+const HOM_GLOBAL_ADAPTIVE: u32 = 2;
+const HOM_LOCAL_ADAPTIVE: u32 = 3;
+
+/// C's `%g`, the precision `infoStreamPrint` prints lambda with.
+fn fmt_g6(v: f64) -> alloc::string::String {
+    openmodelica_sim_meta::driver::format_g(v, 6)
+}
+
+/// C's two openings of the local equidistant sweep.
+/// C's opening of the local adaptive approach's lambda0 pre-solve.
+fn log_local_adaptive_start(sys_num: u32) {
+    let s = crate::omclog::INIT_HOMOTOPY;
+    crate::omclog::info(
+        s,
+        false,
+        &alloc::format!("Local homotopy with adaptive step size started for nonlinear system {sys_num}."),
+    );
+    crate::omclog::info(s, true, "homotopy process\n---------------------------");
+    crate::omclog::info(s, false, "solve lambda0-system");
+}
+
+fn log_local_homotopy_start(sys_num: u32, wanted: bool) {
+    let msg = if wanted {
+        alloc::format!("Local homotopy with equidistant step size started for nonlinear system {sys_num}.")
+    } else {
+        alloc::format!(
+            "Failed to solve the initial system {sys_num} without homotopy method. \
+             The local homotopy method with equidistant step size is used now."
+        )
+    };
+    if wanted {
+        crate::omclog::info(crate::omclog::INIT_HOMOTOPY, false, &msg);
+    } else {
+        crate::omclog::warning(crate::omclog::ASSERT, false, &msg);
+    }
+}
+
 /// Storage behind C's `oldValueList`: linear memory in the solver, a `Vec` in tests.
 pub(crate) trait History {
     /// Entries currently stored, newest-stored first.
@@ -1580,6 +1837,13 @@ pub extern "C" fn rt_nls_register(k: u32, hist_addr: u32, n: u32) {
     let roster = unsafe { &mut *ROSTER.0.get() };
     roster.truncate(k as usize);
     roster.push((hist_addr, n as usize));
+}
+
+/// C's `sysNumber`: the index in `nonlinearSystemData` the homotopy messages quote
+/// (not the equation index). The roster is registered in that order.
+fn nls_sys_number(hist_addr: u32) -> u32 {
+    let roster = unsafe { &*ROSTER.0.get() };
+    roster.iter().position(|(h, _)| *h == hist_addr).unwrap_or(0) as u32
 }
 
 /// C's `NONLINEAR_SYSTEM_DATA::numberOf{Iterations,FEval,JEval}`: per system,
@@ -2790,8 +3054,17 @@ pub extern "C" fn rt_solve_nls(
     sparse_default: u32,
     lss_handle: u32,
     eq_index: u32,
+    hom_support: u32,
+    hom_method: u32,
+    lambda_addr: u32,
 ) -> i32 {
-    let n = n as usize;
+    // Under an adaptive approach a homotopy-carrying system has one unknown more
+    // than residuals: `__HOM_LAMBDA`, the lambda slot (C's `size` vs `size-1`).
+    // `n` below is the residual count; the homotopy solver drives the extra one.
+    let lambda_unknown = hom_support != 0
+        && (hom_method == HOM_GLOBAL_ADAPTIVE || hom_method == HOM_LOCAL_ADAPTIVE)
+        && n > 1;
+    let n = n as usize - usize::from(lambda_unknown);
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
     // is smooth; mode 2 (init) is fresh throughout; mode 1 (event) re-solves with
     // fresh relations until the discrete state stabilizes (mixed-system iteration).
@@ -2801,8 +3074,10 @@ pub extern "C" fn rt_solve_nls(
     let saved_assert_seen = NLS_ASSERT_SEEN.swap(0, Ordering::Relaxed);
     let saved_throw_seen = NLS_THROW_SEEN.swap(0, Ordering::Relaxed);
     // Scratch buffers in the shared linear memory so the model callbacks (which
-    // take wasm pointers) can read `x` / write `r`.
-    let x_ptr = rt_alloc((n * 8) as u32);
+    // take wasm pointers) can read `x` / write `r`. `x` carries lambda too, as C's
+    // `residualFunc` addresses `xloc[n]`.
+    let m = n + usize::from(lambda_unknown);
+    let x_ptr = rt_alloc((m * 8) as u32);
     let r_ptr = rt_alloc((n * 8) as u32);
 
     // Function-pointer values are `__indirect_function_table` indices on wasm.
@@ -2848,8 +3123,11 @@ pub extern "C" fn rt_solve_nls(
             }
             return;
         }
-        for i in 0..n {
-            unsafe { store_f64(x_ptr + (i * 8) as u32, xs[i]) };
+        for i in 0..m {
+            // A solver iterating only the residual coordinates leaves lambda where
+            // the caller set it, not at C's uninitialized `xloc[n]`.
+            let v = xs.get(i).copied().unwrap_or_else(|| unsafe { load_f64(lambda_addr) });
+            unsafe { store_f64(x_ptr + (i * 8) as u32, v) };
         }
         // Asserts are recoverable while the residual runs (C's ERROR_NONLINEARSOLVER).
         let saved = enter_eval();
@@ -2870,12 +3148,15 @@ pub extern "C" fn rt_solve_nls(
     // Analytic Jacobian callback: `jac(sim_data, x, jptr)` fills a column-major
     // `n×n` matrix, or the `nnz` CSC values when the system is solved sparsely.
     // `u32::MAX` means none, so numeric `hybrd` is used.
-    let has_jac = jac_idx != u32::MAX;
+    // A homotopy system's symbolic Jacobian is `n×m`, which only the arc-length
+    // solver can use; the plain ladder there takes finite differences.
+    let has_hom_jac = lambda_unknown && jac_idx != u32::MAX;
+    let has_jac = jac_idx != u32::MAX && !lambda_unknown;
     // `sparse_default` also says which buffer `jac` fills: CSC values where the codegen
     // chose to solve sparsely, a dense column-major `n×n` for the rest.
     let jac_csc = has_jac && sparse_default != 0;
-    let jac_len = if jac_csc { nnz as usize } else { n * n };
-    let jac_ptr = if has_jac { rt_alloc((jac_len * 8) as u32) } else { 0 };
+    let jac_len = if jac_csc { nnz as usize } else { n * m };
+    let jac_ptr = if has_jac || has_hom_jac { rt_alloc((jac_len * 8) as u32) } else { 0 };
     // `-nls=` overrides the codegen-time choice (C's per-system `nlsMethod`): `kinsol`
     // takes every patterned system, the dense solvers force dense, unset keeps it.
     let pick = crate::solvers::nls();
@@ -2994,145 +3275,297 @@ pub extern "C" fn rt_solve_nls(
     let mut settled = false;
     // C's `alreadyTested`: the mixed re-check below fires at most once.
     let mut retried = false;
-    // C's `x0`, which the mixed retry restarts from.
-    let start_point = x.clone();
-    let converged = loop {
-        // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
-        // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
-        // O(n^3) per step, which is what the sparse choice exists to avoid.
-        let converged = if sparse {
-            kinsol_sparse_solve(
-                n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
-                pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
-            )
-        } else if pick == Nls::Newton {
-            solve_newton_c(
-                n, &mut x, &warm, &nominal, &mut res_scaling, discrete_call, &mut eval, &mut jaceval,
-                has_jac,
-            )
-        } else if pick == Nls::Homotopy {
-            // Both start directions, as C's runHomotopy.
-            let mut ok = false;
-            for &dir in &[1.0f64, -1.0] {
-                let mut hx = guess.clone();
-                if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
-                    x.copy_from_slice(&hx);
-                    ok = true;
-                    break;
-                }
-            }
-            ok
-        } else {
-            // C's default `NLS_MIXED` runs `solveHomotopy`, whose primary solver is
-            // `newtonAlgorithm`; minpack `hybrd` is only its fallback, restarted from the
-            // same start point. `-nls=hybrid` selects `solveHybrd` alone and skips ahead.
-            // Both share the retry/homotopy tail below.
-            let start = x.clone();
-            // C's `nlsx`, which `solveHomotopy` overwrites with the start point its entry
-            // phase settled on. `solveHybrd` restarts from that, not from the raw guess.
-            let mut nlsx = start.clone();
-            let mut converged = false;
-            // C's `solveHomotopy` opens one `LOG_NLS_V` block over everything down to
-            // its homotopy runs.
-            let homotopy_solver = matches!(pick, Nls::Default | Nls::Mixed);
-            // C's `discreteCall` covers the initial system too, so it is not
-            // `discrete_call` (which is only about holding relations).
-            let t =
-                HomotopyTrace { eq_index, time, discrete: saved_rel_fresh != 0, initial: saved_rel_fresh == 2 };
-            if homotopy_solver {
-                (converged, settled) = newton_c(
-                    n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
-                    has_jac, Some(&t),
-                );
-                if !converged {
-                    stat_inc(STAT_NLS_NEWTON_FAIL);
-                    x.copy_from_slice(&start);
-                }
-            }
-            settled &= converged;
-            // C's `solveHomotopy` on `newtonAlgorithm`'s `info == -1`.
-            if !converged {
-                stat_inc(STAT_NLS_RETRY);
-                // C's `discreteCall` is set for an initial system too; only an event call
-                // has relations to hold, so only there does the continuity flag move.
-                let mut set_cont = |c: bool| {
-                    if saved_rel_fresh == 1 {
-                        unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
-                    }
-                };
-                converged = hybrd_c(
-                    n, &mut x, &nlsx, &warm, &nominal, &bounds, &t, &mut eval, &mut set_cont,
-                );
-            }
-            // The rungs below are not `solveHomotopy`'s; they catch what C gives up on.
-            // `nls_accept` takes only a point at tolerance, so none can report a non-root.
-            if !converged {
-                stat_inc(STAT_NLS_RETRY);
-                x.copy_from_slice(&warm);
-                converged = newton_solve(n, &mut x, &mut eval);
-            }
-            // An initial system gets a second `newtonAlgorithm`, from `x0`.
-            if !converged && saved_rel_fresh == 2 {
-                x.copy_from_slice(&guess);
-                converged = newton_c(
-                    n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
-                    has_jac, None,
+    // C's `x0`, which the mixed retry restarts from; re-taken per homotopy attempt.
+    let mut start_point;
+    // C's `solve_nonlinear_system` homotopy dispatch: only a *local* equidistant
+    // approach sweeps here.
+    let equidistant_homotopy = saved_rel_fresh == 2
+        && hom_support != 0
+        && hom_method == HOM_LOCAL_EQUIDISTANT
+        && crate::solvers::init_lambda_steps() >= 1;
+    // C's `solveWithHomotopySolver`, run after the loop below.
+    let adaptive_homotopy = saved_rel_fresh == 2 && lambda_unknown;
+    let homotopy_deactivated = !(equidistant_homotopy || adaptive_homotopy);
+    let run_plain = homotopy_deactivated || !crate::solvers::homotopy_on_first_try();
+    let hom_steps = crate::solvers::init_lambda_steps();
+    let original_lambda = if lambda_addr != 0 { unsafe { load_f64(lambda_addr) } } else { 1.0 };
+    // C's lambda0-system pre-solve, which only the *local* adaptive approach runs.
+    let pre_lambda0 = adaptive_homotopy && hom_method == HOM_LOCAL_ADAPTIVE;
+    let mut lambda0_ok = true;
+    // -2 = the lambda0 pre-solve, -1 = C's plain `solveNLS` attempt,
+    // 0..=hom_steps = the local equidistant lambda sweep.
+    let mut attempt: i32 = if run_plain {
+        -1
+    } else if pre_lambda0 {
+        -2
+    } else if equidistant_homotopy {
+        0
+    } else {
+        i32::MIN // the arc-length solver alone
+    };
+    let sys_num = nls_sys_number(hist_addr);
+    if attempt == 0 {
+        log_local_homotopy_start(sys_num, true);
+    }
+    if attempt == -2 {
+        log_local_adaptive_start(sys_num);
+    }
+    let mut converged = if attempt == i32::MIN { false } else { 'attempts: loop {
+        if attempt == -2 {
+            // C sets `lambda = 0` before the lambda0-system pre-solve.
+            unsafe { store_f64(lambda_addr, 0.0) };
+        }
+        if attempt >= 0 {
+            let lambda = (attempt as f64 / hom_steps as f64).min(1.0);
+            unsafe { store_f64(lambda_addr, lambda) };
+            crate::omclog::info(
+                crate::omclog::INIT_HOMOTOPY,
+                false,
+                &alloc::format!("[system {sys_num}] homotopy parameter lambda = {}", fmt_g6(lambda)),
+            );
+        }
+        settled = false;
+        retried = false;
+        start_point = x.clone();
+        let attempt_converged = loop {
+            // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
+            // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
+            // O(n^3) per step, which is what the sparse choice exists to avoid.
+            let converged = if sparse {
+                kinsol_sparse_solve(
+                    n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
+                    pat_addr, nnz as usize, jac_csc, lss_handle, &mut eval,
                 )
-                .0;
-            }
-            if !converged {
-                stat_inc(STAT_NLS_RETRY);
-                converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-            }
-            if !converged {
-                x.copy_from_slice(&guess);
-                converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
-            }
-            if !converged {
-                x.copy_from_slice(&guess);
-                converged = lm_solve(n, &mut x, &mut eval);
-            }
-            if !converged {
-                x.copy_from_slice(&warm);
-                converged = lm_solve(n, &mut x, &mut eval);
-            }
-            // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
-            if !converged && saved_rel_fresh == 2 {
-                // Forward then reversed start direction, as C's runHomotopy.
-                for &dir in &[1.0f64, -1.0f64] {
+            } else if pick == Nls::Newton {
+                solve_newton_c(
+                    n, &mut x, &warm, &nominal, &mut res_scaling, discrete_call, &mut eval, &mut jaceval,
+                    has_jac,
+                )
+            } else if pick == Nls::Homotopy {
+                // Both start directions, as C's runHomotopy.
+                let mut ok = false;
+                for &dir in &[1.0f64, -1.0] {
                     let mut hx = guess.clone();
                     if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
                         x.copy_from_slice(&hx);
-                        converged = true;
+                        ok = true;
                         break;
                     }
                 }
-            }
-            if homotopy_solver {
-                if !converged {
-                    crate::omclog::debug_string(crate::omclog::NLS_V, "Homotopy solver did not converge!");
+                ok
+            } else {
+                // C's default `NLS_MIXED` runs `solveHomotopy`, whose primary solver is
+                // `newtonAlgorithm`; minpack `hybrd` is only its fallback, restarted from the
+                // same start point. `-nls=hybrid` selects `solveHybrd` alone and skips ahead.
+                // Both share the retry/homotopy tail below.
+                let start = x.clone();
+                // C's `nlsx`, which `solveHomotopy` overwrites with the start point its entry
+                // phase settled on. `solveHybrd` restarts from that, not from the raw guess.
+                let mut nlsx = start.clone();
+                let mut converged = false;
+                // C's `solveHomotopy` opens one `LOG_NLS_V` block over everything down to
+                // its homotopy runs.
+                let homotopy_solver = matches!(pick, Nls::Default | Nls::Mixed);
+                // C's `discreteCall` covers the initial system too, so it is not
+                // `discrete_call` (which is only about holding relations).
+                let t =
+                    HomotopyTrace { eq_index, time, discrete: saved_rel_fresh != 0, initial: saved_rel_fresh == 2 };
+                if homotopy_solver {
+                    (converged, settled) = newton_c(
+                        n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
+                        has_jac, Some(&t),
+                    );
+                    if !converged {
+                        stat_inc(STAT_NLS_NEWTON_FAIL);
+                        x.copy_from_slice(&start);
+                    }
                 }
-                crate::omclog::close(crate::omclog::NLS_V);
+                settled &= converged;
+                // C's `solveHomotopy` on `newtonAlgorithm`'s `info == -1`.
+                if !converged {
+                    stat_inc(STAT_NLS_RETRY);
+                    // C's `discreteCall` is set for an initial system too; only an event call
+                    // has relations to hold, so only there does the continuity flag move.
+                    let mut set_cont = |c: bool| {
+                        if saved_rel_fresh == 1 {
+                            unsafe { store_u32(rel_fresh_addr, u32::from(!c)) };
+                        }
+                    };
+                    converged = hybrd_c(
+                        n, &mut x, &nlsx, &warm, &nominal, &bounds, &t, &mut eval, &mut set_cont,
+                    );
+                }
+                // The rungs below are not `solveHomotopy`'s; they catch what C gives up on.
+                // `nls_accept` takes only a point at tolerance, so none can report a non-root.
+                if !converged {
+                    stat_inc(STAT_NLS_RETRY);
+                    x.copy_from_slice(&warm);
+                    converged = newton_solve(n, &mut x, &mut eval);
+                }
+                // An initial system gets a second `newtonAlgorithm`, from `x0`.
+                if !converged && saved_rel_fresh == 2 {
+                    x.copy_from_slice(&guess);
+                    converged = newton_c(
+                        n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
+                        has_jac, None,
+                    )
+                    .0;
+                }
+                if !converged {
+                    stat_inc(STAT_NLS_RETRY);
+                    converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+                }
+                if !converged {
+                    x.copy_from_slice(&guess);
+                    converged = hybrd_scaled(n, &mut x, &mut fvec, &nominal, maxfev, &mut eval);
+                }
+                if !converged {
+                    x.copy_from_slice(&guess);
+                    converged = lm_solve(n, &mut x, &mut eval);
+                }
+                if !converged {
+                    x.copy_from_slice(&warm);
+                    converged = lm_solve(n, &mut x, &mut eval);
+                }
+                // C's mixed-solver homotopy fallback: track H(x,λ)=F(x)−(1−λ)·F(x0) from λ=0 to 1.
+                if !converged && saved_rel_fresh == 2 {
+                    // Forward then reversed start direction, as C's runHomotopy.
+                    for &dir in &[1.0f64, -1.0f64] {
+                        let mut hx = guess.clone();
+                        if homotopy_solve(n, &mut hx, &nominal, dir, &mut eval) {
+                            x.copy_from_slice(&hx);
+                            converged = true;
+                            break;
+                        }
+                    }
+                }
+                if homotopy_solver {
+                    if !converged {
+                        crate::omclog::debug_string(crate::omclog::NLS_V, "Homotopy solver did not converge!");
+                    }
+                    crate::omclog::close(crate::omclog::NLS_V);
+                }
+                converged
+            };
+            // C's `solveHomotopy` mixed tail: relations live at the solution, and if the
+            // branch moved, the *same* ladder again from the start point with them live.
+            if !converged || !mixed || retried {
+                break converged;
             }
-            converged
+            unsafe { store_u32(rel_fresh_addr, 1) };
+            let uncounted = n_feval.get();
+            eval(&x, &mut scratch);
+            n_feval.set(uncounted);
+            settled = true;
+            if (0..n_rel).all(|i| unsafe { load_u32(rel_addr + i * 4) } == rel_backup[i as usize]) {
+                break converged;
+            }
+            retried = true;
+            settled = false;
+            x.copy_from_slice(&start_point);
         };
-        // C's `solveHomotopy` mixed tail: relations live at the solution, and if the
-        // branch moved, the *same* ladder again from the start point with them live.
-        if !converged || !mixed || retried {
-            break converged;
+        // C's step loop stops at the first lambda that does not converge, and the plain
+        // attempt falls through to the sweep.
+        if attempt == -2 {
+            lambda0_ok = attempt_converged;
+            crate::omclog::info(
+                crate::omclog::INIT_HOMOTOPY,
+                false,
+                &alloc::format!(
+                    "solving lambda0-system done with{} success\n---------------------------",
+                    if attempt_converged { "" } else { "no" }
+                ),
+            );
+            crate::omclog::close(crate::omclog::INIT_HOMOTOPY);
+            break 'attempts false;
         }
-        unsafe { store_u32(rel_fresh_addr, 1) };
-        let uncounted = n_feval.get();
-        eval(&x, &mut scratch);
-        n_feval.set(uncounted);
-        settled = true;
-        if (0..n_rel).all(|i| unsafe { load_u32(rel_addr + i * 4) } == rel_backup[i as usize]) {
-            break converged;
+        if attempt < 0 {
+            if attempt_converged {
+                break 'attempts true;
+            }
+            if adaptive_homotopy {
+                crate::omclog::warning(
+                    crate::omclog::ASSERT,
+                    false,
+                    &alloc::format!(
+                        "Failed to solve the initial system {sys_num} without homotopy method."
+                    ),
+                );
+                if pre_lambda0 {
+                    log_local_adaptive_start(sys_num);
+                    attempt = -2;
+                    continue;
+                }
+                break 'attempts false;
+            }
+            if !equidistant_homotopy {
+                break 'attempts false;
+            }
+            log_local_homotopy_start(sys_num, false);
+            attempt = 0;
+            continue;
         }
-        retried = true;
-        settled = false;
-        x.copy_from_slice(&start_point);
-    };
+        if !attempt_converged {
+            crate::stat_add(crate::STAT_HOMOTOPY_STEPS, hom_steps as u64);
+            break 'attempts false;
+        }
+        crate::omclog::info(
+            crate::omclog::INIT_HOMOTOPY,
+            false,
+            &alloc::format!(
+                "[system {sys_num}] homotopy parameter lambda = {} done\n---------------------------",
+                fmt_g6((attempt as f64 / hom_steps as f64).min(1.0))
+            ),
+        );
+        if attempt >= hom_steps {
+            crate::stat_add(crate::STAT_HOMOTOPY_STEPS, hom_steps as u64);
+            break 'attempts true;
+        }
+        // The next lambda starts from this one's solution, as C's `nlsx` does.
+        attempt += 1;
+        warm.copy_from_slice(&x);
+        guess.copy_from_slice(&x);
+        nlsx_old.copy_from_slice(&x);
+    } };
+    // C's `solveWithInitHomotopy`: run along the model's own homotopy path.
+    if adaptive_homotopy && !converged && (hom_method == HOM_GLOBAL_ADAPTIVE || lambda0_ok) {
+        crate::omclog::info(
+            crate::omclog::INIT_HOMOTOPY,
+            false,
+            "run along the homotopy path and solve the actual system",
+        );
+        unsafe { store_f64(lambda_addr, 0.0) };
+        let mut y = x.clone();
+        y.push(0.0);
+        let mut hom_jac = |ys: &[f64], out: &mut [f64]| {
+            stat_inc(STAT_NLS_JAC);
+            note_jac_eval();
+            let jacf: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(jac_idx as usize) };
+            for i in 0..m {
+                unsafe { store_f64(x_ptr + (i * 8) as u32, ys[i]) };
+            }
+            let saved = enter_eval();
+            jacf(sim_data, x_ptr, jac_ptr);
+            leave_eval(saved);
+            for (k, v) in out.iter_mut().enumerate() {
+                *v = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
+            }
+        };
+        let steps = init_homotopy_solve(
+            n,
+            &mut y,
+            &nominal,
+            &bounds,
+            &mut eval,
+            has_hom_jac.then_some(&mut hom_jac as &mut dyn FnMut(&[f64], &mut [f64])),
+        );
+        if let Some(steps) = steps {
+            x.copy_from_slice(&y[..n]);
+            crate::stat_add(crate::STAT_HOMOTOPY_STEPS, steps as u64);
+            converged = true;
+            settled = false;
+        }
+    }
     if retried {
         // `hybrd_c`'s rung may have left the flag held.
         unsafe { store_u32(rel_fresh_addr, 1) };
@@ -3143,6 +3576,12 @@ pub extern "C" fn rt_solve_nls(
         let uncounted = n_feval.get();
         eval(&x, &mut scratch);
         n_feval.set(uncounted);
+    }
+    // C's `data->simulationInfo->lambda = originalLambda` closing
+    // `solve_nonlinear_system` — after the last evaluation, so the torn variables
+    // keep the values the solve left them at, not their values at the old lambda.
+    if lambda_addr != 0 {
+        unsafe { store_f64(lambda_addr, original_lambda) };
     }
     for i in 0..n {
         unsafe { store_f64(scale_addr + (i * 8) as u32, res_scaling[i]) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -92,6 +92,92 @@ pub(crate) fn max_step_factor() -> f64 {
     f64::from_bits(MAX_STEP_FACTOR.load(Ordering::Relaxed))
 }
 
+/// `-ils` (C's `init_lambda_steps`, default 3) and `-homotopyOnFirstTry` /
+/// `-noHomotopyOnFirstTry` as C's tri-state flag: 0 unset, 1 on, 2 off.
+static INIT_LAMBDA_STEPS: AtomicU32 = AtomicU32::new(3);
+static HOMOTOPY_ON_FIRST_TRY: AtomicU32 = AtomicU32::new(0);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_homotopy(init_lambda_steps: u32, on_first_try: u32) {
+    INIT_LAMBDA_STEPS.store(init_lambda_steps, Ordering::Relaxed);
+    HOMOTOPY_ON_FIRST_TRY.store(on_first_try, Ordering::Relaxed);
+}
+
+pub(crate) fn init_lambda_steps() -> i32 {
+    INIT_LAMBDA_STEPS.load(Ordering::Relaxed) as i32
+}
+
+/// C sets the flag itself for a model with homotopy support, so an unset flag
+/// reads as set here (only `-noHomotopyOnFirstTry` turns it off).
+pub(crate) fn homotopy_on_first_try() -> bool {
+    HOMOTOPY_ON_FIRST_TRY.load(Ordering::Relaxed) != 2
+}
+
+/// C's `model_help.c` homotopy constants. A cell rather than atomics: read once
+/// per run, and the runtime is single-threaded (as `nls::RosterCell`).
+struct HomCell(core::cell::UnsafeCell<openmodelica_sim_meta::simflags::HomTuning>);
+unsafe impl Sync for HomCell {}
+static HOM: HomCell = HomCell(core::cell::UnsafeCell::new(
+    openmodelica_sim_meta::simflags::HomTuning {
+        adapt_bend: 0.5,
+        h_eps: 1e-5,
+        tau_dec: 10.0,
+        tau_dec_pred: 2.0,
+        tau_inc: 2.0,
+        tau_inc_threshold: 10.0,
+        tau_max: 10.0,
+        tau_min: 1e-4,
+        tau_start: 0.2,
+        max_lambda_steps: 0,
+        max_newton_steps: 20,
+        max_tries: 10,
+        orthogonal_backtrace: false,
+        neg_start_dir: false,
+    },
+));
+
+pub(crate) fn hom_tuning() -> openmodelica_sim_meta::simflags::HomTuning {
+    unsafe { *HOM.0.get() }
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn rt_set_homotopy_tuning(
+    adapt_bend: f64,
+    h_eps: f64,
+    tau_dec: f64,
+    tau_dec_pred: f64,
+    tau_inc: f64,
+    tau_inc_threshold: f64,
+    tau_max: f64,
+    tau_min: f64,
+    tau_start: f64,
+    max_lambda_steps: u32,
+    max_newton_steps: u32,
+    max_tries: u32,
+    orthogonal_backtrace: u32,
+    neg_start_dir: u32,
+) {
+    unsafe {
+        *HOM.0.get() = openmodelica_sim_meta::simflags::HomTuning {
+            adapt_bend,
+            h_eps,
+            tau_dec,
+            tau_dec_pred,
+            tau_inc,
+            tau_inc_threshold,
+            tau_max,
+            tau_min,
+            tau_start,
+            max_lambda_steps,
+            max_newton_steps,
+            max_tries,
+            orthogonal_backtrace: orthogonal_backtrace != 0,
+            neg_start_dir: neg_start_dir != 0,
+        };
+    }
+}
+
 /// Set the four selectors for the next run. Host-driven builds call this through
 /// the export; the in-wasm session calls [`apply_flags`] instead.
 #[unsafe(no_mangle)]
@@ -115,6 +201,14 @@ pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     rt_set_solvers(nls, nls_ls, ls, lss);
     let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::newton_tuning(f);
     rt_set_newton_tuning(ftol, xtol, msf);
+    let (steps, first) = openmodelica_sim_meta::simflags::homotopy_codes(f);
+    rt_set_homotopy(steps, first);
+    let h = openmodelica_sim_meta::simflags::hom_tuning(f);
+    rt_set_homotopy_tuning(
+        h.adapt_bend, h.h_eps, h.tau_dec, h.tau_dec_pred, h.tau_inc, h.tau_inc_threshold,
+        h.tau_max, h.tau_min, h.tau_start, h.max_lambda_steps, h.max_newton_steps, h.max_tries,
+        h.orthogonal_backtrace as u32, h.neg_start_dir as u32,
+    );
 }
 
 pub(crate) fn nls() -> Nls {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -453,14 +453,18 @@ fn took_error_stage(e: &mut dyn SimEngine, addr: u32) -> bool {
 }
 
 /// Must match the runtime's `N_STATS`.
-pub const RT_STATS: usize = 24;
+pub const RT_STATS: usize = 25;
 
 pub const RT_STAT_NAMES: [&str; RT_STATS] = [
     "alloc", "array_new", "record_new", "str_new", "nls_solve", "nls_res", "nls_jac", "nls_fail", "nls_retry",
     "elem_ptr", "nls_iter", "nls_newton_fail", "nls_guess_hit", "nls_accept", "nls_store_back",
     "nls_vary_start", "nls_stale", "newton_irregular", "newton_lambda", "newton_negstep",
-    "newton_maxiter", "newton_stuck", "newton_jac", "newton_singular",
+    "newton_maxiter", "newton_stuck", "newton_jac", "newton_singular", "homotopy_steps",
 ];
+
+/// Lambda steps the runtime's locally-continued systems took, part of the same
+/// `homotopySteps` the driver's own continuation feeds.
+pub const RT_STAT_HOMOTOPY_STEPS: usize = 24;
 
 /// Read a runtime String heap value (`[refcount:u32][len:u32][utf8]`, handle at
 /// its base; `0` is null) into a Rust `String`.
@@ -884,8 +888,9 @@ fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
 /// overrides.
 const HOMOTOPY_STEPS: i32 = 3;
 
+/// C clamps a negative `-ils` to 0, which turns the continuation off entirely.
 fn homotopy_steps() -> i32 {
-    crate::simflags::with_flags(|f| f.init_lambda_steps).unwrap_or(HOMOTOPY_STEPS).max(1)
+    crate::simflags::with_flags(|f| f.init_lambda_steps).unwrap_or(HOMOTOPY_STEPS).max(0)
 }
 
 // Parameter / start `-override`s for the next run, resolved to `(SimData offset,
@@ -1187,14 +1192,16 @@ mod chatter_store {
 /// "finished successfully with N homotopy steps" / "without homotopy method"
 /// (the driver only returns a `&'static str`). 0 = no homotopy was used.
 mod init_report {
-    use core::sync::atomic::{AtomicU32, Ordering};
+    use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     static HOMOTOPY_STEPS: AtomicU32 = AtomicU32::new(0);
+    static LOCAL: AtomicBool = AtomicBool::new(false);
     /// The homotopy step a failed initialization gave up at, and the system that
     /// did not converge there, both biased by one.
     static FAILED_STEP: AtomicU32 = AtomicU32::new(0);
     static FAILED_SYSTEM: AtomicU32 = AtomicU32::new(0);
     pub fn reset() {
         HOMOTOPY_STEPS.store(0, Ordering::Relaxed);
+        LOCAL.store(false, Ordering::Relaxed);
         FAILED_STEP.store(0, Ordering::Relaxed);
         FAILED_SYSTEM.store(0, Ordering::Relaxed);
     }
@@ -1204,11 +1211,19 @@ mod init_report {
     pub fn failed_system() -> Option<u32> {
         FAILED_SYSTEM.load(Ordering::Relaxed).checked_sub(1)
     }
-    pub fn set_homotopy_steps(n: u32) {
-        HOMOTOPY_STEPS.store(n, Ordering::Relaxed);
+    /// C's `homotopySteps +=`, fed by the driver and every local sweep alike.
+    pub fn add_homotopy_steps(n: u32) {
+        HOMOTOPY_STEPS.fetch_add(n, Ordering::Relaxed);
     }
     pub fn homotopy_steps() -> u32 {
         HOMOTOPY_STEPS.load(Ordering::Relaxed)
+    }
+    /// C's `usedLocal`.
+    pub fn set_local(local: bool) {
+        LOCAL.store(local, Ordering::Relaxed);
+    }
+    pub fn local() -> bool {
+        LOCAL.load(Ordering::Relaxed)
     }
     pub fn set_failed_step(step: i32) {
         FAILED_STEP.store(step as u32 + 1, Ordering::Relaxed);
@@ -1222,6 +1237,11 @@ mod init_report {
 /// to format the initialization success message like the C runtime.
 pub fn init_homotopy_steps() -> u32 {
     init_report::homotopy_steps()
+}
+
+/// Whether those steps were a *local* approach's, which C names in the same line.
+pub fn init_homotopy_local() -> bool {
+    init_report::local()
 }
 
 /// `lambda` of the homotopy step the last initialization failed at, for the host
@@ -1650,6 +1670,12 @@ fn init_model(
     start_time: f64,
     model: Option<&SimMeta>,
 ) -> Result<()> {
+    // C's `initializeNonlinearSystems`, which reports its dropped patterns here.
+    if let Some(m) = model {
+        for w in &m.nls_warnings {
+            omclog::warning(omclog::STDOUT, false, w);
+        }
+    }
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_f64(e, sim_data + TIME_OFF, start_time)?;
@@ -1747,13 +1773,16 @@ fn symbolic_initialization(
     // read in an initial equation sees `start`. `-iim=none` never gets here, and the
     // homotopy retry below does not re-store.
     seed_pre_from_live(e, sim_data, layout)?;
-    solve_initial_system(e, sim_data, layout, inputs, model)?;
+    init_report::set_local(!layout.homotopy_method.is_global());
+    let res = solve_initial_system(e, sim_data, layout, inputs, model);
+    // A local approach counts its steps inside the runtime; collect them.
+    init_report::add_homotopy_steps(e.rt_stats()[RT_STAT_HOMOTOPY_STEPS] as u32);
+    res?;
     check_removed_initial_equations(e, sim_data, layout, model)
 }
 
-/// A model with `homotopy()` goes straight to the global equidistant continuation,
-/// unless `-noHomotopyOnFirstTry` asks for the direct solve first with the
-/// continuation as the fallback.
+/// C's `symbolic_initialization` homotopy dispatch: only a *global* approach
+/// continues here, a local one leaving the job to `rt_solve_nls`.
 fn solve_initial_system(
     e: &mut dyn SimEngine,
     sim_data: u32,
@@ -1761,30 +1790,72 @@ fn solve_initial_system(
     inputs: &[crate::InputVar],
     model: Option<&SimMeta>,
 ) -> Result<()> {
-    if !layout.has_homotopy {
+    use crate::HomotopyMethod as H;
+    let method = layout.homotopy_method;
+    if layout.has_homotopy && crate::simflags::with_flags(|f| f.homotopy_on_first_try).is_none() {
+        omclog::info(
+            omclog::INIT_HOMOTOPY,
+            false,
+            "Model contains homotopy operator: Use adaptive homotopy method to solve initialization \
+             problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".",
+        );
+    }
+    let mut solve_with_global = layout.has_homotopy
+        && ((method == H::GlobalEquidistant && homotopy_steps() >= 1) || method == H::GlobalAdaptive);
+    if !solve_with_global {
         return direct_initial_solve(e, sim_data, layout);
     }
-    if homotopy_on_first_try() {
-        run_homotopy_continuation(e, sim_data, layout)?;
-        init_report::set_homotopy_steps(homotopy_steps() as u32);
+    if !homotopy_on_first_try() {
+        omclog::info(omclog::INIT_HOMOTOPY, false, "Try to solve the initialization problem without homotopy first.");
+        if direct_initial_solve(e, sim_data, layout).is_ok() {
+            solve_with_global = false;
+        } else {
+            omclog::warning(
+                omclog::ASSERT,
+                false,
+                "Failed to solve the initialization problem without homotopy method. \
+                 If homotopy is available the homotopy method is used now.",
+            );
+            // C's catch arm resets everything to start before the continuation runs.
+            init_report::reset();
+            let _ = rethrow_store::take();
+            seed_start_values(e, sim_data, layout, inputs, model)?;
+        }
+    }
+    if !solve_with_global {
         return Ok(());
     }
-    if direct_initial_solve(e, sim_data, layout).is_ok() {
+    if method == H::GlobalEquidistant {
+        run_homotopy_continuation(e, sim_data, layout, model)?;
+        init_report::add_homotopy_steps(homotopy_steps() as u32);
         return Ok(());
+    }
+    // GLOBAL_ADAPTIVE: the simplified lambda = 0 system first, then the actual one,
+    // whose homotopy-carrying component runs the arc-length continuation itself.
+    omclog::info(omclog::INIT_HOMOTOPY, false, "Global homotopy with adaptive step size started.");
+    omclog::info(omclog::INIT_HOMOTOPY, true, "homotopy process\n---------------------------");
+    write_f64(e, sim_data + layout.lambda_off, 0.0)?;
+    omclog::info(omclog::INIT_HOMOTOPY, false, "solve simplified lambda0-DAE");
+    call_initial_equations_lambda0(e, sim_data, layout)?;
+    omclog::info(omclog::INIT_HOMOTOPY, false, "solving simplified lambda0-DAE done\n---------------------------");
+    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+    e.call1("functionInitialEquations", sim_data)?;
+    omclog::close(omclog::INIT_HOMOTOPY);
+    check_nls(e, sim_data, layout)
+}
+
+/// The continuation's lambda = 0 step, falling back to the full initial system.
+fn call_initial_equations_lambda0(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+    if layout.has_init_lambda0 {
+        return e.call1("functionInitialEquations_lambda0", sim_data);
     }
     omclog::warning(
-        omclog::ASSERT,
+        omclog::INIT_HOMOTOPY,
         false,
-        "Failed to solve the initialization problem without homotopy method. \
-         If homotopy is available the homotopy method is used now.",
+        "No initialEquation_lambda0 was generated. Using normal initial equation system with lambda=0 instead.",
     );
-    // C's catch arm resets everything to start before the continuation runs.
-    init_report::reset();
-    let _ = rethrow_store::take();
-    seed_start_values(e, sim_data, layout, inputs, model)?;
-    run_homotopy_continuation(e, sim_data, layout)?;
-    init_report::set_homotopy_steps(homotopy_steps() as u32);
-    Ok(())
+    e.call1("functionInitialEquations", sim_data)
 }
 
 /// C's over-determined check: the removed initial equations are residuals of the
@@ -2051,26 +2122,116 @@ fn homotopy_on_first_try() -> bool {
 /// lambda 0 → 1 in `HOMOTOPY_STEPS` steps, step 0 solving the simplified
 /// `functionInitialEquations_lambda0`, each step seeded by the previous solution.
 /// Leaves lambda = 1.
-fn run_homotopy_continuation(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+fn run_homotopy_continuation(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    model: Option<&SimMeta>,
+) -> Result<()> {
     let steps = homotopy_steps();
+    omclog::info(omclog::INIT_HOMOTOPY, false, "Global homotopy with equidistant step size started.");
+    let mut path = HomotopyPath::open(model, "equidistant_global_homotopy.csv");
+    path.header(model);
+    omclog::info(omclog::INIT_HOMOTOPY, true, "homotopy process\n---------------------------");
     // C runs every step unconditionally and checks the systems once at the end
     // (`check_nonlinear_solutions`), so a system that misses at lambda = 1/3 and
     // lands at lambda = 1 is not a failure. A model assert still aborts.
     for step in 0..=steps {
-        write_f64(e, sim_data + layout.lambda_off, (step as f64 / steps as f64).min(1.0))?;
-        write_i32(e, sim_data + layout.nls_fail_off, 0)?;
+        let lambda = (step as f64 / steps as f64).min(1.0);
+        write_f64(e, sim_data + layout.lambda_off, lambda)?;
+        omclog::info(omclog::INIT_HOMOTOPY, false, &format!("homotopy parameter lambda = {}", format_g(lambda, 6)));
         if step == 0 {
-            e.call1("functionInitialEquations_lambda0", sim_data)?;
+            call_initial_equations_lambda0(e, sim_data, layout)?;
         } else {
+            write_i32(e, sim_data + layout.nls_fail_off, 0)?;
             e.call1("functionInitialEquations", sim_data)?;
         }
+        omclog::info(
+            omclog::INIT_HOMOTOPY,
+            false,
+            &format!("homotopy parameter lambda = {} done\n---------------------------", format_g(lambda, 6)),
+        );
+        path.row(e, sim_data, layout, lambda);
     }
+    omclog::close(omclog::INIT_HOMOTOPY);
+    path.finish();
     write_f64(e, sim_data + layout.lambda_off, 1.0)?;
     if check_nls(e, sim_data, layout).is_err() {
+        omclog::error(
+            omclog::ASSERT,
+            false,
+            "Failed to solve the initialization problem with global homotopy with equidistant step size.",
+        );
         init_report::set_failed_step(steps);
         return Err("CodegenWasmJit: homotopy initialization did not converge at lambda");
     }
     Ok(())
+}
+
+/// C's `log_homotopy_lambda_vars`: with `-lv=LOG_INIT_HOMOTOPY` the real variable
+/// vector is appended to `<prefix>_<name>` at every accepted lambda. Inert without
+/// a filesystem, as C's `OMC_NO_FILESYSTEM` builds are.
+struct HomotopyPath {
+    #[cfg(feature = "std")]
+    file: Option<(String, String)>,
+}
+
+impl HomotopyPath {
+    fn open(model: Option<&SimMeta>, name: &str) -> Self {
+        #[cfg(feature = "std")]
+        {
+            let file = match model {
+                Some(m) if omclog::active(omclog::INIT_HOMOTOPY) => {
+                    let path = format!("{}_{name}", m.prefix);
+                    omclog::info(
+                        omclog::INIT_HOMOTOPY,
+                        false,
+                        &format!("The homotopy path will be exported to {path}."),
+                    );
+                    Some((path, String::new()))
+                }
+                _ => None,
+            };
+            HomotopyPath { file }
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let _ = (model, name);
+            HomotopyPath {}
+        }
+    }
+
+    fn header(&mut self, model: Option<&SimMeta>) {
+        #[cfg(feature = "std")]
+        if let (Some((_, buf)), Some(m)) = (self.file.as_mut(), model) {
+            buf.push_str("\"lambda\"");
+            for name in &m.soti.reals {
+                buf.push_str(&format!(",\"{name}\""));
+            }
+            buf.push('\n');
+        }
+    }
+
+    fn row(&mut self, e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, lambda: f64) {
+        let _ = (sim_data, layout, lambda, e);
+        #[cfg(feature = "std")]
+        if let Some((_, buf)) = self.file.as_mut() {
+            buf.push_str(&format_g(lambda, 16));
+            for i in 0..2 * layout.n_states + layout.n_real_alg {
+                let v = read_f64(e, sim_data + crate::REAL_OFF + i * 8).unwrap_or(f64::NAN);
+                buf.push(',');
+                buf.push_str(&format_g(v, 16));
+            }
+            buf.push('\n');
+        }
+    }
+
+    fn finish(&mut self) {
+        #[cfg(feature = "std")]
+        if let Some((path, buf)) = self.file.take() {
+            let _ = std::fs::write(path, buf);
+        }
+    }
 }
 
 /// Append one trajectory row to `rows`: the real part `[time | realVars]`

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -83,6 +83,41 @@ pub enum WTy {
     F64,
 }
 
+/// C's `HOMOTOPY_METHOD`, selected by `--homotopyApproach` (and forced to
+/// [`Self::None`] by `--replaceHomotopy`). The numbering is C's.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum HomotopyMethod {
+    LocalEquidistant = 0,
+    #[default]
+    GlobalEquidistant = 1,
+    GlobalAdaptive = 2,
+    LocalAdaptive = 3,
+    None = 4,
+}
+
+impl HomotopyMethod {
+    pub fn from_code(c: u8) -> Self {
+        match c {
+            0 => Self::LocalEquidistant,
+            2 => Self::GlobalAdaptive,
+            3 => Self::LocalAdaptive,
+            4 => Self::None,
+            _ => Self::GlobalEquidistant,
+        }
+    }
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+    /// The parameter reaches the whole initial system, not just the component.
+    pub fn is_global(self) -> bool {
+        matches!(self, Self::GlobalEquidistant | Self::GlobalAdaptive)
+    }
+    /// The step size is the arc-length continuation's, not `1/init_lambda_steps`.
+    pub fn is_adaptive(self) -> bool {
+        matches!(self, Self::GlobalAdaptive | Self::LocalAdaptive)
+    }
+}
+
 /// Fully-resolved layout of one model's `SimData` block. All offsets are byte
 /// offsets within the block; all are compile-time constants baked into the
 /// generated module. This is the single source of truth: the codegen computes it
@@ -99,6 +134,12 @@ pub struct Layout {
     /// A nonlinear system carries the homotopy operator (C's `homotopySupport`), so
     /// the driver runs the continuation over `functionInitialEquations_lambda0`.
     pub has_homotopy: bool,
+    /// `--homotopyApproach` as C's `homotopyMethod` callback field: whose
+    /// continuation runs, and whether it is equidistant or adaptive.
+    pub homotopy_method: HomotopyMethod,
+    /// A simplified lambda = 0 system was generated, so the continuation's first
+    /// step can call `functionInitialEquations_lambda0`.
+    pub has_init_lambda0: bool,
     /// The model has `delay(...)` or `spatialDistribution(...)`, i.e. an operator
     /// with an internal history that `functionStoreDelayed` /
     /// `functionStoreSpatialDistribution` must be fed at every accepted point.
@@ -280,6 +321,8 @@ impl Layout {
         n_removed_init: u32,
         has_when: bool,
         has_homotopy: bool,
+        homotopy_method: HomotopyMethod,
+        has_init_lambda0: bool,
         has_history_ops: bool,
     ) -> Self {
         let n_real = 2 * n_states + n_real_alg; // states | ders | algs
@@ -336,7 +379,7 @@ impl Layout {
         let removed_init_idx_off = removed_init_res_off + 8;
         let total = removed_init_idx_off + 4;
         Layout {
-            n_states, n_real_alg, has_when, has_homotopy, has_history_ops, lambda_off, rparam_off, int_off, iparam_off,
+            n_states, n_real_alg, has_when, has_homotopy, homotopy_method, has_init_lambda0, has_history_ops, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off,
             terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
@@ -867,6 +910,9 @@ pub struct SimMeta {
     /// Modelica source of each residual `functionRemovedInitialEquations` checks;
     /// C bakes the same text into the generated `errorStreamPrint`.
     pub removed_init_desc: Vec<String>,
+    /// C's `initializeNonlinearSystems` startup warnings, decided at compile time:
+    /// so far only a sparsity pattern `sparsitySanityCheck` rejects.
+    pub nls_warnings: Vec<String>,
     /// C's `simulationInfo->sensitivityParList`: the `SimData` offsets of the
     /// parameters `--calculateSensitivities` selected, in block order.
     pub sens_params: Vec<u32>,
@@ -1177,6 +1223,8 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
     }
     o.push(l.has_when as u8);
     o.push(l.has_homotopy as u8);
+    o.push(l.homotopy_method.code());
+    o.push(l.has_init_lambda0 as u8);
     o.push(l.has_history_ops as u8);
 }
 fn put_jac(o: &mut Vec<u8>, j: &Option<JacAInfo>) {
@@ -1292,6 +1340,10 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     }
     put_u32(&mut o, m.removed_init_desc.len() as u32);
     for d in &m.removed_init_desc {
+        put_str(&mut o, d);
+    }
+    put_u32(&mut o, m.nls_warnings.len() as u32);
+    for d in &m.nls_warnings {
         put_str(&mut o, d);
     }
     put_u32(&mut o, m.sample_index.len() as u32);
@@ -1544,10 +1596,14 @@ impl<'a> Reader<'a> {
             total: self.u32()?,
             has_when: false,
             has_homotopy: false,
+            homotopy_method: HomotopyMethod::default(),
+            has_init_lambda0: false,
             has_history_ops: false,
         };
         l.has_when = self.u8()? != 0;
         l.has_homotopy = self.u8()? != 0;
+        l.homotopy_method = HomotopyMethod::from_code(self.u8()?);
+        l.has_init_lambda0 = self.u8()? != 0;
         l.has_history_ops = self.u8()? != 0;
         Ok(l)
     }
@@ -1651,6 +1707,11 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let mut removed_init_desc = Vec::with_capacity(nridesc);
     for _ in 0..nridesc {
         removed_init_desc.push(r.string()?);
+    }
+    let nwarn = r.u32()? as usize;
+    let mut nls_warnings = Vec::with_capacity(nwarn);
+    for _ in 0..nwarn {
+        nls_warnings.push(r.string()?);
     }
     let sample_index = r.u32s()?.into_iter().map(|v| v as i32).collect();
     let mut soti = SotiVars::default();
@@ -1809,7 +1870,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
-        removed_init_desc, sample_index, soti, sens_params, nls_vars, dae, clocks, lin, opt, inputs,
+        removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, dae, clocks, lin, opt, inputs,
     })
 }
 
@@ -1821,7 +1882,10 @@ mod tests {
 
     fn sample() -> SimMeta {
         SimMeta {
-            layout: Layout::new(2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, 2, 1, false, false, false),
+            layout: Layout::new(
+                2, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 1, 2, 1, 2, 6, 5, 2, 1, false, false,
+                HomotopyMethod::GlobalEquidistant, false, false,
+            ),
             start_time: 0.0,
             stop_time: 1.0,
             n_intervals: 500,
@@ -1871,6 +1935,7 @@ mod tests {
                 AttrLog { kind: 3, name: "y".to_string() },
             ],
             removed_init_desc: vec!["4.0 - z".to_string()],
+            nls_warnings: Vec::new(),
             sample_index: vec![1],
             soti: SotiVars::default(),
             sens_params: vec![88],

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -357,7 +357,9 @@ pub fn message_text(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
             s.last_type[i] = ty;
             s.last_stream = stream;
         }
-        if indent_next {
+        // C's `messageText` recurses for the second line and returns, so a
+        // multi-line message never opens a block however `indentNext` is set.
+        if indent_next && !msg.contains('\n') {
             s.level[i] += 1;
         }
     });
@@ -367,6 +369,14 @@ pub fn message_text(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
 /// C's `%<width>.<prec>g`.
 pub fn g(v: f64, width: usize, prec: i32) -> String {
     pad(crate::driver::format_g(v, prec), width)
+}
+
+/// C's `%<width>.<prec>f`: fixed point, no exponent.
+pub fn f(v: f64, width: usize, prec: usize) -> String {
+    if !v.is_finite() {
+        return alloc::format!("{v}");
+    }
+    pad(alloc::format!("{v:.prec$}"), width)
 }
 
 /// C's `%<width>.<prec>e`: always an exponent, at least two exponent digits.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -109,6 +109,8 @@ pub struct SimFlags {
     /// `-mbi`: bisection steps allowed when locating a state event, 0 = C's own
     /// bound from the bracket width (`maxBisectionIterations`).
     pub max_bisection_iter: Option<u32>,
+    /// The `-hom*` tuning of the arc-length homotopy solver (C's `model_help.c`).
+    pub hom: HomFlags,
     /// `-newtonFTol` / `-newtonXTol` / `-newtonMaxStepFactor`: C's `newtonFTol`,
     /// `newtonXTol` and `maxStepFactor`, shared by the homotopy Newton and KINSOL.
     pub newton_ftol: Option<f64>,
@@ -616,6 +618,27 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "iit" => f.init_time = Some(real(name, &value(name)?)?),
             "mei" => f.max_event_iter = Some(int(name, &value(name)?)?.max(0) as u32),
             "mbi" => f.max_bisection_iter = Some(int(name, &value(name)?)?.max(0) as u32),
+            "homAdaptBend" => f.hom.adapt_bend = Some(real(name, &value(name)?)?),
+            "homHEps" => f.hom.h_eps = Some(real(name, &value(name)?)?),
+            "homMaxLambdaSteps" => f.hom.max_lambda_steps = Some(int(name, &value(name)?)?.into()),
+            "homMaxNewtonSteps" => f.hom.max_newton_steps = Some(int(name, &value(name)?)?.into()),
+            "homMaxTries" => f.hom.max_tries = Some(int(name, &value(name)?)?.into()),
+            "homTauDecFac" => f.hom.tau_dec = Some(real(name, &value(name)?)?),
+            "homTauDecFacPredictor" => f.hom.tau_dec_pred = Some(real(name, &value(name)?)?),
+            "homTauIncFac" => f.hom.tau_inc = Some(real(name, &value(name)?)?),
+            "homTauIncThreshold" => f.hom.tau_inc_threshold = Some(real(name, &value(name)?)?),
+            "homTauMax" => f.hom.tau_max = Some(real(name, &value(name)?)?),
+            "homTauMin" => f.hom.tau_min = Some(real(name, &value(name)?)?),
+            "homTauStart" => f.hom.tau_start = Some(real(name, &value(name)?)?),
+            "homBacktraceStrategy" => {
+                let v = value(name)?;
+                f.hom.orthogonal_backtrace = match v.as_str() {
+                    "fix" => false,
+                    "orthogonal" => true,
+                    _ => return Err(format!("-homBacktraceStrategy={v}: expected fix or orthogonal")),
+                };
+            }
+            "homNegStartDir" => f.hom.neg_start_dir = true,
             "newtonFTol" => f.newton_ftol = Some(real(name, &value(name)?)?),
             "newtonXTol" => f.newton_xtol = Some(real(name, &value(name)?)?),
             "newtonMaxStepFactor" => f.newton_max_step_factor = Some(real(name, &value(name)?)?),
@@ -767,11 +790,102 @@ fn output_format(v: &str) -> Result<String, String> {
     }
 }
 
+/// The `-hom*` flags, mirroring the `model_help.c` globals.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct HomFlags {
+    pub adapt_bend: Option<f64>,
+    pub h_eps: Option<f64>,
+    pub max_lambda_steps: Option<i64>,
+    pub max_newton_steps: Option<i64>,
+    pub max_tries: Option<i64>,
+    pub tau_dec: Option<f64>,
+    pub tau_dec_pred: Option<f64>,
+    pub tau_inc: Option<f64>,
+    pub tau_inc_threshold: Option<f64>,
+    pub tau_max: Option<f64>,
+    pub tau_min: Option<f64>,
+    pub tau_start: Option<f64>,
+    /// `-homBacktraceStrategy=orthogonal` (C's `homBacktraceStrategy == 2`).
+    pub orthogonal_backtrace: bool,
+    /// `-homNegStartDir`: start the continuation towards decreasing lambda.
+    pub neg_start_dir: bool,
+}
+
+/// [`HomFlags`] with C's defaults filled in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HomTuning {
+    pub adapt_bend: f64,
+    pub h_eps: f64,
+    pub tau_dec: f64,
+    pub tau_dec_pred: f64,
+    pub tau_inc: f64,
+    pub tau_inc_threshold: f64,
+    pub tau_max: f64,
+    pub tau_min: f64,
+    pub tau_start: f64,
+    /// 0 = C's `homMaxLambdaSteps` default, which the solver reads as `size*100`.
+    pub max_lambda_steps: u32,
+    pub max_newton_steps: u32,
+    pub max_tries: u32,
+    pub orthogonal_backtrace: bool,
+    pub neg_start_dir: bool,
+}
+
+pub fn hom_tuning(f: &SimFlags) -> HomTuning {
+    HomTuning {
+        adapt_bend: f.hom.adapt_bend.unwrap_or(0.5),
+        h_eps: f.hom.h_eps.unwrap_or(1e-5),
+        tau_dec: f.hom.tau_dec.unwrap_or(10.0),
+        tau_dec_pred: f.hom.tau_dec_pred.unwrap_or(2.0),
+        tau_inc: f.hom.tau_inc.unwrap_or(2.0),
+        tau_inc_threshold: f.hom.tau_inc_threshold.unwrap_or(10.0),
+        tau_max: f.hom.tau_max.unwrap_or(10.0),
+        tau_min: f.hom.tau_min.unwrap_or(1e-4),
+        tau_start: f.hom.tau_start.unwrap_or(0.2),
+        max_lambda_steps: f.hom.max_lambda_steps.unwrap_or(0).max(0) as u32,
+        max_newton_steps: f.hom.max_newton_steps.unwrap_or(20).max(0) as u32,
+        max_tries: f.hom.max_tries.unwrap_or(10).max(0) as u32,
+        orthogonal_backtrace: f.hom.orthogonal_backtrace,
+        neg_start_dir: f.hom.neg_start_dir,
+    }
+}
+
 /// C's `simulation_runtime.cpp` startup notices for the flags that move a solver
 /// constant, in its order. Rendered by the caller, which owns the run's log.
 pub fn notices(f: &SimFlags) -> Vec<(crate::omclog::LogType, String)> {
     let g = |v: f64| crate::driver::format_g(v, 6);
+    let ff = |v: f64| crate::omclog::f(v, 0, 6);
     let mut out = Vec::new();
+    for (name, v) in [
+        ("homAdaptBend", f.hom.adapt_bend),
+        ("homHEps", f.hom.h_eps),
+    ] {
+        if let Some(v) = v {
+            out.push((crate::omclog::INFO, format!("homotopy parameter {name} changed to {}", ff(v))));
+        }
+    }
+    for (name, v) in [
+        ("homMaxLambdaSteps", f.hom.max_lambda_steps),
+        ("homMaxNewtonSteps", f.hom.max_newton_steps),
+        ("homMaxTries", f.hom.max_tries),
+    ] {
+        if let Some(v) = v {
+            out.push((crate::omclog::INFO, format!("homotopy parameter {name} changed to {v}")));
+        }
+    }
+    for (name, v) in [
+        ("homTauDecreasingFactor", f.hom.tau_dec),
+        ("homTauDecreasingFactorPredictor", f.hom.tau_dec_pred),
+        ("homTauIncreasingFactor", f.hom.tau_inc),
+        ("homTauIncreasingThreshold", f.hom.tau_inc_threshold),
+        ("homTauMax", f.hom.tau_max),
+        ("homTauMin", f.hom.tau_min),
+        ("homTauStart", f.hom.tau_start),
+    ] {
+        if let Some(v) = v {
+            out.push((crate::omclog::INFO, format!("homotopy parameter {name} changed to {}", ff(v))));
+        }
+    }
     if f.deprecated_density_flag {
         out.push((
             crate::omclog::WARNING,
@@ -795,6 +909,16 @@ pub fn notices(f: &SimFlags) -> Vec<(crate::omclog::LogType, String)> {
             "Simulation flag jacobianThreads not available. This runtime evaluates Jacobians \
              single-threaded."
                 .to_string(),
+        ));
+    }
+    if let Some(n) = f.init_lambda_steps {
+        out.push((
+            crate::omclog::INFO,
+            if n <= 0 {
+                "Number of lambda steps set to 0. Homotopy is disabled.".to_string()
+            } else {
+                format!("Number of lambda steps for homotopy approach changed to {n}")
+            },
         ));
     }
     if let Some(v) = f.steady_state_tol {
@@ -841,6 +965,19 @@ pub fn newton_tuning(f: &SimFlags) -> (f64, f64, f64) {
         f.newton_ftol.unwrap_or(1e-12),
         f.newton_xtol.unwrap_or(1e-12),
         f.newton_max_step_factor.unwrap_or(1e12),
+    )
+}
+
+/// `-ils` and the tri-state `-homotopyOnFirstTry` for the wasm runtime's
+/// `rt_set_homotopy`: 0 unset, 1 on, 2 off.
+pub fn homotopy_codes(f: &SimFlags) -> (u32, u32) {
+    (
+        f.init_lambda_steps.unwrap_or(3).max(0) as u32,
+        match f.homotopy_on_first_try {
+            None => 0,
+            Some(true) => 1,
+            Some(false) => 2,
+        },
     )
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -979,6 +979,25 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         });
         wts(set.call(&mut store, ftol, xtol, msf))?;
     }
+    // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_homotopy") {
+        let h = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::homotopy_codes(f)
+        });
+        wts(set.call(&mut store, h.0, h.1))?;
+    }
+    // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<
+        (f64, f64, f64, f64, f64, f64, f64, f64, f64, u32, u32, u32, u32, u32), ()>(
+        &store, "rt_set_homotopy_tuning",
+    ) {
+        let h = openmodelica_sim_meta::simflags::with_flags(openmodelica_sim_meta::simflags::hom_tuning);
+        wts(set.call(
+            &mut store, h.adapt_bend, h.h_eps, h.tau_dec, h.tau_dec_pred, h.tau_inc,
+            h.tau_inc_threshold, h.tau_max, h.tau_min, h.tau_start, h.max_lambda_steps,
+            h.max_newton_steps, h.max_tries, h.orthogonal_backtrace as u32, h.neg_start_dir as u32,
+        ))?;
+    }
     let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
     if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_log_streams") {
         wts(set.call(&mut store, log_mask as u32, (log_mask >> 32) as u32))?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -993,6 +993,26 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         });
         wts(set.call(&mut store, t))?;
     }
+    // `-ils` / `-homotopyOnFirstTry`: a local approach sweeps inside `rt_solve_nls`.
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_homotopy") {
+        let h = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::homotopy_codes(f)
+        });
+        wts(set.call(&mut store, h))?;
+    }
+    // The arc-length solver's `-hom*` constants.
+    if let Ok(set) = rt_inst
+        .get_typed_func::<(f64, f64, f64, f64, f64, f64, f64, f64, f64, u32, u32, u32, u32, u32), ()>(
+            &mut store, "rt_set_homotopy_tuning",
+        )
+    {
+        let h = openmodelica_sim_meta::simflags::with_flags(openmodelica_sim_meta::simflags::hom_tuning);
+        wts(set.call(&mut store, (
+            h.adapt_bend, h.h_eps, h.tau_dec, h.tau_dec_pred, h.tau_inc, h.tau_inc_threshold,
+            h.tau_max, h.tau_min, h.tau_start, h.max_lambda_steps, h.max_newton_steps, h.max_tries,
+            h.orthogonal_backtrace as u32, h.neg_start_dir as u32,
+        )))?;
+    }
     // Same for `-lv`: the nonlinear solver logs from inside the module.
     let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
     if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_log_streams") {

--- a/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
@@ -2,7 +2,7 @@
 // keywords: initialization, homotopy, solver
 // status: correct
 // cflags:
-// teardown_command: rm -rf initializationTests.homotopy4_solver* _initializationTests.homotopy4_solver* homotopy4_solver_system.log output.log
+// teardown_command: rm -rf initializationTests.homotopy4_solver* _initializationTests.homotopy4_solver* output.log
 // cflags: -d=-newInst
 //
 //
@@ -53,102 +53,58 @@ end initializationTests;
 // Test local approach with equidistant step size
 setCommandLineOptions("--homotopyApproach=equidistantLocal"); getErrorString();
 buildModel(initializationTests.homotopy4_solver); getErrorString();
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
 
 // Test global approach with equidistant step size
 setCommandLineOptions("--homotopyApproach=equidistantGlobal"); getErrorString();
 buildModel(initializationTests.homotopy4_solver); getErrorString();
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
 
 // Test local approach with adaptive step size
 setCommandLineOptions("--homotopyApproach=adaptiveLocal"); getErrorString();
 buildModel(initializationTests.homotopy4_solver); getErrorString();
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
 
-
-// Test gloabl approach
+// Test global approach with adaptive step size
 setCommandLineOptions("--homotopyApproach=adaptiveGlobal"); getErrorString();
 buildModel(initializationTests.homotopy4_solver); getErrorString();
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-system(realpath(".") + "/initializationTests.homotopy4_solver -lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", "homotopy4_solver_system.log"); getErrorString();
-readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
-
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
+simulate(initializationTests.homotopy4_solver, simflags="-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry", resimulateExecutable="initializationTests.homotopy4_solver"); getErrorString();
 
 // Result:
 // true
@@ -159,9 +115,10 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // "Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac2. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac3. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// 0
-// ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -209,10 +166,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -259,10 +218,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -310,10 +271,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -360,10 +323,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -411,10 +376,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -461,10 +428,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -512,10 +481,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -562,10 +533,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -613,10 +586,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -663,7 +638,8 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // true
 // ""
 // {"initializationTests.homotopy4_solver", "initializationTests.homotopy4_solver_init.xml"}
@@ -671,9 +647,10 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac11. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac14. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// 0
-// ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -723,10 +700,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -775,10 +754,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -828,10 +809,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -880,10 +863,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -933,10 +918,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -985,10 +972,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -1038,10 +1027,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -1090,10 +1081,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -1143,10 +1136,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry'",
+//     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -1195,16 +1190,18 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // true
 // ""
 // {"initializationTests.homotopy4_solver", "initializationTests.homotopy4_solver_init.xml"}
 // "Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac21. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac22. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1267,10 +1264,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1332,141 +1331,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
-// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
-// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
-// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1529,10 +1399,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1594,141 +1466,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
-// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
-// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
-// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1791,10 +1534,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1856,16 +1601,288 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Local homotopy with adaptive step size started for nonlinear system 0.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve lambda0-system
+// LOG_INIT_HOMOTOPY | info    | solving lambda0-system done with success
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_local_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.618547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.698547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.778547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.858547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 local homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
 // true
 // ""
 // {"initializationTests.homotopy4_solver", "initializationTests.homotopy4_solver_init.xml"}
 // "Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac28. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac31. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1928,10 +1945,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=hybrid -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -1993,141 +2012,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
-// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
-// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -2190,10 +2080,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=kinsol -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -2255,141 +2147,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
-// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
-// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
-// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
-// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
-// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -2452,10 +2215,12 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
-// 0
+// end SimulationResult;
 // ""
-// "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=newton -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
 // LOG_INIT          | info    | ### START INITIALIZATION ###
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
@@ -2517,5 +2282,276 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=homotopy -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "initializationTests.homotopy4_solver_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initializationTests.homotopy4_solver', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V -stopTime=0.0 -stepSize=0.0 -nls=mixed -homotopyOnFirstTry'",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with adaptive step size started.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | solve simplified lambda0-DAE
+// LOG_INIT_HOMOTOPY | info    | solving simplified lambda0-DAE done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | run along the homotopy path and solve the actual system
+// LOG_INIT_HOMOTOPY | info    | Homotopy run:  1
+// LOG_INIT_HOMOTOPY | info    | startDirection =    1.0000000000e+00
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_nonlinsys0_adaptive_global_homotopy_pos.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.0287318
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.298547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.338547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.378547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.418547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.458547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.498547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.538547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.578547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.658547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.738547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.818547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.978547
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | Total number of lambda steps for this homotopy loop: 14
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real __HOM_LAMBDA(start=0, nominal=1) = 0 (pre: 0)
+// |                 | |       | | | [2] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [3] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [4] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [5] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [6] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [7] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
+// |                 | |       | | | [8] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [10] Real x2(start=0, nominal=1) = 3 (pre: 0)
+// |                 | |       | | | [11] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [12] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [13] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [14] Real y2(start=0, nominal=1) = -3 (pre: 0)
+// |                 | |       | | | [15] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [16] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [17] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [18] Real z2(start=0, nominal=1) = 9 (pre: 0)
+// |                 | |       | | | [19] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 14 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
 // endResult


### PR DESCRIPTION
Only the global equidistant continuation existed, unlogged. Follow C's `initialization.c` / `nonlinearSystem.c` / `nonlinearSolverHomotopy.c` for the other three, with the `LOG_INIT_HOMOTOPY` output and the `-hom*` / `-ils` flags that go with them.

| approach          | where the continuation runs                    |
| ----------------- | ---------------------------------------------- |
| equidistantGlobal | the driver, over `functionInitialEquations`    |
| equidistantLocal  | `rt_solve_nls`, per system carrying homotopy() |
| adaptive*         | the arc-length solver, over the model's lambda |

`SimLayout::homotopy_method` carries `--homotopyApproach` into the module and `rt_solve_nls` takes it per call. An adaptive approach makes the backend append `__HOM_LAMBDA` as an extra unknown, which the codegen rejected outright; it now maps that cref to the lambda slot and emits the n×(n+1) Jacobian the arc-length solver wants.

Two fixes behind wrong answers rather than failures:

- `rt_solve_nls` restored lambda before its closing residual evaluation, recomputing every torn variable at the old lambda. homotopy4 followed C's path step for step and still landed on another root.
- C's `messageText` never opens an indent block for a multi-line message (it recurses for the second line and returns before `omc_level++`); omclog did, misindenting the rest of the stream.

homotopy4_solver.mos ran the built executable, which this target does not emit; it now resimulates through `resimulateExecutable` instead. That passes on the C target. Under wasm-jit 36 of its 40 runs match: the homotopy-path CSV export needs a filesystem the wasm runtime lacks, and `-nls=hybrid` takes minpack to the system's other root.

homotopy1-7 and setNumberOfInitLambda pass under wasm-jit.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
