### PR TITLE
wasm-jit: inverse algorithms and array logical ops

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -60,7 +60,8 @@ use crate::CodegenWasmJitFunctions::{
     SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
-    NlsResidual, emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
+    NlsResidual, NlsResiduals, backup_known_outputs, restore_known_outputs,
+    emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_entwined_assign, emit_generic_assign, emit_resizable_assign,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
     external_general_why, note_declined_external, reset_declined_externals,
@@ -3770,7 +3771,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     let when_scan = eqs_with_branches(&all_eqs);
     let has_when = dae_eqs.iter().map(|(e, _)| e).chain(when_scan.iter()).any(|e| match &**e {
         SimCode::SimEqSystem::SES_WHEN { .. } => true,
-        SimCode::SimEqSystem::SES_ALGORITHM { statements, .. } => {
+        SimCode::SimEqSystem::SES_ALGORITHM { statements, .. }
+        | SimCode::SimEqSystem::SES_INVERSE_ALGORITHM { statements, .. } => {
             (&**statements).into_iter().any(|s| matches!(&**s, DAE::Statement::STMT_WHEN { .. }))
         }
         _ => false,
@@ -6266,6 +6268,17 @@ pub(crate) fn lower_equation(
         E::SES_LINEAR { lSystem, .. } => lower_linear_system(ctx, lSystem, eq_index),
         E::SES_NONLINEAR { nlSystem, .. } => lower_nonlinear_system(ctx, nlSystem, eq_index),
         E::SES_ALGORITHM { statements, .. } => ctx.sim_stmts(statements),
+        // Inside a nonlinear system the residual function backs the known outputs
+        // up around the body; standalone this is C's `equationAlgorithm`.
+        E::SES_INVERSE_ALGORITHM { statements, knownOutputCrefs, insideNonLinearSystem, .. } => {
+            if *insideNonLinearSystem {
+                return ctx.sim_stmts(statements);
+            }
+            let known: Vec<Arc<DAE::ComponentRef>> = lst(knownOutputCrefs).cloned().collect();
+            let saved = backup_known_outputs(ctx, &known)?;
+            ctx.sim_stmts(statements)?;
+            restore_known_outputs(ctx, &known, &saved)
+        }
         E::SES_WHEN { conditions, whenStmtLst, elseWhen, .. } => {
             ctx.sim_when(conditions, whenStmtLst, elseWhen)
         }
@@ -6614,7 +6627,7 @@ fn lower_nonlinear_system(
 /// [`build_nls_fns`] (which emits the callbacks).
 fn nls_parts(
     nlsystem: &SimCode::NonlinearSystem,
-) -> Result<(Vec<Arc<SimCode::SimEqSystem>>, Vec<NlsResidual>, Vec<Arc<DAE::ComponentRef>>)> {
+) -> Result<(Vec<Arc<SimCode::SimEqSystem>>, NlsResiduals, Vec<Arc<DAE::ComponentRef>>)> {
     use SimCode::SimEqSystem as E;
     let mut inner: Vec<Arc<SimCode::SimEqSystem>> = Vec::new();
     let mut residuals: Vec<NlsResidual> = Vec::new();
@@ -6633,17 +6646,24 @@ fn nls_parts(
             _ => inner.push(e.clone()),
         }
     }
+    let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
     if residuals.is_empty() {
+        // An inverse algorithm is the system's lone equation and its own residual.
+        if let [e] = inner.as_slice() {
+            if let E::SES_INVERSE_ALGORITHM { knownOutputCrefs, .. } = &**e {
+                let known = lst(knownOutputCrefs).cloned().collect();
+                return Ok((inner, NlsResiduals::InverseAlgorithm(known), iter_vars));
+            }
+        }
         return Err("CodegenWasmJit: SES_NONLINEAR has no residual equations");
     }
-    let iter_vars: Vec<Arc<DAE::ComponentRef>> = lst(&nlsystem.crefs).cloned().collect();
     // A for-residual's count is only known at run time, so validate the unknown
     // count only for scalar-only systems.
     let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
     if all_scalar && iter_vars.len() != residuals.len() {
         return Err("CodegenWasmJit: SES_NONLINEAR unknown/residual count mismatch");
     }
-    Ok((inner, residuals, iter_vars))
+    Ok((inner, NlsResiduals::Explicit(residuals), iter_vars))
 }
 
 /// Scan the compiled equation lists for `SES_NONLINEAR` systems (deduplicated by

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -3131,8 +3131,7 @@ fn store_fresh_into_cref(ctx: &mut FnCtx, cref: &DAE::ComponentRef, wty: WTy, vt
 /// Lower `(l1, l2, …) := f(args)` (`STMT_TUPLE_ASSIGN`): call the multi-output
 /// generated function (which leaves its results on the stack, first result
 /// deepest), then move each owned result into its target local. A `_` (wildcard)
-/// target discards its value (releasing it if heap). Targets must be simple
-/// locals; subscripted / qualified tuple targets are not supported.
+/// target discards its value (releasing it if heap).
 fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &DAE::Exp) -> Result<()> {
     let DAE::Exp::CALL { path, expLst, attr } = call else {
         return Err("CodegenWasmJit: tuple assignment rhs is not a function call");
@@ -3158,21 +3157,64 @@ fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &
         }
     }
     for (i, lhs_exp) in lhs_v.iter().enumerate() {
-        let sty = &results[i];
-        let vt = temps[i];
-        let DAE::Exp::CREF { componentRef, .. } = &***lhs_exp else {
-            return Err("CodegenWasmJit: tuple-assignment target is not a cref");
-        };
-        // `_` output: discard (release a heap value).
-        if let DAE::ComponentRef::WILD = &**componentRef {
-            if let Some(release_fn) = sty.release_fn() {
-                ctx.emit(we::Instruction::LocalGet(vt));
-                ctx.emit(we::Instruction::Call(rt_index(release_fn)?));
-            }
-            continue;
-        }
-        store_fresh_into_cref(ctx, componentRef, sty.wty(), vt)?;
+        store_fresh_into_tuple_target(ctx, lhs_exp, &results[i], temps[i])?;
     }
+    Ok(())
+}
+
+/// Store one freshly-owned tuple result into its target expression.
+fn store_fresh_into_tuple_target(ctx: &mut FnCtx, target: &DAE::Exp, sty: &SigTy, vt: u32) -> Result<()> {
+    use DAE::Exp as E;
+    match target {
+        E::CREF { componentRef, .. } => {
+            // `_` output: discard (release a heap value).
+            if let DAE::ComponentRef::WILD = &**componentRef {
+                if let Some(release_fn) = sty.release_fn() {
+                    ctx.emit(we::Instruction::LocalGet(vt));
+                    ctx.emit(we::Instruction::Call(rt_index(release_fn)?));
+                }
+                return Ok(());
+            }
+            store_fresh_into_cref(ctx, componentRef, sty.wty(), vt)
+        }
+        // Alias elimination replaces a record-valued target by its components, as a
+        // constructor call or a `RECORD` (C's `tupleReturnVariableUpdates`).
+        E::RECORD { exps, .. } => scatter_record_target(ctx, exps, sty, vt),
+        E::CALL { expLst, .. } => scatter_record_target(ctx, expLst, sty, vt),
+        _ => Err("CodegenWasmJit: unsupported tuple-assignment target"),
+    }
+}
+
+/// Scatter the freshly-owned record in `vt` into `targets` (one per field, in
+/// declaration order), then release it.
+fn scatter_record_target(
+    ctx: &mut FnCtx,
+    targets: &List<Arc<DAE::Exp>>,
+    sty: &SigTy,
+    vt: u32,
+) -> Result<()> {
+    let SigTy::Record { fields, .. } = sty else {
+        return Err("CodegenWasmJit: record-destructuring tuple target for a non-record output");
+    };
+    let targets: Vec<&Arc<DAE::Exp>> = targets.into_iter().collect();
+    if targets.len() != fields.len() {
+        return Err("CodegenWasmJit: record-destructuring tuple target has the wrong field count");
+    }
+    let layout = record_layout(fields);
+    for (i, (_, fty)) in fields.iter().enumerate() {
+        let ft = ctx.alloc_temp(fty.wty());
+        ctx.emit(we::Instruction::LocalGet(vt));
+        field_load(ctx, fty.wty(), layout.data_off + layout.field_off[i]);
+        ctx.emit(we::Instruction::LocalSet(ft));
+        if fty.is_heap() {
+            // The record still holds its reference; the store consumes one.
+            ctx.emit(we::Instruction::LocalGet(ft));
+            ctx.emit(we::Instruction::Call(rt_index("rt_retain")?));
+        }
+        store_fresh_into_tuple_target(ctx, targets[i], fty, ft)?;
+    }
+    ctx.emit(we::Instruction::LocalGet(vt));
+    ctx.emit(we::Instruction::Call(rt_index("rt_record_release")?));
     Ok(())
 }
 
@@ -6190,7 +6232,8 @@ pub(crate) use generic_calls::{emit_entwined_assign, emit_generic_assign, emit_r
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
-    LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual,
+    LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual, NlsResiduals,
+    backup_known_outputs, restore_known_outputs,
     compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
     compile_linear_system_symbolic, emit_linz_jac_body, emit_nls_jac_body, emit_nls_jac_csc_body,
     emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring,
@@ -6320,8 +6363,8 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             let DAE::Operator::NOT { .. } = operator else {
                 return Err("CodegenWasmJit: unsupported logical unary operator");
             };
-            // Element-wise `not` over a Boolean array.
-            if matches!(exp_sigty(exp), Ok(SigTy::Array { .. })) {
+            // Element-wise `not` over a Boolean array (`daeExpLunary`).
+            if matches!(logical_operator_sigty(operator), Some(SigTy::Array { .. })) {
                 emit_unary_array(ctx, exp, "rt_array_not_i32")?;
                 return Ok(WTy::I32);
             }
@@ -6334,7 +6377,7 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::LBINARY { exp1, operator, exp2 } => {
             // Element-wise `and`/`or` over Boolean arrays (operands are array
             // handles, not i32 truth values — a scalar I32And would corrupt them).
-            if matches!(exp_sigty(exp1), Ok(SigTy::Array { .. })) {
+            if matches!(logical_operator_sigty(operator), Some(SigTy::Array { .. })) {
                 let (op_code, ty) = match operator {
                     DAE::Operator::AND { ty } => (OP_AND, ty),
                     DAE::Operator::OR { ty } => (OP_OR, ty),
@@ -6602,6 +6645,15 @@ fn operator_sigty(op: &DAE::Operator) -> Result<SigTy> {
     sig_ty_quiet(ty)
 }
 
+/// The result type of `and`/`or`/`not`: `Bool`, or a Boolean array when the
+/// operands are arrays. Only the operator records this — a nested logical
+/// operand's own type annotation is just the element type.
+fn logical_operator_sigty(op: &DAE::Operator) -> Option<SigTy> {
+    use DAE::Operator as O;
+    let (O::AND { ty } | O::OR { ty } | O::NOT { ty }) = op else { return None };
+    sig_ty_quiet(ty).ok()
+}
+
 /// The type an operator the frontend left untyped works on: whichever of String,
 /// Real or Integer an operand carries, in Modelica's promotion order.
 fn operand_sigty(e1: &DAE::Exp, e2: &DAE::Exp) -> Result<SigTy> {
@@ -6659,7 +6711,10 @@ fn exp_sigty(exp: &DAE::Exp) -> Result<SigTy> {
             Ok(s) => s,
             Err(_) => exp_sigty(exp)?,
         },
-        E::RELATION { .. } | E::LBINARY { .. } | E::LUNARY { .. } => SigTy::Bool,
+        E::LBINARY { operator, .. } | E::LUNARY { operator, .. } => {
+            logical_operator_sigty(operator).unwrap_or(SigTy::Bool)
+        }
+        E::RELATION { .. } => SigTy::Bool,
         E::IFEXP { expThen, .. } => exp_sigty(expThen)?,
         E::SHARED_LITERAL { exp, .. } => exp_sigty(exp)?,
         // Array-valued expressions carry their (array) type directly.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -48,6 +48,13 @@ pub(crate) enum NlsResidual {
     },
 }
 
+/// What closes a nonlinear system: residual expressions, or — for a lone
+/// `SES_INVERSE_ALGORITHM` — the known output crefs whose displacement is it.
+pub(crate) enum NlsResiduals {
+    Explicit(Vec<NlsResidual>),
+    InverseAlgorithm(Vec<Arc<DAE::ComponentRef>>),
+}
+
 /// Emit the body of a nonlinear system's `residual(sim_data, x, r)` callback
 /// (wasm locals: 0 = `SimData`, 1 = `x` pointer, 2 = `r` pointer). Copies the
 /// `n` unknowns from `x` into their `slots`, runs the inner (torn) equations via
@@ -56,7 +63,7 @@ pub(crate) enum NlsResidual {
 pub(crate) fn emit_nls_residual_body(
     ctx: &mut FnCtx,
     slots: &[u32],
-    residuals: &[NlsResidual],
+    residuals: &NlsResiduals,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
@@ -66,6 +73,12 @@ pub(crate) fn emit_nls_residual_body(
         ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
         ctx.emit(I::F64Store(mem_arg(off, 3)));
     }
+    let residuals = match residuals {
+        NlsResiduals::Explicit(r) => r,
+        NlsResiduals::InverseAlgorithm(known) => {
+            return emit_inverse_algorithm_residual(ctx, slots.len(), known, lower_inner)
+        }
+    };
     lower_inner(ctx)?;
     // All-scalar systems keep sequential `r[i]` addressing; a for-residual forces
     // `res_index`-based addressing throughout (C's `res[res_index + shift]`).
@@ -85,6 +98,78 @@ pub(crate) fn emit_nls_residual_body(
         }
     }
     Ok(())
+}
+
+/// C's `OLD_<i>` backup of the outputs an inverse algorithm must not change.
+pub(crate) fn backup_known_outputs(
+    ctx: &mut FnCtx,
+    crefs: &[Arc<DAE::ComponentRef>],
+) -> Result<Vec<(u32, WTy)>> {
+    let mut saved = Vec::with_capacity(crefs.len());
+    for cr in crefs {
+        let wty = compile_sim_cref_read(ctx, cr)?
+            .ok_or("CodegenWasmJit: inverse-algorithm output is not a simulation variable")?;
+        let t = ctx.alloc_temp(wty);
+        ctx.emit(we::Instruction::LocalSet(t));
+        saved.push((t, wty));
+    }
+    Ok(saved)
+}
+
+/// Put the [`backup_known_outputs`] values back.
+pub(crate) fn restore_known_outputs(
+    ctx: &mut FnCtx,
+    crefs: &[Arc<DAE::ComponentRef>],
+    saved: &[(u32, WTy)],
+) -> Result<()> {
+    for (cr, &(local, wty)) in crefs.iter().zip(saved) {
+        if !compile_sim_cref_assign(ctx, cr, RhsSource::Temp { local, wty })? {
+            return Err("CodegenWasmJit: inverse-algorithm output is not a simulation variable");
+        }
+    }
+    Ok(())
+}
+
+/// Residual of an inverse-algorithm system: run it from the current guess and
+/// accumulate each known output's squared displacement into `r[i % n]`,
+/// restoring the outputs afterwards so the solve moves only the unknowns.
+fn emit_inverse_algorithm_residual(
+    ctx: &mut FnCtx,
+    n: usize,
+    known: &[Arc<DAE::ComponentRef>],
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    if n == 0 {
+        return Err("CodegenWasmJit: inverse-algorithm system has no unknowns");
+    }
+    let saved = backup_known_outputs(ctx, known)?;
+    lower_inner(ctx)?;
+    for i in 0..n as u32 {
+        ctx.emit(I::LocalGet(2)); // r
+        ctx.emit(I::F64Const(0.0.into()));
+        ctx.emit(I::F64Store(mem_arg(i * 8, 3)));
+    }
+    let d = ctx.alloc_temp(WTy::F64);
+    for (i, (cr, &(old, old_wty))) in known.iter().zip(&saved).enumerate() {
+        let dest = (i % n) as u32;
+        ctx.emit(I::LocalGet(old));
+        coerce(ctx, old_wty, WTy::F64);
+        let w = compile_sim_cref_read(ctx, cr)?
+            .ok_or("CodegenWasmJit: inverse-algorithm output is not a simulation variable")?;
+        coerce(ctx, w, WTy::F64);
+        ctx.emit(I::F64Sub);
+        ctx.emit(I::LocalSet(d));
+        ctx.emit(I::LocalGet(2)); // r
+        ctx.emit(I::LocalGet(2));
+        ctx.emit(I::F64Load(mem_arg(dest * 8, 3)));
+        ctx.emit(I::LocalGet(d));
+        ctx.emit(I::LocalGet(d));
+        ctx.emit(I::F64Mul);
+        ctx.emit(I::F64Add);
+        ctx.emit(I::F64Store(mem_arg(dest * 8, 3)));
+    }
+    restore_known_outputs(ctx, known, &saved)
 }
 
 /// Emit a `SES_FOR_RESIDUAL`: nested `for` loops (outermost first) storing


### PR DESCRIPTION
Three gaps the `algorithms_functions` tests hit.

`STMT_TUPLE_ASSIGN` only accepted a cref per target. Alias elimination replaces a record-valued target by its components — as a `RECORD` expression or a constructor `CALL` — so scatter the returned record's fields into them, as `tupleReturnVariableUpdates` does.

`SES_INVERSE_ALGORITHM` was unhandled in both of its shapes. Alone it is the algorithm run forwards with its already-known outputs restored afterwards; wrapped in a nonlinear system it is also the residual, which is how far running it moves those outputs (squared, spread round-robin over the residual slots). Follows `equationAlgorithm` and `generateNonLinearResidualFunction`.

`and`/`or`/`not` dispatched to the element-wise array path on the first operand's type annotation, which for a nested logical expression is only `Boolean`. `a and b and c` therefore fed array handles to `i32.and`. Key on the operator's type instead, as `daeExpLbinary`/`daeExpLunary` do.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
