### PR TITLE
wasm-jit: plain relations in clocked partitions

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -6981,7 +6981,9 @@ fn compile_relation(
     // re-evaluates. A Real inequality gets a hysteresis band (`compile_relation_hyst`)
     // at events and in the crossing function, but stays exact at init (`rel_fresh == 2`)
     // so a start value like `v <= 0` at `v == 0` resolves as written.
-    let indexed = matches!(ctx.sim(), Ok(s) if index >= 0 && (index as u32) < s.n_relations);
+    // A clocked partition is C's `contextOther`: plain relations.
+    let indexed = matches!(ctx.sim(), Ok(s) if index >= 0 && (index as u32) < s.n_relations
+        && s.sub_clock_off.is_none());
     if !indexed {
         return compile_relation_fresh(ctx, e1, op, e2);
     }


### PR DESCRIPTION
C generates the clocked partition bodies with `contextOther` (`CodegenC.tpl:functionEquationsSynchronous`), and `daeExpRelationSim` matches only the simulation, DAE-mode, Jacobian and zero-crossing contexts. A relation inside a clocked partition is therefore a plain comparison, re-evaluated whenever the clock ticks.

wasm-jit lowered it as an indexed relation instead, held on `relationsPre[]` outside events. Nothing outside the partition updates `relations[]` at a tick, so every relation in a clocked partition stayed frozen at the value it got during initialization:
`MSL_timeBasedStep`'s `step.y` never left the `time < startTime` branch and held 1 for the whole run instead of stepping to 4 at t=0.2.

Fixes `simulation/modelica/NBackend/clocked/MSL_timeBasedStep`.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
