### PR TITLE
Fix six flattening tests for wasm-jit

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -715,7 +715,8 @@ void partestRust(partition) {
   // MetaModelica code generation only works against the C runtime.
   // fmuCSources checks the generated C files or the list in the XML - wasm-jit does not use C
   // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
-  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-fmuCSources'
+  // stackoverflow: Rust aborts on stack overflow, MMC unwinds out of the SEGV handler
+  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-fmuCSources,-stackoverflow'
   // wasmtime reserves ~4 GiB of address space per wasm memory, and shrinking that
   // reservation to fit an RLIMIT_AS costs the bounds-check-free fast path.
   String asLimit = params.RUST_PARTEST_SIMCODETARGET == 'wasm-jit'

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica/src/main.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica/src/main.rs
@@ -2,16 +2,18 @@ use std::ffi::CString;
 use std::io::Write;
 use std::os::raw::{c_char, c_int};
 
-/// Default worker-thread stack size: 4 MiB - use env. var to increase it.
+/// Default worker-thread stack size: 64 MiB - use env. var to change it.
 ///
 /// MMC's generated C code eliminates tail calls and uses small stack frames,
 /// so the C omc fits deep traversals into the default 8 MiB main stack. The
 /// Rust port only lowers *self* tail calls (mmtorust's `#[tailcall]` pass)
 /// and its frames are larger, so workloads like `DumpGraphviz.dump` over the
 /// whole compiler sources overflow 8 MiB and Rust aborts (no recovery, unlike
-/// MMC's SEGV-handler unwind). The reservation is virtual address space only
-/// — Linux commits stack pages lazily — so the cost of the headroom is nil.
-const DEFAULT_STACK_SIZE: usize = 4 * 1024 * 1024;
+/// MMC's SEGV-handler unwind). The frontend's own recursion guards assume the
+/// same headroom: `Inst` gives up at a depth of 256, which needs ~16 MiB here.
+/// The reservation is virtual address space only — Linux commits stack pages
+/// lazily — so the cost of the headroom is nil.
+const DEFAULT_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 // The compiler itself lives in `libOpenModelicaCompiler.so` (the
 // `libopenmodelica_compiler` cdylib). This executable is a thin launcher that

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1553,13 +1553,13 @@ pub(crate) fn compile_include_library(
     prefix: &str,
     includes: &[String],
     include_dirs: &[String],
-    symbols: &[String],
+    missing: &[ExtCallSig],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
     if includes.is_empty() {
         return Ok(None);
     }
-    let wrappers = openmodelica_wasm_jit::model::ext_addr_wrappers(symbols);
+    let wrappers = openmodelica_wasm_jit::model::ext_wrappers(missing);
     let n = notes.len();
     match compile_include_tu(prefix, includes, include_dirs, &wrappers, notes)? {
         None if !wrappers.is_empty() => {
@@ -1632,7 +1632,7 @@ pub(crate) fn compile_include_library(
     _prefix: &str,
     includes: &[String],
     _include_dirs: &[String],
-    _symbols: &[String],
+    _missing: &[ExtCallSig],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
     if includes.is_empty() {
@@ -1682,7 +1682,7 @@ fn wasm_builtins(sysroot: &std::path::Path) -> Option<std::path::PathBuf> {
 
 /// The `external "C"` functions neither `libs` nor the libraries every run loads
 /// (libc, ModelicaExternalC) export — what an `Include` still has to provide.
-pub(crate) fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<String> {
+pub(crate) fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> Vec<ExtCallSig> {
     let mut defined: HashSet<&str> = HashSet::new();
     for bytes in libs.iter().map(|l| &l.bytes[..]).chain([LIBC_PIC, EXTERNAL_C_DYLINK]) {
         for payload in wasmparser::Parser::new(0).parse_all(bytes).flatten() {
@@ -1691,7 +1691,7 @@ pub(crate) fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary
             }
         }
     }
-    ext_imports.iter().map(|s| s.name.as_str()).filter(|n| !defined.contains(n)).map(String::from).collect()
+    ext_imports.iter().filter(|s| !defined.contains(s.name.as_str())).cloned().collect()
 }
 
 /// The `-L` directories of a linker flag string (`-Ldir`, `-L"dir"`, `-L dir`).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -10009,11 +10009,14 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
     let mut sig = format!("{in_codes}\n{out_codes}\n");
     if !ext_imports.is_empty() {
         let mut notes: Vec<String> = Vec::new();
-        // Only the wasm modules: the function JIT calls them wasm->wasm, with no
-        // libffi trampoline to reach a platform library through.
-        let libs = crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?.wasm;
+        let resolved = crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?;
+        let libs = resolved.wasm;
         for lib in &libs {
             sig.push_str(&format!("lib\t{}\n", lib.name));
+        }
+        // What the wasm modules do not define is called through libffi.
+        for lib in &resolved.native {
+            sig.push_str(&format!("nlib\t{lib}\n"));
         }
         // An implementation given as C source in an `Include`.
         let includes: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes).map(|s| s.to_string()).collect();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -151,25 +151,52 @@ fn define_external_imports(
     let engine = linker.engine().clone();
     let loaded = dl::load(&mut *store, &engine, memory, table, &ext_rt.alloc, &libs, &host)
         .map_err(|e| record_dylink_error(e))?;
+    // A dlopen each, so only once a symbol needs one.
+    let mut native: Option<NativeExternals> = None;
     for s in &sig.ext_imports {
         let functype = wasmtime::FuncType::new(
             &engine,
             s.wasm_params().iter().map(|t| valtype(t.wty())),
             s.wasm_results().iter().map(|t| valtype(t.wty())),
         );
-        let target = loaded.func_or_addr(&mut *store, &s.name).ok_or_else(|| {
-            record_dylink_error(format!(
+        if let Some(target) = loaded.func_or_addr(&mut *store, &s.name) {
+            let f = dl::bind_in_wasm_external(&mut *store, s, &functype, target, &ext_rt)
+                .map_err(record_dylink_error)?
+                .ok_or("CodegenWasmJit: external \"C\" function has the wrong signature in the library")?;
+            wt(linker.define(&mut *store, "ext", &s.name, f))?;
+            continue;
+        }
+        // No wasm library defines it: the implementation is a platform one, as it
+        // is for the C target. LAPACK and omc's own runtime live in this process.
+        let native = native.get_or_insert_with(|| NativeExternals::new(&sig.native_libs));
+        let Some(addr) = native.resolve(&s.name) else {
+            return Err(record_dylink_error(format!(
                 "external \"C\" function `{}` is in none of the model's libraries{}",
                 s.name,
-                sig.notes.iter().map(|n| format!("\n  {n}")).collect::<String>()
-            ))
-        })?;
-        let f = dl::bind_in_wasm_external(&mut *store, s, &functype, target, &ext_rt)
-            .map_err(record_dylink_error)?
-            .ok_or("CodegenWasmJit: external \"C\" function has the wrong signature in the library")?;
-        wt(linker.define(&mut *store, "ext", &s.name, f))?;
+                sig.notes.iter().chain(native.errors.iter()).map(|n| format!("\n  {n}")).collect::<String>()
+            )));
+        };
+        openmodelica_wasm_jit::sim_runtime::define_native_external(linker, s, functype, addr, memory, &ext_rt)?;
     }
     Ok(())
+}
+
+/// The `external "C"` implementations outside wasm: the platform shared libraries
+/// the `Library` annotations resolved to, then the process image.
+struct NativeExternals {
+    handles: Vec<usize>,
+    errors: Vec<String>,
+}
+
+impl NativeExternals {
+    fn new(paths: &[String]) -> Self {
+        let (handles, errors) = openmodelica_util::dynload::load_external_libraries(paths);
+        NativeExternals { handles, errors }
+    }
+
+    fn resolve(&self, name: &str) -> Option<usize> {
+        openmodelica_util::dynload::external_symbol_in(&self.handles, name)
+    }
 }
 
 /// The reason (a missing symbol, a library built without `-shared`) is specific
@@ -191,6 +218,8 @@ struct Sig {
     inputs: Vec<SigTy>,
     outputs: Vec<SigTy>,
     libs: Vec<String>,
+    /// The same implementations as platform shared libraries.
+    native_libs: Vec<String>,
     ext_imports: Vec<ExtCallSig>,
     notes: Vec<String>,
 }
@@ -204,17 +233,19 @@ fn read_sig(path: &str) -> Result<Sig> {
     let inputs = parse(lines.next())?;
     let outputs = parse(lines.next())?;
     let mut libs = Vec::new();
+    let mut native_libs = Vec::new();
     let mut ext_imports = Vec::new();
     let mut notes = Vec::new();
     for line in lines {
         match line.split_once('\t') {
             Some(("lib", rest)) => libs.push(rest.to_string()),
+            Some(("nlib", rest)) => native_libs.push(rest.to_string()),
             Some(("ext", rest)) => ext_imports.push(super::parse_ext_sig(rest)?),
             Some(("note", rest)) => notes.push(rest.to_string()),
             _ => {}
         }
     }
-    Ok(Sig { inputs, outputs, libs, ext_imports, notes })
+    Ok(Sig { inputs, outputs, libs, native_libs, ext_imports, notes })
 }
 
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Settings.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Settings.rs
@@ -139,33 +139,48 @@ pub fn setInstallationDirectoryPath(inString: ArcStr) {
 /// and replaces it with a generic message that never mentions
 /// `OPENMODELICAHOME` — without the stderr line the actual cause is invisible.
 fn strip_bin_path(path: &str) -> Result<ArcStr> {
-    fn cannot_deduce(path: &str) -> &'static str {
-        let msg = format!(
+    strip_bin_path_opt(path).ok_or_else(|| {
+        eprintln!(
             "could not deduce the OpenModelica installation directory from \
              executable path: [{path}], please set OPENMODELICAHOME"
         );
-        eprintln!("{msg}");
         "error"
-    }
+    })
+}
 
+fn strip_bin_path_opt(path: &str) -> Option<ArcStr> {
     if !path.contains("bin") && !path.contains("lib") {
-        return Err(cannot_deduce(path));
+        return None;
     }
     let mut s = path.to_string();
     loop {
-        match s.rfind('/') {
-            Some(idx) => {
-                let removed = s.split_off(idx); // removed starts with '/'
-                if &removed[1..] == "bin" || &removed[1..] == "lib" {
-                    break;
-                }
-            }
-            // C asserts the slash exists; reaching the start without finding a
-            // bin/lib component is the same unrecoverable situation.
-            None => return Err(cannot_deduce(path)),
+        // C asserts the slash exists; reaching the start without finding a
+        // bin/lib component is the same unrecoverable situation.
+        let idx = s.rfind('/')?;
+        let removed = s.split_off(idx); // removed starts with '/'
+        if &removed[1..] == "bin" || &removed[1..] == "lib" {
+            break;
         }
     }
-    Ok(ArcStr::from(s))
+    Some(ArcStr::from(s))
+}
+
+/// `dladdr` on our own code: the path of the shared library the compiler lives in,
+/// as the loader opened it — what C deduces the prefix from. It keeps the runpath
+/// it was reached through, `..` and all (`<omhome>/bin/..` for the omc launcher's
+/// `$ORIGIN/../lib/…`), and unlike the executable's own path it is still right
+/// when the compiler is embedded in another program, as OMEdit does.
+#[cfg(unix)]
+fn self_library_path() -> Option<ArcStr> {
+    let mut info: libc::Dl_info = unsafe { std::mem::zeroed() };
+    // SAFETY: a code address in this library; `dladdr` only reads it.
+    if unsafe { libc::dladdr(self_library_path as *const libc::c_void, &mut info) } == 0
+        || info.dli_fname.is_null()
+    {
+        return None;
+    }
+    let name = unsafe { std::ffi::CStr::from_ptr(info.dli_fname) };
+    Some(ArcStr::from(name.to_str().ok()?))
 }
 
 pub fn getInstallationDirectoryPath() -> Result<ArcStr> {
@@ -174,12 +189,12 @@ pub fn getInstallationDirectoryPath() -> Result<ArcStr> {
     //
     // Resolution order here:
     //   1. the cached value (set previously or by `setInstallationDirectoryPath`);
-    //   2. the install root (the directory above the executable's `bin`/`lib`),
-    //      normalized — no literal `..` (strict consumers like Chromium reject it);
-    //   3. `$OPENMODELICAHOME` — the dev-workflow fallback for running the
+    //   2. the prefix of the library this code is in, as C deduces it;
+    //   3. the install root (the directory above the executable's `bin`/`lib`);
+    //   4. `$OPENMODELICAHOME` — the dev-workflow fallback for running the
     //      port straight out of `target/debug` (also what the C
     //      OMC_BOOTSTRAPPING build reads);
-    //   4. the `strip_bin_path` prefix of the executable as a last resort.
+    //   5. the `strip_bin_path` prefix of the executable as a last resort.
     {
         let state = STATE.lock().unwrap();
         if let Some(p) = &state.installation_path {
@@ -196,6 +211,14 @@ pub fn getInstallationDirectoryPath() -> Result<ArcStr> {
     {
         let path = convert_to_forward_slashes(&env);
         let mut state = STATE.lock().unwrap();
+        state.installation_path = Some(path.clone());
+        return Ok(path);
+    }
+
+    #[cfg(unix)]
+    if let Some(path) = self_library_path().as_deref().and_then(strip_bin_path_opt) {
+        let mut state = STATE.lock().unwrap();
+        set_env_var("OPENMODELICAHOME", &path);
         state.installation_path = Some(path.clone());
         return Ok(path);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -38,9 +38,13 @@ impl Loaded {
     pub fn func(&self, name: &str) -> Option<&Func> {
         self.funcs.get(name)
     }
-    /// `name`, else what its `Include` address wrapper points at.
+    /// `name`, else its `Include` wrapper: the call one for a macro, or what the
+    /// address one points at.
     pub fn func_or_addr(&self, store: &mut wasmtime::Store<WasiCtx>, name: &str) -> Option<Func> {
         if let Some(f) = self.funcs.get(name) {
+            return Some(f.clone());
+        }
+        if let Some(f) = self.funcs.get(&format!("{}{name}", crate::model::EXT_CALL_PREFIX)) {
             return Some(f.clone());
         }
         let w = self.funcs.get(&format!("{}{name}", crate::model::EXT_ADDR_PREFIX))?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -161,8 +161,8 @@ impl ExtIncludes {
     /// Build the sources into a host shared library and return its path. Per-process
     /// temp directory: it stays mapped as long as the model can be resimulated.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn compile(&self, symbols: &[String]) -> std::result::Result<String, String> {
-        let wrappers = ext_addr_wrappers(symbols);
+    pub fn compile(&self, missing: &[ExtCallSig]) -> std::result::Result<String, String> {
+        let wrappers = ext_wrappers(missing);
         match self.compile_tu(&wrappers) {
             Err(e) if !wrappers.is_empty() => self.compile_tu("").map_err(|_| e),
             r => r,
@@ -210,7 +210,7 @@ impl ExtIncludes {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn compile(&self, _symbols: &[String]) -> std::result::Result<String, String> {
+    pub fn compile(&self, _missing: &[ExtCallSig]) -> std::result::Result<String, String> {
         Err("the implementation comes from an `Include` annotation with C source, which has to be \
              compiled — the browser omc has no compiler. Provide it as a `Library` built with \
              `clang --target=wasm32-wasip1 -fPIC -shared`"
@@ -222,13 +222,73 @@ impl ExtIncludes {
 /// a wrapper handing back the address needs no prototype and reaches it anyway.
 pub const EXT_ADDR_PREFIX: &str = "omc_ext_addr_";
 
-/// Taking the address of a function the sources never declare does not compile,
-/// so the caller falls back to the unit without these.
-pub fn ext_addr_wrappers(symbols: &[String]) -> String {
-    symbols
-        .iter()
-        .map(|s| format!("void (*{EXT_ADDR_PREFIX}{s}(void))(void) {{ return (void (*)(void)) {s}; }}\n"))
-        .collect()
+/// A function-like macro has no address, so the *call* is what the unit provides
+/// — which is all the C target ever compiles, expanding the macro at its own
+/// call site.
+pub const EXT_CALL_PREFIX: &str = "omc_ext_call_";
+
+/// One wrapper per function still to be found. Taking the address of a function
+/// the sources never declare does not compile, so the caller falls back to the
+/// unit without these.
+pub fn ext_wrappers(sigs: &[ExtCallSig]) -> String {
+    let mut out = String::new();
+    for sig in sigs {
+        let name = &sig.name;
+        match ext_call_wrapper(sig) {
+            Some(call) => out.push_str(&format!(
+                "#ifdef {name}\n{call}#else\n{}#endif\n",
+                ext_addr_wrapper(name)
+            )),
+            None => out.push_str(&ext_addr_wrapper(name)),
+        }
+    }
+    out
+}
+
+fn ext_addr_wrapper(name: &str) -> String {
+    format!("void (*{EXT_ADDR_PREFIX}{name}(void))(void) {{ return (void (*)(void)) {name}; }}\n")
+}
+
+/// `T omc_ext_call_f(A a0, …) { return f(a0, …); }`. `None` when an argument has
+/// no C spelling the declaration alone fixes (a record's struct).
+fn ext_call_wrapper(sig: &ExtCallSig) -> Option<String> {
+    let byref = sig.lang == crate::sig::ExtLang::Fortran77;
+    let mut params = String::new();
+    for (i, (ty, is_out)) in sig.args.iter().enumerate() {
+        let ptr = *is_out || byref || matches!(ty, crate::sig::SigTy::Array { .. });
+        params.push_str(&format!(
+            "{}{}{} a{i}",
+            if i == 0 { "" } else { ", " },
+            ext_c_type(ty)?,
+            if ptr { "*" } else { "" }
+        ));
+    }
+    let args: Vec<String> = (0..sig.args.len()).map(|i| format!("a{i}")).collect();
+    let (ret, call) = match &sig.ret {
+        Some(ty) => (ext_c_type(ty)?.to_owned(), "return "),
+        None => ("void".to_owned(), ""),
+    };
+    Some(format!(
+        "{ret} {EXT_CALL_PREFIX}{}({}) {{ {call}{}({}); }}\n",
+        sig.name,
+        if params.is_empty() { "void".to_owned() } else { params },
+        sig.name,
+        args.join(", ")
+    ))
+}
+
+/// The C type the language specification maps a Modelica type to; an array is its
+/// element type, passed by pointer.
+fn ext_c_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
+    use crate::sig::SigTy;
+    Some(match ty {
+        SigTy::Int | SigTy::Bool => "int",
+        SigTy::Real => "double",
+        SigTy::Str => "const char*",
+        SigTy::Ptr => "void*",
+        SigTy::Array { elem, .. } => ext_c_type(elem)?,
+        SigTy::Record { .. } | SigTy::Func { .. } => return None,
+    })
 }
 
 /// What the C target's generated `<prefix>_includes.h` opens with, so external C
@@ -238,7 +298,9 @@ pub const INCLUDE_TU_PROLOGUE: &str = "\
 #include \"ModelicaUtilities.h\"  /* Make Modelica C util functions available for external includes. */\n";
 
 /// The same for a wasm unit, where `openmodelica.h` cannot be opened — it reaches the
-/// Boehm GC and `setjmp`. Name what external source uses it for instead.
+/// Boehm GC and `setjmp`. Name what external source uses it for instead. Nothing
+/// omc-specific: source needing more than the specification's C interface includes
+/// it itself.
 pub const INCLUDE_TU_PROLOGUE_WASM: &str = "\
 #include <stddef.h>\n\
 #include <stdio.h>\n\

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -376,11 +376,11 @@ impl NativeExternals {
         if !self.built_includes {
             self.built_includes = true;
             if let Some(inc) = &model.ext_includes {
-                let missing: Vec<String> = model
+                let missing: Vec<crate::sig::ExtCallSig> = model
                     .ext_imports
                     .iter()
-                    .map(|s| s.name.clone())
-                    .filter(|n| self.symbol(n).is_none())
+                    .filter(|s| self.symbol(&s.name).is_none())
+                    .cloned()
                     .collect();
                 let errors = self.errors.len();
                 // A wrapper for a function the sources only declare leaves an
@@ -395,10 +395,10 @@ impl NativeExternals {
         None
     }
 
-    /// Build the `Include` sources with `symbols` reachable by address, and load
-    /// the result. Searched first: it is the model's own source.
-    fn load_includes(&mut self, inc: &model::ExtIncludes, symbols: &[String]) -> bool {
-        let path = match inc.compile(symbols) {
+    /// Build the `Include` sources with `missing` reachable, and load the result.
+    /// Searched first: it is the model's own source.
+    fn load_includes(&mut self, inc: &model::ExtIncludes, missing: &[crate::sig::ExtCallSig]) -> bool {
+        let path = match inc.compile(missing) {
             Ok(p) => p,
             Err(e) => {
                 self.errors.push(e);
@@ -412,10 +412,14 @@ impl NativeExternals {
         loaded
     }
 
-    /// The symbol itself, else the address its `Include` wrapper hands back.
+    /// The symbol itself, else its `Include` wrapper: the call one for a macro,
+    /// the address one for a function with no external linkage.
     fn symbol(&self, name: &str) -> Option<usize> {
         use openmodelica_util::dynload::external_symbol_in;
         if let Some(addr) = external_symbol_in(&self.handles, name) {
+            return Some(addr);
+        }
+        if let Some(addr) = external_symbol_in(&self.handles, &format!("{}{name}", model::EXT_CALL_PREFIX)) {
             return Some(addr);
         }
         let wrapper = external_symbol_in(&self.handles, &format!("{}{name}", model::EXT_ADDR_PREFIX))?;
@@ -439,10 +443,6 @@ fn define_external_imports(
     rt: &crate::dylink_engine::ExtRt,
     libs: &crate::dylink_engine::Loaded,
 ) -> Result<()> {
-    let rt_str_new = rt.str_new.clone();
-    let rt_str_data = rt.str_data.clone();
-    let rt_release = rt.release.clone();
-    let nls = rt.nls.clone();
     registry_reset();
     sim_driver::clear_runtime_error();
     openmodelica_util::dynload::install_modelica_message_interception(
@@ -470,20 +470,34 @@ fn define_external_imports(
             crate::set_engine_error_detail(unresolved_external_detail(&sig.name, model, &native.errors));
             "external \"C\" function not found in any loaded library"
         })?;
-        let name = sig.name.clone();
-        let sig = sig.clone();
-        let rt_str_new = rt_str_new.clone();
-        let rt_str_data = rt_str_data.clone();
-        let rt_release = rt_release.clone();
-        let nls = nls.clone();
-        wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
-            // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-            unsafe {
-                call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &rt_release, &nls, args, rets)
-            }
-            .map_err(|e| wasmtime::Error::msg(format!("{e}")))
-        }))?;
+        define_native_external(linker, sig, functype, addr, memory, rt)?;
     }
+    Ok(())
+}
+
+/// Bind `ext.<sig.name>` to native `addr` through the libffi trampoline. Shared
+/// with the `-d=gen` function JIT, whose externals resolve the same way.
+pub fn define_native_external(
+    linker: &mut wasmtime::Linker<WasiCtx>,
+    sig: &crate::sig::ExtCallSig,
+    functype: wasmtime::FuncType,
+    addr: usize,
+    memory: wasmtime::Memory,
+    rt: &crate::dylink_engine::ExtRt,
+) -> Result<()> {
+    let name = sig.name.clone();
+    let sig = sig.clone();
+    let rt_str_new = rt.str_new.clone();
+    let rt_str_data = rt.str_data.clone();
+    let rt_release = rt.release.clone();
+    let nls = rt.nls.clone();
+    wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
+        // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
+        unsafe {
+            call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &rt_release, &nls, args, rets)
+        }
+        .map_err(|e| wasmtime::Error::msg(format!("{e}")))
+    }))?;
     Ok(())
 }
 

--- a/testsuite/flattening/modelica/algorithms-functions/StackOverflowTest.mos
+++ b/testsuite/flattening/modelica/algorithms-functions/StackOverflowTest.mos
@@ -1,5 +1,6 @@
 // status: correct
 // cflags: -d=-newInst
+// suite: stackoverflow
 
 loadString("model StackOverflowTest
   function f

--- a/testsuite/flattening/modelica/external-functions/ExternalFunction6.mo
+++ b/testsuite/flattening/modelica/external-functions/ExternalFunction6.mo
@@ -6,7 +6,7 @@ class ExternalFunction6
   function fn
     input Integer i1;
     output Integer i;
-  external "C" i=myFn(i1) annotation(Include="#define myFn(X) (modelica_integer)(2*(X))");
+  external "C" i=myFn(i1) annotation(Include="#define myFn(X) (2*(X))");
   end fn;
 
   constant Integer i = fn(2);

--- a/testsuite/flattening/modelica/external-functions/ExternalFunctionArray.mo
+++ b/testsuite/flattening/modelica/external-functions/ExternalFunctionArray.mo
@@ -12,6 +12,7 @@ function get_results
   input Integer n;
   output Real res[n];
   external "C" getresults(m, property, res, n) annotation(Include="
+#include <assert.h>
 void getresults(double m,const char *str,double *res, int n) {
   assert(n == 2);
   res[0]=m*1.5;res[1]=m*2.5;

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -86,7 +86,7 @@ my $osname = $^O;
 # it belongs to are enabled. 'disabled' is such a tag: a test carrying it is not
 # part of the testsuite at all, see %suite_enabled.
 my @category_suites = qw(default cpp cppmsl tearing hpcom);
-my @tag_suites = qw(metamodelica 63bit antlr fmuCSources disabled);
+my @tag_suites = qw(metamodelica 63bit antlr fmuCSources stackoverflow disabled);
 my %suite_enabled = (
   default      => 1,  # Everything not claimed by another category.
   cpp          => 1,  # */cppruntime/*
@@ -97,6 +97,8 @@ my %suite_enabled = (
   '63bit'      => 1,  # Needs a 63/64-bit Modelica Integer.
   antlr        => 1,  # Expects ANTLR's syntax error positions and wording.
   fmuCSources  => 1,  # Inspects sources/ inside an FMU, which only the C export has.
+  stackoverflow => 1, # Recurses until the stack runs out; needs MMC's SEGV-handler
+                      # recovery, which the Rust port has no equivalent of.
   # Not part of the testsuite: the tests a makefile lists as failing, not
   # compiling, not simulating or needing a manual setup. They are the tests that
   # fail, hang or eat the machine, so they are opt-in and rtest skips them too

--- a/testsuite/rust-ignore-tests.txt
+++ b/testsuite/rust-ignore-tests.txt
@@ -6,10 +6,9 @@
 # deselect them with -suites=-antlr,-63bit. Keep the two in sync.
 #
 # Rust aborts the process on stack overflow (no catchable recursion limit),
-# unlike MMC which unwinds. Any test that deliberately drives deep recursion
-# to hit a recursion-limit / stack-overflow error message will differ.
+# unlike MMC which unwinds out of its SEGV handler. A test that recurses without
+# bound to reach that error message differs; it carries '// suite: stackoverflow'.
 ./flattening/modelica/algorithms-functions/StackOverflowTest.mos
-./flattening/modelica/declarations/ErrorRecursionLimit.mo
 #
 # Parser error position: the hand-written recursive-descent parser reports a
 # "No viable alternative near token: X" syntax error at a different token than


### PR DESCRIPTION
`ExternalFunction6` gives its implementation as a function-like macro, which has no address for the `Include` unit's `omc_ext_addr_*` wrapper to hand back, so the unit did not compile and the symbol stayed missing. The preprocessor now picks the wrapper that fits, compiling the *call* for a macro — all the C target does, expanding it at its call site:

    #ifdef myFn
    int omc_ext_call_myFn(int a0) { return myFn(a0); }
    #else
    void (*omc_ext_addr_myFn(void))(void)
    { return (void (*)(void)) myFn; }
    #endif

Argument types are the ones the language specification maps Modelica to. Both loaders look up the call wrapper before the address one.

`LeastSquares` reaches LAPACK's `dgelsy`, which no wasm library defines. The `-d=gen` function JIT bound wasm modules only, so it now falls back to the libffi trampoline the simulation host already uses, over the `Library` annotations' platform paths (new `nlib` sidecar lines) and then the process image, where omc's own LAPACK lives.

`MissingFunction1` prints the shared libraries it searched. `Settings.getInstallationDirectoryPath` derived the prefix from `current_exe`, where C `dladdr`s the compiler library and strips its `bin`/`lib` component, keeping the runpath it was loaded through — hence `<omhome>/bin/..`. Matching that also gets the prefix right when the compiler is embedded in another program, as OMEdit does, and the executable is not omc at all.

`ExternalFunctionArray` calls `assert` and `ExternalFunction6` cast to `modelica_integer`; both were reaching what `openmodelica.h` happens to pull into the C target's translation unit. A wasm unit offers only the specification's C interface, so the sources now say what they need.

`ErrorRecursionLimit` ran out of stack before `Inst` could reach its own recursion guard. The 16-frame `instElement`/`instVar`/`instClass` cycle costs ~46 KiB per nesting level here, so its limit of 256 needs ~12 MiB and the worker had 4 MiB — despite a comment about not fitting in 8. Now 64 MiB, as susan already reserves; the stack is address space Linux commits lazily.

`StackOverflowTest` recurses without bound to reach a message only MMC's SEGV-handler unwind produces. It is marked `// suite: stackoverflow` and deselected in the Rust partest runs, as `63bit` and `antlr` are.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
