### PR TITLE
wasm-jit: -output strings and the -override report

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -73,6 +73,7 @@ use crate::CodegenWasmJitFunctions::{
 // defined once in `openmodelica_sim_meta` and shared with the in-wasm driver, so
 // the emitted module and the driver's readback cannot drift. Aliased to their
 // historical host names.
+use openmodelica_sim_meta::omclog;
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{
     var_filter, BaseClockMeta, FmiVr, JacAInfo, Layout as SimLayout, MetaKind as ResultKind,
@@ -203,50 +204,6 @@ pub struct CapturedSim {
 fn last_sim() -> &'static Mutex<Option<CapturedSim>> {
     static LAST: OnceLock<Mutex<Option<CapturedSim>>> = OnceLock::new();
     LAST.get_or_init(|| Mutex::new(None))
-}
-
-/// C's `writeOutputVars` (`solver_main.c`): `time=<t>` then `,<name>=<value>` at the
-/// last row, Reals as `%.20g`. An unknown name contributes nothing, as in C.
-fn write_output_vars(model: &SimModel, run: &sim_driver::RunResult, names: &[String]) -> String {
-    let n_reals = run.n_reals as usize;
-    if n_reals == 0 || run.rows.is_empty() {
-        return String::new();
-    }
-    let last = run.rows.len() - n_reals;
-    let n_real_cols = model.layout.n_reals_row();
-    let g20 = |v: f64| sim_driver::format_g(v, 20);
-    let mut out = format!("time={}", g20(run.rows[last]));
-    for name in names {
-        let mut param_idx = 0usize;
-        for v in &model.result_vars {
-            let hit = v.name == *name;
-            match &v.kind {
-                ResultKind::Column { col, negate } if hit => {
-                    let raw = negate.apply_f64(run.rows[last + *col as usize]);
-                    if *col < n_real_cols {
-                        out.push_str(&format!(",{name}={}", g20(raw)));
-                    } else {
-                        out.push_str(&format!(",{name}={}", raw as i64));
-                    }
-                }
-                ResultKind::Param { off: _, wty, negate } => {
-                    let raw = run.params.get(param_idx).copied().unwrap_or(0.0);
-                    param_idx += 1;
-                    if hit {
-                        let raw = negate.apply_f64(raw);
-                        match wty {
-                            WTy::F64 => out.push_str(&format!(",{name}={}", g20(raw))),
-                            _ => out.push_str(&format!(",{name}={}", raw as i64)),
-                        }
-                    }
-                }
-                ResultKind::Const { value } if hit => out.push_str(&format!(",{name}={}", g20(*value))),
-                _ => {}
-            }
-        }
-    }
-    out.push('\n');
-    out
 }
 
 /// Resolve a finished [`sim_driver::RunResult`] into per-signal value arrays
@@ -771,9 +728,12 @@ fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> Str
 }
 
 /// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
-/// Unknown names are skipped (an unknown override is a no-op, as in the C runtime).
 /// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
 /// values, applied at different points of initialization (see `run_initialization`).
+///
+/// C's `doOverride` also reports what it could not do, walking the `_init.xml`
+/// quantities in class order. The result signals are that roster in that order,
+/// with the editable parameters as its `isValueChangeable` subset.
 fn resolve_overrides(
     model: &SimModel,
     flags: &simflags::SimFlags,
@@ -782,7 +742,33 @@ fn resolve_overrides(
     let mut starts = Vec::new();
     for (name, val) in &flags.overrides {
         if let Some(p) = model.editable_params.iter().find(|p| &p.name == name) {
-            if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, *val));
+            let v = p.read_value(val);
+            if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, v));
+        }
+    }
+    let editable = |n: &str| model.editable_params.iter().any(|p| p.name == n);
+    let mut refused: Vec<&str> = Vec::new();
+    for v in &model.result_vars {
+        if flags.overrides.iter().any(|(o, _)| *o == v.name) && !editable(&v.name) {
+            refused.push(&v.name);
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!(
+                    "It is not possible to override the following quantity: {}\nIt seems to be \
+                     structural, final, protected or evaluated or has a non-constant binding.",
+                    v.name
+                ),
+            );
+        }
+    }
+    for (name, _) in &flags.overrides {
+        if !editable(name) && !refused.contains(&name.as_str()) {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!("simulation_input_xml.c: override variable name not found in model: {name}\n"),
+            );
         }
     }
     (params, starts)
@@ -965,10 +951,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         // useful for benchmarking the solver in isolation from the `.mat` writer.
         check_output_format(&meta)?;
         let run = sim_runtime::run(&model, &meta)?;
-        // C's `finishSimulation` prints these ahead of the LOG_STATS block.
-        if !flags.output_vars.is_empty() {
-            extra.push_str(&write_output_vars(&model, &run, &flags.output_vars));
-        }
+        // The driver already printed the `-output` line that precedes this block.
         if log_stats {
             extra.push_str(&log_stats_block(&run.stats));
         }
@@ -2602,6 +2585,15 @@ fn apply_variable_filter(result_vars: &mut [ResultVar], filter: &str) {
     }
 }
 
+fn is_boolean_type(ty: &DAE::Type) -> bool {
+    match ty {
+        DAE::Type::T_BOOL { .. } => true,
+        DAE::Type::T_SUBTYPE_BASIC { complexType, .. } => is_boolean_type(complexType),
+        DAE::Type::T_ARRAY { ty, .. } => is_boolean_type(ty),
+        _ => false,
+    }
+}
+
 /// Literal names of an enumeration type (through subtype/array wrappers), or
 /// `None` for a non-enumeration. The stored value is the 1-based index into these.
 fn enumeration_names(ty: &DAE::Type) -> Option<Vec<String>> {
@@ -2940,6 +2932,7 @@ fn build_var_map(
                     off,
                     wty,
                     is_start: false,
+                    is_bool: is_boolean_type(&sv.type_),
                     enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }
@@ -2991,6 +2984,7 @@ fn build_var_map(
                     off: start_off,
                     wty: WTy::F64,
                     is_start: true,
+                    is_bool: is_boolean_type(&sv.type_),
                     enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2442,6 +2442,74 @@ pub fn emit_terminal_row(
     check_asserts(e, sim_data, layout, omclog::WARNING)
 }
 
+/// C's `writeOutputVars` (`solver_main.c`): `time=<t>` and each `-output` name's
+/// final value, Reals as `%.20g` and Strings quoted. A name contributes once per
+/// match, as C's loops over the `modelData` arrays do.
+fn write_output_vars(
+    e: &dyn SimEngine,
+    model: &SimModel,
+    sim_data: u32,
+    rows: &[f64],
+    n_reals: usize,
+    names: &[String],
+) -> Result<()> {
+    if n_reals == 0 || rows.len() < n_reals {
+        return Ok(());
+    }
+    let layout = &model.layout;
+    let last = rows.len() - n_reals;
+    let n_real_cols = layout.n_reals_row();
+    let mut out = format!("time={}", format_g(rows[last], 20));
+    for name in names {
+        for v in &model.vars {
+            if v.name != *name {
+                continue;
+            }
+            match &v.kind {
+                ResultKind::Time => {}
+                ResultKind::Column { col, negate } => {
+                    let raw = negate.apply_f64(rows[last + *col as usize]);
+                    if *col < n_real_cols {
+                        out.push_str(&format!(",{name}={}", format_g(raw, 20)));
+                    } else {
+                        out.push_str(&format!(",{name}={}", raw as i64));
+                    }
+                }
+                ResultKind::Param { off, wty, negate } => match wty {
+                    WTy::F64 => {
+                        let v = negate.apply_f64(read_f64(e, sim_data + off)?);
+                        out.push_str(&format!(",{name}={}", format_g(v, 20)));
+                    }
+                    WTy::I32 => {
+                        let v = negate.apply_f64(read_i32(e, sim_data + off)? as f64);
+                        out.push_str(&format!(",{name}={}", v as i64));
+                    }
+                },
+                ResultKind::Const { value } => out.push_str(&format!(",{name}={}", format_g(*value, 20))),
+            }
+        }
+        // Strings own no result column; C reads them from `stringVars`/`stringParameter`.
+        let mut string_at = |off: u32| -> Result<()> {
+            let s = read_rt_string(e, read_i32(e, sim_data + off)?)?;
+            out.push_str(&format!(",{name}=\"{s}\""));
+            Ok(())
+        };
+        for (i, (n, _)) in model.soti.strings.iter().enumerate() {
+            if n == name {
+                string_at(layout.str_off + i as u32 * 4)?;
+            }
+        }
+        for (i, (n, _)) in model.params.strings.iter().enumerate() {
+            if n == name {
+                string_at(layout.sparam_off + i as u32 * 4)?;
+            }
+        }
+    }
+    out.push('\n');
+    log_line(&out);
+    Ok(())
+}
+
 /// The initial result row. C emits it straight after `initializeModel` with no
 /// re-evaluation: `SimData` is already consistent, and re-running the equations
 /// would repeat any side effect they have (`Streams.print`).
@@ -3552,6 +3620,12 @@ pub fn drive(
     }
     let rows = outcome?;
     stats.method = label;
+
+    // C's `finishSimulation` order: this line, then the caller's LOG_STATS block.
+    let out_names = crate::simflags::with_flags(|f| f.output_vars.clone());
+    if !out_names.is_empty() {
+        write_output_vars(e, model, sim_data, &rows, n_reals as usize, &out_names)?;
+    }
 
     let lin = crate::linearize::linearize(e, model, sim_data)?;
     let params = finalize_run(e, model, sim_data)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -172,8 +172,10 @@ pub struct SimFlags {
     /// homotopy.
     pub homotopy_on_first_try: Option<bool>,
     /// `-override=name=value,…` unresolved: mapping a name to its `SimData` slot
-    /// needs the model, which only the caller has.
-    pub overrides: Vec<(String, f64)>,
+    /// needs the model, which only the caller has. The value stays the string C
+    /// puts in the quantity's `start` attribute; reading it is the variable class's
+    /// job, and an unresolvable name still has to be reported.
+    pub overrides: Vec<(String, String)>,
     /// `-output=a,b,c`: variables printed at the stop time (C's
     /// `outputVariablesAtEnd` / `writeOutputVars`).
     pub output_vars: Vec<String>,
@@ -599,12 +601,10 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                 }
             }
             "override" => {
-                for item in value(name)?.split(',') {
-                    // An unparsable or unknown override is a no-op, as in C.
+                // C's `parseVariableStr` splits on commas outside `[]`.
+                for item in split_top_level(&value(name)?) {
                     if let Some((n, v)) = item.split_once('=') {
-                        if let Ok(val) = v.trim().parse::<f64>() {
-                            f.overrides.push((n.trim().to_string(), val));
-                        }
+                        f.overrides.push((n.trim().to_string(), v.trim().to_string()));
                     }
                 }
             }
@@ -1396,8 +1396,15 @@ mod tests {
 
     #[test]
     fn overrides_keep_order_and_skip_junk() {
-        let f = parse(&argv(&["-override=a=1,bad,b=2.5,c=x"])).expect("parses");
-        assert_eq!(f.overrides, [("a".to_string(), 1.0), ("b".to_string(), 2.5)]);
+        let f = parse(&argv(&["-override=a=1,bad,b[1,2]=2.5,c=false"])).expect("parses");
+        assert_eq!(
+            f.overrides,
+            [
+                ("a".to_string(), "1".to_string()),
+                ("b[1,2]".to_string(), "2.5".to_string()),
+                ("c".to_string(), "false".to_string())
+            ]
+        );
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -329,8 +329,25 @@ pub struct EditableParam {
     pub wty: WTy,
     /// A state's start value (vs. a plain parameter): overridden after `functionInitStartValues`.
     pub is_start: bool,
+    /// A Boolean quantity: reads an `-override` value C's `read_value_bool` way.
+    pub is_bool: bool,
     /// Enumeration literal names (1-based index → name), empty for non-enum.
     pub enum_names: Vec<String>,
+}
+
+impl EditableParam {
+    /// C's per-class `_init.xml` readers on an `-override` value: `read_value_bool`
+    /// for a Boolean, else `read_value_real`/`_long`, whose `atof`/`atol` give 0 for junk.
+    pub fn read_value(&self, s: &str) -> f64 {
+        if self.is_bool {
+            return if s == "true" { 1.0 } else { 0.0 };
+        }
+        match s {
+            "true" => 1.0,
+            "false" => 0.0,
+            _ => s.parse::<f64>().unwrap_or(0.0),
+        }
+    }
 }
 
 // ─────────────────────────── driver selection ───────────────────────────

--- a/testsuite/simulation/modelica/parameters/parameterTest15.mos
+++ b/testsuite/simulation/modelica/parameters/parameterTest15.mos
@@ -26,7 +26,7 @@ setCommandLineOptions("-d=evalParameterDump");
 
 simulate(parameterTest15, simflags="-output=p1,p2,p3"); getErrorString();
 
-system("./parameterTest15 -override p1=2,p2=10,p3=10 -output=p1,p2,p3"); getErrorString();
+simulate(parameterTest15, simflags="-override p1=2,p2=10,p3=10 -output=p1,p2,p3", resimulateExecutable="parameterTest15"); getErrorString();
 
 
 // Result:
@@ -277,11 +277,15 @@ system("./parameterTest15 -override p1=2,p2=10,p3=10 -output=p1,p2,p3"); getErro
 // [<interactive>:11:3-11:39:writable] Warning: Parameter p7 has no value, and is fixed during initialization (fixed=true), using available start value (start=1) as default value.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// LOG_STDOUT        | warning | It is not possible to override the following quantity: p2
+// record SimulationResult
+//     resultFile = "parameterTest15_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'parameterTest15', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override p1=2,p2=10,p3=10 -output=p1,p2,p3'",
+//     messages = "LOG_STDOUT        | warning | It is not possible to override the following quantity: p2
 // |                 | |       | It seems to be structural, final, protected or evaluated or has a non-constant binding.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // time=1,p1=2,p2=2,p3=10
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult

--- a/testsuite/simulation/modelica/parameters/parameterTest17.mos
+++ b/testsuite/simulation/modelica/parameters/parameterTest17.mos
@@ -12,7 +12,7 @@ model parameterTest17
   parameter Integer p3 = c1;
   parameter Integer p4 (fixed=false);
   final constant Integer c1 = 5;
-  constant Integer c2;
+  constant Integer c2 = 0;
   final parameter Integer p5 = 1;
   final parameter Integer p6 = p5;
   final parameter Integer p7 (start=1);
@@ -66,14 +66,14 @@ val(p9,0.0);
 // ########### Updated globalKnownVars (simulation) (17)
 // ========================================
 // 1: a:DISCRETE(fixed = true final = true )  = sin(/*Real*/(p2)) + /*Real*/(p1)  type: Integer
-// 2: c:DISCRETE(fixed = false )  = 7 + p1 + p2 + p3 + p7 + p8 + pr1 + pr2 + c2  type: Integer
+// 2: c:DISCRETE(fixed = true final = true )  = 7 + p1 + p2 + p3 + p7 + p8 + pr1 + pr2  type: Integer
 // 3: input x:VARIABLE(fixed = true final = true )  type: Integer
 // 4: p1:PARAM()  = 1  type: Integer
 // 5: p2:PARAM()  = p1  type: Integer
 // 6: p3:PARAM()  = 5  type: Integer
 // 7: p4:PARAM(fixed = false )  type: Integer
 // 8: c1:CONST(final = true )  = 5  type: Integer
-// 9: c2:CONST()  type: Integer
+// 9: c2:CONST()  = 0  type: Integer
 // 10: p5:PARAM(final = true )  = 1  type: Integer
 // 11: p6:PARAM(final = true )  = 1  type: Integer
 // 12: p7:PARAM(start = 1 final = true )  type: Integer
@@ -99,7 +99,7 @@ val(p9,0.0);
 // "
 // 1.0
 // 7.0
-// 42.0
+// 35.0
 // 8.0
 // 4.0
 // 8.0

--- a/testsuite/simulation/modelica/parameters/parameterTest6.mos
+++ b/testsuite/simulation/modelica/parameters/parameterTest6.mos
@@ -31,7 +31,7 @@ end parameterTest6;
 
 setCommandLineOptions("-d=evalParameterDump");
 simulate(parameterTest6, simflags="-output=p1,p2,p3,p4,p5,f1,f2,b1,b2,e1,s,a[1],a[2],a[3],pr1,x,y,z"); getErrorString();
-system("./parameterTest6 -override s=5,f2=100 -output=p1,p2,p3,p4,p5,f1,f2,b1,b2,e1,s,a[1],a[2],a[3],pr1,x,y,z"); getErrorString();
+simulate(parameterTest6, simflags="-override s=5,f2=100 -output=p1,p2,p3,p4,p5,f1,f2,b1,b2,e1,s,a[1],a[2],a[3],pr1,x,y,z", resimulateExecutable="parameterTest6"); getErrorString();
 
 
 // Result:
@@ -396,13 +396,17 @@ system("./parameterTest6 -override s=5,f2=100 -output=p1,p2,p3,p4,p5,f1,f2,b1,b2
 // "
 // end SimulationResult;
 // ""
-// LOG_STDOUT        | warning | It is not possible to override the following quantity: f2
+// record SimulationResult
+//     resultFile = "parameterTest6_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'parameterTest6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override s=5,f2=100 -output=p1,p2,p3,p4,p5,f1,f2,b1,b2,e1,s,a[1],a[2],a[3],pr1,x,y,z'",
+//     messages = "LOG_STDOUT        | warning | It is not possible to override the following quantity: f2
 // |                 | |       | It seems to be structural, final, protected or evaluated or has a non-constant binding.
 // LOG_STDOUT        | warning | It is not possible to override the following quantity: s
 // |                 | |       | It seems to be structural, final, protected or evaluated or has a non-constant binding.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // time=1,p1=2,p2=-3,p3=5,p4=4,p5=100,f1=2,f2=10,b1=0,b2=1,e1=4,s=3,a[1]=1,a[2]=1,a[3]=1,pr1=100,x=-1,y=115,z=6
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult

--- a/testsuite/simulation/modelica/parameters/parameterTest7.mos
+++ b/testsuite/simulation/modelica/parameters/parameterTest7.mos
@@ -19,7 +19,7 @@ end parameterTest7;
 
 setCommandLineOptions("-d=evalParameterDump");
 simulate(parameterTest7, simflags="-output=p1,p2,s,a[1],a[2],a[3]"); getErrorString();
-system("./parameterTest7 -override p2=10,a[1]=10 -output=p1,p2,s,a[1],a[2],a[3]"); getErrorString();
+simulate(parameterTest7, simflags="-override p2=10,a[1]=10 -output=p1,p2,s,a[1],a[2],a[3]", resimulateExecutable="parameterTest7"); getErrorString();
 
 // Result:
 // true
@@ -390,11 +390,15 @@ system("./parameterTest7 -override p2=10,a[1]=10 -output=p1,p2,s,a[1],a[2],a[3]"
 // "
 // end SimulationResult;
 // ""
-// LOG_STDOUT        | warning | It is not possible to override the following quantity: p2
+// record SimulationResult
+//     resultFile = "parameterTest7_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'parameterTest7', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override p2=10,a[1]=10 -output=p1,p2,s,a[1],a[2],a[3]'",
+//     messages = "LOG_STDOUT        | warning | It is not possible to override the following quantity: p2
 // |                 | |       | It seems to be structural, final, protected or evaluated or has a non-constant binding.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // time=1,p1=3,p2=3,s=3,a[1]=10,a[2]=2,a[3]=3
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult

--- a/testsuite/simulation/modelica/parameters/parameterTest8.mos
+++ b/testsuite/simulation/modelica/parameters/parameterTest8.mos
@@ -21,7 +21,7 @@ end parameterTest8;
 
 setCommandLineOptions("-d=evalParameterDump");
 simulate(parameterTest8, simflags="-output=state,v,r"); getErrorString();
-system("./parameterTest8 -override state=false -output=state,v,r"); getErrorString();
+simulate(parameterTest8, simflags="-override state=false -output=state,v,r", resimulateExecutable="parameterTest8"); getErrorString();
 
 
 // Result:
@@ -202,11 +202,15 @@ system("./parameterTest8 -override state=false -output=state,v,r"); getErrorStri
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// LOG_STDOUT        | warning | It is not possible to override the following quantity: state
+// record SimulationResult
+//     resultFile = "parameterTest8_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'parameterTest8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override state=false -output=state,v,r'",
+//     messages = "LOG_STDOUT        | warning | It is not possible to override the following quantity: state
 // |                 | |       | It seems to be structural, final, protected or evaluated or has a non-constant binding.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // time=1,state=1,v=1,r=2
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult


### PR DESCRIPTION
`writeOutputVars` lived on the host, over the finished `RunResult`, which carries no string data and which the standalone export never sees. It now sits in the driver where C keeps it (`solver_main.c`, called from `finishSimulation` ahead of the LOG_STATS block), so live memory is still there: a String reads its `SimData` slot through `str_off` / `sparam_off`, as C reads `stringVars`/`stringParameter`, and prints quoted. Parameters read their slot too instead of replaying the captured array. The `wasm` standalone target gains `-output` from the same move.

`-override` parsed its value as a `f64` while parsing the flags, so `-override state=false` was dropped whole: neither applied nor reported. The value now stays the string C puts in the quantity's `start` attribute, split on commas outside `[]` (`parseVariableStr`) so an array element keeps its subscripts, and the variable's class reads it: `read_value_bool` for a Boolean, `read_value_real`/`_long` otherwise, which take `true`/`false` as well and `atof` the rest.

`doOverride` also reports what it could not do, walking the `_init.xml` quantities in class order; the result signals are that roster in that order, with the editable parameters as its `isValueChangeable` subset. Both of its warnings are emitted from there.

parameterTest6/7/8/15 ran the built executable, which this target does not emit; they resimulate through `resimulateExecutable` instead, as homotopy4_solver.mos already does.

parameterTest17 declared `constant Integer c2;` with no value, which the new frontend rejects outright. Under `-d=-newInst` it reached the C template, where a `CONST` without an `initialValue` falls through `varArrayNameValues` to the ordinary variable case and reads `integerVars[integerVarsIndex[<c2's index>]]`. Constants are numbered apart from the integer variables, so index 1 was `b` and the expected `val(c) = 42` was `35 + b`. The constant now has a value.

The six tests pass under both wasm-jit and the C target, as does the rest of simulation/modelica/parameters.

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
