### PR TITLE
wasm-jit: *_info.json under infoXmlOperations

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -731,6 +731,11 @@ algorithm
       CodegenWasmJit.translateModel(simCode);
       guid := System.getUUIDStr();
       SerializeInitXML.simulationInitFile(simCode, guid);
+      // The wasm module carries its own metadata, so *_info.json is only needed
+      // for debugging; emit it when the infoXmlOperations debug flag is set.
+      if Flags.isSet(Flags.INFO_XML_OPERATIONS) then
+        SerializeModelInfo.serialize(simCode, true);
+      end if;
     then ();
 
     case "wasm" algorithm

--- a/testsuite/openmodelica/cruntime/xmlFiles/testxmlInfoAllEqnsCorrectOrder.mos
+++ b/testsuite/openmodelica/cruntime/xmlFiles/testxmlInfoAllEqnsCorrectOrder.mos
@@ -2,7 +2,7 @@
 // keywords: xml-file
 // status: correct
 // teardown_command: rm -rf testModel* output.log testModel_info.json.filtered
-// cflags: -d=-newInst
+// cflags: -d=-newInst -d=infoXmlOperations
 //
 //
 // checks for correct order of equations in *_info.json file,


### PR DESCRIPTION
The wasm module carries its own metadata, so the runtime does not read *_info.json. Emit it only when the infoXmlOperations debug flag is set, rather than on every translate/simulate like the C target.

Enable the flag in testxmlInfoAllEqnsCorrectOrder so the file is present for its eqIndex-order check. The generated file is byte-identical to the C target's.

Assisted-by: Qwen 3.8 27B
