### PR TITLE
wasm-jit: support -single precision result files

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -8346,7 +8346,7 @@ fn write_mat4(
     params: &[f64],
     keep: &[bool],
 ) -> Result<()> {
-    use openmodelica_mat_writer::MatVar;
+    use openmodelica_mat_writer::{MatVar, Precision};
     // `params` is positional over the unfiltered `Param` signals.
     let mut kept_params: Vec<f64> = Vec::new();
     let mut param_idx = 0usize;
@@ -8362,8 +8362,18 @@ fn write_mat4(
         }
         vars.push(MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() });
     }
-    let bytes =
-        openmodelica_mat_writer::write_mat4(&vars, meta.start_time, meta.stop_time, rows, n_reals, &kept_params);
+    // `-single` narrows the real data to 4-byte float (C's `FLAG_SINGLE_PRECISION`).
+    let precision =
+        simflags::with_flags(|f| if f.single_precision { Precision::Single } else { Precision::Double });
+    let bytes = openmodelica_mat_writer::write_mat4(
+        &vars,
+        meta.start_time,
+        meta.stop_time,
+        rows,
+        n_reals,
+        &kept_params,
+        precision,
+    );
     let _ = &model.model_name; // (kept for diagnostics)
     write_output(path, &bytes).map_err(|e| "CodegenWasmJit: cannot write")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -24,7 +24,7 @@
 //! - `wasm-merge runtime.wasm rt model.wasm model` connects both directions,
 //!   leaving only the WASI imports (satisfied by `wasmtime`/the worker shim).
 
-use openmodelica_mat_writer::MatVar;
+use openmodelica_mat_writer::{MatVar, Precision};
 use openmodelica_sim_meta::driver::{self, SimEngine};
 use openmodelica_sim_meta::simflags;
 use openmodelica_sim_meta::{self as meta, MetaKind, SimMeta};
@@ -230,6 +230,9 @@ fn run() {
             }
             matvars.push(MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() });
         }
+        // `-single` narrows the real data to 4-byte float (C's `FLAG_SINGLE_PRECISION`).
+        let precision =
+            simflags::with_flags(|f| if f.single_precision { Precision::Single } else { Precision::Double });
         openmodelica_mat_writer::write_mat4(
             &matvars,
             m.start_time,
@@ -237,6 +240,7 @@ fn run() {
             &result.rows,
             result.n_reals,
             &kept_params,
+            precision,
         )
     } else {
         use openmodelica_plt_writer::{Neg as PltNeg, PltKind, PltVar};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_mat_writer/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_mat_writer/src/lib.rs
@@ -46,6 +46,27 @@ pub enum MatKind {
     Const { value: f64 },
 }
 
+/// The precision of the real-valued result data (`data_1`/`data_2`). Mirrors C's
+/// `MatVer4Type_t` for the real matrices; the `-single` flag selects
+/// [`Precision::Single`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Precision {
+    /// 8-byte IEEE double (C's `MatVer4Type_DOUBLE`).
+    Double,
+    /// 4-byte IEEE single (C's `MatVer4Type_SINGLE`).
+    Single,
+}
+
+impl Precision {
+    /// The mat v4 type code for the real matrices (C's `MatVer4Type_t`).
+    fn type_code(self) -> i32 {
+        match self {
+            Precision::Double => 0,
+            Precision::Single => 10,
+        }
+    }
+}
+
 /// One signal in the result file (C-compatible order: time, states, derivatives,
 /// algebraics, then parameters). `name`/`comment` borrow the caller's strings.
 pub struct MatVar<'a> {
@@ -56,8 +77,9 @@ pub struct MatVar<'a> {
 
 /// Serialize the MATLAB v4 result file for `signals`. `rows` is the row-major
 /// time-variant buffer (`n_reals` columns per row, column 0 = time); `params`
-/// holds the scalar parameter values in `MatKind::Param` order. Returns the file
-/// bytes.
+/// holds the scalar parameter values in `MatKind::Param` order. `precision`
+/// selects the storage width of the real data (`data_1`/`data_2`). Returns the
+/// file bytes.
 pub fn write_mat4(
     signals: &[MatVar],
     start_time: f64,
@@ -65,6 +87,7 @@ pub fn write_mat4(
     rows: &[f64],
     n_reals: u32,
     params: &[f64],
+    precision: Precision,
 ) -> Vec<u8> {
     let n_reals = n_reals as usize;
     let n_rows = if n_reals == 0 { 0 } else { rows.len() / n_reals };
@@ -211,7 +234,7 @@ pub fn write_mat4(
         data_1[idx] = v;
         data_1[n_data1 + idx] = v;
     }
-    write_double_matrix(&mut out, "data_1", n_data1, 2, &data_1);
+    write_real_matrix(&mut out, "data_1", n_data1, 2, &data_1, precision);
 
     // data_2 (n_reals2 x n_rows double, column-major): time + the varying columns.
     let n_reals2 = 1 + varying_cols.len();
@@ -223,7 +246,7 @@ pub fn write_mat4(
             data_2.push(if neg == Neg::Not { 1.0 - v } else { v });
         }
     }
-    write_double_matrix(&mut out, "data_2", n_reals2, n_rows, &data_2);
+    write_real_matrix(&mut out, "data_2", n_reals2, n_rows, &data_2, precision);
 
     out
 }
@@ -245,10 +268,13 @@ fn write_mat_header(out: &mut Vec<u8>, name: &str, ty: i32, mrows: usize, ncols:
     out.push(0);
 }
 
-fn write_double_matrix(out: &mut Vec<u8>, name: &str, mrows: usize, ncols: usize, data: &[f64]) {
-    write_mat_header(out, name, mat_type(0, false), mrows, ncols);
+fn write_real_matrix(out: &mut Vec<u8>, name: &str, mrows: usize, ncols: usize, data: &[f64], precision: Precision) {
+    write_mat_header(out, name, precision.type_code(), mrows, ncols);
     for v in data {
-        out.extend_from_slice(&v.to_le_bytes());
+        match precision {
+            Precision::Double => out.extend_from_slice(&v.to_le_bytes()),
+            Precision::Single => out.extend_from_slice(&(*v as f32).to_le_bytes()),
+        }
     }
 }
 
@@ -303,6 +329,8 @@ mod tests {
                 1 // char/uint8
             } else if (ty / 10) % 10 == 2 {
                 4 // int32
+            } else if (ty / 10) % 10 == 1 {
+                4 // single
             } else {
                 8 // double
             };
@@ -318,6 +346,9 @@ mod tests {
 
     fn f64s(payload: &[u8]) -> Vec<f64> {
         payload.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect()
+    }
+    fn f32s(payload: &[u8]) -> Vec<f32> {
+        payload.chunks_exact(4).map(|c| f32::from_le_bytes(c.try_into().unwrap())).collect()
     }
     fn i32s(payload: &[u8]) -> Vec<i32> {
         payload.chunks_exact(4).map(|c| i32::from_le_bytes(c.try_into().unwrap())).collect()
@@ -336,7 +367,7 @@ mod tests {
         // 3 communication points; x ramps 0,1,2.
         let rows = [0.0, 0.0, /*r1*/ 0.5, 1.0, /*r2*/ 1.0, 2.0];
         let params = [7.0]; // p = 7
-        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &params);
+        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &params, Precision::Double);
 
         // name matrix: 4 columns, one per signal, column-major null-padded.
         let (mrows, ncols, name_payload) = find_matrix(&buf, "name");
@@ -381,7 +412,7 @@ mod tests {
         ];
         // n_reals = 3: [time, x, b]; b toggles, so its column stays time-variant.
         let rows = [0.0, 1.0, 0.0, /*r1*/ 0.5, 2.0, 1.0];
-        let buf = write_mat4(&vars, 0.0, 0.5, &rows, 3, &[1.0]);
+        let buf = write_mat4(&vars, 0.0, 0.5, &rows, 3, &[1.0], Precision::Double);
 
         let (_r, _c, di) = find_matrix(&buf, "dataInfo");
         let di = i32s(di);
@@ -398,5 +429,77 @@ mod tests {
         let (m2, n2, d2) = find_matrix(&buf, "data_2");
         assert_eq!((m2, n2), (4, 2));
         assert_eq!(f64s(d2), vec![0.0, 1.0, 0.0, 1.0, 0.5, 2.0, 1.0, 0.0]);
+    }
+
+    /// The type code of a named matrix's header (to assert `-single`'s 10).
+    fn matrix_type(buf: &[u8], want: &str) -> i32 {
+        let mut p = 0;
+        while p + 20 <= buf.len() {
+            let ty = i32::from_le_bytes(buf[p..p + 4].try_into().unwrap());
+            let mrows = i32::from_le_bytes(buf[p + 4..p + 8].try_into().unwrap()) as usize;
+            let ncols = i32::from_le_bytes(buf[p + 8..p + 12].try_into().unwrap()) as usize;
+            let namelen = i32::from_le_bytes(buf[p + 16..p + 20].try_into().unwrap()) as usize;
+            let name = core::str::from_utf8(&buf[p + 20..p + 20 + namelen - 1]).unwrap();
+            let p_elt = if ty % 10 == 1 { 1 } else if (ty / 10) % 10 == 2 { 4 } else if (ty / 10) % 10 == 1 { 4 } else { 8 };
+            let data_off = p + 20 + namelen;
+            if name == want {
+                return ty;
+            }
+            p = data_off + mrows * ncols * p_elt;
+        }
+        panic!("matrix `{want}` not found");
+    }
+
+    /// `-single`: the real matrices carry type code 10 and 4-byte elements, and
+    /// the values round-trip as `f32`.
+    #[test]
+    fn single_precision() {
+        let vars = [
+            MatVar { name: "time", comment: "", kind: MatKind::Time },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+            MatVar { name: "p", comment: "", kind: MatKind::Param { negate: Neg::None } },
+        ];
+        // 2 rows; x is 0.5 and 1.5 (exact in f32), p = 7 (exact in f32).
+        let rows = [0.0, 0.5, 1.0, 1.5];
+        let buf = write_mat4(&vars, 0.0, 1.0, &rows, 2, &[7.0], Precision::Single);
+
+        assert_eq!(matrix_type(&buf, "data_1"), 10);
+        assert_eq!(matrix_type(&buf, "data_2"), 10);
+
+        let (m1, n1, d1) = find_matrix(&buf, "data_1");
+        assert_eq!(d1.len(), m1 * n1 * 4); // 4-byte elements
+        assert_eq!(f32s(d1), vec![0.0, 7.0, 1.0, 7.0]);
+        let (m2, n2, d2) = find_matrix(&buf, "data_2");
+        assert_eq!(d2.len(), m2 * n2 * 4);
+        assert_eq!(f32s(d2), vec![0.0, 0.5, 1.0, 1.5]);
+    }
+
+    /// A value not exact in `f32` rounds to the nearest single, as C's cast does.
+    #[test]
+    fn single_precision_rounds() {
+        let vars = [
+            MatVar { name: "time", comment: "", kind: MatKind::Time },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+        ];
+        // 1/3 is not exact in f32; the stored value must equal the f32 rounding.
+        let rows = [0.0, 1.0 / 3.0];
+        let buf = write_mat4(&vars, 0.0, 0.0, &rows, 2, &[], Precision::Single);
+        let (_r, _c, d2) = find_matrix(&buf, "data_2");
+        let d2 = f32s(d2);
+        assert_eq!(d2[1], (1.0 / 3.0) as f32);
+    }
+
+    /// The single-precision file is smaller than the double one, as the test
+    /// `s2 > s1` checks.
+    #[test]
+    fn single_precision_is_smaller() {
+        let vars = [
+            MatVar { name: "time", comment: "", kind: MatKind::Time },
+            MatVar { name: "x", comment: "", kind: MatKind::Column { col: 1, negate: Neg::None } },
+        ];
+        let rows = [0.0, 0.0, 1.0, 0.5, 2.0, 1.5];
+        let single = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], Precision::Single);
+        let double = write_mat4(&vars, 0.0, 2.0, &rows, 2, &[], Precision::Double);
+        assert!(single.len() < double.len());
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -98,6 +98,10 @@ pub struct SimFlags {
     pub output_format: Option<String>,
     /// `-noemit`: no result file, C's `sim_noemit` (which it treats as `empty`).
     pub noemit: bool,
+    /// `-single`: store the `.mat` real data (`data_1`/`data_2`) as 4-byte single
+    /// precision (C's `FLAG_SINGLE_PRECISION`). The simulation itself always runs
+    /// in double; this only narrows the result file.
+    pub single_precision: bool,
     /// `-outputPath=<dir>`: holds `<prefix>_res.<format>` unless `-r` names a file.
     pub output_path: Option<String>,
     /// `-iit=<t>`: where `-iif`'s result file is read (C's `init_time`, default the
@@ -614,6 +618,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "tolerance" => f.tolerance = Some(real(name, &value(name)?)?),
             "outputFormat" => f.output_format = Some(output_format(&value(name)?)?),
             "noemit" => f.noemit = true,
+            "single" => f.single_precision = true,
             "outputPath" => f.output_path = Some(value(name)?),
             "iit" => f.init_time = Some(real(name, &value(name)?)?),
             "mei" => f.max_event_iter = Some(int(name, &value(name)?)?.max(0) as u32),
@@ -1446,6 +1451,12 @@ mod tests {
         assert!(parse(&argv(&["-outputFormat=nope"])).expect_err("unknown").contains("Unknown"));
         // `-noemit` is C's `sim_noemit`, which it treats exactly as `empty`.
         assert!(parse(&argv(&["-noemit"])).expect("parses").noemit);
+    }
+
+    #[test]
+    fn the_single_flag_selects_single_precision_output() {
+        assert!(!parse(&argv(&[])).expect("parses").single_precision);
+        assert!(parse(&argv(&["-single"])).expect("parses").single_precision);
     }
 
     #[test]

--- a/testsuite/openmodelica/cruntime/simoptions/testSinglePrecision.mos
+++ b/testsuite/openmodelica/cruntime/simoptions/testSinglePrecision.mos
@@ -24,31 +24,35 @@ equation
 
 end testModel;");
 
-buildModel(testModel, stopTime=3.0);getErrorString();
-system("./testModel -single -r single.mat");
-system("./testModel -r double.mat");
-echo(false);
+simulate(testModel, stopTime=3.0, simflags="-single -r single.mat");
+simulate(testModel, stopTime=3.0, simflags="-r double.mat", resimulateExecutable="testModel");
 (b1,s1,m1) := OpenModelica.Scripting.stat("single.mat");
 (b2,s2,m1) := OpenModelica.Scripting.stat("double.mat");
-echo(true);
 b1 and b2;
 s2 > s1;
 diffSimulationResults("single.mat", "double.mat", "single-double-diff");getErrorString();
 
 // Result:
 // true
-// {"testModel", "testModel_init.xml"}
-// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// record SimulationResult
+//     resultFile = "single.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'testModel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-single -r single.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// end SimulationResult;
+// record SimulationResult
+//     resultFile = "double.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 3.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'testModel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r double.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
-// true
+// "
+// end SimulationResult;
+//
+//
 // true
 // true
 // (true, {})
-// ""
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
 // endResult


### PR DESCRIPTION
Match the C runtime's FLAG_SINGLE_PRECISION: -single stores the MATLAB v4 real matrices (data_1/data_2) as 4-byte floats with type code 10 instead of 8-byte doubles. The simulation itself still runs in double precision.

- mat_writer: new Precision enum, write_mat4 takes it
- simflags: parse -single into SimFlags.single_precision
- CodegenWasmJit/standalone: pass the precision to write_mat4
- testSinglePrecision: use simulate/resimulateExecutable instead of buildModel + system, which wasm-jit does not produce

Assisted-by: Qwen3.8 27B