### PR TITLE
wasm-jit: honour -lv=-LOG_STDOUT in ModelicaMessage

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# The simulation's captured stdout, where `ModelicaMessage` output lands.
-openmodelica_wasi.workspace = true
+# `omclog`: the `-lv` mask `ModelicaMessage` prints through.
+openmodelica_sim_meta.workspace = true
 
 # libc (dlsym RTLD_NEXT / malloc for the non-simulation forward) is native-only;
 # the wasm build always allocates from the arena.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_modelica_utilities/src/lib.rs
@@ -15,6 +15,8 @@
 use std::cell::{Cell, RefCell};
 use std::os::raw::c_char;
 
+use openmodelica_sim_meta::omclog;
+
 thread_local! {
     /// Set while a simulation external "C" call is in flight (between
     /// `omrs_sim_external_begin` and `_end`). Only then does `ModelicaAllocateString`
@@ -142,16 +144,15 @@ pub fn format_log_stdout(msg: &str, prefix: &str) -> String {
     out
 }
 
-/// Emit `msg` to the running simulation's captured stdout if an external call is
-/// in flight; returns whether it was taken. The caller's format string
-/// `\n`-terminates the line, which the prefixing re-adds.
-fn take_message(msg: *const c_char, prefix: &str) -> bool {
+/// Emit `msg` on `LOG_STDOUT` if an external call is in flight; returns whether it
+/// was taken. `emit` is C's `va_infoStreamPrint`/`va_warningStreamPrint`, so
+/// `-lv=-LOG_STDOUT` drops the message as it does there.
+fn take_message(msg: *const c_char, emit: fn(omclog::Stream, bool, &str)) -> bool {
     if !SIM_MODE.with(Cell::get) || msg.is_null() {
         return false;
     }
     let text = unsafe { std::ffi::CStr::from_ptr(msg) }.to_string_lossy().into_owned();
-    let line = format_log_stdout(text.strip_suffix('\n').unwrap_or(&text), prefix);
-    openmodelica_wasi::wasi::stdout_write(line.as_bytes());
+    emit(omclog::STDOUT, false, text.strip_suffix('\n').unwrap_or(&text));
     true
 }
 
@@ -159,9 +160,9 @@ fn take_message(msg: *const c_char, prefix: &str) -> bool {
 // `dynload::install_modelica_message_interception`.
 
 pub extern "C" fn modelica_message_hook(msg: *const c_char) -> i32 {
-    take_message(msg, LOG_STDOUT_INFO) as i32
+    take_message(msg, omclog::info) as i32
 }
 
 pub extern "C" fn modelica_warning_hook(msg: *const c_char) -> i32 {
-    take_message(msg, LOG_STDOUT_WARNING) as i32
+    take_message(msg, omclog::warning) as i32
 }

--- a/testsuite/simulation/libraries/3rdParty/Buildings/ReaderTMY3_total.mos
+++ b/testsuite/simulation/libraries/3rdParty/Buildings/ReaderTMY3_total.mos
@@ -3,7 +3,8 @@
 loadModel(Modelica,{"3.2.2"});getErrorString();
 loadFile("ReaderTMY3_total.mo");getErrorString();
 buildModel(ReaderTMY3_total, stopTime=0);getErrorString();
-system("./ReaderTMY3_total", outputFile="ignored.txt");getErrorString();
+// -lv=-LOG_STDOUT: the table reader logs the weather file's absolute path.
+simulate(ReaderTMY3_total, stopTime=0, simflags="-lv=-LOG_STDOUT", resimulateExecutable="ReaderTMY3_total");getErrorString();
 
 // Result:
 // true
@@ -12,6 +13,12 @@ system("./ReaderTMY3_total", outputFile="ignored.txt");getErrorString();
 // ""
 // {"ReaderTMY3_total", "ReaderTMY3_total_init.xml"}
 // ""
-// 0
+// record SimulationResult
+//     resultFile = "ReaderTMY3_total_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ReaderTMY3_total', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=-LOG_STDOUT'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
 // ""
 // endResult


### PR DESCRIPTION
`ModelicaMessage`/`ModelicaWarning` from an external "C" function were written straight to the run's captured stdout with a hand-rolled
`LOG_STDOUT        | info    | ` prefix, so the stream mask never
reached them. C routes both through `va_infoStreamPrint(OMC_LOG_STDOUT,
...)` / `va_warningStreamPrint` (util/ModelicaUtilities.c), which
consult `omc_useStream` and `-w`. Call `omclog::info`/`omclog::warning`
instead: same sink, same `messageText` rendering, filtered the same way.

ReaderTMY3_total ran the built executable with `system("./<model>")`, which the wasm-jit target does not produce -- it JIT-compiles the model and keeps it in the omc process. Use `resimulateExecutable`, which is what that argument is for and which still runs `./<model>` for the C target. The table reader logs the weather file's absolute path, so the run disables LOG_STDOUT -- the old test discarded the output entirely.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
