### PR TITLE
wasm-jit: fix the NPendulum linear_system tests

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -321,6 +321,10 @@ if(RUST_OMC_ENABLE_SUNDIALS)
   # SuiteSparse toolchain: base wasi toolchain + include dirs for KLU headers.
   # CMAKE_C_FLAGS_INIT is a STRING (not list) so no semicolon issues.
   set(_sundials_cflags "-O2 -I${_suitesparse_sources}/AMD/Include -I${_suitesparse_sources}/COLAMD/Include -I${_suitesparse_sources}/BTF/Include -I${_suitesparse_sources}/SuiteSparse_config")
+  # UMFPACK adds its own headers and `NBLAS`, its no-BLAS build, there being no
+  # BLAS for wasm. Passed as CMAKE_C_FLAGS, not through the toolchain's
+  # CMAKE_C_FLAGS_INIT, which an already-configured build directory ignores.
+  set(_suitesparse_cflags "${_sundials_cflags} -DNBLAS -I${_suitesparse_sources}/UMFPACK/Include")
   set(_sundials_toolchain ${CMAKE_CURRENT_BINARY_DIR}/sundials-wasi-toolchain.cmake)
   file(WRITE ${_sundials_toolchain}
     "set(CMAKE_SYSTEM_NAME WASI)\n"
@@ -342,16 +346,22 @@ if(RUST_OMC_ENABLE_SUNDIALS)
     LIST_SEPARATOR |
     CMAKE_ARGS
       -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DCMAKE_C_FLAGS=${_suitesparse_cflags}
       -DBUILD_SHARED_LIBS=OFF
-      -DSUITESPARSE_ENABLE_PROJECTS=suitesparse_config|amd|colamd|btf|klu
+      -DSUITESPARSE_ENABLE_PROJECTS=suitesparse_config|amd|colamd|btf|klu|umfpack
       -DSUITESPARSE_USE_FORTRAN=OFF
       -DSUITESPARSE_USE_OPENMP=OFF
       -DSUITESPARSE_USE_CUDA=OFF
       -DSUITESPARSE_DEMOS=OFF
       -DSUITESPARSE_USE_STRICT=OFF
       -DKLU_USE_CHOLMOD=OFF
+      -DUMFPACK_USE_CHOLMOD=OFF
+      # An empty BLAS_LIBRARIES takes SuiteSparseBLAS's "user supplied" path
+      # instead of find_package(BLAS); BLA_VENDOR only picks name-mangling defines.
+      -DBLAS_LIBRARIES=
+      -DBLA_VENDOR=Generic
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_suitesparse_ep_build} --parallel
-      --target KLU_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static
+      --target KLU_static UMFPACK_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
     EXCLUDE_FROM_ALL ON)
@@ -394,6 +404,7 @@ if(RUST_OMC_ENABLE_SUNDIALS)
     COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_WASM_DIR}/lib
     COMMAND ${CMAKE_COMMAND} -E copy
       ${_suitesparse_ep_build}/KLU/libklu.a
+      ${_suitesparse_ep_build}/UMFPACK/libumfpack.a
       ${_suitesparse_ep_build}/AMD/libamd.a
       ${_suitesparse_ep_build}/COLAMD/libcolamd.a
       ${_suitesparse_ep_build}/BTF/libbtf.a

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1646,6 +1646,10 @@ pub(crate) fn emit_solve_nls_call(ctx: &mut FnCtx, job: NlsJob) -> Result<()> {
 /// `SimData`): per seed column, seed it, zero the result slots, run the column
 /// equations and store the rows as column `j` at `out_off` (`out[j*rows + i]`).
 /// C's `functionJacX` loop; the constant equations run in the caller.
+///
+/// The column body is emitted once inside a wasm loop, so the code size is
+/// independent of the column count; unrolled it runs past wasmtime's
+/// per-function body limit.
 pub(crate) fn emit_linz_jac_body(
     ctx: &mut FnCtx,
     out_off: u32,
@@ -1658,31 +1662,141 @@ pub(crate) fn emit_linz_jac_body(
     if result_offs.len() != rows {
         return Err("CodegenWasmJit: linearization Jacobian row count mismatch");
     }
-    let store_const = |ctx: &mut FnCtx, off: u32, val: f64| {
-        ctx.emit(I::LocalGet(0));
-        ctx.emit(I::F64Const(val.into()));
-        ctx.emit(I::F64Store(mem_arg(off, 3)));
-    };
-    for j in 0..seed_offs.len() {
-        for (k, &soff) in seed_offs.iter().enumerate() {
-            store_const(ctx, soff, if k == j { 1.0 } else { 0.0 });
-        }
-        for &roff in result_offs.iter().flatten() {
-            store_const(ctx, roff, 0.0);
-        }
-        lower_column(ctx)?;
-        for (i, roff) in result_offs.iter().enumerate() {
-            let out = out_off + ((j * rows + i) as u32) * 8;
-            match roff {
-                Some(roff) => {
-                    ctx.emit(I::LocalGet(0));
-                    ctx.emit(I::LocalGet(0));
-                    ctx.emit(I::F64Load(mem_arg(*roff, 3)));
-                    ctx.emit(I::F64Store(mem_arg(out, 3)));
-                }
-                None => store_const(ctx, out, 0.0),
-            }
-        }
+    let n_cols = seed_offs.len();
+    if n_cols == 0 {
+        return Ok(());
     }
+    // A row the backend left out has no slot; the column's zero fill is its value.
+    let present: Vec<(u32, u32)> = result_offs
+        .iter()
+        .enumerate()
+        .filter_map(|(i, off)| off.map(|off| (i as u32, off)))
+        .collect();
+
+    // Scratch index tables (i32): seed_tab | res_row | res_off.
+    let seed_tab_off: u32 = 0;
+    let res_row_off: u32 = (n_cols * 4) as u32;
+    let res_off_off: u32 = res_row_off + (present.len() * 4) as u32;
+    let scratch_bytes: u32 = res_off_off + (present.len() * 4) as u32;
+    let base = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(scratch_bytes as i32));
+    ctx.emit(I::Call(rt_index("rt_alloc")?));
+    ctx.emit(I::LocalSet(base));
+    let store_i32 = |ctx: &mut FnCtx, off: u32, v: i32| {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::I32Const(v));
+        ctx.emit(I::I32Store(mem_arg(off, 2)));
+    };
+    for (k, &soff) in seed_offs.iter().enumerate() {
+        store_i32(ctx, seed_tab_off + (k as u32) * 4, soff as i32);
+    }
+    for (m, &(row, off)) in present.iter().enumerate() {
+        store_i32(ctx, res_row_off + (m as u32) * 4, row as i32);
+        store_i32(ctx, res_off_off + (m as u32) * 4, off as i32);
+    }
+
+    for &soff in seed_offs {
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::F64Const(0.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(soff, 3)));
+    }
+
+    let jloc = ctx.alloc_temp(WTy::I32);
+    let iloc = ctx.alloc_temp(WTy::I32);
+    let mloc = ctx.alloc_temp(WTy::I32);
+    // `out_off + j*rows*8` relative to `data`.
+    let colbase = ctx.alloc_temp(WTy::I32);
+    jac_count_loop(ctx, jloc, n_cols as i32, &mut |ctx| {
+        jac_slot_addr(ctx, base, seed_tab_off, jloc);
+        ctx.emit(I::F64Const(1.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(0, 3)));
+        jac_count_loop(ctx, mloc, present.len() as i32, &mut |ctx| {
+            jac_slot_addr(ctx, base, res_off_off, mloc);
+            ctx.emit(I::F64Const(0.0f64.into()));
+            ctx.emit(I::F64Store(mem_arg(0, 3)));
+            Ok(())
+        })?;
+        lower_column(ctx)?;
+        ctx.emit(I::LocalGet(0));
+        ctx.emit(I::LocalGet(jloc));
+        ctx.emit(I::I32Const((rows * 8) as i32));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        ctx.emit(I::LocalSet(colbase));
+        // C memsets the column, so a structurally-zero row keeps its 0.
+        jac_count_loop(ctx, iloc, rows as i32, &mut |ctx| {
+            ctx.emit(I::LocalGet(colbase));
+            ctx.emit(I::LocalGet(iloc));
+            ctx.emit(I::I32Const(8));
+            ctx.emit(I::I32Mul);
+            ctx.emit(I::I32Add);
+            ctx.emit(I::F64Const(0.0f64.into()));
+            ctx.emit(I::F64Store(mem_arg(out_off, 3)));
+            Ok(())
+        })?;
+        jac_count_loop(ctx, mloc, present.len() as i32, &mut |ctx| {
+            ctx.emit(I::LocalGet(colbase));
+            ctx.emit(I::LocalGet(base));
+            ctx.emit(I::LocalGet(mloc));
+            ctx.emit(I::I32Const(4));
+            ctx.emit(I::I32Mul);
+            ctx.emit(I::I32Add);
+            ctx.emit(I::I32Load(mem_arg(res_row_off, 2)));
+            ctx.emit(I::I32Const(8));
+            ctx.emit(I::I32Mul);
+            ctx.emit(I::I32Add);
+            jac_slot_addr(ctx, base, res_off_off, mloc);
+            ctx.emit(I::F64Load(mem_arg(0, 3)));
+            ctx.emit(I::F64Store(mem_arg(out_off, 3)));
+            Ok(())
+        })?;
+        jac_slot_addr(ctx, base, seed_tab_off, jloc);
+        ctx.emit(I::F64Const(0.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(0, 3)));
+        Ok(())
+    })?;
+
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    Ok(())
+}
+
+/// Push `data + tab[idx]`, `tab` being an i32 offset table at `base`.
+fn jac_slot_addr(ctx: &mut FnCtx, base: u32, tab: u32, idx: u32) {
+    use we::Instruction as I;
+    ctx.emit(I::LocalGet(0));
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::LocalGet(idx));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(tab, 2)));
+    ctx.emit(I::I32Add);
+}
+
+/// Emit `for loc in 0..end { body }`.
+fn jac_count_loop(
+    ctx: &mut FnCtx,
+    loc: u32,
+    end: i32,
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(loc));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(loc));
+    ctx.emit(I::I32Const(end));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    body(ctx)?;
+    ctx.emit(I::LocalGet(loc));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(loc));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End);
+    ctx.emit(I::End);
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
@@ -24,6 +24,7 @@ const LIBS: &[&str] = &[
     "sundials_sunmatrixdense",
     "sundials_nvecserial",
     "klu",
+    "umfpack",
     "amd",
     "colamd",
     "btf",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2398,21 +2398,29 @@ pub extern "C" fn rt_lin_solves() -> u64 {
 /// and 0 is returned; 1 only when the system is genuinely unsolvable.
 ///
 /// LU with partial pivoting (like C's `dgesv`), then a total-pivot search on a
-/// singular matrix, mirroring C's `LS_DEFAULT`; `-ls=klu` uses KLU instead.
+/// singular matrix, mirroring C's `LS_DEFAULT`; `-ls=klu`/`-ls=umfpack` use
+/// SuiteSparse instead.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
     #[cfg(sundials)]
-    if solvers::ls() == solvers::Ls::Klu {
-        return sundials::klu_solve_dense(a_ptr, b_ptr, n);
+    match solvers::ls() {
+        solvers::Ls::Klu => return sundials::klu_solve_dense(a_ptr, b_ptr, n),
+        // Singular: fall through to the total-pivot search, C's own fallback.
+        solvers::Ls::Umfpack => match sundials::umfpack_solve_dense(a_ptr, b_ptr, n) {
+            0 => return 0,
+            2 => return 1,
+            _ => {}
+        },
+        _ => {}
     }
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
     let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
     // `-ls=totalpivot` skips straight to the total-pivot search; LAPACK (C's
     // `dgesv`, and the default) is partial-pivot LU with that as its singular
-    // fallback.
-    let lu_first = solvers::ls() != solvers::Ls::TotalPivot;
+    // fallback. `-ls=umfpack` only gets here having found the matrix singular.
+    let lu_first = !matches!(solvers::ls(), solvers::Ls::TotalPivot | solvers::Ls::Umfpack);
     if (lu_first && nls::lu_solve(a, b, n)) || nls::total_pivot_solve(a, b, n) {
         0
     } else {
@@ -2477,8 +2485,10 @@ pub extern "C" fn rt_solve_lin_dense_sparse(a_ptr: u32, b_ptr: u32, n: u32) -> i
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
     #[cfg(sundials)]
-    if solvers::lss() == solvers::Lss::Klu {
-        return sundials::klu_solve_dense(a_ptr, b_ptr, n);
+    match solvers::lss() {
+        solvers::Lss::Klu => return sundials::klu_solve_dense(a_ptr, b_ptr, n),
+        solvers::Lss::Umfpack => return (sundials::umfpack_solve_dense(a_ptr, b_ptr, n) != 0) as i32,
+        solvers::Lss::Rsparse => {}
     }
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
 
@@ -2554,6 +2564,7 @@ pub extern "C" fn rt_solve_lin_sparse_cached(
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let backend = match solvers::lss() {
         solvers::Lss::Klu => solvers::Sparse::Klu,
+        solvers::Lss::Umfpack => solvers::Sparse::Umfpack,
         solvers::Lss::Rsparse => solvers::Sparse::Rsparse,
     };
     lin_sparse_cached(handle, colptr, rowidx, values, b_ptr, n, nnz, backend)
@@ -2577,8 +2588,10 @@ pub(crate) fn lin_sparse_cached(
     let nnz = nnz as usize;
 
     #[cfg(sundials)]
-    if backend == solvers::Sparse::Klu {
-        return sundials::klu_solve_cached(handle, colptr, rowidx, values, b_ptr, n, nnz);
+    match backend {
+        solvers::Sparse::Klu => return sundials::klu_solve_cached(handle, colptr, rowidx, values, b_ptr, n, nnz),
+        solvers::Sparse::Umfpack => return sundials::umfpack_solve_cached(handle, colptr, rowidx, values, b_ptr, n, nnz),
+        solvers::Sparse::Rsparse => {}
     }
     #[cfg(not(sundials))]
     let _ = backend;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -39,12 +39,14 @@ pub(crate) enum Ls {
     Lapack,
     TotalPivot,
     Klu,
+    Umfpack,
 }
 
 /// `-lss`, for a sparse (torn) linear system.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Lss {
     Klu,
+    Umfpack,
     Rsparse,
 }
 
@@ -52,6 +54,7 @@ pub(crate) enum Lss {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Sparse {
     Klu,
+    Umfpack,
     Rsparse,
 }
 
@@ -238,6 +241,7 @@ pub(crate) fn ls() -> Ls {
     match LS.load(Ordering::Relaxed) {
         3 => Ls::TotalPivot,
         4 if cfg!(sundials) => Ls::Klu,
+        5 if cfg!(sundials) => Ls::Umfpack,
         _ => Ls::Lapack, // 0 unset, 1 default, 2 lapack — C's dense default
     }
 }
@@ -246,6 +250,7 @@ pub(crate) fn lss() -> Lss {
     match LSS.load(Ordering::Relaxed) {
         _ if !cfg!(sundials) => Lss::Rsparse,
         3 => Lss::Rsparse,
+        4 => Lss::Umfpack,
         _ => Lss::Klu, // 0 unset, 1 default, 2 klu — C's sparse default
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -50,9 +50,52 @@ pub extern "C" fn rt_sundials_selftest() -> i32 {
     0
 }
 
+/// The CSC of `Aᵀ` both SuiteSparse wrappers factorize, as C's
+/// `setAElementKlu`/`setAElementUmfpack` fill it, plus `perm`: where each entry
+/// reads from in the caller's CSC-of-`A` values.
+#[cfg(sundials)]
+pub(crate) struct Transposed {
+    ap: alloc::vec::Vec<i32>,
+    ai: alloc::vec::Vec<i32>,
+    perm: alloc::vec::Vec<u32>,
+    ax: alloc::vec::Vec<f64>,
+}
+
+#[cfg(sundials)]
+impl Transposed {
+    fn new(n: usize, colptr: &[i32], rowidx: &[i32]) -> Option<Transposed> {
+        let nnz = *colptr.get(n)? as usize;
+        let mut ap = alloc::vec![0i32; n + 1];
+        for &r in &rowidx[..nnz] {
+            ap[r as usize + 1] += 1;
+        }
+        for r in 0..n {
+            ap[r + 1] += ap[r];
+        }
+        let mut fill: alloc::vec::Vec<i32> = ap[..n].to_vec();
+        let mut ai = alloc::vec![0i32; nnz];
+        let mut perm = alloc::vec![0u32; nnz];
+        for c in 0..n {
+            for k in colptr[c] as usize..colptr[c + 1] as usize {
+                let slot = &mut fill[rowidx[k] as usize];
+                ai[*slot as usize] = c as i32;
+                perm[*slot as usize] = k as u32;
+                *slot += 1;
+            }
+        }
+        Some(Transposed { ap, ai, perm, ax: alloc::vec![0.0f64; nnz] })
+    }
+
+    fn gather(&mut self, values: *const f64) {
+        let src = unsafe { core::slice::from_raw_parts(values, self.perm.len()) };
+        for (dst, &k) in self.ax.iter_mut().zip(&self.perm) {
+            *dst = src[k as usize];
+        }
+    }
+}
+
 #[cfg(sundials)]
 pub(crate) mod klu {
-    use alloc::vec::Vec;
     use core::ffi::c_void;
 
     /// `klu_common` of the `SUNDIALS_INDEX_SIZE=32` build (`Int` = `int`), mirrored
@@ -131,12 +174,7 @@ pub(crate) mod klu {
         common: Common,
         symbolic: *mut c_void,
         numeric: *mut c_void,
-        /// CSC of `Aᵀ` (= CSR of `A`).
-        ap: Vec<i32>,
-        ai: Vec<i32>,
-        /// Where each `ap`/`ai` entry reads from in the caller's CSC-of-`A` values.
-        perm: Vec<u32>,
-        axt: Vec<f64>,
+        t: super::Transposed,
     }
 
     /// Below this reciprocal pivot growth the reused pivots are no longer good
@@ -146,36 +184,14 @@ pub(crate) mod klu {
     impl Solver {
         /// `colptr`/`rowidx` are the caller's CSC of `A`; the transpose is built here.
         pub fn new(n: usize, colptr: &[i32], rowidx: &[i32]) -> Option<Solver> {
-            let nnz = *colptr.get(n)? as usize;
-            let mut ap = alloc::vec![0i32; n + 1];
-            for &r in &rowidx[..nnz] {
-                ap[r as usize + 1] += 1;
-            }
-            for r in 0..n {
-                ap[r + 1] += ap[r];
-            }
-            let mut fill: Vec<i32> = ap[..n].to_vec();
-            let mut ai = alloc::vec![0i32; nnz];
-            let mut perm = alloc::vec![0u32; nnz];
-            for c in 0..n {
-                for k in colptr[c] as usize..colptr[c + 1] as usize {
-                    let slot = &mut fill[rowidx[k] as usize];
-                    ai[*slot as usize] = c as i32;
-                    perm[*slot as usize] = k as u32;
-                    *slot += 1;
-                }
-            }
             let mut s = Solver {
                 common: Common::defaults()?,
                 symbolic: core::ptr::null_mut(),
                 numeric: core::ptr::null_mut(),
-                ap,
-                ai,
-                perm,
-                axt: alloc::vec![0.0f64; nnz],
+                t: super::Transposed::new(n, colptr, rowidx)?,
             };
             s.symbolic = unsafe {
-                klu_analyze(n as i32, s.ap.as_mut_ptr(), s.ai.as_mut_ptr(), &mut s.common)
+                klu_analyze(n as i32, s.t.ap.as_mut_ptr(), s.t.ai.as_mut_ptr(), &mut s.common)
             };
             (!s.symbolic.is_null()).then_some(s)
         }
@@ -183,12 +199,9 @@ pub(crate) mod klu {
         /// Factorize with `values` (the caller's CSC-of-`A` order) and solve
         /// `A x = b` in place. `false` if the matrix is singular or a KLU call failed.
         pub fn solve(&mut self, values: *const f64, b: *mut f64, n: usize) -> bool {
-            let src = unsafe { core::slice::from_raw_parts(values, self.perm.len()) };
-            for (dst, &k) in self.axt.iter_mut().zip(&self.perm) {
-                *dst = src[k as usize];
-            }
-            let ax = self.axt.as_mut_ptr();
-            let (ap, ai) = (self.ap.as_mut_ptr(), self.ai.as_mut_ptr());
+            self.t.gather(values);
+            let ax = self.t.ax.as_mut_ptr();
+            let (ap, ai) = (self.t.ap.as_mut_ptr(), self.t.ai.as_mut_ptr());
             if !self.numeric.is_null() {
                 let ok = unsafe {
                     klu_refactor(ap, ai, ax, self.symbolic, self.numeric, &mut self.common) != 0
@@ -222,10 +235,137 @@ pub(crate) mod klu {
 }
 
 #[cfg(sundials)]
+pub(crate) mod umfpack {
+    use alloc::vec::Vec;
+    use core::ffi::c_void;
+
+    const CONTROL: usize = 20;
+    const INFO: usize = 90;
+    const PIVOT_TOLERANCE: usize = 3;
+    const STRATEGY: usize = 5;
+    const IRSTEP: usize = 7;
+    const SCALE: usize = 16;
+    /// `A.'x = b`; the stored matrix is `Aᵀ`, so this solves `A x = b`.
+    const SYS_AAT: i32 = 2;
+    const OK: i32 = 0;
+    pub const WARNING_SINGULAR_MATRIX: i32 = 1;
+
+    unsafe extern "C" {
+        fn umfpack_di_defaults(control: *mut f64);
+        fn umfpack_di_symbolic(
+            n_row: i32, n_col: i32, ap: *const i32, ai: *const i32, ax: *const f64,
+            symbolic: *mut *mut c_void, control: *const f64, info: *mut f64,
+        ) -> i32;
+        fn umfpack_di_numeric(
+            ap: *const i32, ai: *const i32, ax: *const f64, symbolic: *mut c_void,
+            numeric: *mut *mut c_void, control: *const f64, info: *mut f64,
+        ) -> i32;
+        fn umfpack_di_wsolve(
+            sys: i32, ap: *const i32, ai: *const i32, ax: *const f64, x: *mut f64, b: *const f64,
+            numeric: *mut c_void, control: *const f64, info: *mut f64, wi: *mut i32, w: *mut f64,
+        ) -> i32;
+        fn umfpack_di_free_symbolic(symbolic: *mut *mut c_void);
+        fn umfpack_di_free_numeric(numeric: *mut *mut c_void);
+    }
+
+    /// C's `DATA_UMFPACK` (`linearSolverUmfpack.c`): pre-ordering on the first
+    /// solve (C's `numberSolving == 0`), refactorized on every solve.
+    pub struct Solver {
+        symbolic: *mut c_void,
+        numeric: *mut c_void,
+        control: [f64; CONTROL],
+        info: [f64; INFO],
+        t: super::Transposed,
+        /// `umfpack_di_wsolve`'s workspaces and its separate solution vector.
+        wi: Vec<i32>,
+        w: Vec<f64>,
+        x: Vec<f64>,
+    }
+
+    impl Solver {
+        /// `colptr`/`rowidx` are the caller's CSC of `A`; the transpose is built here.
+        pub fn new(n: usize, colptr: &[i32], rowidx: &[i32]) -> Option<Solver> {
+            let mut control = [0.0f64; CONTROL];
+            unsafe { umfpack_di_defaults(control.as_mut_ptr()) };
+            // C's `allocateUmfPackData`. The first three restate UMFPACK's own
+            // defaults; `STRATEGY` is out of range (0/1/3), read back as auto.
+            control[PIVOT_TOLERANCE] = 0.1;
+            control[IRSTEP] = 2.0;
+            control[SCALE] = 1.0;
+            control[STRATEGY] = 5.0;
+            Some(Solver {
+                symbolic: core::ptr::null_mut(),
+                numeric: core::ptr::null_mut(),
+                control,
+                info: [0.0f64; INFO],
+                t: super::Transposed::new(n, colptr, rowidx)?,
+                wi: alloc::vec![0i32; n],
+                w: alloc::vec![0.0f64; 5 * n],
+                x: alloc::vec![0.0f64; n],
+            })
+        }
+
+        /// Factorize with `values` (the caller's CSC-of-`A` order) and solve
+        /// `A x = b` in place, returning UMFPACK's status.
+        pub fn solve(&mut self, values: *const f64, b: *mut f64, n: usize) -> i32 {
+            self.t.gather(values);
+            let (ap, ai, ax) = (self.t.ap.as_ptr(), self.t.ai.as_ptr(), self.t.ax.as_ptr());
+            let mut status = OK;
+            if self.symbolic.is_null() {
+                status = unsafe {
+                    umfpack_di_symbolic(
+                        n as i32, n as i32, ap, ai, ax,
+                        &mut self.symbolic, self.control.as_ptr(), self.info.as_mut_ptr(),
+                    )
+                };
+            }
+            if !self.numeric.is_null() {
+                unsafe { umfpack_di_free_numeric(&mut self.numeric) };
+            }
+            if status == OK {
+                status = unsafe {
+                    umfpack_di_numeric(
+                        ap, ai, ax, self.symbolic, &mut self.numeric,
+                        self.control.as_ptr(), self.info.as_mut_ptr(),
+                    )
+                };
+            }
+            if status == OK {
+                status = unsafe {
+                    umfpack_di_wsolve(
+                        SYS_AAT, ap, ai, ax, self.x.as_mut_ptr(), b, self.numeric,
+                        self.control.as_ptr(), self.info.as_mut_ptr(),
+                        self.wi.as_mut_ptr(), self.w.as_mut_ptr(),
+                    )
+                };
+            }
+            if status == OK {
+                unsafe { core::ptr::copy_nonoverlapping(self.x.as_ptr(), b, n) };
+            }
+            status
+        }
+    }
+
+    impl Drop for Solver {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.numeric.is_null() {
+                    umfpack_di_free_numeric(&mut self.numeric);
+                }
+                umfpack_di_free_symbolic(&mut self.symbolic);
+            }
+        }
+    }
+}
+
+#[cfg(sundials)]
 std::thread_local! {
     /// One [`klu::Solver`] per system `handle`, so the symbolic analysis is done
     /// once per run as it is in C.
     static KLU_CACHE: core::cell::RefCell<std::collections::HashMap<u32, klu::Solver>> =
+        core::cell::RefCell::new(std::collections::HashMap::new());
+    /// The same for [`umfpack::Solver`].
+    static UMFPACK_CACHE: core::cell::RefCell<std::collections::HashMap<u32, umfpack::Solver>> =
         core::cell::RefCell::new(std::collections::HashMap::new());
 }
 
@@ -234,6 +374,7 @@ pub(crate) fn reset_caches() {
     #[cfg(sundials)]
     {
         KLU_CACHE.with(|c| c.borrow_mut().clear());
+        UMFPACK_CACHE.with(|c| c.borrow_mut().clear());
         KIN_CACHE.with(|c| c.borrow_mut().clear());
     }
 }
@@ -259,12 +400,30 @@ pub(crate) fn klu_solve_cached(handle: u32, colptr: u32, rowidx: u32, values: u3
     })
 }
 
-/// KLU solve of a dense column-major `A` (`n*n` f64 at `a_ptr`): scan the
-/// structural nonzeros into CSC and factorize from scratch, there being no system
-/// handle to cache under. 0 solved, 1 singular.
+/// UMFPACK solve of the CSC system `A x = b` (`b ← x`), reusing `handle`'s
+/// pre-ordering. 0 solved, 1 not.
 #[cfg(sundials)]
-pub(crate) fn klu_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
-    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+pub(crate) fn umfpack_solve_cached(handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: usize, nnz: usize) -> i32 {
+    UMFPACK_CACHE.with(|cell| {
+        let mut cache = cell.borrow_mut();
+        let entry = match cache.entry(handle) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                let colp = unsafe { core::slice::from_raw_parts(colptr as *const i32, n + 1) };
+                let rowi = unsafe { core::slice::from_raw_parts(rowidx as *const i32, nnz) };
+                match umfpack::Solver::new(n, colp, rowi) {
+                    Some(s) => slot.insert(s),
+                    None => return 1,
+                }
+            }
+        };
+        (entry.solve(values as *const f64, b_ptr as *mut f64, n) != 0) as i32
+    })
+}
+
+/// A dense column-major `A` as CSC of its structural nonzeros.
+#[cfg(sundials)]
+fn csc_from_dense(a: &[f64], n: usize) -> (alloc::vec::Vec<i32>, alloc::vec::Vec<i32>, alloc::vec::Vec<f64>) {
     let mut colptr = alloc::vec::Vec::with_capacity(n + 1);
     let mut rowidx = alloc::vec::Vec::new();
     let mut values = alloc::vec::Vec::new();
@@ -279,9 +438,34 @@ pub(crate) fn klu_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
         }
         colptr.push(rowidx.len() as i32);
     }
+    (colptr, rowidx, values)
+}
+
+/// KLU solve of a dense column-major `A` (`n*n` f64 at `a_ptr`): scan the
+/// structural nonzeros into CSC and factorize from scratch, there being no system
+/// handle to cache under. 0 solved, 1 singular.
+#[cfg(sundials)]
+pub(crate) fn klu_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
+    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+    let (colptr, rowidx, values) = csc_from_dense(a, n);
     match klu::Solver::new(n, &colptr, &rowidx) {
         Some(mut s) => !s.solve(values.as_ptr(), b_ptr as *mut f64, n) as i32,
         None => 1,
+    }
+}
+
+/// [`klu_solve_dense`] with UMFPACK. A singular matrix (1) reports separately
+/// from an outright failure (2), so the caller can retry with total pivoting as
+/// C's `solveUmfPack` retries with its own rank-deficient back-substitution.
+#[cfg(sundials)]
+pub(crate) fn umfpack_solve_dense(a_ptr: u32, b_ptr: u32, n: usize) -> i32 {
+    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+    let (colptr, rowidx, values) = csc_from_dense(a, n);
+    let Some(mut s) = umfpack::Solver::new(n, &colptr, &rowidx) else { return 2 };
+    match s.solve(values.as_ptr(), b_ptr as *mut f64, n) {
+        0 => 0,
+        umfpack::WARNING_SINGULAR_MATRIX => 1,
+        _ => 2,
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -65,6 +65,7 @@ pub enum Ls {
     Lapack = 2,
     TotalPivot = 3,
     Klu = 4,
+    Umfpack = 5,
 }
 
 /// `-lss`. `Rsparse` is wasm-jit's own solver, not a C runtime value.
@@ -74,6 +75,7 @@ pub enum Lss {
     Default = 1,
     Klu = 2,
     Rsparse = 3,
+    Umfpack = 4,
 }
 
 /// `-idaLS`, the linear solver IDA's Newton iteration uses.
@@ -322,14 +324,15 @@ pub struct Capabilities {
 
 /// Reject flag values this runtime cannot honour.
 pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
+    // KLU and UMFPACK ride on the same SuiteSparse archives.
     if !cap.klu {
-        for (flag, requested) in [
-            ("lss", f.lss == Some(Lss::Klu)),
-            ("ls", f.ls == Some(Ls::Klu)),
-            ("nlsLS", f.nls_ls == Some(NlsLs::Klu)),
+        for (flag, name) in [
+            ("lss", (f.lss == Some(Lss::Klu)).then_some("klu").or((f.lss == Some(Lss::Umfpack)).then_some("umfpack"))),
+            ("ls", (f.ls == Some(Ls::Klu)).then_some("klu").or((f.ls == Some(Ls::Umfpack)).then_some("umfpack"))),
+            ("nlsLS", (f.nls_ls == Some(NlsLs::Klu)).then_some("klu")),
         ] {
-            if requested {
-                return Err(format!("-{flag}=klu: this runtime has no KLU linear solver"));
+            if let Some(name) = name {
+                return Err(format!("-{flag}={name}: this runtime has no SuiteSparse linear solver"));
             }
         }
     }
@@ -1093,6 +1096,7 @@ const LS_VALUES: &[Value<Ls>] = &[
     ("lapack", Ls::Lapack, Offer::Always),
     ("totalpivot", Ls::TotalPivot, Offer::Always),
     ("klu", Ls::Klu, Offer::WithSundials),
+    ("umfpack", Ls::Umfpack, Offer::WithSundials),
 ];
 
 /// `-lss`
@@ -1100,6 +1104,7 @@ const LSS_VALUES: &[Value<Lss>] = &[
     ("default", Lss::Default, Offer::Never),
     ("rsparse", Lss::Rsparse, Offer::Always),
     ("klu", Lss::Klu, Offer::WithSundials),
+    ("umfpack", Lss::Umfpack, Offer::WithSundials),
 ];
 
 /// `-idaLS`. All five reach a SUNLinearSolver; the whole entry rides on `cap.ida`.
@@ -1252,7 +1257,9 @@ mod tests {
 
     #[test]
     fn unavailable_solvers_are_rejected_with_the_flag_named() {
-        for (arg, needle) in [("-lss=klu", "KLU"), ("-ls=klu", "KLU"), ("-nlsLS=klu", "KLU"),
+        for (arg, needle) in [("-lss=klu", "-lss=klu"), ("-ls=klu", "-ls=klu"),
+                              ("-nlsLS=klu", "-nlsLS=klu"), ("-lss=umfpack", "-lss=umfpack"),
+                              ("-ls=umfpack", "-ls=umfpack"),
                               ("-s=ida", "dassl"), ("-s=cvode", "dassl")] {
             let f = parse(&argv(&[arg])).expect("parses");
             let e = check(&f, NOTHING).expect_err("must reject");
@@ -1290,9 +1297,10 @@ mod tests {
                 }
             }
         }
-        // KLU and KINSOL come from the archives, so neither shows up above.
-        assert!(!supported(NOTHING).iter().any(|(_, v)| v.contains(&"klu")));
-        assert!(!supported(NOTHING).iter().any(|(_, v)| v.contains(&"kinsol")));
+        // KLU, UMFPACK and KINSOL come from the archives, so none shows up above.
+        for v in ["klu", "umfpack", "kinsol"] {
+            assert!(!supported(NOTHING).iter().any(|(_, vals)| vals.contains(&v)));
+        }
     }
 
     /// The other direction: a value [`check`] rejects must not be offered.
@@ -1329,6 +1337,8 @@ mod tests {
         let f = parse(&argv(&["-nls=kinsol", "-nlsLS=totalpivot", "-ls=klu", "-lss=rsparse"]))
             .expect("parses");
         assert_eq!(f.solver_codes(), (2, 2, 4, 3));
+        let f = parse(&argv(&["-ls=umfpack", "-lss=umfpack"])).expect("parses");
+        assert_eq!(f.solver_codes(), (0, 0, 5, 4));
     }
 
     #[test]

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -367,7 +367,8 @@ int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData, double* aux_x)
 
   int unz = solverData->info[UMFPACK_UNZ];
 
-  Up = (int*) malloc((solverData->n_row + 1) * sizeof(int));
+  /* umfpack_di_get_numeric writes Up[n_col+1], Ui[unz] and Ux[unz] */
+  Up = (int*) malloc((solverData->n_col + 1) * sizeof(int));
   Ui = (int*) malloc(unz * sizeof(int));
   Ux = (double*) malloc(unz * sizeof(double));
 
@@ -441,23 +442,23 @@ int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData, double* aux_x)
     else
     {
       infoStreamPrint(OMC_LOG_LS_V, 0, "error: system is not solvable*");
-      /* free all used memory */
-      free(Up);
-      free(Ui);
-      free(Ux);
-
-      free(Q);
-      free(Rs);
-
-      free(b);
-      free(y);
-      free(z);
-      return -1;
+      success = -1;
+      goto cleanup;
     }
   }
 
   current_rank = rank;
-  current_unz = unz;
+  /* U is column-stored, so column j owns Ui/Ux[Up[j] .. Up[j+1]-1] and its last
+   * entry is the diagonal; current_unz is that entry's index, as every use below
+   * assumes. unz is one past the end of the whole array. */
+  if (Up[current_rank + 1] <= Up[current_rank])
+  {
+    /* no pivot in this column - nothing to back-substitute with */
+    infoStreamPrint(OMC_LOG_LS_V, 0, "error: system is not solvable*");
+    success = -1;
+    goto cleanup;
+  }
+  current_unz = Up[current_rank + 1] - 1;
 
   while ((stop == 0) && (current_rank > 1))
   {
@@ -493,18 +494,8 @@ int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData, double* aux_x)
         else
         {
           infoStreamPrint(OMC_LOG_LS_V, 0, "error: system is not solvable");
-          /* free all used memory */
-          free(Up);
-          free(Ui);
-          free(Ux);
-
-          free(Q);
-          free(Rs);
-
-          free(b);
-          free(y);
-          free(z);
-          return -1;
+          success = -1;
+          goto cleanup;
         }
 
         current_rank--;
@@ -523,9 +514,16 @@ int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData, double* aux_x)
   {
     /* get diagonal element r_ii, j shows where the element is in vector Ux, Ui */
     j = Up[i];
-    while (Ui[j] != i)
+    while ((j < Up[i + 1]) && (Ui[j] != i))
     {
       j++;
+    }
+    if (j >= Up[i + 1])
+    {
+      /* a singular U can miss a diagonal; searching on would run off Ui */
+      infoStreamPrint(OMC_LOG_LS_V, 0, "error: system is not solvable*");
+      success = -1;
+      goto cleanup;
     }
     r_ii = Ux[j];
     sum = 0.0;
@@ -548,6 +546,7 @@ int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData, double* aux_x)
     aux_x[Q[i]] = z[i];
   }
 
+cleanup:
   /* free all used memory */
   free(Up);
   free(Ui);

--- a/testsuite/simulation/modelica/linear_system/NPendulum.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum.mos
@@ -1,7 +1,7 @@
 // name:      NPendulum10
 // keywords:  arrays
 // status:    correct
-// teardown_command: rm -f simcall_*.log NPendulum.pendulum*
+// teardown_command: rm -f NPendulum.pendulum*
 // cflags: -d=-newInst
 //
 // Simulate NPendulum with N=10 with different linear solvers
@@ -15,22 +15,19 @@ getErrorString();
 setCommandLineOptions("--maxSizeLinearTearing=4000"); getErrorString();
 buildModel(NPendulum.pendulum); getErrorString();
 
-system(realpath(".") + "/NPendulum.pendulum -ls totalpivot", "simcall_totalpivot.log");
-readFile("simcall_totalpivot.log"); remove("simcall_totalpivot.log");
+simulate(NPendulum.pendulum, simflags="-ls totalpivot", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.0001,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls lapack", "simcall_lapack.log");
-readFile("simcall_lapack.log"); remove("simcall_lapack.log");
+simulate(NPendulum.pendulum, simflags="-ls lapack", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.0001,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls umfpack", "simcall_umfpack.log");
-readFile("simcall_umfpack.log"); remove("simcall_umfpack.log");
+simulate(NPendulum.pendulum, simflags="-ls umfpack", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.0001,
@@ -38,16 +35,14 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 
 /*
 Lis solver doesn't work here
-system(realpath(".") + "/NPendulum.pendulum -ls lis", "simcall_lis.log");
-readFile("simcall_lis.log"); remove("simcall_lis.log");
+simulate(NPendulum.pendulum, simflags="-ls lis", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.0001,
   {"phi[10]"});
 */
 
-system(realpath(".") + "/NPendulum.pendulum -ls klu", "simcall_klu.log");
-readFile("simcall_klu.log"); remove("simcall_klu.log");
+simulate(NPendulum.pendulum, simflags="-ls klu", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.0001,
@@ -57,22 +52,19 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 setCommandLineOptions("--maxSizeLinearTearing=0"); getErrorString();
 buildModel(NPendulum.pendulum); getErrorString();
 
-system(realpath(".") + "/NPendulum.pendulum -ls totalpivot ", "simcall_totalpivot.log");
-readFile("simcall_totalpivot.log"); remove("simcall_totalpivot.log");
+simulate(NPendulum.pendulum, simflags="-ls totalpivot", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls lapack ", "simcall_lapack.log");
-readFile("simcall_lapack.log"); remove("simcall_lapack.log");
+simulate(NPendulum.pendulum, simflags="-ls lapack", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
   {"phi[10]"});
 
-system(realpath(".") + "/NPendulum.pendulum -ls umfpack ", "simcall_umfpack.log");
-readFile("simcall_umfpack.log"); remove("simcall_umfpack.log");
+simulate(NPendulum.pendulum, simflags="-ls umfpack", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
@@ -80,16 +72,14 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 
 /*
 Lis solver doesn't work here
-system(realpath(".") + "/NPendulum.pendulum -ls lis", "simcall_lis.log");
-readFile("simcall_lis.log"); remove("simcall_lis.log");
+simulate(NPendulum.pendulum, simflags="-ls lis", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
   {"phi[10]"});
 */
 
-system(realpath(".") + "/NPendulum.pendulum -ls klu ", "simcall_klu.log");
-readFile("simcall_klu.log"); remove("simcall_klu.log");
+simulate(NPendulum.pendulum, simflags="-ls klu", resimulateExecutable="NPendulum.pendulum");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_10.mat",
   "NPendulum_diff.csv",0.01,0.01,
@@ -106,57 +96,73 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 // ""
 // {"NPendulum.pendulum", "NPendulum.pendulum_init.xml"}
 // ""
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls totalpivot'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lapack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls umfpack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls klu'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
 // true
 // "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.
 // "
 // {"NPendulum.pendulum", "NPendulum.pendulum_init.xml"}
 // ""
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls totalpivot'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lapack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls umfpack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
-// 0
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls klu'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
 // {"Files Equal!"}
 // endResult

--- a/testsuite/simulation/modelica/linear_system/NPendulum40.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum40.mos
@@ -1,6 +1,7 @@
 // name:      NPendulum40
 // keywords:  arrays
 // status:    correct
+// teardown_command: rm -f NPendulum.pendulum40*
 // cflags: -d=-newInst
 //
 
@@ -10,12 +11,12 @@ getErrorString();
 setCommandLineOptions("--maxSizeLinearTearing=0");
 setCommandLineOptions("--generateDynamicJacobian=symbolic");
 buildModel(NPendulum.pendulum40); getErrorString();
-system("./NPendulum.pendulum40 -ls umfpack -lssMinSize=4000 -jacobian=coloredSymbolical");
+simulate(NPendulum.pendulum40, simflags="-ls umfpack -lssMinSize=4000 -jacobian=coloredSymbolical", resimulateExecutable="NPendulum.pendulum40");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_40.mat",
   "NPendulum_diff.csv",0.01,0.0001,
   {"pendel.phi[40]"});
-system("./NPendulum.pendulum40 -ls klu -lssMinSize=4000 -jacobian=coloredSymbolical");
+simulate(NPendulum.pendulum40, simflags="-ls klu -lssMinSize=4000 -jacobian=coloredSymbolical", resimulateExecutable="NPendulum.pendulum40");
 res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/linear_system/NPendulum_40.mat",
   "NPendulum_diff.csv",0.01,0.0001,
@@ -31,16 +32,24 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res
 // true
 // {"NPendulum.pendulum40", "NPendulum.pendulum40_init.xml"}
 // ""
-// LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum40_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum40', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls umfpack -lssMinSize=4000 -jacobian=coloredSymbolical'",
+//     messages = "LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
 // |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // {"Files Equal!"}
-// LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
+// record SimulationResult
+//     resultFile = "NPendulum.pendulum40_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NPendulum.pendulum40', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls klu -lssMinSize=4000 -jacobian=coloredSymbolical'",
+//     messages = "LOG_STDOUT        | warning | The flags -lssMaxDensity, -lssMinSize, -nlssMaxDensity and -nlssMinSize are
 // |                 | |       | deprecated and ignored: the compiler chooses dense or sparse per system.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // {"Files Equal!"}
 // endResult


### PR DESCRIPTION
Three things stood between these two tests and the wasm-jit target.

`-ls umfpack` / `-lss umfpack` did not exist. They now run the real SuiteSparse UMFPACK, cross-compiled to wasm32-wasip1 next to KLU. There is no BLAS for wasm, so it uses UMFPACK's own `NBLAS` path; `SuiteSparseBLAS.cmake` is satisfied with an empty `BLAS_LIBRARIES` and `BLA_VENDOR=Generic`. The wrapper mirrors `linearSolverUmfpack.c`: pre-ordering on the first solve, refactorized on every solve, and `umfpack_di_wsolve(UMFPACK_Aat, ...)` over the CSC of A^T that KLU already builds (now a shared helper). A singular matrix falls back to the runtime's total-pivot search.

`emit_linz_jac_body` unrolled the column equations once per seed column. For NPendulum.pendulum40 (80 states) that meant a 26 MB `linearJacA` in a 31 MB module, past wasmtime's per-function body limit of 7654321 bytes, so the module would not even parse. The column body now sits in a wasm loop over scratch offset tables, as `emit_nls_jac_csc_body` already did: 331 KB in a 4.5 MB module.

Both tests drove the model with `buildModel` followed by `system("./model -ls ...")`, which has no executable to run under wasm-jit; they now use `simulate(..., resimulateExecutable=...)`.

Reading the C solver alongside turned up three out-of-bounds reads in its own `solveSingularSystem`, fixed here too:

* `current_unz` is used throughout as the index of the last (diagonal) entry of column `current_rank`, but it was seeded with `unz`, one past the end of `Ui`/`Ux`. The first loop iteration read both arrays out of bounds, as did the back-substitution seed below it, since the loop always exits at once. It is now `Up[rank+1]-1`, with a guard for an empty column.
* the diagonal search `while (Ui[j] != i) j++;` walks off `Ui` when a column of a singular U carries no entry on its own row, which is exactly the case this routine is for. It is now bounded by `Up[i+1]`.
* `umfpack_di_get_numeric` documents `Up[n_col+1]`; only `n_row+1` was allocated. Equal for the square systems OMC builds, but wrong.

The two duplicated free-and-return blocks became a `cleanup` label, so the two new error exits do not add a third and fourth copy. The routine still returns a vector that does not solve the system while reporting success; that is a separate defect, not addressed here.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
