### PR TITLE
wasm-jit: reductions over array iterators

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -4738,10 +4738,163 @@ fn emit_range_count(
     Ok(cnt)
 }
 
-/// Emit nested `for` loops over the given Integer-range iterators (the first is
-/// the outermost), running `body` at the innermost point. Each iterator's
-/// optional `guardExp` wraps the inner work in an `if`, so a filtered-out
-/// combination is skipped. Relative branch depths make the nesting compose.
+/// Run `body` once per iteration of a reduction's iterators: over their
+/// cartesian product (`COMBINE`, first iterator outermost) or with every
+/// iterator advancing together (`THREAD`).
+fn emit_red_iteration(
+    ctx: &mut FnCtx,
+    thread: bool,
+    iters: &[&Arc<DAE::ReductionIterator>],
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    if thread && iters.len() > 1 {
+        emit_red_thread(ctx, iters, body)
+    } else {
+        emit_red_nest(ctx, iters, body)
+    }
+}
+
+/// `f(u, v)` vectorized over two unknown dimensions becomes
+/// `array(f(x, y) thread for x in u, y in v)`.
+fn red_is_thread(info: &DAE::ReductionInfo) -> bool {
+    matches!(info.iterType, Absyn::ReductionIterType::THREAD)
+}
+
+const THREAD_LEN: &str = "thread reduction over iterators of different lengths";
+
+/// One pass advances every iterator once. C's `endLoop` odometer throws when
+/// only some can advance, so unequal lengths are a runtime error — checked up
+/// front here, which leaves one counter to drive them all.
+fn emit_red_thread(
+    ctx: &mut FnCtx,
+    iters: &[&Arc<DAE::ReductionIterator>],
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let mut binds = Vec::with_capacity(iters.len());
+    for iter in iters {
+        binds.push(bind_thread_iter(ctx, iter)?);
+    }
+    let n = binds[0].count();
+    for b in &binds[1..] {
+        ctx.emit(I::LocalGet(n));
+        ctx.emit(I::LocalGet(b.count()));
+        ctx.emit(I::I32Ne);
+        ctx.emit(I::If(we::BlockType::Empty));
+        emit_runtime_error(ctx, THREAD_LEN)?;
+        ctx.emit(I::End);
+    }
+    let k = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(k));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(k));
+    ctx.emit(I::LocalGet(n));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    for b in &binds {
+        if let ThreadIter::Array { arr, it, elem, .. } = b {
+            ctx.emit(I::LocalGet(*arr));
+            ctx.emit(I::LocalGet(k));
+            ctx.emit(I::I32Const(1));
+            ctx.emit(I::I32Add);
+            emit_elem_ptr(ctx, elem)?;
+            elem_load(ctx, elem);
+            ctx.emit(I::LocalSet(*it));
+        }
+    }
+    emit_red_thread_guarded(ctx, iters, body)?;
+    for b in &binds {
+        if let ThreadIter::Range { it, step_l, .. } = b {
+            ctx.emit(I::LocalGet(*it));
+            ctx.emit(I::LocalGet(*step_l));
+            ctx.emit(I::I32Add);
+            ctx.emit(I::LocalSet(*it));
+        }
+    }
+    ctx.emit(I::LocalGet(k));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(k));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End); // loop
+    ctx.emit(I::End); // block
+    for b in &binds {
+        if let ThreadIter::Array { arr, .. } = b {
+            release_temp_array(ctx, *arr)?;
+        }
+    }
+    Ok(())
+}
+
+/// Loop state for one iterator of a [`emit_red_thread`] pass.
+enum ThreadIter {
+    Range { it: u32, step_l: u32, count: u32 },
+    Array { arr: u32, it: u32, elem: SigTy, count: u32 },
+}
+
+impl ThreadIter {
+    fn count(&self) -> u32 {
+        match self {
+            ThreadIter::Range { count, .. } | ThreadIter::Array { count, .. } => *count,
+        }
+    }
+}
+
+/// Bind one `THREAD` iterator ahead of the loop: its iterator local and length.
+fn bind_thread_iter(ctx: &mut FnCtx, iter: &Arc<DAE::ReductionIterator>) -> Result<ThreadIter> {
+    use we::Instruction as I;
+    if let DAE::Exp::RANGE { start, step, stop, .. } = &*iter.exp {
+        let (it, step_l, stop_l) = emit_range_iter(ctx, &iter.id, start, step, stop)?;
+        // `it` still holds `start`.
+        let count = emit_range_count_locals(ctx, it, step_l, stop_l);
+        return Ok(ThreadIter::Range { it, step_l, count });
+    }
+    let elem = red_iter_elem_sigty(iter)?;
+    if compile_exp(ctx, &iter.exp)? != WTy::I32 {
+        return Err("CodegenWasmJit: reduction over a non-array, non-range iterator not supported");
+    }
+    let arr = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalSet(arr));
+    let count = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalGet(arr));
+    ctx.emit(I::Call(rt_index("rt_array_total")?));
+    ctx.emit(I::LocalSet(count));
+    let it = ctx.alloc_temp(elem.wty());
+    ctx.locals.insert(iter.id.to_string(), (it, elem.clone()));
+    if elem.is_heap() {
+        ctx.borrowed_locals.push(it);
+    }
+    Ok(ThreadIter::Array { arr, it, elem, count })
+}
+
+/// The `THREAD` body, run under every iterator's `guardExp`.
+fn emit_red_thread_guarded(
+    ctx: &mut FnCtx,
+    iters: &[&Arc<DAE::ReductionIterator>],
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    let Some((iter, rest)) = iters.split_first() else {
+        return body(ctx);
+    };
+    match &iter.guardExp {
+        Some(guard) => {
+            let w = compile_exp(ctx, guard)?;
+            coerce(ctx, w, WTy::I32);
+            ctx.emit(we::Instruction::If(we::BlockType::Empty));
+            emit_red_thread_guarded(ctx, rest, body)?;
+            ctx.emit(we::Instruction::End);
+            Ok(())
+        }
+        None => emit_red_thread_guarded(ctx, rest, body),
+    }
+}
+
+/// Emit nested `for` loops over the given iterators (the first is the
+/// outermost), running `body` at the innermost point. An iterator is either an
+/// Integer range or an array expression (`for x in v`, C's non-`RANGE` arm of
+/// `daeExpReduction`). Relative branch depths make the nesting compose.
 fn emit_red_nest(
     ctx: &mut FnCtx,
     iters: &[&Arc<DAE::ReductionIterator>],
@@ -4751,23 +4904,14 @@ fn emit_red_nest(
         return body(ctx);
     };
     let DAE::Exp::RANGE { start, step, stop, .. } = &*iter.exp else {
-        return Err("CodegenWasmJit: reduction over a non-range iterator not supported");
+        return emit_red_nest_array(ctx, iter, rest, body);
     };
     let (it, step_l, stop_l) = emit_range_iter(ctx, &iter.id, start, step, stop)?;
     ctx.emit(we::Instruction::Block(we::BlockType::Empty));
     ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
     emit_range_done(ctx, step, it, step_l, stop_l);
     ctx.emit(we::Instruction::BrIf(1));
-    match &iter.guardExp {
-        Some(guard) => {
-            let w = compile_exp(ctx, guard)?;
-            coerce(ctx, w, WTy::I32);
-            ctx.emit(we::Instruction::If(we::BlockType::Empty));
-            emit_red_nest(ctx, rest, &mut *body)?;
-            ctx.emit(we::Instruction::End);
-        }
-        None => emit_red_nest(ctx, rest, &mut *body)?,
-    }
+    emit_red_guarded(ctx, iter, rest, body)?;
     ctx.emit(we::Instruction::LocalGet(it));
     ctx.emit(we::Instruction::LocalGet(step_l));
     ctx.emit(we::Instruction::I32Add);
@@ -4778,7 +4922,132 @@ fn emit_red_nest(
     Ok(())
 }
 
-/// Lower an iterator reduction over Integer ranges. The folding forms
+/// One level of [`emit_red_nest`] for an iterator over an array expression:
+/// evaluate it once, then loop `k = 1..total` binding the iterator to `arr[k]`.
+/// As in [`compile_for_array`] the element is *borrowed*.
+fn emit_red_nest_array(
+    ctx: &mut FnCtx,
+    iter: &Arc<DAE::ReductionIterator>,
+    rest: &[&Arc<DAE::ReductionIterator>],
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    let elem = red_iter_elem_sigty(iter)?;
+    if compile_exp(ctx, &iter.exp)? != WTy::I32 {
+        return Err("CodegenWasmJit: reduction over a non-array, non-range iterator not supported");
+    }
+    let arr = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(arr));
+    let n = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalGet(arr));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_total")?));
+    ctx.emit(we::Instruction::LocalSet(n));
+    let k = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::LocalSet(k));
+    let it = ctx.alloc_temp(elem.wty());
+    ctx.locals.insert(iter.id.to_string(), (it, elem.clone()));
+    if elem.is_heap() {
+        ctx.borrowed_locals.push(it);
+    }
+
+    ctx.emit(we::Instruction::Block(we::BlockType::Empty));
+    ctx.emit(we::Instruction::Loop(we::BlockType::Empty));
+    ctx.emit(we::Instruction::LocalGet(k));
+    ctx.emit(we::Instruction::LocalGet(n));
+    ctx.emit(we::Instruction::I32GtS);
+    ctx.emit(we::Instruction::BrIf(1));
+    ctx.emit(we::Instruction::LocalGet(arr));
+    ctx.emit(we::Instruction::LocalGet(k));
+    emit_elem_ptr(ctx, &elem)?;
+    elem_load(ctx, &elem);
+    ctx.emit(we::Instruction::LocalSet(it));
+    emit_red_guarded(ctx, iter, rest, body)?;
+    ctx.emit(we::Instruction::LocalGet(k));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::I32Add);
+    ctx.emit(we::Instruction::LocalSet(k));
+    ctx.emit(we::Instruction::Br(0));
+    ctx.emit(we::Instruction::End); // loop
+    ctx.emit(we::Instruction::End); // block
+    release_temp_array(ctx, arr)
+}
+
+/// The inner levels of [`emit_red_nest`], run under this iterator's `guardExp`.
+fn emit_red_guarded(
+    ctx: &mut FnCtx,
+    iter: &Arc<DAE::ReductionIterator>,
+    rest: &[&Arc<DAE::ReductionIterator>],
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    match &iter.guardExp {
+        Some(guard) => {
+            let w = compile_exp(ctx, guard)?;
+            coerce(ctx, w, WTy::I32);
+            ctx.emit(we::Instruction::If(we::BlockType::Empty));
+            emit_red_nest(ctx, rest, body)?;
+            ctx.emit(we::Instruction::End);
+            Ok(())
+        }
+        None => emit_red_nest(ctx, rest, body),
+    }
+}
+
+/// The element type an array-expression iterator binds, from the iterable we
+/// load out of, falling back to the iterator's declared type. A matrix would
+/// bind a row, which C's flat `_get1` does not do either.
+fn red_iter_elem_sigty(iter: &DAE::ReductionIterator) -> Result<SigTy> {
+    match exp_sigty(&iter.exp) {
+        Ok(SigTy::Array { elem, rank: 1 }) => Ok((*elem).clone()),
+        Ok(SigTy::Array { .. }) => {
+            Err("CodegenWasmJit: reduction over a multi-dimensional array iterator not supported")
+        }
+        _ => sig_ty(&iter.ty),
+    }
+}
+
+/// `max(0, (stop - start)/step + 1)`, in a fresh local, from locals holding a
+/// range's start, step and stop.
+fn emit_range_count_locals(ctx: &mut FnCtx, start: u32, step_l: u32, stop_l: u32) -> u32 {
+    use we::Instruction as I;
+    let cnt = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalGet(stop_l));
+    ctx.emit(I::LocalGet(start));
+    ctx.emit(I::I32Sub);
+    ctx.emit(I::LocalGet(step_l));
+    ctx.emit(I::I32DivS);
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(cnt));
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalGet(cnt));
+    ctx.emit(I::LocalGet(cnt));
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::I32LtS);
+    ctx.emit(I::Select);
+    ctx.emit(I::LocalSet(cnt));
+    cnt
+}
+
+/// The element count of one comprehension iterator, in a fresh local: an Integer
+/// range's [`emit_range_count`], or the iterable array's element total.
+fn emit_red_iter_count(ctx: &mut FnCtx, iter: &DAE::ReductionIterator) -> Result<u32> {
+    if let DAE::Exp::RANGE { start, step, stop, .. } = &*iter.exp {
+        return emit_range_count(ctx, start, step, stop);
+    }
+    if compile_exp(ctx, &iter.exp)? != WTy::I32 {
+        return Err("CodegenWasmJit: array comprehension over a non-array, non-range iterator not supported");
+    }
+    let arr = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(arr));
+    let cnt = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalGet(arr));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_total")?));
+    ctx.emit(we::Instruction::LocalSet(cnt));
+    release_temp_array(ctx, arr)?;
+    Ok(cnt)
+}
+
+/// Lower an iterator reduction over Integer ranges or arrays. The folding forms
 /// `sum/product/min/max(expr for i in A, j in B, ...)` (`foldExp` present) build
 /// `acc = default; for i,j,... { acc = foldExp(acc, expr) }`, where `foldExp`
 /// reads the accumulator (`resultName`) and per-iteration value (`foldName`) as
@@ -4800,6 +5069,7 @@ fn compile_reduction(
     if iters.is_empty() {
         return Err("CodegenWasmJit: reduction with no iterators");
     }
+    let thread = red_is_thread(info);
 
     if let Some(fold) = &info.foldExp {
         // Folding reduction. `info.exprType` is the accumulator type.
@@ -4817,7 +5087,7 @@ fn compile_reduction(
         ctx.locals.insert(info.foldName.to_string(), (foldval, elem_sty.clone()));
         emit_value_const(ctx, default, elem_wty)?;
         ctx.emit(we::Instruction::LocalSet(acc));
-        emit_red_nest(ctx, &iters, &mut |ctx| {
+        emit_red_iteration(ctx, thread, &iters, &mut |ctx| {
             let w = compile_exp(ctx, expr)?;
             coerce(ctx, w, elem_wty);
             ctx.emit(we::Instruction::LocalSet(foldval));
@@ -4837,19 +5107,20 @@ fn compile_reduction(
     }
     let elem_sty = exp_sigty(expr)?;
     if let SigTy::Array { elem: base, rank: erank } = &elem_sty {
-        return compile_array_comprehension_flat(ctx, expr, &iters, base, *erank);
+        return compile_array_comprehension_flat(ctx, expr, thread, &iters, base, *erank);
     }
     let elem_wty = elem_sty.wty();
-    let n = iters.len() as u32;
 
-    // Per-iterator element counts (forward order).
+    // The result's dimensions: one per iterator (forward order), or one shared
+    // by iterators that advance together.
     let mut counts = Vec::with_capacity(iters.len());
     for it in &iters {
-        let DAE::Exp::RANGE { start, step, stop, .. } = &*it.exp else {
-            return Err("CodegenWasmJit: array comprehension over a non-range iterator not supported");
-        };
-        counts.push(emit_range_count(ctx, start, step, stop)?);
+        counts.push(emit_red_iter_count(ctx, it)?);
     }
+    if thread {
+        counts.truncate(1);
+    }
+    let n = counts.len() as u32;
     // total = product of the counts.
     let total = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::I32Const(1));
@@ -4882,7 +5153,7 @@ fn compile_reduction(
     ctx.emit(we::Instruction::LocalSet(idx));
     let rev: Vec<&Arc<DAE::ReductionIterator>> = iters.iter().rev().cloned().collect();
     let store_sty = elem_sty.clone();
-    emit_red_nest(ctx, &rev, &mut |ctx| {
+    emit_red_iteration(ctx, thread, &rev, &mut |ctx| {
         ctx.emit(we::Instruction::LocalGet(res));
         ctx.emit(we::Instruction::LocalGet(idx));
         ctx.emit(we::Instruction::I32Const(1));
@@ -4929,7 +5200,7 @@ fn compile_fold_heap(
         ctx.emit(I::I32Const(0));
         ctx.emit(I::LocalSet(l));
     }
-    emit_red_nest(ctx, iters, &mut |ctx| {
+    emit_red_iteration(ctx, red_is_thread(info), iters, &mut |ctx| {
         let nv = ctx.alloc_temp(WTy::I32);
         compile_exp(ctx, expr)?; // owned element
         ctx.emit(I::LocalSet(nv));
@@ -4983,19 +5254,20 @@ fn compile_fold_heap(
 fn compile_array_comprehension_flat(
     ctx: &mut FnCtx,
     expr: &DAE::Exp,
+    thread: bool,
     iters: &[&Arc<DAE::ReductionIterator>],
     base: &SigTy,
     erank: u32,
 ) -> Result<WTy> {
     use we::Instruction as I;
-    let n = iters.len() as u32;
     let mut counts = Vec::with_capacity(iters.len());
     for it in iters {
-        let DAE::Exp::RANGE { start, step, stop, .. } = &*it.exp else {
-            return Err("CodegenWasmJit: array comprehension over a non-range iterator not supported");
-        };
-        counts.push(emit_range_count(ctx, start, step, stop)?);
+        counts.push(emit_red_iter_count(ctx, it)?);
     }
+    if thread {
+        counts.truncate(1);
+    }
+    let n = counts.len() as u32;
     let outer = ctx.alloc_temp(WTy::I32);
     ctx.emit(I::I32Const(1));
     ctx.emit(I::LocalSet(outer));
@@ -5022,7 +5294,7 @@ fn compile_array_comprehension_flat(
         Ok(())
     };
     let rev: Vec<&Arc<DAE::ReductionIterator>> = iters.iter().rev().cloned().collect();
-    emit_red_nest(ctx, &rev, &mut |ctx| {
+    emit_red_iteration(ctx, thread, &rev, &mut |ctx| {
         let h = ctx.alloc_temp(WTy::I32);
         compile_exp(ctx, expr)?; // owned element array
         ctx.emit(I::LocalSet(h));


### PR DESCRIPTION
A reduction iterator may range over an array expression rather than an Integer range: `sum(abs(v))` inside a function becomes, after vectorization and simplification, `sum(abs(x) for x in v)`. Lower that the way the C target does in the non-RANGE arm of daeExpReduction -- evaluate the iterable once, then loop over its elements -- reusing the borrowed-element binding of `for x in v loop`.

Handle THREAD iterators while at it: `f(u, v)` vectorized over two unknown dimensions becomes `array(f(x, y) thread for x in u, y in v)`, which the nesting would have evaluated as a cartesian product. They now advance in lockstep, iterators of unequal length are a runtime error as in C's endLoop odometer, and a threaded comprehension gets one shared dimension instead of one per iterator.

Fixes simulation/libraries/msl31/Modelica.Math.Matrices.norm.mos, which failed to build with "reduction over a non-range iterator not supported".

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
