### PR TITLE
Convert tests to resimulateExecutable

### DIFF
--- a/testsuite/openmodelica/interactive-API/Bug3974.mos
+++ b/testsuite/openmodelica/interactive-API/Bug3974.mos
@@ -14,8 +14,8 @@ equation
 end ModelTestBug3974;
 "); getErrorString();
 buildModel(ModelTestBug3974); getErrorString();
-system("./ModelTestBug3974 -r ModelTestBug39741.mat"); getErrorString();
-system("./ModelTestBug3974 -override a=2 -r ModelTestBug39742.mat"); getErrorString();
+simulate(ModelTestBug3974, simflags="-r ModelTestBug39741.mat", resimulateExecutable="ModelTestBug3974"); getErrorString();
+simulate(ModelTestBug3974, simflags="-override a=2 -r ModelTestBug39742.mat", resimulateExecutable="ModelTestBug3974"); getErrorString();
 writeFile("ModelTestBug3974.html", diffSimulationResultsHtml("x", "ModelTestBug39741.mat", "ModelTestBug39742.mat")); getErrorString();
 echo(false);
 str := readFile("ModelTestBug3974.html"); getErrorString();
@@ -29,13 +29,21 @@ v;
 // ""
 // {"ModelTestBug3974", "ModelTestBug3974_init.xml"}
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "ModelTestBug39741.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelTestBug3974', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r ModelTestBug39741.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "ModelTestBug39742.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelTestBug3974', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override a=2 -r ModelTestBug39742.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // true
 // ""

--- a/testsuite/openmodelica/interactive-API/Ticket5696.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket5696.mos
@@ -26,8 +26,11 @@ writeFile("override.txt",
 b=5
 c=6
 "); getErrorString();
-writeFile("logOverride.txt", ""); getErrorString();
-system("./TestOverride -stopTime=0 -override=b=1 -overrideFile=override.txt -lv=LOG_ALL | grep overrid", "logOverride.txt"); getErrorString();
+echo(false);
+simulate(TestOverride, simflags="-stopTime=0 -override=b=1 -overrideFile=override.txt -lv=LOG_ALL", resimulateExecutable="TestOverride");
+echo(true);
+getErrorString();
+system("grep overrid TestOverride.log > logOverride.txt"); getErrorString();
 readFile("logOverride.txt"); getErrorString();
 
 // Result:

--- a/testsuite/simulation/modelica/arrays/Issue14470.mos
+++ b/testsuite/simulation/modelica/arrays/Issue14470.mos
@@ -38,10 +38,10 @@ end RecordTest;
 
 // The order of the prints isn't deterministic.
 buildModel(RecordTest.LabelArray); getErrorString();
-system("./RecordTest.LabelArray", "RecordTest.LabelArray_systemCall.log"); getErrorString();
-system("grep 'Position:' RecordTest.LabelArray_systemCall.log | sort > RecordTest.LabelArray_systemCall.log.tmp && mv RecordTest.LabelArray_systemCall.log.tmp RecordTest.LabelArray_systemCall.log"); getErrorString();
+simulate(RecordTest.LabelArray, resimulateExecutable="RecordTest.LabelArray"); getErrorString();
+system("grep 'Position:' RecordTest.LabelArray.log | sort > RecordTest.LabelArray.log.tmp && mv RecordTest.LabelArray.log.tmp RecordTest.LabelArray.log"); getErrorString();
 
-readFile("RecordTest.LabelArray_systemCall.log");
+readFile("RecordTest.LabelArray.log");
 
 // Result:
 // true
@@ -51,7 +51,16 @@ readFile("RecordTest.LabelArray_systemCall.log");
 // Notification: Automatically loaded package ModelicaServices 4.1.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica 4.1.0 due to usage.
 // "
-// 0
+// record SimulationResult
+//     resultFile = "RecordTest.LabelArray_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'RecordTest.LabelArray', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_STDOUT        | info    | Position: 0.5, 11.5
+// LOG_STDOUT        | info    | Position: 0.5, 21.5
+// LOG_STDOUT        | info    | Position: 30.5, 31.5
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
 // ""
 // 0
 // ""

--- a/testsuite/simulation/modelica/built_in_functions/Delta.mos
+++ b/testsuite/simulation/modelica/built_in_functions/Delta.mos
@@ -11,9 +11,7 @@ simulate(Delta, variableFilter = "time|x", numberOfIntervals=10, fileNamePrefix 
 buildModel(Delta); getErrorString();
 
 for a in {0,1,2,3} loop
-  str_a := String(a); getErrorString();
-  str_cmd := "./Delta -override a=" + str_a;
-  system(str_cmd, "output.txt"); getErrorString();
+  simulate(Delta, simflags="-override a=" + String(a), resimulateExecutable="Delta"); getErrorString();
   res := deltaSimulationResults("Delta_res.mat","Delta_reference_res.mat", "1norm", {"x"});getErrorString();
   res1 := deltaSimulationResults("Delta_res.mat","Delta_reference_res.mat", "2norm", {"x"});getErrorString();
   res2 := deltaSimulationResults("Delta_res.mat","Delta_reference_res.mat", "maxerr", {"x"});getErrorString();

--- a/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
+++ b/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
@@ -15,30 +15,26 @@ setCommandLineOptions("-d=newInst,symJacConstantSplit --generateDynamicJacobian=
 buildModel(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler); getErrorString();
 
 // Test DASSL
-system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=dassl -jacobian=symbolical", "out.log"); getErrorString();
-readFile("out.log"); remove("out.log");
+simulate(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler, simflags="-s=dassl -jacobian=symbolical", resimulateExecutable="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler"); getErrorString();
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
                       getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
-system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=dassl -jacobian=coloredSymbolical", "out.log"); getErrorString();
-readFile("out.log"); remove("out.log");
+simulate(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler, simflags="-s=dassl -jacobian=coloredSymbolical", resimulateExecutable="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler"); getErrorString();
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
                       getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
 // Test IDA
-system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=symbolical", "out.log"); getErrorString();
-readFile("out.log"); remove("out.log");
+simulate(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler, simflags="-s=ida -jacobian=symbolical", resimulateExecutable="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler"); getErrorString();
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
                       getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
 getErrorString();
 
-system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=coloredSymbolical", "out.log"); getErrorString();
-readFile("out.log"); remove("out.log");
+simulate(Modelica.Fluid.Examples.DrumBoiler.DrumBoiler, simflags="-s=ida -jacobian=coloredSymbolical", resimulateExecutable="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler"); getErrorString();
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
                       getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff",
                       vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
@@ -53,37 +49,45 @@ getErrorString();
 // {"Modelica.Fluid.Examples.DrumBoiler.DrumBoiler", "Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_init.xml"}
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // "
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5400.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.DrumBoiler.DrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -jacobian=symbolical'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // (true, {})
 // ""
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5400.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.DrumBoiler.DrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -jacobian=coloredSymbolical'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // (true, {})
 // ""
-// 0
-// ""
-// "LOG_STDOUT        | warning | Symbolic Jacobians without coloring are currently not supported by IDA. Colored symbolical Jacobian will be used.
+// record SimulationResult
+//     resultFile = "Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5400.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.DrumBoiler.DrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=ida -jacobian=symbolical'",
+//     messages = "LOG_STDOUT        | warning | Symbolic Jacobians without coloring are currently not supported by IDA. Colored symbolical Jacobian will be used.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // (true, {})
 // ""
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5400.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.DrumBoiler.DrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=ida -jacobian=coloredSymbolical'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // (true, {})
 // ""
 // endResult

--- a/testsuite/simulation/modelica/linear_system/analyticJacProblem3.mos
+++ b/testsuite/simulation/modelica/linear_system/analyticJacProblem3.mos
@@ -11,12 +11,12 @@ setCommandLineOptions("--maxSizeLinearTearing=0 +d=LSanalyticJacobian"); getErro
 
 buildModel(linear_system.problem3); getErrorString();
 
-system(realpath(".") + "/linear_system.problem3"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls lis"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls lapack"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls umfpack"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls klu"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls totalpivot"); getErrorString();
+simulate(linear_system.problem3, resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls lis", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls lapack", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls umfpack", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls klu", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls totalpivot", resimulateExecutable="linear_system.problem3"); getErrorString();
 
 // Result:
 // true
@@ -25,28 +25,52 @@ system(realpath(".") + "/linear_system.problem3 -ls totalpivot"); getErrorString
 // ""
 // {"linear_system.problem3", "linear_system.problem3_init.xml"}
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lis'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lapack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls umfpack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls klu'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls totalpivot'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult

--- a/testsuite/simulation/modelica/linear_system/problem3.mos
+++ b/testsuite/simulation/modelica/linear_system/problem3.mos
@@ -11,12 +11,12 @@ setCommandLineOptions("--maxSizeLinearTearing=0"); getErrorString();
 
 buildModel(linear_system.problem3); getErrorString();
 
-system(realpath(".") + "/linear_system.problem3"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls lis"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls lapack"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls umfpack"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls klu"); getErrorString();
-system(realpath(".") + "/linear_system.problem3 -ls totalpivot"); getErrorString();
+simulate(linear_system.problem3, resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls lis", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls lapack", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls umfpack", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls klu", resimulateExecutable="linear_system.problem3"); getErrorString();
+simulate(linear_system.problem3, simflags="-ls totalpivot", resimulateExecutable="linear_system.problem3"); getErrorString();
 
 // Result:
 // true
@@ -25,28 +25,52 @@ system(realpath(".") + "/linear_system.problem3 -ls totalpivot"); getErrorString
 // ""
 // {"linear_system.problem3", "linear_system.problem3_init.xml"}
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lis'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls lapack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls umfpack'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls klu'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "linear_system.problem3_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linear_system.problem3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-ls totalpivot'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // ""
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/Burger_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/Burger_01.mos
@@ -19,12 +19,10 @@ setCommandLineOptions("--generateDynamicJacobian=symbolic"); getErrorString();
 buildModel(burgerEq); getErrorString();
 
 // Create reference results
-system(realpath(".") + "/burgerEq -s=dassl -r burgerEq_ref.mat", "refSimulation.log");
-print(readFile("refSimulation.log"));
+simulate(burgerEq, simflags="-s=dassl -r burgerEq_ref.mat", resimulateExecutable="burgerEq");
 
 // Simulate with ESDIRK3 and KINSOL+KLU
-system(realpath(".") + "/burgerEq -s=gbode -gbm=esdirk3 -gbnls=kinsol -tolerance=1e-6", "burgerEq_esdirk3.log");
-print(readFile("burgerEq_esdirk3.log"));
+simulate(burgerEq, simflags="-s=gbode -gbm=esdirk3 -gbnls=kinsol -tolerance=1e-6", resimulateExecutable="burgerEq");
 
 diffSimulationResults(actualFile = "burgerEq_res.mat",
                       expectedFile = "burgerEq_ref.mat",
@@ -34,8 +32,7 @@ diffSimulationResults(actualFile = "burgerEq_res.mat",
 getErrorString();
 
 // Simulate with ESDIRK4 and internal gbnls
-system(realpath(".") + "/burgerEq -s=gbode -gbm=esdirk4 -gbnls=internal -gberr=embedded -tolerance=1e-6", "burgerEq_esdirk4.log");
-print(readFile("burgerEq_esdirk4.log"));
+simulate(burgerEq, simflags="-s=gbode -gbm=esdirk4 -gbnls=internal -gberr=embedded -tolerance=1e-6", resimulateExecutable="burgerEq");
 
 diffSimulationResults(actualFile = "burgerEq_res.mat",
                       expectedFile = "burgerEq_ref.mat",
@@ -45,8 +42,7 @@ diffSimulationResults(actualFile = "burgerEq_res.mat",
 getErrorString();
 
 // Simulate with Radau IIA 3-step and internal gbnls
-system(realpath(".") + "/burgerEq -s=gbode -gbm=radauIIA3 -gbnls=internal -gberr=embedded -tolerance=1e-6", "burgerEq_radauIIA3.log");
-print(readFile("burgerEq_radauIIA3.log"));
+simulate(burgerEq, simflags="-s=gbode -gbm=radauIIA3 -gbnls=internal -gberr=embedded -tolerance=1e-6", resimulateExecutable="burgerEq");
 
 diffSimulationResults(actualFile = "burgerEq_res.mat",
                       expectedFile = "burgerEq_ref.mat",
@@ -56,8 +52,7 @@ diffSimulationResults(actualFile = "burgerEq_res.mat",
 getErrorString();
 
 // Simulate with expl euler
-system(realpath(".") + "/burgerEq -s=gbode -gbm=expl_euler -gbnls=kinsol -gbratio=0.05 -tolerance=1e-6", "burgerEq_euler_test.log");
-print(readFile("burgerEq_euler_test.log"));
+simulate(burgerEq, simflags="-s=gbode -gbm=expl_euler -gbnls=kinsol -gbratio=0.05 -tolerance=1e-6", resimulateExecutable="burgerEq");
 
 diffSimulationResults(actualFile = "burgerEq_res.mat",
                       expectedFile = "burgerEq_ref.mat",
@@ -67,8 +62,7 @@ diffSimulationResults(actualFile = "burgerEq_res.mat",
 getErrorString();
 
 // Simulate with fehlberg78
-system(realpath(".") + "/burgerEq -s=gbode -gbm=fehlberg78 -gbnls=kinsol -gbratio=0 -tolerance=1e-8", "burgerEq_fehlberg78.log");
-print(readFile("burgerEq_fehlberg78.log"));
+simulate(burgerEq, simflags="-s=gbode -gbm=fehlberg78 -gbnls=kinsol -gbratio=0 -tolerance=1e-8", resimulateExecutable="burgerEq");
 
 diffSimulationResults(actualFile = "burgerEq_res.mat",
                       expectedFile = "burgerEq_ref.mat",
@@ -86,38 +80,56 @@ getErrorString();
 // ""
 // {"burgerEq", "burgerEq_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "burgerEq_ref.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -r burgerEq_ref.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "
+// end SimulationResult;
+// record SimulationResult
+//     resultFile = "burgerEq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=esdirk3 -gbnls=kinsol -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "burgerEq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=esdirk4 -gbnls=internal -gberr=embedded -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "burgerEq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=radauIIA3 -gbnls=internal -gberr=embedded -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "burgerEq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=expl_euler -gbnls=kinsol -gbratio=0.05 -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "burgerEq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'burgerEq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=fehlberg78 -gbnls=kinsol -gbratio=0 -tolerance=1e-8'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/HeatingSystem.mos
+++ b/testsuite/simulation/modelica/solver/gbode/HeatingSystem.mos
@@ -20,12 +20,10 @@ setCommandLineOptions("--generateDynamicJacobian=symbolic"); getErrorString();
 buildModel(HeatingSystem); getErrorString();
 
 // Create reference results
-system(realpath(".") + "/HeatingSystem -s=dassl -r HeatingSystem_ref.mat -tolerance=1e-8", "refSimulation.log");
-print(readFile("refSimulation.log"));
+simulate(HeatingSystem, simflags="-s=dassl -r HeatingSystem_ref.mat -tolerance=1e-8", resimulateExecutable="HeatingSystem");
 
 // Simulate with gauss2 & KINSOL+KLU
-system(realpath(".") + "/HeatingSystem -s=gbode -gbm=esdirk4 -jacobian=coloredSymbolical -tolerance=1e-6", "HeatingSystem_esdirk4.log");
-print(readFile("HeatingSystem_esdirk4.log"));
+simulate(HeatingSystem, simflags="-s=gbode -gbm=esdirk4 -jacobian=coloredSymbolical -tolerance=1e-6", resimulateExecutable="HeatingSystem");
 
 diffSimulationResults(actualFile = "HeatingSystem_res.mat",
                       expectedFile = "HeatingSystem_ref.mat",
@@ -34,8 +32,7 @@ diffSimulationResults(actualFile = "HeatingSystem_res.mat",
 getErrorString();
 
 // Simulate with sdirk2 & KINSOL+KLU
-system(realpath(".") + "/HeatingSystem -s=gbode -gbm=fehlberg78 -tolerance=1e-6", "HeatingSystem_fehlberg78.log");
-print(readFile("HeatingSystem_fehlberg78.log"));
+simulate(HeatingSystem, simflags="-s=gbode -gbm=fehlberg78 -tolerance=1e-6", resimulateExecutable="HeatingSystem");
 
 diffSimulationResults(actualFile = "HeatingSystem_res.mat",
                       expectedFile = "HeatingSystem_ref.mat",
@@ -44,8 +41,7 @@ diffSimulationResults(actualFile = "HeatingSystem_res.mat",
 getErrorString();
 
 // Simulate with sdirk2 & KINSOL+KLU
-system(realpath(".") + "/HeatingSystem -s=gbode -gbm=dopri45 -gbctrl=const -gbint=dense_output -tolerance=1e-6 -stepSize=10", "HeatingSystem_dopri45.log");
-print(readFile("HeatingSystem_dopri45.log"));
+simulate(HeatingSystem, simflags="-s=gbode -gbm=dopri45 -gbctrl=const -gbint=dense_output -tolerance=1e-6 -stepSize=10", resimulateExecutable="HeatingSystem");
 
 diffSimulationResults(actualFile = "HeatingSystem_res.mat",
                       expectedFile = "HeatingSystem_ref.mat",
@@ -65,26 +61,38 @@ getErrorString();
 // ""
 // {"HeatingSystem", "HeatingSystem_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "HeatingSystem_ref.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 864000.0, numberOfIntervals = 2880, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'HeatingSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -r HeatingSystem_ref.mat -tolerance=1e-8'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// "
+// end SimulationResult;
+// record SimulationResult
+//     resultFile = "HeatingSystem_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 864000.0, numberOfIntervals = 2880, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'HeatingSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=esdirk4 -jacobian=coloredSymbolical -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "HeatingSystem_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 864000.0, numberOfIntervals = 2880, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'HeatingSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=fehlberg78 -tolerance=1e-6'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "HeatingSystem_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 864000.0, numberOfIntervals = 2880, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'HeatingSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbm=dopri45 -gbctrl=const -gbint=dense_output -tolerance=1e-6 -stepSize=10'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // (true, {})
 // ""
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/IRK_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/IRK_01.mos
@@ -34,8 +34,7 @@ buildModel(SlowFastDynamics);
 getErrorString();
 
 // Create reference results
-system(realpath(".") + "/SlowFastDynamics -s=dassl -r SlowFastDynamics_ref.mat ", "refSimulation.log");
-print(readFile("refSimulation.log"));
+simulate(SlowFastDynamics, simflags="-s=dassl -r SlowFastDynamics_ref.mat ", resimulateExecutable="SlowFastDynamics");
 
 // Test all RK methods
 for rkMethod in rkMethods loop
@@ -43,10 +42,8 @@ for rkMethod in rkMethods loop
     for errCtrl in errCtrls loop
       print("--------------------------------------------------------\n");
       print("Running RK " + rkMethod + " with NLS " + nlsMethod + " and errCtrl " + errCtrl + ":\n");
-      logFile := "SlowFastDynamics_" + rkMethod + "_" + nlsMethod + "_" + errCtrl + ".log";
       system("rm -f SlowFastDynamics_res.mat");
-      system(realpath(".") + "/SlowFastDynamics -s=gbode -gbm=" + rkMethod + " -gbnls=" + nlsMethod + " -gberr=" + errCtrl, logFile);
-      print(readFile(logFile) + "\n");
+      simulate(SlowFastDynamics, simflags="-s=gbode -gbm=" + rkMethod + " -gbnls=" + nlsMethod + " -gberr=" + errCtrl, resimulateExecutable="SlowFastDynamics");
 
       (success, failVars) := diffSimulationResults(actualFile = "SlowFastDynamics_res.mat",
                                                    expectedFile = "SlowFastDynamics_ref.mat",
@@ -76,159 +73,72 @@ end for;
 // ""
 // {"SlowFastDynamics", "SlowFastDynamics_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "SlowFastDynamics_ref.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SlowFastDynamics', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -r SlowFastDynamics_ref.mat '",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // --------------------------------------------------------
 // Running RK impl_euler with NLS newton and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK impl_euler with NLS newton and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK impl_euler with NLS newton and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK impl_euler with NLS kinsol and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK impl_euler with NLS kinsol and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK impl_euler with NLS kinsol and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS newton and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS newton and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS newton and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS kinsol and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS kinsol and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk2 with NLS kinsol and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS newton and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS newton and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS newton and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS kinsol and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS kinsol and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS kinsol and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS newton and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS newton and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS newton and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS kinsol and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS kinsol and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS kinsol and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS newton and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS newton and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS newton and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS kinsol and errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS kinsol and errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS kinsol and errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/RK_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/RK_01.mos
@@ -36,18 +36,15 @@ buildModel(SlowFastDynamics);
 getErrorString();
 
 // Create reference results
-system(realpath(".") + "/SlowFastDynamics -s=dassl -r SlowFastDynamics_ref.mat ", "refSimulation.log");
-print(readFile("refSimulation.log"));
+simulate(SlowFastDynamics, simflags="-s=dassl -r SlowFastDynamics_ref.mat ", resimulateExecutable="SlowFastDynamics");
 
 // Test all RK methods
 for rkMethod in rkMethods loop
   for errCtrl in errCtrls loop
     print("\n--------------------------------------------------------\n");
     print("Running RK " + rkMethod + " with errCtrl " + errCtrl + ":\n");
-    logFile := "SlowFastDynamics_"+ rkMethod + "_" + errCtrl + ".log";
     system("rm -f SlowFastDynamics_res.mat");
-    system(realpath(".") + "/SlowFastDynamics -s=gbode -gbint=hermite -gbm=" + rkMethod + " -gberr=" + errCtrl, logFile);
-    print(readFile(logFile) + "\n");
+    simulate(SlowFastDynamics, simflags="-s=gbode -gbint=hermite -gbm=" + rkMethod + " -gberr=" + errCtrl, resimulateExecutable="SlowFastDynamics");
 
     (success, failVars) := diffSimulationResults(actualFile = "SlowFastDynamics_res.mat",
                                 expectedFile = "SlowFastDynamics_ref.mat",
@@ -75,171 +72,93 @@ end for;
 // ""
 // {"SlowFastDynamics", "SlowFastDynamics_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "SlowFastDynamics_ref.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SlowFastDynamics', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -r SlowFastDynamics_ref.mat '",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 //
 // --------------------------------------------------------
 // Running RK expl_euler with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK expl_euler with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK expl_euler with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK dopri45 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK dopri45 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK dopri45 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK merson with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK merson with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK merson with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg12 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg12 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg12 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg45 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg45 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg45 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg78 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg78 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK fehlberg78 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk810 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk810 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk810 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1012 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1012 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1012 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1214 with errCtrl default:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1214 with errCtrl richardson:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK rk1214 with errCtrl embedded:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/multiRateInternal_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/multiRateInternal_01.mos
@@ -24,8 +24,7 @@ getErrorString();
 buildModel(SlowFastDynamics);
 getErrorString();
 
-system(realpath(".") + "/SlowFastDynamics -s=gbode -gbratio=0.5 -gbm=radauIIA3 -gbfm=radauIIA3 -gbnls=internal -gberr=embedded -gbferr=embedded", "multirateInternal.log");
-print(readFile("multirateInternal.log"));
+simulate(SlowFastDynamics, simflags="-s=gbode -gbratio=0.5 -gbm=radauIIA3 -gbfm=radauIIA3 -gbnls=internal -gberr=embedded -gbferr=embedded", resimulateExecutable="SlowFastDynamics");
 
 // Result:
 // true
@@ -34,8 +33,11 @@ print(readFile("multirateInternal.log"));
 // ""
 // {"SlowFastDynamics", "SlowFastDynamics_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "SlowFastDynamics_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SlowFastDynamics', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=gbode -gbratio=0.5 -gbm=radauIIA3 -gbfm=radauIIA3 -gbnls=internal -gberr=embedded -gbferr=embedded'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 // endResult

--- a/testsuite/simulation/modelica/solver/gbode/multiRate_01.mos
+++ b/testsuite/simulation/modelica/solver/gbode/multiRate_01.mos
@@ -35,17 +35,14 @@ buildModel(SlowFastDynamics);
 getErrorString();
 
 // Create reference results
-system(realpath(".") + "/SlowFastDynamics -s=dassl -r SlowFastDynamics_ref.mat ", "refSimulation.log");
-print(readFile("refSimulation.log"));
+simulate(SlowFastDynamics, simflags="-s=dassl -r SlowFastDynamics_ref.mat ", resimulateExecutable="SlowFastDynamics");
 
 // Test all RK methods
 for rkMethod in rkMethods loop
   for nlsMethod in nlsMethods loop
     print("\n--------------------------------------------------------\n");
     print("Running RK " + rkMethod + " with NLS " + nlsMethod + ":\n");
-    logFile := "SlowFastDynamics_"+ rkMethod + "_" + nlsMethod + ".log";
-    system(realpath(".") + "/SlowFastDynamics -s=gbode -gbratio=0.5 -gbm=" + rkMethod + " -gbnls=" + nlsMethod, logFile);
-    print(readFile(logFile) + "\n");
+    simulate(SlowFastDynamics, simflags="-s=gbode -gbratio=0.5 -gbm=" + rkMethod + " -gbnls=" + nlsMethod, resimulateExecutable="SlowFastDynamics");
 
     (success, failVars) := diffSimulationResults(actualFile = "SlowFastDynamics_res.mat",
                                  expectedFile = "SlowFastDynamics_ref.mat",
@@ -73,57 +70,36 @@ end for;
 // ""
 // {"SlowFastDynamics", "SlowFastDynamics_init.xml"}
 // ""
-// 0
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "SlowFastDynamics_ref.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'SlowFastDynamics', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=dassl -r SlowFastDynamics_ref.mat '",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-//
+// "
+// end SimulationResult;
 //
 // --------------------------------------------------------
 // Running RK expl_euler with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK impl_euler with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK sdirk3 with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK esdirk2 with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK esdirk3 with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK esdirk4 with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK merson with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // --------------------------------------------------------
 // Running RK dopri45 -gbint=dense_output_errctrl with NLS newton:
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-//
 //
 // endResult

--- a/testsuite/simulation/modelica/solver/problem6-cvode.mos
+++ b/testsuite/simulation/modelica/solver/problem6-cvode.mos
@@ -18,8 +18,7 @@ setCommandLineOptions("-d=newInst"); getErrorString();
 buildModel(testSolver.problem6); getErrorString();
 
 // Test default settings
-system(realpath(".") + "/testSolver.problem6 -s=cvode -stopTime=3.0 -stepSize=0.006", "testSolver_problem6_default.log"); getErrorString();
-readFile("testSolver_problem6_default.log"); remove("testSolver_problem6_default.log");
+simulate(testSolver.problem6, simflags="-s=cvode -stopTime=3.0 -stepSize=0.006", resimulateExecutable="testSolver.problem6"); getErrorString();
 
 echo(false);  /* Silence readSimulationResult */
 s:=readSimulationResultSize(resfile);
@@ -31,8 +30,7 @@ res[1,s];
 if res2[1,s] > -1e-2 then 1 else 0;
 
 // Test CVODE with BDF method and Newton integrator
-system(realpath(".") + "/testSolver.problem6 -s=cvode -cvodeLinearMultistepMethod=CV_BDF -cvodeNonlinearSolverIteration=CV_NEWTON -stopTime=3.0 -stepSize=0.006 ", "testSolver_problem6_BDF.log"); getErrorString();
-readFile("testSolver_problem6_BDF.log"); remove("testSolver_problem6_BDF.log");
+simulate(testSolver.problem6, simflags="-s=cvode -cvodeLinearMultistepMethod=CV_BDF -cvodeNonlinearSolverIteration=CV_NEWTON -stopTime=3.0 -stepSize=0.006 ", resimulateExecutable="testSolver.problem6"); getErrorString();
 
 echo(false);  /* Silence readSimulationResult */
 s:=readSimulationResultSize(resfile);
@@ -44,8 +42,7 @@ res[1,s];
 if res2[1,s] > -1e-2 then 1 else 0;
 
 // Test CVODE with Adams method and Newton integrator
-system(realpath(".") + "/testSolver.problem6 -s=cvode -cvodeLinearMultistepMethod=CV_ADAMS -cvodeNonlinearSolverIteration=CV_FUNCTIONAL -stopTime=3.0 -stepSize=0.006 ", "testSolver_problem6_ADAMS.log"); getErrorString();
-readFile("testSolver_problem6_ADAMS.log"); remove("testSolver_problem6_ADAMS.log");
+simulate(testSolver.problem6, simflags="-s=cvode -cvodeLinearMultistepMethod=CV_ADAMS -cvodeNonlinearSolverIteration=CV_FUNCTIONAL -stopTime=3.0 -stepSize=0.006 ", resimulateExecutable="testSolver.problem6"); getErrorString();
 
 echo(false);  /* Silence readSimulationResult */
 s:=readSimulationResultSize(resfile);
@@ -66,32 +63,38 @@ if res2[1,s] > -1e-2 then 1 else 0;
 // {"testSolver.problem6", "testSolver.problem6_init.xml"}
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "testSolver.problem6_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'testSolver.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=cvode -stopTime=3.0 -stepSize=0.006'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // true
 // 1.0
 // 0.0
 // 1
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "testSolver.problem6_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'testSolver.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=cvode -cvodeLinearMultistepMethod=CV_BDF -cvodeNonlinearSolverIteration=CV_NEWTON -stopTime=3.0 -stepSize=0.006 '",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // true
 // 1.0
 // 0.0
 // 1
-// 0
-// ""
-// "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "testSolver.problem6_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'testSolver.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s=cvode -cvodeLinearMultistepMethod=CV_ADAMS -cvodeNonlinearSolverIteration=CV_FUNCTIONAL -stopTime=3.0 -stepSize=0.006 '",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// true
+// end SimulationResult;
+// ""
 // true
 // 1.0
 // 0.0


### PR DESCRIPTION
Replace system() calls that execute the built executable with simulate(..., resimulateExecutable=...) so the tests run through the resimulate path instead of spawning a process. The record's messages field replaces the read/print of the log file.

Tests updated:

- openmodelica/interactive-API/Bug3974.mos
- openmodelica/interactive-API/Ticket5696.mos
- simulation/modelica/arrays/Issue14470.mos
- simulation/modelica/built_in_functions/Delta.mos
- simulation/modelica/jacobian/reuseConstantPartsJac1.mos
- simulation/modelica/linear_system/analyticJacProblem3.mos
- simulation/modelica/linear_system/problem3.mos
- simulation/modelica/solver/gbode/Burger_01.mos
- simulation/modelica/solver/gbode/HeatingSystem.mos
- simulation/modelica/solver/gbode/IRK_01.mos
- simulation/modelica/solver/gbode/RK_01.mos
- simulation/modelica/solver/gbode/multiRateInternal_01.mos
- simulation/modelica/solver/gbode/multiRate_01.mos
- simulation/modelica/solver/problem6-cvode.mos

Baselines were regenerated with the bootstrapped C OMC; all tests pass on the C target.

Notes:

- Ticket5696.mos: keep -lv=LOG_ALL for the full log; wrap the simulate in echo(false)/echo(true) so the record (with the non-deterministic LOG_STATS timings) is not printed. The grep on the resimulate log file still checks the override behavior.
- Issue14470.mos: the log file is named after the executable.
- IRK_01.mos / RK_01.mos: keep `rm -f <exe>_res.mat` in the loops since resimulate reuses one result file name.

Issue14178.mos was left unchanged: its -logFormat=xml is only supported by the C target.

Assisted-by: Qwen3.8 27B

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
