### PR TITLE
Comp: Fix noEvent suppression for spatialDistribution output events

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -651,6 +651,7 @@ uniontype EventInfo
     DoubleEnded.MutableList<ZeroCrossing> relations "list of zero crossing function as before";
     ZeroCrossingSet samples       "[deprecated] list of sample as before, only used by cpp runtime (TODO: REMOVE ME)";
     Integer numberMathEvents      "stores the number of math function that trigger events e.g. floor, ceil, integer, ...";
+    list<Integer> noEventSpatialDistributions "indices of spatialDistribution calls with noEvent() wrapped inputs, suppressing output events";
   end EVENT_INFO;
 end EventInfo;
 

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -121,6 +121,7 @@ protected
   list<DAE.Element> elems, aliaseqns;
   AvlTreePathFunction.Tree functionTree;
   list<BackendDAE.TimeEvent> timeEvents;
+  list<Integer> noEventSpatialDistributions;
   Integer numCheckpoints;
   BackendDAE.EqSystem syst;
 algorithm
@@ -134,7 +135,7 @@ algorithm
     functionTree := FCore.getFunctionTree(inCache);
     //deactivated because of some codegen errors: functionTree := renameFunctionParameter(functionTree);
     functionTree := lowerFunctions(functionTree);
-    (DAE.DAE(elems), functionTree, timeEvents) := processBuiltinExpressions(lst, functionTree);
+    (DAE.DAE(elems), functionTree, timeEvents, noEventSpatialDistributions) := processBuiltinExpressions(lst, functionTree);
     (varlst, globalKnownVarLst, extvarlst, eqns, reqns, ieqns, constrs, clsAttrs, extObjCls, aliaseqns, _) :=
       lower2(listReverse(elems), functionTree, HashTableExpToExp.emptyHashTable());
 
@@ -158,7 +159,7 @@ algorithm
     eqnarr := BackendEquation.listEquation(eqns);
     reqnarr := BackendEquation.listEquation(reqns);
     ieqnarr := BackendEquation.listEquation(ieqns);
-    einfo := BackendDAE.EVENT_INFO(timeEvents, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0);
+    einfo := BackendDAE.EVENT_INFO(timeEvents, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0, noEventSpatialDistributions);
     symjacs := {(NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),
                 (NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),
                 (NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),
@@ -1027,59 +1028,70 @@ protected function processBuiltinExpressions "author: lochel
   output DAE.DAElist outDAE;
   output AvlTreePathFunction.Tree outTree;
   output list<BackendDAE.TimeEvent> outTimeEvents;
+  output list<Integer> outNoEventSpatialDistributions;
 protected
   HashTableExpToIndex.HashTable ht;
 algorithm
   ht := HashTableExpToIndex.emptyHashTable();
-  (outDAE, outTree, (_, (_, _, _, _, outTimeEvents))) := DAEUtil.traverseDAE(inDAE, functionTree, Expression.traverseSubexpressionsHelper, (transformBuiltinExpression, (ht, 0, 0, 0, {})));
+  (outDAE, outTree, (_, (_, _, _, _, outTimeEvents, outNoEventSpatialDistributions))) := DAEUtil.traverseDAE(inDAE, functionTree, Expression.traverseSubexpressionsHelper, (transformBuiltinExpression, (ht, 0, 0, 0, {}, {})));
 end processBuiltinExpressions;
 
 protected function transformBuiltinExpression "author: lochel
   Helper for transformBuiltinExpressions"
   input DAE.Exp inExp;
-  input tuple<HashTableExpToIndex.HashTable, Integer /*iDelay*/, Integer /*iSample*/,  Integer /*iSpatial*/, list<BackendDAE.TimeEvent>> inTuple;
+  input tuple<HashTableExpToIndex.HashTable, Integer /*iDelay*/, Integer /*iSample*/,  Integer /*iSpatial*/, list<BackendDAE.TimeEvent>, list<Integer> /*noEventSpatialDistributions*/> inTuple;
   output DAE.Exp outExp;
-  output tuple<HashTableExpToIndex.HashTable, Integer /*iDelay*/, Integer /*iSample*/,  Integer /*iSpatial*/, list<BackendDAE.TimeEvent>> outTuple;
+  output tuple<HashTableExpToIndex.HashTable, Integer /*iDelay*/, Integer /*iSample*/,  Integer /*iSpatial*/, list<BackendDAE.TimeEvent>, list<Integer> /*noEventSpatialDistributions*/> outTuple;
 algorithm
   (outExp,outTuple) := match (inExp, inTuple)
     local
-      DAE.Exp start, interval;
+      DAE.Exp start, interval, in0, in1;
       list<DAE.Exp> es;
       HashTableExpToIndex.HashTable ht;
       Integer iDelay, iSample, iSpatial;
       list<BackendDAE.TimeEvent> timeEvents;
+      list<Integer> noEventSpDs;
+      Boolean hasNoEvent;
       DAE.CallAttributes attr;
 
     // delay [already in ht]
-    case (DAE.CALL(Absyn.IDENT("delay"), es, attr), (ht, _, _, _, _)) guard(BaseHashTable.hasKey(inExp, ht))
+    case (DAE.CALL(Absyn.IDENT("delay"), es, attr), (ht, _, _, _, _, _)) guard(BaseHashTable.hasKey(inExp, ht))
     then (DAE.CALL(Absyn.IDENT("delay"), DAE.ICONST(BaseHashTable.get(inExp, ht))::es, attr), inTuple);
 
     // delay [not yet in ht]
-    case (DAE.CALL(Absyn.IDENT("delay"), es, attr), (ht, iDelay, iSample, iSpatial, timeEvents)) algorithm
+    case (DAE.CALL(Absyn.IDENT("delay"), es, attr), (ht, iDelay, iSample, iSpatial, timeEvents, noEventSpDs)) algorithm
       ht := BaseHashTable.add((inExp, iDelay+1), ht);
-    then (DAE.CALL(Absyn.IDENT("delay"), DAE.ICONST(iDelay)::es, attr), (ht, iDelay+1, iSample, iSpatial, timeEvents));
+    then (DAE.CALL(Absyn.IDENT("delay"), DAE.ICONST(iDelay)::es, attr), (ht, iDelay+1, iSample, iSpatial, timeEvents, noEventSpDs));
 
     // spatialDistribution [already in ht]
-    case (DAE.CALL(Absyn.IDENT("spatialDistribution"), es, attr), (ht, _, _, _, _)) guard(BaseHashTable.hasKey(inExp, ht))
+    case (DAE.CALL(Absyn.IDENT("spatialDistribution"), es, attr), (ht, _, _, _, _, _)) guard(BaseHashTable.hasKey(inExp, ht))
     then (DAE.CALL(Absyn.IDENT("spatialDistribution"), DAE.ICONST(BaseHashTable.get(inExp, ht))::es, attr), inTuple);
 
     // spatialDistribution [not yet in ht]
-    case (DAE.CALL(Absyn.IDENT("spatialDistribution"), es, attr), (ht, iDelay, iSample, iSpatial, timeEvents)) algorithm
+    // Detect noEvent() on the inputs here, before the simplifier propagates it
+    // onto the relations inside the arguments (where the wrapping itself is lost).
+    case (DAE.CALL(Absyn.IDENT("spatialDistribution"), es as {in0, in1, _, _, _, _}, attr), (ht, iDelay, iSample, iSpatial, timeEvents, noEventSpDs)) algorithm
       ht := BaseHashTable.add((inExp, iSpatial+1), ht);
-    then (DAE.CALL(Absyn.IDENT("spatialDistribution"), DAE.ICONST(iSpatial)::es, attr), (ht, iDelay, iSample, iSpatial+1, timeEvents));
+      hasNoEvent := match (in0, in1)
+        case (DAE.CALL(path = Absyn.IDENT("noEvent")), _) then true;
+        case (_, DAE.CALL(path = Absyn.IDENT("noEvent"))) then true;
+        else false;
+      end match;
+      noEventSpDs := if hasNoEvent then iSpatial::noEventSpDs else noEventSpDs;
+    then (DAE.CALL(Absyn.IDENT("spatialDistribution"), DAE.ICONST(iSpatial)::es, attr), (ht, iDelay, iSample, iSpatial+1, timeEvents, noEventSpDs));
 
     // sample [already in ht]
-    case (DAE.CALL(Absyn.IDENT("sample"), es as {_, interval}, attr), (ht, _, _, _, _))
+    case (DAE.CALL(Absyn.IDENT("sample"), es as {_, interval}, attr), (ht, _, _, _, _, _))
       guard (not Types.isClockOrSubTypeClock(Expression.typeof(interval)) and BaseHashTable.hasKey(inExp, ht)) algorithm
     then (DAE.CALL(Absyn.IDENT("sample"), DAE.ICONST(BaseHashTable.get(inExp, ht))::es, attr), inTuple);
 
     // sample [not yet in ht]
-    case (DAE.CALL(Absyn.IDENT("sample"), es as {start, interval}, attr), (ht, iDelay, iSample, iSpatial, timeEvents))
-    guard (not Types.isClockOrSubTypeClock(Expression.typeof(interval))) algorithm
+    case (DAE.CALL(Absyn.IDENT("sample"), es as {start, interval}, attr), (ht, iDelay, iSample, iSpatial, timeEvents, noEventSpDs))
+      guard (not Types.isClockOrSubTypeClock(Expression.typeof(interval))) algorithm
       iSample := iSample+1;
       timeEvents := List.appendElt(BackendDAE.SAMPLE_TIME_EVENT(iSample, start, interval, NONE()), timeEvents);
       ht := BaseHashTable.add((inExp, iSample), ht);
-    then (DAE.CALL(Absyn.IDENT("sample"), DAE.ICONST(iSample)::es, attr), (ht, iDelay, iSample, iSpatial, timeEvents));
+    then (DAE.CALL(Absyn.IDENT("sample"), DAE.ICONST(iSample)::es, attr), (ht, iDelay, iSample, iSpatial, timeEvents, noEventSpDs));
 
     else (inExp,inTuple);
   end match;

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -9640,7 +9640,7 @@ end collapseRemovedEqs1;
 public function emptyEventInfo
   output BackendDAE.EventInfo info;
 algorithm
-  info := BackendDAE.EVENT_INFO({}, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0);
+  info := BackendDAE.EVENT_INFO({}, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0, {});
 end emptyEventInfo;
 
 public function getSubClock

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -2356,6 +2356,7 @@ public function replaceEventInfo
 
 protected
   Integer numberMathEvents;
+  list<Integer> noEventSpDs;
   list<BackendDAE.TimeEvent> timeEvents;
   BackendDAE.ZeroCrossingSet zeroCrossingLst, sampleLst;
   DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
@@ -2365,13 +2366,13 @@ protected
   end Func;
   Func zc;
 algorithm
-  BackendDAE.EVENT_INFO(timeEvents, zeroCrossingLst, relationsLst, sampleLst, numberMathEvents) := eInfoIn;
+  BackendDAE.EVENT_INFO(timeEvents, zeroCrossingLst, relationsLst, sampleLst, numberMathEvents, noEventSpDs) := eInfoIn;
   timeEvents := List.map2(timeEvents, replaceTimeEvents, inVariableReplacements, inFuncTypeExpExpToBooleanOption);
   zc := function replaceZeroCrossing(inVariableReplacements=inVariableReplacements);
   DoubleEnded.mapNoCopy_1(zeroCrossingLst.zc, zc, inFuncTypeExpExpToBooleanOption);
   DoubleEnded.mapNoCopy_1(sampleLst.zc, zc, inFuncTypeExpExpToBooleanOption);
   DoubleEnded.mapNoCopy_1(relationsLst, zc, inFuncTypeExpExpToBooleanOption);
-  eInfoOut := BackendDAE.EVENT_INFO(timeEvents,zeroCrossingLst,relationsLst,sampleLst,numberMathEvents);
+  eInfoOut := BackendDAE.EVENT_INFO(timeEvents,zeroCrossingLst,relationsLst,sampleLst,numberMathEvents,noEventSpDs);
 end replaceEventInfo;
 
 protected function replaceTimeEvents

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -579,6 +579,7 @@ algorithm
       BackendDAE.EventInfo einfo;
       list<BackendDAE.Equation> eqs_lst, eqs_lst1;
       list<BackendDAE.TimeEvent> timeEvents;
+      list<Integer> noEventSpDs;
       BackendDAE.ZeroCrossingSet zero_crossings, sampleLst;
       DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
       Integer countMathFunctions;
@@ -592,7 +593,8 @@ algorithm
         BackendDAE.SHARED( globalKnownVars=globalKnownVars, eventInfo=einfo) := inShared;
         BackendDAE.EVENT_INFO( timeEvents=timeEvents, zeroCrossings=zero_crossings,
                                samples=sampleLst, relations=relations,
-                               numberMathEvents=countMathFunctions ) := einfo;
+                               numberMathEvents=countMathFunctions,
+                               noEventSpatialDistributions=noEventSpDs ) := einfo;
         eqs_lst := BackendEquation.equationList(eqns);
         (zero_crossings, eqs_lst1, countMathFunctions, relations, sampleLst) :=
         findZeroCrossings2( vars, globalKnownVars, eqs_lst, 0,
@@ -612,7 +614,7 @@ algorithm
         else
         end try;
         einfo := BackendDAE.EVENT_INFO( timeEvents, zero_crossings, relations, sampleLst,
-                                           countMathFunctions );
+                                           countMathFunctions, noEventSpDs );
       then (outSyst, BackendDAEUtil.setSharedEventInfo(inShared, einfo));
   end match;
 end findZeroCrossings1;

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -998,6 +998,7 @@ public
       Expression initVals           "initial grid values";
       Integer initSize              "number of initial points";
       Option<Expression> condition  "guard condition of the enclosing if-branch, if any";
+      Boolean noEvent               "true when either input is wrapped in noEvent()";
     end SPATIAL_DISTRIBUTION;
 
     function collect
@@ -1062,7 +1063,7 @@ public
           slst      := Pointer.access(spatial_lst);
           index     := listLength(slst);
           exp.call  := Call.setArguments(call, Expression.INTEGER(index) :: {in0, in1, pos, dir, initPnts, initVals});
-          Pointer.update(spatial_lst, SPATIAL_DISTRIBUTION(index, in0, in1, pos, dir, initPnts, initVals, arrayLength(initPnts.elements), condition) :: slst);
+          Pointer.update(spatial_lst, SPATIAL_DISTRIBUTION(index, in0, in1, pos, dir, initPnts, initVals, arrayLength(initPnts.elements), condition, Expression.isCallNamed(in0, "noEvent") or Expression.isCallNamed(in1, "noEvent")) :: slst);
         then exp;
 
         // just traverse deeper
@@ -1099,7 +1100,8 @@ public
         initPnts  = Expression.toDAE(sd.initPnts),
         initVals  = Expression.toDAE(sd.initVals),
         initSize  = sd.initSize,
-        condition = if isSome(sd.condition) then SOME(Expression.toDAE(Util.getOption(sd.condition))) else NONE()
+        condition = if isSome(sd.condition) then SOME(Expression.toDAE(Util.getOption(sd.condition))) else NONE(),
+        noEvent   = sd.noEvent
       );
     end convert;
 

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -273,6 +273,7 @@ uniontype SpatialDistribution
     DAE.Exp initVals      "initial grid values";
     Integer initSize      "number of initial points";
     Option<DAE.Exp> condition "guard condition of the enclosing if-branch, if any";
+    Boolean noEvent       "true when either input is wrapped in noEvent(), suppressing output events";
   end SPATIAL_DISTRIBUTION;
 end SpatialDistribution;
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -5893,13 +5893,27 @@ function extractSpatialDistributionInfo
   output SimCode.SpatialDistributionInfo spatialInfo;
 protected
   list<SimCode.SpatialDistribution> spatial_lst;
+  list<SimCode.SpatialDistribution> noEventLst = {};
+  list<Integer> noEventSpDs;
   Mutable<Integer> maxIndex_ptr = Mutable.create(-1);
 algorithm
   // Traverse top-down so we can keep track of the guard condition of the
   // enclosing if-branch a spatialDistribution() operator sits in. The
   // storeSpatialDistribution() callback must be guarded by the same condition
+  // as the operator's evaluation.
   (_, (_, spatial_lst)) := BackendDAEUtil.traverseBackendDAEExps(dlow, Expression.traverseSubexpressionsTopDownHelper, (function extractSpatialDistributionInfoExp(maxIndex_ptr = maxIndex_ptr), (NONE(), {})));
-  spatialInfo := SimCode.SPATIAL_DISTRIBUTION_INFO(spatial_lst, Mutable.access(maxIndex_ptr));
+  // The noEvent() detection has to happen in the backend (BackendDAECreate),
+  // before the simplifier propagates noEvent() onto the relations inside the
+  // inputs. Read the collected indices from the event info.
+  BackendDAE.SHARED(eventInfo = BackendDAE.EVENT_INFO(noEventSpatialDistributions = noEventSpDs)) := dlow.shared;
+  for sd in spatial_lst loop
+    noEventLst := (match sd
+        case SimCode.SPATIAL_DISTRIBUTION() guard List.contains(noEventSpDs, sd.index, intEq)
+        then SimCode.SPATIAL_DISTRIBUTION(sd.index, sd.in0, sd.in1, sd.pos, sd.dir, sd.initPnts, sd.initVals, sd.initSize, sd.condition, true);
+        else sd;
+      end match) :: noEventLst;
+  end for;
+  spatialInfo := SimCode.SPATIAL_DISTRIBUTION_INFO(listReverse(noEventLst), Mutable.access(maxIndex_ptr));
 end extractSpatialDistributionInfo;
 
 function extractSpatialDistributionInfoExp
@@ -5907,7 +5921,9 @@ function extractSpatialDistributionInfoExp
    together with the guard condition of the enclosing if-branch it sits in.
    The condition is carried in the traversal argument and conjoined per branch
    (then = cond, else = not cond) so the generated storeSpatialDistribution
-   callback can be guarded by the same event as the operator's evaluation."
+   callback can be guarded by the same event as the operator's evaluation.
+   noEvent() on the inputs is detected earlier, in BackendDAECreate, and read
+   from the event info in extractSpatialDistributionInfo."
   input output DAE.Exp callExp;
   output Boolean cont "Continue descending flag for Expression.traverseExpTopDown";
   input output tuple<Option<DAE.Exp>, list<SimCode.SpatialDistribution>> tpl "current guard condition and collected operators";
@@ -5929,7 +5945,7 @@ algorithm
           Error.addInternalError("function extractDelayedExpressions failed: initialPoints and initialValues of spatialDistribution are not of the same size.", sourceInfo());
         end if;
         initSize := Expression.sizeOf(Expression.typeof(initPnts));
-        spatialInfo := SimCode.SPATIAL_DISTRIBUTION(i, in0, in1, pos, dir, initPnts, initVals, initSize, curCond) :: spatialInfo;
+        spatialInfo := SimCode.SPATIAL_DISTRIBUTION(i, in0, in1, pos, dir, initPnts, initVals, initSize, curCond, false) :: spatialInfo;
     then (true, (curCond, spatialInfo));
 
     // Descend into the branches ourselves so the accumulated guard condition

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4019,13 +4019,15 @@ template functionInitSpatialDistribution(SpatialDistributionInfo spatialInfo, St
 ::=
   let &varDecls = buffer ""
   let &auxFunction = buffer ""
-  let storePart = (match spatialInfo case SPATIAL_DISTRIBUTION_INFO(__) then (spatialDistributions |> SPATIAL_DISTRIBUTION(index=index, initPnts=initPnts, initVals=initVals, initSize=initSize) =>
+  let storePart = (match spatialInfo case SPATIAL_DISTRIBUTION_INFO(__) then (spatialDistributions |> SPATIAL_DISTRIBUTION(index=index, initPnts=initPnts, initVals=initVals, initSize=initSize, noEvent=noEvt) =>
       let &preExp = buffer ""
       let initPntsT = daeExp(initPnts, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
       let initValsT = daeExp(initVals, contextSimulationNonDiscrete, &preExp, &varDecls, &auxFunction)
+      let suppressEvents = if noEvt then "1" else "0"
       <<
       <%preExp%>
-      initSpatialDistribution(data, threadData, <%index%>, &<%initPntsT%>, &<%initValsT%>, <%initSize%>);<%\n%>
+      initSpatialDistribution(data, threadData, <%index%>, &<%initPntsT%>, &<%initValsT%>, <%initSize%>);
+      data->simulationInfo->spatialDistributionData[<%index%>].suppressEvents = <%suppressEvents%>;
       >>
     ))
   <<

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -605,6 +605,7 @@ end SparsityRow;
       DAE.Exp initVals      "initial grid values";
       Integer initSize      "number of initial points";
       Option<DAE.Exp> condition "guard condition of the enclosing if-branch, if any";
+      Boolean noEvent       "true when either input is wrapped in noEvent()";
     end SPATIAL_DISTRIBUTION;
   end SpatialDistribution;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/spatialDistribution.c
@@ -139,6 +139,7 @@ SPATIAL_DISTRIBUTION_DATA* allocSpatialDistribution(unsigned int nSpatialDistrib
     spatialDistributionData[i].transportedQuantity = allocDoubleEndedList(sizeof(TRANSPORTED_QUANTITY_DATA)); /* empty double ended list */
     spatialDistributionData[i].storedEvents = allocDoubleEndedList(sizeof(TRANSPORTED_EVENT_DATA));           /* empty double ended list */
     spatialDistributionData[i].lastStoredEventValue = 0;
+    spatialDistributionData[i].suppressEvents = 0;
   }
 
   return spatialDistributionData;
@@ -351,7 +352,13 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     TRANSPORTED_QUANTITY_DATA* front = (TRANSPORTED_QUANTITY_DATA*) firstDataDoubleEndedList(transportedQuantityList);
     if (fabs(-posX - front->position) < spatialPosEps(-posX, front->position)) {
       if (fabs(front->value - in0) > spatialValEps(front->value, in0)) {
-        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, front->position, in0, 1 /* true */);
+        if (spatialDistribution->suppressEvents) {
+          /* noEvent(): store the value but skip the event node so the
+             zero-crossing function never reports a sign change. */
+          addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, front->position, in0, 0 /* false */);
+        } else {
+          addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, front->position, in0, 1 /* true */);
+        }
       }
     } else {
       addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX, in0, 0 /* false */);
@@ -360,7 +367,12 @@ void storeSpatialDistribution(DATA* data, threadData_t *threadData, unsigned int
     TRANSPORTED_QUANTITY_DATA* last = (TRANSPORTED_QUANTITY_DATA*) lastDataDoubleEndedList(transportedQuantityList);
     if (fabs(-posX+1 - last->position) < spatialPosEps(-posX+1, last->position)) {
       if (fabs(last->value - in1) > spatialValEps(last->value, in1)) {
-        addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, last->position, in1, 1 /* true */);
+        if (spatialDistribution->suppressEvents) {
+          /* noEvent(): store the value but skip the event node. */
+          addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, last->position, in1, 0 /* false */);
+        } else {
+          addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, last->position, in1, 1 /* true */);
+        }
       }
     } else {
       addNewNodeSpatialDistribution(threadData, spatialDistribution, isPositiveVelocity, -posX+1, in1, 0 /* false */);
@@ -553,6 +565,12 @@ double spatialDistributionZeroCrossing(DATA* data, threadData_t *threadData, uns
   /* Access spatialDistribution */
   spatialDistribution = &(data->simulationInfo->spatialDistributionData[index]);
   storedEventsList = spatialDistribution->storedEvents;
+
+  /* When suppressEvents is set (noEvent() wraps either input), return the
+   * previous zero-crossing value so the solver never detects a sign change. */
+  if (spatialDistribution->suppressEvents) {
+    return data->simulationInfo->zeroCrossingsPre[relationIndex];
+  }
 
   /* Shift x so the operator starts at x = 0 (only the change of x matters).
    * Do NOT capture the start position here: the zero-crossing function is

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -799,6 +799,10 @@ typedef struct SPATIAL_DISTRIBUTION_DATA {
   DOUBLE_ENDED_LIST* transportedQuantity;
   DOUBLE_ENDED_LIST* storedEvents;
   int lastStoredEventValue;
+  int suppressEvents;  /* when set, storeSpatialDistribution skips event-node
+                          creation so the zero-crossing function never reports
+                          an event; used when noEvent() wraps the inputs of
+                          spatialDistribution. */
 } SPATIAL_DISTRIBUTION_DATA;
 
 typedef struct SIMULATION_INFO

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/Makefile
@@ -18,6 +18,7 @@ TESTFILES = \
 	largePositionReversal.mos \
 	rampInput.mos \
 	frozenBranchInitialEvent.mos \
+	noEvent.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/noEvent.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/noEvent.mos
@@ -1,0 +1,60 @@
+// name:                noEvent.mos
+// keywords:            spatialDistribution, noEvent
+// status:              correct
+// teardown_command:    rm -f Issue14357Model*
+//
+// When noEvent() wraps the inputs of spatialDistribution(), the output must
+// not generate state events: the discontinuity is transported smoothly.
+// With LOG_EVENTS we expect the input event at time=0.1 (time < 0.1) but no
+// event at time=0.2666 when the transported discontinuity reaches the output.
+
+loadModel(Modelica); getErrorString();
+loadString("
+model Issue14357Model
+  Real x;
+  Real v;
+  Real in0, out0, out1;
+equation
+  der(x) = v;
+  v = 6;
+  in0 = if time < 0.1 then 0 else 1;
+  (out0, out1) = spatialDistribution(noEvent(in0), 0, x, true);
+end Issue14357Model;
+"); getErrorString();
+
+simulate(Issue14357Model, stopTime=0.5, numberOfIntervals=50, simflags="-lv=LOG_EVENTS"); getErrorString();
+
+// Before the transport delay (1/v = 1/6), out1 must still be 0.
+val(out1, 0.1);
+val(out1, 0.25);
+// After the delay the transported value 1 arrives.
+val(out1, 0.3);
+val(out1, 0.5);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Issue14357Model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 50, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue14357Model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_EVENTS'",
+//     messages = "LOG_EVENTS        | info    | status of relations at time=0
+// |                 | |       | | [1] (pre: false) false = spatialDistributionZeroCrossing(0, 0, x, true)
+// |                 | |       | | [2] (pre:  true)  true = time < 0.1
+// LOG_EVENTS        | info    | status of zero crossings at time=0
+// |                 | |       | | [1] (pre:  0) -1 = spatialDistributionZeroCrossing(0, 0, x, true) > 0.0
+// |                 | |       | | [2] (pre:  0)  1 = time < 0.1
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_EVENTS        | info    | state event at time=0.10000000011
+// |                 | |       | | [2] time < 0.1
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0.0
+// 0.0
+// 1.0
+// 1.0
+// endResult


### PR DESCRIPTION
When noEvent() wraps the inputs of spatialDistribution(), the output must not generate state events: the discontinuity is transported smoothly through the operator without triggering a zero-crossing at the output.

Root cause: the compiler generated a spatialDistributionZeroCrossing() zero-crossing for every spatialDistribution call, regardless of whether its inputs were wrapped in noEvent().  The runtime then created event nodes in the stored profile whenever the input value changed at the same spatial position, causing the zero-crossing function to report a sign change and the solver to detect a state event.

Fix (compiler + runtime):

1. Detect noEvent() on both in0 and in1 of each spatialDistribution call in the old backend (SimCodeUtil.mo) and new backend (NBEvents.mo).
2. Carry a Boolean noEvent field in the SimCode.SpatialDistribution record.
3. In CodegenC.tpl / CodegenC.mo, generate spatialDistributionData[i].suppressEvents = 1 in the init function when the flag is set.
4. In the C runtime (spatialDistribution.c), read the suppressEvents flag in storeSpatialDistribution and skip event-node creation (isEvent=0) when it is set.  Value nodes are still stored so the profile is transported correctly.

Closes #14357
