### PR TITLE
Comp/SimRT: Fix CVODE FMU crash on fmi2Terminate/fmi2Reset

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -814,6 +814,12 @@ void fmi2FreeInstance(fmi2Component c)
     return;
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2FreeInstance...")
 
+  /* Free CS simulator (CVODE & co) first, while the model data it references
+   * (e.g. the states array wrapped by the solver's N_Vector y) is still alive. */
+  if (comp->solverInfo) {
+    FMI2CS_deInitializeSolverData(comp);
+  }
+
   /* call external objects destructors */
   comp->fmuData->callback->callExternalObjectDestructors(comp->fmuData, comp->threadData);
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
@@ -871,9 +877,6 @@ void fmi2FreeInstance(fmi2Component c)
   freeMemory(comp->input_real_derivative); comp->input_real_derivative = NULL;
 
   freeMemory(comp->fmuData->modelData->resourcesDir);
-  if (comp->solverInfo) {
-    FMI2CS_deInitializeSolverData(comp);
-  }
 
   /* free simuation data */
   freeMemory(comp->fmuData->modelData);
@@ -1040,6 +1043,13 @@ fmi2Status fmi2Reset(fmi2Component c)
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2Reset")
 
   setThreadData(comp);
+  /* Free CS simulator (CVODE & co) first, while the model data it references
+   * (e.g. the states array wrapped by the solver's N_Vector y) is still alive,
+   * see #16319/#14074/#8615. */
+  if (comp->solverInfo) {
+    FMI2CS_deInitializeSolverData(comp);
+  }
+
   /* Free modelData */
   if (!(comp->state & model_state_terminated)) {
     /* call external objects destructors */
@@ -1058,11 +1068,6 @@ fmi2Status fmi2Reset(fmi2Component c)
 #endif
     /* free data struct */
     deInitializeDataStruc(comp->fmuData);
-  }
-
-  /* Free CS simulator */
-  if (comp->solverInfo) {
-    FMI2CS_deInitializeSolverData(comp);
   }
 
   /* Initialize modelData */

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -860,6 +860,12 @@ void omcFreeInstance(ModelInstance* c)
     return;
   FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcFreeInstance...")
 
+  /* Free CS simulator (CVODE & co) first, while the model data it references
+   * (e.g. the states array wrapped by the solver's N_Vector y) is still alive. */
+  if (comp->solverInfo) {
+    FMI3CS_deInitializeSolverData(comp);
+  }
+
   /* call external objects destructors */
   comp->fmuData->callback->callExternalObjectDestructors(comp->fmuData, comp->threadData);
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
@@ -917,9 +923,6 @@ void omcFreeInstance(ModelInstance* c)
   free(comp->input_real_derivative); comp->input_real_derivative = NULL;
 
   free(comp->fmuData->modelData->resourcesDir);
-  if (comp->solverInfo) {
-    FMI3CS_deInitializeSolverData(comp);
-  }
 
   /* free simuation data */
   free(comp->fmuData->modelData);
@@ -1085,6 +1088,13 @@ fmi3Status omcReset(ModelInstance* c)
   FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcReset")
 
   setThreadData(comp);
+  /* Free CS simulator (CVODE & co) first, while the model data it references
+   * (e.g. the states array wrapped by the solver's N_Vector y) is still alive,
+   * see #16319/#14074/#8615. */
+  if (comp->solverInfo) {
+    FMI3CS_deInitializeSolverData(comp);
+  }
+
   /* Free modelData */
   if (!(comp->state & model_state_terminated)) {
     /* call external objects destructors */
@@ -1103,11 +1113,6 @@ fmi3Status omcReset(ModelInstance* c)
 #endif
     /* free data struct */
     deInitializeDataStruc(comp->fmuData);
-  }
-
-  /* Free CS simulator */
-  if (comp->solverInfo) {
-    FMI3CS_deInitializeSolverData(comp);
   }
 
   /* Initialize modelData */


### PR DESCRIPTION
Free the CS solver (CVODE & co) before deInitializeDataStruc in fmi2FreeInstance/fmi2Reset (and FMI3 omcFreeInstance/omcReset), while the model data it references (states array wrapped by the solver's N_Vector y) is still alive. Previously the solver was torn down after the model data, leaving dangling pointers and crashing importers (FMPy, Hopsan, Dymola) at teardown. See #16319, #14074, #8615.


Closes #16319
Closes #14074
Closes #8615
