### PR TITLE
Keep scalar product when a slice cannot expand

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -2424,6 +2424,8 @@ algorithm
         true := listLength(expl1) <= 3;
         expl2 := list(Expression.crefToExp(c) for c in ComponentReference.expandCref(cr2, true));
         true := listLength(expl1) == listLength(expl2);
+        // expandCref leaves a non-constant slice alone; expMul would make it an array product.
+        true := List.none(expl1, isArrayTypedExp) and List.none(expl2, isArrayTypedExp);
         expl := List.threadMap(expl1, expl2, Expression.expMul);
         exp := List.reduce(expl, Expression.expAdd);
       then
@@ -2438,6 +2440,11 @@ algorithm
 
   end match;
 end simplifyScalarProduct;
+
+protected function isArrayTypedExp
+  input DAE.Exp exp;
+  output Boolean b = Expression.isArrayType(Expression.typeof(exp));
+end isArrayTypedExp;
 
 protected function unliftOperator
   input DAE.Exp inArray;

--- a/testsuite/simulation/modelica/inlineFunction/Makefile
+++ b/testsuite/simulation/modelica/inlineFunction/Makefile
@@ -16,6 +16,7 @@ inlineFunction8.mos \
 inlineFunction9.mos \
 inlineFunction10.mos \
 inlineFunction11.mos \
+inlineScalarProductSlice.mos \
 forceComplexEq.mos \
 forceComplexEq2.mos \
 forceComplexEq3.mos \

--- a/testsuite/simulation/modelica/inlineFunction/inlineScalarProductSlice.mos
+++ b/testsuite/simulation/modelica/inlineFunction/inlineScalarProductSlice.mos
@@ -1,0 +1,52 @@
+// name: inlineScalarProductSlice
+// keywords: inline, scalar product, slice
+// status: correct
+//
+// A scalar product of two crefs sliced with a non-constant bound must not
+// become an element-wise array product.
+
+loadString("
+model inlineScalarProductSlice
+  function dot
+    input Integer n;
+    input Real a[n];
+    input Real b[n];
+    input Integer m;
+    output Real d;
+  algorithm
+    d := a[1:m]*b[1:m];
+    annotation(Inline=true);
+  end dot;
+  constant Integer n = 3;
+  Real a[n];
+  Real b[n];
+  Integer m;
+  Real d;
+equation
+  a = {1, 2, 3} * (1 + time);
+  b = {4, 5, 6} * (1 + time);
+  m = 1 + integer(2 * time);
+  d = dot(n, a, b, m);
+end inlineScalarProductSlice;
+"); getErrorString();
+
+simulate(inlineScalarProductSlice, stopTime = 1.0); getErrorString();
+
+// m = 1, 2, 3 -> d = (1 + time)^2 * {4, 14, 32}
+val(m, {0.25, 0.75, 1.0});
+val(d, {0.25, 0.75, 1.0});
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "inlineScalarProductSlice_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'inlineScalarProductSlice', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// {1.0,2.0,3.0}
+// {6.25,42.875,128.0}
+// endResult


### PR DESCRIPTION
Regression from a481f08a01 "[OF] Always expand scalar products of crefs" (#14794). That change expands both operands of `v1 * v2` with `ComponentReference.expandCref` and multiplies them pairwise using `Expression.expMul`. `expandCref` cannot expand a slice with a non-constant bound and returns the cref unchanged, so the sum of products collapses to `expMul(v1, v2)`, which builds a `MUL_ARR` element-wise product for two array operands. The result is an array-valued right-hand side assigned to a scalar.

Only take the expansion path when every expanded factor is scalar. Whole arrays and constant slices still expand as #14794 intended.

Reproduced with the inlined `temporalSuperposition` call in `Buildings.Fluid.Geothermal.Borefields.Examples.RectangularBorefield`, whose body is `QAgg_flow[1:curCel]*kappa[1:curCel]`:

| target                | before                          |
| --------------------- | ------------------------------- |
| C, when-equation      | no assignment emitted at all    |
| C, plain equation     | generated C does not compile    |
| wasm-jit              | array assigned to a scalar slot |

The silent case is the damaging one: `delTBor` peaked at 0.304 K instead of 2.695 K because `delTBor0` was never updated.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

The MWE from #13853 still works with these changes

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
