### PR TITLE
Susan output directory

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -116,20 +116,20 @@ set(OMC_MM_ALWAYS_SOURCES
 
 # Only files needed for compiling MetaModelica
 # "Template";
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/AbsynDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCFunctions.mo
+    ${OMC_GENERATED_MO_DIR}/Template/AbsynDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCFunctions.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenWasmJit.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenUtil.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/DAEDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/ExpressionDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/GenerateAPIFunctionsTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/SCodeDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenUtil.mo
+    ${OMC_GENERATED_MO_DIR}/Template/DAEDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/ExpressionDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/GenerateAPIFunctionsTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/SCodeDumpTpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplAbsyn.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/susan_codegen/TplCodegen.mo
+    ${OMC_GENERATED_MO_DIR}/susan_codegen/TplCodegen.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplMain.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/Tpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplParser.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/Unparsing.mo
+    ${OMC_GENERATED_MO_DIR}/Template/Unparsing.mo
 
   # Only files needed for compiling MetaModelica
   # "Global";
@@ -446,39 +446,39 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SimCodeUtilShared.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/ReduceDAE.mo
 
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/AbsynToJulia.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/AbsynJLDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenEmbeddedC.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCppCommon.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCpp.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCppOMSI.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCppHpcom.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCppHpcomOMSI.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCppInit.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU1.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU2.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU3.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCpp.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCppOMSI.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenOMSI_common.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenOMSIC.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenOMSIC_Equations.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenOMSICpp.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCppHpcom.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCppHpcomOMSI.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenJS.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenMidToC.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenUtilSimulation.mo
+    ${OMC_GENERATED_MO_DIR}/Template/AbsynToJulia.mo
+    ${OMC_GENERATED_MO_DIR}/Template/AbsynJLDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenC.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenEmbeddedC.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCppCommon.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCpp.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCppOMSI.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCppHpcom.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCppHpcomOMSI.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenCppInit.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMU.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMU1.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMU2.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMU3.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCommon.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCpp.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCppOMSI.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenOMSI_common.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenOMSIC.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenOMSIC_Equations.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenOMSICpp.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCppHpcom.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCppHpcomOMSI.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenJS.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenMidToC.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenUtilSimulation.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenWasmJitFunctions.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenXML.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/GraphvizDump.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/GraphMLDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/NFInstDumpTpl.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeDump.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/VisualXMLTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/CodegenXML.mo
+    ${OMC_GENERATED_MO_DIR}/Template/GraphvizDump.mo
+    ${OMC_GENERATED_MO_DIR}/Template/GraphMLDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/NFInstDumpTpl.mo
+    ${OMC_GENERATED_MO_DIR}/Template/SimCodeDump.mo
+    ${OMC_GENERATED_MO_DIR}/Template/VisualXMLTpl.mo
 
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/Autoconf.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/AvlTree.mo

--- a/OMCompiler/Compiler/.cmake/template_compilation.cmake
+++ b/OMCompiler/Compiler/.cmake/template_compilation.cmake
@@ -1,4 +1,13 @@
 
+# Where the *.mo (and the Susan log) generated from the *.tpl are written.
+# Consumers refer to this directory rather than Compiler/Template:
+# meta_modelica_source_list.cmake for the compiler build, and
+# LoadCompilerSources.mos via OMCOMPILERGENERATEDSOURCES for the bootstrapping tests.
+# The source layout is mirrored below it (generated-mo/Template,
+# generated-mo/susan_codegen, ...) so a consumer only has to swap the root.
+set(OMC_GENERATED_MO_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated-mo
+    CACHE INTERNAL "Build-tree root holding the .mo generated from Susan templates.")
+
 # This macro takes a template file and list of dependencies as inputs.
 # You can use it as:
 #           omc_add_template_target(SOURCE CodegenC.tpl
@@ -21,11 +30,12 @@ macro(omc_add_template_target)
 
     get_filename_component(file_name_no_ext ${template_file} NAME_WLE)
     get_filename_component(source_dir ${template_file} DIRECTORY)
-    set(output_mo_file ${source_dir}/${file_name_no_ext}.mo)
-    # omc generates the mo file in the current dir. So we might as well put the log
-    # there for now.
-    # set(output_log_file ${output_dir}/${file_name_no_ext}.log)
-    set(output_log_file ${source_dir}/${file_name_no_ext}.log)
+    # Mirror the template's own directory (Template, susan_codegen, ...) under
+    # the generated-mo root, so the tree matches the source layout.
+    get_filename_component(source_subdir ${source_dir} NAME)
+    set(output_dir ${OMC_GENERATED_MO_DIR}/${source_subdir})
+    set(output_mo_file ${output_dir}/${file_name_no_ext}.mo)
+    set(output_log_file ${output_dir}/${file_name_no_ext}.log)
 
     add_custom_command(
         # We need to work in the directory where the tpl files are located because
@@ -37,7 +47,8 @@ macro(omc_add_template_target)
         # (rust_omc.cmake) it is the rust_susan stamp, so each *.mo is
         # regenerated after the Susan binary is (re)built.
         DEPENDS ${template_file} ${depends_on} ${TPL_EXTRA_DEPENDS}
-        COMMAND ${OMC_EXE} -d=failtrace ${template_file} > ${output_log_file} || (cat ${output_log_file} && false)
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
+        COMMAND ${OMC_EXE} -d=failtrace --tplOutputDir=${output_dir} ${template_file} > ${output_log_file} || (cat ${output_log_file} && false)
 
         OUTPUT ${output_mo_file}
         COMMENT "Generating ${output_mo_file} from ${template_file}"
@@ -55,13 +66,6 @@ macro(omc_add_template_target)
     # message(STATUS "Added Susan template target ${template_file}")
 
 endmacro(omc_add_template_target)
-
-
-
-
-
-
-
 
 
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/AbsynDumpTpl.tpl
@@ -97,8 +101,6 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/SCodeDumpTpl
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/Unparsing.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeTV.mo)
 
-
-
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCFunctions.tpl
@@ -123,7 +125,7 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU.t
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU2.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU3.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.tpl
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.mo
+                        DEPENDS ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCommon.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeBackendTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenCFunctions.tpl
@@ -132,7 +134,7 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU.t
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU1.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.tpl
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.mo
+                        DEPENDS ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCommon.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeBackendTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenUtil.tpl)
@@ -140,7 +142,7 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU1.
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU2.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.tpl
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.mo
+                        DEPENDS ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCommon.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeBackendTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenUtil.tpl)
@@ -148,7 +150,7 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU2.
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMU3.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.tpl
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenFMUCommon.mo
+                        DEPENDS ${OMC_GENERATED_MO_DIR}/Template/CodegenFMUCommon.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/SimCodeBackendTV.mo
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenC.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenUtil.tpl)
@@ -282,10 +284,5 @@ omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/CodegenJS.tp
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/Template/VisualXMLTpl.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Template/VisualXMLTplTV.mo)
 
-
-
-
 omc_add_template_target(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/susan_codegen/TplCodegen.tpl
                         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/susan_codegen/TplCodegenTV.mo)
-
-

--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -501,7 +501,7 @@ algorithm
     case {f} /* A template file .tpl (in the Susan language)*/
       algorithm
         isCodegenTemplateFile(f);
-        TplMain.main(f);
+        TplMain.main(f, Flags.getConfigString(Flags.TPL_OUTPUT_DIR));
       then
         ();
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_susan/src/main.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_susan/src/main.rs
@@ -6,9 +6,12 @@
 //! `omc`/`bomc`.
 //!
 //! Usage:  `susan [flags] <file.tpl>`  (run with the template's directory as the
-//! working directory; the `<file>.mo` is written next to the input, as omc did).
-//! Leading `-…` flags (e.g. `-d=failtrace`, passed by the CMake template rule)
-//! are accepted and ignored; the first non-flag argument is the template file.
+//! working directory). `--tplOutputDir=<dir>` writes the `<file>.mo` there —
+//! the same omc config flag, which the build rules use to keep the generated
+//! sources out of the source tree; without it the `.mo` is written next to the
+//! input, as omc did. Other leading `-…` flags (e.g. `-d=failtrace`, passed by
+//! the CMake template rule) are accepted and ignored; the first non-flag
+//! argument is the template file.
 //!
 //! This is deliberately a thin wrapper over the single library entry point
 //! `TplMain::main`: the flags global is valid by default (see
@@ -27,12 +30,22 @@ use openmodelica_susan::TplMain;
 /// address space only (committed lazily), so the headroom is effectively free.
 const DEFAULT_STACK_SIZE: usize = 64 * 1024 * 1024;
 
+const OUTPUT_DIR_FLAG: &str = "--tplOutputDir=";
+
 fn run() -> i32 {
-    let Some(file) = std::env::args().skip(1).find(|a| !a.starts_with('-')).map(ArcStr::from) else {
-        eprintln!("usage: susan [flags] <file.tpl>");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some(file) = args.iter().find(|a| !a.starts_with('-')).map(ArcStr::from) else {
+        eprintln!("usage: susan [--tplOutputDir=<dir>] [flags] <file.tpl>");
         return 1;
     };
-    match TplMain::main(file) {
+    // Last one wins, like omc's own flag parsing.
+    let out_dir = args
+        .iter()
+        .filter_map(|a| a.strip_prefix(OUTPUT_DIR_FLAG))
+        .next_back()
+        .map(ArcStr::from)
+        .unwrap_or_default();
+    match TplMain::main(file, out_dir) {
         Ok(()) => 0,
         Err(_) => {
             // `TplMain`/`translateFile` already printed the error buffer and the

--- a/OMCompiler/Compiler/Template/TplMain.mo
+++ b/OMCompiler/Compiler/Template/TplMain.mo
@@ -63,6 +63,7 @@ constant SourceInfo dsi = TplAbsyn.dummySourceInfo;
 
 public function main
   input String inFile;
+  input String inOutputDir = "";
 
 algorithm
   () := match inFile
@@ -77,7 +78,7 @@ algorithm
     case file
       algorithm
         Print.clearBuf();
-        translateFile(file);
+        translateFile(file, inOutputDir);
         strErrBuf := Print.getErrorString();
         strErrBuf := if strErrBuf == "" then "" else ("### Error Buffer ###\n"+strErrBuf+"\n### End of Error Buffer ###\n");
         print(strErrBuf);
@@ -89,6 +90,7 @@ end main;
 
 public function translateFile
   input String inFile;
+  input String inOutputDir = "";
 
 algorithm
   () := matchcontinue inFile
@@ -107,6 +109,9 @@ algorithm
 
         destFile := System.stringReplace(file + "*", ".tpl*", ".mo");
         false := stringEq(file, destFile);
+        if inOutputDir <> "" then
+          destFile := inOutputDir + "/" + System.basename(destFile);
+        end if;
 
         //print(destFile);
         tplPackage := TplParser.templPackageFromFile(file);

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1443,6 +1443,9 @@ constant ConfigFlag FMU_NATIVE_PLATFORMS = CONFIG_FLAG(171,
 constant ConfigFlag TEARING_COST_MARGIN = CONFIG_FLAG(170, "tearingCostMargin",
   NONE(), EXTERNAL(), REAL_FLAG(2.0), NONE(),
   "How much cheaper solving a linear system untorn has to be estimated before its\ntearing set is dropped. Raise it to keep tearing systems the estimate would give\nup on, lower it towards 0 to tear less (default 2).");
+constant ConfigFlag TPL_OUTPUT_DIR = CONFIG_FLAG(172, "tplOutputDir",
+  NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
+  "Directory the .mo generated from a Susan .tpl is written to. Empty (the\ndefault) writes it next to the .tpl, which is how the templates used to be\ngenerated into the source tree.");
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1436,13 +1436,13 @@ constant ConfigFlag FMU_VERSION = CONFIG_FLAG(169, "fmiVersion",
   NONE(), EXTERNAL(), ENUM_FLAG(FMI_VERSION_20, {("1.0", FMI_VERSION_10), ("2.0", FMI_VERSION_20), ("3.0", FMI_VERSION_30)}),
   SOME(STRING_OPTION({"1.0", "2.0", "3.0"})),
   "FMI version for FMU export: 1.0, 2.0, 3.0.");
+constant ConfigFlag TEARING_COST_MARGIN = CONFIG_FLAG(170, "tearingCostMargin",
+  NONE(), EXTERNAL(), REAL_FLAG(2.0), NONE(),
+  "How much cheaper solving a linear system untorn has to be estimated before its\ntearing set is dropped. Raise it to keep tearing systems the estimate would give\nup on, lower it towards 0 to tear less (default 2).");
 constant ConfigFlag FMU_NATIVE_PLATFORMS = CONFIG_FLAG(171,
   "", NONE(), INTERNAL(), STRING_FLAG(""), NONE(),
   "buildModelFMU's non-wasm platforms, comma separated: the wasm FMU also carries
    a precompiled artifact and a loader library for each of them.");
-constant ConfigFlag TEARING_COST_MARGIN = CONFIG_FLAG(170, "tearingCostMargin",
-  NONE(), EXTERNAL(), REAL_FLAG(2.0), NONE(),
-  "How much cheaper solving a linear system untorn has to be estimated before its\ntearing set is dropped. Raise it to keep tearing systems the estimate would give\nup on, lower it towards 0 to tear less (default 2).");
 constant ConfigFlag TPL_OUTPUT_DIR = CONFIG_FLAG(172, "tplOutputDir",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   "Directory the .mo generated from a Susan .tpl is written to. Empty (the\ndefault) writes it next to the .tpl, which is how the templates used to be\ngenerated into the source tree.");

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -440,7 +440,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.FMU_PLATFORMS,
   Flags.FMU_VERSION,
   Flags.TEARING_COST_MARGIN,
-  Flags.FMU_NATIVE_PLATFORMS
+  Flags.FMU_NATIVE_PLATFORMS,
+  Flags.TPL_OUTPUT_DIR
 };
 
 public function new

--- a/testsuite/openmodelica/bootstrapping/LoadCompilerSources.mos
+++ b/testsuite/openmodelica/bootstrapping/LoadCompilerSources.mos
@@ -3,6 +3,11 @@
 // "FrontEnd";
 if true then /* Suppress output */
   prefixPath := if getEnvironmentVar("OMCOMPILERSOURCES")=="" then "../../../OMCompiler/Compiler/" else (getEnvironmentVar("OMCOMPILERSOURCES")+"/");
+  // The Template/*.mo generated from the *.tpl are build artifacts and live in
+  // the build tree, not next to their template. OMCOMPILERGENERATEDSOURCES says
+  // where (rtest passes it through); unset means they are next to the sources,
+  // which is where a build without --tplOutputDir still puts them.
+  generatedPath := if getEnvironmentVar("OMCOMPILERGENERATEDSOURCES")=="" then prefixPath else (getEnvironmentVar("OMCOMPILERGENERATEDSOURCES")+"/");
   setCommandLineOptions("+g=MetaModelica");
   files := {
     prefixPath + "FrontEnd/Absyn.mo",
@@ -182,29 +187,29 @@ if true then /* Suppress output */
     prefixPath + "Script/StaticScript.mo",
 
   // "Template";
-    prefixPath + "Template/AbsynDumpTpl.mo",
-    prefixPath + "Template/CodegenC.mo",
-    prefixPath + "Template/CodegenCpp.mo",
-    prefixPath + "Template/CodegenCppHpcom.mo",
-    prefixPath + "Template/CodegenFMU.mo",
-    prefixPath + "Template/CodegenFMUCpp.mo",
-    prefixPath + "Template/CodegenJS.mo",
-    prefixPath + "Template/CodegenUtil.mo",
-    prefixPath + "Template/CodegenXML.mo",
-    prefixPath + "Template/DAEDumpTpl.mo",
-    prefixPath + "Template/ExpressionDumpTpl.mo",
-    prefixPath + "Template/GraphMLDumpTpl.mo",
-    prefixPath + "Template/GraphvizDump.mo",
-    prefixPath + "Template/NFInstDumpTpl.mo",
-    prefixPath + "Template/SCodeDumpTpl.mo",
-    prefixPath + "Template/SimCodeDump.mo",
+    generatedPath + "Template/AbsynDumpTpl.mo",
+    generatedPath + "Template/CodegenC.mo",
+    generatedPath + "Template/CodegenCpp.mo",
+    generatedPath + "Template/CodegenCppHpcom.mo",
+    generatedPath + "Template/CodegenFMU.mo",
+    generatedPath + "Template/CodegenFMUCpp.mo",
+    generatedPath + "Template/CodegenJS.mo",
+    generatedPath + "Template/CodegenUtil.mo",
+    generatedPath + "Template/CodegenXML.mo",
+    generatedPath + "Template/DAEDumpTpl.mo",
+    generatedPath + "Template/ExpressionDumpTpl.mo",
+    generatedPath + "Template/GraphMLDumpTpl.mo",
+    generatedPath + "Template/GraphvizDump.mo",
+    generatedPath + "Template/NFInstDumpTpl.mo",
+    generatedPath + "Template/SCodeDumpTpl.mo",
+    generatedPath + "Template/SimCodeDump.mo",
     prefixPath + "Template/Tpl.mo",
     prefixPath + "Template/TplAbsyn.mo",
     prefixPath + "Template/TplCodegen.mo",
     prefixPath + "Template/TplMain.mo",
     prefixPath + "Template/TplParser.mo",
-    prefixPath + "Template/Unparsing.mo",
-    prefixPath + "Template/VisualXMLTpl.mo",
+    generatedPath + "Template/Unparsing.mo",
+    generatedPath + "Template/VisualXMLTpl.mo",
 
   // "Global";
     prefixPath + "Global/Global.mo",

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -50,6 +50,11 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   $ENV{'REFERENCEFILES'} = "$1testsuite/ReferenceFiles";
   $ENV{'OMLIBRARYCOMMON'} = "$1testsuite/simulation/libraries/common";
   $ENV{'OMCOMPILERSOURCES'} = "$1OMCompiler/Compiler";
+  # Where the Template/*.mo generated from the *.tpl live. They are build
+  # artifacts and a CMake build keeps them in its build tree (--tplOutputDir),
+  # so honour an OMCOMPILERGENERATEDSOURCES set by the caller; default to the
+  # source tree, which is where a build without that flag leaves them.
+  $ENV{'OMCOMPILERGENERATEDSOURCES'} ||= "$1OMCompiler/Compiler";
   $ENV{'OPENMODELICALIBRARY'} = "$1/libraries/.openmodelica/libraries";
   # In WSL, we need to mark the environment variable as one we pass from WSL to WIN32
   if (defined $ENV{'WSLENV'}) {

--- a/testsuite/special/MatlabTranslator/LoadCompilerSources.mos
+++ b/testsuite/special/MatlabTranslator/LoadCompilerSources.mos
@@ -3,6 +3,11 @@
 // "FrontEnd";
 if true then /* Suppress output */
   prefixPath := if getEnvironmentVar("OMCOMPILERSOURCES")=="" then "../../../OMCompiler/Compiler/" else (getEnvironmentVar("OMCOMPILERSOURCES")+"/");
+  // The Template/*.mo generated from the *.tpl are build artifacts and live in
+  // the build tree, not next to their template. OMCOMPILERGENERATEDSOURCES says
+  // where (rtest passes it through); unset means they are next to the sources,
+  // which is where a build without --tplOutputDir still puts them.
+  generatedPath := if getEnvironmentVar("OMCOMPILERGENERATEDSOURCES")=="" then prefixPath else (getEnvironmentVar("OMCOMPILERGENERATEDSOURCES")+"/");
   setCommandLineOptions("+g=MetaModelica");
   files := {
     prefixPath + "FrontEnd/Absyn.mo",
@@ -180,29 +185,29 @@ if true then /* Suppress output */
     prefixPath + "Script/RewriteRules.mo",
 
   // "Template";
-    prefixPath + "Template/AbsynDumpTpl.mo",
-    prefixPath + "Template/CodegenC.mo",
-    prefixPath + "Template/CodegenCpp.mo",
-    prefixPath + "Template/CodegenCppHpcom.mo",
-    prefixPath + "Template/CodegenFMU.mo",
-    prefixPath + "Template/CodegenFMUCpp.mo",
-    prefixPath + "Template/CodegenJS.mo",
-    prefixPath + "Template/CodegenUtil.mo",
-    prefixPath + "Template/CodegenXML.mo",
-    prefixPath + "Template/DAEDumpTpl.mo",
-    prefixPath + "Template/ExpressionDumpTpl.mo",
-    prefixPath + "Template/GraphvizDump.mo",
-    prefixPath + "Template/GraphMLDumpTpl.mo",
-    prefixPath + "Template/NFInstDumpTpl.mo",
-    prefixPath + "Template/SCodeDumpTpl.mo",
-    prefixPath + "Template/SimCodeDump.mo",
+    generatedPath + "Template/AbsynDumpTpl.mo",
+    generatedPath + "Template/CodegenC.mo",
+    generatedPath + "Template/CodegenCpp.mo",
+    generatedPath + "Template/CodegenCppHpcom.mo",
+    generatedPath + "Template/CodegenFMU.mo",
+    generatedPath + "Template/CodegenFMUCpp.mo",
+    generatedPath + "Template/CodegenJS.mo",
+    generatedPath + "Template/CodegenUtil.mo",
+    generatedPath + "Template/CodegenXML.mo",
+    generatedPath + "Template/DAEDumpTpl.mo",
+    generatedPath + "Template/ExpressionDumpTpl.mo",
+    generatedPath + "Template/GraphvizDump.mo",
+    generatedPath + "Template/GraphMLDumpTpl.mo",
+    generatedPath + "Template/NFInstDumpTpl.mo",
+    generatedPath + "Template/SCodeDumpTpl.mo",
+    generatedPath + "Template/SimCodeDump.mo",
     prefixPath + "Template/TplAbsyn.mo",
     prefixPath + "Template/TplCodegen.mo",
     prefixPath + "Template/TplMain.mo",
     prefixPath + "Template/Tpl.mo",
     prefixPath + "Template/TplParser.mo",
-    prefixPath + "Template/Unparsing.mo",
-    prefixPath + "Template/VisualXMLTpl.mo",
+    generatedPath + "Template/Unparsing.mo",
+    generatedPath + "Template/VisualXMLTpl.mo",
 
   // "Global";
     prefixPath + "Global/Global.mo",


### PR DESCRIPTION
### Related Issues

Closes https://github.com/OpenModelica/OpenModelica/issues/16334.

### Purpose

* New argument `--tplOutputDir` to write generated Meta Modelica files to target directory
* Update CMake build to keep source directory `OMCompiler/Compiler/Template` clean

### Approach

* Generated Meta Modelica files end up in `OMC_GENERATED_MO_DIR` pointing to `${CMAKE_CURRENT_BINARY_DIR}/generated-mo`
* Updated bootstrapping sources
