### PR TITLE
OMEdit: scope the omc event pump to long ops

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -157,6 +157,14 @@ option(RUST_OMC_PREBUILT_GENERATED_SRC
   "Assume the mmtorust-generated *.rs are already present (e.g. unstashed from an earlier CI stage) and skip the transpile."
   OFF)
 
+# Each client is a separate cargo build resolving the workspace to a different
+# feature set than the cdylib, sharing one target directory: cargo cannot reuse
+# the fingerprints, so every compiler crate is rebuilt per client, every build.
+# The browser OMShell pages come from the wasm target and are not affected.
+option(RUST_OMC_OMSHELL_CLIENTS
+  "Build the desktop egui + dioxus/Blitz OMShell clients. Off by default: each is a separate cargo feature resolution and rebuilds every compiler crate."
+  OFF)
+
 # cargo target/ lives in the build tree, not the source crate tree.
 set(RUST_OMC_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR}/rust-target
     CACHE PATH "Directory for cargo's target/ output of the Rust omc build.")
@@ -1018,14 +1026,12 @@ function(omc_rust_setup_codegen)
             DESTINATION lib/wasm32-wasi/omc/lib/wasm32-wasip1 COMPONENT omc)
   endif()
 
-  # The native egui OMShell client (omshell_egui), built when the GUI clients are
-  # enabled (OM_ENABLE_GUI_CLIENTS, the same flag that drives OMEdit). It links the
-  # compiler in-process as an ordinary cargo dependency (omshell_omc ->
+  # The desktop egui OMShell client (omshell_egui). It links the compiler
+  # in-process as an ordinary cargo dependency (omshell_omc ->
   # openmodelica_backend_main), so building it compiles the compiler crates too;
   # hence the DEPENDS on rust_codegen (the generated sources must exist first).
-  # The browser build of OMShell is handled by the wasm target (also gated on
-  # OM_ENABLE_GUI_CLIENTS).
-  if(OM_ENABLE_GUI_CLIENTS)
+  # The browser build of OMShell is handled by the wasm target.
+  if(OM_ENABLE_GUI_CLIENTS AND RUST_OMC_OMSHELL_CLIENTS)
     # Serialised after rust_omc: concurrent cargo-xwin runs race on the shared clang-cl wrapper.
     add_custom_target(rust_omshell_egui ALL
       WORKING_DIRECTORY ${RUST_OMC_DIR}

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -729,10 +729,12 @@ algorithm
       // translateModel records the lowering error and fails, so the message
       // surfaces (getErrorString / OMEdit) instead of a later "no prepared model".
       CodegenWasmJit.translateModel(simCode);
-      guid := System.getUUIDStr();
-      SerializeInitXML.simulationInitFile(simCode, guid);
-      // The wasm module carries its own metadata, so *_info.json is only needed
-      // for debugging; emit it when the infoXmlOperations debug flag is set.
+      // The wasm module carries its own metadata; *_init.xml is only read by
+      // OMEdit's variable browser and *_info.json only for debugging.
+      if Flags.isSet(Flags.OMEDIT) then
+        guid := System.getUUIDStr();
+        SerializeInitXML.simulationInitFile(simCode, guid);
+      end if;
       if Flags.isSet(Flags.INFO_XML_OPERATIONS) then
         SerializeModelInfo.serialize(simCode, true);
       end if;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -573,6 +573,8 @@ constant DebugFlag CHECK_DEF_USE = DEBUG_FLAG(200, "checkDefUse", false,
   "Warns about variables in functions that cannot statically be proven to be defined (given a value) before they are used, e.g. variables only assigned on some control flow paths. Per the Modelica specification using an uninitialized variable is an error.");
 constant DebugFlag TEARING_COST = DEBUG_FLAG(201, "tearingCost", false,
   "Dumps the estimated cost of every torn system against solving it untorn.");
+constant DebugFlag OMEDIT = DEBUG_FLAG(202, "omedit", false,
+  "Set by OMEdit, so the compiler can emit output only a GUI consumes.");
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -262,7 +262,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.FLOW_ALIAS_ELIMINATION,
   Flags.DUMP_CHECK_MODEL,
   Flags.CHECK_DEF_USE,
-  Flags.TEARING_COST
+  Flags.TEARING_COST,
+  Flags.OMEDIT
 };
 
 protected

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1471,7 +1471,11 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
     mpOMCProxy->setCommandLineOptions(QString("-d=gendebugsymbols"));
   }
   bool includeResources = OptionsDialog::instance()->getFMIPage()->getIncludeResourcesCheckBox()->isChecked();
-  bool isTranslationSuccessful = mpOMCProxy->translateModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms, includeResources);
+  bool isTranslationSuccessful;
+  {
+    OMCLongOperation longOperation;
+    isTranslationSuccessful = mpOMCProxy->translateModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms, includeResources);
+  }
   // hide progress bar
   hideProgressBar();
   // clear the status bar message
@@ -3759,10 +3763,10 @@ void MainWindow::showCancelOperationButton(bool show)
 
 /*!
  * \brief MainWindow::setOmcOperationRunning
- * Disables everything but the status-bar Cancel button for the duration of an
- * omc command, so the pumped event loop (omedit_pump_events) can deliver the
- * Cancel click without re-entering the non-reentrant compiler. Also parks the
- * auto-save timer, which would otherwise fire an omc command mid-operation.
+ * Disables everything but the status-bar Cancel button for the duration of a
+ * long omc operation, so the pumped event loop (omedit_pump_events) can deliver
+ * the Cancel click without re-entering the non-reentrant compiler. Also parks
+ * the auto-save timer, which would otherwise fire an omc command mid-operation.
  */
 void MainWindow::setOmcOperationRunning(bool running)
 {
@@ -3787,8 +3791,8 @@ void MainWindow::setOmcOperationRunning(bool running)
       mpAutoSaveTimer->start();
     }
   }
-  // The button is revealed by OmcBusyScope's delayed timer so quick commands
-  // don't flash it; here we only guarantee it is hidden once the op ends.
+  // The button is revealed by OMCLongOperation's delayed timer so a quick
+  // operation doesn't flash it; here we only guarantee it is hidden once it ends.
   if (!running) {
     showCancelOperationButton(false);
   }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -502,10 +502,10 @@ bool omcWorkerStageFile(const char *path) {
 // omc invokes this at every cancel check (System.checkCancel); it hands the
 // thread back to Qt so the Cancel click is delivered (flipping the flag omc then
 // reads) and progress repaints. Rate-limited — checkCancel fires per class.
-// Reentering omc is prevented by OmcBusyScope disabling all UI but Cancel.
+// Reentering omc is prevented by OMCLongOperation disabling all UI but Cancel.
 // Reflect the compiler's last-reported progress (read via the backend getters)
 // on the status bar while an in-process op is in flight. Tracks whether it was
-// the one that made the bar visible so OmcBusyScope can restore it on completion.
+// the one that made the bar visible so the scope can restore it on completion.
 static bool g_omcNativeOwnsBar = false;
 static void omcDriveNativeProgress()
 {
@@ -555,55 +555,65 @@ extern "C" void omedit_pump_events()
   QCoreApplication::processEvents();
 }
 
-// Registers omedit_pump_events with whichever omc backend is linked, once.
-static void omedit_install_pump()
+static void omedit_set_pump(bool install)
 {
 #if defined(OMC_RUST_ABI)
-  omc_compiler_set_pump_callback(omedit_pump_events);
+  omc_compiler_set_pump_callback(install ? omedit_pump_events : nullptr);
 #else
-  System_setPumpCallback(omedit_pump_events);
+  System_setPumpCallback(install ? omedit_pump_events : nullptr);
+#endif
+}
+#endif // !__EMSCRIPTEN__
+
+static int g_omcLongOperationDepth = 0;
+
+/*!
+ * \brief OMCLongOperation::OMCLongOperation
+ */
+OMCLongOperation::OMCLongOperation()
+{
+  g_omcLongOperationDepth++;
+#if !defined(__EMSCRIPTEN__)
+  if (g_omcLongOperationDepth > 1) {
+    return;
+  }
+#if defined(OMC_RUST_ABI)
+  omc_compiler_clear_cancel();
+#else
+  System_clearCancel();
+#endif
+  omedit_set_pump(true);
+  if (MainWindow::instance()) {
+    MainWindow::instance()->setOmcOperationRunning(true);
+  }
+  // Delayed so a quick operation never flashes the button. The UI-disable above
+  // is immediate — the pump can fire before this fires.
+  mShowCancelButtonTimer.setSingleShot(true);
+  QObject::connect(&mShowCancelButtonTimer, &QTimer::timeout, []() {
+    if (MainWindow::instance()) MainWindow::instance()->showCancelOperationButton(true);
+  });
+  mShowCancelButtonTimer.start(100);
 #endif
 }
 
-// Marks omc busy for the duration of a command: at the outermost call it clears
-// any stale cancel and disables the UI (except Cancel) so the pumped event loop
-// can't reenter the non-reentrant compiler. Nested calls (e.g. loadModelCB) are
-// no-ops. RAII so early returns in sendCommand still restore the UI.
-namespace {
-int g_omcCommandDepth = 0;
-struct OmcBusyScope {
-  bool outer;
-  // Reveal Cancel only if the op runs past this; quick commands (the vast
-  // majority) finish first and never flash the button. The UI-disable itself
-  // is immediate — the pump can fire mid-op, so reentrancy must be blocked now.
-  QTimer showButtonTimer;
-  OmcBusyScope() : outer(g_omcCommandDepth == 0) {
-    g_omcCommandDepth++;
-    if (outer) {
-#if defined(OMC_RUST_ABI)
-      omc_compiler_clear_cancel();
-#else
-      System_clearCancel();
+/*!
+ * \brief OMCLongOperation::~OMCLongOperation
+ */
+OMCLongOperation::~OMCLongOperation()
+{
+  g_omcLongOperationDepth--;
+#if !defined(__EMSCRIPTEN__)
+  if (g_omcLongOperationDepth > 0) {
+    return;
+  }
+  mShowCancelButtonTimer.stop();
+  omedit_set_pump(false);
+  omcClearNativeProgress();
+  if (MainWindow::instance()) {
+    MainWindow::instance()->setOmcOperationRunning(false);
+  }
 #endif
-      if (MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(true);
-      showButtonTimer.setSingleShot(true);
-      QObject::connect(&showButtonTimer, &QTimer::timeout, []() {
-        if (MainWindow::instance()) MainWindow::instance()->showCancelOperationButton(true);
-      });
-      showButtonTimer.start(100);
-    }
-  }
-  ~OmcBusyScope() {
-    g_omcCommandDepth--;
-    if (outer) {
-      showButtonTimer.stop();
-      omcClearNativeProgress();
-      if (MainWindow::instance()) MainWindow::instance()->setOmcOperationRunning(false);
-    }
-  }
-};
 }
-#endif // !__EMSCRIPTEN__
 
 /*!
  * \class OMCProxy
@@ -823,12 +833,12 @@ bool OMCProxy::initializeOMC(threadData_t *threadData)
   threadData->loadModelCB = MainWindow::LoadModelCallbackFunction;
   MMC_CATCH_TOP(return false;)
   mpOMCInterface = new OMCInterface(threadData);
-  omedit_install_pump();
 #endif
   connect(mpOMCInterface, SIGNAL(logCommand(QString)), this, SLOT(logCommand(QString)));
   connect(mpOMCInterface, SIGNAL(logResponse(QString,QString,double)), this, SLOT(logResponse(QString,QString,double)));
   connect(mpOMCInterface, SIGNAL(throwException(QString)), SLOT(showException(QString)));
   mHasInitialized = true;
+  setOMEditDebugFlag();
   // get OpenModelica version
   QString version = getVersion();
   Helper::OpenModelicaVersion = version;
@@ -928,9 +938,6 @@ void OMCProxy::sendCommand(const QString expression, bool saveToHistory)
     }
   }
 #else
-  // Busy scope (outermost call) clears any stale cancel and disables all UI but
-  // the Cancel button, so omedit_pump_events can run the event loop safely.
-  OmcBusyScope omcBusy;
   if (!omc_Main_handleCommand(threadData, mmc_mk_scon(expression.toUtf8().constData()), &reply_str)) {
     if (expression == "quit()") {
       return;
@@ -3279,11 +3286,22 @@ bool OMCProxy::clearCommandLineOptions()
 {
   bool result = mpOMCInterface->clearCommandLineOptions();
   if (result) {
+    setOMEditDebugFlag();
     return true;
   } else {
     printMessagesStringInternal();
     return false;
   }
+}
+
+/*!
+ * \brief OMCProxy::setOMEditDebugFlag
+ * Tells omc that OMEdit is its host, so it emits the output only a GUI reads.
+ * A property of the session, hence re-applied whenever the options are cleared.
+ */
+void OMCProxy::setOMEditDebugFlag()
+{
+  setCommandLineOptions("-d=omedit");
 }
 
 bool OMCProxy::enableNewInstantiation()

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -45,6 +45,8 @@
 #include "Util/Helper.h"
 #include "Util/Utilities.h"
 
+#include <QTimer>
+
 class CustomExpressionBox;
 class OutputPlainTextEdit;
 class ElementInfo;
@@ -231,6 +233,7 @@ public:
   QList<QString> getCommandLineOptions();
   bool setCommandLineOptions(QString options);
   bool clearCommandLineOptions();
+  void setOMEditDebugFlag();
   bool enableNewInstantiation();
   bool disableNewInstantiation();
   QString makeDocumentationUriToFileName(QString documentation);
@@ -298,6 +301,27 @@ public slots:
   void openOMCLoggerWidget();
   void sendCustomExpression();
   void openOMCDiffWidget();
+};
+
+/*!
+ * \class OMCLongOperation
+ * \brief Scopes an omc call worth interrupting: a translation, an FMU export or
+ * an in-process (wasm-jit) simulation.
+ *
+ * omc only gets its event-pump callback while such a scope is alive; running the
+ * event loop at every cancel check is what keeps a long call interruptible, but
+ * for the short commands behind e.g. undo/redo it is pure flicker. Nested scopes
+ * are no-ops.
+ */
+class OMCLongOperation
+{
+public:
+  OMCLongOperation();
+  ~OMCLongOperation();
+  OMCLongOperation(const OMCLongOperation &) = delete;
+  OMCLongOperation& operator=(const OMCLongOperation &) = delete;
+private:
+  QTimer mShowCancelButtonTimer;
 };
 
 class CustomExpressionBox : public QLineEdit

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1132,7 +1132,11 @@ bool SimulationDialog::translateModel(QString simulationParameters)
   if (mpLinearizationDumpLanguageComboBox->currentText() != QStringLiteral("none")) {
     MainWindow::instance()->getOMCProxy()->setCommandLineOptions("+linearizationDumpLanguage=" + mpLinearizationDumpLanguageComboBox->currentText());
   }
-  bool result = MainWindow::instance()->getOMCProxy()->translateModel(mClassName, simulationParameters);
+  bool result;
+  {
+    OMCLongOperation longOperation;
+    result = MainWindow::instance()->getOMCProxy()->translateModel(mClassName, simulationParameters);
+  }
   // reset simulation settings
   OptionsDialog::instance()->saveSimulationSettings();
   return result;

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -515,7 +515,10 @@ void SimulationOutputWidget::runWasmJitSimulation(const QString &simulationParam
     mpCancelButton->setEnabled(true);
   }
 #endif
-  pOMCProxy->sendCommand(command);
+  {
+    OMCLongOperation longOperation;
+    pOMCProxy->sendCommand(command);
+  }
 #if defined(__EMSCRIPTEN__)
   mIsWasmJitSimulationRunning = false;
   mpCancelButton->setEnabled(false);

--- a/testsuite/openmodelica/cruntime/xmlFiles/isChangeable1.mos
+++ b/testsuite/openmodelica/cruntime/xmlFiles/isChangeable1.mos
@@ -2,6 +2,7 @@
 // keywords: xml, init, changeable value
 // status: correct
 // teardown_command: rm isChangeable1.xml
+// cflags: -d=omedit
 
 loadString("
 model isChangeable1

--- a/testsuite/openmodelica/cruntime/xmlFiles/isChangeableTuple.mos
+++ b/testsuite/openmodelica/cruntime/xmlFiles/isChangeableTuple.mos
@@ -2,6 +2,7 @@
 // keywords: xml, init, changeable value, tuple
 // status: correct
 // teardown_command: rm isChangeableTuple.xml
+// cflags: -d=omedit
 
 loadString("
 model isChangeableTuple

--- a/testsuite/openmodelica/cruntime/xmlFiles/testxmlInitForChangeableparameter.mos
+++ b/testsuite/openmodelica/cruntime/xmlFiles/testxmlInitForChangeableparameter.mos
@@ -2,7 +2,7 @@
 // keywords: xml, init, parameters, changeable value
 // status: correct
 // teardown_command: rm -f testParameters*
-// cflags: -d=-newInst
+// cflags: -d=-newInst,omedit
 //
 
 loadString("

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 2.0 export
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5673.xml
-// cflags: -d=-newInst
+// cflags: -d=-newInst,omedit
 
 loadString("
 package aliasCheck

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 2.0 export
 // status: correct
 // teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5670.xml
-// cflags: -d=-newInst
+// cflags: -d=-newInst,omedit
 
 loadString("
 model ticket5670

--- a/testsuite/simulation/modelica/NBackend/functions/inlineAttributes15947.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/inlineAttributes15947.mos
@@ -1,7 +1,7 @@
 // name: inlineAttributes15947
 // keywords: NewBackend inline attributes min max nominal start
 // status: correct
-// cflags: --newBackend
+// cflags: --newBackend -d=omedit
 // teardown_command: rm -rf InlineAttrNB15947*
 //
 // New backend test for issue #15947: the input/output attributes

--- a/testsuite/simulation/modelica/inlineFunction/inlineAttributes15947.mos
+++ b/testsuite/simulation/modelica/inlineFunction/inlineAttributes15947.mos
@@ -2,6 +2,7 @@
 // keywords: inline attributes min max nominal unit
 // status: correct
 // teardown_command: rm -rf InlineAttr15947*
+// cflags: -d=omedit
 //
 // Tests that function input/output attributes (min/max/nominal/unit) are not
 // dropped when a function is inlined, in both the old and the new backend.


### PR DESCRIPTION
The pump was installed for the whole session, so every omc command ran `QCoreApplication::processEvents` at each cancel check and disabled the UI for its duration. For the short commands behind undo/redo that is only flicker.

Install it from a new `OMCLongOperation` scope instead, entered around the three operations worth interrupting: `translateModel`, the FMU export and the in-process wasm-jit simulation. Outside a scope omc runs uninterrupted, with no pump, no progress bar and no UI disable.

Add a debug flag `omedit`, set by OMCProxy at startup and re-applied after `clearCommandLineOptions` (`translateModel` clears the options right before translating). The wasm-jit target now writes its `<model>_init.xml` only under that flag: the module carries its own metadata, so only OMEdit's variable browser reads it.

Also gate the desktop egui/dioxus OMShell clients behind a new `RUST_OMC_OMSHELL_CLIENTS` option, off by default. Each is a separate cargo feature resolution sharing one target directory, so building them recompiles every compiler crate. The browser OMShell pages are built by the wasm target and are unaffected.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
