### PR TITLE
wasm-jit: fix use-after-free in String assignment

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6683,7 +6683,7 @@ name = "openmodelica_modelica_utilities"
 version = "0.1.0"
 dependencies = [
  "libc",
- "openmodelica_wasi",
+ "openmodelica_sim_meta",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2571,7 +2571,8 @@ fn is_result_output(sv: &SimCodeVar::SimVar) -> bool {
 /// filters every name that does not match `^(<filter>)$`. C matches per run; the
 /// runtimes have no regex engine, so it is settled here into
 /// [`var_filter::FILTERED`], protected variables included (`-emit_protected`
-/// can reach them).
+/// can reach them). It walks the variable and *alias* arrays only, so a plain
+/// parameter is never filtered.
 fn apply_variable_filter(result_vars: &mut [ResultVar], filter: &str) {
     if filter == ".*" || filter.is_empty() {
         return;
@@ -2581,7 +2582,8 @@ fn apply_variable_filter(result_vars: &mut [ResultVar], filter: &str) {
         return;
     };
     for v in result_vars.iter_mut() {
-        if !matches!(v.kind, ResultKind::Time) && !re.is_match(&v.name) {
+        let is_param = matches!(v.kind, ResultKind::Param { .. }) && v.filter & var_filter::ALIAS == 0;
+        if !matches!(v.kind, ResultKind::Time) && !is_param && !re.is_match(&v.name) {
             v.filter |= var_filter::FILTERED;
         }
     }
@@ -4390,23 +4392,40 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     }
 
     // --- External-object destructors (teardown). One function that calls each
-    // extObj's `<class>.destructor(handle)` in reverse construction order, reading
-    // the handle from its SimData slot. Emitted (and exported) only when the model
-    // has external objects, so output is byte-identical otherwise. ---
+    // extObj's `<class>.destructor(handle)`, reading the handle from its SimData
+    // slot, in `listReverse(extObjInfo.vars)` order as CodegenC's
+    // `callExternalObjectDestructors` does — the causalized construction order,
+    // a different permutation from the `extObjVars` slot order. ---
     let extobj_vars: Vec<&SimCodeVar::SimVar> = lst(&vars.extObjVars).collect();
+    let extobj_slot: HashMap<String, u32> = extobj_vars
+        .iter()
+        .enumerate()
+        .map(|(i, sv)| Ok((sim_cref_key(&sv.name)?, layout.eobj_off + (i as u32) * 4)))
+        .collect::<Result<_>>()?;
+    let mut destruct_order: Vec<&SimCodeVar::SimVar> = lst(&sim_code.extObjInfo.vars).collect();
+    if destruct_order.len() != extobj_vars.len()
+        || destruct_order.iter().any(|sv| {
+            sim_cref_key(&sv.name).is_ok_and(|k| !extobj_slot.contains_key(&k))
+        })
+    {
+        destruct_order = extobj_vars.clone();
+    }
+    destruct_order.reverse();
     // Always emitted + exported (empty when the model has no external objects) so
     // the standalone `wasm-merge` and interactive table always resolve it. It is
     // the first body after the fixed base functions, so its index stays `eq_base+8`.
     let destructors_idx = {
         use we::Instruction as I;
         let mut f = we::Function::new([]);
-        for (i, sv) in extobj_vars.iter().enumerate().rev() {
+        for sv in &destruct_order {
             let key = extobj_destructor_key(sv)?;
             let didx = by_name
                 .get(&key)
                 .ok_or_else(|| "CodegenWasmJit: external-object destructor was not compiled")?
                 .index;
-            let slot = layout.eobj_off + (i as u32) * 4;
+            let slot = *extobj_slot
+                .get(&sim_cref_key(&sv.name)?)
+                .ok_or_else(|| "CodegenWasmJit: external object has no SimData slot")?;
             f.instruction(&I::LocalGet(0)); // SimData*
             f.instruction(&I::I32Load(crate::CodegenWasmJitFunctions::mem_arg(slot, 2))); // handle
             f.instruction(&I::Call(didx));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -6163,12 +6163,20 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
     }
     let data = ctx.sim()?.data_local;
     if slot.heap {
-        // Release the handle the slot currently holds before overwriting it with
-        // the new (owned) one; the rhs reference transfers into the slot. The slot
-        // starts null (zeroed `SimData`), and `rt_release` is null-safe.
+        // Release-on-overwrite *after* the rhs: `s := s + x` reads the slot, so
+        // releasing first would free a value the rhs still needs. The slot starts
+        // null (zeroed `SimData`), and `rt_release` is null-safe.
+        let rw = rhs.push(ctx)?;
+        coerce(ctx, rw, slot.wty);
+        let t = ctx.alloc_temp(WTy::I32);
+        ctx.emit(we::Instruction::LocalSet(t));
         ctx.emit(we::Instruction::LocalGet(data));
         ctx.emit(we::Instruction::I32Load(mem_arg(slot.off, 2)));
         ctx.emit(we::Instruction::Call(rt_index("rt_release")?));
+        ctx.emit(we::Instruction::LocalGet(data));
+        ctx.emit(we::Instruction::LocalGet(t));
+        ctx.emit(we::Instruction::I32Store(mem_arg(slot.off, 2)));
+        return Ok(true);
     }
     // Stack order for a store is [addr, value]: push the base, evaluate the rhs,
     // coerce to the slot type, then store at the constant offset.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -1024,7 +1024,8 @@ impl SimMeta {
     /// `filterOutput` as the file is opened.
     ///
     /// `matcher` is a compiled `-variableFilter` (wrapped in C's `^(…)$`) and
-    /// *replaces* [`var_filter::FILTERED`]; `None` keeps it.
+    /// *replaces* [`var_filter::FILTERED`]; `None` keeps it. A plain parameter is
+    /// exempt either way — `initializeOutputFilter` never touches one.
     pub fn output_keep(&self, matcher: Option<&dyn Fn(&str) -> bool>) -> Vec<bool> {
         let (emit_protected, ignore_hide) =
             crate::simflags::with_flags(|f| (f.emit_protected, f.ignore_hide_result));
@@ -1035,17 +1036,26 @@ impl SimMeta {
                 if matches!(v.kind, MetaKind::Time) {
                     return true; // never filtered
                 }
-                if v.filter & var_filter::PROTECTED != 0
-                    && !(emit_protected && v.filter & var_filter::ENCRYPTED == 0)
-                {
+                // C's `shouldFilterOutput`: either flag *clears* the verdict both
+                // reasons set, so `-emit_protected` alone emits a variable that is
+                // protected *and* `HideResult=true`.
+                let protected = v.filter & var_filter::PROTECTED != 0;
+                let hidden = v.filter & var_filter::HIDE_RESULT != 0;
+                let mut filtered = protected || hidden;
+                if protected && emit_protected && v.filter & var_filter::ENCRYPTED == 0 {
+                    filtered = false;
+                }
+                if hidden && ignore_hide {
+                    filtered = false;
+                }
+                if filtered {
                     return false;
                 }
-                if v.filter & var_filter::HIDE_RESULT != 0 && !ignore_hide {
-                    return false;
-                }
+                let is_param =
+                    matches!(v.kind, MetaKind::Param { .. }) && v.filter & var_filter::ALIAS == 0;
                 match matcher {
-                    Some(m) => m(&v.name),
-                    None => v.filter & var_filter::FILTERED == 0,
+                    Some(m) if !is_param => m(&v.name),
+                    _ => v.filter & var_filter::FILTERED == 0,
                 }
             })
             .collect();
@@ -2053,11 +2063,11 @@ mod tests {
         assert_eq!(names(m.output_keep(None)), ["time", "x", "y", "p", "n"]);
 
         // A `-variableFilter` replaces the model's verdict, so `k` is reachable;
-        // `time` is never filtered.
+        // `time` is never filtered and the parameter `p` is exempt.
         f.ignore_hide_result = false;
         simflags::set_flags(f);
         let only_k = |n: &str| n == "k";
-        assert_eq!(names(m.output_keep(Some(&only_k))), ["time", "k"]);
+        assert_eq!(names(m.output_keep(Some(&only_k))), ["time", "p", "k"]);
     }
 
     /// C's `read_experiment`: the command line replaces what the model was


### PR DESCRIPTION
`compile_sim_cref_assign` released the handle a heap (String) `SimData` slot held *before* evaluating the right-hand side, so a self-referential assignment freed the value it was about to read. In `Buildings.Utilities.IO.Files.BaseClasses.FileWriter`:

    str := str + String(u[i], significantDigits=significantDigits)
           + delimiter;

`rt_real_format` got the just-freed block back from the allocator and `rt_concat` then read a clobbered length header:

    LOG_ERROR | error | wasm-jit simulation failed: wasm engine error
        0: <unknown>!<wasm function 1025>
        1: <unknown>!functionAlgebraics$0
      memory fault at wasm address 0x2010006

Evaluate the rhs into a temp, release, then store — what the local and array-element paths already do.

Comparing the result against the C target surfaced two more divergences in the same model:

- External-object destructors ran in `extObjVars` slot order, but CodegenC's `callExternalObjectDestructors` uses `listReverse(extObjInfo.vars)` — the causalized construction order, a different permutation. A `Buildings.Utilities.Plotters` backend writes its html file from its destructor, so the plot sections came out in the wrong order.
- `variableFilter` was applied to parameters, and `PROTECTED` / `HIDE_RESULT` were treated as independent reasons. C's `initializeOutputFilter` walks only the variable and alias arrays, and `shouldFilterOutput` lets either `-emit_protected` or `-ignoreHideResult` clear the verdict both reasons set. The model lost 220 of its 235 result variables to this.

The `Buildings.Utilities.Plotters` example
`ControlsVerification_CoolingCoilValve` now simulates, and against the C target its csv and html output are byte-identical, both result files hold the same 235 variables, and `diffSimulationResults` reports no differences. `CoupledClutches` (plain, `-emit_protected`, and `variableFilter`), `FreeBody` and `RealNetwork1` match as well.

`Cargo.lock` is regenerated: e7c7e67c06 changed the openmodelica_modelica_utilities dependency without updating it.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
