### PR TITLE
Fix install runtime depends Windows

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -385,10 +385,16 @@ if(WIN32)
     message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
   endif()
 
-  if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles" AND "$ENV{VisualStudioVersion}" STREQUAL "")
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
-  else()
+  # MSYS2 exports MSYSTEM_PREFIX as a POSIX-style path (e.g. "/ucrt64"). When
+  # cmake is invoked directly from an MSYS2 shell, MSYS2 auto-translates that
+  # to an absolute Windows path (relative to its own install root) before the
+  # native cmake.exe process ever sees it, so it can be used as-is. Only if it
+  # is still POSIX-style (translation didn't happen) do we resolve it
+  # ourselves against OMDEV's msys tree.
+  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
     string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+  else()
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
   endif()
 
   set(OMCOMPILER_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/Compiler/bin)


### PR DESCRIPTION
### Related Issues

```
-- Installing: C:/dev/OM64bit/build/bin/libOpenModelicaCompiler.dll
CMake Error at OMCompiler/Compiler/cmake_install.cmake:72 (file):
  file Could not resolve runtime dependencies:

    libcurl-4.dll
    libgcc_s_seh-1.dll
    libiconv-2.dll
    libintl-8.dll
    libopenblas.dll
    libstdc++-6.dll
    libsystre-0.dll
    libwinpthread-1.dll
Call Stack (most recent call first):
  OMCompiler/cmake_install.cmake:57 (include)
  cmake_install.cmake:42 (include)

mingw32-make: *** [Makefile:129: install] Error 1
```

### Purpose

Fix MSYS prefix.

