### PR TITLE
wasm-jit: run-time index on scattered arrays

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -57,7 +57,7 @@ use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
     ArrayGroup, Attr, AttrTargets, BUILTINS, ConstGroup, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, Literals, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
-    SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
+    ScatterGroup, SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
     NlsResidual, NlsResiduals, backup_known_outputs, restore_known_outputs,
@@ -2481,16 +2481,18 @@ pub(crate) struct SimVarMap {
     start_slots: Arc<HashMap<String, u32>>,
     /// Finalized array-variable groups (base cref key -> contiguous slot range).
     array_groups: Arc<HashMap<String, ArrayGroup>>,
+    /// The arrays that are not one contiguous range (see `ScatterGroup`).
+    scatter_groups: Arc<HashMap<String, ScatterGroup>>,
     /// `varKind = CONST` variables own no `SimData` slot: a reference is the
     /// binding literal, as in C's `varArrayNameValues`. `const_groups` is the
     /// `array_groups` counterpart, `const_acc` its transient accumulator.
     consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
     const_groups: Arc<HashMap<String, ConstGroup>>,
     const_acc: HashMap<String, Vec<(Vec<i32>, Arc<DAE::Exp>, WTy)>>,
-    /// Transient accumulator: base cref key -> the scalarized elements seen
-    /// (subscripts, byte offset, value type). Finalized into `array_groups` at the
-    /// end of [`build_var_map`].
-    array_acc: HashMap<String, Vec<(Vec<i32>, Vec<String>, u32, WTy)>>,
+    /// Transient accumulator: base cref key -> the scalarized elements seen.
+    /// Finalized into `array_groups` / `scatter_groups` at the end of
+    /// [`build_var_map`].
+    array_acc: HashMap<String, Vec<AccElem>>,
     /// `SimData` byte offset of the `terminate` flag (see [`SimLayout`]).
     terminate_off: u32,
     terminal_off: u32,
@@ -2893,6 +2895,7 @@ fn build_var_map(
         starts: Arc::default(),
         start_slots: Arc::default(),
         array_groups: Arc::default(),
+        scatter_groups: Arc::default(),
         consts: Arc::default(),
         const_groups: Arc::default(),
         const_acc: HashMap::new(),
@@ -3133,16 +3136,15 @@ fn build_var_map(
         };
         Arc::make_mut(&mut map.vars).insert(sim_cref_key(&av.name)?, slot);
         // An alias array is assigned as a whole, so it needs a group over the
-        // target's slots. A negated element could not be gathered as it stands.
-        if slot.negate == Neg::None {
-            for g in array_element_keys(&av.name)? {
-                map.array_acc.entry(g.base).or_default().push((
-                    g.subs,
-                    g.pieces,
-                    slot.off,
-                    slot.wty,
-                ));
-            }
+        // target's slots.
+        for g in array_element_keys(&av.name)? {
+            map.array_acc.entry(g.base).or_default().push(AccElem {
+                subs: g.subs,
+                pieces: g.pieces,
+                off: slot.off,
+                wty: slot.wty,
+                neg: slot.negate,
+            });
         }
         if let (Some(name), Some(kind)) = (
             result_name(&cref_display(&av.name)?),
@@ -3175,16 +3177,22 @@ fn build_var_map(
     }
     // Same for the array accumulator, so `pre(x[i])` with a non-constant subscript
     // resolves through a `$PRE.<base>` group.
-    let pre_groups: Vec<(String, Vec<(Vec<i32>, Vec<String>, u32, WTy)>)> = map
+    let pre_groups: Vec<(String, Vec<AccElem>)> = map
         .array_acc
         .iter()
         .filter_map(|(base, elems)| {
             let pre: Option<Vec<_>> = elems
                 .iter()
-                .map(|(subs, pieces, off, wty)| {
-                    let mut pieces = pieces.clone();
+                .map(|e| {
+                    let mut pieces = e.pieces.clone();
                     pieces[0].insert_str(0, "$PRE.");
-                    Some((subs.clone(), pieces, layout.pre_slot_off(*off)?, *wty))
+                    Some(AccElem {
+                        subs: e.subs.clone(),
+                        pieces,
+                        off: layout.pre_slot_off(e.off)?,
+                        wty: e.wty,
+                        neg: e.neg,
+                    })
                 })
                 .collect();
             Some((format!("$PRE.{base}"), pre?))
@@ -3205,7 +3213,13 @@ fn insert_var(map: &mut SimVarMap, sv: &SimCodeVar::SimVar, off: u32, wty: WTy, 
     Arc::make_mut(&mut map.vars).insert(key.clone(), SimSlot { off, wty, negate: Neg::None, heap });
     Arc::make_mut(&mut map.starts).insert(key, sv.initialValue.clone());
     for g in array_element_keys(&sv.name)? {
-        map.array_acc.entry(g.base).or_default().push((g.subs, g.pieces, off, wty));
+        map.array_acc.entry(g.base).or_default().push(AccElem {
+            subs: g.subs,
+            pieces: g.pieces,
+            off,
+            wty,
+            neg: Neg::None,
+        });
     }
     Ok(())
 }
@@ -3262,6 +3276,16 @@ struct GroupEntry {
     base: String,
     subs: Vec<i32>,
     pieces: Vec<String>,
+}
+
+/// One scalarized element accumulated for an array base: where it sits in the
+/// array, how the group spells its key, and where its value lives.
+struct AccElem {
+    subs: Vec<i32>,
+    pieces: Vec<String>,
+    off: u32,
+    wty: WTy,
+    neg: Neg,
 }
 
 /// The name with every subscript stripped, the subscripts outermost-first, and
@@ -3332,22 +3356,25 @@ fn const_int_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<Option<
 /// element `[i1,…,in]` equals `base_off + rowmajor_index * stride`). If the
 /// backend ever lays them out differently, fail loudly rather than silently
 /// build a wrong array — there is no heuristic fallback.
+///
+/// A well-shaped group that is not contiguous becomes a [`ScatterGroup`] instead,
+/// which is enough to select one element by a run-time subscript.
 fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
     let acc = std::mem::take(&mut map.array_acc);
     for (base, elems) in acc {
         let Some(first) = elems.first() else { continue };
-        let rank = first.0.len();
-        // A group that cannot be treated as one contiguous whole-array is skipped,
-        // not fatal: individual element references still resolve through their own
-        // slots, and a genuine whole-array reference fails later as "unknown
-        // variable". Only truly malformed shapes (non-positive index) are errors.
-        if elems.iter().any(|(s, _, _, _)| s.len() != rank) {
+        let rank = first.subs.len();
+        // A group that cannot be treated as one whole-array is skipped, not fatal:
+        // individual element references still resolve through their own slots, and
+        // a genuine whole-array reference fails later as "unknown variable". Only
+        // truly malformed shapes (non-positive index) are errors.
+        if elems.iter().any(|e| e.subs.len() != rank) {
             continue; // ragged rank (element and its own sub-slice both present)
         }
         // Shape: 1-based max index per axis.
         let mut dims = vec![0u32; rank];
-        for (subs, _, _, _) in &elems {
-            for (axis, &ix) in subs.iter().enumerate() {
+        for e in &elems {
+            for (axis, &ix) in e.subs.iter().enumerate() {
                 if ix < 1 {
                     record_error(format!(
                         "CodegenWasmJit: non-positive subscript {ix} for array variable `{base}`"));
@@ -3358,28 +3385,34 @@ fn finalize_array_groups(map: &mut SimVarMap) -> Result<()> {
         }
         let total: u32 = dims.iter().product();
         if total as usize != elems.len() {
-            // Not all elements present (e.g. a sub-slice is its own variable):
-            // cannot treat as one contiguous whole-array. Skip; a whole-array
-            // reference then fails loudly with "unknown variable".
-            continue;
+            continue; // not all elements present (e.g. a sub-slice is its own variable)
         }
-        let wty = first.3;
-        if elems.iter().any(|(_, _, _, w)| *w != wty) {
-            continue; // mixed element storage types: not a uniform contiguous array
+        let wty = first.wty;
+        if elems.iter().any(|e| e.wty != wty) {
+            continue; // mixed element storage types: not a uniform array
         }
+        // Row-major element table. `total == elems.len()` only rules out a hole if
+        // no two elements share an index, so an unfilled entry skips the group.
+        let mut table = vec![None; total as usize];
+        for e in &elems {
+            let lin = e.subs.iter().enumerate().fold(0u32, |lin, (axis, &ix)| lin * dims[axis] + (ix as u32 - 1));
+            table[lin as usize] = Some((e.off, e.neg));
+        }
+        let Some(table) = table.into_iter().collect::<Option<Vec<_>>>() else { continue };
+        // Contiguous row-major and unnegated? If not (aliased elsewhere, or the
+        // elements straddle SimData regions) the array cannot be gathered or
+        // assigned as a whole; only a single element resolves.
         let stride = match wty { WTy::F64 => 8, WTy::I32 => 4 };
-        let Some(base_off) = elems.iter().map(|(_, _, o, _)| *o).min() else { continue };
-        // Contiguous row-major? If any element's slot is elsewhere (aliased, or the
-        // elements straddle SimData regions), this is not one contiguous block, so
-        // skip the group rather than aborting the whole build.
-        let contiguous = elems.iter().all(|(subs, _, off, _)| {
-            let lin = subs.iter().enumerate().fold(0u32, |lin, (axis, &ix)| lin * dims[axis] + (ix as u32 - 1));
-            *off == base_off + lin * stride
+        let base_off = table[0].0;
+        let contiguous = table.iter().enumerate().all(|(lin, &(off, neg))| {
+            neg == Neg::None && off == base_off + lin as u32 * stride
         });
         if !contiguous {
+            Arc::make_mut(&mut map.scatter_groups)
+                .insert(base, ScatterGroup { wty, dims, elems: table });
             continue;
         }
-        let key_pieces = first.1.clone();
+        let key_pieces = first.pieces.clone();
         Arc::make_mut(&mut map.array_groups)
             .insert(base, ArrayGroup { base_off, wty, dims, total, key_pieces });
     }
@@ -5638,6 +5671,7 @@ fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         starts: var_map.starts.clone(),
         start_slots: var_map.start_slots.clone(),
         array_groups: var_map.array_groups.clone(),
+        scatter_groups: var_map.scatter_groups.clone(),
         consts: var_map.consts.clone(),
         const_groups: var_map.const_groups.clone(),
         terminate_off: var_map.terminate_off,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1333,6 +1333,9 @@ pub(crate) struct SimCtx {
     /// as one runtime array object (gather on read, scatter on assign). See
     /// `compile_sim_cref_read`/`compile_sim_cref_assign`.
     pub(crate) array_groups: Arc<HashMap<String, ArrayGroup>>,
+    /// The same keys for the arrays that are not one contiguous range; only a
+    /// run-time subscript resolves through these (see `ScatterGroup`).
+    pub(crate) scatter_groups: Arc<HashMap<String, ScatterGroup>>,
     /// `varKind = CONST` variables own no slot: a reference is the binding
     /// literal, as in C's `varArrayNameValues`.
     pub(crate) consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
@@ -1545,6 +1548,17 @@ impl ArrayGroup {
         }
         s
     }
+}
+
+/// An array with no [`ArrayGroup`] because its scalarized elements are not one
+/// contiguous block: alias elimination pointed them at unrelated slots, or one is
+/// a negated alias. A run-time subscript selects between their own offsets.
+#[derive(Clone)]
+pub(crate) struct ScatterGroup {
+    pub(crate) wty: WTy,
+    pub(crate) dims: Vec<u32>,
+    /// `SimData` byte offset and alias negation of each element, row-major.
+    pub(crate) elems: Vec<(u32, Neg)>,
 }
 
 /// A constant array's elements, row-major; it owns no `SimData` slots.
@@ -5425,12 +5439,14 @@ fn sim_pre_is_stored(ctx: &FnCtx, cref: &DAE::ComponentRef) -> Result<bool> {
         }
     }
     if let Some((base, _)) = array_ref_of(cref)? {
-        if sim.array_groups.contains_key(&base) {
+        if sim.array_groups.contains_key(&base) || sim.scatter_groups.contains_key(&base) {
             return Ok(true);
         }
     }
     match sim_array_base_subs(cref)? {
-        Some((base, _)) => Ok(sim.array_groups.contains_key(&base)),
+        Some((base, _)) => {
+            Ok(sim.array_groups.contains_key(&base) || sim.scatter_groups.contains_key(&base))
+        }
         None => Ok(false),
     }
 }
@@ -5850,16 +5866,7 @@ fn emit_sim_array_elem_addr(
     }
     let (_, stride) = sim_array_elem_kind_stride(group.wty);
     let data = ctx.sim()?.data_local;
-    ctx.emit(we::Instruction::I32Const(0)); // acc = 0
-    for (k, exp) in sub_exps.iter().enumerate() {
-        ctx.emit(we::Instruction::I32Const(group.dims[k] as i32));
-        ctx.emit(we::Instruction::I32Mul); // acc * dims[k]
-        let wt = compile_exp(ctx, exp)?;
-        coerce(ctx, wt, WTy::I32);
-        ctx.emit(we::Instruction::I32Const(1));
-        ctx.emit(we::Instruction::I32Sub); // e_k - 1 (1-based -> 0-based)
-        ctx.emit(we::Instruction::I32Add); // acc = acc*dims[k] + (e_k - 1)
-    }
+    emit_sim_flat_index(ctx, &group.dims, sub_exps)?;
     // addr = data + base_off + linear * stride
     ctx.emit(we::Instruction::I32Const(stride as i32));
     ctx.emit(we::Instruction::I32Mul);
@@ -5867,6 +5874,94 @@ fn emit_sim_array_elem_addr(
     ctx.emit(we::Instruction::I32Add);
     ctx.emit(we::Instruction::I32Const(group.base_off as i32));
     ctx.emit(we::Instruction::I32Add);
+    Ok(group.wty)
+}
+
+/// Push the 0-based row-major index of element `[e1,…,en]` of an array shaped
+/// `dims`, built at run time (Horner: `acc = acc*dims[k] + (e_k - 1)`).
+fn emit_sim_flat_index(ctx: &mut FnCtx, dims: &[u32], sub_exps: &[Arc<DAE::Exp>]) -> Result<()> {
+    ctx.emit(we::Instruction::I32Const(0));
+    for (k, exp) in sub_exps.iter().enumerate() {
+        ctx.emit(we::Instruction::I32Const(dims[k] as i32));
+        ctx.emit(we::Instruction::I32Mul);
+        let wt = compile_exp(ctx, exp)?;
+        coerce(ctx, wt, WTy::I32);
+        ctx.emit(we::Instruction::I32Const(1));
+        ctx.emit(we::Instruction::I32Sub); // e_k - 1 (1-based -> 0-based)
+        ctx.emit(we::Instruction::I32Add);
+    }
+    Ok(())
+}
+
+/// Apply an alias negation to the value on the stack, as C's `crefToCStr` does.
+fn emit_neg(ctx: &mut FnCtx, wty: WTy, neg: Neg) {
+    match wty {
+        WTy::F64 => {
+            if neg != Neg::None {
+                ctx.emit(we::Instruction::F64Neg);
+            }
+        }
+        WTy::I32 => match neg {
+            Neg::None => {}
+            // wasm has no `i32.neg`.
+            Neg::Arith => {
+                ctx.emit(we::Instruction::I32Const(-1));
+                ctx.emit(we::Instruction::I32Mul);
+            }
+            // A Boolean is stored as 0/1, so `!v` is `v == 0`.
+            Neg::Not => ctx.emit(we::Instruction::I32Eqz),
+        },
+    }
+}
+
+/// Select element `[e1,…,en]` of a [`ScatterGroup`] with a chain of `select`s over
+/// the run-time index, picking the element's offset — or its value, when the
+/// elements carry different alias negations. Leaves the element's byte address on
+/// the stack with `addr_only` (for a store), otherwise its value.
+fn emit_sim_scatter_elem(
+    ctx: &mut FnCtx,
+    group: &ScatterGroup,
+    sub_exps: &[Arc<DAE::Exp>],
+    addr_only: bool,
+) -> Result<WTy> {
+    use we::Instruction as I;
+    let negated = group.elems.iter().any(|(_, n)| *n != Neg::None);
+    if addr_only && negated {
+        return Err("CodegenWasmJit: assignment to negated alias");
+    }
+    let data = ctx.sim()?.data_local;
+    emit_sim_flat_index(ctx, &group.dims, sub_exps)?;
+    let flat = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalSet(flat));
+    // `acc = flat != k ? acc : <element k>`: one value on the stack, no branches.
+    for (k, &(off, neg)) in group.elems.iter().enumerate() {
+        if negated {
+            ctx.emit(I::LocalGet(data));
+            match group.wty {
+                WTy::F64 => ctx.emit(I::F64Load(mem_arg(off, 3))),
+                WTy::I32 => ctx.emit(I::I32Load(mem_arg(off, 2))),
+            }
+            emit_neg(ctx, group.wty, neg);
+        } else {
+            ctx.emit(I::I32Const(off as i32));
+        }
+        if k > 0 {
+            ctx.emit(I::LocalGet(flat));
+            ctx.emit(I::I32Const(k as i32));
+            ctx.emit(I::I32Ne);
+            ctx.emit(I::Select);
+        }
+    }
+    if !negated {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::I32Add);
+        if !addr_only {
+            match group.wty {
+                WTy::F64 => ctx.emit(I::F64Load(mem_arg(0, 3))),
+                WTy::I32 => ctx.emit(I::I32Load(mem_arg(0, 2))),
+            }
+        }
+    }
     Ok(group.wty)
 }
 
@@ -5939,6 +6034,9 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 }
                 return Ok(Some(wty));
             }
+            if let Some(group) = ctx.sim()?.scatter_groups.get(&base).filter(|g| g.dims.len() == sub_exps.len()).cloned() {
+                return emit_sim_scatter_elem(ctx, &group, &sub_exps, false).map(Some);
+            }
         }
     }
     // Contiguous slice `base[i,…,:]`: gather the row-major block.
@@ -5994,25 +6092,10 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
     let data = ctx.sim()?.data_local;
     ctx.emit(we::Instruction::LocalGet(data));
     match slot.wty {
-        WTy::F64 => {
-            ctx.emit(we::Instruction::F64Load(mem_arg(slot.off, 3)));
-            if slot.negate != Neg::None {
-                ctx.emit(we::Instruction::F64Neg);
-            }
-        }
-        WTy::I32 => {
-            ctx.emit(we::Instruction::I32Load(mem_arg(slot.off, 2)));
-            match slot.negate {
-                Neg::None => {}
-                Neg::Arith => {
-                    ctx.emit(we::Instruction::I32Const(0));
-                    ctx.emit(we::Instruction::I32Sub);
-                }
-                // A Boolean is stored as 0/1, so `!v` is `v == 0`.
-                Neg::Not => ctx.emit(we::Instruction::I32Eqz),
-            }
-        }
+        WTy::F64 => ctx.emit(we::Instruction::F64Load(mem_arg(slot.off, 3))),
+        WTy::I32 => ctx.emit(we::Instruction::I32Load(mem_arg(slot.off, 2))),
     }
+    emit_neg(ctx, slot.wty, slot.negate);
     if slot.heap {
         // Reading a heap (String) slot yields an owned reference, like reading a
         // heap local: retain so the slot keeps its reference while the value flows
@@ -6088,8 +6171,15 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
     // Array element with a non-constant subscript: store to the run-time address.
     if let Some((base, sub_exps)) = array_ref_of(cref)? {
         if sub_exps.iter().any(|e| const_index_value(e).is_none()) {
-            if let Some(group) = ctx.sim()?.array_groups.get(&base).filter(|g| g.dims.len() == sub_exps.len()).cloned() {
-                let wty = emit_sim_array_elem_addr(ctx, &group, &sub_exps)?; // [addr]
+            // Either group leaves the element's address on the stack.
+            let elem = match ctx.sim()?.array_groups.get(&base).filter(|g| g.dims.len() == sub_exps.len()).cloned() {
+                Some(group) => Some(emit_sim_array_elem_addr(ctx, &group, &sub_exps)?),
+                None => match ctx.sim()?.scatter_groups.get(&base).filter(|g| g.dims.len() == sub_exps.len()).cloned() {
+                    Some(group) => Some(emit_sim_scatter_elem(ctx, &group, &sub_exps, true)?),
+                    None => None,
+                },
+            };
+            if let Some(wty) = elem {
                 let rw = rhs.push(ctx)?;
                 coerce(ctx, rw, wty);
                 match wty {

--- a/testsuite/simulation/modelica/arrays/DynamicSubscriptAliasArray.mos
+++ b/testsuite/simulation/modelica/arrays/DynamicSubscriptAliasArray.mos
@@ -1,0 +1,54 @@
+// name: DynamicSubscriptAliasArray
+// keywords: array alias subscript
+// status: correct
+// teardown_command: rm -rf DynamicSubscriptAliasArray_* DynamicSubscriptAliasArray DynamicSubscriptAliasArray.log DynamicSubscriptAliasArray.wasm
+//
+// A subscript only known at run time on an array whose elements alias unrelated
+// variables (a parameter and two algebraic variables), so the scalarized elements
+// are not one contiguous storage range. wasm-jit used to reject this with
+// "Internal error CodegenWasmJit: cannot resolve `s[k].v` to a simulation
+// variable".
+//
+// Only successful code generation is checked: the C code generator addresses such
+// an element relative to the first one, so `y` differs between the targets.
+
+loadString("
+model DynamicSubscriptAliasArray
+  connector Sig
+    Real v;
+    flow Real f;
+  end Sig;
+  Sig s[3];
+  parameter Real p = 10;
+  Real a, c;
+  Integer k(start = 1, fixed = true);
+  Real y;
+equation
+  a = 1 + time;
+  c = 100 + time;
+  s[1].v = a;
+  s[2].v = p;
+  s[3].v = c;
+  y = s[k].v;
+  when time > 0.3 then
+    k = 2;
+  elsewhen time > 0.6 then
+    k = 3;
+  end when;
+end DynamicSubscriptAliasArray;
+"); getErrorString();
+
+simulate(DynamicSubscriptAliasArray, stopTime = 1.0, numberOfIntervals = 4); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "DynamicSubscriptAliasArray_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 4, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DynamicSubscriptAliasArray', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -32,6 +32,7 @@ Bug3916.mos \
 ConstructFunc.mos \
 crefIndex.mos \
 DimConvert.mos \
+DynamicSubscriptAliasArray.mos \
 gc.mos \
 gc2980.mos \
 Issue14470.mos \


### PR DESCRIPTION
A subscript only known at run time resolved through the contiguous `ArrayGroup` of the array's scalarized elements, and there is no such group when alias elimination has pointed those elements at unrelated slots. `StewartPlatform.Scenarios.StewartPlatform_InverseDynamic2` reads `poseInput[pre(count)].stopTime` on a connector array whose six elements alias six different components' parameters, and failed with

    Internal error CodegenWasmJit: cannot resolve
    `path.switch2.poseInput[$PRE.path.switch2.count].stopTime`
    to a simulation variable

Record a `ScatterGroup` for such an array instead: the row-major table of its elements' offsets and alias negations. A run-time subscript picks one with a chain of `select`s - one load, no branches.

Elements that are negated aliases now join the accumulated group too, so the shape is derived from all of them. The contiguous path rejects a group containing one rather than silently gathering it unnegated; it previously got a too-small `dims` when the negated element carried the largest index.

Folding the two copies of the negation emission into `emit_neg` also fixes the integer `Neg::Arith` case, which emitted `i32.const 0; i32.sub` after the load, i.e. `v - 0`.

Note that the C code generator gets this construct wrong: `daeExpCrefRhsSimContext` addresses the element as `(&realVars[realVarsIndex[<element 1>]])[flat_index]`, which is only sound when the elements are contiguous. In the model above C's `path.switch2.count` sticks at 2 from t = 2.13 onwards, where wasm-jit switches at each of the six `stopTime` values. The new testcase therefore only checks that code generation succeeds.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
