### PR TITLE
wasm-jit: match C after a state-set switch

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -6553,13 +6553,13 @@ fn lower_linear_system(
         }
         return compile_linear_system_analytic(
             ctx, &vars, &res_exps, &seed_offs, &result_offs,
-            &mut lower_inner, &mut lower_constant, &mut lower_column, use_sparse,
+            &mut lower_inner, &mut lower_constant, &mut lower_column, use_sparse, lsystem.index,
         );
     }
 
     // C keys `method` off `ls.jacobianMatrix` alone, not off whether it assembles
     // `A` from one.
-    compile_linear_system(ctx, &vars, &res_exps, &mut lower_inner, use_sparse, lsystem.jacobianMatrix.is_some())
+    compile_linear_system(ctx, &vars, &res_exps, &mut lower_inner, use_sparse, lsystem.jacobianMatrix.is_some(), lsystem.index)
 }
 
 /// Whether a torn linear system uses the sparse solver (C's density/size

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -449,8 +449,9 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // String (Booleans are coerced to 0/1 i32). Borrows the format handle.
     ("rt_string_format_int", &[WTy::I32, WTy::I32], &[WTy::I32]),
     // Dense linear solve `A x = b` in place (A column-major `n*n` f64 at a_ptr,
-    // b `n` f64 at b_ptr; solution overwrites b). Returns 0 ok, 1 singular.
-    ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // b `n` f64 at b_ptr; solution overwrites b), then the equation index and time
+    // the fallback warning needs. Returns 0 ok, 1 singular.
+    ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64], &[WTy::I32]),
     // Sparse linear solve `A x = b` in place, A in CSC: (colptr n+1 i32, rowidx
     // nnz i32, values nnz f64, b_ptr n f64, n, nnz) -> 0 ok / 1 singular. The C
     // runtime's KLU path (AMD-ordered sparse LU); see `rt_solve_lin_sparse`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -604,6 +604,7 @@ pub(crate) fn compile_linear_system(
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
     use_sparse: bool,
     method1: bool,
+    index: i32,
 ) -> Result<()> {
     let n = iter_vars.len();
     if n == 0 {
@@ -734,7 +735,17 @@ pub(crate) fn compile_linear_system(
     ctx.emit(we::Instruction::End); // block
 
     // --- solve, scatter, recover the torn variables, free the scratch. ---
-    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, method1.then_some(x0_off), lower_inner)
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, method1.then_some(x0_off), index, lower_inner)
+}
+
+/// `rt_linsolve`'s trailing `(index, time)`, read only by its fallback warning.
+fn emit_linsolve_context(ctx: &mut FnCtx, index: i32) -> Result<()> {
+    use we::Instruction as I;
+    let data = ctx.sim()?.data_local;
+    ctx.emit(I::I32Const(index));
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::F64Load(mem_arg(0, 3))); // `time` — `SimData` offset 0
+    Ok(())
 }
 
 /// Trap (runtime error) when the solver returned nonzero (singular) — consumes the
@@ -820,6 +831,7 @@ fn emit_scatter_recover_free(
 /// Solve the assembled dense `A dx = b` (column-major `A` at `base+0`, `b` at
 /// `base+b_off`), then scatter/recover/free. `use_sparse` picks
 /// `rt_solve_lin_dense_sparse` vs `rt_linsolve`.
+#[allow(clippy::too_many_arguments)]
 fn emit_lin_solve_scatter(
     ctx: &mut FnCtx,
     base: u32,
@@ -828,6 +840,7 @@ fn emit_lin_solve_scatter(
     slots: &[u32],
     use_sparse: bool,
     x0_off: Option<u32>,
+    index: i32,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
@@ -837,6 +850,9 @@ fn emit_lin_solve_scatter(
     ctx.emit(I::I32Add); // b_ptr
     ctx.emit(I::I32Const(n as i32));
     let solver = if use_sparse { "rt_solve_lin_dense_sparse" } else { "rt_linsolve" };
+    if !use_sparse {
+        emit_linsolve_context(ctx, index)?;
+    }
     ctx.emit(I::Call(rt_index(solver)?));
     emit_singular_check(ctx)?;
     emit_scatter_recover_free(ctx, base, b_off, n, slots, x0_off, lower_inner)
@@ -859,6 +875,7 @@ pub(crate) fn compile_linear_system_analytic(
     lower_constant: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
     lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
     use_sparse: bool,
+    index: i32,
 ) -> Result<()> {
     use we::Instruction as I;
     let n = iter_vars.len();
@@ -1021,7 +1038,7 @@ pub(crate) fn compile_linear_system_analytic(
     ctx.emit(I::End);
     ctx.emit(I::End);
 
-    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, Some(xold_off), lower_inner)
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, Some(xold_off), index, lower_inner)
 }
 
 /// Greedy distance-1 column coloring (Curtis-Powell-Reid) of the CSC pattern:
@@ -1511,12 +1528,13 @@ pub(crate) fn compile_linear_system_symbolic(
             ctx.emit(I::F64Store(mem_arg(elem_off, 3)));
         }
         emit_b_exps(ctx, base, b_off, b_exps)?;
-        // rt_linsolve(a_ptr, b_ptr, n).
+        // rt_linsolve(a_ptr, b_ptr, n, index, time).
         ctx.emit(I::LocalGet(base)); // a_ptr (a_off == 0)
         ctx.emit(I::LocalGet(base));
         ctx.emit(I::I32Const(b_off as i32));
         ctx.emit(I::I32Add);
         ctx.emit(I::I32Const(n as i32));
+        emit_linsolve_context(ctx, index)?;
         ctx.emit(I::Call(rt_index("rt_linsolve")?));
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2435,7 +2435,7 @@ pub extern "C" fn rt_lin_solves() -> u64 {
 /// singular matrix, mirroring C's `LS_DEFAULT`; `-ls=klu`/`-ls=umfpack` use
 /// SuiteSparse instead.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
+pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
     #[cfg(sundials)]
@@ -2455,11 +2455,53 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     // `dgesv`, and the default) is partial-pivot LU with that as its singular
     // fallback. `-ls=umfpack` only gets here having found the matrix singular.
     let lu_first = !matches!(solvers::ls(), solvers::Ls::TotalPivot | solvers::Ls::Umfpack);
-    if (lu_first && nls::lu_solve(a, b, n)) || nls::total_pivot_solve(a, b, n) {
-        0
-    } else {
-        1
+    if lu_first {
+        if nls::lu_solve(a, b, n) {
+            ls_solved(eq_index);
+            return 0;
+        }
+        ls_report_fallback(eq_index, time);
     }
+    if nls::total_pivot_solve(a, b, n) { 0 } else { 1 }
+}
+
+/// C's per-system `linsys->failed` / `numberOfFailures`: the first failure after
+/// a success warns on stdout, a run of them only on `LOG_LS`.
+struct LsFailures(core::cell::UnsafeCell<alloc::vec::Vec<(i32, bool, u64)>>);
+unsafe impl Sync for LsFailures {}
+static LS_FAILURES: LsFailures = LsFailures(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+
+fn ls_failure_entry(eq_index: i32) -> &'static mut (i32, bool, u64) {
+    let v = unsafe { &mut *LS_FAILURES.0.get() };
+    if let Some(i) = v.iter().position(|e| e.0 == eq_index) {
+        return &mut v[i];
+    }
+    v.push((eq_index, false, 0));
+    v.last_mut().unwrap()
+}
+
+fn ls_solved(eq_index: i32) {
+    ls_failure_entry(eq_index).1 = false;
+}
+
+/// C's `solve_linear_system` `LS_DEFAULT` branch.
+fn ls_report_fallback(eq_index: i32, time: f64) {
+    let e = ls_failure_entry(eq_index);
+    let stream = if e.1 { omclog::LS } else { omclog::STDOUT };
+    e.1 = true;
+    e.2 += 1;
+    omclog::warning_with_limit(
+        stream,
+        e.2,
+        solvers::max_warn_displays(),
+        &alloc::format!(
+            "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS."
+        ),
+    );
+}
+
+pub fn reset_ls_failures() {
+    unsafe { &mut *LS_FAILURES.0.get() }.clear();
 }
 
 /// Solve a sparse `n`×`n` system `A x = b` in place, `A` given in CSC:

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -284,6 +284,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     // Any prior session is dropped (frees its buffers) before starting a new one.
     *session() = None;
     crate::reset_lin_solves();
+    crate::reset_ls_failures();
     crate::reset_stats();
     crate::sundials::reset_caches();
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -95,6 +95,18 @@ pub(crate) fn max_step_factor() -> f64 {
     f64::from_bits(MAX_STEP_FACTOR.load(Ordering::Relaxed))
 }
 
+/// `-lvMaxWarn`, C's `maxWarnDisplays` (`DEFAULT_FLAG_LV_MAX_WARN`).
+static MAX_WARN_DISPLAYS: AtomicU32 = AtomicU32::new(3);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_max_warn(n: u32) {
+    MAX_WARN_DISPLAYS.store(n, Ordering::Relaxed);
+}
+
+pub(crate) fn max_warn_displays() -> u64 {
+    MAX_WARN_DISPLAYS.load(Ordering::Relaxed) as u64
+}
+
 /// `-ils` (C's `init_lambda_steps`, default 3) and `-homotopyOnFirstTry` /
 /// `-noHomotopyOnFirstTry` as C's tri-state flag: 0 unset, 1 on, 2 off.
 static INIT_LAMBDA_STEPS: AtomicU32 = AtomicU32::new(3);
@@ -204,6 +216,7 @@ pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     rt_set_solvers(nls, nls_ls, ls, lss);
     let (ftol, xtol, msf) = openmodelica_sim_meta::simflags::newton_tuning(f);
     rt_set_newton_tuning(ftol, xtol, msf);
+    rt_set_max_warn(f.max_warn.unwrap_or(3));
     let (steps, first) = openmodelica_sim_meta::simflags::homotopy_codes(f);
     rt_set_homotopy(steps, first);
     let h = openmodelica_sim_meta::simflags::hom_tuning(f);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -4730,11 +4730,10 @@ impl Driver for DasslDriver {
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated; // terminate() fired: keep this row, stop
             }
-            // Re-select states at the accepted point. A switch changes the meaning of
-            // the state vector (a discontinuity), so refresh the derivatives, re-read
-            // y/yp from the reinitialised states, and restart DASKR (INFO(1)=0).
+            // Re-read y/yp and restart DASKR (INFO(1)=0). No `functionODE` in
+            // between: C's `dassl_step` takes YPRIME from the ring buffer, so it
+            // restarts on the derivatives of the *previous* selection.
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
-                e.call1("functionODE", sim_data)?;
                 for i in 0..n_states {
                     self.y[i] = read_f64(e, states_base + (i as u32) * 8)?;
                     self.yp[i] = read_f64(e, ders_base + (i as u32) * 8)?;
@@ -7754,10 +7753,8 @@ impl Driver for IdaDriver {
             if terminated(e, sim_data, layout)? {
                 break Advance::Terminated;
             }
-            // A state-set switch changes the meaning of the state vector, so
-            // re-read it and restart IDA (see `DasslDriver`).
+            // Restart IDA on the reinitialised states (see `DasslDriver`).
             if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
-                e.call1("functionODE", sim_data)?;
                 for i in 0..n_states {
                     ida.y_mut()[i] = read_f64(e, states_base + (i as u32) * 8)?;
                     ida.yp_mut()[i] = read_f64(e, self.ders_base + (i as u32) * 8)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -307,6 +307,27 @@ pub fn warning(stream: Stream, indent_next: bool, msg: &str) {
     }
 }
 
+/// C's `warningStreamPrintWithLimit`, `max_displayed` being `-lvMaxWarn`.
+pub fn warning_with_limit(stream: Stream, n_displayed: u64, max_displayed: u64, msg: &str) {
+    if !(active(stream) || store::with(|s| s.use_stream & SHOW_ALL_WARNINGS != 0)) {
+        return;
+    }
+    if n_displayed <= max_displayed {
+        message_text(WARNING, stream, false, msg);
+    }
+    if n_displayed == max_displayed {
+        message_text(
+            INFO,
+            stream,
+            false,
+            &format!(
+                "Too many warnings, reached display limit of {max_displayed}. Suppressing further warning messages of the same type."
+            ),
+        );
+        message_text(INFO, stream, false, "Change limit with simulation flag -lvMaxWarn=<newLimit>");
+    }
+}
+
 pub fn error(stream: Stream, indent_next: bool, msg: &str) {
     message_text(ERROR, stream, indent_next, msg);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -141,6 +141,8 @@ pub struct SimFlags {
     /// name fails at parse time as in C and no reader re-derives the implications.
     /// [`parse`] fills it; a default-constructed `SimFlags` has no stream on.
     pub log_mask: crate::omclog::Mask,
+    /// `-lvMaxWarn`: C's `maxWarnDisplays`, how often a repeating warning shows.
+    pub max_warn: Option<u32>,
     pub abort_slow: bool,
     /// `-alarm`: seconds after which the run is aborted (C's `FLAG_ALARM`, where
     /// it is a `SIGALRM` on the simulation executable). 0 disables it, as in C.
@@ -602,6 +604,13 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                         f.log.push(s.to_uppercase());
                     }
                 }
+            }
+            "lvMaxWarn" => {
+                f.max_warn = Some(
+                    value(name)?
+                        .parse::<u32>()
+                        .map_err(|_| "-lvMaxWarn takes an integer argument".to_string())?,
+                )
             }
             "override" => {
                 // C's `parseVariableStr` splits on commas outside `[]`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -980,6 +980,11 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         wts(set.call(&mut store, ftol, xtol, msf))?;
     }
     // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_set_max_warn") {
+        let n = openmodelica_sim_meta::simflags::with_flags(|f| f.max_warn.unwrap_or(3));
+        wts(set.call(&mut store, n))?;
+    }
+    // See the wasmtime counterpart.
     if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_homotopy") {
         let h = openmodelica_sim_meta::simflags::with_flags(|f| {
             openmodelica_sim_meta::simflags::homotopy_codes(f)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1007,6 +1007,11 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         });
         wts(set.call(&mut store, t))?;
     }
+    // `-lvMaxWarn`: the warnings it caps are printed in-wasm.
+    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_set_max_warn") {
+        let n = openmodelica_sim_meta::simflags::with_flags(|f| f.max_warn.unwrap_or(3));
+        wts(set.call(&mut store, n))?;
+    }
     // `-ils` / `-homotopyOnFirstTry`: a local approach sweeps inside `rt_solve_nls`.
     if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_homotopy") {
         let h = openmodelica_sim_meta::simflags::with_flags(|f| {


### PR DESCRIPTION
C's `dassl_step` takes YPRIME from `localData[1]`, and `perform_simulation.c.inc` runs `stateSelection` after `updateContinuousSystem`. A `$STATESET` switch therefore reinitialises the state slots while the derivative array still holds the previous selection's values, and the integrator restarts from that inconsistent pair. IDA aliases the same buffer (`ida_solver.c`). The wasm-jit drivers re-ran `functionODE` first, so they restarted consistently instead.

In PointGravityWithPointMasses2 the quaternion sets switch at t=1.668, C's stale `der(Q[2])` lands on the out-of-plane `Q[3]` slot and kicks it to ~7.5e-8. wasm-jit kept every out-of-plane variable at exactly 0.0 for the whole run; `diffSimulationResults` scales its tube to each variable's own range, so that failed against a reference whose range is 1e-6.

Also print the total-pivot fallback warning `solve_linear_system` emits when the default (LAPACK) solver reports the matrix singular. `rt_linsolve` gains the equation index and time it needs, and tracks `linsys->failed` / `numberOfFailures` per system so the first failure after a success goes to stdout and a run of them only to LOG_LS. `-lvMaxWarn` now parses and caps the repeats, as C's `warningStreamPrintWithLimit` does.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
