### PR TITLE
[Build] Fix MSYS2 prefix resolution in the Windows install rules

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -377,25 +377,7 @@ endif()
 # They are part of "compiler" installation component. This means that you can
 # install just the files in this component by specifying its name.
 if(WIN32)
-  # Escape the environment variable path
-  if(NOT DEFINED ENV{OMDEV})
-    message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
-  endif()
-  if(NOT DEFINED ENV{MSYSTEM_PREFIX})
-    message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
-  endif()
-
-  # MSYS2 exports MSYSTEM_PREFIX as a POSIX-style path (e.g. "/ucrt64"). When
-  # cmake is invoked directly from an MSYS2 shell, MSYS2 auto-translates that
-  # to an absolute Windows path (relative to its own install root) before the
-  # native cmake.exe process ever sees it, so it can be used as-is. Only if it
-  # is still POSIX-style (translation didn't happen) do we resolve it
-  # ourselves against OMDEV's msys tree.
-  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
-  else()
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
-  endif()
+  omc_get_msys_prefix(MSYSTEM_PREFIX_ESCAPED)
 
   set(OMCOMPILER_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/Compiler/bin)
   set(SIMULATION_RUNTIME_LIB_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}OMCompiler/SimulationRuntime/c)

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -37,10 +37,16 @@ if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
     message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
   endif()
 
-  if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles" AND "$ENV{VisualStudioVersion}" STREQUAL "")
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
-  else()
+  # MSYS2 exports MSYSTEM_PREFIX as a POSIX-style path (e.g. "/ucrt64"). When
+  # cmake is invoked directly from an MSYS2 shell, MSYS2 auto-translates that
+  # to an absolute Windows path (relative to its own install root) before the
+  # native cmake.exe process ever sees it, so it can be used as-is. Only if it
+  # is still POSIX-style (translation didn't happen) do we resolve it
+  # ourselves against OMDEV's msys tree.
+  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
     string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
+  else()
+    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
   endif()
 
   # TODO: This is stupid, but I can't get install with RUNTIME_DEPENDENCIES to run.

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -26,28 +26,11 @@ endif()
 
 if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
 
-  # Escape the environment variable path
-  if(NOT DEFINED ENV{OMDEV})
-    message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
-  endif()
   if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(FATAL_ERROR "No 32-bit version of UCRT available!")
   endif()
-  if(NOT DEFINED ENV{MSYSTEM_PREFIX})
-    message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
-  endif()
 
-  # MSYS2 exports MSYSTEM_PREFIX as a POSIX-style path (e.g. "/ucrt64"). When
-  # cmake is invoked directly from an MSYS2 shell, MSYS2 auto-translates that
-  # to an absolute Windows path (relative to its own install root) before the
-  # native cmake.exe process ever sees it, so it can be used as-is. Only if it
-  # is still POSIX-style (translation didn't happen) do we resolve it
-  # ourselves against OMDEV's msys tree.
-  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
-  else()
-    string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
-  endif()
+  omc_get_msys_prefix(MSYSTEM_PREFIX_ESCAPED)
 
   # TODO: This is stupid, but I can't get install with RUNTIME_DEPENDENCIES to run.
   # It needs to link to libs that are installed to ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR},

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -130,6 +130,8 @@ else()
 endif()
 
 if(MINGW)
+  omc_get_msys_prefix(MSYSTEM_PREFIX_ESCAPED)
+
   # Find windeployqt6
   find_program(WINDEPLOYQT_EXECUTABLE
     NAMES windeployqt windeployqt6

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -69,6 +69,8 @@ install(TARGETS OMPlotLib)
 omc_install_gui_client(OMPlot)
 
 if(MINGW)
+  omc_get_msys_prefix(MSYSTEM_PREFIX_ESCAPED)
+
   # Find windeployqt6
   find_program(WINDEPLOYQT_EXECUTABLE
     NAMES windeployqt windeployqt6

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(OMShell PRIVATE Qt${OM_QT_MAJOR_VERSION}::PrintSupport)
 omc_install_gui_client(OMShell)
 
 if(MINGW)
+  omc_get_msys_prefix(MSYSTEM_PREFIX_ESCAPED)
+
   # Find windeployqt6
   find_program(WINDEPLOYQT_EXECUTABLE
     NAMES windeployqt windeployqt6

--- a/cmake/omc_utils.cmake
+++ b/cmake/omc_utils.cmake
@@ -32,3 +32,29 @@ macro(omc_install_gui_client target)
   install(TARGETS ${target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                             BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
 endmacro()
+
+# Resolve the MSYS2 installation prefix (the ucrt64 tree) into an absolute
+# Windows path with forward slashes and store it in ${out_var}.
+#
+# MSYS2 exports MSYSTEM_PREFIX as a POSIX-style path (e.g. "/ucrt64"). When
+# cmake is invoked directly from an MSYS2 shell, MSYS2 auto-translates that to
+# an absolute Windows path (relative to its own install root) before the native
+# cmake.exe process ever sees it, so it can be used as-is. Only if it is still
+# POSIX-style (translation didn't happen) do we resolve it ourselves against
+# OMDEV's msys tree.
+function(omc_get_msys_prefix out_var)
+  if(NOT DEFINED ENV{MSYSTEM_PREFIX})
+    message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
+  endif()
+
+  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
+    string(REPLACE "\\" "/" msys_prefix "$ENV{MSYSTEM_PREFIX}")
+  else()
+    if(NOT DEFINED ENV{OMDEV})
+      message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
+    endif()
+    string(REPLACE "\\" "/" msys_prefix "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
+  endif()
+
+  set(${out_var} "${msys_prefix}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Follow-up to #16339, which fixed this bug in `OMCompiler/Compiler/CMakeLists.txt` but left the identical code in OMEdit untouched.

Two commits: the reported failure first, then the shared helper that removes the duplication and fixes a second, latent bug in the other three GUI clients.

## 1. The reported failure

`mingw32-make install` fails on Windows/OMDev with a doubled path:

```
CMake Error at OMEdit/OMEditGUI/cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "C:/OMDevUCRT/tools/msys/C:/OMDevUCRT/tools/msys/ucrt64/bin/Qt6OpenGL.dll":
  File exists.
Call Stack (most recent call first):
  OMEdit/cmake_install.cmake:47 (include)
  cmake_install.cmake:62 (include)

mingw32-make: *** [Makefile:129: install] Error 1
```

(The trailing `File exists.` is a stale `errno` from CMake, not a real diagnostic.)

`OMEdit/OMEditGUI/CMakeLists.txt` picked the base directory from the *generator* instead of from the value of `MSYSTEM_PREFIX`:

```cmake
if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles" AND "$ENV{VisualStudioVersion}" STREQUAL "")
  string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
else()
  string(REPLACE "\\" "/" MSYSTEM_PREFIX_ESCAPED "$ENV{MSYSTEM_PREFIX}")
endif()
```

When cmake is invoked from an MSYS2 shell, MSYS2 auto-translates `MSYSTEM_PREFIX` to an absolute Windows path (`C:/OMDevUCRT/tools/msys/ucrt64`) before the native `cmake.exe` process ever sees it. The unconditional prepend then yields `C:/OMDevUCRT/tools/msys/` + `C:/OMDevUCRT/tools/msys/ucrt64`.

The bad value feeds four places in the file — the `Qt6OpenGL.dll` `install(FILES ...)`, `install(TARGETS ... RUNTIME_DEPENDENCIES DIRECTORIES ...)`, the status message, and the `find_program` hint for `windeployqt6` — so all four were wrong; the install rule simply failed first.

Fixed with the same drive-letter test #16339 introduced for the compiler.

## 2. `MSYSTEM_PREFIX_ESCAPED` was never set in OMPlot, OMNotebook and OMShell

All three pass `"${MSYSTEM_PREFIX_ESCAPED}/bin"` as the `HINTS` for locating `windeployqt6`:

- `OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt`
- `OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt`
- `OMShell/OMShell/OMShellGUI/CMakeLists.txt`

but none of them ever assigns that variable. It is only assigned in `OMEdit/OMEditGUI` and `OMCompiler/Compiler`, which are *sibling* directory scopes — the top level adds OMPlot, OMEdit, OMShell and OMNotebook as four separate subdirectories, so no value ever reaches them. The hint expanded to `/bin` and `find_program` silently fell back to a `PATH` search.

`WINDEPLOYQT_EXECUTABLE` is a cache variable shared by all four directories, and OMPlot is configured first (top-level `CMakeLists.txt:270`), so that `PATH` result is also what OMEdit ends up using — its correct `HINTS` never got the chance to apply. In practice this works only because an MSYS2 shell has `ucrt64/bin` on `PATH` anyway; on a `PATH` with a different Qt kit's `windeployqt` it deploys the wrong runtime, and on one without any it turns into a hard configure error via `REQUIRED`.

## The helper

`omc_get_msys_prefix(<out_var>)` in `cmake/omc_utils.cmake`, called from all five places, so the prefix is resolved identically everywhere:

```cmake
function(omc_get_msys_prefix out_var)
  if(NOT DEFINED ENV{MSYSTEM_PREFIX})
    message(FATAL_ERROR "Environment variable \"MSYSTEM_PREFIX\" is not set.")
  endif()

  if("$ENV{MSYSTEM_PREFIX}" MATCHES "^[A-Za-z]:")
    string(REPLACE "\\" "/" msys_prefix "$ENV{MSYSTEM_PREFIX}")
  else()
    if(NOT DEFINED ENV{OMDEV})
      message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
    endif()
    string(REPLACE "\\" "/" msys_prefix "$ENV{OMDEV}\\tools\\msys\\$ENV{MSYSTEM_PREFIX}")
  endif()

  set(${out_var} "${msys_prefix}" PARENT_SCOPE)
endfunction()
```

Both invocation styles are handled: an MSYS2 shell (already-translated absolute path, used as-is) and a plain Windows shell where the translation never happened (resolved against the OMDev msys tree). `cmake/omc_utils.cmake` is included at top-level line 31, before any `add_subdirectory`, so the function is visible in all of them.

No functional change for OMEdit and `OMCompiler/Compiler`: the helper keeps the #16339 drive-letter test verbatim. The only behavioural difference is that the `OMDEV` check now lives in the branch that is its only user, so a build from an MSYS2 shell no longer requires `OMDEV` to be set just to reach the prefix computation.

## Testing

The helper was exercised directly with `cmake -P` over the cases that matter:

| `MSYSTEM_PREFIX` | `OMDEV` | result |
| --- | --- | --- |
| `C:/OMDevUCRT/tools/msys/ucrt64` | `C:\OMDevUCRT` | `C:/OMDevUCRT/tools/msys/ucrt64` (the reported failure, now correct) |
| `C:\OMDevUCRT\tools\msys\ucrt64` | `C:\OMDevUCRT` | `C:/OMDevUCRT/tools/msys/ucrt64` |
| `/ucrt64` | `C:\OMDevUCRT` | `C:/OMDevUCRT/tools/msys/ucrt64` |
| unset | — | `FATAL_ERROR`: `MSYSTEM_PREFIX` is not set |
| `/ucrt64` | unset | `FATAL_ERROR`: `OMDEV` is not set |

I do not have a Windows/MinGW machine here, so the install and `windeployqt6` steps themselves have not been run end to end — that needs the Windows CI or @adrpo's OMDev build.

## Not touched

`OMCompiler/SimulationRuntime/cpp` and `OMSICpp` also derive a `MSYSTEM_PREFIX_ESCAPED`, but they use `$ENV{MSYSTEM_PREFIX}` verbatim without any prepend, for Boost roots rather than for install rules. Converting them would change behaviour in the untranslated case, so they are deliberately left alone.

---
generated by Claude Code
