### PR TITLE
wasm-jit: check the step a linear solve took

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -450,8 +450,15 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_string_format_int", &[WTy::I32, WTy::I32], &[WTy::I32]),
     // Dense linear solve `A x = b` in place (A column-major `n*n` f64 at a_ptr,
     // b `n` f64 at b_ptr; solution overwrites b), then the equation index and time
-    // the fallback warning needs. Returns 0 ok, 1 singular.
-    ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64], &[WTy::I32]),
+    // the fallback warning needs and whether a `rt_ls_check_step` follows.
+    // Returns 0 ok, 1 singular.
+    ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),
+    // The same `A` re-solved with total pivoting: (a_ptr, b_ptr, n) -> 0 ok / 1
+    // inconsistent. C's fallback for a method-1 step `rt_ls_check_step` rejected.
+    ("rt_linsolve_totalpivot", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // Method-1 step test: (res_ptr, b_ptr, n, index, time, dense) -> 1 when the
+    // step must be redone, `b` then holding `-res`. See `rt_ls_check_step`.
+    ("rt_ls_check_step", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),
     // Sparse linear solve `A x = b` in place, A in CSC: (colptr n+1 i32, rowidx
     // nnz i32, values nnz f64, b_ptr n f64, n, nnz) -> 0 ok / 1 singular. The C
     // runtime's KLU path (AMD-ordered sparse LU); see `rt_solve_lin_sparse`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -734,11 +734,13 @@ pub(crate) fn compile_linear_system(
     ctx.emit(we::Instruction::End); // loop
     ctx.emit(we::Instruction::End); // block
 
-    // --- solve, scatter, recover the torn variables, free the scratch. ---
-    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, method1.then_some(x0_off), index, lower_inner)
+    // --- solve, scatter, recover the torn variables, free the scratch. `res0` is
+    // spent by now, so the step check reuses it. ---
+    let m1 = method1.then_some(Method1 { res_off: res0_off, res_exps });
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, m1, index, lower_inner)
 }
 
-/// `rt_linsolve`'s trailing `(index, time)`, read only by its fallback warning.
+/// The `(index, time)` a solver's warnings need.
 fn emit_linsolve_context(ctx: &mut FnCtx, index: i32) -> Result<()> {
     use we::Instruction as I;
     let data = ctx.sim()?.data_local;
@@ -753,6 +755,15 @@ fn emit_linsolve_context(ctx: &mut FnCtx, index: i32) -> Result<()> {
 fn emit_singular_check(ctx: &mut FnCtx) -> Result<()> {
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
     emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
+    ctx.emit(we::Instruction::End);
+    Ok(())
+}
+
+/// C's `check_linear_solution` for a solver with no fallback left — consumes the
+/// i32 result on the stack.
+fn emit_lin_unsolved(ctx: &mut FnCtx, index: i32) -> Result<()> {
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    emit_runtime_error(ctx, &format!("Solving linear system {index} failed. For more information use -lv LOG_LS."))?;
     ctx.emit(we::Instruction::End);
     Ok(())
 }
@@ -798,15 +809,14 @@ fn old_slot(old_real: Option<(u32, u32)>, off: u32) -> Option<u32> {
 }
 
 /// Scatter the solve's result (at `base+b_off`) into `slots`, recover the torn
-/// variables (`lower_inner` at the solution), and free `base`. `x0_off` makes the
-/// result a step to add to it (C's method 1); without it, the solution itself.
+/// variables (`lower_inner` at the solution), and free `base`. C's method 0, whose
+/// solution is the unknowns themselves; method 1 steps instead ([`emit_lin_step`]).
 fn emit_scatter_recover_free(
     ctx: &mut FnCtx,
     base: u32,
     b_off: u32,
     n: usize,
     slots: &[u32],
-    x0_off: Option<u32>,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
@@ -815,14 +825,96 @@ fn emit_scatter_recover_free(
         ctx.emit(I::LocalGet(data));
         ctx.emit(I::LocalGet(base));
         ctx.emit(I::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
-        if let Some(x0_off) = x0_off {
-            ctx.emit(I::LocalGet(base));
-            ctx.emit(I::F64Load(mem_arg(x0_off + (j as u32) * 8, 3)));
-            ctx.emit(I::F64Add);
-        }
         ctx.emit(I::F64Store(mem_arg(slots[j], 3)));
     }
     lower_inner(ctx)?;
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    Ok(())
+}
+
+/// A method-1 system's step check: `res_exps` re-evaluated at the step, into the
+/// scratch at `res_off`.
+struct Method1<'a> {
+    res_off: u32,
+    res_exps: &'a [&'a Arc<DAE::Exp>],
+}
+
+/// Take the step `dx` at `base+b_off`, recover the torn variables there, and hold
+/// it to C's method-1 residual test (`rt_ls_check_step`). A rejected step is redone
+/// with total pivoting on the same `A` — `solve_linear_system`'s `LS_DEFAULT`
+/// fallback, which C reaches by re-assembling from the stepped unknowns. The retry
+/// is a second pass of this same body, so it recomputes what C recomputes.
+#[allow(clippy::too_many_arguments)]
+fn emit_lin_step(
+    ctx: &mut FnCtx,
+    base: u32,
+    b_off: u32,
+    n: usize,
+    slots: &[u32],
+    use_sparse: bool,
+    index: i32,
+    m1: &Method1,
+    lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let data = ctx.sim()?.data_local;
+    // `retry` guards the second pass: C never checks the total-pivot step.
+    let retry = (!use_sparse).then(|| {
+        let l = ctx.alloc_temp(WTy::I32);
+        ctx.emit(I::I32Const(0));
+        ctx.emit(I::LocalSet(l));
+        ctx.emit(I::Block(we::BlockType::Empty));
+        ctx.emit(I::Loop(we::BlockType::Empty));
+        l
+    });
+
+    for j in 0..n {
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::F64Load(mem_arg(slots[j], 3)));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + (j as u32) * 8, 3)));
+        ctx.emit(I::F64Add);
+        ctx.emit(I::F64Store(mem_arg(slots[j], 3)));
+    }
+    emit_residual_eval(ctx, base, m1.res_exps, m1.res_off, lower_inner)?;
+
+    if let Some(retry) = retry {
+        ctx.emit(I::LocalGet(retry));
+        ctx.emit(I::BrIf(1));
+    }
+    // rt_ls_check_step(res_ptr, b_ptr, n, index, time, dense).
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(m1.res_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::I32Const(b_off as i32));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Const(n as i32));
+    emit_linsolve_context(ctx, index)?;
+    ctx.emit(I::I32Const(!use_sparse as i32)); // `dense`: a rejected step can retry
+    ctx.emit(I::Call(rt_index("rt_ls_check_step")?));
+    match retry {
+        Some(retry) => {
+            ctx.emit(I::I32Eqz);
+            ctx.emit(I::BrIf(1));
+            ctx.emit(I::LocalGet(base)); // a_ptr, untouched by the solve
+            ctx.emit(I::LocalGet(base));
+            ctx.emit(I::I32Const(b_off as i32));
+            ctx.emit(I::I32Add);
+            ctx.emit(I::I32Const(n as i32));
+            ctx.emit(I::Call(rt_index("rt_linsolve_totalpivot")?));
+            emit_singular_check(ctx)?;
+            ctx.emit(I::I32Const(1));
+            ctx.emit(I::LocalSet(retry));
+            ctx.emit(I::Br(0));
+            ctx.emit(I::End); // loop
+            ctx.emit(I::End); // block
+        }
+        None => emit_lin_unsolved(ctx, index)?,
+    }
+
     ctx.emit(I::LocalGet(base));
     ctx.emit(I::Call(rt_index("rt_free")?));
     Ok(())
@@ -839,7 +931,7 @@ fn emit_lin_solve_scatter(
     n: usize,
     slots: &[u32],
     use_sparse: bool,
-    x0_off: Option<u32>,
+    m1: Option<Method1>,
     index: i32,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
@@ -852,10 +944,14 @@ fn emit_lin_solve_scatter(
     let solver = if use_sparse { "rt_solve_lin_dense_sparse" } else { "rt_linsolve" };
     if !use_sparse {
         emit_linsolve_context(ctx, index)?;
+        ctx.emit(I::I32Const(m1.is_some() as i32)); // a step check follows
     }
     ctx.emit(I::Call(rt_index(solver)?));
     emit_singular_check(ctx)?;
-    emit_scatter_recover_free(ctx, base, b_off, n, slots, x0_off, lower_inner)
+    match &m1 {
+        Some(m1) => emit_lin_step(ctx, base, b_off, n, slots, use_sparse, index, m1, lower_inner),
+        None => emit_scatter_recover_free(ctx, base, b_off, n, slots, lower_inner),
+    }
 }
 
 /// Lower a torn linear system `A dx = b` by analytic-Jacobian assembly (C's method
@@ -897,12 +993,13 @@ pub(crate) fn compile_linear_system_analytic(
     }
     let data = ctx.sim()?.data_local;
 
-    // Scratch: A (n*n column-major f64) | b (n f64) | xold (n f64) | seed_tab
-    // (n i32) | res_tab (n i32). The two i32 tables hold the seed/result slot
-    // offsets so the column loop can index them at run time.
+    // Scratch: A (n*n column-major f64) | b (n f64) | xold (n f64) | res (n f64)
+    // | seed_tab (n i32) | res_tab (n i32). The two i32 tables hold the
+    // seed/result slot offsets so the column loop can index them at run time.
     let b_off: u32 = (n * n * 8) as u32;
     let xold_off: u32 = b_off + (n * 8) as u32;
-    let seed_tab_off: u32 = xold_off + (n * 8) as u32;
+    let res_off: u32 = xold_off + (n * 8) as u32;
+    let seed_tab_off: u32 = res_off + (n * 8) as u32;
     let res_tab_off: u32 = seed_tab_off + (n * 4) as u32;
     let scratch_bytes: u32 = res_tab_off + (n * 4) as u32;
     let base = ctx.alloc_temp(WTy::I32);
@@ -1038,7 +1135,8 @@ pub(crate) fn compile_linear_system_analytic(
     ctx.emit(I::End);
     ctx.emit(I::End);
 
-    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, Some(xold_off), index, lower_inner)
+    let m1 = Method1 { res_off, res_exps };
+    emit_lin_solve_scatter(ctx, base, b_off, n, &slots, use_sparse, Some(m1), index, lower_inner)
 }
 
 /// Greedy distance-1 column coloring (Curtis-Powell-Reid) of the CSC pattern:
@@ -1137,12 +1235,13 @@ pub(crate) fn compile_linear_system_analytic_csc(
     let data = ctx.sim()?.data_local;
 
     // Scratch (f64 regions first for 8-alignment): values (nnz) | b (n) | xold (n)
-    // | colptr (n+1 i32) | rowidx (nnz i32) | seed_tab (n i32) | res_tab (n i32) |
-    // color_ptr (ncolors+1 i32) | color_cols (n i32).
+    // | res (n) | colptr (n+1 i32) | rowidx (nnz i32) | seed_tab (n i32) |
+    // res_tab (n i32) | color_ptr (ncolors+1 i32) | color_cols (n i32).
     let values_off: u32 = 0;
     let b_off: u32 = (nnz * 8) as u32;
     let xold_off: u32 = b_off + (n * 8) as u32;
-    let colptr_off: u32 = xold_off + (n * 8) as u32;
+    let res_off: u32 = xold_off + (n * 8) as u32;
+    let colptr_off: u32 = res_off + (n * 8) as u32;
     let rowidx_off: u32 = colptr_off + ((n + 1) * 4) as u32;
     let seed_tab_off: u32 = rowidx_off + (nnz * 4) as u32;
     let res_tab_off: u32 = seed_tab_off + (n * 4) as u32;
@@ -1367,7 +1466,8 @@ pub(crate) fn compile_linear_system_analytic_csc(
     ctx.emit(I::I32Const(nnz as i32));
     ctx.emit(I::Call(rt_index("rt_solve_lin_sparse_cached")?));
     emit_singular_check(ctx)?;
-    emit_scatter_recover_free(ctx, base, b_off, n, &slots, Some(xold_off), lower_inner)
+    let m1 = Method1 { res_off, res_exps };
+    emit_lin_step(ctx, base, b_off, n, &slots, true, handle, &m1, lower_inner)
 }
 
 /// C's linear sparse-solver selection: density below `lssMaxDensity` (default
@@ -1528,13 +1628,14 @@ pub(crate) fn compile_linear_system_symbolic(
             ctx.emit(I::F64Store(mem_arg(elem_off, 3)));
         }
         emit_b_exps(ctx, base, b_off, b_exps)?;
-        // rt_linsolve(a_ptr, b_ptr, n, index, time).
+        // rt_linsolve(a_ptr, b_ptr, n, index, time, method1).
         ctx.emit(I::LocalGet(base)); // a_ptr (a_off == 0)
         ctx.emit(I::LocalGet(base));
         ctx.emit(I::I32Const(b_off as i32));
         ctx.emit(I::I32Add);
         ctx.emit(I::I32Const(n as i32));
         emit_linsolve_context(ctx, index)?;
+        ctx.emit(I::I32Const(0)); // method 0: the solution is the unknowns
         ctx.emit(I::Call(rt_index("rt_linsolve")?));
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2429,13 +2429,15 @@ pub extern "C" fn rt_lin_solves() -> u64 {
 
 /// Solve the dense `n`×`n` system `A x = b` in place: `A` is `a_ptr` as `n*n`
 /// f64 in **column-major** order, `b` is `b_ptr` as `n` f64. On success `b ← x`
-/// and 0 is returned; 1 only when the system is genuinely unsolvable.
+/// and 0 is returned; 1 only when the system is genuinely unsolvable. `A` is left
+/// intact for [`rt_linsolve_totalpivot`].
 ///
 /// LU with partial pivoting (like C's `dgesv`), then a total-pivot search on a
 /// singular matrix, mirroring C's `LS_DEFAULT`; `-ls=klu`/`-ls=umfpack` use
-/// SuiteSparse instead.
+/// SuiteSparse instead. `method1`: a [`rt_ls_check_step`] follows, and is what
+/// decides whether the system is solved.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64) -> i32 {
+pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64, method1: i32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let n = n as usize;
     #[cfg(sundials)]
@@ -2456,43 +2458,128 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, tim
     // fallback. `-ls=umfpack` only gets here having found the matrix singular.
     let lu_first = !matches!(solvers::ls(), solvers::Ls::TotalPivot | solvers::Ls::Umfpack);
     if lu_first {
-        if nls::lu_solve(a, b, n) {
-            ls_solved(eq_index);
-            return 0;
+        match nls::lu_solve_singular_pivot(a, b, n) {
+            None => {
+                if method1 == 0 {
+                    ls_solved(eq_index);
+                }
+                return 0;
+            }
+            Some(k) => {
+                let count = ls_note_failure(eq_index);
+                // C prints `dgesv`'s 1-based `info` one too high; keep the text.
+                omclog::warning_with_limit(
+                    omclog::LS,
+                    count,
+                    solvers::max_warn_displays(),
+                    &alloc::format!(
+                        "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}, system is singular for U[{p}, {p}].",
+                        p = k + 2
+                    ),
+                );
+                ls_report_fallback(eq_index, time, count);
+                ls_failure_entry(eq_index).fell_back = true;
+            }
         }
-        ls_report_fallback(eq_index, time);
     }
     if nls::total_pivot_solve(a, b, n) { 0 } else { 1 }
 }
 
+/// C's `solveTotalPivot` fallback for a step [`rt_ls_check_step`] rejected: the
+/// same `A` — a linear system's Jacobian does not depend on its unknowns, so C's
+/// re-evaluation of it lands on the same numbers — against the negated residual.
+/// 0 ok, 1 inconsistent. Same `solve_linear_system` call, so not a new solve.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_linsolve_totalpivot(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
+    let n = n as usize;
+    let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
+    let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+    if nls::total_pivot_solve(a, b, n) { 0 } else { 1 }
+}
+
+/// C's method-1 step test (`solveLapack`, `solveKlu`, …): the step `dx` only counts
+/// if the residual `res` re-evaluated at `x + dx` is small — an ill-conditioned
+/// matrix passes the factorization and still leaves the equations unsatisfied.
+/// Returns 1 when the solve must be redone, with `-res` in `b` to step on from
+/// where the unknowns now are. Only the `-ls` (`dense`) solvers have that retry;
+/// a sparse system's rejected step leaves it unsolved, as in C.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_ls_check_step(res_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64, dense: i32) -> i32 {
+    // `-ls=totalpivot` has no check, and a fallback solve's step already is one.
+    if dense != 0 && matches!(solvers::ls(), solvers::Ls::TotalPivot) {
+        return 0;
+    }
+    if core::mem::replace(&mut ls_failure_entry(eq_index).fell_back, false) {
+        return 0;
+    }
+    let n = n as usize;
+    let res = unsafe { core::slice::from_raw_parts(res_ptr as *const f64, n) };
+    let norm = nls::enorm(res);
+    if !(norm.is_nan() || norm > 1e-4) {
+        ls_solved(eq_index);
+        return 0;
+    }
+    let count = ls_note_failure(eq_index);
+    omclog::warning_with_limit(
+        omclog::LS,
+        count,
+        solvers::max_warn_displays(),
+        &alloc::format!(
+            "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}. Residual norm is {}.",
+            openmodelica_sim_meta::driver::format_g(norm, 15)
+        ),
+    );
+    if dense != 0 {
+        ls_report_fallback(eq_index, time, count);
+        let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+        for (bi, &ri) in b.iter_mut().zip(res) {
+            *bi = -ri;
+        }
+    }
+    1
+}
+
 /// C's per-system `linsys->failed` / `numberOfFailures`: the first failure after
 /// a success warns on stdout, a run of them only on `LOG_LS`.
-struct LsFailures(core::cell::UnsafeCell<alloc::vec::Vec<(i32, bool, u64)>>);
+struct LsFailure {
+    eq_index: i32,
+    failed: bool,
+    failures: u64,
+    /// The last solve was the total-pivot fallback, whose step C takes unchecked.
+    fell_back: bool,
+}
+struct LsFailures(core::cell::UnsafeCell<alloc::vec::Vec<LsFailure>>);
 unsafe impl Sync for LsFailures {}
 static LS_FAILURES: LsFailures = LsFailures(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
 
-fn ls_failure_entry(eq_index: i32) -> &'static mut (i32, bool, u64) {
+fn ls_failure_entry(eq_index: i32) -> &'static mut LsFailure {
     let v = unsafe { &mut *LS_FAILURES.0.get() };
-    if let Some(i) = v.iter().position(|e| e.0 == eq_index) {
+    if let Some(i) = v.iter().position(|e| e.eq_index == eq_index) {
         return &mut v[i];
     }
-    v.push((eq_index, false, 0));
+    v.push(LsFailure { eq_index, failed: false, failures: 0, fell_back: false });
     v.last_mut().unwrap()
 }
 
 fn ls_solved(eq_index: i32) {
-    ls_failure_entry(eq_index).1 = false;
+    ls_failure_entry(eq_index).failed = false;
+}
+
+/// C's `++systemData->numberOfFailures`, shared by both warnings of one failure.
+fn ls_note_failure(eq_index: i32) -> u64 {
+    let e = ls_failure_entry(eq_index);
+    e.failures += 1;
+    e.failures
 }
 
 /// C's `solve_linear_system` `LS_DEFAULT` branch.
-fn ls_report_fallback(eq_index: i32, time: f64) {
+fn ls_report_fallback(eq_index: i32, time: f64, count: u64) {
     let e = ls_failure_entry(eq_index);
-    let stream = if e.1 { omclog::LS } else { omclog::STDOUT };
-    e.1 = true;
-    e.2 += 1;
+    let stream = if e.failed { omclog::LS } else { omclog::STDOUT };
+    e.failed = true;
     omclog::warning_with_limit(
         stream,
-        e.2,
+        count,
         solvers::max_warn_displays(),
         &alloc::format!(
             "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS."

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -326,7 +326,7 @@ const LAMBDA_MIN: f64 = 9.765625e-4;
 
 /// Euclidean norm (C's `enorm_`). NaN propagates, so a diverged residual falls
 /// through every `< eps` test to the iteration-limit failure.
-fn enorm(v: &[f64]) -> f64 {
+pub(crate) fn enorm(v: &[f64]) -> f64 {
     let mut s = 0.0;
     for &x in v {
         s += x * x;
@@ -338,15 +338,25 @@ fn enorm(v: &[f64]) -> f64 {
 /// Returns `true` on success, `false` on a singular/failed factorization (in
 /// which case `b` is unchanged). Shared by [`newton_solve`] and `rt_linsolve`.
 pub(crate) fn lu_solve(a: &[f64], b: &mut [f64], n: usize) -> bool {
+    lu_solve_singular_pivot(a, b, n).is_none()
+}
+
+/// [`lu_solve`] reporting `dgesv`'s `info`: `None` on success, else the 0-based
+/// index of the first zero pivot on `U`'s diagonal.
+pub(crate) fn lu_solve_singular_pivot(a: &[f64], b: &mut [f64], n: usize) -> Option<usize> {
     use nalgebra::{DMatrix, DVector};
     let am = DMatrix::<f64>::from_column_slice(n, n, a);
     let bv = DVector::<f64>::from_column_slice(b);
-    match am.lu().solve(&bv) {
+    let lu = am.lu();
+    match lu.solve(&bv) {
         Some(x) => {
             b.copy_from_slice(x.as_slice());
-            true
+            None
         }
-        None => false,
+        None => {
+            let u = lu.u();
+            Some((0..n).find(|&i| u[(i, i)] == 0.0).unwrap_or(n.saturating_sub(1)))
+        }
     }
 }
 


### PR DESCRIPTION
C's method-1 linear solvers do not trust their own factorization: after `x = xold + dx` they re-evaluate the residual there and reject the step when its norm is NaN or above 1e-4, because an ill-conditioned matrix passes the factorization and still leaves the equations unsatisfied. `solve_linear_system` then warns and re-solves with total pivoting.

The wasm-jit runtime had the singular-matrix half of that fallback but never the residual test, so it silently accepted such a step.

`rt_ls_check_step` is the test, emitting both of C's warnings off one shared failure counter so `-lvMaxWarn` counts failures rather than messages. `rt_linsolve` takes a `method1` flag: it no longer marks a system solved before the step is checked, since `linsys->failed` must still hold the previous call's outcome when the log stream is picked. `emit_lin_step` emits step / recover / residual once inside a two-pass loop, so the retry recomputes what C recomputes, and re-solves the untouched `A` through `rt_linsolve_totalpivot`.

This affects every torn linear system with a symbolic Jacobian. Sparse (`-lss`) systems get the check without the fallback, as C's KLU and UMFPACK leave such a system unsolved.

Fixes DifferenceAmplifier, which reached the same results as C but without the three warnings its expected output carries.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
