### PR TITLE
wasm-jit: lower bare function references

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -6689,7 +6689,11 @@ fn compile_exp(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<WTy> {
             emit_str_literal(ctx, string.as_bytes())?;
             Ok(WTy::I32)
         }
-        E::CREF { componentRef, .. } => {
+        E::CREF { componentRef, ty } => {
+            if let DAE::Type::T_FUNCTION_REFERENCE_FUNC { .. } = &**ty {
+                closures::compile_fnref_cref(ctx, componentRef, ty)?;
+                return Ok(WTy::I32);
+            }
             // Simulation mode: model variables (states, derivatives, algebraics,
             // parameters, `time`, `$START`/`$PRE`) live in the shared `SimData`
             // block, not in wasm locals. Resolve those first; `None` means an

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 use metamodelica::{List, Result};
+use openmodelica_frontend_base::ComponentReference;
 use openmodelica_frontend_types::DAE;
 use openmodelica_simcode_types::SimCodeFunction;
 use wasm_encoder as we;
@@ -158,8 +159,29 @@ pub(crate) fn compile_parteval(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<()> {
     let DAE::Exp::PARTEVALFUNCTION { path, expList, ty, origType } = exp else {
         return Err("CodegenWasmJit: not a PARTEVALFUNCTION");
     };
-    let target = mangle(path)?;
-    let Some(info) = ctx.by_name.get(&target) else {
+    let exps: Vec<&Arc<DAE::Exp>> = (&**expList).into_iter().collect();
+    emit_reference(ctx, &mangle(path)?, &exps, ty, origType)
+}
+
+/// `function f()` with nothing applied, which the frontend leaves as a `CREF`
+/// of function-reference type rather than a `PARTEVALFUNCTION`.
+pub(crate) fn compile_fnref_cref(
+    ctx: &mut FnCtx,
+    cref: &DAE::ComponentRef,
+    ty: &DAE::Type,
+) -> Result<()> {
+    let path = ComponentReference::crefToPath(Arc::new(cref.clone()))?;
+    emit_reference(ctx, &mangle(&path)?, &[], ty, ty)
+}
+
+fn emit_reference(
+    ctx: &mut FnCtx,
+    target: &str,
+    exps: &[&Arc<DAE::Exp>],
+    ty: &DAE::Type,
+    origType: &DAE::Type,
+) -> Result<()> {
+    let Some(info) = ctx.by_name.get(target) else {
         return Err("CodegenWasmJit: function reference to a function that was not compiled");
     };
     let (target_index, target_sig) = (info.index, info.sig.clone());
@@ -172,12 +194,11 @@ pub(crate) fn compile_parteval(ctx: &mut FnCtx, exp: &DAE::Exp) -> Result<()> {
     }
     let applied: Vec<usize> =
         (0..all_names.len()).filter(|i| !residual_names.contains(&all_names[*i])).collect();
-    let exps: Vec<&Arc<DAE::Exp>> = (&**expList).into_iter().collect();
     if applied.len() != exps.len() {
         return Err("CodegenWasmJit: function reference applies a different number of arguments than it drops");
     }
     let applied_tys: Vec<SigTy> = applied.iter().map(|i| target_sig.params[*i].clone()).collect();
-    let slot = intern_thunk(&target, target_index, &target_sig, &applied, &residual_names, &all_names)?;
+    let slot = intern_thunk(target, target_index, &target_sig, &applied, &residual_names, &all_names)?;
 
     let env = ctx.alloc_temp(WTy::I32);
     let env_flds = env_fields(&applied_tys);

--- a/testsuite/simulation/modelica/algorithms_functions/FunctionPointer.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/FunctionPointer.mos
@@ -1,0 +1,86 @@
+// name: FunctionPointer
+// keywords: function pointer
+// status: correct
+// teardown_command: rm -rf FunctionPointer.Test* output.log
+
+loadString("
+package FunctionPointer
+  partial function pfunc
+    input Real u;
+    output Real y;
+  end pfunc;
+
+  function func
+    input Real u;
+    output Real y;
+  algorithm
+    y := 2*u;
+  end func;
+
+  function func2
+    input Real u;
+    input Real v;
+    input Integer[:] w;
+    output Real y;
+  algorithm
+    y := u + v + sum(w);
+  end func2;
+
+  function feval
+    input FunctionPointer.pfunc f;
+    input Real u;
+    output Real y;
+  algorithm
+    y := f(u);
+  end feval;
+
+  function feval2
+    input FunctionPointer.pfunc f;
+    input Real u;
+    output Real y;
+  algorithm
+    y := f(u) + feval(function func2(v = u, w = {integer(u)}), u);
+  end feval2;
+
+  function feval3
+    input FunctionPointer.pfunc f;
+    input Real u;
+    output Real y;
+  algorithm
+    y := f(u) + feval(function f(), u);
+  end feval3;
+
+  model Test
+    input Real u = 0; // prevent presolving
+    Real x, y, z;
+  equation
+    x = feval2(function func(), u + 4);
+    y = feval2(function func2(v = 1, w = {2, 3}), u + 4);
+    z = feval3(function func(), u + 4);
+    annotation(experiment(StopTime = 0));
+  end Test;
+end FunctionPointer;
+");
+getErrorString();
+
+simulate(FunctionPointer.Test);
+val(x, 0);
+val(y, 0);
+val(z, 0);
+getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FunctionPointer.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'FunctionPointer.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// 20.0
+// 22.0
+// 16.0
+// ""
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -25,6 +25,7 @@ FuncDer.mos  \
 FunctionIndirectRecursion.mos \
 FunctionIndirectRecursion2.mos \
 FunctionInReinit.mos \
+FunctionPointer.mos \
 FunctionTupleRecord.mos \
 Interpolation.mos \
 InverseAlgorithm1.mos \


### PR DESCRIPTION
A function reference that applies no arguments, such as

    function Modelica.Math.Nonlinear.Examples.UtilityFunctions.fun4()

is not a `PARTEVALFUNCTION`. The frontend leaves a plain `DAE.CREF` typed `T_FUNCTION_REFERENCE_FUNC` whose cref names the function, which `CodegenCFunctions.tpl` lowers in `daeExpCrefRhs` as `boxvar_<crefFunctionName(cr)>`. CodegenWasmJit had no such case, so the cref fell through to the ordinary variable paths and reported its head ident as an unknown variable:

    Internal error CodegenWasmJit: reference to unknown variable
    `Modelica` in function
    `Modelica.Math.Nonlinear.Examples.quadratureLobatto1`

Split `compile_parteval` into a shared `emit_reference` and build the same closure object over an empty environment, every formal residual. `crefToPath` + `mangle` reproduces `crefFunctionName`, both being `pathStringUnquoteReplaceDot(path, "_")`.

Dispatch the new case ahead of `compile_sim_cref_read` and the qualified-cref descent: the same reference written in a model equation otherwise resolves against the simulation variables instead, giving

    Internal error CodegenWasmJit: simulation reference to unknown
    variable `FunctionPointer.func`

`ModelicaTest.Math.TestNonlinear` now simulates under wasm-jit and its own integral and zero-crossing assertions pass; values agree with the C target except for one adaptive-quadrature result differing by 8e-14, which comes from the pre-existing partial-application path.

`FunctionPointer.mos` is the C-target sibling of the Cpp-only `openmodelica/cppruntime/functionPointerTest.mos`, covering a bare reference, a partial application, and re-referencing a function-pointer variable. It passes on both targets and fails on both counts above without this change.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
