### PR TITLE
wasm-jit: build external "C" in the compile phase

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -463,11 +463,12 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
 /// measured as `timeCompile` rather than leaking into `timeSimulation`. It joins
 /// the background model-module compile (started by `translateModel`) and forces
 /// the runtime module (compiled-once / AOT-cached), stashing the compiled model
-/// module for `runSimulation`. Errors are deferred — `runSimulation` recompiles
-/// and reports them — so this never fails the build by itself.
-pub fn finishCompile(fileNamePrefix: ArcStr) {
+/// module for `runSimulation`. A JIT-compile error is deferred — `runSimulation`
+/// recompiles and reports it — but the `external "C"` implementations are resolved
+/// here, so a broken `Include` fails the build rather than the run.
+pub fn finishCompile(fileNamePrefix: ArcStr) -> Result<()> {
     let model = sim_models().lock().unwrap_or_else(|e| e.into_inner()).get(&fileNamePrefix.to_string()).cloned();
-    let Some(model) = model else { return };
+    let Some(model) = model else { return Ok(()) };
     // Force the runtime module (so its compile/cache-load is in `timeCompile`).
     let _ = sim_runtime::runtime_module();
     // Join the background model-module compile and stash the result.
@@ -476,6 +477,12 @@ pub fn finishCompile(fileNamePrefix: ArcStr) {
         // Deferred: `runSimulation` recompiles and reports the error via the log.
         Err(_) => {}
     }
+    let missing = missing_ext_symbols(&model.ext_imports, &model.ext_libs);
+    if let Err(e) = sim_runtime::prepare_native_externals(&model, &missing) {
+        record_error(format!("CodegenWasmJit: the model's `external \"C\"` implementations are unavailable:\n{e}"));
+        return Err("CodegenWasmJit: external \"C\" implementation unavailable");
+    }
+    Ok(())
 }
 
 /// `CodegenWasmJit.emitStandalone`: the `wasm` simCodeTarget's counterpart of
@@ -1536,6 +1543,7 @@ pub(crate) fn compile_include_library(
     prefix: &str,
     includes: &[String],
     include_dirs: &[String],
+    cflags: &str,
     missing: &[ExtCallSig],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
@@ -1544,10 +1552,10 @@ pub(crate) fn compile_include_library(
     }
     let wrappers = openmodelica_wasm_jit::model::ext_wrappers(missing);
     let n = notes.len();
-    match compile_include_tu(prefix, includes, include_dirs, &wrappers, notes)? {
+    match compile_include_tu(prefix, includes, include_dirs, cflags, &wrappers, notes)? {
         None if !wrappers.is_empty() => {
             notes.truncate(n);
-            compile_include_tu(prefix, includes, include_dirs, "", notes)
+            compile_include_tu(prefix, includes, include_dirs, cflags, "", notes)
         }
         r => Ok(r),
     }
@@ -1558,6 +1566,7 @@ fn compile_include_tu(
     prefix: &str,
     includes: &[String],
     include_dirs: &[String],
+    cflags: &str,
     wrappers: &str,
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
@@ -1568,14 +1577,15 @@ fn compile_include_tu(
     std::fs::create_dir_all(&dir).map_err(|_| "CodegenWasmJit: cannot create a temporary directory")?;
     let tu = dir.join(format!("{prefix}_includes.c"));
     let out = dir.join(format!("{prefix}_includes.wasm"));
-    let prologue = openmodelica_wasm_jit::model::INCLUDE_TU_PROLOGUE_WASM;
-    std::fs::write(&tu, prologue.to_owned() + &includes.join("\n") + "\n" + wrappers)
+    std::fs::write(&tu, includes.join("\n") + "\n" + wrappers)
         .map_err(|_| "CodegenWasmJit: cannot write the external \"C\" translation unit")?;
 
     let mut cmd = Command::new(&clang);
     cmd.args(["--target=wasm32-wasip1", "-O1", "-fPIC", "-shared", "-nodefaultlibs"])
         .arg(format!("--sysroot={}", sysroot.display()))
         .args(["-Wl,--export-all", "-Wl,--allow-undefined"]);
+    // Only the preprocessor part of `--cflags`: the rest is host code generation.
+    cmd.args(openmodelica_wasm_jit::model::cflags_cpp_args(cflags));
     // Compiled in a temporary directory, so `#include "x.h"` needs the model's own.
     if let Ok(cwd) = std::env::current_dir() {
         cmd.arg("-I").arg(cwd);
@@ -1600,7 +1610,8 @@ fn compile_include_tu(
     };
     if !output.status.success() {
         notes.push(format!(
-            "the `Include` C sources did not compile for the wasm target:\n{}",
+            "the `Include` C sources did not compile for the wasm target:\n{}\n{}",
+            openmodelica_wasm_jit::model::command_line(&cmd),
             String::from_utf8_lossy(&output.stderr)
         ));
         return Ok(None);
@@ -1615,6 +1626,7 @@ pub(crate) fn compile_include_library(
     _prefix: &str,
     includes: &[String],
     _include_dirs: &[String],
+    _cflags: &str,
     _missing: &[ExtCallSig],
     notes: &mut Vec<String>,
 ) -> Result<Option<ExtLibrary>> {
@@ -3999,7 +4011,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
                 ExtHost::Wasm => {
                     let missing = missing_ext_symbols(&ext_imports, &ext_libs.wasm);
                     if !missing.is_empty() {
-                        if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &missing, &mut ext_lib_notes)? {
+                        if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &mp.cflags, &missing, &mut ext_lib_notes)? {
                             ext_libs.wasm.push(l);
                         }
                     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -10463,7 +10463,7 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
         let includes: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
         let dirs: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.makefileParams.includes).map(|s| s.to_string()).collect();
         let missing = crate::CodegenWasmJit::missing_ext_symbols(&ext_imports, &libs);
-        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &missing, &mut notes)? {
+        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &fn_code.makefileParams.cflags, &missing, &mut notes)? {
             let path = format!("{base}_includes.wasm");
             openmodelica_wasi::fs::write(&path, &l.bytes)
                 .map_err(|_| "CodegenWasmJitFunctions: cannot stage the compiled include library")?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -124,8 +124,9 @@ impl ExtArchives {
             .map_err(|e| format!("`{}` could not be run to link the static libraries: {e}", self.ccompiler))?;
         if !output.status.success() {
             return Err(format!(
-                "the static libraries ({}) did not link into a loadable one:\n{}",
+                "the static libraries ({}) did not link into a loadable one:\n{}\n{}",
                 self.archives.join(", "),
+                command_line(&cmd),
                 String::from_utf8_lossy(&output.stderr)
             ));
         }
@@ -160,8 +161,33 @@ pub struct ExtIncludes {
 impl ExtIncludes {
     /// Build the sources into a host shared library and return its path. Per-process
     /// temp directory: it stays mapped as long as the model can be resimulated.
+    /// Built once, so the run reuses what the compile phase built.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn compile(&self, missing: &[ExtCallSig]) -> std::result::Result<String, String> {
+        use std::sync::{LazyLock, Mutex};
+        static COMPILED: LazyLock<Mutex<HashMap<String, std::result::Result<String, String>>>> =
+            LazyLock::new(|| Mutex::new(HashMap::new()));
+        let key = format!(
+            "{}\n{}\n{}\n{}\n{}",
+            self.prefix,
+            self.cflags,
+            self.include_dirs.join(" "),
+            self.sources.join("\n"),
+            missing.iter().map(|s| &*s.name).collect::<Vec<_>>().join(" ")
+        );
+        let cached = COMPILED.lock().unwrap().get(&key).cloned();
+        match cached {
+            Some(r) => r,
+            None => {
+                let r = self.compile_uncached(missing);
+                COMPILED.lock().unwrap().insert(key, r.clone());
+                r
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn compile_uncached(&self, missing: &[ExtCallSig]) -> std::result::Result<String, String> {
         let wrappers = ext_wrappers(missing);
         match self.compile_tu(&wrappers) {
             Err(e) if !wrappers.is_empty() => self.compile_tu("").map_err(|_| e),
@@ -178,13 +204,14 @@ impl ExtIncludes {
         let stem = if wrappers.is_empty() { "includes_exports" } else { "includes" };
         let tu = dir.join(format!("{}_{stem}.c", self.prefix));
         let out = dir.join(format!("{}_{stem}{}", self.prefix, self.dllext));
-        std::fs::write(&tu, INCLUDE_TU_PROLOGUE.to_owned() + &self.sources.join("\n") + "\n" + wrappers)
+        // No prologue: external C source includes what it uses. A source that needs
+        // more gets it from `--cflags`, as `-include`.
+        std::fs::write(&tu, self.sources.join("\n") + "\n" + wrappers)
             .map_err(|e| format!("cannot write {}: {e}", tu.display()))?;
 
         let mut cmd = Command::new(&self.ccompiler);
         cmd.args(["-shared", "-fPIC", "-O1"]);
-        // `--cflags`, minus the make variables it is written to be expanded with.
-        cmd.args(self.cflags.split_whitespace().filter(|f| !f.starts_with("${") && !f.starts_with("$(")));
+        cmd.args(split_cflags(&self.cflags));
         // Compiled in a temporary directory, so `#include "x.h"` needs the model's own.
         if let Ok(cwd) = std::env::current_dir() {
             cmd.arg("-I").arg(cwd);
@@ -201,7 +228,8 @@ impl ExtIncludes {
             .map_err(|e| format!("`{}` could not be run to compile the `Include` C sources: {e}", self.ccompiler))?;
         if !output.status.success() {
             return Err(format!(
-                "the `Include` C sources did not compile:\n{}",
+                "the `Include` C sources did not compile:\n{}\n{}",
+                command_line(&cmd),
                 String::from_utf8_lossy(&output.stderr)
             ));
         }
@@ -291,24 +319,6 @@ fn ext_c_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
     })
 }
 
-/// What the C target's generated `<prefix>_includes.h` opens with, so external C
-/// source sees the same declarations wherever it is built.
-pub const INCLUDE_TU_PROLOGUE: &str = "\
-#include \"openmodelica.h\"       /* Defines OPENMODELICA_H_ for libraries to test if called from OpenModelica. */\n\
-#include \"ModelicaUtilities.h\"  /* Make Modelica C util functions available for external includes. */\n";
-
-/// The same for a wasm unit, where `openmodelica.h` cannot be opened — it reaches the
-/// Boehm GC and `setjmp`. Name what external source uses it for instead. Nothing
-/// omc-specific: source needing more than the specification's C interface includes
-/// it itself.
-pub const INCLUDE_TU_PROLOGUE_WASM: &str = "\
-#include <stddef.h>\n\
-#include <stdio.h>\n\
-#include <stdlib.h>\n\
-#include <string.h>\n\
-#include <math.h>\n\
-#include \"ModelicaUtilities.h\"\n";
-
 /// omc's own C headers, plus the bundled `gc.h` that `openmodelica.h` reaches —
 /// the `-I` set the C target's makefile compiles the same source with.
 pub fn omc_c_include_dirs() -> [String; 2] {
@@ -316,6 +326,72 @@ pub fn omc_c_include_dirs() -> [String; 2] {
         .map(|p| p.to_string())
         .unwrap_or_default();
     [format!("{home}/include/omc/c"), format!("{home}/include/omc")]
+}
+
+/// `--cflags` split as the makefile's shell splits it, so a quoted `-I` path with
+/// spaces stays one argument. Drops the make variables it is written to expand with.
+pub fn split_cflags(cflags: &str) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut started = false;
+    let mut quote: Option<char> = None;
+    for c in cflags.chars() {
+        match c {
+            '"' | '\'' if quote == Some(c) => quote = None,
+            '"' | '\'' if quote.is_none() => {
+                quote = Some(c);
+                started = true;
+            }
+            _ if c.is_whitespace() && quote.is_none() => {
+                if started {
+                    args.push(std::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            _ => {
+                cur.push(c);
+                started = true;
+            }
+        }
+    }
+    if started {
+        args.push(cur);
+    }
+    args.retain(|f| !f.starts_with("${") && !f.starts_with("$("));
+    args
+}
+
+/// The preprocessor options in `--cflags`, without the host code-generation flags
+/// a wasm target rejects.
+pub fn cflags_cpp_args(cflags: &str) -> Vec<String> {
+    const OPTS: [&str; 4] = ["-I", "-isystem", "-D", "-include"];
+    let args = split_cflags(cflags);
+    let mut out = Vec::new();
+    let mut it = args.into_iter();
+    while let Some(a) = it.next() {
+        if OPTS.contains(&&*a) {
+            if let Some(v) = it.next() {
+                out.push(a);
+                out.push(v);
+            }
+        } else if OPTS.iter().any(|o| a.starts_with(o)) {
+            out.push(a);
+        }
+    }
+    out
+}
+
+/// The command as a shell would have been given it, for an error to show.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn command_line(cmd: &std::process::Command) -> String {
+    std::iter::once(cmd.get_program())
+        .chain(cmd.get_args())
+        .map(|a| {
+            let a = a.to_string_lossy();
+            if a.contains(char::is_whitespace) { format!("\"{a}\"") } else { a.into_owned() }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// A user-settable parameter (an editable initial condition): display name, unit,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
@@ -34,6 +34,10 @@ pub fn take_compiled_model(_model: &SimModel) -> std::result::Result<Module, Str
     return Err(NO_ENGINE.to_string())
 }
 
+pub fn prepare_native_externals(_model: &SimModel, _sigs: &[crate::sig::ExtCallSig]) -> std::result::Result<(), String> {
+    Ok(())
+}
+
 pub fn run(_model: &SimModel, _meta: &openmodelica_sim_meta::SimMeta) -> std::result::Result<RunResult, String> {
     return Err(NO_ENGINE.to_string())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -243,6 +243,12 @@ pub fn take_compiled_model(model: &SimModel) -> std::result::Result<wasmer::Modu
     }
 }
 
+/// Nothing to prepare: the `external "C"` implementations are in the
+/// ModelicaExternalC side module, built into omc.
+pub fn prepare_native_externals(_model: &SimModel, _sigs: &[crate::sig::ExtCallSig]) -> std::result::Result<(), String> {
+    Ok(())
+}
+
 type Store = wasmer::Store;
 
 /// `SimEngine`-trait / host-import errors: collapse to the crate `&'static str`

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -340,6 +340,19 @@ fn unresolved_external_detail(name: &str, model: &SimModel, load_errors: &[Strin
     s
 }
 
+/// Load the libraries `sigs` are to be found in, link the model's archives and
+/// build its `Include` sources. Called from `buildModel`'s compile phase; the
+/// builds are cached, so instantiation reuses them.
+pub fn prepare_native_externals(model: &SimModel, sigs: &[crate::sig::ExtCallSig]) -> std::result::Result<(), String> {
+    let mut native = NativeExternals::default();
+    for sig in sigs {
+        if native.resolve(&sig.name, model).is_none() {
+            return Err(unresolved_external_detail(&sig.name, model, &native.errors));
+        }
+    }
+    Ok(())
+}
+
 /// The model's `external "C"` implementations outside wasm, resolved on demand: the
 /// platform libraries its `Library` annotations name (its archives linked into
 /// one), then — only once those and the process image have come up short — its

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -75,12 +75,16 @@ algorithm
 end runSimulation;
 
 function finishCompile
-  " Force the model's wasm modules to finish JIT-compiling. Called from
+  " Force the model's wasm modules to finish JIT-compiling and resolve its
+    external \"C\" implementations, building the Include C sources. Called from
     buildModel's compile phase (the wasm-jit counterpart of compiling the C
     executable) so the compile cost is attributed to timeCompile rather than
-    timeSimulation. Implemented in Rust. "
+    timeSimulation. Implemented in Rust; fails if an external \"C\"
+    implementation is unavailable. "
   input String fileNamePrefix;
 algorithm
+  Error.addInternalError("CodegenWasmJit.finishCompile: the wasm-jit target is only implemented in the Rust omc build", sourceInfo());
+  fail();
 end finishCompile;
 
 function emitStandalone

--- a/testsuite/simulation/modelica/external_functions/ExtObj.h
+++ b/testsuite/simulation/modelica/external_functions/ExtObj.h
@@ -1,3 +1,5 @@
+#include <stddef.h> /* size_t */
+
 typedef struct { /* User-defined datastructure of the table */
 double* array; /* nrow*ncolumn vector */
 int nrow; /* number of rows */

--- a/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mo
+++ b/testsuite/simulation/modelica/external_functions/RecordMemberArguments.mo
@@ -17,6 +17,9 @@ model ExtRecordMemberArguments
     annotation (
 
     Include="
+#include <stddef.h>
+#include <stdio.h>
+
 void foo(const double* myRealMatrix, size_t dim_myRealMatrix_1, size_t dim_myRealMatrix_2, const double myRealVar, const int* myIntegerArray, size_t dim_myIntegerArray_1, int myIntegerVar, const int* myBooleanArray, size_t dim_myBooleanArray_1, int myBooleanVar, const char** myStringArray, size_t dim_myStringArray_1, const char* myStringVar) {
   size_t i, j;
   printf(\"myRealMatrix (%zu x %zu):\\n\", dim_myRealMatrix_1, dim_myRealMatrix_2);

--- a/testsuite/simulation/modelica/others/Random.mo
+++ b/testsuite/simulation/modelica/others/Random.mo
@@ -6,7 +6,10 @@ package Modelica
     function print "Print string to terminal or file"
       input String string="" "String to be printed";
       input String fileName="" "File where to print (empty string is the terminal)";
-    external "C" myPuts(string,fileName) annotation(Include="#define myPuts(X,Y) fputs(X,stdout)");
+    external "C" myPuts(string,fileName) annotation(Include="
+#include <stdio.h>
+#define myPuts(X,Y) fputs(X,stdout)
+");
     end print;
 
   end Streams;

--- a/testsuite/simulation/modelica/types/ExtRecordMemberArguments.mo
+++ b/testsuite/simulation/modelica/types/ExtRecordMemberArguments.mo
@@ -11,6 +11,7 @@ model ExtRecordMemberArguments
     annotation (
 
     Include="
+#include <stdio.h>
 void foo(const int* myBooleanArray, size_t dim_myBooleanArray_1, const int* myBooleanMatrix, size_t dim_myBooleanMatrix_1, size_t dim_myBooleanMatrix_2) {
   size_t i, j;
 


### PR DESCRIPTION
finishCompile now resolves the model's external "C" implementations — loading its libraries, linking its archives and compiling its Include C sources — where the C target compiles and links the same code. A broken Include is a build error instead of a failed run, and the builds are cached so instantiation reuses them.

Three fixes it exposed:

| Was | Now |
| --- | --- |
| `--cflags` split on whitespace | split as a shell would | | the failing command not shown | printed with the compiler output | | every unit opened with omc headers | no prologue at all |

Splitting on whitespace broke every quoted `-I` path with a space in it, MSL's own `Modelica 4.1.0+maint.om/Resources/C-Sources` among them, so a `setCFlags` could not add an include directory. The wasm-target include compile now also gets the preprocessor part of `--cflags`.

The prologue used to include openmodelica.h and ModelicaUtilities.h. External C source is supposed to include what it uses, so the unit opens with nothing; a source needing more gets it from `--cflags` as `-include`. ExtObj.h and RecordMemberArguments leaned on the prologue for size_t and printf and now include their own headers.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
