### PR TITLE
wasm-jit: use the model's own usertab

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1457,7 +1457,7 @@ use openmodelica_wasm_jit::{FMI3_CS_SUNDIALS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER
 /// "C"`. Any is empty when that omc was built without the toolchain.
 use openmodelica_wasi_libc::{
     available as external_c_available, sundials_available, EXTERNAL_C_DYLINK, LIBC_PIC,
-    SUNDIALS_DYLINK, WASI_P1_ADAPTER,
+    SUNDIALS_DYLINK, USERTAB_DYLINK, WASI_P1_ADAPTER,
 };
 
 // ===========================================================================
@@ -1981,6 +1981,10 @@ fn link_fmu_component(
             l = l.library("modelicaexternalc", EXTERNAL_C_DYLINK, false).map_err(link_err)?;
         }
         l = l.library("libc", LIBC_PIC, false).map_err(link_err)?;
+        if has_ext {
+            // Last, so a `usertab` from the model's own libraries wins.
+            l = l.library("usertab", USERTAB_DYLINK, false).map_err(link_err)?;
+        }
         l = l.adapter("wasi_snapshot_preview1", WASI_P1_ADAPTER).map_err(link_err)?;
     }
     l.encode().map_err(link_err)
@@ -4010,7 +4014,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
                 // decision has to be made here, off the libraries' exports.
                 ExtHost::Wasm => {
                     let missing = missing_ext_symbols(&ext_imports, &ext_libs.wasm);
-                    if !missing.is_empty() {
+                    // `usertab` is no `external "C"`, so never among `missing`.
+                    if !missing.is_empty() || sources.iter().any(|s| s.contains("usertab")) {
                         if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &mp.cflags, &missing, &mut ext_lib_notes)? {
                             ext_libs.wasm.push(l);
                         }
@@ -4062,6 +4067,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     // used as the per-step function (in place of `algebraicEquations`), and
     // pre-values are saved after each step so the next step's edge test sees them.
     let algebraic_eqs = if has_when { all_eqs } else { flatten_eqs_ll(&sim_code.algebraicEquations) };
+    let output_eqs = if has_when { flatten_eqs_ll(&sim_code.algebraicEquations) } else { Vec::new() };
     // pre := live regions, appended to the per-step (algebraic) function when the
     // model has `when`-equations (see `sim_save_pre_values`).
     let save_pre: Vec<(u32, u32, u32)> = if has_when {
@@ -4599,6 +4605,22 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
         idx
     };
+    // C's `functionAlgebraics` + `storePreValues`. Only a `has_when` model needs its
+    // own: there `functionAlgebraics` is fused with the when-bodies a getter must not fire.
+    let outputs_idx = {
+        let idx = import_base + bodies.len() as u32;
+        if has_when {
+            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        } else {
+            use we::Instruction as I;
+            let mut f = we::Function::new([]);
+            f.instruction(&I::LocalGet(0));
+            f.instruction(&I::Call(eqfn.algebraics));
+            f.instruction(&I::End);
+            bodies.push(f);
+        }
+        idx
+    };
     bodies[simulate_slot] = build_simulate(&layout, &eqfn, has_asserts.then_some(check_asserts_idx))?;
     let update_relations_idx = {
         let idx = import_base + bodies.len() as u32;
@@ -4777,6 +4799,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     functions.function(eqfn_type); // functionInitialEquations_lambda0: (i32) -> ()
     functions.function(eqfn_type); // functionCheckAsserts: (i32) -> ()
     functions.function(eqfn_type); // functionZeroCrossingsEquations: (i32) -> ()
+    functions.function(eqfn_type); // functionOutputs: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateRelations: (i32) -> ()
     functions.function(eqfn_type); // functionStoreDelayed: (i32) -> ()
     functions.function(eqfn_type); // functionInitDelay: (i32) -> ()
@@ -4898,6 +4921,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     exports.export("functionInitStartValues", we::ExportKind::Func, eqfn.init_start_values);
     exports.export("functionODE", we::ExportKind::Func, eqfn.ode);
     exports.export("functionAlgebraics", we::ExportKind::Func, eqfn.algebraics);
+    exports.export("functionOutputs", we::ExportKind::Func, outputs_idx);
     exports.export("simulate", we::ExportKind::Func, simulate_idx);
     exports.export("om_meta_ptr", we::ExportKind::Func, om_meta_ptr_idx);
     exports.export("om_meta_len", we::ExportKind::Func, om_meta_len_idx);
@@ -4956,6 +4980,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         ("functionInitStartValues", eqfn.init_start_values),
         ("functionODE", eqfn.ode),
         ("functionAlgebraics", eqfn.algebraics),
+        ("functionOutputs", outputs_idx),
         ("simulate", simulate_idx),
         ("om_meta_ptr", om_meta_ptr_idx),
         ("om_meta_len", om_meta_len_idx),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -45,6 +45,7 @@ unsafe extern "C" {
     fn functionInitialEquations_lambda0(sim_data: u32);
     fn functionODE(sim_data: u32);
     fn functionAlgebraics(sim_data: u32);
+    fn functionOutputs(sim_data: u32);
     fn functionStateSetJacobians(sim_data: u32);
     fn functionZeroCrossings(sim_data: u32);
     fn functionZeroCrossingsEquations(sim_data: u32);
@@ -266,6 +267,7 @@ impl SimEngine for Engine {
                 "functionInitialEquations_lambda0" => functionInitialEquations_lambda0(arg),
                 "functionODE" => functionODE(arg),
                 "functionAlgebraics" => functionAlgebraics(arg),
+                "functionOutputs" => functionOutputs(arg),
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
                 "functionZeroCrossings" => functionZeroCrossings(arg),
                 "functionZeroCrossingsEquations" => functionZeroCrossingsEquations(arg),
@@ -427,13 +429,11 @@ impl MeState {
         let _ = driver::seed_start_state(&mut e, self.sim_data, &self.meta);
     }
 
-    /// Refresh algebraics/derivatives so getters report consistent values.
+    /// `functionOutputs`, not `functionAlgebraics`: a getter runs no discrete update.
     fn eval(&self) {
         let mut e = Engine;
         let _ = e.call1("functionODE", self.sim_data);
-        if !self.layout.has_when {
-            let _ = e.call1("functionAlgebraics", self.sim_data);
-        }
+        let _ = e.call1("functionOutputs", self.sim_data);
     }
 
     /// C's `updateIfNeeded`. In Initialization Mode the update is the initial
@@ -699,6 +699,10 @@ macro_rules! shared_instance_methods {
             Ok(up) => up,
             Err(err) => return Err(err_status(err)),
         };
+
+        // C's `discreteCall = 0` at the end of `functionDAE`: left in event mode, every
+        // later evaluation restores the relations and hides the next crossing.
+        st.write_i32(layout.rel_fresh_off, 0);
 
         // C's `internalEventUpdate`: the timers, then the earliest of the next
         // sample and the next activation.
@@ -1212,7 +1216,10 @@ impl GuestModelExchangeInstance for Instance {
         &self,
         _no_set_fmu_state_prior_to_current_point: bool,
     ) -> Result<CompletedStepResult, Status> {
-        let st = self.st.borrow();
+        let mut st = self.st.borrow_mut();
+        // C's `internal_CompletedIntegratorStep`; it leaves `_need_update` set.
+        st.eval();
+        st.need_update = true;
         Ok(CompletedStepResult {
             enter_event_mode: false,
             terminate_simulation: st.read_i32(st.layout.terminate_off) != 0,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -296,6 +296,7 @@ pub const MODEL_FNS: &[&str] = &[
     "functionInitialEquations",
     "functionODE",
     "functionAlgebraics",
+    "functionOutputs",
     "functionStateSetJacobians",
     "functionZeroCrossings",
     "initSample",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -481,7 +481,50 @@ pub fn load_external_libraries(paths: &[String]) -> (Vec<usize>, Vec<String>) {
 /// Resolve against `handles` — the model's own libraries, which shadow a same-named
 /// symbol elsewhere — then against the process image.
 pub fn external_symbol_in(handles: &[usize], name: &str) -> Option<usize> {
-    handles.iter().find_map(|&h| dl::sym(h, name)).or_else(|| external_symbol(name))
+    symbol_in(handles, name).or_else(|| external_symbol(name))
+}
+
+/// Resolve against `handles` alone: for [`usertab`] the process image holds a
+/// fallback, so only the model's own definition is an answer.
+pub fn symbol_in(handles: &[usize], name: &str) -> Option<usize> {
+    handles.iter().find_map(|&h| dl::sym(h, name))
+}
+
+static USERTAB: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+type UsertabFn = unsafe extern "C-unwind" fn(
+    *mut libc::c_char,
+    libc::c_int,
+    *mut libc::c_int,
+    *mut libc::c_int,
+    *mut *mut f64,
+) -> libc::c_int;
+
+pub fn set_usertab(addr: Option<usize>) {
+    USERTAB.store(addr.unwrap_or(0), std::sync::atomic::Ordering::Relaxed);
+}
+
+/// `usertab`, for a `tableOnFile` table with no `fileName`. Preempts the weak dummy
+/// `libModelicaStandardTables` carries: the compiler image comes first in the scope.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn usertab(
+    table_name: *mut libc::c_char,
+    nipo: libc::c_int,
+    dim: *mut libc::c_int,
+    col_wise: *mut libc::c_int,
+    table: *mut *mut f64,
+) -> libc::c_int {
+    let hook = USERTAB.load(std::sync::atomic::Ordering::Relaxed);
+    if hook != 0 {
+        let f: UsertabFn = unsafe { std::mem::transmute(hook) };
+        return unsafe { f(table_name, nipo, dim, col_wise, table) };
+    }
+    // The runtime's own, so the installed interception reports and throws.
+    if let Some(addr) = dl::open_self().ok().and_then(|me| dl::sym(me, "ModelicaError")) {
+        let err: unsafe extern "C-unwind" fn(*const libc::c_char) = unsafe { std::mem::transmute(addr) };
+        unsafe { err(c"Function \"usertab\" is not implemented\n".as_ptr()) };
+    }
+    1
 }
 
 /// Install the panic-mode `ModelicaError`/`omc_assert` interception for the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
@@ -35,6 +35,10 @@ fn main() {
         .unwrap_or_else(|e| panic!("failed to build the PIC ModelicaExternalC dylink module: {e}"));
     copy(&module, &mec_dest);
 
+    let usertab = build_usertab_dylink(&out_dir, &sysroot, triple)
+        .unwrap_or_else(|e| panic!("failed to build the PIC usertab dummy dylink module: {e}"));
+    copy(&usertab, &out_dir.join("usertab_dylink.wasm"));
+
     // Only a CVODE/IDA Co-Simulation FMU needs this, so an absent sundials tree
     // leaves an empty blob rather than failing the build.
     let sundials_dest = out_dir.join("sundials_dylink.wasm");
@@ -186,7 +190,7 @@ fn ensure_pic_wasi_sysroot() -> PathBuf {
     panic!("OMC_WASI_PIC_SYSROOT={} has no lib/wasm32-wasip1/libc.so", p.display());
 }
 
-/// Compile ModelicaExternalC (+ `DummyUsertab`, `external_c_callbacks.c`,
+/// Compile ModelicaExternalC (+ `external_c_callbacks.c`,
 /// `external_c_stubs.c`) to a PIC dylink side module, then strip its
 /// `_initialize` export: reactor mode emits both `_initialize` and
 /// `__wasm_call_ctors`, and `wit_component::Linker` rejects a library
@@ -196,10 +200,12 @@ fn build_external_c_dylink(crate_dir: &Path, out_dir: &Path, sysroot: &Path, tri
     let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES").ok().map(PathBuf::from).ok_or_else(|| {
         "OMC_EXTERNAL_C_SOURCES not set".to_owned()
     })?;
+    // No usertab source, so it stays an `env.usertab` import the FMU link resolves
+    // against the model's own libraries first.
     let names = [
         "ModelicaStandardTables.c", "ModelicaStrings.c", "ModelicaRandom.c",
         "ModelicaIO.c", "ModelicaMatIO.c", "snprintf.c",
-        "ModelicaInternal.c", "ModelicaFFT.c", "ModelicaStandardTablesDummyUsertab.c",
+        "ModelicaInternal.c", "ModelicaFFT.c",
     ];
     let mut srcs: Vec<PathBuf> = names.iter().map(|n| c_sources.join(n)).collect();
     if let Some(missing) = srcs.iter().find(|p| !p.exists()) {
@@ -241,6 +247,41 @@ fn build_external_c_dylink(crate_dir: &Path, out_dir: &Path, sysroot: &Path, tri
     let stripped = strip_wasm_export(&bytes, "_initialize");
     let out = out_dir.join("modelicaexternalc_dylink_stripped.wasm");
     std::fs::write(&out, &stripped).map_err(|e| format!("write dylink: {e}"))?;
+    Ok(out)
+}
+
+/// The C dummy `usertab` on its own, so the FMU link can put it behind a model's own.
+fn build_usertab_dylink(out_dir: &Path, sysroot: &Path, triple: &str) -> Result<PathBuf, String> {
+    let c_sources = std::env::var("OMC_EXTERNAL_C_SOURCES").ok().map(PathBuf::from)
+        .ok_or_else(|| "OMC_EXTERNAL_C_SOURCES not set".to_owned())?;
+    let src = c_sources.join("ModelicaStandardTablesUsertab.c");
+    if !src.exists() {
+        return Err(format!("missing {}", src.display()));
+    }
+    println!("cargo:rerun-if-changed={}", src.display());
+
+    let raw = out_dir.join("usertab_dylink_raw.wasm");
+    let builtins = find_wasm_builtins().ok_or("no libclang_rt.builtins-wasm32.a found")?;
+    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
+    let status = Command::new(&clang)
+        .arg(format!("--target={triple}"))
+        .arg(format!("--sysroot={}", sysroot.display()))
+        .args(["-O2", "-fPIC", "-nodefaultlibs", "-mexec-model=reactor", "-DDUMMY_FUNCTION_USERTAB"])
+        .arg("-I").arg(&c_sources)
+        .arg(&src)
+        .args(["-Wl,--experimental-pic", "-Wl,--shared", "-Wl,--no-entry",
+               "-Wl,--export=usertab", "-Wl,--allow-undefined"])
+        .arg(&builtins)
+        .arg("-o").arg(&raw)
+        .status()
+        .map_err(|e| format!("spawn {clang}: {e}"))?;
+    if !status.success() {
+        return Err(format!("clang (usertab dylink) exited with {status}"));
+    }
+    let bytes = std::fs::read(&raw).map_err(|e| format!("read raw usertab dylink: {e}"))?;
+    let out = out_dir.join("usertab_dylink_stripped.wasm");
+    std::fs::write(&out, strip_wasm_export(&bytes, "_initialize"))
+        .map_err(|e| format!("write usertab dylink: {e}"))?;
     Ok(out)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/src/lib.rs
@@ -5,6 +5,9 @@
 /// ModelicaExternalC as a PIC dylink side module.
 pub static EXTERNAL_C_DYLINK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/modelicaexternalc_dylink.wasm"));
 
+/// The dummy `usertab` ModelicaExternalC imports, separate so it can be linked last.
+pub static USERTAB_DYLINK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/usertab_dylink.wasm"));
+
 /// A `-fPIC` wasi-libc `libc.so` dylink module (Debian's is non-PIC).
 pub static LIBC_PIC: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libc_pic.wasm"));
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -377,9 +377,11 @@ fn define_external_imports(
             openmodelica_wasi::wasi::stdout_write(side_msg(&env, ptr).as_bytes());
         },
     );
-    // `usertab` (user-defined table callback) is never used by the standard table
-    // blocks; provide a stub that reports "not found".
-    let usertab = Function::new_typed(&mut *store, |_: i32, _: i32, _: i32, _: i32, _: i32| -> i32 { 1 });
+    // This host cannot build the model's `Include`, so only the C dummy is left.
+    let usertab = Function::new_typed(&mut *store, |_: i32, _: i32, _: i32, _: i32, _: i32| -> i32 {
+        openmodelica_error::ErrorExt::runtime_error("Function \"usertab\" is not implemented\n");
+        1
+    });
     // `ModelicaAllocateString(len)` — allocate the returned string buffer in the
     // side module's own memory (its `malloc`, filled in after instantiation) and
     // record the offset so the trampoline can free it after copying the result out.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -366,23 +366,28 @@ struct NativeExternals {
 }
 
 impl NativeExternals {
-    fn resolve(&mut self, name: &str, model: &SimModel) -> Option<usize> {
-        if !self.loaded {
-            self.loaded = true;
-            let (handles, errors) = openmodelica_util::dynload::load_external_libraries(&model.ext_native_libs);
-            self.handles = handles;
-            self.errors = errors;
-            if let Some(archives) = &model.ext_archives {
-                match archives.link() {
-                    Ok(path) => {
-                        let (h, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
-                        self.handles.extend(h);
-                        self.errors.extend(errors);
-                    }
-                    Err(e) => self.errors.push(e),
+    fn ensure_loaded(&mut self, model: &SimModel) {
+        if self.loaded {
+            return;
+        }
+        self.loaded = true;
+        let (handles, errors) = openmodelica_util::dynload::load_external_libraries(&model.ext_native_libs);
+        self.handles = handles;
+        self.errors = errors;
+        if let Some(archives) = &model.ext_archives {
+            match archives.link() {
+                Ok(path) => {
+                    let (h, errors) = openmodelica_util::dynload::load_external_libraries(&[path]);
+                    self.handles.extend(h);
+                    self.errors.extend(errors);
                 }
+                Err(e) => self.errors.push(e),
             }
         }
+    }
+
+    fn resolve(&mut self, name: &str, model: &SimModel) -> Option<usize> {
+        self.ensure_loaded(model);
         if let Some(addr) = self.symbol(name) {
             return Some(addr);
         }
@@ -440,7 +445,26 @@ impl NativeExternals {
         let w: extern "C" fn() -> usize = unsafe { std::mem::transmute(wrapper) };
         Some(w()).filter(|a| *a != 0)
     }
+
+    /// The model's own `usertab`: no `external "C"`, so never among `ext_imports`.
+    fn usertab(&mut self, model: &SimModel) -> Option<usize> {
+        use openmodelica_util::dynload::symbol_in;
+        self.ensure_loaded(model);
+        if let Some(addr) = symbol_in(&self.handles, USERTAB) {
+            return Some(addr);
+        }
+        // Building an `Include` that defines none is a compiler run for nothing.
+        let inc = model.ext_includes.as_ref()?;
+        if self.built_includes || !inc.sources.iter().any(|s| s.contains(USERTAB)) {
+            return None;
+        }
+        self.built_includes = true;
+        self.load_includes(inc, &[]);
+        symbol_in(&self.handles, USERTAB)
+    }
 }
+
+const USERTAB: &str = "usertab";
 
 /// Define the model's external "C" function imports (wasm module `ext`) from the
 /// host. Uses the model's `ext_imports` (the C-call `SigTy` signature) rather than
@@ -485,6 +509,9 @@ fn define_external_imports(
         })?;
         define_native_external(linker, sig, functype, addr, memory, rt)?;
     }
+    // No `external "C"` means no `Include`/`Library`, hence no `usertab`.
+    let usertab = (!model.ext_imports.is_empty()).then(|| native.usertab(model)).flatten();
+    openmodelica_util::dynload::set_usertab(usertab);
     Ok(())
 }
 


### PR DESCRIPTION
ModelicaStandardTables calls `usertab` for a `tableOnFile` table with an empty `fileName`. The C target links the model's own — from its `Include` C source, `usertab.c` — into the simulation executable, where it preempts the weak dummy alias libModelicaStandardTables carries. Neither wasm host had an equivalent, so every such model failed with `Function "usertab" is not implemented`.

Native: `dynload::usertab` is exported from libOpenModelicaCompiler.so, which sits ahead of the dlopen'ed ffi/libModelicaStandardTables.so in the global symbol scope, so it preempts that weak dummy the same way. `define_external_imports` resolves the model's own from its libraries once per simulation.

FMU: for one dylink library to override a symbol another defines, the defining module has to leave it undefined — wasm-ld binds an intra-module call to a local definition, even a weak one, and emits no GOT.func import, so wit_component::Linker never gets a say. So ModelicaExternalC is built with no usertab source (making it an `env.usertab` import) and the C dummy moves into its own usertab_dylink.wasm, which link_fmu_component registers last, behind the model's own libraries.

The FMU driver needed three more fixes before the tables tracked:

* `eval()` skipped `functionAlgebraics` for a `has_when` model, where it is the fused per-step function a getter must not run. Adds `functionOutputs` — `algebraicEquations` plus the pre-value save, i.e. C's `functionAlgebraics` + `storePreValues`.
* `completed_integrator_step` did nothing. C's evaluates and leaves `_need_update` set, which matters because `fmi3GetEventIndicators` clears it after `functionODE` alone, as C does.
* `event_update` leaves the relations in event mode and the adapter never reset them, so every later evaluation re-evaluated and stored them, hiding the next crossing from the importer.

The browser host has no external-library loader at all, so its `env.usertab` stub now reports the C dummy's message rather than returning a bare error.

Verified against the C target: all five ModelicaTest `*_usertab` models match under `simulate()` (`diffSimulationResults` at 1e-6), and the time-table, 1D and 2D usertab FMUs produce traces identical to their C FMI 3.0 FMUs. BouncingBall (state events + reinit) and a plain continuous model are unchanged over 300 rows, ME and CS.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
