### PR TITLE
wasm-jit: C's unsolved-linear-system messages

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -453,9 +453,11 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // the fallback warning needs and whether a `rt_ls_check_step` follows.
     // Returns 0 ok, 1 singular.
     ("rt_linsolve", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),
-    // The same `A` re-solved with total pivoting: (a_ptr, b_ptr, n) -> 0 ok / 1
-    // inconsistent. C's fallback for a method-1 step `rt_ls_check_step` rejected.
-    ("rt_linsolve_totalpivot", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // The same `A` re-solved with total pivoting: (a_ptr, b_ptr, n, index, time) ->
+    // 0 ok / 1 inconsistent. C's fallback for a step `rt_ls_check_step` rejected.
+    ("rt_linsolve_totalpivot", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64], &[WTy::I32]),
+    // C's `check_linear_solution` + throw for an unsolved system: (index, time).
+    ("rt_ls_failed", &[WTy::I32, WTy::F64], &[]),
     // Method-1 step test: (res_ptr, b_ptr, n, index, time, dense) -> 1 when the
     // step must be redone, `b` then holding `-res`. See `rt_ls_check_step`.
     ("rt_ls_check_step", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -750,21 +750,20 @@ fn emit_linsolve_context(ctx: &mut FnCtx, index: i32) -> Result<()> {
     Ok(())
 }
 
-/// Trap (runtime error) when the solver returned nonzero (singular) — consumes the
-/// i32 result on the stack.
-fn emit_singular_check(ctx: &mut FnCtx) -> Result<()> {
-    ctx.emit(we::Instruction::If(we::BlockType::Empty));
-    emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
-    ctx.emit(we::Instruction::End);
-    Ok(())
-}
-
-/// C's `check_linear_solution` for a solver with no fallback left — consumes the
-/// i32 result on the stack.
-fn emit_lin_unsolved(ctx: &mut FnCtx, index: i32) -> Result<()> {
-    ctx.emit(we::Instruction::If(we::BlockType::Empty));
-    emit_runtime_error(ctx, &format!("Solving linear system {index} failed. For more information use -lv LOG_LS."))?;
-    ctx.emit(we::Instruction::End);
+/// C's `check_linear_solution` plus the `throwStreamPrintWithEquationIndexes` its
+/// generated equation function runs into — consumes the solver's i32 result on the
+/// stack. `rt_ls_failed` returns only inside a nonlinear-solver trial.
+fn emit_lin_unsolved(ctx: &mut FnCtx, index: i32, base: u32) -> Result<()> {
+    use we::Instruction as I;
+    ctx.emit(I::If(we::BlockType::Empty));
+    emit_linsolve_context(ctx, index)?;
+    ctx.emit(I::Call(rt_index("rt_ls_failed")?));
+    ctx.emit(I::LocalGet(base));
+    ctx.emit(I::Call(rt_index("rt_free")?));
+    release_heap_locals(ctx)?;
+    push_outputs(ctx);
+    ctx.emit(I::Return);
+    ctx.emit(I::End);
     Ok(())
 }
 
@@ -904,15 +903,16 @@ fn emit_lin_step(
             ctx.emit(I::I32Const(b_off as i32));
             ctx.emit(I::I32Add);
             ctx.emit(I::I32Const(n as i32));
+            emit_linsolve_context(ctx, index)?;
             ctx.emit(I::Call(rt_index("rt_linsolve_totalpivot")?));
-            emit_singular_check(ctx)?;
+            emit_lin_unsolved(ctx, index, base)?;
             ctx.emit(I::I32Const(1));
             ctx.emit(I::LocalSet(retry));
             ctx.emit(I::Br(0));
             ctx.emit(I::End); // loop
             ctx.emit(I::End); // block
         }
-        None => emit_lin_unsolved(ctx, index)?,
+        None => emit_lin_unsolved(ctx, index, base)?,
     }
 
     ctx.emit(I::LocalGet(base));
@@ -947,7 +947,7 @@ fn emit_lin_solve_scatter(
         ctx.emit(I::I32Const(m1.is_some() as i32)); // a step check follows
     }
     ctx.emit(I::Call(rt_index(solver)?));
-    emit_singular_check(ctx)?;
+    emit_lin_unsolved(ctx, index, base)?;
     match &m1 {
         Some(m1) => emit_lin_step(ctx, base, b_off, n, slots, use_sparse, index, m1, lower_inner),
         None => emit_scatter_recover_free(ctx, base, b_off, n, slots, lower_inner),
@@ -1465,7 +1465,7 @@ pub(crate) fn compile_linear_system_analytic_csc(
     ctx.emit(I::I32Const(n as i32));
     ctx.emit(I::I32Const(nnz as i32));
     ctx.emit(I::Call(rt_index("rt_solve_lin_sparse_cached")?));
-    emit_singular_check(ctx)?;
+    emit_lin_unsolved(ctx, handle, base)?;
     let m1 = Method1 { res_off, res_exps };
     emit_lin_step(ctx, base, b_off, n, &slots, true, handle, &m1, lower_inner)
 }
@@ -1639,9 +1639,7 @@ pub(crate) fn compile_linear_system_symbolic(
         ctx.emit(I::Call(rt_index("rt_linsolve")?));
     }
 
-    ctx.emit(I::If(we::BlockType::Empty)); // nonzero => singular
-    emit_runtime_error(ctx, "wasm-jit: linear system is singular (no unique solution)")?;
-    ctx.emit(I::End);
+    emit_lin_unsolved(ctx, index, base)?;
 
     // Scatter the solution into the unknown slots.
     for j in 0..n {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2482,7 +2482,7 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, tim
             }
         }
     }
-    if nls::total_pivot_solve(a, b, n) { 0 } else { 1 }
+    ls_total_pivot(a, b, n, eq_index, time)
 }
 
 /// C's `solveTotalPivot` fallback for a step [`rt_ls_check_step`] rejected: the
@@ -2490,11 +2490,46 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, tim
 /// re-evaluation of it lands on the same numbers — against the negated residual.
 /// 0 ok, 1 inconsistent. Same `solve_linear_system` call, so not a new solve.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_linsolve_totalpivot(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
+pub extern "C" fn rt_linsolve_totalpivot(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64) -> i32 {
     let n = n as usize;
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
     let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
-    if nls::total_pivot_solve(a, b, n) { 0 } else { 1 }
+    ls_total_pivot(a, b, n, eq_index, time)
+}
+
+/// C's `solveTotalPivot`, whose under-determined return warns on stdout.
+fn ls_total_pivot(a: &[f64], b: &mut [f64], n: usize, eq_index: i32, time: f64) -> i32 {
+    if nls::total_pivot_solve(a, b, n) {
+        return 0;
+    }
+    omclog::warning(
+        omclog::STDOUT,
+        false,
+        &alloc::format!("Error solving linear system of equations (no. {eq_index}) at time {time:.6}."),
+    );
+    1
+}
+
+/// C's `check_linear_solution` for a system left unsolved, then the
+/// `throwStreamPrintWithEquationIndexes` the generated equation function runs into.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_ls_failed(eq_index: i32, time: f64) {
+    use openmodelica_sim_meta::driver::format_g;
+    if nls::throw_reports() {
+        omclog::warning(
+            omclog::STDOUT,
+            true,
+            &alloc::format!(
+                "Solving linear system {eq_index} fails at time {}. For more information use -lv LOG_LS.",
+                format_g(time, 6)
+            ),
+        );
+        omclog::close_warning(omclog::STDOUT);
+    }
+    nls::throw_stream(&alloc::format!(
+        "Solving linear system {eq_index} failed at time={}.\nFor more information please use -lv LOG_LS.",
+        format_g(time, 15)
+    ));
 }
 
 /// C's method-1 step test (`solveLapack`, `solveKlu`, …): the step `dx` only counts

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -184,12 +184,17 @@ pub extern "C" fn rt_throw_stream(msg: u32) {
     throw_stream(core::str::from_utf8(unsafe { crate::str_bytes(msg) }).unwrap_or(""))
 }
 
+/// Whether the next [`throw_stream`] reports, for a caller with its own message.
+pub(crate) fn throw_reports() -> bool {
+    !(rt_nls_recovering() != 0 && note_slot().load(Ordering::Relaxed) != 0)
+}
+
 pub(crate) fn throw_stream(s: &str) {
     let recovering = rt_nls_recovering() != 0;
     // C's `longjmp` leaves the rest of the evaluation unreached, so it reports one
     // throw per evaluation. Here each frame returns and the ones above it carry on:
     // report only the throw C's jump would have carried out.
-    if !(recovering && note_slot().load(Ordering::Relaxed) != 0) {
+    if throw_reports() {
         if recovering {
             if crate::omclog::active(crate::omclog::ASSERT) {
                 crate::omclog::message_text(crate::omclog::DEBUG_TYPE, crate::omclog::ASSERT, false, s);


### PR DESCRIPTION
A `SES_LINEAR` system no solver could solve was reported as a failed model `assert()`, via `rt_assert`.  C reaches it through `throwStreamPrint`, which prints the message alone on `LOG_ASSERT` with no "The following assertion has been violated" header, and it prints two warnings first that wasm-jit had no counterpart for.

Route the failure through `rt_throw_stream` instead and add the missing warnings, so `SingularModel2` now logs what the C runtime logs:

| stage | message |
| --- | --- |
| `solveTotalPivot` | `Error solving linear system of equations (no. N) at time T.` | | `check_linear_solution` | `Solving linear system N fails at time T. ...` | | generated `eqFunction` | `Solving linear system N failed at time=T.` |

`rt_ls_failed` carries the last two; `ls_total_pivot` the first, shared by `rt_linsolve` and `rt_linsolve_totalpivot` (which now takes the equation index and time its warning needs).  Since `throw_stream` returns rather than unwinds inside a nonlinear-solver trial, its stdout warning is gated on the same `throw_reports` predicate that decides whether the throw itself is reported.

`emit_singular_check` and `emit_lin_unsolved` collapse into one emitter used by every linear-solver call site (dense, dense-sparse, sparse-cached, analytic-CSC, symbolic, and the method-1 retry), which also frees the solve scratch on the recoverable path.

Fixes simulation/libraries/3rdParty/MathematicalAspects/05_SingularModel under --simCodeTarget=wasm-jit.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
