### PR TITLE
[FMI] Apply imported FMU parameters before initialization (#16354), and two related import fixes

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -3340,8 +3340,8 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input FMI1CoSimulation fmi1cs;
         input Real realValuesReferences[:];
         input Real realValues[size(realValuesReferences, 1)];
-        output Real out_Values[size(realValuesReferences, 1)];
-        external "C" fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, out_Values, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        output Real out_Values[size(realValuesReferences, 1)] = realValues;
+        external "C" fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetReal;
 
       function fmi1GetInteger
@@ -3356,8 +3356,8 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input FMI1CoSimulation fmi1cs;
         input Real integerValuesReferences[:];
         input Integer integerValues[size(integerValuesReferences, 1)];
-        output Real out_Values[size(integerValuesReferences, 1)];
-        external "C" fmi1SetInteger_OMC(fmi1cs, size(integerValuesReferences, 1), integerValuesReferences, integerValues, out_Values, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        output Integer out_Values[size(integerValuesReferences, 1)] = integerValues;
+        external "C" fmi1SetInteger_OMC(fmi1cs, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetInteger;
 
       function fmi1GetBoolean
@@ -3372,8 +3372,8 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input FMI1CoSimulation fmi1cs;
         input Real booleanValuesReferences[:];
         input Boolean booleanValues[size(booleanValuesReferences, 1)];
-        output Boolean out_Values[size(booleanValuesReferences, 1)];
-        external "C" fmi1SetBoolean_OMC(fmi1cs, size(booleanValuesReferences, 1), booleanValuesReferences, booleanValues, out_Values, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        output Boolean out_Values[size(booleanValuesReferences, 1)] = booleanValues;
+        external "C" fmi1SetBoolean_OMC(fmi1cs, size(booleanValuesReferences, 1), booleanValuesReferences, booleanValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetBoolean;
 
       function fmi1GetString
@@ -3388,8 +3388,8 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         input FMI1CoSimulation fmi1cs;
         input Real stringValuesReferences[:];
         input String stringValues[size(stringValuesReferences, 1)];
-        output String out_Values[size(stringValuesReferences, 1)];
-        external "C" fmi1SetString_OMC(fmi1cs, size(stringValuesReferences, 1), stringValuesReferences, stringValues, out_Values, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+        output String out_Values[size(stringValuesReferences, 1)] = stringValues;
+        external "C" fmi1SetString_OMC(fmi1cs, size(stringValuesReferences, 1), stringValuesReferences, stringValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetString;
     end fmi1Functions;
   end <%if stringEq(name, "") then fmiInfo.fmiModelIdentifier+"_"+getFMIType(fmiInfo)+"_FMU" else name%>;

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -2065,13 +2065,15 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
     %>
   initial algorithm
     flowParamsStart := 1;
+    flowInitInputs := 1;
     flowStartTime := fmi1Functions.fmi1SetTime(fmi1me, time, 1);
-    flowInitialized := fmi1Functions.fmi1Initialize(fmi1me, flowParamsStart+flowInitInputs+flowStartTime);
+    /* the parameters must be set before the FMU is initialized,
+       otherwise the FMU computes its calculated parameters from the default values */
     <%if not stringEq(realParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1me, {"+realParametersVRs+"}, {"+realParametersNames+"});"%>
     <%if not stringEq(integerParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetIntegerParameter(fmi1me, {"+integerParametersVRs+"}, {"+integerParametersNames+"});"%>
     <%if not stringEq(booleanParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetBooleanParameter(fmi1me, {"+booleanParametersVRs+"}, {"+booleanParametersNames+"});"%>
     <%if not stringEq(stringParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetStringParameter(fmi1me, {"+stringParametersVRs+"}, {"+stringParametersNames+"});"%>
-    flowInitInputs := 1;
+    flowInitialized := fmi1Functions.fmi1Initialize(fmi1me, flowParamsStart+flowInitInputs+flowStartTime);
   initial equation
     <%if not stringEq(realDependentParametersVRs, "") then "{"+realDependentParametersNames+"} = fmi1Functions.fmi1GetReal(fmi1me, {"+realDependentParametersVRs+"}, flowInitialized);"%>
     <%if not stringEq(integerDependentParametersVRs, "") then "{"+integerDependentParametersNames+"} = fmi1Functions.fmi1GetInteger(fmi1me, {"+integerDependentParametersVRs+"}, flowInitialized);"%>
@@ -2454,11 +2456,13 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
     flowInitInputs := 1;
     flowStartTime := fmi2Functions.fmi2SetupExperiment(fmi2me, false, 0.0, time, false, 0.0, flowParamsStart+flowInitInputs);
     flowEnterInitialization := fmi2Functions.fmi2EnterInitialization(fmi2me, flowParamsStart+flowInitInputs+flowStartTime);
-    flowInitialized := fmi2Functions.fmi2ExitInitialization(fmi2me, flowParamsStart+flowInitInputs+flowStartTime+flowEnterInitialization);
+    /* the parameters must be set while the FMU is still in Initialization Mode,
+       otherwise the FMU computes its calculated parameters from the default values */
     <%if not stringEq(realParametersVRs, "") then "flowParamsStart := fmi2Functions.fmi2SetRealParameter(fmi2me, {"+realParametersVRs+"}, {"+realParametersNames+"});"%>
     <%if not stringEq(integerParametersVRs, "") then "flowParamsStart := fmi2Functions.fmi2SetIntegerParameter(fmi2me, {"+integerParametersVRs+"}, {"+integerParametersNames+"});"%>
     <%if not stringEq(booleanParametersVRs, "") then "flowParamsStart := fmi2Functions.fmi2SetBooleanParameter(fmi2me, {"+booleanParametersVRs+"}, {"+booleanParametersNames+"});"%>
     <%if not stringEq(stringParametersVRs, "") then "flowParamsStart := fmi2Functions.fmi2SetStringParameter(fmi2me, {"+stringParametersVRs+"}, {"+stringParametersNames+"});"%>
+    flowInitialized := fmi2Functions.fmi2ExitInitialization(fmi2me, flowParamsStart+flowInitInputs+flowStartTime+flowEnterInitialization);
   initial equation
     <%if not stringEq(realDependentParametersVRs, "") then "{"+realDependentParametersNames+"} = fmi2Functions.fmi2GetReal(fmi2me, {"+realDependentParametersVRs+"}, flowInitialized);"%>
     <%if not stringEq(integerDependentParametersVRs, "") then "{"+integerDependentParametersNames+"} = fmi2Functions.fmi2GetInteger(fmi2me, {"+integerDependentParametersVRs+"}, flowInitialized);"%>
@@ -2877,11 +2881,13 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
     flowInitInputs := 1;
     flowStartTime := flowParamsStart+flowInitInputs;
     flowEnterInitialization := fmi3Functions.fmi3EnterInitialization(fmi3me, false, 0.0, time, false, 0.0, flowParamsStart+flowInitInputs);
-    flowInitialized := fmi3Functions.fmi3ExitInitialization(fmi3me, flowParamsStart+flowInitInputs+flowStartTime+flowEnterInitialization);
+    /* the parameters must be set while the FMU is still in Initialization Mode,
+       otherwise the FMU computes its calculated parameters from the default values */
     <%if not stringEq(realParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetRealParameter(fmi3me, {"+realParametersVRs+"}, {"+realParametersNames+"});"%>
     <%if not stringEq(integerParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetIntegerParameter(fmi3me, {"+integerParametersVRs+"}, {"+integerParametersNames+"});"%>
     <%if not stringEq(booleanParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetBooleanParameter(fmi3me, {"+booleanParametersVRs+"}, {"+booleanParametersNames+"});"%>
     <%if not stringEq(stringParametersVRs, "") then "flowParamsStart := fmi3Functions.fmi3SetStringParameter(fmi3me, {"+stringParametersVRs+"}, {"+stringParametersNames+"});"%>
+    flowInitialized := fmi3Functions.fmi3ExitInitialization(fmi3me, flowParamsStart+flowInitInputs+flowStartTime+flowEnterInitialization);
   initial equation
     <%if not stringEq(realDependentParametersVRs, "") then "{"+realDependentParametersNames+"} = fmi3Functions.fmi3GetReal(fmi3me, {"+realDependentParametersVRs+"}, flowInitialized);"%>
     <%if not stringEq(integerDependentParametersVRs, "") then "{"+integerDependentParametersNames+"} = fmi3Functions.fmi3GetInteger(fmi3me, {"+integerDependentParametersVRs+"}, flowInitialized);"%>

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI1Common.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI1Common.c
@@ -162,28 +162,67 @@ void fmi1SetInteger_OMC(void* in_fmi1, int numberOfValueReferences, double* inte
 }
 
 /*
+ * Returns the FMI 1.0 import instance of either an FMI1ModelExchange (fmiType 1) or an
+ * FMI1CoSimulation (fmiType 2) external object, or NULL for anything else.
+ */
+static fmi1_import_t* fmi1_import_instance(void* in_fmi1, int fmiType)
+{
+  if (fmiType == 1) {
+    return ((FMI1ModelExchange*)in_fmi1)->FMIImportInstance;
+  } else if (fmiType == 2) {
+    return ((FMI1CoSimulation*)in_fmi1)->FMIImportInstance;
+  }
+  return NULL;
+}
+
+/*
+ * Convert a Modelica boolean array to an FMI 1.0 boolean array.
+ * A Modelica boolean is a modelica_boolean, i.e. an int, and an FMI 1.0 one is an
+ * fmi1_boolean_t, i.e. a char, so the two arrays cannot share a buffer.
+ */
+static void modelica_to_fmi1_boolean(const int* modelicaBoolean, fmi1_boolean_t* fmiBoolean, int size)
+{
+  int i;
+  for (i = 0; i < size; i++) {
+    fmiBoolean[i] = modelicaBoolean[i] ? fmi1_true : fmi1_false;
+  }
+}
+
+/*
+ * Convert an FMI 1.0 boolean array to a Modelica boolean array.
+ */
+static void fmi1_to_modelica_boolean(const fmi1_boolean_t* fmiBoolean, int* modelicaBoolean, int size)
+{
+  int i;
+  for (i = 0; i < size; i++) {
+    modelicaBoolean[i] = fmiBoolean[i] ? 1 : 0;
+  }
+}
+
+/*
  * Wrapper for the FMI function fmiGetBoolean.
  * parameter flowStatesInput is dummy and is only used to run the equations in sequence.
  * Returns booleanValues.
  */
 void fmi1GetBoolean_OMC(void* in_fmi1, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, int* booleanValues, int fmiType)
 {
-  if (fmiType == 1) {
-    FMI1ModelExchange* FMI1ME = (FMI1ModelExchange*)in_fmi1;
-    fmi1_value_reference_t* valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValuesReferences);
-    fmi1_status_t status = fmi1_import_get_boolean(FMI1ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi1_boolean_t*)booleanValues);
-    free(valuesReferences_int);
-    if (status != fmi1_status_ok && status != fmi1_status_warning) {
-      ModelicaFormatError("fmiGetBoolean failed with status : %s\n", fmi1_status_to_string(status));
-    }
-  } else if (fmiType == 2) {
-    FMI1CoSimulation* FMI1CS = (FMI1CoSimulation*)in_fmi1;
-    fmi1_value_reference_t* valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValuesReferences);
-    fmi1_status_t status = fmi1_import_get_boolean(FMI1CS->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi1_boolean_t*)booleanValues);
-    free(valuesReferences_int);
-    if (status != fmi1_status_ok && status != fmi1_status_warning) {
-      ModelicaFormatError("fmiGetBoolean failed with status : %s\n", fmi1_status_to_string(status));
-    }
+  fmi1_import_t* FMIImportInstance = fmi1_import_instance(in_fmi1, fmiType);
+  fmi1_value_reference_t* valuesReferences_int;
+  fmi1_boolean_t* fmiBoolean;
+  fmi1_status_t status;
+
+  if (FMIImportInstance == NULL) {
+    return;
+  }
+
+  valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValuesReferences);
+  fmiBoolean = malloc(sizeof(fmi1_boolean_t)*numberOfValueReferences);
+  status = fmi1_import_get_boolean(FMIImportInstance, valuesReferences_int, numberOfValueReferences, fmiBoolean);
+  fmi1_to_modelica_boolean(fmiBoolean, booleanValues, numberOfValueReferences);
+  free(fmiBoolean);
+  free(valuesReferences_int);
+  if (status != fmi1_status_ok && status != fmi1_status_warning) {
+    ModelicaFormatError("fmiGetBoolean failed with status : %s\n", fmi1_status_to_string(status));
   }
 }
 
@@ -193,22 +232,23 @@ void fmi1GetBoolean_OMC(void* in_fmi1, int numberOfValueReferences, double* bool
  */
 void fmi1SetBoolean_OMC(void* in_fmi1, int numberOfValueReferences, double* booleanValueReferences, int* booleanValues, int fmiType)
 {
-  if (fmiType == 1) {
-    FMI1ModelExchange* FMI1ME = (FMI1ModelExchange*)in_fmi1;
-    fmi1_value_reference_t* valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValueReferences);
-    fmi1_status_t status = fmi1_import_set_boolean(FMI1ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi1_boolean_t*)booleanValues);
-    free(valuesReferences_int);
-    if (status != fmi1_status_ok && status != fmi1_status_warning) {
-      ModelicaFormatError("fmiSetBoolean failed with status : %s\n", fmi1_status_to_string(status));
-    }
-  } else if (fmiType == 2) {
-    FMI1CoSimulation* FMI1CS = (FMI1CoSimulation*)in_fmi1;
-    fmi1_value_reference_t* valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValueReferences);
-    fmi1_status_t status = fmi1_import_set_boolean(FMI1CS->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi1_boolean_t*)booleanValues);
-    free(valuesReferences_int);
-    if (status != fmi1_status_ok && status != fmi1_status_warning) {
-      ModelicaFormatError("fmiSetBoolean failed with status : %s\n", fmi1_status_to_string(status));
-    }
+  fmi1_import_t* FMIImportInstance = fmi1_import_instance(in_fmi1, fmiType);
+  fmi1_value_reference_t* valuesReferences_int;
+  fmi1_boolean_t* fmiBoolean;
+  fmi1_status_t status;
+
+  if (FMIImportInstance == NULL) {
+    return;
+  }
+
+  valuesReferences_int = real_to_fmi1_value_reference(numberOfValueReferences, booleanValueReferences);
+  fmiBoolean = malloc(sizeof(fmi1_boolean_t)*numberOfValueReferences);
+  modelica_to_fmi1_boolean(booleanValues, fmiBoolean, numberOfValueReferences);
+  status = fmi1_import_set_boolean(FMIImportInstance, valuesReferences_int, numberOfValueReferences, fmiBoolean);
+  free(fmiBoolean);
+  free(valuesReferences_int);
+  if (status != fmi1_status_ok && status != fmi1_status_warning) {
+    ModelicaFormatError("fmiSetBoolean failed with status : %s\n", fmi1_status_to_string(status));
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI2Common.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI2Common.c
@@ -73,36 +73,37 @@ fmi2_value_reference_t* real_to_fmi2_value_reference(int numberOfValueReferences
 }
 
 /**
- * @brief Convert Modelica boolean array (signed char) to FMI boolean array (int).
+ * @brief Convert a Modelica boolean array to an FMI 2.0 boolean array.
+ *
+ * A Modelica boolean is a modelica_boolean, i.e. an int, and an FMI 2.0 one is an
+ * fmi2_boolean_t. Copying element-wise keeps this correct whatever either side
+ * happens to typedef its boolean to.
  *
  * @param modelicaBoolean Input array of Modelica booleans.
  * @param fmiBoolean      Output array of FMI booleans.
  * @param size            Number of elements to convert.
- * @return Always returns 0.
  */
-int signedchar_to_int(signed char* modelicaBoolean, int* fmiBoolean, int size)
+static void modelica_to_fmi2_boolean(const int* modelicaBoolean, fmi2_boolean_t* fmiBoolean, int size)
 {
   int i;
   for (i = 0; i < size; i++) {
-    fmiBoolean[i] = (int) modelicaBoolean[i];
+    fmiBoolean[i] = modelicaBoolean[i] ? fmi2_true : fmi2_false;
   }
-  return 0;
 }
+
 /**
- * @brief Convert FMI boolean array (int) to Modelica boolean array (signed char).
+ * @brief Convert an FMI 2.0 boolean array to a Modelica boolean array.
  *
  * @param fmiBoolean      Input array of FMI booleans.
  * @param modelicaBoolean Output array of Modelica booleans.
  * @param size            Number of elements to convert.
- * @return Always returns 0.
  */
-int int_to_signedchar(int* fmiBoolean, signed char* modelicaBoolean, int size)
+static void fmi2_to_modelica_boolean(const fmi2_boolean_t* fmiBoolean, int* modelicaBoolean, int size)
 {
   int i;
   for (i = 0; i < size; i++) {
-    modelicaBoolean[i] = (signed char) fmiBoolean[i];
+    modelicaBoolean[i] = fmiBoolean[i] ? 1 : 0;
   }
-  return 0;
 }
 
 /**
@@ -194,7 +195,7 @@ void fmi2SetInteger_OMC(void* in_fmi2, int numberOfValueReferences, double* inte
 /**
  * @brief Wrapper for fmi2GetBoolean.
  *
- * Retrieves boolean values and converts them from FMI int to Modelica signed char.
+ * Retrieves boolean values and converts them from fmi2_boolean_t to Modelica booleans.
  *
  * @param in_fmi2                  FMI2 model exchange instance.
  * @param numberOfValueReferences  Number of value references.
@@ -202,16 +203,15 @@ void fmi2SetInteger_OMC(void* in_fmi2, int numberOfValueReferences, double* inte
  * @param flowStatesInput          Dummy parameter used to enforce equation ordering.
  * @param booleanValues            Output array for the retrieved boolean values.
  */
-void fmi2GetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, signed char* booleanValues)
+void fmi2GetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, int* booleanValues)
 {
   FMI2ModelExchange* FMI2ME = (FMI2ModelExchange*)in_fmi2;
   fmi2_value_reference_t* valuesReferences_int = real_to_fmi2_value_reference(numberOfValueReferences, booleanValuesReferences);
-  int* fmiBoolean = malloc(sizeof(int)*numberOfValueReferences);
+  fmi2_boolean_t* fmiBoolean = malloc(sizeof(fmi2_boolean_t)*numberOfValueReferences);
   fmi2_status_t status = fmi2_import_get_boolean(FMI2ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, fmiBoolean);
-  int_to_signedchar(fmiBoolean, booleanValues, numberOfValueReferences);
+  fmi2_to_modelica_boolean(fmiBoolean, booleanValues, numberOfValueReferences);
   free(fmiBoolean);
   free(valuesReferences_int);
-
 
   if (status != fmi2_status_ok && status != fmi2_status_warning) {
     ModelicaFormatError("fmi2GetBoolean failed with status : %s\n", fmi2_status_to_string(status));
@@ -221,7 +221,7 @@ void fmi2GetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* bool
 /**
  * @brief Wrapper for fmi2SetBoolean.
  *
- * Converts Modelica signed char booleans to FMI int before setting.
+ * Converts Modelica booleans to fmi2_boolean_t before setting.
  * Only sets values in instantiated, initialization, or event mode.
  *
  * @param in_fmi2                  FMI2 model exchange instance.
@@ -229,14 +229,14 @@ void fmi2GetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* bool
  * @param booleanValuesReferences  Value references encoded as doubles.
  * @param booleanValues            Boolean values to set.
  */
-void fmi2SetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* booleanValuesReferences, signed char* booleanValues)
+void fmi2SetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* booleanValuesReferences, int* booleanValues)
 {
   FMI2ModelExchange* FMI2ME = (FMI2ModelExchange*)in_fmi2;
   if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode) {
     fmi2_value_reference_t* valuesReferences_int = real_to_fmi2_value_reference(numberOfValueReferences, booleanValuesReferences);
-    int* fmiBoolean = malloc(sizeof(int)*numberOfValueReferences);
+    fmi2_boolean_t* fmiBoolean = malloc(sizeof(fmi2_boolean_t)*numberOfValueReferences);
     fmi2_status_t status;
-    signedchar_to_int(booleanValues, fmiBoolean, numberOfValueReferences);
+    modelica_to_fmi2_boolean(booleanValues, fmiBoolean, numberOfValueReferences);
     status = fmi2_import_set_boolean(FMI2ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, fmiBoolean);
     free(fmiBoolean);
     free(valuesReferences_int);

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI3Common.c
@@ -144,10 +144,10 @@ void fmi3SetInteger_OMC(void* in_fmi3, int numberOfValueReferences, double* inte
 /**
  * @brief Wrapper for fmi3GetBoolean.
  *
- * Modelica booleans are signed char and FMI 3.0 ones are fmi3_boolean_t, so the values
- * are read into a buffer of the FMI type and copied over.
+ * Modelica booleans are modelica_boolean, i.e. int, and FMI 3.0 ones are fmi3_boolean_t,
+ * i.e. bool, so the values are read into a buffer of the FMI type and copied over.
  */
-void fmi3GetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, signed char* booleanValues)
+void fmi3GetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, double flowStatesInput, int* booleanValues)
 {
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
   fmi3_value_reference_t* valuesReferences_int = real_to_fmi3_value_reference(numberOfValueReferences, booleanValuesReferences);
@@ -156,7 +156,7 @@ void fmi3GetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* bool
                                                  fmiBooleans, numberOfValueReferences);
   int i;
   for (i = 0; i < numberOfValueReferences; i++) {
-    booleanValues[i] = (signed char)fmiBooleans[i];
+    booleanValues[i] = fmiBooleans[i] ? 1 : 0;
   }
   free(fmiBooleans);
   free(valuesReferences_int);
@@ -168,7 +168,7 @@ void fmi3GetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* bool
 /**
  * @brief Wrapper for fmi3SetBoolean.
  */
-void fmi3SetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, signed char* booleanValues)
+void fmi3SetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* booleanValuesReferences, int* booleanValues)
 {
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3;
   if (FMI3ME->FMISolvingMode == fmi3_instantiated_mode || FMI3ME->FMISolvingMode == fmi3_initialization_mode || FMI3ME->FMISolvingMode == fmi3_event_mode || FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
@@ -177,7 +177,7 @@ void fmi3SetBoolean_OMC(void* in_fmi3, int numberOfValueReferences, double* bool
     fmi3_status_t status;
     int i;
     for (i = 0; i < numberOfValueReferences; i++) {
-      fmiBooleans[i] = (fmi3_boolean_t)booleanValues[i];
+      fmiBooleans[i] = booleanValues[i] ? fmi3_true : fmi3_false;
     }
     status = fmi3_import_set_boolean(FMI3ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences,
                                      fmiBooleans, numberOfValueReferences);

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI3ModelExchange.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI3ModelExchange.c
@@ -178,9 +178,11 @@ void fmi3SetTime_OMC(void* in_fmi3me, double time)
 void fmi3GetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates, double flowParams, double* states)
 {
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
-  fmi3_status_t status = fmi3_import_get_continuous_states(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
-  if (status != fmi3_status_ok && status != fmi3_status_warning) {
-    ModelicaFormatError("fmi3GetContinuousStates failed with status : %s\n", fmi3_status_to_string(status));
+  if (numberOfContinuousStates > 0) {
+    fmi3_status_t status = fmi3_import_get_continuous_states(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3GetContinuousStates failed with status : %s\n", fmi3_status_to_string(status));
+    }
   }
 }
 
@@ -191,7 +193,7 @@ void fmi3GetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates, 
 double fmi3SetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates, double flowParams, double* states)
 {
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
-  if (FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
+  if (numberOfContinuousStates > 0 && FMI3ME->FMISolvingMode == fmi3_continuousTime_mode) {
     fmi3_status_t status = fmi3_import_set_continuous_states(FMI3ME->FMIImportInstance, (const fmi3_float64_t*)states, numberOfContinuousStates);
     if (status != fmi3_status_ok && status != fmi3_status_warning) {
       ModelicaFormatError("fmi3SetContinuousStates failed with status : %s\n", fmi3_status_to_string(status));
@@ -207,9 +209,11 @@ double fmi3SetContinuousStates_OMC(void* in_fmi3me, int numberOfContinuousStates
 void fmi3GetEventIndicators_OMC(void* in_fmi3me, int numberOfEventIndicators, double flowStates, double* events)
 {
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
-  fmi3_status_t status = fmi3_import_get_event_indicators(FMI3ME->FMIImportInstance, (fmi3_float64_t*)events, numberOfEventIndicators);
-  if (status != fmi3_status_ok && status != fmi3_status_warning) {
-    ModelicaFormatError("fmi3GetEventIndicators failed with status : %s\n", fmi3_status_to_string(status));
+  if (numberOfEventIndicators > 0) {
+    fmi3_status_t status = fmi3_import_get_event_indicators(FMI3ME->FMIImportInstance, (fmi3_float64_t*)events, numberOfEventIndicators);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3GetEventIndicators failed with status : %s\n", fmi3_status_to_string(status));
+    }
   }
 }
 
@@ -223,9 +227,11 @@ void fmi3GetDerivatives_OMC(void* in_fmi3me, int numberOfContinuousStates, doubl
   FMI3ModelExchange* FMI3ME = (FMI3ModelExchange*)in_fmi3me;
   /* FMI Library still calls this fmi3_import_get_derivatives, though FMI 3.0 renamed
      the function it wraps to fmi3GetContinuousStateDerivatives. */
-  fmi3_status_t status = fmi3_import_get_derivatives(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
-  if (status != fmi3_status_ok && status != fmi3_status_warning) {
-    ModelicaFormatError("fmi3GetContinuousStateDerivatives failed with status : %s\n", fmi3_status_to_string(status));
+  if (numberOfContinuousStates > 0) {
+    fmi3_status_t status = fmi3_import_get_derivatives(FMI3ME->FMIImportInstance, (fmi3_float64_t*)states, numberOfContinuousStates);
+    if (status != fmi3_status_ok && status != fmi3_status_warning) {
+      ModelicaFormatError("fmi3GetContinuousStateDerivatives failed with status : %s\n", fmi3_status_to_string(status));
+    }
   }
 }
 

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/Issue14456.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/Issue14456.mos
@@ -1,7 +1,7 @@
 // name: Issue14456.mos
 // keywords: fmu export and run
 // status: correct
-// teardown_command: rm -rf roomM370*.c roomM370*.h roomM370-tmp index.html roomM370.fmu roomM370_cs_systemCall.log model_res.mat
+// teardown_command: rm -rf roomM370*.c roomM370*.h roomM370-tmp index.html roomM370.fmu roomM370_cs_systemCall.log roomM370_res.mat roomM370_info.json model_res.mat
 
 setCommandLineOptions("--fmiFlags=s:cvode"); getErrorString();
 loadFile("roomM370.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/CoSimulationStandAlone/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulationStandAlone/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
+fmi1_cs_import_setters.mos \
 
 # test that currently fail. Move up when fixed. 
 # Run make testfailing

--- a/testsuite/openmodelica/fmi/CoSimulationStandAlone/fmi1_cs_import_setters.mos
+++ b/testsuite/openmodelica/fmi/CoSimulationStandAlone/fmi1_cs_import_setters.mos
@@ -1,0 +1,40 @@
+// name:     fmi1_cs_import_setters
+// keywords: fmi import co-simulation
+// status:   correct
+// teardown_command: rm -rf vanDerPol_cs_st_FMU.mo binaries sources documentation resources model.png modelDescription.xml vanDerPol.log vanDerPol_info.json output.log
+// cflags:   -d=-newInst
+//
+// The four setters of an imported FMI 1.0 Co-Simulation FMU used to be called with the
+// function's own out_Values output as an extra argument, so the runtime's fmiType parameter
+// received it instead of the literal 2, matched neither branch and the setter silently did
+// nothing. fmi1SetInteger also declared output Real while the wrapper assigns its result to
+// Integer variables. Matching the exact call keeps the arity pinned: a regression returns 0
+// matches instead of 1.
+//
+// OpenModelica cannot export FMI 1.0 Co-Simulation FMUs, so this imports one of the FMUs
+// that ship with the testsuite. Only the generated wrapper is inspected, never simulated,
+// so the win32-only binaries inside the FMU do not matter.
+//
+
+importFMU("testedFMU/fmusdk1.0.2/vanDerPol.fmu"); getErrorString();
+
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1SetReal_OMC\\(fmi1cs, size\\(realValuesReferences, 1\\), realValuesReferences, realValues, 2\\)", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1SetInteger_OMC\\(fmi1cs, size\\(integerValuesReferences, 1\\), integerValuesReferences, integerValues, 2\\)", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1SetBoolean_OMC\\(fmi1cs, size\\(booleanValuesReferences, 1\\), booleanValuesReferences, booleanValues, 2\\)", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1SetString_OMC\\(fmi1cs, size\\(stringValuesReferences, 1\\), stringValuesReferences, stringValues, 2\\)", 1, true, false);
+
+// fmi1SetInteger returns Integer, which is what the wrapper assigns it to
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "output Integer out_Values\\[size\\(integerValuesReferences, 1\\)\\] = integerValues;", 1, true, false);
+
+// Result:
+// "vanDerPol_cs_st_FMU.mo"
+// "Warning: module = fmi1_xml_get_default_experiment_start: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// Warning: module = fmi1_xml_get_default_experiment_stop: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// Warning: module = fmi1_xml_get_default_experiment_tolerance: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// "
+// (1, {"fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, 2)"})
+// (1, {"fmi1SetInteger_OMC(fmi1cs, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 2)"})
+// (1, {"fmi1SetBoolean_OMC(fmi1cs, size(booleanValuesReferences, 1), booleanValuesReferences, booleanValues, 2)"})
+// (1, {"fmi1SetString_OMC(fmi1cs, size(stringValuesReferences, 1), stringValuesReferences, stringValues, 2)"})
+// (1, {"output Integer out_Values[size(integerValuesReferences, 1)] = integerValues;"})
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 FMI1MEfmpy.mos \
 FMI1MEcvodeFlag.mos \
 FMI1MEInputOutput.mos \
+fmi1_import_boolean.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/fmi1_import_boolean.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/fmi1_import_boolean.mos
@@ -1,0 +1,68 @@
+// name:     fmi1_import_boolean
+// keywords: fmu export import boolean
+// status:   correct
+// teardown_command: rm -rf binaries sources modelDescription.xml resources BooleanImportFMU* BooleanImport* output.log
+// cflags:   -d=-newInst
+//
+// A Modelica boolean is a modelica_boolean, i.e. an int, but the FMI import runtime used to
+// exchange the boolean arrays with the generated wrapper as signed char, so it wrote one byte
+// into every four byte slot and the rest of each element stayed uninitialized. Three booleans
+// are used on purpose: a single one survived the mismatch by accident on a little endian
+// machine.
+//
+
+loadString("
+model BooleanImportFMU
+  parameter Boolean bp1 = false;
+  parameter Boolean bp2 = false;
+  parameter Boolean bp3 = true;
+  Boolean bo1;
+  Boolean bo2;
+  Boolean bo3;
+equation
+  bo1 = not bp1;
+  bo2 = bp2 and bp3;
+  bo3 = bp1 or bp2;
+end BooleanImportFMU;
+"); getErrorString();
+
+buildModelFMU(BooleanImportFMU, version="1.0", fmuType="me"); getErrorString();
+importFMU("BooleanImportFMU.fmu"); getErrorString();
+loadFile("BooleanImportFMU_me_FMU.mo"); getErrorString();
+
+loadString("
+model BooleanImport
+  BooleanImportFMU_me_FMU fmu(bp1 = true, bp2 = true, bp3 = false);
+end BooleanImport;
+"); getErrorString();
+
+simulate(BooleanImport, stopTime=0.0); getErrorString();
+
+// bo1 = not true = false, bo2 = true and false = false, bo3 = true or true = true
+val(fmu.bo1, 0.0);
+val(fmu.bo2, 0.0);
+val(fmu.bo3, 0.0);
+
+// Result:
+// true
+// ""
+// "BooleanImportFMU.fmu"
+// ""
+// "BooleanImportFMU_me_FMU.mo"
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "BooleanImport_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'BooleanImport', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 1.0
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/FMUResourceTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/FMUResourceTest.mos
@@ -1,7 +1,7 @@
 // name: FMUResourceTest
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf binaries sources resources modelDescription.xml FMUResourceTest_Test* FMUResourceTest.Test* output.log
+// teardown_command: rm -rf @ binaries sources resources modelDescription.xml FMUResourceTest_Test* FMUResourceTest.Test* output.log
 // cflags: -d=newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorldEvent.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorldEvent.mos
@@ -1,7 +1,7 @@
 // name:     HelloFMIWorldEvent
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml HelloFMI20World.fmu HelloFMI20World* HelloFMI20World/* output.log
+// teardown_command: rm -rf binaries sources modelDescription.xml HelloFMI20World.fmu HelloFMI20World* HelloFMI20World/* output.log resources
 // cflags: -d=-newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/IntegerNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/IntegerNetwork1.mos
@@ -1,7 +1,7 @@
 // name:     IntegerNetwork1
 // keywords: IntegerNetwork1 FMI-Export FMI-Import
 // status:   correct
-// teardown_command: rm -rf binaries sources modelDescription.xml IntegerNetwork1.fmu IntegerNetwork1_me_FMU.mo IntegerNetwork1.lib* IntegerNetwork1.so IntegerNetwork1.dll IntegerNetwork1_*.c IntegerNetwork1_*.h IntegerNetwork1_*.o IntegerNetwork1_*.json
+// teardown_command: rm -rf binaries sources modelDescription.xml IntegerNetwork1.fmu IntegerNetwork1_me_FMU.mo IntegerNetwork1.lib* IntegerNetwork1.so IntegerNetwork1.dll IntegerNetwork1_*.c IntegerNetwork1_*.h IntegerNetwork1_*.o IntegerNetwork1_*.json documentation resources
 // cflags: -d=-newInst
 // Integer variables, Integer input variables, no continuous-time states, time events, state events
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905.mos
@@ -1,7 +1,7 @@
 // name: Issue13905
 // keywords: FMI 2.0 export memory pool function scope
 // status: correct
-// teardown_command: rm -rf Issue13905.fmu Issue13905.fmutmp/ Issue13905.scoped Issue13905.notscoped Issue13905.log Issue13905_info.json Issue13905_me_FMU* Issue13905_res.mat index.html
+// teardown_command: rm -rf Issue13905.fmu Issue13905.fmutmp/ Issue13905.scoped Issue13905.notscoped Issue13905.log Issue13905_info.json Issue13905_me_FMU* Issue13905_res.mat index.html binaries sources modelDescription.xml
 //
 // Regression test for #13905. FMU functions allocate from the memory pool, which is only rolled
 // back at the FMI entry points, so a function that allocates in a loop accumulates for the whole

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905_pool_expand.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue13905_pool_expand.mos
@@ -1,7 +1,7 @@
 // name: Issue13905_pool_expand
 // keywords: FMI 2.0 export memory pool
 // status: correct
-// teardown_command: rm -rf Issue13905_pool_expand.fmu Issue13905_pool_expand.fmutmp/ Issue13905_pool_expand.log Issue13905_pool_expand_info.json Issue13905_pool_expand_me_FMU* Issue13905_pool_expand_res.mat index.html
+// teardown_command: rm -rf Issue13905_pool_expand.fmu Issue13905_pool_expand.fmutmp/ Issue13905_pool_expand.log Issue13905_pool_expand_info.json Issue13905_pool_expand_me_FMU* Issue13905_pool_expand_res.mat index.html binaries sources modelDescription.xml
 //
 // Regression test for #13905. pool_expand() ignored its `len` argument and always made the new
 // block 1.5x the previous one, while pool_malloc() documents that "the new block should, at

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue16354.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Issue16354.mos
@@ -1,0 +1,66 @@
+// name:     Issue16354
+// keywords: fmu export import parameter initialization
+// status:   correct
+// teardown_command: rm -rf binaries sources modelDescription.xml Issue16354FMU* Issue16354Import* output.log
+// cflags:   -d=-newInst
+//
+// The parameter modifiers of an imported Model Exchange FMU have to reach the FMU
+// before it leaves Initialization Mode, otherwise the FMU computes the values that
+// depend on them from the default values instead. See #16354.
+//
+
+loadString("
+model Issue16354FMU
+  parameter Real rp = 4.0;
+  parameter Integer ip = 4;
+  parameter Boolean bp = false;
+  parameter String sp = \"default\";
+  Real rx;
+  Integer ix;
+equation
+  rx = 2.0*rp;
+  ix = 2*ip;
+end Issue16354FMU;
+"); getErrorString();
+
+buildModelFMU(Issue16354FMU, version="2.0", fmuType="me"); getErrorString();
+importFMU("Issue16354FMU.fmu"); getErrorString();
+loadFile("Issue16354FMU_me_FMU.mo"); getErrorString();
+
+loadString("
+model Issue16354Import
+  Issue16354FMU_me_FMU fmu(rp = 5.0, ip = 5, bp = true, sp = \"modified\");
+end Issue16354Import;
+"); getErrorString();
+
+simulate(Issue16354Import, stopTime=0.0); getErrorString();
+
+// rp and ip are the modifiers, rx and ix are what the FMU computes from them.
+// Before the fix the FMU still used the defaults and returned rx = 8.0, ix = 8.
+val(fmu.rp, 0.0);
+val(fmu.rx, 0.0);
+val(fmu.ix, 0.0);
+
+// Result:
+// true
+// ""
+// "Issue16354FMU.fmu"
+// ""
+// "Issue16354FMU_me_FMU.mo"
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Issue16354Import_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Issue16354Import', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 5.0
+// 10.0
+// 10.0
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -33,6 +33,7 @@ fmi2_array_attributes_nb.mos \
 fmi2_array_attributes.mos \
 Issue13905.mos \
 Issue13905_pool_expand.mos \
+Issue16354.mos \
 fmi2_array_nonscalarized.mos \
 fmi2_arrays_initial_unknowns.mos \
 fmi2_string_variability.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -34,6 +34,7 @@ fmi2_array_attributes.mos \
 Issue13905.mos \
 Issue13905_pool_expand.mos \
 Issue16354.mos \
+fmi_import_boolean.mos \
 fmi2_array_nonscalarized.mos \
 fmi2_arrays_initial_unknowns.mos \
 fmi2_string_variability.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
@@ -1,7 +1,7 @@
 // name:     ChuaCircuit
 // keywords: simulation MSL Examples
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml ChuaCircuit.fmu ChuaCircuit_* ChuaCircuit_me_FMU.mo ChuaCircuit.libs ChuaCircuit.lib ChuaCircuit.so ChuaCircuit.dll ChuaCircuit.c ChuaCircuit.makefile
+// teardown_command: rm -rf binaries sources modelDescription.xml ChuaCircuit.fmu ChuaCircuit_* ChuaCircuit_me_FMU.mo ChuaCircuit.libs ChuaCircuit.lib ChuaCircuit.so ChuaCircuit.dll ChuaCircuit.c ChuaCircuit.makefile documentation resources
 // cflags: -d=-newInst
 // Simulation Results
 // Modelica Standard Library

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
@@ -1,7 +1,7 @@
 // name:     DoublePendulum
 // keywords: DoublePendulum FMI-Export FMI-Import
 // status: correct
-// teardown_command: rm -rf Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum.* Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum_* binaries sources modelDescription.xml DoublePendulum.fmu DoublePendulum_me_FMU.mo DoublePendulum.lib* DoublePendulum.so DoublePendulum.dll DoublePendulum_*.c DoublePendulum_*.h DoublePendulum_*.o DoublePendulum_*.json
+// teardown_command: rm -rf Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum.* Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum_* binaries sources modelDescription.xml DoublePendulum.fmu DoublePendulum_me_FMU.mo DoublePendulum.lib* DoublePendulum.so DoublePendulum.dll DoublePendulum_*.c DoublePendulum_*.h DoublePendulum_*.o DoublePendulum_*.json documentation resources
 // cflags: -d=-newInst
 // Simulation Results
 // Modelica Standard Library

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
@@ -1,7 +1,7 @@
 // name:     Pendulum
 // keywords: Pendulum FMI-Export FMI-Import
 // status: correct
-// teardown_command: rm -rf Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.* Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum_* binaries sources modelDescription.xml Pendulum.fmu Pendulum_me_FMU.mo Pendulum.lib* Pendulum.so Pendulum.dll Pendulum_*.c Pendulum_*.h Pendulum_*.o Pendulum_*.json
+// teardown_command: rm -rf Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.* Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum_* binaries sources modelDescription.xml Pendulum.fmu Pendulum_me_FMU.mo Pendulum.lib* Pendulum.so Pendulum.dll Pendulum_*.c Pendulum_*.h Pendulum_*.o Pendulum_*.json documentation resources
 // cflags: -d=-newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/TestSourceCodeFMU.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/TestSourceCodeFMU.mos
@@ -1,5 +1,6 @@
 // keywords: fmu export import
 // status: correct
+// teardown_command: rm -rf TestSourceCodeFMU.fmu TestSourceCodeFMU_me_FMU.mo TestSourceCodeFMU.log TestSourceCodeFMU_info.json binaries sources resources documentation modelDescription.xml
 // cflags: -d=-newInst
 
 setCFlags(getCFlags() + " -g"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ZeroStates.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ZeroStates.mos
@@ -1,7 +1,7 @@
 // name:     ZeroStates
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml ZeroStates20.fmu ZeroStates20* ZeroStates20/* output.log
+// teardown_command: rm -rf binaries sources modelDescription.xml ZeroStates20.fmu ZeroStates20* ZeroStates20/* output.log resources
 // cflags: -d=-newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi2_array_attributes.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 2.0 export array nominal scalarized
 // suite: fmuCSources
 // status: correct
-// teardown_command: rm -rf fmi2_array_attributes.fmu fmi2_array_attributes.fmutmp/ fmi2_array_attributes.dims fmi2_array_attributes.log fmi2_array_attributes_info.json fmi2_array_attributes_me_FMU* fmi2_array_attributes_res.mat index.html
+// teardown_command: rm -rf fmi2_array_attributes.fmu fmi2_array_attributes.fmutmp/ fmi2_array_attributes.dims fmi2_array_attributes.log fmi2_array_attributes_info.json fmi2_array_attributes_me_FMU* fmi2_array_attributes_res.mat index.html binaries sources modelDescription.xml
 //
 // Regression test for #15926. A scalarized array variable whose nominal/min
 // attribute is bound to a parameter must not be marked as a runtime array in

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_import_boolean.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_import_boolean.mos
@@ -1,0 +1,68 @@
+// name:     fmi_import_boolean
+// keywords: fmu export import boolean
+// status:   correct
+// teardown_command: rm -rf binaries sources modelDescription.xml BooleanImportFMU* BooleanImport* output.log
+// cflags:   -d=-newInst
+//
+// A Modelica boolean is a modelica_boolean, i.e. an int, but the FMI import runtime used to
+// exchange the boolean arrays with the generated wrapper as signed char, so it wrote one byte
+// into every four byte slot and the rest of each element stayed uninitialized. Three booleans
+// are used on purpose: a single one survived the mismatch by accident on a little endian
+// machine.
+//
+
+loadString("
+model BooleanImportFMU
+  parameter Boolean bp1 = false;
+  parameter Boolean bp2 = false;
+  parameter Boolean bp3 = true;
+  Boolean bo1;
+  Boolean bo2;
+  Boolean bo3;
+equation
+  bo1 = not bp1;
+  bo2 = bp2 and bp3;
+  bo3 = bp1 or bp2;
+end BooleanImportFMU;
+"); getErrorString();
+
+buildModelFMU(BooleanImportFMU, version="2.0", fmuType="me"); getErrorString();
+importFMU("BooleanImportFMU.fmu"); getErrorString();
+loadFile("BooleanImportFMU_me_FMU.mo"); getErrorString();
+
+loadString("
+model BooleanImport
+  BooleanImportFMU_me_FMU fmu(bp1 = true, bp2 = true, bp3 = false);
+end BooleanImport;
+"); getErrorString();
+
+simulate(BooleanImport, stopTime=0.0); getErrorString();
+
+// bo1 = not true = false, bo2 = true and false = false, bo3 = true or true = true
+val(fmu.bo1, 0.0);
+val(fmu.bo2, 0.0);
+val(fmu.bo3, 0.0);
+
+// Result:
+// true
+// ""
+// "BooleanImportFMU.fmu"
+// ""
+// "BooleanImportFMU_me_FMU.mo"
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "BooleanImport_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'BooleanImport', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 1.0
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/issue10978.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/issue10978.mos
@@ -1,7 +1,7 @@
 // name:     issue10978
 // keywords: fmi assert null threadData
 // status: correct
-// teardown_command: rm -rf issue10978.fmu issue10978_me_FMU* output.log
+// teardown_command: rm -rf issue10978.fmu issue10978_me_FMU* output.log binaries sources modelDescription.xml resources
 // cflags: -d=-newInst
 
 loadString("

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testAssert.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testAssert.mos
@@ -1,7 +1,7 @@
 // name:     testAssert
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml testAssertFMI* output.log testAssertFMI/*
+// teardown_command: rm -rf binaries sources modelDescription.xml testAssertFMI* output.log testAssertFMI/* resources
 // cflags: -d=-newInst
 
 loadString("

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3034.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3034.mos
@@ -1,7 +1,7 @@
 // name:  testBug3034
 // keywords: FMI 2.0 export
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_Bug3034* output.log
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_Bug3034* output.log resources
 // cflags: -d=-newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3763.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3763.mos
@@ -1,4 +1,5 @@
 // status: correct
+// teardown_command: rm -rf DrumBoiler.fmu DrumBoiler.log DrumBoiler_info.json binaries sources resources documentation modelDescription.xml
 // cflags: -d=-newInst
 
 loadModel(Modelica, {"3.2.3"});getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
@@ -1,7 +1,7 @@
 // name:  testBug5673
 // keywords: FMI 2.0 export
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5673.xml
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5673.xml aliasCheck.test2.fmu
 // cflags: -d=-newInst,omedit
 
 loadString("

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
@@ -1,7 +1,7 @@
 // name:  testChangeParam
 // keywords: FMI 2.0 export
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_ChangeParam* output.log
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml test_ChangeParam* output.log resources
 // cflags: -d=-newInst
 //
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testInitialEquationsFMI.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testInitialEquationsFMI.mos
@@ -1,7 +1,7 @@
 // name:     testInitialEquationsFMI
 // keywords: initialization, start values, initial equation, fmi
 // status:   correct
-// teardown_command: rm -rf initializationTestsFMI.initial_equation* initial_equation* output.log
+// teardown_command: rm -rf initializationTestsFMI.initial_equation* initial_equation* output.log binaries sources modelDescription.xml resources
 // cflags: -d=-newInst
 //
 //  test start values and initial equations

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
@@ -1,7 +1,7 @@
 // name:  ticket5670
 // keywords: FMI 2.0 export
 // status: correct
-// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5670.xml
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5670.xml ticket5670.fmu
 // cflags: -d=-newInst,omedit
 
 loadString("

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -6,6 +6,7 @@ fmi3_array_attributes_nb.mos \
 fmi3_array_nonscalarized.mos \
 fmi3_arrays.mos \
 fmi3_import_me.mos \
+fmi3_import_boolean.mos \
 fmi3_arrays_approx.mos \
 fmi3_arrays_start_vector.mos \
 fmi3_attributes_01.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 3.0 export array nominal scalarized
 // suite: fmuCSources
 // status: correct
-// teardown_command: rm -rf fmi3_array_attributes.fmu fmi3_array_attributes.fmutmp/ fmi3_array_attributes.dims fmi3_array_attributes.log fmi3_array_attributes_info.json index.html
+// teardown_command: rm -rf fmi3_array_attributes.fmu fmi3_array_attributes.fmutmp/ fmi3_array_attributes.dims fmi3_array_attributes.log fmi3_array_attributes_info.json index.html fmi3_array_attributes_FMU.libs fmi3_array_attributes_FMU.makefile fmi3_array_attributes_external_functions.json resources
 //
 // #15926, FMI 3.0, old backend, scalarized (default), C runtime. A scalarized
 // array element must not be dimensioned in the exported FMU init.

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes_nb.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_attributes_nb.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 3.0 export array nominal scalarized NewBackend
 // suite: fmuCSources
 // status: correct
-// teardown_command: rm -rf fmi3_array_attributes_nb.fmu fmi3_array_attributes_nb.fmutmp/ fmi3_array_attributes_nb.dims fmi3_array_attributes_nb.log fmi3_array_attributes_nb_info.json index.html
+// teardown_command: rm -rf fmi3_array_attributes_nb.fmu fmi3_array_attributes_nb.fmutmp/ fmi3_array_attributes_nb.dims fmi3_array_attributes_nb.log fmi3_array_attributes_nb_info.json index.html fmi3_array_attributes_nb_FMU.libs fmi3_array_attributes_nb_FMU.makefile fmi3_array_attributes_nb_external_functions.json resources
 //
 // #15926, FMI 3.0, new backend, scalarized (default), C runtime. A scalarized
 // array element must not be dimensioned in the exported FMU init.

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_nonscalarized.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_array_nonscalarized.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 3.0 export array non-scalarized NewBackend
 // suite: fmuCSources
 // status: correct
-// teardown_command: rm -rf fmi3_array_nonscalarized.fmu fmi3_array_nonscalarized.fmutmp/ fmi3_array_nonscalarized.dims fmi3_array_nonscalarized.xml fmi3_array_nonscalarized_tmp.xml fmi3_array_nonscalarized.log fmi3_array_nonscalarized_info.json index.html
+// teardown_command: rm -rf fmi3_array_nonscalarized.fmu fmi3_array_nonscalarized.fmutmp/ fmi3_array_nonscalarized.dims fmi3_array_nonscalarized.xml fmi3_array_nonscalarized_tmp.xml fmi3_array_nonscalarized.log fmi3_array_nonscalarized_info.json index.html fmi3_array_nonscalarized_FMU.libs fmi3_array_nonscalarized_FMU.makefile fmi3_array_nonscalarized_external_functions.json resources
 //
 // #15926, FMI 3.0, new backend, non-scalarized arrays (--simCodeScalarize=false),
 // C runtime. The array is exported as one native FMI 3.0 Float64 with a

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays.mos
@@ -1,7 +1,7 @@
 // name: fmi3_arrays.mos
 // keywords: FMI 3.0 export array
 // status: correct
-// teardown_command: rm -rf fmi3_arrays.fmu fmi3_arrays.xml fmi3_arrays_tmp.xml fmi3_arrays.fmutmp/ fmi3_arrays.log fmi3_arrays_info.json index.html
+// teardown_command: rm -rf fmi3_arrays.fmu fmi3_arrays.xml fmi3_arrays_tmp.xml fmi3_arrays.fmutmp/ fmi3_arrays.log fmi3_arrays_info.json index.html fmi3_arrays_FMU.libs fmi3_arrays_FMU.makefile fmi3_arrays_external_functions.json resources
 //
 // Native FMI 3.0 array variables exported with the new backend
 // (--newBackend --simCodeScalarize=false): one typed element with one value

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays_approx.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays_approx.mos
@@ -1,7 +1,7 @@
 // name: fmi3_arrays_approx.mos
 // keywords: FMI 3.0 export array initial approx
 // status: correct
-// teardown_command: rm -rf fmi3_arrays_approx.fmu fmi3_arrays_approx.xml fmi3_arrays_approx_tmp.xml fmi3_arrays_approx.fmutmp/ fmi3_arrays_approx.log fmi3_arrays_approx_info.json index.html
+// teardown_command: rm -rf fmi3_arrays_approx.fmu fmi3_arrays_approx.xml fmi3_arrays_approx_tmp.xml fmi3_arrays_approx.fmutmp/ fmi3_arrays_approx.log fmi3_arrays_approx_info.json index.html fmi3_arrays_approx_FMU.libs fmi3_arrays_approx_FMU.makefile fmi3_arrays_approx_external_functions.json resources
 //
 // FMI 3.0 native array state with an unfixed start value (fixed = false). The
 // start is a guess, so the continuous-time state must be exported with

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays_start_vector.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_arrays_start_vector.mos
@@ -1,7 +1,7 @@
 // name: fmi3_arrays_start_vector.mos
 // keywords: FMI 3.0 export array start vector
 // status: correct
-// teardown_command: rm -rf fmi3_arrays_start_vector.fmu fmi3_arrays_start_vector.xml fmi3_arrays_start_vector_tmp.xml fmi3_arrays_start_vector.fmutmp/ fmi3_arrays_start_vector.log fmi3_arrays_start_vector_info.json index.html
+// teardown_command: rm -rf fmi3_arrays_start_vector.fmu fmi3_arrays_start_vector.xml fmi3_arrays_start_vector_tmp.xml fmi3_arrays_start_vector.fmutmp/ fmi3_arrays_start_vector.log fmi3_arrays_start_vector_info.json index.html fmi3_arrays_start_vector_FMU.libs fmi3_arrays_start_vector_FMU.makefile fmi3_arrays_start_vector_external_functions.json resources
 //
 // FMI 3.0 native array state with element-wise start values (start = {1,2,3}).
 // Checks the start attribute emitted for the array variable x.

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
@@ -1,7 +1,7 @@
 // name: fmi3_attributes_01.mos
 // keywords: FMI 3.0 export
 // status: correct
-// teardown_command: rm -rf fmi3_attributes_01.fmu fmi3_attributes_01.xml fmi3_attributes_01_tmp.xml fmi3_attributes_01.fmutmp/ fmi3_attributes_01_res.mat fmi3_attributes_01_fmpy.csv fmi3_attributes_01_diff.*.csv fmi3_attributes_01_info.json fmi3_attributes_01.log fmi3_attributes_01_*.bin index.html
+// teardown_command: rm -rf fmi3_attributes_01.fmu fmi3_attributes_01.xml fmi3_attributes_01_tmp.xml fmi3_attributes_01.fmutmp/ fmi3_attributes_01_res.mat fmi3_attributes_01_fmpy.csv fmi3_attributes_01_diff.*.csv fmi3_attributes_01_info.json fmi3_attributes_01.log fmi3_attributes_01_*.bin index.html fmi3_attributes_01_FMU.libs fmi3_attributes_01_FMU.makefile fmi3_attributes_01_external_functions.json resources
 
 setCommandLineOptions("-d=newInst"); getErrorString();
 

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_binary_extobj.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_binary_extobj.mos
@@ -1,7 +1,7 @@
 // name: fmi3_binary_extobj.mos
 // keywords: FMI 3.0 export ExternalObject Binary
 // status: correct
-// teardown_command: rm -rf M.fmu M.fmutmp/ M_md.xml M.log M_info.json index.html
+// teardown_command: rm -rf M.fmu M.fmutmp/ M_md.xml M.log M_info.json index.html M_FMU.libs M_FMU.makefile M_external_functions.json resources
 //
 // A Modelica ExternalObject is an opaque handle (void*). It is exported to FMI 3.0
 // as a <Binary> variable whose value is the raw handle bytes (fmi3GetBinary /

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_builddescription.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_builddescription.mos
@@ -2,7 +2,7 @@
 // keywords: FMI 3.0 export buildDescription source
 // suite: fmuCSources
 // status: correct
-// teardown_command: rm -rf Mbd.fmu Mbd.fmutmp/ Mbd_bd.xml Mbd.log Mbd_info.json index.html
+// teardown_command: rm -rf Mbd.fmu Mbd.fmutmp/ Mbd_bd.xml Mbd.log Mbd_info.json index.html Mbd_FMU.libs Mbd_FMU.makefile Mbd_external_functions.json resources
 //
 // FMI 3.0 source FMUs ship sources/buildDescription.xml describing how to build
 // them (the source file list that FMI 2.0 kept in modelDescription <SourceFiles>).

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_clocks.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_clocks.mos
@@ -1,7 +1,7 @@
 // name: fmi3_clocks.mos
 // keywords: FMI 3.0 export clocks synchronous
 // status: correct
-// teardown_command: rm -rf Mclk.fmu Mclk.fmutmp/ Mclk_md.xml Mclk.log Mclk_info.json index.html
+// teardown_command: rm -rf Mclk.fmu Mclk.fmutmp/ Mclk_md.xml Mclk.log Mclk_info.json index.html Mclk_FMU.libs Mclk_FMU.makefile Mclk_external_functions.json resources
 //
 // FMI 3.0 Clocks: a model clock (here a periodic Clock(0.1) driving sample())
 // is exported as an output <Clock> variable in modelDescription.xml with its

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_directional_derivatives.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_directional_derivatives.mos
@@ -1,7 +1,7 @@
 // name: fmi3_directional_derivatives.mos
 // keywords: FMI 3.0 export directional derivatives jacobian
 // status: correct
-// teardown_command: rm -rf Mdd.fmu Mdd.fmutmp/ Mdd_md.xml Mdd.log Mdd_info.json index.html
+// teardown_command: rm -rf Mdd.fmu Mdd.fmutmp/ Mdd_md.xml Mdd.log Mdd_info.json index.html Mdd_FMU.libs Mdd_FMU.makefile Mdd_external_functions.json resources
 //
 // FMI 3.0 directional derivatives. With -d=-disableDirectionalDerivatives the
 // FMIDER Jacobian is generated, the ModelExchange element advertises

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_fmustate.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_fmustate.mos
@@ -1,7 +1,7 @@
 // name: fmi3_fmustate.mos
 // keywords: FMI 3.0 export FMUState serialization
 // status: correct
-// teardown_command: rm -rf Mst.fmu Mst.fmutmp/ Mst_md.xml Mst.log Mst_info.json index.html
+// teardown_command: rm -rf Mst.fmu Mst.fmutmp/ Mst_md.xml Mst.log Mst_info.json index.html Mst_FMU.libs Mst_FMU.makefile Mst_external_functions.json resources
 //
 // FMI 3.0 FMU state: the runtime implements fmi3GetFMUState / fmi3SetFMUState /
 // fmi3FreeFMUState and fmi3SerializedFMUStateSize / fmi3SerializeFMUState /

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_graphics.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_graphics.mos
@@ -1,7 +1,7 @@
 // name: fmi3_graphics.mos
 // keywords: FMI 3.0 export graphics icon annotations terminals ports
 // status: correct
-// teardown_command: rm -rf GfxPorts.fmu GfxPorts.fmutmp/ GfxPorts.log GfxPorts_info.json index.html
+// teardown_command: rm -rf GfxPorts.fmu GfxPorts.fmutmp/ GfxPorts.log GfxPorts_info.json index.html GfxPorts_FMU.libs GfxPorts_FMU.makefile GfxPorts_external_functions.json resources
 //
 // FMI 3.0 graphical user annotations. The model Icon is rendered to
 // terminalsAndIcons/icon.png (+ icon.svg companion) and an FMI 3.0

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_boolean.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_boolean.mos
@@ -1,0 +1,71 @@
+// name:     fmi3_import_boolean
+// keywords: fmu export import boolean
+// status:   correct
+// teardown_command: rm -rf binaries sources modelDescription.xml terminalsAndIcons BooleanImportFMU* BooleanImport* output.log resources
+// cflags:   -d=-newInst
+//
+// A Modelica boolean is a modelica_boolean, i.e. an int, but the FMI import runtime used to
+// exchange the boolean arrays with the generated wrapper as signed char, so it wrote one byte
+// into every four byte slot and the rest of each element stayed uninitialized. Three booleans
+// are used on purpose: a single one survived the mismatch by accident on a little endian
+// machine.
+//
+
+loadString("
+model BooleanImportFMU
+  parameter Boolean bp1 = false;
+  parameter Boolean bp2 = false;
+  parameter Boolean bp3 = true;
+  Boolean bo1;
+  Boolean bo2;
+  Boolean bo3;
+equation
+  bo1 = not bp1;
+  bo2 = bp2 and bp3;
+  bo3 = bp1 or bp2;
+end BooleanImportFMU;
+"); getErrorString();
+
+buildModelFMU(BooleanImportFMU, version="3.0", fmuType="me"); getErrorString();
+importFMU("BooleanImportFMU.fmu"); getErrorString();
+loadFile("BooleanImportFMU_me_FMU.mo"); getErrorString();
+
+loadString("
+model BooleanImport
+  BooleanImportFMU_me_FMU fmu(bp1 = true, bp2 = true, bp3 = false);
+end BooleanImport;
+"); getErrorString();
+
+simulate(BooleanImport, stopTime=0.0); getErrorString();
+
+// bo1 = not true = false, bo2 = true and false = false, bo3 = true or true = true
+val(fmu.bo1, 0.0);
+val(fmu.bo2, 0.0);
+val(fmu.bo3, 0.0);
+
+// Result:
+// true
+// ""
+// "BooleanImportFMU.fmu"
+// ""
+// "BooleanImportFMU_me_FMU.mo"
+// "Warning: module = Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3ModelDescription.xsd' is ignored. Using standard fmiModelDescription.xsd., log level = WARNING: FMI3XML
+// "
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "BooleanImport_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'BooleanImport', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "module = FMI3XML, log level = WARNING: Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3ModelDescription.xsd' is ignored. Using standard fmiModelDescription.xsd.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_ASSERT        | debug   | fmi3SetContinuousStates failed with status : Error
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 1.0
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_boolean.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_boolean.mos
@@ -60,7 +60,6 @@ val(fmu.bo3, 0.0);
 //     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'BooleanImport', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "module = FMI3XML, log level = WARNING: Attribute noNamespaceSchemaLocation='https://raw.githubusercontent.com/modelica/fmi-standard/main/schema/fmi3ModelDescription.xsd' is ignored. Using standard fmiModelDescription.xsd.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_ASSERT        | debug   | fmi3SetContinuousStates failed with status : Error
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
@@ -6,7 +6,7 @@
 // the wrapper. The result is cos(t), which is what der(x) = v, der(v) = -x with
 // x(0) = 1 and v(0) = 0 has to give. See OpenModelica/OpenModelica#16173.
 //
-// teardown_command: rm -rf Osc3.fmu Osc3_me_FMU.mo Osc3_me_FMU* Osc3.log Osc3_info.json Osc3.fmutmp/ binaries sources documentation modelDescription.xml terminalsAndIcons resources
+// teardown_command: rm -rf Osc3.fmu Osc3_me_FMU.mo Osc3_me_FMU* Osc3.log Osc3_info.json Osc3.fmutmp/ binaries sources documentation modelDescription.xml terminalsAndIcons Osc3_FMU.libs Osc3_FMU.makefile Osc3_external_functions.json resources
 
 setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
 

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_import_me.mos
@@ -6,7 +6,7 @@
 // the wrapper. The result is cos(t), which is what der(x) = v, der(v) = -x with
 // x(0) = 1 and v(0) = 0 has to give. See OpenModelica/OpenModelica#16173.
 //
-// teardown_command: rm -rf Osc3.fmu Osc3_me_FMU.mo Osc3_me_FMU* Osc3.log Osc3_info.json Osc3.fmutmp/ binaries sources documentation modelDescription.xml
+// teardown_command: rm -rf Osc3.fmu Osc3_me_FMU.mo Osc3_me_FMU* Osc3.log Osc3_info.json Osc3.fmutmp/ binaries sources documentation modelDescription.xml terminalsAndIcons resources
 
 setCommandLineOptions("--allowNonStandardModelica=reinitInAlgorithms"); getErrorString();
 

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
@@ -1,7 +1,7 @@
 // name: fmi3_msl_adder4
 // keywords: FMI 3.0 export MSL Digital enumeration FMPy
 // status: correct
-// teardown_command: rm -rf Adder4.fmu Adder4.fmutmp/ Adder4_ref* Adder4_fmpy.csv Adder4_diff.*.csv Adder4_info.json *.log
+// teardown_command: rm -rf Adder4.fmu Adder4.fmutmp/ Adder4_ref* Adder4_fmpy.csv Adder4_diff.*.csv Adder4_info.json *.log Adder4_FMU.libs Adder4_FMU.makefile Adder4_external_functions.json resources
 //
 // MSL 4.1.0 round-trip check (discrete/digital model with enumeration variables):
 // export Modelica.Electrical.Digital.Examples.Adder4 as an FMI 3.0 Model Exchange

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
@@ -1,7 +1,7 @@
 // name: fmi3_msl_engine1a
 // keywords: FMI 3.0 export MSL MultiBody FMPy
 // status: correct
-// teardown_command: rm -rf Engine1a.fmu Engine1a.fmutmp/ Engine1a_ref* Engine1a_fmpy.csv Engine1a_diff.*.csv Engine1a_info.json *.log
+// teardown_command: rm -rf Engine1a.fmu Engine1a.fmutmp/ Engine1a_ref* Engine1a_fmpy.csv Engine1a_diff.*.csv Engine1a_info.json *.log Engine1a_FMU.libs Engine1a_FMU.makefile Engine1a_external_functions.json resources
 //
 // MSL 4.1.0 round-trip check (continuous MultiBody model): export
 // Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a as an FMI 3.0 Model

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals.mos
@@ -1,7 +1,7 @@
 // name: fmi3_terminals.mos
 // keywords: FMI 3.0 export terminals connector
 // status: correct
-// teardown_command: rm -rf Ctrl.fmu Ctrl.fmutmp/ Ctrl_term.xml Ctrl.log Ctrl_info.json index.html
+// teardown_command: rm -rf Ctrl.fmu Ctrl.fmutmp/ Ctrl_term.xml Ctrl.log Ctrl_info.json index.html Ctrl_FMU.libs Ctrl_FMU.makefile Ctrl_external_functions.json resources
 //
 // FMI 3.0 Terminals: variables that stem from a connector (detected from the
 // flat-model component type, i.e. a connector-typed cref qualifier) are grouped

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias.mos
@@ -1,7 +1,7 @@
 // name: fmi3_terminals_alias.mos
 // keywords: FMI 3.0 export terminals connector flange causalization
 // status: correct
-// teardown_command: rm -rf Inertia2.fmu Inertia2.fmutmp/ Inertia2_term.xml Inertia2.log Inertia2_info.json index.html
+// teardown_command: rm -rf Inertia2.fmu Inertia2.fmutmp/ Inertia2_term.xml Inertia2.log Inertia2_info.json index.html Inertia2_FMU.libs Inertia2_FMU.makefile Inertia2_external_functions.json resources
 //
 // FMI 3.0 flange causalization (issue #15686). A model with unconnected acausal
 // (physical) connectors is exported with a causal FMU boundary: the flow variable

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias_nb.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias_nb.mos
@@ -1,7 +1,7 @@
 // name: fmi3_terminals_alias_nb.mos
 // keywords: FMI 3.0 export terminals connector flange newBackend
 // status: correct
-// teardown_command: rm -rf Inertia2.fmu Inertia2.fmutmp/ Inertia2_term.xml Inertia2.log Inertia2_info.json index.html
+// teardown_command: rm -rf Inertia2.fmu Inertia2.fmutmp/ Inertia2_term.xml Inertia2.log Inertia2_info.json index.html Inertia2_FMU.libs Inertia2_FMU.makefile Inertia2_external_functions.json resources
 //
 // New-backend (--newBackend) counterpart of fmi3_terminals_alias.mos. The FMI 3.0
 // terminals, variableKind (inflow for the flow member, signal for the potential),

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_types.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_types.mos
@@ -1,7 +1,7 @@
 // name: fmi3_types.mos
 // keywords: FMI 3.0 export typed variables
 // status: correct
-// teardown_command: rm -rf fmi3_types.fmu fmi3_types.xml fmi3_types_tmp.xml fmi3_types.fmutmp/ fmi3_types.log fmi3_types_info.json index.html
+// teardown_command: rm -rf fmi3_types.fmu fmi3_types.xml fmi3_types_tmp.xml fmi3_types.fmutmp/ fmi3_types.log fmi3_types_info.json index.html fmi3_types_FMU.libs fmi3_types_FMU.makefile fmi3_types_external_functions.json resources
 
 setCommandLineOptions("-d=newInst"); getErrorString();
 


### PR DESCRIPTION
Fixes #16354, and two further defects found in the same code while fixing it.

---

## 1. Parameter modifiers are applied after initialization (#16354)

When an FMU is imported for Model Exchange, the generated wrapper calls the `fmiSet*Parameter`
helpers **after** the FMU has already finished initialising:

```
flowStartTime           := fmi2SetupExperiment(...)
flowEnterInitialization := fmi2EnterInitialization(...)
flowInitialized         := fmi2ExitInitialization(...)   // the FMU initialises here
flowParamsStart         := fmi2SetRealParameter(...)     // the modifier arrives too late
```

Everything the FMU derives from a parameter — its `calculatedParameter`s — is therefore
computed from the **default** values. The wrapper-level parameter shows the modifier, the
value the FMU computed from it does not.

Reported for FMI 2.0, but the same ordering is copy-pasted into all three Model Exchange
import templates: FMI 1.0 sets the parameters after `fmi1Initialize`, FMI 2.0 and FMI 3.0
after `fmi*ExitInitialization`.

Reproducer from the issue:

```mo
model FMU_mo
  parameter Real par = 4;
  Real x;
equation
  x = par;
end FMU_mo;
```

exported as FMI 2.0, imported again, then instantiated with a modifier:

```mo
model MWE
  FMU_mo_me_FMU FMU_mo_me_FMU1(par = 5);
end MWE;
```

gives `par = 5` but `x = 4`.

**Fix.** In `OMCompiler/Compiler/Template/CodegenFMU.tpl` the four
`Set{Real,Integer,Boolean,String}Parameter` calls now run while the FMU can still accept them:
before `fmi1Initialize` for FMI 1.0, and between `Enter` and `ExitInitialization` for FMI 2.0
and FMI 3.0. Setting a `causality="parameter"` variable inside Initialization Mode is allowed
by both the FMI 2.0 and FMI 3.0 state machines. No new flow variable was needed — the setters
already assign `flowParamsStart`, which the `ExitInitialization` argument sums, so the
ordering dependency carries over. `flowInitInputs := 1;` also moved above its first use in the
FMI 1.0 template, where it was read by the `fmi1Initialize` argument before being assigned.

`importFMU1CoSimulationStandAlone` never emits parameter setters at all, so there was nothing
to reorder there. That remains a separate gap.

**Verified** in both directions for each version, with
`parameter Real par = 4; Real x; x = 2*par;` exported, imported and instantiated with
`par = 5`. The pre-fix numbers for FMI 1.0 and 3.0 come from reverting the *generated wrapper*
to the old statement order and re-simulating, so no second compiler build was needed.

| import | before | after |
| --- | --- | --- |
| FMI 1.0 ME | `x = 8` | `x = 10` |
| FMI 2.0 ME | `x = 8` | `x = 10` |
| FMI 3.0 ME | `x = 8` | `x = 10` |

The issue's own model gives `x = 4` before and `x = 5` after.

Test: `testsuite/openmodelica/fmi/ModelExchange/2.0/Issue16354.mos`. It exports an FMU
carrying a Real, Integer, Boolean and String parameter, so all four setters are emitted and
covered, and checks the two values the FMU calculates from the modified Real and Integer
parameters.

---

## 2. Booleans read back from an imported FMU are uninitialized garbage

While writing the test above, a `Boolean` local of an imported FMU turned out to read back as
garbage that differs on every run:

```mo
model M
  parameter Boolean bp = false;
  Boolean bx;
equation
  bx = not bp;
end M;
```

exported as FMI 2.0 ME and imported gives `bx = -8.06e8`, `1.93e9`, ... instead of `true`.

`modelica_boolean` is `int` (`openmodelica_types.h:106`) and OM's external-`C` mapping passes
Boolean arrays as `int*` — the prototypes OM generates for its own FMUs say so:

```c
extern void fmi2GetBoolean_OMC(..., int* /*_booleanValues*/);
```

but the import runtime declared those parameters `signed char*` and wrote one byte per
four-byte slot, leaving three bytes of every element uninitialized. All three versions were
wrong, each in a different way:

| | Modelica side | FMI side | what the wrapper did |
| --- | --- | --- | --- |
| FMI 1.0 | `int*` ok | `fmi1_boolean_t` = `char` | cast the `int*` buffer straight to `char*` |
| FMI 2.0 | `signed char*` wrong | `fmi2_boolean_t` = `int` | truncated `int`→`char` into an `int` array |
| FMI 3.0 | `signed char*` wrong | `fmi3_boolean_t` = `bool` | wrote `signed char` into an `int` array |

**Fix** in `FMI1Common.c`, `FMI2Common.c` and `FMI3Common.c`: the Modelica-facing arrays are
`int*` everywhere, and each version converts element-wise through a correctly typed
`fmi*_boolean_t` scratch buffer using `fmi*_true`/`fmi*_false`, so neither side depends on
what the other typedefs its boolean to. The FMI 1.0 get/set also needed the Model
Exchange/Co-Simulation instance lookup factored into a helper so the scratch buffer is not
duplicated per branch.

**Verified** with three booleans — a single one survives the mismatch by accident on a little
endian machine. Expected `false, false, true`:

| import | before | after |
| --- | --- | --- |
| FMI 1.0 ME | `1.909e9, 1.909e9, 29621` | `false, false, true` |
| FMI 2.0 ME | `0, -1.795e9, 30420` | `false, false, true` |
| FMI 3.0 ME | `0, -4.865e8, 29621` | `false, false, true` |

The FMI 1.0 and 2.0 "before" columns are from an unpatched build. FMI 3.0 import does not
exist there, so its "before" came from reverting `FMI3Common.c` alone and rebuilding.

Tests: `fmi1_import_boolean.mos`, `fmi_import_boolean.mos` and `fmi3_import_boolean.mos` in
the three `testsuite/openmodelica/fmi/ModelExchange/<version>` directories.

---

## 3. FMI 1.0 Co-Simulation import calls its setters with the wrong arity

All four `fmi1Set*_OMC` calls in `importFMU1CoSimulationStandAlone` passed the function's own
`out_Values` output as an extra argument:

```mo
output Real out_Values[size(realValuesReferences, 1)];
external "C" fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, out_Values, 2);
```

while the runtime function takes five parameters ending in `fmiType`. So `fmiType` received
`out_Values` instead of the literal `2`, matched neither branch, and every setter silently did
nothing. `fmi1SetInteger` additionally declared `output Real` while the wrapper assigns its
result to `Integer` variables.

**Fix**: mirror the Model Exchange form — bind the output (`= <inputValues>`) and drop it from
the external call.

**Verified** end to end with a purpose-built FMI 1.0 Co-Simulation FMU carrying one input and
one output of Real, Integer and Boolean type. OM cannot export FMI 1.0 Co-Simulation FMUs, and
the two fmusdk FMUs in the testsuite ship win32 binaries only and have no inputs, so the FMU
was built for linux64 from the fmusdk 1.0.2 template that ships inside `vanDerPol.fmu`.

- unpatched: the import fails outright with
  `Internal error SimCodeUtil.createEquationsForSystems failed`, so an FMI 1.0 CS FMU with any
  input could not be imported at all.
- patched: it simulates, and `ry = 8 = 2*4`, `iy = 15 = 3*5`, `by = false = not true` — all
  three inputs reach the FMU.

Test: `testsuite/openmodelica/fmi/CoSimulationStandAlone/fmi1_cs_import_setters.mos`. The
`fmi1Functions` package is emitted whatever the FMU contains, so importing one of the fmusdk
FMUs that already ship with the testsuite generates the code this fix touches. Only the
generated wrapper is inspected, never simulated, so that FMU's win32-only binaries do not
matter and nothing prebuilt has to be added to the repository. Each setter call is matched
exactly, so reintroducing the extra `out_Values` argument turns the 1 match into 0 rather than
still matching loosely — all five patterns return 0 matches on an unpatched compiler and 1
here.

This also activates the `CoSimulationStandAlone` directory, whose `TESTFILES` was empty.

---

## 4. FMI 3.0 import calls into an FMU that has no continuous states

`fmi2SetContinuousStates_OMC` guards its call with `numberOfContinuousStates > 0`, but the
FMI 3.0 twin guarded only on the solving mode. An imported FMU with no continuous states was
therefore asked to set 0 states, returned `fmi3Error`, and `ModelicaFormatError` turned that
into an abort:

```
LOG_ASSERT | debug | fmi3SetContinuousStates failed with status : Error
```

The bad call happened on every run. Whether it was fatal depended on the build: a gcc-built
runtime carried on to the end of the simulation, a clang-built one died there and left no
result file — which is why this showed up in CI while passing locally.

`SetContinuousStates`, `GetContinuousStates` and `GetContinuousStateDerivatives` are now
guarded on `numberOfContinuousStates > 0`, and `GetEventIndicators` on
`numberOfEventIndicators > 0`, so an FMU is never handed a zero-length array. FMI 2.0 already
behaves this way and `ZeroStates.mos` covers it there; the new `fmi3_import_boolean` is the
first FMI 3.0 *import* test with no continuous states, which is why nothing caught this
before. Its expected output had the error line baked into it and is regenerated.

---

## 5. Testsuite leftovers

No teardown_command in `testsuite/openmodelica/fmi/ModelExchange/3.0` listed the
`<Model>_FMU.libs`, `<Model>_FMU.makefile` and `<Model>_external_functions.json` files the FMU
build drops next to the `.fmu`, nor the `resources/` directory it writes the jacobian binaries
into. They accumulate in the source tree, and because the tests export FMUs from the working
directory, a stray directory left by one test gets packed into the FMU of the next one.

That is not hypothetical: `fmi3_import_me` unzips a `terminalsAndIcons/` from the FMU it
imports and never removed it, so the next test's exported FMU carried it and its log filled
with unrelated `FMI3XML` "Unknown attribute" errors. That is what made the new FMI 3.0 boolean
test's expected output wrong the first time round.

`teardown_command` runs unconditionally, before rtest looks at the result, so this also cleans
up after failing tests — which is where most of the accumulated leftovers came from. The
entries are named explicitly rather than globbed on the model name: for tests such as
`fmi3_array_attributes` the model is named after the test, so `<Model>*` would match the `.mos`
source itself.

`ModelExchange/2.0` had the same problem in nineteen tests, attributed the same way — by
running each test on its own from a clean directory and diffing the directory contents:

| leftover | tests |
| --- | --- |
| `binaries/`, `sources/`, `modelDescription.xml` | `fmi2_array_attributes`, `Issue13905`, `Issue13905_pool_expand`, `issue10978`, `testInitialEquationsFMI`, `TestSourceCodeFMU` |
| `documentation/` | `IntegerNetwork1`, `DoublePendulum`, `Pendulum`, `ChuaCircuit` |
| `resources/` | those four plus `HelloFMIWorldEvent`, `testAssert`, `testBug3034`, `testChangeParam`, `ZeroStates`, `issue10978`, `testInitialEquationsFMI`, `TestSourceCodeFMU` |
| a stray `.fmu` or wrapper `.mo` | `testBug3763`, `testBug5673`, `ticket5670`, `TestSourceCodeFMU` |

`testBug3763` and `TestSourceCodeFMU` had no `teardown_command` at all, so both got one.
`FMUResourceTest` does `mkdir("@")` and `cd("@")` and builds inside that directory, so its
existing patterns never matched anything and the directory itself was never removed.

The `*.log`, `*_info.json` and `*.bin` files these directories also produce are left alone:
`testsuite/.gitignore` already covers them.

`ModelExchange/1.0` needed nothing beyond the new test's own teardown; the existing tests there
already use broad globs.

`CoSimulation/2.0` had one more: `Issue14456`'s teardown listed `model_res.mat`, but
OMSimulator writes the result as `roomM370_res.mat`, so it was never removed.

Every directory in `testsuite/openmodelica/fmi` now runs with nothing left behind, verified by
running each test on its own from a clean directory and by a full pass of the tree.

---

## Test results

The whole `testsuite/openmodelica/fmi/**` tree passes, and the ModelExchange directories are
now left clean afterwards.

| directory | result |
| --- | --- |
| `CoSimulation/2.0` | 9/9 |
| `CoSimulation/3.0` | 2/2 |
| `CoSimulationStandAlone` | 1/1 |
| `ModelExchange/1.0` | 4/4 |
| `ModelExchange/2.0` | 70/70 |
| `ModelExchange/3.0` | 21/21 |
| `ScheduledExecution/3.0` | 1/1 |

Note that `Compiler/Template/Codegen*.mo` is gitignored and regenerated by the build, so only
the `.tpl` is committed.

---
generated by Claude Code
