### PR TITLE
wasm-jit: interactive-API test parity with C

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -745,32 +745,74 @@ fn resolve_overrides(
     model: &SimModel,
     flags: &simflags::SimFlags,
 ) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
-    let mut params = Vec::new();
-    let mut starts = Vec::new();
+    let raw = flags.override_raw.as_deref();
+    let file = flags.override_file.as_ref();
+    if let (Some(raw), Some((path, _))) = (raw, file) {
+        omclog::info(omclog::SOLVER, false, &format!("using -override={raw} and -overrideFile={path}"));
+    }
+    if let Some((path, _)) = file {
+        omclog::info(omclog::SOLVER, false, &format!("read override values from file: {path}"));
+    }
+    if raw.is_none() && file.is_none() {
+        omclog::info(omclog::SOLVER, false, "NO override given on the command line.");
+        return (Vec::new(), Vec::new());
+    }
+    let given = |v: Option<&str>| v.unwrap_or("[not given]").to_string();
+    omclog::info(omclog::SOLVER, false, &format!("-override={}", given(raw)));
+    omclog::info(omclog::SOLVER, false, &format!("-overrideFile={}", given(file.map(|(_, j)| j.as_str()))));
+
+    // C fills a hash map, so a repeated name keeps the last value and warns.
+    let mut map: Vec<(&str, &str)> = Vec::new();
     for (name, val) in &flags.overrides {
-        if let Some(p) = model.editable_params.iter().find(|p| &p.name == name) {
-            let v = p.read_value(val);
-            if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, v));
+        match map.iter_mut().find(|(n, _)| *n == name) {
+            Some((_, old)) => {
+                omclog::warning(
+                    omclog::STDOUT,
+                    false,
+                    &format!("You are overriding variable: {name}={old} again with {name}={val}."),
+                );
+                *old = val;
+            }
+            None => map.push((name, val)),
         }
     }
-    let editable = |n: &str| model.editable_params.iter().any(|p| p.name == n);
-    let mut refused: Vec<&str> = Vec::new();
+
+    let mut params = Vec::new();
+    let mut starts = Vec::new();
+    let mut used: Vec<&str> = Vec::new();
+    // C's `singleOverride` walks the `_init.xml` quantities in class order.
     for v in &model.result_vars {
-        if flags.overrides.iter().any(|(o, _)| *o == v.name) && !editable(&v.name) {
-            refused.push(&v.name);
+        let Some(&(name, val)) = map.iter().find(|(n, _)| *n == v.name) else { continue };
+        used.push(name);
+        let Some(p) = model.editable_params.iter().find(|p| p.name == name) else {
             omclog::warning(
                 omclog::STDOUT,
                 false,
                 &format!(
-                    "It is not possible to override the following quantity: {}\nIt seems to be \
+                    "It is not possible to override the following quantity: {name}\nIt seems to be \
                      structural, final, protected or evaluated or has a non-constant binding.",
-                    v.name
+                ),
+            );
+            continue;
+        };
+        omclog::info(omclog::SOLVER, false, &format!("override {name} = {val}"));
+        // C warns only for the real and integer parameters (`warn_small_override`).
+        let numeric_param = !p.is_start && (p.wty == WTy::F64 || !p.is_bool);
+        if numeric_param && val.parse::<f64>().is_ok_and(|v| v.abs() < 1e-6) {
+            omclog::warning(
+                omclog::STDOUT,
+                false,
+                &format!(
+                    "You are overriding {name} with a small value or zero.\nThis could lead to \
+                     numerically dirty solutions or divisions by zero if not tearingStrictness=veryStrict.",
                 ),
             );
         }
+        let v = p.read_value(val);
+        if p.is_start { &mut starts } else { &mut params }.push((p.off, p.wty, v));
     }
-    for (name, _) in &flags.overrides {
-        if !editable(name) && !refused.contains(&name.as_str()) {
+    for (name, _) in &map {
+        if !used.contains(name) {
             omclog::warning(
                 omclog::STDOUT,
                 false,
@@ -778,6 +820,7 @@ fn resolve_overrides(
             );
         }
     }
+    omclog::info(omclog::SOLVER, false, "override done!");
     (params, starts)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -501,6 +501,16 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_div_sim", &[WTy::F64, WTy::F64, WTy::I32, WTy::F64, WTy::I32], &[WTy::F64]),
     // System `k`'s solver state (address, size), for `rt_nls_clean_history`.
     ("rt_nls_register", &[WTy::I32, WTy::I32, WTy::I32], &[]),
+    // `rt_nls_note_assert` plus C's log line for the absorbed assertion:
+    // `(msg, file, sline, scol, eline, ecol, isReadOnly, cond, initial, sim_data)`.
+    (
+        "rt_nls_assert_failed",
+        &[
+            WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32,
+            WTy::I32,
+        ],
+        &[],
+    ),
 ];
 
 /// Model global holding the base index at which this module's per-system
@@ -4109,22 +4119,42 @@ fn emit_assert(
         ctx.emit(we::Instruction::End);
         return Ok(());
     }
-    emit_nls_recoverable_return(ctx)?;
+    // C evaluates the message (`preExpMsg`) once, ahead of either arm.
     let mw = compile_exp(ctx, msg)?; // owned message String handle
     if mw != WTy::I32 {
         return Err("CodegenWasmJit: assert message is not a String");
     }
-    emit_str_literal(ctx, file.as_bytes())?; // file String handle
-    ctx.emit(we::Instruction::I32Const(info.lineNumberStart));
-    ctx.emit(we::Instruction::I32Const(info.columnNumberStart));
-    ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
-    ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
-    ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
-    if in_function {
-        ctx.emit(we::Instruction::I32Const(0));
-    } else {
-        emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
-    }
+    let msg_h = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(msg_h));
+    // Both arms take these; `initial` and `sim_data` follow.
+    let mut report_args = |ctx: &mut FnCtx| -> Result<()> {
+        ctx.emit(we::Instruction::LocalGet(msg_h));
+        emit_str_literal(ctx, file.as_bytes())?; // file String handle
+        ctx.emit(we::Instruction::I32Const(info.lineNumberStart));
+        ctx.emit(we::Instruction::I32Const(info.columnNumberStart));
+        ctx.emit(we::Instruction::I32Const(info.lineNumberEnd));
+        ctx.emit(we::Instruction::I32Const(info.columnNumberEnd));
+        ctx.emit(we::Instruction::I32Const(info.isReadOnly as i32));
+        if in_function {
+            ctx.emit(we::Instruction::I32Const(0));
+        } else {
+            emit_str_literal(ctx, dumped_exp(cond)?.as_bytes())?; // dumped condition, for the report
+        }
+        Ok(())
+    };
+    // A residual's own assert is C's `ERROR_NONLINEARSOLVER`: logged where it fires,
+    // then unwound into the solver.
+    ctx.emit(we::Instruction::Call(rt_index("rt_nls_recovering")?));
+    ctx.emit(we::Instruction::If(we::BlockType::Empty));
+    report_args(ctx)?;
+    emit_initial_flag(ctx);
+    emit_sim_data_or_zero(ctx);
+    ctx.emit(we::Instruction::Call(rt_index("rt_nls_assert_failed")?));
+    release_heap_locals(ctx)?;
+    push_outputs(ctx);
+    ctx.emit(we::Instruction::Return);
+    ctx.emit(we::Instruction::End);
+    report_args(ctx)?;
     emit_initial_flag(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     // Trap unless the driver took it (suppressed during the event search).
@@ -4133,6 +4163,14 @@ fn emit_assert(
     ctx.emit(we::Instruction::End);
     ctx.emit(we::Instruction::End);
     Ok(())
+}
+
+/// The running `SimData` pointer, or 0 outside a simulation.
+fn emit_sim_data_or_zero(ctx: &mut FnCtx) {
+    match ctx.sim.as_ref().map(|s| s.data_local) {
+        Some(data) => ctx.emit(we::Instruction::LocalGet(data)),
+        None => ctx.emit(we::Instruction::I32Const(0)),
+    }
 }
 
 /// A model error inside a nonlinear-solver residual is recoverable in C

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -59,10 +59,25 @@ fn step_size() -> f64 {
 
 /// C's `threadData->currentErrorStage`, as two words the driver stores into: `[0]`
 /// the stage, `[1]` set when a model error was absorbed there.
-/// `ERROR_NONLINEARSOLVER` is [`NLS_DEPTH`], the runtime's own nesting, instead.
 pub const ERROR_SIMULATION: u32 = 0;
 pub const ERROR_INTEGRATOR: u32 = 1;
+/// `solve_nonlinear_system`'s own region, which begins after C's `updateInnerEquation`.
+pub const ERROR_NONLINEARSOLVER: u32 = 2;
 static ERROR_STAGE: [AtomicU32; 2] = [AtomicU32::new(ERROR_SIMULATION), AtomicU32::new(0)];
+
+/// C's `saveJumpState`: the stage held over the solver region and put back after.
+struct StageGuard(u32);
+
+impl Drop for StageGuard {
+    fn drop(&mut self) {
+        ERROR_STAGE[0].store(self.0, Ordering::Relaxed);
+    }
+}
+
+fn enter_nls_stage() -> StageGuard {
+    let saved = ERROR_STAGE[0].swap(ERROR_NONLINEARSOLVER, Ordering::Relaxed);
+    StageGuard(saved)
+}
 
 /// Address of [`ERROR_STAGE`], so the driver marks a region with a store rather than
 /// a wasm call per evaluation (as for [`rt_context_addr`]).
@@ -149,13 +164,74 @@ fn attempt_aborted() -> bool {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_recovering() -> i32 {
     (NLS_DEPTH.load(Ordering::Relaxed) > 0
-        || ERROR_STAGE[0].load(Ordering::Relaxed) == ERROR_INTEGRATOR) as i32
+        || matches!(ERROR_STAGE[0].load(Ordering::Relaxed), ERROR_INTEGRATOR | ERROR_NONLINEARSOLVER))
+        as i32
 }
 
 /// Model side: flag that a recoverable assert fired at the current trial point.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_note_assert() {
     note_slot().store(1, Ordering::Relaxed);
+}
+
+/// Model side (emitted by `emit_assert`): a failed `assert()` the solver absorbs.
+/// C's `omc_assert_simulation` logs it where it fires, before the `longjmp` the
+/// solver catches. `sim_data` is 0 outside a simulation; the three String handles
+/// are this call's to release.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_assert_failed(
+    msg: i32,
+    file: i32,
+    sline: i32,
+    scol: i32,
+    eline: i32,
+    ecol: i32,
+    read_only: i32,
+    cond: i32,
+    initial: i32,
+    sim_data: i32,
+) {
+    // C's `longjmp` ends the evaluation at its first model error, so the asserts
+    // after it never run. Here every frame returns and the rest carries on, so
+    // report only what C's jump would have reached -- as [`throw_stream`] does.
+    let report = throw_reports() && assert_logged();
+    note_slot().store(1, Ordering::Relaxed);
+    if report {
+        use openmodelica_sim_meta::TIME_OFF;
+        use openmodelica_sim_meta::driver::{AssertInfo, log_assert_block};
+        let info = AssertInfo {
+            msg: rt_string(msg),
+            file: rt_string(file),
+            read_only: read_only != 0,
+            line_start: sline,
+            col_start: scol,
+            line_end: eline,
+            col_end: ecol,
+        };
+        let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
+        log_assert_block(&info, &rt_string(cond), time, initial != 0);
+    }
+    for h in [msg, file, cond] {
+        if h != 0 {
+            crate::rt_release(h as u32);
+        }
+    }
+}
+
+/// C's stage switch in `va_omc_assert_simulation_withEquationIndexes`.
+fn assert_logged() -> bool {
+    match ERROR_STAGE[0].load(Ordering::Relaxed) {
+        ERROR_NONLINEARSOLVER => crate::omclog::active(crate::omclog::NLS),
+        ERROR_INTEGRATOR => crate::omclog::active(crate::omclog::SOLVER),
+        _ => true,
+    }
+}
+
+fn rt_string(h: i32) -> alloc::string::String {
+    if h == 0 {
+        return alloc::string::String::new();
+    }
+    alloc::string::String::from_utf8_lossy(unsafe { crate::str_bytes(h as u32) }).into_owned()
 }
 
 /// Where [`rt_nls_note_assert`] records: the residual's own flag, or the
@@ -3286,6 +3362,8 @@ pub extern "C" fn rt_solve_nls(
     if log_nls {
         log_nls_enter(eq_index, time, &nlsx_old, &nominal);
     }
+    // C's `ERROR_NONLINEARSOLVER` region starts here, after `updateInnerEquation`.
+    let _stage = enter_nls_stage();
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
     // Last residual eval was at the returned `x`, so the epilogue need not repeat

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
@@ -407,15 +407,17 @@ pub fn getCheckpointMessages() -> Arc<List<TotalMessage>> {
     })
 }
 
-/// Drain and return all queued messages, oldest first (the newest message
-/// is consed last in `ErrorImpl__getMessages`, ending up at the tail).
+/// `Error_getMessages`: `listReverse(ErrorImpl__getMessages())`, so newest first.
 pub fn getMessages() -> Arc<List<TotalMessage>> {
     with_state(|s| {
-        let mut out = nil::<TotalMessage>();
+        let mut newest_first = Vec::with_capacity(s.queue.len());
         while !s.queue.is_empty() {
-            let total = s.queue.last().unwrap().as_total();
-            out = cons(total, out);
+            newest_first.push(s.queue.last().unwrap().as_total());
             pop_message(s, false);
+        }
+        let mut out = nil::<TotalMessage>();
+        for total in newest_first.into_iter().rev() {
+            out = cons(total, out);
         }
         out
     })

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -1516,7 +1516,7 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> Stri
     format!("{pos}\n{head}\n{body}")
 }
 
-fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
+pub fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
     let block = assert_block(info, cond, time, initial);
     // C's `assertCommonVar` (the math-domain guards, no condition and no source
     // position): the warning names the time, a debug line carries the message.
@@ -3951,6 +3951,7 @@ struct IdaCtx {
     sens: SensPush,
     /// `--daeMode` only; null for an explicit ODE.
     dae: *const DaeSolve,
+    ramp: LambdaRamp,
 }
 
 #[cfg(sundials)]
@@ -3961,7 +3962,32 @@ impl Default for IdaCtx {
             pattern: core::ptr::null(),
             sens: SensPush::default(),
             dae: core::ptr::null(),
+            ramp: LambdaRamp::default(),
         }
+    }
+}
+
+/// C's daeMode homotopy ramp (`ida_solver.c`): where the actual DAE Jacobian is
+/// singular at the start point, `lambda` is ramped 0 → 1 over the start of the
+/// interval with the integrator step capped. Armed only after IDA fails there.
+#[cfg(sundials)]
+#[derive(Clone, Copy, Default)]
+struct LambdaRamp {
+    /// `SimData` slot of `simulationInfo->lambda`.
+    off: u32,
+    start: f64,
+    /// Ramp window; 0 until armed.
+    tramp: f64,
+    active: bool,
+}
+
+#[cfg(sundials)]
+impl LambdaRamp {
+    fn lambda_at(&self, t: f64) -> Option<f64> {
+        if !self.active || self.tramp <= 0.0 {
+            return None;
+        }
+        Some(if t < self.start + self.tramp { (t - self.start) / self.tramp } else { 1.0 })
     }
 }
 
@@ -5211,7 +5237,10 @@ struct IdaState {
     atol: Vec<f64>,
     n_roots: usize,
     work_retries: u32,
+    /// C's `restartAfterLSFail`: the one `IDAReInit` retry a failed step gets.
+    restarted: bool,
     setup: IdaSetup,
+    stop_time: f64,
 }
 
 #[cfg(sundials)]
@@ -5266,6 +5295,7 @@ impl IdaState {
     ) -> Result<Progress> {
         self.ensure(e, sim_data, *t, y, yp, ctx)?;
         let ida = self.ida.as_mut().expect("built by `ensure`");
+        self.setup.finish_ramp(e, sim_data, ida, *t)?;
         unsafe { (*ctx).ida = self.setup.ctx(Some(ida)) };
         if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
             return Err("CodegenWasmJit: IDA setup failed");
@@ -5283,9 +5313,38 @@ impl IdaState {
                 self.work_retries += 1;
                 Progress::WorkQuota
             }
+            // C's `ida_solver_step`: one `IDAReInit` retry for a failed setup, or for
+            // the degenerate DAE start point the ramp recovers from.
+            crate::sundials::Stop::Failed(flag)
+                if !self.restarted
+                    && (flag == crate::sundials::IDA_LSETUP_FAIL
+                        || self.setup.ramp_recovers(flag, *t)) =>
+            {
+                if self.setup.ramp_recovers(flag, *t) {
+                    self.setup.arm_ramp(ida, self.stop_time);
+                    omclog::warning(
+                        omclog::SOLVER,
+                        false,
+                        &format!(
+                            "##IDA## degenerate DAE operating point at t = {} (flag {flag}); \
+                             activating homotopy ramp",
+                            format_g(*t, 15)
+                        ),
+                    );
+                }
+                ida.reinit(*t);
+                self.restarted = true;
+                omclog::warning(
+                    omclog::SOLVER,
+                    false,
+                    &format!("##IDA## solver failed, try once again at time = {}", format_g(*t, 15)),
+                );
+                Progress::WorkQuota
+            }
             crate::sundials::Stop::Failed(_) => Progress::Failed("CodegenWasmJit: IDA failed"),
             other => {
                 self.work_retries = 0;
+                self.restarted = false;
                 match other {
                     crate::sundials::Stop::Root => Progress::Root,
                     _ => Progress::Reached,
@@ -5493,7 +5552,9 @@ impl SolverCore {
                 atol,
                 n_roots: nrt as usize,
                 work_retries: 0,
+                restarted: false,
                 setup: IdaSetup::new(model)?,
+                stop_time: model.stop_time,
             }),
             _ => Solver::Daskr(DaskrState::new(model, n_states, nrt, rtol, atol)),
         };
@@ -7349,6 +7410,7 @@ struct IdaSetup {
     /// `--daeMode`: the residual and the unknown vector this IDA solves over;
     /// `None` for an explicit ODE.
     dae: Option<Box<DaeSolve>>,
+    ramp: LambdaRamp,
 }
 
 /// What the DAE-mode residual and Jacobian need beyond an ODE model's: the shape of
@@ -7511,6 +7573,7 @@ impl IdaSetup {
             sens_off: layout.sens_off,
             sens_scratch: vec![0.0; n_sens],
             dae,
+            ramp: LambdaRamp { off: layout.lambda_off, start: model.start_time, ..Default::default() },
         })
     }
 
@@ -7597,7 +7660,50 @@ impl IdaSetup {
                 None => SensPush::default(),
             },
             dae: self.dae.as_deref().map_or(core::ptr::null(), |d| d as *const DaeSolve),
+            ramp: self.ramp,
         }
+    }
+
+    /// C's `idaHomotopyRampRecovers`. The Jacobian is only singular to the accuracy
+    /// of the difference quotient, so a failed corrector counts as well as a failed
+    /// factorization.
+    fn ramp_recovers(&self, flag: core::ffi::c_int, t: f64) -> bool {
+        use crate::sundials::{IDA_CONV_FAIL, IDA_ERR_FAIL, IDA_LSETUP_FAIL};
+        self.dae.is_some()
+            && !self.ramp.active
+            && init_homotopy_steps() > 0
+            && matches!(flag, IDA_LSETUP_FAIL | IDA_CONV_FAIL | IDA_ERR_FAIL)
+            && t <= self.ramp.start
+    }
+
+    /// C's `idaActivateHomotopyRamp`.
+    fn arm_ramp(&mut self, ida: &mut crate::sundials::Ida, stop_time: f64) {
+        self.ramp.tramp = match env_var("OMC_DAE_HOMOTOPY_TRAMP").and_then(|v| v.parse().ok()) {
+            Some(v) => v,
+            None => 0.1 * (stop_time - self.ramp.start),
+        };
+        self.ramp.active = true;
+        if self.ramp.tramp > 0.0 {
+            ida.set_max_step(self.ramp.tramp / 50.0);
+        }
+    }
+
+    /// Past the ramp window: lift the step cap and pin lambda, as C does at the top
+    /// of `ida_solver_step`.
+    fn finish_ramp(
+        &mut self,
+        e: &mut dyn SimEngine,
+        sim_data: u32,
+        ida: &mut crate::sundials::Ida,
+        t: f64,
+    ) -> Result<()> {
+        if !(self.ramp.active && self.ramp.tramp > 0.0 && t >= self.ramp.start + self.ramp.tramp) {
+            return Ok(());
+        }
+        ida.set_max_step(0.0);
+        write_f64(e, sim_data + self.ramp.off, 1.0)?;
+        self.ramp.active = false;
+        Ok(())
     }
 }
 
@@ -7638,6 +7744,9 @@ unsafe fn ida_residual(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, 
         e.call1("functionUpdateBoundParameters", ctx.sim_data)?;
     }
     write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+    if let Some(lambda) = ctx.ida.ramp.lambda_at(t) {
+        write_f64(e, ctx.sim_data + ctx.ida.ramp.off, lambda)?;
+    }
     unsafe { ida_push_unknowns(ctx, y, yp) }?;
     if let Some(d) = unsafe { ctx.ida.dae.as_ref() } {
         e.call2(MODEL_FN_DAE, ctx.sim_data, eval_stage::DYNAMIC)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -207,6 +207,8 @@ struct State {
     level: [i16; N_STREAMS],
     last_type: [LogType; N_STREAMS],
     last_stream: Stream,
+    /// `-logFormat=xml`: C's `setStreamPrintXML(1)`.
+    xml: bool,
 }
 
 impl State {
@@ -218,6 +220,7 @@ impl State {
             level: [0; N_STREAMS],
             last_type: [0; N_STREAMS],
             last_stream: UNKNOWN,
+            xml: false,
         }
     }
 }
@@ -257,9 +260,16 @@ mod store {
 /// inherits an unclosed block.
 pub fn set_mask(m: Mask) {
     store::with(|s| {
+        let xml = s.xml;
         *s = State::new();
         s.use_stream = m;
+        s.xml = xml;
     });
+}
+
+/// C's `setStreamPrintXML`: write every message as a `<message …>` element.
+pub fn set_xml(v: bool) {
+    store::with(|s| s.xml = v);
 }
 
 pub fn mask() -> Mask {
@@ -334,26 +344,43 @@ pub fn error(stream: Stream, indent_next: bool, msg: &str) {
 
 /// C's `messageClose`: end a block opened with `indent_next`.
 pub fn close(stream: Stream) {
-    store::with(|s| {
-        if mask_has(s.use_stream, stream) {
+    let end = store::with(|s| {
+        if !mask_has(s.use_stream, stream) {
+            return false;
+        }
+        if !s.xml {
             s.level[stream as usize] -= 1;
         }
+        s.xml
     });
+    if end {
+        crate::driver::log_line("</message>\n");
+    }
 }
 
 /// C's `messageCloseWarning`: [`close`] for a block [`warning`] opened, so `-w`
 /// keeps the level balanced on an inactive stream.
 pub fn close_warning(stream: Stream) {
-    store::with(|s| {
-        if mask_has(s.use_stream, stream) || s.use_stream & SHOW_ALL_WARNINGS != 0 {
+    let end = store::with(|s| {
+        if !(mask_has(s.use_stream, stream) || s.use_stream & SHOW_ALL_WARNINGS != 0) {
+            return false;
+        }
+        if !s.xml {
             s.level[stream as usize] -= 1;
         }
+        s.xml
     });
+    if end {
+        crate::driver::log_line("</message>\n");
+    }
 }
 
 /// C's `messageText`. A newline in `msg` starts a `subline`: `|` in both header
 /// columns and no level indent, as C's recursive call gives.
 pub fn message_text(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
+    if store::with(|s| s.xml) {
+        return message_xml(ty, stream, indent_next, msg);
+    }
     let mut out = String::new();
     store::with(|s| {
         let i = stream as usize;
@@ -384,6 +411,26 @@ pub fn message_text(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
             s.level[i] += 1;
         }
     });
+    crate::driver::log_line(&out);
+}
+
+/// C's `messageXML`: the whole message as one element's `text` attribute, left
+/// open for [`close`] when `indent_next`.
+fn message_xml(ty: LogType, stream: Stream, indent_next: bool, msg: &str) {
+    let mut out = format!(
+        "<message stream=\"{}\" type=\"{}\" text=\"",
+        STREAM_NAME[stream as usize], TYPE_DESC[ty as usize]
+    );
+    for c in msg.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(c),
+        }
+    }
+    out.push_str(if indent_next { "\">\n" } else { "\" />\n" });
     crate::driver::log_line(&out);
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -129,6 +129,8 @@ pub struct SimFlags {
     /// `-w`: print warnings whose stream is inactive. Carried in
     /// [`log_mask`](Self::log_mask) as [`omclog::SHOW_ALL_WARNINGS`](crate::omclog::SHOW_ALL_WARNINGS).
     pub show_all_warnings: bool,
+    /// `-logFormat=xml`, installed by [`set_flags`] (C's `setStreamPrintXML`).
+    pub log_xml: bool,
     /// `-daeMode`, deprecated in C: `--daeMode` at translation is what selects it.
     pub dae_mode: bool,
     pub nls: Option<Nls>,
@@ -181,6 +183,10 @@ pub struct SimFlags {
     /// puts in the quantity's `start` attribute; reading it is the variable class's
     /// job, and an unresolvable name still has to be reported.
     pub overrides: Vec<(String, String)>,
+    /// C's `overrideStr1`: the raw `-override=` value, which `doOverride` logs.
+    pub override_raw: Option<String>,
+    /// C's `overrideStr2`: `-overrideFile`'s `(path, lines joined with commas)`.
+    pub override_file: Option<(String, String)>,
     /// `-output=a,b,c`: variables printed at the stop time (C's
     /// `outputVariablesAtEnd` / `writeOutputVars`).
     pub output_vars: Vec<String>,
@@ -641,13 +647,13 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
                         .map_err(|_| "-lvMaxWarn takes an integer argument".to_string())?,
                 )
             }
-            "override" => {
-                // C's `parseVariableStr` splits on commas outside `[]`.
-                for item in split_top_level(&value(name)?) {
-                    if let Some((n, v)) = item.split_once('=') {
-                        f.overrides.push((n.trim().to_string(), v.trim().to_string()));
-                    }
-                }
+            "override" => push_raw_str(f.override_raw.get_or_insert_with(String::new), value(name)?),
+            "overrideFile" => {
+                let path = value(name)?;
+                let joined = read_override_file(&path)?;
+                let (paths, lines) = f.override_file.get_or_insert_with(Default::default);
+                push_raw_str(paths, path);
+                push_raw_str(lines, joined);
             }
             "output" => f.output_vars = split_top_level(&value(name)?),
             "startTime" => f.start_time = Some(real(name, &value(name)?)?),
@@ -688,13 +694,12 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "steadyStateTol" => f.steady_state_tol = Some(real(name, &value(name)?)?),
             "w" => f.show_all_warnings = true,
             "daeMode" => f.dae_mode = true,
-            // C's only other formats are the XML ones its `-port` server speaks.
-            "logFormat" => {
-                let v = value(name)?;
-                if v != "text" {
-                    return Err(format!("-logFormat={v}: this runtime writes plain text logs only"));
-                }
-            }
+            // C's third format, `xmltcp`, belongs to its `-port` server.
+            "logFormat" => match value(name)?.as_str() {
+                "text" => f.log_xml = false,
+                "xml" => f.log_xml = true,
+                v => return Err(format!("-logFormat={v}: this runtime writes `text` or `xml` logs")),
+            },
             "emit_protected" => f.emit_protected = true,
             "ignoreHideResult" => f.ignore_hide_result = true,
             "variableFilter" => f.variable_filter = Some(value(name)?),
@@ -809,11 +814,52 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             }
         }
     }
+    // C's `doOverride` reads `-override` first, then the file; a later entry for the
+    // same name wins.
+    for raw in [f.override_raw.as_deref(), f.override_file.as_ref().map(|(_, j)| j.as_str())] {
+        for item in raw.into_iter().flat_map(split_top_level) {
+            if let Some((n, v)) = item.split_once('=') {
+                f.overrides.push((n.trim().to_string(), v.trim().to_string()));
+            }
+        }
+    }
     f.log_mask = crate::omclog::mask_from_streams(&f.log)?;
     if f.show_all_warnings {
         f.log_mask |= crate::omclog::SHOW_ALL_WARNINGS;
     }
     Ok(f)
+}
+
+/// C's `FLAG_REPEAT_POLICY_COMBINE` for a repeated `-override`/`-overrideFile`.
+fn push_raw_str(dst: &mut String, v: String) {
+    if !dst.is_empty() {
+        dst.push(',');
+    }
+    dst.push_str(&v);
+}
+
+/// C's `-overrideFile` read: every `\n`-terminated line, trimmed, `//`-comments
+/// dropped, joined with commas into one `-override` string.
+#[cfg(feature = "std")]
+fn read_override_file(path: &str) -> Result<String, String> {
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        format!("simulation_input_xml.c: could not read overrideFile {path}: {e}")
+    })?;
+    let mut out = Vec::new();
+    for line in text.split_inclusive('\n').filter(|l| l.ends_with('\n')) {
+        let line = line.trim();
+        // C's comment test reads both characters whatever the first one is.
+        if line.is_empty() || line.starts_with('/') || line.as_bytes().get(1) == Some(&b'/') {
+            continue;
+        }
+        out.push(line);
+    }
+    Ok(out.join(","))
+}
+
+#[cfg(not(feature = "std"))]
+fn read_override_file(path: &str) -> Result<String, String> {
+    Err(format!("-overrideFile={path}: this runtime has no filesystem"))
 }
 
 /// C's `initializeResultData` formats. `mat`, `csv`, `plt` and `empty` are the
@@ -1207,6 +1253,7 @@ mod store {
 
 pub fn set_flags(f: SimFlags) {
     crate::omclog::set_mask(f.log_mask);
+    crate::omclog::set_xml(f.log_xml);
     store::set(f);
 }
 
@@ -1517,7 +1564,8 @@ mod tests {
         let msgs = notices(&f);
         assert_eq!(msgs.len(), 1);
         assert!(msgs.iter().all(|(ty, _)| *ty == crate::omclog::WARNING));
-        assert!(parse(&argv(&["-logFormat=xml"])).is_err());
+        assert!(parse(&argv(&["-logFormat=xml"])).expect("parses").log_xml);
+        assert!(parse(&argv(&["-logFormat=xmltcp"])).is_err());
     }
 
     // C's `-alarm=0` disables the alarm rather than setting a zero-second one.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sundials.rs
@@ -19,6 +19,16 @@ pub type NVector = *mut c_void;
 pub type SunMatrix = *mut c_void;
 type SunLinearSolver = *mut c_void;
 type SunContext = *mut c_void;
+type SunLogger = *mut c_void;
+type SunErrHandlerFn = unsafe extern "C" fn(
+    c_int,
+    *const core::ffi::c_char,
+    *const core::ffi::c_char,
+    *const core::ffi::c_char,
+    c_int,
+    *mut c_void,
+    SunContext,
+);
 
 /// `int f(realtype t, N_Vector y, N_Vector ydot, void *user_data)`.
 pub type RhsFn = unsafe extern "C" fn(f64, NVector, NVector, *mut c_void) -> c_int;
@@ -42,7 +52,55 @@ fn sun_context() -> SunContext {
     if unsafe { SUNContext_Create(SUN_COMM_NULL, &mut ctx) } != SUN_SUCCESS {
         return core::ptr::null_mut();
     }
+    silence_logger(ctx);
+    unsafe { SUNContext_PushErrHandler(ctx, err_handler, core::ptr::null_mut()) };
     ctx
+}
+
+/// C's `sundialsSilenceLogger`. An empty filename disables a stream.
+fn silence_logger(ctx: SunContext) {
+    let mut logger: SunLogger = core::ptr::null_mut();
+    if unsafe { SUNContext_GetLogger(ctx, &mut logger) } != SUN_SUCCESS || logger.is_null() {
+        return;
+    }
+    let empty = c"".as_ptr();
+    unsafe {
+        SUNLogger_SetErrorFilename(logger, empty);
+        SUNLogger_SetWarningFilename(logger, empty);
+        SUNLogger_SetInfoFilename(logger, empty);
+        SUNLogger_SetDebugFilename(logger, empty);
+    }
+}
+
+/// C's `sundialsErrorHandlerFunction`: the muted diagnostics, on `LOG_SOLVER`.
+unsafe extern "C" fn err_handler(
+    line: c_int,
+    func: *const core::ffi::c_char,
+    file: *const core::ffi::c_char,
+    msg: *const core::ffi::c_char,
+    err_code: c_int,
+    _user_data: *mut c_void,
+    _ctx: SunContext,
+) {
+    if !crate::omclog::active(crate::omclog::SOLVER) {
+        return;
+    }
+    let text = |p: *const core::ffi::c_char| match p.is_null() {
+        true => alloc::string::String::new(),
+        false => unsafe { core::ffi::CStr::from_ptr(p) }.to_string_lossy().into_owned(),
+    };
+    crate::omclog::info(crate::omclog::SOLVER, true, "#### SUNDIALS error message #####");
+    crate::omclog::info(
+        crate::omclog::SOLVER,
+        false,
+        &alloc::format!(
+            " -> error code {err_code}\n -> function {}\n -> at {}:{line}",
+            text(func),
+            text(file)
+        ),
+    );
+    crate::omclog::info(crate::omclog::SOLVER, false, &alloc::format!(" Message: {}", text(msg)));
+    crate::omclog::close(crate::omclog::SOLVER);
 }
 /// `mxstep` internal steps taken without reaching `tout`; resuming continues.
 pub const CV_TOO_MUCH_WORK: c_int = -1;
@@ -51,6 +109,12 @@ unsafe extern "C" {
     /// `SUNComm` is a plain `int` without MPI, and `SUN_COMM_NULL` is 0.
     fn SUNContext_Create(comm: c_int, ctx: *mut SunContext) -> c_int;
     fn SUNContext_Free(ctx: *mut SunContext) -> c_int;
+    fn SUNContext_GetLogger(ctx: SunContext, logger: *mut SunLogger) -> c_int;
+    fn SUNContext_PushErrHandler(ctx: SunContext, handler: SunErrHandlerFn, data: *mut c_void) -> c_int;
+    fn SUNLogger_SetErrorFilename(logger: SunLogger, name: *const core::ffi::c_char) -> c_int;
+    fn SUNLogger_SetWarningFilename(logger: SunLogger, name: *const core::ffi::c_char) -> c_int;
+    fn SUNLogger_SetInfoFilename(logger: SunLogger, name: *const core::ffi::c_char) -> c_int;
+    fn SUNLogger_SetDebugFilename(logger: SunLogger, name: *const core::ffi::c_char) -> c_int;
 
     fn N_VNew_Serial(vec_length: SunIndex, ctx: SunContext) -> NVector;
     fn N_VDestroy(v: NVector);
@@ -340,6 +404,11 @@ pub type IdaJacFn = unsafe extern "C" fn(
 
 /// `mxstep` internal steps taken without reaching `tout`; resuming continues.
 pub const IDA_TOO_MUCH_WORK: c_int = -1;
+/// Error test failures on one step, corrector convergence failures, and a failed
+/// linear-solver setup — what `ida_solver_step` restarts from.
+pub const IDA_ERR_FAIL: c_int = -3;
+pub const IDA_CONV_FAIL: c_int = -4;
+pub const IDA_LSETUP_FAIL: c_int = -6;
 
 const IDA_NORMAL: c_int = 1;
 const IDA_ONE_STEP: c_int = 2;
@@ -369,6 +438,7 @@ unsafe extern "C" {
     fn IDASetMaxConvFails(mem: *mut c_void, maxncf: c_int) -> c_int;
     fn IDASetNonlinConvCoef(mem: *mut c_void, epcon: f64) -> c_int;
     fn IDASetInitStep(mem: *mut c_void, hin: f64) -> c_int;
+    fn IDASetMaxStep(mem: *mut c_void, hmax: f64) -> c_int;
     fn IDASolve(mem: *mut c_void, tout: f64, tret: *mut f64, yret: NVector, ypret: NVector, itask: c_int) -> c_int;
     fn IDAGetCurrentStep(mem: *mut c_void, hcur: *mut f64) -> c_int;
 
@@ -600,6 +670,11 @@ impl Ida {
 
     pub fn set_init_step(&mut self, h: f64) -> bool {
         unsafe { IDASetInitStep(self.mem, h) == IDA_SUCCESS }
+    }
+
+    /// `IDASetMaxStep`; 0 lifts the cap.
+    pub fn set_max_step(&mut self, h: f64) -> bool {
+        unsafe { IDASetMaxStep(self.mem, h) == IDA_SUCCESS }
     }
 
     /// `IDACalcIC(IDA_YA_YDP_INIT)`: solve for the algebraic unknowns and every

--- a/testsuite/openmodelica/interactive-API/Issue14178.mos
+++ b/testsuite/openmodelica/interactive-API/Issue14178.mos
@@ -5,12 +5,21 @@
 // tests if the xml output works fine
 // teardown_command: rm -rf ThermofluidStream.Examples.EspressoMachine* Issue14178*.txt
 //
+// The run goes through resimulateExecutable rather than system("./<model>"), so
+// the simulation target decides how to re-run the model it just built.
+//
 
 loadFile("Issue14178.mo"); getErrorString();
 buildModel(ThermofluidStream.Examples.EspressoMachine);
-system("./ThermofluidStream.Examples.EspressoMachine -logFormat=xml", outputFile="Issue14178_log.txt");
-system("cat Issue14178_log.txt | grep \"<message\" | grep -v \"/>\" | wc -l > Issue14178_start_tag.txt");
-system("cat Issue14178_log.txt | grep \"</message\" | wc -l > Issue14178_end_tag.txt");
+echo(false);
+xmlLog := simulate(ThermofluidStream.Examples.EspressoMachine, simflags="-logFormat=xml",
+                   resimulateExecutable="ThermofluidStream.Examples.EspressoMachine");
+// A record member is not accepted as a call argument, so bind it first.
+xmlText := xmlLog.messages;
+echo(true);
+writeFile("Issue14178_log.txt", xmlText);
+system("grep \"<message\" Issue14178_log.txt | grep -v \"/>\" | wc -l > Issue14178_start_tag.txt");
+system("grep \"</message\" Issue14178_log.txt | wc -l > Issue14178_end_tag.txt");
 readFile("Issue14178_start_tag.txt") == readFile("Issue14178_end_tag.txt");
 
 
@@ -18,7 +27,8 @@ readFile("Issue14178_start_tag.txt") == readFile("Issue14178_end_tag.txt");
 // true
 // ""
 // {"ThermofluidStream.Examples.EspressoMachine", "ThermofluidStream.Examples.EspressoMachine_init.xml"}
-// 0
+// true
+// true
 // 0
 // 0
 // true

--- a/testsuite/rust-ignore-tests.txt
+++ b/testsuite/rust-ignore-tests.txt
@@ -64,14 +64,6 @@
 # 64-bit modelica_integer (then labs), the port's Integer is i32 so the embedded
 # hash value differs. Only those hash numbers differ; not fixable without i64.
 ./openmodelica/interactive-API/Obfuscation1.mos
-#
-# Library version: the image ships Modelica 3.2.3+maint and 4.1.0 only. This
-# test does loadModel(Modelica,{"3.1"}) and dumps MSL annotations/algorithms
-# (Resistor docs, Blocks.Sources.BooleanTable); 3.2.3 differs from the recorded
-# 3.1 content (<i>/<HTML> vs <em>/<html>, different BooleanTable body). The boot
-# omc produces the same 3.2.3 content — purely a library-version mismatch, not a
-# port codegen difference.
-./openmodelica/interactive-API/interactive_api_calls.mos
 # Backend does operations in different order
 ./simulation/modelica/NBackend/differentation/adjoint_jacobian2.mos
 ./simulation/modelica/NBackend/functions/function_annotation_der.mos


### PR DESCRIPTION
The five failing `openmodelica/interactive-API` tests under `--simCodeTarget=wasm-jit` were runtime gaps, not test problems.

| Test | Gap |
| --- | --- |
| `interactive_api_calls` | `getMessages` returned the queue un-reversed | | `Ticket5696` | `-overrideFile` and `doOverride`'s log missing | | `ModelicaError` | an assert absorbed by the NLS was never logged | | `daeModeHomotopy` | IDA had no degenerate-start-point recovery | | `Issue14178` | no `-logFormat=xml`, and the test ran `./<model>` |

`ErrorExt.getMessages` binds `Error_getMessages`, which is `listReverse(ErrorImpl__getMessages())`; the port implemented the un-reversed `ErrorImpl__` variant, so `getMessagesStringInternal()` handed back the message list backwards. This failed on every target, and its `rust-ignore-tests.txt` entry (an MSL 3.1 version mismatch) no longer reproduces, so it goes too.

`-overrideFile` is now read as `doOverride` reads it, merged after `-override` with the duplicate warning, and the whole `LOG_SOLVER` block it prints is emitted -- including the per-quantity `override x = v` lines in `_init.xml` class order and the small-value warning.

A failed `assert()` inside a nonlinear-solver residual returned through `rt_nls_note_assert()` without recording anything, so C's `LOG_ASSERT` block never appeared. It now reports through `rt_nls_assert_failed`, which logs where the assert fires as `omc_assert_simulation` does. That needed the missing `ERROR_NONLINEARSOLVER` stage, saved and restored around the solver region exactly where `solve_nonlinear_system` sets it -- which is also what keeps the second assert of the test out of the log, as in C.

IDA lacked `ida_solver_step`'s recovery: on `LSETUP_FAIL`/`CONV_FAIL`/ `ERR_FAIL` at the start time it arms the homotopy ramp (lambda 0 -> 1 over `OMC_DAE_HOMOTOPY_TRAMP`, default 10% of the interval, with the step capped at a fiftieth of it) and retries once via `IDAReInit`. The colored sparse Jacobian was verified exact against an uncolored difference quotient first, so the ramp is the only thing that was missing. `sundialsSilenceLogger` and the error handler come along, so SUNDIALS' own `[ERROR][rank 0]` line goes to `LOG_SOLVER` instead of leaking into the result.

`-logFormat=xml` is C's `messageXML`/`messageCloseXML` in `omclog`. `Issue14178` ran the built executable, which only the C code generator produces; it now re-runs through `resimulateExecutable` and takes the log from `SimulationResult.messages`, which every target can serve.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
