### PR TITLE
wasm-jit: external "C" ABI, records, RHSFinalFlag

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1783,7 +1783,9 @@ enum NativeLib {
 }
 
 fn is_link_input(name: &str) -> bool {
-    name.ends_with(".a") || name.ends_with(".o")
+    // `gcc -c -o x.lib` spells an object file the MSVC way. On Windows the suffix
+    // is a real static/import library, which no `cc -shared` makes loadable.
+    name.ends_with(".a") || name.ends_with(".o") || (!cfg!(windows) && (name.ends_with(".lib") || name.ends_with(".obj")))
 }
 
 /// The platform library a host linker spec names. A `-lfoo` nothing under `dirs`
@@ -1801,7 +1803,7 @@ fn find_native_library(spec: &str, dirs: &[String]) -> Option<NativeLib> {
         None => spec,
     };
     // `.lib` is both spellings on Windows, with no `cc -shared` to sort them out.
-    if name.ends_with(".obj") || name.ends_with(".lib") {
+    if cfg!(windows) && (name.ends_with(".obj") || name.ends_with(".lib")) {
         return None;
     }
     let found = |p: String| Some(if is_link_input(&p) { NativeLib::Archive(p) } else { NativeLib::Shared(p) });

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -10041,8 +10041,14 @@ fn release_temp_array(ctx: &mut FnCtx, t: u32) -> Result<()> {
 /// (the whole dimension vector, an `Integer[ndims]`). `a`'s owned handle is
 /// released after.
 fn compile_size(ctx: &mut FnCtx, exp: &DAE::Exp, sz: Option<&DAE::Exp>) -> Result<()> {
-    let SigTy::Array { rank, .. } = exp_sigty(exp)? else {
-        return Err("CodegenWasmJit: size() of a non-array expression");
+    // Only the whole-vector form needs the rank statically — as well, since the
+    // frontend leaves a dimension expression's operand `T_UNKNOWN`.
+    let rank = match sz {
+        Some(_) => 0,
+        None => match exp_sigty(exp)? {
+            SigTy::Array { rank, .. } => rank,
+            _ => return Err("CodegenWasmJit: size() of a non-array expression"),
+        },
     };
     compile_exp(ctx, exp)?; // owned array handle
     let arr_t = ctx.alloc_temp(WTy::I32);
@@ -10505,23 +10511,39 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
     if !ext_imports.is_empty() {
         let mut notes: Vec<String> = Vec::new();
         let resolved = crate::CodegenWasmJit::resolve_ext_libraries(&fn_code.makefileParams, &mut notes)?;
-        let libs = resolved.wasm;
-        for lib in &libs {
+        let wasm_libs = resolved.wasm;
+        for lib in &wasm_libs {
             sig.push_str(&format!("lib\t{}\n", lib.name));
         }
-        // What the wasm modules do not define is called through libffi.
-        for lib in &resolved.native {
+        // C source: an `Include`, or a `Library` naming a `.c` file.
+        let sources: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes)
+            .map(|s| s.to_string())
+            .chain(resolved.sources)
+            .collect();
+        let dirs: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.makefileParams.includes).map(|s| s.to_string()).collect();
+        // A host build compiles them the way the C target does and calls them
+        // through libffi, as `build_sim_model` does: the in-wasm `Modelica*`
+        // callbacks are host imports, which cannot take C varargs, so a
+        // `ModelicaFormatMessage` there would lose its arguments. The browser has
+        // no host library to call, so there the wasm unit is all.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let missing = crate::CodegenWasmJit::missing_ext_symbols(&ext_imports, &wasm_libs);
+            if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &sources, &dirs, &fn_code.makefileParams.cflags, &missing, &mut notes)? {
+                let path = format!("{base}_includes.wasm");
+                openmodelica_wasi::fs::write(&path, &l.bytes)
+                    .map_err(|_| "CodegenWasmJitFunctions: cannot stage the compiled include library")?;
+                sig.push_str(&format!("lib\t{path}\n"));
+            }
+        }
+        // The model's own code first: it shadows a same-named symbol in a `Library`
+        // shared object, as the C target's own link order does.
+        #[cfg(not(target_arch = "wasm32"))]
+        for lib in native_fallbacks(&base, fn_code, &resolved.archives, &sources, &dirs, &ext_imports, &wasm_libs, &mut notes) {
             sig.push_str(&format!("nlib\t{lib}\n"));
         }
-        // An implementation given as C source in an `Include`.
-        let includes: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.externalFunctionIncludes).map(|s| s.to_string()).collect();
-        let dirs: Vec<String> = crate::CodegenWasmJit::lst(&fn_code.makefileParams.includes).map(|s| s.to_string()).collect();
-        let missing = crate::CodegenWasmJit::missing_ext_symbols(&ext_imports, &libs);
-        if let Some(l) = crate::CodegenWasmJit::compile_include_library(&base, &includes, &dirs, &fn_code.makefileParams.cflags, &missing, &mut notes)? {
-            let path = format!("{base}_includes.wasm");
-            openmodelica_wasi::fs::write(&path, &l.bytes)
-                .map_err(|_| "CodegenWasmJitFunctions: cannot stage the compiled include library")?;
-            sig.push_str(&format!("lib\t{path}\n"));
+        for lib in &resolved.native {
+            sig.push_str(&format!("nlib\t{lib}\n"));
         }
         for e in &ext_imports {
             sig.push_str(&format!("ext\t{}\n", write_ext_sig(e)));
@@ -10535,6 +10557,56 @@ fn translate_functions_inner(fn_code: &SimCodeFunction::FunctionCode) -> Result<
     openmodelica_wasi::fs::write(&format!("{base}.wasm"), &bytes).map_err(|_| "CodegenWasmJitFunctions: cannot write wasm")?;
     openmodelica_wasi::fs::write(&format!("{base}.wasm.sig"), sig.as_bytes()).map_err(|_| "CodegenWasmJitFunctions: cannot write wasm.sig")?;
     Ok(())
+}
+
+/// Host libraries holding the `external "C"` implementations no module in
+/// `wasm_libs` defines: the `Library` archives linked into a loadable one, and the
+/// C sources compiled. Built in the compile phase, as the simulation's are.
+#[cfg(not(target_arch = "wasm32"))]
+fn native_fallbacks(
+    base: &str,
+    fn_code: &SimCodeFunction::FunctionCode,
+    archives: &[String],
+    sources: &[String],
+    dirs: &[String],
+    ext_imports: &[ExtCallSig],
+    wasm_libs: &[openmodelica_wasm_jit::model::ExtLibrary],
+    notes: &mut Vec<String>,
+) -> Vec<String> {
+    let missing = crate::CodegenWasmJit::missing_ext_symbols(ext_imports, wasm_libs);
+    if missing.is_empty() {
+        return Vec::new();
+    }
+    let mp = &fn_code.makefileParams;
+    let mut out = Vec::new();
+    if !sources.is_empty() {
+        let inc = openmodelica_wasm_jit::model::ExtIncludes {
+            sources: sources.to_vec(),
+            include_dirs: dirs.to_vec(),
+            ccompiler: mp.ccompiler.to_string(),
+            cflags: mp.cflags.to_string(),
+            dllext: mp.dllext.to_string(),
+            prefix: base.to_string(),
+        };
+        match inc.compile(&missing) {
+            Ok(path) => out.push(path),
+            Err(e) => notes.push(e),
+        }
+    }
+    if !archives.is_empty() {
+        let arch = openmodelica_wasm_jit::model::ExtArchives {
+            archives: archives.to_vec(),
+            symbols: ext_imports.iter().map(|s| s.name.clone()).collect(),
+            ccompiler: mp.ccompiler.to_string(),
+            dllext: mp.dllext.to_string(),
+            prefix: base.to_string(),
+        };
+        match arch.link() {
+            Ok(path) => out.push(path),
+            Err(e) => notes.push(e),
+        }
+    }
+    out
 }
 
 /// `CodegenWasmJitFunctions.loadAndExecute`: instantiate `<fileName>.wasm` and

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -195,8 +195,11 @@ pub(super) fn load_and_execute(
     // Clear any stale pending assertion before the call (defensive — each call
     // consumes its own).
     openmodelica_wasm_jit::host::clear_pending_assert();
+    openmodelica_wasm_jit::host::flush_stdio();
     // wasmer returns the result values directly (no out-parameter buffer).
-    let results = match func.call(&mut store, &params) {
+    let call_res = func.call(&mut store, &params);
+    openmodelica_wasm_jit::host::flush_stdio();
+    let results = match call_res {
         Ok(r) => r,
         Err(e) => {
             // A failed `assert` records its message + source info via the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -195,7 +195,7 @@ impl NativeExternals {
     }
 
     fn resolve(&self, name: &str) -> Option<usize> {
-        openmodelica_util::dynload::external_symbol_in(&self.handles, name)
+        openmodelica_wasm_jit::model::external_symbol_or_wrapper(&self.handles, name)
     }
 }
 
@@ -349,7 +349,9 @@ pub(super) fn load_and_execute(
     // Clear any stale pending assertion before the call (defensive — each call
     // consumes its own).
     openmodelica_wasm_jit::host::clear_pending_assert();
+    openmodelica_wasm_jit::host::flush_stdio();
     let call_res = func.call(&mut store, &params, &mut results);
+    openmodelica_wasm_jit::host::flush_stdio();
     if call_res.is_err() {
         // A failed `assert` records its message + source info via the `rt_assert`
         // host import, then traps. Route it to the error buffer (matching the C

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -38,6 +38,8 @@ unsafe extern "C" {
     fn rt_host_set_no_throw(v: i32);
     /// Initialization is over; the host splits its output capture there.
     fn rt_host_init_done();
+    /// C's `RHSFinalFlag`: the external "C" libraries are the host's, so is the flag.
+    fn rt_host_rhs_final(v: i32);
 }
 
 fn init_done_hook() {
@@ -174,6 +176,9 @@ impl SimEngine for InWasmEngine {
     }
     fn clean_nls_history(&mut self, time: f64) {
         crate::nls::rt_nls_clean_history(time);
+    }
+    fn set_rhs_final(&mut self, final_eval: bool) {
+        unsafe { rt_host_rhs_final(final_eval as i32) };
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -401,6 +401,9 @@ pub trait SimEngine {
     /// C's `cleanUpOldValueListAfterEvent`. Default: none (an engine that never
     /// integrates).
     fn clean_nls_history(&mut self, _time: f64) {}
+    /// C's `RHSFinalFlag` (`dassl.c`): 0 while DASKR evaluates the residual, 1
+    /// while the accepted step's outputs are evaluated, for `external "C"` to read.
+    fn set_rhs_final(&mut self, _final_eval: bool) {}
 }
 
 /// C's `EVAL_CONTEXT`, mirrored from the runtime's `nls.rs`. `unsetContext` restores
@@ -4649,6 +4652,7 @@ impl DasslDriver {
         // Silence DASKR's own diagnostic printing (it would go to stdout and corrupt
         // the omc result record); failures are surfaced here via IDID instead.
         daskr::auxiliary::xsetf(0);
+        e.set_rhs_final(false); // C's `dassl_initial`
         let layout = &model.layout;
         // Init (with homotopy fallback). No state events on this path, so relations
         // stay fresh (mode 2); `rt_solve_nls` still holds them internally.
@@ -4782,6 +4786,10 @@ impl Driver for DasslDriver {
         // output interval ahead) and emits a second row at the start time.
         if no_grid && !self.no_grid_primed {
             self.no_grid_primed = true;
+            // The step size is zero, so C's `dassl_step` takes its "desired step
+            // size too small" branch instead of calling DASKR: a zero-length Euler
+            // step, which leaves the states alone, and one `functionODE`.
+            eval_ode(e, sim_data, layout)?;
             emit_row(e, &mut self.rows, sim_data, layout, self.t, stop)?;
         }
 
@@ -4900,6 +4908,7 @@ impl Driver for DasslDriver {
             if logging {
                 log_dassl_step(self.t);
             }
+            e.set_rhs_final(false); // C's `dassl_step`: clear for DASKR's own evaluations
             unsafe {
                 solver::ddaskr(
                     dassl_res, neq, &mut self.t, self.y.as_mut_ptr(), self.yp.as_mut_ptr(),
@@ -4909,6 +4918,7 @@ impl Driver for DasslDriver {
                     solver::dummy_psol, solver::dummy_rt, nrt, self.jroot.as_mut_ptr(),
                 );
             }
+            e.set_rhs_final(true); // ... and set for the output evaluation
             if logging && self.idid != -1 {
                 log_dassl_stats(self.idid, self.t, &self.rwork, &self.iwork);
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -490,6 +490,40 @@ pub fn symbol_in(handles: &[usize], name: &str) -> Option<usize> {
     handles.iter().find_map(|&h| dl::sym(h, name))
 }
 
+/// C's `RHSFinalFlag` (`dassl.c`). External C source declares it `extern` and
+/// reads it, so it has to be a real exported symbol of the compiler image.
+#[unsafe(no_mangle)]
+pub static mut RHSFinalFlag: libc::c_int = 0;
+
+/// A library the linker could only build with a definition of its own (see
+/// `ExtArchives::link_attempt`) reads a different `int` from the one above, so
+/// every copy is kept in step.
+static RHS_FINAL_COPIES: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+/// Record the `RHSFinalFlag` each of `handles` exports, if it is not ours.
+pub fn register_rhs_final_flag(handles: &[usize]) {
+    let mine = (&raw const RHSFinalFlag) as usize;
+    let mut copies = RHS_FINAL_COPIES.lock().unwrap();
+    copies.clear();
+    for &h in handles {
+        if let Some(addr) = dl::sym(h, "RHSFinalFlag")
+            && addr != mine
+            && !copies.contains(&addr)
+        {
+            copies.push(addr);
+        }
+    }
+}
+
+/// Set [`RHSFinalFlag`] and every copy [`register_rhs_final_flag`] found.
+pub fn set_rhs_final_flag(value: bool) {
+    let v = value as libc::c_int;
+    unsafe { RHSFinalFlag = v };
+    for &addr in RHS_FINAL_COPIES.lock().unwrap().iter() {
+        unsafe { *(addr as *mut libc::c_int) = v };
+    }
+}
+
 static USERTAB: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 type UsertabFn = unsafe extern "C-unwind" fn(

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -501,6 +501,8 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     wt(linker.func_wrap("env", "rt_host_init_done", || openmodelica_sim_meta::driver::signal_init_done()))?;
     wt(linker.func_wrap("env", "rt_host_set_no_throw", |v: i32| set_no_throw_asserts(v != 0)))?;
     wt(linker.func_wrap("env", "rt_host_runtime_error", || openmodelica_sim_meta::driver::note_runtime_error_flag()))?;
+    // The external "C" libraries are the host's, so C's `RHSFinalFlag` is too.
+    wt(linker.func_wrap("env", "rt_host_rhs_final", |v: i32| openmodelica_util::dynload::set_rhs_final_flag(v != 0)))?;
     // The model's violations land here even when the driver runs in-wasm; hand
     // them over so that driver can format the `LOG_ASSERT` block.
     wt(linker.func_wrap(
@@ -702,6 +704,8 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
     imports.define("env", "rt_host_init_done", Function::new_typed(store, || openmodelica_sim_meta::driver::signal_init_done()));
     imports.define("env", "rt_host_set_no_throw", Function::new_typed(store, |v: i32| set_no_throw_asserts(v != 0)));
     imports.define("env", "rt_host_runtime_error", Function::new_typed(store, || openmodelica_sim_meta::driver::note_runtime_error_flag()));
+    // The wasmer host has no external-library loader, so the flag has nowhere to go.
+    imports.define("env", "rt_host_rhs_final", Function::new_typed(store, |_v: i32| {}));
     // See the wasmtime counterpart.
     imports.define(
         "env",
@@ -787,6 +791,17 @@ pub fn define_uri_import(
         },
     );
     imports.define("rt", "rt_uri_to_filename", f);
+}
+
+/// libc's `stdout`, where a host `external "C"` prints, is a different buffer
+/// from ours; flush both around a call so the two stay in order.
+pub fn flush_stdio() {
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe {
+        libc::fflush(std::ptr::null_mut());
+    }
 }
 
 /// Redirect the process's stdout/stderr into the run's log for one capture phase

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -109,6 +109,16 @@ impl ExtArchives {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn link_uncached(&self) -> std::result::Result<String, String> {
+        match self.link_attempt(false) {
+            // A non-PIC member cannot reach an *imported* symbol from `.text`, so a
+            // runtime global it reads has to be defined in the library itself.
+            Err(e) => self.link_attempt(true).map_err(|_| e),
+            ok => ok,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn link_attempt(&self, runtime_globals: bool) -> std::result::Result<String, String> {
         use std::process::Command;
         let dir = std::env::temp_dir().join(format!("om-extc-{}", std::process::id()));
         std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
@@ -119,6 +129,16 @@ impl ExtArchives {
             cmd.arg(format!("-Wl,-u,{sym}"));
         }
         cmd.args(&self.archives);
+        if runtime_globals {
+            let tu = dir.join(format!("{}_globals.c", self.prefix));
+            // `protected` binds the reference at link time — a non-PIC `.text`
+            // takes no dynamic relocation — yet keeps the symbol exported, so
+            // `dynload::register_rhs_final_flag` can find this copy.
+            let vis = if cfg!(windows) { "" } else { " __attribute__((visibility(\"protected\")))" };
+            std::fs::write(&tu, format!("int RHSFinalFlag{vis};\n"))
+                .map_err(|e| format!("cannot write {}: {e}", tu.display()))?;
+            cmd.arg("-fPIC").arg(&tu);
+        }
         let output = cmd
             .output()
             .map_err(|e| format!("`{}` could not be run to link the static libraries: {e}", self.ccompiler))?;
@@ -250,9 +270,9 @@ impl ExtIncludes {
 /// a wrapper handing back the address needs no prototype and reaches it anyway.
 pub const EXT_ADDR_PREFIX: &str = "omc_ext_addr_";
 
-/// A function-like macro has no address, so the *call* is what the unit provides
-/// — which is all the C target ever compiles, expanding the macro at its own
-/// call site.
+/// Calling through the unit is what the C target does: with the declaration in
+/// scope the compiler converts each argument to what the callee really takes
+/// (`ExternalMedia`'s `setState_ph` declares a `double` for a Modelica `Integer`).
 pub const EXT_CALL_PREFIX: &str = "omc_ext_call_";
 
 /// One wrapper per function still to be found. Taking the address of a function
@@ -263,10 +283,8 @@ pub fn ext_wrappers(sigs: &[ExtCallSig]) -> String {
     for sig in sigs {
         let name = &sig.name;
         match ext_call_wrapper(sig) {
-            Some(call) => out.push_str(&format!(
-                "#ifdef {name}\n{call}#else\n{}#endif\n",
-                ext_addr_wrapper(name)
-            )),
+            // A macro has no address to hand back.
+            Some(call) => out.push_str(&format!("{call}#ifndef {name}\n{}#endif\n", ext_addr_wrapper(name))),
             None => out.push_str(&ext_addr_wrapper(name)),
         }
     }
@@ -277,17 +295,17 @@ fn ext_addr_wrapper(name: &str) -> String {
     format!("void (*{EXT_ADDR_PREFIX}{name}(void))(void) {{ return (void (*)(void)) {name}; }}\n")
 }
 
-/// `T omc_ext_call_f(A a0, …) { return f(a0, …); }`. `None` when an argument has
-/// no C spelling the declaration alone fixes (a record's struct).
+/// `T omc_ext_call_f(A a0, …) { return f(a0, …); }`. `None` when the result has no
+/// C spelling the declaration alone fixes (a record returned by value).
 fn ext_call_wrapper(sig: &ExtCallSig) -> Option<String> {
     let byref = sig.lang == crate::sig::ExtLang::Fortran77;
     let mut params = String::new();
     for (i, (ty, is_out)) in sig.args.iter().enumerate() {
-        let ptr = *is_out || byref || matches!(ty, crate::sig::SigTy::Array { .. });
+        let ptr = *is_out || byref || matches!(ty, crate::sig::SigTy::Array { .. } | crate::sig::SigTy::Record { .. });
         params.push_str(&format!(
             "{}{}{} a{i}",
             if i == 0 { "" } else { ", " },
-            ext_c_type(ty)?,
+            ext_c_arg_type(ty)?,
             if ptr { "*" } else { "" }
         ));
     }
@@ -305,6 +323,15 @@ fn ext_call_wrapper(sig: &ExtCallSig) -> Option<String> {
     ))
 }
 
+/// [`ext_c_type`] for an *argument*: a record goes as a `void*`, which converts to
+/// whatever struct pointer the callee declares.
+fn ext_c_arg_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
+    match ty {
+        crate::sig::SigTy::Record { .. } => Some("void"),
+        other => ext_c_type(other),
+    }
+}
+
 /// The C type the language specification maps a Modelica type to; an array is its
 /// element type, passed by pointer.
 fn ext_c_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
@@ -317,6 +344,24 @@ fn ext_c_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
         SigTy::Array { elem, .. } => ext_c_type(elem)?,
         SigTy::Record { .. } | SigTy::Func { .. } => return None,
     })
+}
+
+/// The `Include`'s call wrapper if it built one, else the symbol itself, else the
+/// address wrapper (a function with no external linkage). The wrapper first: only
+/// it carries the argument conversions ([`EXT_CALL_PREFIX`]).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn external_symbol_or_wrapper(handles: &[usize], name: &str) -> Option<usize> {
+    use openmodelica_util::dynload::external_symbol_in;
+    if let Some(addr) = external_symbol_in(handles, &format!("{EXT_CALL_PREFIX}{name}")) {
+        return Some(addr);
+    }
+    if let Some(addr) = external_symbol_in(handles, name) {
+        return Some(addr);
+    }
+    let wrapper = external_symbol_in(handles, &format!("{EXT_ADDR_PREFIX}{name}"))?;
+    // Safety: the generated wrapper is `void (*w(void))(void)`.
+    let w: extern "C" fn() -> usize = unsafe { std::mem::transmute(wrapper) };
+    Some(w()).filter(|a| *a != 0)
 }
 
 /// omc's own C headers, plus the bundled `gc.h` that `openmodelica.h` reaches —

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -430,20 +430,8 @@ impl NativeExternals {
         loaded
     }
 
-    /// The symbol itself, else its `Include` wrapper: the call one for a macro,
-    /// the address one for a function with no external linkage.
     fn symbol(&self, name: &str) -> Option<usize> {
-        use openmodelica_util::dynload::external_symbol_in;
-        if let Some(addr) = external_symbol_in(&self.handles, name) {
-            return Some(addr);
-        }
-        if let Some(addr) = external_symbol_in(&self.handles, &format!("{}{name}", model::EXT_CALL_PREFIX)) {
-            return Some(addr);
-        }
-        let wrapper = external_symbol_in(&self.handles, &format!("{}{name}", model::EXT_ADDR_PREFIX))?;
-        // Safety: the generated wrapper is `void (*w(void))(void)`.
-        let w: extern "C" fn() -> usize = unsafe { std::mem::transmute(wrapper) };
-        Some(w()).filter(|a| *a != 0)
+        model::external_symbol_or_wrapper(&self.handles, name)
     }
 
     /// The model's own `usertab`: no `external "C"`, so never among `ext_imports`.
@@ -512,6 +500,8 @@ fn define_external_imports(
     // No `external "C"` means no `Include`/`Library`, hence no `usertab`.
     let usertab = (!model.ext_imports.is_empty()).then(|| native.usertab(model)).flatten();
     openmodelica_util::dynload::set_usertab(usertab);
+    // A library that had to define its own `RHSFinalFlag` reads that copy.
+    openmodelica_util::dynload::register_rhs_final_flag(&native.handles);
     Ok(())
 }
 
@@ -527,16 +517,11 @@ pub fn define_native_external(
 ) -> Result<()> {
     let name = sig.name.clone();
     let sig = sig.clone();
-    let rt_str_new = rt.str_new.clone();
-    let rt_str_data = rt.str_data.clone();
-    let rt_release = rt.release.clone();
-    let nls = rt.nls.clone();
+    let rt = rt.clone();
     wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
         // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-        unsafe {
-            call_external(addr, &sig, &mut caller, memory, &rt_str_new, &rt_str_data, &rt_release, &nls, args, rets)
-        }
-        .map_err(|e| wasmtime::Error::msg(format!("{e}")))
+        unsafe { call_external(addr, &sig, &mut caller, memory, &rt, args, rets) }
+            .map_err(|e| wasmtime::Error::msg(format!("{e}")))
     }))?;
     Ok(())
 }
@@ -575,8 +560,10 @@ const EXT_CHECKPOINT: arcstr::ArcStr = arcstr::literal!("wasm-jit external \"C\"
 /// cell's written value, in order — scalars directly, external-object pointers via
 /// the registry, and `char*` outputs copied into a fresh in-wasm String
 /// (`rt_str_new`+`rt_str_data`). A `String[…]` output array is written back
-/// element by element (C's `unpack_string_array`). The whole call is bracketed by
-/// `sim_external_begin/end` so any `ModelicaAllocateString` uses our arena.
+/// element by element (C's `unpack_string_array`); a record as a pointer to its
+/// [`host_c_record_layout`] struct, copied field by field both ways. The whole call
+/// is bracketed by `sim_external_begin/end` so any `ModelicaAllocateString` uses
+/// our arena.
 ///
 /// A `FORTRAN 77` external takes every argument by reference and its arrays
 /// column-major — the marshalling `extFunCallF77` puts in the generated wrapper.
@@ -585,10 +572,7 @@ unsafe fn call_external(
     sig: &crate::sig::ExtCallSig,
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
     memory: wasmtime::Memory,
-    rt_str_new: &wasmtime::TypedFunc<u32, u32>,
-    rt_str_data: &wasmtime::TypedFunc<u32, u32>,
-    rt_release: &wasmtime::TypedFunc<u32, ()>,
-    nls: &Option<NlsHooks>,
+    rt: &crate::dylink_engine::ExtRt,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
 ) -> Result<()> {
@@ -596,6 +580,8 @@ unsafe fn call_external(
     use core::ffi::c_void;
     use libffi::middle::{Cif, Type};
     use wasmtime::Val;
+
+    let (rt_str_new, rt_str_data, rt_release, nls) = (&rt.str_new, &rt.str_data, &rt.release, &rt.nls);
 
     // Raw libffi call, declared `C-unwind` so a Rust panic raised by the
     // ModelicaError interception (`omrs_runtime_abort`) can unwind back through
@@ -623,9 +609,11 @@ unsafe fn call_external(
     // Output `String[…]`: (index into `str_arrays`, wasm element-area offset).
     let mut str_out_arrays: Vec<(usize, usize)> = Vec::new();
     let mut types: Vec<Type> = Vec::with_capacity(sig.args.len());
-    // One 8-byte native cell per `_Out_` pointer arg (fits int/double/pointer),
-    // in output order; the C call writes through the pointer we pass.
-    let mut out_cells: Vec<(SigTy, Box<[u8; 8]>)> = Vec::new();
+    // One native cell per `_Out_` pointer arg, in output order; the C call writes
+    // through the pointer we pass.
+    let mut out_cells: Vec<OutCell> = Vec::new();
+    // Record arguments' C structs, kept alive for the call.
+    let mut in_records: Vec<Vec<u64>> = Vec::new();
     // Fortran by-reference input cells, kept alive for the call.
     let mut in_cells: Vec<Box<[u8; 8]>> = Vec::new();
     // (buffer, wasm element-area offset, dims, element size, is output).
@@ -640,15 +628,23 @@ unsafe fn call_external(
             // pre-allocated on the wasm side and passed by pointer (filled in place,
             // like an input array — handled by the `Array` arm below).
             if *is_out && !matches!(ty, SigTy::Array { .. }) {
-                // The cell is one C value wide, and a record output is a struct
-                // whose layout only its own C declaration fixes.
+                // A record output is a struct the callee fills in place.
+                if let SigTy::Record { fields, .. } = ty {
+                    let layout = host_c_record_layout(fields)
+                        .ok_or("CodegenWasmJit: external \"C\" : record field type not marshalled")?;
+                    let mut buf: Vec<u64> = vec![0; layout.words()];
+                    slots.push(Slot::P(buf.as_mut_ptr() as *mut c_void));
+                    types.push(Type::pointer());
+                    out_cells.push(OutCell::Record { fields: fields.clone(), layout, buf });
+                    continue;
+                }
                 if !matches!(ty, SigTy::Real | SigTy::Int | SigTy::Bool | SigTy::Str | SigTy::Ptr) {
                     return Err("CodegenWasmJit: external \"C\" : output argument type not marshalled");
                 }
                 let mut cell: Box<[u8; 8]> = Box::new([0u8; 8]);
                 slots.push(Slot::P(cell.as_mut_ptr() as *mut c_void));
                 types.push(Type::pointer());
-                out_cells.push((ty.clone(), cell));
+                out_cells.push(OutCell::Scalar(ty.clone(), cell));
                 continue;
             }
             let v = &args[in_i];
@@ -742,6 +738,16 @@ unsafe fn call_external(
                     }
                     types.push(Type::pointer());
                 }
+                // The language specification maps a record to a struct pointer.
+                SigTy::Record { fields, .. } => {
+                    let layout = host_c_record_layout(fields)
+                        .ok_or("CodegenWasmJit: external \"C\" : record field type not marshalled")?;
+                    let mut buf: Vec<u64> = vec![0; layout.words()];
+                    record_to_c_host(mem, fields, &layout, v.unwrap_i32() as usize, &mut buf, &mut cstrings)?;
+                    slots.push(Slot::P(buf.as_mut_ptr() as *mut c_void));
+                    types.push(Type::pointer());
+                    in_records.push(buf);
+                }
                 other => return Err("CodegenWasmJit: external \"C\" : input argument type not yet marshalled"),
             }
         }
@@ -788,11 +794,16 @@ unsafe fn call_external(
             wt(nls.note(caller))?;
             return wt(zero_results(sig, caller, rt_str_new, rets));
         }
-        // The run reports itself through its log alone, as C's separate executable
-        // does, so the buffer the message also went to is rolled back.
         let msg = openmodelica_error::ErrorExt::take_last_runtime_error();
-        openmodelica_error::ErrorExt::rollBack(EXT_CHECKPOINT);
-        sim_driver::note_runtime_error(&msg.unwrap_or_else(|| format!("external \"C\" `{}` failed", sig.name)));
+        // A run reports itself through its log alone, as C's separate executable
+        // does. The `-d=gen` function JIT (no solver, hence no `nls`) has no log:
+        // there the buffer is how the error reaches `getErrorString`.
+        if nls.is_some() {
+            openmodelica_error::ErrorExt::rollBack(EXT_CHECKPOINT);
+            sim_driver::note_runtime_error(&msg.unwrap_or_else(|| format!("external \"C\" `{}` failed", sig.name)));
+        } else {
+            openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
+        }
         return Err("CodegenWasmJit: external \"C\" raised a runtime error");
     }
     openmodelica_error::ErrorExt::delCheckpoint(EXT_CHECKPOINT);
@@ -830,6 +841,18 @@ unsafe fn call_external(
     }
     drop(cstrings);
 
+    // A filled `_Out_` record becomes a fresh in-wasm record object; done before
+    // the string closure below, which takes `caller`.
+    let mut out_handles: Vec<Option<u32>> = Vec::with_capacity(out_cells.len());
+    for cell in &out_cells {
+        out_handles.push(match cell {
+            OutCell::Record { fields, layout, buf } => {
+                Some(record_from_c_host(&mut *caller, memory, rt, fields, layout, buf)?)
+            }
+            OutCell::Scalar(..) => None,
+        });
+    }
+
     // Build an in-wasm String from a native `char*` (NUL-terminated), returning its
     // offset. Re-enters the runtime (`rt_str_new` may grow memory, so `data_mut` is
     // re-fetched after).
@@ -855,14 +878,208 @@ unsafe fn call_external(
         rets[ri] = result_val(ret_ty, rvalue, &mut make_string)?;
         ri += 1;
     }
-    for (ty, cell) in &out_cells {
-        rets[ri] = result_val(ty, **cell, &mut make_string)?;
+    for (cell, handle) in out_cells.iter().zip(&out_handles) {
+        rets[ri] = match cell {
+            OutCell::Scalar(ty, raw) => result_val(ty, **raw, &mut make_string)?,
+            OutCell::Record { .. } => Val::I32(handle.unwrap_or(0) as i32),
+        };
         ri += 1;
     }
     openmodelica_modelica_utilities::sim_external_end();
     Ok(())
 }
 
+/// One `_Out_` pointer argument's native cell, in output order.
+enum OutCell {
+    Scalar(crate::sig::SigTy, Box<[u8; 8]>),
+    Record { fields: std::sync::Arc<Vec<(arcstr::ArcStr, crate::sig::SigTy)>>, layout: HostCRecord, buf: Vec<u64> },
+}
+
+/// The C struct a record maps to on the *host* ABI — not the wasm32 one
+/// `dylink_wasmtime` builds, where `modelica_integer` is 4 bytes, nor the record
+/// object's own layout.
+struct HostCRecord {
+    size: usize,
+    align: usize,
+    offsets: Vec<usize>,
+}
+
+impl HostCRecord {
+    fn words(&self) -> usize {
+        self.size.div_ceil(8).max(1)
+    }
+}
+
+/// `openmodelica_types.h`: `modelica_integer` is a `long`, `modelica_boolean` an
+/// `int`, a `String`/external object a pointer.
+fn host_c_size_align(t: &crate::sig::SigTy) -> Option<(usize, usize)> {
+    use crate::sig::SigTy;
+    use std::mem::{align_of, size_of};
+    Some(match t {
+        SigTy::Real => (8, 8),
+        SigTy::Int => (size_of::<std::os::raw::c_long>(), align_of::<std::os::raw::c_long>()),
+        SigTy::Bool => (size_of::<std::os::raw::c_int>(), align_of::<std::os::raw::c_int>()),
+        SigTy::Str | SigTy::Ptr | SigTy::Array { .. } => (size_of::<usize>(), align_of::<usize>()),
+        SigTy::Record { fields, .. } => {
+            let l = host_c_record_layout(fields)?;
+            (l.size, l.align)
+        }
+        SigTy::Func { .. } => return None,
+    })
+}
+
+fn host_c_record_layout(fields: &[(arcstr::ArcStr, crate::sig::SigTy)]) -> Option<HostCRecord> {
+    let mut off = 0usize;
+    let mut align = 1usize;
+    let mut offsets = Vec::with_capacity(fields.len());
+    for (_, t) in fields {
+        let (sz, a) = host_c_size_align(t)?;
+        off = off.next_multiple_of(a);
+        offsets.push(off);
+        off += sz;
+        align = align.max(a);
+    }
+    Some(HostCRecord { size: off.next_multiple_of(align), align, offsets })
+}
+
+fn as_bytes_mut(buf: &mut [u64]) -> &mut [u8] {
+    // Safety: `u64` has no invalid bit patterns and the slice covers the same bytes.
+    unsafe { std::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len() * 8) }
+}
+
+/// Copy the record object at `handle` in wasm memory into the C struct `buf`.
+fn record_to_c_host(
+    mem: &[u8],
+    fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
+    layout: &HostCRecord,
+    handle: usize,
+    buf: &mut [u64],
+    cstrings: &mut Vec<std::ffi::CString>,
+) -> Result<()> {
+    use crate::sig::SigTy;
+    let obj = crate::sig::record_layout(fields);
+    let base = handle + obj.data_off as usize;
+    let dst = as_bytes_mut(buf);
+    for (i, (_, ty)) in fields.iter().enumerate() {
+        let src = base + obj.field_off[i] as usize;
+        let at = layout.offsets[i];
+        let handle_of = || u32::from_le_bytes(mem[src..src + 4].try_into().unwrap()) as usize;
+        match ty {
+            SigTy::Real => dst[at..at + 8].copy_from_slice(&mem[src..src + 8]),
+            SigTy::Int => {
+                let v = i32::from_le_bytes(mem[src..src + 4].try_into().unwrap()) as std::os::raw::c_long;
+                dst[at..at + std::mem::size_of::<std::os::raw::c_long>()].copy_from_slice(&v.to_le_bytes());
+            }
+            SigTy::Bool => dst[at..at + 4].copy_from_slice(&mem[src..src + 4]),
+            SigTy::Str => {
+                let h = handle_of();
+                let bytes: &[u8] = if h == 0 {
+                    &[]
+                } else {
+                    let len = u32::from_le_bytes(mem[h + 4..h + 8].try_into().unwrap()) as usize;
+                    &mem[h + 8..h + 8 + len]
+                };
+                let cs = std::ffi::CString::new(bytes)
+                    .map_err(|_| "external \"C\" : string field has an interior NUL")?;
+                let p = cs.as_ptr() as usize;
+                cstrings.push(cs);
+                dst[at..at + std::mem::size_of::<usize>()].copy_from_slice(&p.to_le_bytes());
+            }
+            SigTy::Ptr => {
+                let p = registry_get(i32::from_le_bytes(mem[src..src + 4].try_into().unwrap()));
+                dst[at..at + std::mem::size_of::<usize>()].copy_from_slice(&p.to_le_bytes());
+            }
+            // The element data, so the callee reads/writes the model's own array.
+            SigTy::Array { .. } => {
+                let h = handle_of();
+                let (_, data_off) = crate::host::array_abi::dims_and_data(mem, h)
+                    .ok_or("external \"C\" : malformed array field")?;
+                let p = mem.as_ptr() as usize + h + data_off;
+                dst[at..at + std::mem::size_of::<usize>()].copy_from_slice(&p.to_le_bytes());
+            }
+            SigTy::Record { fields: inner, .. } => {
+                let h = handle_of();
+                let inner_layout =
+                    host_c_record_layout(inner).ok_or("external \"C\" : record field type not marshalled")?;
+                // Inlined at `at`, so built apart and copied in.
+                let mut tmp: Vec<u64> = vec![0; inner_layout.words()];
+                record_to_c_host(mem, inner, &inner_layout, h, &mut tmp, cstrings)?;
+                let size = inner_layout.size;
+                dst[at..at + size].copy_from_slice(&as_bytes_mut(&mut tmp)[..size]);
+            }
+            SigTy::Func { .. } => return Err("external \"C\" : record field type not marshalled"),
+        }
+    }
+    Ok(())
+}
+
+/// The inverse of [`record_to_c_host`]: a fresh in-wasm record object holding what
+/// the callee wrote into the C struct.
+fn record_from_c_host(
+    caller: &mut wasmtime::Caller<'_, WasiCtx>,
+    memory: wasmtime::Memory,
+    rt: &crate::dylink_engine::ExtRt,
+    fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
+    layout: &HostCRecord,
+    buf: &[u64],
+) -> Result<u32> {
+    use crate::sig::SigTy;
+    let obj = crate::sig::record_layout(fields);
+    let handle = wt(rt.record_new.call(&mut *caller, (obj.heap.len() as u32, obj.size)))?;
+    // The inline table the runtime releases the record's heap fields by.
+    for (k, (kind, off)) in obj.heap.iter().enumerate() {
+        let at = (handle + 8 + k as u32 * 8) as usize;
+        let mem = memory.data_mut(&mut *caller);
+        mem[at..at + 4].copy_from_slice(&kind.to_le_bytes());
+        mem[at + 4..at + 8].copy_from_slice(&off.to_le_bytes());
+    }
+    // Safety: as in `as_bytes_mut`.
+    let src = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 8) };
+    for (i, (_, ty)) in fields.iter().enumerate() {
+        let at = layout.offsets[i];
+        let dst = (handle + obj.data_off + obj.field_off[i]) as usize;
+        match ty {
+            SigTy::Real => memory.data_mut(&mut *caller)[dst..dst + 8].copy_from_slice(&src[at..at + 8]),
+            SigTy::Int => {
+                let v = std::os::raw::c_long::from_le_bytes(
+                    src[at..at + std::mem::size_of::<std::os::raw::c_long>()].try_into().unwrap(),
+                ) as i32;
+                memory.data_mut(&mut *caller)[dst..dst + 4].copy_from_slice(&v.to_le_bytes());
+            }
+            SigTy::Bool => memory.data_mut(&mut *caller)[dst..dst + 4].copy_from_slice(&src[at..at + 4]),
+            SigTy::Ptr => {
+                let p = usize::from_le_bytes(src[at..at + std::mem::size_of::<usize>()].try_into().unwrap());
+                let h = registry_put(p);
+                memory.data_mut(&mut *caller)[dst..dst + 4].copy_from_slice(&h.to_le_bytes());
+            }
+            SigTy::Str => {
+                let p = usize::from_le_bytes(src[at..at + std::mem::size_of::<usize>()].try_into().unwrap())
+                    as *const std::os::raw::c_char;
+                let bytes: &[u8] =
+                    if p.is_null() { &[] } else { unsafe { std::ffi::CStr::from_ptr(p) }.to_bytes() };
+                let soff = wt(rt.str_new.call(&mut *caller, bytes.len() as u32))?;
+                let doff = wt(rt.str_data.call(&mut *caller, soff))? as usize;
+                let mem = memory.data_mut(&mut *caller);
+                mem[doff..doff + bytes.len()].copy_from_slice(bytes);
+                mem[dst..dst + 4].copy_from_slice(&soff.to_le_bytes());
+            }
+            SigTy::Record { fields: inner, .. } => {
+                let inner_layout =
+                    host_c_record_layout(inner).ok_or("external \"C\" : record field type not marshalled")?;
+                let words: Vec<u64> = src[at..at + inner_layout.words() * 8]
+                    .chunks_exact(8)
+                    .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+                    .collect();
+                let h = record_from_c_host(&mut *caller, memory, rt, inner, &inner_layout, &words)?;
+                memory.data_mut(&mut *caller)[dst..dst + 4].copy_from_slice(&h.to_le_bytes());
+            }
+            // An array field is the model's own object, filled in place.
+            SigTy::Array { .. } => {}
+            SigTy::Func { .. } => return Err("external \"C\" : record field type not marshalled"),
+        }
+    }
+    Ok(handle)
+}
 
 pub fn run(model: &SimModel, meta: &SimMeta) -> std::result::Result<sim_driver::RunResult, String> {
     let bench = crate::model::sim_bench_enabled();
@@ -1283,6 +1500,9 @@ impl sim_driver::SimEngine for WasmtimeEngine {
         if let Ok(f) = self.rt_inst.get_typed_func::<f64, ()>(&mut self.store, "rt_nls_clean_history") {
             let _ = f.call(&mut self.store, time);
         }
+    }
+    fn set_rhs_final(&mut self, final_eval: bool) {
+        openmodelica_util::dynload::set_rhs_final_flag(final_eval);
     }
 }
 

--- a/testsuite/simulation/modelica/external_functions/ts.mo
+++ b/testsuite/simulation/modelica/external_functions/ts.mo
@@ -131,6 +131,8 @@ package ExternalMedia
           output MolarMass MM "molar mass";
           external "C" MM = TwoPhaseMedium_getMolarMass_C_impl(mediumName, libraryName, substanceName)
         annotation(Include = "
+#include <assert.h>
+#include <stdio.h>
 double TwoPhaseMedium_getMolarMass_C_impl(const char* mediumName, const char* libraryName, const char* substanceName)
 {
   assert(mediumName[0] != 0); assert(libraryName[0] != 0); assert(substanceName[0] != 0);
@@ -143,6 +145,7 @@ double TwoPhaseMedium_getMolarMass_C_impl(const char* mediumName, const char* li
           output Temperature Tc "Critical temperature";
           external "C" Tc = TwoPhaseMedium_getCriticalTemperature_C_impl(mediumName, libraryName, substanceName)
         annotation(Include = "
+#include <assert.h>
 double TwoPhaseMedium_getCriticalTemperature_C_impl(const char* mediumName, const char* libraryName, const char* substanceName)
 {
   assert(mediumName[0] != 0); assert(libraryName[0] != 0); assert(substanceName[0] != 0);
@@ -154,6 +157,7 @@ double TwoPhaseMedium_getCriticalTemperature_C_impl(const char* mediumName, cons
           output AbsolutePressure pc "Critical temperature";
           external "C" pc = TwoPhaseMedium_getCriticalPressure_C_impl(mediumName, libraryName, substanceName)
         annotation(Include = "
+#include <assert.h>
 double TwoPhaseMedium_getCriticalPressure_C_impl(const char* mediumName, const char* libraryName, const char* substanceName)
 {
   assert(mediumName[0] != 0); assert(libraryName[0] != 0); assert(substanceName[0] != 0);
@@ -165,6 +169,7 @@ double TwoPhaseMedium_getCriticalPressure_C_impl(const char* mediumName, const c
           output MolarVolume vc "Critical molar volume";
           external "C" vc = TwoPhaseMedium_getCriticalMolarVolume_C_impl(mediumName, libraryName, substanceName)
         annotation(Include = "
+#include <assert.h>
 double TwoPhaseMedium_getCriticalMolarVolume_C_impl(const char* mediumName, const char* libraryName, const char* substanceName)
 {
   assert(mediumName[0] != 0); assert(libraryName[0] != 0); assert(substanceName[0] != 0);
@@ -179,7 +184,8 @@ double TwoPhaseMedium_getCriticalMolarVolume_C_impl(const char* mediumName, cons
           input FixedPhase phase = 0 "2 for two-phase, 1 for one-phase, 0 if not known";
           output ThermodynamicState state;
           external "C" TwoPhaseMedium_setState_ph_C_impl(p, h, phase, state, mediumName, libraryName, substanceName)
-        annotation(Include = "typedef struct {
+        annotation(Include = "#include <assert.h>
+typedef struct {
   //! Temperature
   double T;
   //! Velocity of sound


### PR DESCRIPTION
Five `simulation/modelica/external_functions` tests, and what each needed:

| Test | Gap |
| --- | --- |
| `TestRoots` | `size(a, d)` demanded the operand's rank statically | | `ExtObj` | a `Library` naming an object file with an MSVC suffix | | `ModelicaUtilities` | the `-d=gen` function JIT built no host lib | | `ts` | a record `_Out_` argument, and the callee's own prototype | | `ExternalRHSFlag` | `RHSFinalFlag` was neither defined nor set |

`compile_size` only needs the rank for the whole-vector `size(a)`; a dimension expression's operand is `T_UNKNOWN`, which is why the rank was unavailable at all.

`gcc -c -o ExtObj.lib` names an object file the MSVC way and the C target links it as one, so `is_link_input` accepts `.lib`/`.obj` off Windows.

The function JIT now builds the same host libraries the simulation build does — archives linked, `Include` and `.c`-`Library` sources compiled — and calls them through libffi; the in-wasm side module is built only in the browser. The in-wasm `Modelica*` callbacks are host imports, which cannot take C varargs, so `ModelicaFormatMessage` there printed its format string with `%s` unsubstituted. A script-level external error now stays in the Error buffer, which is how it reaches `getErrorString`, instead of being rolled back into a run log that does not exist.

`ExternalMedia`'s `setState_ph` declares `double phase` for a Modelica `Integer` and fills a record through a pointer. Calling the raw symbol with our own signature put `phase` in `rdi`, so `state` was read from it. `omc_ext_call_<name>` is therefore emitted for every external, not only for a macro, and preferred when resolving: with the callee's declaration in scope the C compiler inserts exactly the conversions the C target's generated call gets. Records are marshalled with the *host* ABI, where `modelica_integer` is a `long`.

`RHSFinalFlag` is exported from the compiler image for a PIC library to bind to. A non-PIC archive cannot — `R_X86_64_PC32` against an imported symbol is not something ld will put in a shared object — so the link is retried with a `protected`-visibility definition of its own, which the host then keeps in step. The flag is set around `ddaskr` where dassl.c sets it, over an `env.rt_host_rhs_final` import for the in-wasm driver. One print was still missing: with `-noEquidistantTimeGrid` C's first step takes the "desired step size too small" branch, whose `functionODE` is not counted in `nCallsODE`, so `DasslDriver` now evaluates there too.

`ts.mo`'s `Include` sources include `<assert.h>`/`<stdio.h>` themselves, as ExtObj.h and RecordMemberArguments do since #16349.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
