### PR TITLE
testsuite: a cSources suite for C-file checks

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -728,10 +728,10 @@ void partestRust(partition) {
   String simCodeTargetArg = params.RUST_PARTEST_SIMCODETARGET ? " -simCodeTarget=${params.RUST_PARTEST_SIMCODETARGET}" : ''
   // cpp/hpcom: the Rust omc is built without the C++ runtime. metamodelica:
   // MetaModelica code generation only works against the C runtime.
-  // fmuCSources checks the generated C files or the list in the XML - wasm-jit does not use C
+  // cSources/fmuCSources check generated C files or FMU sources - wasm-jit does not use C
   // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
   // stackoverflow: Rust aborts on stack overflow, MMC unwinds out of the SEGV handler
-  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-fmuCSources,-stackoverflow'
+  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-cSources,-fmuCSources,-stackoverflow'
   // wasmtime reserves ~4 GiB of address space per wasm memory, and shrinking that
   // reservation to fit an RLIMIT_AS costs the bounds-check-free fast path.
   String asLimit = params.RUST_PARTEST_SIMCODETARGET == 'wasm-jit'

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -86,7 +86,7 @@ my $osname = $^O;
 # it belongs to are enabled. 'disabled' is such a tag: a test carrying it is not
 # part of the testsuite at all, see %suite_enabled.
 my @category_suites = qw(default cpp cppmsl tearing hpcom);
-my @tag_suites = qw(metamodelica 63bit antlr fmuCSources stackoverflow disabled);
+my @tag_suites = qw(metamodelica 63bit antlr cSources fmuCSources stackoverflow disabled);
 my %suite_enabled = (
   default      => 1,  # Everything not claimed by another category.
   cpp          => 1,  # */cppruntime/*
@@ -96,6 +96,7 @@ my %suite_enabled = (
   metamodelica => 1,  # Needs MetaModelica code generation, i.e. the C runtime.
   '63bit'      => 1,  # Needs a 63/64-bit Modelica Integer.
   antlr        => 1,  # Expects ANTLR's syntax error positions and wording.
+  cSources     => 1,  # Inspects the generated C files, which only the C target writes.
   fmuCSources  => 1,  # Inspects sources/ inside an FMU, which only the C export has.
   stackoverflow => 1, # Recurses until the stack runs out; needs MMC's SEGV-handler
                       # recovery, which the Rust port has no equivalent of.

--- a/testsuite/simulation/libraries/3rdParty/ScalableTestSuite/Advection_N3200.mos
+++ b/testsuite/simulation/libraries/3rdParty/ScalableTestSuite/Advection_N3200.mos
@@ -1,10 +1,10 @@
 // status: correct
+// suite: cSources
 // This is a test for equationsPerFile compiling as it should
 
 loadFile("Advection_N3200.mo");getErrorString();
 
-setCommandLineOptions("--daeMode -d=nogen");
-extraSimFlags := "-mei=4000 -daeMode -s=ida -idaLS=klu --equationsPerFile=200";
+setCommandLineOptions("--daeMode --equationsPerFile=200 -d=nogen");
 setCFlags(getCFlags() + " -Os");
 
 file := "AdvectionReaction_N_3200_total_06inz_part2.c";
@@ -22,7 +22,6 @@ end if;
 // true
 // ""
 // true
-// "-mei=4000 -daeMode -s=ida -idaLS=klu --equationsPerFile=200"
 // true
 // "AdvectionReaction_N_3200_total_06inz_part2.c"
 //


### PR DESCRIPTION
`Advection_N3200` asserts that
`AdvectionReaction_N_3200_total_06inz_part2.c` exists, so it only means anything for the C code generator: `--equationsPerFile` is a CodegenC flag ("Generate code for at most this many equations per C-file") and no other simCodeTarget writes C files. Tag it and let `partestRust` deselect it, the way `fmuCSources` already deselects the FMU tests that read `sources/`.

wasm-jit itself is fine on this model. It translates in 12.8s against C's 17s, splits the equations into `functionInitialEquations$0..$22` and `evaluateDAEResiduals$0..$26` -- the chunk budget is its `--equationsPerFile` -- and simulates `-daeMode -s=ida -idaLS=klu` in 22.5s against C's 35.7s.

While here: `--equationsPerFile=200` sat in `extraSimFlags`, a variable nothing reads (there is no `simulate()` in this test, and no other test uses the name), so the test ran at the default of 500 rather than what it claims to check. Moving it into `setCommandLineOptions` takes the split from 13 to 33 `_06inz` parts and from 7 to 16 `_16dae` ones.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
