### PR TITLE
OMEdit wasm: link the simulation metadata tables

### DIFF
--- a/OMEdit/OMEditGUI/wasm/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/wasm/CMakeLists.txt
@@ -121,6 +121,12 @@ list(APPEND OMEDITLIB_SOURCES
   # QAbstractFileEngineHandler that serves worker-VFS files to main-thread QFile.
   ${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp PROPERTIES SKIP_AUTOMOC ON)
+# The simulation metadata tables OMCProxy reads (SOLVER_METHOD_NAME, FLAG_NAME,
+# OMC_LOG_STREAM_NAME, ...); native OMEdit gets them from libOpenModelicaCompiler.
+list(APPEND OMEDITLIB_SOURCES ${SIMRT}/util/simulation_options.c ${SIMRT}/util/omc_error.c)
+# omc_error.c reaches <gc.h> for threadData_t; declarations only, no collector call.
+set_source_files_properties(${SIMRT}/util/omc_error.c PROPERTIES
+  INCLUDE_DIRECTORIES ${OM_ROOT}/OMCompiler/3rdParty/gc/include)
 # TimeManager drives the result-replay time slider in VariablesWidget. It is the
 # one Animation/ source that has no OpenSceneGraph/GL dependency (just rtclock +
 # QTimer), so compile it (rtclock entry points are provided by wasm_stubs.cpp)


### PR DESCRIPTION
OMCProxy fills the Simulation Setup combo boxes straight from the C runtime's tables (SOLVER_METHOD_NAME, JACOBIAN_METHOD_NAME, LS_NAME, NLS_NAME, INIT_METHOD_NAME, OMC_LOG_STREAM_NAME) and validates __OpenModelica_simulationFlags against FLAG_NAME. Native OMEdit gets them from libOpenModelicaCompiler, which mirrors them as Rust statics; the Qt-for-WebAssembly build links neither that library nor the C runtime, and it links with --allow-undefined, so every table resolved to address 0 and read back as NULL.

The result was a Simulation Setup dialog with six empty combo boxes and an empty -s= on the command line, which the wasm-jit runtime rejects the way C's setupSolver does:

  unrecognized value `' for -s (accepted: dassl, dasslrt, euler, ...)

Compile the runtime's own definitions into OMEditLib. Both files build clean for wasm: simulation_options.c is pure data with no undefined symbols, and omc_error.c only needs the Boehm headers on the include path to declare threadData_t - its undefined set is libc plus FLAG_NAME, nothing reaching the collector.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
