### PR TITLE
wasm-jit: generic residuals, $START NLS unknowns

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -6888,6 +6888,14 @@ fn nls_parts(
                     res_index: *res_index,
                 });
             }
+            E::SES_GENERIC_RESIDUAL { iterators, scal_indices, exp, res_index, .. } => {
+                residuals.push(NlsResidual::Generic {
+                    iterators: lst(iterators).cloned().collect(),
+                    scal_indices: lst(scal_indices).copied().collect(),
+                    exp: exp.clone(),
+                    res_index: *res_index,
+                });
+            }
             _ => inner.push(e.clone()),
         }
     }
@@ -6902,12 +6910,12 @@ fn nls_parts(
         }
         return Err("CodegenWasmJit: SES_NONLINEAR has no residual equations");
     }
-    // A for-residual's count is only known at run time, so validate the unknown
-    // count only for scalar-only systems. An adaptive approach appends
-    // `__HOM_LAMBDA` without a residual: the arc-length condition closes it.
-    let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
+    // Only checkable when every residual's row count is static. An adaptive
+    // approach appends `__HOM_LAMBDA` without a residual: the arc-length
+    // condition closes it.
     let extra = usize::from(is_homotopy_lambda(iter_vars.last()));
-    if all_scalar && iter_vars.len() != residuals.len() + extra {
+    let rows = residuals.iter().try_fold(0usize, |acc, r| r.rows().map(|n| acc + n));
+    if rows.is_some_and(|rows| iter_vars.len() != rows + extra) {
         return Err("CodegenWasmJit: SES_NONLINEAR unknown/residual count mismatch");
     }
     Ok((inner, NlsResiduals::Explicit(residuals), iter_vars))
@@ -7342,6 +7350,28 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
     let n = lst(&nlsystem.crefs).count();
     let rows = n - nls_lambda_extra(nlsystem) as usize;
     n > 0 && count(&jm.seedVars) as usize == n && nls_jac_result_rows(jm, rows).is_some()
+}
+
+/// The `SimData` slot a torn system's iteration variable reads and writes. An
+/// initialization system can solve for a start value, and C's `cref` makes
+/// `$START.<var>` an lvalue into that variable's `attribute.start` — its start
+/// slot here. `Ok(None)` leaves naming the system to the caller.
+pub(crate) fn iteration_var_slot(
+    vars: &HashMap<String, SimSlot>,
+    start_slots: &HashMap<String, u32>,
+    cr: &Arc<DAE::ComponentRef>,
+) -> Result<Option<u32>> {
+    let key = sim_cref_key(cr)?;
+    if let Some(off) = key.strip_prefix("$START.").and_then(|k| start_slots.get(k)) {
+        return Ok(Some(*off));
+    }
+    match vars.get(&key) {
+        None => Ok(None),
+        Some(slot) if slot.wty != WTy::F64 => {
+            Err("CodegenWasmJit: torn-system unknown is not a Real variable")
+        }
+        Some(slot) => Ok(Some(slot.off)),
+    }
 }
 
 /// 1 when the last unknown is `__HOM_LAMBDA`, which has no residual row: C's
@@ -7940,16 +7970,9 @@ fn build_nls_fns(
             slots.push(var_map.lambda_off);
             continue;
         }
-        let key = sim_cref_key(cr)?;
-        let slot = var_map
-            .vars
-            .get(&key)
-            .copied()
-            .ok_or_else(|| "CodegenWasmJit: nonlinear-system unknown has no slot")?;
-        if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: nonlinear-system unknown is not a Real variable");
-        }
-        slots.push(slot.off);
+        let off = iteration_var_slot(&var_map.vars, &var_map.start_slots, cr)?
+            .ok_or("CodegenWasmJit: nonlinear-system unknown has no slot")?;
+        slots.push(off);
     }
     let mk_sim = || sim_ctx(var_map);
     let finish = |ctx: FnCtx| -> we::Function {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -6676,7 +6676,9 @@ pub(crate) mod shared_lits;
 
 #[path = "CodegenWasmJitFunctions/generic_calls.rs"]
 mod generic_calls;
-pub(crate) use generic_calls::{emit_entwined_assign, emit_generic_assign, emit_resizable_assign};
+pub(crate) use generic_calls::{
+    emit_entwined_assign, emit_generic_assign, emit_index_list_loop, emit_resizable_assign,
+};
 
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/generic_calls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/generic_calls.rs
@@ -31,39 +31,10 @@ pub(crate) fn emit_generic_assign(
     call_index: i32,
     scal_indices: &Arc<List<i32>>,
 ) -> Result<()> {
-    use we::Instruction as I;
     let call = lookup_call(ctx, call_index)?;
     let indices: Vec<i32> = (&**scal_indices).into_iter().copied().collect();
-    if indices.is_empty() {
-        return Ok(());
-    }
-    let table = emit_const_int_table(ctx, &indices)?;
-    let k = ctx.alloc_temp(WTy::I32);
-    ctx.emit(I::I32Const(0));
-    ctx.emit(I::LocalSet(k));
-    ctx.emit(I::Block(we::BlockType::Empty));
-    ctx.emit(I::Loop(we::BlockType::Empty));
-    ctx.emit(I::LocalGet(k));
-    ctx.emit(I::I32Const(indices.len() as i32));
-    ctx.emit(I::I32GeS);
-    ctx.emit(I::BrIf(1));
-    let idx = ctx.alloc_temp(WTy::I32);
-    ctx.emit(I::LocalGet(table));
-    ctx.emit(I::LocalGet(k));
-    ctx.emit(I::I32Const(4));
-    ctx.emit(I::I32Mul);
-    ctx.emit(I::I32Add);
-    ctx.emit(I::I32Load(mem_arg(0, 2)));
-    ctx.emit(I::LocalSet(idx));
-    emit_index_body(ctx, &call, idx)?;
-    ctx.emit(I::LocalGet(k));
-    ctx.emit(I::I32Const(1));
-    ctx.emit(I::I32Add);
-    ctx.emit(I::LocalSet(k));
-    ctx.emit(I::Br(0));
-    ctx.emit(I::End); // loop
-    ctx.emit(I::End); // block
-    Ok(())
+    let iters: Vec<BackendDAE::SimIterator> = (&**call_iters(&call)).into_iter().cloned().collect();
+    emit_index_list_loop(ctx, &iters, &indices, &mut |ctx, _| emit_call_body(ctx, &call))
 }
 
 /// `SES_ENTWINED_ASSIGN`: calls interleaved in `call_order`, each consuming its
@@ -110,16 +81,25 @@ fn lookup_call(ctx: &FnCtx, call_index: i32) -> Result<SimCode::SimGenericCall> 
         .ok_or("CodegenWasmJit: for-equation names an unknown generic call")
 }
 
-/// C's `genericIterator`: recover each iterator from `idx` by mixed-radix
-/// division (first listed iterator least significant), then run the body.
 fn emit_index_body(ctx: &mut FnCtx, call: &SimCode::SimGenericCall, idx: u32) -> Result<()> {
-    use we::Instruction as I;
     let iters: Vec<BackendDAE::SimIterator> = (&**call_iters(call)).into_iter().cloned().collect();
+    emit_decoded_iters(ctx, &iters, idx, &mut |ctx| emit_call_body(ctx, call))
+}
+
+/// C's `genericIterator`: recover each iterator from `idx` by mixed-radix
+/// division (first listed iterator least significant), then run `body`.
+pub(crate) fn emit_decoded_iters(
+    ctx: &mut FnCtx,
+    iters: &[BackendDAE::SimIterator],
+    idx: u32,
+    body: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
     let tmp = ctx.alloc_temp(WTy::I32);
     ctx.emit(I::LocalGet(idx));
     ctx.emit(I::LocalSet(tmp));
     let mut bounds = Vec::new();
-    for iter in &iters {
+    for iter in iters {
         let it = ctx.alloc_temp(WTy::I32);
         let (name, size) = match iter {
             BackendDAE::SimIterator::SIM_ITERATOR_RANGE { name, start, step, size, .. } => {
@@ -159,10 +139,51 @@ fn emit_index_body(ctx: &mut FnCtx, call: &SimCode::SimGenericCall, idx: u32) ->
         bounds.push(bind_iter(ctx, name, it, SigTy::Int)?);
         bounds.extend(emit_sub_iters(ctx, iter_sub_iter(iter), it)?);
     }
-    emit_call_body(ctx, call)?;
+    body(ctx)?;
     for b in bounds.into_iter().rev() {
         unbind_iter(ctx, b);
     }
+    Ok(())
+}
+
+/// C's `for(i_ …) { tmp = idx_lst[i_]; … }`: [`emit_decoded_iters`] per index in
+/// `scal_indices`, with `body` handed the local holding the position `i_`.
+pub(crate) fn emit_index_list_loop(
+    ctx: &mut FnCtx,
+    iters: &[BackendDAE::SimIterator],
+    scal_indices: &[i32],
+    body: &mut dyn FnMut(&mut FnCtx, u32) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    if scal_indices.is_empty() {
+        return Ok(());
+    }
+    let table = emit_const_int_table(ctx, scal_indices)?;
+    let k = ctx.alloc_temp(WTy::I32);
+    let idx = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::LocalSet(k));
+    ctx.emit(I::Block(we::BlockType::Empty));
+    ctx.emit(I::Loop(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(k));
+    ctx.emit(I::I32Const(scal_indices.len() as i32));
+    ctx.emit(I::I32GeS);
+    ctx.emit(I::BrIf(1));
+    ctx.emit(I::LocalGet(table));
+    ctx.emit(I::LocalGet(k));
+    ctx.emit(I::I32Const(4));
+    ctx.emit(I::I32Mul);
+    ctx.emit(I::I32Add);
+    ctx.emit(I::I32Load(mem_arg(0, 2)));
+    ctx.emit(I::LocalSet(idx));
+    emit_decoded_iters(ctx, iters, idx, &mut |ctx| body(ctx, k))?;
+    ctx.emit(I::LocalGet(k));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Add);
+    ctx.emit(I::LocalSet(k));
+    ctx.emit(I::Br(0));
+    ctx.emit(I::End); // loop
+    ctx.emit(I::End); // block
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -37,8 +37,9 @@ fn emit_residual_eval(
     Ok(())
 }
 
-/// A nonlinear system residual: a scalar `SES_RESIDUAL`, or a `SES_FOR_RESIDUAL`
-/// (a run `r[res_index + shift]` from iterating `exp` over integer ranges).
+/// A nonlinear system residual: a scalar `SES_RESIDUAL`, a `SES_FOR_RESIDUAL`
+/// (a run `r[res_index + shift]` from iterating `exp` over integer ranges), or a
+/// `SES_GENERIC_RESIDUAL` (the same over a list of flat indices).
 pub(crate) enum NlsResidual {
     Scalar { exp: Arc<DAE::Exp>, res_index: i32 },
     For {
@@ -46,6 +47,23 @@ pub(crate) enum NlsResidual {
         exp: Arc<DAE::Exp>,
         res_index: i32,
     },
+    Generic {
+        iterators: Vec<BackendDAE::SimIterator>,
+        scal_indices: Vec<i32>,
+        exp: Arc<DAE::Exp>,
+        res_index: i32,
+    },
+}
+
+impl NlsResidual {
+    /// Rows of `r` written; `None` for a for-residual (run-time ranges).
+    pub(crate) fn rows(&self) -> Option<usize> {
+        match self {
+            NlsResidual::Scalar { .. } => Some(1),
+            NlsResidual::Generic { scal_indices, .. } => Some(scal_indices.len()),
+            NlsResidual::For { .. } => None,
+        }
+    }
 }
 
 /// What closes a nonlinear system: residual expressions, or — for a lone
@@ -80,8 +98,8 @@ pub(crate) fn emit_nls_residual_body(
         }
     };
     lower_inner(ctx)?;
-    // All-scalar systems keep sequential `r[i]` addressing; a for-residual forces
-    // `res_index`-based addressing throughout (C's `res[res_index + shift]`).
+    // All-scalar systems keep sequential `r[i]` addressing; a for- or generic
+    // residual forces `res_index`-based addressing throughout.
     let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
     for (i, res) in residuals.iter().enumerate() {
         match res {
@@ -95,9 +113,38 @@ pub(crate) fn emit_nls_residual_body(
             NlsResidual::For { iterators, exp, res_index } => {
                 emit_for_residual(ctx, iterators, exp, *res_index, &[])?;
             }
+            NlsResidual::Generic { iterators, scal_indices, exp, res_index } => {
+                emit_generic_residual(ctx, iterators, scal_indices, exp, *res_index)?;
+            }
         }
     }
     Ok(())
+}
+
+/// Emit a `SES_GENERIC_RESIDUAL`: `r[res_index + i] = exp` for the `i`-th flat
+/// index of `scal_indices`, with the iterators decoded from it.
+fn emit_generic_residual(
+    ctx: &mut FnCtx,
+    iterators: &[BackendDAE::SimIterator],
+    scal_indices: &[i32],
+    exp: &Arc<DAE::Exp>,
+    res_index: i32,
+) -> Result<()> {
+    use we::Instruction as I;
+    emit_index_list_loop(ctx, iterators, scal_indices, &mut |ctx, k| {
+        // addr = r + (res_index + k) * 8
+        ctx.emit(I::LocalGet(2)); // r
+        ctx.emit(I::I32Const(res_index));
+        ctx.emit(I::LocalGet(k));
+        ctx.emit(I::I32Add);
+        ctx.emit(I::I32Const(8));
+        ctx.emit(I::I32Mul);
+        ctx.emit(I::I32Add);
+        let w = compile_exp(ctx, exp)?;
+        coerce(ctx, w, WTy::F64);
+        ctx.emit(I::F64Store(mem_arg(0, 3)));
+        Ok(())
+    })
 }
 
 /// C's `OLD_<i>` backup of the outputs an inverse algorithm must not change.
@@ -616,17 +663,10 @@ pub(crate) fn compile_linear_system(
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(n);
     for cr in iter_vars {
-        let key = sim_cref_key(cr)?;
-        let slot = ctx
-            .sim()?
-            .vars
-            .get(&key)
-            .copied()
-            .ok_or_else(|| "CodegenWasmJit: linear-system unknown has no slot")?;
-        if slot.wty != WTy::F64 {
-            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
-        }
-        slots.push(slot.off);
+        let sim = ctx.sim()?;
+        let off = crate::CodegenWasmJit::iteration_var_slot(&sim.vars, &sim.start_slots, cr)?
+            .ok_or("CodegenWasmJit: linear-system unknown has no slot")?;
+        slots.push(off);
     }
     let data = ctx.sim()?.data_local;
 


### PR DESCRIPTION
`Buildings.Fluid.Humidifiers.Examples.Humidifier_u` failed in codegen with `SES_NONLINEAR unknown/residual count mismatch`. Its initialization system tripped two independent gaps.

`SES_GENERIC_RESIDUAL` was unhandled, so `nls_parts` filed it as an inner equation and the system read 6 unknowns against 5 residuals. It is C's `equationGenericResidual`: a for-residual visiting its iteration space at a list of flat indices rather than over the whole range. The mixed-radix decode already existed for
`SES_GENERIC_ASSIGN`, so `emit_index_body` is split into `emit_decoded_iters` and `emit_index_list_loop` and both paths share it. The count check now sums rows instead of residual entries; a for-residual's is still only known at run time, so a system holding one skips the check as before.

The sixth unknown, `$START.humDyn.vol.dynBal.medium.d`, had no slot. An initialization system can solve for a start value, and C's `cref` makes such a reference an lvalue into that variable's `attribute.start` — its start slot here, not `vars`. Resolved by a new `iteration_var_slot`, shared with the linear torn-system path. C's nominal/min/max for the unknown come from `generateStaticInitialData`'s `index < 0` arm, which is already the Rust default.

The test now matches its expected output, homotopy step count included. Against the local C target at the test's `tolerance=1e-6`, 6 of 663 result variables differ; at `1e-10` all 663 compare equal, so those 6 are integrator noise on near-zero derivatives rather than a runtime gap.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
