### PR TITLE
[FMI] Send the parameters of an imported FMI 1.0 Co-Simulation FMU to the FMU (#16363)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -3246,14 +3246,27 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
     <%dumpFMIModelVariablesList("1.0", fmiModelVariablesList, fmiTypeDefinitionsList, generateInputConnectors, generateOutputConnectors)%>
   protected
     FMI1CoSimulation fmi1cs = FMI1CoSimulation(logLevel, fmuWorkingDir, "<%fmiInfo.fmiModelIdentifier%>", debugLogging, fmuLocation, mimeType, timeout, visible, interactive, startTime, stopTimeDefined, stopTime);
+    parameter Real flowParamsStart(fixed=false);
     parameter Real flowInitialized(fixed=false);
     Real flowStep;
     <%if not stringEq(realInputVariablesVRs, "") then "Real "+realInputVariablesReturnNames+";"%>
     <%if not stringEq(integerInputVariablesVRs, "") then "Integer "+integerInputVariablesReturnNames+";"%>
     <%if not stringEq(booleanInputVariablesVRs, "") then "Boolean "+booleanInputVariablesReturnNames+";"%>
     <%if not stringEq(stringInputVariablesVRs, "") then "String "+stringInputVariablesReturnNames+";"%>
+  initial algorithm
+    flowParamsStart := 1;
+    /* the parameters must be set before the slave is initialized,
+       otherwise the FMU computes its calculated parameters from the default values */
+    <%if not stringEq(realParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1cs, {"+realParametersVRs+"}, {"+realParametersNames+"});"%>
+    <%if not stringEq(integerParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetIntegerParameter(fmi1cs, {"+integerParametersVRs+"}, {"+integerParametersNames+"});"%>
+    <%if not stringEq(booleanParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetBooleanParameter(fmi1cs, {"+booleanParametersVRs+"}, {"+booleanParametersNames+"});"%>
+    <%if not stringEq(stringParametersVRs, "") then "flowParamsStart := fmi1Functions.fmi1SetStringParameter(fmi1cs, {"+stringParametersVRs+"}, {"+stringParametersNames+"});"%>
+    flowInitialized := fmi1Functions.fmi1InitializeSlave(fmi1cs, flowParamsStart);
   initial equation
-    flowInitialized = fmi1Functions.fmi1InitializeSlave(fmi1cs, 1);
+    <%if not stringEq(realDependentParametersVRs, "") then "{"+realDependentParametersNames+"} = fmi1Functions.fmi1GetReal(fmi1cs, {"+realDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(integerDependentParametersVRs, "") then "{"+integerDependentParametersNames+"} = fmi1Functions.fmi1GetInteger(fmi1cs, {"+integerDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(booleanDependentParametersVRs, "") then "{"+booleanDependentParametersNames+"} = fmi1Functions.fmi1GetBoolean(fmi1cs, {"+booleanDependentParametersVRs+"}, flowInitialized);"%>
+    <%if not stringEq(stringDependentParametersVRs, "") then "{"+stringDependentParametersNames+"} = fmi1Functions.fmi1GetString(fmi1cs, {"+stringDependentParametersVRs+"}, flowInitialized);"%>
   equation
     <%if not boolAnd(stringEq(realOutputVariablesNames, ""), stringEq(realOutputVariablesVRs, "")) then "{"+realOutputVariablesNames+"} = fmi1Functions.fmi1GetReal(fmi1cs, {"+realOutputVariablesVRs+"}, flowInitialized);"%>
     <%if not boolAnd(stringEq(integerOutputVariablesNames, ""), stringEq(integerOutputVariablesVRs, "")) then "{"+integerOutputVariablesNames+"} = fmi1Functions.fmi1GetInteger(fmi1cs, {"+integerOutputVariablesVRs+"}, flowInitialized);"%>
@@ -3344,6 +3357,14 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         external "C" fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetReal;
 
+      function fmi1SetRealParameter
+        input FMI1CoSimulation fmi1cs;
+        input Real realValuesReferences[:];
+        input Real realValues[size(realValuesReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi1SetReal_OMC(fmi1cs, size(realValuesReferences, 1), realValuesReferences, realValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi1SetRealParameter;
+
       function fmi1GetInteger
         input FMI1CoSimulation fmi1cs;
         input Real integerValuesReferences[:];
@@ -3359,6 +3380,14 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         output Integer out_Values[size(integerValuesReferences, 1)] = integerValues;
         external "C" fmi1SetInteger_OMC(fmi1cs, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetInteger;
+
+      function fmi1SetIntegerParameter
+        input FMI1CoSimulation fmi1cs;
+        input Real integerValuesReferences[:];
+        input Integer integerValues[size(integerValuesReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi1SetInteger_OMC(fmi1cs, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi1SetIntegerParameter;
 
       function fmi1GetBoolean
         input FMI1CoSimulation fmi1cs;
@@ -3376,6 +3405,14 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         external "C" fmi1SetBoolean_OMC(fmi1cs, size(booleanValuesReferences, 1), booleanValuesReferences, booleanValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetBoolean;
 
+      function fmi1SetBooleanParameter
+        input FMI1CoSimulation fmi1cs;
+        input Real booleanValuesReferences[:];
+        input Boolean booleanValues[size(booleanValuesReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi1SetBoolean_OMC(fmi1cs, size(booleanValuesReferences, 1), booleanValuesReferences, booleanValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi1SetBooleanParameter;
+
       function fmi1GetString
         input FMI1CoSimulation fmi1cs;
         input Real stringValuesReferences[:];
@@ -3391,6 +3428,14 @@ case FMIIMPORT(fmiInfo=INFO(__),fmiExperimentAnnotation=EXPERIMENTANNOTATION(__)
         output String out_Values[size(stringValuesReferences, 1)] = stringValues;
         external "C" fmi1SetString_OMC(fmi1cs, size(stringValuesReferences, 1), stringValuesReferences, stringValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
       end fmi1SetString;
+
+      function fmi1SetStringParameter
+        input FMI1CoSimulation fmi1cs;
+        input Real stringValuesReferences[:];
+        input String stringValues[size(stringValuesReferences, 1)];
+        output Real out_Value = 1;
+        external "C" fmi1SetString_OMC(fmi1cs, size(stringValuesReferences, 1), stringValuesReferences, stringValues, 2) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end fmi1SetStringParameter;
     end fmi1Functions;
   end <%if stringEq(name, "") then fmiInfo.fmiModelIdentifier+"_"+getFMIType(fmiInfo)+"_FMU" else name%>;
   >>

--- a/testsuite/openmodelica/fmi/CoSimulationStandAlone/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulationStandAlone/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
+fmi1_cs_import_parameters.mos \
 fmi1_cs_import_setters.mos \
 
 # test that currently fail. Move up when fixed. 

--- a/testsuite/openmodelica/fmi/CoSimulationStandAlone/fmi1_cs_import_parameters.mos
+++ b/testsuite/openmodelica/fmi/CoSimulationStandAlone/fmi1_cs_import_parameters.mos
@@ -1,0 +1,61 @@
+// name:     fmi1_cs_import_parameters
+// keywords: fmi import co-simulation parameter
+// status:   correct
+// teardown_command: rm -rf vanDerPol_cs_st_FMU.mo binaries sources documentation resources model.png modelDescription.xml vanDerPol.log vanDerPol_info.json output.log
+// cflags:   -d=-newInst
+//
+// importFMU1CoSimulationStandAlone computed all sixteen parameter bindings and then never
+// referenced a single one of them, so an imported FMI 1.0 Co-Simulation FMU was never told
+// about its parameters: a modifier on the wrapper was silently dropped and the FMU kept
+// running with its own defaults. The Model Exchange templates have always emitted these
+// setters, and #16354 fixed the order in which they run.
+//
+// vanDerPol declares mu as a parameter with start="1" and value reference 4. The setter has
+// to be emitted, and it has to run before fmi1InitializeSlave, otherwise the FMU computes
+// its calculated parameters from the default values instead.
+//
+// OpenModelica cannot export FMI 1.0 Co-Simulation FMUs, so this imports one of the FMUs
+// that ship with the testsuite. Only the generated wrapper is inspected, never simulated,
+// so the win32-only binaries inside the FMU do not matter.
+//
+
+importFMU("testedFMU/fmusdk1.0.2/vanDerPol.fmu"); getErrorString();
+
+// the parameter reaches the FMU at all
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "flowParamsStart := fmi1Functions\\.fmi1SetRealParameter\\(fmi1cs, \\{4\\.0\\}, \\{mu\\}\\);", 1, true, false);
+
+// and it reaches it before the slave is initialized, the second one being the same two
+// statements the other way around so that the order is really what is being asserted
+regexBool(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1SetRealParameter\\(fmi1cs, \\{4\\.0\\}, \\{mu\\}\\);\n[^\n]*flowInitialized := fmi1Functions\\.fmi1InitializeSlave\\(fmi1cs, flowParamsStart\\);");
+regexBool(readFile("vanDerPol_cs_st_FMU.mo"), "fmi1InitializeSlave\\(fmi1cs, flowParamsStart\\);\n[^\n]*fmi1SetRealParameter\\(fmi1cs, \\{4\\.0\\}, \\{mu\\}\\);");
+
+// the four helpers the setters call, none of which existed in this package before
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "function fmi1SetRealParameter", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "function fmi1SetIntegerParameter", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "function fmi1SetBooleanParameter", 1, true, false);
+regex(readFile("vanDerPol_cs_st_FMU.mo"), "function fmi1SetStringParameter", 1, true, false);
+
+// the wrapper is still a well formed model
+loadFile("vanDerPol_cs_st_FMU.mo"); getErrorString();
+checkModel(vanDerPol_cs_st_FMU); getErrorString();
+
+// Result:
+// "vanDerPol_cs_st_FMU.mo"
+// "Warning: module = fmi1_xml_get_default_experiment_start: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// Warning: module = fmi1_xml_get_default_experiment_stop: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// Warning: module = fmi1_xml_get_default_experiment_tolerance: returning default value, since no attribute was defined in modelDescription, log level = WARNING: FMI1XML
+// "
+// (1, {"flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1cs, {4.0}, {mu});"})
+// true
+// false
+// (1, {"function fmi1SetRealParameter"})
+// (1, {"function fmi1SetIntegerParameter"})
+// (1, {"function fmi1SetBooleanParameter"})
+// (1, {"function fmi1SetStringParameter"})
+// true
+// ""
+// "Check of vanDerPol_cs_st_FMU completed successfully.
+// Class vanDerPol_cs_st_FMU has 5 equation(s) and 5 variable(s).
+// 1 of these are trivial equation(s)."
+// ""
+// endResult


### PR DESCRIPTION
Fixes #16363

### What was wrong

`importFMU1CoSimulationStandAlone` in `OMCompiler/Compiler/Template/CodegenFMU.tpl` computes all sixteen parameter bindings

```
let realParametersVRs   = dumpVariables(fmiModelVariablesList, "real", "parameter", false, 1, "1.0")
let realParametersNames = dumpVariables(fmiModelVariablesList, "real", "parameter", false, 2, "1.0")
...
let stringDependentParametersNames = dumpVariables(fmiModelVariablesList, "string", "parameter", true, 2, "1.0")
```

and then never references a single one of them.

`testsuite/openmodelica/fmi/CoSimulationStandAlone/testedFMU/fmusdk1.0.2/vanDerPol.fmu` declares `mu` as a parameter with `start="1"` at value reference 4. The wrapper generated for it declares

```mo
parameter Real mu = 1.0;
```

and its entire equation section is

```mo
initial equation
  flowInitialized = fmi1Functions.fmi1InitializeSlave(fmi1cs, 1);
equation
  {x0, der_x0_, x1, der_x1_} = fmi1Functions.fmi1GetReal(fmi1cs, {0.0, 1.0, 2.0, 3.0}, flowInitialized);
  flowStep = fmi1Functions.fmi1DoStep(fmi1cs, time, communicationStepSize, true, flowInitialized);
```

There is no `fmi1Set*` for a parameter anywhere in the file, and nothing reads the FMU's calculated parameters back. So

```mo
model UseVanDerPol
  vanDerPol_cs_st_FMU fmu(mu = 5.0);
end UseVanDerPol;
```

reports `fmu.mu = 5.0` in the result file while the FMU integrates with `mu = 1`.

This is the same class of defect as #16354, but the inverse: there the Model Exchange templates applied the parameters at the wrong *time*, here the Co-Simulation template does not apply them *at all*. #16357 deliberately left this template alone, since it emitted no setters to reorder.

### What this changes

Follows the shape the three Model Exchange templates already have. The bare `initial equation` becomes an `initial algorithm` that sets the parameters and only then initializes the slave, the data dependency through `flowParamsStart` pinning the order:

```mo
initial algorithm
  flowParamsStart := 1;
  /* the parameters must be set before the slave is initialized,
     otherwise the FMU computes its calculated parameters from the default values */
  flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1cs, {4.0}, {mu});
  flowInitialized := fmi1Functions.fmi1InitializeSlave(fmi1cs, flowParamsStart);
initial equation
  // dependent (calculated) parameters read back here with fmi1Get* on flowInitialized
```

FMI 1.0 Co-Simulation allows setting a `variability="parameter"` variable between `fmiInstantiateSlave` and `fmiInitializeSlave`, which is exactly where these calls now land.

The four `fmi1Set*Parameter` helpers did not exist in this package and are added, calling the same `_OMC` entry points as their Model Exchange counterparts with the Co-Simulation discriminator `2`. No runtime change was needed — `OMCompiler/SimulationRuntime/c/fmi/FMI1Common.c` already handles `fmiType == 2` for all four setters.

This affects FMI 1.0 Co-Simulation import only. `importFMUModelica` dispatches 2.0 and 3.0 Co-Simulation FMUs to the Model Exchange templates.

### Verification

Before, grepping the generated `vanDerPol_cs_st_FMU.mo` for any parameter setter returned nothing. After, it emits

```mo
flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1cs, {4.0}, {mu});
```

ahead of `fmi1InitializeSlave`, and `bouncingBall.fmu` batches its two parameters into one call, `{3.0, 4.0}, {g, e}`. `checkModel` accepts the generated wrapper in both cases.

Since these FMUs cannot be simulated here, the wrapper was taken one step further and translated to C, which shows the setter is not constant folded away and that the ordering survives into the initialization code — `vanDerPol_cs_st_FMU_06inz.c`:

```c
array_alloc_scalar_real_array(&tmp0, 1, (modelica_real)4.0);
array_alloc_scalar_real_array(&tmp1, 1, (modelica_real)(data->simulationInfo->realParameter[...] /* mu PARAM */));
(... /* flowParamsStart PARAM */) = omc_..._fmi1SetRealParameter(threadData, (data->simulationInfo->extObjs[0]), tmp0, tmp1);

(... /* flowInitialized PARAM */) = omc_..._fmi1InitializeSlave(threadData, (data->simulationInfo->extObjs[0]), (... /* flowParamsStart PARAM */));
```

i.e. value reference 4 is handed the current value of `mu` — which is where a modifier lands — and `fmi1InitializeSlave` runs afterwards, consuming `flowParamsStart`. The external function body carries the Co-Simulation discriminator:

```c
fmi1SetReal_OMC(_fmi1cs_ext, size_of_dimension_base_array(_realValuesReferences, 1), _realValuesReferences_c89, _realValues_c89, ((modelica_integer) 2));
```

New test `fmi1_cs_import_parameters.mos` asserts that the setter is emitted, that it runs before `fmi1InitializeSlave`, and that the four helpers exist. The ordering is checked with the same two statements in **both** orders, so an ordering regression is distinguishable from the setter simply disappearing — matching only forwards would still pass if both statements moved together. Checked against an unpatched compiler: the setter and the four helpers go `1 → 0` matches and the forward ordering goes `true → false`.

`testsuite/openmodelica/fmi/CoSimulationStandAlone` runs 2/2, `ModelExchange/1.0` 4/4.

### Coverage limits

Only the Real setter branch is reachable from within the repository:

- neither fmusdk FMU that ships in the testsuite has an Integer, Boolean or String parameter, nor a calculated one
- both carry **win32 binaries only**, so the wrapper cannot be simulated on Linux
- OpenModelica cannot export FMI 1.0 Co-Simulation FMUs (`translateModelFMU(…, version="1.0", fmuType="cs")` errors out), so no linux64 FMI 1.0 CS FMU can be built here either

The other three setter branches and the dependent-parameter reads are character for character the Model Exchange form with `fmi1cs` and the discriminator `2` substituted.

---
generated by Claude Code
