### PR TITLE
[OMEdit] Evaluate annotation names declared outside the model (#16270)

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -260,18 +260,24 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
         QPair<double, bool> value = MainWindow::instance()->getVariablesWidget()->readVariableValue(vname, time, false);
         if (value.second) {
           return FlatModelica::Expression(value.first);
-        } else {
-          throw std::runtime_error(vname.toStdString() + " could not be found in " + pModel->getName().toStdString());
         }
       } else {
         // qDebug() << "Evaluating variable:" << vname << "from model:" << (pModel ? pModel->getName() : "null") << "using value:" << value;
         auto valueOrBindingExpression = pModel ? pModel->getVariableValueOrBinding(vname, value) : nullptr;
-        if (!valueOrBindingExpression) {
-          throw std::runtime_error(vname.toStdString() + " could not be found in " + pModel->getName().toStdString());
-        } else {
+        if (valueOrBindingExpression) {
           return *valueOrBindingExpression;
         }
       }
+      /* The name is not a variable of the model and is not in the result file. It can still
+       * be a constant declared somewhere else in the library, e.g. Modelica.Constants.eps,
+       * which the instance API gives us as a fully qualified name. Ask OMC for its value.
+       */
+      auto pConstantExpression = lookupConstant(vname);
+      if (pConstantExpression) {
+        return *pConstantExpression;
+      }
+      throw std::runtime_error(vname.toStdString() + " could not be found in "
+                               + (pModel ? pModel->getName().toStdString() : std::string("the model")));
     };
 
     // Keep evaluating until the expression reduces to a literal. Some DynamicSelect
@@ -298,6 +304,35 @@ FlatModelica::Expression DynamicAnnotation::evaluate_helper(FlatModelica::Expres
 
     return FlatModelica::Expression();
   }
+}
+
+/*!
+ * \brief DynamicAnnotation::lookupConstant
+ * Returns the value of a name that is not an element of the model, e.g. a constant
+ * declared somewhere else in the library like Modelica.Constants.eps.
+ * The values are cached since the annotation is evaluated over and over again while
+ * the animation runs.
+ * \param name
+ * \return the value, or 0 if the name has no value.
+ */
+const FlatModelica::Expression *DynamicAnnotation::lookupConstant(const QString &name)
+{
+  auto it = mConstants.find(name);
+  if (it == mConstants.end()) {
+    FlatModelica::Expression expression;
+    const QString value = MainWindow::instance()->getOMCProxy()->evaluateConstant(name);
+    if (!value.isEmpty()) {
+      try {
+        expression = FlatModelica::Expression::parse(value);
+      } catch (const std::exception &e) {
+        if (MainWindow::instance()->isDebug()) {
+          qDebug() << "Failed to parse the value of" << name << ":" << e.what();
+        }
+      }
+    }
+    it = mConstants.insert(name, expression);
+  }
+  return it.value().isNull() ? nullptr : &it.value();
 }
 
 void DynamicAnnotation::setExp()

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -37,6 +37,7 @@
 #define DYNAMICANNOTATION_H
 
 #include <QString>
+#include <QHash>
 #include "FlatModelica/Expression.h"
 
 class Element;
@@ -94,6 +95,7 @@ class DynamicAnnotation
     FlatModelica::Expression evaluate_wrap_helper(FlatModelica::Expression *pExpression, ModelInstance::Model *pModel,bool readFromResultFileForDynamicSelect, double time);
     FlatModelica::Expression evaluate_helper(FlatModelica::Expression *pExpression, ModelInstance::Model *pModel, bool readFromResultFileForDynamicSelect,
                                              double time, bool value);
+    const FlatModelica::Expression *lookupConstant(const QString &name);
 
   protected:
     virtual void fromExp(const FlatModelica::Expression &exp) = 0;
@@ -102,6 +104,11 @@ class DynamicAnnotation
   protected:
     FlatModelica::Expression mExp;
     State mState = State::None;
+    /*!
+     * Values of the names that are not elements of the model, see lookupConstant.
+     * A null expression means the name has no value.
+     */
+    QHash<QString, FlatModelica::Expression> mConstants;
 };
 
 #endif /* DYNAMICANNOTATION_H */

--- a/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
@@ -342,10 +342,21 @@ namespace FlatModelica
           readDigits();
         }
 
-        if (_next != _str.cend() && *_next == 'e') {
-          _token.type = Token::REAL;
-          ++_next;
-          readDigits();
+        if (_next != _str.cend() && (*_next == 'e' || *_next == 'E')) {
+          /* The exponent may be signed, e.g. 1e-10. Only take the e if an exponent
+           * really follows it, so that a name starting with an e stays a name.
+           */
+          auto exponent = _next + 1;
+
+          if (exponent != _str.cend() && (*exponent == '+' || *exponent == '-')) {
+            ++exponent;
+          }
+
+          if (exponent != _str.cend() && std::isdigit(*exponent)) {
+            _token.type = Token::REAL;
+            _next = exponent;
+            readDigits();
+          }
         }
 
         _token.data = std::string(start, _next);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -1185,6 +1185,35 @@ QString OMCProxy::getErrorString(bool warningsAsErrors)
 }
 
 /*!
+ * \brief OMCProxy::evaluateConstant
+ * Evaluates a fully qualified name in the scripting environment and returns its value,
+ * e.g. Modelica.Constants.eps gives 2.220446049250313e-16.
+ * Used for names that are not elements of the model at hand, like a constant declared
+ * somewhere else in the library.
+ * \param name
+ * \return the value as a Modelica literal, or an empty string if the name has no value.
+ */
+QString OMCProxy::evaluateConstant(const QString &name)
+{
+  /* Only a dotted sequence of identifiers is evaluated so that the scripting environment
+   * is never handed anything but a name.
+   */
+  static QRegularExpression qualifiedName("^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$");
+  if (!qualifiedName.match(name).hasMatch()) {
+    return "";
+  }
+  sendCommand(name);
+  const QString result = getResult().trimmed();
+  if (result.isEmpty()) {
+    /* A name that has no value leaves an error behind. Consume it since the caller
+     * handles the name as unknown instead of showing the error to the user.
+     */
+    getErrorString();
+  }
+  return result;
+}
+
+/*!
  * \brief OMCProxy::printMessagesStringInternal
  * Gets the errors by using the getMessagesStringInternal API.
  * Reads all the errors and add them to the Messages Browser.

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -108,6 +108,7 @@ public:
   bool isLoggingEnabled() {return mIsLoggingEnabled;}
   bool isLoadModelError() const {return mLoadModelError;}
   QString getErrorString(bool warningsAsErrors = false);
+  QString evaluateConstant(const QString &name);
   bool printMessagesStringInternal();
   int getMessagesStringInternal();
   void setCurrentError(int errorIndex);

--- a/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
+++ b/OMEdit/Testsuite/DynamicAnnotation/DynamicAnnotationTest.cpp
@@ -74,6 +74,13 @@ void DynamicAnnotationTest::initTestCase()
   if (!MainWindow::instance()->getOMCProxy()->existClass("EnableNonLiteral")) {
     QFAIL(QString("Failed to load file %1").arg(enableNonLiteralFileName).toStdString().c_str());
   }
+
+  // load EnableExternalConstant.mo (regression model for #16270)
+  const QString enableExternalConstantFileName = QFINDTESTDATA("EnableExternalConstant.mo");
+  MainWindow::instance()->getLibraryWidget()->openFile(enableExternalConstantFileName);
+  if (!MainWindow::instance()->getOMCProxy()->existClass("EnableExternalConstant")) {
+    QFAIL(QString("Failed to load file %1").arg(enableExternalConstantFileName).toStdString().c_str());
+  }
 }
 
 void DynamicAnnotationTest::evaluate()
@@ -142,6 +149,35 @@ void DynamicAnnotationTest::evaluate_data()
       << "mainClass"
       << "realParam"
       << true;
+
+  /* Regression test for #16270: the expression uses a constant that is declared outside
+   * the model, which is neither an element of the model nor a variable in the result file.
+   * The evaluator used to give up on the whole expression and leave the enable at its
+   * default true, it now asks OMC for the value of the name.
+   */
+  QTest::newRow("Evaluate Dialog(enable = constant of another package)")
+      << "EnableExternalConstant.ClassWithInstances"
+      << "mainClass"
+      << "constantParam"
+      << false;
+
+  QTest::newRow("Evaluate Dialog(enable = constant of another package > 1)")
+      << "EnableExternalConstant.ClassWithInstances"
+      << "mainClass"
+      << "comparedParam"
+      << false;
+
+  QTest::newRow("Evaluate Dialog(enable = constant of another package < 1)")
+      << "EnableExternalConstant.ClassWithInstances"
+      << "mainClass"
+      << "enabledParam"
+      << true;
+
+  QTest::newRow("Evaluate Dialog(enable = Modelica.Constants.eps > 1)")
+      << "EnableExternalConstant.ClassWithInstances"
+      << "mainClass"
+      << "mslParam"
+      << false;
 }
 
 void DynamicAnnotationTest::evaluate_nested()

--- a/OMEdit/Testsuite/DynamicAnnotation/EnableExternalConstant.mo
+++ b/OMEdit/Testsuite/DynamicAnnotation/EnableExternalConstant.mo
@@ -1,0 +1,33 @@
+within ;
+package EnableExternalConstant
+  "Regression model for #16270.
+
+   An annotation expression may use a constant that is declared outside the model,
+   e.g. Modelica.Constants.eps or a constant in another package of the same library.
+   The instance API gives such a name to OMEdit as a fully qualified cref, and it is
+   neither an element of the model nor a variable in the result file, so the OMEdit
+   evaluator used to give up on the whole expression. A DynamicSelect on an icon then
+   kept showing its static part, and a Dialog(enable=...) kept its default.
+
+   The Dialog(enable=...) path is used here because the test harness can drive it
+   without a simulation result file."
+
+  package Constants
+    constant Boolean disabled = false;
+    constant Real threshold = 0.5;
+  end Constants;
+
+  model MainClass
+    parameter Real constantParam = 5 annotation(Dialog(enable = EnableExternalConstant.Constants.disabled));
+    parameter Real comparedParam = 5 annotation(Dialog(enable = EnableExternalConstant.Constants.threshold > 1));
+    parameter Real enabledParam = 5 annotation(Dialog(enable = EnableExternalConstant.Constants.threshold < 1));
+    parameter Real mslParam = 5 annotation(Dialog(enable = Modelica.Constants.eps > 1));
+  end MainClass;
+
+  model ClassWithInstances
+    MainClass mainClass annotation(
+      Placement(transformation(origin = {10, 10}, extent = {{-10, -10}, {10, 10}})));
+  end ClassWithInstances;
+
+  annotation(uses(Modelica(version="4.0.0")));
+end EnableExternalConstant;

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -197,6 +197,30 @@ void ExpressionTest::operators_data()
     << "1 + 4 * 5 / 2 + x"
     << "12";
 
+  /* Regression tests for #16270: the exponent of a number may be signed and may
+   * be written with an uppercase E. 1e-10 used to be read as 1e followed by -10,
+   * which the parser then took for a subtraction.
+   */
+  QTest::newRow("negative exponent")
+    << "1e-10 > 0"
+    << "true";
+
+  QTest::newRow("negative exponent value")
+    << "1e-10 == 0.0000000001"
+    << "true";
+
+  QTest::newRow("positive exponent value")
+    << "1e+10 == 10000000000.0"
+    << "true";
+
+  QTest::newRow("uppercase exponent")
+    << "1E-10 == 1e-10"
+    << "true";
+
+  QTest::newRow("negative exponent of a real")
+    << "2.220446049250313e-16 > 0"
+    << "true";
+
   QTest::newRow("array + array")
     << "{1, 2, 3} + {4, 5, 6}"
     << "{5,7,9}";


### PR DESCRIPTION
Fixes #16270.

`DynamicSelect` on an icon stops working as soon as the dynamic expression mentions a constant that is declared somewhere else in the library:

```mo
// never animates, visible stays at the static value
Polygon(visible = DynamicSelect(false, P > Modelica.Constants.eps), ...)

// animates
Polygon(visible = DynamicSelect(false, P > 0), ...)
```

## What goes wrong

`getModelInstance` does not constant fold annotation expressions — `NFApi.dumpJSONAnnotationExp2` instantiates, types and simplifies, but never evaluates — so the name reaches OMEdit as a plain cref:

```json
"rhs": {"$kind": "cref", "parts": [{"name": "Modelica"}, {"name": "Constants"}, {"name": "eps"}]}
```

`DynamicAnnotation::evaluate_helper` resolves names from only two sources: the result file (the animation) and the elements of the model (everything else). A name that is in neither makes `var_eval` throw, which fails the evaluation of the *whole* expression, so the shape keeps its static value. The same holds for a `Dialog(enable = ...)`, which keeps its default, and for a plain `lineThickness = Modelica.Constants.eps` — this is not specific to `DynamicSelect`.

There is a second bug behind that one. OMEdit's FlatModelica tokenizer took the `e` of a number literal and then read only digits, with no sign, so `1e-10` came out as `1e` followed by `-10` and the parser made a *subtraction* of it. An uppercase `E` was not recognised at all. That one is independent of the instance API: an annotation written with `1e-10` straight in the source is mis-parsed today too.

## The fix

Two commits.

### 1. Ask OMC for the value of the name

Ask OMC for the value of such a name. Two things make that work:

- the instance API always gives these crefs fully qualified — a relatively written `consts.test` inside `t3.M` comes out as `t3.consts.test` — so the scripting environment can evaluate them;
- an unknown name, or a name that is a class, gives an empty result, so nothing bogus comes back.

`OMCProxy::evaluateConstant` evaluates the name and consumes the error that a name without a value leaves behind. It only accepts a dotted sequence of identifiers, so the scripting environment is never handed anything but a name.

`DynamicAnnotation::lookupConstant` is consulted only *after* the result file and the model have been tried, so the existing resolution order is untouched and only expressions that fail today take the new path. The values are cached per annotation, since the animation evaluates the expression again for every time point.

This was deliberately not fixed by folding the constants in the frontend: that JSON is what OMEdit writes back into the user's source when a shape is edited, so `Modelica.Constants.eps` would silently turn into `2.22e-16` in their model.

### 2. Read the signed exponent

`readNumber` now reads an optional sign and accepts both `e` and `E`. The `e` is only taken when an exponent really follows it, so a name that starts with an `e` stays a name.

Without this the first commit alone does not fix the issue: the value fetched from OMC arrived at the evaluator as `0 - 16`, and since `sin(time) > -16` everywhere the shape stayed permanently visible rather than blinking.

## Tests

`OMEdit/Testsuite/DynamicAnnotation/EnableExternalConstant.mo` and four rows in `DynamicAnnotationTest::evaluate_data`. The `Dialog(enable = ...)` path is used because the harness can drive it without a simulation result file — the same reason the #15965 regression test uses it — and it goes through the same `var_eval`.

```
$ ctest --test-dir build_cmake/OMEdit/Testsuite -R DynamicAnnotation
Totals: 17 passed, 0 failed
```

Three of the four new rows fail without the production change (checked by reverting only `DynamicAnnotation.*` and `OMCProxy.*` and rebuilding):

```
FAIL!  : evaluate(Evaluate Dialog(enable = constant of another package))
FAIL!  : evaluate(Evaluate Dialog(enable = constant of another package > 1))
FAIL!  : evaluate(Evaluate Dialog(enable = Modelica.Constants.eps > 1))
Totals: 14 passed, 3 failed
```

For the exponent, five rows in `ExpressionTest::operators_data` — `1e-10 > 0`, `1e-10 == 0.0000000001`, `1e+10 == 10000000000.0`, `1E-10 == 1e-10`, `2.220446049250313e-16 > 0`. All five fail with only `Expression.cpp` reverted:

```
Totals: 70 passed, 5 failed      # without the fix
Totals: 75 passed, 0 failed      # with the fix
```

Whole OMEdit suite passes (11/11, `Homotopy` excluded — it simulates a model and hits the 5 min QTest watchdog, and does so identically without these changes).

The reporter's model was also checked by hand in OMEdit: all three rectangles now blink, where before only `P > 0` did.

---
generated by Claude Code
