### PR TITLE
wasm-jit: -csvInput drives the simulation

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -4461,22 +4461,26 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
             .collect();
         optimization::build_opt_info(sim_code, vars, &reals, jacs, &var_map)?
     };
-    // C's `inputNames` / `nInputVars`. A real input takes the file's value through
-    // its `start` attribute; another type has none here, so it takes it in its own
-    // slot, where C's `input_function` puts it. No slot ⇒ no column to receive.
+    // C's `inputNames` / `nInputVars`. No slot ⇒ no column to receive.
     let mut input_vars: Vec<openmodelica_sim_meta::InputVar> = Vec::new();
     for sv in lst(&vars.inputVars) {
         let key = sim_cref_key(&sv.name)?;
         let name = cref_display(&sv.name)?;
         match all_reals.iter().position(|r| sim_cref_key(&r.name).ok().as_deref() == Some(key.as_str())) {
             Some(i) => input_vars.push(openmodelica_sim_meta::InputVar {
-                off: layout.real_start_off(i as u32),
+                off: openmodelica_sim_meta::REAL_OFF + i as u32 * 8,
+                start_off: layout.real_start_off(i as u32),
                 wty: WTy::F64,
                 name,
             }),
             None => {
                 if let Some(slot) = var_map.vars.get(&key) {
-                    input_vars.push(openmodelica_sim_meta::InputVar { off: slot.off, wty: slot.wty, name });
+                    input_vars.push(openmodelica_sim_meta::InputVar {
+                        off: slot.off,
+                        start_off: slot.off,
+                        wty: slot.wty,
+                        name,
+                    });
                 }
             }
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -862,6 +862,17 @@ pub(crate) fn write_i32(e: &mut dyn SimEngine, addr: u32, v: i32) -> Result<()> 
     e.write_bytes(addr, &v.to_le_bytes())
 }
 
+/// Move the model clock. C pairs `timeValue = t` with `externalInputUpdate` +
+/// `input_function` in each solver's residual and root callback, in
+/// `updateContinuousSystem` and in the event bisection; every one of those goes
+/// through here, so `-csvInput` is applied once, for all of them.
+pub(crate) fn write_time(e: &mut dyn SimEngine, sim_data: u32, t: f64) -> Result<()> {
+    write_f64(e, sim_data + TIME_OFF, t)?;
+    #[cfg(feature = "std")]
+    crate::extinput::apply(e, sim_data, t);
+    Ok(())
+}
+
 /// Error out if a nonlinear system raised the `nls_fail` flag during the last
 /// equation call in a context that cannot back off (initialisation, an output
 /// point, the Euler loop). The DASSL residual handles this recoverably instead.
@@ -1694,7 +1705,7 @@ fn init_model(
     }
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
-    write_f64(e, sim_data + TIME_OFF, start_time)?;
+    write_time(e, sim_data, start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
     run_initialization_impl(e, sim_data, layout, inputs, model)?;
     if let Some(m) = model {
@@ -1927,7 +1938,7 @@ fn report_init_failure() -> &'static str {
 /// over a zeroed `SimData` can produce a NaN instead.
 pub fn seed_start_state(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) -> Result<()> {
     // `functionInitDelay` before any equation function, as in `init_model`.
-    write_f64(e, sim_data + TIME_OFF, model.start_time)?;
+    write_time(e, sim_data, model.start_time)?;
     e.call1_if_present("functionInitDelay", sim_data)?;
     seed_start_values(e, sim_data, &model.layout, &model.inputs, Some(model))
 }
@@ -2369,7 +2380,7 @@ fn store_operators_at(
     if !layout.has_history_ops {
         return Ok(());
     }
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     eval_continuous(e, sim_data, layout)?;
     store_operators(e, sim_data, layout)
 }
@@ -2421,7 +2432,7 @@ fn emit_row(
     stop: f64,
 ) -> Result<()> {
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     eval_continuous(e, sim_data, layout)?;
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
@@ -2447,7 +2458,7 @@ pub fn emit_terminal_row(
         return Ok(());
     }
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     write_i32(e, sim_data + layout.terminal_off, 1)?;
     // A discrete call, so relations are live (C's `updateDiscreteSystem`
     // prologue): a condition that only becomes true at `stop` flips here.
@@ -2538,7 +2549,7 @@ pub(crate) fn emit_initial_row(
     layout: &SimLayout,
     time: f64,
 ) -> Result<()> {
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     capture_row(e, rows, sim_data, layout)?;
     check_asserts(e, sim_data, layout, omclog::WARNING)
 }
@@ -2547,7 +2558,7 @@ pub(crate) fn emit_initial_row(
 /// `functionAlgebraics` for `has_when` models — there it saves `pre` early, which
 /// would break the post-event edge test.
 fn capture_pre(e: &mut dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout, time: f64) -> Result<()> {
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     if layout.has_when {
         eval_ode(e, sim_data, layout)?;
     } else {
@@ -2608,31 +2619,17 @@ fn seed_pre_from_live(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) 
 /// `-csvInput` at `t0`, and `input_function_updateStartValues` writes them back as
 /// the start attributes — so `setAllVarsToStart` puts the file's values on the
 /// inputs. Runs before the attribute equations and `-iif`, both of which C lets
-/// win over the file.
+/// win over the file. Armed for the integration loop separately, in [`drive`].
 #[cfg(feature = "std")]
 fn apply_external_input(
     e: &mut dyn SimEngine,
     sim_data: u32,
     inputs: &[crate::InputVar],
 ) -> Result<()> {
-    if inputs.is_empty() {
-        return Ok(());
-    }
-    let Some(file) = crate::simflags::with_flags(|f| f.csv_input.clone()) else { return Ok(()) };
-    let names: Vec<&str> = inputs.iter().map(|v| v.name.as_str()).collect();
-    let Some(mut ext) = crate::extinput::ExternalInput::load(&file, &names) else { return Ok(()) };
-    // C's `input_function_init`; `externalInputUpdate` rewrites every entry (a
-    // column the file lacks becomes 0, from its `calloc`ed rows), so this only
-    // matters for the shape.
-    let mut u = crate::extinput::empty(inputs.len());
+    let slot = crate::extinput::Slot::Start;
+    let Some(mut hook) = crate::extinput::ExtInputHook::load(inputs, slot) else { return Ok(()) };
     let t = read_f64(e, sim_data + TIME_OFF)?;
-    ext.update(t, &mut u);
-    for (input, v) in inputs.iter().zip(&u) {
-        match input.wty {
-            crate::WTy::F64 => write_f64(e, sim_data + input.off, *v)?,
-            crate::WTy::I32 => write_i32(e, sim_data + input.off, *v as i32)?,
-        }
-    }
+    hook.apply(e, sim_data, t);
     Ok(())
 }
 
@@ -2988,7 +2985,7 @@ fn read_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout,
 /// an assert outside it does not fire on every trial point of the root search.
 fn probe_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, time: f64, out: &mut [f64]) -> Result<()> {
     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     eval_zc_equations(e, sim_data, layout)?;
     read_zero_crossings(e, sim_data, layout, out)
 }
@@ -3001,7 +2998,7 @@ fn update_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayou
     drain_asserts(e, sim_data, omclog::INFO)?;
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     eval_continuous(e, sim_data, layout)?;
     let _ = e.take_pending_warnings();
     read_zero_crossings(e, sim_data, layout, out)
@@ -3179,7 +3176,7 @@ impl Samples {
                 write_i32(e, self.active_off + k as u32 * 4, 1)?;
             }
         }
-        write_f64(e, sim_data + TIME_OFF, t)?;
+        write_time(e, sim_data, t)?;
         if self.dae {
             e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE)?;
         } else {
@@ -3210,7 +3207,7 @@ fn fire_time_event(
     layout: &SimLayout,
     te: f64,
 ) -> Result<()> {
-    write_f64(e, sim_data + TIME_OFF, te)?;
+    write_time(e, sim_data, te)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
     refresh_relations(e, sim_data, layout)?;
     samples.fire(e, sim_data, te)?;
@@ -3241,7 +3238,7 @@ fn fire_clocks(
     let mut did_event = false;
     for _ in 0..MAX_EVENT_ITER {
         sync.take_fired(e, time)?;
-        write_f64(e, sim_data + TIME_OFF, time)?;
+        write_time(e, sim_data, time)?;
         let fired = sync.handle_timers(e, time, eps, rows.as_deref_mut())?;
         if fired == Fired::None {
             break;
@@ -3324,7 +3321,7 @@ pub fn event_update(
         *v = read_f64(e, states_base + (i as u32) * 8)?;
     }
 
-    write_f64(e, sim_data + TIME_OFF, time)?;
+    write_time(e, sim_data, time)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
 
@@ -3547,6 +3544,14 @@ pub fn make_driver(
     }
 }
 
+/// Whether `-csvInput` was given; never in wasm, which has no filesystem.
+fn csv_input_given() -> bool {
+    #[cfg(feature = "std")]
+    return crate::simflags::with_flags(|f| f.csv_input.is_some());
+    #[cfg(not(feature = "std"))]
+    false
+}
+
 /// Listing what `make_driver` accepts; `simflags::check` rejects the rest earlier,
 /// so this is only reached by a `method=` the model was compiled with.
 const UNSUPPORTED_METHOD: &str = if cfg!(sundials) {
@@ -3655,7 +3660,9 @@ pub fn drive(
             #[cfg(not(all(ipopt, feature = "std")))]
             unreachable!("optimization::AVAILABLE is false");
         }
-        if !use_events && method == "euler" && !host_driven {
+        // `-csvInput` moves the inputs between steps, which the in-wasm loop cannot
+        // do: it never returns until it is done.
+        if !use_events && method == "euler" && !host_driven && !csv_input_given() {
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
@@ -3667,6 +3674,13 @@ pub fn drive(
         let (mut driver, l) =
             make_driver(e, model, sim_data, method).map_err(|err| enrich_trap_init(e, err, model.start_time))?;
         label = l;
+        // C's bracket up to `externalInputFree`: from here on the file drives the
+        // inputs. Initialization got its one application in `apply_external_input`.
+        #[cfg(feature = "std")]
+        let mut hook =
+            crate::extinput::ExtInputHook::load(&model.inputs, crate::extinput::Slot::Live);
+        #[cfg(feature = "std")]
+        let _armed = hook.as_mut().map(crate::extinput::arm);
         // Infinite budget runs to completion; the per-step cancel poll still lets a
         // native embedder interrupt. `OMC_WASM_SIM_YIELD_MS` forces a finite budget to
         // self-test yield/resume (must be `.mat`-identical to the un-yielded run).
@@ -3904,12 +3918,6 @@ struct ResCtx {
     jac_ypsave: Vec<f64>,
     /// Jacobian evaluations (colors summed over all Jacobian assemblies).
     nje: u64,
-    /// `-csvInput` for the optimizer's initial guess: C's `functionODE_residual`
-    /// re-reads the external input at *every* residual evaluation, so the hook is
-    /// applied here rather than only at the step boundaries. Null when there is none;
-    /// type-erased so the optimization module's types stay out of the driver.
-    ext_input: *mut core::ffi::c_void,
-    ext_apply: Option<unsafe fn(*mut core::ffi::c_void, &mut dyn SimEngine, u32, f64)>,
     /// Linear-memory address of the runtime's evaluation context (0 = unsupported).
     ctx_addr: u32,
     /// Linear-memory address of the runtime's error stage (0 = unsupported).
@@ -4021,7 +4029,7 @@ unsafe fn dassl_rt(
         // system can't converge; keep that transient failure from leaking into the
         // next checked evaluation by clearing the flag around this probe.
         write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
-        write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
+        write_time(e, ctx.sim_data, unsafe { *t })?;
         let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, ctx.n_states * 8) };
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
@@ -4078,10 +4086,7 @@ unsafe fn dassl_res(
     let n = ctx.n_states;
     let run = (|| -> Result<()> {
         write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?; // clear before the solve
-        write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
-        if let Some(f) = ctx.ext_apply {
-            unsafe { f(ctx.ext_input, e, ctx.sim_data, *t) };
-        }
+        write_time(e, ctx.sim_data, unsafe { *t })?;
         let y_bytes = unsafe { core::slice::from_raw_parts(y as *const u8, n * 8) };
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ODE);
@@ -4321,7 +4326,7 @@ unsafe fn dassl_jac(
         false => (0..n as u32).collect(),
     };
     let run = (|| -> Result<()> {
-        write_f64(e, ctx.sim_data + TIME_OFF, unsafe { *t })?;
+        write_time(e, ctx.sim_data, unsafe { *t })?;
         if jac_method_symbolic(ctx.jac_method) {
             // C's `jacA_symColored` / `jacA_sym`. This residual is G = y' − f, the
             // negative of C's F = f − y', so ∂f/∂y enters negated (and the `cj·I`
@@ -4857,8 +4862,6 @@ impl Driver for DasslDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: self.nje,
-            ext_input: core::ptr::null_mut(),
-            ext_apply: None,
             ctx_addr: e.context_addr(),
             err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
@@ -5431,7 +5434,6 @@ fn model_ode<'a>(
         sim_data: ctx.sim_data,
         states_base,
         ders_base,
-        time_off: TIME_OFF,
         nls_fail_off: ctx.nls_fail_off,
         ctx_addr: ctx.ctx_addr,
         jac_a: unsafe { ctx.jac.as_ref() },
@@ -5857,8 +5859,6 @@ impl SolverCore {
             jac_ders: Vec::new(),
             jac_ypsave: vec![0.0; self.n_unknowns],
             nje: self.nje,
-            ext_input: core::ptr::null_mut(),
-            ext_apply: None,
             ctx_addr: e.context_addr(),
             err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
@@ -6170,7 +6170,7 @@ impl SolverCore {
                     }
                     if !emitted {
                         // C's `updateContinuousSystem`.
-                        write_f64(e, sim_data + TIME_OFF, self.t)?;
+                        write_time(e, sim_data, self.t)?;
                         eval_continuous(e, sim_data, layout)?;
                     }
                     store_operators(e, sim_data, layout)?;
@@ -6191,7 +6191,7 @@ impl SolverCore {
                 if rooted {
                     let troot = self.t;
                     if stop_at_event {
-                        write_f64(e, sim_data + TIME_OFF, troot)?;
+                        write_time(e, sim_data, troot)?;
                         return Ok(Step::Event { time: troot });
                     }
                     self.state_events += 1;
@@ -6249,7 +6249,7 @@ impl SolverCore {
                 }
                 self.t = target;
                 self.write_states(e)?;
-                write_f64(e, sim_data + TIME_OFF, self.t)?;
+                write_time(e, sim_data, self.t)?;
                 self.refresh_yp(e)?;
                 *did_step = true;
             }
@@ -6260,7 +6260,7 @@ impl SolverCore {
                 event_step = true;
                 if stop_at_event {
                     self.t = te;
-                    write_f64(e, sim_data + TIME_OFF, te)?;
+                    write_time(e, sim_data, te)?;
                     return Ok(Step::Event { time: te });
                 }
                 log_time_event(te, samp, model);
@@ -6300,7 +6300,7 @@ impl SolverCore {
             }
             // C's `handleTimers`, plus any event clock a `when` body above just fired.
             if !sync.is_empty() {
-                write_f64(e, sim_data + TIME_OFF, target)?;
+                write_time(e, sim_data, target)?;
                 sync.take_fired(e, target)?;
             }
             if sync.next_time() <= target + SYNC_EPS {
@@ -6430,7 +6430,7 @@ impl CsDriver {
                 }
             }
             self.core.t = t_target;
-            write_f64(e, sim_data + TIME_OFF, t_target)?;
+            write_time(e, sim_data, t_target)?;
             e.call1_if_present("functionAlgebraics", sim_data)?;
             return Ok(CsStep::Reached);
         }
@@ -6449,7 +6449,7 @@ impl CsDriver {
         // Refresh the outputs at the communication point, and re-select states there
         // (see `DasslDriver`).
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-        write_f64(e, sim_data + TIME_OFF, t_target)?;
+        write_time(e, sim_data, t_target)?;
         e.call1("functionODE", sim_data)?;
         e.call1_if_present("functionAlgebraics", sim_data)?;
         if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
@@ -6491,11 +6491,11 @@ impl CsDriver {
             let te = self.samp.next_time();
             if te <= t_target + eps {
                 self.core.t = te;
-                write_f64(e, sim_data + TIME_OFF, te)?;
+                write_time(e, sim_data, te)?;
                 return Ok(CsStep::Event { time: te });
             }
             self.core.t = t_target;
-            write_f64(e, sim_data + TIME_OFF, t_target)?;
+            write_time(e, sim_data, t_target)?;
             e.call1_if_present("functionAlgebraics", sim_data)?;
             return Ok(CsStep::Reached);
         }
@@ -6511,7 +6511,7 @@ impl CsDriver {
         }
         // Communication point reached with no event: refresh outputs like `step_to`.
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-        write_f64(e, sim_data + TIME_OFF, t_target)?;
+        write_time(e, sim_data, t_target)?;
         e.call1("functionODE", sim_data)?;
         e.call1_if_present("functionAlgebraics", sim_data)?;
         if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
@@ -6841,7 +6841,7 @@ impl Driver for EventsDriver {
                         }
                     }
                     if !self.sync.is_empty() {
-                        write_f64(e, sim_data + TIME_OFF, subtarget)?;
+                        write_time(e, sim_data, subtarget)?;
                         self.sync.take_fired(e, subtarget)?;
                     }
                     if self.sync.next_time() <= subtarget + SYNC_EPS {
@@ -7013,7 +7013,7 @@ unsafe extern "C" fn cvode_rhs(
     let n = ctx.n_states;
     let run = (|| -> Result<()> {
         write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
-        write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+        write_time(e, ctx.sim_data, t)?;
         let y_bytes = unsafe { core::slice::from_raw_parts(crate::sundials::nv_data(y) as *const u8, n * 8) };
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ODE);
@@ -7044,7 +7044,7 @@ unsafe extern "C" fn cvode_rhs(
 unsafe fn eval_roots(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, gout: *mut f64) -> Result<()> {
     let e = unsafe { &mut *ctx.engine };
     write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?;
-    write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+    write_time(e, ctx.sim_data, t)?;
     unsafe { ida_push_unknowns(ctx, y, yp) }?;
     set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
     if unsafe { ctx.ida.dae.as_ref() }.is_some() {
@@ -7232,8 +7232,6 @@ impl Driver for CvodeDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: 0,
-            ext_input: core::ptr::null_mut(),
-            ext_apply: None,
             ctx_addr: e.context_addr(),
             err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
@@ -7753,7 +7751,7 @@ unsafe fn ida_residual(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, 
     if sens.n > 0 {
         e.call1("functionUpdateBoundParameters", ctx.sim_data)?;
     }
-    write_f64(e, ctx.sim_data + TIME_OFF, t)?;
+    write_time(e, ctx.sim_data, t)?;
     if let Some(lambda) = ctx.ida.ramp.lambda_at(t) {
         write_f64(e, ctx.sim_data + ctx.ida.ramp.off, lambda)?;
     }
@@ -8131,8 +8129,6 @@ impl Driver for IdaDriver {
             jac_ders: Vec::new(),
             jac_ypsave: Vec::new(),
             nje: 0,
-            ext_input: core::ptr::null_mut(),
-            ext_apply: None,
             ctx_addr: e.context_addr(),
             err_stage_addr: e.error_stage_addr(),
             nominals: self.nominals.as_ptr(),
@@ -8246,12 +8242,6 @@ impl Driver for IdaDriver {
 
 // ───────────────────── optimization: the initial guess's stepper ─────────────────────
 
-/// Publish the time the stepper jumped to (the no-state case).
-#[cfg(ipopt)]
-fn driver_write_time(e: &mut dyn SimEngine, sim_data: u32, t: f64) -> Result<()> {
-    write_f64(e, sim_data + TIME_OFF, t)
-}
-
 /// C's `smallIntSolverStep` (`optimization/DataManagement/InitialGuess.c`): DASSL
 /// stepped to a given time with no event handling and no output rows.
 ///
@@ -8262,8 +8252,6 @@ fn driver_write_time(e: &mut dyn SimEngine, sim_data: u32, t: f64) -> Result<()>
 #[cfg(ipopt)]
 pub(crate) struct GuessStepper {
     core: SolverCore,
-    /// `-csvInput`'s hook, applied at every residual evaluation like C's.
-    ext: Option<*mut core::ffi::c_void>,
 }
 
 #[cfg(ipopt)]
@@ -8279,13 +8267,7 @@ impl GuessStepper {
         daskr::auxiliary::xsetf(0); // DASKR's own printing would corrupt the log
         let mut core = SolverCore::new(e, model, sim_data, t0, "dassl", None)?;
         core.read_states(e)?;
-        Ok(GuessStepper { core, ext: None })
-    }
-
-    /// Install `-csvInput`'s external-input hook (a `*mut ExtInputHook`, kept alive
-    /// by the caller for as long as this stepper is used).
-    pub(crate) fn set_external_input(&mut self, hook: *mut core::ffi::c_void) {
-        self.ext = Some(hook);
+        Ok(GuessStepper { core })
     }
 
     pub(crate) fn time(&self) -> f64 {
@@ -8307,14 +8289,10 @@ impl GuessStepper {
         // with `NEQ = 0` would `STOP` inside its Fortran, taking omc down with it.
         if layout.n_states == 0 {
             self.core.t = tstop;
-            driver_write_time(e, self.core.sim_data, tstop)?;
+            write_time(e, self.core.sim_data, tstop)?;
             return eval_continuous(e, self.core.sim_data, layout);
         }
         let mut ctx = self.core.res_ctx(e, layout);
-        if let Some(hook) = self.ext {
-            ctx.ext_input = hook;
-            ctx.ext_apply = Some(crate::optimization::EXT_INPUT_APPLY);
-        }
         let _guard = ResCtxGuard;
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
         let mut did_step = false;
@@ -8347,8 +8325,9 @@ impl GuessStepper {
             }
         }
         self.core.write_states(e)?;
-        // C's `dassl_step` publishes the accepted time before `updateContinuousSystem`.
-        driver_write_time(e, self.core.sim_data, self.core.t)?;
+        // C's `dassl_step` publishes the accepted time before
+        // `updateContinuousSystem`, which re-reads the input there.
+        write_time(e, self.core.sim_data, self.core.t)?;
         eval_continuous(e, self.core.sim_data, layout)
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
@@ -1,8 +1,9 @@
 //! `-csvInput`: the external input trajectory, C's `simulation/solver/external_input.c`.
 //!
-//! Read at initialization, where C lets the file set the inputs' start values
-//! (`initializeModel`), and by the optimizer's initial guess
-//! (`initial_guess_ipopt_sim`).
+//! Applied once at initialization, where C lets the file set the inputs' start
+//! values (`initializeModel`), then armed for the integration loop and for the
+//! optimizer's initial guess — but not for the Ipopt iterations, whose inputs
+//! come from `vopt`.
 
 use alloc::format;
 use alloc::string::String;
@@ -40,7 +41,7 @@ impl ExternalInput {
             _ => (',', &text[..]),
         };
         let mut lines = body.lines().filter(|l| !l.trim().is_empty());
-        let header: Vec<&str> = lines.next()?.split(sep).map(str::trim).collect();
+        let header: Vec<String> = lines.next()?.split(sep).map(unquote).collect();
         // Which csv column feeds each input; -1 in C, `None` here.
         let col: Vec<Option<usize>> =
             input_names.iter().map(|n| header.iter().position(|h| h == n)).collect();
@@ -48,7 +49,7 @@ impl ExternalInput {
         let mut u: Vec<Vec<f64>> = Vec::new();
         for line in lines {
             let row: Vec<f64> =
-                line.split(sep).map(|v| v.trim().parse::<f64>().unwrap_or(0.0)).collect();
+                line.split(sep).map(|v| unquote(v).parse::<f64>().unwrap_or(0.0)).collect();
             let Some(&time) = row.first() else { continue };
             t.push(time);
             u.push(col.iter().map(|c| c.and_then(|c| row.get(c).copied()).unwrap_or(0.0)).collect());
@@ -102,6 +103,15 @@ impl ExternalInput {
     }
 }
 
+/// One field as libcsv hands it to C's `read_csv`: unquoted, `""` collapsed.
+fn unquote(field: &str) -> String {
+    let f = field.trim();
+    match f.strip_prefix('"').and_then(|f| f.strip_suffix('"')) {
+        Some(inner) => inner.replace("\"\"", "\""),
+        None => String::from(f),
+    }
+}
+
 fn copy_row(row: &[f64], out: &mut [f64]) {
     for (o, v) in out.iter_mut().zip(row) {
         *o = *v;
@@ -120,34 +130,86 @@ pub(crate) fn empty(n: usize) -> Vec<f64> {
     vec![0.0; n]
 }
 
-/// The external input as the DASSL residual sees it: C's `functionODE_residual`
-/// calls `externalInputUpdate` + `input_function` at *every* evaluation, so the
-/// guess's integrator must too, not just at the step boundaries.
+/// Which slot of an input the file's value goes to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Slot {
+    Start,
+    Live,
+}
+
+/// C's `externalInputUpdate` + `input_function` as one step.
 pub(crate) struct ExtInputHook {
     pub(crate) ext: ExternalInput,
-    /// `SimData` offsets of the input variables, in input order.
-    pub(crate) input_offs: Vec<u32>,
+    /// `SimData` offset and width of each input variable, in input order.
+    slots: Vec<(u32, crate::WTy)>,
     /// Scratch mirroring C's `simulationInfo->inputVars`.
-    pub(crate) inputs: Vec<f64>,
+    inputs: Vec<f64>,
 }
 
 impl ExtInputHook {
-    /// C's `externalInputUpdate` + `input_function` at time `t`.
-    fn apply(&mut self, e: &mut dyn crate::driver::SimEngine, sim_data: u32, t: f64) {
-        self.ext.update(t, &mut self.inputs);
-        for (k, &off) in self.input_offs.iter().enumerate() {
-            let _ = crate::driver::write_f64(e, sim_data + off, self.inputs[k]);
+    /// `None` when the flag is absent, the file unreadable or the model has no
+    /// input.
+    pub(crate) fn load(inputs: &[crate::InputVar], slot: Slot) -> Option<alloc::boxed::Box<Self>> {
+        if inputs.is_empty() {
+            return None;
         }
+        let file = crate::simflags::with_flags(|f| f.csv_input.clone())?;
+        let names: Vec<&str> = inputs.iter().map(|v| v.name.as_str()).collect();
+        let ext = ExternalInput::load(&file, &names)?;
+        let slots = inputs
+            .iter()
+            .map(|v| (if slot == Slot::Start { v.start_off } else { v.off }, v.wty))
+            .collect();
+        Some(alloc::boxed::Box::new(ExtInputHook { ext, slots, inputs: empty(inputs.len()) }))
     }
 
-    /// The type-erased entry point [`crate::driver::ResCtx`] holds, so the residual
-    /// can call it without this module's types leaking into the driver.
-    pub(crate) unsafe fn apply_erased(
-        this: *mut core::ffi::c_void,
-        e: &mut dyn crate::driver::SimEngine,
-        sim_data: u32,
-        t: f64,
-    ) {
-        unsafe { (*(this as *mut ExtInputHook)).apply(e, sim_data, t) }
+    /// The same for the optimizer, whose inputs are real `SimData` indices.
+    pub(crate) fn load_reals(indices: &[u32], names: &[&str]) -> Option<alloc::boxed::Box<Self>> {
+        let file = crate::simflags::with_flags(|f| f.csv_input.clone())?;
+        let ext = ExternalInput::load(&file, names)?;
+        Some(alloc::boxed::Box::new(ExtInputHook {
+            ext,
+            slots: indices.iter().map(|&i| (crate::REAL_OFF + i * 8, crate::WTy::F64)).collect(),
+            inputs: empty(indices.len()),
+        }))
+    }
+
+    /// C's `externalInputUpdate` + `input_function` at time `t`.
+    pub(crate) fn apply(&mut self, e: &mut dyn crate::driver::SimEngine, sim_data: u32, t: f64) {
+        self.ext.update(t, &mut self.inputs);
+        for (&(off, wty), &v) in self.slots.iter().zip(&self.inputs) {
+            let _ = match wty {
+                crate::WTy::F64 => crate::driver::write_f64(e, sim_data + off, v),
+                crate::WTy::I32 => crate::driver::write_i32(e, sim_data + off, v as i32),
+            };
+        }
+    }
+}
+
+/// The armed hook, consulted by every write of the model clock. A single global
+/// for the reason `RES_CTX` is one: runs are serialized per process.
+static ACTIVE: core::sync::atomic::AtomicPtr<ExtInputHook> =
+    core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+
+/// C's `externalInputallocate` .. `externalInputFree` bracket. Boxed rather than
+/// borrowed because the caller keeps reading the trajectory while it is armed.
+pub(crate) struct Armed;
+
+pub(crate) fn arm(hook: &mut alloc::boxed::Box<ExtInputHook>) -> Armed {
+    ACTIVE.store(&mut **hook as *mut ExtInputHook, core::sync::atomic::Ordering::Relaxed);
+    Armed
+}
+
+impl Drop for Armed {
+    fn drop(&mut self) {
+        ACTIVE.store(core::ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// C's `externalInputUpdate` + `input_function`; nothing without `-csvInput`.
+pub(crate) fn apply(e: &mut dyn crate::driver::SimEngine, sim_data: u32, t: f64) {
+    let hook = ACTIVE.load(core::sync::atomic::Ordering::Relaxed);
+    if !hook.is_null() {
+        unsafe { (*hook).apply(e, sim_data, t) };
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/nls.rs
@@ -25,7 +25,7 @@ use alloc::vec::Vec;
 use super::tableau::{GmType, Tableau};
 use crate::gbode::math::{abs, pow, sqrt};
 use crate::JacAInfo;
-use crate::driver::{Result, SimEngine, write_f64};
+use crate::driver::{Result, SimEngine};
 
 /// C's `DBL_ABSORPTION`.
 const DBL_ABSORPTION: f64 = 10.0 * f64::EPSILON;
@@ -83,7 +83,6 @@ pub struct Ode<'a> {
     pub sim_data: u32,
     pub states_base: u32,
     pub ders_base: u32,
-    pub time_off: u32,
     pub nls_fail_off: u32,
     pub ctx_addr: u32,
     /// Sparsity + coloring for the finite-difference Jacobian; `None` ⇒ dense
@@ -99,7 +98,7 @@ pub struct Ode<'a> {
 
 impl Ode<'_> {
     pub fn eval(&mut self, t: f64, y: &[f64], f: &mut [f64]) -> Result<()> {
-        write_f64(self.e, self.sim_data + self.time_off, t)?;
+        crate::driver::write_time(self.e, self.sim_data, t)?;
         let mut bytes = vec![0u8; y.len() * 8];
         for (i, v) in y.iter().enumerate() {
             bytes[i * 8..i * 8 + 8].copy_from_slice(&v.to_le_bytes());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
@@ -776,7 +776,6 @@ mod tests {
             sim_data: SIM_DATA,
             states_base: STATES,
             ders_base: DERS,
-            time_off: 0,
             nls_fail_off: NLS_FAIL_OFF,
             ctx_addr: 0,
             jac_a: None,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -963,12 +963,13 @@ pub struct SimMeta {
     pub inputs: Vec<InputVar>,
 }
 
-/// One `input` variable, as `-csvInput` reaches it: `off` is a real input's `start`
-/// attribute slot (published by `setAllVarsToStart`) and any other type's own slot,
-/// which is where C's `input_function` puts it.
+/// One `input` variable. C writes the file's value both to the `start` attribute,
+/// for `setAllVarsToStart` to publish (`start_off`), and to the variable itself
+/// before every evaluation (`off`); a non-real input has only the one slot.
 #[derive(Clone, Debug, PartialEq)]
 pub struct InputVar {
     pub off: u32,
+    pub start_off: u32,
     pub wty: WTy,
     /// The result name the file's column header has to match.
     pub name: String,
@@ -1518,6 +1519,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     put_u32(&mut o, m.inputs.len() as u32);
     for v in &m.inputs {
         put_u32(&mut o, v.off);
+        put_u32(&mut o, v.start_off);
         o.push(matches!(v.wty, WTy::F64) as u8);
         put_str(&mut o, &v.name);
     }
@@ -1927,8 +1929,9 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let mut inputs = Vec::new();
     for _ in 0..r.u32()? {
         let off = r.u32()?;
+        let start_off = r.u32()?;
         let wty = if r.u8()? != 0 { WTy::F64 } else { WTy::I32 };
-        inputs.push(InputVar { off, wty, name: r.string()? });
+        inputs.push(InputVar { off, start_off, wty, name: r.string()? });
     }
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
@@ -2065,7 +2068,7 @@ mod tests {
                 jac_c: None,
                 jac_d: None,
             }),
-            inputs: vec![InputVar { off: 96, wty: WTy::F64, name: "u".to_string() }],
+            inputs: vec![InputVar { off: 96, start_off: 104, wty: WTy::F64, name: "u".to_string() }],
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/mod.rs
@@ -36,19 +36,6 @@ pub const AVAILABLE: bool = cfg!(all(ipopt, feature = "std"));
 pub use run::run_optimizer;
 
 #[cfg(all(ipopt, feature = "std"))]
-pub(crate) use crate::extinput::ExtInputHook;
-
-/// The driver's type-erased entry point into `-csvInput`'s hook, so the residual can
-/// re-read the external input without this module's types reaching `driver`.
-#[cfg(all(ipopt, feature = "std"))]
-pub(crate) const EXT_INPUT_APPLY: unsafe fn(
-    *mut core::ffi::c_void,
-    &mut dyn crate::driver::SimEngine,
-    u32,
-    f64,
-) = ExtInputHook::apply_erased;
-
-#[cfg(all(ipopt, feature = "std"))]
 mod run {
     use alloc::format;
     use alloc::string::String;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/setup.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/optimization/setup.rs
@@ -1055,15 +1055,10 @@ fn initial_guess_sim(data: &mut OptData, o: i32) -> Result<i32> {
         .iter()
         .map(|&i| data.names.get(i as usize).map(String::as_str).unwrap_or(""))
         .collect();
-    let mut ext = crate::simflags::with_flags(|f| f.csv_input.clone())
-        .and_then(|file| crate::extinput::ExternalInput::load(&file, &input_names))
-        .map(|ext| {
-            alloc::boxed::Box::new(crate::extinput::ExtInputHook {
-                ext,
-                input_offs: opt.inputs.iter().map(|&i| crate::REAL_OFF + i * 8).collect(),
-                inputs: crate::extinput::empty(nu),
-            })
-        });
+    let mut ext = crate::extinput::ExtInputHook::load_reals(&opt.inputs, &input_names);
+    // The file drives the inputs for the guess only; the Ipopt iterations take
+    // theirs from `vopt`.
+    let _armed = ext.as_mut().map(crate::extinput::arm);
     if ext.is_none() {
         let u0 = data.bounds.u0.clone();
         data.model.inputs.copy_from_slice(&u0);
@@ -1076,11 +1071,6 @@ fn initial_guess_sim(data: &mut OptData, o: i32) -> Result<i32> {
     let sim_data = data.model.sim_data;
     let e = unsafe { &mut *engine };
     let mut stepper = driver::GuessStepper::new(e, &meta, sim_data, data.start_time)?;
-    // C re-reads the external input at every residual evaluation
-    // (`functionODE_residual`), not just per step.
-    if let Some(hook) = ext.as_mut() {
-        stepper.set_external_input(&mut **hook as *mut _ as *mut core::ffi::c_void);
-    }
 
     // C's pre-simulation: when the Optimica `startTime` is beyond the experiment's,
     // simulate up to it first and emit those rows.


### PR DESCRIPTION
`-csvInput` was applied only in `initializeModel`, so an `input` variable kept its start value for a whole run, and the optimizer's initial guess kept whatever the last DASKR residual evaluation had left. C calls `externalInputUpdate` + `input_function` before every evaluation it makes: in each solver's residual and root callback, in `updateContinuousSystem` at each step end, in `rungekutta_step` and `sym_euler_step`, and in the event bisection.

Rather than reproduce those call sites one by one across six drivers, apply the file where the model clock moves — `write_time`, which every one of those paths already goes through, plus `Ode::eval` for gbode and the fixed-step schemes. The trajectory is armed for the integration loop and for the initial guess only (a process global, like `RES_CTX`, since runs are serialized per process): C's `externalInputallocate` .. `externalInputFree` bracket. During the Ipopt iterations the inputs come from `vopt`, so the guess disarms before them. `ResCtx` loses its type-erased hook pair, which this subsumes.

Three supporting fixes:

* `InputVar` carried only the `start` attribute slot, which is what initialization publishes. Driving the input needs the variable's own slot, so it now carries both, and the file's value lands where the equations read it.
* csv fields are RFC 4180, as C gets them from libcsv. A header of `"time","u_f","u_wg"` matched no input name, so every column silently read as 0.
* `-csvInput` with `method="euler"` and no events took the in-wasm Euler loop, which cannot return to the host between steps. It now takes the host driver.

Under `--simCodeTarget=wasm-jit`:
`openmodelica/cruntime/optimization/basic` 53/56 -> 56/56 (DMwarm.mos, DMwarmCsv.mos, DM.mos), matching the C target, and `simulation/modelica/solver` 40/41 -> 41/41 (LotkaVolterraWithInput, all six of its solvers). `simulation/modelica/{events,daemode}` stay 48/48.

On DMwarm the guess was ~2% off on `u_wg` at every collocation point, which moved the Ipopt iterates enough to change which state the `LOG_IPOPT_ERROR` line reports. The guess now agrees with the C target to 1e-12 on the inputs and 5e-8 on the states, the latter being DASSL at the clamped 1e-3 tolerance C uses for the guess.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
