### PR TITLE
OMEdit web: local files, FMU export, -inputPath

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
@@ -275,6 +275,12 @@ self.onmessage = async (e) => {
       let entries;
       try { entries = wasi_readdir(msg.path) || []; } catch (e) { entries = []; }
       self.postMessage({ kind: "vfsListResult", id: msg.id, entries });
+    } else if (msg.cmd === "vfsPut") {
+      // The page writes into this worker's store, so omc and the GUI share one
+      // filesystem and loadFile/setSourceFile find what the GUI wrote.
+      let ok = true;
+      try { wasi_write_file(msg.path, msg.bytes); } catch (e) { ok = false; }
+      self.postMessage({ kind: "vfsPutResult", id: msg.id, ok });
     } else if (msg.cmd === "vfsStat") {
       // WASI path_filestat_get's size (-1 if absent), for the file engine's size().
       let size;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/extinput.rs
@@ -26,8 +26,7 @@ impl ExternalInput {
     /// C's `externalInputallocate`: read the csv and map its columns onto the input
     /// variables by name. `None` when there is no `-csvInput` (C's `active = 0`).
     pub(crate) fn load(file: &str, input_names: &[&str]) -> Option<Self> {
-        // C prefixes `-inputPath` when it is given; this runtime does not implement
-        // that flag, so the name is used as it stands.
+        // `-inputPath` is already folded in by `simflags::parse`.
         let path = String::from(file);
         let Some(text) = read_file(&path) else {
             omclog::error(omclog::STDOUT, false, &format!("Failed to read CSV-file {path}"));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/simflags.rs
@@ -234,8 +234,13 @@ pub struct SimFlags {
     /// `-stateFile=<file>`: `name value` lines overriding start values.
     pub state_file: Option<String>,
     /// `-csvInput=<file>`: external input `time,u…` rows, interpolated for the
-    /// optimizer's initial guess (C's `external_input.c`).
+    /// optimizer's initial guess (C's `external_input.c`). `-inputPath` is folded
+    /// in by [`parse`].
     pub csv_input: Option<String>,
+    /// `-inputPath=<dir>`: where the run's *input* files are read from. C also
+    /// prefixes the `_init.xml`/`_info.json`/sparsity files, which this runtime
+    /// carries in the module, so [`parse`] folds it into the two file flags only.
+    pub input_path: Option<String>,
     /// `-csvOstep=<file>` / `-optDebugJac=<iter>`: the optimizer's debug dumps.
     pub csv_ostep: Option<String>,
     pub opt_debug_jac: Option<String>,
@@ -716,6 +721,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "keepHessian" => f.keep_hessian = Some(int(name, &value(name)?)?),
             "stateFile" => f.state_file = Some(value(name)?),
             "csvInput" => f.csv_input = Some(value(name)?),
+            "inputPath" => f.input_path = Some(value(name)?),
             "csvOstep" => f.csv_ostep = Some(value(name)?),
             "optDebugJac" => f.opt_debug_jac = Some(value(name)?),
             // C declares `-ipopt_jac` but never reads it; accept and ignore, as it does.
@@ -814,6 +820,18 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             }
         }
     }
+    // As C joins it at each read site: always for `-csvInput`, and for `-iif` only
+    // when the name does not already resolve on its own.
+    if let Some(dir) = f.input_path.clone() {
+        if let Some(csv) = &f.csv_input {
+            f.csv_input = Some(format!("{dir}/{csv}"));
+        }
+        if let Some(init) = &f.init_file
+            && !file_exists(init)
+        {
+            f.init_file = Some(format!("{dir}/{init}"));
+        }
+    }
     // C's `doOverride` reads `-override` first, then the file; a later entry for the
     // same name wins.
     for raw in [f.override_raw.as_deref(), f.override_file.as_ref().map(|(_, j)| j.as_str())] {
@@ -860,6 +878,18 @@ fn read_override_file(path: &str) -> Result<String, String> {
 #[cfg(not(feature = "std"))]
 fn read_override_file(path: &str) -> Result<String, String> {
     Err(format!("-overrideFile={path}: this runtime has no filesystem"))
+}
+
+/// C's `omc_file_exists`. False without a filesystem, so the prefix is applied and
+/// the read reports the one path it tried.
+#[cfg(feature = "std")]
+fn file_exists(path: &str) -> bool {
+    std::path::Path::new(path).exists()
+}
+
+#[cfg(not(feature = "std"))]
+fn file_exists(_path: &str) -> bool {
+    false
 }
 
 /// C's `initializeResultData` formats. `mat`, `csv`, `plt` and `empty` are the
@@ -1453,6 +1483,33 @@ mod tests {
         assert_eq!(f.no_equidistant_time, Some(0.5));
     }
 
+    // OMEdit passes `-inputPath=<working directory>` on every run.
+    #[test]
+    fn input_path_prefixes_the_input_files() {
+        let f = parse(&argv(&["-csvInput=u.csv", "-inputPath=/work/M"])).expect("parses");
+        assert_eq!(f.input_path.as_deref(), Some("/work/M"));
+        assert_eq!(f.csv_input.as_deref(), Some("/work/M/u.csv"));
+        // `-iif` names a file that does not resolve on its own, so it is joined too.
+        let f = parse(&argv(&["-inputPath=/work/M", "-iif=M_res.mat"])).expect("parses");
+        assert_eq!(f.init_file.as_deref(), Some("/work/M/M_res.mat"));
+        // Without the flag the names stand as given.
+        let f = parse(&argv(&["-csvInput=u.csv", "-iif=M_res.mat"])).expect("parses");
+        assert_eq!(f.csv_input.as_deref(), Some("u.csv"));
+        assert_eq!(f.init_file.as_deref(), Some("M_res.mat"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn input_path_leaves_an_iif_that_already_resolves() {
+        let dir = std::env::temp_dir().join("om_simflags_input_path");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let init = dir.join("seed_res.mat");
+        std::fs::write(&init, b"").expect("write");
+        let init = init.to_str().expect("utf-8").to_string();
+        let f = parse(&argv(&["-inputPath=/work/M", &format!("-iif={init}")])).expect("parses");
+        assert_eq!(f.init_file.as_deref(), Some(init.as_str()));
+    }
+
     #[test]
     fn a_rejected_options_value_is_not_read_as_a_flag() {
         let e = parse(&argv(&["-idaScaling", "-lv=LOG_STATS"])).expect_err("must reject");
@@ -1509,6 +1566,7 @@ mod tests {
             "-outputFormat=mat",
             "-variableFilter=.*",
             "-r=/tmp/M_res.mat",
+            "-inputPath=/tmp",
             "-jacobian=coloredNumerical",
             "-w",
         ]))
@@ -1517,6 +1575,7 @@ mod tests {
         assert_eq!((f.step_size, f.tolerance), (Some(0.002), Some(1e-6)));
         assert_eq!(f.output_format.as_deref(), Some("mat"));
         assert_eq!(f.result_file.as_deref(), Some("/tmp/M_res.mat"));
+        assert_eq!(f.input_path.as_deref(), Some("/tmp"));
         assert!(f.show_all_warnings && f.log_mask & crate::omclog::SHOW_ALL_WARNINGS != 0);
     }
 

--- a/OMEdit/OMEditGUI/wasm/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/wasm/CMakeLists.txt
@@ -119,8 +119,11 @@ list(APPEND OMEDITLIB_SOURCES
   # there is nothing left to stub here for the OMSimulator C API.)
   ${CMAKE_CURRENT_SOURCE_DIR}/sim_widget_stubs.cpp
   # QAbstractFileEngineHandler that serves worker-VFS files to main-thread QFile.
-  ${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp)
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp PROPERTIES SKIP_AUTOMOC ON)
+  ${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp
+  # Browser file picker / download, for the user's own filesystem.
+  ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp)
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp PROPERTIES SKIP_AUTOMOC ON)
 # The simulation metadata tables OMCProxy reads (SOLVER_METHOD_NAME, FLAG_NAME,
 # OMC_LOG_STREAM_NAME, ...); native OMEdit gets them from libOpenModelicaCompiler.
 list(APPEND OMEDITLIB_SOURCES ${SIMRT}/util/simulation_options.c ${SIMRT}/util/omc_error.c)

--- a/OMEdit/OMEditGUI/wasm/WasmLocalFiles.h
+++ b/OMEdit/OMEditGUI/wasm/WasmLocalFiles.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef WASMLOCALFILES_H
+#define WASMLOCALFILES_H
+
+#if defined(__EMSCRIPTEN__)
+
+#include <QString>
+#include <QStringList>
+
+class QWidget;
+
+/*!
+ * \brief The user's own filesystem: a file picker in, a download out. Opening stages
+ * the picked file in the omc filesystem and returns its path, so loadFile/the
+ * editor/Save are unchanged.
+ */
+namespace WasmLocalFiles
+{
+  QStringList openFiles(const QString &nameFilter, bool multiple);
+  QString saveFileName(QWidget *parent, const QString &caption, const QString &dir, const QString &proposedName);
+  bool download(const QString &path);
+}
+
+#endif // __EMSCRIPTEN__
+#endif // WASMLOCALFILES_H

--- a/OMEdit/OMEditGUI/wasm/local_files.cpp
+++ b/OMEdit/OMEditGUI/wasm/local_files.cpp
@@ -1,0 +1,292 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// The user's own filesystem, which a browser reaches only through a file picker and
+// a download. Done on the DOM rather than with QFileDialog::getOpenFileContent,
+// whose showOpenFilePicker is Chromium-only and whose rejection Qt drops, so a
+// refusal never reaches the callback and a blocking caller waits forever.
+
+#if defined(__EMSCRIPTEN__)
+
+#include "OMEditGUI/wasm/WasmLocalFiles.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QFileInfo>
+#include <QInputDialog>
+#include <QLineEdit>
+#include <QRegularExpression>
+#include <QStringList>
+#include <QTimer>
+
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+
+#include <cstdlib>
+
+// Settles Module.__omeditPick exactly once: `change`, `cancel`, or — where `cancel`
+// is not fired — the window regaining focus with nothing being read.
+EM_JS(void, omedit_pick_open, (const char *accept, int multiple), {
+  const st = { settled: false, reading: false, files: [], error: "" };
+  Module.__omeditPick = st;
+  // Without transient activation click() is ignored and no event ever arrives; the
+  // check is Chromium-only and conservative, so try anyway but time out below.
+  const ua = navigator.userActivation;
+  const activated = !ua || ua.isActive;
+  if (!activated) {
+    st.error = "the browser only opens a file dialog while handling a click or key press";
+  }
+  const input = document.createElement("input");
+  input.type = "file";
+  const acc = UTF8ToString(accept);
+  if (acc) input.accept = acc;
+  if (multiple) input.multiple = true;
+  input.style.display = "none";
+  document.body.appendChild(input);
+  const settle = () => {
+    if (st.settled) return;
+    st.settled = true;
+    try { input.remove(); } catch (e) { /* already gone */ }
+  };
+  input.addEventListener("cancel", settle);
+  input.addEventListener("change", async () => {
+    st.reading = true;
+    try {
+      for (const f of input.files) {
+        st.files.push({ name: f.name, bytes: new Uint8Array(await f.arrayBuffer()) });
+      }
+    } catch (e) {
+      st.error = String(e);
+    }
+    settle();
+  });
+  window.addEventListener("focus", () => {
+    setTimeout(() => { if (!st.reading) settle(); }, 750);
+  }, { once: true });
+  input.click();
+  if (!activated) {
+    setTimeout(() => { if (!st.reading) settle(); }, 3000);
+  }
+});
+
+EM_JS(int, omedit_pick_settled, (), {
+  return (Module.__omeditPick && Module.__omeditPick.settled) ? 1 : 0;
+});
+EM_JS(int, omedit_pick_count, (), {
+  return (Module.__omeditPick && Module.__omeditPick.files.length) || 0;
+});
+EM_JS(char *, omedit_pick_name, (int i), {
+  const f = Module.__omeditPick.files[i];
+  return stringToNewUTF8(f ? f.name : "");
+});
+EM_JS(char *, omedit_pick_bytes, (int i, int *outLen), {
+  const f = Module.__omeditPick.files[i];
+  if (!f) { HEAP32[outLen >> 2] = -1; return 0; }
+  const len = f.bytes.length;
+  const ptr = _malloc(len || 1);
+  HEAPU8.set(f.bytes, ptr);
+  HEAP32[outLen >> 2] = len;
+  return ptr;
+});
+EM_JS(char *, omedit_pick_error, (), {
+  return stringToNewUTF8((Module.__omeditPick && Module.__omeditPick.error) || "");
+});
+EM_JS(void, omedit_pick_release, (), { Module.__omeditPick = null; });
+
+// A download rather than a save picker, so there is nothing to reject.
+EM_JS(void, omedit_download_bytes, (const char *name, const char *bytes, int len), {
+  const blob = new Blob([HEAPU8.slice(bytes, bytes + len)], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = UTF8ToString(name);
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => { a.remove(); URL.revokeObjectURL(url); }, 0);
+});
+
+namespace {
+
+// Where a picked file is staged, so nothing downstream knows it came from outside.
+const QLatin1String kUploadDir("/uploads");
+
+/*!
+ * \brief Qt name filter -> the input's `accept`: "All Files (*.mo *.mol)" becomes
+ * ".mo,.mol". Anything not a plain suffix matches everything, so it yields no accept
+ * list rather than one the user cannot get past.
+ */
+QString acceptFromNameFilter(const QString &nameFilter)
+{
+  QStringList suffixes;
+  static const QRegularExpression parens(QStringLiteral("\\(([^()]*)\\)"));
+  QRegularExpressionMatchIterator groups = parens.globalMatch(nameFilter);
+  while (groups.hasNext()) {
+    const QStringList patterns = groups.next().captured(1).split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    for (const QString &pattern : patterns) {
+      if (!pattern.startsWith(QLatin1String("*.")) || pattern.mid(2).contains(QLatin1Char('*'))
+          || pattern == QLatin1String("*.*")) {
+        return QString();
+      }
+      const QString suffix = QLatin1Char('.') + pattern.mid(2);
+      if (!suffixes.contains(suffix)) {
+        suffixes << suffix;
+      }
+    }
+  }
+  return suffixes.join(QLatin1Char(','));
+}
+
+// One picked file, from the JS side into the omc filesystem.
+QString stageFile(int index)
+{
+  char *rawName = omedit_pick_name(index);
+  const QString name = QFileInfo(QString::fromUtf8(rawName)).fileName();
+  free(rawName);
+  if (name.isEmpty()) {
+    return QString();
+  }
+  int len = -1;
+  char *raw = omedit_pick_bytes(index, &len);
+  if (!raw || len < 0) {
+    free(raw);
+    qWarning() << "[OMEdit-wasm] could not read the picked file" << name;
+    return QString();
+  }
+  const QByteArray content(raw, len);
+  free(raw);
+
+  const QString path = QString("%1/%2").arg(kUploadDir, name);
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    qWarning() << "[OMEdit-wasm] could not stage" << path << file.errorString();
+    return QString();
+  }
+  const bool written = file.write(content) == content.size();
+  file.close();
+  if (!written) {
+    qWarning() << "[OMEdit-wasm] short write staging" << path;
+    return QString();
+  }
+  return path;
+}
+
+} // namespace
+
+/*!
+ * \brief Ask the browser for files and stage them in the omc filesystem.
+ * \return the paths they were staged at, empty if the user cancelled.
+ */
+QStringList WasmLocalFiles::openFiles(const QString &nameFilter, bool multiple)
+{
+  omedit_pick_open(acceptFromNameFilter(nameFilter).toUtf8().constData(), multiple ? 1 : 0);
+  // Wait as every omc call on this thread does (OMCProxy::omcWorkerWaitReply): a
+  // nonzero poll, or Qt never yields to the browser, and exec() re-entered because
+  // it can return without the condition holding.
+  if (!omedit_pick_settled()) {
+    QEventLoop loop;
+    QTimer poll;
+    QObject::connect(&poll, &QTimer::timeout, &loop, [&loop]() {
+      if (omedit_pick_settled()) {
+        loop.quit();
+      }
+    });
+    poll.start(50);
+    while (!omedit_pick_settled()) {
+      loop.exec();
+    }
+  }
+  QStringList paths;
+  const int count = omedit_pick_count();
+  for (int i = 0; i < count; ++i) {
+    const QString path = stageFile(i);
+    if (!path.isEmpty()) {
+      paths << path;
+    }
+  }
+  char *rawError = omedit_pick_error();
+  const QString error = QString::fromUtf8(rawError);
+  free(rawError);
+  omedit_pick_release();
+  // A refusal is silent in the browser, so say so rather than look like a no-op.
+  if (paths.isEmpty() && !error.isEmpty()) {
+    qWarning() << "[OMEdit-wasm] file dialog:" << error;
+  }
+  return paths;
+}
+
+/*!
+ * \brief Only the file name is asked for — the browser picks the directory when the
+ * download runs. The returned path is where the caller writes, in the omc filesystem.
+ */
+QString WasmLocalFiles::saveFileName(QWidget *parent, const QString &caption, const QString &dir,
+                                     const QString &proposedName)
+{
+  bool ok = false;
+  const QString name = QInputDialog::getText(parent, caption,
+                                             QCoreApplication::translate("WasmLocalFiles",
+                                                                         "File name (downloaded once saved):"),
+                                             QLineEdit::Normal, proposedName, &ok);
+  if (!ok) {
+    return QString();
+  }
+  const QString baseName = QFileInfo(name.trimmed()).fileName();
+  if (baseName.isEmpty()) {
+    return QString();
+  }
+  return QString("%1/%2").arg(dir.isEmpty() ? QDir::homePath() : dir, baseName);
+}
+
+/*!
+ * \brief Hand a file the caller has finished writing to the browser as a download.
+ */
+bool WasmLocalFiles::download(const QString &path)
+{
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    qWarning() << "[OMEdit-wasm] nothing to download at" << path << file.errorString();
+    return false;
+  }
+  const QByteArray data = file.readAll();
+  file.close();
+  omedit_download_bytes(QFileInfo(path).fileName().toUtf8().constData(), data.constData(), data.size());
+  return true;
+}
+
+#endif // __EMSCRIPTEN__

--- a/OMEdit/OMEditGUI/wasm/worker_vfs_engine.cpp
+++ b/OMEdit/OMEditGUI/wasm/worker_vfs_engine.cpp
@@ -46,8 +46,10 @@
 // (synchronously, via the same nested-QEventLoop bridge as every other omc call)
 // and serves them. So every QFile/QFileInfo read of a worker-owned file just works.
 //
-// Read-only: writes fall through (return failure). Directory enumeration (QDir)
-// is served via the worker's WASI fd_readdir (omcWorkerListDir).
+// Writes go the same way in reverse: buffered, then pushed to the worker on
+// close/flush (omcWorkerWriteFile), so a model the GUI saves is the file omc reads.
+// The push does not wait, so success means "handed over". Directory enumeration
+// (QDir) is served via the worker's WASI fd_readdir (omcWorkerListDir).
 #if defined(__EMSCRIPTEN__)
 
 #include <QtCore/private/qabstractfileengine_p.h>
@@ -66,6 +68,7 @@
 // Defined in OMEditLIB/OMC/OMCProxy.cpp (shares the omc worker bridge).
 QByteArray omcWorkerReadFile(const char *path);
 QStringList omcWorkerListDir(const char *path);
+bool omcWorkerWriteFile(const char *path, const QByteArray &data);
 
 // True if the page MEMFS already has the path (then the default engine handles it).
 EM_JS(int, omedit_memfs_exists, (const char *path), {
@@ -103,16 +106,73 @@ public:
   bool open(QIODevice::OpenMode openMode,
             std::optional<QFile::Permissions> = std::nullopt) override
   {
-    if (openMode & QIODevice::WriteOnly) return false;
+    if (openMode & (QIODevice::WriteOnly | QIODevice::Append)) {
+      const bool truncate = openMode & QIODevice::Truncate;
+      if (truncate) {
+        mData.clear();
+      } else {
+        ensureFetched();
+      }
+      mWriting = true;
+      mFetched = true;
+      mExists = true;
+      mPos = (openMode & QIODevice::Append) ? mData.size() : 0;
+      // Truncating creates the file even if nothing is ever written to it.
+      mDirty = truncate;
+      return true;
+    }
     if (!ensureFetched()) return false;
     mPos = 0;
     return true;
   }
-  bool close() override { return true; }
+  bool close() override
+  {
+    bool ok = flush();
+    mWriting = false;
+    return ok;
+  }
+
+  // QFile flushes once itself and again as the engine closes; only push if dirty.
+  bool flush() override
+  {
+    if (!mWriting || !mDirty) return true;
+    if (!omcWorkerWriteFile(mName.toUtf8().constData(), mData)) return false;
+    mDirty = false;
+    return true;
+  }
+
+  qint64 write(const char *data, qint64 len) override
+  {
+    if (!mWriting || len < 0) return -1;
+    if (mPos + len > mData.size()) mData.resize(mPos + len);
+    memcpy(mData.data() + mPos, data, len);
+    mPos += len;
+    mDirty = true;
+    return len;
+  }
+
+  // The store keys on the whole path: a directory exists when something is under it.
+  bool mkdir(const QString &, bool, std::optional<QFile::Permissions> = std::nullopt) const override
+  {
+    return true;
+  }
 
   qint64 size() const override { ensureFetched(); return mExists ? mData.size() : 0; }
   qint64 pos() const override { return mPos; }
-  bool seek(qint64 p) override { if (p < 0 || p > mData.size()) return false; mPos = p; return true; }
+  bool seek(qint64 p) override
+  {
+    if (p < 0 || (!mWriting && p > mData.size())) return false;
+    mPos = p;
+    return true;
+  }
+  bool setSize(qint64 n) override
+  {
+    if (!mWriting || n < 0) return false;
+    mData.resize(n);
+    if (mPos > n) mPos = n;
+    mDirty = true;
+    return true;
+  }
   bool isSequential() const override { return false; }
 
   qint64 read(char *data, qint64 maxlen) override
@@ -127,13 +187,14 @@ public:
 
   FileFlags fileFlags(FileFlags type = FileInfoAll) const override
   {
+    // Writable, so QFileInfo::isWritable() on a save path must not say no.
+    const FileFlags perms = ReadOwnerPerm | ReadUserPerm | ReadGroupPerm | ReadOtherPerm
+                            | WriteOwnerPerm | WriteUserPerm | WriteGroupPerm | WriteOtherPerm;
     FileFlags f;
     if (ensureFetched()) {
-      f |= ExistsFlag | FileType;
-      f |= ReadOwnerPerm | ReadUserPerm | ReadGroupPerm | ReadOtherPerm;
+      f |= ExistsFlag | FileType | perms;
     } else if (ensureDirListed()) {
-      f |= ExistsFlag | DirectoryType;
-      f |= ReadOwnerPerm | ReadUserPerm | ReadGroupPerm | ReadOtherPerm;
+      f |= ExistsFlag | DirectoryType | perms;
     }
     return f & type;
   }
@@ -166,7 +227,7 @@ public:
   void setFileName(const QString &file) override
   {
     mName = file; mFetched = false; mExists = false; mData.clear(); mPos = 0;
-    mDirFetched = false; mDirEntries.clear();
+    mDirFetched = false; mDirEntries.clear(); mWriting = false; mDirty = false;
   }
 
 private:
@@ -197,6 +258,8 @@ private:
   mutable QStringList mDirEntries;
   mutable bool mDirFetched = false;
   qint64 mPos = 0;
+  bool mWriting = false;
+  bool mDirty = false;
 };
 
 class WorkerVfsHandler : public QAbstractFileEngineHandler

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -86,6 +86,9 @@
 #include "FMI/FMUExportOutputWidget.h"
 #include "PlotCurve.h"
 #include "LoadCompiledModelDialog.h"
+#if defined(__EMSCRIPTEN__)
+#include "OMEditGUI/wasm/WasmLocalFiles.h"
+#endif
 #include <QtSvg/QSvgGenerator>
 #include <QOpenGLWidget>
 #include <QNetworkProxyFactory>
@@ -1401,10 +1404,13 @@ void MainWindow::checkAllModels(LibraryTreeItem *pLibraryTreeItem)
 
 void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
 {
-  // check for supported targetLanguage C or Cpp
+  // check for a targetLanguage that can produce an FMU
   QString targetLanguage = OptionsDialog::instance()->getSimulationPage()->getTargetLanguageComboBox()->currentText();
-  if (targetLanguage.compare("C") != 0 && targetLanguage.compare("Cpp") != 0) {
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Target Language <b>%1</b> is not supported for FMU Export. Only <b>C</b> and <b>Cpp</b> are supported").arg(targetLanguage),
+  // The wasm targets export inside omc (component + a loader per native platform),
+  // so buildModelFMU finishes the FMU and there is no compile step here.
+  const bool wasmTarget = targetLanguage.compare("wasm") == 0 || targetLanguage.compare("wasm-jit") == 0;
+  if (!wasmTarget && targetLanguage.compare("C") != 0 && targetLanguage.compare("Cpp") != 0) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Target Language <b>%1</b> is not supported for FMU Export. Only <b>C</b>, <b>Cpp</b>, <b>wasm</b> and <b>wasm-jit</b> are supported").arg(targetLanguage),
                                                                   tr("FMU_EXPORT Failed"), Helper::errorLevel));
     return;
   }
@@ -1472,9 +1478,15 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
   }
   bool includeResources = OptionsDialog::instance()->getFMIPage()->getIncludeResourcesCheckBox()->isChecked();
   bool isTranslationSuccessful;
+  QString fmuFileName;
   {
     OMCLongOperation longOperation;
-    isTranslationSuccessful = mpOMCProxy->translateModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms, includeResources);
+    if (wasmTarget) {
+      fmuFileName = mpOMCProxy->buildModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms, includeResources);
+      isTranslationSuccessful = !fmuFileName.isEmpty();
+    } else {
+      isTranslationSuccessful = mpOMCProxy->translateModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms, includeResources);
+    }
   }
   // hide progress bar
   hideProgressBar();
@@ -1482,16 +1494,27 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
   mpStatusBar->clearMessage();
 
   if (isTranslationSuccessful) {
-#if !defined(__EMSCRIPTEN__)
-    // create a FMU compilation window  similar to simulation process
-    FmuExportOutputWidget * pFmuExportOutputWidget = new FmuExportOutputWidget(pLibraryTreeItem, this);
-    MessagesWidget::instance()->addSimulationOutputTab(pFmuExportOutputWidget, pLibraryTreeItem->getName() + "_fmuExport");
-    if (targetLanguage.compare("C") == 0) {
-      pFmuExportOutputWidget->compileModelCRuntime();
-    } else {
-      pFmuExportOutputWidget->compileModelCppRuntime();
-    }
+    if (wasmTarget) {
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Exported <b>%1</b>.").arg(fmuFileName),
+                                                            Helper::scriptingKind, Helper::notificationLevel));
+#if defined(__EMSCRIPTEN__)
+      if (!WasmLocalFiles::download(fmuFileName)) {
+        MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Could not read the exported FMU <b>%1</b>.").arg(fmuFileName),
+                                                              Helper::scriptingKind, Helper::errorLevel));
+      }
 #endif
+    } else {
+#if !defined(__EMSCRIPTEN__)
+      // create a FMU compilation window  similar to simulation process
+      FmuExportOutputWidget * pFmuExportOutputWidget = new FmuExportOutputWidget(pLibraryTreeItem, this);
+      MessagesWidget::instance()->addSimulationOutputTab(pFmuExportOutputWidget, pLibraryTreeItem->getName() + "_fmuExport");
+      if (targetLanguage.compare("C") == 0) {
+        pFmuExportOutputWidget->compileModelCRuntime();
+      } else {
+        pFmuExportOutputWidget->compileModelCppRuntime();
+      }
+#endif
+    }
   } else {
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, QString("Translation of FMU: <b>%1</b> Failed").arg(pLibraryTreeItem->getName()),
                                                                   "Translation Error", Helper::errorLevel));

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -55,6 +55,9 @@
 #include "Git/CommitChangesDialog.h"
 #include "Util/ResourceCache.h"
 #include "Search/FindUsageWidget.h"
+#if defined(__EMSCRIPTEN__)
+#include "OMEditGUI/wasm/WasmLocalFiles.h"
+#endif
 
 #include <QClipboard>
 #include <QDockWidget>
@@ -4762,6 +4765,9 @@ bool LibraryWidget::saveModelicaLibraryTreeItemOneFile(LibraryTreeItem *pLibrary
         pLibraryTreeItem->getModelWidget()->setModelFilePathLabel(fileName);
       }
       mpLibraryTreeModel->updateLibraryTreeItem(pLibraryTreeItem);
+#if defined(__EMSCRIPTEN__)
+      WasmLocalFiles::download(fileName);
+#endif
       /* Save the traceabiliy information and send to Daemon. */
 #if !defined(__EMSCRIPTEN__)
       if(GitCommands::instance()->isSavedUnderGitRepository(pLibraryTreeItem->getFileName()) && OptionsDialog::instance()->getTraceabilityPage()->getTraceabilityGroupBox()->isChecked() ){
@@ -4860,6 +4866,11 @@ bool LibraryWidget::saveModelicaLibraryTreeItemFolder(LibraryTreeItem *pLibraryT
         pLibraryTreeItem->getModelWidget()->setModelFilePathLabel(fileName);
       }
       mpLibraryTreeModel->updateLibraryTreeItem(pLibraryTreeItem);
+#if defined(__EMSCRIPTEN__)
+      // One download per file; the folder structure itself stays in the omc
+      // filesystem for the session.
+      WasmLocalFiles::download(fileName);
+#endif
     } else {
       return false;
     }
@@ -4962,6 +4973,9 @@ bool LibraryWidget::saveTextLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, b
         pLibraryTreeItem->getModelWidget()->setModelFilePathLabel(fileName);
       }
       mpLibraryTreeModel->updateLibraryTreeItem(pLibraryTreeItem);
+#if defined(__EMSCRIPTEN__)
+      WasmLocalFiles::download(fileName);
+#endif
     } else {
       return false;
     }

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -47,6 +47,9 @@
 #include "Modeling/ModelWidgetContainer.h"
 #include "Commands.h"
 #include "Modeling/ItemDelegate.h"
+#if defined(__EMSCRIPTEN__)
+#include "OMEditGUI/wasm/WasmLocalFiles.h"
+#endif
 
 #include <QApplication>
 #include <QMessageBox>
@@ -1359,6 +1362,9 @@ void SaveTotalFileDialog::saveTotalModel()
       mpStripCommentsCheckBox->isChecked(),
       mpObfuscateOutputCheckBox->isChecked(),
       mpUseSimplifiedHeuristic->isChecked());
+#if defined(__EMSCRIPTEN__)
+    WasmLocalFiles::download(fileName);
+#endif
     accept();
   }
 }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -441,6 +441,25 @@ QByteArray omcWorkerReadFile(const char *path) {
   return data;
 }
 
+// Worker-VFS file write, backing the QAbstractFileEngine's write side; entries are
+// overwritten, there is no remove. Deliberately does NOT wait for the reply: files
+// get written from anywhere (a QSettings sync, a destructor, code before exec()) and
+// blocking on the worker there corrupts Qt's pending-event machinery. Ordering holds
+// anyway — Module.__omcSend is one serialised queue.
+EM_JS(void, omedit_post_vfs_put, (const char *path, const char *bytes, int len), {
+  Module.__omcSend({ cmd: "vfsPut", path: UTF8ToString(path),
+                     bytes: HEAPU8.slice(bytes, bytes + len) })
+    .then((r) => { if (!r || !r.ok) console.error("[OMEdit-wasm] vfsPut refused", UTF8ToString(path)); })
+    .catch((e) => console.error("[OMEdit-wasm] vfsPut failed", e));
+});
+
+bool omcWorkerWriteFile(const char *path, const QByteArray &data)
+{
+  if (!omedit_worker_ready()) return false;
+  omedit_post_vfs_put(path, data.constData(), data.size());
+  return true;
+}
+
 // Worker-VFS directory listing (WASI fd_readdir), backing QDir over worker paths.
 // Returns the immediate child names of dir; directories carry a trailing '/'.
 EM_JS(int, omedit_post_vfs_list, (const char *path), {

--- a/OMEdit/OMEditLIB/Options/OptionsDefaults.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDefaults.h
@@ -163,7 +163,12 @@ namespace OptionsDefaults
     QString postCompilationCommand = "";
     bool ignoreCommandLineOptionsAnnotation = false;
     bool ignoreSimulationFlagsAnnotation = false;
+#if defined(__EMSCRIPTEN__)
+    // Saving is a download here, so prompting before every run gets in the way.
+    bool saveClassBeforeSimulation = false;
+#else
     bool saveClassBeforeSimulation = true;
+#endif
     bool switchToPlottingPerspective = true;
     bool closeSimulationOutputWidgetsBeforeSimulation = true;
     bool deleteIntermediateCompilationFiles = true;

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -44,6 +44,9 @@
 #include "Utilities.h"
 #include "Util/ResourceCache.h"
 #include "om_format.h"
+#if defined(__EMSCRIPTEN__)
+#include "OMEditGUI/wasm/WasmLocalFiles.h"
+#endif
 
 #include <QtCore/qmath.h>
 #include <QDir>
@@ -1262,11 +1265,17 @@ QString StringHandler::getSaveFileName(QWidget* parent, const QString &caption, 
     }
   }
 
+#if defined(__EMSCRIPTEN__)
+  Q_UNUSED(filter)
+  Q_UNUSED(selectedFilter)
+  fileName = WasmLocalFiles::saveFileName(parent, caption, dir_str, proposedFileName);
+#else
   if (!proposedFileName.isEmpty()) {
     fileName = QFileDialog::getSaveFileName(parent, caption, QString(dir_str).append("/").append(proposedFileName), filter, selectedFilter);
   } else {
     fileName = QFileDialog::getSaveFileName(parent, caption, dir_str, filter, selectedFilter);
   }
+#endif
 
   if (!fileName.isEmpty()) {
     QFileInfo fileInfo(fileName);
@@ -1287,11 +1296,18 @@ QString StringHandler::getSaveFolderName(QWidget* parent, const QString &caption
   }
 
   QString proposedFileName = *proposedName;
+#if defined(__EMSCRIPTEN__)
+  // A browser cannot receive a directory, so each file written is downloaded alone.
+  Q_UNUSED(filter)
+  Q_UNUSED(selectedFilter)
+  folderName = WasmLocalFiles::saveFileName(parent, caption, dir_str, proposedFileName);
+#else
   if (!proposedFileName.isEmpty()) {
     folderName = QFileDialog::getSaveFileName(parent, caption, QString(dir_str).append("/").append(proposedFileName), filter, selectedFilter);
   } else {
     folderName = QFileDialog::getSaveFileName(parent, caption, dir_str, filter, selectedFilter);
   }
+#endif
   if (!folderName.isEmpty()) {
     StringHandler::setLastOpenDirectory(folderName);
   }
@@ -1309,7 +1325,14 @@ QString StringHandler::getOpenFileName(QWidget* parent, const QString &caption, 
   }
 
   QString fileName = "";
-#if defined(_WIN32)
+#if defined(__EMSCRIPTEN__)
+  // The picker hands over bytes, not a path: they are staged and that path returned.
+  Q_UNUSED(dir_str)
+  Q_UNUSED(caption)
+  Q_UNUSED(parent)
+  Q_UNUSED(selectedFilter)
+  fileName = WasmLocalFiles::openFiles(filter, false).value(0);
+#elif defined(_WIN32)
   fileName = QFileDialog::getOpenFileName(parent, caption, dir_str, filter, selectedFilter);
 #else
   Q_UNUSED(selectedFilter)
@@ -1342,7 +1365,13 @@ QStringList StringHandler::getOpenFileNames(QWidget* parent, const QString &capt
   }
 
   QStringList fileNames;
-#if defined(_WIN32)
+#if defined(__EMSCRIPTEN__)
+  Q_UNUSED(dir_str)
+  Q_UNUSED(caption)
+  Q_UNUSED(parent)
+  Q_UNUSED(selectedFilter)
+  fileNames = WasmLocalFiles::openFiles(filter, true);
+#elif defined(_WIN32)
   fileNames = QFileDialog::getOpenFileNames(parent, caption, dir_str, filter, selectedFilter);
 #else
   Q_UNUSED(selectedFilter);


### PR DESCRIPTION
Open and save against the user's own disk in the browser OMEdit, enable the FMU export there, and implement the one simulation flag OMEdit always passes.

## wasm-jit `-inputPath`

OMEdit appends `-inputPath=<working directory>` to every run, and an unimplemented flag is a hard parse error, so one missing flag rejected the whole simflags list. It is folded into `-csvInput` (always) and `-iif` (only where the name does not already resolve), as C joins it at each read site. The `_init.xml`/`_info.json`/sparsity files C also prefixes are carried in the compiled module, so nothing else needs redirecting.

## The user's filesystem

`worker_vfs_engine.cpp` was read-only, and its handler claims any absolute path the page MEMFS lacks, so refusing writes was not a fallthrough: every main-thread `QFile::open(WriteOnly)` failed and saving a model did nothing, silently. Writes are now buffered and pushed to the omc worker (`vfsPut`), so the GUI and omc share one filesystem and the file the GUI saved is the file `loadFile` reads.

The push deliberately does not wait for a reply. Files get written from contexts that must not block - a QSettings sync, a destructor, code before `exec()` - and blocking on the worker there corrupts Qt's pending-event machinery (`QWasmSuspendResumeControl::sendPendingEvents`, then "cannot have multiple async operations in flight"). Ordering holds without waiting because the worker channel is one serialised queue.

`wasm/local_files.cpp` is the browser side: an `<input type="file">` and a Blob download, driven from JS and polled from C++. Qt's `getOpenFileContent` is not usable from a blocking caller - it goes through `showOpenFilePicker`, which is Chromium-only, and Qt drops the promise rejection, so a refusal never reaches the callback. Hooked in at `StringHandler::getOpenFileName{,s}`, `getSaveFileName` and `getSaveFolderName`, plus a download after each save that produced a file.

Platform limits, not worked around: there is no directory picker, and a folder-structure package is downloaded one file at a time.

## FMU export

What disabled this was the target-language check, not missing support: OptionsDialog selects `wasm-jit` on wasm and `exportModelFMU` rejected anything but C/Cpp before doing any work. It now accepts `wasm` and `wasm-jit` and calls `buildModelFMU`, which finishes the FMU inside omc, so there is no compile step and no `FmuExportOutputWidget`. A native OMEdit set to `wasm-jit` exports as well instead of refusing.

## Also

"Save class before simulation" defaults to false on Emscripten, where saving is a download and the prompt interrupts every run.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
