### PR TITLE
wasm-jit: hold math events while linearizing

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/linearize.rs
@@ -12,7 +12,7 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use crate::driver::{Result, SimEngine, format_g, read_f64, write_f64};
+use crate::driver::{Result, SimEngine, format_g, read_f64, write_f64, write_i32};
 use crate::{LinInfo, LinLanguage, LinVar, REAL_OFF, SimMeta};
 
 /// The linearized model, for the caller to write where its file system is.
@@ -335,6 +335,10 @@ pub fn linearize(e: &mut dyn SimEngine, model: &SimMeta, sim_data: u32) -> Resul
     let layout = &model.layout;
     let (n_x, n_u, n_y, n_z) =
         (layout.n_states as usize, lin.input_vars.len(), lin.output_vars.len(), layout.n_real_alg as usize);
+
+    // C linearizes with `discreteCall == 0`: relations and `mathEventsValuePre`
+    // stay held, so a perturbed state cannot step a discrete value.
+    write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
 
     let mut a = vec![0.0; n_x * n_x];
     let mut b = vec![0.0; n_x * n_u];


### PR DESCRIPTION
`mod`/`div`/`rem`/`ceil`/`floor`/`integer` are event-generating, so `FindZeroCrossings` appends a `mathEventsValuePre` index and the C runtime's `_event_*` only refreshes that slot when `discreteCall && !solveContinuous` — otherwise the call reads the held value, as `relationhysteresis` does for relations. `linearize.cpp` runs its difference quotients with `discreteCall == 0` (only `functionDAE` and `functionInitialEquations` raise it, and both lower it on the way out), so a perturbed state cannot step a discrete value.

`compile_math_event` already mirrors `_event_*` and gates on the port's `discreteCall`, `rel_fresh`, but that flag is host-driven and `emit_terminal_row` leaves it raised. Every perturbed evaluation re-latched the discrete values and differenced the live `trunc`/`floor` across its jump: `testMathFuncs.mos` got a slope of ~1e7 for a delta of ~1e-7 where C reports exactly 0.

Lower it in `linearize()`, ahead of both the numeric passes and the symbolic `linearJac*` reads, as every other host-side continuous evaluation in `driver.rs` already does. C leaves it down afterwards too and `finalize_run` evaluates nothing, so there is nothing to restore.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
