### PR TITLE
[FrontEnd] Say why an external library did not provide the function (#16376)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1266,9 +1266,8 @@ function loadLibraryFunction
   input SourceInfo info;
   output Integer fnHandle = -1;
 protected
-  Integer lib_handle;
   SCode.Annotation ann;
-  list<String> libs = {}, dirs = {}, paths = {}, libs2 = {};
+  list<String> libs = {}, dirs = {}, paths = {}, libs2 = {}, failures = {};
   Boolean found = false;
   String installLibDir;
 algorithm
@@ -1339,42 +1338,112 @@ algorithm
     paths := "" :: paths;
   end if;
 
-  // Disable error messages, we don't care if some paths can't be found.
+  // The messages the search produces are about paths the user never asked for,
+  // so keep them out of the way; what went wrong is collected separately and
+  // reported below if nothing worked.
   ErrorExt.setCheckpoint(getInstanceName());
 
-  // Go through each path and try to find the function.
-  for path in paths loop
-    try
-      if not stringEmpty(path) then
-        path := uriToFilename(path);
-      end if;
+  // First ask for every symbol in the library to be resolved, which is what
+  // calling through it will need.
+  (fnHandle, found, failures) := searchLibraryPaths(paths, fnName, lazy = false, debug = debug);
 
-      lib_handle := lookupLibraryInCache(path);
-
-      if lib_handle == -1 then
-        lib_handle := System.loadLibrary(path, relativePath = false, printDebug = debug);
-        cacheLibrary(path, lib_handle);
-      end if;
-
-      fnHandle := System.lookupFunction(lib_handle, fnName);
-      found := true;
-    else
-    end try;
-
-    if found then
-      break;
-    end if;
-  end for;
+  if not found then
+    // Nothing. Try again binding lazily: a library that has an unresolvable
+    // symbol somewhere else in it can still provide this function.
+    (fnHandle, found, failures) := searchLibraryPaths(paths, fnName, lazy = true, debug = debug);
+  end if;
 
   ErrorExt.rollBack(getInstanceName());
 
   if not found then
-    paths := list("  " + Testsuite.friendly(uriToFilename(p)) for p guard not stringEmpty(p) in paths);
     Error.addSourceMessage(Error.EXTERNAL_FUNCTION_NOT_FOUND,
-      {fnName, stringDelimitList(paths, "\n")}, info);
+      {fnName, stringDelimitList(failures, "\n")}, info);
     fail();
   end if;
 end loadLibraryFunction;
+
+function searchLibraryPaths
+  "Tries each candidate path in turn, and says of each one why it did not
+   provide the function: there is nothing there, it would not load, or it
+   loaded and does not define it."
+  input list<String> paths;
+  input String fnName;
+  input Boolean lazy;
+  input Boolean debug;
+  output Integer fnHandle = -1;
+  output Boolean found = false;
+  output list<String> failures = {};
+protected
+  Integer lib_handle;
+  String file, reason;
+  Boolean resolved;
+algorithm
+  for path in paths loop
+    reason := "";
+    resolved := true;
+
+    try
+      file := if stringEmpty(path) then "" else uriToFilename(path);
+    else
+      file := path;
+      resolved := false;
+      reason := "not a usable file name";
+    end try;
+
+    if resolved then
+      lib_handle := lookupLibraryInCache(file);
+
+      if lib_handle == -1 then
+        try
+          lib_handle := if lazy then
+            System.loadLibraryLazy(file, relativePath = false, printDebug = debug) else
+            System.loadLibrary(file, relativePath = false, printDebug = debug);
+          cacheLibrary(file, lib_handle);
+        else
+          lib_handle := -1;
+          reason := System.getLoadLibraryError();
+          reason := if stringEmpty(reason) then "cannot be loaded" else
+                    "cannot be loaded: " + reason;
+        end try;
+      end if;
+
+      if lib_handle <> -1 then
+        try
+          fnHandle := System.lookupFunction(lib_handle, fnName);
+          found := true;
+        else
+          reason := "loaded, but does not define it";
+        end try;
+      end if;
+    end if;
+
+    if found then
+      break;
+    end if;
+
+    // The empty path means the compiler's own image, which is not a path worth
+    // listing back to the user.
+    if not stringEmpty(file) then
+      failures := describeLibraryFailure(file, reason) :: failures;
+    end if;
+  end for;
+
+  failures := listReverse(failures);
+end searchLibraryPaths;
+
+function describeLibraryFailure
+  input String file;
+  input String reason;
+  output String str;
+algorithm
+  str := "  " + Testsuite.friendly(file);
+
+  if not System.regularFileExists(file) then
+    str := str + " (no such file)";
+  elseif not stringEmpty(reason) then
+    str := str + " (" + Testsuite.friendly(reason) + ")";
+  end if;
+end describeLibraryFailure;
 
 function parseExternalAnnotation
   input String name;

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
@@ -494,6 +494,8 @@ fn registry() -> &'static BTreeMap<&'static str, Fallibility> {
         m.insert("System_initGarbageCollector", Infallible);
         m.insert("System_launchParallelTasks", Fallible);      // MMC_THROW_INTERNAL on pthread error
         m.insert("System_loadLibrary", Fallible);              // throws on dlopen failure
+        m.insert("System_loadLibraryLazy", Fallible);          // throws on dlopen failure
+        m.insert("System_getLoadLibraryError", Infallible);    // pure read of the last message
         m.insert("System_lookupFunction", Fallible);           // -1 → throw
         m.insert("System_makeC89Identifier", Infallible);
         m.insert("System_moFiles", Infallible);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -559,6 +559,12 @@ pub fn getLDFlags() -> ArcStr {
 pub fn loadLibrary(inLib: ArcStr, relativePath: bool, printDebug: bool) -> Result<i32> {
     crate::dynload::load_library(&inLib, relativePath, printDebug)
 }
+pub fn loadLibraryLazy(inLib: ArcStr, relativePath: bool, printDebug: bool) -> Result<i32> {
+    crate::dynload::load_library_lazy(&inLib, relativePath, printDebug)
+}
+pub fn getLoadLibraryError() -> ArcStr {
+    ArcStr::from(crate::dynload::last_load_error())
+}
 pub fn lookupFunction(inLibHandle: i32, inFunc: ArcStr) -> Result<i32> {
     crate::dynload::lookup_function(inLibHandle, &inFunc)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload.rs
@@ -51,9 +51,15 @@ pub(crate) mod dl {
 
     // dlopen flags mirror `SystemImpl__loadLibrary` in the C runtime.
     #[cfg(target_os = "linux")]
-    const FLAGS: c_int = libc::RTLD_LOCAL | libc::RTLD_NOW | libc::RTLD_DEEPBIND;
+    const LOCAL: c_int = libc::RTLD_LOCAL | libc::RTLD_DEEPBIND;
     #[cfg(not(target_os = "linux"))]
-    const FLAGS: c_int = libc::RTLD_LOCAL | libc::RTLD_NOW;
+    const LOCAL: c_int = libc::RTLD_LOCAL;
+
+    const FLAGS: c_int = LOCAL | libc::RTLD_NOW;
+
+    fn flags(lazy: bool) -> c_int {
+        LOCAL | if lazy { libc::RTLD_LAZY } else { libc::RTLD_NOW }
+    }
 
     // C-runtime shared objects external-function libraries link against
     // (DT_NEEDED), preloaded RTLD_GLOBAL so the loader resolves them.
@@ -70,10 +76,15 @@ pub(crate) mod dl {
     }
 
     pub fn open(path: &str) -> Result<usize> {
+        open_with_binding(path, false)
+    }
+
+    pub fn open_with_binding(path: &str, lazy: bool) -> Result<usize> {
         let c = CString::new(path).map_err(|_| "dynload: NUL byte in path")?;
         unsafe { libc::dlerror() }; // clear any stale error
-        let h = unsafe { libc::dlopen(c.as_ptr(), FLAGS) };
+        let h = unsafe { libc::dlopen(c.as_ptr(), flags(lazy)) };
         if h.is_null() {
+            super::record_load_error(last_error());
             return Err("dlopen `{path}`: {}");
         }
         Ok(h as usize)
@@ -158,9 +169,16 @@ pub(crate) mod dl {
     }
 
     pub fn open(path: &str) -> Result<usize> {
+        open_with_binding(path, false)
+    }
+
+    /// Windows resolves imports when the module is loaded and offers no way to
+    /// defer it, so `lazy` has nothing to select here.
+    pub fn open_with_binding(path: &str, _lazy: bool) -> Result<usize> {
         let c = CString::new(path).map_err(|_| "dynload: NUL byte in path")?;
         let h = unsafe { LoadLibraryA(c.as_ptr()) };
         if h.is_null() {
+            super::record_load_error(last_error());
             return Err("LoadLibrary `{path}`: {}");
         }
         Ok(h as usize)
@@ -377,14 +395,40 @@ fn ensure_runtime_solibs() {
 /// `System.loadLibrary`: open the shared object and return a handle.
 /// `relative` resolves the name against the current directory like the C
 /// runtime (`./name`); an empty name opens the running process.
+/// Why the last [`load_library`] failed, for a caller searching a list of
+/// candidate paths: the error it reports is about the whole list, so each
+/// path's reason has to survive until it gives up. Mirrors
+/// `last_load_library_error` in the C runtime.
+static LAST_LOAD_ERROR: Mutex<String> = Mutex::new(String::new());
+
+pub(crate) fn record_load_error(msg: String) {
+    *LAST_LOAD_ERROR.lock().unwrap() = msg;
+}
+
+/// `System.getLoadLibraryError`.
+pub fn last_load_error() -> String {
+    LAST_LOAD_ERROR.lock().unwrap().clone()
+}
+
 pub fn load_library(path: &str, relative: bool, debug: bool) -> Result<i32> {
+    load_library_with_binding(path, relative, debug, false)
+}
+
+/// `System.loadLibraryLazy`: as [`load_library`], but binds symbols when they
+/// are used rather than when the library is loaded.
+pub fn load_library_lazy(path: &str, relative: bool, debug: bool) -> Result<i32> {
+    load_library_with_binding(path, relative, debug, true)
+}
+
+fn load_library_with_binding(path: &str, relative: bool, debug: bool, lazy: bool) -> Result<i32> {
     ensure_runtime_solibs();
+    record_load_error(String::new());
     let handle = if path.is_empty() {
         dl::open_self()?
     } else if relative && !path.starts_with('/') {
-        dl::open(&format!("./{path}"))?
+        dl::open_with_binding(&format!("./{path}"), lazy)?
     } else {
-        dl::open(path)?
+        dl::open_with_binding(path, lazy)?
     };
     let mut reg = REGISTRY.lock().unwrap();
     let idx = reg.next_lib;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/dynload_wasm.rs
@@ -10,6 +10,16 @@ pub fn load_library(_path: &str, _relative: bool, _debug: bool) -> Result<i32> {
     return Err("System.loadLibrary: dynamic loading (dlopen) is unavailable on wasm")
 }
 
+pub fn load_library_lazy(_path: &str, _relative: bool, _debug: bool) -> Result<i32> {
+    return Err("System.loadLibraryLazy: dynamic loading (dlopen) is unavailable on wasm")
+}
+
+/// `System.getLoadLibraryError`. No library is ever loaded here, so there is
+/// never a reason to report for one.
+pub fn last_load_error() -> String {
+    String::new()
+}
+
 pub fn lookup_function(_lib: i32, _name: &str) -> Result<i32> {
     return Err("System.lookupFunction: dynamic loading is unavailable on wasm")
 }

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -287,6 +287,25 @@ public function loadLibrary
   external "C" outLibHandle=System_loadLibrary(inLib, relativePath, printDebug) annotation(Library = "omcruntime");
 end loadLibrary;
 
+public function loadLibraryLazy
+  "As loadLibrary, but binds symbols when they are used instead of when the
+   library is loaded, so a library that has an unresolvable symbol somewhere
+   else in it can still be asked for a function."
+  input String inLib;
+  input Boolean relativePath "If the path is relative or absolute";
+  input Boolean printDebug;
+  output Integer outLibHandle;
+
+  external "C" outLibHandle=System_loadLibraryLazy(inLib, relativePath, printDebug) annotation(Library = "omcruntime");
+end loadLibraryLazy;
+
+public function getLoadLibraryError
+  "Why the last loadLibrary/loadLibraryLazy failed. Empty if it succeeded."
+  output String outError;
+
+  external "C" outError=System_getLoadLibraryError() annotation(Library = "omcruntime");
+end getLoadLibraryError;
+
 public function lookupFunction
   input Integer inLibHandle;
   input String inFunc;

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -630,6 +630,19 @@ extern int System_loadLibrary(const char *name, int relativePath, int printDebug
   return res;
 }
 
+extern int System_loadLibraryLazy(const char *name, int relativePath, int printDebug)
+{
+  int res = SystemImpl__loadLibraryLazy(name, relativePath, printDebug);
+  if (res == -1) MMC_THROW();
+  return res;
+}
+
+extern const char* System_getLoadLibraryError(void)
+{
+  const char *res = SystemImpl__getLoadLibraryError();
+  return strcpy(ModelicaAllocateString(strlen(res)), res);
+}
+
 #if defined(__MINGW32__) || defined(_MSC_VER)
 void* System_subDirectories(const char *directory)
 {

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -145,6 +145,12 @@ extern char **environ;
 static struct modelica_ptr_s ptr_vector[MAX_PTR_INDEX];
 static modelica_integer last_ptr_index = -1;
 
+/* Why the last loadLibrary failed.  A caller that tries a list of candidate
+ * paths needs this: the error it reports is about the whole list, so the
+ * per-path dlerror() has to survive until it decides none of them worked.
+ * Cleared on every attempt, so it never describes an older failure. */
+static char last_load_library_error[1024] = "";
+
 static inline modelica_integer alloc_ptr(void);
 static inline void free_ptr(modelica_integer index);
 static void free_library(modelica_ptr_t lib, modelica_integer printDebug);
@@ -1377,7 +1383,7 @@ static const char* SystemImpl__getUUIDStr(void)
 typedef void (*mmc_GC_function_set_gc_state)(mmc_GC_state_type*);
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
-int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
+static int loadLibraryWithBinding(const char *str, int relativePath, int printDebug, int lazy)
 {
   char libname[MAXPATHLEN];
   char currentDirectory[MAXPATHLEN];
@@ -1387,6 +1393,10 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
   HMODULE h;
   const char* ctokens[2];
   mmc_GC_function_set_gc_state mmc_GC_set_state_lib_function = NULL;
+
+  /* Windows resolves a module's imports when it is loaded and offers no way to
+   * defer it, so there is no lazy binding to select here. */
+  (void) lazy;
 
   if (str[0] != '\0') {
     /* adrpo: use BACKSLASH here as specified here: http://msdn.microsoft.com/en-us/library/ms684175(VS.85).aspx */
@@ -1425,6 +1435,7 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
             0, NULL );
     ctokens[0] = lpMsgBuf;
     ctokens[1] = libname;
+    snprintf(last_load_library_error, sizeof(last_load_library_error), "%s", (const char*) lpMsgBuf);
     c_add_message(NULL,-1, ErrorType_runtime,ErrorLevel_error, gettext("OMC unable to load `%s': %s.\n"), ctokens, 2);
     LocalFree(lpMsgBuf);
     return -1;
@@ -1444,7 +1455,7 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
 }
 
 #else
-int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
+static int loadLibraryWithBinding(const char *str, int relativePath, int printDebug, int lazy)
 {
   char libname[MAXPATHLEN];
   modelica_ptr_t lib = NULL;
@@ -1452,10 +1463,12 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
   void *h = NULL;
   mmc_GC_function_set_gc_state mmc_GC_set_state_lib_function = NULL;
   const char* ctokens[2];
+  /* RTLD_NOW resolves every symbol in the library, so a library with one
+   * unresolvable symbol will not load even when the function being looked up
+   * is fine.  Binding lazily is the fallback for that case. */
+  int flags = RTLD_LOCAL | (lazy ? RTLD_LAZY : RTLD_NOW);
 #if defined(RTLD_DEEPBIND)
-  int flags = RTLD_LOCAL | RTLD_NOW | RTLD_DEEPBIND;
-#else
-  int flags = RTLD_LOCAL | RTLD_NOW;
+  flags |= RTLD_DEEPBIND;
 #endif
 
   if (str[0] != '\0') {
@@ -1472,6 +1485,7 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
   if (h == NULL) {
     ctokens[0] = dlerror();
     ctokens[1] = libname;
+    snprintf(last_load_library_error, sizeof(last_load_library_error), "%s", ctokens[0] ? ctokens[0] : "unknown error");
     c_add_message(NULL,-1, ErrorType_runtime,ErrorLevel_error, gettext("OMC unable to load `%s': %s.\n"), ctokens, 2);
     return -1;
   }
@@ -1491,6 +1505,23 @@ int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
   return libIndex;
 }
 #endif
+
+int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug)
+{
+  last_load_library_error[0] = '\0';
+  return loadLibraryWithBinding(str, relativePath, printDebug, 0 /* resolve now */);
+}
+
+int SystemImpl__loadLibraryLazy(const char *str, int relativePath, int printDebug)
+{
+  last_load_library_error[0] = '\0';
+  return loadLibraryWithBinding(str, relativePath, printDebug, 1 /* resolve on use */);
+}
+
+const char* SystemImpl__getLoadLibraryError(void)
+{
+  return last_load_library_error;
+}
 
 static inline modelica_integer alloc_ptr(void)
 {

--- a/OMCompiler/Compiler/runtime/systemimpl.h
+++ b/OMCompiler/Compiler/runtime/systemimpl.h
@@ -121,5 +121,8 @@ extern int SystemImpl__unescapedStringLength(const char* str);
 extern const char* SystemImpl__iconv(const char * str, const char *from, const char *to, int printError);
 extern const char* SystemImpl__iconv__ascii(const char * str);
 extern void SystemImpl__initGarbageCollector(void);
+extern int SystemImpl__loadLibrary(const char *str, int relativePath, int printDebug);
+extern int SystemImpl__loadLibraryLazy(const char *str, int relativePath, int printDebug);
+extern const char* SystemImpl__getLoadLibraryError(void);
 
 #endif //__SYSTEMIMPL_H

--- a/testsuite/flattening/modelica/ffi/MissingFunction1.mos
+++ b/testsuite/flattening/modelica/ffi/MissingFunction1.mos
@@ -12,14 +12,14 @@ instantiateModel(FFITest.ErrorChecking.MissingFunction1); getErrorString();
 // ""
 // ""
 // "[flattening/modelica/ffi/FFITest/package.mo:252:5-256:25:writable] Error: External function 'missingFunction1_ext' could not be found in any of the given shared libraries:
-//   bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so
-//   flattening/modelica/ffi/FFITest/Resources/Library/linux64/FFITestLib.so
-//   flattening/modelica/ffi/FFITest/Resources/Library/FFITestLib.so
-//   bin/../lib/x86_64-linux-gnu/omc/libFFITestLib.so
-//   flattening/modelica/ffi/FFITest/Resources/Library/linux64/libFFITestLib.so
-//   flattening/modelica/ffi/FFITest/Resources/Library/libFFITestLib.so
-//   bin/../lib/x86_64-linux-gnu/omc/ffi/FFITestLib.so
-//   bin/../lib/x86_64-linux-gnu/omc/ffi/libFFITestLib.so
+//   bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so (no such file)
+//   flattening/modelica/ffi/FFITest/Resources/Library/linux64/FFITestLib.so (no such file)
+//   flattening/modelica/ffi/FFITest/Resources/Library/FFITestLib.so (no such file)
+//   bin/../lib/x86_64-linux-gnu/omc/libFFITestLib.so (no such file)
+//   flattening/modelica/ffi/FFITest/Resources/Library/linux64/libFFITestLib.so (loaded, but does not define it)
+//   flattening/modelica/ffi/FFITest/Resources/Library/libFFITestLib.so (no such file)
+//   bin/../lib/x86_64-linux-gnu/omc/ffi/FFITestLib.so (no such file)
+//   bin/../lib/x86_64-linux-gnu/omc/ffi/libFFITestLib.so (no such file)
 // [flattening/modelica/ffi/FFITest/package.mo:259:7-259:43:writable] Error: Failed to evaluate function: FFITest.ErrorChecking.missingFunction1.
 // "
 // endResult


### PR DESCRIPTION
Fixes #16376.

Constant-evaluating an external function searches eight candidate paths for the library.
When none of them provides the function, the only thing the user is told is the list:

```
Error: External function 'TwoPhaseMedium_getCriticalTemperature_C_impl' could not be
found in any of the given shared libraries:
  .../omc/ExternalMediaLib.so
  .../ExternalMedia 4.1.1/Resources/Library/linux64/libExternalMediaLib.so
  ... six more
```

That is misleading exactly when it matters. In the case this came from, the fifth path is a
library that exists and does define the symbol — `nm` finds it — and the real problem is
that `dlopen` refused to load it. The runtime knows why: `SystemImpl__loadLibrary` builds a
message from `dlerror()`. But `loadLibraryFunction` wraps the whole search in an `ErrorExt`
checkpoint, so the candidates that simply are not there do not spam the user — and rolls the
reason away along with them. There was no way to get it back either: the `printDebug`
argument threaded down to the `LIB LOAD` tracing is an unbound default that no flag sets.

## Say what happened to each candidate

```
Error: External function 'missingFunction1_ext' could not be found in any of the given shared libraries:
  bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so (no such file)
  flattening/modelica/ffi/FFITest/Resources/Library/linux64/FFITestLib.so (no such file)
  flattening/modelica/ffi/FFITest/Resources/Library/FFITestLib.so (no such file)
  bin/../lib/x86_64-linux-gnu/omc/libFFITestLib.so (no such file)
  flattening/modelica/ffi/FFITest/Resources/Library/linux64/libFFITestLib.so (loaded, but does not define it)
  flattening/modelica/ffi/FFITest/Resources/Library/libFFITestLib.so (no such file)
  bin/../lib/x86_64-linux-gnu/omc/ffi/FFITestLib.so (no such file)
  bin/../lib/x86_64-linux-gnu/omc/ffi/libFFITestLib.so (no such file)
```

and for a library that will not load:

```
  .../DepTest/Resources/Library/linux64/libDepTest.so (cannot be loaded: libDepHelper.so: cannot open shared object file: No such file or directory)
```

The reason is read back through a new `System.getLoadLibraryError` rather than left in the
error stream, so the checkpoint still swallows the noise while the one line that matters
survives.

## Retry with lazy binding

The load asks for every symbol in the library to be resolved (`RTLD_NOW`), so a single
unresolvable symbol anywhere in a library stops it providing *any* function, including ones
that have nothing to do with it. So if the eager pass finds nothing, the search runs again
binding lazily. It costs nothing when the eager pass worked, because it only runs when it
did not.

**Trade-off worth knowing:** a lazily bound library that really does need the missing symbol
in the function being called will abort omc when libffi calls it, instead of failing to
load. That only replaces an error that would have been reported anyway, but it is a genuine
change in failure mode and I would rather it be a decision than a surprise.

Windows resolves a module's imports when it loads it and offers no way to defer that, so
lazy is a no-op there. The Rust port keeps its own `dlopen`
(`openmodelica_util/src/dynload.rs`), so it gets both new entry points as well.

`System_loadLibrary`'s signature is untouched — `loadLibraryLazy` is a separate entry point —
because the committed bootstrap sources in `Compiler/boot/bomc/bootstrap-sources/build` are
compiled against this runtime and call the existing one.

## Verified

On a library built for the purpose: one undefined symbol, so `RTLD_NOW` refuses it and
`RTLD_LAZY` does not.

```
RTLD_NOW : libLazyTest.so: undefined symbol: definitelyMissing
RTLD_LAZY: loaded
```

```mo
package LazyTest
  function lazyOk
    input Integer x;
    output Integer y;
    external "C" y = lazyOk(x) annotation(Library = "LazyTest");
  end lazyOk;

  model M
    constant Integer c = lazyOk(41);
    Real r = c;
  end M;
end LazyTest;
```

- patched omc evaluates it and folds the constant — `constant Integer c = 42;`
- the stock master omc reports the old eight-path message and fails
- deleting a dependency of a second such library produces the `cannot be loaded: ...` line
  above, which is the ExternalMedia shape
- `MissingFunction1` covers the two deterministic outcomes and is updated
- the whole `flattening/modelica/ffi` list passes, 27/27

**Not covered by a testsuite case:** the lazy retry itself. It needs a shared library with an
unresolved symbol, and mingw's linker refuses to produce one, so adding it would break the
ffi test library on Windows. It is exercised by hand as above.

**Rust port.** The crate does not stand alone (`openmodelica_util/src/lib.rs` is generated by
the transpile), but it can be checked against the tree the transpile already produced in the
build directory, which is what the first push should have done: copy the three hand-written
files into `build_cmake/OMCompiler/Compiler/rust-src/openmodelica_util/src/` and

```sh
cargo check -p openmodelica_util                                   # native
cargo check -p openmodelica_util --target wasm32-unknown-unknown   # wasm
```

Both are clean now, in ~26s. The first push failed `rust_wasm_cargo` on exactly this
([build 1](https://test.openmodelica.org/jenkins/blue/organizations/jenkins/OpenModelica/detail/PR-16380/1/pipeline/428/)):
on wasm, `crate::dynload` is not `dynload.rs` but the hand-written `dynload_wasm.rs` stub that
`mmtorust`'s `WASM_GATED_TOP_MODULES` substitutes, and the stub had not been given the new
`loadLibraryLazy`/`getLoadLibraryError` entry points. It has them now — the loader reports
itself unavailable there as it does for everything else in that stub, and there is never a
load error to read back. Amended into the commit.

## Why this came up

`ExternalMedia` and Buildings' `Utilities.IO.Python_3_8.*` have been flipping in exact
anti-phase on the daily `master` runs since 2026-08-11, ten run pairs out of ten, because
the run alternates between an Ubuntu 22.04 and an Ubuntu 24.04 node. Establishing that took
cross-referencing a claim table in the library-testing database against report timestamps.
The message this PR produces would have said it outright.

---
generated by Claude Code

