### PR TITLE
[FrontEnd] Let Testsuite.friendly strip a build_cmake tree

### DIFF
--- a/OMCompiler/Compiler/Util/Testsuite.mo
+++ b/OMCompiler/Compiler/Util/Testsuite.mo
@@ -80,7 +80,11 @@ algorithm
     case true
       algorithm
         newName := if Autoconf.os == "Windows_NT" then System.stringReplace(name, "\\", "/") else name;
-        (i,strs) := System.regex(newName, "^(.*/Compiler/)?(.*/testsuite/)?(.*/.openmodelica/libraries/)?(.*/lib/omlibrary/)?(.*/build/(install_cmake/)?)?(.*)$", 8, true, false);
+        // build_cmake/install_cmake is what a CMake build out of the source tree
+        // produces; build/install_cmake is what the testsuite scripts and the CI
+        // jobs use. Strip either, or the paths a test prints are the ones on the
+        // machine that ran it.
+        (i,strs) := System.regex(newName, "^(.*/Compiler/)?(.*/testsuite/)?(.*/.openmodelica/libraries/)?(.*/lib/omlibrary/)?(.*/build(_cmake)?/(install_cmake/)?)?(.*)$", 9, true, false);
         friendly := listGet(strs,i);
 
         // Remove the name of any temporary folders used to sandbox a test case,


### PR DESCRIPTION
`Testsuite.friendly` shortens the paths a test prints, so an expected output does not
contain the directory the build happens to live in. `friendly2`'s regex knows `/build/` and
`/build/install_cmake/`, which is what the CI jobs produce. It does not know
`/build_cmake/install_cmake/`, which is what you get from the documented out-of-source
build:

```
cmake -S . -B build_cmake && cmake --build build_cmake --target install
```

and which `rtest` finds and runs perfectly happily (`rtest:33`). A test that prints a path
under `OPENMODELICAHOME` then fails locally with the whole absolute path where the expected
output has `bin/../lib/...`, and reads as a regression when nothing is wrong.
`flattening/modelica/ffi/MissingFunction1` is one of them.

Same omc binary, two install prefixes, before this change — the install prefix is the only
difference:

```
build_cmake/install_cmake:  /home/adrpo33/ai/om/build_cmake/install_cmake/bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so
build/install_cmake:        bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so
```

## The change

The regex gains an alternative rather than a branch:

```diff
-"^(.*/Compiler/)?(.*/testsuite/)?(.*/.openmodelica/libraries/)?(.*/lib/omlibrary/)?(.*/build/(install_cmake/)?)?(.*)$", 8
+"^(.*/Compiler/)?(.*/testsuite/)?(.*/.openmodelica/libraries/)?(.*/lib/omlibrary/)?(.*/build(_cmake)?/(install_cmake/)?)?(.*)$", 9
```

`maxMatches` goes with it: `System.regex` wants `n+1` for `n` groups, and POSIX extended
regular expressions have no non-capturing group that would have avoided the extra one.

## Risk

None to CI. `/build/` and `/build/install_cmake/` were stripped before and still are — the
Jenkins jobs pass `-DCMAKE_INSTALL_PREFIX=build`, so that is the path they take either way.
The only paths that behave differently are ones under `build_cmake/`, which CI never
produces. And no expected output anywhere in `testsuite/` mentions `build_cmake`
(`grep -rn '^// .*build_cmake' testsuite --include=*.mos` is empty), so nothing can now be
shortened that was not already.

## Verified

`MissingFunction1` passes from a `build_cmake` tree against the expected output CI
generated — that is the case that failed before — and the whole `flattening/modelica/ffi`
list is 27/27.

Found while doing #16376; independent of it, so kept separate. That PR (#16380) touches the
same test and had to have its expected block generated from a `build/install_cmake` install
to match CI. With this merged, either layout produces the same thing.

---
generated by Claude Code
