### PR TITLE
[FrontEnd] setSourceFile: update the file of the class elements too

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -2780,7 +2780,11 @@ algorithm
   Absyn.CLASS(info = SOURCEINFO(fileName = outFilename)) := inClass;
 end classFilename;
 
-public function setClassFilename "Sets the filename where the class is stored."
+public function setClassFilename
+  "Sets the filename where the class is stored. The elements that were stored in
+   the same file as the class are updated too, since they are stored in the new
+   file as well. Elements that come from another file, like the classes of a
+   package stored with a folder structure, keep their filename."
   input Absyn.Class inClass;
   input String fileName;
   output Absyn.Class outClass;
@@ -2789,13 +2793,141 @@ algorithm
     local
       SourceInfo info;
       Absyn.Class cl;
-    case cl as Absyn.CLASS(info=info as SOURCEINFO())
+      String old_filename;
+    case cl as Absyn.CLASS(info=info as SOURCEINFO(fileName = old_filename))
+      guard not stringEq(old_filename, fileName)
       algorithm
         info.fileName := fileName;
         cl.info := info;
+        cl.body := setClassDefFilename(cl.body, old_filename, fileName);
       then cl;
+    else inClass;
   end match;
 end setClassFilename;
+
+protected function setClassDefFilename
+  "Helper to setClassFilename, updates the filename of the elements that were
+   stored in the given file."
+  input output Absyn.ClassDef body;
+  input String oldFilename;
+  input String newFilename;
+algorithm
+  () := match body
+    case Absyn.PARTS()
+      algorithm
+        body.classParts := list(setClassPartFilename(part, oldFilename, newFilename)
+                                for part in body.classParts);
+      then ();
+
+    case Absyn.CLASS_EXTENDS()
+      algorithm
+        body.parts := list(setClassPartFilename(part, oldFilename, newFilename)
+                           for part in body.parts);
+      then ();
+
+    else ();
+  end match;
+end setClassDefFilename;
+
+protected function setClassPartFilename
+  "Helper to setClassDefFilename."
+  input output Absyn.ClassPart part;
+  input String oldFilename;
+  input String newFilename;
+algorithm
+  () := match part
+    case Absyn.PUBLIC()
+      algorithm
+        part.contents := list(setElementItemFilename(e, oldFilename, newFilename)
+                              for e in part.contents);
+      then ();
+
+    case Absyn.PROTECTED()
+      algorithm
+        part.contents := list(setElementItemFilename(e, oldFilename, newFilename)
+                              for e in part.contents);
+      then ();
+
+    else ();
+  end match;
+end setClassPartFilename;
+
+protected function setElementItemFilename
+  "Helper to setClassPartFilename."
+  input output Absyn.ElementItem item;
+  input String oldFilename;
+  input String newFilename;
+algorithm
+  () := match item
+    case Absyn.ELEMENTITEM()
+      algorithm
+        item.element := setElementFilename(item.element, oldFilename, newFilename);
+      then ();
+
+    else ();
+  end match;
+end setElementItemFilename;
+
+protected function setElementFilename
+  "Helper to setElementItemFilename, only updates elements that were stored in
+   the old file."
+  input output Absyn.Element element;
+  input String oldFilename;
+  input String newFilename;
+algorithm
+  () := match element
+    local
+      SourceInfo info;
+
+    case Absyn.ELEMENT(info = info as SOURCEINFO())
+      guard stringEq(info.fileName, oldFilename)
+      algorithm
+        info.fileName := newFilename;
+        element.info := info;
+        element.specification := setElementSpecFilename(element.specification, newFilename);
+      then ();
+
+    case Absyn.DEFINEUNIT(info = info as SOURCEINFO())
+      guard stringEq(info.fileName, oldFilename)
+      algorithm
+        info.fileName := newFilename;
+        element.info := info;
+      then ();
+
+    case Absyn.TEXT(info = info as SOURCEINFO())
+      guard stringEq(info.fileName, oldFilename)
+      algorithm
+        info.fileName := newFilename;
+        element.info := info;
+      then ();
+
+    else ();
+  end match;
+end setElementFilename;
+
+protected function setElementSpecFilename
+  "Helper to setElementFilename."
+  input output Absyn.ElementSpec spec;
+  input String newFilename;
+algorithm
+  () := match spec
+    local
+      SourceInfo info;
+
+    case Absyn.CLASSDEF()
+      algorithm
+        spec.class_ := setClassFilename(spec.class_, newFilename);
+      then ();
+
+    case Absyn.IMPORT(info = info as SOURCEINFO())
+      algorithm
+        info.fileName := newFilename;
+        spec.info := info;
+      then ();
+
+    else ();
+  end match;
+end setElementSpecFilename;
 
 public function setClassName "author: BZ
   Sets the name of the class"

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -145,6 +145,7 @@ setExtendsModifierValue.mos \
 setExtendsModifier.mos \
 setParameterValue.mos \
 setSourceFileListFile.mos \
+setSourceFileMergeAST.mos \
 showDoc.mos \
 showStructuralAnnotations.mos \
 StateMachine.mos \

--- a/testsuite/openmodelica/interactive-API/setSourceFileMergeAST.mos
+++ b/testsuite/openmodelica/interactive-API/setSourceFileMergeAST.mos
@@ -1,0 +1,77 @@
+// status: correct
+// cflags: -d=-newInst
+// Tests that setSourceFile also updates the file of the elements that are
+// stored in the same file as the class. Otherwise loadString with merge=true,
+// which keeps the elements of the old class that come from another file,
+// duplicates the elements of the class that got a new source file. See #16384.
+
+// A package stored with a folder structure, i.e. each class in its own file.
+loadString("within ;
+package P
+end P;", "P/package.mo");
+getErrorString();
+loadString("within P;
+package SP
+end SP;", "P/SP/package.mo");
+getErrorString();
+loadString("within P.SP;
+model M
+  parameter Real a;
+end M;", "P/SP/M.mo");
+getErrorString();
+
+// Saving M in another file, e.g. after the package it belongs to was renamed.
+setSourceFile(P.SP.M, "P/SP2/M.mo");
+getErrorString();
+getClassInformation(P.SP.M);
+getErrorString();
+
+// Reloading the package like OMEdit does when its text is edited.
+loadString("within P;
+package SP
+end SP;", "P/SP/package.mo", "UTF-8", true, true, true, false);
+getErrorString();
+getClassNames(P, true, true, false, false, true, false);
+getErrorString();
+listFile(P.SP.M);
+getErrorString();
+
+// Removing an element of M must stick.
+loadString("within P.SP;
+model M
+  parameter Real b;
+end M;", "P/SP2/M.mo", "UTF-8", true, true, true, false);
+getErrorString();
+listFile(P.SP.M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// ("model", "", false, false, false, "P/SP2/M.mo", false, 2, 1, 4, 6, {}, false, false, "", "", false, "", "", "", "", "")
+// ""
+// true
+// ""
+// {P, P.SP, P.SP.M}
+// ""
+// "within P.SP;
+//
+// model M
+//   parameter Real a;
+// end M;"
+// ""
+// true
+// ""
+// "within P.SP;
+//
+// model M
+//   parameter Real b;
+// end M;"
+// ""
+// endResult


### PR DESCRIPTION
Fixes #16384, found while looking at #16330.

`setSourceFile` only rewrote `Absyn.CLASS.info`, the elements of the class and the nested classes
kept the file name they were parsed from.

`loadString` with `merge = true` keeps the elements of the old class that come from a *different*
file than the class itself, that is how the classes of a package stored with a folder structure
survive when only its `package.mo` is reloaded (`ProgramUtil.mergeClasses` ->
`excludeElementsFromFile`). Once the two file names disagree the class' own elements look foreign,
so they are appended to the freshly parsed class:

* elements are duplicated on every merged `loadString` of the class or of one of its parents,
* elements that were removed from the class text come back.

OMEdit hits this when a package saved with a folder structure is renamed and saved:
`LibraryWidget::saveModelicaLibraryTreeItemFolder` calls `setSourceFile` for the class it just
saved, and the text/script view reloads with `loadString(..., merge = isSaveFolderStructure())`.

### Fix

`AbsynUtil.setClassFilename` now also updates the file name of the elements, of the nested classes
and of their elements, but only for those that were stored in the same file as the class, so a
class stored in another file, like `SubModel3.mo` of a package saved with a folder structure,
keeps its own file.

### Before / after

```mo
loadString("within ;
package P
end P;", "P/package.mo");
loadString("within P;
package SP
end SP;", "P/SP/package.mo");
loadString("within P.SP;
model M
  parameter Real a;
end M;", "P/SP/M.mo");

setSourceFile(P.SP.M, "P/SP2/M.mo");

loadString("within P;
package SP
end SP;", "P/SP/package.mo", "UTF-8", true, true, true, false);
listFile(P.SP.M);
```

before:

```mo
"within P.SP;

model M
  parameter Real a;
  parameter Real a;
end M;"
```

after:

```mo
"within P.SP;

model M
  parameter Real a;
end M;"
```

### Testing

* new test `testsuite/openmodelica/interactive-API/setSourceFileMergeAST.mos`, it also checks that
  removing an element of the class sticks and that the class stored in the other file is still
  there after the merged `loadString`; it duplicates the elements without the fix.
* `testsuite/openmodelica/interactive-API`: 0 out of 176 tests failed.
* `testsuite/openmodelica/diff`: only the pre-existing `Tables.mos` failure, it fails the same way
  with an unpatched master `omc`.

---
generated by Claude Code
