### PR TITLE
[CMake] Point OMEncryption at the MSYS perl on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,25 @@ endif()
 ## Subdirectories ##########################################################################################
 # If asked for encryption support, add and configure the OMEncryption directory.
 if(OM_ENABLE_ENCRYPTION)
+  # OMEncryption builds OpenSSL, which is configured by a perl script that, for its MinGW
+  # targets, only accepts a perl reporting paths with forward slashes. In an MSYS2 shell the
+  # first perl in PATH is the MinGW one, which reports MSWin32 style paths and stops that
+  # configure step with "This perl implementation doesn't produce Unix like paths"; the MSYS
+  # perl, which sits in the same directory as cygpath, is the one that works. Point OMEncryption
+  # at it so the encryption build does not depend on the order of PATH. If it is not there we
+  # leave SEMLA_PERL unset and OMEncryption looks for a perl of its own. A perl given on the
+  # command line wins, and it has to be a path CMake can run, so -DSEMLA_PERL=C:/msys64/usr/bin/perl.exe
+  # rather than -DSEMLA_PERL=/usr/bin/perl.exe (an MSYS shell rewrites the latter for you).
+  if(WIN32 AND NOT MSVC AND NOT SEMLA_PERL)
+    find_program(OM_MSYS_CYGPATH NAMES cygpath)
+    mark_as_advanced(OM_MSYS_CYGPATH)
+    if(OM_MSYS_CYGPATH)
+      get_filename_component(om_msys_bin_dir "${OM_MSYS_CYGPATH}" DIRECTORY)
+      find_program(SEMLA_PERL NAMES perl HINTS "${om_msys_bin_dir}" NO_DEFAULT_PATH
+                   DOC "perl used to configure OpenSSL")
+    endif()
+  endif()
+
   omc_add_subdirectory(OMEncryption)
 endif()
 


### PR DESCRIPTION
Building with `-DOM_ENABLE_ENCRYPTION=ON` on Windows (MSYS2/UCRT64) fails while OMEncryption
configures the OpenSSL it builds for SEMLA:

```
Failure!  Makefile wasn't produced.
Please read INSTALL.md and associated NOTES-* files.  You may also have to
look over your available compiler tool chain or change your configuration.

******************************************************************************
This perl implementation doesn't produce Unix like paths (with forward slash
directory separators).  Please use an implementation that matches your
building platform.

This Perl version: 5.38.5 for MSWin32-x64-multi-thread
```

OpenSSL generates a Unix Makefile for its MinGW targets and only accepts a perl that reports
paths with forward slashes. There are two perls in an MSYS2 installation and PATH offers the
wrong one first:

| perl | `File::Spec->catdir('a','b')` | `$^O` |
| --- | --- | --- |
| `/ucrt64/bin/perl.exe` (`mingw-w64-ucrt-x86_64-perl`) | `a\b` | `MSWin32` |
| `/usr/bin/perl.exe` (`perl`) | `a/b` | `cygwin` |

## Change

Where `OMEncryption` is added, locate the MSYS perl and pass it on as `SEMLA_PERL`, so the
encryption build does not depend on the order of PATH. The perl is found through `cygpath`,
which lives in the same directory, rather than by hardcoding a path, so it works whatever the
MSYS installation is called.

- If that perl is not there, `SEMLA_PERL` is left unset and OMEncryption looks for a perl of its
  own, reporting a wrong one while configuring rather than halfway through the build.
- A perl given on the command line wins over both. It has to be a path CMake can run, so
  `-DSEMLA_PERL=C:/msys64/usr/bin/perl.exe`; an MSYS shell rewrites `/usr/bin/perl.exe` into
  that form for you, `cmd`/PowerShell does not.
- MSVC is left alone. Its `VC-*` targets generate an nmake Makefile and want a *native* Windows
  perl, which is the opposite requirement.
- Non-Windows builds are unaffected: the block is inside `if(WIN32 AND NOT MSVC ...)`, and perl
  there already reports Unix like paths.

This needs the companion change in the OMEncryption repository, commit `e741229` "add
SEMLA_PERL configuration", which is what reads `SEMLA_PERL`. Without it OpenSSL is configured
with whatever perl comes first in PATH, exactly as before, so this change is inert rather than
harmful on its own.

## Testing

With the OMDev UCRT64 toolchain, against OMEncryption carrying the companion change:

- MSYS perl present: `SEMLA_PERL:FILEPATH=C:/OMDev/tools/msys/usr/bin/perl.exe`, and
  OMEncryption reports `Will configure OpenSSL with C:/OMDev/tools/msys/usr/bin/perl.exe`.
- MSYS perl not found here: `SEMLA_PERL` stays `NOTFOUND` and OMEncryption's own lookup finds it.
- `-DSEMLA_PERL=<mingw perl>`: overrides the detection and is rejected while configuring, naming
  the offending perl.
- `-DSEMLA_PERL=<msys perl>`: overrides the detection and is used.

OpenSSL 3.0.8 then configures for target `mingw64` and builds, installing `libcrypto.a` and
`libssl.a` where SEMLA's imported `ssl` and `crypto` targets expect them.

There is no ticket for this one; the failure came up while building encryption support on
Windows.

---
generated by Claude Code
