### PR TITLE
[Testsuite] Give a test its directory dependencies on Windows

### DIFF
--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -110,6 +110,27 @@ sub make_external_link {
   }
 }
 
+# Windows cannot hard-link a directory, and Perl's symlink() needs a privilege
+# the build nodes do not hold, so a directory dependency is reproduced as an
+# NTFS junction instead - any user may create one, and both MSYS and native
+# tools follow it like a real directory.
+sub windows_junction {
+  my $src = shift;
+  my $dst = shift;
+
+  my $abs = Cwd::abs_path($src);
+  return 0 unless defined $abs;
+  # /mnt/c/... (WSL) and /c/... (MSYS) both name the drive C:.
+  $abs =~ s{^/mnt/([A-Za-z])/}{$1:/};
+  $abs =~ s{^/([A-Za-z])/}{$1:/};
+  return 0 unless $abs =~ m{^[A-Za-z]:/};
+  $abs =~ s{/}{\\}g;
+  my $win_dst = $dst;
+  $win_dst =~ s{/}{\\}g;
+  system("cmd /c mklink /J \"$win_dst\" \"$abs\" > nul 2>&1");
+  return (-d $dst) ? 1 : 0;
+}
+
 # Creates a symbolic link to a file, but only if the file exists.
 sub symlink_if_exists {
   my $src = shift;
@@ -117,7 +138,11 @@ sub symlink_if_exists {
 
   if (-e $src) {
     if ($isWSL or ($osname eq 'MSWin32')) {
-      link($src, $dst);
+      if (-d $src) {
+        windows_junction($src, $dst);
+      } else {
+        link($src, $dst);
+      }
     } else {
       symlink($src, $dst);
     }


### PR DESCRIPTION
Fixes #16388

## Problem

`testsuite/partest/runtest.pl` runs each test in a `<test>_temp<N>` sandbox and
links the files the test needs into that sandbox. On Windows and WSL,
`symlink_if_exists` uses `link()` rather than `symlink()`, because Perl's
`symlink()` on Win32 needs `SeCreateSymbolicLinkPrivilege`, which the build nodes
do not hold.

A hard link, however, cannot point at a directory. Measured with the MSYS2 UCRT64
perl on a Windows machine:

```
osname=MSWin32
link-dir=FAIL: Permission denied
link-file=OK
symlink-dir=FAIL: Operation not permitted
```

Neither call can produce the directory, `symlink_if_exists` ignores the return
value, and the test then runs without its data. Directories lost this way include
`testedFMU/`, `scripts/`, `libs/`, `manual/`, the dataReconciliation
`resources/`, and `ReferenceFiles` / `ReferenceGraphs` from
`make_test_specific_links`.

The failure surfaces much later, on the missing files, which is why this never
looked like a linking problem:

```
"Error: File not Found: testedFMU/fmusdk1.0.2/vanDerPol.fmu.
"
Error: Error opening file: vanDerPol_cs_st_FMU.mo: No such file or directory.
Error: Failed to load file vanDerPol_cs_st_FMU.mo: file does not exist.
```

## Fix

Reproduce a directory dependency as an NTFS junction instead. `cmd /c mklink /J`
needs no privilege and no Developer Mode, and both MSYS and native tools follow a
junction like a real directory. File dependencies keep using `link()`, and
nothing changes on Linux or macOS.

## Effect

All 276 currently failing
[OM_Win](https://test.openmodelica.org/jenkins/job/Windows/job/OM_Win/) tests
were re-run on a Windows build of current master (`v1.28.0-dev-412`), once with
this patch and once with `runtest.pl` reverted, so the delta is attributable to
the change alone rather than to the machine or the compiler version.

**85 of the 276 pass with the patch and fail without it:**

| directory | recovered |
|---|---:|
| `openmodelica/dataReconciliation` | 42 |
| `openmodelica/conversion` | 20 |
| `openmodelica/cruntime/optimization/basic` | 13 |
| `simulation/modelica/commonSubExp` | 4 |
| `simulation/modelica/hpcom` | 3 |
| `openmodelica/interactive-API` | 1 |
| `openmodelica/fmi/CoSimulationStandAlone` | 1 |
| `flattening/modelica/mosfiles` | 1 |

A further 52 tests pass on this machine with or without the patch, so they are
not counted above - those are stale-CI or environment differences, not this fix.
The remaining 139 failures have other causes and are out of scope here; the two
largest reproduce exactly as on Jenkins and are worth their own issues
(`metamodelica/meta`, 15, and `openmodelica/fmi/ModelExchange/3.0`, 13).

## Testing

No new test. This changes how the test harness itself stages files, so the
existing suite is the test. Linux and macOS are unaffected because the new branch
is taken only under `$isWSL or $osname eq 'MSWin32'`.

---
generated by Claude Code
