### PR TITLE
Make array subscripts fail instead of panicking

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -766,8 +766,8 @@ void partestRust(partition) {
     if (params.RUST_PARTEST_JUNIT) {
       junit testResults: 'testsuite/partest/result.xml', allowEmptyResults: true, skipPublishingChecks: true
     }
-    sh "cp testsuite/partest/result.xml partest-rust-partest-junit-${partition}.xml"
-    archiveArtifacts artifacts: 'partest-rust-partest-junit-${partition}.xml', allowEmptyArchive: true, fingerprint: true
+    sh "cp testsuite/partest/result.xml partest-rust-partest-junit-${partition}.xml || true"
+    archiveArtifacts artifacts: "partest-rust-partest-junit-${partition}.xml", allowEmptyArchive: true, fingerprint: true
   }
 }
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -1281,7 +1281,8 @@ function makeSmoothCall
   output Expression callExp;
 algorithm
   callExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.SMOOTH,
-    {Expression.INTEGER(order), arg}, Expression.variability(arg), Purity.PURE));
+    {Expression.INTEGER(order), arg}, Expression.variability(arg), Purity.PURE,
+    Expression.typeOf(arg)));
 end makeSmoothCall;
 
 protected function removeStreamSetElement

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
@@ -65,6 +65,18 @@ pub unsafe fn arrayInitSlot<A>(arr: Array<A>, index: i32, val: A) -> Array<A> {
     arr
 }
 
+/// [`arrayInitSlot`] with `arrayUpdate`'s bounds check.
+///
+/// # Safety
+/// As [`arrayInitSlot`], minus the in-bounds requirement.
+pub unsafe fn arrayInitSlotChecked<A>(arr: Array<A>, index: i32, val: A) -> Result<Array<A>> {
+    if index < 1 || index as usize > arr.borrow().len() {
+        return Err("array index out of bounds");
+    }
+    #[allow(unsafe_op_in_unsafe_fn)]
+    Ok(unsafe { arrayInitSlot(arr, index, val) })
+}
+
 /// Creates a new array with uninitialized elements.
 /// The MetaModelica signature takes a `dummy` argument purely as a type witness;
 /// the codegen drops it because Rust generics already carry the element type.

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
@@ -101,6 +101,20 @@ pub fn arrayUpdate<A: Clone>(arr: Array<A>, index: i32, new_value: A) -> Result<
     Ok(arr)
 }
 
+/// 1-based element read for a subscripted reference (`a[i]`), with `arrayGet`
+/// semantics: out of range is a catchable failure, not a panic. Non-positive
+/// indices wrap to a huge `usize` and `get` rejects them.
+#[inline(always)]
+pub fn index_checked<A>(v: &[A], index: i32) -> Result<&A> {
+    v.get((index - 1) as usize).ok_or("array index out of bounds")
+}
+
+/// [`index_checked`] for a subscripted assignment (`a[i] := v`).
+#[inline(always)]
+pub fn index_mut_checked<A>(v: &mut [A], index: i32) -> Result<&mut A> {
+    v.get_mut((index - 1) as usize).ok_or("array index out of bounds")
+}
+
 /// Creates a (deep, by-element) copy of the array. O(n).
 /// The returned array does NOT share storage with the input.
 pub fn arrayCopy<A: Clone>(arr: Array<A>) -> Array<A> {

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -8126,7 +8126,7 @@ fn emit_const_str_operand<'a>(exp: &TypedExp, ctx: &mut GenCtx, top_level: &'a B
             if node.ty != Ty::Str { return None; }
             // No borrow guard possible: the match guard above requires all
             // segments to be subscript-free.
-            Some(emit_var(name, segments, ty, ctx, top_level).0)
+            Some(emit_var(name, segments, ty, /*is_const=*/true, ctx, top_level).0)
         }
         TypedExp::If { cond, then_, elseif, else_, .. } => {
             // Lower to a Rust `if … else if … else` chain so the condition
@@ -8367,7 +8367,7 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
             }).unzip();
             let name: &String = owned_name.as_ref().unwrap_or(name);
             let segments: &Vec<CrefSegment> = owned_segments.as_ref().unwrap_or(segments);
-            let (mut var_str, has_borrow_guard) = emit_var(name, segments, ty, ctx, top_level);
+            let (mut var_str, has_borrow_guard) = emit_var(name, segments, ty, is_const, ctx, top_level);
             // If this reference resolves to a `pub const fn` / `pub fn` getter
             // emitted by `emit_node` for a non-Sync constant (see
             // `collect_const_fn_getters` + the const-emittable/non-Sync branch),
@@ -11546,7 +11546,7 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
             };
             let arg3 = args.get(2).map(|a| emit_call_arg_with_formal(a, elem_formal.as_ref(), is_const, ctx, top_level)).unwrap_or_default();
             if arr_is_uninit {
-                Ok(format!("unsafe {{ metamodelica::Dangerous::arrayInitSlot({arg1}, {arg2}, {arg3}) }}"))
+                Ok(ctx.q(&format!("unsafe {{ metamodelica::Dangerous::arrayInitSlotChecked({arg1}, {arg2}, {arg3}) }}")))
             } else {
                 // Lower through `metamodelica::arrayUpdate`, for the same two
                 // reasons as `arrayGet` above: (a) the argument expressions
@@ -11709,6 +11709,18 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
     }
 }
 
+/// Emit a 1-based subscript read `base[idx]`. MetaModelica subscripts fail
+/// (catchably) out of range, so route them through `index_checked`;
+/// [`crate::fallibility::Walk::scan_cref`] marks the caller fallible to match.
+/// A `const` item has no `?` target and rustc checks the index itself.
+fn emit_index(base: &str, idx: &str, is_const: bool, ctx: &mut GenCtx) -> String {
+    if is_const {
+        format!("{base}[({idx}-1) as usize]")
+    } else {
+        format!("(*{})", ctx.q(&format!("metamodelica::index_checked(&{base}, {idx})")))
+    }
+}
+
 /// Emit a variable reference, handling subscripts and the package/field boundary.
 ///
 /// The second tuple element reports whether the emitted expression contains an
@@ -11723,6 +11735,7 @@ fn emit_var<'a>(
     name: &str,
     segments: &[CrefSegment],
     _ty: &Ty,
+    is_const: bool,
     ctx: &mut GenCtx,
     top_level: &'a BTreeMap<String, NameNode<'a>>,
 ) -> (String, bool) {
@@ -11773,7 +11786,8 @@ fn emit_var<'a>(
                 has_borrow_guard = true;
             }
             for sub in &real_segments[0].subscripts {
-                base = format!("{}[({}-1) as usize]", base, emit_exp(sub, false, ctx, top_level));
+                let idx = emit_exp(sub, false, ctx, top_level);
+                base = emit_index(&base, &idx, is_const, ctx);
             }
         }
         base
@@ -11838,7 +11852,8 @@ fn emit_var<'a>(
                     has_borrow_guard = true;
                 }
                 for sub in &last_seg.subscripts {
-                    b = format!("{}[({}-1) as usize]", b, emit_exp(sub, false, ctx, top_level));
+                    let idx = emit_exp(sub, false, ctx, top_level);
+                    b = emit_index(&b, &idx, is_const, ctx);
                 }
                 b
             } else {
@@ -11959,7 +11974,8 @@ fn emit_var<'a>(
                     has_borrow_guard = true;
                 }
                 for sub in &first.subscripts {
-                    res = format!("{}[({}-1) as usize]", res, emit_exp(sub, false, ctx, top_level));
+                    let idx = emit_exp(sub, false, ctx, top_level);
+                    res = emit_index(&res, &idx, is_const, ctx);
                 }
             }
             cur_ty = field_ty;
@@ -11985,7 +12001,8 @@ fn emit_var<'a>(
             has_borrow_guard = true;
         }
         for sub in &seg.subscripts {
-            res = format!("{}[({}-1) as usize]", res, emit_exp(sub, false, ctx, top_level));
+            let idx = emit_exp(sub, false, ctx, top_level);
+            res = emit_index(&res, &idx, is_const, ctx);
         }
         cur_ty = field_ty;
         for _ in &seg.subscripts {
@@ -20411,11 +20428,14 @@ fn emit_stmt<'a>(
                         writeln!(out, "{indent}    let {tmp} = {scrut_expr};").unwrap();
                         writeln!(out, "{indent}    let {idx_tmp} = {idx_str};").unwrap();
                         if let Some(bind) = hoisted_bind {
-                            writeln!(out, "{indent}    {bind}[({idx_tmp}-1) as usize] = {tmp};").unwrap();
+                            let slot = ctx.q(&format!("metamodelica::index_mut_checked(&mut {bind}, {idx_tmp})"));
+                            writeln!(out, "{indent}    *{slot} = {tmp};").unwrap();
                         } else if base_is_uninit {
-                            writeln!(out, "{indent}    unsafe {{ metamodelica::Dangerous::arrayInitSlot({base_str}.clone(), {idx_tmp}, {tmp}); }}").unwrap();
+                            let upd = ctx.q(&format!("unsafe {{ metamodelica::Dangerous::arrayInitSlotChecked({base_str}.clone(), {idx_tmp}, {tmp}) }}"));
+                            writeln!(out, "{indent}    let _ = {upd};").unwrap();
                         } else {
-                            writeln!(out, "{indent}    {base_str}.borrow_mut()[({idx_tmp}-1) as usize] = {tmp};").unwrap();
+                            let slot = ctx.q(&format!("metamodelica::index_mut_checked(&mut {base_str}.borrow_mut(), {idx_tmp})"));
+                            writeln!(out, "{indent}    *{slot} = {tmp};").unwrap();
                         }
                         writeln!(out, "{indent}}}").unwrap();
                     }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
@@ -546,11 +546,40 @@ impl Walk {
         }
     }
 
+    /// A subscripted reference (`a[i]`) is fallible: it lowers to
+    /// `arrayGet`/`listGet`, which fail out of range. Must agree with codegen's
+    /// [`crate::codegen`] `emit_index`, or `GenCtx::q` panics on the mismatch.
+    fn scan_cref(&mut self, cr: &Absyn::ComponentRef) {
+        use Absyn::ComponentRef::*;
+        let mut cur = cr;
+        loop {
+            let (subs, next) = match cur {
+                CREF_FULLYQUALIFIED { componentRef } => (None, Some(componentRef)),
+                CREF_QUAL { subscripts, componentRef, .. } => (Some(subscripts), Some(componentRef)),
+                CREF_IDENT { subscripts, .. } => (Some(subscripts), None),
+                WILD | ALLWILD => (None, None),
+            };
+            if let Some(subs) = subs {
+                for s in &**subs {
+                    if let Absyn::Subscript::SUBSCRIPT { subscript } = &**s {
+                        self.has_fail = true;
+                        self.scan_exp(subscript);
+                    }
+                }
+            }
+            match next {
+                Some(n) => cur = n,
+                None => return,
+            }
+        }
+    }
+
     fn scan_exp(&mut self, e: &Absyn::Exp) {
         use Absyn::Exp::*;
         match e {
             INTEGER { .. } | REAL { .. } | STRING { .. } | BOOL { .. } | END | BREAK => {}
-            CREF { .. } | CODE { .. } => {}
+            CREF { componentRef } => self.scan_cref(componentRef),
+            CODE { .. } => {}
             BINARY { exp1, op, exp2 } => {
                 // `/` (and its element-wise form `./`) is Real division, whose
                 // zero-divisor case is a recoverable MetaModelica failure — the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1172,7 +1172,16 @@ pub(crate) fn sig_ty_quiet(ty: &DAE::Type) -> Result<SigTy> {
             closures::reference_sigty(ty)?
         }
         DAE::Type::T_SUBTYPE_BASIC { .. } => return Err("CodegenWasmJit: subtype-basic types not yet supported"),
-        _ => return Err("CodegenWasmJit: type not supported"),
+        // Name the variant: `Err` is `&'static str`, and a quiet probe never
+        // reaches `record_error`'s unparsed form.
+        DAE::Type::T_UNKNOWN { .. } => return Err("CodegenWasmJit: type not supported: T_UNKNOWN"),
+        DAE::Type::T_CLOCK { .. } => return Err("CodegenWasmJit: type not supported: Clock"),
+        DAE::Type::T_NORETCALL { .. } => return Err("CodegenWasmJit: type not supported: T_NORETCALL"),
+        DAE::Type::T_FUNCTION { .. } => return Err("CodegenWasmJit: type not supported: T_FUNCTION"),
+        DAE::Type::T_TUPLE { .. } => return Err("CodegenWasmJit: type not supported: T_TUPLE"),
+        DAE::Type::T_CODE { .. } => return Err("CodegenWasmJit: type not supported: T_CODE"),
+        DAE::Type::T_ANYTYPE { .. } => return Err("CodegenWasmJit: type not supported: T_ANYTYPE"),
+        _ => return Err("CodegenWasmJit: type not supported: MetaModelica type"),
     })
 }
 
@@ -7245,8 +7254,10 @@ fn exp_wty_hint(ctx: &FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         // The CREF carries its (possibly field) type directly — handles a plain
         // local and a `r.field` reference alike.
         E::CREF { ty, .. } => sig_ty(ty)?.wty(),
-        E::BINARY { operator, .. } => operator_wty(operator)?,
-        E::UNARY { operator, .. } => operator_wty(operator)?,
+        // Through `exp_sigty` for its operand fallback: taking the operator's
+        // own type made the hint fail on `T_UNKNOWN` operators that
+        // `compile_binary` compiles fine.
+        E::BINARY { .. } | E::UNARY { .. } => exp_sigty(exp)?.wty(),
         E::IFEXP { expThen, .. } => exp_wty_hint(ctx, expThen)?,
         E::CALL { attr, .. } => match identity_builtin_arg(exp) {
             Some(inner) if sig_ty_quiet(&call_value_ty(&attr.ty)).is_err() => exp_wty_hint(ctx, &inner)?,
@@ -7264,10 +7275,6 @@ fn exp_wty_hint(ctx: &FnCtx, exp: &DAE::Exp) -> Result<WTy> {
         E::UNBOX { ty, .. } => sig_ty(ty)?.wty(),
         _ => WTy::F64,
     })
-}
-
-fn operator_wty(op: &DAE::Operator) -> Result<WTy> {
-    Ok(operator_sigty(op)?.wty())
 }
 
 /// The integer value of a `Real` literal exponent, or `None` if it is not an
@@ -7291,9 +7298,9 @@ fn exp_is_half(e: &DAE::Exp) -> bool {
     matches!(e, DAE::Exp::RCONST { real } if real.into_inner() == 0.5)
 }
 
-/// The `SigTy` an arithmetic operator works on / produces. Unlike
-/// [`operator_wty`] this distinguishes Integer/Boolean and, crucially, String
-/// (so `+` on Strings can be lowered to `rt_concat` rather than `i32.add`).
+/// The `SigTy` an arithmetic operator works on / produces. Unlike a bare
+/// `WTy` this distinguishes Integer/Boolean and, crucially, String (so `+` on
+/// Strings can be lowered to `rt_concat` rather than `i32.add`).
 fn operator_sigty(op: &DAE::Operator) -> Result<SigTy> {
     use DAE::Operator as O;
     let ty = match op {
@@ -7453,7 +7460,12 @@ fn compile_unary(ctx: &mut FnCtx, op: &DAE::Operator, exp: &DAE::Exp) -> Result<
     let DAE::Operator::UMINUS { ty } = op else {
         return Err("CodegenWasmJit: unsupported unary operator");
     };
-    let wty = sig_ty_quiet(ty)?.wty();
+    // C's `daeExpUnary` lets the operand's type decide; fall back the same way
+    // `compile_binary` does when the frontend left the operator `T_UNKNOWN`.
+    let wty = match sig_ty_quiet(ty) {
+        Ok(s) => s.wty(),
+        Err(_) => exp_sigty(exp)?.wty(),
+    };
     let w = compile_exp(ctx, exp)?;
     coerce(ctx, w, wty);
     match wty {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
@@ -337,28 +337,29 @@ fn test_get_range() -> Result<()> {
     Ok(())
 }
 
-// heapSort returns Array<i32>, not Result
 #[test]
-fn test_heap_sort() {
+fn test_heap_sort() -> Result<()> {
     let a = arr(vec![3, 1, 4, 1, 5, 9, 2, 6]);
-    let result = Array::heapSort(a);
+    let result = Array::heapSort(a)?;
     assert_eq!(*result.borrow(), vec![1, 1, 2, 3, 4, 5, 6, 9]);
+    Ok(())
 }
 
 #[test]
-fn test_heap_sort_empty() {
+fn test_heap_sort_empty() -> Result<()> {
     let a: metamodelica::Array<i32> = arrayFromVec(vec![]);
-    let result = Array::heapSort(a);
+    let result = Array::heapSort(a)?;
     assert!(result.borrow().is_empty());
+    Ok(())
 }
 
-// insertList returns Array<T>, not Result
 #[test]
-fn test_insert_list() {
+fn test_insert_list() -> Result<()> {
     let a = arr(vec![0, 0, 0, 0, 0]);
     let lst = list![1i32, 2, 3];
-    let result = Array::insertList(a, Arc::clone(&lst), 2);
+    let result = Array::insertList(a, Arc::clone(&lst), 2)?;
     assert_eq!(*result.borrow(), vec![0, 1, 2, 3, 0]);
+    Ok(())
 }
 
 #[test]
@@ -504,17 +505,18 @@ fn test_min_element() {
     assert_eq!(result, 1);
 }
 
-// position returns i32, not Result
 #[test]
-fn test_position_found() {
+fn test_position_found() -> Result<()> {
     let a = arr(vec![1, 2, 3, 4, 5]);
-    assert_eq!(Array::position(a, 3, 5), 3);
+    assert_eq!(Array::position(a, 3, 5)?, 3);
+    Ok(())
 }
 
 #[test]
-fn test_position_not_found() {
+fn test_position_not_found() -> Result<()> {
     let a = arr(vec![1, 2, 3]);
-    assert_eq!(Array::position(a, 99, 3), 0);
+    assert_eq!(Array::position(a, 99, 3)?, 0);
+    Ok(())
 }
 
 #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
@@ -269,7 +269,7 @@ fn test_count() {
 #[test]
 fn test_counting_sort() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    let result = L::countingSort(Arc::clone(&lst), 9);
+    let result = L::countingSort(Arc::clone(&lst), 9)?;
     assert_eq!(result, list![1i32, 1, 2, 3, 4, 5, 6, 9]);
     Ok(())
 }
@@ -721,11 +721,12 @@ fn test_from_option_none() -> Result<()> {
 
 // ── GetAtIndexLst ──
 #[test]
-fn test_get_at_index_lst() {
+fn test_get_at_index_lst() -> Result<()> {
     let lst = list![10i32, 20, 30];
     let positions = list![1i32, 2, 3];
-    let result = L::getAtIndexLst(Arc::clone(&lst), Arc::clone(&positions), false);
+    let result = L::getAtIndexLst(Arc::clone(&lst), Arc::clone(&positions), false)?;
     assert_eq!(result, list![10i32, 20, 30]);
+    Ok(())
 }
 
 // ── GetIndexFirst ──
@@ -784,7 +785,7 @@ fn test_has_several_elements_false() -> Result<()> {
 #[test]
 fn test_heap_sort_int_list() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    let result = L::heapSortIntList(Arc::clone(&lst));
+    let result = L::heapSortIntList(Arc::clone(&lst))?;
     assert_eq!(result, list![1i32, 1, 2, 3, 4, 5, 6, 9]);
     Ok(())
 }


### PR DESCRIPTION
MetaModelica `a[i]` compiles to `arrayGet`/`arrayUpdate`, which raise a catchable failure when the index is out of range. mmtorust lowered it to a bare Rust index, which panics, so `Physiolibrary.Fluid.Examples. MinimalRespiration` aborted omc at Initialization.mo:1763 instead of falling through `consistencyCheck`'s matchcontinue to the arm that classifies the equation as inconsistent. It now reports the same "No system for the symbolic initialization was generated" as the C compiler.

Subscript reads and `a[i] := v` writes go through the new bounds-checked `index_checked` / `index_mut_checked`, and the fallibility analysis marks any subscripting function fallible to match. It also scans the subscript expressions themselves, which it skipped entirely before - a fallible call inside a subscript was not seen. 99 functions gained a `Result`.

`arrayUpdate` on an array from `arrayCreateNoInit` used the unchecked `Dangerous::arrayInitSlot`, where an out-of-range index was undefined behaviour rather than a failure; it now uses `arrayInitSlotChecked`.

Type the smooth() that actualStream expands to

`NFConnectEquations.makeSmoothCall` built the call without a return type, so it inherited `NFBuiltinFuncs.SMOOTH`'s `Type.UNKNOWN()` - `smooth` is generic. Everything derived from it inherited that too: `Expression.negate` uses `typeof(e)`, so `-smooth(...)` became `UMINUS(T_UNKNOWN)`. `NFBuiltinCall.typeSmoothCall` already passes the argument's type; do the same here.

wasm-jit took the result type of `-e` and of an if-expression block from the operator's own type, so those untyped operators failed the whole module for `AES.Coursework.ThermSys_Transport.
Stratified_storage_tank_case_001`. Fall back to the operand type the way `compile_binary` and C's `daeExpUnary` do. The model now simulates, with results identical to the C target. `sig_ty_quiet` also names the type variant it cannot handle, which the single shared message did not.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
