### PR TITLE
[Testsuite] Run a setup_command under sh on Windows

### DIFF
--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -182,6 +182,42 @@ sub setup_command_toolchain
   }
 }
 
+# A setup_command/teardown_command is a POSIX shell line, and it spells the
+# toolchain as $OMC_CC/$OMC_CFLAGS/... so a test does not hardcode gcc. Perl's
+# system() on Win32 hands such a line to cmd.exe, which does not expand $VAR: the
+# command then ran with the names taken literally and the compiler was never
+# invoked, leaving "'$OMC_CC' is not recognized as an internal or external
+# command" in the log. Run it under sh instead, the shell these commands are
+# written for and the one the Windows testsuite already runs under.
+#
+# The log is redirected from Perl rather than by appending ">>$log 2>&1" to the
+# command, because $log is a native Windows path and sh would eat its backslashes
+# as escapes (C:\OMDev\tools -> C:OMDevtools). Other platforms keep the plain
+# shell redirection they always had.
+sub run_test_command
+{
+  my $cmd = shift;
+  my $logfile = shift;
+
+  if ($^O ne 'MSWin32') {
+    $cmd = "$cmd >>$logfile 2>&1" if defined $logfile;
+    return system($cmd);
+  }
+
+  return system('sh', '-c', $cmd) unless defined $logfile;
+
+  open(my $saved_out, '>&', \*STDOUT) or die "cannot save STDOUT: $!";
+  open(my $saved_err, '>&', \*STDERR) or die "cannot save STDERR: $!";
+  my $rc = 1;
+  if (open(STDOUT, '>>', $logfile)) {
+    open(STDERR, '>&', \*STDOUT);
+    $rc = system('sh', '-c', $cmd);
+  }
+  open(STDOUT, '>&', $saved_out);
+  open(STDERR, '>&', $saved_err);
+  return $rc;
+}
+
 sub isMinGW_UCRT {
   my $temp = $ENV{'MSYSTEM'};
   if (defined $temp) {
@@ -228,7 +264,7 @@ sub setbaselineone
     $log = "$tmpdir/log-$f";
     system "rm -f $log";
     if ($setup_command) {
-      if ( system "$setup_command" ) {
+      if ( run_test_command($setup_command) ) {
         my $end_t = time-$start_t;
         print "== Failed to set baseline for $f (system $setup_command failed)";
         print " [time: $end_t]\n";
@@ -254,7 +290,7 @@ sub setbaselineone
     }
     unlink "$testTempFile$f";
     if ($teardown_command) {
-      system $teardown_command;
+      run_test_command($teardown_command);
     }
 
     open(RES,">$baseline");
@@ -323,7 +359,7 @@ sub runone
     $log = "$tmpdir/log-$f";
     system "rm -f $log";
     if ($setup_command) {
-      if ( system "$setup_command >>$log 2>&1" ) {
+      if ( run_test_command($setup_command, $log) ) {
         print " setup_command failed";
         return 1;
       }
@@ -348,7 +384,7 @@ sub runone
     }
     unlink "$testTempFile$f";
     if ($teardown_command) {
-      system "$teardown_command >>$log 2>&1";
+      run_test_command($teardown_command, $log);
     }
     my $end_t = time-$start_t;
 


### PR DESCRIPTION
Fixes #16391

## Problem

A testsuite `setup_command` is a POSIX shell line, and it spells the toolchain as
`$OMC_CC` / `$OMC_CFLAGS` / ... so a test does not hardcode gcc — `rtest`'s
`setup_command_toolchain()` puts those in the environment:

```
// setup_command: $OMC_CC $OMC_CFLAGS $OMC_EXTLIB_FLAGS -o Foo$OMC_EXTLIB_EXT Foo.c $OMC_EXTLIB_LIBS
```

`rtest` ran it with `system "$setup_command >>$log 2>&1"`. Perl's `system()` on
Win32 hands a line like that to `cmd.exe`, which does not expand `$VAR`, so the
compiler was never invoked and every affected test died before it started:

```
'$OMC_CC' is not recognized as an internal or external command,
operable program or batch file.
 setup_command failed
```

Demonstrated with the MSYS2 UCRT64 perl:

```
osname=MSWin32
--- via cmd.exe (what rtest does now):
$OMC_CC $OMC_CFLAGS
--- via sh -c:
gcc -fPIC
```

## Fix

Run these commands under `sh`, which is the shell they are written for and which
the Windows testsuite already runs under.

The log is redirected from Perl rather than by appending `>>$log 2>&1` to the
command. That part matters: `$log` is a native Windows path, and `sh` eats its
backslashes as escapes, so going through `sh` with the redirection attached turns
`C:\OMDev\tools\msys\tmp` into `C:OMDevtoolsmsystmp` and the command fails on a
directory that does not exist:

```
sh: line 1: C:OMDevtoolsmsystmp/omc-rtest-adrpo33/.../log-ExternalCFuncInputOnly.mos: No such file or directory
```

Other platforms keep the plain shell redirection they always had — the new branch
is taken only under `$^O eq 'MSWin32'`.

## Effect

Verified on a Windows build of current master, running the affected tests with
and without the change. These five fail unpatched (at 0s, `setup_command failed`)
and pass with it:

```
flattening/modelica/records/EmptyRecordTestConstructor.mos
flattening/modelica/records/NestedRecordTestConstructor.mos
flattening/modelica/records/SimpleRecordTestConstructor.mos
simulation/modelica/external_functions/QualifiedCrefArg.mos
simulation/modelica/external_functions/ExtObjStringParam.mos
```

Six more get past `setup_command` and now fail later, on causes of their own, so
they are not claimed here. `ExternalCFuncInputOnly` for instance reaches the
model build and is rejected by a stricter gcc:

```
error: passing argument 1 of 'WriteDataC' from incompatible pointer type
 note: expected 'Data *' but argument is of type 'ExternalCFuncInputOnly_Data_external *'
```

That one looks like a real codegen bug worth its own issue — an older gcc on the
Linux nodes only warns about it.

## Testing

No new test. This changes how the harness runs a test's own setup step, so the
existing suite is the test; Linux and macOS behaviour is unchanged.

---
generated by Claude Code
