### PR TITLE
[Script] Unload a generated function's shared object after calling it

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -2348,6 +2348,20 @@ algorithm
           libHandle := System.loadLibrary(fileName + Autoconf.dllExt, relativePath = true, printDebug = print_debug);
           funcHandle := System.lookupFunction(libHandle, stringAppend("in_", funcstr));
           newval := DynLoad.executeFunction(funcHandle, vallst, print_debug);
+          // lookupFunction takes a reference on the library, so freeing the
+          // library alone only drops the count from two to one and the shared
+          // object is never unloaded. On Windows that keeps the file locked, and
+          // the next call to the same function cannot relink its .dll: the code
+          // generation fails and the call silently evaluates to nothing.
+          //
+          // Only Windows needs the unload. Unix can relink a loaded .so, since
+          // that just replaces the inode, and unloading there would change
+          // behaviour: a generated function's shared object carries static state
+          // that currently survives between calls in a session, e.g. the seed
+          // behind System.realRand (openmodelica/bootstrapping/System.mos).
+          if Autoconf.os == "Windows_NT" then
+            System.freeFunction(funcHandle, print_debug);
+          end if;
           System.freeLibrary(libHandle, print_debug);
         end if;
         execStat("executeFunction("+AbsynUtil.pathString(funcpath)+")");


### PR DESCRIPTION
Fixes #16393

## Problem

Calling the same MetaModelica function twice in one `omc` session works the first
time and silently evaluates to nothing afterwards on Windows:

```mo
package three
  function mNoFail
    input Integer i;
    output Integer o;
  algorithm
    o := match (i) case (1) then 11; case (_) then 22; end match;
  end mNoFail;
end three;
```

```
setCommandLineOptions("-g=MetaModelica -d=gen -d=-newInst");
loadFile("three.mo");
three.mNoFail(2); three.mNoFail(2); three.mNoFail(2);
```

Unix prints `22 22 22`. Windows prints `22` and then two empty results, with an
empty `getErrorString()`. A function simple enough to be constant-evaluated
(`o := i + 1`) is unaffected because it never goes through code generation, which
is why this shows up on `match` bodies.

With `-d=dynload`, the second call never reaches the library load on Windows,
while Unix prints a second `LIB LOAD` and succeeds:

```
[dynload]: [SOME SYMTAB] not in in CF list: .three.mNoFail
LIB LOAD name[C:\temp\mmprobe\three_mNoFail.dll] index[0] handle[2477326336].
[dynload]: output results:
TYPE[3] -> INT: 22
22
[dynload]: [SOME SYMTAB] not in in CF list: .three.mNoFail
[dynload]: FAILED to constant evaluate function: .three.mNoFail
```

## Cause

`cevalCallFunction` loads the generated shared object, looks the function up in
it, calls it, and then frees only the *library* handle. But `lookupFunction`
takes its own reference:

* `SystemImpl__loadLibrary` allocates the handle with `lib->cnt = 1`
* `SystemImpl__lookupFunction` does `++(lib->cnt)` — the source comments it
  `// lib->cnt = 2`
* `System.freeLibrary` then sees `cnt (2) > 1`, decrements to 1 and **never calls
  `dlclose`/`FreeLibrary`**
* `System.freeFunction` was never called at all

There is no `LIB UNLOAD` line in the trace above even with `printDebug` on, which
confirms the module is still loaded.

So the module stays loaded for the life of the process. On Unix that is only a
leak — relinking a loaded `.so` replaces the inode and the next call picks up the
new one. On Windows the loaded `.dll` is locked, so the relink inside
`cevalGenerateFunction` fails, the whole case fails, and the call falls through
to "FAILED to constant evaluate function" without recording an error, which is
why both the result and the error string come back empty.

## Fix

Free the function handle as well, which drops the count to zero and actually
unloads the module — **on Windows only**.

Unix deliberately keeps the old behaviour. It can relink a loaded `.so` because
that just replaces the inode, so it does not need the unload; and unloading there
is not behaviour-neutral. A generated function's shared object carries static
state that currently survives between calls within a session:
`openmodelica/bootstrapping/System.mos` shows it, because the seed behind
`System.realRand` lives in the module, so reloading it per call restarts the
sequence and `randTest`'s second and third results change. That is also why the
gcc build sees this and the clang build does not — the two resolve the runtime
symbols in the generated module differently. Fixing the leak on Unix is a
separate question and does not belong in a Windows bug fix.

## Effect

Verified on a Windows build of current master. All 15 `metamodelica/meta` tests
that fail on the OM_Win job pass with this change:

```
BuiltinList BuiltinMisc BuiltinReal BuiltinString EqPatternm Equality Failure
ListReductionCodegen MatchCase12 MatchCaseGuard MatchCaseInteractive1
MatchCaseInteractive2 MatchElse1 MatchIfEquation1 Try
```

Unix behaviour is unchanged.

## Testing

No new test — the 15 tests above already cover it and are currently red on
Windows.

Because the module is now genuinely unloaded rather than leaked, the risk worth
checking is a returned value that still points into it. All 137 tests that
already pass on this Windows build were re-run with the change: **137 of 137
still pass, nothing regressed**. Those cover functions returning lists, tuples,
records, strings and Option values, so the values coming back from
`DynLoad.executeFunction` do not reference the unloaded module.

---
generated by Claude Code
