### PR TITLE
[Script] Let system() inherit our stdout on Windows when there is no log file

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -621,8 +621,13 @@ int runProcess(const char* cmd, const char* outFile)
   startupInfo.cb         = sizeof(startupInfo);   // Size of struct in bytes
   startupInfo.dwFlags    |= STARTF_USESTDHANDLES; // Additional handles in hStdInput, hStdOutput and hStdError elements
   startupInfo.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
-  startupInfo.hStdError  = logFileHandle;
-  startupInfo.hStdOutput = logFileHandle;
+  /* Without an output file the child writes where we write, as it does on Unix
+   * where systemCall simply lets the fork inherit. STARTF_USESTDHANDLES with a
+   * NULL handle does not mean "inherit", it hands the child an invalid stdout:
+   * anything that checks its writes then fails, e.g. system("... | grep ...")
+   * returns grep's write-error status 2 and prints nothing. */
+  startupInfo.hStdError  = logFileHandle ? logFileHandle : GetStdHandle(STD_ERROR_HANDLE);
+  startupInfo.hStdOutput = logFileHandle ? logFileHandle : GetStdHandle(STD_OUTPUT_HANDLE);
 
   BOOL bSuccess = CreateProcessW(NULL,
     unicodeCommand,

--- a/testsuite/simulation/libraries/common/ModelTesting.mos
+++ b/testsuite/simulation/libraries/common/ModelTesting.mos
@@ -159,7 +159,11 @@ elseif (modelTestingType == OpenModelicaModelTesting.Kind.VerifiedSimulation) or
   modelNameStr := typeNameString(modelName);
   referenceFile := if referenceFile == "" then getEnvironmentVar("REFERENCEFILES") + "/"+referenceFileDir+"/" + modelNameStr + ".mat" else referenceFile;
   if regularFileExists(referenceFile+".xz") then
-    system("if test ! -f "+referenceFile+" || test "+referenceFile+".xz -nt "+referenceFile+"; then xz --keep --decompress --force "+referenceFile+".xz ; fi");
+    (refFileExists, _, refFileTime) := stat(referenceFile);
+    (_, _, refFileXzTime) := stat(referenceFile + ".xz");
+    if not refFileExists or refFileXzTime > refFileTime then
+      system("xz --keep --decompress --force " + referenceFile + ".xz");
+    end if;
     referenceExists := true;
   elseif regularFileExists(referenceFile) then
     referenceExists := true;
@@ -169,7 +173,11 @@ elseif (modelTestingType == OpenModelicaModelTesting.Kind.VerifiedSimulation) or
   /* adrpo: we might run into sandbox and here we get a relative file, try to add ../ */
   if not referenceExists then
     if regularFileExists("../" + referenceFile+".xz") then
-      system("if test ! -f ../"+referenceFile+" || test ../"+referenceFile+".xz -nt ../"+referenceFile+"; then xz --keep --decompress --force ../"+referenceFile+".xz ; fi");
+      (refFileExists, _, refFileTime) := stat("../" + referenceFile);
+      (_, _, refFileXzTime) := stat("../" + referenceFile + ".xz");
+      if not refFileExists or refFileXzTime > refFileTime then
+        system("xz --keep --decompress --force ../" + referenceFile + ".xz");
+      end if;
       referenceExists := true;
     elseif regularFileExists("../" + referenceFile) then
       referenceExists := true;


### PR DESCRIPTION
Fixes #16395

## Problem

`system("...")` with no output file handed the child an invalid stdout on
Windows, so any child that checks its writes failed and nothing it printed
reached the log:

```
system("grep --version");                 // 2, prints nothing
system("grep --version > out.txt 2>&1");  // 0, out.txt has the output
```

`2` is GNU grep's *write error* status. Every grep invocation hit it:

```
"grep no args:"     2
"grep --version:"   2
"grep -V:"          2
"grep on a file:"   2
"findstr /?:"       0
"echo hi:"          0
```

`findstr` and `echo` only appeared to work because they do not check whether
their writes succeed. The same `grep --version` run under `cmd.exe` directly
prints normally and exits 0, so this was not a PATH problem.

## Cause

`runProcess` sets `STARTF_USESTDHANDLES` and then assigns `logFileHandle` to both
`hStdOutput` and `hStdError`:

```c
startupInfo.dwFlags    |= STARTF_USESTDHANDLES;
startupInfo.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
startupInfo.hStdError  = logFileHandle;
startupInfo.hStdOutput = logFileHandle;
```

but `logFileHandle` is only created `if (*outFile)`. With no output file it stays
`NULL`, and `STARTF_USESTDHANDLES` with a `NULL` handle does not mean "inherit" —
it gives the child an invalid stdout.

The Unix branch of `SystemImpl__systemCall` never had the problem: it only
redirects when `outFile` is set, and otherwise the fork inherits, which is how a
test's `system()` output reaches the testsuite log.

## Fix

Fall back to our own std handles when there is no output file, which is what the
Unix branch gets by inheriting.

## Effect

This silently broke every test that inspects something through a pipe, e.g.

```
system("unzip -cqq GfxPorts.fmu terminalsAndIcons/icon.svg | grep -oE \"<rect|>GfxPorts<\"");
```

recorded status `2` and no output, where the expected result has the matched
lines and `0`.

Verified on a Windows build of current master.
`openmodelica/fmi/ModelExchange/3.0/fmi3_clocks.mos` and `fmi3_binary_extobj.mos`
go from red to green, and the pipes in the rest of that directory now produce
their output. Those other tests still fail, but on unrelated causes — for
instance `fmi3_graphics.mos` now differs only in the order the icon files are
listed out of the zip, which is a collation difference rather than this bug.

## A latent bug this exposes

Letting the child's stderr through surfaces a second, pre-existing problem, so
this PR carries its fix as well. `ModelTesting.mos` chose whether to unpack a
reference `.mat` with

```
system("if test ! -f X || test X.xz -nt X; then xz --keep --decompress --force X.xz ; fi");
```

which only ever worked on Unix — `cmd.exe`'s `if` parser stops at the `!` and
answers `! was unexpected at this time.`, so the reference file was never
decompressed on Windows. That went unnoticed precisely because the child's stderr
went nowhere. With this PR's change the message reaches the log and breaks the
comparison of every library test using that script, so the second commit replaces
the shell line with `stat()` from the script itself, which is portable.

Measured: without that second commit 27 library tests (msl32, msl31,
Modelica_DeviceDrivers, cppruntime) would go red; with it they are green again.

## Testing

No new test; this is Windows-only behaviour of an existing scripting builtin, and
the tests above already cover it. Unix is untouched — the change is inside the
`__MINGW32__`/`_MSC_VER` branch.

---
generated by Claude Code
