### PR TITLE
[Testsuite] Keep the FMI 3.0 system() commands to portable shell

### DIFF
--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_builddescription.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_builddescription.mos
@@ -17,9 +17,9 @@ buildModelFMU(Mbd, version="3.0", fmuType="me"); getErrorString();
 
 system("unzip -cqq Mbd.fmu sources/buildDescription.xml > Mbd_bd.xml"); getErrorString();
 // the structural lines (the long per-file SourceFile list is omitted)
-system("grep -E 'fmiBuildDescription fmiVersion|BuildConfiguration modelIdentifier|SourceFileSet language|PreprocessorDefinition|IncludeDirectory' Mbd_bd.xml | sed 's/^ *//'"); getErrorString();
+system("grep -E \"fmiBuildDescription fmiVersion|BuildConfiguration modelIdentifier|SourceFileSet language|PreprocessorDefinition|IncludeDirectory\" Mbd_bd.xml | sed \"s/^ *//\""); getErrorString();
 // the model's own translation unit must be listed
-system("grep -c '<SourceFile name=\"Mbd.c\"/>' Mbd_bd.xml"); getErrorString();
+system("grep -c \"<SourceFile name=.Mbd.c./>\" Mbd_bd.xml"); getErrorString();
 
 // Result:
 // true

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_fmustate.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_fmustate.mos
@@ -15,7 +15,7 @@ loadString("model Mst Real x(start = 1.0); equation der(x) = -x; end Mst;"); get
 buildModelFMU(Mst, version="3.0", fmuType="me"); getErrorString();
 
 system("unzip -cqq Mst.fmu modelDescription.xml > Mst_md.xml"); getErrorString();
-system("grep -E 'canGetAndSetFMUState|canSerializeFMUState' Mst_md.xml | sed 's/^ *//'"); getErrorString();
+system("grep -E \"canGetAndSetFMUState|canSerializeFMUState\" Mst_md.xml | sed \"s/^ *//\""); getErrorString();
 
 // Result:
 // true

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias.mos
@@ -37,10 +37,20 @@ system("unzip -cqq Inertia2.fmu terminalsAndIcons/terminalsAndIcons.xml > Inerti
 readFile("Inertia2_term.xml"); getErrorString();
 
 // the flanges are causalized: flow -> input, potential -> output
-system("for v in flange_a.phi flange_a.tau flange_b.phi flange_b.tau; do echo \"$v $(unzip -cqq Inertia2.fmu modelDescription.xml | grep \"name=\\\"$v\\\"\" | grep -oE 'causality=\"[a-z]+\"')\"; done"); getErrorString();
+// The loop lives here rather than in the shell: cmd.exe has no for..do..done and
+// does not treat '' as quoting, so a POSIX one-liner silently does nothing on
+// Windows. The quotes inside the patterns are matched with . for the same reason.
+for v in {"flange_a.phi", "flange_a.tau", "flange_b.phi", "flange_b.tau"} loop
+  print(v + " ");
+  system("unzip -cqq Inertia2.fmu modelDescription.xml | grep \"name=." + v + ".\" | grep -oE \"causality=.[a-z]+.\"");
+end for;
+getErrorString();
 
 // every terminal member references a variable that exists in modelDescription.xml
-system("for v in flange_a.tau flange_a.phi flange_b.tau flange_b.phi; do unzip -cqq Inertia2.fmu modelDescription.xml | grep -q \"name=\\\"$v\\\"\" && echo \"$v ok\"; done"); getErrorString();
+for v in {"flange_a.tau", "flange_a.phi", "flange_b.tau", "flange_b.phi"} loop
+  system("unzip -cqq Inertia2.fmu modelDescription.xml | grep -q \"name=." + v + ".\" && echo " + v + " ok");
+end for;
+getErrorString();
 
 // Result:
 // true
@@ -69,12 +79,12 @@ system("for v in flange_a.tau flange_a.phi flange_b.tau flange_b.phi; do unzip -
 // flange_a.tau causality="input"
 // flange_b.phi causality="output"
 // flange_b.tau causality="input"
-// 0
+//
 // ""
 // flange_a.tau ok
 // flange_a.phi ok
 // flange_b.tau ok
 // flange_b.phi ok
-// 0
+//
 // ""
 // endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias_nb.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_terminals_alias_nb.mos
@@ -40,11 +40,21 @@ readFile("Inertia2_term.xml"); getErrorString();
 
 // new backend: flange is NOT causalized (flow stays a parameter) and the potential
 // is kept as an FMI 3.0 <Alias> of the state
-system("for v in flange_a.tau flange_b.tau; do echo \"$v $(unzip -cqq Inertia2.fmu modelDescription.xml | grep \"name=\\\"$v\\\"\" | grep -oE 'causality=\"[a-z]+\"')\"; done"); getErrorString();
-system("unzip -cqq Inertia2.fmu modelDescription.xml | grep -oE '<Alias name=\"flange_[ab].phi\"'"); getErrorString();
+// The loop lives here rather than in the shell: cmd.exe has no for..do..done and
+// does not treat '' as quoting, so a POSIX one-liner silently does nothing on
+// Windows. The quotes inside the patterns are matched with . for the same reason.
+for v in {"flange_a.tau", "flange_b.tau"} loop
+  print(v + " ");
+  system("unzip -cqq Inertia2.fmu modelDescription.xml | grep \"name=." + v + ".\" | grep -oE \"causality=.[a-z]+.\"");
+end for;
+getErrorString();
+system("unzip -cqq Inertia2.fmu modelDescription.xml | grep -oE \"<Alias name=.flange_[ab].phi.\""); getErrorString();
 
 // every terminal member references a variable that exists in modelDescription.xml
-system("for v in flange_a.tau flange_a.phi flange_b.tau flange_b.phi; do unzip -cqq Inertia2.fmu modelDescription.xml | grep -q \"name=\\\"$v\\\"\" && echo \"$v ok\"; done"); getErrorString();
+for v in {"flange_a.tau", "flange_a.phi", "flange_b.tau", "flange_b.phi"} loop
+  system("unzip -cqq Inertia2.fmu modelDescription.xml | grep -q \"name=." + v + ".\" && echo " + v + " ok");
+end for;
+getErrorString();
 
 // Result:
 // true
@@ -73,7 +83,7 @@ system("for v in flange_a.tau flange_a.phi flange_b.tau flange_b.phi; do unzip -
 // ""
 // flange_a.tau causality="parameter"
 // flange_b.tau causality="parameter"
-// 0
+//
 // ""
 // <Alias name="flange_a.phi"
 // <Alias name="flange_b.phi"
@@ -83,6 +93,6 @@ system("for v in flange_a.tau flange_a.phi flange_b.tau flange_b.phi; do unzip -
 // flange_a.phi ok
 // flange_b.tau ok
 // flange_b.phi ok
-// 0
+//
 // ""
 // endResult


### PR DESCRIPTION
Fixes #16397

## Problem

These tests inspect the produced FMU with `system()` commands written in POSIX
shell. `omc` runs such a line through `/bin/sh` on Unix but `cmd.exe` on Windows,
so they did not do what the test intends there.

`cmd.exe` does not treat `'` as quoting, so it split the command at the `|`
inside the pattern:

```
system("grep -E 'canGetAndSetFMUState|canSerializeFMUState' Mst_md.xml | sed 's/^ *//'");

'canSerializeFMUState'' is not recognized as an internal or external command,
operable program or batch file.
255
```

and it has no `for ... do ... done`, so it stopped at the variable:

```
system("for v in flange_a.phi flange_a.tau; do echo \"$v $(unzip ...)\"; done");

v was unexpected at this time.
```

A third case is a pattern carrying its own double quotes,
`grep -c '<SourceFile name="Mbd.c"/>'`, which no single level of quoting survives
on both platforms.

Until #16395 the child's output went nowhere, which is why none of this was
visible — the tests simply compared against empty output.

## Fix

Keep the commands to what both shells agree on:

* double quotes rather than single quotes
* a `.` in the pattern where a literal quote is wanted
* the loop moved into the `.mos` script instead of the shell

Nothing here becomes Windows-specific.

The output is unchanged on Unix except for the trailing `0` after the two loops:
a `system()` call inside a script-level `for` is a statement rather than an
echoed expression, so the expected blocks lose those two zeros. They were
regenerated from an actual run rather than edited by hand.

## Verification

Run on both a Linux build and a Windows build of current master. All four are
green on each:

```
fmi3_fmustate.mos
fmi3_builddescription.mos
fmi3_terminals_alias.mos
fmi3_terminals_alias_nb.mos
```

With this and #16396, `openmodelica/fmi/ModelExchange/3.0` goes from 0/13 to
7/13 passing on Windows.

## Not covered here

The remaining six fail for reasons of their own:

* `fmi3_attributes_01`, `fmi3_msl_adder4`, `fmi3_msl_engine1a` drive
  `simulate_fmu_fmpy.py`, and the Windows node has no working `fmpy`
  (`ModuleNotFoundError: No module named 'fmpy'`). That is an environment
  question — install it there, or skip these on Windows. The traceback was
  invisible on Jenkins until #16396; the next run should show it.
* `fmi3_graphics` differs only in the order `unzip -l | sort` lists the icon
  files — Windows collates `icon.png` before `RealInputI.png`, Unix after.
* `fmi3_import_boolean`, `fmi3_import_me` fail on something else again.

---
generated by Claude Code
