### PR TITLE
[Testsuite] Skip the FMPy round-trip tests on Windows

### DIFF
--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
@@ -1,6 +1,12 @@
 // name: fmi3_attributes_01.mos
 // keywords: FMI 3.0 export
 // status: correct
+// suite: disabled-windows
+// The FMU is simulated back with FMPy. The Windows build node has no python3
+// that can import fmpy: OMDev's python cannot install it (rpds-py has no wheel
+// for MSYS2 python and wants Rust to build), and the native Python that does
+// have it ships no python3.exe. Re-enable once a python3 with fmpy is available
+// there.
 // teardown_command: rm -rf fmi3_attributes_01.fmu fmi3_attributes_01.xml fmi3_attributes_01_tmp.xml fmi3_attributes_01.fmutmp/ fmi3_attributes_01_res.mat fmi3_attributes_01_fmpy.csv fmi3_attributes_01_diff.*.csv fmi3_attributes_01_info.json fmi3_attributes_01.log fmi3_attributes_01_*.bin index.html fmi3_attributes_01_FMU.libs fmi3_attributes_01_FMU.makefile fmi3_attributes_01_external_functions.json resources
 
 setCommandLineOptions("-d=newInst"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
@@ -1,6 +1,12 @@
 // name: fmi3_msl_adder4
 // keywords: FMI 3.0 export MSL Digital enumeration FMPy
 // status: correct
+// suite: disabled-windows
+// The FMU is simulated back with FMPy. The Windows build node has no python3
+// that can import fmpy: OMDev's python cannot install it (rpds-py has no wheel
+// for MSYS2 python and wants Rust to build), and the native Python that does
+// have it ships no python3.exe. Re-enable once a python3 with fmpy is available
+// there.
 // teardown_command: rm -rf Adder4.fmu Adder4.fmutmp/ Adder4_ref* Adder4_fmpy.csv Adder4_diff.*.csv Adder4_info.json *.log Adder4_FMU.libs Adder4_FMU.makefile Adder4_external_functions.json resources
 //
 // MSL 4.1.0 round-trip check (discrete/digital model with enumeration variables):

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
@@ -1,6 +1,12 @@
 // name: fmi3_msl_engine1a
 // keywords: FMI 3.0 export MSL MultiBody FMPy
 // status: correct
+// suite: disabled-windows
+// The FMU is simulated back with FMPy. The Windows build node has no python3
+// that can import fmpy: OMDev's python cannot install it (rpds-py has no wheel
+// for MSYS2 python and wants Rust to build), and the native Python that does
+// have it ships no python3.exe. Re-enable once a python3 with fmpy is available
+// there.
 // teardown_command: rm -rf Engine1a.fmu Engine1a.fmutmp/ Engine1a_ref* Engine1a_fmpy.csv Engine1a_diff.*.csv Engine1a_info.json *.log Engine1a_FMU.libs Engine1a_FMU.makefile Engine1a_external_functions.json resources
 //
 // MSL 4.1.0 round-trip check (continuous MultiBody model): export

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -87,6 +87,9 @@ $skipped=0;
 # or need a setup nobody has. They are only run when asked for, with -disabled or
 # RTEST_RUN_DISABLED=1 (which is what partest's disabled suite and the makefiles'
 # failingtest targets set).
+#
+# 'disabled-windows' is the same thing but only where the setup is missing, i.e.
+# a test that is fine on Unix and has nothing to run on with on Windows.
 $run_disabled=($ENV{'RTEST_RUN_DISABLED'} ? 1 : 0);
 $setbaseline=0;
 $verbose="yes";
@@ -552,7 +555,7 @@ sub dofile
     }
 
     # A disabled test is neither run nor counted, it is only reported as skipped.
-    if (!$run_disabled and grep { $_ eq "disabled" } split(/[,\s]+/, $info{"suite"})) {
+    if (!$run_disabled and grep { $_ eq "disabled" or ($_ eq "disabled-windows" and $^O eq 'MSWin32') } split(/[,\s]+/, $info{"suite"})) {
       printf(" %s %-82s... disabled\n", '.', $info{'name'});
       $skipped = $skipped + 1;
       return 0;


### PR DESCRIPTION
Fixes #16399

## Problem

`fmi3_attributes_01`, `fmi3_msl_adder4` and `fmi3_msl_engine1a` simulate the
exported FMU back with FMPy, through `python3 ../../simulate_fmu_fmpy.py`. No
`python3` on the Windows build node can import `fmpy`:

```
Traceback (most recent call last):
  File ".../simulate_fmu_fmpy.py", line 23, in <module>
    from fmpy import simulate_fmu
ModuleNotFoundError: No module named 'fmpy'
```

On Jenkins this was invisible until #16395 was fixed — the child's output went
nowhere, so the test merely reported `(false, {})` and a missing CSV.

It is not a matter of just installing it:

* OMDev's python (MSYS2 UCRT64, 3.14.5) pulls `rpds-py`, which has no wheel for
  that interpreter and wants maturin and a Rust toolchain to build from source.
  `numpy` 2.4.6 and `scipy` 1.17.1 are already there, so they are not the
  obstacle.
* The native `C:\Program Files\Python3\python.exe` **does** have fmpy 0.3.29, but
  that installation ships no `python3.exe`, so putting it earlier on PATH does
  not help either.

## Fix

Skip the three on Windows until a `python3` that can import `fmpy` exists there.

`rtest` already knows `// suite: disabled` for tests that need a setup nobody
has. This adds `disabled-windows` for the narrower case — a test that is fine on
Unix and has nothing to run on with on Windows. Both remain overridable with
`-disabled` and `RTEST_RUN_DISABLED`, and both are *reported* rather than passed
over quietly:

```
 . fmi3_msl_adder4      ... disabled
 . fmi3_msl_engine1a    ... disabled
 . fmi3_attributes_01   ... disabled

== 3 disabled tests skipped, run them with rtest -disabled
```

Each test carries a comment saying why and what would let it come back.

## Verification

Both platforms, on builds of current master:

* Windows — the three are reported as disabled, nothing else changes
* Linux — the three still run and pass (`ok`, 14s / 42s / 5s)

## Follow-up

This is a stop-gap, not the answer. A real fix is one of: ship a `python3.exe` in
OMDev pointing at a python with fmpy; add fmpy to OMDev's python once a prebuilt
`rpds-py` for MSYS2 exists; or have rtest export the interpreter the way it
already exports `OMC_CC`, with the tests defaulting to `python3`.

---
generated by Claude Code
