### PR TITLE
wasm-jit: simulation at the C runtime's speed

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -758,8 +758,19 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
 # ---------------------------------------------------------------------------
 # Step 1+2: build mmtorust (release), transpile the Susan subset, build susan.
 # A stamp file marks completion; cargo itself handles incremental rebuilds, so
-# the command always runs but is a fast no-op when nothing changed.
+# the command is a fast no-op when only some of its inputs changed.
+#
+# The stamp has to name those inputs: a stamp rule with no DEPENDS is up to date
+# the moment the file exists, so the rule never runs a second time and every
+# later build compiles the templates with the `susan` of the first one.
 # ---------------------------------------------------------------------------
+file(GLOB_RECURSE SUSAN_TOOL_SOURCES CONFIGURE_DEPENDS ${RUST_OMC_DIR}/mmtorust/src/*.rs)
+list(APPEND SUSAN_TOOL_SOURCES
+     ${RUST_OMC_DIR}/mmtorust/Cargo.toml
+     ${RUST_OMC_DIR}/openmodelica_susan/Cargo.toml
+     ${RUST_OMC_DIR}/openmodelica_susan/src/main.rs)
+# The subset's *.mo: the rest of openmodelica_susan/src is transpiled from them.
+file(STRINGS ${RUST_SUSAN_SOURCES} SUSAN_SUBSET_MO REGEX "\\.mo$")
 set(SUSAN_STAMP ${CMAKE_CURRENT_BINARY_DIR}/rust_susan.stamp)
 add_custom_command(
   OUTPUT ${SUSAN_STAMP}
@@ -774,6 +785,7 @@ add_custom_command(
   COMMAND ${MMTORUST_BIN} --sources ${RUST_SUSAN_SOURCES}
   COMMAND ${CARGO_BUILD} --release -p openmodelica_susan --bin susan
   COMMAND ${CMAKE_COMMAND} -E touch ${SUSAN_STAMP}
+  DEPENDS ${SUSAN_TOOL_SOURCES} ${SUSAN_SUBSET_MO} ${RUST_SUSAN_SOURCES}
   COMMENT "Rust: building mmtorust + Susan template compiler (release)"
   VERBATIM)
 add_custom_target(rust_susan DEPENDS ${SUSAN_STAMP})

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -172,6 +172,7 @@ openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
 openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
 openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
 openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+openmodelica_codegen_wasm_jit_runtime/src/sysstats.rs
 openmodelica_codegen_wasm_jit_runtime/src/uri.rs
 openmodelica_fmi3_wasm/Cargo.lock
 openmodelica_fmi3_wasm/Cargo.toml
@@ -288,9 +289,11 @@ openmodelica_sim_meta/src/optimization/mod.rs
 openmodelica_sim_meta/src/optimization/model.rs
 openmodelica_sim_meta/src/optimization/setup.rs
 openmodelica_sim_meta/src/qss.rs
+openmodelica_sim_meta/src/rtclock.rs
 openmodelica_sim_meta/src/simflags.rs
 openmodelica_sim_meta/src/sundials.rs
 openmodelica_sim_meta/src/sync.rs
+openmodelica_sim_meta/src/sysstat.rs
 openmodelica_simcode_types/Cargo.toml
 openmodelica_simcode_util/Cargo.toml
 openmodelica_susan/Cargo.toml

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -129,13 +129,56 @@ const REAL_OFF: u32 = 8;
 pub(crate) use openmodelica_sim_meta::SolveStats;
 
 
+/// C's `SOLVER_METHOD_NAME` names the integrator, not the driver running it:
+/// `dassl-events` is `dassl`.
+fn solver_method_name(label: &str) -> &str {
+    label.split('-').next().unwrap_or(label)
+}
+
 /// Render the `LOG_STATS` block the C runtime emits at simulation end, so it shows
 /// in the simulation log (and thus the OMEdit output widget). Host-only: the
 /// in-wasm driver only fills the counters; formatting is a host concern.
+///
+/// Same lines, order and quantities as `solver_main.c`'s `### STATISTICS ###`,
+/// off the [`rtclock`] snapshot the driver leaves in `SolveStats`.
 fn log_stats_block(s: &SolveStats) -> String {
-    format!(
-        "LOG_STATS         | info    | ### STATISTICS ###\n\
-         LOG_STATS         | info    | events\n\
+    use openmodelica_sim_meta::driver::format_g;
+    use openmodelica_sim_meta::rtclock;
+    let t = |ix: usize| s.timers[ix];
+    let total = t(rtclock::TOTAL);
+    // C's `total100`; a zero total (clocks off) would make every share NaN.
+    let pct = |v: f64| if total > 0.0 { v * 100.0 / total } else { 0.0 };
+    let line = |v: f64, what: &str| {
+        format!("LOG_STATS         | info    | | {:>12}s [{:5.1}%] {what}\n", format_g(v, 6), pct(v))
+    };
+    // C's "simulation": what none of the other clocks claimed.
+    let sim = total
+        - t(rtclock::OVERHEAD)
+        - t(rtclock::EVENT)
+        - t(rtclock::OUTPUT)
+        - t(rtclock::STEP)
+        - t(rtclock::INIT)
+        - t(rtclock::PREINIT)
+        - t(rtclock::SOLVER);
+    let mut out = String::from("LOG_STATS         | info    | ### STATISTICS ###\n");
+    out.push_str("LOG_STATS         | info    | timer\n");
+    for (v, what) in [(t(rtclock::INIT_XML), "reading init.xml"), (t(rtclock::INFO_XML), "reading info.xml")] {
+        out.push_str(&format!("LOG_STATS         | info    | | {:>12}s          {what}\n", format_g(v, 6)));
+    }
+    out.push_str(&line(t(rtclock::PREINIT), "pre-initialization"));
+    out.push_str(&line(t(rtclock::INIT), "initialization"));
+    out.push_str(&line(t(rtclock::STEP), "steps"));
+    out.push_str(&line(t(rtclock::SOLVER), "solver (excl. callbacks)"));
+    out.push_str(&line(t(rtclock::OUTPUT), "creating output-file"));
+    out.push_str(&line(t(rtclock::EVENT), "event-handling"));
+    out.push_str(&line(t(rtclock::OVERHEAD), "overhead"));
+    out.push_str(&line(sim, "simulation"));
+    out.push_str(&format!(
+        "LOG_STATS         | info    | | {:>12}s [100.0%] total\n",
+        format_g(total, 6)
+    ));
+    out.push_str(&format!(
+        "LOG_STATS         | info    | events\n\
          LOG_STATS         | info    | |   {:5} state events\n\
          LOG_STATS         | info    | |   {:5} time events\n\
          LOG_STATS         | info    | solver: {}\n\
@@ -144,10 +187,93 @@ fn log_stats_block(s: &SolveStats) -> String {
          LOG_STATS         | info    | |   {:5} evaluations of jacobian\n\
          LOG_STATS         | info    | |   {:5} error test failures\n\
          LOG_STATS         | info    | |   {:5} convergence test failures\n\
-         LOG_STATS         | info    | |   {:5} linear system solves\n",
-        s.state_events, s.time_events, s.method, s.steps,
-        s.res_evals, s.jac_evals, s.err_test_fails, s.conv_test_fails, s.lin_solves,
-    )
+         LOG_STATS         | info    | | {}s time of jacobian evaluation\n",
+        s.state_events, s.time_events, solver_method_name(s.method), s.steps,
+        s.res_evals, s.jac_evals, s.err_test_fails, s.conv_test_fails,
+        format_g(t(rtclock::JACOBIAN), 6),
+    ));
+    if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS_V) {
+        out.push_str(&log_stats_v_block(s));
+    }
+    out
+}
+
+/// `solver_main.c`'s `LOG_STATS_V` sections: how often each model entry point ran
+/// and what share of the run it took, then the systems.
+fn log_stats_v_block(s: &SolveStats) -> String {
+    use openmodelica_sim_meta::driver::format_g;
+    use openmodelica_sim_meta::rtclock;
+    let total = s.timers[rtclock::TOTAL];
+    let pct = |v: f64| if total > 0.0 { v * 100.0 / total } else { 0.0 };
+    let mut out = String::from("LOG_STATS_V       | info    | function calls\n");
+    let mut timed = |n: u64, what: &str, v: f64, out: &mut String| {
+        if n == 0 {
+            return;
+        }
+        out.push_str(&format!("LOG_STATS_V       | info    | | {n:5} {what}\n"));
+        out.push_str(&format!(
+            "LOG_STATS_V       | info    | | | {:>12}s [{:5.1}%]\n",
+            format_g(v, 6),
+            pct(v)
+        ));
+    };
+    for (ix, what) in [
+        (rtclock::DAE, "calls of functionDAE"),
+        (rtclock::FUNCTION_ODE, "calls of functionODE"),
+        (rtclock::RESIDUALS, "calls of functionODE_residual"),
+        (rtclock::ALGEBRAICS, "calls of functionAlgebraics"),
+        (rtclock::JACOBIAN, "evaluations of jacobian"),
+    ] {
+        timed(s.tcalls[ix], what, s.timers[ix], &mut out);
+    }
+    out.push_str(&format!(
+        "LOG_STATS_V       | info    | | {:5} calls of updateDiscreteSystem\n\
+         LOG_STATS_V       | info    | | {:5} calls of functionZeroCrossingsEquations\n",
+        s.tcalls[rtclock::DISCRETE], s.tcalls[rtclock::ZC_EQUATIONS],
+    ));
+    timed(s.tcalls[rtclock::ZC], "calls of functionZeroCrossings", s.timers[rtclock::ZC], &mut out);
+    out.push_str(&sys_stats_section(s, false));
+    out.push_str(&sys_stats_section(s, true));
+    out
+}
+
+/// `printLinearSystemSolvingStatistics` / `printNonLinearSystemSolvingStatistics`
+/// for every system of one kind, in equation-index order as C stores them.
+fn sys_stats_section(s: &SolveStats, nonlinear: bool) -> String {
+    use openmodelica_sim_meta::driver::format_g;
+    let head = if nonlinear { "non-linear systems" } else { "linear systems" };
+    let mut out = format!("LOG_STATS_V       | info    | {head}\n");
+    let mut systems: Vec<_> = s.systems.iter().filter(|x| x.nonlinear == nonlinear).collect();
+    systems.sort_by_key(|x| x.eq_index);
+    for x in systems {
+        let calls = x.calls.max(1) as f64;
+        if nonlinear {
+            out.push_str(&format!(
+                "LOG_STATS_V       | info    | | Non-linear system {} of size {} solver statistics:\n\
+                 LOG_STATS_V       | info    | | |  number of calls                : {}\n\
+                 LOG_STATS_V       | info    | | |  number of iterations           : {}\n\
+                 LOG_STATS_V       | info    | | |  number of function evaluations : {}\n\
+                 LOG_STATS_V       | info    | | |  number of jacobian evaluations : {}\n\
+                 LOG_STATS_V       | info    | | |  time of jacobian evaluations   : {:.6}\n\
+                 LOG_STATS_V       | info    | | |  average time per call          : {:.6}\n\
+                 LOG_STATS_V       | info    | | |  total time                     : {:.6}\n",
+                x.eq_index, x.size, x.calls, x.iters, x.res_evals, x.jac_evals,
+                x.jac, x.total / calls, x.total,
+            ));
+        } else {
+            let density = 100.0 * f64::from(x.nnz) / f64::from(x.size * x.size).max(1.0);
+            out.push_str(&format!(
+                "LOG_STATS_V       | info    | | Linear system {} with (size = {}, nonZeroElements = {}, density = {:.2} %) solver statistics:\n\
+                 LOG_STATS_V       | info    | | |  number of calls                : {}\n\
+                 LOG_STATS_V       | info    | | |  average time per call          : {}\n\
+                 LOG_STATS_V       | info    | | |  time of jacobian evaluations   : {}\n\
+                 LOG_STATS_V       | info    | | |  total time                     : {}\n",
+                x.eq_index, x.size, x.nnz, density, x.calls,
+                format_g(x.total / calls, 6), format_g(x.jac, 6), format_g(x.total, 6),
+            ));
+        }
+    }
+    out
 }
 
 
@@ -1549,12 +1675,23 @@ pub(crate) fn resolve_ext_libraries(
     }
     let mut out = ExtLibraries::default();
     let mut seen: HashSet<String> = HashSet::new();
+    // A `Library` yields `<name>.wasm` and the `-l<name>` a native host falls back
+    // to, both naming the same file. Placing one twice re-runs its `_initialize`.
+    let mut placed: HashSet<String> = HashSet::new();
     for lib in lst(&mp.libs) {
         let lib = lib.to_string();
         if !seen.insert(lib.clone()) {
             continue;
         }
         if !lib.ends_with(".wasm") {
+            // A wasm build installed beside the native one: its functions bind
+            // wasm->wasm, where the native one costs a host trampoline per call.
+            if let Some((path, bytes)) = find_wasm_library(&lib, &dirs) {
+                if placed.insert(path.clone()) {
+                    out.wasm.push(ExtLibrary { name: path, bytes, fixed: true });
+                }
+                continue;
+            }
             if let Some(path) = find_source_library(&lib, &dirs) {
                 out.sources.push(format!("#include \"{}\"", path.replace('\\', "/")));
             } else {
@@ -1575,7 +1712,9 @@ pub(crate) fn resolve_ext_libraries(
             ));
             continue;
         };
-        out.wasm.push(ExtLibrary { name: path, bytes });
+        if placed.insert(path.clone()) {
+            out.wasm.push(ExtLibrary { name: path, bytes, fixed: true });
+        }
     }
     Ok(out)
 }
@@ -1663,7 +1802,7 @@ fn compile_include_tu(
     }
     let bytes = std::fs::read(&out).map_err(|_| "CodegenWasmJit: cannot read the compiled include library")?;
     let _ = std::fs::remove_dir_all(&dir);
-    Ok(Some(ExtLibrary { name: format!("{prefix}_includes.wasm"), bytes }))
+    Ok(Some(ExtLibrary { name: format!("{prefix}_includes.wasm"), bytes, fixed: false }))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1836,6 +1975,37 @@ fn find_ext_library(name: &str, dirs: &[String]) -> Option<(String, Vec<u8>)> {
         }
     }
     None
+}
+
+/// [`find_ext_library`] for a linker spec (`-lFoo`, `Foo`, `dir/Foo.wasm`).
+fn find_wasm_library(spec: &str, dirs: &[String]) -> Option<(String, Vec<u8>)> {
+    let name = match spec.strip_prefix("-l") {
+        Some(n) => n,
+        // Any other linker flag (`-L`, `-Wl,…`, `-pthread`) names no library.
+        None if spec.starts_with('-') => return None,
+        None => spec,
+    };
+    find_ext_library(name, dirs)
+}
+
+/// Whether the built-in ModelicaExternalC side module defines an `external "C"`
+/// the model's own libraries leave open ([`SimModel::ext_builtin`]). It carries
+/// the whole MSL C set, which no installed `.wasm` names, so it is matched by
+/// symbol rather than by `Library` name.
+///
+/// It does not join `ext_libs`: those are the model's *own*, and the FMU link adds
+/// this one itself.
+fn builtin_wasm_needed(ext_imports: &[ExtCallSig], libs: &[ExtLibrary]) -> bool {
+    if EXTERNAL_C_DYLINK.is_empty() {
+        return false;
+    }
+    let mut open: HashSet<&str> = ext_imports.iter().map(|s| s.name.as_str()).collect();
+    for l in libs {
+        for n in wasm_exports(&l.bytes) {
+            open.remove(n);
+        }
+    }
+    !open.is_empty() && wasm_exports(EXTERNAL_C_DYLINK).any(|n| open.contains(n))
 }
 
 /// Renames the model's `rt`/`ext` import modules → `env`, the dylink convention
@@ -4082,8 +4252,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     let mut ext_libs = ExtLibraries::default();
     let mut ext_includes = None;
     let mut ext_archives = None;
+    let mut ext_builtin = false;
     if !ext_imports.is_empty() {
         ext_libs = resolve_ext_libraries(&sim_code.makefileParams, &mut ext_lib_notes)?;
+        ext_builtin = builtin_wasm_needed(&ext_imports, &ext_libs.wasm);
         // What the `Library` annotations did not provide may come from an `Include`
         // carrying the C source, though most carry only the declarations.
         let mp = &sim_code.makefileParams;
@@ -5220,6 +5392,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         layout,
         result_vars,
         ext_libs: ext_libs.wasm,
+        ext_builtin,
         ext_native_libs: ext_libs.native,
         ext_archives,
         ext_includes,
@@ -6678,6 +6851,19 @@ pub(crate) fn lower_equation(
 /// The residual-probing path ([`compile_linear_system`]) is the fallback for the
 /// rare system without a usable `simJac`.
 fn lower_linear_system(
+    ctx: &mut FnCtx,
+    lsystem: &SimCode::LinearSystem,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+) -> Result<()> {
+    // C measures `solve_linear_system` from before the `A`/`b` assembly, which here
+    // is emitted code rather than a runtime call, so the bracket spans the system.
+    let n = lst(&lsystem.vars).count() as i32;
+    crate::CodegenWasmJitFunctions::emit_ls_bracket(ctx, lsystem.index, n, lin_system_nnz(lsystem) as i32, true)?;
+    lower_linear_system_body(ctx, lsystem, eq_index)?;
+    crate::CodegenWasmJitFunctions::emit_ls_bracket(ctx, lsystem.index, n, 0, false)
+}
+
+fn lower_linear_system_body(
     ctx: &mut FnCtx,
     lsystem: &SimCode::LinearSystem,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -458,6 +458,10 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_linsolve_totalpivot", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64], &[WTy::I32]),
     // C's `check_linear_solution` + throw for an unsolved system: (index, time).
     ("rt_ls_failed", &[WTy::I32, WTy::F64], &[]),
+    // `LOG_STATS_V`'s per-system bracket, C's `solve_linear_system`: the generated
+    // code assembles `A`/`b` itself, so it has to open the clock. (index, size, nnz).
+    ("rt_ls_begin", &[WTy::I32, WTy::I32, WTy::I32], &[]),
+    ("rt_ls_end", &[], &[]),
     // Method-1 step test: (res_ptr, b_ptr, n, index, time, dense) -> 1 when the
     // step must be redone, `b` then holding `-res`. See `rt_ls_check_step`.
     ("rt_ls_check_step", &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::F64, WTy::I32], &[WTy::I32]),
@@ -6941,7 +6945,7 @@ pub(crate) use sim_systems::{
     backup_known_outputs, restore_known_outputs,
     compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
     compile_linear_system_symbolic, emit_linz_jac_body, emit_nls_jac_body, emit_nls_jac_csc_body,
-    emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring,
+    emit_ls_bracket, emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring,
     lin_use_sparse, nls_use_sparse,
 };
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -138,11 +138,11 @@ fn define_external_imports(
         return Err("CodegenWasmJit: this omc was built without the PIC wasi-libc, so it cannot \
                     load an external \"C\" library");
     }
-    libs.push(dl::Library { name: "libc.so".to_string(), bytes: libc.to_vec() });
+    libs.push(dl::Library::builtin("libc.so", libc));
     for path in &sig.libs {
         let bytes = openmodelica_wasi::fs::read(path)
             .map_err(|_| "CodegenWasmJit: cannot read an external \"C\" library")?;
-        libs.push(dl::Library { name: path.clone(), bytes });
+        libs.push(dl::Library::model(path, bytes));
     }
     let table = rt_inst
         .get_table(&mut *store, "__indirect_function_table")
@@ -286,7 +286,7 @@ pub(super) fn load_and_execute(
     // module name "rt", plus the `env` math builtins.
     let cache = jit_cache();
     let module = get_or_compile_module(cache, &bytes)?;
-    let mut store = wasmtime::Store::new(&cache.engine, WasiCtx::new(".", Vec::new()));
+    let mut store = wasmtime::Store::new(&cache.engine, WasiCtx::new("/", Vec::new()));
     let rt_inst = wt(cache.env_linker.instantiate(&mut store, &cache.runtime_module))?;
     let mut linker = cache.env_linker.clone();
     wt(linker.instance(&mut store, "rt", rt_inst))?;
@@ -716,7 +716,7 @@ mod tests {
     fn runtime_instance() -> (Store, wasmtime::Instance) {
         let engine = wasmtime::Engine::default();
         let module = wasmtime::Module::new(&engine, RUNTIME_WASM).unwrap();
-        let mut store = wasmtime::Store::new(&engine, WasiCtx::new(".", Vec::new()));
+        let mut store = wasmtime::Store::new(&engine, WasiCtx::new("/", Vec::new()));
         let mut linker = wasmtime::Linker::new(&engine);
         openmodelica_wasm_jit::host::add_host_builtins(&mut linker).unwrap();
         let inst = linker.instantiate(&mut store, &module).unwrap();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -1714,6 +1714,21 @@ fn emit_b_exps(
     Ok(())
 }
 
+/// `rt_ls_begin` / `rt_ls_end` around a lowered linear system, C's
+/// `solve_linear_system` bracket for the `LOG_STATS_V` per-system statistics.
+pub(crate) fn emit_ls_bracket(ctx: &mut FnCtx, index: i32, n: i32, nnz: i32, begin: bool) -> Result<()> {
+    use we::Instruction as I;
+    if !begin {
+        ctx.emit(I::Call(rt_index("rt_ls_end")?));
+        return Ok(());
+    }
+    ctx.emit(I::I32Const(index));
+    ctx.emit(I::I32Const(n));
+    ctx.emit(I::I32Const(nnz));
+    ctx.emit(I::Call(rt_index("rt_ls_begin")?));
+    Ok(())
+}
+
 /// Emit the call to the runtime nonlinear solver `rt_solve_nls` for one
 /// `SES_NONLINEAR` system. The Newton driver (forward-difference Jacobian +
 /// `rt_linsolve` + damped line search) lives in the runtime (`nls.rs`); this

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub use nls::{rt_nls_clean_history, rt_set_step_size};
 #[cfg(test)]
 mod nls_c_trace;
 mod solvers;
+mod sysstats;
 mod spatial;
 // SUNDIALS/KLU. The archives are wasip1-only (they need a libc) and only linked
 // when the build script found them, so `cfg(sundials)` gates the calls; the module
@@ -2415,6 +2416,43 @@ pub extern "C" fn rt_lin_solves() -> u64 {
     lin_solves()
 }
 
+/// Enter a linear system, C's `solve_linear_system`: the generated code assembles
+/// `A` and `b`, so the bracket starts there. [`rt_ls_end`] closes it.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_ls_begin(eq_index: i32, size: u32, nnz: u32) {
+    sysstats::begin(eq_index, false, size, nnz);
+}
+
+/// Leave the linear system [`rt_ls_begin`] entered. Iterations and evaluations are
+/// a nonlinear system's statistics; C leaves them at zero here too.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_ls_end() {
+    sysstats::end([0; 3]);
+}
+
+/// The host's wall clock. Same rule as `rt_reinit_note`: the `env` import only
+/// where a host binds it (`host_log`). The standalone command installs its own;
+/// the FMI3 adapter has neither, and leaves its timers at zero.
+#[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
+mod host_clock {
+    #[link(wasm_import_module = "env")]
+    unsafe extern "C" {
+        fn rt_host_now_ms() -> f64;
+    }
+    pub(crate) fn now_ms() -> f64 {
+        unsafe { rt_host_now_ms() }
+    }
+}
+
+/// Install the host clock and arm (or disarm) the per-system statistics for a run;
+/// the host-driven path has no session to do it.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_stats_start(on: u32) {
+    #[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
+    openmodelica_sim_meta::driver::set_clock(host_clock::now_ms);
+    sysstats::enable(on != 0);
+}
+
 /// Solve the dense `n`×`n` system `A x = b` in place: `A` is `a_ptr` as `n*n`
 /// f64 in **column-major** order, `b` is `b_ptr` as `n` f64. On success `b ← x`
 /// and 0 is returned; 1 only when the system is genuinely unsolvable. `A` is left
@@ -2427,6 +2465,7 @@ pub extern "C" fn rt_lin_solves() -> u64 {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, n: u32, eq_index: i32, time: f64, method1: i32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    sysstats::mark_assembly_done();
     let n = n as usize;
     #[cfg(sundials)]
     match solvers::ls() {
@@ -2623,6 +2662,7 @@ pub fn reset_ls_failures() {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_solve_lin_sparse(colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: u32, nnz: u32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    sysstats::mark_assembly_done();
     let n = n as usize;
     let nnz = nnz as usize;
     let colp = unsafe { core::slice::from_raw_parts(colptr as *const i32, n + 1) };
@@ -2669,6 +2709,7 @@ pub extern "C" fn rt_solve_lin_sparse(colptr: u32, rowidx: u32, values: u32, b_p
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_solve_lin_dense_sparse(a_ptr: u32, b_ptr: u32, n: u32) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    sysstats::mark_assembly_done();
     let n = n as usize;
     #[cfg(sundials)]
     match solvers::lss() {
@@ -2748,6 +2789,7 @@ pub extern "C" fn rt_solve_lin_sparse_cached(
     nnz: u32,
 ) -> i32 {
     LIN_SOLVES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    sysstats::mark_assembly_done();
     let backend = match solvers::lss() {
         solvers::Lss::Klu => solvers::Sparse::Klu,
         solvers::Lss::Umfpack => solvers::Sparse::Umfpack,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -1962,6 +1962,16 @@ fn note_jac_eval() {
     JAC_EVALS.fetch_add(1, Ordering::Relaxed);
 }
 
+/// C's `numberOfIterations`, `numberOfFEval` and `numberOfJEval` as run totals; a
+/// solve's own share is the difference across it, less what a nested solve took.
+fn sys_counts() -> [u64; 3] {
+    [
+        crate::rt_stat(STAT_NLS_ITER),
+        crate::rt_stat(STAT_NLS_RES),
+        JAC_EVALS.load(Ordering::Relaxed),
+    ]
+}
+
 fn counters_of(eq_index: u32) -> &'static mut [u64; 3] {
     let v = unsafe { &mut *COUNTERS.0.get() };
     let pos = match v.iter().position(|(i, _)| *i == eq_index) {
@@ -2260,6 +2270,7 @@ fn newton_c(
                     eval: &mut dyn FnMut(&[f64], &mut [f64]),
                     jaceval: &mut dyn FnMut(&[f64], &mut [f64])| {
         arm_attempt();
+        let t0 = crate::sysstats::tick();
         JAC_DEPTH.fetch_add(1, Ordering::Relaxed);
         if !has_jac {
             note_jac_eval();
@@ -2290,6 +2301,7 @@ fn newton_c(
             }
         }
         JAC_DEPTH.fetch_sub(1, Ordering::Relaxed);
+        crate::sysstats::add_jacobian_time(crate::sysstats::tick() - t0);
         !attempt_aborted()
     };
 
@@ -3163,6 +3175,9 @@ pub extern "C" fn rt_solve_nls(
         && (hom_method == HOM_GLOBAL_ADAPTIVE || hom_method == HOM_LOCAL_ADAPTIVE)
         && n > 1;
     let n = n as usize - usize::from(lambda_unknown);
+    // C's `solve_nonlinear_system` opens the system's clock before anything else.
+    crate::sysstats::begin(eq_index as i32, true, n as u32, nnz);
+    let sys0 = sys_counts();
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
     // is smooth; mode 2 (init) is fresh throughout; mode 1 (event) re-solves with
     // fresh relations until the discrete state stabilizes (mixed-system iteration).
@@ -3470,10 +3485,12 @@ pub extern "C" fn rt_solve_nls(
                 // `discrete_call` (which is only about holding relations).
                 let t =
                     HomotopyTrace { eq_index, time, discrete: saved_rel_fresh != 0, initial: saved_rel_fresh == 2 };
+                // C wraps `newtonAlgorithm`'s reporting in `OMC_ACTIVE_STREAM(LOG_NLS_V)`.
+                let trace = crate::omclog::active(crate::omclog::NLS_V).then_some(&t);
                 if homotopy_solver {
                     (converged, settled) = newton_c(
                         n, &mut x, &nominal, &bounds, &mut res_scaling, &mut nlsx, &mut eval, &mut jaceval,
-                        has_jac, Some(&t),
+                        has_jac, trace,
                     );
                     if !converged {
                         stat_inc(STAT_NLS_NEWTON_FAIL);
@@ -3732,6 +3749,8 @@ pub extern "C" fn rt_solve_nls(
     NLS_ASSERT_SEEN.store(saved_assert_seen, Ordering::Relaxed);
     NLS_THROW_SEEN.store(saved_throw_seen, Ordering::Relaxed);
 
+    let now = sys_counts();
+    crate::sysstats::end([now[0] - sys0[0], now[1] - sys0[1], now[2] - sys0[2]]);
     rt_free(x_ptr);
     rt_free(r_ptr);
     if has_jac {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -46,7 +46,7 @@ fn init_done_hook() {
     unsafe { rt_host_init_done() };
 }
 
-fn now_ms_hook() -> f64 {
+pub(crate) fn now_ms_hook() -> f64 {
     unsafe { rt_host_now_ms() }
 }
 fn cancel_hook() -> bool {
@@ -95,7 +95,7 @@ impl SimEngine for InWasmEngine {
         dst.copy_from_slice(buf);
         Ok(())
     }
-    fn call1(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+    fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         let slot = slot_of(name).ok_or("in-wasm engine: unknown model function")?;
         if !self.present(slot) {
             return Err("in-wasm engine: required model function not exported");
@@ -105,17 +105,17 @@ impl SimEngine for InWasmEngine {
         f(arg);
         Ok(())
     }
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         let slot = match slot_of(name) {
             Some(s) => s,
             None => return Ok(()),
         };
         if self.present(slot) {
-            self.call1(name, arg)?;
+            self.call1_raw(name, arg)?;
         }
         Ok(())
     }
-    fn call2(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
         let slot = slot_of(name).ok_or("in-wasm engine: unknown model function")?;
         if !self.present(slot) {
             return Err("in-wasm engine: required model function not exported");
@@ -316,6 +316,18 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     });
 
     driver::set_clock(now_ms_hook);
+    // This session runs its own start/advance/finish instead of `drive`, so the
+    // run's clocks start (and, in `finish`, stop) here.
+    use openmodelica_sim_meta::rtclock;
+    rtclock::reset(
+        openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS)
+            || openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS_V),
+    );
+    rtclock::tick(rtclock::TOTAL);
+    rtclock::tick(rtclock::PREINIT);
+    crate::sysstats::enable(openmodelica_sim_meta::omclog::active(
+        openmodelica_sim_meta::omclog::STATS_V,
+    ));
     driver::set_cancel_hook(cancel_hook);
     driver::set_init_done_hook(init_done_hook);
     driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
@@ -402,6 +414,9 @@ fn finish(s: &mut Session) {
         s.lin.extend_from_slice(f.content.as_bytes());
     }
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
+    use openmodelica_sim_meta::rtclock;
+    rtclock::accumulate(rtclock::TOTAL);
+    (s.stats.timers, s.stats.tcalls) = rtclock::snapshot();
     s.finished = true;
 }
 
@@ -461,6 +476,14 @@ pub extern "C" fn rt_sim_stat(which: u32) -> u64 {
         5 => s.stats.state_events,
         6 => s.stats.time_events,
         7 => crate::lin_solves(),
-        _ => 0,
+        // The `LOG_STATS` timers: seconds as `f64` bits, then the call counts.
+        n => {
+            use openmodelica_sim_meta::rtclock::{N, STAT_SLOT_BASE};
+            match (n - STAT_SLOT_BASE) as usize {
+                i if i < N => s.stats.timers[i].to_bits(),
+                i if i < 2 * N => s.stats.tcalls[i - N],
+                _ => 0,
+            }
+        }
     })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -98,7 +98,7 @@ impl SimEngine for StandaloneEngine {
         dst.copy_from_slice(buf);
         Ok(())
     }
-    fn call1(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+    fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         unsafe {
             match name {
                 "functionParameters" => functionParameters(arg),
@@ -133,15 +133,15 @@ impl SimEngine for StandaloneEngine {
         }
         Ok(())
     }
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         // Every entry point is always exported (empty stub if unused), so a plain
         // call is a no-op when the feature is absent.
-        self.call1(name, arg)
+        self.call1_raw(name, arg)
     }
     // Importing `evaluateDAEResiduals` (or the two synchronous dispatchers) would
     // leave every model without that feature with an unresolved `model.*` import,
     // so the standalone export supports neither.
-    fn call2(&mut self, name: &str, _a: u32, _b: u32) -> driver::Result<()> {
+    fn call2_raw(&mut self, name: &str, _a: u32, _b: u32) -> driver::Result<()> {
         Err(match name {
             driver::MODEL_FN_DAE => {
                 "wasm-jit standalone: --daeMode models are not supported by the standalone export"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sysstats.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sysstats.rs
@@ -1,0 +1,155 @@
+//! C's per-system solver statistics: `LINEAR_SYSTEM_DATA` / `NONLINEAR_SYSTEM_DATA`'s
+//! `numberOfCall`, `totalTime`, `jacobianTime` (and the nonlinear iteration /
+//! evaluation counts), which `LOG_STATS_V` renders as its "linear systems" and
+//! "non-linear systems" sections.
+//!
+//! The systems are solved in-wasm whichever driver owns the run, so this is where
+//! they are measured; the host reads the table back through
+//! [`rt_sys_stats_ptr`]/[`rt_sys_stats_len`] and formats it. Off unless the host
+//! turned it on (`rt_stats_start`) — every bracket costs two clock reads, which on
+//! a host-driven run are calls out of wasm.
+
+use alloc::vec::Vec;
+use openmodelica_sim_meta::sysstat::{SysStat, WORDS};
+
+use core::cell::UnsafeCell;
+
+/// A system entered and not yet left. C counts the iterations and evaluations of a
+/// *nested* system (a medium inversion inside a flow residual) against that system
+/// alone, so a frame remembers what its children took and the parent subtracts it.
+/// The clocks are wall time and do nest, as C's do.
+struct Open {
+    slot: usize,
+    start: f64,
+    jac: f64,
+    child: [u64; 3],
+}
+
+struct Table {
+    on: bool,
+    sys: Vec<SysStat>,
+    open: Vec<Open>,
+    /// Flattened [`SysStat::to_words`], kept alive for the host to read out of
+    /// linear memory.
+    words: Vec<f64>,
+}
+
+struct Store(UnsafeCell<Table>);
+unsafe impl Sync for Store {}
+static TABLE: Store =
+    Store(UnsafeCell::new(Table { on: false, sys: Vec::new(), open: Vec::new(), words: Vec::new() }));
+
+#[inline]
+fn table() -> &'static mut Table {
+    unsafe { &mut *TABLE.0.get() }
+}
+
+#[inline]
+fn now_ms() -> f64 {
+    openmodelica_sim_meta::driver::now_ms_host()
+}
+
+/// Start measuring (or stop, and forget what the last run recorded).
+pub fn enable(on: bool) {
+    let t = table();
+    t.on = on;
+    t.sys.clear();
+    t.open.clear();
+    t.words.clear();
+}
+
+#[inline]
+pub fn enabled() -> bool {
+    table().on
+}
+
+fn slot(eq_index: i32, nonlinear: bool, size: u32, nnz: u32) -> usize {
+    let t = table();
+    if let Some(i) = t.sys.iter().position(|s| s.eq_index == eq_index && s.nonlinear == nonlinear) {
+        return i;
+    }
+    t.sys.push(SysStat { eq_index, nonlinear, size, nnz, ..SysStat::default() });
+    t.sys.len() - 1
+}
+
+/// Enter a system — C's `rt_ext_tp_tick(&linsys->totalTimeClock)` at the top of
+/// `solve_linear_system` / `solve_nonlinear_system`.
+pub fn begin(eq_index: i32, nonlinear: bool, size: u32, nnz: u32) {
+    if !enabled() {
+        return;
+    }
+    let i = slot(eq_index, nonlinear, size, nnz);
+    table().open.push(Open { slot: i, start: now_ms(), jac: 0.0, child: [0; 3] });
+}
+
+/// A linear system's `A` and `b` are assembled by the generated code ahead of the
+/// solve, so the solve entry points are where C's `jacobianTime` ends. First mark
+/// wins: a rejected step re-enters the solver within the same call.
+pub fn mark_assembly_done() {
+    if !enabled() {
+        return;
+    }
+    let t = table();
+    let Some(f) = t.open.last_mut() else { return };
+    if f.jac == 0.0 && !t.sys[f.slot].nonlinear {
+        f.jac = now_ms() - f.start;
+    }
+}
+
+/// Add a nonlinear system's Jacobian time — C's `nlsData->jacobianTimeClock`, which
+/// brackets each assembly rather than ending at the solve.
+pub fn add_jacobian_time(ms: f64) {
+    if !enabled() {
+        return;
+    }
+    if let Some(f) = table().open.last_mut() {
+        f.jac += ms;
+    }
+}
+
+/// Leave the innermost system, charging it the elapsed time and one call. The
+/// counts are C's `numberOfIterations` / `numberOfFEval` / `numberOfJEval` as run
+/// totals since [`begin`]; what a nested system took is moved to it.
+pub fn end(counts: [u64; 3]) {
+    if !enabled() {
+        return;
+    }
+    let t = table();
+    let Some(f) = t.open.pop() else { return };
+    let s = &mut t.sys[f.slot];
+    s.calls += 1;
+    s.total += (now_ms() - f.start) / 1000.0;
+    s.jac += f.jac / 1000.0;
+    s.iters += counts[0] - f.child[0];
+    s.res_evals += counts[1] - f.child[1];
+    s.jac_evals += counts[2] - f.child[2];
+    if let Some(p) = t.open.last_mut() {
+        for k in 0..3 {
+            p.child[k] += counts[k];
+        }
+    }
+}
+
+/// A clock read while measuring, for a bracket that times a sub-region itself.
+#[inline]
+pub fn tick() -> f64 {
+    if enabled() { now_ms() } else { 0.0 }
+}
+
+/// Flatten the table for the host and return its address; valid until the next
+/// call. Paired with [`rt_sys_stats_len`].
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sys_stats_ptr() -> u32 {
+    let t = table();
+    t.words.clear();
+    for s in &t.sys {
+        t.words.extend_from_slice(&s.to_words());
+    }
+    t.words.as_ptr() as u32
+}
+
+/// Number of `f64` words [`rt_sys_stats_ptr`] published (`WORDS` per system).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sys_stats_len() -> u32 {
+    (table().sys.len() * WORDS) as u32
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -266,7 +266,7 @@ impl SimEngine for Engine {
         dst.copy_from_slice(buf);
         Ok(())
     }
-    fn call1(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+    fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         unsafe {
             match name {
                 "functionParameters" => functionParameters(arg),
@@ -298,7 +298,7 @@ impl SimEngine for Engine {
         }
         Ok(())
     }
-    fn call2(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
         unsafe {
             match name {
                 driver::MODEL_FN_UPDATE_SYNC => functionUpdateSynchronous(a, b),
@@ -311,8 +311,8 @@ impl SimEngine for Engine {
         Ok(())
     }
     /// A name this adapter does not import is a function the model does not have.
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> driver::Result<()> {
-        match self.call1(name, arg) {
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
+        match self.call1_raw(name, arg) {
             Err(UNKNOWN_MODEL_FN) => Ok(()),
             r => r,
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -17,6 +17,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 
 use crate::omclog;
+use crate::rtclock;
 use crate::simflags::JacobianMethod;
 use crate::sync::SYNC_EPS;
 use crate::{
@@ -326,6 +327,22 @@ pub const MODEL_FNS: &[&str] = &[
     "functionJacA_column",
 ];
 
+/// The clock a model entry point runs under, where `CodegenC.tpl` ticks one inside
+/// the generated function of the same name. `None` leaves the call unmeasured, as
+/// every entry point is once the clocks are off.
+fn model_fn_clock(name: &str) -> Option<usize> {
+    if !rtclock::enabled() {
+        return None;
+    }
+    match name {
+        "functionODE" => Some(rtclock::FUNCTION_ODE),
+        "functionAlgebraics" => Some(rtclock::ALGEBRAICS),
+        "functionZeroCrossings" => Some(rtclock::ZC),
+        "functionZeroCrossingsEquations" => Some(rtclock::ZC_EQUATIONS),
+        _ => None,
+    }
+}
+
 /// The model entry points that are not `fn(SimData*)`: `--daeMode`'s residual
 /// takes the evaluation stage as a second argument (C's `currentEvalStage`), and
 /// the two synchronous dispatchers take a clock index.
@@ -353,13 +370,38 @@ pub trait SimEngine {
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()>;
     /// Call the exported `fn(u32) -> ()` `name` (an equation function). Backends
     /// cache the resolved function; a missing export is an error.
-    fn call1(&mut self, name: &str, arg: u32) -> Result<()>;
-    /// Like [`call1`] but a no-op if `name` is not exported (optional teardown
-    /// hooks such as `callExternalObjectDestructors`).
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()>;
+    fn call1_raw(&mut self, name: &str, arg: u32) -> Result<()>;
+    /// Like [`SimEngine::call1_raw`] but a no-op if `name` is not exported (optional
+    /// teardown hooks such as `callExternalObjectDestructors`).
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> Result<()>;
     /// Call the exported `fn(u32, u32) -> ()` `name` — only [`MODEL_FN_DAE`],
     /// whose second argument is the evaluation stage.
-    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()>;
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> Result<()>;
+    /// [`SimEngine::call1_raw`] under the clock C's generated entry point ticks
+    /// around its own body ([`model_fn_clock`]); every driver goes through here.
+    fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
+        let Some(ix) = model_fn_clock(name) else { return self.call1_raw(name, arg) };
+        rtclock::tick(ix);
+        let out = self.call1_raw(name, arg);
+        rtclock::accumulate(ix);
+        out
+    }
+    fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()> {
+        let Some(ix) = model_fn_clock(name) else { return self.call1_if_present_raw(name, arg) };
+        rtclock::tick(ix);
+        let out = self.call1_if_present_raw(name, arg);
+        rtclock::accumulate(ix);
+        out
+    }
+    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
+        if name != MODEL_FN_DAE {
+            return self.call2_raw(name, a, b);
+        }
+        rtclock::tick(rtclock::DAE);
+        let out = self.call2_raw(name, a, b);
+        rtclock::accumulate(rtclock::DAE);
+        out
+    }
     /// Call the exported `simulate(sim_data, start, stop, n_steps) -> buf`, the
     /// in-wasm Euler driver; returns the result-buffer pointer.
     fn call_simulate(&mut self, sim_data: u32, start: f64, stop: f64, n_steps: u32) -> Result<u32>;
@@ -387,6 +429,11 @@ pub trait SimEngine {
     /// The runtime's `rt_stat` counters, in slot order. Default: none.
     fn rt_stats(&mut self) -> [u64; RT_STATS] {
         [0; RT_STATS]
+    }
+    /// The per-system solver statistics the runtime recorded for `LOG_STATS_V`
+    /// (`rt_sys_stats_ptr`). Default: none — a backend with no runtime to ask.
+    fn sys_stats(&mut self) -> Vec<crate::sysstat::SysStat> {
+        Vec::new()
     }
     /// Address of the runtime's evaluation context, or 0 when the backend has no
     /// such export.
@@ -1826,6 +1873,7 @@ fn init_model(
             omclog::warning(omclog::STDOUT, false, w);
         }
     }
+    rtclock::enter_init();
     // `functionInitDelay` reads `startTime` from `TIME_OFF`; init the buffers
     // before any equation function (`rt_delay_eval` traps on unallocated ones).
     write_time(e, sim_data, start_time)?;
@@ -1866,6 +1914,7 @@ fn init_model(
     // C's `initializeModel` ends with `checkForAsserts` — before the
     // initialization-success line.
     check_asserts(e, sim_data, layout, omclog::WARNING)?;
+    rtclock::accumulate(rtclock::INIT);
     Ok(())
 }
 
@@ -2395,6 +2444,14 @@ impl HomotopyPath {
 /// assigns. Used by the host-driven drivers; the in-wasm `simulate` emits the
 /// same layout.
 pub(crate) fn capture_row(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    // C's `emit` — the result writer's share of the run (`SIM_TIMER_OUTPUT`).
+    rtclock::tick(rtclock::OUTPUT);
+    let out = capture_row_values(e, rows, sim_data, layout);
+    rtclock::accumulate(rtclock::OUTPUT);
+    out
+}
+
+fn capture_row_values(e: &dyn SimEngine, rows: &mut Vec<f64>, sim_data: u32, layout: &SimLayout) -> Result<()> {
     for i in 0..layout.n_reals_row() {
         rows.push(read_f64(e, sim_data + i * 8)?);
     }
@@ -3195,6 +3252,7 @@ fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 /// consistent set and chatter on the integrator instead. Assumes the event time is
 /// already written.
 pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    rtclock::tick(rtclock::DISCRETE); // C's `callStatistics.updateDiscreteSystem`
     // Each pass freezes `relationsPre = relations` so the NLS in `functionODE` holds
     // this pass's relations, then re-evaluates the continuous system; the discrete
     // state settles across passes. Comparing the snapshot before and after the
@@ -3774,6 +3832,12 @@ pub fn drive(
     let start = model.start_time;
     let stop = model.stop_time;
 
+    // C's `measure_time_flag`: the clocks run only when the block that renders
+    // them will be printed.
+    rtclock::reset(omclog::active(omclog::STATS) || omclog::active(omclog::STATS_V));
+    rtclock::tick(rtclock::TOTAL);
+    rtclock::tick(rtclock::PREINIT);
+
     let mut stats = SolveStats::default();
     let use_events = layout.n_samples > 0 || layout.n_zc > 0 || !model.clocks.is_empty();
     let method = resolve_sim_solver_method(method, layout)?;
@@ -3893,6 +3957,9 @@ pub fn drive(
 
     let lin = crate::linearize::linearize(e, model, sim_data)?;
     let params = finalize_run(e, model, sim_data)?;
+    rtclock::accumulate(rtclock::TOTAL);
+    (stats.timers, stats.tcalls) = rtclock::snapshot();
+    stats.systems = e.sys_stats();
     Ok((RunResult { rows, n_reals, params, stats, lin }, label))
 }
 
@@ -4227,6 +4294,7 @@ unsafe fn dassl_rt(
     }
     let ctx = unsafe { &mut *ctx };
     let e = unsafe { &mut *ctx.engine };
+    let _clock = rtclock::Handover::new(rtclock::SOLVER, rtclock::EVENT);
     let run = (|| -> Result<()> {
         // A root probe may sit at an awkward candidate state where a nonlinear
         // system can't converge; keep that transient failure from leaking into the
@@ -4287,6 +4355,7 @@ unsafe fn dassl_res(
     let ctx = unsafe { &mut *ctx };
     let e = unsafe { &mut *ctx.engine };
     let n = ctx.n_states;
+    let _clock = rtclock::Handover::new(rtclock::SOLVER, rtclock::RESIDUALS);
     let save = set_error_stage(e, ctx.err_stage_addr, ERROR_INTEGRATOR);
     let run = (|| -> Result<()> {
         write_i32(e, ctx.sim_data + ctx.nls_fail_off, 0)?; // clear before the solve
@@ -4513,6 +4582,7 @@ unsafe fn dassl_jac(
     let cj = unsafe { *cj };
     let h = unsafe { *h };
     ctx.jac_ders.resize(n * 8, 0);
+    let _clock = rtclock::Handover::new(rtclock::SOLVER, rtclock::JACOBIAN);
     // One assembly, however many colours it takes, as C's DASSL counts it.
     ctx.nje += 1;
     // C holds `ERROR_INTEGRATOR` over the whole DDASKR call, and there is no `IRES`
@@ -5377,6 +5447,7 @@ impl DaskrState {
         if logging {
             log_dassl_step(*t);
         }
+        rtclock::tick(rtclock::SOLVER);
         unsafe {
             solver::ddaskr(
                 dassl_res, neq, t, y.as_mut_ptr(), yp.as_mut_ptr(), &mut tt,
@@ -5387,6 +5458,7 @@ impl DaskrState {
                 self.jroot.as_mut_ptr(),
             );
         }
+        rtclock::accumulate(rtclock::SOLVER);
         if logging && self.idid != -1 {
             log_dassl_stats(self.idid, *t, &self.rwork, &self.iwork);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
@@ -740,7 +740,7 @@ mod tests {
             self.mem[a..a + buf.len()].copy_from_slice(buf);
             Ok(())
         }
-        fn call1(&mut self, name: &str, _arg: u32) -> Result<()> {
+        fn call1_raw(&mut self, name: &str, _arg: u32) -> Result<()> {
             match name {
                 "functionODE" => {
                     let v = self.f64_at(STATES + 8);
@@ -756,10 +756,10 @@ mod tests {
             }
             Ok(())
         }
-        fn call1_if_present(&mut self, _name: &str, _arg: u32) -> Result<()> {
+        fn call1_if_present_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
             Ok(())
         }
-        fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
+        fn call2_raw(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
             Err("unused")
         }
         fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -34,8 +34,10 @@ pub mod omclog;
 pub(crate) mod extinput;
 pub mod optimization;
 pub(crate) mod qss;
+pub mod rtclock;
 pub mod simflags;
 pub mod sync;
+pub mod sysstat;
 #[cfg(sundials)]
 pub mod sundials;
 
@@ -868,6 +870,13 @@ pub struct SolveStats {
     pub state_events: u64,
     pub time_events: u64,
     pub lin_solves: u64,
+    /// [`rtclock`] at the end of the run: seconds per clock, and how often each was
+    /// opened. Travels with the stats so an in-wasm run's timers reach the host.
+    pub timers: [f64; rtclock::N],
+    pub tcalls: [u64; rtclock::N],
+    /// Per linear/nonlinear system, for `LOG_STATS_V`. Read out of the wasm runtime
+    /// (which solves them) by the host after the run; empty unless it was on.
+    pub systems: alloc::vec::Vec<sysstat::SysStat>,
 }
 
 /// One FMI value reference and the `SimData` slot it names. The value references

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -585,14 +585,19 @@ pub fn debug_string(stream: Stream, msg: &str) {
     info(stream, false, msg);
 }
 
-/// C's `debugInt`: `"%s %d"`.
+/// C's `debugInt`: `"%s %d"`. Built only when the stream is on, as C's variadic
+/// `infoStreamPrint` is — the nonlinear solver calls these per iteration.
 pub fn debug_int(stream: Stream, msg: &str, v: i32) {
-    info(stream, false, &format!("{msg} {v}"));
+    if active(stream) {
+        info(stream, false, &format!("{msg} {v}"));
+    }
 }
 
-/// C's `debugDouble`: `"%s %18.10e"`.
+/// C's `debugDouble`: `"%s %18.10e"`; guarded as [`debug_int`] is.
 pub fn debug_double(stream: Stream, msg: &str, v: f64) {
-    info(stream, false, &format!("{msg} {}", e(v, 18, 10)));
+    if active(stream) {
+        info(stream, false, &format!("{msg} {}", e(v, 18, 10)));
+    }
 }
 
 /// C's `debugVectorDouble`: a `name [n-dim]` block holding one line of

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
@@ -1,0 +1,156 @@
+//! C's `rtclock.c` simulation timers — the accumulators `LOG_STATS` renders.
+//!
+//! Clock indices and tick placement follow the C runtime one for one, so a
+//! `-lv=LOG_STATS` block from either target splits the run the same way. As in C
+//! the timers only run when the block will be printed (`measure_time_flag`, which
+//! `LOG_STATS`/`-cpu` raise); [`enabled`] gates every tick site.
+//!
+//! `STEP` and `OVERHEAD` have no tick site in the C runtime either — they are
+//! printed, and stay zero.
+
+use crate::driver::now_ms_host;
+
+pub const TOTAL: usize = 0;
+pub const INIT: usize = 1;
+pub const STEP: usize = 2;
+pub const OUTPUT: usize = 3;
+pub const EVENT: usize = 4;
+pub const JACOBIAN: usize = 5;
+pub const PREINIT: usize = 6;
+pub const OVERHEAD: usize = 7;
+pub const FUNCTION_ODE: usize = 8;
+pub const RESIDUALS: usize = 9;
+pub const ALGEBRAICS: usize = 10;
+pub const ZC: usize = 11;
+pub const SOLVER: usize = 12;
+pub const INIT_XML: usize = 13;
+pub const INFO_XML: usize = 14;
+pub const DAE: usize = 15;
+/// C keeps these two as `callStatistics` counters rather than clocks; they have no
+/// time, only a call count, and `LOG_STATS_V` prints them beside the clocked ones.
+pub const ZC_EQUATIONS: usize = 16;
+pub const DISCRETE: usize = 17;
+pub const N: usize = 18;
+
+/// One run's clocks: seconds accumulated, the open tick, and the call count
+/// [`accumulate`] closed.
+#[derive(Clone, Copy)]
+struct Clocks {
+    on: bool,
+    tick: [f64; N],
+    acc: [f64; N],
+    ncall: [u64; N],
+}
+
+const EMPTY: Clocks = Clocks { on: false, tick: [0.0; N], acc: [0.0; N], ncall: [0; N] };
+
+// The driver is single-threaded per run (as is the in-wasm session), so a plain
+// cell is enough and keeps `tick` off the atomics.
+struct Store(core::cell::UnsafeCell<Clocks>);
+unsafe impl Sync for Store {}
+static CLOCKS: Store = Store(core::cell::UnsafeCell::new(EMPTY));
+
+#[inline]
+fn clocks() -> &'static mut Clocks {
+    unsafe { &mut *CLOCKS.0.get() }
+}
+
+/// Start a run's measurement (C's `measure_time_flag` block in
+/// `startNonInteractiveSimulation`), or leave every timer off and zero.
+pub fn reset(on: bool) {
+    *clocks() = Clocks { on, ..EMPTY };
+}
+
+#[inline]
+pub fn enabled() -> bool {
+    clocks().on
+}
+
+/// C's `rt_tick`: open the clock and count the call.
+#[inline]
+pub fn tick(ix: usize) {
+    let c = clocks();
+    if c.on {
+        c.tick[ix] = now_ms_host();
+        c.ncall[ix] += 1;
+    }
+}
+
+/// C's `rt_accumulate`: close the clock opened by [`tick`].
+#[inline]
+pub fn accumulate(ix: usize) {
+    let c = clocks();
+    if c.on {
+        c.acc[ix] += now_ms_host() - c.tick[ix];
+    }
+}
+
+/// C's `rt_ncall`.
+fn ncall(ix: usize) -> u64 {
+    clocks().ncall[ix]
+}
+
+/// C's `solver_main` head: pre-initialization ends where initialization begins.
+/// Idempotent, so a second initialization pass (a homotopy retry, an FMI reset)
+/// does not charge the gap before the first one all over again.
+pub fn enter_init() {
+    if ncall(INIT) == 0 {
+        accumulate(PREINIT);
+    }
+    tick(INIT);
+}
+
+/// Every clock as `(seconds, calls)`, for the snapshot that travels with
+/// [`crate::SolveStats`] out of an in-wasm run.
+pub fn snapshot() -> ([f64; N], [u64; N]) {
+    let c = clocks();
+    let mut secs = [0.0f64; N];
+    for (s, a) in secs.iter_mut().zip(c.acc.iter()) {
+        *s = a / 1000.0;
+    }
+    (secs, c.ncall)
+}
+
+/// `rt_sim_stat` slot holding clock `ix`'s seconds (as `f64::to_bits`), and the one
+/// holding its call count. The in-wasm session has no other way out; the solver
+/// counters occupy the slots below [`STAT_SLOT_BASE`].
+pub const STAT_SLOT_BASE: u32 = 8;
+const fn stat_slot_secs(ix: usize) -> u32 {
+    STAT_SLOT_BASE + ix as u32
+}
+const fn stat_slot_calls(ix: usize) -> u32 {
+    STAT_SLOT_BASE + N as u32 + ix as u32
+}
+
+/// Read a snapshot back out of an in-wasm session's `rt_sim_stat` — the host side
+/// of [`stat_slot_secs`].
+pub fn read_stat_slots<E>(
+    stats: &mut crate::SolveStats,
+    mut stat: impl FnMut(u32) -> Result<u64, E>,
+) -> Result<(), E> {
+    for ix in 0..N {
+        stats.timers[ix] = f64::from_bits(stat(stat_slot_secs(ix))?);
+        stats.tcalls[ix] = stat(stat_slot_calls(ix))?;
+    }
+    Ok(())
+}
+
+/// Move a region's time from `from` to `to` for the duration of a callback the
+/// enclosing clock must not be charged for — C's `rt_accumulate(SOLVER)` +
+/// `rt_tick(EVENT)` pairs around the DASKR callbacks.
+pub struct Handover(usize, usize);
+
+impl Handover {
+    pub fn new(from: usize, to: usize) -> Self {
+        accumulate(from);
+        tick(to);
+        Handover(from, to)
+    }
+}
+
+impl Drop for Handover {
+    fn drop(&mut self) {
+        accumulate(self.1);
+        tick(self.0);
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sysstat.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/sysstat.rs
@@ -1,0 +1,64 @@
+//! One linear or nonlinear system's solver statistics, as C keeps them in
+//! `LINEAR_SYSTEM_DATA` / `NONLINEAR_SYSTEM_DATA` and prints them under
+//! `LOG_STATS_V`.
+//!
+//! The systems are solved inside the wasm runtime, so the table is built there and
+//! handed to the host as a flat `f64` array. The word order lives here, with the
+//! struct, so the two sides cannot disagree about it.
+
+/// `f64` words one system occupies in that array.
+pub const WORDS: usize = 10;
+
+#[derive(Clone, Copy, Default, PartialEq, Debug)]
+pub struct SysStat {
+    /// The system's equation index, which is how C names it in the log.
+    pub eq_index: i32,
+    pub nonlinear: bool,
+    pub size: u32,
+    pub nnz: u32,
+    pub calls: u64,
+    /// Nonlinear only: C's `numberOfIterations` / `numberOfFEval` / `numberOfJEval`.
+    pub iters: u64,
+    pub res_evals: u64,
+    pub jac_evals: u64,
+    /// Seconds in the system, and the share of that spent assembling its Jacobian.
+    pub total: f64,
+    pub jac: f64,
+}
+
+impl SysStat {
+    pub fn to_words(&self) -> [f64; WORDS] {
+        [
+            self.eq_index as f64,
+            self.nonlinear as u32 as f64,
+            self.size as f64,
+            self.nnz as f64,
+            self.calls as f64,
+            self.iters as f64,
+            self.res_evals as f64,
+            self.jac_evals as f64,
+            self.total,
+            self.jac,
+        ]
+    }
+
+    pub fn from_words(w: &[f64]) -> Self {
+        SysStat {
+            eq_index: w[0] as i32,
+            nonlinear: w[1] != 0.0,
+            size: w[2] as u32,
+            nnz: w[3] as u32,
+            calls: w[4] as u64,
+            iters: w[5] as u64,
+            res_evals: w[6] as u64,
+            jac_evals: w[7] as u64,
+            total: w[8],
+            jac: w[9],
+        }
+    }
+}
+
+/// Decode a whole published table.
+pub fn decode(words: &[f64]) -> alloc::vec::Vec<SysStat> {
+    words.chunks_exact(WORDS).map(SysStat::from_words).collect()
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/fs.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/fs.rs
@@ -171,9 +171,24 @@ pub fn create_dir_all(path: &str) -> io::Result<()> {
 
 pub fn rename(from: &str, to: &str) -> io::Result<()> {
     if IN_MEMORY {
-        let bytes = crate::read(from).ok_or_else(|| not_found(from))?;
-        crate::write(to, bytes);
-        crate::remove(from);
+        if let Some(bytes) = crate::read(from) {
+            crate::write(to, bytes);
+            crate::remove(from);
+            return Ok(());
+        }
+        // A directory: every key beneath it moves.
+        let prefix = format!("{}/", from.trim_end_matches('/'));
+        let moved: Vec<(String, Vec<u8>)> = crate::list()
+            .into_iter()
+            .filter_map(|k| k.strip_prefix(&prefix).map(|r| (r.to_string(), crate::read(&k).unwrap_or_default())))
+            .collect();
+        if moved.is_empty() {
+            return Err(not_found(from));
+        }
+        for (rest, bytes) in moved {
+            crate::remove(&format!("{prefix}{rest}"));
+            crate::write(&format!("{}/{rest}", to.trim_end_matches('/')), bytes);
+        }
         Ok(())
     } else {
         std::fs::rename(from, to)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
@@ -1,5 +1,6 @@
-//! A minimal `wasi_snapshot_preview1` implementation backed by this crate's
-//! in-memory store, so the backing store is swappable behind a standard surface.
+//! A minimal `wasi_snapshot_preview1` implementation over this crate's [`fs`]
+//! facade, so a guest sees the same files omc does: real ones natively, the
+//! in-memory store on the web.
 //!
 //! The ABI methods take a [`GuestMem`] (the guest's linear memory) and follow the
 //! preview1 pointer/struct layout — for a guest wasm module driven by an engine.
@@ -91,6 +92,9 @@ pub const OFLAGS_TRUNC: i32 = 1 << 3;
 // read-open in `path_open`.
 pub const RIGHTS_FD_WRITE: u64 = 1 << 6;
 
+// fdflags (`__wasi_fdflags_t`): `fopen(…, "a")`'s O_APPEND.
+pub const FDFLAGS_APPEND: i32 = 1 << 0;
+
 // `fd_seek` whence.
 pub const WHENCE_SET: i32 = 0;
 pub const WHENCE_CUR: i32 = 1;
@@ -111,23 +115,26 @@ enum Fd {
     PreopenDir { name: String },
     /// A directory opened by name, enumerated by `fd_readdir` against `vfs_path`.
     Dir { vfs_path: String },
-    /// A regular file. Writable files buffer in `buf` and flush to the VFS on
-    /// close; read files are loaded from the VFS at `path_open`.
+    /// A regular file, held whole in `buf` and written back as it grows.
     File {
         vfs_path: String,
         buf: Vec<u8>,
         pos: usize,
         writable: bool,
         dirty: bool,
+        /// Every write goes to the end, whatever `pos` says (`O_APPEND`).
+        append: bool,
+        /// How much of `buf` is out already, so a sequential writer appends.
+        flushed: usize,
     },
 }
 
 /// Per-run WASI state: the fd table, the directory relative paths resolve
 /// against, the program arguments, and the exit code captured from `proc_exit`.
 pub struct WasiCtx {
-    /// Directory that `path_open` resolves relative names against — the VFS key
-    /// prefix. Empty means relative names map to bare VFS keys (matching how
-    /// omc's `File` runtime keys files today, with no cwd on wasm).
+    /// Directory that `path_open` resolves relative names against. Empty leaves
+    /// them as they are (matching how omc's `File` runtime keys files today, with
+    /// no cwd on wasm).
     cwd: String,
     next_fd: u32,
     fds: HashMap<u32, Fd>,
@@ -170,8 +177,9 @@ impl GuestMem for SliceMem<'_> {
 }
 
 impl WasiCtx {
-    /// A context whose preopen `"."` maps to `cwd` in the VFS (use `""` for bare
-    /// keys) and whose `argv` is `args` (typically just the program name).
+    /// A context whose preopen anchors the guest's paths at `cwd` (`""` for bare
+    /// keys) and whose `argv` is `args`. wasi-libc strips the preopen name `"."` to
+    /// the empty prefix, so what reaches the ABI has lost its leading `/`.
     pub fn new(cwd: impl Into<String>, args: Vec<String>) -> Self {
         let mut fds = HashMap::new();
         fds.insert(1, Fd::Stdout);
@@ -180,13 +188,27 @@ impl WasiCtx {
         WasiCtx { cwd: cwd.into(), next_fd: PREOPEN_FD + 1, fds, args, exit_code: None }
     }
 
-    /// Map a guest-supplied relative path onto its VFS key.
+    /// The file a guest-supplied path names; a relative one is taken against the
+    /// preopen.
     fn resolve(&self, name: &str) -> String {
         let name = name.strip_prefix("./").unwrap_or(name);
-        if self.cwd.is_empty() {
+        if self.cwd.is_empty() || name.starts_with('/') {
             name.to_string()
         } else {
-            format!("{}/{}", self.cwd, name)
+            format!("{}/{name}", self.cwd.trim_end_matches('/'))
+        }
+    }
+
+    /// Write what a writable fd gained since the last flush: nothing tears a side
+    /// module down, so a stream that is never closed must still reach the file.
+    fn flush_file(vfs_path: &str, buf: &[u8], flushed: &mut usize) {
+        let ok = if *flushed == 0 || *flushed > buf.len() {
+            crate::fs::write(vfs_path, buf).is_ok()
+        } else {
+            crate::fs::append(vfs_path, &buf[*flushed..]).is_ok()
+        };
+        if ok {
+            *flushed = buf.len();
         }
     }
 
@@ -226,14 +248,22 @@ impl WasiCtx {
         match self.fds.get_mut(&fd) {
             Some(Fd::Stdout) => write_std(&gathered, false),
             Some(Fd::Stderr) => write_std(&gathered, true),
-            Some(Fd::File { buf, pos, writable: true, dirty, .. }) => {
+            Some(Fd::File { vfs_path, buf, pos, writable: true, dirty, append, flushed }) => {
+                if *append {
+                    *pos = buf.len();
+                }
                 let end = *pos + gathered.len();
                 if buf.len() < end {
                     buf.resize(end, 0);
                 }
                 buf[*pos..end].copy_from_slice(&gathered);
+                // Overwriting what is already out there: the file has to go again whole.
+                if *pos < *flushed {
+                    *flushed = 0;
+                }
                 *pos = end;
                 *dirty = true;
+                Self::flush_file(vfs_path, buf, flushed);
             }
             Some(_) => return ERRNO_BADF,
             None => return ERRNO_BADF,
@@ -304,9 +334,9 @@ impl WasiCtx {
     }
 
     /// `path_open`: open `path` (relative to a preopen dir fd) and return a fresh
-    /// fd. A write-open (rights include `fd_write`, or `O_CREAT`/`O_TRUNC`)
-    /// starts an empty buffer that flushes to the VFS on close; a read-open loads
-    /// the file from the VFS (ENOENT if absent).
+    /// fd. A write-open (rights include `fd_write`, or `O_CREAT`/`O_TRUNC`) starts
+    /// from what is there unless `O_TRUNC`, as `fopen(…, "a")` expects; a read-open
+    /// loads the file (ENOENT if absent).
     #[allow(clippy::too_many_arguments)]
     pub fn path_open<M: GuestMem>(
         &mut self,
@@ -318,7 +348,7 @@ impl WasiCtx {
         oflags: i32,
         fs_rights_base: u64,
         _fs_rights_inheriting: u64,
-        _fdflags: i32,
+        fdflags: i32,
         opened_fd: u32,
     ) -> i32 {
         let Some(bytes) = Self::rd_bytes(mem, path, path_len) else { return ERRNO_FAULT };
@@ -336,11 +366,25 @@ impl WasiCtx {
         let writable = (fs_rights_base & RIGHTS_FD_WRITE) != 0
             || (oflags & (OFLAGS_CREAT | OFLAGS_TRUNC)) != 0;
         let file = if writable {
-            Fd::File { vfs_path, buf: Vec::new(), pos: 0, writable: true, dirty: true }
+            let buf = match oflags & OFLAGS_TRUNC {
+                0 => crate::fs::read(&vfs_path).unwrap_or_default(),
+                _ => Vec::new(),
+            };
+            let mut flushed = buf.len();
+            // C creates (or truncates) the file at `fopen`, not at the first write.
+            if flushed == 0 {
+                Self::flush_file(&vfs_path, &buf, &mut flushed);
+            }
+            Fd::File {
+                vfs_path, buf, pos: 0, writable: true, dirty: true,
+                append: fdflags & FDFLAGS_APPEND != 0, flushed,
+            }
         } else {
-            match crate::read(&vfs_path) {
-                Some(buf) => Fd::File { vfs_path, buf, pos: 0, writable: false, dirty: false },
-                None => return ERRNO_NOENT,
+            match crate::fs::read(&vfs_path) {
+                Ok(buf) => Fd::File {
+                    vfs_path, buf, pos: 0, writable: false, dirty: false, append: false, flushed: 0,
+                },
+                Err(_) => return ERRNO_NOENT,
             }
         };
         let fd = self.next_fd;
@@ -352,11 +396,11 @@ impl WasiCtx {
         ERRNO_SUCCESS
     }
 
-    /// `fd_close`: flush a dirty writable file to the VFS and drop the fd.
+    /// `fd_close`: write out what the fd still holds and drop it.
     pub fn fd_close(&mut self, fd: u32) -> i32 {
         match self.fds.remove(&fd) {
-            Some(Fd::File { vfs_path, buf, writable: true, dirty: true, .. }) => {
-                crate::write(&vfs_path, buf);
+            Some(Fd::File { vfs_path, buf, writable: true, dirty: true, mut flushed, .. }) => {
+                Self::flush_file(&vfs_path, &buf, &mut flushed);
                 ERRNO_SUCCESS
             }
             Some(_) => ERRNO_SUCCESS,
@@ -388,7 +432,7 @@ impl WasiCtx {
     /// `fd_filestat_get`: fill a 64-byte `filestat` for an open fd.
     pub fn fd_filestat_get<M: GuestMem>(&mut self, mem: &mut M, fd: u32, buf: u32) -> i32 {
         let (filetype, size, mtime) = match self.fds.get(&fd) {
-            Some(Fd::File { buf, vfs_path, .. }) => (FILETYPE_REGULAR_FILE, buf.len() as u64, crate::mtime(vfs_path).map(|d| d.as_nanos() as u64).unwrap_or(0)),
+            Some(Fd::File { buf, vfs_path, .. }) => (FILETYPE_REGULAR_FILE, buf.len() as u64, file_mtime(vfs_path)),
             Some(Fd::PreopenDir { .. } | Fd::Dir { .. }) => (FILETYPE_DIRECTORY, 0, 0),
             Some(Fd::Stdout | Fd::Stderr) => (FILETYPE_CHARACTER_DEVICE, 0, 0),
             None => return ERRNO_BADF,
@@ -400,9 +444,13 @@ impl WasiCtx {
     pub fn path_filestat_get<M: GuestMem>(&mut self, mem: &mut M, _dirfd: u32, _flags: u32, path: u32, path_len: u32, buf: u32) -> i32 {
         let Some(bytes) = Self::rd_bytes(mem, path, path_len) else { return ERRNO_FAULT };
         let vfs_path = self.resolve(&String::from_utf8_lossy(&bytes));
-        match crate::read(&vfs_path) {
-            Some(b) => Self::write_filestat(mem, buf, FILETYPE_REGULAR_FILE, b.len() as u64, crate::mtime(&vfs_path).map(|d| d.as_nanos() as u64).unwrap_or(0)),
-            None => ERRNO_NOENT,
+        let mtime = file_mtime(&vfs_path);
+        if crate::fs::is_dir(&vfs_path) {
+            return Self::write_filestat(mem, buf, FILETYPE_DIRECTORY, 0, mtime);
+        }
+        match crate::fs::len(&vfs_path) {
+            Ok(n) => Self::write_filestat(mem, buf, FILETYPE_REGULAR_FILE, n, mtime),
+            Err(_) => ERRNO_NOENT,
         }
     }
 
@@ -424,27 +472,24 @@ impl WasiCtx {
 
     // ── path mutations ───────────────────────────────────────────────────────
 
-    /// `path_create_directory`: store directories are implicit, so a no-op success.
     pub fn path_create_directory<M: GuestMem>(&mut self, mem: &mut M, _dirfd: u32, path: u32, path_len: u32) -> i32 {
-        if Self::rd_bytes(mem, path, path_len).is_none() {
-            return ERRNO_FAULT;
-        }
-        ERRNO_SUCCESS
+        let Some(bytes) = Self::rd_bytes(mem, path, path_len) else { return ERRNO_FAULT };
+        let dir = self.resolve(&String::from_utf8_lossy(&bytes));
+        if crate::fs::create_dir_all(&dir).is_ok() { ERRNO_SUCCESS } else { ERRNO_NOENT }
     }
 
     /// `path_unlink_file`.
     pub fn path_unlink_file<M: GuestMem>(&mut self, mem: &mut M, _dirfd: u32, path: u32, path_len: u32) -> i32 {
         let Some(bytes) = Self::rd_bytes(mem, path, path_len) else { return ERRNO_FAULT };
         let vfs_path = self.resolve(&String::from_utf8_lossy(&bytes));
-        if crate::remove(&vfs_path) { ERRNO_SUCCESS } else { ERRNO_NOENT }
+        if crate::fs::remove_file(&vfs_path).is_ok() { ERRNO_SUCCESS } else { ERRNO_NOENT }
     }
 
-    /// `path_remove_directory`: drop every store entry under the directory.
+    /// `path_remove_directory`: the directory and everything under it.
     pub fn path_remove_directory<M: GuestMem>(&mut self, mem: &mut M, _dirfd: u32, path: u32, path_len: u32) -> i32 {
         let Some(bytes) = Self::rd_bytes(mem, path, path_len) else { return ERRNO_FAULT };
         let dir = self.resolve(&String::from_utf8_lossy(&bytes));
-        remove_subtree(&dir);
-        ERRNO_SUCCESS
+        if crate::fs::remove_dir_all(&dir).is_ok() { ERRNO_SUCCESS } else { ERRNO_NOENT }
     }
 
     /// `path_rename`: move a file or a whole subtree.
@@ -454,7 +499,7 @@ impl WasiCtx {
         let Some(nb) = Self::rd_bytes(mem, new_path, new_len) else { return ERRNO_FAULT };
         let from = self.resolve(&String::from_utf8_lossy(&ob));
         let to = self.resolve(&String::from_utf8_lossy(&nb));
-        rename_path(&from, &to)
+        if crate::fs::rename(&from, &to).is_ok() { ERRNO_SUCCESS } else { ERRNO_NOENT }
     }
 
     /// `fd_prestat_get`: report the single preopen dir; EBADF for everything else
@@ -573,7 +618,8 @@ impl WasiCtx {
             Some(Fd::Dir { vfs_path }) => vfs_path.clone(),
             _ => return ERRNO_BADF,
         };
-        let entries = readdir(&dir_key);
+        let mut entries = crate::fs::read_dir(&dir_key).unwrap_or_default();
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
         const HDR: u32 = 24;
         let mut written = 0u32;
         let mut idx = cookie;
@@ -616,10 +662,12 @@ impl WasiCtx {
     /// preview1 `path_open` for a read-only open of the absolute key `path`.
     /// Returns the new fd, or `None` (ENOENT) if the file is absent.
     pub fn open_read(&mut self, path: &str) -> Option<u32> {
-        let buf = crate::read(path)?;
+        let buf = crate::fs::read(path).ok()?;
         let fd = self.next_fd;
         self.next_fd += 1;
-        self.fds.insert(fd, Fd::File { vfs_path: path.to_string(), buf, pos: 0, writable: false, dirty: false });
+        self.fds.insert(fd, Fd::File {
+            vfs_path: path.to_string(), buf, pos: 0, writable: false, dirty: false, append: false, flushed: 0,
+        });
         Some(fd)
     }
 
@@ -638,42 +686,13 @@ impl WasiCtx {
     }
 }
 
-/// Remove `dir` itself and every key beneath `dir/`.
-fn remove_subtree(dir: &str) {
-    let norm = crate::normalize(dir);
-    crate::remove(&norm);
-    let prefix = format!("{norm}/");
-    for key in crate::list() {
-        if key.starts_with(&prefix) {
-            crate::remove(&key);
-        }
-    }
-}
-
-/// Move a single file, or every key under a directory subtree.
-fn rename_path(from: &str, to: &str) -> i32 {
-    let from = crate::normalize(from);
-    let to = crate::normalize(to);
-    if let Some(bytes) = crate::read(&from) {
-        // Only a real store entry can move; `read` also resolves immutable builtins.
-        if crate::remove(&from) {
-            crate::write(&to, bytes);
-            return ERRNO_SUCCESS;
-        }
-    }
-    let from_prefix = format!("{from}/");
-    let moved: Vec<(String, Vec<u8>)> = crate::list()
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(&from_prefix).map(|r| (r.to_string(), crate::read(&k).unwrap_or_default())))
-        .collect();
-    if moved.is_empty() {
-        return ERRNO_NOENT;
-    }
-    for (rest, bytes) in moved {
-        crate::remove(&format!("{from_prefix}{rest}"));
-        crate::write(&format!("{to}/{rest}"), bytes);
-    }
-    ERRNO_SUCCESS
+/// `filestat`'s `mtim`: nanoseconds since the epoch, 0 for anything without one.
+fn file_mtime(path: &str) -> u64 {
+    crate::fs::modified(path)
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
 }
 
 /// One directory entry from [`readdir`].
@@ -724,35 +743,59 @@ mod path_ops_tests {
 
     #[test]
     fn path_mutations_and_dir_fd() {
-        crate::write("/wasi_pathops/a.txt", b"AAA".to_vec());
-        crate::write("/wasi_pathops/b.txt", b"BBB".to_vec());
+        let root = if crate::fs::IN_MEMORY {
+            "/wasi_pathops".to_string()
+        } else {
+            format!("{}/om-wasi-pathops-{}", std::env::temp_dir().display(), std::process::id())
+        };
+        crate::fs::create_dir_all(&root).unwrap();
+        crate::fs::write(&format!("{root}/a.txt"), b"AAA").unwrap();
+        crate::fs::write(&format!("{root}/b.txt"), b"BBB").unwrap();
 
         let mut ctx = WasiCtx::new("", vec!["t".into()]);
-        let mut buf = vec![0u8; 4096];
+        let mut buf = vec![0u8; 8192];
         let mut mem = SliceMem(&mut buf);
 
-        let (op, ol) = put(mem.0, 0, "wasi_pathops/a.txt");
-        let (np, nl) = put(mem.0, 64, "wasi_pathops/c.txt");
+        let (op, ol) = put(mem.0, 0, &format!("{root}/a.txt"));
+        let (np, nl) = put(mem.0, 1024, &format!("{root}/c.txt"));
         assert_eq!(ctx.path_rename(&mut mem, 3, op, ol, 3, np, nl), ERRNO_SUCCESS);
-        assert_eq!(crate::read("/wasi_pathops/c.txt").as_deref(), Some(&b"AAA"[..]));
-        assert!(crate::read("/wasi_pathops/a.txt").is_none());
+        assert_eq!(crate::fs::read(&format!("{root}/c.txt")).unwrap(), b"AAA");
+        assert!(crate::fs::read(&format!("{root}/a.txt")).is_err());
 
-        let (p, l) = put(mem.0, 128, "wasi_pathops/b.txt");
+        let (p, l) = put(mem.0, 2048, &format!("{root}/b.txt"));
         assert_eq!(ctx.path_unlink_file(&mut mem, 3, p, l), ERRNO_SUCCESS);
         assert_eq!(ctx.path_unlink_file(&mut mem, 3, p, l), ERRNO_NOENT);
 
-        let (dp, dl) = put(mem.0, 256, "wasi_pathops");
-        assert_eq!(ctx.path_open(&mut mem, 3, 0, dp, dl, OFLAGS_DIRECTORY, 0, 0, 0, 300), ERRNO_SUCCESS);
-        let dfd = WasiCtx::rd_u32(&mem, 300).unwrap();
-        assert_eq!(ctx.fd_readdir(&mut mem, dfd, 512, 512, 0, 320), ERRNO_SUCCESS);
-        let used = WasiCtx::rd_u32(&mem, 320).unwrap() as usize;
-        assert!(mem.0[512..512 + used].windows(5).any(|w| w == b"c.txt"));
+        let (dp, dl) = put(mem.0, 3072, &root);
+        assert_eq!(ctx.path_open(&mut mem, 3, 0, dp, dl, OFLAGS_DIRECTORY, 0, 0, 0, 4000), ERRNO_SUCCESS);
+        let dfd = WasiCtx::rd_u32(&mem, 4000).unwrap();
+        assert_eq!(ctx.fd_readdir(&mut mem, dfd, 4096, 512, 0, 4004), ERRNO_SUCCESS);
+        let used = WasiCtx::rd_u32(&mem, 4004).unwrap() as usize;
+        assert!(mem.0[4096..4096 + used].windows(5).any(|w| w == b"c.txt"));
 
-        let (rp, rl) = put(mem.0, 1100, "wasi_pathops");
+        // A directory stats as one, and `fopen(…, "a")` keeps what is there.
+        assert_eq!(ctx.path_filestat_get(&mut mem, 3, 0, dp, dl, 5000), ERRNO_SUCCESS);
+        assert_eq!(mem.0[5000 + 16], FILETYPE_DIRECTORY);
+        let (ap, al) = put(mem.0, 6000, &format!("{root}/c.txt"));
+        assert_eq!(
+            ctx.path_open(&mut mem, 3, 0, ap, al, OFLAGS_CREAT, RIGHTS_FD_WRITE, 0, FDFLAGS_APPEND, 6100),
+            ERRNO_SUCCESS
+        );
+        let afd = WasiCtx::rd_u32(&mem, 6100).unwrap();
+        let (wp, wl) = put(mem.0, 6200, "BBB");
+        let _ = WasiCtx::wr_u32(&mut mem, 6300, wp);
+        let _ = WasiCtx::wr_u32(&mut mem, 6304, wl);
+        assert_eq!(ctx.fd_write(&mut mem, afd, 6300, 1, 6400), ERRNO_SUCCESS);
+        assert_eq!(ctx.fd_close(afd), ERRNO_SUCCESS);
+        assert_eq!(crate::fs::read(&format!("{root}/c.txt")).unwrap(), b"AAABBB");
+
+        let (rp, rl) = put(mem.0, 7000, &root);
         assert_eq!(ctx.path_remove_directory(&mut mem, 3, rp, rl), ERRNO_SUCCESS);
-        assert!(crate::read("/wasi_pathops/c.txt").is_none());
+        assert!(crate::fs::read(&format!("{root}/c.txt")).is_err());
 
-        let (cp, cl) = put(mem.0, 1200, "newdir");
+        let (cp, cl) = put(mem.0, 7200, &format!("{root}/newdir"));
         assert_eq!(ctx.path_create_directory(&mut mem, 3, cp, cl), ERRNO_SUCCESS);
+        assert!(crate::fs::is_dir(&format!("{root}/newdir")) || crate::fs::IN_MEMORY);
+        let _ = crate::fs::remove_dir_all(&root);
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
@@ -11,6 +11,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// What wasi-libc's `<unistd.h>` says, given to the ModelicaExternalC sources
+/// directly: they reach that header only for `__unix__`/`__linux__`/`__APPLE_CC__`,
+/// so on wasm they derive no `_POSIX_` and give up on functions wasi-libc has.
+const POSIX_VERSION: &str = "-D_POSIX_VERSION=200809L";
+
 fn main() {
     let crate_dir = PathBuf::from(env("CARGO_MANIFEST_DIR"));
     let out_dir = PathBuf::from(env("OUT_DIR"));
@@ -247,7 +252,7 @@ fn build_external_c_dylink(crate_dir: &Path, out_dir: &Path, sysroot: &Path, tri
     let status = Command::new(&clang)
         .arg(format!("--target={triple}"))
         .arg(format!("--sysroot={}", sysroot.display()))
-        .args(["-O2", "-fPIC", "-nodefaultlibs", "-mexec-model=reactor",
+        .args(["-O2", "-fPIC", "-nodefaultlibs", "-mexec-model=reactor", POSIX_VERSION,
                "-DNO_MUTEX", "-DHAVE_ZLIB", "-Wno-error=implicit-function-declaration"])
         .arg("-I").arg(&c_sources)
         .arg("-I").arg(&zlib_dir)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -738,7 +738,8 @@ fn build_external_c_wasm(crate_dir: &Path, out_dir: &Path) {
         "no libclang_rt.builtins-wasm32.a found (need libclang-rt-*-dev-wasm32)"
     }).unwrap_or_else(|e| panic!("{e}"));
     let mut cmd = Command::new(&clang);
-    cmd.args(["--target=wasm32-wasip1", "-O2", "-mexec-model=reactor",
+    // `-D_POSIX_VERSION` as for the dylink build; see `openmodelica_wasi_libc`.
+    cmd.args(["--target=wasm32-wasip1", "-O2", "-mexec-model=reactor", "-D_POSIX_VERSION=200809L",
                "-nodefaultlibs", "-DNO_MUTEX", "-DHAVE_ZLIB", "-DOM_EXT_HOST_ALLOC",
                "-Wno-error=implicit-function-declaration"])
         .arg(format!("--sysroot={sysroot}"))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -19,6 +19,24 @@ type Result<T> = std::result::Result<T, String>;
 pub struct Library {
     pub name: String,
     pub bytes: Vec<u8>,
+    /// Worth an on-disk AOT artifact: a built-in library or one a `Library`
+    /// annotation named, so every run loads the same bytes. One compiled from a
+    /// model's own `Include` sources is not — caching it would leave a file per
+    /// model behind, and only that process ever reloads it.
+    pub fixed: bool,
+}
+
+impl Library {
+    pub fn model(name: &str, bytes: Vec<u8>) -> Self {
+        Library { name: name.to_string(), bytes, fixed: false }
+    }
+    fn ext(l: &crate::model::ExtLibrary) -> Self {
+        Library { name: l.name.clone(), bytes: l.bytes.clone(), fixed: l.fixed }
+    }
+    /// One of the libraries built into omc, which also takes the on-disk artifact.
+    pub fn builtin(name: &str, bytes: &'static [u8]) -> Self {
+        Library { name: name.to_string(), bytes: bytes.to_vec(), fixed: true }
+    }
 }
 
 pub struct Loaded {
@@ -127,8 +145,21 @@ pub fn load(
     let mut wasi = wasmtime::Linker::new(engine);
     crate::wasi_shim::add_to_linker(&mut wasi).map_err(|e| format!("dylink: {e}"))?;
 
-    let mut weak: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Every library's exports before any is placed: a PIC library reaches even its
+    // own exported symbols through `env`, so they can be interposed, and one may
+    // call what a later one defines. Such an import gets a trampoline, bound below.
+    let mut modules = Vec::with_capacity(libs.len());
+    let mut defined: std::collections::HashSet<String> = std::collections::HashSet::new();
     for lib in libs {
+        let module = crate::sim_runtime::library_module(engine, &lib.name, &lib.bytes, lib.fixed)
+            .map_err(|e| format!("external \"C\" library `{}` is not valid wasm: {e}", lib.name))?;
+        defined.extend(module.exports().filter(|e| e.ty().func().is_some()).map(|e| e.name().to_string()));
+        modules.push(module);
+    }
+    let mut deferred: HashMap<String, DeferredTarget> = HashMap::new();
+
+    let mut weak: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (lib, module) in libs.iter().zip(&modules) {
         let dl = dylink::parse(&lib.bytes).ok_or_else(|| {
             format!(
                 "external \"C\" library `{}` is not a shared library (no dylink.0 section) \
@@ -139,9 +170,8 @@ pub fn load(
         weak.extend(dl.weak_imports.iter().cloned());
         place(
             store,
-            engine,
+            module,
             &lib.name,
-            &lib.bytes,
             &dl,
             memory,
             table,
@@ -149,10 +179,17 @@ pub fn load(
             &stack_pointer,
             &wasi,
             host_imports,
+            &defined,
+            &mut deferred,
             &mut got_mem,
             &mut got_func,
             &mut loaded,
         )?;
+    }
+    for (sym, target) in &deferred {
+        if let Some(f) = loaded.funcs.get(sym) {
+            let _ = target.set(*f);
+        }
     }
 
     for (sym, g) in &got_mem {
@@ -191,8 +228,35 @@ pub fn load(
                 .map_err(|e| format!("external \"C\" library `{}` failed to initialise: {e}", lib.name))?;
         }
     }
+    set_guest_cwd(store, rt_alloc, memory, &loaded)?;
     unbuffer_stdout(store, &loaded)?;
     Ok(loaded)
+}
+
+/// Give libc the process's own working directory: `__wasilibc_find_relpath`
+/// resolves every path a library opens against `__wasilibc_cwd`, which is `"/"` out
+/// of the box. A later `chdir` frees only a buffer libc allocated itself.
+fn set_guest_cwd(
+    store: &mut wasmtime::Store<WasiCtx>,
+    rt_alloc: &wasmtime::TypedFunc<u32, u32>,
+    memory: Memory,
+    loaded: &Loaded,
+) -> Result<()> {
+    let (Some(&slot), Ok(cwd)) = (loaded.data.get("__wasilibc_cwd"), openmodelica_wasi::fs::cwd()) else {
+        return Ok(());
+    };
+    let bytes = cwd.as_bytes();
+    let p = rt_alloc
+        .call(&mut *store, bytes.len() as u32 + 1)
+        .map_err(|e| format!("rt_alloc: {e}"))?;
+    let data = memory.data_mut(&mut *store);
+    let too_small = "dylink: the shared memory is too small for the working directory";
+    let dst = data.get_mut(p as usize..p as usize + bytes.len() + 1).ok_or(too_small)?;
+    dst[..bytes.len()].copy_from_slice(bytes);
+    dst[bytes.len()] = 0;
+    let ptr = data.get_mut(slot as usize..slot as usize + 4).ok_or(too_small)?;
+    ptr.copy_from_slice(&p.to_le_bytes());
+    Ok(())
 }
 
 /// Nothing flushes libc's buffer — the module is torn down, not exited — so a
@@ -255,9 +319,8 @@ fn func_slot(store: &mut wasmtime::Store<WasiCtx>, loaded: &mut Loaded, sym: &st
 #[allow(clippy::too_many_arguments)]
 fn place(
     store: &mut wasmtime::Store<WasiCtx>,
-    engine: &wasmtime::Engine,
+    module: &wasmtime::Module,
     lib_name: &str,
-    bytes: &[u8],
     dl: &Dylink,
     memory: Memory,
     table: Table,
@@ -265,13 +328,12 @@ fn place(
     stack_pointer: &Global,
     wasi: &wasmtime::Linker<WasiCtx>,
     host_imports: &HashMap<String, Func>,
+    defined: &std::collections::HashSet<String>,
+    deferred: &mut HashMap<String, DeferredTarget>,
     got_mem: &mut HashMap<String, Global>,
     got_func: &mut HashMap<String, Global>,
     loaded: &mut Loaded,
 ) -> Result<()> {
-    let module = wasmtime::Module::new(engine, bytes)
-        .map_err(|e| format!("external \"C\" library `{lib_name}` is not valid wasm: {e}"))?;
-
     let memory_base = alloc_aligned(store, rt_alloc, dl.mem.mem_size, dl.mem.mem_align())?;
     let table_base = if dl.mem.table_size == 0 {
         table.size(&*store)
@@ -294,7 +356,7 @@ fn place(
             ("GOT.mem", sym) => Extern::Global(got_entry(store, got_mem, sym)?),
             ("GOT.func", sym) => Extern::Global(got_entry(store, got_func, sym)?),
             ("env", sym) => {
-                // Another library's export, else a host import, else undefined.
+                // A placed library's export, else a host import, else deferred.
                 let ty = imp
                     .ty()
                     .func()
@@ -302,6 +364,7 @@ fn place(
                     .ok_or_else(|| format!("external \"C\" library `{lib_name}` imports env.{sym}, which is not a function"))?;
                 match loaded.funcs.get(sym).or_else(|| host_imports.get(sym)) {
                     Some(f) => Extern::Func(*f),
+                    None if defined.contains(sym) => Extern::Func(deferred_import(store, &ty, deferred, sym)),
                     None => Extern::Func(missing_symbol_stub(store, &ty, lib_name, sym)),
                 }
             }
@@ -402,6 +465,27 @@ fn missing_symbol_stub(
         Err(wasmtime::Error::msg(msg.clone()))
     })
 }
+
+/// Where a deferred `env` import ends up, once every library is instantiated.
+type DeferredTarget = std::sync::Arc<std::sync::OnceLock<Func>>;
+
+/// A trampoline over the [`DeferredTarget`] `load` fills in; one target per symbol.
+fn deferred_import(
+    store: &mut wasmtime::Store<WasiCtx>,
+    ty: &FuncType,
+    deferred: &mut HashMap<String, DeferredTarget>,
+    sym: &str,
+) -> Func {
+    let target = deferred.entry(sym.to_string()).or_default().clone();
+    let sym = sym.to_string();
+    Func::new(&mut *store, ty.clone(), move |mut caller: Caller<'_, WasiCtx>, args, rets| {
+        match target.get() {
+            Some(f) => f.call(&mut caller, args, rets),
+            None => Err(wasmtime::Error::msg(format!("external \"C\": `{sym}` was never defined"))),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,8 +518,8 @@ mod tests {
             return None;
         }
         Some([
-            Library { name: "libc.so".into(), bytes: openmodelica_wasi_libc::LIBC_PIC.to_vec() },
-            Library { name: name.into(), bytes },
+            Library::builtin("libc.so", openmodelica_wasi_libc::LIBC_PIC),
+            Library::model(name, bytes),
         ])
     }
 
@@ -443,7 +527,7 @@ mod tests {
     fn runtime() -> (wasmtime::Store<WasiCtx>, wasmtime::Engine, wasmtime::Instance) {
         let engine = wasmtime::Engine::default();
         let module = wasmtime::Module::new(&engine, crate::RUNTIME_WASM).unwrap();
-        let mut store = wasmtime::Store::new(&engine, WasiCtx::new(".", Vec::new()));
+        let mut store = wasmtime::Store::new(&engine, WasiCtx::new("/", Vec::new()));
         let mut linker = wasmtime::Linker::new(&engine);
         crate::host::add_host_builtins(&mut linker).unwrap();
         let inst = linker.instantiate(&mut store, &module).unwrap();
@@ -597,7 +681,7 @@ mod tests {
         let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
-        let libs = [Library { name: "obj.o".into(), bytes: std::fs::read(&o).unwrap() }];
+        let libs = [Library::model("obj.o", std::fs::read(&o).unwrap())];
         let err = match load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()) {
             Err(e) => e,
             Ok(_) => panic!("an object file was accepted as a library"),
@@ -621,7 +705,7 @@ pub fn load_ext_libraries(
     let table = rt_inst
         .get_table(&mut *store, "__indirect_function_table")
         .ok_or_else(|| "CodegenWasmJit: runtime has no __indirect_function_table export".to_string())?;
-    if model.ext_libs.is_empty() {
+    if model.ext_libs.is_empty() && !model.ext_builtin {
         return load(store, engine, memory, table, &rt.alloc, &[], &HashMap::new());
     }
     let libc = openmodelica_wasi_libc::LIBC_PIC;
@@ -630,10 +714,21 @@ pub fn load_ext_libraries(
                     load an external \"C\" library"
             .to_string());
     }
-    let mut libs = Vec::with_capacity(model.ext_libs.len() + 1);
-    libs.push(Library { name: "libc.so".to_string(), bytes: libc.to_vec() });
+    let mut libs = Vec::with_capacity(model.ext_libs.len() + 3);
+    libs.push(Library::builtin("libc.so", libc));
     for l in &model.ext_libs {
-        libs.push(Library { name: l.name.clone(), bytes: l.bytes.clone() });
+        libs.push(Library::ext(l));
+    }
+    // After the model's own libraries, so those still define a symbol they share.
+    // Binding an `external "C"` here makes the call wasm->wasm; the dlopen
+    // fallback costs a host trampoline and libffi marshalling per call.
+    if model.ext_builtin {
+        libs.push(Library::builtin("modelicaexternalc", openmodelica_wasi_libc::EXTERNAL_C_DYLINK));
+        // The dummy `usertab` ModelicaExternalC imports; last, so a `usertab` from
+        // the model's own libraries wins.
+        if !openmodelica_wasi_libc::USERTAB_DYLINK.is_empty() {
+            libs.push(Library::builtin("usertab", openmodelica_wasi_libc::USERTAB_DYLINK));
+        }
     }
     let host = modelica_utilities_imports(store, rt);
     load(store, engine, memory, table, &rt.alloc, &libs, &host)
@@ -648,14 +743,20 @@ fn shared_cstr(caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: i32) -> String {
     String::from_utf8_lossy(&rest[..len]).into_owned()
 }
 
+/// A message without its trailing newline; the log adds its own, as C does.
+fn trim_eol(msg: &str) -> &str {
+    msg.strip_suffix('\n').unwrap_or(msg)
+}
+
 /// The ModelicaUtilities a library may call: host imports, because the messages
-/// belong in omc's error buffer. A formatted variant gets `(format, va_list)` and
-/// is not interpolated, as on the web target.
+/// belong in the run's log (or, outside a run, in omc's error buffer). A formatted
+/// variant gets `(format, va_list)` and is not interpolated, as on the web target.
 pub fn modelica_utilities_imports(
     store: &mut wasmtime::Store<WasiCtx>,
     rt: &ExtRt,
 ) -> HashMap<String, wasmtime::Func> {
     use wasmtime::{Caller, Func};
+    use openmodelica_sim_meta::omclog;
     let mut m: HashMap<String, Func> = HashMap::new();
 
     let nls = rt.nls.clone();
@@ -671,33 +772,54 @@ pub fn modelica_utilities_imports(
             raise_model_error(&nls, &mut caller, fmt)
         },
     );
-    let warning = |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
+    // C sends both to `OMC_LOG_STDOUT`. The `-d=gen` function JIT has no run and no
+    // such log, and neither does the compiler process in C.
+    let in_run = rt.nls.is_some();
+    let warning = move |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
         let msg = shared_cstr(&mut caller, ptr);
-        openmodelica_error::ErrorExt::runtime_warning(&msg);
+        if in_run {
+            omclog::warning(omclog::STDOUT, false, trim_eol(&msg));
+        } else {
+            openmodelica_error::ErrorExt::runtime_warning(&msg);
+        }
     };
-    let warning_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
+    let warning_fmt = move |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
         let msg = shared_cstr(&mut caller, fmt);
-        openmodelica_error::ErrorExt::runtime_warning(&msg);
+        if in_run {
+            omclog::warning(omclog::STDOUT, false, trim_eol(&msg));
+        } else {
+            openmodelica_error::ErrorExt::runtime_warning(&msg);
+        }
     };
 
-    let message = |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
-        let msg = shared_cstr(&mut caller, ptr);
-        openmodelica_wasi::wasi::stdout_write(msg.as_bytes());
+    let message = move |mut caller: Caller<'_, WasiCtx>, ptr: i32| {
+        if in_run {
+            let msg = shared_cstr(&mut caller, ptr);
+            omclog::info(omclog::STDOUT, false, trim_eol(&msg));
+        }
     };
-    let message_fmt = |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
-        let msg = shared_cstr(&mut caller, fmt);
-        openmodelica_wasi::wasi::stdout_write(msg.as_bytes());
+    let message_fmt = move |mut caller: Caller<'_, WasiCtx>, fmt: i32, _va: i32| {
+        if in_run {
+            let msg = shared_cstr(&mut caller, fmt);
+            omclog::info(omclog::STDOUT, false, trim_eol(&msg));
+        }
     };
 
     m.insert("ModelicaError".into(), err_fn(&mut *store, nls.clone()));
     m.insert("ModelicaFormatError".into(), err_fmt_fn(&mut *store, nls.clone()));
-    m.insert("ModelicaVFormatError".into(), err_fmt_fn(&mut *store, nls));
+    m.insert("ModelicaVFormatError".into(), err_fmt_fn(&mut *store, nls.clone()));
     m.insert("ModelicaWarning".into(), Func::wrap(&mut *store, warning));
     m.insert("ModelicaFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
     m.insert("ModelicaVFormatWarning".into(), Func::wrap(&mut *store, warning_fmt));
     m.insert("ModelicaMessage".into(), Func::wrap(&mut *store, message));
     m.insert("ModelicaFormatMessage".into(), Func::wrap(&mut *store, message_fmt));
     m.insert("ModelicaVFormatMessage".into(), Func::wrap(&mut *store, message_fmt));
+
+    // A side module carrying `external_c_callbacks.c` has the `Modelica*` entry
+    // points itself, so what arrives here is already through `vsnprintf`.
+    m.insert("rt_ext_error".into(), err_fn(&mut *store, nls));
+    m.insert("rt_ext_message".into(), Func::wrap(&mut *store, message));
+    m.insert("rt_ext_warning".into(), Func::wrap(&mut *store, warning));
 
     // The simulation's allocator, so a string the callee builds is readable from
     // the model's memory.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -159,13 +159,13 @@ impl openmodelica_sim_meta::driver::SimEngine for MemEngine<'_> {
     fn write_bytes(&mut self, _addr: u32, _buf: &[u8]) -> metamodelica::Result<()> {
         Err("wasm-jit: MemEngine is read-only")
     }
-    fn call1(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
+    fn call1_raw(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
         Err("wasm-jit: MemEngine cannot call the model")
     }
-    fn call1_if_present(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
+    fn call1_if_present_raw(&mut self, _name: &str, _arg: u32) -> metamodelica::Result<()> {
         Err("wasm-jit: MemEngine cannot call the model")
     }
-    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> metamodelica::Result<()> {
+    fn call2_raw(&mut self, _name: &str, _a: u32, _b: u32) -> metamodelica::Result<()> {
         Err("wasm-jit: MemEngine cannot call the model")
     }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> metamodelica::Result<u32> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -26,6 +26,10 @@ pub struct SimModel {
     /// The model's own `external "C"` libraries, loaded into the simulation's
     /// memory, where they define the `ext_imports` the runtime cannot resolve.
     pub ext_libs: Vec<ExtLibrary>,
+    /// The model reaches an `external "C"` its own libraries leave open that the
+    /// built-in ModelicaExternalC side module defines. The JIT host loads that
+    /// module too, so those bind wasm->wasm rather than through the path below.
+    pub ext_builtin: bool,
     /// The same implementations as platform shared libraries, for a symbol no wasm
     /// library defines: a native host dlopens them and calls in through libffi.
     /// Empty in the browser.
@@ -76,6 +80,10 @@ impl SimModel {
 pub struct ExtLibrary {
     pub name: String,
     pub bytes: Vec<u8>,
+    /// A prebuilt library a `Library` annotation named, so every run loads the same
+    /// bytes: worth an on-disk AOT artifact. False for one compiled out of a
+    /// model's own `Include` sources.
+    pub fixed: bool,
 }
 
 /// The static archives and object files a `Library` annotation resolved to

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -365,16 +365,20 @@ fn define_external_imports(
         .get_function("rt_ext_error")
         .map_err(|_| "CodegenWasmJit: the runtime module exports no `rt_ext_error`")?
         .clone();
+    // C sends both to `OMC_LOG_STDOUT`, where the run's log picks them up.
+    use openmodelica_sim_meta::omclog;
     let rt_ext_warning = Function::new_typed_with_env(
         &mut *store, &err_env,
         move |env: FunctionEnvMut<SideErrEnv>, ptr: i32| {
-            openmodelica_error::ErrorExt::runtime_warning(&side_msg(&env, ptr));
+            let msg = side_msg(&env, ptr);
+            omclog::warning(omclog::STDOUT, false, msg.strip_suffix('\n').unwrap_or(&msg));
         },
     );
     let rt_ext_message = Function::new_typed_with_env(
         &mut *store, &err_env,
         move |env: FunctionEnvMut<SideErrEnv>, ptr: i32| {
-            openmodelica_wasi::wasi::stdout_write(side_msg(&env, ptr).as_bytes());
+            let msg = side_msg(&env, ptr);
+            omclog::info(omclog::STDOUT, false, msg.strip_suffix('\n').unwrap_or(&msg));
         },
     );
     // This host cannot build the model's `Include`, so only the C dummy is left.
@@ -1016,6 +1020,11 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         wts(set.call(&mut store, log_mask as u32, (log_mask >> 32) as u32))?;
     }
     // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_stats_start") {
+        let on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::STATS_V);
+        wts(set.call(&mut store, on as u32))?;
+    }
+    // See the wasmtime counterpart.
     if openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS)
         && let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32), ()>(&store, "rt_nls_set_names")
     {
@@ -1090,17 +1099,17 @@ impl sim_driver::SimEngine for WasmerEngine {
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
         self.memory.view(&self.store).write(addr as u64, buf).map_err(|e| "CodegenWasmJit: mem write")
     }
-    fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
+    fn call1_raw(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;
         wt(f.call(&mut self.store, arg))
     }
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()> {
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> Result<()> {
         if self.instance.exports.get_extern(name).is_none() {
             return Ok(());
         }
-        self.call1(name, arg)
+        self.call1_raw(name, arg)
     }
-    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
         let f = match self.funcs2.get(name) {
             Some(f) => f.clone(),
             None => {
@@ -1130,6 +1139,22 @@ impl sim_driver::SimEngine for WasmerEngine {
             Ok(f) => f.call(&mut self.store).unwrap_or(0),
             Err(_) => 0,
         }
+    }
+    fn sys_stats(&mut self) -> Vec<openmodelica_sim_meta::sysstat::SysStat> {
+        let get = |name| self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, name);
+        let (Ok(ptr), Ok(len)) = (get("rt_sys_stats_ptr"), get("rt_sys_stats_len")) else {
+            return Vec::new();
+        };
+        let (Ok(n), Ok(addr)) = (len.call(&mut self.store), ptr.call(&mut self.store)) else {
+            return Vec::new();
+        };
+        let mut bytes = vec![0u8; n as usize * 8];
+        if self.memory.view(&self.store).read(addr as u64, &mut bytes).is_err() {
+            return Vec::new();
+        }
+        let words: Vec<f64> =
+            bytes.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect();
+        openmodelica_sim_meta::sysstat::decode(&words)
     }
     fn context_addr(&mut self) -> u32 {
         match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_context_addr") {
@@ -1169,6 +1194,8 @@ pub struct InWasmSession {
     stat_f: wasmer::TypedFunction<u32, u64>,
     lin_ptr: wasmer::TypedFunction<(), u32>,
     lin_len: wasmer::TypedFunction<(), u32>,
+    sys_ptr: wasmer::TypedFunction<(), u32>,
+    sys_len: wasmer::TypedFunction<(), u32>,
     free_f: wasmer::TypedFunction<(), ()>,
 }
 
@@ -1235,6 +1262,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_stat"))?,
         lin_ptr: gf(&store, "rt_sim_lin_ptr")?,
         lin_len: gf(&store, "rt_sim_lin_len")?,
+        sys_ptr: gf(&store, "rt_sys_stats_ptr")?,
+        sys_len: gf(&store, "rt_sys_stats_len")?,
         free_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_free"))?,
         store,
         memory,
@@ -1262,13 +1291,13 @@ impl sim_driver::SimEngine for InWasmSession {
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
         self.memory.view(&self.store).write(addr as u64, buf).map_err(|_| "CodegenWasmJit: mem write")
     }
-    fn call1(&mut self, _name: &str, _arg: u32) -> Result<()> {
+    fn call1_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Err("CodegenWasmJit: call1 on in-wasm session (unreachable)")
     }
-    fn call1_if_present(&mut self, _name: &str, _arg: u32) -> Result<()> {
+    fn call1_if_present_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Ok(())
     }
-    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
+    fn call2_raw(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
         Err("CodegenWasmJit: call2 on in-wasm session (unreachable)")
     }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
@@ -1312,6 +1341,10 @@ impl InWasmSession {
         let rows = read_vec(&self.memory, &self.store, rp, rn)?;
         let params = read_vec(&self.memory, &self.store, pp, pn)?;
         let mut stats = openmodelica_sim_meta::SolveStats::default();
+        let sp = wt(self.sys_ptr.call(&mut self.store))?;
+        let sn = wt(self.sys_len.call(&mut self.store))? as usize;
+        stats.systems =
+            openmodelica_sim_meta::sysstat::decode(&read_vec(&self.memory, &self.store, sp, sn)?);
         let mut stat = |i: u32| wt(self.stat_f.call(&mut self.store, i));
         stats.steps = stat(0)?;
         stats.res_evals = stat(1)?;
@@ -1320,6 +1353,8 @@ impl InWasmSession {
         stats.conv_test_fails = stat(4)?;
         stats.state_events = stat(5)?;
         stats.time_events = stat(6)?;
+        stats.lin_solves = stat(7)?;
+        openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
         Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -168,16 +168,18 @@ pub fn runtime_module() -> std::result::Result<&'static wasmtime::Module, String
 /// reboots and not shared between users (unlike a world-writable temp dir, where
 /// the sticky bit would stop other users refreshing it). Falls back to the
 /// system temp dir if `$HOME` is unset or the cache dir can't be created.
-fn runtime_cache_path(epoch: bool) -> std::path::PathBuf {
+fn aot_cache_key(blob: &[u8], epoch: bool) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
-    runtime_blob().len().hash(&mut h);
-    runtime_blob().hash(&mut h);
+    blob.len().hash(&mut h);
+    blob.hash(&mut h);
     std::env::var("OMC_WASM_OPT_LEVEL").unwrap_or_default().hash(&mut h);
     std::env::var("OMC_WASM_NO_INLINE").is_ok().hash(&mut h);
     epoch.hash(&mut h);
-    let key = h.finish();
+    h.finish()
+}
 
+fn aot_cache_path(tag: &str, key: u64) -> std::path::PathBuf {
     let home = openmodelica_util::Settings::getHomeDir(false);
     let dir = if home.is_empty() {
         Some(std::env::temp_dir())
@@ -186,23 +188,23 @@ fn runtime_cache_path(epoch: bool) -> std::path::PathBuf {
         std::fs::create_dir_all(&d).ok().map(|_| d)
     };
     let dir = dir.unwrap_or_else(std::env::temp_dir);
-    dir.join(format!("wasmjit-runtime-{key:016x}.cwasm"))
+    dir.join(format!("wasmjit-{tag}-{key:016x}.cwasm"))
 }
 
-fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module, String> {
-    let engine = if epoch { alarm_engine() } else { plain_engine() };
-    let path = runtime_cache_path(epoch);
+/// Compile a *fixed* wasm blob through the on-disk AOT cache: the `external "C"`
+/// side libraries take ~0.7 s to compile against ~6 ms to load the artifact.
+fn aot_module(engine: &wasmtime::Engine, tag: &str, blob: &[u8], epoch: bool) -> std::result::Result<wasmtime::Module, String> {
+    let path = aot_cache_path(tag, aot_cache_key(blob, epoch));
     // Try the AOT artifact first (microseconds). `deserialize_file` is unsafe
-    // because it trusts the artifact; it is one we produced under temp_dir, and
-    // wasmtime validates version/config compatibility (erroring otherwise).
-    if path.exists() {
-        if let Ok(m) = unsafe { wasmtime::Module::deserialize_file(engine, &path) } {
-            return Ok(m);
-        }
-        // Incompatible/corrupt cache (e.g. wasmtime upgrade): fall through to
-        // recompile and overwrite it below.
+    // because it trusts the artifact; it is one we produced under the cache dir,
+    // and wasmtime validates version/config compatibility (erroring otherwise).
+    if path.exists()
+        && let Ok(m) = unsafe { wasmtime::Module::deserialize_file(engine, &path) }
+    {
+        return Ok(m);
     }
-    let module = wts(wasmtime::Module::new(engine, runtime_blob()))?;
+    // Incompatible/corrupt cache (e.g. a wasmtime upgrade): recompile over it.
+    let module = wts(wasmtime::Module::new(engine, blob))?;
     // Best-effort: persist the compiled artifact for the next process. Write to
     // a temp sibling then rename, so a concurrent reader never sees a partial file.
     if let Ok(bytes) = module.serialize() {
@@ -212,6 +214,34 @@ fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module,
         }
     }
     Ok(module)
+}
+
+/// Compile an `external "C"` side library, memoized for the process so
+/// re-simulating a model does not recompile it. A [`Library::fixed`] one also
+/// takes the on-disk artifact.
+pub fn library_module(
+    engine: &wasmtime::Engine,
+    name: &str,
+    blob: &[u8],
+    fixed: bool,
+) -> std::result::Result<wasmtime::Module, String> {
+    let key = aot_cache_key(blob, alarm_secs() != 0);
+    static MEMO: OnceLock<std::sync::Mutex<HashMap<u64, wasmtime::Module>>> = OnceLock::new();
+    let memo = MEMO.get_or_init(Default::default);
+    if let Some(m) = memo.lock().unwrap_or_else(|e| e.into_inner()).get(&key) {
+        return Ok(m.clone());
+    }
+    let m = match fixed {
+        true => aot_module(engine, &format!("lib-{name}"), blob, alarm_secs() != 0)?,
+        false => wts(wasmtime::Module::new(engine, blob))?,
+    };
+    memo.lock().unwrap_or_else(|e| e.into_inner()).insert(key, m.clone());
+    Ok(m)
+}
+
+fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module, String> {
+    let engine = if epoch { alarm_engine() } else { plain_engine() };
+    aot_module(engine, "runtime", runtime_blob(), epoch)
 }
 
 /// JIT-compile a generated model module on the shared engine. Called either on a
@@ -505,6 +535,74 @@ fn define_external_imports(
     Ok(())
 }
 
+/// One C argument, held by value so `avalue` can point at it.
+enum Slot {
+    I(i64),
+    F(f64),
+    P(*mut core::ffi::c_void),
+}
+
+// Scratch for [`call_external`]'s argument list, taken and put back so a nested
+// call (or one that unwound) just allocates its own.
+thread_local! {
+    static SLOT_SCRATCH: std::cell::Cell<Vec<Slot>> = const { std::cell::Cell::new(Vec::new()) };
+    static AVALUE_SCRATCH: std::cell::Cell<Vec<*mut core::ffi::c_void>> =
+        const { std::cell::Cell::new(Vec::new()) };
+}
+
+/// libffi's prepared call interface for one external, built once when the import
+/// is bound rather than per call — `ffi_prep_cif` classifies the whole argument
+/// list.
+///
+/// A prepared `ffi_cif` is immutable and `ffi_call` only reads it, so sharing it
+/// is sound even though it holds pointers into the type list it owns.
+struct PreparedCif {
+    cif: libffi::middle::Cif,
+    /// libffi widens a return narrower than `ffi_arg`, so never under 8 bytes.
+    ret_size: usize,
+}
+unsafe impl Send for PreparedCif {}
+unsafe impl Sync for PreparedCif {}
+
+/// The C type of each argument in `ffi_call` order — the classification
+/// [`call_external`]'s phase 1 marshals into, derived from the signature alone.
+fn ffi_arg_types(sig: &crate::sig::ExtCallSig) -> Vec<libffi::middle::Type> {
+    use crate::sig::SigTy;
+    use libffi::middle::Type;
+    let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
+    sig.args
+        .iter()
+        .map(|(ty, is_out)| match ty {
+            // An `_Out_` scalar/string/record gets a scratch cell passed by pointer;
+            // an output array is filled in place, like an input one.
+            _ if *is_out && !matches!(ty, SigTy::Array { .. }) => Type::pointer(),
+            // FORTRAN 77 takes every argument by reference.
+            SigTy::Real if !fortran => Type::f64(),
+            SigTy::Int | SigTy::Bool if !fortran => Type::i64(),
+            _ => Type::pointer(),
+        })
+        .collect()
+}
+
+/// Prepare the call interface, or `None` for a return type [`call_external`]
+/// refuses — it reports that per call, as before.
+fn prepare_cif(sig: &crate::sig::ExtCallSig) -> Option<PreparedCif> {
+    use crate::sig::SigTy;
+    use libffi::middle::{Cif, Type};
+    let (ret_type, ret_size) = match &sig.ret {
+        None => (Type::void(), 8),
+        Some(SigTy::Real) => (Type::f64(), 8),
+        Some(SigTy::Int) | Some(SigTy::Bool) => (Type::i32(), 8),
+        Some(SigTy::Str) | Some(SigTy::Ptr) => (Type::pointer(), 8),
+        // A member-less struct is no C type `ffi_prep_cif` accepts.
+        Some(SigTy::Record { fields, .. }) if !fields.is_empty() => {
+            (c_record_ffi_type(fields), c_record_layout(fields).size as usize)
+        }
+        Some(_) => return None,
+    };
+    Some(PreparedCif { cif: Cif::new(ffi_arg_types(sig), ret_type), ret_size })
+}
+
 /// Bind `ext.<sig.name>` to native `addr` through the libffi trampoline. Shared
 /// with the `-d=gen` function JIT, whose externals resolve the same way.
 pub fn define_native_external(
@@ -518,9 +616,10 @@ pub fn define_native_external(
     let name = sig.name.clone();
     let sig = sig.clone();
     let rt = rt.clone();
+    let prepared = prepare_cif(&sig);
     wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
         // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-        unsafe { call_external(addr, &sig, &mut caller, memory, &rt, args, rets) }
+        unsafe { call_external(addr, &sig, prepared.as_ref(), &mut caller, memory, &rt, args, rets) }
             .map_err(|e| wasmtime::Error::msg(format!("{e}")))
     }))?;
     Ok(())
@@ -570,6 +669,7 @@ const EXT_CHECKPOINT: arcstr::ArcStr = arcstr::literal!("wasm-jit external \"C\"
 unsafe fn call_external(
     addr: usize,
     sig: &crate::sig::ExtCallSig,
+    prepared: Option<&PreparedCif>,
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
     memory: wasmtime::Memory,
     rt: &crate::dylink_engine::ExtRt,
@@ -578,7 +678,6 @@ unsafe fn call_external(
 ) -> Result<()> {
     use crate::sig::SigTy;
     use core::ffi::c_void;
-    use libffi::middle::{Cif, Type};
 
     // Raw libffi call, declared `C-unwind` so a Rust panic raised by the
     // ModelicaError interception (`omrs_runtime_abort`) can unwind back through
@@ -593,19 +692,17 @@ unsafe fn call_external(
         );
     }
 
-    enum Slot {
-        I(i64),
-        F(f64),
-        P(*mut c_void),
-    }
     let fortran = sig.lang == crate::sig::ExtLang::Fortran77;
-    let mut slots: Vec<Slot> = Vec::with_capacity(sig.args.len());
+    // Reused across calls (put back below): one heap allocation each otherwise.
+    let mut slots: Vec<Slot> = SLOT_SCRATCH.with(|c| c.take());
+    let mut avalue: Vec<*mut c_void> = AVALUE_SCRATCH.with(|c| c.take());
+    slots.clear();
+    avalue.clear();
     let mut cstrings: Vec<std::ffi::CString> = Vec::new();
     // `const char**` argument vectors, kept alive alongside the strings they point at.
     let mut str_arrays: Vec<Vec<*const std::os::raw::c_char>> = Vec::new();
     // Output `String[…]`: (index into `str_arrays`, wasm element-area offset).
     let mut str_out_arrays: Vec<(usize, usize)> = Vec::new();
-    let mut types: Vec<Type> = Vec::with_capacity(sig.args.len());
     // One native cell per `_Out_` pointer arg, in output order; the C call writes
     // through the pointer we pass.
     let mut out_cells: Vec<(SigTy, Cell)> = Vec::new();
@@ -629,7 +726,6 @@ unsafe fn call_external(
                     _ => return Err("CodegenWasmJit: external \"C\" : output argument type not marshalled"),
                 };
                 slots.push(Slot::P(cell.ptr()));
-                types.push(Type::pointer());
                 out_cells.push((ty.clone(), cell));
                 continue;
             }
@@ -643,20 +739,17 @@ unsafe fn call_external(
                     _ => cell.bytes_mut()[..4].copy_from_slice(&v.unwrap_i32().to_le_bytes()),
                 }
                 slots.push(Slot::P(cell.ptr()));
-                types.push(Type::pointer());
                 in_cells.push(cell);
                 continue;
             }
             match ty {
                 SigTy::Real => {
                     slots.push(Slot::F(v.unwrap_f64()));
-                    types.push(Type::f64());
                 }
                 // Marshalled 64-bit: on SysV x86-64 every integer/pointer arg fills
                 // a full 64-bit slot, correct for `int`/`long`/`size_t` alike.
                 SigTy::Int | SigTy::Bool => {
                     slots.push(Slot::I(v.unwrap_i32() as i64));
-                    types.push(Type::i64());
                 }
                 SigTy::Str => {
                     let off = v.unwrap_i32() as usize;
@@ -665,11 +758,9 @@ unsafe fn call_external(
                         .map_err(|_| "external \"C\" : string argument has an interior NUL")?;
                     slots.push(Slot::P(cs.as_ptr() as *mut c_void));
                     cstrings.push(cs);
-                    types.push(Type::pointer());
                 }
                 SigTy::Ptr => {
                     slots.push(Slot::P(registry_get(v.unwrap_i32()) as *mut c_void));
-                    types.push(Type::pointer());
                 }
                 // Array: a native pointer to the runtime array's contiguous
                 // row-major data (`align8(16 + ndims*4)` past the header). The C
@@ -706,7 +797,6 @@ unsafe fn call_external(
                             str_out_arrays.push((str_arrays.len(), base));
                         }
                         str_arrays.push(ptrs);
-                        types.push(Type::pointer());
                         continue;
                     }
                     if !matches!(&**elem, SigTy::Real | SigTy::Int | SigTy::Bool) {
@@ -722,14 +812,12 @@ unsafe fn call_external(
                     } else {
                         slots.push(Slot::P((mem.as_ptr() as usize + base) as *mut c_void));
                     }
-                    types.push(Type::pointer());
                 }
                 // By pointer, as C's `_copy_to_external` builds it.
                 SigTy::Record { fields, .. } => {
                     let mut cell = Cell::new(c_record_layout(fields).size as usize);
                     record_to_native(mem, fields, v.unwrap_i32() as usize, cell.bytes_mut(), &mut cstrings)?;
                     slots.push(Slot::P(cell.ptr()));
-                    types.push(Type::pointer());
                     in_cells.push(cell);
                 }
                 other => return Err("CodegenWasmJit: external \"C\" : input argument type not yet marshalled"),
@@ -737,31 +825,17 @@ unsafe fn call_external(
         }
     }
     // libffi `avalue`: a pointer to each slot's stored value.
-    let mut avalue: Vec<*mut c_void> = slots
-        .iter_mut()
-        .map(|s| match s {
-            Slot::I(x) => x as *mut i64 as *mut c_void,
-            Slot::F(x) => x as *mut f64 as *mut c_void,
-            Slot::P(x) => x as *mut *mut c_void as *mut c_void,
-        })
-        .collect();
-    // libffi classifies a returned struct from its members, so the callee's ABI
-    // decides between registers and a hidden `sret` pointer.
-    let (ret_type, ret_size) = match &sig.ret {
-        None => (Type::void(), 8),
-        Some(SigTy::Real) => (Type::f64(), 8),
-        Some(SigTy::Int) | Some(SigTy::Bool) => (Type::i32(), 8),
-        Some(SigTy::Str) | Some(SigTy::Ptr) => (Type::pointer(), 8),
-        // A member-less struct is no C type `ffi_prep_cif` accepts.
-        Some(SigTy::Record { fields, .. }) if !fields.is_empty() => {
-            (c_record_ffi_type(fields), c_record_layout(fields).size as usize)
-        }
-        Some(other) => return Err("CodegenWasmJit: external \"C\" : return type not yet marshalled"),
+    avalue.extend(slots.iter_mut().map(|s| match s {
+        Slot::I(x) => x as *mut i64 as *mut c_void,
+        Slot::F(x) => x as *mut f64 as *mut c_void,
+        Slot::P(x) => x as *mut *mut c_void as *mut c_void,
+    }));
+    // Prepared when the import was bound; `None` is a return type not marshalled.
+    let Some(prepared) = prepared else {
+        return Err("CodegenWasmJit: external \"C\" : return type not yet marshalled");
     };
-    let cif = Cif::new(types, ret_type);
-    // libffi widens a return narrower than `ffi_arg` to it, so never under 8 bytes.
-    let mut rvalue = Cell::new(ret_size);
-    let cif_ptr = cif.as_raw_ptr() as *mut c_void;
+    let mut rvalue = Cell::new(prepared.ret_size);
+    let cif_ptr = prepared.cif.as_raw_ptr() as *mut c_void;
     let target = unsafe { std::mem::transmute::<usize, unsafe extern "C-unwind" fn()>(addr) };
     let rvalue_ptr = rvalue.ptr();
     let avalue_ptr = avalue.as_mut_ptr();
@@ -843,6 +917,11 @@ unsafe fn call_external(
     // A `char*` an output still points at is one the callee never wrote.
     drop(cstrings);
     openmodelica_modelica_utilities::sim_external_end();
+    // Hand the buffers back for the next call, emptied so no stale pointer is kept.
+    slots.clear();
+    avalue.clear();
+    SLOT_SCRATCH.with(|c| c.set(slots));
+    AVALUE_SCRATCH.with(|c| c.set(avalue));
     Ok(())
 }
 
@@ -1047,6 +1126,31 @@ pub fn run(model: &SimModel, meta: &SimMeta) -> std::result::Result<sim_driver::
     Ok(result)
 }
 
+/// The runtime's `LOG_STATS_V` per-system table, decoded out of linear memory.
+/// Empty when the runtime never armed it (`rt_stats_start`).
+fn read_sys_stats(
+    store: &mut Store,
+    rt_inst: &wasmtime::Instance,
+    memory: &wasmtime::Memory,
+) -> Vec<openmodelica_sim_meta::sysstat::SysStat> {
+    let (Ok(ptr), Ok(len)) = (
+        rt_inst.get_typed_func::<(), u32>(&mut *store, "rt_sys_stats_ptr"),
+        rt_inst.get_typed_func::<(), u32>(&mut *store, "rt_sys_stats_len"),
+    ) else {
+        return Vec::new();
+    };
+    let (Ok(n), Ok(addr)) = (len.call(&mut *store, ()), ptr.call(&mut *store, ())) else {
+        return Vec::new();
+    };
+    let mut bytes = vec![0u8; n as usize * 8];
+    if memory.read(&*store, addr as usize, &mut bytes).is_err() {
+        return Vec::new();
+    }
+    let words: Vec<f64> =
+        bytes.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect();
+    openmodelica_sim_meta::sysstat::decode(&words)
+}
+
 /// One-shot in-wasm run (used by [`run`] under `OMC_WASM_INWASM_DRIVER`): start,
 /// pump to completion with an unbounded budget, read the result.
 fn run_inwasm(model: &SimModel, bench: bool) -> std::result::Result<sim_driver::RunResult, String> {
@@ -1132,7 +1236,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
 
     // Phase 2: instantiate (sharing the runtime's linear memory).
     let t_inst = Instant::now();
-    let mut store = wasmtime::Store::new(engine, WasiCtx::new(".", Vec::new()));
+    let mut store = wasmtime::Store::new(engine, WasiCtx::new("/", Vec::new()));
     if let secs @ 1.. = alarm_secs() {
         ALARM_FIRED.with(|f| f.set(false));
         store.set_epoch_deadline(secs as u64);
@@ -1226,6 +1330,12 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
     if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_log_streams") {
         wts(set.call(&mut store, (log_mask as u32, (log_mask >> 32) as u32)))?;
+    }
+    // The linear/nonlinear systems are solved in-wasm, so their `LOG_STATS_V`
+    // statistics are measured there; hand the module the host clock and arm them.
+    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_stats_start") {
+        let on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::STATS_V);
+        wts(set.call(&mut store, on as u32))?;
     }
     // `-lv=LOG_NLS` names the iteration variables, which only the metadata has. The
     // roster is per model, so it is cleared first and pushed only when the stream is
@@ -1366,17 +1476,17 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
         self.memory.write(&mut self.store, addr as usize, buf).map_err(|e| "CodegenWasmJit: mem write")
     }
-    fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
+    fn call1_raw(&mut self, name: &str, arg: u32) -> Result<()> {
         let f = self.func(name)?;
         wt(f.call(&mut self.store, arg))
     }
-    fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()> {
+    fn call1_if_present_raw(&mut self, name: &str, arg: u32) -> Result<()> {
         if self.instance.get_func(&mut self.store, name).is_none() {
             return Ok(());
         }
-        self.call1(name, arg)
+        self.call1_raw(name, arg)
     }
-    fn call2(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> Result<()> {
         let f = match self.funcs2.get(name) {
             Some(f) => f.clone(),
             None => {
@@ -1405,6 +1515,10 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             Ok(f) => f.call(&mut self.store, ()).unwrap_or(0),
             Err(_) => 0,
         }
+    }
+    fn sys_stats(&mut self) -> Vec<openmodelica_sim_meta::sysstat::SysStat> {
+        let out = read_sys_stats(&mut self.store, &self.rt_inst, &self.memory);
+        out
     }
     fn rt_stats(&mut self) -> [u64; sim_driver::RT_STATS] {
         let mut out = [0u64; sim_driver::RT_STATS];
@@ -1459,6 +1573,8 @@ pub struct InWasmSession {
     stat_f: wasmtime::TypedFunc<u32, u64>,
     lin_ptr: wasmtime::TypedFunc<(), u32>,
     lin_len: wasmtime::TypedFunc<(), u32>,
+    sys_ptr: wasmtime::TypedFunc<(), u32>,
+    sys_len: wasmtime::TypedFunc<(), u32>,
     free_f: wasmtime::TypedFunc<(), ()>,
 }
 
@@ -1521,6 +1637,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.get_typed_func::<u32, u64>(&mut store, "rt_sim_stat"))?,
         lin_ptr: gf(&mut store, "rt_sim_lin_ptr")?,
         lin_len: gf(&mut store, "rt_sim_lin_len")?,
+        sys_ptr: gf(&mut store, "rt_sys_stats_ptr")?,
+        sys_len: gf(&mut store, "rt_sys_stats_len")?,
         free_f: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_sim_free"))?,
         store,
         memory,
@@ -1548,13 +1666,13 @@ impl sim_driver::SimEngine for InWasmSession {
     fn write_bytes(&mut self, addr: u32, buf: &[u8]) -> Result<()> {
         self.memory.write(&mut self.store, addr as usize, buf).map_err(|_| "CodegenWasmJit: mem write")
     }
-    fn call1(&mut self, _name: &str, _arg: u32) -> Result<()> {
+    fn call1_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Err("CodegenWasmJit: call1 on in-wasm session (unreachable)")
     }
-    fn call1_if_present(&mut self, _name: &str, _arg: u32) -> Result<()> {
+    fn call1_if_present_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
         Ok(())
     }
-    fn call2(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
+    fn call2_raw(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
         Err("CodegenWasmJit: call2 on in-wasm session (unreachable)")
     }
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
@@ -1600,6 +1718,9 @@ impl InWasmSession {
         let rows = read_vec(&mut self.store, &self.memory, &self.rows_ptr, &self.rows_len)?;
         let params = read_vec(&mut self.store, &self.memory, &self.params_ptr, &self.params_len)?;
         let mut stats = openmodelica_sim_meta::SolveStats::default();
+        stats.systems = openmodelica_sim_meta::sysstat::decode(&read_vec(
+            &mut self.store, &self.memory, &self.sys_ptr, &self.sys_len,
+        )?);
         let mut stat = |i: u32| wt(self.stat_f.call(&mut self.store, i));
         stats.steps = stat(0)?;
         stats.res_evals = stat(1)?;
@@ -1609,6 +1730,7 @@ impl InWasmSession {
         stats.state_events = stat(5)?;
         stats.time_events = stat(6)?;
         stats.lin_solves = stat(7)?;
+        openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
         Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
@@ -441,21 +441,21 @@ mod tests {
     /// Build a tiny wasip1 command module that, from `_start`:
     ///   * `path_open`s a relative name for writing (CREAT|TRUNC, write rights),
     ///   * `fd_write`s a fixed payload,
-    ///   * `fd_close`s (flushing to the VFS),
+    ///   * `fd_close`s (flushing the file out),
     ///   * `proc_exit(0)`.
     /// The data segment lays out, from address 0:
     ///   [0]   the path string         (`path_bytes`)
-    ///   [64]  the payload string      (`data_bytes`)
-    ///   [128] iovec { buf=64, len }
-    ///   [136] scratch: opened-fd out  (u32)
-    ///   [140] scratch: nwritten out   (u32)
+    ///   [256] the payload string      (`data_bytes`)
+    ///   [512] iovec { buf=256, len }
+    ///   [520] scratch: opened-fd out  (u32)
+    ///   [524] scratch: nwritten out   (u32)
     fn build_writer_module(path: &str, data: &str) -> Vec<u8> {
         use we::Instruction as I;
         const PATH_OFF: i32 = 0;
-        const DATA_OFF: i32 = 64;
-        const IOVEC_OFF: i32 = 128;
-        const OPENED_FD_OFF: i32 = 136;
-        const NWRITTEN_OFF: i32 = 140;
+        const DATA_OFF: i32 = 256;
+        const IOVEC_OFF: i32 = 512;
+        const OPENED_FD_OFF: i32 = 520;
+        const NWRITTEN_OFF: i32 = 524;
         const WASI: &str = "wasi_snapshot_preview1";
 
         let mut m = we::Module::new();
@@ -547,28 +547,36 @@ mod tests {
         m.finish()
     }
 
+    /// A run directory of our own, since the shim serves real files natively.
+    fn test_root(tag: &str) -> String {
+        format!("{}/om-wasi-shim-{tag}-{}", std::env::temp_dir().display(), std::process::id())
+    }
+
     #[test]
-    fn wasi_writes_through_vfs() {
-        let path = "wasi_shim_test_out.txt";
-        let payload = "hello from wasi over the vfs\n";
-        let wasm = build_writer_module(path, payload);
+    fn wasi_writes_through_fs() {
+        let root = test_root("abs");
+        openmodelica_wasi::fs::create_dir_all(&root).unwrap();
+        let path = format!("{root}/wasi_shim_test_out.txt");
+        let payload = "hello from wasi over the fs facade\n";
+        let wasm = build_writer_module(&path, payload);
         let code = run_command(&wasm, "", vec!["sim".to_string()]).unwrap();
         assert_eq!(code, 0);
-        let got = openmodelica_wasi::read(path).expect("file should exist in the VFS");
+        let got = openmodelica_wasi::fs::read(&path).expect("file should exist");
         assert_eq!(String::from_utf8(got).unwrap(), payload);
-        openmodelica_wasi::remove(path);
+        let _ = openmodelica_wasi::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn wasi_writes_under_cwd_prefix() {
-        let path = "res.mat";
+        let root = test_root("cwd");
+        openmodelica_wasi::fs::create_dir_all(&root).unwrap();
         let payload = "MATDATA";
-        let wasm = build_writer_module(path, payload);
-        let code = run_command(&wasm, "rundir", vec!["sim".to_string()]).unwrap();
+        let wasm = build_writer_module("res.mat", payload);
+        let code = run_command(&wasm, &root, vec!["sim".to_string()]).unwrap();
         assert_eq!(code, 0);
-        // cwd "rundir" + relative "res.mat" -> VFS key "rundir/res.mat".
-        let got = openmodelica_wasi::read("rundir/res.mat").expect("file under cwd prefix");
+        // cwd <root> + relative "res.mat" -> <root>/res.mat.
+        let got = openmodelica_wasi::fs::read(&format!("{root}/res.mat")).expect("file under cwd prefix");
         assert_eq!(String::from_utf8(got).unwrap(), payload);
-        openmodelica_wasi::remove("rundir/res.mat");
+        let _ = openmodelica_wasi::fs::remove_dir_all(&root);
     }
 }


### PR DESCRIPTION
FullRobot (stopTime=2) took 4.03s against the C target's 1.10s. None of that gap was code quality: a wasm->host call costs ~90ns here, a cross-module call_indirect 4.4ns, and straight-line f64 load/mul/add/store runs at 1.00ns/op in wasm against 1.13ns/op natively. It was what the runtime did around the generated code.

| model (stopTime) | C | before | after |
| --- | --- | --- | --- |
| MultiBody RobotR3.FullRobot (2) | 1.10s | 4.03s | 1.09-1.16s | | MultiBody Loops.EngineV6 (1) | 11.67s | - | 10.98s |

`diffSimulationResults` against the C target reports zero differing variables for FullRobot.

**Log messages built for streams that are off.** `newton_c` handed its `HomotopyTrace` to every solve, so the `trace.is_some()` blocks in the Newton loop ran a dozen `debug_double` calls per iteration -- and `omclog::debug_int`/`debug_double` built the message *before* `info()` checked the stream, each one a scientific-notation float format plus a `String`. That was ~15us per iteration against C's ~1us per whole solve. C never pays it: `infoStreamPrint` is variadic and formats nothing when the stream is off. Both helpers now check `active(stream)` first, as `debug_vector_double` beside them already did, and the trace is handed over only when `LOG_NLS_V` is on -- where C wraps the same block.

**`external "C"` prefers a wasm build of the library.** A `CombiTable1D` lookup inside a friction residual ran 1.25M times in this model, each one a host trampoline plus `call_external`'s marshalling. `bind_in_wasm_external` already binds a scalar import straight to a wasm export when the library is a loaded side module, which makes it a plain wasm->wasm call, so `resolve_ext_libraries` now looks for `<name>.wasm` beside a `Library` before falling back to the C source or the native shared object. The MSL C set has no installed `.wasm` but is embedded in omc as `modelicaexternalc_dylink.wasm`, so it is matched by *symbol* (`SimModel::ext_builtin`) and loaded after the model's own libraries.

Side libraries take the runtime module's on-disk AOT cache, keyed by their content hash: ModelicaExternalC is 0.44s to compile (1.39s under `-n=1`, which compiles serially) against 2.9ms to load the artifact. `Library::fixed` decides: a built-in or `Library`-named library gets an artifact, one built from a model's own `Include` sources gets only the process memo, since caching that would leave a file per model behind. In a testsuite run (rtest points HOME at `<root>/libraries`, so one cache serves every test) that is +3.8s once per machine and ~5ms a run. `parallel_compilation` is not part of wasmtime's artifact compatibility check, so `-n=1` runs and normal runs share one cache.

Also on the external path: `call_external` built a libffi `Cif` per call; it is now prepared when the import is bound, and the argument vectors come from a thread-local instead of the heap.

**`LOG_STATS` parity, which is how the above was found.** `-lv=LOG_STATS` renders C's whole `### STATISTICS ###` block, timer section and `time of jacobian evaluation` included, and `LOG_STATS_V` adds the
"function calls", "linear systems" and "non-linear systems" sections -- same lines, order and quantities as `solver_main.c`, so the two targets can be diffed directly. `rtclock.rs` is C's `rtclock.c` ticked where C ticks it; the per-system statistics are measured in wasm (that is where the systems are solved) and read back through `rt_sys_stats_ptr`. As in C the clocks only run when the block will be printed, so an ordinary run pays nothing.

**`rust_susan.stamp` had no `DEPENDS`**, so make treated it as up to date the moment the file existed and never rebuilt `susan` again. A build directory configured before #16335 (which added `--tplOutputDir`) kept compiling every template with a `susan` that ignored the flag, wrote the
`.mo` into the source tree, left `generated-mo/Template/` empty, and the transpile then silently dropped every `*Tpl` module.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
