### PR TITLE
[Testsuite] Let the FMPy tests ask for their interpreter (FMPY_TOOL)

### DIFF
--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_attributes_01.mos
@@ -30,7 +30,10 @@ readFile("fmi3_attributes_01.xml"); getErrorString();
 // model in OpenModelica, simulate the FMU with FMPy, and check that the FMU
 // reproduces OpenModelica's own (non-FMU) simulation results.
 simulate(fmi3_attributes_01, stopTime=1.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py fmi3_attributes_01.fmu fmi3_attributes_01_fmpy.csv 1.0 x y"); getErrorString();
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py fmi3_attributes_01.fmu fmi3_attributes_01_fmpy.csv 1.0 x y"); getErrorString();
 diffSimulationResults("fmi3_attributes_01_fmpy.csv", "fmi3_attributes_01_res.mat", "fmi3_attributes_01_diff", vars={"x","y"}); getErrorString();
 
 // Result:

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_adder4.mos
@@ -15,7 +15,10 @@ simulate(Modelica.Electrical.Digital.Examples.Adder4, stopTime=5.0, fileNamePref
 
 buildModelFMU(Modelica.Electrical.Digital.Examples.Adder4, version="3.0", fmuType="me", fileNamePrefix="Adder4"); getErrorString();
 
-system("python3 ../../simulate_fmu_fmpy.py Adder4.fmu Adder4_fmpy.csv 5.0 Adder1.s Adder1.c_out Adder4.s Adder4.c_out"); getErrorString();
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py Adder4.fmu Adder4_fmpy.csv 5.0 Adder1.s Adder1.c_out Adder4.s Adder4.c_out"); getErrorString();
 diffSimulationResults("Adder4_fmpy.csv", "Adder4_ref_res.mat", "Adder4_diff", vars={"Adder1.s","Adder1.c_out","Adder4.s","Adder4.c_out"}); getErrorString();
 
 // Result:

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos
@@ -14,7 +14,10 @@ simulate(Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a, stopTime=5.0, fil
 
 buildModelFMU(Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a, version="3.0", fmuType="me", fileNamePrefix="Engine1a"); getErrorString();
 
-system("python3 ../../simulate_fmu_fmpy.py Engine1a.fmu Engine1a_fmpy.csv 5.0 inertia.phi inertia.w"); getErrorString();
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py Engine1a.fmu Engine1a_fmpy.csv 5.0 inertia.phi inertia.w"); getErrorString();
 diffSimulationResults("Engine1a_fmpy.csv", "Engine1a_ref_res.mat", "Engine1a_diff", vars={"inertia.phi","inertia.w"}); getErrorString();
 
 // Result:

--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -234,7 +234,10 @@ sub enter_sandbox {
     elsif (/loadFile.*\(\"(.*)\"\)/)   { make_link($1); }
     elsif (/runScript.*\(\"(.*)\"\)/)  { make_link($1); }
     elsif (/importFMU.*\(\"(.*)\"\)/)  { make_link($1); }
-    elsif (/system\(\"\s*python[0-9]*\s+(\S+\.py)/) { make_external_link($1); }
+    # The interpreter is not always spelled out: a test may take it from the
+    # environment, e.g. system("\"" + getEnvironmentVar("FMPY_TOOL") + "\" ../../x.py").
+    # Link whatever .py the command names, however it is invoked.
+    elsif (/system\(.*?[\s\"]([\w.\/-]+\.py)\b/) { make_external_link($1); }
     elsif (/system\(\"(gcc|g\+\+).*\s(\w*\.\w*)\s(\w*\.\w*)/) {
       my $header = lib_to_header($2);
       make_link($header);

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -177,6 +177,12 @@ sub setup_command_toolchain
   for my $k (keys %tc) {
     $ENV{$k} = $tc{$k} unless defined $ENV{$k};
   }
+  # The FMU round-trip tests drive FMPy through simulate_fmu_fmpy.py, and which
+  # interpreter can import fmpy is a property of the machine rather than of the
+  # test: on Windows OMDev's python cannot install it, while a native Python
+  # often already has it. Let the tests ask for the interpreter instead of
+  # hardcoding python3, so a node only has to set FMPY_TOOL.
+  $ENV{'FMPY_TOOL'} = 'python3' unless defined $ENV{'FMPY_TOOL'};
   if ($wasm && !$ENV{'OMC_EXTLIB_LIBS'}) {
     print "Warning: no libclang_rt.builtins-wasm32.a found; external \"C\" setup_commands may fail to link.\n";
   }


### PR DESCRIPTION
Fixes #16399.

## What this does

The FMU round-trip tests drive FMPy through `python3 ../../simulate_fmu_fmpy.py`.
Which interpreter can import `fmpy` is a property of the machine rather than of
the test: on Windows OMDev's python cannot install it (`rpds-py` has no wheel for
MSYS2 python 3.14 and wants Rust to build), while another python on the same box
may have it.

So let `rtest` hand the interpreter over in `FMPY_TOOL`, next to where it already
exports `OMC_CC` and friends, and let the tests ask for it. Anything already in
the environment wins and the default is `python3`, so Unix is unchanged and a
Windows node only has to point `FMPY_TOOL` at a python that can import fmpy.

The lookup is kept inside the `system()` call as one expression on purpose: a
top-level assignment would echo its value into the log, and
`echo(false)`/`echo(true)` around it would echo `true` — either of which changes
what the test compares.

## Note for whoever configures a node

Install fmpy into that interpreter's **own** site-packages, i.e. a venv, not a
`--user` install. `rtest` overrides `APPDATA` to point at the testsuite's
libraries directory, and python resolves user site-packages through `APPDATA`, so
a `--user` install imports fine by hand and disappears under rtest:

```
with the real APPDATA:                       fmpy ok
with APPDATA overridden the way rtest does:  ModuleNotFoundError: No module named 'fmpy'
```

A venv keeps its packages inside itself and is unaffected. Verified with a venv
at `C:\dev\OMDevPyEnv`.

## Second commit: partest has to link the helper

partest sandboxes each test one directory deeper than the test itself, so a
helper invoked as `../../simulate_fmu_fmpy.py` no longer resolves — that is what
`make_external_link` is for. Which helper to link was found with

```perl
elsif (/system\(\"\s*python[0-9]*\s+(\S+\.py)/) { make_external_link($1); }
```

which requires the line to start `system("python3 ...`, so taking the interpreter
from `FMPY_TOOL` stopped the link being made. The test then passed when run
directly and failed in the sandbox, which is exactly what CI reported:

```
python3: can't open file '.../fmi3_msl_engine1a.mos_temp3057/../../simulate_fmu_fmpy.py':
[Errno 2] No such file or directory
```

Match the `.py` the command names instead of the interpreter in front of it. The
existing `system("python3 ...")` callers keep working, and how the interpreter is
spelled stops mattering.

Verified **under partest** (not just rtest — only the sandbox exercises this),
with the pre-existing link deleted first so it is really created, on a Linux and
a Windows build:

```
[fmi3_attributes_01.mos] OK   [fmi3_msl_adder4.mos] OK   [fmi3_msl_engine1a.mos] OK
```

## Blocker

This makes fmpy *run* on Windows — verified, the failure changes from
`ModuleNotFoundError` to a real fmpy exception — but the three tests still cannot
pass, because of #16402: FMI 3.0 export on Windows writes
`binaries/x86_64-win/` instead of the `x86_64-windows` platform tuple, so FMPy
refuses the FMU:

```
File "...\fmpy\simulation.py", line 704, in simulate_fmu
    raise Exception(f"The FMU cannot be simulated on the current platform ({platform}).")
Exception: The FMU cannot be simulated on the current platform (win64).
```

#16402 is now fixed (#16404, merged), so with this PR the three tests pass on
Windows rather than needing to be skipped — #16400 can be closed.

---
generated by Claude Code
