### PR TITLE
[FMI] Use the FMI 3.0 platform tuple for Windows binaries

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -173,7 +173,14 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/isfmi3")
   # FMI 3.0 uses the platform tuple "{architecture}-{os}" for the binaries folder
   # (e.g. x86_64-linux), unlike FMI 1.0/2.0 which use "{os}{bitness}" (e.g. linux64).
-  set(FMU_TARGET_PLATFORM "${FMU_TARGET_ARCH}-${FMU_TARGET_SYSTEM_NAME}")
+  # The two schemes do not spell Windows the same way: FMI 1.0/2.0 want "win"
+  # (win64), FMI 3.0 wants it in full (x86_64-windows). Linux and darwin are the
+  # same word in both, so only this one has to be translated.
+  set(FMU_TARGET_SYSTEM_TUPLE "${FMU_TARGET_SYSTEM_NAME}")
+  if(FMU_TARGET_SYSTEM_NAME STREQUAL "win")
+    set(FMU_TARGET_SYSTEM_TUPLE "windows")
+  endif()
+  set(FMU_TARGET_PLATFORM "${FMU_TARGET_ARCH}-${FMU_TARGET_SYSTEM_TUPLE}")
 elseif(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
   set(FMU_TARGET_PLATFORM "${FMU_TARGET_SYSTEM_NAME}64")
 else()


### PR DESCRIPTION
Fixes #16402

## Problem

An FMI 3.0 FMU exported on Windows put its binary in `binaries/x86_64-win/`. The
FMI 3.0 platform tuple for 64-bit Windows is **`x86_64-windows`**, so other FMI
tools refuse the FMU. FMPy, for one:

```
File "...\fmpy\simulation.py", line 704, in simulate_fmu
    raise Exception(f"The FMU cannot be simulated on the current platform ({platform}).")
Exception: The FMU cannot be simulated on the current platform (win64).
```

The binary itself was fine and complete; only the directory name was wrong.

## Cause

The FMU's `CMakeLists.txt.in` derives both naming schemes from one variable.
FMI 1.0/2.0 spell the system `win` and append the bitness, giving `win64`;
FMI 3.0 joins architecture and system with a dash, which turned that same `win`
into `x86_64-win`. Linux and darwin are the same word in both schemes, which is
why only Windows was affected.

## Fix

Translate the system name for the FMI 3.0 tuple only, leaving `win64` alone.

OpenModelica's Cpp code generator already had this right —
`Compiler/Template/CodegenFMUCpp.tpl` has `case "win64" then 'x86_64-windows'` —
so this brings the C runtime export in line with it and with the standard.

## Verification

On a Windows build of current master:

| | before | after |
|---|---|---|
| FMI 3.0 | `binaries/x86_64-win/FChk.dll` | `binaries/x86_64-windows/FChk.dll` |
| FMI 2.0 | `binaries/win64/FChk2.dll` | `binaries/win64/FChk2.dll` — unchanged |

On a Linux build, `binaries/x86_64-linux/` — unchanged.

The three FMI 3.0 round-trip tests that simulate the exported FMU back with an
independent importer now pass on Windows, where they could not before:

```
+ fmi3_attributes_01.mos   ... ok [time: 43]
+ fmi3_msl_adder4          ... ok [time: 106]
+ fmi3_msl_engine1a        ... ok [time: 81]
== 0 out of 3 tests failed
```

Those runs need a `python3` that can import fmpy, which is #16399 / PR #16403 —
but that was never the whole story: with fmpy available and this bug still
present, the tests failed anyway on the rejected FMU.

## Consequence for the other PRs

With this fixed, #16400 (skip the three tests on Windows) is no longer needed,
and #16403 (`FMPY_TOOL`) becomes useful rather than parked.

---
generated by Claude Code
