### PR TITLE
wasm FMU: log to stdout, C's CS event semantics

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2028,8 +2028,9 @@ fn wasm_exports(bytes: &[u8]) -> impl Iterator<Item = &str> {
 
 /// Link the adapter + model into an fmi-ls-wasm component (pure Rust, so it runs in
 /// the browser omc too). When the model uses `external "C"`, ModelicaExternalC +
-/// PIC `libc.so` are added as shared-everything libraries and libc's preview1
-/// imports bridged to the component's preview2 WASI by the reactor adapter.
+/// PIC `libc.so` are added as shared-everything libraries. The reactor adapter
+/// bridges preview1 to the component's preview2 WASI: libc's calls, and the FMI
+/// adapter's own `fd_write` for the simulation log.
 fn link_fmu_component(
     model_wasm: &[u8],
     adapter: &[u8],
@@ -2070,8 +2071,10 @@ fn link_fmu_component(
             // Last, so a `usertab` from the model's own libraries wins.
             l = l.library("usertab", USERTAB_DYLINK, false).map_err(link_err)?;
         }
-        l = l.adapter("wasi_snapshot_preview1", WASI_P1_ADAPTER).map_err(link_err)?;
     }
+    // Unconditional: the adapter is also what gives the FMU the stdout its
+    // simulation log goes to.
+    l = l.adapter("wasi_snapshot_preview1", WASI_P1_ADAPTER).map_err(link_err)?;
     l.encode().map_err(link_err)
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -31,7 +31,7 @@ use openmodelica_sim_meta::driver::{
     SimEngine,
 };
 #[cfg(feature = "cs")]
-use openmodelica_sim_meta::driver::{CsDriver, CsStep};
+use openmodelica_sim_meta::driver::{CsDefer, CsDriver, CsStep};
 use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, Neg, WTy, REAL_OFF, TIME_OFF};
 
 // ── Model kernel imports ─────────────────────────────────────────────────────
@@ -70,10 +70,43 @@ unsafe extern "C" {
 }
 
 // ── Messages ─────────────────────────────────────────────────────────────────
-// A component has no stdout, so the `log-message` callback (`fmi3LogMessage`) is
-// the FMU's only channel: `print`, assertions and the `-lv` solver lines all leave
-// through it, with the statuses and categories C's FMU gives them
-// (`fmu3_model_interface.c`).
+// Two channels, as C's FMU has: `messageText` prints the `-lv` streams to stdout,
+// and the `log-message` callback (`fmi3LogMessage`) carries what
+// `fmu3_model_interface.c` sends through `FILTERED_LOG`.
+
+/// The FMU's stdout, which for a component is WASI's: `fd_write` on the preview1
+/// descriptor, which the adapter `CodegenWasmJit::link_fmu_component` composes in
+/// bridges to `wasi:cli/stdout`.
+mod stdio {
+    const STDOUT: i32 = 1;
+
+    #[repr(C)]
+    struct Ciovec {
+        buf: *const u8,
+        len: usize,
+    }
+
+    #[link(wasm_import_module = "wasi_snapshot_preview1")]
+    unsafe extern "C" {
+        #[link_name = "fd_write"]
+        fn fd_write(fd: i32, iovs: *const Ciovec, iovs_len: usize, nwritten: *mut usize) -> i32;
+    }
+
+    /// C's `printf` + `fflush(NULL)`: written whole and now, so it interleaves
+    /// with the importer's own output in the order the two produced it.
+    pub fn print(bytes: &[u8]) {
+        let mut rest = bytes;
+        while !rest.is_empty() {
+            let iov = Ciovec { buf: rest.as_ptr(), len: rest.len() };
+            let mut n = 0usize;
+            let rc = unsafe { fd_write(STDOUT, &iov, 1, &mut n) };
+            if rc != 0 || n == 0 || n > rest.len() {
+                return;
+            }
+            rest = &rest[n..];
+        }
+    }
+}
 
 /// C's `logCategoriesNames`, which is also what `CodegenFMU3` declares in
 /// `modelDescription.xml`. `logFmi3Call` is unused: the adapter logs no call trace.
@@ -90,10 +123,6 @@ const CATEGORIES: [&str; 11] = [
     "logAll",
     "logFmi3Call",
 ];
-const CAT_EVENTS: u32 = 0;
-const CAT_SINGULAR_LS: u32 = 1;
-const CAT_NLS: u32 = 2;
-const CAT_DSS: u32 = 3;
 const CAT_WARNING: u32 = 4;
 const CAT_ERROR: u32 = 6;
 const CAT_ALL: u32 = 9;
@@ -101,13 +130,11 @@ const CAT_ALL: u32 = 9;
 struct Logger {
     /// `instanceName`, which the callback reports alongside the message.
     name: String,
-    /// `loggingOn`.
-    on: bool,
-    /// Bit per [`CATEGORIES`] index.
+    /// Bit per [`CATEGORIES`] index; empty until `loggingOn`.
     cats: u32,
 }
 
-static mut LOGGER: Logger = Logger { name: String::new(), on: false, cats: 0 };
+static mut LOGGER: Logger = Logger { name: String::new(), cats: 0 };
 
 /// The sink is a bare `fn(&str)`, so its context is a static (wasm, single-threaded).
 fn logger() -> &'static mut Logger {
@@ -137,52 +164,11 @@ fn fmi_log(status: Status, cat: u32, msg: &str) {
     }
 }
 
-/// The runtime's and driver's log lines. The FMI logger is the FMU's only
-/// channel, so the stream and type become a category and an `fmi3Status` — the
-/// mapping C's FMU makes at each `FILTERED_LOG` site. Through [`fmi_log`], so the
-/// importer's category filter applies.
-fn log_sink(stream: omclog::Stream, ty: omclog::LogType, s: &str) {
-    if !logger().on {
-        return;
-    }
-    let cat = match stream {
-        omclog::EVENTS | omclog::EVENTS_V | omclog::ZEROCROSSINGS => CAT_EVENTS,
-        omclog::NLS | omclog::NLS_V | omclog::NLS_HOMOTOPY | omclog::NLS_JAC
-        | omclog::NLS_RES | omclog::NLS_EXTRAPOLATE => CAT_NLS,
-        omclog::LS | omclog::LS_V => CAT_SINGULAR_LS,
-        omclog::DSS | omclog::DSS_JAC => CAT_DSS,
-        // An assert is C's `logStatusError` whatever type it carries.
-        omclog::ASSERT => CAT_ERROR,
-        _ => match ty {
-            omclog::ERROR => CAT_ERROR,
-            omclog::WARNING => CAT_WARNING,
-            _ => CAT_ALL,
-        },
-    };
-    let status = match ty {
-        omclog::ERROR => Status::Error,
-        omclog::WARNING => Status::Warning,
-        _ => Status::Ok,
-    };
-    fmi_log(status, cat, s);
-}
-
-/// The `-lv` streams the model-diagnostics categories stand for. Only
-/// `set-debug-logging` reaches this: C's FMU leaves every stream but stdout and
-/// assert off.
-fn stream_mask(cats: u32) -> omclog::Mask {
-    let mut streams: Vec<&str> = Vec::new();
-    for (cat, stream) in [
-        (CAT_EVENTS, "LOG_EVENTS"),
-        (CAT_SINGULAR_LS, "LOG_LS"),
-        (CAT_NLS, "LOG_NLS"),
-        (CAT_DSS, "LOG_DSS"),
-    ] {
-        if cats & (1 << cat) != 0 || cats & (1 << CAT_ALL) != 0 {
-            streams.push(stream);
-        }
-    }
-    omclog::mask_from_streams(&streams).unwrap_or(omclog::ALWAYS_ON)
+/// The runtime's and driver's log lines. C's `messageText` prints every type with
+/// `printf`, so they go to stdout with the stream and type in the header, not to
+/// the logger.
+fn log_sink(_stream: omclog::Stream, _ty: omclog::LogType, s: &str) {
+    stdio::print(s.as_bytes());
 }
 
 /// C's `omcInstantiate`: every category follows `loggingOn` until
@@ -190,10 +176,9 @@ fn stream_mask(cats: u32) -> omclog::Mask {
 fn init_logging(name: String, logging_on: bool) {
     let l = logger();
     l.name = name;
-    l.on = logging_on;
     l.cats = if logging_on { !0 } else { 0 };
     driver::set_log_sink(log_sink);
-    omclog::set_mask(omclog::ALWAYS_ON);
+    omclog::set_mask(omclog::FMU_STREAMS);
 }
 
 /// The runtime `String` behind a handle, empty for the null handle.
@@ -253,10 +238,11 @@ pub extern "C" fn rt_assert_warning(
     fmi_log(Status::Warning, CAT_WARNING, &assert_message(msg, file, sline));
 }
 
-/// The `print` builtin: model output, which C sends to stdout — not a `-lv` stream.
+/// The `print` builtin: model output, which C sends to stdout unformatted — not a
+/// `-lv` stream.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_print(str: i32) {
-    log_sink(omclog::STDOUT, omclog::INFO, &rt_string(str));
+    stdio::print(rt_string(str).as_bytes());
 }
 
 /// Per-row assert formatting: the FMI master steps the model instead of the emitted
@@ -389,8 +375,10 @@ struct MeState {
     cs: Option<CsDriver>,
     /// `eventModeUsed` from instantiation: `do-step` stops at and reports each event
     /// for the master, rather than handling it internally.
+    /// FMI's `eventModeUsed`/`earlyReturnAllowed`, folded into who resolves an
+    /// event and where the step may stop.
     #[cfg(feature = "cs")]
-    event_mode: bool,
+    defer: openmodelica_sim_meta::driver::CsDefer,
     vrs: Vrs,
     mode: Mode,
     /// C's `_need_update`, consumed by `update_if_needed`.
@@ -576,7 +564,7 @@ fn new_state() -> Option<MeState> {
         #[cfg(feature = "cs")]
         cs: None,
         #[cfg(feature = "cs")]
-        event_mode: false,
+        defer: CsDefer::None,
         mode: Mode::Instantiated,
         need_update: true,
         init_overrides: Vec::new(),
@@ -616,12 +604,8 @@ macro_rules! shared_instance_methods {
                 None => unknown.push(c),
             }
         }
-        {
-            let l = logger();
-            l.on = logging_on;
-            l.cats = cats;
-        }
-        omclog::set_mask(stream_mask(cats));
+        // The `FILTERED_LOG` filter only: C leaves the `-lv` streams alone here.
+        logger().cats = cats;
         for c in unknown {
             log_raw(
                 Status::Warning,
@@ -674,10 +658,10 @@ macro_rules! shared_instance_methods {
         // action after init is an event iteration (`update-discrete-states`), which
         // must run through the driver's sample schedule, so build it eagerly.
         #[cfg(feature = "cs")]
-        if st.event_mode {
+        if st.defer != CsDefer::None {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
-            let meta = st.meta.clone();
-            match CsDriver::new(&mut Engine, &meta, sim_data, t) {
+            let (meta, defer) = (st.meta.clone(), st.defer);
+            match CsDriver::new(&mut Engine, &meta, sim_data, t, defer) {
                 Ok(d) => st.cs = Some(d),
                 Err(_) => return Status::Error,
             }
@@ -699,7 +683,7 @@ macro_rules! shared_instance_methods {
         let mut e = Engine;
 
         #[cfg(feature = "cs")]
-        let up = if st.event_mode {
+        let up = if st.defer != CsDefer::None {
             // Route through the driver so its sample schedule advances in step with
             // the integrator (see `CsDriver::do_event_update`).
             let meta = st.meta.clone();
@@ -1274,7 +1258,7 @@ impl GuestCoSimulationInstance for Instance {
         _visible: bool,
         logging_on: bool,
         event_mode_used: bool,
-        _early_return_allowed: bool,
+        early_return_allowed: bool,
         _required_intermediate_variables: Vec<u32>,
     ) -> Option<CoSimulationInstance> {
         init_logging(instance_name, logging_on);
@@ -1282,13 +1266,18 @@ impl GuestCoSimulationInstance for Instance {
         // the FMU's `resources/` as this component's root, not the host path.
         openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
         let mut st = new_state()?;
-        st.event_mode = event_mode_used;
+        st.defer = match (event_mode_used, early_return_allowed) {
+            (false, _) => CsDefer::None,
+            (true, false) => CsDefer::AtTarget,
+            (true, true) => CsDefer::Any,
+        };
+        // C's `fmi2Instantiate` sets the internal solver up here, CS only.
+        driver::log_cs_solver_setup(&st.meta, st.defer);
         Some(CoSimulationInstance::new(Instance { st: RefCell::new(st) }))
     }
 
-    /// Integrate to the communication point. Under `eventModeUsed` it stops at the
-    /// first event and returns `event-handling-needed`; otherwise events are handled
-    /// internally.
+    /// Integrate to the communication point, reporting the events the instance's
+    /// [`CsDefer`] leaves to the master and resolving the rest.
     fn do_step(
         &self,
         current_communication_point: f64,
@@ -1297,7 +1286,7 @@ impl GuestCoSimulationInstance for Instance {
     ) -> Result<DoStepResult, Status> {
         let mut st = self.st.borrow_mut();
         let target = current_communication_point + communication_step_size;
-        let event_mode = st.event_mode;
+        let defer = st.defer;
         let meta = st.meta.clone();
         let mut e = Engine;
         // Build the driver on first use, over the initialized state at the start
@@ -1305,17 +1294,13 @@ impl GuestCoSimulationInstance for Instance {
         // Event Mode already built it in exit-initialization-mode.
         if st.cs.is_none() {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
-            match CsDriver::new(&mut e, &meta, sim_data, t) {
+            match CsDriver::new(&mut e, &meta, sim_data, t, defer) {
                 Ok(d) => st.cs = Some(d),
                 Err(e) => return Err(err_status(e)),
             }
         }
         let Some(mut driver) = st.cs.take() else { return Err(Status::Error) };
-        let outcome = if event_mode {
-            driver.step_to_event(&mut e, &meta, target)
-        } else {
-            driver.step_to(&mut e, &meta, target)
-        };
+        let outcome = driver.step_to(&mut e, &meta, target, defer);
         let last = driver.time();
         st.cs = Some(driver);
         // C's `fmi2DoStep`: the getters now report the new time's values.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/fmi3-co-simulation.wit
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/fmi3-co-simulation.wit
@@ -41,14 +41,17 @@ interface co-simulation {
 
   /// Result of a fmi3DoStep call.
   record do-step-result {
-    /// The FMU completed the step up to (at least) the requested time.
-    /// When early-return is enabled this may be less than end-point.
+    /// How far the FMU integrated. Equal to the requested end point unless the
+    /// step returned early, in which case it is where the FMU stopped.
     last-successful-time: f64,
-    /// True if the FMU returned early (canReturnEarlyAfterIntermediateUpdate).
+    /// True if the FMU met an event it has not resolved: the master drives
+    /// fmi3EnterEventMode / fmi3UpdateDiscreteStates / fmi3EnterStepMode. Only
+    /// possible when the instance was created with event-mode-used.
     event-handling-needed: bool,
     /// True if the FMU requests termination.
     terminate-simulation:  bool,
-    /// True if the step was entirely discarded and must be retried.
+    /// True if the step stopped before the requested end point. Only possible
+    /// when the instance was created with early-return-allowed.
     early-return:          bool,
   }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
@@ -326,6 +326,9 @@ fn load_component(engine: &Engine, res: &Path) -> wasmtime::Result<Component> {
 
 fn new_store(engine: &Engine, res: &str, env: *mut c_void, log: Log, iu: IntermediateUpdateCb) -> wasmtime::Result<Store<Host>> {
     let mut builder = wasmtime_wasi::WasiCtxBuilder::new();
+    // C's `messageText` puts the simulation log on the importer's stdout with
+    // `printf`; the component's stdout is WASI's, so it has to be this library's.
+    builder.inherit_stdout().inherit_stderr();
     // What fmi3Instantiate* points at: a file-based CombiTable reads its table
     // through this preopen.
     if Path::new(res).is_dir() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -5416,39 +5416,47 @@ struct CvodeState {
     atol: Vec<f64>,
     n_roots: usize,
     work_retries: u32,
+    /// Whether building the block still logs the banner; an FMU already did, at
+    /// `fmi2Instantiate`.
+    banner: bool,
+}
+
+/// `cvode_solver_initial`'s `LOG_SOLVER` banner. Every line but the tolerance and
+/// the root-finding answer reports a configuration this port fixes.
+#[cfg(sundials)]
+fn log_cvode_configuration(rtol: f64, root_finding: bool) {
+    for line in [
+        "CVODE linear multistep method CV_BDF",
+        "CVODE maximum integration order CV_ITER_NEWTON",
+        "CVODE use equidistant time grid YES",
+    ] {
+        omclog::info(omclog::SOLVER, false, line);
+    }
+    omclog::info(
+        omclog::SOLVER,
+        false,
+        &format!("CVODE Using relative error tolerance {}", format_e(rtol)),
+    );
+    omclog::info(omclog::SOLVER, false, "CVODE Using dense internal linear solver SUNLinSol_Dense.");
+    omclog::info(omclog::SOLVER, false, "CVODE Use internal dense numeric jacobian method.");
+    omclog::info(
+        omclog::SOLVER,
+        false,
+        &format!("CVODE uses internal root finding method {}", if root_finding { "YES" } else { "NO" }),
+    );
+    for line in [
+        "CVODE maximum absolut step size 0",
+        "CVODE initial step size is set automatically",
+        "CVODE maximum integration order 5",
+        "CVODE maximum number of nonlinear convergence failures permitted during one step 10",
+        "CVODE BDF stability limit detection algorithm OFF",
+    ] {
+        omclog::info(omclog::SOLVER, false, line);
+    }
 }
 
 #[cfg(sundials)]
 impl CvodeState {
-    /// `cvode_solver.c`'s `LOG_SOLVER` banner. The configuration is fixed here, so
-    /// every line but the tolerance is constant.
-    fn log_configuration(&self) {
-        for line in [
-            "CVODE linear multistep method CV_BDF",
-            "CVODE maximum integration order CV_ITER_NEWTON",
-            "CVODE use equidistant time grid YES",
-        ] {
-            omclog::info(omclog::SOLVER, false, line);
-        }
-        omclog::info(
-            omclog::SOLVER,
-            false,
-            &format!("CVODE Using relative error tolerance {}", format_e(self.rtol)),
-        );
-        for line in [
-            "CVODE Using dense internal linear solver SUNLinSol_Dense.",
-            "CVODE Use internal dense numeric jacobian method.",
-            "CVODE uses internal root finding method NO",
-            "CVODE maximum absolut step size 0",
-            "CVODE initial step size is set automatically",
-            "CVODE maximum integration order 5",
-            "CVODE maximum number of nonlinear convergence failures permitted during one step 10",
-            "CVODE BDF stability limit detection algorithm OFF",
-        ] {
-            omclog::info(omclog::SOLVER, false, line);
-        }
-    }
-
     /// The CVODE block is built on the first step, when `y` first holds the state
     /// to start from. `ctx` is the callbacks' `user_data`; it lives on the stack of
     /// one `advance`, so it is rebound on every call rather than stored.
@@ -5461,7 +5469,9 @@ impl CvodeState {
                     *t, y, self.rtol, &self.atol, self.n_roots, cvode_rhs, root,
                 )
                 .ok_or("CodegenWasmJit: CVODE initialization failed")?;
-                self.log_configuration();
+                if self.banner {
+                    log_cvode_configuration(self.rtol, self.n_roots > 0);
+                }
                 self.cv.insert(cv)
             }
         };
@@ -5746,7 +5756,7 @@ enum Step {
     Reached { grid_covered: bool, event_step: bool },
     Terminated,
     /// Located an event at `time`, discrete update left undone for the caller to
-    /// report (CS Event Mode). Only returned under `stop_at_event`.
+    /// report (CS Event Mode). Only returned when [`CsDefer`] asks for it.
     Event { time: f64 },
     /// Out of budget mid-target; call again with the same `tout`.
     Yielded,
@@ -5809,7 +5819,14 @@ impl SolverCore {
         #[cfg(sundials)]
         let solver = match method {
             "cvode" => {
-                Solver::Cvode(CvodeState { cv: None, rtol: tol, atol, n_roots: nrt as usize, work_retries: 0 })
+                Solver::Cvode(CvodeState {
+                    cv: None,
+                    rtol: tol,
+                    atol,
+                    n_roots: nrt as usize,
+                    work_retries: 0,
+                    banner: true,
+                })
             }
             "ida" => Solver::Ida(IdaState {
                 ida: None,
@@ -5972,6 +5989,20 @@ impl SolverCore {
             return Err(CHATTER_ABORT_ERR);
         }
         Ok(())
+    }
+
+    /// C's `cvode_solver_initial` under `isFMI`, whose banner
+    /// [`log_cs_solver_setup`] has already logged.
+    fn fmi_cs_solver_setup(&mut self, defer: CsDefer) {
+        #[cfg(sundials)]
+        if let Solver::Cvode(c) = &mut self.solver {
+            c.banner = false;
+            if defer != CsDefer::Any {
+                c.n_roots = 0;
+            }
+        }
+        #[cfg(not(sundials))]
+        let _ = defer;
     }
 
     /// Restart the integrator at the current `(t, y)`, banking the run totals its
@@ -6326,7 +6357,7 @@ impl SolverCore {
     /// samples due on the way. `rows` collects the pre/post-event rows when the
     /// caller wants them; CS passes `None`. A `Yielded` return resumes on the same
     /// `tout` (the integrator continues where it left off), so yields are safe points.
-    /// `stop_at_event` (CS Event Mode) stops at the first event and returns
+    /// `defer` (CS Event Mode) stops at an event the master owns and returns
     /// [`Step::Event`] instead of updating in place.
     #[allow(clippy::too_many_arguments)]
     fn integrate_to(
@@ -6340,7 +6371,7 @@ impl SolverCore {
         deadline: f64,
         mut rows: Option<&mut Vec<f64>>,
         did_step: &mut bool,
-        stop_at_event: bool,
+        defer: CsDefer,
     ) -> Result<Step> {
         let layout = &model.layout;
         let sim_data = self.sim_data;
@@ -6351,6 +6382,11 @@ impl SolverCore {
         let step_eps = small_step_eps(span);
         let mut grid_covered = false;
         let mut event_step = false;
+        let defers = |t: f64| match defer {
+            CsDefer::None => false,
+            CsDefer::AtTarget => t >= tout - eps,
+            CsDefer::Any => true,
+        };
 
         loop {
             // Yield at the loop boundary (before any state mutation).
@@ -6437,6 +6473,9 @@ impl SolverCore {
                         *did_step = true;
                         event_step = true;
                         self.note_chatter(model, flips[0])?;
+                        if defers(self.t) {
+                            return Ok(Step::Event { time: self.t });
+                        }
                         if self.handle_zc_flips(e, model, ctx, sync, rows.as_deref_mut(), &flips)? {
                             return Ok(Step::Terminated);
                         }
@@ -6448,7 +6487,7 @@ impl SolverCore {
                 // crossing, so the root itself is the event.
                 if rooted {
                     let troot = self.t;
-                    if stop_at_event {
+                    if defers(troot) {
                         write_time(e, sim_data, troot)?;
                         return Ok(Step::Event { time: troot });
                     }
@@ -6516,7 +6555,7 @@ impl SolverCore {
             if te <= target + SAMPLE_EPS {
                 *did_step = true;
                 event_step = true;
-                if stop_at_event {
+                if defers(te) {
                     self.t = te;
                     write_time(e, sim_data, te)?;
                     return Ok(Step::Event { time: te });
@@ -6588,9 +6627,16 @@ impl SolverCore {
                 // exactly when the caller writes that row and stores after it.
                 if rows.is_none() {
                     store_operators_at(e, sim_data, layout, self.t)?;
+                    // `fmi2DoStep`'s own detection: the only one an FMU without
+                    // root finding has, and it lands on the communication point.
                     let flips = save_zero_crossings(e, sim_data, layout)?;
-                    if !flips.is_empty() && self.handle_zc_flips(e, model, ctx, sync, None, &flips)? {
-                        return Ok(Step::Terminated);
+                    if !flips.is_empty() {
+                        if defers(self.t) {
+                            return Ok(Step::Event { time: self.t });
+                        }
+                        if self.handle_zc_flips(e, model, ctx, sync, None, &flips)? {
+                            return Ok(Step::Terminated);
+                        }
                     }
                 }
                 return Ok(Step::Reached { grid_covered, event_step });
@@ -6600,10 +6646,9 @@ impl SolverCore {
 }
 
 /// Co-Simulation: the FMU owns the integration, the importer picks the
-/// communication points. Unlike [`EventsDriver`] there is no output grid and
-/// no rows. [`step_to`](CsDriver::step_to) handles events internally
-/// (`eventModeUsed = false`); [`step_to_event`](CsDriver::step_to_event) stops at
-/// each event and reports it for the master to drive (`eventModeUsed = true`).
+/// communication points. Unlike [`EventsDriver`] there is no output grid and no
+/// rows. [`step_to`](CsDriver::step_to) takes a [`CsDefer`] saying which events it
+/// reports for the master to drive instead of resolving them itself.
 ///
 /// The caller initializes the model (`run_initialization`) before building this,
 /// since FMI does that in its own Initialization Mode.
@@ -6615,12 +6660,26 @@ pub struct CsDriver {
     /// The step `euler`/`rungekutta` take (the model's own output step); `None` for a
     /// variable-step method, which is handed the whole interval.
     fixed_h: Option<f64>,
-    /// A `do_event_update` ran since the last step, so `step_to_event` must re-read
+    /// A `do_event_update` ran since the last step, so `step_to` must re-read
     /// states and restart DASKR.
     resume_reinit: bool,
 }
 
-/// What [`CsDriver::step_to`] / [`step_to_event`](CsDriver::step_to_event) did.
+/// Which events the FMU reports to the master instead of resolving itself: C's
+/// `doStepInternal` gate `eventModeUsed && (earlyReturnAllowed || t >= tEnd)`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CsDefer {
+    /// `eventModeUsed = false`: the FMU resolves every event. Also the standalone
+    /// drivers, which have no master.
+    None,
+    /// Event Mode without early return: the step must still reach the
+    /// communication point, so only an event landing there is reported.
+    AtTarget,
+    /// Event Mode with `earlyReturnAllowed`: any event is reported where it happens.
+    Any,
+}
+
+/// What [`CsDriver::step_to`] did.
 pub enum CsStep {
     /// Reached the requested time.
     Reached,
@@ -6630,10 +6689,45 @@ pub enum CsStep {
     Terminated,
 }
 
+/// C's `FMI2CS_initializeSolverData`: an FMU's solver is set up in
+/// `fmi2Instantiate`, and for CVODE `LOG_SOLVER` is forced on across
+/// `cvode_solver_initial` so the banner reaches the log either way. `defer` decides
+/// the root-finding line — see [`CsDriver::new`].
+pub fn log_cs_solver_setup(model: &SimModel, defer: CsDefer) {
+    let Ok(method) = resolve_solver_method(&model.method, model.layout.dae_mode()) else { return };
+    // "No states present, continuing without ODE solver": C falls back to euler,
+    // which has nothing to set up and nothing to say.
+    if method != "cvode" || model.layout.n_states == 0 {
+        return;
+    }
+    #[cfg(sundials)]
+    {
+        let tol = if model.tolerance > 0.0 { model.tolerance } else { 1e-6 };
+        let mask = omclog::mask();
+        omclog::set_mask(mask | (1 << omclog::SOLVER));
+        log_cvode_configuration(tol, defer == CsDefer::Any);
+        omclog::set_mask(mask);
+    }
+    #[cfg(not(sundials))]
+    let _ = defer;
+}
+
 impl CsDriver {
     /// Build over an already-initialized model at time `t`, integrating with the
     /// method the FMU was exported with (`buildModelFMU`'s `method=`).
-    pub fn new(e: &mut (dyn SimEngine + 'static), model: &SimModel, sim_data: u32, t: f64) -> Result<Self> {
+    ///
+    /// The integrator watches event indicators only under [`CsDefer::Any`], the one
+    /// mode whose master can be handed the crossing time (Event Mode with early
+    /// return). Otherwise the FMU resolves the event itself, and does it as C's
+    /// `fmi2DoStep` does: no root finding (`cvodeGetConfig(…, isFMI)`) and the sign
+    /// change picked up at the communication point.
+    pub fn new(
+        e: &mut (dyn SimEngine + 'static),
+        model: &SimModel,
+        sim_data: u32,
+        t: f64,
+        defer: CsDefer,
+    ) -> Result<Self> {
         daskr::auxiliary::xsetf(0);
         let layout = &model.layout;
         let method = resolve_solver_method(&model.method, layout.dae_mode())?;
@@ -6647,6 +6741,7 @@ impl CsDriver {
         let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
         sync.take_fired(e, t)?;
         let mut core = SolverCore::new(&*e, model, sim_data, t, method, alloc_gbode(model, method)?)?;
+        core.fmi_cs_solver_setup(defer);
         let mut pivots = init_state_pivots(&model.state_sets);
         if core.n_states > 0 {
             if !model.state_sets.is_empty() && run_state_selection_initial(e, sim_data, &model.state_sets, &mut pivots)? {
@@ -6664,21 +6759,42 @@ impl CsDriver {
         self.core.t
     }
 
-    /// Advance to `t_target`, handling events on the way. No budget: an importer's
-    /// `do-step` runs to completion.
+    /// Advance to `t_target`. `defer` decides which events are reported to the
+    /// master rather than resolved here. No budget: an importer's `do-step` runs to
+    /// completion.
     pub fn step_to(
         &mut self,
         e: &mut (dyn SimEngine + 'static),
         model: &SimModel,
         t_target: f64,
+        defer: CsDefer,
     ) -> Result<CsStep> {
         let layout = &model.layout;
         let sim_data = self.core.sim_data;
+        // A reinit or discrete change in the master's update needs a DASKR restart.
+        if self.resume_reinit {
+            if self.core.n_states > 0 {
+                e.call1("functionODE", sim_data)?;
+                self.core.read_states(e)?;
+                self.core.restart()?;
+            }
+            self.resume_reinit = false;
+        }
         // No continuous states: only the samples move the model along.
         if self.core.n_states == 0 {
             let eps = t_target.abs().max(1.0) * 1e-10;
+            let defers = |t: f64| match defer {
+                CsDefer::None => false,
+                CsDefer::AtTarget => t >= t_target - eps,
+                CsDefer::Any => true,
+            };
             while self.samp.next_time() <= t_target + eps {
                 let te = self.samp.next_time();
+                if defers(te) {
+                    self.core.t = te;
+                    write_time(e, sim_data, te)?;
+                    return Ok(CsStep::Event { time: te });
+                }
                 write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
                 event_update(e, sim_data, layout, Some(&mut self.samp), te)?;
                 self.core.time_events += 1;
@@ -6694,14 +6810,12 @@ impl CsDriver {
         }
 
         self.refresh_ders(e)?;
-        let outcome = self.integrate_chunked(e, model, t_target, false)?;
+        let outcome = self.integrate_chunked(e, model, t_target, defer)?;
         match outcome {
             Step::Terminated => return Ok(CsStep::Terminated),
-            // `deadline` is +inf, CS does not cancel, and `stop_at_event` is off on
-            // this path, so none of these can arise.
-            Step::Yielded | Step::Cancelled | Step::Event { .. } => {
-                return Err("CodegenWasmJit: CS step yielded unexpectedly")
-            }
+            Step::Event { time } => return Ok(CsStep::Event { time }),
+            // `deadline` is +inf and CS does not cancel.
+            Step::Yielded | Step::Cancelled => return Err("CodegenWasmJit: CS step yielded unexpectedly"),
             Step::Reached { .. } => {}
         }
         // Refresh the outputs at the communication point, and re-select states there
@@ -6721,69 +6835,7 @@ impl CsDriver {
         Ok(CsStep::Reached)
     }
 
-    /// Event Mode step (`eventModeUsed = true`): integrate toward `t_target`,
-    /// stopping at the first event and returning [`CsStep::Event`] without the
-    /// discrete update — the master runs that via [`do_event_update`] and resumes.
-    ///
-    /// [`do_event_update`]: CsDriver::do_event_update
-    pub fn step_to_event(
-        &mut self,
-        e: &mut (dyn SimEngine + 'static),
-        model: &SimModel,
-        t_target: f64,
-    ) -> Result<CsStep> {
-        let layout = &model.layout;
-        let sim_data = self.core.sim_data;
-        // A reinit or discrete change in the master's update needs a DASKR restart.
-        if self.resume_reinit {
-            if self.core.n_states > 0 {
-                e.call1("functionODE", sim_data)?;
-                self.core.read_states(e)?;
-                self.core.restart()?;
-            }
-            self.resume_reinit = false;
-        }
-        // No continuous states: stop at the next sample in the step for the master.
-        if self.core.n_states == 0 {
-            let eps = t_target.abs().max(1.0) * 1e-10;
-            let te = self.samp.next_time();
-            if te <= t_target + eps {
-                self.core.t = te;
-                write_time(e, sim_data, te)?;
-                return Ok(CsStep::Event { time: te });
-            }
-            self.core.t = t_target;
-            write_time(e, sim_data, t_target)?;
-            e.call1_if_present("functionAlgebraics", sim_data)?;
-            return Ok(CsStep::Reached);
-        }
-
-        self.refresh_ders(e)?;
-        let outcome = self.integrate_chunked(e, model, t_target, true)?;
-        match outcome {
-            Step::Terminated => return Ok(CsStep::Terminated),
-            Step::Event { time } => return Ok(CsStep::Event { time }),
-            // `deadline` is +inf and CS does not cancel.
-            Step::Yielded | Step::Cancelled => return Err("CodegenWasmJit: CS step yielded unexpectedly"),
-            Step::Reached { .. } => {}
-        }
-        // Communication point reached with no event: refresh outputs like `step_to`.
-        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-        write_time(e, sim_data, t_target)?;
-        e.call1("functionODE", sim_data)?;
-        e.call1_if_present("functionAlgebraics", sim_data)?;
-        if !model.state_sets.is_empty() && run_state_selection(e, sim_data, &model.state_sets, &mut self.pivots)? {
-            e.call1("functionODE", sim_data)?;
-            self.core.read_states(e)?;
-            self.core.restart()?;
-        }
-        if terminated(e, sim_data, layout)? {
-            return Ok(CsStep::Terminated);
-        }
-        Ok(CsStep::Reached)
-    }
-
-    /// The master's `update-discrete-states` at the event `step_to_event` stopped on.
+    /// The master's `update-discrete-states` at the event `step_to` stopped on.
     /// Fires any sample through the driver's own schedule so it stays in step with
     /// the integrator, and flags a DASKR restart for the next step.
     pub fn do_event_update(
@@ -6826,7 +6878,7 @@ impl CsDriver {
         e: &mut (dyn SimEngine + 'static),
         model: &SimModel,
         t_target: f64,
-        stop_at_event: bool,
+        defer: CsDefer,
     ) -> Result<Step> {
         let layout = &model.layout;
         let eps = t_target.abs().max(1.0) * 1e-12;
@@ -6851,7 +6903,7 @@ impl CsDriver {
             let t_before = self.core.t;
             let outcome = self.core.integrate_to(
                 e, model, &mut ctx, &mut self.samp, &mut self.sync, target, f64::INFINITY, None,
-                &mut did_step, stop_at_event,
+                &mut did_step, defer,
             )?;
             // On the chunk that asked for the caller's target, wherever rounding left
             // `t`: a tighter test on `t` asks for the same chunk forever.
@@ -7192,7 +7244,7 @@ impl Driver for EventsDriver {
             open_assert_window();
             match self.core.integrate_to(
                 e, model, &mut ctx, &mut self.samp, &mut self.sync, tout, deadline,
-                Some(&mut self.rows), &mut did_step, false,
+                Some(&mut self.rows), &mut did_step, CsDefer::None,
             )? {
                 Step::Yielded => {
                     // Resume on the same row; `mid_row` keeps `grid_covered`.
@@ -7201,8 +7253,8 @@ impl Driver for EventsDriver {
                 }
                 Step::Cancelled => return Ok(Advance::Cancelled),
                 Step::Terminated => break Advance::Terminated,
-                // `stop_at_event` is false here, so `Event` never arises.
-                Step::Event { .. } => unreachable!("stop_at_event is off for the output-grid driver"),
+                // Nothing is deferred here, so `Event` never arises.
+                Step::Event { .. } => unreachable!("the output-grid driver defers no event"),
                 Step::Reached { grid_covered, event_step } => {
                     self.grid_covered |= grid_covered;
                     self.did_event_step |= event_step;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/omclog.rs
@@ -130,6 +130,11 @@ pub type Mask = u64;
 /// The three streams C activates without `-lv`, and which [`deactivate`] leaves.
 pub const ALWAYS_ON: Mask = (1 << STDOUT) | (1 << ASSERT) | (1 << SUCCESS);
 
+/// What an FMU has on for its whole life: `initDumpSystem` never runs there, so
+/// `omc_useStream` is a zeroed static and `fmi2Instantiate` turns these two on.
+/// `fmi2SetDebugLogging` does not touch them.
+pub const FMU_STREAMS: Mask = (1 << STDOUT) | (1 << ASSERT);
+
 /// C's `omc_showAllWarnings` (`-w`): a warning prints even on an inactive stream.
 /// It rides in the mask, above every stream index, so the single value a run pushes
 /// into the wasm runtime carries it too.

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -2413,6 +2413,13 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
   {
     /* fprintf(stderr, "DoStep %g -> %g State: %s\n", comp->fmuData->localData[0]->timeValue, tNext, stateToString(comp)); */
 
+    /* Both describe this sub-step only. Left set, a time event or zero
+       crossing in an earlier sub-step would make every later one end in a
+       spurious event iteration (and, in Event Mode, report an event that
+       is not there). */
+    zc_event = 0;
+    time_event = 0;
+
     // set the real Inputs with output_derivative values
 #if NUMBER_OF_REAL_INPUTS > 0
     for (int i = 0; i < NUMBER_OF_REALS; ++i)

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -2479,6 +2479,13 @@ static fmi3Status doStepInternal(ModelInstance* c, fmi3Float64 currentCommunicat
   {
     /* fprintf(stderr, "DoStep %g -> %g State: %s\n", comp->fmuData->localData[0]->timeValue, tNext, stateToString(comp)); */
 
+    /* Both describe this sub-step only. Left set, a time event or zero
+       crossing in an earlier sub-step would make every later one end in a
+       spurious event iteration (and, in Event Mode, report an event that
+       is not there). */
+    zc_event = 0;
+    time_event = 0;
+
     // set the real Inputs with output_derivative values
 #if NUMBER_OF_REAL_INPUTS > 0
     for (int i = 0; i < NUMBER_OF_REALS; ++i)


### PR DESCRIPTION
Fixes the four `openmodelica/fmi/CoSimulation/2.0` tests that differed under `--simCodeTarget=wasm-jit`, plus `Issue14456` and `simpleStiffFMU`, which had the same two causes.

## The FMU's stdout

C's `messageText` prints every `-lv` stream line with `printf` whatever its type, so an FMU's simulation log lands on the importer's stdout and OMSimulator's captured output picks it up. A component had no stdout, so the lines went to the FMI logger and were lost - the whole CVODE banner among them.

`openmodelica_fmi3_wasm::stdio` imports
`wasi_snapshot_preview1.fd_write` and writes fd 1, one write per message as C's `fflush(NULL)` does; the ordering against the importer's own lines depends on that, and OMSimulator flushes each of its own (`stream << std::endl`). `link_fmu_component` therefore links the preview1 reactor adapter unconditionally rather than only when `has_ext || sundials` pulls libc in, and the native loader inherits stdout/stderr. The FMI logger keeps what C sends through `FILTERED_LOG`: assertions, warnings, failure reasons.

Which streams print had to change with the sink. `initDumpSystem` never runs in an FMU, so `omc_useStream` is a zeroed static and `fmi2Instantiate` turns on exactly `LOG_STDOUT|LOG_ASSERT` - hence `omclog::FMU_STREAMS`. With `ALWAYS_ON` every FMU would have begun printing `LOG_SUCCESS | info | The initialization finished ...`. And `fmi2SetDebugLogging` does not touch `omc_useStream`, so `set_debug_logging` no longer remaps categories onto `-lv` streams.

## Co-Simulation events

`cvodeGetConfig(&config, threadData, isFMI)` clears `config->solverRootFinding` because it is an FMU, so `CVodeRootInit` is never called and `fmi2DoStep` compares event indicators across the whole step, at the communication point. That is the whole of `FmuExportFlags`'s third-decimal difference: C bounces the ball at t=0.452, the end of the 2 ms step, not at t=0.4515236. Standalone, both runtimes already agreed.

`CsDefer` replaces `integrate_to`'s `stop_at_event` flag and models C's gate `eventModeUsed && (earlyReturnAllowed || t >= tEnd)` directly, so every event site asks one predicate who owns the event:

| `CsDefer` | FMI arguments | events |
| --- | --- | --- |
| `None` | `eventModeUsed = false` | all resolved internally | | `AtTarget` | Event Mode, no early return | only one at the communication point reported | | `Any` | Event Mode + `earlyReturnAllowed` | reported where they happen |

`earlyReturnAllowed` was dropped on the floor before, so the FMU could return early from a step the master had forbidden it to. Two further sites deferred nothing where C defers: a flip found at the communication point, and one at an accepted fixed-step boundary.

Root finding now stays on only under `CsDefer::Any`, the one mode whose master can be handed the crossing time. That keeps FMI 2.0 and non-event -mode Co-Simulation bit-comparable with the C export, and keeps the exact crossing for the case early return exists to serve - C uses `isFMI` in both, so its own event mode reports the step boundary.

`log_cs_solver_setup` is `FMI2CS_initializeSolverData`: called from `instantiate_co_simulation` only, it forces `LOG_SOLVER` on across the banner and skips it when the method is not cvode or the model has no states. `CvodeState.banner` suppresses the lazy one the first step would otherwise log. The banner's root-finding line reports the real configuration instead of a hardcoded `NO`; standalone C prints `YES`.

## C runtime: `zc_event`/`time_event` were sticky

Both are declared outside `doStepInternal`'s integration loop and never cleared, so a time event or zero crossing in one sub-step made every later one end in a spurious event iteration - `didEventStep = 1`, hence a `cvode_solver_reinit` per sub-step - and, in Event Mode, report an event that was not there. Reachable whenever a time event falls strictly inside a communication step. Measured on a sampled oscillator: x(0.05) moves from 0.9990882196 to 0.9990886860, with the event count unchanged.

## Verified

`openmodelica/fmi/CoSimulation/2.0`, `.../ModelExchange/2.0`, `.../ModelExchange/3.0` and `omsimulator` under
`--simCodeTarget=wasm-jit`, 130 tests: 34 failures before, 28 after, no new ones. The remainder are pre-existing - 13 carry `// suite: fmuCSources`, which partest excludes for the wasm job.

A plain FMI 2.0 ME FMU with no external `"C"` and no SUNDIALS, the case that previously linked no WASI adapter at all, still exports, loads and simulates.

The C change is verified to compile in both interface versions and to have the effect above; its rtest lanes need a complete C install tree, which this working copy does not have, so Jenkins covers those.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
