### PR TITLE
wasm-jit: per-operand nominal in the ZC band

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -7714,9 +7714,9 @@ fn emit_div_sim(ctx: &mut FnCtx, e2: &DAE::Exp) -> Result<WTy> {
 
 fn compile_relation(
     ctx: &mut FnCtx,
-    e1: &DAE::Exp,
+    e1: &Arc<DAE::Exp>,
     op: &DAE::Operator,
-    e2: &DAE::Exp,
+    e2: &Arc<DAE::Exp>,
     index: i32,
     asub: &Option<(Arc<DAE::Exp>, i32, i32)>,
 ) -> Result<WTy> {
@@ -7768,9 +7768,9 @@ fn compile_relation(
 /// (`0 <= index < n_relations`).
 fn compile_relation_indexed(
     ctx: &mut FnCtx,
-    e1: &DAE::Exp,
+    e1: &Arc<DAE::Exp>,
     op: &DAE::Operator,
-    e2: &DAE::Exp,
+    e2: &Arc<DAE::Exp>,
     index: i32,
     asub: &Option<(Arc<DAE::Exp>, i32, i32)>,
 ) -> Result<WTy> {
@@ -7855,16 +7855,19 @@ fn compile_relation_indexed(
 /// `tolZC` is read from `SimData` (`zctol_off`).
 fn compile_relation_hyst(
     ctx: &mut FnCtx,
-    e1: &DAE::Exp,
+    e1: &Arc<DAE::Exp>,
     op: &DAE::Operator,
-    e2: &DAE::Exp,
+    e2: &Arc<DAE::Exp>,
     slot: u32,
     dir_off: u32,
 ) -> Result<()> {
     use we::Instruction as I;
     let data = ctx.sim()?.data_local;
     let zctol_off = ctx.sim()?.zctol_off;
-    let nom = nominal_const(e1).max(nominal_const(e2));
+
+    let nom = ctx.alloc_temp(WTy::F64);
+    emit_relation_nominal(ctx, e1, e2)?;
+    ctx.emit(I::LocalSet(nom));
 
     let a = ctx.alloc_temp(WTy::F64);
     let wa = compile_exp(ctx, e1)?;
@@ -7882,7 +7885,7 @@ fn compile_relation_hyst(
     ctx.emit(I::LocalGet(b));
     ctx.emit(I::F64Abs);
     ctx.emit(I::F64Max);
-    ctx.emit(I::F64Const(nom.into()));
+    ctx.emit(I::LocalGet(nom));
     ctx.emit(I::F64Add);
     ctx.emit(I::LocalGet(data));
     ctx.emit(I::F64Load(mem_arg(zctol_off, 3)));
@@ -7930,13 +7933,37 @@ fn emit_hyst_cmp(ctx: &mut FnCtx, op: &DAE::Operator, diff: u32, eps: u32, dir: 
     Ok(())
 }
 
-/// A relation operand's nominal magnitude for the hysteresis band: the literal's
-/// magnitude for a constant, else the default nominal `1.0`.
-fn nominal_const(e: &DAE::Exp) -> f64 {
+/// Leave `max(|nominal(e1)|, |nominal(e2)|)` — the scale term of the hysteresis
+/// band — on the stack as an f64, from the same `getExpNominal` derivation C's
+/// `daeExpNominalTmp` uses.
+fn emit_relation_nominal(ctx: &mut FnCtx, e1: &Arc<DAE::Exp>, e2: &Arc<DAE::Exp>) -> Result<()> {
+    let n1 = nominal_exp(e1);
+    let n2 = nominal_exp(e2);
+    match (nominal_const(&n1), nominal_const(&n2)) {
+        (Some(c1), Some(c2)) => ctx.emit(we::Instruction::F64Const(c1.max(c2).into())),
+        _ => {
+            let w1 = compile_exp(ctx, &n1)?;
+            coerce(ctx, w1, WTy::F64);
+            ctx.emit(we::Instruction::F64Abs);
+            let w2 = compile_exp(ctx, &n2)?;
+            coerce(ctx, w2, WTy::F64);
+            ctx.emit(we::Instruction::F64Abs);
+            ctx.emit(we::Instruction::F64Max);
+        }
+    }
+    Ok(())
+}
+
+fn nominal_exp(e: &Arc<DAE::Exp>) -> Arc<DAE::Exp> {
+    openmodelica_backend::SimCodeUtil::getExpNominal(Arc::clone(e))
+        .unwrap_or_else(|_| Arc::new(DAE::Exp::RCONST { real: 1.0.into() }))
+}
+
+fn nominal_const(e: &DAE::Exp) -> Option<f64> {
     match e {
-        DAE::Exp::RCONST { real } => real.into_inner().abs(),
-        DAE::Exp::ICONST { integer } => (*integer as f64).abs(),
-        _ => 1.0,
+        DAE::Exp::RCONST { real } => Some(real.into_inner().abs()),
+        DAE::Exp::ICONST { integer } => Some((*integer as f64).abs()),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
C's zero-crossing hysteresis band is

    eps = tolZC * (max(|a|,|b|) + max(|a_nominal|,|b_nominal|))

and CodegenCFunctions fills the two nominals per operand from `SimCodeUtil.getExpNominal` (`daeExpNominalTmp`): a variable's `nominal` attribute, a parameter's own value, or 1.0 as the last resort. The wasm-jit band used the literal magnitude for constants and 1.0 for everything else.

Call `getExpNominal` instead, constant-folding when both nominals fold and emitting the nominal expressions otherwise.

For `Modelica.Mechanics.Translational.Examples.PreLoad` both nominals of `innerContactA.s_rel < innerContactA.s_rel0` are 1e-3, so the band was 500x too wide and the first contact event fired at t=1.75e-7 instead of 7.83e-9. Only that one output row differed, but it is the row compareSimulationResults looks at first.

| event | before | after / C |
| ----- | ------ | --------- |
| 1 | 1.7549835183e-07 | 7.83475641418e-09 |
| 2 | 0.000773350924701 | 0.000773350799602 |
| 3 | 0.000775069032 | 0.000775068908265 |

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
