### PR TITLE
wasm-jit: keep root probes out of the g snapshot

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -4846,7 +4846,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         bodies.push(if zero_crossings.is_empty() {
             empty_eqfn()
         } else {
-            build_zero_crossings_fn(&zero_crossings, &layout, &var_map, &by_name, &mut literals)?
+            build_zero_crossings_fn(&zero_crossings, &var_map, &by_name, &mut literals)?
         });
         idx
     };
@@ -5075,7 +5075,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         }
     }
     functions.function(eqfn_type); // initSample: (i32) -> ()
-    functions.function(eqfn_type); // functionZeroCrossings: (i32) -> ()
+    functions.function(sync_fn_type); // functionZeroCrossings: (i32 SimData, i32 gout) -> ()
     functions.function(eqfn_type); // functionStateSetJacobians: (i32) -> ()
     functions.function(eqfn_type); // functionJacA_constantEqns: (i32) -> ()
     functions.function(eqfn_type); // functionJacA_column: (i32) -> ()
@@ -6642,19 +6642,17 @@ fn build_update_bound_attrs_fn(
     Ok(func)
 }
 
-/// Build the `functionZeroCrossings(SimData*)` function: evaluate each crossing's
-/// `lhs - rhs` into the zero-crossing region (see [`FnCtx::emit_zero_crossings`]).
-/// Called by the driver's DASKR root callback.
+/// Build `functionZeroCrossings(SimData*, gout)`: evaluate each crossing into
+/// `gout` (see [`FnCtx::emit_zero_crossings`]).
 fn build_zero_crossings_fn(
     crossings: &[ZcInfo],
-    layout: &SimLayout,
     var_map: &SimVarMap,
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Literals,
 ) -> Result<we::Function> {
     let sim = SimCtx { zc_context: true, ..sim_ctx(var_map) };
-    let mut ctx = FnCtx::new_sim(sim, by_name, literals);
-    ctx.emit_zero_crossings(crossings, layout.zc_off)?;
+    let mut ctx = FnCtx::new_sim_params(sim, by_name, literals, 2);
+    ctx.emit_zero_crossings(crossings, 1)?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {
@@ -8599,13 +8597,13 @@ fn eq_index_of(eq: &SimCode::SimEqSystem) -> i32 {
     }
 }
 
-/// An empty `(i32) -> ()` function body. Used for the optional equation functions
-/// (`initSample`, `functionZeroCrossings`, `functionStateSetJacobians`,
-/// `functionInitialEquations_lambda0`) when a model lacks that feature, so the
-/// model still *exports* every driver entry point. The standalone `wasm-merge`
-/// (and the interactive shared table) then always resolve them; the shared driver
-/// only calls one when the corresponding metadata count is nonzero, so the stub is
-/// never entered.
+/// An empty function body, valid for any void signature. Used for the optional
+/// equation functions (`initSample`, `functionZeroCrossings`,
+/// `functionStateSetJacobians`, `functionInitialEquations_lambda0`) when a model
+/// lacks that feature, so the model still *exports* every driver entry point. The
+/// standalone `wasm-merge` (and the interactive shared table) then always resolve
+/// them; the shared driver only calls one when the corresponding metadata count is
+/// nonzero, so the stub is never entered.
 fn empty_eqfn() -> we::Function {
     let mut f = we::Function::new([]);
     f.instruction(&we::Instruction::End);
@@ -9026,14 +9024,18 @@ mod link_tests {
         // `evaluateDAEResiduals` is left out with `simulate`: the standalone runtime
         // imports neither with this shape (the DAE residual takes two arguments and
         // only a `--daeMode` model has one).
+        let two_arg = [
+            openmodelica_sim_meta::driver::MODEL_FN_UPDATE_SYNC,
+            openmodelica_sim_meta::driver::MODEL_FN_EQS_SYNC,
+            openmodelica_sim_meta::driver::MODEL_FN_ZC,
+        ];
         let one_arg: Vec<&str> = openmodelica_sim_meta::driver::MODEL_FNS
             .iter()
             .copied()
             .filter(|n| {
                 *n != "simulate"
                     && *n != openmodelica_sim_meta::driver::MODEL_FN_DAE
-                    && *n != openmodelica_sim_meta::driver::MODEL_FN_UPDATE_SYNC
-                    && *n != openmodelica_sim_meta::driver::MODEL_FN_EQS_SYNC
+                    && !two_arg.contains(n)
             })
             .collect();
 
@@ -9044,8 +9046,9 @@ mod link_tests {
         funcs.function(2); // om_meta_ptr
         funcs.function(2); // om_meta_len
         funcs.function(3); // simulate
-        funcs.function(4); // functionUpdateSynchronous
-        funcs.function(4); // functionEquationsSynchronous
+        for _ in &two_arg {
+            funcs.function(4);
+        }
         funcs.function(5); // om_throw_model_error
         m.section(&funcs);
 
@@ -9058,17 +9061,14 @@ mod link_tests {
         exports.export("om_meta_ptr", we::ExportKind::Func, meta_ptr_idx);
         exports.export("om_meta_len", we::ExportKind::Func, meta_ptr_idx + 1);
         exports.export("simulate", we::ExportKind::Func, meta_ptr_idx + 2);
+        for (i, name) in two_arg.iter().enumerate() {
+            exports.export(name, we::ExportKind::Func, meta_ptr_idx + 3 + i as u32);
+        }
         exports.export(
-            openmodelica_sim_meta::driver::MODEL_FN_UPDATE_SYNC,
+            "om_throw_model_error",
             we::ExportKind::Func,
-            meta_ptr_idx + 3,
+            meta_ptr_idx + 3 + two_arg.len() as u32,
         );
-        exports.export(
-            openmodelica_sim_meta::driver::MODEL_FN_EQS_SYNC,
-            we::ExportKind::Func,
-            meta_ptr_idx + 4,
-        );
-        exports.export("om_throw_model_error", we::ExportKind::Func, meta_ptr_idx + 5);
         m.section(&exports);
 
         let mut code = we::CodeSection::new();
@@ -9093,14 +9093,12 @@ mod link_tests {
         sim.instruction(&I::I32Const(0));
         sim.instruction(&I::End);
         code.function(&sim);
-        // functionUpdateSynchronous(_, _): noop.
-        let mut sync_update = we::Function::new([]);
-        sync_update.instruction(&I::End);
-        code.function(&sync_update);
-        // functionEquationsSynchronous(_, _): noop.
-        let mut sync_eqs = we::Function::new([]);
-        sync_eqs.instruction(&I::End);
-        code.function(&sync_eqs);
+        // The two-argument entry points: noop.
+        for _ in &two_arg {
+            let mut f = we::Function::new([]);
+            f.instruction(&I::End);
+            code.function(&f);
+        }
         // om_throw_model_error(): the emitter's no-external-"C" body.
         let mut throw = we::Function::new([]);
         throw.instruction(&I::Unreachable);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -2058,20 +2058,17 @@ impl<'a> FnCtx<'a> {
         Ok(())
     }
 
-    /// Emit `functionZeroCrossings`: for each crossing `k`, store its `g` value as
-    /// f64 at `zc_off + k*8`. A `Diff` crossing stores the continuous `lhs - rhs`;
-    /// a `Bool` crossing stores `expr ? 1 : -1`, matching the C target's
-    /// `gout[k] = (relation_) ? 1 : -1`. The driver's DASKR root callback reads
-    /// these; a sign change locates the event.
+    /// Emit `functionZeroCrossings`: store each crossing `k`'s g-value as f64 at
+    /// `gout + k*8`, `gout` being the second parameter. A `Bool` crossing stores
+    /// `expr ? 1 : -1`, as C's `gout[k] = (relation_) ? 1 : -1`.
     pub(crate) fn emit_zero_crossings(
         &mut self,
         crossings: &[crate::CodegenWasmJit::ZcInfo],
-        zc_off: u32,
+        gout_local: u32,
     ) -> Result<()> {
         use crate::CodegenWasmJit::ZcInfo;
-        let data = self.sim()?.data_local;
         for (k, zc) in crossings.iter().enumerate() {
-            self.emit(we::Instruction::LocalGet(data));
+            self.emit(we::Instruction::LocalGet(gout_local));
             match zc {
                 ZcInfo::Bool { expr } => {
                     // `select` picks `1.0` when the condition (top of stack) is
@@ -2092,7 +2089,7 @@ impl<'a> FnCtx<'a> {
                     self.emit(we::Instruction::Select);
                 }
             }
-            self.emit(we::Instruction::F64Store(mem_arg(zc_off + k as u32 * 8, 3)));
+            self.emit(we::Instruction::F64Store(mem_arg(k as u32 * 8, 3)));
         }
         Ok(())
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/spatial.rs
@@ -25,6 +25,7 @@ use crate::omclog;
 /// The relation evaluation modes `rt_spatial_eval` is handed (`SimLayout`'s
 /// `rel_fresh`): continuous integration, an event update, the initial system.
 const MODE_CONTINUOUS: u32 = 0;
+#[cfg(test)]
 const MODE_EVENT: u32 = 1;
 
 /// C `SPATIAL_EPS` (`epsilon.h`).
@@ -564,9 +565,7 @@ impl Spatial {
         in1: f64,
         pos_x: f64,
         positive: bool,
-        // `mode` is the relation evaluation mode; C's `discreteCall` is
-        // `mode != MODE_CONTINUOUS`, but only a genuine event update announces a
-        // discontinuity.
+        // C's `discreteCall` is `mode != MODE_CONTINUOUS`.
         mode: u32,
     ) -> (f64, f64) {
         let pos_x = self.shift(pos_x);
@@ -600,11 +599,6 @@ impl Spatial {
                 "x got reinitialized during an event at time {}. OpenModelica can't handle that.",
                 f(time)
             ));
-        }
-
-        // This event update is announcing the discontinuities at the output edge.
-        if mode == MODE_EVENT {
-            self.consume_events(pos_x, positive);
         }
 
         let (out0, out1) = if delta < pos_eps(self.old_pos_x, pos_x) {
@@ -674,41 +668,6 @@ impl Spatial {
         omclog::close(omclog::SPATIALDISTR);
         self.out1 = out1;
         (out0, out1)
-    }
-
-    /// Drop the discontinuities that have reached the output edge: the event call
-    /// this is made from is announcing them, and the accepted step's
-    /// [`Spatial::store`] has already cut their jump into the output. Keeping them
-    /// would leave [`Spatial::zc`] reporting the pre-event value at the located root,
-    /// and an integrator that re-primes its root finder from the value *at* that root
-    /// reports the same crossing again a step later.
-    fn consume_events(&mut self, pos_x: f64, positive: bool) {
-        let read = Self::out_pos(pos_x, positive);
-        loop {
-            let ev = match if positive { self.events.back() } else { self.events.front() } {
-                Some(ev) => *ev,
-                None => return,
-            };
-            let reached = if positive {
-                ev.pos > read - pos_eps(ev.pos, read)
-            } else {
-                ev.pos < read + pos_eps(ev.pos, read)
-            };
-            if !reached {
-                return;
-            }
-            self.last_event_sign = ev.sign;
-            if positive {
-                self.events.pop_back();
-            } else {
-                self.events.pop_front();
-            }
-            omclog::info(
-                omclog::SPATIALDISTR,
-                false,
-                &format!("Announced event ({},{}) leaves the event list.", e(ev.pos), e(ev.sign)),
-            );
-        }
     }
 
     /// C `spatialDistributionZeroCrossing`: flips sign every time a stored
@@ -933,38 +892,17 @@ mod tests {
     }
 
     #[test]
-    fn an_announced_crossing_is_not_reported_twice() {
-        // The discontinuity at 0.5 reaches the output edge at x = 0.5. Reproduce what
-        // a root-finding integrator does: locate it, store the accepted point, run the
-        // event update — after which the crossing function must already read the
-        // post-event value, or the next step reports the same crossing again.
-        // Two of them, so the list is not left empty (which would hold the previous
-        // value for a different reason).
+    fn an_announced_crossing_leaves_the_list_only_in_prune() {
+        // C removes a discontinuity in `pruneSpatialDistribution` alone; evaluating
+        // the operator never touches the event list.
         let mut s = belt(&[0.0, 0.3, 0.3, 0.5, 0.5, 1.0], &[3.0, 3.0, 2.0, 2.0, 1.0, 1.0]);
         let before = s.zc(0.0, true, 0.0);
         assert_eq!(s.zc(0.5, true, 0.0), before, "not flipped yet at the root");
         s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_CONTINUOUS);
         s.store(0, 0.5, 0.0, 0.0, 0.5, true);
         s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_EVENT);
-        // No sign change is left for the integrator to find at or past the root, so
-        // the crossing is reported once instead of again a step later.
-        let after = s.zc(0.5, true, before);
-        assert_eq!(after, -before, "announced: the value has moved on");
-        assert_eq!(s.zc(0.5001, true, after), after, "and stays there");
-        assert_eq!(s.zc(0.55, true, after), after);
-    }
-
-    #[test]
-    fn the_last_announced_crossing_holds_its_value() {
-        // With nothing left in the list the crossing function holds the previous
-        // value, which is again no sign change for the integrator to re-find.
-        let mut s = belt(&[0.0, 0.5, 0.5, 1.0], &[2.0, 2.0, 1.0, 1.0]);
-        let before = s.zc(0.0, true, 0.0);
-        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_CONTINUOUS);
-        s.store(0, 0.5, 0.0, 0.0, 0.5, true);
-        s.eval(0, 0.5, 0.0, 0.0, 0.5, true, MODE_EVENT);
-        assert_eq!(s.zc(0.5, true, before), before);
-        assert_eq!(s.zc(0.6, true, before), before);
+        assert_eq!(s.zc(0.5, true, before), before, "the event update left the list alone");
+        assert_eq!(s.zc(0.5001, true, before), -before, "flipped once x is past it");
     }
 
     #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -42,7 +42,7 @@ unsafe extern "C" {
     fn functionODE(sim_data: u32);
     fn functionAlgebraics(sim_data: u32);
     fn functionStateSetJacobians(sim_data: u32);
-    fn functionZeroCrossings(sim_data: u32);
+    fn functionZeroCrossings(sim_data: u32, gout: u32);
     fn functionZeroCrossingsEquations(sim_data: u32);
     fn functionUpdateRelations(sim_data: u32);
     fn functionCheckAsserts(sim_data: u32);
@@ -108,7 +108,6 @@ impl SimEngine for StandaloneEngine {
                 "functionODE" => functionODE(arg),
                 "functionAlgebraics" => functionAlgebraics(arg),
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
-                "functionZeroCrossings" => functionZeroCrossings(arg),
                 "functionZeroCrossingsEquations" => functionZeroCrossingsEquations(arg),
                 "functionUpdateRelations" => functionUpdateRelations(arg),
                 "functionCheckAsserts" => functionCheckAsserts(arg),
@@ -138,10 +137,14 @@ impl SimEngine for StandaloneEngine {
         // call is a no-op when the feature is absent.
         self.call1_raw(name, arg)
     }
-    // Importing `evaluateDAEResiduals` (or the two synchronous dispatchers) would
-    // leave every model without that feature with an unresolved `model.*` import,
-    // so the standalone export supports neither.
-    fn call2_raw(&mut self, name: &str, _a: u32, _b: u32) -> driver::Result<()> {
+    fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
+        if name == driver::MODEL_FN_ZC {
+            unsafe { functionZeroCrossings(a, b) };
+            return Ok(());
+        }
+        // Importing `evaluateDAEResiduals` (or the two synchronous dispatchers) would
+        // leave every model without that feature with an unresolved `model.*` import,
+        // so the standalone export supports neither.
         Err(match name {
             driver::MODEL_FN_DAE => {
                 "wasm-jit standalone: --daeMode models are not supported by the standalone export"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -47,7 +47,7 @@ unsafe extern "C" {
     fn functionAlgebraics(sim_data: u32);
     fn functionOutputs(sim_data: u32);
     fn functionStateSetJacobians(sim_data: u32);
-    fn functionZeroCrossings(sim_data: u32);
+    fn functionZeroCrossings(sim_data: u32, gout: u32);
     fn functionZeroCrossingsEquations(sim_data: u32);
     fn functionUpdateRelations(sim_data: u32);
     fn functionCheckAsserts(sim_data: u32);
@@ -277,7 +277,6 @@ impl SimEngine for Engine {
                 "functionAlgebraics" => functionAlgebraics(arg),
                 "functionOutputs" => functionOutputs(arg),
                 "functionStateSetJacobians" => functionStateSetJacobians(arg),
-                "functionZeroCrossings" => functionZeroCrossings(arg),
                 "functionZeroCrossingsEquations" => functionZeroCrossingsEquations(arg),
                 "functionUpdateRelations" => functionUpdateRelations(arg),
                 "functionCheckAsserts" => functionCheckAsserts(arg),
@@ -301,6 +300,7 @@ impl SimEngine for Engine {
     fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
         unsafe {
             match name {
+                driver::MODEL_FN_ZC => functionZeroCrossings(a, b),
                 driver::MODEL_FN_UPDATE_SYNC => functionUpdateSynchronous(a, b),
                 driver::MODEL_FN_EQS_SYNC => functionEquationsSynchronous(a, b),
                 // Importing `evaluateDAEResiduals` would leave every non-DAE model
@@ -1194,7 +1194,7 @@ impl GuestModelExchangeInstance for Instance {
         if st.layout.n_zc == 0 {
             return Ok(Vec::new());
         }
-        if e.call1("functionZeroCrossings", st.sim_data).is_err() {
+        if e.call2(driver::MODEL_FN_ZC, st.sim_data, st.sim_data + st.layout.zc_off).is_err() {
             return Err(Status::Error);
         }
         Ok((0..st.layout.n_zc).map(|i| st.read_f64(st.layout.zc_off + i * 8)).collect())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -344,11 +344,13 @@ fn model_fn_clock(name: &str) -> Option<usize> {
 }
 
 /// The model entry points that are not `fn(SimData*)`: `--daeMode`'s residual
-/// takes the evaluation stage as a second argument (C's `currentEvalStage`), and
-/// the two synchronous dispatchers take a clock index.
+/// takes the evaluation stage as a second argument (C's `currentEvalStage`), the
+/// two synchronous dispatchers take a clock index, and the crossing function takes
+/// where to put its g-values (C's `gout`).
 pub const MODEL_FN_DAE: &str = "evaluateDAEResiduals";
 pub const MODEL_FN_UPDATE_SYNC: &str = "functionUpdateSynchronous";
 pub const MODEL_FN_EQS_SYNC: &str = "functionEquationsSynchronous";
+pub const MODEL_FN_ZC: &str = "functionZeroCrossings";
 
 /// C's `EVAL_*` (`dae_mode.c`): which stage of the step an equation belongs to.
 /// `evaluateDAEResiduals` runs exactly those whose `evalStages` intersect it.
@@ -1908,7 +1910,7 @@ fn init_model(
     if layout.n_zc > 0 {
         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
         save_zc_pre(e, sim_data, layout)?;
-        e.call1("functionZeroCrossings", sim_data)?;
+        e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
     }
     write_i32(e, sim_data + layout.initial_off, 0)?;
     // C's `initializeModel` ends with `checkForAsserts` — before the
@@ -2928,7 +2930,7 @@ fn save_zero_crossings(
         return Ok(Vec::new());
     }
     save_zc_pre(e, sim_data, layout)?;
-    e.call1("functionZeroCrossings", sim_data)?;
+    e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
     zc_sign_changed(e, sim_data, layout)
 }
 
@@ -2942,7 +2944,7 @@ fn save_zero_crossings_after_event(
     if layout.n_zc == 0 {
         return Ok(());
     }
-    e.call1("functionZeroCrossings", sim_data)?;
+    e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
     save_zc_pre(e, sim_data, layout)
 }
 
@@ -3160,7 +3162,7 @@ fn update_relations_pre(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout
 /// re-evaluates relations regardless of the flag.
 fn read_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, out: &mut [f64]) -> Result<()> {
     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-    e.call1("functionZeroCrossings", sim_data)?;
+    e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
     for (i, v) in out.iter_mut().enumerate() {
         *v = read_f64(e, sim_data + layout.zc_off + (i as u32) * 8)?;
     }
@@ -4174,7 +4176,10 @@ struct ResCtx {
     nls_fail_off: u32,
     /// Number of residual (right-hand-side) evaluations, for the bench line.
     nfe: u64,
-    /// `SimData` offset of the zero-crossing value region (for the root callback).
+    /// `SimData` offset of the root callback's own g-value buffer (C's `gout`).
+    zc_probe_off: u32,
+    /// `SimData` offset of the accepted-point g-values, which the hand-written
+    /// solvers probe through, as `gbode_events.c` does.
     zc_off: u32,
     /// Number of zero-crossings (root functions).
     n_zc: usize,
@@ -4313,10 +4318,10 @@ unsafe fn dassl_rt(
         e.write_bytes(ctx.states_base, y_bytes)?;
         set_context(e, ctx.ctx_addr, CONTEXT_EVENTS);
         e.call1("functionZeroCrossingsEquations", ctx.sim_data)?;
-        e.call1("functionZeroCrossings", ctx.sim_data)?;
+        e.call2(MODEL_FN_ZC, ctx.sim_data, ctx.sim_data + ctx.zc_probe_off)?;
         set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
         let rval_bytes = unsafe { core::slice::from_raw_parts_mut(rval as *mut u8, ctx.n_zc * 8) };
-        e.read_bytes(ctx.sim_data + ctx.zc_off, rval_bytes)?;
+        e.read_bytes(ctx.sim_data + ctx.zc_probe_off, rval_bytes)?;
         Ok(())
     })();
     if let Err(err) = run {
@@ -5142,6 +5147,7 @@ impl Driver for DasslDriver {
             n_states,
             nls_fail_off: layout.nls_fail_off,
             nfe: self.nfe,
+            zc_probe_off: 0,
             zc_off: 0,
             n_zc: 0,
             err: None,
@@ -6199,6 +6205,7 @@ impl SolverCore {
             n_states: self.n_states,
             nls_fail_off: layout.nls_fail_off,
             nfe: self.nfe,
+            zc_probe_off: layout.zc_probe_off,
             zc_off: layout.zc_off,
             n_zc: layout.n_zc as usize,
             err: None,
@@ -7486,10 +7493,10 @@ unsafe fn eval_roots(ctx: &mut ResCtx, t: f64, y: *const f64, yp: *const f64, go
     } else {
         e.call1("functionZeroCrossingsEquations", ctx.sim_data)?;
     }
-    e.call1("functionZeroCrossings", ctx.sim_data)?;
+    e.call2(MODEL_FN_ZC, ctx.sim_data, ctx.sim_data + ctx.zc_probe_off)?;
     set_context(e, ctx.ctx_addr, CONTEXT_ALGEBRAIC);
     let out = unsafe { core::slice::from_raw_parts_mut(gout as *mut u8, ctx.n_zc * 8) };
-    e.read_bytes(ctx.sim_data + ctx.zc_off, out)
+    e.read_bytes(ctx.sim_data + ctx.zc_probe_off, out)
 }
 
 /// `CVRootFn`.
@@ -7668,6 +7675,7 @@ impl Driver for CvodeDriver {
             n_states,
             nls_fail_off: layout.nls_fail_off,
             nfe: 0,
+            zc_probe_off: 0,
             zc_off: 0,
             n_zc: 0,
             err: None,
@@ -8611,6 +8619,7 @@ impl Driver for IdaDriver {
             n_states,
             nls_fail_off: layout.nls_fail_off,
             nfe: 0,
+            zc_probe_off: 0,
             zc_off: 0,
             n_zc: 0,
             err: None,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/nls.rs
@@ -126,7 +126,7 @@ impl Ode<'_> {
         crate::driver::set_context_events(self.e, self.ctx_addr);
         let run = (|| -> Result<()> {
             self.eval(t, y, &mut f)?;
-            self.e.call1("functionZeroCrossings", self.sim_data)?;
+            self.e.call2(crate::driver::MODEL_FN_ZC, self.sim_data, self.sim_data + self.zc_off)?;
             let mut bytes = vec![0u8; zc.len() * 8];
             self.e.read_bytes(self.sim_data + self.zc_off, &mut bytes)?;
             for (i, v) in zc.iter_mut().enumerate() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/gbode/step.rs
@@ -747,11 +747,6 @@ mod tests {
                     self.set_f64(DERS, v);
                     self.set_f64(DERS + 8, -G);
                 }
-                // The codegen emits crossings as ±1, not the relation expression.
-                "functionZeroCrossings" => {
-                    let h = self.f64_at(STATES);
-                    self.set_f64(SIM_DATA + ZC_OFF, if h > 0.0 { 1.0 } else { -1.0 });
-                }
                 _ => return Err("unexpected model function"),
             }
             Ok(())
@@ -759,8 +754,14 @@ mod tests {
         fn call1_if_present_raw(&mut self, _name: &str, _arg: u32) -> Result<()> {
             Ok(())
         }
-        fn call2_raw(&mut self, _name: &str, _a: u32, _b: u32) -> Result<()> {
-            Err("unused")
+        fn call2_raw(&mut self, name: &str, _a: u32, gout: u32) -> Result<()> {
+            // The codegen emits crossings as ±1, not the relation expression.
+            if name != crate::driver::MODEL_FN_ZC {
+                return Err("unexpected model function");
+            }
+            let h = self.f64_at(STATES);
+            self.set_f64(gout, if h > 0.0 { 1.0 } else { -1.0 });
+            Ok(())
         }
         fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> Result<u32> {
             Err("unused")

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -199,6 +199,10 @@ pub struct Layout {
     /// per crossing). `delayZeroCrossing` reads it; the driver snapshots it from
     /// `zc_off` at init and after each accepted point/event.
     pub zc_pre_off: u32,
+    /// Where an integrator's root callback writes its g-values (one f64 per
+    /// crossing): C's `gout`, kept apart from `zc_off` so a probe never overwrites
+    /// the accepted-point snapshot.
+    pub zc_probe_off: u32,
     /// Number of indexed relations (hysteresis count).
     pub n_rel: u32,
     /// Base of the held relation values (one i32 per indexed relation).
@@ -359,7 +363,8 @@ impl Layout {
         let sample_active_off = sample_off + n_samples * 16;
         let zc_off = (sample_active_off + n_samples * 4 + 7) & !7;
         let zc_pre_off = zc_off + n_zc * 8;
-        let relations_off = zc_pre_off + n_zc * 8;
+        let zc_probe_off = zc_pre_off + n_zc * 8;
+        let relations_off = zc_probe_off + n_zc * 8;
         let rel_fresh_off = relations_off + n_rel * 4;
         let stored_rel_off = rel_fresh_off + 4;
         let relations_pre_off = stored_rel_off + n_rel * 4;
@@ -391,7 +396,7 @@ impl Layout {
         Layout {
             n_states, n_real_alg, has_when, has_homotopy, homotopy_method, has_init_lambda0, has_history_ops, has_old_real, lambda_off, rparam_off, int_off, iparam_off,
             bool_off, bparam_off, str_off, sparam_off, eobj_off, pre_real_off, pre_int_off, pre_bool_off, old_real_off,
-            terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off,
+            terminate_off, terminal_off, initial_off, term_info_off, n_out_off, nls_fail_off, n_samples, sample_off, sample_active_off, n_zc, zc_off, zc_pre_off, zc_probe_off,
             n_rel, relations_off, rel_fresh_off, stored_rel_off, relations_pre_off, stateset_off, nls_jac_off, n_math,
             mathevents_off, zctol_off, start_off, real_nom_off, state_nom_off, state_max_off, n_sens, sens_off,
             n_dae_res, dae_res_off, n_dae_aux, dae_aux_off, n_dae_alg, dae_alg_nom_off,
@@ -1227,7 +1232,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 13;
+const VERSION: u32 = 14;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -1256,7 +1261,7 @@ fn put_layout(o: &mut Vec<u8>, l: &Layout) {
         l.n_states, l.n_real_alg, l.lambda_off, l.rparam_off, l.int_off, l.iparam_off, l.bool_off,
         l.bparam_off, l.str_off, l.sparam_off, l.eobj_off, l.pre_real_off, l.pre_int_off, l.pre_bool_off, l.old_real_off,
         l.terminate_off, l.terminal_off, l.initial_off, l.term_info_off, l.n_out_off, l.nls_fail_off, l.n_samples, l.sample_off, l.sample_active_off,
-        l.n_zc, l.zc_off, l.zc_pre_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
+        l.n_zc, l.zc_off, l.zc_pre_off, l.zc_probe_off, l.n_rel, l.relations_off, l.rel_fresh_off, l.stored_rel_off, l.relations_pre_off,
         l.stateset_off, l.nls_jac_off, l.n_math, l.mathevents_off, l.zctol_off, l.start_off,
         l.real_nom_off, l.state_nom_off, l.state_max_off, l.n_sens, l.sens_off,
         l.n_dae_res, l.dae_res_off, l.n_dae_aux, l.dae_aux_off, l.n_dae_alg, l.dae_alg_nom_off,
@@ -1626,6 +1631,7 @@ impl<'a> Reader<'a> {
             n_zc: self.u32()?,
             zc_off: self.u32()?,
             zc_pre_off: self.u32()?,
+            zc_probe_off: self.u32()?,
             n_rel: self.u32()?,
             relations_off: self.u32()?,
             rel_fresh_off: self.u32()?,


### PR DESCRIPTION
C's `function_ZeroCrossings(data, threadData, gout)` takes the destination array as a parameter, and `dassl.c`, `ida_solver.c` and `cvode_solver.c` pass the integrator's own `gout`. A root probe therefore never touches `simulationInfo->zeroCrossings`, the accepted-point snapshot `saveZeroCrossings` shifts into `zeroCrossingsPre` and `checkForStateEvent` compares against. That second detection is not redundant: a crossing is emitted as `gout[i] = relation ? 1 : -1`, and DASKR's root finder regularly walks past the step such a step function flips in — the accepted-point sign comparison is what catches it, which is why C locates those events on the output grid.

The wasm-jit `functionZeroCrossings` always wrote `SimData`'s own crossing region, and the DASKR/IDA/CVODE root callbacks read the values back out of it, so every probe overwrote the accepted-point snapshot. `save_zero_crossings` then compared the last probe's g-values against this accepted point instead of the previous accepted point, dropping crossings DASKR had not rooted and inventing others.

Give the emitted `functionZeroCrossings` C's `gout` parameter and add a `SimData` probe region for the integrator callbacks to write into. The hand-written solvers keep probing through the accepted-point region, as `gbode_events.c` does. The layout gains a region, so the metadata wire version goes to 14.

`AixLib.ThermalZones.ReducedOrder.Validation.VDI6007.TestCase11` lost the `conHeaCoo.y > hysteresis.uHigh` event at t=108060 and only caught up at the next `sample(3600, 3600)`, 3540 s later — once a day, every day of the 60-day run. `mean`'s hourly average then drifted far enough from the VDI reference that `assEqu`'s `when terminal()` assert fired, which is the reported `unreachable` in `functionAlgebraics`.

| statistic | C | wasm-jit |
| --------- | ---: | ---: |
| state events | 540 | 540 |
| time events | 1440 | 1440 |
| steps taken | 113737 | 113707 |

Every result variable now agrees with the C runtime to 1e-5 relative over the whole run; the `LOG_EVENTS` streams of the first 120000 s are identical bar one event's crossing list.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
