### PR TITLE
[Testsuite] Let the remaining FMPy tests ask for their interpreter

### DIFF
--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_cs_01.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_cs_01.mos
@@ -26,7 +26,10 @@ readFile("fmi3_cs_01.xml"); getErrorString();
 // model in OpenModelica, co-simulate the FMU with FMPy, and check that the FMU
 // reproduces OpenModelica's own (non-FMU) simulation results.
 simulate(fmi3_cs_01, stopTime=1.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py fmi3_cs_01.fmu fmi3_cs_01_fmpy.csv 1.0 x y"); getErrorString();
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py fmi3_cs_01.fmu fmi3_cs_01_fmpy.csv 1.0 x y"); getErrorString();
 diffSimulationResults("fmi3_cs_01_fmpy.csv", "fmi3_cs_01_res.mat", "fmi3_cs_01_diff", vars={"x","y"}); getErrorString();
 
 // Result:

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_msl_clocked_drive.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_msl_clocked_drive.mos
@@ -16,7 +16,10 @@ simulate(Modelica.Clocked.Examples.SimpleControlledDrive.ExactlyClockedWithDiscr
 
 buildModelFMU(Modelica.Clocked.Examples.SimpleControlledDrive.ExactlyClockedWithDiscreteController, version="3.0", fmuType="cs", fileNamePrefix="ClkDrive"); getErrorString();
 
-system("python3 ../../simulate_fmu_fmpy.py ClkDrive.fmu ClkDrive_fmpy.csv 5.0 load.w load.phi"); getErrorString();
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py ClkDrive.fmu ClkDrive_fmpy.csv 5.0 load.w load.phi"); getErrorString();
 diffSimulationResults("ClkDrive_fmpy.csv", "ClkDrive_ref_res.mat", "ClkDrive_diff", vars={"load.w","load.phi"}); getErrorString();
 
 // Result:

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos
@@ -56,28 +56,32 @@ equation
 end DirectFeedthrough;
 "); getErrorString();
 
+// Which interpreter can import fmpy is a property of the machine, not of the
+// test, so rtest hands it over in FMPY_TOOL; python3 is the default. Kept as one
+// expression so the script prints nothing extra.
+
 // ExpDecay: a single continuous state.
 buildModelFMU(ExpDecay, version="1.0", fmuType="me"); getErrorString();
 simulate(ExpDecay, stopTime=1.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py ExpDecay.fmu ExpDecay_fmpy.csv 1.0 x"); getErrorString();
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py ExpDecay.fmu ExpDecay_fmpy.csv 1.0 x"); getErrorString();
 diffSimulationResults("ExpDecay_fmpy.csv", "ExpDecay_res.mat", "ExpDecay_diff", vars={"x"}); getErrorString();
 
 // SampleCount: a continuous state plus a time event (sample) driving a counter.
 buildModelFMU(SampleCount, version="1.0", fmuType="me"); getErrorString();
 simulate(SampleCount, stopTime=1.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py SampleCount.fmu SampleCount_fmpy.csv 1.0 x n"); getErrorString();
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py SampleCount.fmu SampleCount_fmpy.csv 1.0 x n"); getErrorString();
 diffSimulationResults("SampleCount_fmpy.csv", "SampleCount_res.mat", "SampleCount_diff", vars={"x","n"}); getErrorString();
 
 // Oscillator: two coupled continuous states.
 buildModelFMU(Oscillator, version="1.0", fmuType="me"); getErrorString();
 simulate(Oscillator, stopTime=3.141592653589793); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py Oscillator.fmu Oscillator_fmpy.csv 3.141592653589793 x v"); getErrorString();
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py Oscillator.fmu Oscillator_fmpy.csv 3.141592653589793 x v"); getErrorString();
 diffSimulationResults("Oscillator_fmpy.csv", "Oscillator_res.mat", "Oscillator_diff", vars={"x","v"}); getErrorString();
 
 // StateEvent: a continuous state with a state event (the b = x > 0.5 crossing).
 buildModelFMU(StateEvent, version="1.0", fmuType="me"); getErrorString();
 simulate(StateEvent, stopTime=2.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py StateEvent.fmu StateEvent_fmpy.csv 2.0 x y"); getErrorString();
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py StateEvent.fmu StateEvent_fmpy.csv 2.0 x y"); getErrorString();
 diffSimulationResults("StateEvent_fmpy.csv", "StateEvent_res.mat", "StateEvent_diff", vars={"x","y"}); getErrorString();
 
 // DirectFeedthrough: a stateless algebraic output y = 2*time. With no continuous states an FMI 1.0
@@ -86,7 +90,7 @@ diffSimulationResults("StateEvent_fmpy.csv", "StateEvent_res.mat", "StateEvent_d
 // y = 0 for all time. See #15838.
 buildModelFMU(DirectFeedthrough, version="1.0", fmuType="me"); getErrorString();
 simulate(DirectFeedthrough, stopTime=1.0); getErrorString();
-system("python3 ../../simulate_fmu_fmpy.py DirectFeedthrough.fmu DirectFeedthrough_fmpy.csv 1.0 y"); getErrorString();
+system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py DirectFeedthrough.fmu DirectFeedthrough_fmpy.csv 1.0 y"); getErrorString();
 diffSimulationResults("DirectFeedthrough_fmpy.csv", "DirectFeedthrough_res.mat", "DirectFeedthrough_diff", vars={"y"}); getErrorString();
 // Result:
 // true


### PR DESCRIPTION
Fixes #16410.

#16403 gave the FMPy round-trip tests an `FMPY_TOOL` escape hatch, because the `python3` on PATH on Windows is OMDev's MSYS2 one and it cannot install fmpy (#16399). It converted only the three `openmodelica/fmi/ModelExchange/3.0` tests, and left three others driving the same `simulate_fmu_fmpy.py` through a hardcoded `python3`:

| test | call sites |
| --- | ---: |
| `openmodelica/fmi/CoSimulation/3.0/fmi3_cs_01.mos` | 1 |
| `openmodelica/fmi/CoSimulation/3.0/fmi3_msl_clocked_drive.mos` | 1 |
| `openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos` | 5 |

All three are red on OM_Win (most recently build 5777). This applies the existing expression to all seven sites:

```mo
system("\"" + (if getEnvironmentVar("FMPY_TOOL") == "" then "python3" else getEnvironmentVar("FMPY_TOOL")) + "\" ../../simulate_fmu_fmpy.py ...");
```

`simulate_fmu_fmpy.py` is the only fmpy entry point in the testsuite and no `.mos` names the interpreter any other way now, so this is every call site.

## Verification

Both platforms, through **partest**.

**Windows** (MSYS2/UCRT64, `FMPY_TOOL=C:/dev/OMDevPyEnv/Scripts/python.exe`, a venv with fmpy 0.3.31):

| test | before | after |
| --- | --- | --- |
| `fmi3_cs_01.mos` | Failed | **OK** |
| `fmi3_msl_clocked_drive.mos` | Failed | **OK** |
| `FMI1MEfmpy.mos` | Failed | Failed (see below) |

The "before" column is with `FMPY_TOOL` already set, so it isolates the hardcoded `python3` as the cause. As a control, an already-converted test in the same tree passes with the variable set and fails without it.

**Linux** (local build, `FMPY_TOOL` unset so the `python3` fallback is exercised): all three pass.

```
[fmi3_cs_01.mos] OK
[FMI1MEfmpy.mos] OK
[fmi3_msl_clocked_drive.mos] OK
```

## FMI1MEfmpy is not green yet

Past the interpreter lookup it hits two failures that have nothing to do with this change. Both are worth their own tickets and neither is caused here — before this change the test died at its first fmpy call instead.

1. **`SampleCount` — an fmpy version regression, not a platform one.** Under fmpy **0.3.31** it fails on Linux *and* Windows with

   ```
   RuntimeError: CVode error (code -27) in module cvHandleFailure,
   function .../sundials-7.5.0/src/cvode/cvode.c: tout too close to t0 to start integration.
   ```

   Under fmpy **0.3.29** the same FMU passes. Confirmed by running the test on Linux against a 0.3.31 venv, where it reproduces exactly, and against 0.3.29, where it does not.

2. **`StateEvent` — Windows only.** The importer process dies with exit code `-1073740791` = `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`). It does **not** reproduce on Linux even with the same fmpy 0.3.31, so this one is genuinely platform-specific rather than a version difference.

`ExpDecay`, `Oscillator` and `DirectFeedthrough` all pass on Windows with this change.

---
generated by Claude Code
