### PR TITLE
[Runtime] Do not hand a NULL path to the UCRT on Windows

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -519,6 +519,11 @@ void modelInfoInit(MODEL_DATA_XML* xml)
 {
   // check for file exists, as --fmiFilter=blackBox or protected will not export the _info.json file
   int fileExists;
+  /* An FMI 1.0 FMU compiles the info JSON in and leaves fileName NULL, so there is
+     no file to look for. */
+  if (!xml->fileName) {
+    return;
+  }
   if (omc_flag[FLAG_INPUT_PATH])
   {
     const char *jsonFile;

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -47,10 +47,30 @@ wchar_t* longabspath(wchar_t* unicodePath);
  * @return wchar_t*  A wide character representation of the multibyte string. The caller is responsible for deallocating the memory.
  */
 wchar_t* omc_multibyte_to_wchar_str(const char* in_mb_str) {
-  int length = MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, NULL, 0);
+  int length;
+  wchar_t* out_wc_str;
 
-  wchar_t* out_wc_str = (wchar_t*) malloc(length * sizeof(wchar_t));
-  MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, out_wc_str, length);
+  /* MultiByteToWideChar returns 0 for a NULL or otherwise unconvertible input.
+     Returning malloc(0) here would hand the caller an unterminated, uninitialised
+     buffer that it then reads as a string. */
+  if (!in_mb_str) {
+    return NULL;
+  }
+
+  length = MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, NULL, 0);
+  if (length <= 0) {
+    return NULL;
+  }
+
+  out_wc_str = (wchar_t*) malloc(length * sizeof(wchar_t));
+  if (!out_wc_str) {
+    return NULL;
+  }
+
+  if (MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, out_wc_str, length) <= 0) {
+    free(out_wc_str);
+    return NULL;
+  }
 
   return out_wc_str;
 }
@@ -95,7 +115,19 @@ FILE* omc_fopen(const char *filename, const char *mode)
   wchar_t* unicodeMode = omc_multibyte_to_wchar_str(mode);
 
   wchar_t* unicodeLongFileName = longabspath(unicodeFilename);
-  FILE *f = _wfopen(unicodeLongFileName, unicodeMode);
+  FILE *f;
+
+  /* The UCRT kills the process through the invalid parameter handler when one of
+     these is NULL, instead of returning an error, so do not let a path we failed
+     to resolve reach it. */
+  if (!unicodeLongFileName || !unicodeMode) {
+    free(unicodeLongFileName);
+    free(unicodeFilename);
+    free(unicodeMode);
+    return NULL;
+  }
+
+  f = _wfopen(unicodeLongFileName, unicodeMode);
 
   free(unicodeLongFileName);
   free(unicodeFilename);
@@ -188,10 +220,18 @@ int omc_stat(const char *filename, omc_stat_t* statbuf)
 {
   wchar_t* unicodeFilename = omc_multibyte_to_wchar_str(filename);
   wchar_t* unicodeLongFileName = longabspath(unicodeFilename);
+  int res;
+
+  /* See omc_fopen: _wstat(NULL, ...) terminates the process rather than failing. A
+     path that could not be resolved simply does not exist as far as callers care. */
+  if (!unicodeLongFileName) {
+    free(unicodeFilename);
+    return -1;
+  }
 
   // _wstat not working on MINGW64 with \\?\, because it links to the MSVCRT (Microsoft Visual C++ Runtime)
   // We need to use UCRT64, which links to UCRT (Universal C Runtime)
-  int res = _wstat(unicodeLongFileName, statbuf);
+  res = _wstat(unicodeLongFileName, statbuf);
 
   free(unicodeLongFileName);
   free(unicodeFilename);
@@ -259,6 +299,11 @@ int omc_unlink(const char *filename) {
 #if defined(__MINGW32__) || defined(_MSC_VER)
   wchar_t* unicodeFilename = omc_multibyte_to_wchar_str(filename);
   wchar_t* unicodeLongFileName = longabspath(unicodeFilename);
+  /* See omc_fopen: _wunlink(NULL) terminates the process rather than failing. */
+  if (!unicodeFilename) {
+    free(unicodeLongFileName);
+    return -1;
+  }
   result = _wunlink(unicodeFilename);
   free(unicodeLongFileName);
   free(unicodeFilename);
@@ -305,6 +350,10 @@ wchar_t* longabspath(wchar_t* unicodePath) {
   wchar_t unicodeAbsPath[BUFSIZE];
   wchar_t unicodeLongAbsPath[BUFSIZE];
   wchar_t* path;
+
+  if (!unicodePath) {
+    return NULL;
+  }
 
   retval = GetFullPathNameW(unicodePath, BUFSIZE, unicodeAbsPath, NULL);
   if (retval == 0)


### PR DESCRIPTION
Fixes #16413.

Every FMI 1.0 Model Exchange FMU exported by OpenModelica could kill the importing process on Windows, inside `fmi1InstantiateModel`, before any simulation ran — exit code `-1073740791` = `0xC0000409`, no message, nothing a debugger could intercept. It fired on roughly one freshly started importer in five to eight, so an FMI 1.0 FMU was unusable at random. FMI 2.0/3.0 and Linux were unaffected.

## The chain

An FMI 1.0 FMU compiles its info JSON in instead of shipping it as a file, so the generated code sets the name to `NULL` — FMI 2.0 stores a real path, which is exactly why it never crashed:

```c
/* FMI 1.0, sources/<Model>.c */
data->modelData->modelDataXml.fileName = NULL;
/* FMI 2.0 */
GC_asprintf(&...modelDataXml.fileName, "%s/<Model>_info.json", ...resourcesDir);
```

`modelInfoInit` passed that `NULL` to `omc_file_exists`, which on Windows reached `omc_multibyte_to_wchar_str(NULL)`:

```c
int length = MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, NULL, 0);  /* fails -> 0 */
wchar_t* out_wc_str = (wchar_t*) malloc(length * sizeof(wchar_t));     /* malloc(0)  */
MultiByteToWideChar(CP_UTF8, 0, in_mb_str, -1, out_wc_str, length);    /* fails, writes nothing */
return out_wc_str;                                                     /* uninitialised, unterminated */
```

Neither conversion call was checked, so callers got a zero-size heap block and read it as a wide string. `longabspath` then either resolved whatever garbage was there — harmless — or, when the bytes happened to begin with `L'\0'`, failed with `ERROR_INVALID_NAME` and returned `NULL`. `omc_stat` handed that to `_wstat(NULL, ...)`, and the UCRT's default invalid-parameter handler is `__fastfail`.

**That dependence on uninitialised heap contents is the whole reason it was intermittent**, and why it vanished under a debugger (gdb: 12/12 clean) and under added `fprintf` tracing (40/40 clean) — both perturb the heap.

Resolved stack, captured from inside a CRT invalid-parameter handler installed in the importing process:

```
StateEvent.dll+0x47032  ->  StateEvent_fmiInstantiateModel + 0x242
StateEvent.dll+0x1b7c0  ->  modelInfoInit + 0x150
StateEvent.dll+0x37503  ->  omc_file_exists + 0x83
ucrtbase.dll+0x73754    ->  invalid parameter -> __fastfail
```

## The fix

Three guards, each independently sufficient:

* `omc_multibyte_to_wchar_str` checks its argument, both `MultiByteToWideChar` calls and the `malloc`, returning `NULL` rather than an uninitialised buffer. This is the actual undefined behaviour and every caller in the runtime was exposed to it, not only this path.
* `omc_stat`, `omc_fopen` and `omc_unlink` no longer pass `NULL` to `_wstat`/`_wfopen`/`_wunlink`; `longabspath` tolerates a `NULL` path. On Windows an invalid argument to these is a process kill, not an error return.
* `modelInfoInit` returns early on a `NULL` `fileName` — which is what Linux already did implicitly, since `stat(NULL)` returns `-1` and it took the "file missing" branch.

## Verification

**Windows** (MSYS2/UCRT64), each FMU instantiated in a fresh process 60 times, old and new runtime interleaved in a single batch on the same machine so the baseline is contemporaneous:

| FMU | runtime | killed |
| --- | --- | ---: |
| `ExpDecay` (`der(x) = -x`) | unfixed | 3/60 |
| `ExpDecay` | **fixed** | **0/60** |
| `StateEvent` | unfixed | 3/60 |
| `StateEvent` | **fixed** | **0/60** |

Earlier baselines on the same machine were 8/60 and 5/25 for `ExpDecay`, 3/25 for `StateEvent`, 1/25 for `Oscillator`, and 0/60 for the FMI 2.0 export of the same model.

**Linux**: both files compile clean with `-Wall`, and the only change that is live on Linux is the `modelInfoInit` early return — everything in `omc_file.c` sits inside `#if defined(__MINGW32__) || defined(_MSC_VER)`. That early return is semantically identical to the existing behaviour: with `fileName` already `NULL`, the old code called `stat(NULL)`, got `-1`, and ran `xml->fileName = NULL; return;`.

In the interest of being straight about it: I did **not** get an end-to-end Linux runtime rebuild, because that build tree's configure currently fails on an unrelated sundials option (`SUNDIALS_ENABLE_PACKAGE_FUSED_KERNELS`). The Linux argument above is a compile check plus the equivalence of the two code paths, not a measured run.

No new test: the failure is probabilistic, so a deterministic regression test is not practical. `openmodelica/fmi/ModelExchange/1.0/FMI1MEfmpy.mos` exercises this path — it exports five FMI 1.0 ME FMUs and imports each with an independent FMI master — and was one of the tests flaking because of it.

---
generated by Claude Code
